### PR TITLE
[REG2.070] Improve forward reference resolution during field type analysis

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -32,8 +32,8 @@ import ddmd.visitor;
 
 enum Sizeok : int
 {
-    SIZEOKnone,             // size of aggregate is not yet able to compute
-    SIZEOKfwd,              // size of aggregate is ready to compute
+    SIZEOKnone,             // size of aggregate is not yet computed
+    SIZEOKfwd,              // size of aggregate is finalizing
     SIZEOKdone,             // size of aggregate is set correctly
 }
 
@@ -221,7 +221,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      * Runs semantic() for all instance field variables, but also
      * the field types can reamin yet not resolved forward references,
      * except direct recursive definitions.
-     * After the process sizeok is set to SIZEOKfwd.
      *
      * Returns:
      *      false if any errors occur.
@@ -232,6 +231,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             return true;
 
         //printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);
+        fields.setDim(0);
 
         extern (C++) static int func(Dsymbol s, void* param)
         {
@@ -241,17 +241,23 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             if (v.storage_class & STCmanifest)
                 return 0;
 
+            auto ad = cast(AggregateDeclaration)param;
+
             if (v._scope)
                 v.semantic(null);
+            // Note: Aggregate fields or size could have determined during v.semantic.
+            if (ad.sizeok != SIZEOKnone)
+                return 1;
+
             if (v.aliassym)
                 return 0;   // If this variable was really a tuple, skip it.
+            if (!v.isField())
+                return 0;   // not an instance field
 
-            if (v.storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCctfe | STCtemplateparameter))
-                return 0;
-            if (!v.isField() || v.semanticRun < PASSsemanticdone)
+            if (v.semanticRun < PASSsemanticdone && (!v.type || !v.type.deco))
                 return 1;   // unresolvable forward reference
 
-            auto ad = cast(AggregateDeclaration)param;
+            //printf("\t[%d] %s, type = %s %s\n", ad.fields.dim, v.toPrettyChars(), v.type.deco, v.type.toChars());
             ad.fields.push(v);
 
             if (v.storage_class & STCref)
@@ -270,23 +276,24 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             return 0;
         }
 
-        fields.setDim(0);
-
         for (size_t i = 0; i < members.dim; i++)
         {
             auto s = (*members)[i];
             if (s.apply(&func, cast(void*)this))
+            {
+                if (sizeok != SIZEOKnone)
+                    return true;
                 return false;
+            }
         }
-
-        if (sizeok != SIZEOKdone)
-            sizeok = SIZEOKfwd;
 
         return true;
     }
 
     /***************************************
      * Collect all instance fields, then determine instance size.
+     * After the process sizeok is set to SIZEOKdone.
+     *
      * Returns:
      *      false if failed to determine the size.
      */
@@ -294,11 +301,33 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     {
         //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
-        // The previous instance size finalizing had:
+        // Previous instance size finalizing had failed.
         if (type.ty == Terror)
-            return false;   // failed already
+            return false;
+
+        // Instance size is already calculated.
         if (sizeok == SIZEOKdone)
-            return true;    // succeeded
+            return true;
+
+        auto errorNoSize()
+        {
+            // There's unresolvable forward reference.
+            if (type != Type.terror)
+                error(loc, "no size because of forward reference");
+
+            // Don't cache errors from speculative semantic, might be resolvable later.
+            // https://issues.dlang.org/show_bug.cgi?id=16574
+            if (!global.gag)
+            {
+                type = Type.terror;
+                errors = true;
+            }
+            return false;
+        }
+
+        // Detect circular dependency while instance size finalizing.
+        if (sizeok == SIZEOKfwd)
+            return errorNoSize();
 
         if (!members)
         {
@@ -310,37 +339,29 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             semantic(null);
 
         // Determine the instance size of base class first.
-        if (auto cd = isClassDeclaration())
+        auto cd = isClassDeclaration();
+        if (cd && cd.baseClass)
         {
-            cd = cd.baseClass;
-            if (cd && !cd.determineSize(loc))
-                goto Lfail;
+            if (!cd.baseClass.determineSize(loc))
+                return false;
+            if (sizeok == SIZEOKdone)
+                return true;
         }
 
-        // Determine instance fields when sizeok == SIZEOKnone
+        //printf("+AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
+
+        // Determine instance fields
         if (!determineFields())
-            goto Lfail;
-        if (sizeok != SIZEOKdone)
-            finalizeSize();
-
-        // this aggregate type has:
-        if (type.ty == Terror)
-            return false;   // marked as invalid during the finalizing.
+            return errorNoSize();
+        // Note: Aggregate size could have determined during determineFields.
         if (sizeok == SIZEOKdone)
-            return true;    // succeeded to calculate instance size.
+            return true;
 
-    Lfail:
-        // There's unresolvable forward reference.
-        if (type != Type.terror)
-            error(loc, "no size because of forward reference");
-        // Don't cache errors from speculative semantic, might be resolvable later.
-        // https://issues.dlang.org/show_bug.cgi?id=16574
-        if (!global.gag)
-        {
-            type = Type.terror;
-            errors = true;
-        }
-        return false;
+        sizeok = SIZEOKfwd;
+
+        finalizeSize();
+
+        return sizeok == SIZEOKdone ? true : errorNoSize();
     }
 
     abstract void finalizeSize();
@@ -573,7 +594,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     static void alignmember(structalign_t alignment, uint size, uint* poffset)
     {
-        //printf("alignment = %d, size = %d, offset = %d\n",alignment,size,offset);
+        //printf("alignment = %d, size = %d, offset = %d\n", alignment, size, *poffset);
         switch (alignment)
         {
         case cast(structalign_t)1:
@@ -729,10 +750,16 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             vthis.storage_class |= STCfield;
             vthis.parent = this;
             vthis.protection = Prot(PROTpublic);
+
+            if (sizeok != SIZEOKnone)
+            {
+                vthis.error("cannot be further field because it will change the determined %s size", toChars());
+            }
+
             vthis.alignment = t.alignment();
             vthis.semanticRun = PASSsemanticdone;
 
-            if (sizeok == SIZEOKfwd)
+            if (sizeok == SIZEOKnone)
                 fields.push(vthis);
         }
     }

--- a/src/aliasthis.d
+++ b/src/aliasthis.d
@@ -49,6 +49,8 @@ extern (C++) final class AliasThis : Dsymbol
 
     override void semantic(Scope* sc)
     {
+        //printf("AliasThis::semantic(%s)\n", ident.toChars());
+
         Dsymbol p = sc.parent.pastMixin();
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
@@ -94,6 +96,8 @@ extern (C++) final class AliasThis : Dsymbol
         }
 
         ad.aliasthis = s;
+
+        //printf("-AliasThis::semantic(%s) s = %s %s\n", ident.toChars(), s.kind(), s.toChars());
     }
 
     override const(char)* kind() const

