### PR TITLE
posix.mak: bootstrap using DMD 2.072.2

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -2,7 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.068.2 # same as in dmd/src/posix.mak
+HOST_DMD_VER=2.072.2 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -67,11 +67,11 @@ ifeq (,$(AUTO_BOOTSTRAP))
 else
   # Auto-bootstrapping, will download dmd automatically
   # Keep var below in sync with other occurrences of that variable, e.g. in circleci.sh
-  HOST_DMD_VER=2.068.2
+  HOST_DMD_VER=2.072.2
   HOST_DMD_ROOT=/tmp/.host_dmd-$(HOST_DMD_VER)
-  # dmd.2.068.2.osx.zip or dmd.2.068.2.linux.tar.xz
+  # dmd.2.072.2.osx.zip or dmd.2.072.2.linux.tar.xz
   HOST_DMD_BASENAME=dmd.$(HOST_DMD_VER).$(OS)$(if $(filter $(OS),freebsd),-$(MODEL),)
-  # http://downloads.dlang.org/releases/2.x/2.068.2/dmd.2.068.2.linux.tar.xz
+  # http://downloads.dlang.org/releases/2.x/2.072.2/dmd.2.072.2.linux.tar.xz
   HOST_DMD_URL=http://downloads.dlang.org/releases/2.x/$(HOST_DMD_VER)/$(HOST_DMD_BASENAME)
   HOST_DMD=$(HOST_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))/dmd
   HOST_DMD_PATH=$(HOST_DMD)


### PR DESCRIPTION
On modern Debian/Ubuntu systems, which requires everything being
compiled with -fPIC, bootstrapping fails. The default boostraping compiler 2.068 is not setup
correctly to support -fPIC out of the box, resulting in compilation
failures. Moving to 2.072 which enforfces -fPIC in dmd.conf resolves
this.