### PR TITLE
CircleCI: merge PR branch into master before testing

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -57,15 +57,15 @@ coverage() {
         local base_branch=$CIRCLE_BRANCH
     fi
 
-    # merge upstream branch with changes, s.t. we check with the latest changes
+    # merge testee PR with base branch (master) before testing
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
-        local current_branch=$(git rev-parse --abbrev-ref HEAD)
-        git config user.name dummyuser
-        git config user.email dummyuser@dummyserver.com
-        git remote add upstream https://github.com/dlang/dmd.git
-        git fetch upstream
-        git checkout -f upstream/$base_branch
-        git merge -m "Automatic merge" $current_branch
+        local head=$(git rev-parse HEAD)
+        git fetch https://github.com/dlang/dmd.git $base_branch --depth=1
+        git checkout -f FETCH_HEAD
+        local base=$(git rev-parse HEAD)
+        git config user.name 'CI'
+        git config user.email '<>'
+        git merge -m "Merge $head into $base" $head
     fi
 
     for proj in druntime phobos; do

--- a/circleci.sh
+++ b/circleci.sh
@@ -60,7 +60,7 @@ coverage() {
     # merge testee PR with base branch (master) before testing
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
         local head=$(git rev-parse HEAD)
-        git fetch https://github.com/dlang/dmd.git $base_branch --depth=1
+        git fetch https://github.com/dlang/dmd.git $base_branch
         git checkout -f FETCH_HEAD
         local base=$(git rev-parse HEAD)
         git config user.name 'CI'


### PR DESCRIPTION
(Yet another improvement to our automation infrastructure)

Similar to the already merged PRs at Druntime and Phobos:

https://github.com/dlang/druntime/pull/1723
https://github.com/dlang/phobos/pull/4955

In general it makes a lot of sense to merge to merge with the upstream branch, s.t. changes are always tested as they would be merged (DAutoTest and auto-tester behave in the same way).

I added some minor updates to the script as well, e.g. always using `--depth 1` caused a stupid error at Phobos when done with the tools repo.