### PR TITLE
Merge pull request #6363 from WalterBright/fix17029

### DIFF
--- a/src/escape.d
+++ b/src/escape.d
@@ -471,9 +471,12 @@ private bool checkEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                 !(!refs && p.parent == sc.func))
             {
                 // Only look for errors if in module listed on command line
-                if (!gag)
-                    error(e.loc, "scope variable %s may not be returned", v.toChars());
-                result = true;
+                if (global.params.vsafe) // https://issues.dlang.org/show_bug.cgi?id=17029
+                {
+                    if (!gag)
+                        error(e.loc, "scope variable %s may not be returned", v.toChars());
+                    result = true;
+                }
                 continue;
             }
         }

--- a/test/fail_compilation/fail7294.d
+++ b/test/fail_compilation/fail7294.d
@@ -1,9 +1,0 @@
-// 7294
-
-Object foo()
-{
-    scope obj = new Object;
-    return obj;
-}
-
-

--- a/test/fail_compilation/fail_scope.d
+++ b/test/fail_compilation/fail_scope.d
@@ -3,13 +3,6 @@ PERMUTE_ARGS:
 REQUIRED_ARGS: -dip25
 TEST_OUTPUT:
 ---
-fail_compilation/fail_scope.d(30): Error: scope variable da may not be returned
-fail_compilation/fail_scope.d(32): Error: scope variable o may not be returned
-fail_compilation/fail_scope.d(33): Error: scope variable dg may not be returned
-fail_compilation/fail_scope.d(35): Error: scope variable da may not be returned
-fail_compilation/fail_scope.d(37): Error: scope variable o may not be returned
-fail_compilation/fail_scope.d(38): Error: scope variable dg may not be returned
-fail_compilation/fail_scope.d(40): Error: scope variable p may not be returned
 fail_compilation/fail_scope.d(45): Error: escaping reference to local variable string
 fail_compilation/fail_scope.d(63): Error: escaping reference to local variable s
 fail_compilation/fail_scope.d(74): Error: fail_scope.foo8 called with argument types (int) matches both:
@@ -23,6 +16,13 @@ fail_compilation/fail_scope.d(108): Error: escaping reference to outer local var
 fail_compilation/fail_scope.d(127): Error: escaping reference to local variable s
 fail_compilation/fail_scope.d(137): Error: escaping reference to local variable i
 ---
+//fail_compilation/fail_scope.d(30): Error: scope variable da may not be returned
+//fail_compilation/fail_scope.d(32): Error: scope variable o may not be returned
+//fail_compilation/fail_scope.d(33): Error: scope variable dg may not be returned
+//fail_compilation/fail_scope.d(35): Error: scope variable da may not be returned
+//fail_compilation/fail_scope.d(37): Error: scope variable o may not be returned
+//fail_compilation/fail_scope.d(38): Error: scope variable dg may not be returned
+//fail_compilation/fail_scope.d(40): Error: scope variable p may not be returned
 */
 
 alias int delegate() dg_t;


### PR DESCRIPTION
fix Issue 17029 - [Reg 2.072] scope variable may not be returned

Conflicts:
    src/escape.d

Cherry-picking this into the scope branch since it also fixes the remaining bug with vibe.d and dub.