### PR TITLE
Fix issue 17073 - Do not ignore the explicit initializers

### DIFF
--- a/src/todt.d
+++ b/src/todt.d
@@ -740,8 +740,12 @@ private void membersToDt(AggregateDeclaration ad, DtBuilder dtb,
     {
         if (elements && !(*elements)[firstFieldIndex + i])
             continue;
-        else if (ad.fields[i]._init && ad.fields[i]._init.isVoidInitializer())
-            continue;
+
+        if (!elements || !(*elements)[firstFieldIndex + i])
+        {
+            if (ad.fields[i]._init && ad.fields[i]._init.isVoidInitializer())
+                continue;
+        }
 
         VarDeclaration vd;
         size_t k;
@@ -753,8 +757,12 @@ private void membersToDt(AggregateDeclaration ad, DtBuilder dtb,
 
             if (elements && !(*elements)[firstFieldIndex + j])
                 continue;
-            if (v2._init && v2._init.isVoidInitializer())
-                continue;
+
+            if (!elements || !(*elements)[firstFieldIndex + j])
+            {
+                if (v2._init && v2._init.isVoidInitializer())
+                    continue;
+            }
 
             // find the nearest field
             if (!vd || v2.offset < vd.offset)

--- a/test/runnable/b17073.d
+++ b/test/runnable/b17073.d
@@ -1,0 +1,13 @@
+struct S0
+{
+    int x = void;
+}
+struct S1
+{
+    S0  x = S0(42);
+}
+void main()
+{
+    S1  x;
+    assert(x.x.x == 42);
+}


### PR DESCRIPTION
We don't really care about the _init being void-initialized when the
user has supplied an explicit value for a given field of the aggregate.

And yes, the check is ugly, suggestions are welcome.