### PR TITLE
[Trivial] Fix C++ headers.

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -45,7 +45,7 @@ public:
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
     void addComment(const utf8_t *comment);
-    const char *kind() const;
+    const char *kind();
     bool oneMember(Dsymbol **ps, Identifier *ident);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     bool hasPointers();
@@ -114,7 +114,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind() const;
+    const char *kind();
     const char *toPrettyChars(bool unused);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -147,7 +147,7 @@ public:
     void setScope(Scope *sc);
     void semantic(Scope *sc);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    const char *kind() const;
+    const char *kind();
     AnonDeclaration *isAnonDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -160,7 +160,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void semantic(Scope *sc);
-    const char *kind() const;
+    const char *kind();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -190,7 +190,7 @@ public:
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     void semantic(Scope *sc);
-    const char *kind() const;
+    const char *kind();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -209,7 +209,7 @@ public:
     void setScope(Scope *sc);
     void compileIt(Scope *sc);
     void semantic(Scope *sc);
-    const char *kind() const;
+    const char *kind();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -229,7 +229,7 @@ public:
     void semantic2(Scope *sc);
     static Expressions *concat(Expressions *udas1, Expressions *udas2);
     Expressions *getAttributes();
-    const char *kind() const;
+    const char *kind();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/expression.h
+++ b/src/expression.h
@@ -1027,6 +1027,9 @@ class CommaExp : public BinExp
 public:
     bool isGenerated;
     bool allowCommaExp;
+
+    CommaExp(Loc loc, Expression *e1, Expression *e2, bool generated = true);
+
     Expression *semantic(Scope *sc);
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();

--- a/src/statement.h
+++ b/src/statement.h
@@ -324,9 +324,8 @@ public:
     Expression *condition;
     Statement *ifbody;
     Statement *elsebody;
-    Loc endloc;                 // location of closing curly bracket
-
     VarDeclaration *match;      // for MatchExpression results
+    Loc endloc;                 // location of closing curly bracket
 
     Statement *syntaxCopy();
     IfStatement *isIfStatement() { return this; }


### PR DESCRIPTION
Fixed these issues:
- wrong order of fields in IfStatement
- wrong virtual function `kind()` override (similar to #5885 )
- added back the CommaExp constructor to silence a C++ warning that the class needs a user-defined constructor to initialize its members.