### PR TITLE
Fix issue 14964 - Introduce the isAlias trait

### DIFF
--- a/src/idgen.d
+++ b/src/idgen.d
@@ -358,6 +358,7 @@ Msgtable[] msgtable =
     { "getUnitTests" },
     { "getVirtualIndex" },
     { "getPointerBitmap" },
+    { "isAlias" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/traits.d
+++ b/src/traits.d
@@ -98,6 +98,7 @@ static this()
         "getUnitTests",
         "getVirtualIndex",
         "getPointerBitmap",
+        "isAlias",
     ];
 
     traitsStringTable._init(40);
@@ -365,6 +366,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
     if (e.ident != Id.compiles &&
         e.ident != Id.isSame &&
+        e.ident != Id.isAlias &&
         e.ident != Id.identifier &&
         e.ident != Id.getProtection)
     {
@@ -548,6 +550,25 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     if (e.ident == Id.isLazy)
     {
         return isDeclX(d => (d.storage_class & STClazy) != 0);
+    }
+    if (e.ident == Id.isAlias)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        auto ta = isType((*e.args)[0]);
+        if (!ta || ta.ty != Tident)
+        {
+            e.error("argument is not an identifier");
+            return new ErrorExp();
+        }
+
+        if (auto s = sc.search(e.loc, (cast(TypeIdentifier)ta).ident, null))
+        {
+            if (s.isAliasDeclaration())
+               return True();
+        }
+        return False();
     }
     if (e.ident == Id.identifier)
     {

--- a/test/compilable/b14964.d
+++ b/test/compilable/b14964.d
@@ -1,0 +1,22 @@
+template foo(alias S, int W)
+{
+    static assert( __traits(isAlias, S));
+    static assert(!__traits(isAlias, W));
+}
+
+struct S(T)
+{
+    static assert( __traits(isAlias, T));
+}
+
+void main()
+{
+    int var;
+    alias par = var;
+    alias foo1 = foo!(S,4);
+    auto s = new S!int;
+    static assert( __traits(isAlias, par));
+    static assert( __traits(isAlias, foo1));
+    static assert(!__traits(isAlias, var));
+    static assert(!__traits(isAlias, s));
+}

--- a/test/fail_compilation/bb14964.d
+++ b/test/fail_compilation/bb14964.d
@@ -1,0 +1,8 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/bb14964.d(7): Error: argument is not an identifier
+fail_compilation/bb14964.d(8): Error: expected 1 arguments for isAlias but had 2
+---
+*/
+static assert( __traits(isAlias, int));
+static assert( __traits(isAlias, a, b));


### PR DESCRIPTION
Quick'n'dirty implementation, possibly needs more testing to uncover some edge cases.