### PR TITLE
fix errors with AVX vector code generation

### DIFF
--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -871,11 +871,11 @@ L1:
         return e;
   }
   /* Replace (e + e) with (e * 2)       */
-  else if (el_match(e1,e2) && !el_sideeffect(e1) && !tyfloating(e->Ety))
+  else if (el_match(e1,e2) && !el_sideeffect(e1) && !tyfloating(e1->Ety))
   {
         e->Eoper = OPmul;
         el_free(e2);
-        e->E2 = el_long(e->Ety,2);
+        e->E2 = el_long(e1->Ety,2);
         again = 1;
         return e;
   }


### PR DESCRIPTION
I was initially mystified how dmd could pass the test suite with these bugs, since the test suite was failing when I tried them. But then I remembered Brad had said that many (most?) of the test machines do not have AVX-capable CPUs, and hence the AVX tests did not run.