### PR TITLE
write Elf string literals to .rodata.strM.N sections

### DIFF
--- a/src/backend/cgobj.c
+++ b/src/backend/cgobj.c
@@ -576,6 +576,20 @@ int Obj::data_readonly(char *p, int len)
     return Obj::data_readonly(p, len, &pseg);
 }
 
+/*****************************
+ * Get segment for readonly string literals.
+ * The linker will pool strings in this section.
+ * Params:
+ *    sz = number of bytes per character (1, 2, or 4)
+ * Returns:
+ *    segment index
+ */
+int Obj::string_literal_segment(unsigned sz)
+{
+    assert(0);
+    return 0;
+}
+
 segidx_t Obj::seg_debugT()
 {
     return DEBTYP;

--- a/src/backend/elfobj.c
+++ b/src/backend/elfobj.c
@@ -669,6 +669,29 @@ int Obj::data_readonly(char *p, int len)
 }
 
 /******************************
+ * Get segment for readonly string literals.
+ * The linker will pool strings in this section.
+ * Params:
+ *    sz = number of bytes per character (1, 2, or 4)
+ * Returns:
+ *    segment index
+ */
+int Obj::string_literal_segment(unsigned sz)
+{
+    /* Elf special sections:
+     * .rodata.strM.N - M is size of character
+     *                  N is alignment
+     * .rodata.cstN   - N fixed size readonly constants N bytes in size,
+     *              aligned to the same size
+     */
+    static const char name[3][4] = { "1.1", "2.2", "4.4" };
+    const int i = (sz == 4) ? 2 : sz - 1;
+    const IDXSEC seg =
+        ElfObj::getsegment(".rodata.str", name[i], SHT_PROGBITS, SHF_ALLOC, sz);
+    return seg;
+}
+
+/******************************
  * Perform initialization that applies to all .o output files.
  *      Called before any other obj_xxx routines
  */

--- a/src/backend/global.d
+++ b/src/backend/global.d
@@ -389,6 +389,7 @@ void writefunc(Symbol *sfunc);
 void alignOffset(int seg,targ_size_t datasize);
 void out_reset();
 Symbol *out_readonly_sym(tym_t ty, void *p, int len);
+Symbol *out_string_literal(const(char)* str, uint len, uint sz);
 
 /* blockopt.c */
 // Workaround 2.066.x bug by resolving the TYMAX value before using it as dimension.

--- a/src/backend/global.h
+++ b/src/backend/global.h
@@ -381,6 +381,7 @@ void writefunc(Symbol *sfunc);
 void alignOffset(int seg,targ_size_t datasize);
 void out_reset();
 Symbol *out_readonly_sym(tym_t ty, void *p, int len);
+Symbol *out_string_literal(const char *str, unsigned len, unsigned sz);
 
 /* blockopt.c */
 extern unsigned bc_goal[BCMAX];

--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -440,6 +440,19 @@ int Obj::data_readonly(char *p, int len)
     return Obj::data_readonly(p, len, &pseg);
 }
 
+/*****************************
+ * Get segment for readonly string literals.
+ * The linker will pool strings in this section.
+ * Params:
+ *    sz = number of bytes per character (1, 2, or 4)
+ * Returns:
+ *    segment index
+ */
+int Obj::string_literal_segment(unsigned sz)
+{
+    return CDATA;
+}
+
 /******************************
  * Perform initialization that applies to all .o output files.
  *      Called before any other obj_xxx routines

--- a/src/backend/mscoffobj.c
+++ b/src/backend/mscoffobj.c
@@ -297,6 +297,20 @@ int MsCoffObj::data_readonly(char *p, int len)
     return MsCoffObj::data_readonly(p, len, &pseg);
 }
 
+/*****************************
+ * Get segment for readonly string literals.
+ * The linker will pool strings in this section.
+ * Params:
+ *    sz = number of bytes per character (1, 2, or 4)
+ * Returns:
+ *    segment index
+ */
+int MsCoffObj::string_literal_segment(unsigned sz)
+{
+    assert(0);
+    return 0;
+}
+
 /******************************
  * Start a .obj file.
  * Called before any other obj_xxx routines.

--- a/src/backend/obj.d
+++ b/src/backend/obj.d
@@ -86,6 +86,7 @@ class Obj
     void fltused();
     int data_readonly(char *p, int len, int *pseg);
     int data_readonly(char *p, int len);
+    int string_literal_segment(uint sz);
     Symbol *sym_cdata(tym_t, char *, int);
     void func_start(Symbol *sfunc);
     void func_term(Symbol *sfunc);
@@ -160,6 +161,7 @@ class MsCoffObj : Obj
     override void fltused();
     override int data_readonly(char *p, int len, int *pseg);
     override int data_readonly(char *p, int len);
+    override int string_literal_segment(uint sz);
     override Symbol *sym_cdata(tym_t, char *, int);
     static  uint addstr(Outbuffer *strtab, const(char)* );
     override void func_start(Symbol *sfunc);
@@ -250,6 +252,7 @@ class Obj
     static void fltused();
     static int data_readonly(char *p, int len, int *pseg);
     static int data_readonly(char *p, int len);
+    static int string_literal_segment(uint sz);
     static Symbol *sym_cdata(tym_t, char *, int);
     static void func_start(Symbol *sfunc);
     static void func_term(Symbol *sfunc);

--- a/src/backend/obj.h
+++ b/src/backend/obj.h
@@ -85,6 +85,7 @@ class Obj
     VIRTUAL void fltused();
     VIRTUAL int data_readonly(char *p, int len, int *pseg);
     VIRTUAL int data_readonly(char *p, int len);
+    VIRTUAL int string_literal_segment(unsigned sz);
     VIRTUAL symbol *sym_cdata(tym_t, char *, int);
     VIRTUAL void func_start(Symbol *sfunc);
     VIRTUAL void func_term(Symbol *sfunc);
@@ -193,6 +194,7 @@ class MsCoffObj : public Obj
     VIRTUAL void fltused();
     VIRTUAL int data_readonly(char *p, int len, int *pseg);
     VIRTUAL int data_readonly(char *p, int len);
+    VIRTUAL int string_literal_segment(unsigned sz);
     VIRTUAL symbol *sym_cdata(tym_t, char *, int);
     static unsigned addstr(Outbuffer *strtab, const char *);
     VIRTUAL void func_start(Symbol *sfunc);

--- a/src/e2ir.d
+++ b/src/e2ir.d
@@ -5713,16 +5713,7 @@ Symbol *toStringSymbol(const(char)* str, size_t len, size_t sz, bool comdat = fa
         }
         else
         {
-            si = symbol_generate(SCstatic,type_static_array(len * sz, tstypes[TYchar]));
-            out_readonly(si);    // set up for read-only symbol
-
-            scope dtb = new DtBuilder();
-            dtb.nbytes(cast(uint)(len * sz), str);
-            dtb.nzeros(cast(uint)sz);       // include terminating 0
-            si.Sdt = dtb.finish();
-            si.Sfl = FLdata;
-            si.Salignment = cast(uint)sz;
-            outdata(si);
+            si = out_string_literal(str, cast(uint)len, cast(uint)sz);
         }
 
         sv.ptrvalue = cast(void *)si;


### PR DESCRIPTION
The `.rodata.strM.N` sections are special, as the Elf linker will pool the string literals in it.

Also moved much of the string literal logic from `e2ir.d` to `backend/out.c` because it's really a back end issue.