### PR TITLE
ThisExp.var is always a VarDeclaration in checkEscape.

### DIFF
--- a/src/ddmd/escape.d
+++ b/src/ddmd/escape.d
@@ -705,9 +705,8 @@ private void escapeByValue(Expression e, EscapeByResults* er)
 
         override void visit(ThisExp e)
         {
-            VarDeclaration v = e.var.isVarDeclaration();
-            if (v)
-                er.byvalue.push(v);
+            if (e.var)
+                er.byvalue.push(e.var);
         }
 
         override void visit(DotVarExp e)
@@ -981,9 +980,8 @@ private void escapeByRef(Expression e, EscapeByResults* er)
 
         override void visit(ThisExp e)
         {
-            auto v = e.var.isVarDeclaration();
-            if (v)
-                er.byref.push(v);
+            if (e.var)
+                er.byref.push(e.var);
         }
 
         override void visit(PtrExp e)


### PR DESCRIPTION
Saves an extra call, however it looks like e.var can be null because of statementsem.d:

    rs.exp = new ThisExp(Loc());
    rs.exp.type = tret;

Which bypasses the semantic analysis. If isVarDeclaration() wasn't
final, or methods were guarded by 'null this' checks, then a segfault or
error would have been noticed long ago.