### PR TITLE
Fix issue 15428 - Properly detach the temporary scope for compiles()

### DIFF
--- a/src/traits.d
+++ b/src/traits.d
@@ -1060,6 +1060,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                     err = true;
             }
 
+            // Carefully detach the scope from the parent and throw it away as
+            // we only need it to evaluate the expression
+            // https://issues.dlang.org/show_bug.cgi?id=15428
+            sc2.freeFieldinit();
+            sc2.enclosing = null;
             sc2.pop();
 
             if (global.endGagging(errors) || err)

--- a/test/compilable/b15428.d
+++ b/test/compilable/b15428.d
@@ -1,0 +1,13 @@
+class A
+{
+    this() {}
+}
+
+class B : A
+{
+    this()
+    {
+        static if (__traits(compiles, super()))
+            super();
+    }
+}

--- a/test/fail_compilation/fail9665a.d
+++ b/test/fail_compilation/fail9665a.d
@@ -150,7 +150,7 @@ struct S3
 /+
 TEST_OUTPUT:
 ---
-fail_compilation/fail9665a.d(162): Error: immutable field 'v' initialized multiple times
+fail_compilation/fail9665a.d(163): Error: static assert  (__traits(compiles, this.v = 1)) is false
 ---
 +/
 struct S4
@@ -159,7 +159,8 @@ struct S4
     this(int)
     {
         static assert(__traits(compiles, v = 1));
-        v = 1;  // multiple initialization
+        v = 1;
+        static assert(__traits(compiles, v = 1)); // multiple initialization
     }
 }
 


### PR DESCRIPTION
I won't say this is the most elegant way to detach the `Scope` but it works :)
The change to `fail9665a.d` has been made because it didn't make much sense IMO, the `compiles` trait compiles the expression speculatively and throws the results away, therefore `v` was still uninitialized.