### PR TITLE
put string literals in COMDAT sections

### DIFF
--- a/src/glue.d
+++ b/src/glue.d
@@ -1611,7 +1611,7 @@ elem *toEfilenamePtr(Module m)
     //printf("toEfilenamePtr(%s)\n", m.toChars());
     const(char)* id = m.srcfile.toChars();
     size_t len = strlen(id);
-    Symbol* s = toStringSymbol(id, len, 1);
+    Symbol* s = toStringSymbol(id, len, 1, global.params.isWindows);
     return el_ptr(s);
 }
 


### PR DESCRIPTION
This puts Windows file name strings into COMDATs. This should substantially reduce bloat, as common strings will get pooled.

If this is successful, we'll do this for all string literals.