### PR TITLE
[REG2.072a] Set STCfield before variable type analysis

### DIFF
--- a/src/declaration.d
+++ b/src/declaration.d
@@ -1090,10 +1090,6 @@ extern (C++) class VarDeclaration : Declaration
             printf("linkage = %d\n", sc.linkage);
             //if (strcmp(toChars(), "mul") == 0) assert(0);
         }
-        //if (semanticRun > PASSinit)
-        //    return;
-        //semanticRun = PSSsemantic;
-
         if (semanticRun >= PASSsemanticdone)
             return;
 
@@ -1104,19 +1100,50 @@ extern (C++) class VarDeclaration : Declaration
             scx = sc;
             _scope = null;
         }
+        //printf("+VarDeclaration::semantic('%s', parent = '%s') semanticRun = %d\n",
+        //    toChars(), sc.parent ? sc.parent.toChars() : null, semanticRun);
 
-        /* Pick up storage classes from context, but except synchronized,
-         * override, abstract, and final.
-         */
-        storage_class |= (sc.stc & ~(STCsynchronized | STCoverride | STCabstract | STCfinal));
-        if (storage_class & STCextern && _init)
-            error("extern symbols cannot have initializers");
+        if (semanticRun == PASSinit)
+        {
+            parent = sc.parent;
+            //printf("this = %p, parent = %p, '%s'\n", this, parent, parent.toChars());
 
-        userAttribDecl = sc.userAttribDecl;
+            protection = sc.protection;
+            alignment = sc.alignment();
 
-        AggregateDeclaration ad = isThis();
-        if (ad)
-            storage_class |= ad.storage_class & STC_TYPECTOR;
+            linkage = sc.linkage;
+
+            /* Pick up storage classes from context, but except synchronized,
+             * override, abstract, and final.
+             */
+            storage_class |= (sc.stc & ~(STCsynchronized | STCoverride | STCabstract | STCfinal));
+            if (storage_class & STCextern && _init)
+                error("extern symbols cannot have initializers");
+
+            if (storage_class & (STCstatic | STCextern | STCmanifest |
+                                 STCtemplateparameter | STCtls | STCgshared | STCctfe))
+            {
+            }
+            else if (auto ad = toParent().isAggregateDeclaration())
+            {
+                storage_class |= ad.storage_class & STC_TYPECTOR;
+                storage_class |= STCfield;
+
+                if (auto id = ad.isInterfaceDeclaration())
+                {
+                    error("field not allowed in interface");
+                }
+                else if (ad.sizeok == SIZEOKdone)
+                {
+                    error("cannot be further field because it will change the determined %s size", ad.toChars());
+                }
+            }
+            //printf("sc.stc = %llx\n", sc.stc);
+            //printf("storage_class = x%llx\n", storage_class);
+
+            userAttribDecl = sc.userAttribDecl;
+        }
+        semanticRun = PASSsemantic;
 
         /* If auto type inference, do the inference
          */
@@ -1163,25 +1190,21 @@ extern (C++) class VarDeclaration : Declaration
             inuse--;
             sc2.pop();
         }
-        //printf(" semantic type = %s\n", type ? type.toChars() : "null");
         if (type.ty == Terror)
             errors = true;
 
+        /* Storage class can modify the type
+         */
+        type = type.addStorageClass(storage_class);
+
         type.checkDeprecated(loc, sc);
-        linkage = sc.linkage;
-        this.parent = sc.parent;
-        //printf("this = %p, parent = %p, '%s'\n", this, parent, parent.toChars());
-        protection = sc.protection;
+        //printf(" semantic type = %s\n", type.toChars());
 
         /* If scope's alignment is the default, use the type's alignment,
          * otherwise the scope overrrides.
          */
-        alignment = sc.alignment();
         if (alignment == STRUCTALIGN_DEFAULT)
-            alignment = type.alignment(); // use type's alignment
-
-        //printf("sc.stc = %x\n", sc.stc);
-        //printf("storage_class = x%x\n", storage_class);
+            alignment = type.alignment();
 
         if (global.params.vcomplex)
             type.checkComplexTransition(loc);
@@ -1195,8 +1218,6 @@ extern (C++) class VarDeclaration : Declaration
                     error("__gshared not allowed in safe functions; use shared");
             }
         }
-
-        Dsymbol parent = toParent();
 
         Type tb = type.toBasetype();
         Type tbn = tb.baseElemOf();
@@ -1381,13 +1402,16 @@ extern (C++) class VarDeclaration : Declaration
             v2.parent = this.parent;
             v2.isexp = true;
             aliassym = v2;
+
+            // Continue to reject fail_compilation/fail7851.d.
+            storage_class &= ~STCfield;
+
             semanticRun = PASSsemanticdone;
             return;
         }
 
-        /* Storage class can modify the type
-         */
-        type = type.addStorageClass(storage_class);
+        Dsymbol parent = toParent();
+        assert(parent);
 
         /* Adjust storage class to reflect type
          */
@@ -1436,53 +1460,39 @@ extern (C++) class VarDeclaration : Declaration
             }
         }
 
