### PR TITLE
Declarations inside a C++ namespace should also be marked isdataseg

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -2064,7 +2064,8 @@ extern (C++) class VarDeclaration : Declaration
         version (none)
         {
             printf("VarDeclaration::isDataseg(%p, '%s')\n", this, toChars());
-            printf("%llx, isModule: %p, isTemplateInstance: %p\n", storage_class & (STCstatic | STCconst), parent.isModule(), parent.isTemplateInstance());
+            printf("%llx, isModule: %p, isTemplateInstance: %p, isNspace: %p\n",
+                   storage_class & (STCstatic | STCconst), parent.isModule(), parent.isTemplateInstance(), parent.isNspace());
             printf("parent = '%s'\n", parent.toChars());
         }
 
@@ -2084,7 +2085,7 @@ extern (C++) class VarDeclaration : Declaration
                 type = Type.terror;
             }
             else if (storage_class & (STCstatic | STCextern | STCtls | STCgshared) ||
-                parent.isModule() || parent.isTemplateInstance())
+                parent.isModule() || parent.isTemplateInstance() || parent.isNspace())
             {
                 isdataseg = 1; // It is in the DataSegment
             }

--- a/test/compilable/test15578.d
+++ b/test/compilable/test15578.d
@@ -1,4 +1,4 @@
-private:
+__gshared private:
     int j;
     extern(C++, ns) int k;
 


### PR DESCRIPTION
Fixes ICE in gdc, where in the following code:
```
extern(C++, ns) int k;
```
Because of returning false from `isDataseg()`, it wrongly treats the variable as local, rather than global.