### PR TITLE
Fix Issue 17057 - trait allMembers incorrectly includes imports

### DIFF
--- a/src/traits.d
+++ b/src/traits.d
@@ -951,6 +951,8 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 }
                 if (sm.isTypeInfoDeclaration()) // Bugzilla 15177
                     return 0;
+                if (!sds.isModule() && sm.isImport()) // Bugzilla 17057
+                    return 0;
 
                 //printf("\t%s\n", sm.ident.toChars());
 

--- a/test/compilable/test17057.d
+++ b/test/compilable/test17057.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -de
+// PERMUTE_ARGS:
+
+class LeClass {
+    import std.stdio;
+}
+
+void main()
+{
+    static assert([__traits(allMembers, LeClass)] == ["toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]);
+}
+


### PR DESCRIPTION
The issue was that imports were treated as class members when declared outside of functions. I added an extra check which excludes that particular case.