### PR TITLE
Fix issue 9999,10560 - Deprecate the implicit int to bool conversion for integer literals

### DIFF
--- a/src/dcast.d
+++ b/src/dcast.d
@@ -328,6 +328,9 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             TY toty = t.toBasetype().ty;
             TY oldty = ty;
 
+            if (m == MATCHnomatch && t.ty == Tbool)
+                e.deprecation("Implicit conversion of integer literal to bool is deprecated");
+
             if (m == MATCHnomatch && t.ty == Tenum)
                 return;
 

--- a/src/denum.d
+++ b/src/denum.d
@@ -664,7 +664,16 @@ extern (C++) final class EnumMember : VarDeclaration
                 if (!ed.isAnonymous())
                     ed.memtype = t;
             }
-            Expression e = new IntegerExp(loc, 0, Type.tint32);
+
+            Expression e;
+            if (t.ty == Tbool)
+            {
+                e = new IntegerExp(loc, 0, Type.tbool);
+            }
+            else
+            {
+                e = new IntegerExp(loc, 0, Type.tint32);
+            }
             e = e.implicitCastTo(sc, t);
             e = e.ctfeInterpret();
 

--- a/test/compilable/b9999.d
+++ b/test/compilable/b9999.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -main
+int f1(bool) { return 1; }
+int f1(T)(T) { return 2; }
+
+static assert(f1(    0) == 1);
+static assert(f1(    1) == 1);
+static assert(f1(   1U) == 1);
+static assert(f1(4 - 3) == 1);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2394,7 +2394,7 @@ bool bug8216()
     assert(!ptr4cmp(&b[2], &b[9], &a[1], &a[2]));
     assert(!ptr4cmp(&b[1], &b[9], &b[2], &b[8]));
     assert( ptr4cmp(&b[2], &b[8], &b[1], &b[9]));
-    return 1;
+    return true;
 }
 static assert(bug8216());
 
@@ -2757,7 +2757,7 @@ bool bug9364()
 {
     S9364 s;
     auto k = (&s).i;
-    return 1;
+    return true;
 }
 
 static assert(bug9364());
@@ -4374,7 +4374,7 @@ bool bug10217()
     }
     auto yyy = S.init.tupleof[$ - 1];
     assert(!yyy);
-    return 1;
+    return true;
 }
 
 static assert(bug10217());

--- a/test/fail_compilation/warn7444.d
+++ b/test/fail_compilation/warn7444.d
@@ -57,7 +57,7 @@ No warning
 void test10214()
 {
     bool[1] arr;
-    arr = 0;
+    arr = false;
     pragma(msg, "No warning");
 }
 

--- a/test/runnable/imports/a12037.d
+++ b/test/runnable/imports/a12037.d
@@ -43,7 +43,7 @@ private:
     }
 
 public:
-    @property bool sign() { return 1; }
+    @property bool sign() { return true; }
     @property void sign(bool) {}
 
     this(F)(F input)

--- a/test/runnable/imports/linktypeinfo_file.d
+++ b/test/runnable/imports/linktypeinfo_file.d
@@ -28,6 +28,6 @@ struct DirIterator
 
 auto dirEntries(string path)
 {
-    bool f(int de) { return 1; }
+    bool f(int de) { return true; }
     return filter!f(DirIterator());
 }

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -140,13 +140,13 @@ class A5
     override bool opEquals(Object o)
     {
         printf("A.opEquals!(%p)\n", o);
-        return 1;
+        return true;
     }
 
     int opUnary(string s)()
     {
         printf("A.opUnary!(%.*s)\n", s.length, s.ptr);
-        return 0;
+        return false;
     }
 
     T opCast(T)()
@@ -162,7 +162,7 @@ class B5 : A5
     override bool opEquals(Object o)
     {
         printf("B.opEquals!(%p)\n", o);
-        return 1;
+        return true;
     }
 }
 

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -449,7 +449,7 @@ void test17()
 void test18()
 {
   bool[] x = new bool[100];
-  x[] = 1;
+  x[] = true;
   bool[] y = x.dup;
   assert(y[99]);
 }
@@ -457,7 +457,7 @@ void test18()
 
 /**************************************/
 
