### PR TITLE
refactor traits.d: eliminate use of goto

### DIFF
--- a/src/traits.d
+++ b/src/traits.d
@@ -379,11 +379,20 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         return new ErrorExp();
     }
 
+    Expression True()
+    {
+        return new IntegerExp(e.loc, true, Type.tbool);
+    }
+
+    Expression False()
+    {
+        return new IntegerExp(e.loc, false, Type.tbool);
+    }
+
     Expression isX(T)(bool function(T) fp)
     {
-        int result = 0;
         if (!dim)
-            goto Lfalse;
+            return False();
         foreach (o; *e.args)
         {
             static if (is(T == Type))
@@ -393,7 +402,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             {
                 auto s = getDsymbol(o);
                 if (!s)
-                    goto Lfalse;
+                    return False();
             }
             static if (is(T == Dsymbol))
                 alias y = s;
@@ -403,12 +412,9 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 auto y = s.isFuncDeclaration();
 
             if (!y || !fp(y))
-                goto Lfalse;
+                return False();
         }
-        result = 1;
-
-    Lfalse:
-        return new IntegerExp(e.loc, result, Type.tbool);
+        return True();
     }
 
     alias isTypeX = isX!Type;
@@ -481,12 +487,9 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         Type tb = t.baseElemOf();
         if (auto sd = tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null)
         {
-            if (sd.isPOD())
-                goto Ltrue;
-            else
-                goto Lfalse;
+            return sd.isPOD() ? True() : False();
         }
-        goto Ltrue;
+        return True();
     }
     if (e.ident == Id.isNested)
     {
@@ -500,17 +503,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         else if (auto ad = s.isAggregateDeclaration())
         {
-            if (ad.isNested())
-                goto Ltrue;
-            else
-                goto Lfalse;
+            return ad.isNested() ? True() : False();
         }
         else if (auto fd = s.isFuncDeclaration())
         {
-            if (fd.isNested())
-                goto Ltrue;
-            else
-                goto Lfalse;
+            return fd.isNested() ? True() : False();
         }
 
         e.error("aggregate or function expected instead of '%s'", o.toChars());
@@ -713,16 +710,13 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             if (sym)
             {
                 if (auto sm = sym.search(e.loc, id))
-                    goto Ltrue;
+                    return True();
             }
 
             /* Take any errors as meaning it wasn't found
              */
             ex = ex.trySemantic(scx);
-            if (!ex)
-                goto Lfalse;
-            else
-                goto Ltrue;
+            return ex ? True() : False();
         }
         else if (e.ident == Id.getMember)
         {
@@ -1024,7 +1018,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
          * compile without error
          */
         if (!dim)
-            goto Lfalse;
+            return False();
 
         foreach (o; *e.args)
         {
@@ -1070,10 +1064,10 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
             if (global.endGagging(errors) || err)
             {
-                goto Lfalse;
+                return False();
             }
         }
-        goto Ltrue;
+        return True();
     }
     if (e.ident == Id.isSame)
     {
@@ -1100,7 +1094,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                     printf("%s\n", ea.toChars());
                 if (auto ta = isType(o1))
                     printf("%s\n", ta.toChars());
-                goto Lfalse;
+                return False();
             }
             else
                 printf("%s %s\n", s1.kind(), s1.toChars());
@@ -1112,11 +1106,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             if (ea1 && ea2)
             {
                 if (ea1.equals(ea2))
-                    goto Ltrue;
+                    return True();
             }
         }
         if (!s1 || !s2)
-            goto Lfalse;
+            return False();
         s1 = s1.toAlias();
         s2 = s2.toAlias();
 
@@ -1125,10 +1119,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         if (auto fa2 = s2.isFuncAliasDeclaration())
             s2 = fa2.toAliasFunc();
 
-        if (s1 == s2)
-            goto Ltrue;
-        else
-            goto Lfalse;
+        return (s1 == s2) ? True() : False();
     }
     if (e.ident == Id.getUnitTests)
     {
@@ -1230,10 +1221,4 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     else
         e.error("unrecognized trait '%s'", e.ident.toChars());
     return new ErrorExp();
-
-Lfalse:
-    return new IntegerExp(e.loc, 0, Type.tbool);
-
-Ltrue:
-    return new IntegerExp(e.loc, 1, Type.tbool);
 }


### PR DESCRIPTION
Much of the utility of `goto` goes away when the language supports nested functions.