### PR TITLE
reboot #6081: Fix issue 14859 - 16MiB size limit for static array

### DIFF
--- a/src/mtype.d
+++ b/src/mtype.d
@@ -4780,13 +4780,14 @@ extern (C++) final class TypeSArray : TypeArray
             if (d1 != d2)
             {
             Loverflow:
-                error(loc, "%s size %llu * %llu exceeds 16MiB size limit for static array", toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1);
+                error(loc, "%s size %llu * %llu exceeds 0x%llx size limit for static array",
+                        toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1, Target.maxStaticDataSize);
                 goto Lerror;
             }
             Type tbx = tbn.baseElemOf();
             if (tbx.ty == Tstruct && !(cast(TypeStruct)tbx).sym.members || tbx.ty == Tenum && !(cast(TypeEnum)tbx).sym.members)
             {
-                /* To avoid meaningess error message, skip the total size limit check
+                /* To avoid meaningless error message, skip the total size limit check
                  * when the bottom of element type is opaque.
                  */
             }
@@ -4796,7 +4797,7 @@ extern (C++) final class TypeSArray : TypeArray
                  * run on them for the size, since they may be forward referenced.
                  */
                 bool overflow = false;
-                if (mulu(tbn.size(loc), d2, overflow) >= 0x100_0000 || overflow) // put a 'reasonable' limit on it
+                if (mulu(tbn.size(loc), d2, overflow) >= Target.maxStaticDataSize || overflow)
                     goto Loverflow;
             }
         }

--- a/src/target.h
+++ b/src/target.h
@@ -33,6 +33,7 @@ struct Target
     static int c_longsize;           // size of a C 'long' or 'unsigned long' type
     static int c_long_doublesize;    // size of a C 'long double'
     static int classinfosize;        // size of 'ClassInfo'
+    static unsigned long long maxStaticDataSize;  // maximum size of static data
 
     static void init();
     // Type sizes and support.

--- a/src/toobj.d
+++ b/src/toobj.d
@@ -851,9 +851,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 vd.error("size overflow");
                 return;
             }
-            if (sz64 >= 0x1000000)  // there has to be some 'reasonable' limit on the size
+            if (sz64 >= Target.maxStaticDataSize)
             {
-                vd.error("size of x%llx exceeds max allowed size 0x100_0000", sz64);
+                vd.error("size of 0x%llx exceeds max allowed size 0x%llx", sz64, Target.maxStaticDataSize);
             }
             uint sz = cast(uint)sz64;
 

--- a/test/fail_compilation/fail4611.d
+++ b/test/fail_compilation/fail4611.d
@@ -1,7 +1,6 @@
 /*
-TEST_OUTPUT:
 ---
-fail_compilation/fail4611.d(15): Error: Vec[1000000000] size 4 * 1000000000 exceeds 16MiB size limit for static array
+fail_compilation/fail4611.d(15): Error: Vec[1000000000] size 4 * 1000000000 exceeds 0x7fffffff size limit for static array
 ---
 */
 

--- a/test/fail_compilation/staticarrayoverflow.d
+++ b/test/fail_compilation/staticarrayoverflow.d
@@ -1,7 +1,6 @@
 /*
 REQUIRED_ARGS: -m64
 PERMUTE_ARGS:
-TEST_OUTPUT:
 ---
 fail_compilation/staticarrayoverflow.d(21): Error: static array S[1879048192] size overflowed to 7516192768000
 fail_compilation/staticarrayoverflow.d(21): Error: variable staticarrayoverflow.y size overflow


### PR DESCRIPTION
This is a reboot of #6081 which was apparently abandoned by its author.

Halp - how do I add target specific error messages to the fail_compilation directory?