### PR TITLE
fix Issue 17123 - [REG 2.073] Issues with return @safe inference

### DIFF
--- a/src/escape.d
+++ b/src/escape.d
@@ -524,7 +524,8 @@ private bool checkEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                  *   auto dg = () return { return &x; }
                  * Because dg.ptr points to x, this is returning dt.ptr+offset
                  */
-                sc.func.storage_class |= STCreturn;
+                if (global.params.vsafe)
+                    sc.func.storage_class |= STCreturn;
             }
 
         }

--- a/test/compilable/fix17123.d
+++ b/test/compilable/fix17123.d
@@ -1,0 +1,14 @@
+/*
+PERMUTE_ARGS:
+
+https://issues.dlang.org/show_bug.cgi?id=17123
+ */
+
+void test()
+{
+    char[256] buffer;
+
+    char[] delegate() read = () {
+        return buffer[];
+    };
+}


### PR DESCRIPTION
This one is just for the stable branch.