### PR TITLE
fix building OMF lib with DMD64

### DIFF
--- a/src/libomf.d
+++ b/src/libomf.d
@@ -469,7 +469,7 @@ private:
             uint trailerPosn;
             ushort ndicpages;
             ubyte flags;
-            char* filler;
+            uint filler;
         }
 
         Libheader libHeader;


### PR DESCRIPTION
I've been building OMF libraries with a 64-bit build of DMD for a long time, but these suddenly are corrupt. I suspect the recent refactoring changed the file layout slightly, revealing this long standing bug in the library header struct.

Not sure this is worth a bugzilla entry as the Windows 64-bit build is not released.