### PR TITLE
fix travis builds: strtol needs a common signature for dmd 2.073 and later

### DIFF
--- a/src/libmscoff.d
+++ b/src/libmscoff.d
@@ -477,7 +477,7 @@ private:
         Port.writelongBE(cast(uint)objsymbols.dim, buf.ptr);
         libbuf.write(buf.ptr, 4);
         // Sort objsymbols[] in module offset order
-        qsort(objsymbols.data, objsymbols.dim, (objsymbols.data[0]).sizeof, &MSCoffObjSymbol_offset_cmp);
+        qsort(objsymbols.data, objsymbols.dim, (objsymbols.data[0]).sizeof, cast(_compare_fp_t)&MSCoffObjSymbol_offset_cmp);
         uint lastoffset;
         for (size_t i = 0; i < objsymbols.dim; i++)
         {
@@ -517,7 +517,7 @@ private:
         Port.writelongLE(cast(uint)objsymbols.dim, buf.ptr);
         libbuf.write(buf.ptr, 4);
         // Sort objsymbols[] in lexical order
-        qsort(objsymbols.data, objsymbols.dim, (objsymbols.data[0]).sizeof, &MSCoffObjSymbol_cmp);
+        qsort(objsymbols.data, objsymbols.dim, (objsymbols.data[0]).sizeof, cast(_compare_fp_t)&MSCoffObjSymbol_cmp);
         for (size_t i = 0; i < objsymbols.dim; i++)
         {
             MSCoffObjSymbol* os = objsymbols[i];

--- a/src/libomf.d
+++ b/src/libomf.d
@@ -322,7 +322,7 @@ private:
                 return false;
         }
         // Sort the symbols
-        qsort(objsymbols.tdata(), objsymbols.dim, (objsymbols[0]).sizeof, &NameCompare);
+        qsort(objsymbols.tdata(), objsymbols.dim, (objsymbols[0]).sizeof, cast(_compare_fp_t)&NameCompare);
         // Add each of the symbols
         for (size_t i = 0; i < objsymbols.dim; i++)
         {

--- a/src/mars.d
+++ b/src/mars.d
@@ -55,6 +55,9 @@ import ddmd.target;
 import ddmd.tokens;
 import ddmd.utils;
 
+// strtol redeclared here because its signature changed from 2.073 to 2.074
+import core.stdc.config;
+extern(C) c_long strtol(inout(char)* nptr, inout(char)** endptr, int base);
 
 /**
  * Print DMD's logo on stdout
@@ -417,7 +420,7 @@ private int tryMain(size_t argc, const(char)** argv)
                     {
                         long percent;
                         errno = 0;
-                        percent = strtol(p + 5, cast(char**)&p, 10);
+                        percent = strtol(p + 5, &p, 10);
                         if (*p || errno || percent > 100)
                             goto Lerror;
                         global.params.covPercent = cast(ubyte)percent;
@@ -538,7 +541,7 @@ private int tryMain(size_t argc, const(char)** argv)
                 {
                     long num;
                     errno = 0;
-                    num = strtol(p + 9, cast(char**)&p, 10);
+                    num = strtol(p + 9, &p, 10);
                     if (*p || errno || num > INT_MAX)
                         goto Lerror;
                     global.errorLimit = cast(uint)num;
@@ -614,7 +617,7 @@ Language changes listed by -transition=id:
                     {
                         long num;
                         errno = 0;
-                        num = strtol(p + 12, cast(char**)&p, 10);
+                        num = strtol(p + 12, &p, 10);
                         if (*p || errno || num > INT_MAX)
                             goto Lerror;
                         // Bugzilla issue number
@@ -865,7 +868,7 @@ Language changes listed by -transition=id:
                     {
                         long level;
                         errno = 0;
-                        level = strtol(p + 7, cast(char**)&p, 10);
+                        level = strtol(p + 7, &p, 10);
                         if (*p || errno || level > INT_MAX)
                             goto Lerror;
                         DebugCondition.setGlobalLevel(cast(int)level);
@@ -891,7 +894,7 @@ Language changes listed by -transition=id:
                     {
                         long level;
                         errno = 0;
-                        level = strtol(p + 9, cast(char**)&p, 10);
+                        level = strtol(p + 9, &p, 10);
                         if (*p || errno || level > INT_MAX)
                             goto Lerror;
                         VersionCondition.setGlobalLevel(cast(int)level);

--- a/src/s2ir.d
+++ b/src/s2ir.d
@@ -572,7 +572,7 @@ extern (C++) class S2irVisitor : Visitor
             }
 
             if (numcases)
-                qsort(s.cases.data, numcases, RootObject.sizeof, &sort_compare);
+                qsort(s.cases.data, numcases, RootObject.sizeof, cast(_compare_fp_t)&sort_compare);
 
             /* Create a sorted array of the case strings, and si
              * will be the symbol for it.


### PR DESCRIPTION
Travis builds dmd with both dmd 2.073 and rebuilts itself. With strtol having changed the signature in core.stdc.stdlib, we need to support both until we update the prebuilt compiler.