### PR TITLE
Fix Issue 15616 - missing candidate in error message

### DIFF
--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -4168,17 +4168,27 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
             overloadApply(hasOverloads ? fd : null, (Dsymbol s)
             {
                 auto fd = s.isFuncDeclaration();
-                if (!fd || fd.errors || fd.type.ty == Terror)
-                    return 0;
-                auto tf = cast(TypeFunction)fd.type;
-                .errorSupplemental(fd.loc, "%s%s", fd.toPrettyChars(),
-                    parametersTypeToChars(tf.parameters, tf.varargs));
-                if (global.params.verbose || --numToDisplay != 0 || !fd.overnext)
+                auto td = s.isTemplateDeclaration();
+                if (fd)
+                {
+                    if (fd.errors || fd.type.ty == Terror)
+                        return 0;
+
+                    auto tf = cast(TypeFunction)fd.type;
+                    .errorSupplemental(fd.loc, "%s%s", fd.toPrettyChars(),
+                        parametersTypeToChars(tf.parameters, tf.varargs));
+                }
+                else
+                {
+                    .errorSupplemental(td.loc, "%s", td.toPrettyChars());
+                }
+
+                if (global.params.verbose || --numToDisplay != 0 || !fd)
                     return 0;
 
                 // Too many overloads to sensibly display.
                 int num = 0;
-                overloadApply(fd.overnext, (s){ num += !!s.isFuncDeclaration(); return 0; });
+                overloadApply(fd.overnext, (s){ ++num; return 0; });
                 if (num > 0)
                     .errorSupplemental(loc, "... (%d more, -v to show) ...", num);
                 return 1;   // stop iterating

--- a/test/fail_compilation/fail15616a.d
+++ b/test/fail_compilation/fail15616a.d
@@ -1,0 +1,42 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail15616a.d(41): Error: none of the overloads of 'foo' are callable using argument types (double), candidates are:
+fail_compilation/fail15616a.d(14):        fail15616a.foo(int a)
+fail_compilation/fail15616a.d(17):        fail15616a.foo(int a, int b)
+fail_compilation/fail15616a.d(26):        fail15616a.foo(int a, int b, int c)
+fail_compilation/fail15616a.d(29):        fail15616a.foo(string a)
+fail_compilation/fail15616a.d(32):        fail15616a.foo(string a, string b)
+fail_compilation/fail15616a.d(41):        ... (3 more, -v to show) ...
+---
+*/
+
+void foo(int a)
+{}
+
+void foo(int a, int b)
+{}
+
+void foo(T)(T a) if (is(T == float))
+{}
+
+void foo(T)(T a) if (is(T == char))
+{}
+
+void foo(int a, int b, int c)
+{}
+
+void foo(string a)
+{}
+
+void foo(string a, string b)
+{}
+
+void foo(string a, string b, string c)
+{}
+
+
+void main()
+{
+    foo(3.14);
+}

--- a/test/fail_compilation/fail15616b.d
+++ b/test/fail_compilation/fail15616b.d
@@ -1,0 +1,44 @@
+/*
+REQUIRED_ARGS: -v
+---
+fail_compilation/fail15616b.d(43): Error: none of the overloads of 'foo' are callable using argument types (double), candidates are:
+fail_compilation/fail15616b.d(16):        fail15616b.foo(int a)
+fail_compilation/fail15616b.d(19):        fail15616b.foo(int a, int b)
+fail_compilation/fail15616b.d(28):        fail15616b.foo(int a, int b, int c)
+fail_compilation/fail15616b.d(31):        fail15616b.foo(string a)
+fail_compilation/fail15616b.d(34):        fail15616b.foo(string a, string b)
+fail_compilation/fail15616b.d(37):        fail15616b.foo(string a, string b, string c)
+fail_compilation/fail15616b.d(22):        fail15616b.foo(T)(T a) if (is(T == float))
+fail_compilation/fail15616b.d(25):        fail15616b.foo(T)(T a) if (is(T == char))
+---
+*/
+
+void foo(int a)
+{}
+
+void foo(int a, int b)
+{}
+
+void foo(T)(T a) if (is(T == float))
+{}
+
+void foo(T)(T a) if (is(T == char))
+{}
+
+void foo(int a, int b, int c)
+{}
+
+void foo(string a)
+{}
+
+void foo(string a, string b)
+{}
+
+void foo(string a, string b, string c)
+{}
+
+
+void main()
+{
+    foo(3.14);
+}


### PR DESCRIPTION
Dmd does not print templated function candidates when none of the overloads of a function are callable.
Example : 

void foo(int a) {}
void foo(T)(T a) if (is(T == float)) {}
void bar() { foo(3.4); }

/d897/f111.d(5): Error: None of the overloads of 'foo' are callable using argument types (double), candidates are:
/d897/f111.d(1):        f111.foo(int a)

Since the following call works:
void bar() {float g = 3.4; foo(g)}

All function candidates (templated or not) should be printed.

After reading the code, I saw that the branches for printing the candidates are as follows: (this a heavily reduced version)
if (only templated overloads) { print them}
else (print function overloads).

I modified the code so that the second branch prints all overloads, not just untemplated overloads