### PR TITLE
[scope] fix Issue 17076 don't infer 'return' if return type doesn't have pointers

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -1900,7 +1900,8 @@ extern (C++) class FuncDeclaration : Declaration
                             if (!nrvo_can)
                                 exp = doCopyOrMove(sc2, exp);
 
-                            checkEscape(sc2, exp, false);
+                            if (tret.hasPointers())
+                                checkEscape(sc2, exp, false);
                         }
 
                         exp = checkGC(sc2, exp);

--- a/test/runnable/testscope.d
+++ b/test/runnable/testscope.d
@@ -299,6 +299,11 @@ void test11()
 
 /********************************************/
 
+byte typify13(T)(byte val) { return val; }
+alias INT8_C13  = typify13!byte;
+
+/********************************************/
+
 void main()
 {
     test1();


### PR DESCRIPTION
Accomplished by not needing to check escaping pointers via return if the return type doesn't have indirections.