### PR TITLE
[WIP] write references to mutable pointers in data and tls segment

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -3708,6 +3708,13 @@ void Obj::gotref(Symbol *s)
 {
 }
 
+/*****************************************
+ * write a reference to a mutable pointer into the object file
+ * Input:
+ *      s       symbol that contains the pointer
+ *      soff    offset of the pointer inside the symbols' memory
+ */
+
 void Obj::write_pointerRef(Symbol* s, unsigned soff)
 {
     if (!obj.ptrref_buf)
@@ -3718,6 +3725,13 @@ void Obj::write_pointerRef(Symbol* s, unsigned soff)
     obj.ptrref_buf->write(&soff, sizeof(soff));
 }
 
+/*****************************************
+ * flush a single pointer reference saved by write_pointerRef
+ * to the object file
+ * Input:
+ *      s       symbol that contains the pointer
+ *      soff    offset of the pointer inside the symbols' memory
+ */
 STATIC void objflush_pointerRef(Symbol* s, unsigned soff)
 {
     bool isTls = (s->Sfl == FLtlsdata);
@@ -3761,6 +3775,10 @@ STATIC void objflush_pointerRef(Symbol* s, unsigned soff)
     SegData[segi]->SDoffset = offset;
 }
 
+/*****************************************
+ * flush all pointer references saved by write_pointerRef
+ * to the object file
+ */
 STATIC void objflush_pointerRefs()
 {
     if (!obj.ptrref_buf)

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -3722,7 +3722,7 @@ void Obj::write_pointerRef(Symbol* s, unsigned soff)
 
     // defer writing pointer references until the symbols are written out
     obj.ptrref_buf->write(&s, sizeof(s));
-    obj.ptrref_buf->write(&soff, sizeof(soff));
+    obj.ptrref_buf->write32(soff);
 }
 
 /*****************************************
@@ -3748,23 +3748,21 @@ STATIC void objflush_pointerRef(Symbol* s, unsigned soff)
         // Put out LNAMES record
         objrecord(LNAMES,lnames,sizeof(lnames_dat) - 1);
 
-        int dsegattr = I32
-            ? SEG_ATTR(SEG_ALIGN4,SEG_C_PUBLIC,0,USE32)
-            : SEG_ATTR(SEG_ALIGN2,SEG_C_PUBLIC,0,USE16);
+        int dsegattr = obj.csegattr;
 
         // Put out beginning segment
-        objsegdef(dsegattr,0,obj.lnameidx,DATACLASS);
+        objsegdef(dsegattr,0,obj.lnameidx,CODECLASS);
         obj.lnameidx++;
         obj.segidx++;
 
         // Put out segment definition record
-        segi = obj_newfarseg(0,DATACLASS);
-        objsegdef(dsegattr,0,obj.lnameidx,DATACLASS);
+        segi = obj_newfarseg(0,CODECLASS);
+        objsegdef(dsegattr,0,obj.lnameidx,CODECLASS);
         SegData[segi]->attr = dsegattr;
         assert(SegData[segi]->segidx == obj.segidx);
 
         // Put out ending segment
-        objsegdef(dsegattr,0,obj.lnameidx + 1,DATACLASS);
+        objsegdef(dsegattr,0,obj.lnameidx + 1,CODECLASS);
 
         obj.lnameidx += 2;              // for next time
         obj.segidx += 2;

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -296,6 +296,10 @@ struct Objstate
 
 #if MARS
     int fmsegi;                 // SegData[] of FM segment
+    int datrefsegi;             // SegData[] of DATA pointer ref segment
+    int tlsrefsegi;             // SegData[] of TLS pointer ref segment
+
+    Outbuffer *ptrref_buf;      // buffer for pointer references
 #endif
 
     int tlssegi;                // SegData[] of tls segment
@@ -333,6 +337,7 @@ STATIC void linnum_flush(void);
 STATIC void linnum_term(void);
 STATIC void objsegdef (int attr,targ_size_t size,int segnamidx,int classnamidx);
 STATIC void obj_modend();
+STATIC void objflush_pointerRefs();
 STATIC void objfixupp (struct FIXUP *);
 STATIC void outextdata();
 STATIC void outpubdata();
@@ -739,6 +744,7 @@ void Obj::term(const char *objfilename)
         {   obj_defaultlib();
             outfixlist();               // backpatches
         }
+        objflush_pointerRefs();
 
         if (config.fulltypes)
             cv_term();                  // write out final debug info
@@ -3700,6 +3706,77 @@ symbol *Obj::tlv_bootstrap()
 
 void Obj::gotref(Symbol *s)
 {
+}
+
+void Obj::write_pointerRef(Symbol* s, unsigned soff)
+{
+    if (!obj.ptrref_buf)
+        obj.ptrref_buf = new Outbuffer;
+
+    // defer writing pointer references until the symbols are written out
+    obj.ptrref_buf->write(&s, sizeof(s));
+    obj.ptrref_buf->write(&soff, sizeof(soff));
+}
+
+STATIC void objflush_pointerRef(Symbol* s, unsigned soff)
+{
+    bool isTls = (s->Sfl == FLtlsdata);
+    int &segi = isTls ? obj.tlsrefsegi : obj.datrefsegi;
+    symbol_debug(s);
+
+    if (segi == 0)
+    {
+        // We need to always put out the segments in triples, so that the
+        // linker will put them in the correct order.
+        static char lnames_dat[] = { "\03DPB\02DP\03DPE" };
+        static char lnames_tls[] = { "\03TPB\02TP\03TPE" };
+        char* lnames = isTls ? lnames_tls : lnames_dat;
+        // Put out LNAMES record
+        objrecord(LNAMES,lnames,sizeof(lnames_dat) - 1);
+
+        int dsegattr = I32
+            ? SEG_ATTR(SEG_ALIGN4,SEG_C_PUBLIC,0,USE32)
+            : SEG_ATTR(SEG_ALIGN2,SEG_C_PUBLIC,0,USE16);
+
+        // Put out beginning segment
+        objsegdef(dsegattr,0,obj.lnameidx,DATACLASS);
+        obj.lnameidx++;
+        obj.segidx++;
+
+        // Put out segment definition record
+        segi = obj_newfarseg(0,DATACLASS);
+        objsegdef(dsegattr,0,obj.lnameidx,DATACLASS);
+        SegData[segi]->attr = dsegattr;
+        assert(SegData[segi]->segidx == obj.segidx);
+
+        // Put out ending segment
+        objsegdef(dsegattr,0,obj.lnameidx + 1,DATACLASS);
+
+        obj.lnameidx += 2;              // for next time
+        obj.segidx += 2;
+    }
+
+    targ_size_t offset = SegData[segi]->SDoffset;
+    offset += objmod->reftoident(segi, offset, s, soff, CFoff);
+    SegData[segi]->SDoffset = offset;
+}
+
+STATIC void objflush_pointerRefs()
+{
+    if (!obj.ptrref_buf)
+        return;
+
+    unsigned char *p = obj.ptrref_buf->buf;
+    unsigned char *end = obj.ptrref_buf->p;
+    while (p < end)
+    {
+        Symbol* s = *(Symbol**)p;
+        p += sizeof(s);
+        unsigned soff = *(unsigned*)p;
+        p += sizeof(soff);
+        objflush_pointerRef(s, soff);
+    }
+    obj.ptrref_buf->reset();
 }
 
 #endif

--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -3710,9 +3710,9 @@ void Obj::gotref(Symbol *s)
 
 /*****************************************
  * write a reference to a mutable pointer into the object file
- * Input:
- *      s       symbol that contains the pointer
- *      soff    offset of the pointer inside the symbols' memory
+ * Params:
+ *      s    = symbol that contains the pointer
+ *      soff = offset of the pointer inside the Symbol's memory
  */
 
 void Obj::write_pointerRef(Symbol* s, unsigned soff)
