### PR TITLE
posix.mak: Add style target to simplify CI setup

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -34,4 +34,7 @@ install: all
 	mkdir -p $(INSTALL_DIR)/man
 	cp -r docs/man/* $(INSTALL_DIR)/man/
 
+style:
+	@echo "To be done"
+
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
Adds a `style` target, s.t.

- setting up a DLang CI is as easy as `make -f posix.mak style`
- future work can extend this

See also: https://github.com/Dicebot/dlangci/issues/18