### PR TITLE
Fix issue 16598 - Explicitly discard the exp. value in void CondExp

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -1147,6 +1147,12 @@ extern (C++) bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type
             t0 = Type.terror;
             continue;
         }
+        if (e.type.ty == Tvoid)
+        {
+            // void expressions do not concur to the determination of the common
+            // type.
+            continue;
+        }
         if (checkNonAssignmentArrayOp(e))
         {
             t0 = Type.terror;
@@ -15735,11 +15741,17 @@ extern (C++) final class CondExp : BinExp
         if (f0 || f1 || f2)
             return new ErrorExp();
 
-        // If either operand is void, the result is void
         Type t1 = e1.type;
         Type t2 = e2.type;
+        // If either operand is void the result is void, we have to cast both
+        // the expression to void so that we explicitly discard the expression
+        // value if any (bugzilla 16598)
         if (t1.ty == Tvoid || t2.ty == Tvoid)
+        {
             type = Type.tvoid;
+            e1 = e1.castTo(sc, type);
+            e2 = e2.castTo(sc, type);
+        }
         else if (t1 == t2)
             type = t1;
         else

--- a/test/compilable/b16598.d
+++ b/test/compilable/b16598.d
@@ -1,0 +1,15 @@
+struct S
+{
+    this(int) {}
+    ~this() {}
+}
+
+int g(S a, S b)
+{
+    return 1;
+}
+
+void main()
+{
+    true ? g(S(), S(1)) : {}();
+}


### PR DESCRIPTION
If a leaf has `void` as type then the whole expression gets the `void` type, by explicitly discarding the value of the non-void leaf we avoid a nasty ICE during the codegen phase in the attached test case: the `g` function returns an `int` but the frontend states that the whole expression is `void` so no registers are allocated for the return value.