### PR TITLE
DIP 1007: add @__future feature proposal

### DIFF
--- a/src/ddmd/astbase.d
+++ b/src/ddmd/astbase.d
@@ -152,6 +152,7 @@ struct ASTBase
     enum STCinference           = (1L << 46);   // do attribute inference
     enum STCexptemp             = (1L << 47);   // temporary variable that has lifetime restricted to an expression
     enum STCmaybescope          = (1L << 48);   // parameter might be 'scope'
+    enum STCfuture              = (1L << 49);   // introducing new base class function
 
     enum STC_TYPECTOR = (STCconst | STCimmutable | STCshared | STCwild);
 

--- a/src/ddmd/astcodegen.d
+++ b/src/ddmd/astcodegen.d
@@ -69,6 +69,7 @@ struct ASTCodegen
     alias STCdeprecated             = ddmd.declaration.STCdeprecated;
     alias STCstatic                 = ddmd.declaration.STCstatic;
     alias STCextern                 = ddmd.declaration.STCextern;
+    alias STCfuture                 = ddmd.declaration.STCfuture;
 
     alias Dsymbol                   = ddmd.dsymbol.Dsymbol;
     alias Dsymbols                  = ddmd.dsymbol.Dsymbols;

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -129,12 +129,16 @@ enum STCinference           = (1L << 46);   // do attribute inference
 enum STCexptemp             = (1L << 47);   // temporary variable that has lifetime restricted to an expression
 enum STCmaybescope          = (1L << 48);   // parameter might be 'scope'
 enum STCscopeinferred       = (1L << 49);   // 'scope' has been inferred and should not be part of mangling
+enum STCfuture              = (1L << 50);   // introducing new base class function
 
 enum STC_TYPECTOR = (STCconst | STCimmutable | STCshared | STCwild);
 enum STC_FUNCATTR = (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem);
 
 extern (C++) __gshared const(StorageClass) STCStorageClass =
-    (STCauto | STCscope | STCstatic | STCextern | STCconst | STCfinal | STCabstract | STCsynchronized | STCdeprecated | STCoverride | STClazy | STCalias | STCout | STCin | STCmanifest | STCimmutable | STCshared | STCwild | STCnothrow | STCnogc | STCpure | STCref | STCtls | STCgshared | STCproperty | STCsafe | STCtrusted | STCsystem | STCdisable);
+    (STCauto | STCscope | STCstatic | STCextern | STCconst | STCfinal | STCabstract | STCsynchronized |
+     STCdeprecated | STCfuture | STCoverride | STClazy | STCalias | STCout | STCin | STCmanifest |
+     STCimmutable | STCshared | STCwild | STCnothrow | STCnogc | STCpure | STCref | STCtls | STCgshared |
+     STCproperty | STCsafe | STCtrusted | STCsystem | STCdisable);
 
 struct Match
 {
@@ -336,6 +340,11 @@ extern (C++) abstract class Declaration : Dsymbol
     final bool isRef()
     {
         return (storage_class & STCref) != 0;
+    }
+
+    final bool isFuture()
+    {
+        return (storage_class & STCfuture) != 0;
     }
 
     override final Prot prot()

--- a/src/ddmd/id.d
+++ b/src/ddmd/id.d
@@ -179,6 +179,7 @@ immutable Msgtable[] msgtable =
     { "values" },
     { "rehash" },
 
+    { "future", "__future" },
     { "property" },
     { "nogc" },
     { "safe" },

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -1333,6 +1333,8 @@ final class Parser(AST) : Lexer
                 stc = AST.STCsystem;
             else if (token.ident == Id.disable)
                 stc = AST.STCdisable;
+            else if (token.ident == Id.future)
+                stc = AST.STCfuture;
             else
             {
                 // Allow identifier, template instantiation, or function call

--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -1350,7 +1350,7 @@ private void finishVtbl(ClassDeclaration cd)
         // https://issues.dlang.org/show_bug.cgi?id=4869
         fd.functionSemantic();
 
-        if (!cd.isFuncHidden(fd))
+        if (!cd.isFuncHidden(fd) || fd.isFuture())
         {
             // All good, no name hiding to check for
             continue;
@@ -1366,6 +1366,8 @@ private void finishVtbl(ClassDeclaration cd)
                 continue;
             FuncDeclaration fd2 = cd.vtbl[j].isFuncDeclaration();
             if (!fd2.ident.equals(fd.ident))
+                continue;
+            if (fd2.isFuture())
                 continue;
             if (!fd.leastAsSpecialized(fd2) && !fd2.leastAsSpecialized(fd))
                 continue;

--- a/test/compilable/future.d
+++ b/test/compilable/future.d
@@ -1,0 +1,47 @@
+/* PERMUTE_ARGS:
+ * TEST_OUTPUT:
+---
+compilable/future.d(15): Deprecation: @future base class method future.A.msg is being overridden by future.B.msg; rename the latter
+---
+ */
+
+class A
+{
+    @__future char msg() { return 'a'; }
+}
+
+class B : A
+{
+    char msg() { return 'b'; }
+}
+
+class C : B
+{
+    override char msg() { return 'c'; }
+}
+
+class D : A
+{
+    override char msg() { return 'd'; }
+}
+
+int main()
+{
+    auto a = new A();
+    assert(a.msg() == 'a');
+    auto b = new B();
+    assert(b.msg() == 'b');
+    auto c = new C();
+    assert(c.msg() == 'c');
+    auto d = new D();
+    assert(d.msg() == 'd');
+
+    assert(b.A.msg() == 'a');
+
+    auto ba = cast(A)b;
+    assert(ba.msg() == 'a');
+
+    auto da = cast(A)d;
+    assert(da.msg() == 'd');
+    return 0;
+}

--- a/test/runnable/future.d
+++ b/test/runnable/future.d
@@ -1,0 +1,43 @@
+/* PERMUTE_ARGS:
+ */
+
+class A
+{
+    @__future char msg() { return 'a'; }
+}
+
+class B : A
+{
+    char msg() { return 'b'; }
+}
+
+class C : B
+{
+    override char msg() { return 'c'; }
+}
+
+class D : A
+{
+    override char msg() { return 'd'; }
+}
+
+int main()
+{
+    auto a = new A();
+    assert(a.msg() == 'a');
+    auto b = new B();
+    assert(b.msg() == 'b');
+    auto c = new C();
+    assert(c.msg() == 'c');
+    auto d = new D();
+    assert(d.msg() == 'd');
+
+    assert(b.A.msg() == 'a');
+
+    auto ba = cast(A)b;
+    assert(ba.msg() == 'a');
+
+    auto da = cast(A)d;
+    assert(da.msg() == 'd');
+    return 0;
+}


### PR DESCRIPTION
Currently, D has a `deprecation` feature where old symbols can be obsolete in a user-friendly manner. But if one wants to add a virtual function to a base class, there is no way to do it gently if the user has a derived class member function of the same name.

This is an experimental PR based on a proposal by @dicebot to address that. The added member is tagged with `@future`. Any derived function that overrides it without `override` is given a deprecation message.

This PR is meant to experiment with the idea. It is not currently meant to be merged.