@@ -3728,9 +3728,9 @@ void Obj::write_pointerRef(Symbol* s, unsigned soff)
 /*****************************************
  * flush a single pointer reference saved by write_pointerRef
  * to the object file
- * Input:
- *      s       symbol that contains the pointer
- *      soff    offset of the pointer inside the symbols' memory
+ * Params:
+ *      s    = symbol that contains the pointer
+ *      soff = offset of the pointer inside the Symbol's memory
  */
 STATIC void objflush_pointerRef(Symbol* s, unsigned soff)
 {

--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -411,7 +411,7 @@ dt_t *DtBuilder::xoffpatch(Symbol *s, unsigned offset, tym_t ty)
 
 /*************************************
  * Create a reference to another dt.
- * Return the internal symbol used for the other dt
+ * Returns: the internal symbol used for the other dt
  */
 Symbol *DtBuilder::dtoff(dt_t *dt, unsigned offset)
 {

--- a/src/backend/dt.c
+++ b/src/backend/dt.c
@@ -411,8 +411,9 @@ dt_t *DtBuilder::xoffpatch(Symbol *s, unsigned offset, tym_t ty)
 
 /*************************************
  * Create a reference to another dt.
+ * Return the internal symbol used for the other dt
  */
-void DtBuilder::dtoff(dt_t *dt, unsigned offset)
+Symbol *DtBuilder::dtoff(dt_t *dt, unsigned offset)
 {
     type *t = type_alloc(TYint);
     t->Tcount++;
@@ -425,6 +426,7 @@ void DtBuilder::dtoff(dt_t *dt, unsigned offset)
     outdata(s);
 
     xoff(s, offset);
+    return s;
 }
 
 /********************************

--- a/src/backend/dt.d
+++ b/src/backend/dt.d
@@ -55,7 +55,7 @@ final:
     void xoff(Symbol* s, uint offset, tym_t ty);
     dt_t* xoffpatch(Symbol* s, uint offset, tym_t ty);
     void xoff(Symbol* s, uint offset);
-    void dtoff(dt_t* dt, uint offset);
+    Symbol* dtoff(dt_t* dt, uint offset);
     void coff(uint offset);
     void cat(dt_t* dt);
     void cat(DtBuilder dtb);

--- a/src/backend/dt.h
+++ b/src/backend/dt.h
@@ -56,7 +56,7 @@ public:
     void xoff(Symbol *s, unsigned offset, tym_t ty);
     dt_t *xoffpatch(Symbol *s, unsigned offset, tym_t ty);
     void xoff(Symbol *s, unsigned offset);
-    void dtoff(dt_t *dt, unsigned offset);
+    Symbol* dtoff(dt_t *dt, unsigned offset);
     void coff(unsigned offset);
     void cat(dt_t *dt);
     void cat(DtBuilder *dtb);

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -3491,6 +3491,10 @@ symbol *Obj::tlv_bootstrap()
     return NULL;
 }
 
+void Obj::write_pointerRef(Symbol* s, unsigned off)
+{
+}
+
 /******************************************
  * Generate fixup specific to .eh_frame and .gcc_except_table sections.
  * Params:

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -2862,6 +2862,10 @@ symbol *Obj::tlv_bootstrap()
 }
 
 
+void Obj::write_pointerRef(Symbol* s, unsigned off)
+{
+}
+
 /*********************************
  * Define segments for Thread Local Storage variables.
  * Output:

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -2394,9 +2394,9 @@ symbol *MsCoffObj::tlv_bootstrap()
 
 /*****************************************
  * write a reference to a mutable pointer into the object file
- * Input:
- *      s       symbol that contains the pointer
- *      soff    offset of the pointer inside the symbols' memory
+ * Params:
+ *      s    = symbol that contains the pointer
+ *      soff = offset of the pointer inside the Symbol's memory
  */
 void MsCoffObj::write_pointerRef(Symbol* s, unsigned soff)
 {
@@ -2411,9 +2411,9 @@ void MsCoffObj::write_pointerRef(Symbol* s, unsigned soff)
 /*****************************************
  * flush a single pointer reference saved by write_pointerRef
  * to the object file
- * Input:
- *      s       symbol that contains the pointer
- *      soff    offset of the pointer inside the symbols' memory
+ * Params:
+ *      s    = symbol that contains the pointer
+ *      soff = offset of the pointer inside the Symbol's memory
  */
 static void objflush_pointerRef(Symbol* s, unsigned soff)
 {

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -2384,5 +2384,10 @@ symbol *MsCoffObj::tlv_bootstrap()
     return NULL;
 }
 
+void MsCoffObj::write_pointerRef(Symbol* s, unsigned off)
+{
+
+}
+
 #endif
 #endif

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -48,6 +48,7 @@ char *obj_mangle2(Symbol *s,char *dest);
  */
 
 static long elf_align(int size, long offset);
+static void objflush_pointerRefs();
 
 // The object file is built ib several separate pieces
 
@@ -81,6 +82,8 @@ static int jumpTableSeg;                // segment index for __jump_table
 
 static Outbuffer *indirectsymbuf2;      // indirect symbol table of Symbol*'s
 static int pointersSeg;                 // segment index for __pointers
+
+static Outbuffer *ptrref_buf;           // buffer for pointer references
 
 static int floatused;
 
@@ -667,6 +670,7 @@ void MsCoffObj::term(const char *objfilename)
 #endif
     {
         outfixlist();           // backpatches
+        objflush_pointerRefs();
     }
 
     if (configv.addlinenumbers)
@@ -1246,6 +1250,10 @@ void MsCoffObj::ehsections()
     int attr = IMAGE_SCN_CNT_INITIALIZED_DATA | align | IMAGE_SCN_MEM_READ;
     emitSectionBrace("._deh", "_deh", attr, this);
     emitSectionBrace(".minfo", "_minfo", attr, this);
+
+    attr = IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ;
+    emitSectionBrace(".dp", "_DP", attr, NULL); // references to pointers in .data and .bss
+    emitSectionBrace(".tp", "_TP", attr, NULL); // references to pointers in .tls
 
     attr = IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_ALIGN_16BYTES | IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE;
     emitSectionBrace(".data", "_data", attr, NULL);
@@ -2384,9 +2392,64 @@ symbol *MsCoffObj::tlv_bootstrap()
     return NULL;
 }
 
-void MsCoffObj::write_pointerRef(Symbol* s, unsigned off)
+/*****************************************
+ * write a reference to a mutable pointer into the object file
+ * Input:
+ *      s       symbol that contains the pointer
+ *      soff    offset of the pointer inside the symbols' memory
+ */
+void MsCoffObj::write_pointerRef(Symbol* s, unsigned soff)
 {
+    if (!ptrref_buf)
+        ptrref_buf = new Outbuffer;
 
+    // defer writing pointer references until the symbols are written out
+    ptrref_buf->write(&s, sizeof(s));
+    ptrref_buf->write(&soff, sizeof(soff));
+}
+
+/*****************************************
+ * flush a single pointer reference saved by write_pointerRef
+ * to the object file
+ * Input:
+ *      s       symbol that contains the pointer
+ *      soff    offset of the pointer inside the symbols' memory
+ */
+static void objflush_pointerRef(Symbol* s, unsigned soff)
+{
+    bool isTls = (s->Sfl == FLtlsdata);
+    const char* segname = isTls ? ".tp$B" : ".dp$B";
+    int attr = IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_ALIGN_4BYTES | IMAGE_SCN_MEM_READ;
+    int seg = MsCoffObj::getsegment(segname, attr);
+
+    targ_size_t offset = SegData[seg]->SDoffset;
+    MsCoffObj::addrel(seg, offset, s, offset, RELaddr32, 0);
+    Outbuffer* buf = SegData[seg]->SDbuf;
+    buf->setsize(offset);
+    buf->write32(soff);
+    SegData[seg]->SDoffset = buf->size();
+}
+
+/*****************************************
+ * flush all pointer references saved by write_pointerRef
+ * to the object file
+ */
+STATIC void objflush_pointerRefs()
+{
+    if (!ptrref_buf)
+        return;
+
+    unsigned char *p = ptrref_buf->buf;
+    unsigned char *end = ptrref_buf->p;
+    while (p < end)
+    {
+        Symbol* s = *(Symbol**)p;
+        p += sizeof(s);
+        unsigned soff = *(unsigned*)p;
+        p += sizeof(soff);
+        objflush_pointerRef(s, soff);
+    }
+    ptrref_buf->reset();
 }
 
 #endif

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -2405,7 +2405,7 @@ void MsCoffObj::write_pointerRef(Symbol* s, unsigned soff)
 
     // defer writing pointer references until the symbols are written out
     ptrref_buf->write(&s, sizeof(s));
-    ptrref_buf->write(&soff, sizeof(soff));
+    ptrref_buf->write32(soff);
 }
 
 /*****************************************

--- a/src/backend/obj.d
+++ b/src/backend/obj.d
@@ -88,6 +88,7 @@ class Obj
     Symbol *sym_cdata(tym_t, char *, int);
     void func_start(Symbol *sfunc);
     void func_term(Symbol *sfunc);
+    void write_pointerRef(Symbol* s, uint off);
 
     Symbol *tlv_bootstrap();
 
@@ -162,6 +163,7 @@ class MsCoffObj : Obj
     static  uint addstr(Outbuffer *strtab, const(char)* );
     override void func_start(Symbol *sfunc);
     override void func_term(Symbol *sfunc);
+    override void write_pointerRef(Symbol* s, uint off);
 
     static int getsegment(const(char)* sectname, uint flags);
     static int getsegment2( uint shtidx);
@@ -250,6 +252,7 @@ class Obj
     static Symbol *sym_cdata(tym_t, char *, int);
     static void func_start(Symbol *sfunc);
     static void func_term(Symbol *sfunc);
+    static void write_pointerRef(Symbol* s, uint off);
 
     static Symbol *tlv_bootstrap();
 

--- a/src/backend/obj.h
+++ b/src/backend/obj.h
@@ -87,6 +87,7 @@ class Obj
     VIRTUAL symbol *sym_cdata(tym_t, char *, int);
     VIRTUAL void func_start(Symbol *sfunc);
     VIRTUAL void func_term(Symbol *sfunc);
+    VIRTUAL void write_pointerRef(Symbol* s, unsigned off);
 
     VIRTUAL symbol *tlv_bootstrap();
 
@@ -195,6 +196,7 @@ class MsCoffObj : public Obj
     static unsigned addstr(Outbuffer *strtab, const char *);
     VIRTUAL void func_start(Symbol *sfunc);
     VIRTUAL void func_term(Symbol *sfunc);
+    VIRTUAL void write_pointerRef(Symbol* s, unsigned off);
 
     static int getsegment(const char *sectname, unsigned long flags);
     static int getsegment2(unsigned shtidx);

--- a/src/todt.d
+++ b/src/todt.d
@@ -188,7 +188,10 @@ extern (C++) void Initializer_toDt(Initializer init, DtBuilder dtb)
                 {
                     if (tb.ty == Tarray)
                         dtb.size(ai.dim);
-                    dtb.dtoff(dtbarray.finish(), 0);
+                    Symbol* s = dtb.dtoff(dtbarray.finish(), 0);
+                    if (tn.isMutable())
+                        for (int i = 0; i < ai.dim; i++)
+                            write_pointers(tn, s, size * i);
                     break;
                 }
 
@@ -272,7 +275,10 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
             if (e.e1.op == TOKstructliteral)
             {
                 StructLiteralExp sl = cast(StructLiteralExp)e.e1;
-                dtb.xoff(toSymbol(sl), 0);
+                Symbol* s = toSymbol(sl);
+                dtb.xoff(s, 0);
+                if (sl.type.isMutable())
+                    write_pointers(sl.type, s, 0);
                 return;
             }
             visit(cast(UnaExp)e);
@@ -913,7 +919,10 @@ private void toDtElem(TypeSArray tsa, DtBuilder dtb, Expression e)
 private void ClassReferenceExp_toDt(ClassReferenceExp e, DtBuilder dtb, int off)
 {
     //printf("ClassReferenceExp.toDt() %d\n", e.op);
-    dtb.xoff(toSymbol(e), off);
+    Symbol* s = toSymbol(e);
+    dtb.xoff(s, off);
+    if (e.type.isMutable())
+        write_instance_pointers(e.type, s, 0);
 }
 
 extern (C++) void ClassReferenceExp_toInstanceDt(ClassReferenceExp ce, DtBuilder dtb)

--- a/src/toobj.d
+++ b/src/toobj.d
@@ -224,10 +224,10 @@ void genModuleInfo(Module m)
 /*****************************************
  * write pointer references for typed data to the object file
  * a class type is considered to mean a reference to a class instance
- * Input:
- *      type    type of the data to check for pointers
- *      s       symbol that contains the data
- *      offset  offset of the data inside the symbols' memory
+ * Params:
+ *      type   = type of the data to check for pointers
+ *      s      = symbol that contains the data
+ *      offset = offset of the data inside the Symbol's memory
  */
 void write_pointers(Type type, Symbol *s, uint offset)
 {
@@ -241,10 +241,10 @@ void write_pointers(Type type, Symbol *s, uint offset)
 /*****************************************
 * write pointer references for typed data to the object file
 * a class type is considered to mean the instance, not a reference
-* Input:
-*      type    type of the data to check for pointers
-*      s       symbol that contains the data
-*      offset  offset of the data inside the symbols' memory
+* Params:
+*      type   = type of the data to check for pointers
+*      s      = symbol that contains the data
+*      offset = offset of the data inside the Symbol's memory
 */
 void write_instance_pointers(Type type, Symbol *s, uint offset)
 {

--- a/src/toobj.d
+++ b/src/toobj.d
@@ -221,6 +221,14 @@ void genModuleInfo(Module m)
     objmod.moduleinfo(msym);
 }
 
+/*****************************************
+ * write pointer references for typed data to the object file
+ * a class type is considered to mean a reference to a class instance
+ * Input:
+ *      type    type of the data to check for pointers
+ *      s       symbol that contains the data
+ *      offset  offset of the data inside the symbols' memory
+ */
 void write_pointers(Type type, Symbol *s, uint offset)
 {
     uint ty = type.toBasetype().ty;
@@ -230,6 +238,14 @@ void write_pointers(Type type, Symbol *s, uint offset)
     write_instance_pointers(type, s, offset);
 }
 
+/*****************************************
+* write pointer references for typed data to the object file
+* a class type is considered to mean the instance, not a reference
+* Input:
+*      type    type of the data to check for pointers
+*      s       symbol that contains the data
+*      offset  offset of the data inside the symbols' memory
+*/
 void write_instance_pointers(Type type, Symbol *s, uint offset)
 {
     if (!type.hasPointers())

--- a/src/traits.d
+++ b/src/traits.d
@@ -112,48 +112,29 @@ static this()
 /**
  * get an array of size_t values that indicate possible pointer words in memory
  *  if interpreted as the type given as argument
- * the first array element is the size of the type for independent interpretation
- *  of the array
- * following elements bits represent one word (4/8 bytes depending on the target
- *  architecture). If set the corresponding memory might contain a pointer/reference.
- *
- *  [T.sizeof, pointerbit0-31/63, pointerbit32/64-63/128, ...]
+ * returns the size of the type in bytes, d_uns64.max on error
  */
-extern (C++) Expression pointerBitmap(TraitsExp e)
+extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
 {
-    if (!e.args || e.args.dim != 1)
-    {
-        error(e.loc, "a single type expected for trait pointerBitmap");
-        return new ErrorExp();
-    }
-
-    Type t = getType((*e.args)[0]);
-    if (!t)
-    {
-        error(e.loc, "%s is not a type", (*e.args)[0].toChars());
-        return new ErrorExp();
-    }
-
     d_uns64 sz;
     if (t.ty == Tclass && !(cast(TypeClass)t).sym.isInterfaceDeclaration())
-        sz = (cast(TypeClass)t).sym.AggregateDeclaration.size(e.loc);
+        sz = (cast(TypeClass)t).sym.AggregateDeclaration.size(loc);
     else
-        sz = t.size(e.loc);
+        sz = t.size(loc);
     if (sz == SIZE_INVALID)
-        return new ErrorExp();
+        return d_uns64.max;
 
-    const sz_size_t = Type.tsize_t.size(e.loc);
+    const sz_size_t = Type.tsize_t.size(loc);
     if (sz > sz.max - sz_size_t)
     {
-        error(e.loc, "size overflow for type %s", t.toChars());
-        return new ErrorExp();
+        error(loc, "size overflow for type %s", t.toChars());
+        return d_uns64.max;
     }
 
     d_uns64 bitsPerWord = sz_size_t * 8;
     d_uns64 cntptr = (sz + sz_size_t - 1) / sz_size_t;
     d_uns64 cntdata = (cntptr + bitsPerWord - 1) / bitsPerWord;
 
-    Array!(d_uns64) data;
     data.setDim(cast(size_t)cntdata);
     data.zero();
 
@@ -338,21 +319,51 @@ extern (C++) Expression pointerBitmap(TraitsExp e)
         bool error;
     }
 
-    scope PointerBitmapVisitor pbv = new PointerBitmapVisitor(&data, sz_size_t);
+    scope PointerBitmapVisitor pbv = new PointerBitmapVisitor(data, sz_size_t);
     if (t.ty == Tclass)
         pbv.visitClass(cast(TypeClass)t);
     else
         t.accept(pbv);
-    if (pbv.error)
+    return pbv.error ? d_uns64.max : sz;
+}
+
+/**
+ * get an array of size_t values that indicate possible pointer words in memory
+ *  if interpreted as the type given as argument
+ * the first array element is the size of the type for independent interpretation
+ *  of the array
+ * following elements bits represent one word (4/8 bytes depending on the target
+ *  architecture). If set the corresponding memory might contain a pointer/reference.
+ *
+ *  [T.sizeof, pointerbit0-31/63, pointerbit32/64-63/128, ...]
+ */
+extern (C++) Expression pointerBitmap(TraitsExp e)
+{
+    if (!e.args || e.args.dim != 1)
+    {
+        error(e.loc, "a single type expected for trait pointerBitmap");
+        return new ErrorExp();
+    }
+
+    Type t = getType((*e.args)[0]);
+    if (!t)
+    {
+        error(e.loc, "%s is not a type", (*e.args)[0].toChars());
+        return new ErrorExp();
+    }
+
+    Array!(d_uns64) data;
+    d_uns64 sz = getTypePointerBitmap(e.loc, t, &data);
+    if (sz == d_uns64.max)
         return new ErrorExp();
 
     auto exps = new Expressions();
     exps.push(new IntegerExp(e.loc, sz, Type.tsize_t));
-    foreach (d_uns64 i; 0 .. cntdata)
+    foreach (d_uns64 i; 0 .. data.dim)
         exps.push(new IntegerExp(e.loc, data[cast(size_t)i], Type.tsize_t));
 
     auto ale = new ArrayLiteralExp(e.loc, exps);
-    ale.type = Type.tsize_t.sarrayOf(cntdata + 1);
+    ale.type = Type.tsize_t.sarrayOf(data.dim + 1);
     return ale;
 }
 

--- a/src/traits.d
+++ b/src/traits.d
@@ -112,7 +112,7 @@ static this()
 /**
  * get an array of size_t values that indicate possible pointer words in memory
  *  if interpreted as the type given as argument
- * returns the size of the type in bytes, d_uns64.max on error
+ * Returns: the size of the type in bytes, d_uns64.max on error
  */
 extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
 {
@@ -335,7 +335,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
  * following elements bits represent one word (4/8 bytes depending on the target
  *  architecture). If set the corresponding memory might contain a pointer/reference.
  *
- *  [T.sizeof, pointerbit0-31/63, pointerbit32/64-63/128, ...]
+ *  Returns: [T.sizeof, pointerbit0-31/63, pointerbit32/64-63/128, ...]
  */
 extern (C++) Expression pointerBitmap(TraitsExp e)
 {

--- a/test/runnable/testptrref.d
+++ b/test/runnable/testptrref.d
@@ -1,0 +1,126 @@
+
+version(CRuntime_Microsoft) {} else
+version(Win32)
+{
+    extern(C)
+    {
+        extern __gshared void* _DPbegin;
+        extern __gshared void* _DPend;
+        extern __gshared uint _TPbegin;
+        extern __gshared uint _TPend;
+        extern int _tlsstart;
+        extern int _tlsend;
+    }
+    version = ptrref_supported;
+}
+
+struct Struct
+{
+    int x;
+    Struct* next;
+}
+
+class Class
+{
+    void* ptr;
+}
+
+__gshared Struct* gsharedStrctPtr2 = new Struct(7, new Struct(8, null));
+
+int tlsInt;
+void* tlsVar;
+
+shared int sharedInt;
+shared void* sharedVar;
+__gshared void* gsharedVar;
+__gshared void* gsharedVar2;
+immutable int[] arr = [1, 2, 3];
+string tlsStr;
+
+__gshared Struct gsharedStrct;
+Struct[3] tlsStrcArr;
+Class tlsClss;
+
+// expression initializers
+string[] strArr = [ "a", "b" ];
+__gshared Class gsharedClss = new Class;
+__gshared Struct* gsharedStrctPtr = new Struct(7, new Struct(8, null));
+
+debug(PRINT) import core.stdc.stdio;
+
+void main()
+{
+    version(ptrref_supported)
+        testRefPtr();
+}
+
+version(ptrref_supported):
+
+bool findTlsPtr(const(void)* ptr)
+{    
+    debug(PRINT) printf("findTlsPtr %p\n", ptr);
+    for (uint* p = &_TPbegin; p < &_TPend; p++)
+    {
+        void* addr = cast(void*) &_tlsstart + *p;
+        debug(PRINT) printf("  try %p\n", addr);
+        assert(addr < &_tlsend);
+        if (addr == ptr)
+            return true;
+    }
+    return false;
+}
+
+bool findDataPtr(const(void)* ptr)
+{
+    debug(PRINT) printf("findDataPtr %p\n", ptr);
+    for (void** p = &_DPbegin; p < &_DPend; p++)
+    {
+        void* addr = *p;
+        debug(PRINT) printf("  try %p\n", addr);
+        
+        if (addr == ptr)
+            return true;
+    }
+    return false;
+}
+
+void testRefPtr()
+{
+    debug(PRINT) printf("&_DPbegin %p\n", &_DPbegin);
+    debug(PRINT) printf("&_DPend   %p\n", &_DPend);
+
+    assert(!findDataPtr(cast(void*)&sharedInt));
+    assert(!findTlsPtr(&tlsInt));
+
+    assert(findDataPtr(cast(void*)&sharedVar));
+    assert(findDataPtr(&gsharedVar));
+    assert(findDataPtr(&gsharedStrct.next));
+    assert(findDataPtr(&(gsharedClss)));
+    assert(findDataPtr(&(gsharedClss.ptr)));
+
+    assert(findTlsPtr(&tlsVar));
+    assert(findTlsPtr(&tlsClss));
+    assert(findTlsPtr(&tlsStrcArr[0].next));
+    assert(findTlsPtr(&tlsStrcArr[1].next));
+    assert(findTlsPtr(&tlsStrcArr[2].next));
+
+    assert(!findTlsPtr(cast(size_t*)&tlsStr)); // length
+    assert(findTlsPtr(cast(size_t*)&tlsStr + 1)); // ptr
+    
+    // monitor is manually managed
+    assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
+    assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
+
+    assert(!findDataPtr(&arr));
+    assert(!findTlsPtr(&arr));
+    assert(!findDataPtr(cast(size_t*)&arr + 1));
+    assert(!findTlsPtr(cast(size_t*)&arr + 1));
+    
+    assert(findDataPtr(cast(size_t*)&strArr[0] + 1)); // ptr in _DATA!
+    assert(findDataPtr(cast(size_t*)&strArr[1] + 1)); // ptr in _DATA!
+    strArr[1] = "c";
+
+    assert(findDataPtr(&gsharedStrctPtr));
+    assert(findDataPtr(&gsharedStrctPtr.next));
+    assert(findDataPtr(&gsharedStrctPtr.next.next));
+}

--- a/win32.mak
+++ b/win32.mak
@@ -1,6 +1,10 @@
 MAKE=make
 
 auto-tester-build:
+	cd ../druntime
+	git fetch https://github.com/rainers/druntime.git data_ptrref
+	git merge FETCH_HEAD
+	cd ../dmd
 	cd src
 	$(MAKE) -f win32.mak auto-tester-build
 	cd ..


### PR DESCRIPTION
While preparing a new release of Visual D, I noticed that the (rebuilt) dmd version I used so far (2.066 with the precise GC from DConf 2013) generates corrupt DLLs. Instead of trying to figure the reason for this, I tried the precise GC from https://github.com/dlang/druntime/pull/1603, but Visual D still suffers a lot when editing std.datetime with it: there are too many false pointers in the data segment.

With this PR I reimplemented a simple version of the additional info required to scan the data and tls segments precisely: instead of storing type information, it just lists addresses of all mutable pointers. This even makes usage of the heap-precise GC optional.

For example, the phobos unittest executable has a data segment of about 3 MB (and 11 kB TLS), but only 262 (and 282) mutable pointers. So this PR currently adds about 2kB to the data segment.

This PR only implements emission for Windows OMF and COFF, but should be portable to other platforms pretty easily.