### PR TITLE
Fix ddocYear test

### DIFF
--- a/test/compilable/extra-files/ddocYear.html
+++ b/test/compilable/extra-files/ddocYear.html
@@ -492,7 +492,7 @@
   <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
-    2016
+    __YEAR__
   </p>
 </div>
 


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/6173 removed the ```__YEAR__``` tag from https://github.com/dlang/dmd/pull/1699