### PR TITLE
Include function bodies when the return type isn't available.

### DIFF
--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -1742,10 +1742,11 @@ public:
         //printf("FuncDeclaration::toCBuffer() '%s'\n", f->toChars());
         if (stcToBuffer(buf, f.storage_class))
             buf.writeByte(' ');
-        typeToBuffer(f.type, f.ident);
+        auto tf = cast(TypeFunction)f.type;
+        typeToBuffer(tf, f.ident);
         if (hgs.hdrgen == 1)
         {
-            if (f.storage_class & STCauto)
+            if (!tf.next)
             {
                 hgs.autoMember++;
                 bodyToBuffer(f);


### PR DESCRIPTION
If the function's return type isn't available, the user used a storage class or `auto` instead of explicitly specifying a return type, so we need to include a function body.

Fixes https://issues.dlang.org/show_bug.cgi?id=16590