### PR TITLE
[scope] fix ambiguity in scope mangling

### DIFF
--- a/src/dmangle.d
+++ b/src/dmangle.d
@@ -287,7 +287,7 @@ public:
             if (ta.isreturn)
                 buf.writestring("Nj");
             if (ta.isscope && !ta.isreturn)
-                buf.writestring("M");
+                buf.writestring("Nl");
             switch (ta.trust)
             {
             case TRUSTtrusted:

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -556,7 +556,21 @@ class CC
     }
 }
 
-static assert(CC.member.mangleof == "_D6mangle2CC6memberMFMZPi");
+static assert(CC.member.mangleof == "_D6mangle2CC6memberMFNlZPi");
+
+/***************************************************/
+
+void fooA(void delegate (scope void delegate()) dg)
+{
+}
+void fooB(void delegate (void delegate()) scope dg)
+{
+}
+
+//pragma(msg, fooA.mangleof);
+//pragma(msg, fooB.mangleof);
+static assert(typeof(fooA).mangleof != typeof(fooB).mangleof);
+
 
 /***************************************************/
 


### PR DESCRIPTION
The scope mangling for 'this' has to be distinct from that for the first parameter.