### PR TITLE
fix covariant behavior with 'return scope'

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -3698,7 +3698,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     Parameter a = Parameter.getNth(t.parameters, i);
                     Parameter ap = Parameter.getNth(tp.parameters, i);
 
-                    if (!a.isCovariant(ap) ||
+                    if (!a.isCovariant(t.isref, ap) ||
                         !deduceType(a.type, sc, ap.type, parameters, dedtypes))
                     {
                         result = MATCHnomatch;

--- a/src/escape.d
+++ b/src/escape.d
@@ -75,6 +75,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier par, Ex
 
     foreach (VarDeclaration v; er.byvalue)
     {
+        //printf("byvalue %s\n", v.toChars());
         if (v.isDataseg())
             continue;
 
@@ -595,7 +596,7 @@ private void inferReturn(FuncDeclaration fd, VarDeclaration v)
 {
     // v is a local in the current function
 
-    //printf("inferring 'return' for variable '%s'\n", v.toChars());
+    //printf("for function '%s' inferring 'return' for variable '%s'\n", fd.toChars(), v.toChars());
     v.storage_class |= STCreturn;
 
     TypeFunction tf = cast(TypeFunction)fd.type;

--- a/src/expression.d
+++ b/src/expression.d
@@ -4330,7 +4330,7 @@ extern (C++) final class SuperExp : ThisExp
             s = s.toParent();
         assert(s);
         cd = s.isClassDeclaration();
-        //printf("parent is %s %s\n", fd.toParent()->kind(), fd.toParent()->toChars());
+        //printf("parent is %s %s\n", fd.toParent().kind(), fd.toParent().toChars());
         if (!cd)
             goto Lerr;
         if (!cd.baseClass)
@@ -7890,7 +7890,7 @@ extern (C++) abstract class BinExp : Expression
 
         // T opAssign floating yields a floating. Prevent truncating conversions (float to int).
         // See issue 3841.
-        // Should we also prevent double to float (type.isfloating() && type.size() < t2 ->size()) ?
+        // Should we also prevent double to float (type.isfloating() && type.size() < t2.size()) ?
         if (op == TOKaddass || op == TOKminass ||
             op == TOKmulass || op == TOKdivass || op == TOKmodass ||
             op == TOKpowass)
@@ -9973,7 +9973,7 @@ extern (C++) final class CallExp : UnaExp
                     return ue.e1;
                 ethis = ue.e1;
                 tthis = ue.e1.type;
-                if (!f.type.isscope())
+                if (!(f.type.ty == Tfunction && (cast(TypeFunction)f.type).isscope))
                 {
                     if (global.params.vsafe && checkParamArgumentEscape(sc, f, Id.This, ethis, false))
                         return new ErrorExp();
@@ -10247,7 +10247,7 @@ extern (C++) final class CallExp : UnaExp
                 if (tthis)
                     tthis.modToBuffer(&buf);
 
-                //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0]->type.deco);
+                //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0].type.deco);
                 .error(loc, "%s %s %s is not callable using argument types %s", p, e1.toChars(), parametersTypeToChars(tf.parameters, tf.varargs), buf.peekString());
 
                 return new ErrorExp();
@@ -10316,7 +10316,7 @@ extern (C++) final class CallExp : UnaExp
                     argExpTypesToCBuffer(&buf, arguments);
                     buf.writeByte(')');
 
-                    //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0]->type.deco);
+                    //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0].type.deco);
                     .error(loc, "%s %s is not callable using argument types %s", e1.toChars(), parametersTypeToChars(tf.parameters, tf.varargs), buf.peekString());
 
                     f = null;
@@ -10812,7 +10812,7 @@ extern (C++) final class PtrExp : UnaExp
     {
         super(loc, TOKstar, __traits(classInstanceSize, PtrExp), e);
         //if (e.type)
-        //  type = ((TypePointer *)e.type)->next;
+        //  type = ((TypePointer *)e.type).next;
     }
 
     extern (D) this(Loc loc, Expression e, Type t)

--- a/src/func.d
+++ b/src/func.d
@@ -685,6 +685,10 @@ extern (C++) class FuncDeclaration : Declaration
                     sc.stc |= STCref;
             }
 
+            // 'return' on a non-static class member function implies 'scope' as well
+            if (ad && ad.isClassDeclaration() && (tf.isreturn || sc.stc & STCreturn) && !(sc.stc & STCstatic))
+                sc.stc |= STCscope;
+
             sc.linkage = linkage;
 
             if (!tf.isNaked() && !(isThis() || isNested()))
@@ -2376,6 +2380,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         if (ad)
         {
+            //printf("declareThis() %s\n", toChars());
             Type thandle = ad.handleType();
             assert(thandle);
             thandle = thandle.addMod(type.mod);

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -384,7 +384,7 @@ struct Foo12
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1103): Error: scope variable f assigned to non-scope parameter this calling retscope.Foo13.foo
+fail_compilation/retscope.d(1103): Error: scope variable f may not be returned
 ---
 */
 
@@ -490,4 +490,102 @@ void test15() @safe
     bar15(&fp15().d);
 }
 
+
+/*************************************************/
+
+void foo16() @nogc nothrow
+{
+    alias dg_t = string delegate(string) @nogc nothrow;
+
+    dg_t dg = (string s) => s;
+}
+
+/*************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope.d(1701): Error: cannot implicitly convert expression (& func) of type int* function(int* p) to int* function(scope int* p)
+fail_compilation/retscope.d(1702): Error: cannot implicitly convert expression (& func) of type int* function(int* p) to int* function(return scope int* p)
+fail_compilation/retscope.d(1703): Error: cannot implicitly convert expression (& func) of type int* function(int* p) to int* function(return scope int* p)
+fail_compilation/retscope.d(1711): Error: cannot implicitly convert expression (& funcr) of type int* function(return scope int* p) to int* function(scope int* p)
+fail_compilation/retscope.d(1716): Error: cannot implicitly convert expression (& funcrs) of type int* function(return scope int* p) to int* function(scope int* p)
+---
+*/
+
+int* func(int* p);
+int* funcs(scope int* p);
+int* funcr(return int* p);
+int* funcrs(return scope int* p);
+
+void foo17()
+{
+#line 1700
+    typeof(func)   *fp1 = &func;
+    typeof(funcs)  *fp2 = &func; // error
+    typeof(funcr)  *fp3 = &func; // error
+    typeof(funcrs) *fp4 = &func; // error
+
+    typeof(func)   *fq1 = &funcs;
+    typeof(funcs)  *fq2 = &funcs;
+    typeof(funcr)  *fq3 = &funcs;
+    typeof(funcrs) *fq4 = &funcs;
+
+    typeof(func)   *fr1 = &funcr;
+    typeof(funcs)  *fr2 = &funcr; // error
+    typeof(funcr)  *fr3 = &funcr;
+    typeof(funcrs) *fr4 = &funcr;
+
+    typeof(func)   *fs1 = &funcrs;
+    typeof(funcs)  *fs2 = &funcrs; // error
+    typeof(funcr)  *fs3 = &funcrs;
+    typeof(funcrs) *fs4 = &funcrs;
+}
+
+/*************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope.d(1801): Error: cannot implicitly convert expression (&c.func) of type int* delegate() to int* delegate() scope
+fail_compilation/retscope.d(1802): Error: cannot implicitly convert expression (&c.func) of type int* delegate() to int* delegate() return scope
+fail_compilation/retscope.d(1803): Error: cannot implicitly convert expression (&c.func) of type int* delegate() to int* delegate() return scope
+fail_compilation/retscope.d(1811): Error: cannot implicitly convert expression (&c.funcr) of type int* delegate() return scope to int* delegate() scope
+fail_compilation/retscope.d(1816): Error: cannot implicitly convert expression (&c.funcrs) of type int* delegate() return scope to int* delegate() scope
+---
+*/
+
+class C18
+{
+    int* func();
+    int* funcs() scope;
+    int* funcr() return;
+    int* funcrs() return scope;
+}
+
+void foo18()
+{
+    C18 c;
+
+#line 1800
+    typeof(&c.func)   fp1 = &c.func;
+    typeof(&c.funcs)  fp2 = &c.func; // error
+    typeof(&c.funcr)  fp3 = &c.func; // error
+    typeof(&c.funcrs) fp4 = &c.func; // error
+
+    typeof(&c.func)   fq1 = &c.funcs;
+    typeof(&c.funcs)  fq2 = &c.funcs;
+    typeof(&c.funcr)  fq3 = &c.funcs;
+    typeof(&c.funcrs) fq4 = &c.funcs;
+
+    typeof(&c.func)   fr1 = &c.funcr;
+    typeof(&c.funcs)  fr2 = &c.funcr; // error
+    typeof(&c.funcr)  fr3 = &c.funcr;
+    typeof(&c.funcrs) fr4 = &c.funcr;
+
+    typeof(&c.func)   fs1 = &c.funcrs;
+    typeof(&c.funcs)  fs2 = &c.funcrs; // error
+    typeof(&c.funcr)  fs3 = &c.funcrs;
+    typeof(&c.funcrs) fs4 = &c.funcrs;
+}
 

--- a/test/fail_compilation/test16228.d
+++ b/test/fail_compilation/test16228.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -dip25
    TEST_OUTPUT:
 ---
-fail_compilation/test16228.d(22): Error: function has 'return' but does not return any indirections
+fail_compilation/test16228.d(22): Error: function type 'return int()' has 'return' but does not return any indirections
 fail_compilation/test16228.d(23): Error: function test16228.S.foo static member has no 'this' to which 'return' can apply
 ---
 */


### PR DESCRIPTION
This is a significantly better way to check for covariance of function parameters that have combinations of `ref`, `return` and `scope`. It's reduced to an enumeration of 8 cases in `enum SR` which then gets fed into a matrix `covariant[][]` to produce a yay or nay on covariance.

It makes it feasible to reason about this without the various bits of it scattered all through the code.