### PR TITLE
Dlangify printf comments from -> to .

### DIFF
--- a/src/access.d
+++ b/src/access.d
@@ -152,7 +152,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
         return false; // then it is accessible
     }
     // BUG: should enable this check
-    //assert(smember->parent->isBaseOf(this, NULL));
+    //assert(smember.parent.isBaseOf(this, NULL));
     bool result;
     Prot access;
     if (smemberparent == ad)
@@ -192,7 +192,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
     {
         ad.error(loc, "member %s is not accessible", smember.toChars());
         //printf("smember = %s %s, prot = %d, semanticRun = %d\n",
-        //        smember->kind(), smember->toPrettyChars(), smember->prot(), smember->semanticRun);
+        //        smember.kind(), smember.toPrettyChars(), smember.prot(), smember.semanticRun);
         return true;
     }
     return false;
@@ -210,7 +210,7 @@ extern (C++) bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
     if (ad == cd)
         return true;
     // Friends if both are in the same module
-    //if (toParent() == cd->toParent())
+    //if (toParent() == cd.toParent())
     if (cd && ad.getAccessModule() == cd.getAccessModule())
     {
         static if (LOG)
@@ -238,7 +238,7 @@ extern (C++) bool hasPackageAccess(Module mod, Dsymbol s)
 {
     static if (LOG)
     {
-        printf("hasPackageAccess(s = '%s', mod = '%s', s->protection.pkg = '%s')\n", s.toChars(), mod.toChars(), s.prot().pkg ? s.prot().pkg.toChars() : "NULL");
+        printf("hasPackageAccess(s = '%s', mod = '%s', s.protection.pkg = '%s')\n", s.toChars(), mod.toChars(), s.prot().pkg ? s.prot().pkg.toChars() : "NULL");
     }
     Package pkg = null;
     if (s.prot().pkg)
@@ -396,7 +396,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
         if (e)
         {
             printf("checkAccess(%s . %s)\n", e.toChars(), d.toChars());
-            printf("\te->type = %s\n", e.type.toChars());
+            printf("\te.type = %s\n", e.type.toChars());
         }
         else
         {

--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -383,7 +383,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             if (vd._init && vd._init.isVoidInitializer())
                 vx = null;
 
-            // Find overlapped fields with the hole [vd->offset .. vd->offset->size()].
+            // Find overlapped fields with the hole [vd.offset .. vd.offset.size()].
             foreach (j; 0 .. nfields)
             {
                 if (i == j)
@@ -450,7 +450,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             if (vd._init && vd._init.isVoidInitializer())
                 vx = null;
 
-            // Find overlapped fields with the hole [vd->offset .. vd->offset->size()].
+            // Find overlapped fields with the hole [vd.offset .. vd.offset.size()].
             size_t fieldi = i;
             foreach (j; 0 .. nfields)
             {
@@ -720,7 +720,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
             assert(!vthis);
             vthis = new ThisDeclaration(loc, t);
-            //vthis->storage_class |= STCref;
+            //vthis.storage_class |= STCref;
 
             // Emulate vthis.addMember()
             members.push(vthis);
@@ -763,7 +763,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             s = null; // search() looks through ancestor classes
         if (s)
         {
-            // Finish all constructors semantics to determine this->noDefaultCtor.
+            // Finish all constructors semantics to determine this.noDefaultCtor.
             struct SearchCtor
             {
                 extern (C++) static int fp(Dsymbol s, void* ctxt)

--- a/src/argtypes.d
+++ b/src/argtypes.d
@@ -283,7 +283,7 @@ extern (C++) TypeTuple toArgTypes(Type t)
             if (!t.sym.isPOD() || t.sym.fields.dim == 0)
             {
             Lmemory:
-                //printf("\ttoArgTypes() %s => [ ]\n", t->toChars());
+                //printf("\ttoArgTypes() %s => [ ]\n", t.toChars());
                 result = new TypeTuple(); // pass on the stack
                 return;
             }
@@ -421,7 +421,7 @@ extern (C++) TypeTuple toArgTypes(Type t)
                     if (t.sym.fields.dim == 1)
                     {
                         VarDeclaration f = t.sym.fields[0];
-                        //printf("f->type = %s\n", f->type->toChars());
+                        //printf("f.type = %s\n", f.type.toChars());
                         TypeTuple tup = toArgTypes(f.type);
                         if (tup)
                         {
@@ -432,10 +432,10 @@ extern (C++) TypeTuple toArgTypes(Type t)
                     }
                 }
             }
-            //printf("\ttoArgTypes() %s => [%s,%s]\n", t->toChars(), t1 ? t1->toChars() : "", t2 ? t2->toChars() : "");
+            //printf("\ttoArgTypes() %s => [%s,%s]\n", t.toChars(), t1 ? t1.toChars() : "", t2 ? t2.toChars() : "");
             if (t1)
             {
-                //if (t1) printf("test1: %s => %s\n", toChars(), t1->toChars());
+                //if (t1) printf("test1: %s => %s\n", toChars(), t1.toChars());
                 if (t2)
                     result = new TypeTuple(t1, t2);
                 else

--- a/src/arrayop.d
+++ b/src/arrayop.d
@@ -607,7 +607,7 @@ extern (C++) bool isBinAssignArrayOp(TOK op)
  */
 extern (C++) bool isArrayOpOperand(Expression e)
 {
-    //printf("Expression.isArrayOpOperand() %s\n", e->toChars());
+    //printf("Expression.isArrayOpOperand() %s\n", e.toChars());
     if (e.op == TOKslice)
         return true;
     if (e.op == TOKarrayliteral)

--- a/src/attrib.d
+++ b/src/attrib.d
@@ -121,7 +121,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
             for (size_t i = 0; i < d.dim; i++)
             {
                 Dsymbol s = (*d)[i];
-                //printf("\taddMember %s to %s\n", s->toChars(), sds->toChars());
+                //printf("\taddMember %s to %s\n", s.toChars(), sds.toChars());
                 s.addMember(sc2, sds);
             }
             if (sc2 != sc)
@@ -223,7 +223,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
                 for (size_t i = 0; i < d.dim; i++)
                 {
                     Dsymbol s = (*d)[i];
-                    //printf("AttribDeclaration::addComment %s\n", s->toChars());
+                    //printf("AttribDeclaration::addComment %s\n", s.toChars());
                     s.addComment(comment);
                 }
             }
@@ -802,8 +802,8 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
                     offset = 0;
             }
 
-            /* Bugzilla 13613: If the fields in this->members had been already
-             * added in ad->fields, just update *poffset for the subsequent
+            /* Bugzilla 13613: If the fields in this.members had been already
+             * added in ad.fields, just update *poffset for the subsequent
              * field offset calculation.
              */
             if (fieldstart == ad.fields.dim)
@@ -1176,7 +1176,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
 
     override final bool oneMember(Dsymbol* ps, Identifier ident)
     {
-        //printf("ConditionalDeclaration::oneMember(), inc = %d\n", condition->inc);
+        //printf("ConditionalDeclaration::oneMember(), inc = %d\n", condition.inc);
         if (condition.inc)
         {
             Dsymbols* d = condition.include(null, null) ? decl : elsedecl;
@@ -1215,7 +1215,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
                     for (size_t i = 0; i < d.dim; i++)
                     {
                         Dsymbol s = (*d)[i];
-                        //printf("ConditionalDeclaration::addComment %s\n", s->toChars());
+                        //printf("ConditionalDeclaration::addComment %s\n", s.toChars());
                         s.addComment(comment);
                     }
                 }
@@ -1381,7 +1381,7 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
 
     void compileIt(Scope* sc)
     {
-        //printf("CompileDeclaration::compileIt(loc = %d) %s\n", loc.linnum, exp->toChars());
+        //printf("CompileDeclaration::compileIt(loc = %d) %s\n", loc.linnum, exp.toChars());
         auto se = semanticString(sc, exp, "argument to mixin");
         if (!se)
             return;

--- a/src/canthrow.d
+++ b/src/canthrow.d
@@ -238,7 +238,7 @@ extern (C++) bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNot
     VarDeclaration vd;
     TemplateMixin tm;
     TupleDeclaration td;
-    //printf("Dsymbol_toElem() %s\n", s->toChars());
+    //printf("Dsymbol_toElem() %s\n", s.toChars());
     ad = s.isAttribDeclaration();
     if (ad)
     {
@@ -278,7 +278,7 @@ extern (C++) bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNot
     }
     else if ((tm = s.isTemplateMixin()) !is null)
     {
-        //printf("%s\n", tm->toChars());
+        //printf("%s\n", tm.toChars());
         if (tm.members)
         {
             for (size_t i = 0; i < tm.members.dim; i++)

--- a/src/cond.d
+++ b/src/cond.d
@@ -430,7 +430,7 @@ extern (C++) final class VersionCondition : DVCondition
     override int include(Scope* sc, ScopeDsymbol sds)
     {
         //printf("VersionCondition::include() level = %d, versionlevel = %d\n", level, global.params.versionlevel);
-        //if (ident) printf("\tident = '%s'\n", ident->toChars());
+        //if (ident) printf("\tident = '%s'\n", ident.toChars());
         if (inc == 0)
         {
             inc = 2;
@@ -517,7 +517,7 @@ extern (C++) final class StaticIfCondition : Condition
             ++nest;
             sc = sc.push(sc.scopesym);
             sc.sds = sds; // sds gets any addMember()
-            //sc->speculative = true;       // TODO: static if (is(T U)) { /* U is available */ }
+            //sc.speculative = true;       // TODO: static if (is(T U)) { /* U is available */ }
             sc.flags |= SCOPEcondition;
             sc = sc.startCTFE();
             Expression e = exp.semantic(sc);

--- a/src/constfold.d
+++ b/src/constfold.d
@@ -44,7 +44,7 @@ extern (C++) Expression expType(Type type, Expression e)
 /* ================================== isConst() ============================== */
 extern (C++) int isConst(Expression e)
 {
-    //printf("Expression::isConst(): %s\n", e->toChars());
+    //printf("Expression::isConst(): %s\n", e.toChars());
     switch (e.op)
     {
     case TOKint64:
@@ -374,8 +374,8 @@ extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
     if (type.isfloating())
     {
         auto c = complex_t(CTFloat.zero);
-        //e1->type->print();
-        //e2->type->print();
+        //e1.type.print();
+        //e2.type.print();
         if (e2.type.isreal())
         {
             if (e1.type.isreal())
@@ -706,7 +706,7 @@ extern (C++) UnionExp Equal(TOK op, Loc loc, Type type, Expression e1, Expressio
     int cmp = 0;
     real_t r1 = 0;
     real_t r2 = 0;
-    //printf("Equal(e1 = %s, e2 = %s)\n", e1->toChars(), e2->toChars());
+    //printf("Equal(e1 = %s, e2 = %s)\n", e1.toChars(), e2.toChars());
     assert(op == TOKequal || op == TOKnotequal);
     if (e1.op == TOKnull)
     {
@@ -952,7 +952,7 @@ extern (C++) UnionExp Cmp(TOK op, Loc loc, Type type, Expression e1, Expression 
     dinteger_t n;
     real_t r1 = 0;
     real_t r2 = 0;
-    //printf("Cmp(e1 = %s, e2 = %s)\n", e1->toChars(), e2->toChars());
+    //printf("Cmp(e1 = %s, e2 = %s)\n", e1.toChars(), e2.toChars());
     if (e1.op == TOKstring && e2.op == TOKstring)
     {
         StringExp es1 = cast(StringExp)e1;
@@ -1013,8 +1013,8 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     UnionExp ue;
     Type tb = to.toBasetype();
     Type typeb = type.toBasetype();
-    //printf("Cast(type = %s, to = %s, e1 = %s)\n", type->toChars(), to->toChars(), e1->toChars());
-    //printf("\te1->type = %s\n", e1->type->toChars());
+    //printf("Cast(type = %s, to = %s, e1 = %s)\n", type.toChars(), to.toChars(), e1.toChars());
+    //printf("\te1.type = %s\n", e1.type.toChars());
     if (e1.type.equals(type) && type.equals(to))
     {
         emplaceExp!(UnionExp)(&ue, e1);
@@ -1198,7 +1198,7 @@ extern (C++) UnionExp Index(Type type, Expression e1, Expression e2)
 {
     UnionExp ue;
     Loc loc = e1.loc;
-    //printf("Index(e1 = %s, e2 = %s)\n", e1->toChars(), e2->toChars());
+    //printf("Index(e1 = %s, e2 = %s)\n", e1.toChars(), e2.toChars());
     assert(e1.type);
     if (e1.op == TOKstring && e2.op == TOKint64)
     {
@@ -1431,8 +1431,8 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
     Type t;
     Type t1 = e1.type.toBasetype();
     Type t2 = e2.type.toBasetype();
-    //printf("Cat(e1 = %s, e2 = %s)\n", e1->toChars(), e2->toChars());
-    //printf("\tt1 = %s, t2 = %s, type = %s\n", t1->toChars(), t2->toChars(), type->toChars());
+    //printf("Cat(e1 = %s, e2 = %s)\n", e1.toChars(), e2.toChars());
+    //printf("\tt1 = %s, t2 = %s, type = %s\n", t1.toChars(), t2.toChars(), type.toChars());
     if (e1.op == TOKnull && (e2.op == TOKint64 || e2.op == TOKstructliteral))
     {
         e = e2;
@@ -1729,7 +1729,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
 
 extern (C++) UnionExp Ptr(Type type, Expression e1)
 {
-    //printf("Ptr(e1 = %s)\n", e1->toChars());
+    //printf("Ptr(e1 = %s)\n", e1.toChars());
     UnionExp ue;
     if (e1.op == TOKadd)
     {

--- a/src/ctfeexpr.d
+++ b/src/ctfeexpr.d
@@ -458,7 +458,7 @@ extern (C++) UnionExp copyLiteral(Expression e)
 
 /* Deal with type painting.
  * Type painting is a major nuisance: we can't just set
- * e->type = type, because that would change the original literal.
+ * e.type = type, because that would change the original literal.
  * But, we can't simply copy the literal either, because that would change
  * the values of any pointers.
  */
@@ -1178,8 +1178,8 @@ extern (C++) int ctfeRawCmp(Loc loc, Expression e1, Expression e2)
     }
     if (e1.op == TOKtypeid && e2.op == TOKtypeid)
     {
-        // printf("e1: %s\n", e1->toChars());
-        // printf("e2: %s\n", e2->toChars());
+        // printf("e1: %s\n", e1.toChars());
+        // printf("e2: %s\n", e2.toChars());
         Type t1 = isType((cast(TypeidExp)e1).obj);
         Type t2 = isType((cast(TypeidExp)e2).obj);
         assert(t1);
@@ -1352,7 +1352,7 @@ extern (C++) int ctfeEqual(Loc loc, TOK op, Expression e1, Expression e2)
 extern (C++) int ctfeIdentity(Loc loc, TOK op, Expression e1, Expression e2)
 {
     //printf("ctfeIdentity op = '%s', e1 = %s %s, e2 = %s %s\n", Token::toChars(op),
-    //    Token::toChars(e1->op), e1->toChars(), Token::toChars(e2->op), e1->toChars());
+    //    Token::toChars(e1.op), e1.toChars(), Token::toChars(e2.op), e1.toChars());
     int cmp;
     if (e1.op == TOKnull)
     {
@@ -1463,7 +1463,7 @@ extern (C++) UnionExp ctfeCat(Loc loc, Type type, Expression e1, Expression e2)
         emplaceExp!(StringExp)(&ue, loc, s, len);
         StringExp es = cast(StringExp)ue.exp();
         es.sz = sz;
-        es.committed = 0; //es1->committed;
+        es.committed = 0; //es1.committed;
         es.type = type;
         return ue;
     }
@@ -1520,7 +1520,7 @@ extern (C++) Expression findKeyInAA(Loc loc, AssocArrayLiteralExp ae, Expression
  */
 extern (C++) Expression ctfeIndex(Loc loc, Type type, Expression e1, uinteger_t indx)
 {
-    //printf("ctfeIndex(e1 = %s)\n", e1->toChars());
+    //printf("ctfeIndex(e1 = %s)\n", e1.toChars());
     assert(e1.type);
     if (e1.op == TOKstring)
     {

--- a/src/dcast.d
+++ b/src/dcast.d
@@ -106,7 +106,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
 
         override void visit(StringExp e)
         {
-            //printf("StringExp::implicitCastTo(%s of type %s) => %s\n", e->toChars(), e->type->toChars(), t->toChars());
+            //printf("StringExp::implicitCastTo(%s of type %s) => %s\n", e.toChars(), e.type.toChars(), t.toChars());
             visit(cast(Expression)e);
             if (result.op == TOKstring)
             {
@@ -122,7 +122,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
 
         override void visit(FuncExp e)
         {
-            //printf("FuncExp::implicitCastTo type = %p %s, t = %s\n", e->type, e->type ? e->type->toChars() : NULL, t->toChars());
+            //printf("FuncExp::implicitCastTo type = %p %s, t = %s\n", e.type, e.type ? e.type.toChars() : NULL, t.toChars());
             FuncExp fe;
             if (e.matchType(t, sc, &fe) > MATCHnomatch)
             {
@@ -209,7 +209,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             }
             if (ex != e)
             {
-                //printf("\toptimized to %s of type %s\n", e->toChars(), e->type->toChars());
+                //printf("\toptimized to %s of type %s\n", e.toChars(), e.type.toChars());
                 result = ex.implicitConvTo(t);
                 return;
             }
@@ -479,8 +479,8 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 }
 
             case Tpointer:
-                //printf("type = %s\n", type->toBasetype()->toChars());
-                //printf("t = %s\n", t->toBasetype()->toChars());
+                //printf("type = %s\n", type.toBasetype()->toChars());
+                //printf("t = %s\n", t.toBasetype()->toChars());
                 if (ty == Tpointer && e.type.toBasetype().nextOf().ty == t.toBasetype().nextOf().ty)
                 {
                     /* Allow things like:
@@ -550,7 +550,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     Type te = el.type;
                     te = e.sd.fields[i].type.addMod(t.mod);
                     MATCH m2 = el.implicitConvTo(te);
-                    //printf("\t%s => %s, match = %d\n", el->toChars(), te->toChars(), m2);
+                    //printf("\t%s => %s, match = %d\n", el.toChars(), te.toChars(), m2);
                     if (m2 < result)
                         result = m2;
                 }
@@ -1047,7 +1047,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
 
         override void visit(FuncExp e)
         {
-            //printf("FuncExp::implicitConvTo type = %p %s, t = %s\n", e->type, e->type ? e->type->toChars() : NULL, t->toChars());
+            //printf("FuncExp::implicitConvTo type = %p %s, t = %s\n", e.type, e.type ? e.type.toChars() : NULL, t.toChars());
             MATCH m = e.matchType(t, null, null, 1);
             if (m > MATCHnomatch)
             {
@@ -1328,7 +1328,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
 
         override void visit(SliceExp e)
         {
-            //printf("SliceExp::implicitConvTo e = %s, type = %s\n", e->toChars(), e->type->toChars());
+            //printf("SliceExp::implicitConvTo e = %s, type = %s\n", e.toChars(), e.type.toChars());
             visit(cast(Expression)e);
             if (result != MATCHnomatch)
                 return;
@@ -1354,7 +1354,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 Type tbn = tb.nextOf();
                 Type tx = null;
 
-                /* If e->e1 is dynamic array or pointer, the uniqueness of e->e1
+                /* If e.e1 is dynamic array or pointer, the uniqueness of e.e1
                  * is equivalent with the uniqueness of the referred data. And in here
                  * we can have arbitrary typed reference for that.
                  */
@@ -1363,8 +1363,8 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 if (t1b.ty == Tpointer)
                     tx = tbn.pointerTo();
 
-                /* If e->e1 is static array, at least it should be an rvalue.
-                 * If not, e->e1 is a reference, and its uniqueness does not link
+                /* If e.e1 is static array, at least it should be an rvalue.
+                 * If not, e.e1 is a reference, and its uniqueness does not link
                  * to the uniqueness of the referred data.
                  */
                 if (t1b.ty == Tsarray && !e.e1.isLvalue())
@@ -1434,7 +1434,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
         override void visit(Expression e)
         {
-            //printf("Expression::castTo(this=%s, t=%s)\n", e->toChars(), t->toChars());
+            //printf("Expression::castTo(this=%s, t=%s)\n", e.toChars(), t.toChars());
             version (none)
             {
                 printf("Expression::castTo(this=%s, type=%s, t=%s)\n", e.toChars(), e.type.toChars(), t.toChars());
@@ -1459,7 +1459,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type t1b = e.type.toBasetype();
             if (tob.equals(t1b))
             {
-                result = e.copy(); // because of COW for assignment to e->type
+                result = e.copy(); // because of COW for assignment to e.type
                 result.type = t;
                 return;
             }
@@ -1509,7 +1509,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
             else if (tob.ty == Tvector && t1b.ty != Tvector)
             {
-                //printf("test1 e = %s, e->type = %s, tob = %s\n", e->toChars(), e->type->toChars(), tob->toChars());
+                //printf("test1 e = %s, e.type = %s, tob = %s\n", e.toChars(), e.type.toChars(), tob.toChars());
                 TypeVector tv = cast(TypeVector)tob;
                 result = new CastExp(e.loc, e, tv.elementType());
                 result = new VectorExp(e.loc, result, tob);
@@ -1635,7 +1635,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
         Lok:
             result = new CastExp(e.loc, e, t);
             result.type = t; // Don't call semantic()
-            //printf("Returning: %s\n", result->toChars());
+            //printf("Returning: %s\n", result.toChars());
         }
 
         override void visit(ErrorExp e)
@@ -1677,7 +1677,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
         override void visit(NullExp e)
         {
-            //printf("NullExp::castTo(t = %s) %s\n", t->toChars(), toChars());
+            //printf("NullExp::castTo(t = %s) %s\n", t.toChars(), toChars());
             visit(cast(Expression)e);
             if (result.op == TOKnull)
             {
@@ -1698,11 +1698,11 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
         {
             /* This follows copy-on-write; any changes to 'this'
              * will result in a copy.
-             * The this->string member is considered immutable.
+             * The this.string member is considered immutable.
              */
             int copied = 0;
 
-            //printf("StringExp::castTo(t = %s), '%s' committed = %d\n", t->toChars(), e->toChars(), e->committed);
+            //printf("StringExp::castTo(t = %s), '%s' committed = %d\n", t.toChars(), e.toChars(), e.committed);
 
             if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
             {
@@ -1728,7 +1728,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            //printf("\ttype = %s\n", e->type->toChars());
+            //printf("\ttype = %s\n", e.type.toChars());
             if (tb.ty == Tdelegate && typeb.ty != Tdelegate)
             {
                 visit(cast(Expression)e);
@@ -1938,7 +1938,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             if (tb.ty == Tsarray)
             {
                 size_t dim2 = cast(size_t)(cast(TypeSArray)tb).dim.toInteger();
-                //printf("dim from = %d, to = %d\n", (int)se->len, (int)dim2);
+                //printf("dim from = %d, to = %d\n", (int)se.len, (int)dim2);
 
                 // Changing dimensions
                 if (dim2 != se.len)
@@ -2068,7 +2068,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
             result = te;
 
-            /* Questionable behavior: In here, result->type is not set to t.
+            /* Questionable behavior: In here, result.type is not set to t.
              * Therefoe:
              *  TypeTuple!(int, int) values;
              *  auto values2 = cast(long)values;
@@ -2352,7 +2352,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
         override void visit(FuncExp e)
         {
-            //printf("FuncExp::castTo type = %s, t = %s\n", e->type->toChars(), t->toChars());
+            //printf("FuncExp::castTo type = %s, t = %s\n", e.type.toChars(), t.toChars());
             FuncExp fe;
             if (e.matchType(t, sc, &fe, 1) > MATCHnomatch)
             {
@@ -2391,7 +2391,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
         override void visit(SliceExp e)
         {
-            //printf("SliceExp::castTo e = %s, type = %s, t = %s\n", e->toChars(), e->type->toChars(), t->toChars());
+            //printf("SliceExp::castTo e = %s, type = %s, t = %s\n", e.toChars(), e.type.toChars(), t.toChars());
 
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
@@ -2437,7 +2437,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             if (tsa && tsa.dim.equals((cast(TypeSArray)tb).dim))
             {
                 /* Match if the dimensions are equal
-                 * with the implicit conversion of e->e1:
+                 * with the implicit conversion of e.e1:
                  *  cast(float[2]) [2.0, 1.0, 0.0][0..2];
                  */
                 Type t1b = e.e1.type.toBasetype();
@@ -2549,7 +2549,7 @@ extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
 
         override void visit(FuncExp fe)
         {
-            //printf("FuncExp::inferType('%s'), to=%s\n", fe->type ? fe->type->toChars() : "null", t->toChars());
+            //printf("FuncExp::inferType('%s'), to=%s\n", fe.type ? fe.type.toChars() : "null", t.toChars());
             if (t.ty == Tdelegate || t.ty == Tpointer && t.nextOf().ty == Tfunction)
             {
                 fe.fd.treq = t;
@@ -3041,7 +3041,7 @@ Lagain:
                     goto Lincompatible;
                 if (!att1 && e1.type.checkAliasThisRec())
                     att1 = e1.type;
-                //printf("att tmerge(c || c) e1 = %s\n", e1->type->toChars());
+                //printf("att tmerge(c || c) e1 = %s\n", e1.type.toChars());
                 e1 = resolveAliasThis(sc, e1);
                 t1 = e1.type;
                 continue;
@@ -3052,7 +3052,7 @@ Lagain:
                     goto Lincompatible;
                 if (!att2 && e2.type.checkAliasThisRec())
                     att2 = e2.type;
-                //printf("att tmerge(c || c) e2 = %s\n", e2->type->toChars());
+                //printf("att tmerge(c || c) e2 = %s\n", e2.type.toChars());
                 e2 = resolveAliasThis(sc, e2);
                 t2 = e2.type;
                 continue;
@@ -3092,7 +3092,7 @@ Lagain:
                     goto Lincompatible;
                 if (!att2 && e2.type.checkAliasThisRec())
                     att2 = e2.type;
-                //printf("att tmerge(s && s) e2 = %s\n", e2->type->toChars());
+                //printf("att tmerge(s && s) e2 = %s\n", e2.type.toChars());
                 e2b = resolveAliasThis(sc, e2);
                 i1 = e2b.implicitConvTo(t1);
             }
@@ -3102,7 +3102,7 @@ Lagain:
                     goto Lincompatible;
                 if (!att1 && e1.type.checkAliasThisRec())
                     att1 = e1.type;
-                //printf("att tmerge(s && s) e1 = %s\n", e1->type->toChars());
+                //printf("att tmerge(s && s) e1 = %s\n", e1.type.toChars());
                 e1b = resolveAliasThis(sc, e1);
                 i2 = e1b.implicitConvTo(t2);
             }
@@ -3136,7 +3136,7 @@ Lagain:
                 goto Lincompatible;
             if (!att1 && e1.type.checkAliasThisRec())
                 att1 = e1.type;
-            //printf("att tmerge(s || s) e1 = %s\n", e1->type->toChars());
+            //printf("att tmerge(s || s) e1 = %s\n", e1.type.toChars());
             e1 = resolveAliasThis(sc, e1);
             t1 = e1.type;
             t = t1;
@@ -3148,7 +3148,7 @@ Lagain:
                 goto Lincompatible;
             if (!att2 && e2.type.checkAliasThisRec())
                 att2 = e2.type;
-            //printf("att tmerge(s || s) e2 = %s\n", e2->type->toChars());
+            //printf("att tmerge(s || s) e2 = %s\n", e2.type.toChars());
             e2 = resolveAliasThis(sc, e2);
             t2 = e2.type;
             t = t2;
@@ -3387,7 +3387,7 @@ Lerror:
  */
 extern (C++) Expression integralPromotions(Expression e, Scope* sc)
 {
-    //printf("integralPromotions %s %s\n", e->toChars(), e->type->toChars());
+    //printf("integralPromotions %s %s\n", e.toChars(), e.type.toChars());
     switch (e.type.toBasetype().ty)
     {
     case Tvoid:
@@ -3779,7 +3779,7 @@ extern (C++) IntRange getIntRange(Expression e)
 
         override void visit(CondExp e)
         {
-            // No need to check e->econd; assume caller has called optimize()
+            // No need to check e.econd; assume caller has called optimize()
             IntRange ir1 = getIntRange(e.e1);
             IntRange ir2 = getIntRange(e.e2);
             range = ir1.unionWith(ir2)._cast(e.type);

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -394,7 +394,7 @@ extern (C++) final class TupleDeclaration : Declaration
                 RootObject o = (*objects)[i];
                 if (o.dyncast() != DYNCAST_TYPE)
                 {
-                    //printf("\tnot[%d], %p, %d\n", i, o, o->dyncast());
+                    //printf("\tnot[%d], %p, %d\n", i, o, o.dyncast());
                     return null;
                 }
             }
@@ -409,7 +409,7 @@ extern (C++) final class TupleDeclaration : Declaration
             for (size_t i = 0; i < types.dim; i++)
             {
                 Type t = (*types)[i];
-                //printf("type = %s\n", t->toChars());
+                //printf("type = %s\n", t.toChars());
                 version (none)
                 {
                     buf.printf("_%s_%d", ident.toChars(), i);
@@ -436,7 +436,7 @@ extern (C++) final class TupleDeclaration : Declaration
 
     override Dsymbol toAlias2()
     {
-        //printf("TupleDeclaration::toAlias2() '%s' objects = %s\n", toChars(), objects->toChars());
+        //printf("TupleDeclaration::toAlias2() '%s' objects = %s\n", toChars(), objects.toChars());
         for (size_t i = 0; i < objects.dim; i++)
         {
             RootObject o = (*objects)[i];
@@ -494,8 +494,8 @@ extern (C++) final class AliasDeclaration : Declaration
     extern (D) this(Loc loc, Identifier id, Type type)
     {
         super(id);
-        //printf("AliasDeclaration(id = '%s', type = %p)\n", id->toChars(), type);
-        //printf("type = '%s'\n", type->toChars());
+        //printf("AliasDeclaration(id = '%s', type = %p)\n", id.toChars(), type);
+        //printf("type = '%s'\n", type.toChars());
         this.loc = loc;
         this.type = type;
         assert(type);
@@ -504,7 +504,7 @@ extern (C++) final class AliasDeclaration : Declaration
     extern (D) this(Loc loc, Identifier id, Dsymbol s)
     {
         super(id);
-        //printf("AliasDeclaration(id = '%s', s = %p)\n", id->toChars(), s);
+        //printf("AliasDeclaration(id = '%s', s = %p)\n", id.toChars(), s);
         assert(s != this);
         this.loc = loc;
         this.aliassym = s;
@@ -586,7 +586,7 @@ extern (C++) final class AliasDeclaration : Declaration
         //printf("%s parent = %s, gag = %d, instantiated = %d\n", toChars(), parent, global.gag, isInstantiated());
         if (parent && global.gag && !isInstantiated() && !toParent2().isFuncDeclaration())
         {
-            //printf("%s type = %s\n", toPrettyChars(), type->toChars());
+            //printf("%s type = %s\n", toPrettyChars(), type.toChars());
             global.gag = 0;
         }
 
@@ -794,7 +794,7 @@ extern (C++) final class AliasDeclaration : Declaration
             inuse = 2;
             uint olderrors = global.errors;
             Dsymbol s = type.toDsymbol(_scope);
-            //printf("[%s] type = %s, s = %p, this = %p\n", loc.toChars(), type->toChars(), s, this);
+            //printf("[%s] type = %s, s = %p, this = %p\n", loc.toChars(), type.toChars(), s, this);
             if (global.errors != olderrors)
                 goto Lerr;
             if (s)
@@ -812,7 +812,7 @@ extern (C++) final class AliasDeclaration : Declaration
                     goto Lerr;
                 if (global.errors != olderrors)
                     goto Lerr;
-                //printf("t = %s\n", t->toChars());
+                //printf("t = %s\n", t.toChars());
                 inuse = 0;
             }
         }
@@ -956,7 +956,7 @@ extern (C++) final class OverDeclaration : Declaration
 
     override bool overloadInsert(Dsymbol s)
     {
-        //printf("OverDeclaration::overloadInsert('%s') aliassym = %p, overnext = %p\n", s->toChars(), aliassym, overnext);
+        //printf("OverDeclaration::overloadInsert('%s') aliassym = %p, overnext = %p\n", s.toChars(), aliassym, overnext);
         if (overnext)
             return overnext.overloadInsert(s);
         if (s == this)
@@ -1047,7 +1047,7 @@ extern (C++) class VarDeclaration : Declaration
     final extern (D) this(Loc loc, Type type, Identifier id, Initializer _init, StorageClass storage_class = STCundefined)
     {
         super(id);
-        //printf("VarDeclaration('%s')\n", id->toChars());
+        //printf("VarDeclaration('%s')\n", id.toChars());
         assert(id);
         debug
         {
@@ -1125,7 +1125,7 @@ extern (C++) class VarDeclaration : Declaration
             if (needctfe)
                 sc = sc.startCTFE();
 
-            //printf("inferring type for %s with init %s\n", toChars(), init->toChars());
+            //printf("inferring type for %s with init %s\n", toChars(), init.toChars());
             _init = _init.inferType(sc);
             type = _init.toExpression().type;
             if (needctfe)
@@ -1157,14 +1157,14 @@ extern (C++) class VarDeclaration : Declaration
             inuse--;
             sc2.pop();
         }
-        //printf(" semantic type = %s\n", type ? type->toChars() : "null");
+        //printf(" semantic type = %s\n", type ? type.toChars() : "null");
         if (type.ty == Terror)
             errors = true;
 
         type.checkDeprecated(loc, sc);
         linkage = sc.linkage;
         this.parent = sc.parent;
-        //printf("this = %p, parent = %p, '%s'\n", this, parent, parent->toChars());
+        //printf("this = %p, parent = %p, '%s'\n", this, parent, parent.toChars());
         protection = sc.protection;
 
         /* If scope's alignment is the default, use the type's alignment,
@@ -1174,7 +1174,7 @@ extern (C++) class VarDeclaration : Declaration
         if (alignment == STRUCTALIGN_DEFAULT)
             alignment = type.alignment(); // use type's alignment
 
-        //printf("sc->stc = %x\n", sc->stc);
+        //printf("sc.stc = %x\n", sc.stc);
         //printf("storage_class = x%x\n", storage_class);
 
         if (global.params.vcomplex)
@@ -1243,9 +1243,9 @@ extern (C++) class VarDeclaration : Declaration
                     Expression e = (*iexps)[pos];
                     Parameter arg = Parameter.getNth(tt.arguments, pos);
                     arg.type = arg.type.semantic(loc, sc);
-                    //printf("[%d] iexps->dim = %d, ", pos, iexps->dim);
-                    //printf("e = (%s %s, %s), ", Token::tochars[e->op], e->toChars(), e->type->toChars());
-                    //printf("arg = (%s, %s)\n", arg->toChars(), arg->type->toChars());
+                    //printf("[%d] iexps.dim = %d, ", pos, iexps.dim);
+                    //printf("e = (%s %s, %s), ", Token::tochars[e.op], e.toChars(), e.type.toChars());
+                    //printf("arg = (%s, %s)\n", arg.toChars(), arg.type.toChars());
 
                     if (e != ie)
                     {
@@ -1282,9 +1282,9 @@ extern (C++) class VarDeclaration : Declaration
                             Expression ee = (*exps)[u];
                             arg = Parameter.getNth(tt.arguments, pos + u);
                             arg.type = arg.type.semantic(loc, sc);
-                            //printf("[%d+%d] exps->dim = %d, ", pos, u, exps->dim);
-                            //printf("ee = (%s %s, %s), ", Token::tochars[ee->op], ee->toChars(), ee->type->toChars());
-                            //printf("arg = (%s, %s)\n", arg->toChars(), arg->type->toChars());
+                            //printf("[%d+%d] exps.dim = %d, ", pos, u, exps.dim);
+                            //printf("ee = (%s %s, %s), ", Token::tochars[ee.op], ee.toChars(), ee.type.toChars());
+                            //printf("arg = (%s, %s)\n", arg.toChars(), arg.type.toChars());
 
                             size_t iexps_dim = iexps.dim - 1 + exps.dim;
                             if (iexps_dim > nelems)
@@ -1357,12 +1357,12 @@ extern (C++) class VarDeclaration : Declaration
                 if (arg.storageClass & STCparameter)
                     storage_class |= arg.storageClass;
                 auto v = new VarDeclaration(loc, arg.type, id, ti, storage_class);
-                //printf("declaring field %s of type %s\n", v->toChars(), v->type->toChars());
+                //printf("declaring field %s of type %s\n", v.toChars(), v.type.toChars());
                 v.semantic(sc);
 
                 if (sc.scopesym)
                 {
-                    //printf("adding %s to %s\n", v->toChars(), sc->scopesym->toChars());
+                    //printf("adding %s to %s\n", v.toChars(), sc.scopesym.toChars());
                     if (sc.scopesym.members)
                         // Note this prevents using foreach() over members, because the limits can change
                         sc.scopesym.members.push(v);
@@ -1651,7 +1651,7 @@ extern (C++) class VarDeclaration : Declaration
                 // possibilities.
                 if (fd && !(storage_class & (STCmanifest | STCstatic | STCtls | STCgshared | STCextern)) && !_init.isVoidInitializer())
                 {
-                    //printf("fd = '%s', var = '%s'\n", fd->toChars(), toChars());
+                    //printf("fd = '%s', var = '%s'\n", fd.toChars(), toChars());
                     if (!ei)
                     {
                         ArrayInitializer ai = _init.isArrayInitializer();
@@ -2119,7 +2119,7 @@ extern (C++) class VarDeclaration : Declaration
 
     override final bool hasPointers()
     {
-        //printf("VarDeclaration::hasPointers() %s, ty = %d\n", toChars(), type->ty);
+        //printf("VarDeclaration::hasPointers() %s, ty = %d\n", toChars(), type.ty);
         return (!isDataseg() && type.hasPointers());
     }
 
@@ -2212,8 +2212,8 @@ extern (C++) class VarDeclaration : Declaration
                  * classes to determine if there's no way the monitor
                  * could be set.
                  */
-                //if (cd->isInterfaceDeclaration())
-                //    error("interface %s cannot be scope", cd->toChars());
+                //if (cd.isInterfaceDeclaration())
+                //    error("interface %s cannot be scope", cd.toChars());
 
                 if (cd.cpp)
                 {
@@ -2466,7 +2466,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
 
     override final const(char)* toChars()
     {
-        //printf("TypeInfoDeclaration::toChars() tinfo = %s\n", tinfo->toChars());
+        //printf("TypeInfoDeclaration::toChars() tinfo = %s\n", tinfo.toChars());
         OutBuffer buf;
         buf.writestring("typeid(");
         buf.writestring(tinfo.toChars());

--- a/src/delegatize.d
+++ b/src/delegatize.d
@@ -25,7 +25,7 @@ import ddmd.visitor;
 
 extern (C++) Expression toDelegate(Expression e, Type t, Scope* sc)
 {
-    //printf("Expression::toDelegate(t = %s) %s\n", t->toChars(), e->toChars());
+    //printf("Expression::toDelegate(t = %s) %s\n", t.toChars(), e.toChars());
     Loc loc = e.loc;
     auto tf = new TypeFunction(null, t, 0, LINKd);
     if (t.hasWild())

--- a/src/denum.d
+++ b/src/denum.d
@@ -94,7 +94,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             {
                 EnumMember em = (*members)[i].isEnumMember();
                 em.ed = this;
-                //printf("add %s to scope %s\n", em->toChars(), scopesym->toChars());
+                //printf("add %s to scope %s\n", em.toChars(), scopesym.toChars());
                 em.addMember(sc, isAnonymous() ? scopesym : this);
             }
         }
@@ -110,7 +110,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
 
     override void semantic(Scope* sc)
     {
-        //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc->scopesym, sc->scopesym->toChars(), toChars());
+        //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc.scopesym, sc.scopesym.toChars(), toChars());
         //printf("EnumDeclaration::semantic() %p %s\n", this, toChars());
         if (semanticRun >= PASSsemanticdone)
             return; // semantic() already completed
@@ -284,8 +284,8 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         }
         //printf("defaultval = %lld\n", defaultval);
 
-        //if (defaultval) printf("defaultval: %s %s\n", defaultval->toChars(), defaultval->type->toChars());
-        //printf("members = %s\n", members->toChars());
+        //if (defaultval) printf("defaultval: %s %s\n", defaultval.toChars(), defaultval.type.toChars());
+        //printf("members = %s\n", members.toChars());
     }
 
     override bool oneMember(Dsymbol* ps, Identifier ident)
@@ -307,7 +307,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
 
     override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
-        //printf("%s.EnumDeclaration::search('%s')\n", toChars(), ident->toChars());
+        //printf("%s.EnumDeclaration::search('%s')\n", toChars(), ident.toChars());
         if (_scope)
         {
             // Try one last time to resolve this enum

--- a/src/dinterpret.d
+++ b/src/dinterpret.d
@@ -246,7 +246,7 @@ struct CompiledCtfeFunction
 
     extern (C++) void onDeclaration(VarDeclaration v)
     {
-        //printf("%s CTFE declare %s\n", v->loc.toChars(), v->toChars());
+        //printf("%s CTFE declare %s\n", v.loc.toChars(), v.toChars());
         ++numVars;
     }
 
@@ -712,7 +712,7 @@ extern (C++) Expression ctfeInterpret(Expression e)
     if (e.op == TOKerror)
         return e;
     assert(e.type); // Bugzilla 14642
-    //assert(e->type->ty != Terror);    // FIXME
+    //assert(e.type.ty != Terror);    // FIXME
     if (e.type.ty == Terror)
         return new ErrorExp();
 
@@ -949,7 +949,7 @@ extern (C++) Expression interpret(FuncDeclaration fd, InterState* istate, Expres
             ctfeStack.push(vx);
             assert(!hasValue(vx)); // vx is made uninitialized
 
-            // Bugzilla 14299: v->ctfeAdrOnStack should be saved already
+            // Bugzilla 14299: v.ctfeAdrOnStack should be saved already
             // in the stack before the overwrite.
             v.ctfeAdrOnStack = oldadr;
             assert(hasValue(v)); // ref parameter v should refer existing value.
@@ -1496,7 +1496,7 @@ public:
         Expression ei = interpret(s._init, istate);
         if (exceptionOrCant(ei))
             return;
-        assert(!ei); // s->init never returns from function, or jumps out from it
+        assert(!ei); // s.init never returns from function, or jumps out from it
 
         while (1)
         {
@@ -3276,11 +3276,11 @@ public:
             Expression e2 = interpret(e.e2, istate);
             if (exceptionOrCant(e2))
                 return;
-            //printf("e1 = %s %s, e2 = %s %s\n", e1->type->toChars(), e1->toChars(), e2->type->toChars(), e2->toChars());
+            //printf("e1 = %s %s, e2 = %s %s\n", e1.type.toChars(), e1.toChars(), e2.type.toChars(), e2.toChars());
             dinteger_t ofs1, ofs2;
             Expression agg1 = getAggregateFromPointer(e1, &ofs1);
             Expression agg2 = getAggregateFromPointer(e2, &ofs2);
-            //printf("agg1 = %p %s, agg2 = %p %s\n", agg1, agg1->toChars(), agg2, agg2->toChars());
+            //printf("agg1 = %p %s, agg2 = %p %s\n", agg1, agg1.toChars(), agg2, agg2.toChars());
             int cmp = comparePointers(e.loc, e.op, e.type, agg1, ofs1, agg2, ofs2);
             if (cmp == -1)
             {
@@ -3761,7 +3761,7 @@ public:
             }
 
             //printf("\t+L%d existingAA = %s, lastIndex = %s, oldval = %s, newval = %s\n",
-            //    __LINE__, existingAA->toChars(), lastIndex->toChars(), oldval ? oldval->toChars() : NULL, newval->toChars());
+            //    __LINE__, existingAA.toChars(), lastIndex.toChars(), oldval ? oldval.toChars() : NULL, newval.toChars());
             assignAssocArrayElement(e.loc, existingAA, lastIndex, newval);
 
             // Determine the return value
@@ -4268,8 +4268,8 @@ public:
                 const wantCopy = (newval.type.toBasetype().nextOf().baseElemOf().ty == Tstruct);
 
                 //printf("oldval = %p %s[%d..%u]\nnewval = %p %s[%llu..%llu] wantCopy = %d\n",
-                //    aggregate, aggregate->toChars(), lowerbound, upperbound,
-                //    aggr2, aggr2->toChars(), srclower, srcupper, wantCopy);
+                //    aggregate, aggregate.toChars(), lowerbound, upperbound,
+                //    aggr2, aggr2.toChars(), srclower, srcupper, wantCopy);
                 if (wantCopy)
                 {
                     // Currently overlapping for struct array is allowed.
@@ -4913,13 +4913,13 @@ public:
             {
                 assert(e.arguments.dim == 1);
                 Expression ea = (*e.arguments)[0];
-                //printf("1 ea = %s %s\n", ea->type->toChars(), ea->toChars());
+                //printf("1 ea = %s %s\n", ea.type.toChars(), ea.toChars());
                 if (ea.op == TOKslice)
                     ea = (cast(SliceExp)ea).e1;
                 if (ea.op == TOKcast)
                     ea = (cast(CastExp)ea).e1;
 
-                //printf("2 ea = %s, %s %s\n", ea->type->toChars(), Token::toChars(ea->op), ea->toChars());
+                //printf("2 ea = %s, %s %s\n", ea.type.toChars(), Token::toChars(ea.op), ea.toChars());
                 if (ea.op == TOKvar || ea.op == TOKsymoff)
                     result = getVarExp(e.loc, istate, (cast(SymbolExp)ea).var, ctfeNeedRvalue);
                 else if (ea.op == TOKaddress)
@@ -5481,7 +5481,7 @@ public:
             }
             assert(agg.op == TOKarrayliteral || agg.op == TOKstring);
             dinteger_t len = ArrayLength(Type.tsize_t, agg).exp().toInteger();
-            //Type *pointee = ((TypePointer *)agg->type)->next;
+            //Type *pointee = ((TypePointer *)agg.type)->next;
             if (iupr > (len + 1) || iupr < ilwr)
             {
                 e.error("pointer slice [%lld..%lld] exceeds allocated memory block [0..%lld]", ilwr, iupr, len);
@@ -5965,7 +5965,7 @@ public:
         if (e.to.ty == Tarray && e1.op == TOKslice)
         {
             // Note that the slice may be void[], so when checking for dangerous
-            // casts, we need to use the original type, which is se->e1.
+            // casts, we need to use the original type, which is se.e1.
             SliceExp se = cast(SliceExp)e1;
             if (!isSafePointerCast(se.e1.type.nextOf(), e.to.nextOf()))
             {
@@ -6289,7 +6289,7 @@ public:
 
     override void visit(ClassReferenceExp e)
     {
-        //printf("ClassReferenceExp::interpret() %s\n", e->value->toChars());
+        //printf("ClassReferenceExp::interpret() %s\n", e.value.toChars());
         result = e;
     }
 
@@ -6559,7 +6559,7 @@ extern (C++) Expression interpret_values(InterState* istate, Expression earg, Ty
     auto ae = new ArrayLiteralExp(aae.loc, aae.values);
     ae.ownedByCtfe = aae.ownedByCtfe;
     ae.type = returnType;
-    //printf("result is %s\n", e->toChars());
+    //printf("result is %s\n", e.toChars());
     return copyLiteral(ae).copy();
 }
 
@@ -6586,7 +6586,7 @@ extern (C++) Expression interpret_dup(InterState* istate, Expression earg)
             return e;
     }
     aae.type = earg.type.mutableOf(); // repaint type from const(int[int]) to const(int)[int]
-    //printf("result is %s\n", aae->toChars());
+    //printf("result is %s\n", aae.toChars());
     return aae;
 }
 

--- a/src/dmacro.d
+++ b/src/dmacro.d
@@ -40,7 +40,7 @@ private:
         {
             if (table.name == name)
             {
-                //printf("\tfound %d\n", table->textlen);
+                //printf("\tfound %d\n", table.textlen);
                 break;
             }
         }
@@ -95,7 +95,7 @@ public:
         arg = memdup(arg, arglen);
         for (size_t u = start; u + 1 < end;)
         {
-            char* p = cast(char*)buf.data; // buf->data is not loop invariant
+            char* p = cast(char*)buf.data; // buf.data is not loop invariant
             /* Look for $0, but not $$0, and replace it with arg.
              */
             if (p[u] == '$' && (isdigit(p[u + 1]) || p[u + 1] == '+'))
@@ -155,7 +155,7 @@ public:
                     u = mend;
                 }
                 //printf("u = %d, end = %d\n", u, end);
-                //printf("#%.*s#\n", end, &buf->data[0]);
+                //printf("#%.*s#\n", end, &buf.data[0]);
                 continue;
             }
             u++;
@@ -164,7 +164,7 @@ public:
          */
         for (size_t u = start; u + 4 < end;)
         {
-            char* p = cast(char*)buf.data; // buf->data is not loop invariant
+            char* p = cast(char*)buf.data; // buf.data is not loop invariant
             /* A valid start of macro expansion is $(c, where c is
              * an id start character, and not $$(c.
              */
@@ -245,7 +245,7 @@ public:
                         }
                         else
                         {
-                            //printf("\tmacro '%.*s'(%.*s) = '%.*s'\n", m->namelen, m->name, marglen, marg, m->textlen, m->text);
+                            //printf("\tmacro '%.*s'(%.*s) = '%.*s'\n", m.namelen, m.name, marglen, marg, m.textlen, m.text);
                             marg = memdup(marg, marglen);
                             // Insert replacement text
                             buf.spread(v + 1, 2 + m.text.length + 2);
@@ -266,7 +266,7 @@ public:
                             u += mend - (v + 1);
                             mem.xfree(cast(char*)marg);
                             //printf("u = %d, end = %d\n", u, end);
-                            //printf("#%.*s#\n", end - u, &buf->data[u]);
+                            //printf("#%.*s#\n", end - u, &buf.data[u]);
                             continue;
                         }
                     }

--- a/src/dmodule.d
+++ b/src/dmodule.d
@@ -376,7 +376,7 @@ extern (C++) final class Module : Package
     {
         super(ident);
         const(char)* srcfilename;
-        //printf("Module::Module(filename = '%s', ident = '%s')\n", filename, ident->toChars());
+        //printf("Module::Module(filename = '%s', ident = '%s')\n", filename, ident.toChars());
         this.arg = filename;
         srcfilename = FileName.defaultExt(filename, global.mars_ext);
         if (global.run_noext && global.params.run && !FileName.ext(filename) && FileName.exists(srcfilename) == 0 && FileName.exists(filename) == 1)
@@ -408,7 +408,7 @@ extern (C++) final class Module : Package
 
     static Module load(Loc loc, Identifiers* packages, Identifier ident)
     {
-        //printf("Module::load(ident = '%s')\n", ident->toChars());
+        //printf("Module::load(ident = '%s')\n", ident.toChars());
         // Build module filename by turning:
         //  foo.bar.baz
         // into:
@@ -556,7 +556,7 @@ extern (C++) final class Module : Package
     // read file, returns 'true' if succeed, 'false' otherwise.
     bool read(Loc loc)
     {
-        //printf("Module::read('%s') file '%s'\n", toChars(), srcfile->toChars());
+        //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
         if (srcfile.read())
         {
             if (!strcmp(srcfile.toChars(), "object.d"))
@@ -598,7 +598,7 @@ extern (C++) final class Module : Package
     // syntactic parse
     Module parse()
     {
-        //printf("Module::parse(srcfile='%s') this=%p\n", srcfile->name->toChars(), this);
+        //printf("Module::parse(srcfile='%s') this=%p\n", srcfile.name.toChars(), this);
         const(char)* srcname = srcfile.name.toChars();
         //printf("Module::parse(srcname = '%s')\n", srcname);
         isPackageFile = (strcmp(srcfile.name.name(), "package.d") == 0);
@@ -1042,7 +1042,7 @@ extern (C++) final class Module : Package
         {
             Scope.createGlobal(this); // create root scope
         }
-        //printf("Module = %p, linkage = %d\n", sc->scopesym, sc->linkage);
+        //printf("Module = %p, linkage = %d\n", sc.scopesym, sc.linkage);
         // Pass 1 semantic routines: do public side of the definition
         for (size_t i = 0; i < members.dim; i++)
         {
@@ -1108,7 +1108,7 @@ extern (C++) final class Module : Package
         for (size_t i = 0; i < members.dim; i++)
         {
             Dsymbol s = (*members)[i];
-            //printf("Module %s: %s.semantic3()\n", toChars(), s->toChars());
+            //printf("Module %s: %s.semantic3()\n", toChars(), s.toChars());
             s.semantic3(sc);
 
             runDeferredSemantic2();
@@ -1151,7 +1151,7 @@ extern (C++) final class Module : Package
         if (searchCacheIdent == ident && searchCacheFlags == flags)
         {
             //printf("%s Module::search('%s', flags = %d) insearch = %d searchCacheSymbol = %s\n",
-            //        toChars(), ident->toChars(), flags, insearch, searchCacheSymbol ? searchCacheSymbol->toChars() : "null");
+            //        toChars(), ident.toChars(), flags, insearch, searchCacheSymbol ? searchCacheSymbol.toChars() : "null");
             return searchCacheSymbol;
         }
 
@@ -1322,7 +1322,7 @@ extern (C++) final class Module : Package
      */
     int imports(Module m)
     {
-        //printf("%s Module::imports(%s)\n", toChars(), m->toChars());
+        //printf("%s Module::imports(%s)\n", toChars(), m.toChars());
         version (none)
         {
             for (size_t i = 0; i < aimports.dim; i++)

--- a/src/doc.d
+++ b/src/doc.d
@@ -785,7 +785,7 @@ extern (C++) void emitMemberComments(ScopeDsymbol sds, OutBuffer* buf, Scope* sc
     for (size_t i = 0; i < sds.members.dim; i++)
     {
         Dsymbol s = (*sds.members)[i];
-        //printf("\ts = '%s'\n", s->toChars());
+        //printf("\ts = '%s'\n", s.toChars());
         // only expand if parent is a non-template (semantic won't work)
         if (s.comment && s.isTemplateMixin() && s.parent && !s.parent.isTemplateDeclaration())
             expandTemplateMixinComments(cast(TemplateMixin)s, buf, sc);
@@ -914,7 +914,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                 }
                 buf.writestring(ddoc_decl_dd_e);
                 buf.writeByte(')');
-                //printf("buf.2 = [[%.*s]]\n", buf->offset - o0, buf->data + o0);
+                //printf("buf.2 = [[%.*s]]\n", buf.offset - o0, buf.data + o0);
             }
             if (s)
             {
@@ -959,7 +959,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(AggregateDeclaration ad)
         {
-            //printf("AggregateDeclaration::emitComment() '%s'\n", ad->toChars());
+            //printf("AggregateDeclaration::emitComment() '%s'\n", ad.toChars());
             const(char)* com = ad.comment;
             if (TemplateDeclaration td = getEponymousParent(ad))
             {
@@ -982,7 +982,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(TemplateDeclaration td)
         {
-            //printf("TemplateDeclaration::emitComment() '%s', kind = %s\n", td->toChars(), td->kind());
+            //printf("TemplateDeclaration::emitComment() '%s', kind = %s\n", td.toChars(), td.kind());
             if (td.prot().kind == PROTprivate || sc.protection.kind == PROTprivate)
                 return;
             if (!td.comment)
@@ -1017,7 +1017,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(EnumMember em)
         {
-            //printf("EnumMember::emitComment(%p '%s'), comment = '%s'\n", em, em->toChars(), em->comment);
+            //printf("EnumMember::emitComment(%p '%s'), comment = '%s'\n", em, em.toChars(), em.comment);
             if (em.prot().kind == PROTprivate || sc.protection.kind == PROTprivate)
                 return;
             if (!em.comment)
@@ -1041,7 +1041,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                 for (size_t i = 0; i < d.dim; i++)
                 {
                     Dsymbol s = (*d)[i];
-                    //printf("AttribDeclaration::emitComment %s\n", s->toChars());
+                    //printf("AttribDeclaration::emitComment %s\n", s.toChars());
                     emitComment(s, buf, sc);
                 }
             }
@@ -1104,7 +1104,7 @@ extern (C++) void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(Dsymbol s)
         {
-            //printf("Dsymbol::toDocbuffer() %s\n", s->toChars());
+            //printf("Dsymbol::toDocbuffer() %s\n", s.toChars());
             HdrGenState hgs;
             hgs.ddoc = true;
             .toCBuffer(s, buf, &hgs);
@@ -1157,7 +1157,7 @@ extern (C++) void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
             if (!d.ident)
                 return;
             TemplateDeclaration td = getEponymousParent(d);
-            //printf("Declaration::toDocbuffer() %s, originalType = %s, td = %s\n", d->toChars(), d->originalType ? d->originalType->toChars() : "--", td ? td->toChars() : "--");
+            //printf("Declaration::toDocbuffer() %s, originalType = %s, td = %s\n", d.toChars(), d.originalType ? d.originalType.toChars() : "--", td ? td.toChars() : "--");
             HdrGenState hgs;
             hgs.ddoc = true;
             if (d.isDeprecated())
@@ -1212,7 +1212,7 @@ extern (C++) void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(AliasDeclaration ad)
         {
-            //printf("AliasDeclaration::toDocbuffer() %s\n", ad->toChars());
+            //printf("AliasDeclaration::toDocbuffer() %s\n", ad.toChars());
             if (!ad.ident)
                 return;
             if (ad.isDeprecated())
@@ -1300,7 +1300,7 @@ extern (C++) void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(StructDeclaration sd)
         {
-            //printf("StructDeclaration::toDocbuffer() %s\n", sd->toChars());
+            //printf("StructDeclaration::toDocbuffer() %s\n", sd.toChars());
             if (!sd.ident)
                 return;
             version (none)
@@ -1320,7 +1320,7 @@ extern (C++) void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(ClassDeclaration cd)
         {
-            //printf("ClassDeclaration::toDocbuffer() %s\n", cd->toChars());
+            //printf("ClassDeclaration::toDocbuffer() %s\n", cd.toChars());
             if (!cd.ident)
                 return;
             version (none)
@@ -1405,7 +1405,7 @@ struct DocComment
 
     extern (C++) static DocComment* parse(Scope* sc, Dsymbol s, const(char)* comment)
     {
-        //printf("parse(%s): '%s'\n", s->toChars(), comment);
+        //printf("parse(%s): '%s'\n", s.toChars(), comment);
         auto dc = new DocComment();
         dc.a.push(s);
         if (!comment)
@@ -1689,7 +1689,7 @@ struct DocComment
                 s._body = pstart;
                 s.bodylen = pend - pstart;
                 s.nooutput = 0;
-                //printf("Section: '%.*s' = '%.*s'\n", s->namelen, s->name, s->bodylen, s->body);
+                //printf("Section: '%.*s' = '%.*s'\n", s.namelen, s.name, s.bodylen, s.body);
                 sections.push(s);
                 if (!summary && !namelen)
                     summary = s;
@@ -1727,7 +1727,7 @@ struct DocComment
             Section sec = sections[i];
             if (sec.nooutput)
                 continue;
-            //printf("Section: '%.*s' = '%.*s'\n", sec->namelen, sec->name, sec->bodylen, sec->body);
+            //printf("Section: '%.*s' = '%.*s'\n", sec.namelen, sec.name, sec.bodylen, sec.body);
             if (!sec.namelen && i == 0)
             {
                 buf.writestring("$(DDOC_SUMMARY ");
@@ -1972,7 +1972,7 @@ extern (C++) bool isKeyword(const(char)* p, size_t len)
 extern (C++) TypeFunction isTypeFunction(Dsymbol s)
 {
     FuncDeclaration f = s.isFuncDeclaration();
-    /* f->type may be NULL for template members.
+    /* f.type may be NULL for template members.
      */
     if (f && f.type)
     {
@@ -2443,7 +2443,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                 }
                 if (isFunctionParameter(a, start, len))
                 {
-                    //printf("highlighting arg '%s', i = %d, j = %d\n", arg->ident->toChars(), i, j);
+                    //printf("highlighting arg '%s', i = %d, j = %d\n", arg.ident.toChars(), i, j);
                     i = buf.bracket(i, "$(DDOC_PARAM ", j, ")") - 1;
                     break;
                 }
@@ -2461,7 +2461,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
  */
 extern (C++) void highlightCode(Scope* sc, Dsymbol s, OutBuffer* buf, size_t offset)
 {
-    //printf("highlightCode(s = %s '%s')\n", s->kind(), s->toChars());
+    //printf("highlightCode(s = %s '%s')\n", s.kind(), s.toChars());
     OutBuffer ancbuf;
     emitAnchor(&ancbuf, s, sc);
     buf.insert(offset, ancbuf.peekSlice());
@@ -2475,7 +2475,7 @@ extern (C++) void highlightCode(Scope* sc, Dsymbol s, OutBuffer* buf, size_t off
  */
 extern (C++) void highlightCode(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t offset)
 {
-    //printf("highlightCode(a = '%s')\n", a->toChars());
+    //printf("highlightCode(a = '%s')\n", a.toChars());
     bool resolvedTemplateParameters = false;
 
     for (size_t i = offset; i < buf.offset; i++)
@@ -2504,7 +2504,7 @@ extern (C++) void highlightCode(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                 }
                 if (isFunctionParameter(a, start, len))
                 {
-                    //printf("highlighting arg '%s', i = %d, j = %d\n", arg->ident->toChars(), i, j);
+                    //printf("highlighting arg '%s', i = %d, j = %d\n", arg.ident.toChars(), i, j);
                     i = buf.bracket(i, "$(DDOC_PARAM ", j, ")") - 1;
                     continue;
                 }
@@ -2612,7 +2612,7 @@ extern (C++) void highlightCode2(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t 
     scope Lexer lex = new Lexer(null, cast(char*)buf.data, 0, buf.offset - 1, 0, 1);
     OutBuffer res;
     const(char)* lastp = cast(char*)buf.data;
-    //printf("highlightCode2('%.*s')\n", buf->offset - 1, buf->data);
+    //printf("highlightCode2('%.*s')\n", buf.offset - 1, buf.data);
     res.reserve(buf.offset);
     while (1)
     {
@@ -2634,7 +2634,7 @@ extern (C++) void highlightCode2(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t 
                 }
                 if (isFunctionParameter(a, tok.ptr, len))
                 {
-                    //printf("highlighting arg '%s', i = %d, j = %d\n", arg->ident->toChars(), i, j);
+                    //printf("highlighting arg '%s', i = %d, j = %d\n", arg.ident.toChars(), i, j);
                     highlight = "$(D_PARAM ";
                     break;
                 }

--- a/src/dscope.d
+++ b/src/dscope.d
@@ -233,7 +233,7 @@ struct Scope
                 assert(!(enclosing.flags & SCOPEfree));
             if (s == enclosing)
             {
-                printf("this = %p, enclosing = %p, enclosing->enclosing = %p\n", s, &this, enclosing);
+                printf("this = %p, enclosing = %p, enclosing.enclosing = %p\n", s, &this, enclosing);
             }
             assert(s != enclosing);
         }
@@ -249,7 +249,7 @@ struct Scope
 
     extern (C++) Scope* push(ScopeDsymbol ss)
     {
-        //printf("Scope::push(%s)\n", ss->toChars());
+        //printf("Scope::push(%s)\n", ss.toChars());
         Scope* s = push();
         s.scopesym = ss;
         return s;
@@ -667,7 +667,7 @@ struct Scope
             //printf("\tsc = %p\n", sc);
             if (sc.scopesym)
             {
-                //printf("\t\tsc->scopesym = %p\n", sc->scopesym);
+                //printf("\t\tsc.scopesym = %p\n", sc.scopesym);
                 if (!sc.scopesym.symtab)
                     sc.scopesym.symtab = new DsymbolTable();
                 return sc.scopesym.symtabInsert(s);
@@ -725,8 +725,8 @@ struct Scope
             //printf("\tsc = %p\n", sc);
             sc.nofree = 1;
             assert(!(flags & SCOPEfree));
-            //assert(sc != sc->enclosing);
-            //assert(!sc->enclosing || sc != sc->enclosing->enclosing);
+            //assert(sc != sc.enclosing);
+            //assert(!sc.enclosing || sc != sc.enclosing.enclosing);
             //if (++i == 10)
             //    assert(0);
         }

--- a/src/dstruct.d
+++ b/src/dstruct.d
@@ -148,7 +148,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
             {
                 if (sd.inNonRoot())
                 {
-                    //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd->toChars(), sd->inNonRoot());
+                    //printf("deferred sem3 for TypeInfo - sd = %s, inNonRoot = %d\n", sd.toChars(), sd.inNonRoot());
                     Module.addDeferredSemantic3(sd);
                 }
             }

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -356,7 +356,7 @@ extern (C++) class Dsymbol : RootObject
         Dsymbol s = this;
         while (s)
         {
-            //printf("\ts = %s '%s'\n", s->kind(), s->toPrettyChars());
+            //printf("\ts = %s '%s'\n", s.kind(), s.toPrettyChars());
             Module m = s.isModule();
             if (m)
                 return m;
@@ -376,7 +376,7 @@ extern (C++) class Dsymbol : RootObject
         Dsymbol s = this;
         while (s)
         {
-            //printf("\ts = %s '%s'\n", s->kind(), s->toPrettyChars());
+            //printf("\ts = %s '%s'\n", s.kind(), s.toPrettyChars());
             Module m = s.isModule();
             if (m)
                 return m;
@@ -608,8 +608,8 @@ extern (C++) class Dsymbol : RootObject
     void addMember(Scope* sc, ScopeDsymbol sds)
     {
         //printf("Dsymbol::addMember('%s')\n", toChars());
-        //printf("Dsymbol::addMember(this = %p, '%s' scopesym = '%s')\n", this, toChars(), sds->toChars());
-        //printf("Dsymbol::addMember(this = %p, '%s' sds = %p, sds->symtab = %p)\n", this, toChars(), sds, sds->symtab);
+        //printf("Dsymbol::addMember(this = %p, '%s' scopesym = '%s')\n", this, toChars(), sds.toChars());
+        //printf("Dsymbol::addMember(this = %p, '%s' sds = %p, sds.symtab = %p)\n", this, toChars(), sds, sds.symtab);
         parent = sds;
         if (!isAnonymous()) // no name, so can't add it to symbol table
         {
@@ -639,7 +639,7 @@ extern (C++) class Dsymbol : RootObject
      */
     void setScope(Scope* sc)
     {
-        //printf("Dsymbol::setScope() %p %s, %p stc = %llx\n", this, toChars(), sc, sc->stc);
+        //printf("Dsymbol::setScope() %p %s, %p stc = %llx\n", this, toChars(), sc, sc.stc);
         if (!sc.nofree)
             sc.setNoFree(); // may need it even after semantic() finishes
         _scope = sc;
@@ -727,7 +727,7 @@ extern (C++) class Dsymbol : RootObject
      */
     final Dsymbol searchX(Loc loc, Scope* sc, RootObject id)
     {
-        //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident->toChars());
+        //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident.toChars());
         Dsymbol s = toAlias();
         Dsymbol sm;
         if (Declaration d = s.isDeclaration())
@@ -782,7 +782,7 @@ extern (C++) class Dsymbol : RootObject
 
     bool overloadInsert(Dsymbol s)
     {
-        //printf("Dsymbol::overloadInsert('%s')\n", s->toChars());
+        //printf("Dsymbol::overloadInsert('%s')\n", s.toChars());
         return false;
     }
 
@@ -1294,7 +1294,7 @@ public:
     override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
         //printf("%s.ScopeDsymbol::search(ident='%s', flags=x%x)\n", toChars(), ident.toChars(), flags);
-        //if (strcmp(ident->toChars(),"c") == 0) *(char*)0=0;
+        //if (strcmp(ident.toChars(),"c") == 0) *(char*)0=0;
 
         // Look in symbols declared in this module
         if (symtab && !(flags & SearchImportsOnly))
@@ -1323,7 +1323,7 @@ public:
                     continue;
                 int sflags = flags & (IgnoreErrors | IgnoreAmbiguous | IgnoreSymbolVisibility); // remember these in recursive searches
                 Dsymbol ss = (*importedScopes)[i];
-                //printf("\tscanning import '%s', prots = %d, isModule = %p, isImport = %p\n", ss->toChars(), prots[i], ss->isModule(), ss->isImport());
+                //printf("\tscanning import '%s', prots = %d, isModule = %p, isImport = %p\n", ss.toChars(), prots[i], ss.isModule(), ss.isImport());
 
                 if (ss.isModule())
                 {
@@ -1474,7 +1474,7 @@ public:
 
     final void importScope(Dsymbol s, Prot protection)
     {
-        //printf("%s->ScopeDsymbol::importScope(%s, %d)\n", toChars(), s->toChars(), protection);
+        //printf("%s.ScopeDsymbol::importScope(%s, %d)\n", toChars(), s.toChars(), protection);
         // No circular or redundant import's
         if (s != this)
         {
@@ -1786,7 +1786,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
 
     override Dsymbol search(Loc loc, Identifier ident, int flags = IgnoreNone)
     {
-        //printf("ArrayScopeSymbol::search('%s', flags = %d)\n", ident->toChars(), flags);
+        //printf("ArrayScopeSymbol::search('%s', flags = %d)\n", ident.toChars(), flags);
         if (ident == Id.dollar)
         {
             VarDeclaration* pvar;
@@ -2015,14 +2015,14 @@ extern (C++) final class DsymbolTable : RootObject
     // Look up Identifier. Return Dsymbol if found, NULL if not.
     Dsymbol lookup(const Identifier ident)
     {
-        //printf("DsymbolTable::lookup(%s)\n", (char*)ident->string);
+        //printf("DsymbolTable::lookup(%s)\n", (char*)ident.string);
         return cast(Dsymbol)dmd_aaGetRvalue(tab, cast(void*)ident);
     }
 
     // Insert Dsymbol in table. Return NULL if already there.
     Dsymbol insert(Dsymbol s)
     {
-        //printf("DsymbolTable::insert(this = %p, '%s')\n", this, s->ident->toChars());
+        //printf("DsymbolTable::insert(this = %p, '%s')\n", this, s.ident.toChars());
         const ident = s.ident;
         Dsymbol* ps = cast(Dsymbol*)dmd_aaGet(&tab, cast(void*)ident);
         if (*ps)

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -300,12 +300,12 @@ private bool match(RootObject o1, RootObject o2)
     }
 Lmatch:
     static if (debugPrint)
-        printf("\t-> match\n");
+        printf("\t. match\n");
     return true;
 
 Lnomatch:
     static if (debugPrint)
-        printf("\t-> nomatch\n");
+        printf("\t. nomatch\n");
     return false;
 }
 

--- a/src/dversion.d
+++ b/src/dversion.d
@@ -63,7 +63,7 @@ extern (C++) final class DebugSymbol : Dsymbol
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        //printf("DebugSymbol::addMember('%s') %s\n", sds->toChars(), toChars());
+        //printf("DebugSymbol::addMember('%s') %s\n", sds.toChars(), toChars());
         Module m = sds.isModule();
         // Do not add the member to the symbol table,
         // just make sure subsequent debug declarations work.
@@ -157,7 +157,7 @@ extern (C++) final class VersionSymbol : Dsymbol
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        //printf("VersionSymbol::addMember('%s') %s\n", sds->toChars(), toChars());
+        //printf("VersionSymbol::addMember('%s') %s\n", sds.toChars(), toChars());
         Module m = sds.isModule();
         // Do not add the member to the symbol table,
         // just make sure subsequent debug declarations work.

--- a/src/expression.d
+++ b/src/expression.d
@@ -93,10 +93,10 @@ void emplaceExp(T : UnionExp)(T* p, Expression e)
  */
 extern (C++) Expression getRightThis(Loc loc, Scope* sc, AggregateDeclaration ad, Expression e1, Declaration var, int flag = 0)
 {
-    //printf("\ngetRightThis(e1 = %s, ad = %s, var = %s)\n", e1->toChars(), ad->toChars(), var->toChars());
+    //printf("\ngetRightThis(e1 = %s, ad = %s, var = %s)\n", e1.toChars(), ad.toChars(), var.toChars());
 L1:
     Type t = e1.type.toBasetype();
-    //printf("e1->type = %s, var->type = %s\n", e1->type->toChars(), var->type->toChars());
+    //printf("e1.type = %s, var.type = %s\n", e1.type.toChars(), var.type.toChars());
 
     /* If e1 is not the 'this' pointer for ad
      */
@@ -121,7 +121,7 @@ L1:
                 e1.type = tcd.vthis.type;
                 e1.type = e1.type.addMod(t.mod);
                 // Do not call checkNestedRef()
-                //e1 = e1->semantic(sc);
+                //e1 = e1.semantic(sc);
 
                 // Skip up over nested functions, and get the enclosing
                 // class type.
@@ -132,7 +132,7 @@ L1:
                     FuncDeclaration f = s.isFuncDeclaration();
                     if (f.vthis)
                     {
-                        //printf("rewriting e1 to %s's this\n", f->toChars());
+                        //printf("rewriting e1 to %s's this\n", f.toChars());
                         n++;
                         e1 = new VarExp(loc, f.vthis);
                     }
@@ -177,7 +177,7 @@ extern (C++) FuncDeclaration hasThis(Scope* sc)
     while (p && p.isTemplateMixin())
         p = p.parent;
     FuncDeclaration fdthis = p ? p.isFuncDeclaration() : null;
-    //printf("fdthis = %p, '%s'\n", fdthis, fdthis ? fdthis->toChars() : "");
+    //printf("fdthis = %p, '%s'\n", fdthis, fdthis ? fdthis.toChars() : "");
 
     // Go upwards until we find the enclosing member function
     FuncDeclaration fd = fdthis;
@@ -206,7 +206,7 @@ extern (C++) FuncDeclaration hasThis(Scope* sc)
 
     if (!fd.isThis())
     {
-        //printf("test '%s'\n", fd->toChars());
+        //printf("test '%s'\n", fd.toChars());
         goto Lno;
     }
 
@@ -504,7 +504,7 @@ Leproplvalue:
 
 extern (C++) Expression resolveProperties(Scope* sc, Expression e)
 {
-    //printf("resolveProperties(%s)\n", e->toChars());
+    //printf("resolveProperties(%s)\n", e.toChars());
     e = resolvePropertiesX(sc, e);
     if (e.checkRightThis(sc))
         return new ErrorExp();
@@ -526,7 +526,7 @@ extern (C++) bool checkPropertyCall(Expression e, Expression emsg)
         if (ce.f)
         {
             tf = cast(TypeFunction)ce.f.type;
-            /* If a forward reference to ce->f, try to resolve it
+            /* If a forward reference to ce.f, try to resolve it
              */
             if (!tf.deco && ce.f._scope)
             {
@@ -551,7 +551,7 @@ extern (C++) bool checkPropertyCall(Expression e, Expression emsg)
  */
 extern (C++) Expression resolvePropertiesOnly(Scope* sc, Expression e1)
 {
-    //printf("e1 = %s %s\n", Token::toChars(e1->op), e1->toChars());
+    //printf("e1 = %s %s\n", Token::toChars(e1.op), e1.toChars());
     OverloadSet os;
     FuncDeclaration fd;
     TemplateDeclaration td;
@@ -1190,7 +1190,7 @@ extern (C++) bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type
                 continue;
 
             e = e.implicitCastTo(sc, t0);
-            //assert(e->op != TOKerror);
+            //assert(e.op != TOKerror);
             if (e.op == TOKerror)
             {
                 /* Bugzilla 13024: a workaround for the bug in typeMerge -
@@ -1489,7 +1489,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
 
             if (tf.varargs == 2 && i + 1 == nparams)
             {
-                //printf("\t\tvarargs == 2, p->type = '%s'\n", p->type->toChars());
+                //printf("\t\tvarargs == 2, p.type = '%s'\n", p.type.toChars());
                 {
                     MATCH m;
                     if ((m = arg.implicitConvTo(p.type)) > MATCHnomatch)
@@ -1512,7 +1512,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                 case Tsarray:
                 case Tarray:
                     {
-                        /* Create a static array variable v of type arg->type:
+                        /* Create a static array variable v of type arg.type:
                          *  T[dim] __arrayArg = [ arguments[i], ..., arguments[nargs-1] ];
                          *
                          * The array literal in the initializer of the hidden variable
@@ -1567,7 +1567,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                     break;
                 }
                 arg = arg.semantic(sc);
-                //printf("\targ = '%s'\n", arg->toChars());
+                //printf("\targ = '%s'\n", arg.toChars());
                 arguments.setDim(i + 1);
                 (*arguments)[i] = arg;
                 nargs = i + 1;
@@ -1584,7 +1584,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                         wildmatch = MODmerge(wildmatch, wm);
                     else
                         wildmatch = wm;
-                    //printf("[%d] p = %s, a = %s, wm = %d, wildmatch = %d\n", i, p->type->toChars(), arg->type->toChars(), wm, wildmatch);
+                    //printf("[%d] p = %s, a = %s, wm = %d, wildmatch = %d\n", i, p.type.toChars(), arg.type.toChars(), wm, wildmatch);
                 }
             }
         }
@@ -1651,7 +1651,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                     tprm = p.type.substWildTo(wildmatch);
                 if (!tprm.equals(arg.type))
                 {
-                    //printf("arg->type = %s, p->type = %s\n", arg->type->toChars(), p->type->toChars());
+                    //printf("arg.type = %s, p.type = %s\n", arg.type.toChars(), p.type.toChars());
                     arg = arg.implicitCastTo(sc, tprm);
                     arg = arg.optimize(WANTvalue, (p.storageClass & (STCref | STCout)) != 0);
                 }
@@ -1687,8 +1687,8 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                 else
                     arg = toDelegate(arg, arg.type, sc);
             }
-            //printf("arg: %s\n", arg->toChars());
-            //printf("type: %s\n", arg->type->toChars());
+            //printf("arg: %s\n", arg.toChars());
+            //printf("type: %s\n", arg.type.toChars());
 
             /* Look for arguments that cannot 'escape' from the called
              * function.
@@ -1959,7 +1959,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
             (*arguments)[i] = arg;
         }
     }
-    //if (eprefix) printf("eprefix: %s\n", eprefix->toChars());
+    //if (eprefix) printf("eprefix: %s\n", eprefix.toChars());
 
     // If D linkage and variadic, add _arguments[] as first argument
     if (tf.linkage == LINKd && tf.varargs == 1)
@@ -1982,8 +1982,8 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
     Type tret = tf.next;
     if (isCtorCall)
     {
-        //printf("[%s] fd = %s %s, %d %d %d\n", loc.toChars(), fd->toChars(), fd->type->toChars(),
-        //    wildmatch, tf->isWild(), fd->isolateReturn());
+        //printf("[%s] fd = %s %s, %d %d %d\n", loc.toChars(), fd.toChars(), fd.type.toChars(),
+        //    wildmatch, tf.isWild(), fd.isolateReturn());
         if (!tthis)
         {
             assert(sc.intypeof || global.errors);
@@ -2041,7 +2041,7 @@ struct UnionExp
     extern (C++) Expression copy()
     {
         Expression e = exp();
-        //if (e->size > sizeof(u)) printf("%s\n", Token::toChars(e->op));
+        //if (e.size > sizeof(u)) printf("%s\n", Token::toChars(e.op));
         assert(e.size <= u.sizeof);
         if (e.op == TOKcantexp)
             return CTFEExp.cantexp;
@@ -2109,7 +2109,7 @@ extern (C++) DotIdExp typeDotIdExp(Loc loc, Type type, Identifier ident)
  */
 extern (C++) int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
 {
-    //printf("modifyFieldVar(var = %s)\n", var->toChars());
+    //printf("modifyFieldVar(var = %s)\n", var.toChars());
     Dsymbol s = sc.func;
     while (1)
     {
@@ -2271,7 +2271,7 @@ extern (C++) Expression extractOpDollarSideEffect(Scope* sc, UnaExp ue)
 {
     Expression e0;
     Expression e1 = Expression.extractLast(ue.e1, &e0);
-    // Bugzilla 12585: Extract the side effect part if ue->e1 is comma.
+    // Bugzilla 12585: Extract the side effect part if ue.e1 is comma.
 
     if (!isTrivialExp(e1))
     {
@@ -2293,7 +2293,7 @@ extern (C++) Expression extractOpDollarSideEffect(Scope* sc, UnaExp ue)
 }
 
 /**************************************
- * Runs semantic on ae->arguments. Declares temporary variables
+ * Runs semantic on ae.arguments. Declares temporary variables
  * if '$' was used.
  */
 extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
@@ -2302,7 +2302,7 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
     *pe0 = null;
     AggregateDeclaration ad = isAggregate(ae.e1.type);
     Dsymbol slice = search_function(ad, Id.slice);
-    //printf("slice = %s %s\n", slice->kind(), slice->toChars());
+    //printf("slice = %s %s\n", slice.kind(), slice.toChars());
     for (size_t i = 0; i < ae.arguments.dim; i++)
     {
         if (i == 0)
@@ -2317,7 +2317,7 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
             ae.error("multi-dimensional slicing requires template opSlice");
             return new ErrorExp();
         }
-        //printf("[%d] e = %s\n", i, e->toChars());
+        //printf("[%d] e = %s\n", i, e.toChars());
 
         // Create scope for '$' variable for this dimension
         auto sym = new ArrayScopeSymbol(sc, ae);
@@ -2379,12 +2379,12 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
 }
 
 /**************************************
- * Runs semantic on se->lwr and se->upr. Declares a temporary variable
+ * Runs semantic on se.lwr and se.upr. Declares a temporary variable
  * if '$' was used.
  */
 extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, Expression* pe0)
 {
-    //assert(!ae->lengthVar);
+    //assert(!ae.lengthVar);
     if (!ie)
         return ae;
 
@@ -2763,7 +2763,7 @@ extern (C++) abstract class Expression : RootObject
 
     Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        //printf("Expression::modifiableLvalue() %s, type = %s\n", toChars(), type->toChars());
+        //printf("Expression::modifiableLvalue() %s, type = %s\n", toChars(), type.toChars());
         // See if this expression is a modifiable lvalue (i.e. not const)
         if (checkModifiable(sc) == 1)
         {
@@ -2998,7 +2998,7 @@ extern (C++) abstract class Expression : RootObject
      */
     final bool checkPurity(Scope* sc, VarDeclaration v)
     {
-        //printf("v = %s %s\n", v->type->toChars(), v->toChars());
+        //printf("v = %s %s\n", v.type.toChars(), v.toChars());
         /* Look for purity and safety violations when accessing variable v
          * from current function.
          */
@@ -3209,11 +3209,11 @@ extern (C++) abstract class Expression : RootObject
                     sd.error(loc, "is not copyable because it is annotated with @disable");
                     return true;
                 }
-                //checkDeprecated(sc, sd->postblit);        // necessary?
+                //checkDeprecated(sc, sd.postblit);        // necessary?
                 checkPurity(sc, sd.postblit);
                 checkSafety(sc, sd.postblit);
                 checkNogc(sc, sd.postblit);
-                //checkAccess(sd, loc, sc, sd->postblit);   // necessary?
+                //checkAccess(sd, loc, sc, sd.postblit);   // necessary?
                 return false;
             }
         }
@@ -3229,8 +3229,8 @@ extern (C++) abstract class Expression : RootObject
             VarExp ve = cast(VarExp)this;
             if (isNeedThisScope(sc, ve.var))
             {
-                //printf("checkRightThis sc->intypeof = %d, ad = %p, func = %p, fdthis = %p\n",
-                //        sc->intypeof, sc->getStructClassScope(), func, fdthis);
+                //printf("checkRightThis sc.intypeof = %d, ad = %p, func = %p, fdthis = %p\n",
+                //        sc.intypeof, sc.getStructClassScope(), func, fdthis);
                 error("need 'this' for '%s' of type '%s'", ve.var.toChars(), ve.var.type.toChars());
                 return true;
             }
@@ -3245,7 +3245,7 @@ extern (C++) abstract class Expression : RootObject
      */
     final bool checkReadModifyWrite(TOK rmwOp, Expression ex = null)
     {
-        //printf("Expression::checkReadModifyWrite() %s %s", toChars(), ex ? ex->toChars() : "");
+        //printf("Expression::checkReadModifyWrite() %s %s", toChars(), ex ? ex.toChars() : "");
         if (!type || !type.isShared())
             return false;
 
@@ -3277,7 +3277,7 @@ extern (C++) abstract class Expression : RootObject
      *      flag:   1: do not issue error message for invalid modification
      * Returns:
      *      0:      is not modifiable
-     *      1:      is modifiable in default == being related to type->isMutable()
+     *      1:      is modifiable in default == being related to type.isMutable()
      *      2:      is modifiable, because this is a part of initializing.
      */
     int checkModifiable(Scope* sc, int flag = 0)
@@ -3426,7 +3426,7 @@ extern (C++) final class IntegerExp : Expression
     extern (D) this(Loc loc, dinteger_t value, Type type)
     {
         super(loc, TOKint64, __traits(classInstanceSize, IntegerExp));
-        //printf("IntegerExp(value = %lld, type = '%s')\n", value, type ? type->toChars() : "");
+        //printf("IntegerExp(value = %lld, type = '%s')\n", value, type ? type.toChars() : "");
         assert(type);
         if (!type.isscalar())
         {
@@ -4322,7 +4322,7 @@ extern (C++) final class SuperExp : ThisExp
             s = s.toParent();
         assert(s);
         cd = s.isClassDeclaration();
-        //printf("parent is %s %s\n", fd->toParent()->kind(), fd->toParent()->toChars());
+        //printf("parent is %s %s\n", fd.toParent()->kind(), fd.toParent()->toChars());
         if (!cd)
             goto Lerr;
         if (!cd.baseClass)
@@ -4462,7 +4462,7 @@ extern (C++) final class StringExp : Expression
 
     override bool equals(RootObject o)
     {
-        //printf("StringExp::equals('%s') %s\n", o->toChars(), toChars());
+        //printf("StringExp::equals('%s') %s\n", o.toChars(), toChars());
         if (o && o.dyncast() == DYNCAST_EXPRESSION)
         {
             Expression e = cast(Expression)o;
@@ -4548,8 +4548,8 @@ extern (C++) final class StringExp : Expression
             break;
         }
         type = type.semantic(loc, sc);
-        //type = type->immutableOf();
-        //printf("type = %s\n", type->toChars());
+        //type = type.immutableOf();
+        //printf("type = %s\n", type.toChars());
 
         return this;
     }
@@ -4797,7 +4797,7 @@ extern (C++) final class StringExp : Expression
 
     override Expression toLvalue(Scope* sc, Expression e)
     {
-        //printf("StringExp::toLvalue(%s) type = %s\n", toChars(), type ? type->toChars() : NULL);
+        //printf("StringExp::toLvalue(%s) type = %s\n", toChars(), type ? type.toChars() : NULL);
         return (type && type.toBasetype().ty == Tsarray) ? this : Expression.toLvalue(sc, e);
     }
 
@@ -5459,7 +5459,7 @@ extern (C++) final class StructLiteralExp : Expression
     Expression getField(Type type, uint offset)
     {
         //printf("StructLiteralExp::getField(this = %s, type = %s, offset = %u)\n",
-        //  /*toChars()*/"", type->toChars(), offset);
+        //  /*toChars()*/"", type.toChars(), offset);
         Expression e = null;
         int i = getFieldIndex(type, offset);
 
@@ -5473,7 +5473,7 @@ extern (C++) final class StructLiteralExp : Expression
             e = (*elements)[i];
             if (e)
             {
-                //printf("e = %s, e->type = %s\n", e->toChars(), e->type->toChars());
+                //printf("e = %s, e.type = %s\n", e.toChars(), e.type.toChars());
 
                 /* If type is a static array, and e is an initializer for that array,
                  * then the field initializer should be an array literal of e.
@@ -5575,7 +5575,7 @@ extern (C++) final class TypeExp : Expression
     extern (D) this(Loc loc, Type type)
     {
         super(loc, TOKtype, __traits(classInstanceSize, TypeExp));
-        //printf("TypeExp::TypeExp(%s)\n", type->toChars());
+        //printf("TypeExp::TypeExp(%s)\n", type.toChars());
         this.type = type;
     }
 
@@ -5589,7 +5589,7 @@ extern (C++) final class TypeExp : Expression
         if (type.ty == Terror)
             return new ErrorExp();
 
-        //printf("TypeExp::semantic(%s)\n", type->toChars());
+        //printf("TypeExp::semantic(%s)\n", type.toChars());
         Expression e;
         Type t;
         Dsymbol s;
@@ -5597,18 +5597,18 @@ extern (C++) final class TypeExp : Expression
         type.resolve(loc, sc, &e, &t, &s, true);
         if (e)
         {
-            //printf("e = %s %s\n", Token::toChars(e->op), e->toChars());
+            //printf("e = %s %s\n", Token::toChars(e.op), e.toChars());
             e = e.semantic(sc);
         }
         else if (t)
         {
-            //printf("t = %d %s\n", t->ty, t->toChars());
+            //printf("t = %d %s\n", t.ty, t.toChars());
             type = t.semantic(loc, sc);
             e = this;
         }
         else if (s)
         {
-            //printf("s = %s %s\n", s->kind(), s->toChars());
+            //printf("s = %s %s\n", s.kind(), s.toChars());
             e = DsymbolExp.resolve(loc, sc, s, true);
         }
         else
@@ -5837,7 +5837,7 @@ extern (C++) final class TemplateExp : Expression
     extern (D) this(Loc loc, TemplateDeclaration td, FuncDeclaration fd = null)
     {
         super(loc, TOKtemplate, __traits(classInstanceSize, TemplateExp));
-        //printf("TemplateExp(): %s\n", td->toChars());
+        //printf("TemplateExp(): %s\n", td.toChars());
         this.td = td;
         this.fd = fd;
     }
@@ -6028,7 +6028,7 @@ extern (C++) final class NewExp : Expression
                 }
                 return new ErrorExp();
             }
-            // checkDeprecated() is already done in newtype->semantic().
+            // checkDeprecated() is already done in newtype.semantic().
 
             if (cd.isNested())
             {
@@ -6180,7 +6180,7 @@ extern (C++) final class NewExp : Expression
                 error("default construction is disabled for type %s", sd.type.toChars());
                 return new ErrorExp();
             }
-            // checkDeprecated() is already done in newtype->semantic().
+            // checkDeprecated() is already done in newtype.semantic().
 
             if (sd.aggNew)
             {
@@ -6313,7 +6313,7 @@ extern (C++) final class NewExp : Expression
         }
 
         //printf("NewExp: '%s'\n", toChars());
-        //printf("NewExp:type '%s'\n", type->toChars());
+        //printf("NewExp:type '%s'\n", type.toChars());
         semanticTypeInfo(sc, type);
 
         if (newprefix)
@@ -6357,7 +6357,7 @@ extern (C++) final class NewAnonClassExp : Expression
         {
             printf("NewAnonClassExp::semantic() %s\n", toChars());
             //printf("thisexp = %p\n", thisexp);
-            //printf("type: %s\n", type->toChars());
+            //printf("type: %s\n", type.toChars());
         }
 
         Expression d = new DeclarationExp(loc, cd);
@@ -6440,7 +6440,7 @@ extern (C++) final class SymOffExp : SymbolExp
         {
             printf("SymOffExp::semantic('%s')\n", toChars());
         }
-        //var->semantic(sc);
+        //var.semantic(sc);
         if (!type)
             type = var.type.pointerTo();
 
@@ -6480,8 +6480,8 @@ extern (C++) final class VarExp : SymbolExp
             hasOverloads = false;
 
         super(loc, TOKvar, __traits(classInstanceSize, VarExp), var, hasOverloads);
-        //printf("VarExp(this = %p, '%s', loc = %s)\n", this, var->toChars(), loc.toChars());
-        //if (strcmp(var->ident->toChars(), "func") == 0) assert(0);
+        //printf("VarExp(this = %p, '%s', loc = %s)\n", this, var.toChars(), loc.toChars());
+        //if (strcmp(var.ident.toChars(), "func") == 0) assert(0);
         this.type = var.type;
     }
 
@@ -6513,7 +6513,7 @@ extern (C++) final class VarExp : SymbolExp
         }
         if (auto fd = var.isFuncDeclaration())
         {
-            //printf("L%d fd = %s\n", __LINE__, f->toChars());
+            //printf("L%d fd = %s\n", __LINE__, f.toChars());
             if (!fd.functionSemantic())
                 return new ErrorExp();
         }
@@ -6597,7 +6597,7 @@ extern (C++) final class VarExp : SymbolExp
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        //printf("VarExp::modifiableLvalue('%s')\n", var->toChars());
+        //printf("VarExp::modifiableLvalue('%s')\n", var.toChars());
         if (var.storage_class & STCmanifest)
         {
             error("cannot modify manifest constant '%s'", toChars());
@@ -6623,7 +6623,7 @@ extern (C++) final class OverExp : Expression
     extern (D) this(Loc loc, OverloadSet s)
     {
         super(loc, TOKoverloadset, __traits(classInstanceSize, OverExp));
-        //printf("OverExp(this = %p, '%s')\n", this, var->toChars());
+        //printf("OverExp(this = %p, '%s')\n", this, var.toChars());
         vars = s;
         type = Type.tvoid;
     }
@@ -6754,13 +6754,13 @@ extern (C++) final class FuncExp : Expression
 
         if (!type || type == Type.tvoid)
         {
-            /* fd->treq might be incomplete type,
+            /* fd.treq might be incomplete type,
              * so should not semantic it.
              * void foo(T)(T delegate(int) dg){}
              * foo(a=>a); // in IFTI, treq == T delegate(int)
              */
-            //if (fd->treq)
-            //    fd->treq = fd->treq->semantic(loc, sc);
+            //if (fd.treq)
+            //    fd.treq = fd.treq.semantic(loc, sc);
 
             genIdent(sc);
 
@@ -6777,7 +6777,7 @@ extern (C++) final class FuncExp : Expression
                 }
             }
 
-            //printf("td = %p, treq = %p\n", td, fd->treq);
+            //printf("td = %p, treq = %p\n", td, fd.treq);
             if (td)
             {
                 assert(td.parameters && td.parameters.dim);
@@ -6823,7 +6823,7 @@ extern (C++) final class FuncExp : Expression
             {
                 type = new TypePointer(fd.type);
                 type = type.semantic(loc, sc);
-                //type = fd->type->pointerTo();
+                //type = fd.type.pointerTo();
 
                 /* A lambda expression deduced to function pointer might become
                  * to a delegate literal implicitly.
@@ -6831,7 +6831,7 @@ extern (C++) final class FuncExp : Expression
                  *   auto foo(void function() fp) { return 1; }
                  *   assert(foo({}) == 1);
                  *
-                 * So, should keep fd->tok == TOKreserve if fd->treq == NULL.
+                 * So, should keep fd.tok == TOKreserve if fd.treq == NULL.
                  */
                 if (fd.treq && fd.treq.ty == Tpointer)
                 {
@@ -6906,7 +6906,7 @@ extern (C++) final class FuncExp : Expression
 
     MATCH matchType(Type to, Scope* sc, FuncExp* presult, int flag = 0)
     {
-        //printf("FuncExp::matchType('%s'), to=%s\n", type ? type->toChars() : "null", to->toChars());
+        //printf("FuncExp::matchType('%s'), to=%s\n", type ? type.toChars() : "null", to.toChars());
         if (presult)
             *presult = null;
 
@@ -6945,8 +6945,8 @@ extern (C++) final class FuncExp : Expression
             // Parameter types inference from 'tof'
             assert(td._scope);
             TypeFunction tf = cast(TypeFunction)fd.type;
-            //printf("\ttof = %s\n", tof->toChars());
-            //printf("\ttf  = %s\n", tf->toChars());
+            //printf("\ttof = %s\n", tof.toChars());
+            //printf("\ttf  = %s\n", tf.toChars());
             size_t dim = Parameter.dim(tf.parameters);
 
             if (Parameter.dim(tof.parameters) != dim || tof.varargs != tf.varargs)
@@ -7035,7 +7035,7 @@ extern (C++) final class FuncExp : Expression
             assert(tok == TOKfunction || tok == TOKreserved && type.ty == Tpointer);
             tx = tfx.pointerTo();
         }
-        //printf("\ttx = %s, to = %s\n", tx->toChars(), to->toChars());
+        //printf("\ttx = %s, to = %s\n", tx.toChars(), to.toChars());
 
         MATCH m = tx.implicitConvTo(to);
         if (m > MATCHnomatch)
@@ -7155,7 +7155,7 @@ extern (C++) final class DeclarationExp : Expression
             s.parent = sc.parent;
         }
 
-        //printf("inserting '%s' %p into sc = %p\n", s->toChars(), s, sc);
+        //printf("inserting '%s' %p into sc = %p\n", s.toChars(), s, sc);
         // Insert into both local scope and function scope.
         // Must be unique in both.
         if (s.ident)
@@ -7423,7 +7423,7 @@ extern (C++) final class IsExp : Expression
         }
 
         Type tded = null;
-        Scope* sc2 = sc.copy(); // keep sc->flags
+        Scope* sc2 = sc.copy(); // keep sc.flags
         sc2.tinst = null;
         sc2.minst = null;
         sc2.flags |= SCOPEfullinst;
@@ -7602,8 +7602,8 @@ extern (C++) final class IsExp : Expression
              * is(targ : tspec)
              */
             tspec = tspec.semantic(loc, sc);
-            //printf("targ  = %s, %s\n", targ->toChars(), targ->deco);
-            //printf("tspec = %s, %s\n", tspec->toChars(), tspec->deco);
+            //printf("targ  = %s, %s\n", targ.toChars(), targ.deco);
+            //printf("tspec = %s, %s\n", tspec.toChars(), tspec.deco);
 
             if (tok == TOKcolon)
             {
@@ -7639,8 +7639,8 @@ extern (C++) final class IsExp : Expression
             dedtypes.zero();
 
             MATCH m = deduceType(targ, sc, tspec, parameters, &dedtypes);
-            //printf("targ: %s\n", targ->toChars());
-            //printf("tspec: %s\n", tspec->toChars());
+            //printf("targ: %s\n", targ.toChars());
+            //printf("tspec: %s\n", tspec.toChars());
             if (m <= MATCHnomatch || (m != MATCHexact && tok == TOKequal))
             {
                 goto Lno;
@@ -7882,7 +7882,7 @@ extern (C++) abstract class BinExp : Expression
 
         // T opAssign floating yields a floating. Prevent truncating conversions (float to int).
         // See issue 3841.
-        // Should we also prevent double to float (type->isfloating() && type->size() < t2 ->size()) ?
+        // Should we also prevent double to float (type.isfloating() && type.size() < t2 ->size()) ?
         if (op == TOKaddass || op == TOKminass ||
             op == TOKmulass || op == TOKdivass || op == TOKmodass ||
             op == TOKpowass)
@@ -8221,7 +8221,7 @@ extern (C++) class BinAssignExp : BinExp
 
     override final Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        // should check e1->checkModifiable() ?
+        // should check e1.checkModifiable() ?
         return toLvalue(sc, this);
     }
 
@@ -8463,7 +8463,7 @@ extern (C++) final class DotIdExp : UnaExp
         static if (LOGSEMANTIC)
         {
             printf("DotIdExp::semantic(this = %p, '%s')\n", this, toChars());
-            //printf("e1->op = %d, '%s'\n", e1->op, Token::toChars(e1->op));
+            //printf("e1.op = %d, '%s'\n", e1.op, Token::toChars(e1.op));
         }
         Expression e = semanticY(sc, 1);
         if (e && isDotOpDispatch(e))
@@ -8564,7 +8564,7 @@ extern (C++) final class DotIdExp : UnaExp
                 e = new DotIdExp(e.loc, e, Id.offsetof);
                 (*exps)[i] = e;
             }
-            // Don't evaluate te->e0 in runtime
+            // Don't evaluate te.e0 in runtime
             Expression e = new TupleExp(loc, null, exps);
             e = e.semantic(sc);
             return e;
@@ -8572,7 +8572,7 @@ extern (C++) final class DotIdExp : UnaExp
         if (e1.op == TOKtuple && ident == Id.length)
         {
             TupleExp te = cast(TupleExp)e1;
-            // Don't evaluate te->e0 in runtime
+            // Don't evaluate te.e0 in runtime
             Expression e = new IntegerExp(loc, te.exps.dim, Type.tsize_t);
             return e;
         }
@@ -8684,7 +8684,7 @@ extern (C++) final class DotIdExp : UnaExp
                 VarDeclaration v = s.isVarDeclaration();
                 if (v)
                 {
-                    //printf("DotIdExp:: Identifier '%s' is a variable, type '%s'\n", toChars(), v->type->toChars());
+                    //printf("DotIdExp:: Identifier '%s' is a variable, type '%s'\n", toChars(), v.type.toChars());
                     if (!v.type ||
                         !v.type.deco && v.inuse)
                     {
@@ -8777,7 +8777,7 @@ extern (C++) final class DotIdExp : UnaExp
                 OverloadSet o = s.isOverloadSet();
                 if (o)
                 {
-                    //printf("'%s' is an overload set\n", o->toChars());
+                    //printf("'%s' is an overload set\n", o.toChars());
                     return new OverExp(loc, o);
                 }
 
@@ -8803,7 +8803,7 @@ extern (C++) final class DotIdExp : UnaExp
                 ScopeDsymbol sds = s.isScopeDsymbol();
                 if (sds)
                 {
-                    //printf("it's a ScopeDsymbol %s\n", ident->toChars());
+                    //printf("it's a ScopeDsymbol %s\n", ident.toChars());
                     e = new ScopeExp(loc, sds);
                     e = e.semantic(sc);
                     if (eleft)
@@ -9094,8 +9094,8 @@ extern (C++) final class DotVarExp : UnaExp
         version (none)
         {
             printf("DotVarExp::modifiableLvalue(%s)\n", toChars());
-            printf("e1->type = %s\n", e1.type.toChars());
-            printf("var->type = %s\n", var.type.toChars());
+            printf("e1.type = %s\n", e1.type.toChars());
+            printf("var.type = %s\n", var.type.toChars());
         }
 
         return Expression.modifiableLvalue(sc, e);
@@ -10004,11 +10004,11 @@ extern (C++) final class CallExp : UnaExp
                 }
                 version (none)
                 {
-                    printf("ue->e1 = %s\n", ue.e1.toChars());
+                    printf("ue.e1 = %s\n", ue.e1.toChars());
                     printf("f = %s\n", f.toChars());
                     printf("t = %s\n", t.toChars());
                     printf("e1 = %s\n", e1.toChars());
-                    printf("e1->type = %s\n", e1.type.toChars());
+                    printf("e1.type = %s\n", e1.type.toChars());
                 }
 
                 // See if we need to adjust the 'this' pointer
@@ -10234,7 +10234,7 @@ extern (C++) final class CallExp : UnaExp
                 if (tthis)
                     tthis.modToBuffer(&buf);
 
-                //printf("tf = %s, args = %s\n", tf->deco, (*arguments)[0]->type->deco);
+                //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0]->type.deco);
                 .error(loc, "%s %s %s is not callable using argument types %s", p, e1.toChars(), parametersTypeToChars(tf.parameters, tf.varargs), buf.peekString());
 
                 return new ErrorExp();
@@ -10303,7 +10303,7 @@ extern (C++) final class CallExp : UnaExp
                     argExpTypesToCBuffer(&buf, arguments);
                     buf.writeByte(')');
 
-                    //printf("tf = %s, args = %s\n", tf->deco, (*arguments)[0]->type->deco);
+                    //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0]->type.deco);
                     .error(loc, "%s %s is not callable using argument types %s", e1.toChars(), parametersTypeToChars(tf.parameters, tf.varargs), buf.peekString());
 
                     f = null;
@@ -10765,8 +10765,8 @@ extern (C++) final class PtrExp : UnaExp
     extern (D) this(Loc loc, Expression e)
     {
         super(loc, TOKstar, __traits(classInstanceSize, PtrExp), e);
-        //if (e->type)
-        //  type = ((TypePointer *)e->type)->next;
+        //if (e.type)
+        //  type = ((TypePointer *)e.type)->next;
     }
 
     extern (D) this(Loc loc, Expression e, Type t)
@@ -10843,7 +10843,7 @@ extern (C++) final class PtrExp : UnaExp
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
     {
-        //printf("PtrExp::modifiableLvalue() %s, type %s\n", toChars(), type->toChars());
+        //printf("PtrExp::modifiableLvalue() %s, type %s\n", toChars(), type.toChars());
         return Expression.modifiableLvalue(sc, e);
     }
 
@@ -11676,7 +11676,7 @@ extern (C++) final class SliceExp : UnaExp
 
     override Expression toLvalue(Scope* sc, Expression e)
     {
-        //printf("SliceExp::toLvalue(%s) type = %s\n", toChars(), type ? type->toChars() : NULL);
+        //printf("SliceExp::toLvalue(%s) type = %s\n", toChars(), type ? type.toChars() : NULL);
         return (type && type.toBasetype().ty == Tsarray) ? this : Expression.toLvalue(sc, e);
     }
 
@@ -12592,8 +12592,8 @@ extern (C++) class AssignExp : BinExp
         {
             printf("AssignExp::semantic('%s')\n", toChars());
         }
-        //printf("e1->op = %d, '%s'\n", e1->op, Token::toChars(e1->op));
-        //printf("e2->op = %d, '%s'\n", e2->op, Token::toChars(e2->op));
+        //printf("e1.op = %d, '%s'\n", e1.op, Token::toChars(e1.op));
+        //printf("e2.op = %d, '%s'\n", e2.op, Token::toChars(e2.op));
         if (type)
             return this;
 
@@ -12612,7 +12612,7 @@ extern (C++) class AssignExp : BinExp
         }
 
         /* Look for operator overloading of a[arguments] = e2.
-         * Do it before e1->semantic() otherwise the ArrayExp will have been
+         * Do it before e1.semantic() otherwise the ArrayExp will have been
          * converted to unary operator overloading already.
          */
         if (e1.op == TOKarray)
@@ -12728,7 +12728,7 @@ extern (C++) class AssignExp : BinExp
             ae.lengthVar = null;
         }
 
-        /* Run this->e1 semantic.
+        /* Run this.e1 semantic.
          */
         {
             Expression e1x = e1;
@@ -12782,7 +12782,7 @@ extern (C++) class AssignExp : BinExp
         }
         Type t1 = e1.type.toBasetype();
 
-        /* Run this->e2 semantic.
+        /* Run this.e2 semantic.
          * Different from other binary expressions, the analysis of e2
          * depends on the result of e1 in assignments.
          */
@@ -12835,7 +12835,7 @@ extern (C++) class AssignExp : BinExp
                 return e.semantic(sc);
             }
 
-            /* Look for form: e1 = e2->aliasthis.
+            /* Look for form: e1 = e2.aliasthis.
              */
             if (e1.op == TOKtuple)
             {
@@ -12857,9 +12857,9 @@ extern (C++) class AssignExp : BinExp
                     Expression e = (*iexps)[u];
 
                     Parameter arg = Parameter.getNth(tt.arguments, u);
-                    //printf("[%d] iexps->dim = %d, ", u, iexps->dim);
-                    //printf("e = (%s %s, %s), ", Token::tochars[e->op], e->toChars(), e->type->toChars());
-                    //printf("arg = (%s, %s)\n", arg->toChars(), arg->type->toChars());
+                    //printf("[%d] iexps.dim = %d, ", u, iexps.dim);
+                    //printf("e = (%s %s, %s), ", Token::tochars[e.op], e.toChars(), e.type.toChars());
+                    //printf("arg = (%s, %s)\n", arg.toChars(), arg.type.toChars());
 
                     if (!arg || !e.type.implicitConvTo(arg.type))
                     {
@@ -12877,7 +12877,7 @@ extern (C++) class AssignExp : BinExp
                 e2x = e2x.semantic(sc);
                 if (e2x.op == TOKerror)
                     return e2x;
-                // Do not need to overwrite this->e2
+                // Do not need to overwrite this.e2
                 goto Ltupleassign;
             }
         Lnomatch:
@@ -14387,7 +14387,7 @@ extern (C++) final class CatExp : BinExp
         }
         else
         {
-            //printf("(%s) ~ (%s)\n", e1->toChars(), e2->toChars());
+            //printf("(%s) ~ (%s)\n", e1.toChars(), e2.toChars());
             return incompatibleTypes();
         }
 
@@ -15390,7 +15390,7 @@ extern (C++) final class CmpExp : BinExp
             return new ErrorExp();
         }
 
-        //printf("CmpExp: %s, type = %s\n", e->toChars(), e->type->toChars());
+        //printf("CmpExp: %s, type = %s\n", e.toChars(), e.type.toChars());
         return this;
     }
 
@@ -15740,8 +15740,8 @@ extern (C++) final class CondExp : BinExp
          * to:
          *      (auto __cond = cond) ? (... __tmp1) : (... __tmp2)
          * and replace edtors of __tmp1 and __tmp2 with:
-         *      __tmp1->edtor --> __cond && __tmp1.dtor()
-         *      __tmp2->edtor --> __cond || __tmp2.dtor()
+         *      __tmp1.edtor --> __cond && __tmp1.dtor()
+         *      __tmp2.edtor --> __cond || __tmp2.dtor()
          */
         hookDtors(sc);
 
@@ -15808,7 +15808,7 @@ extern (C++) final class CondExp : BinExp
 
             override void visit(Expression e)
             {
-                //printf("(e = %s)\n", e->toChars());
+                //printf("(e = %s)\n", e.toChars());
             }
 
             override void visit(DeclarationExp e)
@@ -15836,14 +15836,14 @@ extern (C++) final class CondExp : BinExp
                             ce.econd = Expression.combine(de, ve);
                         }
 
-                        //printf("\t++v = %s, v->edtor = %s\n", v->toChars(), v->edtor->toChars());
+                        //printf("\t++v = %s, v.edtor = %s\n", v.toChars(), v.edtor.toChars());
                         Expression ve = new VarExp(vcond.loc, vcond);
                         if (isThen)
                             v.edtor = new AndAndExp(v.edtor.loc, ve, v.edtor);
                         else
                             v.edtor = new OrOrExp(v.edtor.loc, ve, v.edtor);
                         v.edtor = v.edtor.semantic(sc);
-                        //printf("\t--v = %s, v->edtor = %s\n", v->toChars(), v->edtor->toChars());
+                        //printf("\t--v = %s, v.edtor = %s\n", v.toChars(), v.edtor.toChars());
                     }
                 }
             }

--- a/src/func.d
+++ b/src/func.d
@@ -356,13 +356,13 @@ public:
              * But for nrvo_var, its dtor should be called only when exception is thrown.
              *
              * Rewrite:
-             *      try { s->body; } finally { nrvo_var->edtor; }
+             *      try { s.body; } finally { nrvo_var.edtor; }
              *      // equivalent with:
-             *      //    s->body; scope(exit) nrvo_var->edtor;
+             *      //    s.body; scope(exit) nrvo_var.edtor;
              * as:
-             *      try { s->body; } catch(Throwable __o) { nrvo_var->edtor; throw __o; }
+             *      try { s.body; } catch(Throwable __o) { nrvo_var.edtor; throw __o; }
              *      // equivalent with:
-             *      //    s->body; scope(failure) nrvo_var->edtor;
+             *      //    s.body; scope(failure) nrvo_var.edtor;
              */
             Statement sexception = new DtorExpStatement(Loc(), fd.nrvo_var.edtor, fd.nrvo_var);
             Identifier id = Identifier.generateId("__o");
@@ -493,7 +493,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         super(id);
         objc = Objc_FuncDeclaration(this);
-        //printf("FuncDeclaration(id = '%s', type = %p)\n", id->toChars(), type);
+        //printf("FuncDeclaration(id = '%s', type = %p)\n", id.toChars(), type);
         //printf("storage_class = x%x\n", storage_class);
         this.storage_class = storage_class;
         this.type = type;
@@ -535,7 +535,7 @@ extern (C++) class FuncDeclaration : Declaration
             printf("FuncDeclaration::semantic(sc = %p, this = %p, '%s', linkage = %d)\n", sc, this, toPrettyChars(), sc.linkage);
             if (isFuncLiteralDeclaration())
                 printf("\tFuncLiteralDeclaration()\n");
-            printf("sc->parent = %s, parent = %s\n", sc.parent.toChars(), parent ? parent.toChars() : "");
+            printf("sc.parent = %s, parent = %s\n", sc.parent.toChars(), parent ? parent.toChars() : "");
             printf("type: %p, %s\n", type, type.toChars());
         }
 
@@ -580,7 +580,7 @@ extern (C++) class FuncDeclaration : Declaration
         if ((storage_class & STC_TYPECTOR) && !(ad || isNested()))
             storage_class &= ~STC_TYPECTOR;
 
-        //printf("function storage_class = x%llx, sc->stc = x%llx, %x\n", storage_class, sc->stc, Declaration::isFinal());
+        //printf("function storage_class = x%llx, sc.stc = x%llx, %x\n", storage_class, sc.stc, Declaration::isFinal());
 
         FuncLiteralDeclaration fld = isFuncLiteralDeclaration();
         if (fld && fld.treq)
@@ -983,9 +983,9 @@ extern (C++) class FuncDeclaration : Declaration
                     if (fdc.toParent() == parent)
                     {
                         //printf("vi = %d,\tthis = %p %s %s @ [%s]\n\tfdc  = %p %s %s @ [%s]\n\tfdv  = %p %s %s @ [%s]\n",
-                        //        vi, this, this->toChars(), this->type->toChars(), this->loc.toChars(),
-                        //            fdc,  fdc ->toChars(), fdc ->type->toChars(), fdc ->loc.toChars(),
-                        //            fdv,  fdv ->toChars(), fdv ->type->toChars(), fdv ->loc.toChars());
+                        //        vi, this, this.toChars(), this.type.toChars(), this.loc.toChars(),
+                        //            fdc,  fdc ->toChars(), fdc ->type.toChars(), fdc ->loc.toChars(),
+                        //            fdv,  fdv ->toChars(), fdv ->type.toChars(), fdv ->loc.toChars());
 
                         // fdc overrides fdv exactly, then this introduces new function.
                         if (fdc.type.mod == fdv.type.mod && this.type.mod != fdv.type.mod)
@@ -1077,7 +1077,7 @@ extern (C++) class FuncDeclaration : Declaration
                          * an interface function?
                          */
                         //if (!isOverride())
-                        //    warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv->toPrettyChars());
+                        //    warning(loc, "overrides base class function %s, but is not marked with 'override'", fdv.toPrettyChars());
 
                         if (fdv.tintro)
                             ti = fdv.tintro;
@@ -1152,7 +1152,7 @@ extern (C++) class FuncDeclaration : Declaration
         else if (isOverride() && !parent.isTemplateInstance())
             error("override only applies to class member functions");
 
-        // Reflect this->type to f because it could be changed by findVtblIndex
+        // Reflect this.type to f because it could be changed by findVtblIndex
         assert(type.ty == Tfunction);
         f = cast(TypeFunction)type;
 
@@ -1345,11 +1345,11 @@ extern (C++) class FuncDeclaration : Declaration
             errors = true;
             return;
         }
-        //printf("FuncDeclaration::semantic3('%s.%s', %p, sc = %p, loc = %s)\n", parent->toChars(), toChars(), this, sc, loc.toChars());
+        //printf("FuncDeclaration::semantic3('%s.%s', %p, sc = %p, loc = %s)\n", parent.toChars(), toChars(), this, sc, loc.toChars());
         //fflush(stdout);
-        //printf("storage class = x%x %x\n", sc->stc, storage_class);
+        //printf("storage class = x%x %x\n", sc.stc, storage_class);
         //{ static int x; if (++x == 2) *(char*)0=0; }
-        //printf("\tlinkage = %d\n", sc->linkage);
+        //printf("\tlinkage = %d\n", sc.linkage);
 
         if (ident == Id.assign && !inuse)
         {
@@ -1373,7 +1373,7 @@ extern (C++) class FuncDeclaration : Declaration
             }
         }
 
-        //printf(" sc->incontract = %d\n", (sc->flags & SCOPEcontract));
+        //printf(" sc.incontract = %d\n", (sc.flags & SCOPEcontract));
         if (semanticRun >= PASSsemantic3)
             return;
         semanticRun = PASSsemantic3;
@@ -1511,7 +1511,7 @@ extern (C++) class FuncDeclaration : Declaration
                     sc2.insert(v_arguments);
                     v_arguments.parent = this;
 
-                    //Type *t = Type::typeinfo->type->constOf()->arrayOf();
+                    //Type *t = Type::typeinfo.type.constOf()->arrayOf();
                     Type t = Type.dtypeinfo.type.arrayOf();
                     _arguments = new VarDeclaration(Loc(), t, Id._arguments, null);
                     _arguments.storage_class |= STCtemp;
@@ -1558,7 +1558,7 @@ extern (C++) class FuncDeclaration : Declaration
                     }
                     Type vtype = fparam.type;
                     auto v = new VarDeclaration(loc, vtype, id, null);
-                    //printf("declaring parameter %s of type %s\n", v->toChars(), v->type->toChars());
+                    //printf("declaring parameter %s of type %s\n", v.toChars(), v.type.toChars());
                     stc |= STCparameter;
                     if (f.varargs == 2 && i + 1 == nparams)
                         stc |= STCvariadic;
@@ -1600,7 +1600,7 @@ extern (C++) class FuncDeclaration : Declaration
                         }
                         assert(fparam.ident);
                         auto v = new TupleDeclaration(loc, fparam.ident, exps);
-                        //printf("declaring tuple %s\n", v->toChars());
+                        //printf("declaring tuple %s\n", v.toChars());
                         v.isexp = true;
                         if (!sc2.insert(v))
                             error("parameter %s.%s is already defined", toChars(), v.toChars());
@@ -1636,7 +1636,7 @@ extern (C++) class FuncDeclaration : Declaration
                     returnLabel = new LabelDsymbol(Id.returnLabel);
                 }
 
-                // scope of out contract (need for vresult->semantic)
+                // scope of out contract (need for vresult.semantic)
                 auto sym = new ScopeDsymbol();
                 sym.parent = sc2.scopesym;
                 sym.loc = loc;
@@ -1798,7 +1798,7 @@ extern (C++) class FuncDeclaration : Declaration
                             fbody = new CompoundStatement(Loc(), s, fbody);
                         }
                     }
-                    //printf("callSuper = x%x\n", sc2->callSuper);
+                    //printf("callSuper = x%x\n", sc2.callSuper);
                 }
 
                 int blockexit = BEnone;
@@ -2248,7 +2248,7 @@ extern (C++) class FuncDeclaration : Declaration
         semantic3Errors = (global.errors != oldErrors) || (fbody && fbody.isErrorStatement());
         if (type.ty == Terror)
             errors = true;
-        //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent->toChars(), toChars(), sc, loc.toChars());
+        //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent.toChars(), toChars(), sc, loc.toChars());
         //fflush(stdout);
     }
 
@@ -2293,9 +2293,9 @@ extern (C++) class FuncDeclaration : Declaration
             {
                 /* Currently dmd cannot resolve forward references per methods,
                  * then setting SIZOKfwd is too conservative and would break existing code.
-                 * So, just stop method attributes inference until ad->semantic() done.
+                 * So, just stop method attributes inference until ad.semantic() done.
                  */
-                //ad->sizeok = SIZEOKfwd;
+                //ad.sizeok = SIZEOKfwd;
             }
             else
                 return functionSemantic3() || !errors;
@@ -2524,9 +2524,9 @@ extern (C++) class FuncDeclaration : Declaration
         }
         if (bestvi == -1 && mismatch)
         {
-            //type->print();
-            //mismatch->type->print();
-            //printf("%s %s\n", type->deco, mismatch->type->deco);
+            //type.print();
+            //mismatch.type.print();
+            //printf("%s %s\n", type.deco, mismatch.type.deco);
             //printf("stc = %llx\n", mismatchstc);
             if (mismatchstc)
             {
@@ -2564,7 +2564,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     override bool overloadInsert(Dsymbol s)
     {
-        //printf("FuncDeclaration::overloadInsert(s = %s) this = %s\n", s->toChars(), toChars());
+        //printf("FuncDeclaration::overloadInsert(s = %s) this = %s\n", s.toChars(), toChars());
         assert(s != this);
         AliasDeclaration ad = s.isAliasDeclaration();
         if (ad)
@@ -2573,7 +2573,7 @@ extern (C++) class FuncDeclaration : Declaration
                 return overnext.overloadInsert(ad);
             if (!ad.aliassym && ad.type.ty != Tident && ad.type.ty != Tinstance)
             {
-                //printf("\tad = '%s'\n", ad->type->toChars());
+                //printf("\tad = '%s'\n", ad.type.toChars());
                 return false;
             }
             overnext = ad;
@@ -2604,9 +2604,9 @@ extern (C++) class FuncDeclaration : Declaration
             if (type)
             {
                 printf("type = %s\n", type.toChars());
-                printf("fd->type = %s\n", fd.type.toChars());
+                printf("fd.type = %s\n", fd.type.toChars());
             }
-            // fd->type can be NULL for overloaded constructors
+            // fd.type can be NULL for overloaded constructors
             if (type && fd.type && fd.type.covariant(type) && fd.type.mod == type.mod && !isFuncAliasDeclaration())
             {
                 //printf("\tfalse: conflict %s\n", kind());
@@ -2694,7 +2694,7 @@ extern (C++) class FuncDeclaration : Declaration
             m.anyf = f;
 
             auto tf = cast(TypeFunction)f.type;
-            //printf("tf = %s\n", tf->toChars());
+            //printf("tf = %s\n", tf.toChars());
 
             MATCH match;
             if (tthis) // non-static functions are preferred than static ones
@@ -2779,7 +2779,7 @@ extern (C++) class FuncDeclaration : Declaration
         FuncDeclaration f = this;
         while (f && f.overnext)
         {
-            //printf("f->overnext = %p %s\n", f->overnext, f->overnext->toChars());
+            //printf("f.overnext = %p %s\n", f.overnext, f.overnext.toChars());
             TemplateDeclaration td = f.overnext.isTemplateDeclaration();
             if (td)
                 return td;
@@ -3276,7 +3276,7 @@ extern (C++) class FuncDeclaration : Declaration
         assert(type.ty == Tfunction);
         TypeFunction tf = cast(TypeFunction)type;
 
-        //printf("parametersIntersect(%s) t = %s\n", tf->toChars(), t->toChars());
+        //printf("parametersIntersect(%s) t = %s\n", tf.toChars(), t.toChars());
 
         size_t dim = Parameter.dim(tf.parameters);
         for (size_t i = 0; i < dim; i++)
@@ -3288,14 +3288,14 @@ extern (C++) class FuncDeclaration : Declaration
             if (!tprmi)
                 continue; // there is no mutable indirection
 
-            //printf("\t[%d] tprmi = %d %s\n", i, tprmi->ty, tprmi->toChars());
+            //printf("\t[%d] tprmi = %d %s\n", i, tprmi.ty, tprmi.toChars());
             if (traverseIndirections(tprmi, t))
                 return false;
         }
         if (AggregateDeclaration ad = isCtorDeclaration() ? null : isThis())
         {
             Type tthis = ad.getType().addMod(tf.mod);
-            //printf("\ttthis = %s\n", tthis->toChars());
+            //printf("\ttthis = %s\n", tthis.toChars());
             if (traverseIndirections(tthis, t))
                 return false;
         }
@@ -3551,14 +3551,14 @@ extern (C++) class FuncDeclaration : Declaration
         for (size_t i = 0; i < closureVars.dim; i++)
         {
             VarDeclaration v = closureVars[i];
-            //printf("\tv = %s\n", v->toChars());
+            //printf("\tv = %s\n", v.toChars());
 
             for (size_t j = 0; j < v.nestedrefs.dim; j++)
             {
                 FuncDeclaration f = v.nestedrefs[j];
                 assert(f != this);
 
-                //printf("\t\tf = %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", f->toChars(), f->isVirtual(), f->isThis(), f->tookAddressOf);
+                //printf("\t\tf = %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", f.toChars(), f.isVirtual(), f.isThis(), f.tookAddressOf);
 
                 /* Look to see if f escapes. We consider all parents of f within
                  * this, and also all siblings which call f; if any of them escape,
@@ -3572,7 +3572,7 @@ extern (C++) class FuncDeclaration : Declaration
                         continue;
                     if (fx.isThis() || fx.tookAddressOf)
                     {
-                        //printf("\t\tfx = %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", fx->toChars(), fx->isVirtual(), fx->isThis(), fx->tookAddressOf);
+                        //printf("\t\tfx = %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", fx.toChars(), fx.isVirtual(), fx.isThis(), fx.tookAddressOf);
 
                         /* Mark as needing closure any functions between this and f
                          */
@@ -3605,17 +3605,17 @@ extern (C++) class FuncDeclaration : Declaration
             Type tret = (cast(TypeFunction)type).next;
             assert(tret);
             tret = tret.toBasetype();
-            //printf("\t\treturning %s\n", tret->toChars());
+            //printf("\t\treturning %s\n", tret.toChars());
             if (tret.ty == Tclass || tret.ty == Tstruct)
             {
                 Dsymbol st = tret.toDsymbol(null);
-                //printf("\t\treturning class/struct %s\n", tret->toChars());
+                //printf("\t\treturning class/struct %s\n", tret.toChars());
                 for (Dsymbol s = st.parent; s; s = s.parent)
                 {
-                    //printf("\t\t\tparent = %s %s\n", s->kind(), s->toChars());
+                    //printf("\t\t\tparent = %s %s\n", s.kind(), s.toChars());
                     if (s == this)
                     {
-                        //printf("\t\treturning local %s\n", st->toChars());
+                        //printf("\t\treturning local %s\n", st.toChars());
                         goto Lyes;
                     }
                 }
@@ -3730,7 +3730,7 @@ extern (C++) class FuncDeclaration : Declaration
 
             /* If inferRetType is true, tret may not be a correct return type yet.
              * So, in here it may be a temporary type for vresult, and after
-             * fbody->semantic() running, vresult->type might be modified.
+             * fbody.semantic() running, vresult.type might be modified.
              */
             vresult = new VarDeclaration(loc, tret, outId ? outId : Id.result, null);
             vresult.storage_class |= STCnodtor;
@@ -3818,7 +3818,7 @@ extern (C++) class FuncDeclaration : Declaration
             sf = fdv.mergeFrequire(sf);
             if (sf && fdv.fdrequire)
             {
-                //printf("fdv->frequire: %s\n", fdv->frequire->toChars());
+                //printf("fdv.frequire: %s\n", fdv.frequire.toChars());
                 /* Make the call:
                  *   try { __require(); }
                  *   catch (Throwable) { frequire; }
@@ -3873,7 +3873,7 @@ extern (C++) class FuncDeclaration : Declaration
             sf = fdv.mergeFensure(sf, oid);
             if (fdv.fdensure)
             {
-                //printf("fdv->fensure: %s\n", fdv->fensure->toChars());
+                //printf("fdv.fensure: %s\n", fdv.fensure.toChars());
                 // Make the call: __ensure(result)
                 Expression eresult = null;
                 if (outId)
@@ -3947,8 +3947,8 @@ extern (C++) class FuncDeclaration : Declaration
         Dsymbol s;
         static __gshared DsymbolTable st = null;
 
-        //printf("genCfunc(name = '%s')\n", id->toChars());
-        //printf("treturn\n\t"); treturn->print();
+        //printf("genCfunc(name = '%s')\n", id.toChars());
+        //printf("treturn\n\t"); treturn.print();
 
         // See if already in table
         if (!st)
@@ -4024,7 +4024,7 @@ extern (C++) Expression addInvariant(Loc loc, Scope* sc, AggregateDeclaration ad
 
             //e = new DsymbolExp(Loc(), inv);
             //e = new CallExp(Loc(), e);
-            //e = e->semantic(sc2);
+            //e = e.semantic(sc2);
 
             /* Bugzilla 13113: Currently virtual invariant calls completely
              * bypass attribute enforcement.
@@ -4311,7 +4311,7 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             }
             else
             {
-                //printf("tf = %s, args = %s\n", tf->deco, (*fargs)[0]->type->deco);
+                //printf("tf = %s, args = %s\n", tf.deco, (*fargs)[0]->type.deco);
                 if (hasOverloads)
                 {
                     .error(loc, "none of the overloads of '%s' are callable using argument types %s, candidates are:",
@@ -4431,7 +4431,7 @@ extern (C++) bool traverseIndirections(Type ta, Type tb, void* p = null, bool re
         {
             VarDeclaration v = sym.fields[i];
             Type tprmi = v.type.addMod(tb.mod);
-            //printf("\ttb = %s, tprmi = %s\n", tb->toChars(), tprmi->toChars());
+            //printf("\ttb = %s, tprmi = %s\n", tb.toChars(), tprmi.toChars());
             if (traverseIndirections(ta, tprmi, &c, reversePass))
                 return true;
         }
@@ -4493,7 +4493,7 @@ extern (C++) bool checkEscapingSiblings(FuncDeclaration f, FuncDeclaration outer
     ps.p = cast(PrevSibling*)p;
     ps.f = f;
 
-    //printf("checkEscapingSiblings(f = %s, outerfunc = %s)\n", f->toChars(), outerFunc->toChars());
+    //printf("checkEscapingSiblings(f = %s, outerfunc = %s)\n", f.toChars(), outerFunc.toChars());
     bool bAnyClosures = false;
     for (size_t i = 0; i < f.siblingCallers.dim; ++i)
     {
@@ -4587,7 +4587,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         this.ident = id ? id : Id.empty;
         this.tok = tok;
         this.fes = fes;
-        //printf("FuncLiteralDeclaration() id = '%s', type = '%s'\n", this->ident->toChars(), type->toChars());
+        //printf("FuncLiteralDeclaration() id = '%s', type = '%s'\n", this.ident.toChars(), type.toChars());
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
@@ -4855,8 +4855,8 @@ extern (C++) final class PostBlitDeclaration : FuncDeclaration
     override void semantic(Scope* sc)
     {
         //printf("PostBlitDeclaration::semantic() %s\n", toChars());
-        //printf("ident: %s, %s, %p, %p\n", ident->toChars(), Id::dtor->toChars(), ident, Id::dtor);
-        //printf("stc = x%llx\n", sc->stc);
+        //printf("ident: %s, %s, %p, %p\n", ident.toChars(), Id::dtor.toChars(), ident, Id::dtor);
+        //printf("stc = x%llx\n", sc.stc);
         if (semanticRun >= PASSsemanticdone)
             return;
         if (_scope)
@@ -4944,7 +4944,7 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
     override void semantic(Scope* sc)
     {
         //printf("DtorDeclaration::semantic() %s\n", toChars());
-        //printf("ident: %s, %s, %p, %p\n", ident->toChars(), Id::dtor->toChars(), ident, Id::dtor);
+        //printf("ident: %s, %s, %p, %p\n", ident.toChars(), Id::dtor.toChars(), ident, Id::dtor);
         if (semanticRun >= PASSsemanticdone)
             return;
         if (_scope)
@@ -5105,7 +5105,7 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
         if (m)
         {
             m.needmoduleinfo = 1;
-            //printf("module1 %s needs moduleinfo\n", m->toChars());
+            //printf("module1 %s needs moduleinfo\n", m.toChars());
         }
     }
 
@@ -5261,7 +5261,7 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
         if (m)
         {
             m.needmoduleinfo = 1;
-            //printf("module2 %s needs moduleinfo\n", m->toChars());
+            //printf("module2 %s needs moduleinfo\n", m.toChars());
         }
     }
 
@@ -5486,7 +5486,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
                 m = sc._module;
             if (m)
             {
-                //printf("module3 %s needs moduleinfo\n", m->toChars());
+                //printf("module3 %s needs moduleinfo\n", m.toChars());
                 m.needmoduleinfo = 1;
             }
         }

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -720,13 +720,13 @@ public:
 
     override void visit(TypeBasic t)
     {
-        //printf("TypeBasic::toCBuffer2(t->mod = %d)\n", t->mod);
+        //printf("TypeBasic::toCBuffer2(t.mod = %d)\n", t.mod);
         buf.writestring(t.dstring);
     }
 
     override void visit(TypeVector t)
     {
-        //printf("TypeVector::toCBuffer2(t->mod = %d)\n", t->mod);
+        //printf("TypeVector::toCBuffer2(t.mod = %d)\n", t.mod);
         buf.writestring("__vector(");
         visitWithMask(t.basetype, t.mod);
         buf.writestring(")");
@@ -769,7 +769,7 @@ public:
 
     override void visit(TypePointer t)
     {
-        //printf("TypePointer::toCBuffer2() next = %d\n", t->next->ty);
+        //printf("TypePointer::toCBuffer2() next = %d\n", t.next.ty);
         if (t.next.ty == Tfunction)
             visitFuncIdentWithPostfix(cast(TypeFunction)t.next, "function");
         else
@@ -787,7 +787,7 @@ public:
 
     override void visit(TypeFunction t)
     {
-        //printf("TypeFunction::toCBuffer2() t = %p, ref = %d\n", t, t->isref);
+        //printf("TypeFunction::toCBuffer2() t = %p, ref = %d\n", t, t.isref);
         visitFuncIdentWithPostfix(t, null);
     }
 
@@ -974,7 +974,7 @@ public:
 
     override void visit(TypeStruct t)
     {
-        // Bugzilla 13776: Don't use ti->toAlias() to avoid forward reference error
+        // Bugzilla 13776: Don't use ti.toAlias() to avoid forward reference error
         // while printing messages.
         TemplateInstance ti = t.sym.parent ? t.sym.parent.isTemplateInstance() : null;
         if (ti && ti.aliasdecl == t.sym)
@@ -985,7 +985,7 @@ public:
 
     override void visit(TypeClass t)
     {
-        // Bugzilla 13776: Don't use ti->toAlias() to avoid forward reference error
+        // Bugzilla 13776: Don't use ti.toAlias() to avoid forward reference error
         // while printing messages.
         TemplateInstance ti = t.sym.parent.isTemplateInstance();
         if (ti && ti.aliasdecl == t.sym)
@@ -1522,7 +1522,7 @@ public:
          */
         if (auto t = isType(oarg))
         {
-            //printf("\tt: %s ty = %d\n", t->toChars(), t->ty);
+            //printf("\tt: %s ty = %d\n", t.toChars(), t.ty);
             typeToBuffer(t, null);
         }
         else if (auto e = isExpression(oarg))
@@ -1739,7 +1739,7 @@ public:
 
     override void visit(FuncDeclaration f)
     {
-        //printf("FuncDeclaration::toCBuffer() '%s'\n", f->toChars());
+        //printf("FuncDeclaration::toCBuffer() '%s'\n", f.toChars());
         if (stcToBuffer(buf, f.storage_class))
             buf.writeByte(' ');
         typeToBuffer(f.type, f.ident);
@@ -1825,7 +1825,7 @@ public:
             buf.writeByte(' ');
         }
         TypeFunction tf = cast(TypeFunction)f.type;
-        // Don't print tf->mod, tf->trust, and tf->linkage
+        // Don't print tf.mod, tf.trust, and tf.linkage
         if (!f.inferRetType && tf.next)
             typeToBuffer(tf.next, null);
         parametersToBuffer(tf.parameters, tf.varargs);
@@ -2064,7 +2064,7 @@ public:
         }
         assert(precedence[e.op] != PREC.zero);
         assert(pr != PREC.zero);
-        //if (precedence[e->op] == 0) e->print();
+        //if (precedence[e.op] == 0) e.print();
         /* Despite precedence, we don't allow a<b<c expressions.
          * They must be parenthesized.
          */
@@ -2472,7 +2472,7 @@ public:
     override void visit(FuncExp e)
     {
         e.fd.accept(this);
-        //buf->writestring(e->fd->toChars());
+        //buf.writestring(e.fd.toChars());
     }
 
     override void visit(DeclarationExp e)

--- a/src/init.d
+++ b/src/init.d
@@ -865,7 +865,7 @@ extern (C++) final class ExpInitializer : Initializer
 
     override Initializer semantic(Scope* sc, Type t, NeedInterpret needInterpret)
     {
-        //printf("ExpInitializer::semantic(%s), type = %s\n", exp->toChars(), t->toChars());
+        //printf("ExpInitializer::semantic(%s), type = %s\n", exp.toChars(), t.toChars());
         if (needInterpret)
             sc = sc.startCTFE();
         exp = exp.semantic(sc);
@@ -998,7 +998,7 @@ extern (C++) final class ExpInitializer : Initializer
             exp = exp.ctfeInterpret();
         else
             exp = exp.optimize(WANTvalue);
-        //printf("-ExpInitializer::semantic(): "); exp->print();
+        //printf("-ExpInitializer::semantic(): "); exp.print();
         return this;
     }
 
@@ -1006,7 +1006,7 @@ extern (C++) final class ExpInitializer : Initializer
     {
         if (t)
         {
-            //printf("ExpInitializer::toExpression(t = %s) exp = %s\n", t->toChars(), exp->toChars());
+            //printf("ExpInitializer::toExpression(t = %s) exp = %s\n", t.toChars(), exp.toChars());
             Type tb = t.toBasetype();
             Expression e = (exp.op == TOKconstruct || exp.op == TOKblit) ? (cast(AssignExp)exp).e2 : exp;
             if (tb.ty == Tsarray && e.implicitConvTo(tb.nextOf()))

--- a/src/lexer.d
+++ b/src/lexer.d
@@ -497,7 +497,7 @@ class Lexer
                                 p++;
                         }
                     }
-                    //printf("t->value = %d\n",t->value);
+                    //printf("t.value = %d\n",t.value);
                     return;
                 }
             case '/':
@@ -1066,7 +1066,7 @@ class Lexer
         while (1)
         {
             tk = peek(tk);
-            //tk->print();
+            //tk.print();
             switch (tk.value)
             {
             case TOKlparen:
@@ -1449,7 +1449,7 @@ class Lexer
                     else
                     {
                         hereid = tok.ident;
-                        //printf("hereid = '%s'\n", hereid->toChars());
+                        //printf("hereid = '%s'\n", hereid.toChars());
                         blankrol = 1;
                     }
                     nest = 0;
@@ -1489,7 +1489,7 @@ class Lexer
                     auto psave = p;
                     p--;
                     scan(&tok); // read in possible heredoc identifier
-                    //printf("endid = '%s'\n", tok.ident->toChars());
+                    //printf("endid = '%s'\n", tok.ident.toChars());
                     if (tok.value == TOKidentifier && tok.ident.equals(hereid))
                     {
                         /* should check that rest of line is blank
@@ -2319,7 +2319,7 @@ class Lexer
     }
 
     /***************************************************
-     * Parse doc comment embedded between t->ptr and p.
+     * Parse doc comment embedded between t.ptr and p.
      * Remove trailing blanks and tabs from lines.
      * Replace all newlines with \n.
      * Remove leading comment character from each line.

--- a/src/libelf.d
+++ b/src/libelf.d
@@ -225,7 +225,7 @@ final class LibElf : Library
                     if (m == objmodules.dim)
                         return corrupt(__LINE__);  // didn't find it
                     ElfObjModule* om = objmodules[m];
-                    //printf("\t%x\n", (char *)om->base - (char *)buf);
+                    //printf("\t%x\n", (char *)om.base - (char *)buf);
                     if (moff + ElfLibHeader.sizeof == cast(char*)om.base - cast(char*)buf)
                     {
                         addSymbol(om, name, 1);
@@ -430,7 +430,7 @@ private:
         }
         static if (LOG)
         {
-            printf("\tlibbuf->moffset = x%x\n", libbuf.offset);
+            printf("\tlibbuf.moffset = x%x\n", libbuf.offset);
         }
         /* Write out the string section
          */
@@ -473,7 +473,7 @@ private:
         }
         static if (LOG)
         {
-            printf("moffset = x%x, libbuf->offset = x%x\n", moffset, libbuf.offset);
+            printf("moffset = x%x, libbuf.offset = x%x\n", moffset, libbuf.offset);
         }
         assert(libbuf.offset == moffset);
     }

--- a/src/libmach.d
+++ b/src/libmach.d
@@ -180,7 +180,7 @@ final class LibMach : Library
                     if (m == objmodules.dim)
                         return corrupt(__LINE__);       // didn't find it
                     MachObjModule* om = objmodules[m];
-                    //printf("\tom offset = x%x\n", (char *)om->base - (char *)buf);
+                    //printf("\tom offset = x%x\n", (char *)om.base - (char *)buf);
                     if (moff == cast(char*)om.base - cast(char*)buf)
                     {
                         addSymbol(om, name[0 .. namelen], 1);
@@ -398,11 +398,11 @@ private:
         }
         while (libbuf.offset & 3)
             libbuf.writeByte(0);
-        //if (libbuf->offset & 4)
-        //    libbuf->write(pad, 4);
+        //if (libbuf.offset & 4)
+        //    libbuf.write(pad, 4);
         static if (LOG)
         {
-            printf("\tlibbuf->moffset = x%x\n", libbuf.offset);
+            printf("\tlibbuf.moffset = x%x\n", libbuf.offset);
         }
         assert(libbuf.offset == hoffset);
         /* Write out each of the object modules
@@ -437,7 +437,7 @@ private:
         }
         static if (LOG)
         {
-            printf("moffset = x%x, libbuf->offset = x%x\n", moffset, libbuf.offset);
+            printf("moffset = x%x, libbuf.offset = x%x\n", moffset, libbuf.offset);
         }
         assert(libbuf.offset == moffset);
     }

--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -149,7 +149,7 @@ final class LibMSCoff : Library
                     return corrupt(__LINE__);
                 if (offset + size > buflen)
                     return corrupt(__LINE__);
-                //printf("header->object_name = '%.*s'\n", MSCOFF_OBJECT_NAME_SIZE, header->object_name);
+                //printf("header.object_name = '%.*s'\n", MSCOFF_OBJECT_NAME_SIZE, header.object_name);
                 if (memcmp(cast(char*)header.object_name, cast(char*)"/               ", MSCOFF_OBJECT_NAME_SIZE) == 0)
                 {
                     if (!flm)
@@ -234,7 +234,7 @@ final class LibMSCoff : Library
                         memcpy(oname, longnames + foff, i);
                         oname[i] = 0;
                         om.name = oname[0 .. i];
-                        //printf("\tname = '%s'\n", om->name);
+                        //printf("\tname = '%s'\n", om.name);
                     }
                     else
                     {
@@ -290,7 +290,7 @@ final class LibMSCoff : Library
                     if (m == objmodules.dim)
                         return corrupt(__LINE__);       // didn't find it
                     MSCoffObjModule* om = objmodules[m];
-                    //printf("\tom offset = x%x\n", (char *)om->base - (char *)buf);
+                    //printf("\tom offset = x%x\n", (char *)om.base - (char *)buf);
                     if (moff == cast(char*)om.base - cast(char*)buf)
                     {
                         addSymbol(om, name, 1);
@@ -482,7 +482,7 @@ private:
         for (size_t i = 0; i < objsymbols.dim; i++)
         {
             MSCoffObjSymbol* os = objsymbols[i];
-            //printf("objsymbols[%d] = '%s', offset = %u\n", i, os->name, os->om->offset);
+            //printf("objsymbols[%d] = '%s', offset = %u\n", i, os.name, os.om.offset);
             if (i)
             {
                 // Should be sorted in module order
@@ -533,7 +533,7 @@ private:
         /*** Write out longnames Member ***/
         if (libbuf.offset & 1)
             libbuf.writeByte('\n');
-        //printf("libbuf %x longnames %x\n", (int)libbuf->offset, (int)LongnamesMemberOffset);
+        //printf("libbuf %x longnames %x\n", (int)libbuf.offset, (int)LongnamesMemberOffset);
         assert(libbuf.offset == LongnamesMemberOffset);
         // header
         memset(&h, ' ', MSCoffLibHeader.sizeof);
@@ -561,7 +561,7 @@ private:
             MSCoffObjModule* om2 = objmodules[i];
             if (libbuf.offset & 1)
                 libbuf.writeByte('\n'); // module alignment
-            //printf("libbuf %x om %x\n", (int)libbuf->offset, (int)om2->offset);
+            //printf("libbuf %x om %x\n", (int)libbuf.offset, (int)om2.offset);
             assert(libbuf.offset == om2.offset);
             if (om2.scan)
             {
@@ -571,13 +571,13 @@ private:
             }
             else
             {
-                // Header is included in om->base[0..length]
+                // Header is included in om.base[0..length]
                 libbuf.write(om2.base, om2.length); // module contents
             }
         }
         static if (LOG)
         {
-            printf("moffset = x%x, libbuf->offset = x%x\n", cast(uint)moffset, cast(uint)libbuf.offset);
+            printf("moffset = x%x, libbuf.offset = x%x\n", cast(uint)moffset, cast(uint)libbuf.offset);
         }
         assert(libbuf.offset == moffset);
     }

--- a/src/libomf.d
+++ b/src/libomf.d
@@ -104,7 +104,7 @@ final class LibOMF : Library
         if (lh.recTyp == 0xF0)
         {
             /* OMF library
-             * The modules are all at buf[g_page_size .. lh->lSymSeek]
+             * The modules are all at buf[g_page_size .. lh.lSymSeek]
              */
             islibrary = 1;
             g_page_size = lh.pagesize + 3;

--- a/src/mars.d
+++ b/src/mars.d
@@ -1359,7 +1359,7 @@ Language changes listed by -transition=id:
             fprintf(global.stdmsg, "parse     %s\n", m.toChars());
         if (!Module.rootModule)
             Module.rootModule = m;
-        m.importedFrom = m; // m->isRoot() == true
+        m.importedFrom = m; // m.isRoot() == true
         if (!global.params.oneobj || modi == 0 || m.isDocFile)
             m.deleteObjFile();
         static if (ASYNCREAD)

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -279,7 +279,7 @@ private Type stripDefaultArgs(Type t)
         tf = cast(TypeFunction)tf.copy();
         tf.parameters = params;
         tf.next = tret;
-        //printf("strip %s\n   <- %s\n", tf->toChars(), t->toChars());
+        //printf("strip %s\n   <- %s\n", tf.toChars(), t.toChars());
         t = tf;
     }
     else if (t.ty == Ttuple)
@@ -305,7 +305,7 @@ private Type stripDefaultArgs(Type t)
         t = t.copy();
         (cast(TypeNext)t).next = n;
     }
-    //printf("strip %s\n", t->toChars());
+    //printf("strip %s\n", t.toChars());
 Lnot:
     return t;
 }
@@ -621,15 +621,15 @@ extern (C++) abstract class Type : RootObject
     override bool equals(RootObject o)
     {
         Type t = cast(Type)o;
-        //printf("Type::equals(%s, %s)\n", toChars(), t->toChars());
+        //printf("Type::equals(%s, %s)\n", toChars(), t.toChars());
         // deco strings are unique
         // and semantic() has been run
         if (this == o || ((t && deco == t.deco) && deco !is null))
         {
-            //printf("deco = '%s', t->deco = '%s'\n", deco, t->deco);
+            //printf("deco = '%s', t.deco = '%s'\n", deco, t.deco);
             return true;
         }
-        //if (deco && t && t->deco) printf("deco = '%s', t->deco = '%s'\n", deco, t->deco);
+        //if (deco && t && t.deco) printf("deco = '%s', t.deco = '%s'\n", deco, t.deco);
         return false;
     }
 
@@ -661,7 +661,7 @@ extern (C++) abstract class Type : RootObject
         {
             printf("Type::covariant(t = %s) %s\n", t.toChars(), toChars());
             printf("deco = %p, %p\n", deco, t.deco);
-            //    printf("ty = %d\n", next->ty);
+            //    printf("ty = %d\n", next.ty);
             printf("mod = %x, %x\n", mod, t.mod);
         }
         if (pstc)
@@ -1030,13 +1030,13 @@ extern (C++) abstract class Type : RootObject
                         printf("t = %s\n", t.toChars());
                 }
                 assert(t.deco);
-                //printf("old value, deco = '%s' %p\n", t->deco, t->deco);
+                //printf("old value, deco = '%s' %p\n", t.deco, t.deco);
             }
             else
             {
                 sv.ptrvalue = cast(char*)(t = stripDefaultArgs(t));
                 deco = t.deco = cast(char*)sv.toDchars();
-                //printf("new value, deco = '%s' %p\n", t->deco, t->deco);
+                //printf("new value, deco = '%s' %p\n", t.deco, t.deco);
             }
         }
         return t;
@@ -1237,7 +1237,7 @@ extern (C++) abstract class Type : RootObject
         uint sz = sizeTy[ty];
         Type t = cast(Type)mem.xmalloc(sz);
         memcpy(cast(void*)t, cast(void*)this, sz);
-        // t->mod = NULL;  // leave mod unchanged
+        // t.mod = NULL;  // leave mod unchanged
         t.deco = null;
         t.arrayof = null;
         t.pto = null;
@@ -1275,7 +1275,7 @@ extern (C++) abstract class Type : RootObject
         Type t = makeConst();
         t = t.merge();
         t.fixTo(this);
-        //printf("-Type::constOf() %p %s\n", t, t->toChars());
+        //printf("-Type::constOf() %p %s\n", t, t.toChars());
         return t;
     }
 
@@ -1449,7 +1449,7 @@ extern (C++) abstract class Type : RootObject
         Type t = makeWild();
         t = t.merge();
         t.fixTo(this);
-        //printf("\t%p %s\n", t, t->toChars());
+        //printf("\t%p %s\n", t, t.toChars());
         return t;
     }
 
@@ -1466,7 +1466,7 @@ extern (C++) abstract class Type : RootObject
         Type t = makeWildConst();
         t = t.merge();
         t.fixTo(this);
-        //printf("\t%p %s\n", t, t->toChars());
+        //printf("\t%p %s\n", t, t.toChars());
         return t;
     }
 
@@ -1483,7 +1483,7 @@ extern (C++) abstract class Type : RootObject
         Type t = makeSharedWild();
         t = t.merge();
         t.fixTo(this);
-        //printf("\t%p %s\n", t, t->toChars());
+        //printf("\t%p %s\n", t, t.toChars());
         return t;
     }
 
@@ -1500,7 +1500,7 @@ extern (C++) abstract class Type : RootObject
         Type t = makeSharedWildConst();
         t = t.merge();
         t.fixTo(this);
-        //printf("\t%p %s\n", t, t->toChars());
+        //printf("\t%p %s\n", t, t.toChars());
         return t;
     }
 
@@ -1511,7 +1511,7 @@ extern (C++) abstract class Type : RootObject
     final void fixTo(Type t)
     {
         // If fixing this: immutable(T*) by t: immutable(T)*,
-        // cache t to this->xto won't break transitivity.
+        // cache t to this.xto won't break transitivity.
         Type mto = null;
         Type tn = nextOf();
         if (!tn || ty != Tsarray && tn.mod == t.nextOf().mod)
@@ -1629,7 +1629,7 @@ extern (C++) abstract class Type : RootObject
 
         check();
         t.check();
-        //printf("fixTo: %s, %s\n", toChars(), t->toChars());
+        //printf("fixTo: %s, %s\n", toChars(), t.toChars());
     }
 
     /***************************
@@ -2314,7 +2314,7 @@ extern (C++) abstract class Type : RootObject
     {
         //printf("Type::implicitConvTo(this=%p, to=%p)\n", this, to);
         //printf("from: %s\n", toChars());
-        //printf("to  : %s\n", to->toChars());
+        //printf("to  : %s\n", to.toChars());
         if (this.equals(to))
             return MATCHexact;
         return MATCHnomatch;
@@ -2330,7 +2330,7 @@ extern (C++) abstract class Type : RootObject
      */
     MATCH constConv(Type to)
     {
-        //printf("Type::constConv(this = %s, to = %s)\n", toChars(), to->toChars());
+        //printf("Type::constConv(this = %s, to = %s)\n", toChars(), to.toChars());
         if (equals(to))
             return MATCHexact;
         if (ty == to.ty && MODimplicitConv(mod, to.mod))
@@ -2343,7 +2343,7 @@ extern (C++) abstract class Type : RootObject
      */
     ubyte deduceWild(Type t, bool isRef)
     {
-        //printf("Type::deduceWild this = '%s', tprm = '%s'\n", toChars(), tprm->toChars());
+        //printf("Type::deduceWild this = '%s', tprm = '%s'\n", toChars(), tprm.toChars());
         if (t.isWild())
         {
             if (isImmutable())
@@ -2445,7 +2445,7 @@ extern (C++) abstract class Type : RootObject
         if (isShared())
             t = t.addMod(MODshared);
 
-        //printf("-Type::substWildTo t = %s\n", t->toChars());
+        //printf("-Type::substWildTo t = %s\n", t.toChars());
         return t;
     }
 
@@ -2582,7 +2582,7 @@ extern (C++) abstract class Type : RootObject
     }
 
     /***************************************
-     * Access the members of the object e. This type is same as e->type.
+     * Access the members of the object e. This type is same as e.type.
      * Params:
      *  flag = DotExpFlag bit flags
      * Returns:
@@ -2636,7 +2636,7 @@ extern (C++) abstract class Type : RootObject
         }
         if (ident == Id.stringof)
         {
-            /* Bugzilla 3796: this should demangle e->type->deco rather than
+            /* Bugzilla 3796: this should demangle e.type.deco rather than
              * pretty-printing the type.
              */
             const s = e.toChars();
@@ -3175,7 +3175,7 @@ extern (C++) abstract class TypeNext : Type
                     t.next = next.constOf();
             }
         }
-        //printf("TypeNext::makeConst() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeConst() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
@@ -3221,7 +3221,7 @@ extern (C++) abstract class TypeNext : Type
                     t.next = next.sharedOf();
             }
         }
-        //printf("TypeNext::makeShared() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeShared() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
@@ -3241,7 +3241,7 @@ extern (C++) abstract class TypeNext : Type
             else
                 t.next = next.sharedConstOf();
         }
-        //printf("TypeNext::makeSharedConst() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeSharedConst() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
@@ -3271,7 +3271,7 @@ extern (C++) abstract class TypeNext : Type
                     t.next = next.wildOf();
             }
         }
-        //printf("TypeNext::makeWild() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeWild() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
@@ -3291,7 +3291,7 @@ extern (C++) abstract class TypeNext : Type
             else
                 t.next = next.wildConstOf();
         }
-        //printf("TypeNext::makeWildConst() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeWildConst() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
@@ -3311,7 +3311,7 @@ extern (C++) abstract class TypeNext : Type
             else
                 t.next = next.sharedWildOf();
         }
-        //printf("TypeNext::makeSharedWild() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeSharedWild() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
@@ -3328,7 +3328,7 @@ extern (C++) abstract class TypeNext : Type
         {
             t.next = next.sharedWildConstOf();
         }
-        //printf("TypeNext::makeSharedWildConst() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeSharedWildConst() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
@@ -3340,13 +3340,13 @@ extern (C++) abstract class TypeNext : Type
         {
             t.next = next.mutableOf();
         }
-        //printf("TypeNext::makeMutable() returns %p, %s\n", t, t->toChars());
+        //printf("TypeNext::makeMutable() returns %p, %s\n", t, t.toChars());
         return t;
     }
 
     override MATCH constConv(Type to)
     {
-        //printf("TypeNext::constConv from = %s, to = %s\n", toChars(), to->toChars());
+        //printf("TypeNext::constConv from = %s, to = %s\n", toChars(), to.toChars());
         if (equals(to))
             return MATCHexact;
 
@@ -3367,7 +3367,7 @@ extern (C++) abstract class TypeNext : Type
         }
         else
         {
-            //printf("\tnext => %s, to->next => %s\n", next->toChars(), tn->toChars());
+            //printf("\tnext => %s, to.next => %s\n", next.toChars(), tn.toChars());
             m = next.equals(tn) ? MATCHconst : MATCHnomatch;
         }
         return m;
@@ -3649,7 +3649,7 @@ extern (C++) final class TypeBasic : Type
         Expression e;
         dinteger_t ivalue;
         real_t fvalue = 0;
-        //printf("TypeBasic::getProperty('%s')\n", ident->toChars());
+        //printf("TypeBasic::getProperty('%s')\n", ident.toChars());
         if (ident == Id.max)
         {
             switch (ty)
@@ -4149,7 +4149,7 @@ extern (C++) final class TypeBasic : Type
 
     override MATCH implicitConvTo(Type to)
     {
-        //printf("TypeBasic::implicitConvTo(%s) from %s\n", to->toChars(), toChars());
+        //printf("TypeBasic::implicitConvTo(%s) from %s\n", to.toChars(), toChars());
         if (this == to)
             return MATCHexact;
 
@@ -4199,7 +4199,7 @@ extern (C++) final class TypeBasic : Type
                     return MATCHnomatch;
                 /* Can't change sign if same size
                  */
-                //if (sz == tosz && (flags ^ tob->flags) & TFLAGSunsigned)
+                //if (sz == tosz && (flags ^ tob.flags) & TFLAGSunsigned)
                 //    return MATCHnomatch;
             }
         }
@@ -4402,7 +4402,7 @@ extern (C++) final class TypeVector : Type
         }
         if (ident == Id.array)
         {
-            //e = e->castTo(sc, basetype);
+            //e = e.castTo(sc, basetype);
             // Keep lvalue-ness
             e = e.copy();
             e.type = basetype;
@@ -4446,7 +4446,7 @@ extern (C++) final class TypeVector : Type
 
     override MATCH implicitConvTo(Type to)
     {
-        //printf("TypeVector::implicitConvTo(%s) from %s\n", to->toChars(), toChars());
+        //printf("TypeVector::implicitConvTo(%s) from %s\n", to.toChars(), toChars());
         if (this == to)
             return MATCHexact;
         if (ty == to.ty)
@@ -4656,7 +4656,7 @@ extern (C++) final class TypeSArray : TypeArray
     extern (D) this(Type t, Expression dim)
     {
         super(Tsarray, t);
-        //printf("TypeSArray(%s)\n", dim->toChars());
+        //printf("TypeSArray(%s)\n", dim.toChars());
         this.dim = dim;
     }
 
@@ -4979,7 +4979,7 @@ extern (C++) final class TypeSArray : TypeArray
 
     override MATCH implicitConvTo(Type to)
     {
-        //printf("TypeSArray::implicitConvTo(to = %s) this = %s\n", to->toChars(), toChars());
+        //printf("TypeSArray::implicitConvTo(to = %s) this = %s\n", to.toChars(), toChars());
         if (to.ty == Tarray)
         {
             TypeDArray ta = cast(TypeDArray)to;
@@ -5072,7 +5072,7 @@ extern (C++) final class TypeSArray : TypeArray
          *    struct S { T* array[0]; }
          * may be a variable length struct.
          */
-        //if (dim->toInteger() == 0)
+        //if (dim.toInteger() == 0)
         //    return false;
 
         if (next.ty == Tvoid)
@@ -5264,7 +5264,7 @@ extern (C++) final class TypeDArray : TypeArray
 
     override MATCH implicitConvTo(Type to)
     {
-        //printf("TypeDArray::implicitConvTo(to = %s) this = %s\n", to->toChars(), toChars());
+        //printf("TypeDArray::implicitConvTo(to = %s) this = %s\n", to.toChars(), toChars());
         if (equals(to))
             return MATCHexact;
 
@@ -5358,7 +5358,7 @@ extern (C++) final class TypeAArray : TypeArray
 
     override Type semantic(Loc loc, Scope* sc)
     {
-        //printf("TypeAArray::semantic() %s index->ty = %d\n", toChars(), index->ty);
+        //printf("TypeAArray::semantic() %s index.ty = %d\n", toChars(), index.ty);
         if (deco)
             return this;
 
@@ -5401,12 +5401,12 @@ extern (C++) final class TypeAArray : TypeArray
             {
                 printf("index is %p %s\n", index, index.toChars());
                 index.check();
-                printf("index->mod = x%x\n", index.mod);
-                printf("index->ito = x%x\n", index.ito);
+                printf("index.mod = x%x\n", index.mod);
+                printf("index.ito = x%x\n", index.ito);
                 if (index.ito)
                 {
-                    printf("index->ito->mod = x%x\n", index.ito.mod);
-                    printf("index->ito->ito = x%x\n", index.ito.ito);
+                    printf("index.ito.mod = x%x\n", index.ito.mod);
+                    printf("index.ito.ito = x%x\n", index.ito.ito);
                 }
             }
         }
@@ -5444,11 +5444,11 @@ extern (C++) final class TypeAArray : TypeArray
                     sd.xeq = sd.xerreq;
             }
 
-            //printf("AA = %s, key: xeq = %p, xhash = %p\n", toChars(), sd->xeq, sd->xhash);
+            //printf("AA = %s, key: xeq = %p, xhash = %p\n", toChars(), sd.xeq, sd.xhash);
             const(char)* s = (index.toBasetype().ty != Tstruct) ? "bottom of " : "";
             if (!sd.xeq)
             {
-                // If sd->xhash != NULL:
+                // If sd.xhash != NULL:
                 //   sd or its fields have user-defined toHash.
                 //   AA assumes that its result is consistent with bitwise equality.
                 // else:
@@ -5643,7 +5643,7 @@ extern (C++) final class TypeAArray : TypeArray
 
     override MATCH implicitConvTo(Type to)
     {
-        //printf("TypeAArray::implicitConvTo(to = %s) this = %s\n", to->toChars(), toChars());
+        //printf("TypeAArray::implicitConvTo(to = %s) this = %s\n", to.toChars(), toChars());
         if (equals(to))
             return MATCHexact;
 
@@ -5761,7 +5761,7 @@ extern (C++) final class TypePointer : TypeNext
 
     override MATCH implicitConvTo(Type to)
     {
-        //printf("TypePointer::implicitConvTo(to = %s) %s\n", to->toChars(), toChars());
+        //printf("TypePointer::implicitConvTo(to = %s) %s\n", to.toChars(), toChars());
         if (equals(to))
             return MATCHexact;
 
@@ -6083,7 +6083,7 @@ extern (C++) final class TypeFunction : TypeNext
             return this;
         }
         //printf("TypeFunction::semantic() this = %p\n", this);
-        //printf("TypeFunction::semantic() %s, sc->stc = %llx, fargs = %p\n", toChars(), sc->stc, fargs);
+        //printf("TypeFunction::semantic() %s, sc.stc = %llx, fargs = %p\n", toChars(), sc.stc, fargs);
 
         bool errors = false;
 
@@ -6299,7 +6299,7 @@ extern (C++) final class TypeFunction : TypeNext
                 if (t.hasWild())
                 {
                     wildparams |= 1;
-                    //if (tf->next && !wildreturn)
+                    //if (tf.next && !wildreturn)
                     //    error(loc, "inout on parameter means inout must be on return type as well (if from D1 code, replace with 'ref')");
                 }
 
@@ -6861,7 +6861,7 @@ extern (C++) final class TypeFunction : TypeNext
             {
                 Expression arg = (*args)[u];
                 assert(arg);
-                //printf("arg: %s, type: %s\n", arg->toChars(), arg->type->toChars());
+                //printf("arg: %s, type: %s\n", arg.toChars(), arg.type.toChars());
 
                 Type targ = arg.type;
                 Type tprm = wildmatch ? p.type.substWildTo(wildmatch) : p.type;
@@ -6870,7 +6870,7 @@ extern (C++) final class TypeFunction : TypeNext
                     m = MATCHconvert;
                 else
                 {
-                    //printf("%s of type %s implicitConvTo %s\n", arg->toChars(), targ->toChars(), tprm->toChars());
+                    //printf("%s of type %s implicitConvTo %s\n", arg.toChars(), targ.toChars(), tprm.toChars());
                     if (flag)
                     {
                         // for partial ordering, value is an irrelevant mockup, just look at the type
@@ -6887,7 +6887,7 @@ extern (C++) final class TypeFunction : TypeNext
                     // Bugzilla 13783: Don't use toBasetype() to handle enum types.
                     Type ta = targ;
                     Type tp = tprm;
-                    //printf("fparam[%d] ta = %s, tp = %s\n", u, ta->toChars(), tp->toChars());
+                    //printf("fparam[%d] ta = %s, tp = %s\n", u, ta.toChars(), tp.toChars());
 
                     if (m && !arg.isLvalue())
                     {
@@ -7134,7 +7134,7 @@ extern (C++) final class TypeDelegate : TypeNext
     {
         //printf("TypeDelegate::implicitConvTo(this=%p, to=%p)\n", this, to);
         //printf("from: %s\n", toChars());
-        //printf("to  : %s\n", to->toChars());
+        //printf("to  : %s\n", to.toChars());
         if (this == to)
             return MATCHexact;
 
@@ -7239,7 +7239,7 @@ extern (C++) abstract class TypeQualified : Type
 
     final void syntaxCopyHelper(TypeQualified t)
     {
-        //printf("TypeQualified::syntaxCopyHelper(%s) %s\n", t->toChars(), toChars());
+        //printf("TypeQualified::syntaxCopyHelper(%s) %s\n", t.toChars(), toChars());
         idents.setDim(t.idents.dim);
         for (size_t i = 0; i < idents.dim; i++)
         {
@@ -7412,14 +7412,14 @@ extern (C++) abstract class TypeQualified : Type
         *ps = null;
         if (s)
         {
-            //printf("\t1: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
+            //printf("\t1: s = '%s' %p, kind = '%s'\n",s.toChars(), s, s.kind());
             Declaration d = s.isDeclaration();
             if (d && (d.storage_class & STCtemplateparameter))
                 s = s.toAlias();
             else
                 s.checkDeprecated(loc, sc); // check for deprecated aliases
             s = s.toAlias();
-            //printf("\t2: s = '%s' %p, kind = '%s'\n",s->toChars(), s, s->kind());
+            //printf("\t2: s = '%s' %p, kind = '%s'\n",s.toChars(), s, s.kind());
             for (size_t i = 0; i < idents.dim; i++)
             {
                 RootObject id = idents[i];
@@ -7458,7 +7458,7 @@ extern (C++) abstract class TypeQualified : Type
                     *pt = Type.terror;
                     return;
                 }
-                //printf("\t3: s = %p %s %s, sm = %p\n", s, s->kind(), s->toChars(), sm);
+                //printf("\t3: s = %p %s %s, sm = %p\n", s, s.kind(), s.toChars(), sm);
                 if (intypeid && !t && sm && sm.needThis())
                     goto L3;
                 if (VarDeclaration v = s.isVarDeclaration())
@@ -7743,7 +7743,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
         resolve(loc, sc, &e, &t, &s);
         if (t)
         {
-            //printf("\tit's a type %d, %s, %s\n", t->ty, t->toChars(), t->deco);
+            //printf("\tit's a type %d, %s, %s\n", t.ty, t.toChars(), t.deco);
             t = t.addMod(mod);
         }
         else
@@ -7757,7 +7757,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
                 error(loc, "%s is used as a type", toChars());
             t = terror;
         }
-        //t->print();
+        //t.print();
         return t;
     }
 
@@ -8553,7 +8553,7 @@ extern (C++) final class TypeStruct : Type
         for (size_t i = 0; i < sym.fields.dim; i++)
         {
             VarDeclaration v = sym.fields[i];
-            //printf("%s [%d] v = (%s) %s, v->offset = %d, v->parent = %s", sym->toChars(), i, v->kind(), v->toChars(), v->offset, v->parent->kind());
+            //printf("%s [%d] v = (%s) %s, v.offset = %d, v.parent = %s", sym.toChars(), i, v.kind(), v.toChars(), v.offset, v.parent.kind());
             if (i == 0)
             {
             }
@@ -8678,7 +8678,7 @@ extern (C++) final class TypeStruct : Type
 
                         // field match
                         MATCH mf = tvf.implicitConvTo(tv);
-                        //printf("\t%s => %s, match = %d\n", v->type->toChars(), tv->toChars(), mf);
+                        //printf("\t%s => %s, match = %d\n", v.type.toChars(), tv.toChars(), mf);
 
                         if (mf <= MATCHnomatch)
                             return mf;
@@ -9430,7 +9430,7 @@ extern (C++) final class TypeClass : Type
                         e1.type = tcd.vthis.type;
                         e1.type = e1.type.addMod(t.mod);
                         // Do not call checkNestedRef()
-                        //e1 = e1->semantic(sc);
+                        //e1 = e1.semantic(sc);
 
                         // Skip up over nested functions, and get the enclosing
                         // class type.
@@ -9440,7 +9440,7 @@ extern (C++) final class TypeClass : Type
                             FuncDeclaration f = s.isFuncDeclaration();
                             if (f.vthis)
                             {
-                                //printf("rewriting e1 to %s's this\n", f->toChars());
+                                //printf("rewriting e1 to %s's this\n", f.toChars());
                                 n++;
                                 e1 = new VarExp(e.loc, f.vthis);
                             }
@@ -9463,7 +9463,7 @@ extern (C++) final class TypeClass : Type
                     }
                 }
             }
-            //printf("e = %s, d = %s\n", e->toChars(), d->toChars());
+            //printf("e = %s, d = %s\n", e.toChars(), d.toChars());
             if (d.semanticRun == PASSinit && d._scope)
                 d.semantic(d._scope);
             checkAccess(e.loc, sc, e, d);
@@ -9507,7 +9507,7 @@ extern (C++) final class TypeClass : Type
 
     override MATCH implicitConvTo(Type to)
     {
-        //printf("TypeClass::implicitConvTo(to = '%s') %s\n", to->toChars(), toChars());
+        //printf("TypeClass::implicitConvTo(to = '%s') %s\n", to.toChars(), toChars());
         MATCH m = constConv(to);
         if (m > MATCHnomatch)
             return m;
@@ -9515,7 +9515,7 @@ extern (C++) final class TypeClass : Type
         ClassDeclaration cdto = to.isClassHandle();
         if (cdto)
         {
-            //printf("TypeClass::implicitConvTo(to = '%s') %s, isbase = %d %d\n", to->toChars(), toChars(), cdto->isBaseInfoComplete(), sym->isBaseInfoComplete());
+            //printf("TypeClass::implicitConvTo(to = '%s') %s, isbase = %d %d\n", to.toChars(), toChars(), cdto.isBaseInfoComplete(), sym.isBaseInfoComplete());
             if (cdto._scope && !cdto.isBaseInfoComplete())
                 cdto.semantic(null);
             if (sym._scope && !sym.isBaseInfoComplete())
@@ -9725,7 +9725,7 @@ extern (C++) final class TypeTuple : Type
     override bool equals(RootObject o)
     {
         Type t = cast(Type)o;
-        //printf("TypeTuple::equals(%s, %s)\n", toChars(), t->toChars());
+        //printf("TypeTuple::equals(%s, %s)\n", toChars(), t.toChars());
         if (this == t)
             return true;
         if (t.ty == Ttuple)
@@ -9806,7 +9806,7 @@ extern (C++) final class TypeSlice : TypeNext
     extern (D) this(Type next, Expression lwr, Expression upr)
     {
         super(Tslice, next);
-        //printf("TypeSlice[%s .. %s]\n", lwr->toChars(), upr->toChars());
+        //printf("TypeSlice[%s .. %s]\n", lwr.toChars(), upr.toChars());
         this.lwr = lwr;
         this.upr = upr;
     }
@@ -9827,7 +9827,7 @@ extern (C++) final class TypeSlice : TypeNext
     {
         //printf("TypeSlice::semantic() %s\n", toChars());
         Type tn = next.semantic(loc, sc);
-        //printf("next: %s\n", tn->toChars());
+        //printf("next: %s\n", tn.toChars());
 
         Type tbn = tn.toBasetype();
         if (tbn.ty != Ttuple)
@@ -9966,13 +9966,13 @@ extern (C++) final class TypeNull : Type
     {
         //printf("TypeNull::implicitConvTo(this=%p, to=%p)\n", this, to);
         //printf("from: %s\n", toChars());
-        //printf("to  : %s\n", to->toChars());
+        //printf("to  : %s\n", to.toChars());
         MATCH m = Type.implicitConvTo(to);
         if (m != MATCHnomatch)
             return m;
 
         // NULL implicitly converts to any pointer type or dynamic array
-        //if (type->ty == Tpointer && type->nextOf()->ty == Tvoid)
+        //if (type.ty == Tpointer && type.nextOf()->ty == Tvoid)
         {
             Type tb = to.toBasetype();
             if (tb.ty == Tnull || tb.ty == Tpointer || tb.ty == Tarray || tb.ty == Taarray || tb.ty == Tclass || tb.ty == Tdelegate)

--- a/src/nspace.d
+++ b/src/nspace.d
@@ -30,7 +30,7 @@ extern (C++) final class Nspace : ScopeDsymbol
     extern (D) this(Loc loc, Identifier ident, Dsymbols* members)
     {
         super(ident);
-        //printf("Nspace::Nspace(ident = %s)\n", ident->toChars());
+        //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());
         this.loc = loc;
         this.members = members;
     }
@@ -64,7 +64,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             sc.parent = this;
             foreach (s; *members)
             {
-                //printf("add %s to scope %s\n", s->toChars(), toChars());
+                //printf("add %s to scope %s\n", s.toChars(), toChars());
                 s.addMember(sc, this);
             }
             sc.pop();
@@ -223,7 +223,7 @@ extern (C++) final class Nspace : ScopeDsymbol
         {
             foreach (s; *members)
             {
-                //printf(" s = %s %s\n", s->kind(), s->toChars());
+                //printf(" s = %s %s\n", s.kind(), s.toChars());
                 if (s.hasPointers())
                 {
                     return true;
@@ -242,7 +242,7 @@ extern (C++) final class Nspace : ScopeDsymbol
         {
             foreach (s; *members)
             {
-                //printf("\t%s\n", s->toChars());
+                //printf("\t%s\n", s.toChars());
                 s.setFieldOffset(ad, poffset, isunion);
             }
         }

--- a/src/opover.d
+++ b/src/opover.d
@@ -462,7 +462,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
         override void visit(UnaExp e)
         {
-            //printf("UnaExp::op_overload() (%s)\n", e->toChars());
+            //printf("UnaExp::op_overload() (%s)\n", e.toChars());
             if (e.e1.op == TOKarray)
             {
                 ArrayExp ae = cast(ArrayExp)e.e1;
@@ -598,7 +598,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     /* Rewrite op(e1) as:
                      *      op(e1.aliasthis)
                      */
-                    //printf("att una %s e1 = %s\n", Token::toChars(op), this->e1->type->toChars());
+                    //printf("att una %s e1 = %s\n", Token::toChars(op), this.e1.type.toChars());
                     Expression e1 = new DotIdExp(e.loc, e.e1, ad.aliasthis.ident);
                     UnaExp ue = cast(UnaExp)e.copy();
                     if (!ue.att1 && e.e1.type.checkAliasThisRec())
@@ -612,7 +612,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
         override void visit(ArrayExp ae)
         {
-            //printf("ArrayExp::op_overload() (%s)\n", ae->toChars());
+            //printf("ArrayExp::op_overload() (%s)\n", ae.toChars());
             ae.e1 = ae.e1.semantic(sc);
             ae.e1 = resolveProperties(sc, ae.e1);
             Expression ae1old = ae.e1;
@@ -637,7 +637,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 AggregateDeclaration ad = isAggregate(t1b);
                 if (!ad)
                 {
-                    // If the non-aggregate expression ae->e1 is indexable or sliceable,
+                    // If the non-aggregate expression ae.e1 is indexable or sliceable,
                     // convert it to the corresponding concrete expression.
                     if (t1b.ty == Tpointer || t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Taarray ||
                         t1b.ty == Ttuple || t1b.ty == Tvector || ae.e1.op == TOKtype)
@@ -717,7 +717,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 {
                     if (!ae.att1 && t1b.checkAliasThisRec())
                         ae.att1 = t1b;
-                    //printf("att arr e1 = %s\n", this->e1->type->toChars());
+                    //printf("att arr e1 = %s\n", this.e1.type.toChars());
                     /* Rewrite op(a[arguments]) as:
                      *      op(a.aliasthis[arguments])
                      */
@@ -737,7 +737,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
          */
         override void visit(CastExp e)
         {
-            //printf("CastExp::op_overload() (%s)\n", e->toChars());
+            //printf("CastExp::op_overload() (%s)\n", e.toChars());
             AggregateDeclaration ad = isAggregate(e.e1.type);
             if (ad)
             {
@@ -782,7 +782,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
         override void visit(BinExp e)
         {
-            //printf("BinExp::op_overload() (%s)\n", e->toChars());
+            //printf("BinExp::op_overload() (%s)\n", e.toChars());
             Identifier id = opId(e);
             Identifier id_r = opId_r(e);
             Expressions args1;
@@ -1029,7 +1029,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                  */
                 if (e.att1 && e.e1.type == e.att1)
                     return;
-                //printf("att bin e1 = %s\n", this->e1->type->toChars());
+                //printf("att bin e1 = %s\n", this.e1.type.toChars());
                 Expression e1 = new DotIdExp(e.loc, e.e1, ad1.aliasthis.ident);
                 BinExp be = cast(BinExp)e.copy();
                 if (!be.att1 && e.e1.type.checkAliasThisRec())
@@ -1049,7 +1049,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                  */
                 if (e.att2 && e.e2.type == e.att2)
                     return;
-                //printf("att bin e2 = %s\n", e->e2->type->toChars());
+                //printf("att bin e2 = %s\n", e.e2.type.toChars());
                 Expression e2 = new DotIdExp(e.loc, e.e2, ad2.aliasthis.ident);
                 BinExp be = cast(BinExp)e.copy();
                 if (!be.att2 && e.e2.type.checkAliasThisRec())
@@ -1063,7 +1063,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
         override void visit(EqualExp e)
         {
-            //printf("EqualExp::op_overload() (%s)\n", e->toChars());
+            //printf("EqualExp::op_overload() (%s)\n", e.toChars());
             Type t1 = e.e1.type.toBasetype();
             Type t2 = e.e2.type.toBasetype();
 
@@ -1293,7 +1293,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
         override void visit(CmpExp e)
         {
-            //printf("CmpExp::op_overload() (%s)\n", e->toChars());
+            //printf("CmpExp::op_overload() (%s)\n", e.toChars());
             result = compare_overload(e, sc, Id.cmp);
         }
 
@@ -1302,7 +1302,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
          */
         override void visit(BinAssignExp e)
         {
-            //printf("BinAssignExp::op_overload() (%s)\n", e->toChars());
+            //printf("BinAssignExp::op_overload() (%s)\n", e.toChars());
             if (e.e1.op == TOKarray)
             {
                 ArrayExp ae = cast(ArrayExp)e.e1;
@@ -1491,7 +1491,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                  */
                 if (e.att1 && e.e1.type == e.att1)
                     return;
-                //printf("att %s e1 = %s\n", Token::toChars(e->op), e->e1->type->toChars());
+                //printf("att %s e1 = %s\n", Token::toChars(e.op), e.e1.type.toChars());
                 Expression e1 = new DotIdExp(e.loc, e.e1, ad1.aliasthis.ident);
                 BinExp be = cast(BinExp)e.copy();
                 if (!be.att1 && e.e1.type.checkAliasThisRec())
@@ -1509,7 +1509,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                  */
                 if (e.att2 && e.e2.type == e.att2)
                     return;
-                //printf("att %s e2 = %s\n", Token::toChars(e->op), e->e2->type->toChars());
+                //printf("att %s e2 = %s\n", Token::toChars(e.op), e.e2.type.toChars());
                 Expression e2 = new DotIdExp(e.loc, e.e2, ad2.aliasthis.ident);
                 BinExp be = cast(BinExp)e.copy();
                 if (!be.att2 && e.e2.type.checkAliasThisRec())
@@ -1531,7 +1531,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
  */
 extern (C++) Expression compare_overload(BinExp e, Scope* sc, Identifier id)
 {
-    //printf("BinExp::compare_overload(id = %s) %s\n", id->toChars(), e->toChars());
+    //printf("BinExp::compare_overload(id = %s) %s\n", id.toChars(), e.toChars());
     AggregateDeclaration ad1 = isAggregate(e.e1.type);
     AggregateDeclaration ad2 = isAggregate(e.e2.type);
     Dsymbol s = null;
@@ -1646,7 +1646,7 @@ extern (C++) Expression compare_overload(BinExp e, Scope* sc, Identifier id)
          */
         if (e.att1 && e.e1.type == e.att1)
             return null;
-        //printf("att cmp_bin e1 = %s\n", e->e1->type->toChars());
+        //printf("att cmp_bin e1 = %s\n", e.e1.type.toChars());
         Expression e1 = new DotIdExp(e.loc, e.e1, ad1.aliasthis.ident);
         BinExp be = cast(BinExp)e.copy();
         if (!be.att1 && e.e1.type.checkAliasThisRec())
@@ -1662,7 +1662,7 @@ extern (C++) Expression compare_overload(BinExp e, Scope* sc, Identifier id)
          */
         if (e.att2 && e.e2.type == e.att2)
             return null;
-        //printf("att cmp_bin e2 = %s\n", e->e2->type->toChars());
+        //printf("att cmp_bin e2 = %s\n", e.e2.type.toChars());
         Expression e2 = new DotIdExp(e.loc, e.e2, ad2.aliasthis.ident);
         BinExp be = cast(BinExp)e.copy();
         if (!be.att2 && e.e2.type.checkAliasThisRec())
@@ -1680,9 +1680,9 @@ extern (C++) Expression build_overload(Loc loc, Scope* sc, Expression ethis, Exp
 {
     assert(d);
     Expression e;
-    //printf("build_overload(id = '%s')\n", id->toChars());
-    //earg->print();
-    //earg->type->print();
+    //printf("build_overload(id = '%s')\n", id.toChars());
+    //earg.print();
+    //earg.type.print();
     Declaration decl = d.isDeclaration();
     if (decl)
         e = new DotVarExp(loc, ethis, decl, false);
@@ -1701,9 +1701,9 @@ extern (C++) Dsymbol search_function(ScopeDsymbol ad, Identifier funcid)
     Dsymbol s = ad.search(Loc(), funcid);
     if (s)
     {
-        //printf("search_function: s = '%s'\n", s->kind());
+        //printf("search_function: s = '%s'\n", s.kind());
         Dsymbol s2 = s.toAlias();
-        //printf("search_function: s2 = '%s'\n", s2->kind());
+        //printf("search_function: s2 = '%s'\n", s2.kind());
         FuncDeclaration fd = s2.isFuncDeclaration();
         if (fd && fd.type.ty == Tfunction)
             return fd;

--- a/src/optimize.d
+++ b/src/optimize.d
@@ -135,7 +135,7 @@ extern (C++) Expression expandVar(int result, VarDeclaration v)
         }
     }
 L1:
-    //if (e) printf("\te = %p, %s, e->type = %d, %s\n", e, e->toChars(), e->type->ty, e->type->toChars());
+    //if (e) printf("\te = %p, %s, e.type = %d, %s\n", e, e.toChars(), e.type.ty, e.type.toChars());
     return e;
 Lerror:
     return new ErrorExp();
@@ -226,7 +226,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(Expression e)
         {
-            //printf("Expression::optimize(result = x%x) %s\n", result, e->toChars());
+            //printf("Expression::optimize(result = x%x) %s\n", result, e.toChars());
         }
 
         override void visit(VarExp e)
@@ -289,7 +289,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(UnaExp e)
         {
-            //printf("UnaExp::optimize() %s\n", e->toChars());
+            //printf("UnaExp::optimize() %s\n", e.toChars());
             if (unaOptimize(e, result))
                 return;
         }
@@ -331,7 +331,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(AddrExp e)
         {
-            //printf("AddrExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("AddrExp::optimize(result = %d) %s\n", result, e.toChars());
             /* Rewrite &(a,b) as (a,&b)
              */
             if (e.e1.op == TOKcomma)
@@ -407,7 +407,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(PtrExp e)
         {
-            //printf("PtrExp::optimize(result = x%x) %s\n", result, e->toChars());
+            //printf("PtrExp::optimize(result = x%x) %s\n", result, e.toChars());
             if (expOptimize(e.e1, result))
                 return;
             // Convert *&ex to ex
@@ -455,7 +455,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(DotVarExp e)
         {
-            //printf("DotVarExp::optimize(result = x%x) %s\n", result, e->toChars());
+            //printf("DotVarExp::optimize(result = x%x) %s\n", result, e.toChars());
             if (expOptimize(e.e1, result))
                 return;
             if (keepLvalue)
@@ -507,7 +507,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(CallExp e)
         {
-            //printf("CallExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("CallExp::optimize(result = %d) %s\n", result, e.toChars());
             // Optimize parameters with keeping lvalue-ness
             if (expOptimize(e.e1, result))
                 return;
@@ -529,11 +529,11 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(CastExp e)
         {
-            //printf("CastExp::optimize(result = %d) %s\n", result, e->toChars());
-            //printf("from %s to %s\n", e->type->toChars(), e->to->toChars());
-            //printf("from %s\n", e->type->toChars());
-            //printf("e1->type %s\n", e->e1->type->toChars());
-            //printf("type = %p\n", e->type);
+            //printf("CastExp::optimize(result = %d) %s\n", result, e.toChars());
+            //printf("from %s to %s\n", e.type.toChars(), e.to.toChars());
+            //printf("from %s\n", e.type.toChars());
+            //printf("e1.type %s\n", e.e1.type.toChars());
+            //printf("type = %p\n", e.type);
             assert(e.type);
             TOK op1 = e.e1.op;
             Expression e1old = e.e1;
@@ -557,18 +557,18 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 if (e1sz == esz)
                 {
                     // Bugzilla 12937: If target type is void array, trying to paint
-                    // e->e1 with that type will cause infinite recursive optimization.
+                    // e.e1 with that type will cause infinite recursive optimization.
                     if (e.type.nextOf().ty == Tvoid)
                         return;
                     ret = e.e1.castTo(null, e.type);
-                    //printf(" returning1 %s\n", ret->toChars());
+                    //printf(" returning1 %s\n", ret.toChars());
                     return;
                 }
             }
 
             if (e.e1.op == TOKstructliteral && e.e1.type.implicitConvTo(e.type) >= MATCHconst)
             {
-                //printf(" returning2 %s\n", e->e1->toChars());
+                //printf(" returning2 %s\n", e.e1.toChars());
             L1:
                 // Returning e1 with changing its type
                 ret = (e1old == e.e1 ? e.e1.copy() : e.e1);
@@ -584,7 +584,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             }
             if (e.e1.op == TOKnull && (e.type.ty == Tpointer || e.type.ty == Tclass || e.type.ty == Tarray))
             {
-                //printf(" returning3 %s\n", e->e1->toChars());
+                //printf(" returning3 %s\n", e.e1.toChars());
                 goto L1;
             }
             if (e.type.ty == Tclass && e.e1.type.ty == Tclass)
@@ -595,14 +595,14 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 int offset;
                 if (cdto.isBaseOf(cdfrom, &offset) && offset == 0)
                 {
-                    //printf(" returning4 %s\n", e->e1->toChars());
+                    //printf(" returning4 %s\n", e.e1.toChars());
                     goto L1;
                 }
             }
             // We can convert 'head const' to mutable
             if (e.to.mutableOf().constOf().equals(e.e1.type.mutableOf().constOf()))
             {
-                //printf(" returning5 %s\n", e->e1->toChars());
+                //printf(" returning5 %s\n", e.e1.toChars());
                 goto L1;
             }
             if (e.e1.isConst())
@@ -630,12 +630,12 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                         ret = Cast(e.loc, e.type, e.to, e.e1).copy();
                 }
             }
-            //printf(" returning6 %s\n", ret->toChars());
+            //printf(" returning6 %s\n", ret.toChars());
         }
 
         override void visit(BinExp e)
         {
-            //printf("BinExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("BinExp::optimize(result = %d) %s\n", result, e.toChars());
             // don't replace const variable with its initializer in e1
             bool e2only = (e.op == TOKconstruct || e.op == TOKblit);
             if (e2only ? expOptimize(e.e2, result) : binOptimize(e, result))
@@ -659,7 +659,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(AddExp e)
         {
-            //printf("AddExp::optimize(%s)\n", e->toChars());
+            //printf("AddExp::optimize(%s)\n", e.toChars());
             if (binOptimize(e, result))
                 return;
             if (e.e1.isConst() && e.e2.isConst())
@@ -684,7 +684,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(MulExp e)
         {
-            //printf("MulExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("MulExp::optimize(result = %d) %s\n", result, e.toChars());
             if (binOptimize(e, result))
                 return;
             if (e.e1.isConst() == 1 && e.e2.isConst() == 1)
@@ -695,7 +695,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(DivExp e)
         {
-            //printf("DivExp::optimize(%s)\n", e->toChars());
+            //printf("DivExp::optimize(%s)\n", e.toChars());
             if (binOptimize(e, result))
                 return;
             if (e.e1.isConst() == 1 && e.e2.isConst() == 1)
@@ -736,13 +736,13 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(ShlExp e)
         {
-            //printf("ShlExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("ShlExp::optimize(result = %d) %s\n", result, e.toChars());
             shift_optimize(e, &Shl);
         }
 
         override void visit(ShrExp e)
         {
-            //printf("ShrExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("ShrExp::optimize(result = %d) %s\n", result, e.toChars());
             shift_optimize(e, &Shr);
         }
 
@@ -869,7 +869,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(CommaExp e)
         {
-            //printf("CommaExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("CommaExp::optimize(result = %d) %s\n", result, e.toChars());
             // Comma needs special treatment, because it may
             // contain compiler-generated declarations. We can interpret them, but
             // otherwise we must NOT attempt to constant-fold them.
@@ -885,12 +885,12 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 if (ret)
                     ret.type = e.type;
             }
-            //printf("-CommaExp::optimize(result = %d) %s\n", result, e->e->toChars());
+            //printf("-CommaExp::optimize(result = %d) %s\n", result, e.e.toChars());
         }
 
         override void visit(ArrayLengthExp e)
         {
-            //printf("ArrayLengthExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("ArrayLengthExp::optimize(result = %d) %s\n", result, e.toChars());
             if (unaOptimize(e, WANTexpand))
                 return;
             // CTFE interpret static immutable arrays (to get better diagnostics)
@@ -911,7 +911,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(EqualExp e)
         {
-            //printf("EqualExp::optimize(result = %x) %s\n", result, e->toChars());
+            //printf("EqualExp::optimize(result = %x) %s\n", result, e.toChars());
             if (binOptimize(e, WANTvalue))
                 return;
             Expression e1 = fromConstInitializer(result, e.e1);
@@ -933,7 +933,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(IdentityExp e)
         {
-            //printf("IdentityExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("IdentityExp::optimize(result = %d) %s\n", result, e.toChars());
             if (binOptimize(e, WANTvalue))
                 return;
             if ((e.e1.isConst() && e.e2.isConst()) || (e.e1.op == TOKnull && e.e2.op == TOKnull))
@@ -974,7 +974,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(IndexExp e)
         {
-            //printf("IndexExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("IndexExp::optimize(result = %d) %s\n", result, e.toChars());
             if (expOptimize(e.e1, result & WANTexpand))
                 return;
             Expression ex = fromConstInitializer(result, e.e1);
@@ -991,7 +991,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(SliceExp e)
         {
-            //printf("SliceExp::optimize(result = %d) %s\n", result, e->toChars());
+            //printf("SliceExp::optimize(result = %d) %s\n", result, e.toChars());
             if (expOptimize(e.e1, result & WANTexpand))
                 return;
             if (!e.lwr)
@@ -1028,12 +1028,12 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 e.upr = null;
                 ret = e;
             }
-            //printf("-SliceExp::optimize() %s\n", ret->toChars());
+            //printf("-SliceExp::optimize() %s\n", ret.toChars());
         }
 
         override void visit(AndAndExp e)
         {
-            //printf("AndAndExp::optimize(%d) %s\n", result, e->toChars());
+            //printf("AndAndExp::optimize(%d) %s\n", result, e.toChars());
             if (expOptimize(e.e1, WANTvalue))
                 return;
             if (e.e1.isBool(false))
@@ -1074,7 +1074,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(OrOrExp e)
         {
-            //printf("OrOrExp::optimize(%d) %s\n", result, e->toChars());
+            //printf("OrOrExp::optimize(%d) %s\n", result, e.toChars());
             if (expOptimize(e.e1, WANTvalue))
                 return;
             if (e.e1.isBool(true))
@@ -1115,7 +1115,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(CmpExp e)
         {
-            //printf("CmpExp::optimize() %s\n", e->toChars());
+            //printf("CmpExp::optimize() %s\n", e.toChars());
             if (binOptimize(e, WANTvalue))
                 return;
             Expression e1 = fromConstInitializer(result, e.e1);
@@ -1127,7 +1127,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
 
         override void visit(CatExp e)
         {
-            //printf("CatExp::optimize(%d) %s\n", result, e->toChars());
+            //printf("CatExp::optimize(%d) %s\n", result, e.toChars());
             if (binOptimize(e, result))
                 return;
             if (e.e1.op == TOKcat)

--- a/src/parse.d
+++ b/src/parse.d
@@ -3032,7 +3032,7 @@ final class Parser : Lexer
         else
             error("enum declaration is invalid");
 
-        //printf("-parseEnum() %s\n", e->toChars());
+        //printf("-parseEnum() %s\n", e.toChars());
         return e;
     }
 
@@ -4329,7 +4329,7 @@ final class Parser : Lexer
         if (pAttrs)
         {
             storage_class |= pAttrs.storageClass;
-            //pAttrs->storageClass = STCundefined;
+            //pAttrs.storageClass = STCundefined;
         }
 
         while (1)
@@ -4432,7 +4432,7 @@ final class Parser : Lexer
                     }
                 }
 
-                //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t->toChars(), storage_class);
+                //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t.toChars(), storage_class);
                 auto f = new FuncDeclaration(loc, Loc(), ident, storage_class | (disable ? STCdisable : 0), t);
                 if (pAttrs)
                     pAttrs.storageClass = STCundefined;
@@ -4658,7 +4658,7 @@ final class Parser : Lexer
 
         bool literal = f.isFuncLiteralDeclaration() !is null;
 
-        // The following is irrelevant, as it is overridden by sc->linkage in
+        // The following is irrelevant, as it is overridden by sc.linkage in
         // TypeFunction::semantic
         linkage = LINKd; // nested functions have D linkage
     L1:
@@ -6230,7 +6230,7 @@ final class Parser : Lexer
             goto Lisnot;
 
     Lis:
-        //printf("\tis declaration, t = %s\n", t->toChars());
+        //printf("\tis declaration, t = %s\n", t.toChars());
         return true;
 
     Lisnot:
@@ -6416,7 +6416,7 @@ final class Parser : Lexer
         Token* t = *pt;
         int parens;
 
-        //printf("Parser::isDeclarator() %s\n", t->toChars());
+        //printf("Parser::isDeclarator() %s\n", t.toChars());
         if (t.value == TOKassign)
             return false;
 
@@ -7015,7 +7015,7 @@ final class Parser : Lexer
                 Token* t2 = peek(t1);
                 if (t1.value == TOKmin && t2.value == TOKgt)
                 {
-                    // skip ident->
+                    // skip ident.
                     nextToken();
                     nextToken();
                     nextToken();

--- a/src/root/filename.d
+++ b/src/root/filename.d
@@ -545,7 +545,7 @@ nothrow:
                     const(char)* cname = null;
                     const(char)* cpath = canonicalName((*path)[i]);
                     //printf("FileName::safeSearchPath(): name=%s; path=%s; cpath=%s\n",
-                    //      name, (char *)path->data[i], cpath);
+                    //      name, (char *)path.data[i], cpath);
                     if (cpath is null)
                         goto cont;
                     cname = canonicalName(combine(cpath, name));

--- a/src/scanmach.d
+++ b/src/scanmach.d
@@ -97,7 +97,7 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol
     for (uint32_t i = 0; i < ncmds; i++)
     {
         load_command* command = cast(load_command*)commands;
-        //printf("cmd = 0x%02x, cmdsize = %u\n", command->cmd, command->cmdsize);
+        //printf("cmd = 0x%02x, cmdsize = %u\n", command.cmd, command.cmdsize);
         switch (command.cmd)
         {
         case LC_SEGMENT:
@@ -162,7 +162,7 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol
                     case N_ABS:
                         break;
                     case N_SECT:
-                        if (s.n_type & N_EXT) /*&& !(s->n_desc & N_REF_TO_WEAK)*/
+                        if (s.n_type & N_EXT) /*&& !(s.n_desc & N_REF_TO_WEAK)*/
                             pAddSymbol(name[0 .. namelen], 1);
                         break;
                     case N_PBUD:
@@ -213,7 +213,7 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol
                     case N_ABS:
                         break;
                     case N_SECT:
-                        if (s.n_type & N_EXT) /*&& !(s->n_desc & N_REF_TO_WEAK)*/
+                        if (s.n_type & N_EXT) /*&& !(s.n_desc & N_REF_TO_WEAK)*/
                             pAddSymbol(name[0 .. namelen], 1);
                         break;
                     case N_PBUD:

--- a/src/sideeffect.d
+++ b/src/sideeffect.d
@@ -265,7 +265,7 @@ extern (C++) void discardValue(Expression e)
                         s = ce.f.toPrettyChars();
                     else if (ce.e1.op == TOKstar)
                     {
-                        // print 'fp' if ce->e1 is (*fp)
+                        // print 'fp' if ce.e1 is (*fp)
                         s = (cast(PtrExp)ce.e1).e1.toChars();
                     }
                     else
@@ -334,7 +334,7 @@ extern (C++) void discardValue(Expression e)
                 return;
             }
             // Don't check e1 until we cast(void) the a,b code generation
-            //discardValue(ce->e1);
+            //discardValue(ce.e1);
             discardValue(ce.e2);
             return;
         }

--- a/src/statement.d
+++ b/src/statement.d
@@ -368,7 +368,7 @@ extern (C++) abstract class Statement : RootObject
 
             override void visit(ScopeStatement s)
             {
-                //printf("ScopeStatement::blockExit(%p)\n", s->statement);
+                //printf("ScopeStatement::blockExit(%p)\n", s.statement);
                 result = s.statement ? s.statement.blockExit(func, mustNotThrow) : BEfallthru;
             }
 
@@ -553,7 +553,7 @@ extern (C++) abstract class Statement : RootObject
 
             override void visit(BreakStatement s)
             {
-                //printf("BreakStatement::blockExit(%p) = x%x\n", s, s->ident ? BEgoto : BEbreak);
+                //printf("BreakStatement::blockExit(%p) = x%x\n", s, s.ident ? BEgoto : BEbreak);
                 result = s.ident ? BEgoto : BEbreak;
             }
 
@@ -1249,7 +1249,7 @@ extern (C++) final class CompileStatement : Statement
 
     override Statements* flatten(Scope* sc)
     {
-        //printf("CompileStatement::flatten() %s\n", exp->toChars());
+        //printf("CompileStatement::flatten() %s\n", exp.toChars());
 
         auto errorStatements()
         {
@@ -2343,7 +2343,7 @@ extern (C++) final class Catch : RootObject
 
     extern (D) this(Loc loc, Type t, Identifier id, Statement handler)
     {
-        //printf("Catch(%s, loc = %s)\n", id->toChars(), loc.toChars());
+        //printf("Catch(%s, loc = %s)\n", id.toChars(), loc.toChars());
         this.loc = loc;
         this.type = t;
         this.ident = id;

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -113,7 +113,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
     override void visit(CompileStatement cs)
     {
-        //printf("CompileStatement::semantic() %s\n", exp->toChars());
+        //printf("CompileStatement::semantic() %s\n", exp.toChars());
         Statements* a = cs.flatten(sc);
         if (!a)
             return;
@@ -294,7 +294,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         {
             if (s)
             {
-                //printf("[%d]: %s\n", i, s->toChars());
+                //printf("[%d]: %s\n", i, s.toChars());
                 s = s.semantic(scd);
                 if (s && !serror)
                     serror = s.isErrorStatement();
@@ -561,7 +561,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 }
             }
 
-            //printf("dim = %d, parameters->dim = %d\n", dim, parameters->dim);
+            //printf("dim = %d, parameters.dim = %d\n", dim, parameters.dim);
             if (foundMismatch && dim != foreachParamCount)
             {
                 const(char)* plural = foreachParamCount > 1 ? "s" : "";
@@ -594,7 +594,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
             TypeTuple tuple = cast(TypeTuple)tab;
             auto statements = new Statements();
-            //printf("aggr: op = %d, %s\n", fs.aggr->op, fs.aggr->toChars());
+            //printf("aggr: op = %d, %s\n", fs.aggr.op, fs.aggr.toChars());
             size_t n;
             TupleExp te = null;
             if (fs.aggr.op == TOKtuple) // expression tuple
@@ -1196,7 +1196,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     {
                         tfld = cast(TypeFunction)tab.nextOf();
                     Lget:
-                        //printf("tfld = %s\n", tfld->toChars());
+                        //printf("tfld = %s\n", tfld.toChars());
                         if (tfld.parameters.dim == 1)
                         {
                             Parameter p = Parameter.getNth(tfld.parameters, 0);
@@ -1225,7 +1225,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     if (tfld)
                     {
                         Parameter prm = Parameter.getNth(tfld.parameters, i);
-                        //printf("\tprm = %s%s\n", (prm->storageClass&STCref?"ref ":""), prm->ident->toChars());
+                        //printf("\tprm = %s%s\n", (prm.storageClass&STCref?"ref ":""), prm.ident.toChars());
                         stc = prm.storageClass & STCref;
                         id = p.ident; // argument copy is not need.
                         if ((p.storageClass & STCref) != stc)
@@ -1544,7 +1544,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             }
             else
             {
-                // See if upr-1 fits in prm->type
+                // See if upr-1 fits in prm.type
                 Expression limit = new MinExp(loc, fs.upr, new IntegerExp(1));
                 limit = limit.semantic(sc);
                 limit = limit.optimize(WANTvalue);
@@ -2194,7 +2194,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         L1:
             foreach (cs2; *sw.cases)
             {
-                //printf("comparing '%s' with '%s'\n", exp->toChars(), cs->exp->toChars());
+                //printf("comparing '%s' with '%s'\n", exp.toChars(), cs.exp.toChars());
                 if (cs2.exp.equals(cs.exp))
                 {
                     cs.error("duplicate case %s in switch statement", cs.exp.toChars());
@@ -2539,7 +2539,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 {
                     int m1 = rs.exp.type.implicitConvTo(tret);
                     int m2 = tret.implicitConvTo(rs.exp.type);
-                    //printf("exp->type = %s m2<-->m1 tret %s\n", exp->type->toChars(), tret->toChars());
+                    //printf("exp.type = %s m2<-->m1 tret %s\n", exp.type.toChars(), tret.toChars());
                     //printf("m1 = %d, m2 = %d\n", m1, m2);
 
                     if (m1 && m2)
@@ -2601,7 +2601,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 {
                     if (!v.isDataseg() && !v.isParameter() && v.toParent2() == fd)
                     {
-                        //printf("Setting nrvo to %s\n", v->toChars());
+                        //printf("Setting nrvo to %s\n", v.toChars());
                         fd.nrvo_var = v;
                     }
                     else
@@ -2610,7 +2610,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 else if (fd.nrvo_var != v)
                     fd.nrvo_can = 0;
             }
-            else //if (!exp->isLvalue())    // keep NRVO-ability
+            else //if (!exp.isLvalue())    // keep NRVO-ability
                 fd.nrvo_can = 0;
         }
         else
@@ -2691,7 +2691,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 sc.fes.cases.push(s);
 
                 // Immediately rewrite "this" return statement as:
-                //  return cases->dim+1;
+                //  return cases.dim+1;
                 rs.exp = new IntegerExp(sc.fes.cases.dim + 1);
                 if (e0)
                 {
@@ -3445,7 +3445,7 @@ Statement semantic(Statement s, Scope* sc)
 
 void semantic(Catch c, Scope* sc)
 {
-    //printf("Catch::semantic(%s)\n", ident->toChars());
+    //printf("Catch::semantic(%s)\n", ident.toChars());
 
     static if (!IN_GCC)
     {

--- a/src/toctype.d
+++ b/src/toctype.d
@@ -56,7 +56,7 @@ public:
 
     override void visit(TypePointer t)
     {
-        //printf("TypePointer::toCtype() %s\n", t->toChars());
+        //printf("TypePointer::toCtype() %s\n", t.toChars());
         t.ctype = type_pointer(Type_toCtype(t.next));
     }
 
@@ -120,7 +120,7 @@ public:
 
     override void visit(TypeStruct t)
     {
-        //printf("TypeStruct::toCtype() '%s'\n", t->sym->toChars());
+        //printf("TypeStruct::toCtype() '%s'\n", t.sym.toChars());
         if (t.mod == 0)
         {
             // Create a new backend type
@@ -155,12 +155,12 @@ public:
             t.ctype.Ttag = mctype.Ttag; // structure tag name
         }
         addMod(t);
-        //printf("t = %p, Tflags = x%x\n", ctype, ctype->Tflags);
+        //printf("t = %p, Tflags = x%x\n", ctype, ctype.Tflags);
     }
 
     override void visit(TypeEnum t)
     {
-        //printf("TypeEnum::toCtype() '%s'\n", t->sym->toChars());
+        //printf("TypeEnum::toCtype() '%s'\n", t.sym.toChars());
         if (t.mod == 0)
         {
             if (!t.sym.memtype)
@@ -194,7 +194,7 @@ public:
         }
         else
             t.ctype = mctype;
-        //printf("t = %p, Tflags = x%x\n", t, t->Tflags);
+        //printf("t = %p, Tflags = x%x\n", t, t.Tflags);
     }
 
     override void visit(TypeClass t)

--- a/src/traits.d
+++ b/src/traits.d
@@ -738,7 +738,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             ex = ex.semantic(scx);
             if (errors < global.errors)
                 e.error("%s cannot be resolved", eorig.toChars());
-            //ex->print();
+            //ex.print();
 
             /* Create tuple of functions of ex
              */
@@ -858,7 +858,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             s = imp.mod;
         }
 
-        //printf("getAttributes %s, attrs = %p, scope = %p\n", s->toChars(), s->userAttribDecl, s->scope);
+        //printf("getAttributes %s, attrs = %p, scope = %p\n", s.toChars(), s.userAttribDecl, s.scope);
         auto udad = s.userAttribDecl;
         auto exps = udad ? udad.getAttributes() : new Expressions();
         auto tup = new TupleExp(e.loc, exps);
@@ -937,7 +937,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             if (!sm)
                 return 1;
-            //printf("\t[%i] %s %s\n", i, sm->kind(), sm->toChars());
+            //printf("\t[%i] %s %s\n", i, sm.kind(), sm.toChars());
             if (sm.ident)
             {
                 const idx = sm.ident.toChars();
@@ -958,7 +958,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 if (sm.isTypeInfoDeclaration()) // Bugzilla 15177
                     return 0;
 
-                //printf("\t%s\n", sm->ident->toChars());
+                //printf("\t%s\n", sm.ident.toChars());
 
                 /* Skip if already present in idents[]
                  */
@@ -1089,7 +1089,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto o2 = (*e.args)[1];
         auto s1 = getDsymbol(o1);
         auto s2 = getDsymbol(o2);
-        //printf("isSame: %s, %s\n", o1->toChars(), o2->toChars());
+        //printf("isSame: %s, %s\n", o1.toChars(), o2.toChars());
         version (none)
         {
             printf("o1: %p\n", o1);

--- a/src/typinf.d
+++ b/src/typinf.d
@@ -79,7 +79,7 @@ extern (C++) Type getTypeInfoType(Type t, Scope* sc)
 
 extern (C++) TypeInfoDeclaration getTypeInfoDeclaration(Type t)
 {
-    //printf("Type::getTypeInfoDeclaration() %s\n", t->toChars());
+    //printf("Type::getTypeInfoDeclaration() %s\n", t.toChars());
     switch (t.ty)
     {
     case Tpointer:


### PR DESCRIPTION
Whenever I look through the DMD codebase I see all these `printf` relicts from C++ with `->`.
Apart from showing a non-glory history, they can't be quickly toggled anymore and thus sometimes appear in the PRs. I quickly ran a replacement tool to do the replacement once in one step:

```
sed 's/\([a-zA-Z0-9]\)->/\1./g' -i */*.d
```

Note that I excluded `backend` and didn't go for `::` to keep the diff "manageable".
If you see this as too much churn, I don't mind. It wasn't much work.