--- a/src/dclass.d
+++ b/src/dclass.d
@@ -1247,6 +1247,8 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         {
             s.setFieldOffset(this, &offset, false);
         }
+        if (type.ty == Terror)
+            return;
 
         sizeok = SIZEOKdone;
 

--- a/src/func.d
+++ b/src/func.d
@@ -1324,7 +1324,7 @@ extern (C++) class FuncDeclaration : Declaration
         }
         //printf("FuncDeclaration::semantic3('%s.%s', %p, sc = %p, loc = %s)\n", parent.toChars(), toChars(), this, sc, loc.toChars());
         //fflush(stdout);
-        //printf("storage class = x%x %x\n", sc.stc, storage_class);
+        //printf("storage class = x%llx %llx\n", sc.stc, storage_class);
         //{ static int x; if (++x == 2) *(char*)0=0; }
         //printf("\tlinkage = %d\n", sc.linkage);
 

--- a/test/compilable/test16574.d
+++ b/test/compilable/test16574.d
@@ -1,9 +1,8 @@
 // https://issues.dlang.org/show_bug.cgi?id=16574
 template Recursive(T) if (is(T == class))
 {
-    // fails because T is still forward referenced
-    // speculative determineSize must not set type to error
-    static assert (!__traits(compiles, { new T; }));
+    // T is forward referenced, but determineSize must not set type to error
+    static assert (__traits(compiles, { new T; }));
     // known size of class
     static assert (is(typeof(T.init) == T));
 
@@ -18,11 +17,10 @@ class C
 
 template Recursive(T) if (is(T == struct))
 {
-    // fails because T is still forward referenced
-    // speculative determineSize must not set type to error
-    static assert (!__traits(compiles, { T t; }));
-    // no size yet for struct
-    static assert (!is(typeof(T.init)));
+    // T is forward referenced, but determineSize must not set type to error
+    static assert (__traits(compiles, { T t; }));
+    // known size of struct
+    static assert (is(typeof(T.init) == T));
 
     alias Recursive = T*;
 }

--- a/test/fail_compilation/fail42.d
+++ b/test/fail_compilation/fail42.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail42.d(22): Error: struct fail42.Qwert no size because of forward reference
+fail_compilation/fail42.d(17): Error: variable fail42.Qwert.asdfg cannot be further field because it will change the determined Qwert size
 ---
 */
 


### PR DESCRIPTION
Original commit, which has been rebased against stable: https://github.com/dlang/dmd/pull/5773/commits/80d139822dcc8d4af5bd46d2bd73a1e2e180183c

If template instantiations occur during field variable type analysis, v.semantic(v._scope) might be invoked to get correct v.type.

Essentially it's equivalent mechanism with the code (`inuse == 1 && type && _scope`) in `AliasDeclaration.toAlias`.

This fixes an ICE in gdc, where in the following struct (from test13613)
```
struct S1
{
    int i;
    mixin MT!"x";
    mixin MT!"y";
}
```
The D frontend implementation inserts four `fields`; `i`, `x`, `y`, and `y` again (because `determineFields` was called recursively).