### PR TITLE
Add RISCV32 and RISCV64 version identifiers

### DIFF
--- a/src/cond.d
+++ b/src/cond.d
@@ -297,6 +297,8 @@ extern (C++) final class VersionCondition : DVCondition
             "MIPS_HardFloat",
             "NVPTX",
             "NVPTX64",
+            "RISCV32",
+            "RISCV64",
             "SPARC",
             "SPARC_V8Plus",
             "SPARC_SoftFloat",

--- a/test/fail_compilation/reserved_version.d
+++ b/test/fail_compilation/reserved_version.d
@@ -55,49 +55,49 @@ fail_compilation/reserved_version.d(157): Error: version identifier 'MIPS_SoftFl
 fail_compilation/reserved_version.d(158): Error: version identifier 'MIPS_HardFloat' is reserved and cannot be set
 fail_compilation/reserved_version.d(159): Error: version identifier 'NVPTX' is reserved and cannot be set
 fail_compilation/reserved_version.d(160): Error: version identifier 'NVPTX64' is reserved and cannot be set
-fail_compilation/reserved_version.d(161): Error: version identifier 'SPARC' is reserved and cannot be set
-fail_compilation/reserved_version.d(162): Error: version identifier 'SPARC_V8Plus' is reserved and cannot be set
-fail_compilation/reserved_version.d(163): Error: version identifier 'SPARC_SoftFloat' is reserved and cannot be set
-fail_compilation/reserved_version.d(164): Error: version identifier 'SPARC_HardFloat' is reserved and cannot be set
-fail_compilation/reserved_version.d(165): Error: version identifier 'SPARC64' is reserved and cannot be set
-fail_compilation/reserved_version.d(166): Error: version identifier 'S390' is reserved and cannot be set
-fail_compilation/reserved_version.d(167): Error: version identifier 'S390X' is reserved and cannot be set
-fail_compilation/reserved_version.d(168): Error: version identifier 'SystemZ' is reserved and cannot be set
-fail_compilation/reserved_version.d(169): Error: version identifier 'HPPA' is reserved and cannot be set
-fail_compilation/reserved_version.d(170): Error: version identifier 'HPPA64' is reserved and cannot be set
-fail_compilation/reserved_version.d(171): Error: version identifier 'SH' is reserved and cannot be set
-fail_compilation/reserved_version.d(172): Error: version identifier 'SH64' is reserved and cannot be set
-fail_compilation/reserved_version.d(173): Error: version identifier 'Alpha' is reserved and cannot be set
-fail_compilation/reserved_version.d(174): Error: version identifier 'Alpha_SoftFloat' is reserved and cannot be set
-fail_compilation/reserved_version.d(175): Error: version identifier 'Alpha_HardFloat' is reserved and cannot be set
-fail_compilation/reserved_version.d(176): Error: version identifier 'LittleEndian' is reserved and cannot be set
-fail_compilation/reserved_version.d(177): Error: version identifier 'BigEndian' is reserved and cannot be set
-fail_compilation/reserved_version.d(178): Error: version identifier 'ELFv1' is reserved and cannot be set
-fail_compilation/reserved_version.d(179): Error: version identifier 'ELFv2' is reserved and cannot be set
-fail_compilation/reserved_version.d(180): Error: version identifier 'CRuntime_Bionic' is reserved and cannot be set
-fail_compilation/reserved_version.d(181): Error: version identifier 'CRuntime_DigitalMars' is reserved and cannot be set
-fail_compilation/reserved_version.d(182): Error: version identifier 'CRuntime_Glibc' is reserved and cannot be set
-fail_compilation/reserved_version.d(183): Error: version identifier 'CRuntime_Microsoft' is reserved and cannot be set
-fail_compilation/reserved_version.d(184): Error: version identifier 'D_Coverage' is reserved and cannot be set
-fail_compilation/reserved_version.d(185): Error: version identifier 'D_Ddoc' is reserved and cannot be set
-fail_compilation/reserved_version.d(186): Error: version identifier 'D_InlineAsm_X86' is reserved and cannot be set
-fail_compilation/reserved_version.d(187): Error: version identifier 'D_InlineAsm_X86_64' is reserved and cannot be set
-fail_compilation/reserved_version.d(188): Error: version identifier 'D_LP64' is reserved and cannot be set
-fail_compilation/reserved_version.d(189): Error: version identifier 'D_X32' is reserved and cannot be set
-fail_compilation/reserved_version.d(190): Error: version identifier 'D_HardFloat' is reserved and cannot be set
-fail_compilation/reserved_version.d(191): Error: version identifier 'D_SoftFloat' is reserved and cannot be set
-fail_compilation/reserved_version.d(192): Error: version identifier 'D_PIC' is reserved and cannot be set
-fail_compilation/reserved_version.d(193): Error: version identifier 'D_SIMD' is reserved and cannot be set
-fail_compilation/reserved_version.d(194): Error: version identifier 'D_Version2' is reserved and cannot be set
-fail_compilation/reserved_version.d(195): Error: version identifier 'D_NoBoundsChecks' is reserved and cannot be set
-fail_compilation/reserved_version.d(198): Error: version identifier 'all' is reserved and cannot be set
-fail_compilation/reserved_version.d(199): Error: version identifier 'none' is reserved and cannot be set
+fail_compilation/reserved_version.d(161): Error: version identifier 'RISCV32' is reserved and cannot be set
+fail_compilation/reserved_version.d(162): Error: version identifier 'RISCV64' is reserved and cannot be set
+fail_compilation/reserved_version.d(163): Error: version identifier 'SPARC' is reserved and cannot be set
+fail_compilation/reserved_version.d(164): Error: version identifier 'SPARC_V8Plus' is reserved and cannot be set
+fail_compilation/reserved_version.d(165): Error: version identifier 'SPARC_SoftFloat' is reserved and cannot be set
+fail_compilation/reserved_version.d(166): Error: version identifier 'SPARC_HardFloat' is reserved and cannot be set
+fail_compilation/reserved_version.d(167): Error: version identifier 'SPARC64' is reserved and cannot be set
+fail_compilation/reserved_version.d(168): Error: version identifier 'S390' is reserved and cannot be set
+fail_compilation/reserved_version.d(169): Error: version identifier 'S390X' is reserved and cannot be set
+fail_compilation/reserved_version.d(170): Error: version identifier 'SystemZ' is reserved and cannot be set
+fail_compilation/reserved_version.d(171): Error: version identifier 'HPPA' is reserved and cannot be set
+fail_compilation/reserved_version.d(172): Error: version identifier 'HPPA64' is reserved and cannot be set
+fail_compilation/reserved_version.d(173): Error: version identifier 'SH' is reserved and cannot be set
+fail_compilation/reserved_version.d(174): Error: version identifier 'SH64' is reserved and cannot be set
+fail_compilation/reserved_version.d(175): Error: version identifier 'Alpha' is reserved and cannot be set
+fail_compilation/reserved_version.d(176): Error: version identifier 'Alpha_SoftFloat' is reserved and cannot be set
+fail_compilation/reserved_version.d(177): Error: version identifier 'Alpha_HardFloat' is reserved and cannot be set
+fail_compilation/reserved_version.d(178): Error: version identifier 'LittleEndian' is reserved and cannot be set
+fail_compilation/reserved_version.d(179): Error: version identifier 'BigEndian' is reserved and cannot be set
+fail_compilation/reserved_version.d(180): Error: version identifier 'ELFv1' is reserved and cannot be set
+fail_compilation/reserved_version.d(181): Error: version identifier 'ELFv2' is reserved and cannot be set
+fail_compilation/reserved_version.d(182): Error: version identifier 'CRuntime_Bionic' is reserved and cannot be set
+fail_compilation/reserved_version.d(183): Error: version identifier 'CRuntime_DigitalMars' is reserved and cannot be set
+fail_compilation/reserved_version.d(184): Error: version identifier 'CRuntime_Glibc' is reserved and cannot be set
+fail_compilation/reserved_version.d(185): Error: version identifier 'CRuntime_Microsoft' is reserved and cannot be set
+fail_compilation/reserved_version.d(186): Error: version identifier 'D_Coverage' is reserved and cannot be set
+fail_compilation/reserved_version.d(187): Error: version identifier 'D_Ddoc' is reserved and cannot be set
+fail_compilation/reserved_version.d(188): Error: version identifier 'D_InlineAsm_X86' is reserved and cannot be set
+fail_compilation/reserved_version.d(189): Error: version identifier 'D_InlineAsm_X86_64' is reserved and cannot be set
+fail_compilation/reserved_version.d(190): Error: version identifier 'D_LP64' is reserved and cannot be set
+fail_compilation/reserved_version.d(191): Error: version identifier 'D_X32' is reserved and cannot be set
+fail_compilation/reserved_version.d(192): Error: version identifier 'D_HardFloat' is reserved and cannot be set
+fail_compilation/reserved_version.d(193): Error: version identifier 'D_SoftFloat' is reserved and cannot be set
+fail_compilation/reserved_version.d(194): Error: version identifier 'D_PIC' is reserved and cannot be set
+fail_compilation/reserved_version.d(195): Error: version identifier 'D_SIMD' is reserved and cannot be set
+fail_compilation/reserved_version.d(196): Error: version identifier 'D_Version2' is reserved and cannot be set
+fail_compilation/reserved_version.d(197): Error: version identifier 'D_NoBoundsChecks' is reserved and cannot be set
+fail_compilation/reserved_version.d(200): Error: version identifier 'all' is reserved and cannot be set
+fail_compilation/reserved_version.d(201): Error: version identifier 'none' is reserved and cannot be set
 ---
 */
 
 // Some extra empty lines to help fixup the manual line numbering after adding new version identifiers
