### PR TITLE
Fix PR #6408 (alignment of global buffers for D_CRITICAL_SECTIONs)

### DIFF
--- a/src/statementsem.d
+++ b/src/statementsem.d
@@ -2982,7 +2982,6 @@ else
             auto id = Identifier.generateId("__critsec");
             auto t = Type.tint8.sarrayOf(Target.ptrsize + Target.critsecsize());
             auto tmp = new VarDeclaration(ss.loc, t, id, null);
-            tmp.alignment = Target.ptrsize;
             tmp.storage_class |= STCtemp | STCgshared | STCstatic;
 
             auto cs = new Statements();
@@ -3016,6 +3015,9 @@ else
 
             s = new CompoundStatement(ss.loc, cs);
             result = s.semantic(sc);
+
+            // set the explicit __critsec alignment after semantic()
+            tmp.alignment = Target.ptrsize;
         }
     }
 


### PR DESCRIPTION
A VarDeclaration's alignment is reset during its semantic(), so set it later.

Wrapping the VarDeclaration in an AlignDeclaration does not work due to a CTFE limitation hit by compilable/interpret3.d (apparently no support for AlignDeclarations yet).