### PR TITLE
fix Issue 17072 - [REG 2.073.0-b1] missing symbols with -inline

### DIFF
--- a/src/escape.d
+++ b/src/escape.d
@@ -532,15 +532,15 @@ private bool checkEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         /* Check for returning a ref variable by 'ref', but should be 'return ref'
          * Infer the addition of 'return', or set result to be the offending expression.
          */
-        if (global.params.useDIP25 &&
-            (v.storage_class & (STCref | STCout)) &&
+        if ( (v.storage_class & (STCref | STCout)) &&
             !(v.storage_class & (STCreturn | STCforeach)))
         {
             if (sc.func.flags & FUNCFLAGreturnInprocess && p == sc.func)
             {
                 inferReturn(sc.func, v);        // infer addition of 'return'
             }
-            else if (sc._module && sc._module.isRoot())
+            else if (global.params.useDIP25 &&
+                     sc._module && sc._module.isRoot())
             {
                 // Only look for errors if in module listed on command line
 

--- a/test/runnable/test17072.d
+++ b/test/runnable/test17072.d
@@ -9,5 +9,5 @@ import core.thread;
 
 void main()
 {
-        Thread.sleep(dur!"msecs"(50));
+        Thread.sleep(dur!"msecs"(0));
 }

--- a/test/runnable/test17072.d
+++ b/test/runnable/test17072.d
@@ -1,6 +1,6 @@
 /*
 REQUIRED_ARGS: -inline
-PERMUTE_ARSG:
+PERMUTE_ARGS: -release -O -dip25
 */
 
 // https://issues.dlang.org/show_bug.cgi?id=17072

--- a/test/runnable/test17072.d
+++ b/test/runnable/test17072.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -inline
+PERMUTE_ARSG:
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=17072
+
+import core.thread;
+
+void main()
+{
+        Thread.sleep(dur!"msecs"(50));
+}


### PR DESCRIPTION
The fix is done by always inferring 'return', just not issuing errors if `-dip25` is not thrown.