### PR TITLE
[scope] infer 'return scope'

### DIFF
--- a/src/escape.d
+++ b/src/escape.d
@@ -231,6 +231,15 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
         if (v.isScope())
         {
+            if (va && va.isScope() && va.storage_class & STCreturn && !(v.storage_class & STCreturn) &&
+                sc.func.setUnsafe())
+            {
+                if (!gag)
+                    error(ae.loc, "scope variable %s assigned to return scope %s", v.toChars(), va.toChars());
+                result = true;
+                continue;
+            }
+
             // If va's lifetime encloses v's, then error
             if (va &&
                 (va.enclosesLifetimeOf(v) && !(v.storage_class & STCparameter) || va.storage_class & STCref) &&
@@ -247,6 +256,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
                 if (!va.isScope() && inferScope)
                 {   //printf("inferring scope for %s\n", va.toChars());
                     va.storage_class |= STCscope;
+                    va.storage_class |= v.storage_class & STCreturn;
                 }
                 continue;
             }

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -19,4 +19,55 @@ fail_compilation/retscope2.d(107): Error: address of variable s assigned to p wi
     p = &s;
 }
 
+/**********************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope2.d(302): Error: scope variable a assigned to return scope b
+---
+*/
+
+#line 300
+@safe int* test300(scope int* a, return scope int* b)
+{
+    b = a;
+    return b;
+}
+
+/**********************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope2.d(403): Error: scope variable a assigned to return scope c
+---
+*/
+
+#line 400
+@safe int* test400(scope int* a, return scope int* b)
+{
+    auto c = b; // infers 'return scope' for 'c'
+    c = a;
+    return c;
+}
+
+/**********************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope2.d(504): Error: scope variable c may not be returned
+---
+*/
+
+#line 500
+@safe int* test500(scope int* a, return scope int* b)
+{
+    scope c = b; // does not infer 'return' for 'c'
+    c = a;
+    return c;
+}
+
+
 


### PR DESCRIPTION
Infer `return scope` for locals as well as `scope`, and plug hole where `scope` variable can be assigned to a `return scope` variable.