-bool[32] x19 = 1;
+bool[32] x19 = true;
 
 void test19()
 {

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -278,14 +278,14 @@ void write14(bool[] c)
 
 void test14()
 {
-     static bool[] a = [ 1, 1, 0, 1, 0 ];
-     static bool[] b = [ 1, 0, 0, 1 ];
+     static bool[] a = [ true, true, false, true, false ];
+     static bool[] b = [ true, false, false, true ];
      bool[] c = a ~ b;
 
-     static bool[] r1 = [1,1,0,1,0,1,0,0,1];
-     static bool[] r2 = [1,1,0,1,0,1,0,0,1,1,1,0,1,0];
-     static bool[] r3 = [1,1,0,1,0,1,0,0,1,1,1,0,1,0,0];
-     static bool[] r4 = [1,1,0,1,0,1,0,0,1,1,1,0,1,0,0,1];
+     static bool[] r1 = [true,true,false,true,false,true,false,false,true];
+     static bool[] r2 = [true,true,false,true,false,true,false,false,true,true,true,false,true,false];
+     static bool[] r3 = [true,true,false,true,false,true,false,false,true,true,true,false,true,false,false];
+     static bool[] r4 = [true,true,false,true,false,true,false,false,true,true,true,false,true,false,false,true];
 
 
      write14(c);
@@ -295,11 +295,11 @@ void test14()
      write14(c);
      assert(c == r2);
 
-     c ~= 0;
+     c ~= false;
      write14(c);
      assert(c == r3);
 
-     c ~= 1;
+     c ~= true;
      write14(c);
      assert(c == r4);
 }
@@ -401,12 +401,12 @@ struct S29(T)
 {
    const bool opEquals(const ref S29!(T) len2)
    {
-     return 0;
+     return false;
    }
 
    const int opCmp(const ref S29!(T) len2)
    {
-     return 0;
+     return false;
    }
 }
 
@@ -643,8 +643,8 @@ void test34()
                 return a~b;
         }
 
