### PR TITLE
TypeInfo.init -> .initializer

### DIFF
--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -1068,7 +1068,7 @@ auto scoped14653(T, A...)(A args)
     Scoped!T result = void;
 
     //emplace!T(result.store[], args);
-    result.store[] = typeid(T).init[];
+    result.store[] = typeid(T).initializer[];
     result.payload.__ctor(args);
 
     return result;

--- a/test/runnable/newdel.d
+++ b/test/runnable/newdel.d
@@ -13,7 +13,7 @@ class Foo
     {   void* p;
 
         printf("Foo.new(sz = %d, x = %d)\n", sz, x);
-        assert(sz == Foo.classinfo.init.length);
+        assert(sz == Foo.classinfo.initializer.length);
         assert(x == 5);
 
         p = core.stdc.stdlib.malloc(sz);

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -774,7 +774,7 @@ void test36()
 {
     A36 a = new A36;
 
-    printf("A36.sizeof = %d\n", a.classinfo.init.length);
+    printf("A36.sizeof = %d\n", a.classinfo.initializer.length);
     printf("%d\n", a.s);
     printf("%d\n", a.a);
     printf("%d\n", a.b);
@@ -782,9 +782,9 @@ void test36()
     printf("%d\n", a.d);
 
     version(D_LP64)
-        assert(a.classinfo.init.length == 36);
+        assert(a.classinfo.initializer.length == 36);
     else
-        assert(a.classinfo.init.length == 28);
+        assert(a.classinfo.initializer.length == 28);
     assert(a.s == 1);
     assert(a.a == 2);
     assert(a.b == 3);

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -335,7 +335,7 @@ int y16;
 class C16
 {
         new(size_t size, byte blah){
-                void* v = (new byte[C16.classinfo.init.length]).ptr;
+                void* v = (new byte[C16.classinfo.initializer.length]).ptr;
                 y16 = 1;
                 assert(blah == 3);
                 return v;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -3595,9 +3595,9 @@ void test220()
   mixin T220!(int);
 
   // all print 8
-  writeln(T220!(int).C.classinfo.init.length);
-  writeln(C.classinfo.init.length);
-  writeln(D220.classinfo.init.length);
+  writeln(T220!(int).C.classinfo.initializer.length);
+  writeln(C.classinfo.initializer.length);
+  writeln(D220.classinfo.initializer.length);
 
   auto c = new C; // segfault in _d_newclass
 }

--- a/test/runnable/test5.d
+++ b/test/runnable/test5.d
@@ -57,9 +57,9 @@ int main()
 {
     bar b = new bar();
 
-    printf("b.size = x%x\n", b.classinfo.init.length);
-    printf("bar.size = x%x\n", bar.classinfo.init.length);
-    assert(b.classinfo.init.length == bar.classinfo.init.length);
+    printf("b.size = x%x\n", b.classinfo.initializer.length);
+    printf("bar.size = x%x\n", bar.classinfo.initializer.length);
+    assert(b.classinfo.initializer.length == bar.classinfo.initializer.length);
     abc(b);
     return 0;
 }

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -583,8 +583,9 @@ class C42
 
 void test42()
 {
-    printf("%d\n", C42.classinfo.init.length);
-    assert(C42.classinfo.init.length == 12 + (void*).sizeof + (void*).sizeof);
+    printf("%d\n", C42.classinfo.initializer.length);
+    assert(C42.classinfo.initializer.length == 12 + (void*).sizeof +
+        (void*).sizeof);
     C42 c = new C42;
     assert(c.a == 1);
     assert(c.b == 2);

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -649,7 +649,8 @@ void test30()
         // It will insert one more `delete m` for the scope destruction, and it will be
         // called during stack unwinding.
         // Instead use bare memory chunk on stack to construct dummy class instance.
-        void[__traits(classInstanceSize, C30)] payload = typeid(C30).init[];
+        void[__traits(classInstanceSize, C30)] payload =
+            typeid(C30).initializer[];
         C30 m = cast(C30)payload.ptr;
         m.__ctor();
 

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -390,7 +390,7 @@ void test13()
 
     auto k = __traits(classInstanceSize, C);
     writeln(k);
-    assert(k == C.classinfo.init.length);
+    assert(k == C.classinfo.initializer.length);
 }
 
 /********************************************************/


### PR DESCRIPTION
TypeInfo.init is deprecated and is going to to be removed.

This is blocking <https://github.com/dlang/druntime/pull/1766>.