-
-
 
 
 
@@ -158,6 +158,8 @@ version = MIPS_SoftFloat;
 version = MIPS_HardFloat;
 version = NVPTX;
 version = NVPTX64;
+version = RISCV32;
+version = RISCV64;
 version = SPARC;
 version = SPARC_V8Plus;
 version = SPARC_SoftFloat;
@@ -250,6 +252,8 @@ debug = MIPS_SoftFloat;
 debug = MIPS_HardFloat;
 debug = NVPTX;
 debug = NVPTX64;
+debug = RISCV32;
+debug = RISCV64;
 debug = SPARC;
 debug = SPARC_V8Plus;
 debug = SPARC_SoftFloat;

--- a/test/fail_compilation/reserved_version_switch.d
+++ b/test/fail_compilation/reserved_version_switch.d
@@ -51,6 +51,8 @@
 // REQUIRED_ARGS: -version=MIPS_HardFloat
 // REQUIRED_ARGS: -version=NVPTX
 // REQUIRED_ARGS: -version=NVPTX64
+// REQUIRED_ARGS: -version=RISCV32
+// REQUIRED_ARGS: -version=RISCV64
 // REQUIRED_ARGS: -version=SPARC
 // REQUIRED_ARGS: -version=SPARC_V8Plus
 // REQUIRED_ARGS: -version=SPARC_SoftFloat
@@ -234,6 +236,8 @@ Error: version identifier 'MIPS_SoftFloat' is reserved and cannot be set
 Error: version identifier 'MIPS_HardFloat' is reserved and cannot be set
 Error: version identifier 'NVPTX' is reserved and cannot be set
 Error: version identifier 'NVPTX64' is reserved and cannot be set
+Error: version identifier 'RISCV32' is reserved and cannot be set
+Error: version identifier 'RISCV64' is reserved and cannot be set
 Error: version identifier 'SPARC' is reserved and cannot be set
 Error: version identifier 'SPARC_V8Plus' is reserved and cannot be set
 Error: version identifier 'SPARC_SoftFloat' is reserved and cannot be set


### PR DESCRIPTION
I have recently forked LDC with the intention of adding RISC-V support, which requires that new version identifiers `RISCV32` and `RISCV64` be added to DMD, so following previous examples this PR adds the identifiers and adjusts the compilation tests accordingly. A PR for dlang.org will follow shortly.