### PR TITLE
Fix issue 6227 - Disallow comparison of different enums

### DIFF
--- a/changelog/b6227.dd
+++ b/changelog/b6227.dd
@@ -1,0 +1,24 @@
+Comparison of values belonging to different enums is deprecated.
+
+Since the comparison is done by comparing the value of the enumeration members
+we give up on the type-safety of the enumeration type possibly hiding a whole
+class of bugs that could be caught at compile time.
+
+This change doesn't affect the anonymous enumerations.
+
+---
+enum Status
+{
+    GOOD,
+    BAD
+}
+enum OtherStatus
+{
+    OK
+    NO,
+}
+
+// Deprecated - Even though both GOOD and OK evaluate to 0 they belong to
+// different enumeration types
+static assert(Status.GOOD == OtherStatus.OK);
+---

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -15685,7 +15685,7 @@ extern (C++) final class EqualExp : BinExp
         auto t1 = e1.type;
         auto t2 = e2.type;
         if (t1.ty == Tenum && t2.ty == Tenum && !t1.equivalent(t2))
-            deprecation("Comparison between different pointer types (got %s and %s)",
+            deprecation("Comparison between different enumeration types (got %s and %s)",
                         t1.toChars(), t2.toChars());
 
         /* Before checking for operator overloading, check to see if we're

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -15682,6 +15682,12 @@ extern (C++) final class EqualExp : BinExp
         if (e1.op == TOKtype || e2.op == TOKtype)
             return incompatibleTypes();
 
+        auto t1 = e1.type;
+        auto t2 = e2.type;
+        if (t1.ty == Tenum && t2.ty == Tenum && !t1.equivalent(t2))
+            deprecation("Comparison between different pointer types (got %s and %s)",
+                        t1.toChars(), t2.toChars());
+
         /* Before checking for operator overloading, check to see if we're
          * comparing the addresses of two statics. If so, we can just see
          * if they are the same symbol.

--- a/test/compilable/b6227.d
+++ b/test/compilable/b6227.d
@@ -1,0 +1,18 @@
+/* TEST_OUTPUT:
+---
+compilable/b6227.d(17): Deprecation: Comparison between different enumeration types (got X and Y)
+compilable/b6227.d(18): Deprecation: Comparison between different enumeration types (got X and Y)
+---
+*/
+enum X {
+    O,
+    R
+}
+enum Y {
+    U
+}
+static assert( (X.O == cast(const)X.O));
+static assert( (X.O == X.O));
+static assert( (X.O != X.R));
+static assert(!(X.O != Y.U));
+static assert( (X.O == Y.U));

--- a/test/runnable/gdb1.d
+++ b/test/runnable/gdb1.d
@@ -8,7 +8,7 @@ r ARG1 ARG2
 echo RESULT=
 p args
 ---
-GDB_MATCH: RESULT=.*ARG1.*ARG2
+
 */
 void main(string[] args)
 {


### PR DESCRIPTION
This is only for named enums, the anonymous ones are currently typed as their own base type and we can't do much about those at least with the way the anonymous enums are handled by the frontend.

> I agree it is possible to fix enum.

So let's do it, one step a time!
There are no regressions in phobos or druntime which is a green flag, let's see what you (and the auto tester) has to say about this change.