### PR TITLE
put string literals in readonly comdats

### DIFF
--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -1724,6 +1724,12 @@ int Obj::comdatsize(Symbol *s, targ_size_t symsize)
     return s->Sseg;
 }
 
+int Obj::readonly_comdat(Symbol *s)
+{
+    assert(0);
+    return 0;
+}
+
 /********************************
  * Get a segment for a segment name.
  * Input:

--- a/src/backend/global.d
+++ b/src/backend/global.d
@@ -383,6 +383,7 @@ void outthunk(Symbol *sthunk, Symbol *sfunc, uint p, tym_t thisty, targ_size_t d
 void outdata(Symbol *s);
 void outcommon(Symbol *s, targ_size_t n);
 void out_readonly(Symbol *s);
+void out_readonly_comdat(Symbol *s, const(void)* p, uint len, uint nzeros);
 void out_regcand(symtab_t *);
 void writefunc(Symbol *sfunc);
 void alignOffset(int seg,targ_size_t datasize);

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -1807,6 +1807,12 @@ int Obj::comdat(Symbol *s)
     return s->Sseg;
 }
 
+int Obj::readonly_comdat(Symbol *s)
+{
+    assert(0);
+    return 0;
+}
+
 /**********************************
  * Get segment.
  * Input:

--- a/src/backend/obj.d
+++ b/src/backend/obj.d
@@ -56,6 +56,7 @@ class Obj
     void moduleinfo(Symbol *scc);
     int comdat(Symbol *);
     int comdatsize(Symbol *, targ_size_t symsize);
+    int readonly_comdat(Symbol *s);
     void setcodeseg(int seg);
     seg_data *tlsseg();
     seg_data *tlsseg_bss();
@@ -129,6 +130,7 @@ class MsCoffObj : Obj
     override void moduleinfo(Symbol *scc);
     override int comdat(Symbol *);
     override int comdatsize(Symbol *, targ_size_t symsize);
+    override int readonly_comdat(Symbol *s);
     override void setcodeseg(int seg);
     override seg_data *tlsseg();
     override seg_data *tlsseg_bss();
@@ -218,6 +220,7 @@ class Obj
     static void moduleinfo(Symbol *scc);
     int comdat(Symbol *);
     static int comdatsize(Symbol *, targ_size_t symsize);
+    int readonly_comdat(Symbol *s);
     static void setcodeseg(int seg);
     seg_data *tlsseg();
     seg_data *tlsseg_bss();

--- a/src/backend/obj.h
+++ b/src/backend/obj.h
@@ -55,6 +55,7 @@ class Obj
     VIRTUAL void moduleinfo(Symbol *scc);
     virtual int  comdat(Symbol *);
     virtual int  comdatsize(Symbol *, targ_size_t symsize);
+    virtual int readonly_comdat(Symbol *s);
     VIRTUAL void setcodeseg(int seg);
     virtual seg_data *tlsseg();
     virtual seg_data *tlsseg_bss();
@@ -162,6 +163,7 @@ class MsCoffObj : public Obj
     VIRTUAL void moduleinfo(Symbol *scc);
     virtual int  comdat(Symbol *);
     virtual int  comdatsize(Symbol *, targ_size_t symsize);
+    virtual int readonly_comdat(Symbol *s);
     VIRTUAL void setcodeseg(int seg);
     virtual seg_data *tlsseg();
     virtual seg_data *tlsseg_bss();

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -1450,6 +1450,21 @@ symbol *out_readonly_sym(tym_t ty, void *p, int len)
     return s;
 }
 
+/*************************************
+ * Output Symbol as a readonly comdat.
+ * Params:
+ *      s = comdat symbol
+ *      p = pointer to the data to write
+ *      len = length of that data
+ *      nzeros = number of trailing zeros to append
+ */
+void out_readonly_comdat(Symbol *s, const void *p, unsigned len, unsigned nzeros)
+{
+    objmod->readonly_comdat(s);         // create comdat segment
+    objmod->write_bytes(SegData[s->Sseg], len, (void *)p);
+    objmod->lidata(s->Sseg, len, nzeros);
+}
+
 void Srcpos::print(const char *func)
 {
     printf("%s(", func);


### PR DESCRIPTION
Read only gives them memory protection from writes, and means they don't have to be duplicated for multiple users of a shared library.