### PR TITLE
Fix Issue 17143 - [REG2.072.0] Declaration is already defined on global enum = tuple(...).expand declaration

### DIFF
--- a/src/expression.d
+++ b/src/expression.d
@@ -8961,7 +8961,7 @@ extern (C++) final class DotVarExp : UnaExp
              *  tuple(e1.a, e1.b, e1.c)
              */
             Expression e0;
-            Expression ev = extractSideEffect(sc, "__tup", e0, e1);
+            Expression ev = sc.func ? extractSideEffect(sc, "__tup", e0, e1) : e1;
 
             auto exps = new Expressions();
             exps.reserve(tup.objects.dim);

--- a/test/compilable/test17143.d
+++ b/test/compilable/test17143.d
@@ -1,0 +1,4 @@
+import std.typecons : tuple;
+enum foo = tuple(1, 2).expand;
+pragma(msg, typeof(foo).stringof);
+pragma(msg, foo.stringof);


### PR DESCRIPTION
Regression was introduced in 53a70e4d66b8bf1b96a51c06eeb2df7fa836f647