### PR TITLE
Fix alignment of global buffers for D_CRITICAL_SECTIONs

### DIFF
--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -2975,13 +2975,14 @@ else
         else
         {
             /* Generate our own critical section, then rewrite as:
-             *  __gshared byte[CriticalSection.sizeof] critsec;
-             *  _d_criticalenter(critsec.ptr);
-             *  try { body } finally { _d_criticalexit(critsec.ptr); }
+             *  __gshared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsec;
+             *  _d_criticalenter(__critsec.ptr);
+             *  try { body } finally { _d_criticalexit(__critsec.ptr); }
              */
             auto id = Identifier.generateId("__critsec");
             auto t = Type.tint8.sarrayOf(Target.ptrsize + Target.critsecsize());
             auto tmp = new VarDeclaration(ss.loc, t, id, null);
+            tmp.alignment = Target.ptrsize;
             tmp.storage_class |= STCtemp | STCgshared | STCstatic;
 
             auto cs = new Statements();


### PR DESCRIPTION
A static array of bytes defaults to 1-byte alignment, which is incompatible with the actual struct. The struct contains a pointer and a native critical section (a struct for most platforms).

The code already assumes the native CS has no alignment greater than the pointer as it assumes no padding inbetween pointer and native CS when computing the overall `D_CRITICAL_SECTION` size as `Target.ptrsize` + native CS size.

Exposed by https://github.com/ldc-developers/ldc/issues/1955.