### PR TITLE
Selective unittests

### DIFF
--- a/src/globals.d
+++ b/src/globals.d
@@ -142,6 +142,7 @@ struct Param
     Array!(const(char)*)* modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array!(const(char)*)* imppath;      // array of char*'s of where to look for import modules
     Array!(const(char)*)* fileImppath;  // array of char*'s of where to look for file import modules
+    Array!(const(char)*)* selectedUnitTestModules;
     const(char)* objdir;                // .obj/.lib file output directory
     const(char)* objname;               // .obj file output name
     const(char)* libname;               // .lib file output name

--- a/src/globals.h
+++ b/src/globals.h
@@ -152,6 +152,8 @@ struct Param
     const char *moduleDepsFile; // filename for deps output
     OutBuffer *moduleDeps;      // contents to be written to deps file
 
+    Strings selectedUnitTestModules; // module names whose unittests shall be selective compiled
+
     // Hidden debug switches
     bool debugb;
     bool debugc;

--- a/src/mars.d
+++ b/src/mars.d
@@ -828,6 +828,22 @@ Language changes listed by -transition=id:
             }
             else if (strcmp(p + 1, "unittest") == 0)
                 global.params.useUnitTests = true;
+            else if (memcmp(p + 1, cast(char*)"unittest", 8) == 0) // selective unittest
+            {
+                // Parse:
+                //      -unittest=MODULE_NAME
+                if (p[9] == '=')
+                {
+                    if (!global.params.selectedUnitTestModules)
+                        global.params.selectedUnitTestModules = new Strings();
+                    const mname = p + 10;
+                    // printf("Selected module: %s\n", mname);
+                    global.params.selectedUnitTestModules.push(mname);
+                }
+                else
+                    goto Lerror;
+                global.params.useUnitTests = true;
+            }
             else if (p[1] == 'I')
             {
                 if (!global.params.imppath)

--- a/src/parse.d
+++ b/src/parse.d
@@ -577,8 +577,13 @@ final class Parser : Lexer
                     break;
                 }
             case TOKunittest:
-                if (global.params.useUnitTests || global.params.doDocComments || global.params.doHdrGeneration)
+                if ((!global.params.selectedUnitTestModules ||
+                     (md &&
+                      md.id &&
+                      (*global.params.selectedUnitTestModules).canFind(md.id.toChars()))) &&
+                    (global.params.useUnitTests || global.params.doDocComments || global.params.doHdrGeneration))
                 {
+                    // printf("Compiling unittests for selected module: %s\n", md.id.toChars());
                     s = parseUnitTest(pAttrs);
                     if (*pLastDecl)
                         (*pLastDecl).ddocUnittest = cast(UnitTestDeclaration)s;

--- a/src/root/array.d
+++ b/src/root/array.d
@@ -192,6 +192,22 @@ public:
         assert(a <= b && b <= dim);
         return data[a .. b];
     }
+
+    static if (is(T == const(char)*))
+    {
+        bool canFind(T ptr) const nothrow pure
+        {
+            for (size_t i = 0; i < dim; ++i)
+            {
+                if (strcmp(data[i], ptr) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
 }
 
 struct BitArray


### PR DESCRIPTION
Add selective unittests parameter to `-unittest` flag.

This will speed up incremental testing in cases such as:

https://github.com/nordlow/elisp/blob/master/mine/flycheck-d-all.el

According to my D development experience so far, I only want to run the unittests of the current module upon save and not the ones in the transitive deps.

I plan to merge my changes in `flycheck-d-all.el` into

https://github.com/flycheck/flycheck-d-unittest/blob/master/flycheck-d-unittest.el 

if/when this gets merged.

This will enable Emacs [Flycheck](http://www.flycheck.org/en/latest/) users to very quickly get incremental feedback on _which lines in the current source module that aren't covered by the unittests_, which, IMHO, is a _very_ useful feature.

The definition of the `canFind` overload in `Array` is ugly, but I currently don't know of a better way.

Any suggestions on how the CLI-help string should be updated?

Current use is, for instance,

```
dmd -unittest=A -unittest=B A.d B.d C.d
```

given that only the modules `A` and `B` should be tested when compiling `A`, `B` and `C`.