### PR TITLE
workaround issue 5227 - add pow() to builtin ctfe functions

### DIFF
--- a/src/builtin.d
+++ b/src/builtin.d
@@ -85,6 +85,17 @@ extern (C++) Expression eval_sqrt(Loc loc, FuncDeclaration fd, Expressions* argu
     return new RealExp(loc, CTFloat.sqrt(arg0.toReal()), arg0.type);
 }
 
+extern (C++) Expression eval_pow(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOKfloat64);
+    const x = arg0.toReal();
+    const y = arg1.toReal();
+    return new RealExp(loc, CTFloat.pow(x, y), arg0.type);
+}
+
 extern (C++) Expression eval_fabs(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
@@ -264,6 +275,12 @@ public extern (C++) void builtin_init()
     {
         add_builtin("_D3std4math6yl2xp1FNaNbNiNfeeZe", &eval_unimp);
     }
+    // @trusted @nogc pure nothrow float function(float, float)
+    add_builtin("_D3std4math12__T3powTfTfZ3powFNaNbNiNeffZf", &eval_pow);
+    // @trusted @nogc pure nothrow double function(double, double)
+    add_builtin("_D3std4math12__T3powTdTdZ3powFNaNbNiNeddZd", &eval_pow);
+    // @trusted @nogc pure nothrow real function(real, real)
+    add_builtin("_D3std4math12__T3powTeTeZ3powFNaNbNiNeeeZe", &eval_pow);
     // @safe @nogc pure nothrow long function(real)
     add_builtin("_D3std4math6rndtolFNaNbNiNfeZl", &eval_unimp);
     // @safe @nogc pure nothrow int function(uint)

--- a/src/root/ctfloat.d
+++ b/src/root/ctfloat.d
@@ -64,6 +64,7 @@ extern (C++) struct CTFloat
     static real_t tan(real_t x) { return core.stdc.math.tanl(x); }
     static real_t sqrt(real_t x) { return core.math.sqrt(x); }
     static real_t fabs(real_t x) { return core.math.fabs(x); }
+    static real_t pow(real_t x, real_t y) { return core.stdc.math.powl(x, y); }
 
     static bool isIdentical(real_t a, real_t b)
     {

--- a/test/compilable/test5227.d
+++ b/test/compilable/test5227.d
@@ -1,0 +1,24 @@
+
+enum cif = 5 ^^ 6.25f;
+enum cid = 5 ^^ 6.25;
+enum cil = 5 ^^ 6.25L;
+
+enum cff = 5.42f ^^ 6.25f;
+enum cfd = 5.42f ^^ 6.25;
+enum cfl = 5.42f ^^ 6.25L;
+
+enum cdf = 5.42 ^^ 6.25f;
+enum cdd = 5.42 ^^ 6.25;
+enum cdl = 5.42 ^^ 6.25L;
+
+enum clf = 5.42L ^^ 6.25f;
+enum cld = 5.42L ^^ 6.25;
+enum cll = 5.42L ^^ 6.25L;
+
+float  funcFloat(float x, float y)    { return x ^^ y; }
+double funcDouble(double x, double y) { return x ^^ y; }
+real   funcReal(real x, real y)       { return x ^^ y; }
+
+enum funcValueF = funcFloat(5.42f, 6.25f);
+enum funcValueD = funcDouble(5.42, 6.25);
+enum funcValueL = funcReal(5.42L, 6.25L);

--- a/test/runnable/test5227.d
+++ b/test/runnable/test5227.d
@@ -1,0 +1,18 @@
+// test to ensure accuracy of "^^" in ctfe is same as runtime pow()
+
+bool checkPow(alias A, alias B)()
+{
+    import std.math : pow;
+    enum ct = A ^^ B;
+    return ct == pow(A, B);
+}
+
+void main()
+{
+    assert(checkPow!(1.75L, 1 / 3.0L)());
+    assert(checkPow!(1 / 3.0L, 1.75L)());
+    assert(checkPow!(3.75L, 2.33L)());
+    assert(checkPow!(138.88L, 74.33L)());
+    assert(checkPow!(138.88L, 0.22L)());
+    assert(checkPow!(247.38L, 5.13L)());
+}


### PR DESCRIPTION
A workaround using builtin ctfe functions instead of fixing pow in std.math to be ctfe compatible.