### PR TITLE
Output DWARF informations for the enum declarations

### DIFF
--- a/src/ddmd/backend/dwarf.c
+++ b/src/ddmd/backend/dwarf.c
@@ -2725,6 +2725,8 @@ unsigned dwarf_typidx(type *t)
                 1,                      // child (the subrange type)
                 DW_AT_name,             DW_FORM_string,
                 DW_AT_byte_size,        DW_FORM_data1,
+                DW_AT_type,             DW_FORM_ref4,
+                DW_AT_enum_class,       DW_FORM_flag,
                 0,                      0,
             };
             static unsigned char abbrevTypeEnumMember[] =
@@ -2745,6 +2747,7 @@ unsigned dwarf_typidx(type *t)
             if (s->Stypidx)
                 return s->Stypidx;
 
+#if 0
             if (se->SEflags & SENforward)
             {
                 static unsigned char abbrevTypeEnumForward[] =
@@ -2762,6 +2765,7 @@ unsigned dwarf_typidx(type *t)
                 infobuf->writeByte(1);                  // DW_AT_declaration
                 break;                  // don't set Stypidx
             }
+#endif
 
             Outbuffer abuf;             // for abbrev
             abuf.write(abbrevTypeEnum, sizeof(abbrevTypeEnum));
@@ -2782,21 +2786,24 @@ unsigned dwarf_typidx(type *t)
             abuf.writeByte(0);
             membercode = dwarf_abbrev_code(abuf.buf, abuf.size());
 
+            unsigned tbase_idx = dwarf_typidx(tbase);
             idx = infobuf->size();
             infobuf->writeuLEB128(code);
             infobuf->writeString(s->Sident);    // DW_AT_name
             infobuf->writeByte(sz);             // DW_AT_byte_size
+            infobuf->write32(tbase_idx);        // DW_AT_type
+            infobuf->writeByte(1);              // DW_AT_enum_class
 
             for (sl = s->Senumlist; sl; sl = list_next(sl))
             {   symbol *sf = (symbol *)list_ptr(sl);
-                unsigned long value = el_tolongt(sf->Svalue);
+                targ_llong value = el_tolongt(sf->Svalue);
 
                 infobuf->writeuLEB128(membercode);
                 infobuf->writeString(sf->Sident);
                 if (tyuns(tbase->Tty))
-                    infobuf->writeuLEB128(value);
+                    infobuf->writeuLEB128_(value);
                 else
-                    infobuf->writesLEB128(value);
+                    infobuf->writesLEB128_(value);
             }
 
             infobuf->writeByte(0);              // no more children

--- a/src/ddmd/backend/outbuf.c
+++ b/src/ddmd/backend/outbuf.c
@@ -305,3 +305,31 @@ void Outbuffer::writeuLEB128(unsigned value)
     } while (value);
 }
 
+void Outbuffer::writesLEB128_(targ_llong value)
+{
+    while (1)
+    {
+        unsigned char b = value & 0x7F;
+
+        value >>= 7;            // arithmetic right shift
+        if (value == 0 && !(b & 0x40) ||
+            value == -1 && (b & 0x40))
+        {
+             writeByte(b);
+             break;
+        }
+        writeByte(b | 0x80);
+    }
+}
+
+void Outbuffer::writeuLEB128_(targ_ullong value)
+{
+    do
+    {   unsigned char b = value & 0x7F;
+
+        value >>= 7;
+        if (value)
+            b |= 0x80;
+        writeByte(b);
+    } while (value);
+}

--- a/src/ddmd/backend/outbuf.h
+++ b/src/ddmd/backend/outbuf.h
@@ -205,4 +205,6 @@ struct Outbuffer
     void writesLEB128(int value);
     void writeuLEB128(unsigned value);
 
+    void writesLEB128_(targ_llong value);
+    void writeuLEB128_(targ_ullong value);
 };

--- a/src/ddmd/backend/type.c
+++ b/src/ddmd/backend/type.c
@@ -473,6 +473,21 @@ type *type_enum(const char *name, type *tbase)
     return t;
 }
 
+/***************************************
+ * Append a member to the enum type.
+ * Input:
+ *      e       enum type
+ *      name    name of the member
+ *      value   value of the member
+ */
+void type_enum_addMember(Symbol *e, const char *name, targ_llong value)
+{
+    Symbol *s2 = symbol_name(name, SCconst, e->Stype);
+    s2->Svalue  = el_long(TYullong, value);
+    s2->Sflags |= SFLvalue;
+    list_append(&e->Senumlist, s2);
+}
+
 /**************************************
  * Create a struct/union/class type.
  * Params:

--- a/src/ddmd/backend/type.d
+++ b/src/ddmd/backend/type.d
@@ -70,6 +70,7 @@ type* type_assoc_array(type* tkey, type* tvalue);
 type* type_delegate(type* tnext);
 extern extern (C) type* type_function(tym_t tyf, type** ptypes, size_t nparams, bool variadic, type* tret);
 type* type_enum(const(char)* name, type* tbase);
+void type_enum_addMember(Symbol *e, const char *name, targ_llong value);
 type* type_struct_class(const(char)* name, uint alignsize, uint structsize,
     type* arg1type, type* arg2type, bool isUnion, bool isClass, bool isPOD);
 

--- a/src/ddmd/toctype.d
+++ b/src/ddmd/toctype.d
@@ -168,9 +168,18 @@ public:
                 // https://issues.dlang.org/show_bug.cgi?id=13792
                 t.ctype = Type_toCtype(Type.tvoid);
             }
-            else if (t.sym.memtype.toBasetype().ty == Tint32)
+            else if (t.sym.memtype.toBasetype().isintegral())
             {
-                t.ctype = type_enum(t.sym.toPrettyChars(true), Type_toCtype(t.sym.memtype));
+                // We only need the bare, un-qualified name
+                t.ctype = type_enum(t.sym.toChars(), Type_toCtype(t.sym.memtype));
+
+                foreach (s; *t.sym.members)
+                {
+                    if (auto em = s.isEnumMember())
+                    {
+                        type_enum_addMember(cast(Symbol*)t.ctype.Ttag, em.toChars(), em.value.toInteger());
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
As noted by @mathias-lang-sociomantic in [this ticket](https://issues.dlang.org/show_bug.cgi?id=15630) `gdb` wouldn't show the value of the enum-typed parameter.
Further investigation showed that this was never implemented or has been thrown away at some point so I took the chance and implemented it and also extended the functionality a bit: it now works with every enum with an integral base type, both signed and unsigned, ranging from {u,}byte to {u,}long.

It hasn't been tested on x86, only x64.

Some technical infos: the `SENforward` flag is now ignored since it was only set once in the whole codebase (in `type_enum` and never cleared) and is not needed for our purpose (I can remove the whole `#if 0` block and/or the flag itself if needed). We now emit a `DW_AT_type` for the enumeration type like other cooler compilers do (I've cross-checked this with `LDC`, we're pretty cool).