### PR TITLE
Fix issue 16697 - Accept __vector as type specialization in is()

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -7646,6 +7646,12 @@ extern (C++) final class IsExp : Expression
                 // not valid for a parameter
                 break;
 
+            case TOKvector:
+                if (targ.ty != Tvector)
+                    goto Lno;
+                tded = (cast(TypeVector)targ).basetype;
+                break;
+
             default:
                 assert(0);
             }

--- a/src/parse.d
+++ b/src/parse.d
@@ -7409,7 +7409,7 @@ final class Parser : Lexer
                     {
                         tok = token.value;
                         nextToken();
-                        if (tok == TOKequal && (token.value == TOKstruct || token.value == TOKunion || token.value == TOKclass || token.value == TOKsuper || token.value == TOKenum || token.value == TOKinterface || token.value == TOKargTypes || token.value == TOKparameters || token.value == TOKconst && peek(&token).value == TOKrparen || token.value == TOKimmutable && peek(&token).value == TOKrparen || token.value == TOKshared && peek(&token).value == TOKrparen || token.value == TOKwild && peek(&token).value == TOKrparen || token.value == TOKfunction || token.value == TOKdelegate || token.value == TOKreturn))
+                        if (tok == TOKequal && (token.value == TOKstruct || token.value == TOKunion || token.value == TOKclass || token.value == TOKsuper || token.value == TOKenum || token.value == TOKinterface || token.value == TOKargTypes || token.value == TOKparameters || token.value == TOKconst && peek(&token).value == TOKrparen || token.value == TOKimmutable && peek(&token).value == TOKrparen || token.value == TOKshared && peek(&token).value == TOKrparen || token.value == TOKwild && peek(&token).value == TOKrparen || token.value == TOKfunction || token.value == TOKdelegate || token.value == TOKreturn || (token.value == TOKvector && peek(&token).value == TOKrparen)))
                         {
                             tok2 = token.value;
                             nextToken();

--- a/test/compilable/b16697.d
+++ b/test/compilable/b16697.d
@@ -1,0 +1,13 @@
+version(D_SIMD)
+{
+    static assert(!is(         float       == __vector)); 
+    static assert(!is(         float[1]    == __vector)); 
+    static assert(!is(         float[4]    == __vector)); 
+    static assert( is(__vector(float[4])   == __vector)); 
+    static assert(!is(__vector(float[3])   == __vector)); 
+    static assert(!is(__vector(float[5])   == __vector)); 
+    static assert( is(__vector(float[4]) X == __vector) &&
+                   is(X == float[4])); 
+    static assert( is(__vector(byte[16]) X == __vector) &&
+                   is(X == byte[16])); 
+}


### PR DESCRIPTION
Ping @WalterBright, is this OK?