### PR TITLE
fix Issue 17117 - erroneous 'escaping reference to local variable'

### DIFF
--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -589,7 +589,6 @@ void foo18()
     typeof(&c.funcrs) fs4 = &c.funcrs;
 }
 
-
 /*********************************************/
 
 @safe void foo19(C)(ref C[] str)  // infer 'scope' for 'str'
@@ -606,6 +605,7 @@ void foo18()
 }
 
 /********************************************/
+
 
 bool foo20(const string a) @safe pure nothrow @nogc
 {
@@ -624,5 +624,27 @@ struct Result(R)
 {
     scope n = Result!string("abc");
     n.empty();
+}
+
+/************************************************/
+
+// https://issues.dlang.org/show_bug.cgi?id=17117
+
+ref int foo21(return ref int s)
+{
+        return s;
+}
+
+int fail21()
+{
+        int s;
+        return foo21(s); // Error: escaping reference to local variable s
+}
+
+int test21()
+{
+        int s;
+        s = foo21(s);
+        return s;
 }
 


### PR DESCRIPTION
Can't reproduce it, so just added the test case.