-        a[]=0;
-        b[]=1;
+        a[]=false;
+        b[]=true;
 
         bool[] arr=concat();
 

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -1177,11 +1177,11 @@ void test51()
 {
     bool b;
     assert(b == false);
-    b &= 1;
+    b &= true;
     assert(b == false);
-    b |= 1;
+    b |= true;
     assert(b == true);
-    b ^= 1;
+    b ^= true;
     assert(b == false);
     b = b | true;
     assert(b == true);

--- a/test/runnable/test7.d
+++ b/test/runnable/test7.d
@@ -434,55 +434,55 @@ void test7()
     int j;
 
     bool[1] a1;
-    a1[] = 1;
+    a1[] = true;
     assert(a1[0] == 1);
 
     bool[2] a2;
-    a2[] = 1;
+    a2[] = true;
     for (i = 0; i < a2.length; i++)
-        assert(a2[i] == 1);
+        assert(a2[i] == true);
 
     bool[3] a3;
-    a3[] = 1;
+    a3[] = true;
     for (i = 0; i < a3.length; i++)
-        assert(a3[i] == 1);
+        assert(a3[i] == true);
 
     bool[4] a4;
-    a4[] = 1;
+    a4[] = true;
     for (i = 0; i < a4.length; i++)
-        assert(a4[i] == 1);
+        assert(a4[i] == true);
 
     bool[8] a8;
-    a8[] = 1;
+    a8[] = true;
     for (i = 0; i < a8.length; i++)
-        assert(a8[i] == 1);
+        assert(a8[i] == true);
 
     bool[27] a27;
-    a27[] = 1;
+    a27[] = true;
     for (i = 0; i < a27.length; i++)
-        assert(a27[i] == 1);
+        assert(a27[i] == true);
 
-    func7(33)[] = 1;
+    func7(33)[] = true;
     assert(b7.length == 33);
     for (i = 0; i < b7.length; i++)
-        assert(b7[i] == 1);
+        assert(b7[i] == true);
 
-    func7(33)[3..6] = 1;
+    func7(33)[3..6] = true;
     //printf("b7.ptr = %p, b7.length = %d\n", b7.ptr, b7.length);
     assert(b7.length == 33);
     for (i = 0; i < b7.length; i++)
     {
         //printf("b7[%d] = %d\n", i, b7[i]);
         if (i >= 3 && i < 6)
-            assert(b7[i] == 1);
+            assert(b7[i] == true);
         else
-            assert(b7[i] == 0);
+            assert(b7[i] == false);
     }
 
-    bool[23] a23 = 1;
+    bool[23] a23 = true;
     i = 16;
     j = 18;
-    a23[i++..++j] = 0;
+    a23[i++..++j] = false;
     printf("i = %d, j = %d\n", i, j);
     assert(i == 17);
     assert(j == 19);
@@ -635,7 +635,7 @@ void test14()
 
 void test15()
 {
-   bool b = 1;
+   bool b = true;
    bool *pb = &b;
    *pb = false;
    assert(!b);
@@ -651,8 +651,8 @@ void foo16(bool[] b1, bool[] b2)
 
 void test16()
 {
-    static bool[16] b1 = [1,1,0,1,0,0,0,0];
-    static bool[16] b2 = [0,0,0,0,0,0,0,0, 0,0,1,0,1,1,1,1];
+    static bool[16] b1 = [true,true,false,true,false,false,false,false];
+    static bool[16] b2 = [false,false,false,false,false,false,false,false,false,false,true,false,true,true,true,true];
 
     foo16(b1, b2);
     assert(b1[0] == false);
@@ -682,8 +682,8 @@ void test17()
 
 void test18()
 {
-    bool b = 1;
-    bool c = 1;
+    bool b = true;
+    bool c = true;
     b |= cast(bool)(3 + c);
     assert(b == true);
 }

--- a/test/runnable/testbitarray.d
+++ b/test/runnable/testbitarray.d
@@ -7,10 +7,10 @@ void main() {
         a.length = 5;
         foreach (ref bool b; a) {
                 assert (b == 0);
-                b = 1;
+                b = true;
         }
         foreach (bool b; a)
-                assert (b == 1); // FAILS, they're all 0
+                assert (b == true); // FAILS, they're all 0
 }
 
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1260,7 +1260,7 @@ const bool[string] stopWords79;
 
 static this()
 {
-    stopWords79 = [ "a"[]:1 ];
+    stopWords79 = [ "a"[]:true ];
 }
 
 void test79()

--- a/test/runnable/testreturn.d
+++ b/test/runnable/testreturn.d
@@ -125,26 +125,26 @@ void test13336()
         {
             alias fooxy = foo!(num, sx, sy);
             static assert(is(typeof(&fooxy) : double function(bool)));
-            assert(fooxy(1) == 1.0);
-            assert(fooxy(0) == 2.5);
+            assert(fooxy(true) == 1.0);
+            assert(fooxy(false) == 2.5);
 
             alias fooyx = foo!(num, sy, sx);
             static assert(is(typeof(&fooyx) : double function(bool)));
-            assert(fooyx(1) == 2.5);
-            assert(fooyx(0) == 1.0);
+            assert(fooyx(true) == 2.5);
+            assert(fooyx(false) == 1.0);
         }
 
         foreach (foo; TypeTuple!(f13336c, f13336d))
         {
             alias fooxy = foo!(num, sx, sy);
             static assert(is(typeof(&fooxy) : double function(bool)));
-            assert(fooxy(1) == 1.0 && result13336 == 1.0);
-            assert(fooxy(0) == 2.5 && result13336 == 2.5);
+            assert(fooxy(true) == 1.0 && result13336 == 1.0);
+            assert(fooxy(false) == 2.5 && result13336 == 2.5);
 
             alias fooyx = foo!(num, sy, sx);
             static assert(is(typeof(&fooyx) : double function(bool)));
-            assert(fooyx(1) == 2.5 && result13336 == 2.5);
-            assert(fooyx(0) == 1.0 && result13336 == 1.0);
+            assert(fooyx(true) == 2.5 && result13336 == 2.5);
+            assert(fooyx(false) == 1.0 && result13336 == 1.0);
         }
     }
 }


### PR DESCRIPTION
As stated by @MartinNowak in #1942 the implicit conversion from `int` to `bool` should be removed and today, 4 years later.
A single PR to phobos [1] and one to DRuntime [2] are needed.

[1] https://github.com/dlang/phobos/pull/5019
[2] https://github.com/dlang/druntime/pull/1732