### PR TITLE
Fix issue 16691: win64 debug info: pass struct value parameters by reference, not pointer

### DIFF
--- a/src/backend/cgcod.c
+++ b/src/backend/cgcod.c
@@ -2635,6 +2635,7 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
                     *pretregs |= BYTEREGS;
                     break;
 
+                case TYnref:
                 case TYnptr:
                 case TYsptr:
                 case TYcptr:

--- a/src/backend/cgcv.c
+++ b/src/backend/cgcv.c
@@ -1859,17 +1859,13 @@ L1:
                         d = debtyp_alloc(10);
                         TOWORD(d->data,0x1002);
                         TOLONG(d->data + 2,next);
-                        // The visual studio debugger gets confused with pointers to arrays, emit a reference instead.
-                        // This especially happens when passing arrays as function arguments because 64bit ABI demands
-                        // passing structs > 8 byte as pointers.
-                        if((config.flags2 & CFG2gms) && t->Tnext && tybasic(t->Tnext->Tty) == TYdarray)
-                            TOLONG(d->data + 6,attribute | 0x20);
-                        else
-                        {
-                            /* BUG: attribute bits are unknown, 0x1000C is maaaagic
-                             */
-                            TOLONG(d->data + 6,attribute | 0x1000C);
-                        }
+                        // see https://github.com/Microsoft/microsoft-pdb/blob/master/include/cvinfo.h#L1514
+                        // add size and pointer type (PTR_64 or PTR_NEAR32)
+                        attribute |= (I64 ? (8 << 13) | 0xC : (4 << 13) | 0xA);
+                        // convert reference to r-value reference to remove & from type display in debugger
+                        if (attribute & 0x20)
+                            attribute |= 0x80;
+                        TOLONG(d->data + 6,attribute);
                         break;
 
                     default:

--- a/src/toir.d
+++ b/src/toir.d
@@ -909,7 +909,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
             elem *ev = el_var(toSymbol(v));
             if (win64ref)
             {
-                ev.Ety = TYnptr;
+                ev.Ety = TYnref;
                 ev = el_una(OPind, tym, ev);
                 if (tybasic(ev.Ety) == TYstruct || tybasic(ev.Ety) == TYarray)
                     ev.ET = Type_toCtype(v.type);


### PR DESCRIPTION
The existing implementation converted all pointers to dynamic arrays into references when -gc is given on the command line. This is a bit coarse, because it doesn't help other types and also converts a regular variable `string* p` to a reference.

Instead the converted parameter should no longer use a pointer, but a reference. This is then emitted as a r-value reference which allows a C++ debugger to display the value without an additional `&`. This works nicely in VS2013 and VS2015. What other debuggers should be checked whether they are compatibe with this change? I don't expect much trouble because it's just an additional flag that has been undocumented until recently.