-        if (storage_class & (STCstatic | STCextern | STCmanifest | STCtemplateparameter | STCtls | STCgshared | STCctfe))
+        if (isField())
         {
-        }
-        else
-        {
-            AggregateDeclaration aad = parent.isAggregateDeclaration();
-            if (aad)
+            if (auto ad = parent.isAggregateDeclaration())
             {
-                if (global.params.vfield && storage_class & (STCconst | STCimmutable) && _init && !_init.isVoidInitializer())
+                if (global.params.vfield &&
+                    storage_class & (STCconst | STCimmutable) &&
+                    _init && !_init.isVoidInitializer())
                 {
                     const(char)* p = loc.toChars();
                     const(char)* s = (storage_class & STCimmutable) ? "immutable" : "const";
                     fprintf(global.stdmsg, "%s: %s.%s is %s field\n", p ? p : "", ad.toPrettyChars(), toChars(), s);
                 }
-                storage_class |= STCfield;
                 if (tbn.ty == Tstruct && (cast(TypeStruct)tbn).sym.noDefaultCtor)
                 {
                     if (!isThisDeclaration() && !_init)
-                        aad.noDefaultCtor = true;
+                        ad.noDefaultCtor = true;
                 }
-            }
-
-            InterfaceDeclaration id = parent.isInterfaceDeclaration();
-            if (id)
-            {
-                error("field not allowed in interface");
-            }
-            else if (aad && aad.sizeok == SIZEOKdone)
-            {
-                error("cannot be further field because it will change the determined %s size", aad.toChars());
             }
 
             /* Templates cannot add fields to aggregates
              */
-            TemplateInstance ti = parent.isTemplateInstance();
-            if (ti)
+            if (auto ti = parent.isTemplateInstance())
             {
                 // Take care of nested templates
                 while (1)
                 {
-                    TemplateInstance ti2 = ti.tempdecl.parent.isTemplateInstance();
+                    auto ti2 = ti.tempdecl.parent.isTemplateInstance();
                     if (!ti2)
                         break;
                     ti = ti2;
                 }
                 // If it's a member template
-                AggregateDeclaration ad2 = ti.tempdecl.isMember();
+                auto ad2 = ti.tempdecl.isMember();
                 if (ad2 && storage_class != STCundefined)
                 {
                     error("cannot use template to add field to aggregate '%s'", ad2.toChars());

--- a/test/compilable/testfwdref.d
+++ b/test/compilable/testfwdref.d
@@ -714,3 +714,52 @@ struct Stmt15726b(T)
 }
 
 Con15726b!int x15726b;
+
+/***************************************************/
+// 16013
+
+struct Impl16013a
+{
+    S16013a _payload;
+}
+
+struct S16013a
+{
+    RC16013a s;
+}
+
+struct RC16013a
+{
+    void opAssign(RC16013a rhs)
+    {}
+    void opAssign(S16013a rhs)
+    {}
+
+    S16013a rcPayload()
+    {
+        return S16013a.init;
+    }
+    alias rcPayload this;
+}
+
+static assert(Impl16013a.sizeof == S16013a.sizeof);
+static assert(S16013a.sizeof == RC16013a.sizeof);
+static assert(RC16013a.sizeof == 1);
+
+// ----
+
+S16013b s16013b;
+
+struct RC16013b
+{
+    void opAssign(RC16013b rhs) {}
+    void opAssign(S16013b rhs) {}
+
+    S16013b refCountedPayload() { return S16013b.init; }
+    alias refCountedPayload this;
+}
+
+struct S16013b
+{
+    RC16013b s;
+}

--- a/test/fail_compilation/fail7851.d
+++ b/test/fail_compilation/fail7851.d
@@ -1,5 +1,13 @@
-// 7851
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail7851.d(38): Error: need 'this' for '__mem_field_0' of type 'int'
+fail_compilation/fail7851.d(38): Error: need 'this' for '__mem_field_1' of type 'long'
+fail_compilation/fail7851.d(38): Error: need 'this' for '__mem_field_2' of type 'float'
+---
+*/
 
+// https://issues.dlang.org/show_bug.cgi?id=7851
 
 template TypeTuple(TList...)
 {
@@ -24,10 +32,9 @@ private template Identity(alias T)
     alias T Identity;
 }
 
-
-void main() {
-  alias Tuple!(int, long, float) TL;
-  foreach (i; TL)
-  { }
+void main()
+{
+    alias Tuple!(int, long, float) TL;
+    foreach (i; TL)
+    { }
 }
-

--- a/test/fail_compilation/gag4269f.d
+++ b/test/fail_compilation/gag4269f.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/gag4269f.d(11): Error: undefined identifier 'Y9', did you mean interface 'X9'?
 fail_compilation/gag4269f.d(11): Error: variable gag4269f.X9.y field not allowed in interface
+fail_compilation/gag4269f.d(11): Error: undefined identifier 'Y9', did you mean interface 'X9'?
 ---
 */
 


### PR DESCRIPTION
Original commits that have been rebased against stable: https://github.com/9rnsr/dmd/commit/8d65628a25386845cedcd1b21d8379be1a4de670 and https://github.com/9rnsr/dmd/commit/a4e1bc96525c722b00b5cae2b1b5ec545e9e8ef0

It makes possible to collect instance fields during field variable type analysis.

Fixes: https://issues.dlang.org/show_bug.cgi?id=16013

PR #6531 depends on this being committed first.