### PR TITLE
Windows fix linker call with quotes

### DIFF
--- a/src/link.d
+++ b/src/link.d
@@ -30,40 +30,41 @@ version (Windows) extern (C) int putenv(const char*);
 version (Windows) extern (C) int spawnlp(int, const char*, const char*, const char*, const char*);
 version (Windows) extern (C) int spawnl(int, const char*, const char*, const char*, const char*);
 version (Windows) extern (C) int spawnv(int, const char*, const char**);
-version (CRuntime_Microsoft)
+version (Windows)
 {
-  // until the new windows bindings are available when building dmd.
-  static if(!is(STARTUPINFOA))
-  {
-    alias STARTUPINFOA = STARTUPINFO;
+    // until the new windows bindings are available when building dmd.
+    static if(!is(STARTUPINFOA))
+    {
+        alias STARTUPINFOA = STARTUPINFO;
 
-    // dwCreationFlags for CreateProcess() and CreateProcessAsUser()
-    enum : DWORD {
-      DEBUG_PROCESS               = 0x00000001,
-      DEBUG_ONLY_THIS_PROCESS     = 0x00000002,
-      CREATE_SUSPENDED            = 0x00000004,
-      DETACHED_PROCESS            = 0x00000008,
-      CREATE_NEW_CONSOLE          = 0x00000010,
-      NORMAL_PRIORITY_CLASS       = 0x00000020,
-      IDLE_PRIORITY_CLASS         = 0x00000040,
-      HIGH_PRIORITY_CLASS         = 0x00000080,
-      REALTIME_PRIORITY_CLASS     = 0x00000100,
-      CREATE_NEW_PROCESS_GROUP    = 0x00000200,
-      CREATE_UNICODE_ENVIRONMENT  = 0x00000400,
-      CREATE_SEPARATE_WOW_VDM     = 0x00000800,
-      CREATE_SHARED_WOW_VDM       = 0x00001000,
-      CREATE_FORCEDOS             = 0x00002000,
-      BELOW_NORMAL_PRIORITY_CLASS = 0x00004000,
-      ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000,
-      CREATE_BREAKAWAY_FROM_JOB   = 0x01000000,
-      CREATE_WITH_USERPROFILE     = 0x02000000,
-      CREATE_DEFAULT_ERROR_MODE   = 0x04000000,
-      CREATE_NO_WINDOW            = 0x08000000,
-      PROFILE_USER                = 0x10000000,
-      PROFILE_KERNEL              = 0x20000000,
-      PROFILE_SERVER              = 0x40000000
+        // dwCreationFlags for CreateProcess() and CreateProcessAsUser()
+        enum : DWORD
+        {
+            DEBUG_PROCESS               = 0x00000001,
+            DEBUG_ONLY_THIS_PROCESS     = 0x00000002,
+            CREATE_SUSPENDED            = 0x00000004,
+            DETACHED_PROCESS            = 0x00000008,
+            CREATE_NEW_CONSOLE          = 0x00000010,
+            NORMAL_PRIORITY_CLASS       = 0x00000020,
+            IDLE_PRIORITY_CLASS         = 0x00000040,
+            HIGH_PRIORITY_CLASS         = 0x00000080,
+            REALTIME_PRIORITY_CLASS     = 0x00000100,
+            CREATE_NEW_PROCESS_GROUP    = 0x00000200,
+            CREATE_UNICODE_ENVIRONMENT  = 0x00000400,
+            CREATE_SEPARATE_WOW_VDM     = 0x00000800,
+            CREATE_SHARED_WOW_VDM       = 0x00001000,
+            CREATE_FORCEDOS             = 0x00002000,
+            BELOW_NORMAL_PRIORITY_CLASS = 0x00004000,
+            ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000,
+            CREATE_BREAKAWAY_FROM_JOB   = 0x01000000,
+            CREATE_WITH_USERPROFILE     = 0x02000000,
+            CREATE_DEFAULT_ERROR_MODE   = 0x04000000,
+            CREATE_NO_WINDOW            = 0x08000000,
+            PROFILE_USER                = 0x10000000,
+            PROFILE_KERNEL              = 0x20000000,
+            PROFILE_SERVER              = 0x40000000
+        }
     }
-  }
 }
 
 /****************************************
@@ -806,45 +807,49 @@ version (Windows)
         }
         // Normalize executable path separators, see Bugzilla 9330
         cmd = toWinPath(cmd);
-        version (CRuntime_Microsoft)
+        // Open scope so dmd doesn't complain about alloca + exception handling
         {
-            // Open scope so dmd doesn't complain about alloca + exception handling
+            // Use process spawning through the WinAPI to avoid issues with executearg0 and spawnlp
+            OutBuffer cmdbuf;
+            cmdbuf.writestring("\"");
+            // write cmd without any quotes
             {
-                // Use process spawning through the WinAPI to avoid issues with executearg0 and spawnlp
-                OutBuffer cmdbuf;
-                cmdbuf.writestring("\"");
-                cmdbuf.writestring(cmd);
-                cmdbuf.writestring("\" ");
-                cmdbuf.writestring(args);
-
-                STARTUPINFOA startInf;
-                startInf.dwFlags = STARTF_USESTDHANDLES;
-                startInf.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
-                startInf.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
-                startInf.hStdError = GetStdHandle(STD_ERROR_HANDLE);
-                PROCESS_INFORMATION procInf;
-
-                BOOL b = CreateProcessA(null, cmdbuf.peekString(), null, null, 1, NORMAL_PRIORITY_CLASS, null, null, &startInf, &procInf);
-                if (b)
+                const(char)* start = cmd;
+                const(char)* cur = start;
+                const(char)* end = cmd + strlen(cmd);
+                while(cur < end)
                 {
-                    WaitForSingleObject(procInf.hProcess, INFINITE);
-                    DWORD returnCode;
-                    GetExitCodeProcess(procInf.hProcess, &returnCode);
-                    status = returnCode;
-                    CloseHandle(procInf.hProcess);
-                }
-                else
-                {
-                    status = -1;
+                    while(cur < end && *cur != '"')
+                    {
+                        cur++;
+                    }
+                    cmdbuf.writestring(start[0..cur-start]);
+                    cur++;
+                    start = cur;
                 }
             }
-        }
-        else
-        {
-            status = executearg0(cmd, args);
-            if (status == -1)
+            cmdbuf.writestring("\" ");
+            cmdbuf.writestring(args);
+
+            STARTUPINFOA startInf;
+            startInf.dwFlags = STARTF_USESTDHANDLES;
+            startInf.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+            startInf.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+            startInf.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+            PROCESS_INFORMATION procInf;
+
+            BOOL b = CreateProcessA(null, cmdbuf.peekString(), null, null, 1, NORMAL_PRIORITY_CLASS, null, null, &startInf, &procInf);
+            if (b)
             {
-                status = spawnlp(0, cmd, cmd, args, null);
+                WaitForSingleObject(procInf.hProcess, INFINITE);
+                DWORD returnCode;
+                GetExitCodeProcess(procInf.hProcess, &returnCode);
+                status = returnCode;
+                CloseHandle(procInf.hProcess);
+            }
+            else
+            {
+                status = -1;
             }
         }
         //if (global.params.verbose)


### PR DESCRIPTION
Fix calling the linker on windows when LINKCMD contains quotes.
Use same code path for 32-bit and 64-bit.

Examples of enviornment variables which cause issues:
LINKCMD=C:\\"Program Files (x86)"\\"Microsoft Visual Studio 14.0"\VC\bin\link.exe
LINKCMD="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\link.exe"

Both are correctly quoted strings in terms of cmd but calling the linker will fail.

The rationale is this:
I have a LINKCMD with quotes and call dmd. Dmd reports that it can't call the linker and I should check PATH. I then run dmd with -v to get the command line dmd executes to call the linker. I copy this command line from the dmd output and paste it into a cmd. The command line executes just fine even though dmd just complained that it doesn't work.