### PR TITLE
fix Issue 16513 - slow findExistingInstance

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -339,7 +339,7 @@ private int arrayObjectMatch(Objects* oa1, Objects* oa2)
  */
 private hash_t arrayObjectHash(Objects* oa1)
 {
-    import ddmd.root.stringtable : mixHash;
+    import ddmd.root.hash : mixHash;
 
     hash_t hash = 0;
     foreach (o1; *oa1)
@@ -372,7 +372,7 @@ private hash_t arrayObjectHash(Objects* oa1)
 private hash_t expressionHash(Expression e)
 {
     import ddmd.root.ctfloat : CTFloat;
-    import ddmd.root.stringtable : calcHash, mixHash;
+    import ddmd.root.hash : calcHash, mixHash;
 
     switch (e.op)
     {

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -219,7 +219,7 @@ endif
 
 ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array ctfloat file \
 	filename man outbuffer port response rmem rootobject speller \
-	stringtable))
+	stringtable hash))
 
 GLUE_OBJS =
 

--- a/src/root/ctfloat.d
+++ b/src/root/ctfloat.d
@@ -74,7 +74,7 @@ extern (C++) struct CTFloat
 
     static size_t hash(real_t a)
     {
-        import ddmd.root.stringtable : calcHash;
+        import ddmd.root.hash : calcHash;
 
         if (isNaN(a))
             a = real_t.nan;

--- a/src/root/ctfloat.d
+++ b/src/root/ctfloat.d
@@ -72,6 +72,16 @@ extern (C++) struct CTFloat
         return memcmp(&a, &b, sz) == 0;
     }
 
+    static size_t hash(real_t a)
+    {
+        import ddmd.root.stringtable : calcHash;
+
+        if (isNaN(a))
+            a = real_t.nan;
+        enum sz = (real_t.mant_dig == 64) ? 10 : real_t.sizeof;
+        return calcHash(cast(ubyte*) &a, sz);
+    }
+
     static bool isNaN(real_t r)
     {
         return !(r == r);

--- a/src/root/hash.d
+++ b/src/root/hash.d
@@ -1,0 +1,72 @@
+/**
+ * Compiler implementation of the D programming language
+ * http://dlang.org
+ *
+ * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:   Martin Nowak, Walter Bright, http://www.digitalmars.com
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:    $(DMDSRC root/_hash.d)
+ */
+
+module ddmd.root.hash;
+
+// MurmurHash2 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+// https://sites.google.com/site/murmurhash/
+uint calcHash(const(char)* data, size_t len) pure nothrow @nogc
+{
+    return calcHash(cast(const(ubyte)*)data, len);
+}
+
+uint calcHash(const(ubyte)* data, size_t len) pure nothrow @nogc
+{
+    // 'm' and 'r' are mixing constants generated offline.
+    // They're not really 'magic', they just happen to work well.
+    enum uint m = 0x5bd1e995;
+    enum int r = 24;
+    // Initialize the hash to a 'random' value
+    uint h = cast(uint)len;
+    // Mix 4 bytes at a time into the hash
+    while (len >= 4)
+    {
+        uint k = data[3] << 24 | data[2] << 16 | data[1] << 8 | data[0];
+        k *= m;
+        k ^= k >> r;
+        h = (h * m) ^ (k * m);
+        data += 4;
+        len -= 4;
+    }
+    // Handle the last few bytes of the input array
+    switch (len & 3)
+    {
+    case 3:
+        h ^= data[2] << 16;
+        goto case;
+    case 2:
+        h ^= data[1] << 8;
+        goto case;
+    case 1:
+        h ^= data[0];
+        h *= m;
+        goto default;
+    default:
+        break;
+    }
+    // Do a few final mixes of the hash to ensure the last few
+    // bytes are well-incorporated.
+    h ^= h >> 13;
+    h *= m;
+    h ^= h >> 15;
+    return h;
+}
+
+// combine and mix two words (MurmurHash2)
+size_t mixHash(size_t h, size_t k)
+{
+    enum uint m = 0x5bd1e995;
+    enum int r = 24;
+
+    k *= m;
+    k ^= k >> r;
+    return (h * m) ^ (k * m);
+}

--- a/src/root/hash.d
+++ b/src/root/hash.d
@@ -60,13 +60,8 @@ uint calcHash(const(ubyte)* data, size_t len) pure nothrow @nogc
     return h;
 }
 
-// combine and mix two words (MurmurHash2)
+// combine and mix two words (boost::hash_combine)
 size_t mixHash(size_t h, size_t k)
 {
-    enum uint m = 0x5bd1e995;
-    enum int r = 24;
-
-    k *= m;
-    k ^= k >> r;
-    return (h * m) ^ (k * m);
+    return h ^ (k + 0x9e3779b9 + (h << 6) + (h >> 2));
 }

--- a/src/root/stringtable.d
+++ b/src/root/stringtable.d
@@ -11,72 +11,10 @@
 module ddmd.root.stringtable;
 
 import core.stdc.string;
-import ddmd.root.rmem;
+import ddmd.root.rmem, ddmd.root.hash;
 
 enum POOL_BITS = 12;
 enum POOL_SIZE = (1U << POOL_BITS);
