### PR TITLE
Fix issue 17086: DMD segfault with multiple template matches and invalid code

### DIFF
--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -5388,8 +5388,10 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
         if (e)
         {
             e = e.syntaxCopy();
-            e = e.semantic(sc);
-            e = resolveProperties(sc, e);
+            if ((e = e.semantic(sc)) is null)
+                return null;
+            if ((e = resolveProperties(sc, e)) is null)
+                return null;
             e = e.resolveLoc(instLoc, sc); // use the instantiated loc
             e = e.optimize(WANTvalue);
         }

--- a/src/expression.d
+++ b/src/expression.d
@@ -902,6 +902,9 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
     else
         return null;
 
+    if (e is null)
+        return null;
+
     // Rewrite
     if (e2)
     {
@@ -8878,7 +8881,7 @@ extern (C++) final class DotIdExp : UnaExp
             if (e1.op == TOKtype || e1.op == TOKtemplate)
                 flag = 0;
             e = e1.type.dotExp(sc, e1, ident, flag | (noderef ? Type.DotExpFlag.noDeref : 0));
-            if (!flag || e)
+            if (e)
                 e = e.semantic(sc);
             return e;
         }

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -2638,7 +2638,7 @@ extern (C++) abstract class Type : RootObject
             e = getProperty(e.loc, ident, flag & DotExpFlag.gag);
 
     Lreturn:
-        if (!(flag & DotExpFlag.gag) || e)
+        if (e)
             e = e.semantic(sc);
         return e;
     }

--- a/test/fail_compilation/testInference.d
+++ b/test/fail_compilation/testInference.d
@@ -205,3 +205,22 @@ void test13729b() pure
     }
     foo();              // cannot call impure function
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/testInference.d(225): Error: testInference.test17086 called with argument types (bool) matches both:
+fail_compilation/testInference.d(219):     testInference.test17086!(bool, false).test17086(bool x)
+and:
+fail_compilation/testInference.d(220):     testInference.test17086!(bool, false).test17086(bool y)
+---
+*/
+
+void test17086 (T, T V = T.init) (T x) { assert(x.foo); }
+void test17086 (T, T V = T.init) (T y) { assert(y.bar); }
+
+void test17086_call ()
+{
+    bool f;
+    test17086(f);
+}


### PR DESCRIPTION
The two conditions in mtype and expression can be simplified, because in the event of 'e' being , we end up with a segfault.
Moreover, the code was just missing a couple of null checks.