### PR TITLE
expression.h: fix declaration of discardValue()

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -72,7 +72,7 @@ Expression *doCopyOrMove(Scope *sc, Expression *e);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, Expression **pe0);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, IntervalExp *ie, Expression **pe0);
 Expression *integralPromotions(Expression *e, Scope *sc);
-void discardValue(Expression *e);
+bool discardValue(Expression *e);
 bool isTrivialExp(Expression *e);
 
 int isConst(Expression *e);


### PR DESCRIPTION
Not that anyone should be calling this anyway from C++.