### PR TITLE
fix Issue 16794 - dmd not working on Ubuntu 16.10

### DIFF
--- a/ini/linux/bin64/dmd.conf
+++ b/ini/linux/bin64/dmd.conf
@@ -2,4 +2,4 @@
 DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib32 -L--export-dynamic
 
 [Environment64]
-DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic
+DFLAGS=-I%@P%/../../src/phobos -I%@P%/../../src/druntime/import -L-L%@P%/../lib64 -L--export-dynamic -fPIC


### PR DESCRIPTION
- enable PIC by default on amd64 linux (no significant overhead, full
  PIC/PIE support)
- also see https://github.com/dlang/installer/pull/207