### PR TITLE
first method-call support

### DIFF
--- a/src/bc.d
+++ b/src/bc.d
@@ -1312,12 +1312,6 @@ const(BCValue) interpret_(const int[] byteCode, const BCValue[] args,
     }
     auto stack = stackPtr ? stackPtr : new long[](ushort.max / 4);
 
-    ulong dataSegHigh = 0; /// 56bit wide of the dataSegOffset
-    uint drOffset = 0; /// data registerOffset
-
-    uint dr; ///dataRegister holds the value of dataDeg[dataSegHigh | drOffset]
-    ubyte db; /// current dataByte a slice of the dataRegister with range [0 .. 4]
-
     // first push the args on
     debug (bc)
         if (!__ctfe)
@@ -1360,8 +1354,6 @@ const(BCValue) interpret_(const int[] byteCode, const BCValue[] args,
             //       assert(0, "unsupported Type " ~ to!string(arg.type));
         }
     }
-    uint cacheIp;
-    uint[16] iCache; // not used right now... but we should!
     uint ip = 4;
     bool cond;
 
@@ -1392,9 +1384,9 @@ const(BCValue) interpret_(const int[] byteCode, const BCValue[] args,
 
         // consider splitting the stackPointer in stackHigh and stackLow
 
-        auto opRefOffset = (lw >> 16) & 0xFFFF;
-        auto lhsOffset = hi & 0xFFFF;
-        auto rhsOffset = (hi >> 16) & 0xFFFF;
+        const uint opRefOffset = (lw >> 16) & 0xFFFF;
+        const uint lhsOffset = hi & 0xFFFF;
+        const uint rhsOffset = (hi >> 16) & 0xFFFF;
 
         auto lhsRef = (stackP + (lhsOffset / 4));
         auto rhs = (stackP + (rhsOffset / 4));
@@ -1882,7 +1874,7 @@ const(BCValue) interpret_(const int[] byteCode, const BCValue[] args,
                     debug writeln("stackOffsetCall: ", stackOffsetCall);
                 }
 
-                __gshared static BCValue[16] callArgs;
+                BCValue[16] callArgs = void;
 
                 foreach(i,ref arg;call.args)
                 {

--- a/src/bc.d
+++ b/src/bc.d
@@ -1302,7 +1302,7 @@ const(BCValue) interpret_(const int[] byteCode, const BCValue[] args,
     BCValue* ev1 = null, BCValue* ev2 = null, const RE* errors = null,
     long[] stackPtr = null, uint stackOffset = 0)  @trusted
 {
-    static uint callDepth;
+    __gshared static uint callDepth;
     import std.conv;
     import std.stdio;
 
@@ -1882,7 +1882,7 @@ const(BCValue) interpret_(const int[] byteCode, const BCValue[] args,
                     debug writeln("stackOffsetCall: ", stackOffsetCall);
                 }
 
-                BCValue[16] callArgs;
+                __gshared static BCValue[16] callArgs;
 
                 foreach(i,ref arg;call.args)
                 {

--- a/src/bc_common.d
+++ b/src/bc_common.d
@@ -287,6 +287,8 @@ struct BCHeapRef
 {
     BCType type;
     BCValueType vType;
+    ushort tmpIndex;
+
     union
     {
         HeapAddr heapAddr;
@@ -300,6 +302,11 @@ struct BCHeapRef
         {
             case BCValueType.StackValue, BCValueType.Parameter :
                 stackAddr = that.stackAddr;
+                tmpIndex = that.tmpIndex;
+            break;
+            case BCValueType.Temporary:
+                stackAddr = that.stackAddr;
+                tmpIndex = that.tmpIndex;
             break;
 
             case BCValueType.HeapValue :
@@ -314,6 +321,7 @@ struct BCHeapRef
                 import std.conv : to;
                 assert(0, "vType unsupported: " ~ to!string(that.vType));
         }
+        type = that.type;
         vType = that.vType;
     }
 }
@@ -483,8 +491,14 @@ struct BCValue
         {
             case BCValueType.StackValue, BCValueType.Parameter :
                 stackAddr = heapRef.stackAddr;
+                tmpIndex = heapRef.tmpIndex;
                 break;
-                
+
+            case BCValueType.Temporary :
+                stackAddr = heapRef.stackAddr;
+                tmpIndex = heapRef.tmpIndex;
+                break;
+
             case BCValueType.HeapValue :
                 heapAddr = heapRef.heapAddr;
                 break;

--- a/src/bc_common.d
+++ b/src/bc_common.d
@@ -113,7 +113,7 @@ struct BCType
     /// 0 means basic type
     uint typeIndex;
     // additional information
-    uint flags;
+    ubyte flags;
 }
 
 enum BCValueType : ubyte
@@ -289,7 +289,6 @@ struct BCBranch
 
 struct BCHeapRef
 {
-    BCType type;
     BCValueType vType;
     ushort tmpIndex;
 
@@ -305,9 +304,6 @@ struct BCHeapRef
         switch(that.vType)
         {
             case BCValueType.StackValue, BCValueType.Parameter :
-                stackAddr = that.stackAddr;
-                tmpIndex = that.tmpIndex;
-            break;
             case BCValueType.Temporary:
                 stackAddr = that.stackAddr;
                 tmpIndex = that.tmpIndex;
@@ -325,7 +321,6 @@ struct BCHeapRef
                 import std.conv : to;
                 assert(0, "vType unsupported: " ~ to!string(that.vType));
         }
-        type = that.type;
         vType = that.vType;
     }
 }
@@ -489,7 +484,6 @@ struct BCValue
 
     this(const BCHeapRef heapRef)
     {
-        this.type = heapRef.type;
         this.vType = heapRef.vType;
         switch (vType)
         {

--- a/src/bc_common.d
+++ b/src/bc_common.d
@@ -253,9 +253,13 @@ struct Imm32
 }
 
 
-BCValue imm32(uint value) pure @safe
+BCValue imm32(uint value) pure @trusted
 {
-    return BCValue(Imm32(value));
+    BCValue ret = void;
+    ret.vType = BCValueType.Immediate;
+    ret.type = BCTypeEnum.i32;
+    ret.imm32 = value;
+    return ret;
 }
 
 struct Imm64

--- a/src/ctfe_bc.d
+++ b/src/ctfe_bc.d
@@ -2178,7 +2178,6 @@ static if (is(BCGen))
                 Alloc(addr, _sharedCtfeState.size(v.type).imm32);
                 Store32(addr, v);
                 v.heapRef = BCHeapRef(addr);
-                v.heapRef.type = retval.type;
 
                 setVariable(vd, v);
                 // register as pointer and set the variable to pointer as well;

--- a/src/ctfe_bc.d
+++ b/src/ctfe_bc.d
@@ -2572,7 +2572,7 @@ static if (is(BCGen))
                     bailout("Could not get field-offset of" ~ vd.toString);
                 }
 
-                //debug (ctfe)
+                debug (ctfe)
                 {
                     import std.stdio;
 
@@ -2974,7 +2974,7 @@ static if (is(BCGen))
                 return;
             }
 
-            if(sv.heapRef != BCHeapRef.init)
+            if(sv.heapRef != BCHeapRef.init && sv.vType == BCValueType.StackValue)
             {
                 LoadFromHeapRef(sv);
             }
@@ -3536,7 +3536,7 @@ static if (is(BCGen))
 
             auto fIndex = findFieldIndexByName(structDeclPtr, vd);
             assert(fIndex != -1, "field " ~ vd.toString ~ "could not be found in" ~ dve.e1.toString);
-            BCStruct bcStructType = _sharedCtfeState .structTypes[structTypeIndex - 1];
+            BCStruct bcStructType = _sharedCtfeState.structTypes[structTypeIndex - 1];
 
             if (bcStructType.memberTypes[fIndex].type != BCTypeEnum.i32)
             {

--- a/src/ctfe_bc.d
+++ b/src/ctfe_bc.d
@@ -3259,7 +3259,7 @@ static if (is(BCGen))
         }
 
         auto bct = toBCType(ie.type);
-        if (bct.type != BCTypeEnum.i32 && bct.type != BCTypeEnum.i64)
+        if (bct.type != BCTypeEnum.i32 && bct.type != BCTypeEnum.i64 && bct.type != BCTypeEnum.Char)
         {
             //NOTE this can happen with cast(char*)size_t.max for example
             bailout("We don't support IntegerExpressions with non-integer types");

--- a/src/ctfe_bc.d
+++ b/src/ctfe_bc.d
@@ -1670,6 +1670,11 @@ public:
             }
             beginFunction(fnIdx - 1);
             visit(fbody);
+            if(fd.type.nextOf.ty == Tvoid)
+            {
+                // insert a dummy return after void functions because they can omit a returnStatement
+                Ret(imm32(0));
+            }
             auto osp2 = sp.addr;
             endFunction();
             if (IGaveUp)

--- a/src/ctfe_bc.d
+++ b/src/ctfe_bc.d
@@ -1530,10 +1530,10 @@ public:
 
     BCValue getVariable(VarDeclaration vd)
     {
-        import ddmd.declaration : STCmanifest, STCref;
-        if (vd.storage_class & STCref)
+        import ddmd.declaration : STCmanifest, STCref, STCstatic;
+        if (vd.storage_class & STCref || vd.storage_class & STCstatic)
         {
-            bailout("cannot handle ref variables");
+            bailout("cannot handle ref or static variables");
             return BCValue.init;
         }
 

--- a/src/ctfe_bc.d
+++ b/src/ctfe_bc.d
@@ -581,10 +581,12 @@ struct BCStruct
     uint size;
 
     BCType[96] memberTypes;
+    bool[96] isVoidInit;
 
-    void addField(SharedCtfeState!BCGenT* state, const BCType bct)
+    void addField(SharedCtfeState!BCGenT* state, const BCType bct, bool isVoidInit)
     {
-        memberTypes[memberTypeCount++] = bct;
+        memberTypes[memberTypeCount] = bct;
+        isVoidInit[memberTypeCount++] = isVoidInit;
         size += state.size(bct);
     }
 
@@ -1260,10 +1262,11 @@ extern (C++) final class BCTypeVisitor : Visitor
         foreach (sMember; sd.fields)
         {
             if (sMember.type.ty == Tstruct && (cast(TypeStruct) sMember.type).sym == sd)
-                assert(0);
+                assert(0, "recursive struct definition this should never happen");
 
             auto bcType = toBCType(sMember.type);
             st.addField(&_sharedCtfeState, bcType);
+
         }
 
         sharedCtfeState.endStruct(&st);

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -142,7 +142,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 
 # D front end
 FRONT_SRCS=access.d aggregate.d aliasthis.d apply.d argtypes.d arrayop.d	\
-	arraytypes.d attrib.d builtin.d asttypename.d bc.d bc_common.d		\
+	arraytypes.d attrib.d builtin.d bc.d bc_common.d			\
 	bc_macro.d bc_printer_backend.d bc_c_backend.d ctfe_bc.d bc_test.d	\
 	canthrow.d clone.d complex.d cond.d constfold.d cppmangle.d ctfeexpr.d	\
 	dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d		\


### PR DESCRIPTION
Method calls are now supported.
They mostly reuse the infrastructure of normal pointer support.

fails travis because of 
`fail_compilation/ctfe10995.d`
Basically I because cannot preserve the VoidValue attribute through a function call.
Doing this will require inter-procedural dataflow-ananlysis.
So it'll be a while until this is ready.