### PR TITLE
machobj.c: use __cstring section for string literals

### DIFF
--- a/src/backend/machobj.c
+++ b/src/backend/machobj.c
@@ -450,7 +450,11 @@ int Obj::data_readonly(char *p, int len)
  */
 int Obj::string_literal_segment(unsigned sz)
 {
-    return CDATA;
+    if (sz == 1)
+    {
+        return MachObj::getsegment("__cstring", "__TEXT", 0, S_CSTRING_LITERALS);
+    }
+    return CDATA;  // no special handling for other wstring, dstring; use __const
 }
 
 /******************************

--- a/src/backend/out.c
+++ b/src/backend/out.c
@@ -545,6 +545,44 @@ Symbol *out_string_literal(const char *str, unsigned len, unsigned sz)
             assert(0);
     }
 
+    /* If there are any embedded zeros, this can't go in the special string segments
+     * which assume that 0 is the end of the string.
+     */
+    switch (sz)
+    {
+        case 1:
+            if (memchr(str, 0, len))
+                s->Sseg = CDATA;
+            break;
+
+        case 2:
+            for (int i = 0; i < len; ++i)
+            {
+                const unsigned short *p = (const unsigned short *)str;
+                if (p[i] == 0)
+                {
+                    s->Sseg = CDATA;
+                    break;
+                }
+            }
+            break;
+
+        case 4:
+            for (int i = 0; i < len; ++i)
+            {
+                const unsigned *p = (const unsigned *)str;
+                if (p[i] == 0)
+                {
+                    s->Sseg = CDATA;
+                    break;
+                }
+            }
+            break;
+
+        default:
+            assert(0);
+    }
+
     DtBuilder dtb;
     dtb.nbytes((unsigned)(len * sz), str);
     dtb.nzeros((unsigned)sz);       // include terminating 0


### PR DESCRIPTION
This is how strings are pooled on OSX. Oddly, this only works for string - not for wstring or dstring. (Elf works for any string type.)