### PR TITLE
Fix Issue 17074: extern(C++, keyword) crashes compiler

### DIFF
--- a/src/parse.d
+++ b/src/parse.d
@@ -2185,7 +2185,10 @@ final class Parser : Lexer
                                     }
                                 }
                                 else
+                                {
                                     error("identifier expected for C++ namespace");
+                                    idents = null;  // error occurred, invalidate list of elements.
+                                }
                                 break;
                             }
                         }

--- a/test/fail_compilation/ice17074.d
+++ b/test/fail_compilation/ice17074.d
@@ -1,0 +1,39 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(9): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(9): Error: found 'cast' when expecting ')'
+fail_compilation/ice17074.d(9): Error: declaration expected, not ')'
+---
+*/
+extern(C++, cast) void ice_keyword();
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(19): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(19): Error: found '__overloadset' when expecting ')'
+fail_compilation/ice17074.d(19): Error: declaration expected, not ')'
+---
+*/
+extern(C++, std.__overloadset) void ice_std_keyword();
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(29): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(29): Error: found '...' when expecting ')'
+fail_compilation/ice17074.d(29): Error: declaration expected, not ')'
+---
+*/
+extern(C++, ...) void ice_token();
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(39): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(39): Error: found '*' when expecting ')'
+fail_compilation/ice17074.d(39): Error: declaration expected, not ')'
+---
+*/
+extern(C++, std.*) void ice_std_token();


### PR DESCRIPTION
This change unsets `idents'` if an error occurred parsing the C++ namespace, so that the later check for `assert(idents.dim)` never fires.

https://issues.dlang.org/show_bug.cgi?id=17074
