### PR TITLE
Fix issue 16355 - Don't emit a __xpostblit when it's not needed.

### DIFF
--- a/test/compilable/b16355.d
+++ b/test/compilable/b16355.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -c
+struct S0 { this(this) {} }
+struct S1 { S0[2] x; }
+struct S2 { S0[0] x; }
+
+// S0 has an explicit and a compiler-generated postblit
+static assert( __traits(hasMember, S0, "__postblit"));
+static assert( __traits(hasMember, S0, "__xpostblit"));
+// S1 has only the compiler-generated postblit
+static assert(!__traits(hasMember, S1, "__postblit"));
+static assert( __traits(hasMember, S1, "__xpostblit"));
+// S2 has no postblit at all since the x array has zero length
+static assert(!__traits(hasMember, S2, "__postblit"));
+static assert(!__traits(hasMember, S2, "__xpostblit"));


### PR DESCRIPTION
Seems the usual tiny oversight, the `CompoundStatement` generated contains nothing so the generated `__xpostblit` amounts to a noop.