-
-// TODO: Merge with root.String
-// MurmurHash2 was written by Austin Appleby, and is placed in the public
-// domain. The author hereby disclaims copyright to this source code.
-// https://sites.google.com/site/murmurhash/
-uint calcHash(const(char)* data, size_t len) pure nothrow @nogc
-{
-    return calcHash(cast(const(ubyte)*)data, len);
-}
-
-uint calcHash(const(ubyte)* data, size_t len) pure nothrow @nogc
-{
-    // 'm' and 'r' are mixing constants generated offline.
-    // They're not really 'magic', they just happen to work well.
-    enum uint m = 0x5bd1e995;
-    enum int r = 24;
-    // Initialize the hash to a 'random' value
-    uint h = cast(uint)len;
-    // Mix 4 bytes at a time into the hash
-    while (len >= 4)
-    {
-        uint k = data[3] << 24 | data[2] << 16 | data[1] << 8 | data[0];
-        k *= m;
-        k ^= k >> r;
-        h = (h * m) ^ (k * m);
-        data += 4;
-        len -= 4;
-    }
-    // Handle the last few bytes of the input array
-    switch (len & 3)
-    {
-    case 3:
-        h ^= data[2] << 16;
-        goto case;
-    case 2:
-        h ^= data[1] << 8;
-        goto case;
-    case 1:
-        h ^= data[0];
-        h *= m;
-        goto default;
-    default:
-        break;
-    }
-    // Do a few final mixes of the hash to ensure the last few
-    // bytes are well-incorporated.
-    h ^= h >> 13;
-    h *= m;
-    h ^= h >> 15;
-    return h;
-}
-
-// combine and mix two words (MurmurHash2)
-size_t mixHash(size_t h, size_t k)
-{
-    enum uint m = 0x5bd1e995;
-    enum int r = 24;
-
-    k *= m;
-    k ^= k >> r;
-    return (h * m) ^ (k * m);
-}
 
 private size_t nextpow2(size_t val) pure nothrow @nogc @safe
 {

--- a/src/root/stringtable.d
+++ b/src/root/stringtable.d
@@ -67,6 +67,17 @@ uint calcHash(const(ubyte)* data, size_t len) pure nothrow @nogc
     return h;
 }
 
+// combine and mix two words (MurmurHash2)
+size_t mixHash(size_t h, size_t k)
+{
+    enum uint m = 0x5bd1e995;
+    enum int r = 24;
+
+    k *= m;
+    k ^= k >> r;
+    return (h * m) ^ (k * m);
+}
+
 private size_t nextpow2(size_t val) pure nothrow @nogc @safe
 {
     size_t res = 1;

--- a/src/root/stringtable.d
+++ b/src/root/stringtable.d
@@ -20,7 +20,12 @@ enum POOL_SIZE = (1U << POOL_BITS);
 // MurmurHash2 was written by Austin Appleby, and is placed in the public
 // domain. The author hereby disclaims copyright to this source code.
 // https://sites.google.com/site/murmurhash/
-private uint calcHash(const(char)* key, size_t len) pure nothrow @nogc
+uint calcHash(const(char)* data, size_t len) pure nothrow @nogc
+{
+    return calcHash(cast(const(ubyte)*)data, len);
+}
+
+uint calcHash(const(ubyte)* data, size_t len) pure nothrow @nogc
 {
     // 'm' and 'r' are mixing constants generated offline.
     // They're not really 'magic', they just happen to work well.
@@ -29,7 +34,6 @@ private uint calcHash(const(char)* key, size_t len) pure nothrow @nogc
     // Initialize the hash to a 'random' value
     uint h = cast(uint)len;
     // Mix 4 bytes at a time into the hash
-    const(ubyte)* data = cast(const(ubyte)*)key;
     while (len >= 4)
     {
         uint k = data[3] << 24 | data[2] << 16 | data[1] << 8 | data[0];

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -187,7 +187,7 @@ BACKOBJ= go.obj gdag.obj gother.obj gflow.obj gloop.obj var.obj el.obj \
 ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 	$(ROOT)/filename.d $(ROOT)/man.d $(ROOT)/outbuffer.d $(ROOT)/port.d \
 	$(ROOT)/response.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
-	$(ROOT)/speller.d $(ROOT)/stringtable.d
+	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d
 
 # D front end
 SRCS = aggregate.h aliasthis.h arraytypes.h	\
@@ -235,7 +235,7 @@ TKSRC= $(TK)\filespec.h $(TK)\mem.h $(TK)\list.h $(TK)\vec.h \
 
 # Root package
 ROOTSRCC=$(ROOT)\newdelete.c
-ROOTSRCD=$(ROOT)\rmem.d $(ROOT)\stringtable.d $(ROOT)\man.d $(ROOT)\port.d \
+ROOTSRCD=$(ROOT)\rmem.d $(ROOT)\stringtable.d $(ROOT)\hash.d $(ROOT)\man.d $(ROOT)\port.d \
 	$(ROOT)\response.d $(ROOT)\rootobject.d $(ROOT)\speller.d $(ROOT)\aav.d \
 	$(ROOT)\ctfloat.d $(ROOT)\outbuffer.d $(ROOT)\filename.d \
 	$(ROOT)\file.d $(ROOT)\array.d


### PR DESCRIPTION
- construct a proper hash to reduce collisions in template instance cache
- in particularly hash all sorts of expressions and combine hashes non-associatively
- the current hash degrades to linear search for many ti arguments, with this
  patch collisions while compiling phobos were reduced from ~36K to 376
- for the reported case (few 1000s alias symbols) compilation is now ~50% faster