### PR TITLE
fix issue 16680: avoid inconsistent usage of Sub and Min in array operations

### DIFF
--- a/src/arrayop.d
+++ b/src/arrayop.d
@@ -316,7 +316,7 @@ extern (C++) void buildArrayIdent(Expression e, OutBuffer* buf, Expressions* arg
             switch (e.op)
             {
             case TOKaddass: s = "Addass";   break;
-            case TOKminass: s = "Subass";   break;
+            case TOKminass: s = "Minass";   break;
             case TOKmulass: s = "Mulass";   break;
             case TOKdivass: s = "Divass";   break;
             case TOKmodass: s = "Modass";   break;
@@ -350,7 +350,7 @@ extern (C++) void buildArrayIdent(Expression e, OutBuffer* buf, Expressions* arg
             switch (e.op)
             {
             case TOKadd:    s = "Add";  break;
-            case TOKmin:    s = "Sub";  break;
+            case TOKmin:    s = "Min";  break;
             case TOKmul:    s = "Mul";  break;
             case TOKdiv:    s = "Div";  break;
             case TOKmod:    s = "Mod";  break;


### PR DESCRIPTION
druntime uses "Min" instead of "Sub", also checked in dmd by `isDruntimeArrayOp`.

Not sure how to test as this just omits code generation for the generic array loops. I checked the disassembly manually, but implementing that for the auto tester is likely not worth it.

There are druntime unittests that test the functions that are now called.
