### PR TITLE
eliminate array bounds error helper function

### DIFF
--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -862,7 +862,6 @@ void MsCoffObj::term(const char *objfilename)
                     {
                         if (I64)
                         {
-//printf("test1 %s %d\n", s->Sident, r->val);
                             rel.r_type = (r->rtype == RELrel)
                                     ? IMAGE_REL_AMD64_REL32
                                     : IMAGE_REL_AMD64_REL32;
@@ -923,7 +922,6 @@ void MsCoffObj::term(const char *objfilename)
                     }
                     else
                     {
-//printf("test2\n");
                         if (I64)
                         {
                             if (pdata)
@@ -1404,12 +1402,18 @@ segidx_t MsCoffObj::getsegment2(IDXSEC shtidx)
     }
     assert(seg_count < seg_max);
     if (SegData[seg])
-    {   seg_data *pseg = SegData[seg];
+    {
+        seg_data *pseg = SegData[seg];
         Outbuffer *b1 = pseg->SDbuf;
         Outbuffer *b2 = pseg->SDrel;
         memset(pseg, 0, sizeof(seg_data));
         if (b1)
             b1->setsize(0);
+        else
+        {
+            b1 = new Outbuffer(4096);
+            b1->reserve(4096);
+        }
         if (b2)
             b2->setsize(0);
         pseg->SDbuf = b1;
@@ -2011,7 +2015,7 @@ unsigned MsCoffObj::bytes(segidx_t seg, targ_size_t offset, unsigned nbytes, voi
     Outbuffer *buf = SegData[seg]->SDbuf;
     if (buf == NULL)
     {
-        //dbg_printf("MsCoffObj::bytes(seg=%d, offset=x%lx, nbytes=%d, p=x%x)\n", seg, offset, nbytes, p);
+        //printf("MsCoffObj::bytes(seg=%d, offset=x%llx, nbytes=%d, p=x%x)\n", seg, offset, nbytes, p);
         //raise(SIGSEGV);
         assert(buf != NULL);
     }


### PR DESCRIPTION
Consolidated the code that builds the error call into `buildArrayBoundsError()` and then fixed it to load the file pointer directly rather than call a helper function.

Once this works, I'll delete the old code, and then amend it to reduce the bloat from redundant file strings being emitted.