### PR TITLE
infer 'scope' for 'this' parameter

### DIFF
--- a/src/func.d
+++ b/src/func.d
@@ -2238,6 +2238,13 @@ extern (C++) class FuncDeclaration : Declaration
             }
         }
 
+        if (vthis && vthis.storage_class & STCmaybescope)
+        {
+            vthis.storage_class &= ~STCmaybescope;
+            vthis.storage_class |= STCscope;
+            f.isscope = true;
+        }
+
         // reset deco to apply inference result to mangled name
         if (f != type)
             f.deco = null;
@@ -2402,6 +2409,8 @@ extern (C++) class FuncDeclaration : Declaration
                 if (tf.isscope)
                     v.storage_class |= STCscope;
             }
+            if (flags & FUNCFLAGinferScope)
+                v.storage_class |= STCmaybescope;
 
             v.semantic(sc);
             if (!sc.insert(v))

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -589,3 +589,26 @@ void foo18()
     typeof(&c.funcrs) fs4 = &c.funcrs;
 }
 
+/********************************************/
+
+
+bool foo20(const string a) @safe pure nothrow @nogc
+{
+    return !a.length;
+}
+
+struct Result(R)
+{
+    R source;
+
+    bool empty() // infer 'scope' for 'this'
+    { return foo20(source); }
+}
+
+@safe void test20()
+{
+    scope n = Result!string("abc");
+    n.empty();
+}
+
+


### PR DESCRIPTION
I had forgotten to do that. It's needed to compile Phobos.