### PR TITLE
propagate error from discardValue()

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -72,7 +72,7 @@ Expression *doCopyOrMove(Scope *sc, Expression *e);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, Expression **pe0);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, IntervalExp *ie, Expression **pe0);
 Expression *integralPromotions(Expression *e, Scope *sc);
-void discardValue(Expression *e);
+bool discardValue(Expression *e);
 bool isTrivialExp(Expression *e);
 
 int isConst(Expression *e);

--- a/src/sideeffect.d
+++ b/src/sideeffect.d
@@ -206,12 +206,14 @@ extern (C++) bool lambdaHasSideEffect(Expression e)
 
 /***********************************
  * The result of this expression will be discarded.
- * Complain if the operation has no side effects (and hence is meaningless).
+ * Print error messages if the operation has no side effects (and hence is meaningless).
+ * Returns:
+ *      true if expression has no side effects
  */
-extern (C++) void discardValue(Expression e)
+extern (C++) bool discardValue(Expression e)
 {
     if (lambdaHasSideEffect(e)) // check side-effect shallowly
-        return;
+        return false;
     switch (e.op)
     {
     case TOKcast:
@@ -222,19 +224,19 @@ extern (C++) void discardValue(Expression e)
                 /*
                  * Don't complain about an expression with no effect if it was cast to void
                  */
-                return;
+                return false;
             }
             break; // complain
         }
     case TOKerror:
-        return;
+        return false;
     case TOKvar:
         {
             VarDeclaration v = (cast(VarExp)e).var.isVarDeclaration();
             if (v && (v.storage_class & STCtemp))
             {
                 // Bugzilla 5810: Don't complain about an internal generated variable.
-                return;
+                return false;
             }
             break;
         }
@@ -274,21 +276,19 @@ extern (C++) void discardValue(Expression e)
                 }
             }
         }
-        return;
+        return false;
     case TOKscope:
         e.error("%s has no effect", e.toChars());
-        return;
+        return true;
     case TOKandand:
         {
             AndAndExp aae = cast(AndAndExp)e;
-            discardValue(aae.e2);
-            return;
+            return discardValue(aae.e2);
         }
     case TOKoror:
         {
             OrOrExp ooe = cast(OrOrExp)e;
-            discardValue(ooe.e2);
-            return;
+            return discardValue(ooe.e2);
         }
     case TOKquestion:
         {
@@ -313,10 +313,10 @@ extern (C++) void discardValue(Expression e)
              */
             if (!lambdaHasSideEffect(ce.e1) && !lambdaHasSideEffect(ce.e2))
             {
-                discardValue(ce.e1);
-                discardValue(ce.e2);
+                return discardValue(ce.e1) |
+                       discardValue(ce.e2);
             }
-            return;
+            return false;
         }
     case TOKcomma:
         {
@@ -331,12 +331,11 @@ extern (C++) void discardValue(Expression e)
                 firstComma = cast(CommaExp)firstComma.e1;
             if (firstComma.e1.op == TOKdeclaration && ce.e2.op == TOKvar && (cast(DeclarationExp)firstComma.e1).declaration == (cast(VarExp)ce.e2).var)
             {
-                return;
+                return false;
             }
             // Don't check e1 until we cast(void) the a,b code generation
             //discardValue(ce.e1);
-            discardValue(ce.e2);
-            return;
+            return discardValue(ce.e2);
         }
     case TOKtuple:
         /* Pass without complaint if any of the tuple elements have side effects.
@@ -345,11 +344,12 @@ extern (C++) void discardValue(Expression e)
          */
         if (!hasSideEffect(e))
             break;
-        return;
+        return false;
     default:
         break;
     }
     e.error("%s has no effect in expression (%s)", Token.toChars(e.op), e.toChars());
+    return true;
 }
 
 /**************************************************

--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -102,7 +102,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 if (f.checkForwardRef(s.exp.loc))
                     s.exp = new ErrorExp();
             }
-            discardValue(s.exp);
+            if (discardValue(s.exp))
+                s.exp = new ErrorExp();
 
             s.exp = s.exp.optimize(WANTvalue);
             s.exp = checkGC(sc, s.exp);


### PR DESCRIPTION
Semantic errors should "poison" the AST.