### PR TITLE
vcg-ast

### DIFF
--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -81,6 +81,7 @@ struct Param
     bool trace;             // insert profiling hooks
     bool tracegc;           // instrument calls to 'new'
     bool verbose;           // verbose compile
+    bool vcg_ast;           // write-out codegen-ast
     bool showColumns;       // print character (column) numbers in diagnostics
     bool vtls;              // identify thread local variables
     bool vgc;               // identify gc usage

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -63,6 +63,7 @@ struct Param
     bool trace;         // insert profiling hooks
     bool tracegc;       // instrument calls to 'new'
     bool verbose;       // verbose compile
+    bool vcg_ast;       // write-out codegen-ast
     bool showColumns;   // print character (column) numbers in diagnostics
     bool vtls;          // identify thread local variables
     char vgc;           // identify gc usage

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -53,7 +53,7 @@ struct HdrGenState
 {
     bool hdrgen;        /// true if generating header file
     bool ddoc;          /// true if generating Ddoc file
-    bool fullDump;     /// true if generarting a full ast_dump
+    bool fullDump;      /// true if generating a full AST dump file
 
     bool fullQual;      /// fully qualify types when printing
     int tpltMember;

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -1463,6 +1463,8 @@ public:
             buf.writenl();
             if (ti.aliasdecl)
             {
+                // the ti.aliasDecl is the instantiated body
+                // if we have it, print it.
                 ti.aliasdecl.accept(this);
             }
         }

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -51,9 +51,11 @@ import ddmd.visitor;
 
 struct HdrGenState
 {
-    bool hdrgen;        // true if generating header file
-    bool ddoc;          // true if generating Ddoc file
-    bool fullQual;      // fully qualify types when printing
+    bool hdrgen;        /// true if generating header file
+    bool ddoc;          /// true if generating Ddoc file
+    bool fullDump;     /// true if generarting a full ast_dump
+
+    bool fullQual;      /// fully qualify types when printing
     int tpltMember;
     int autoMember;
     int forStmtInit;
@@ -1325,7 +1327,7 @@ public:
             if (onemember && onemember.isFuncDeclaration())
                 buf.writestring("foo ");
         }
-        if (hgs.hdrgen && visitEponymousMember(d))
+        if ((hgs.hdrgen || hgs.fullDump) && visitEponymousMember(d))
             return;
         if (hgs.ddoc)
             buf.writestring(d.kind());
@@ -1337,7 +1339,7 @@ public:
         visitTemplateParameters(hgs.ddoc ? d.origParameters : d.parameters);
         buf.writeByte(')');
         visitTemplateConstraint(d.constraint);
-        if (hgs.hdrgen)
+        if (hgs.hdrgen || hgs.fullDump)
         {
             hgs.tpltMember++;
             buf.writenl();
@@ -1752,7 +1754,7 @@ public:
         auto tf = cast(TypeFunction)f.type;
         typeToBuffer(tf, f.ident);
 
-        if (hgs.hdrgen == 1)
+        if (hgs.hdrgen)
         {
             // if the return type is missing (e.g. ref functions or auto)
             if (!tf.next || f.storage_class & STCauto)

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -1458,10 +1458,10 @@ public:
         buf.writestring(ti.name.toChars());
         tiargsToBuffer(ti);
 
-        if (ti.aliasdecl)
+        if (hgs.fullDump)
         {
             buf.writenl();
-            if (hgs.fullDump)
+            if (ti.aliasdecl)
             {
                 ti.aliasdecl.accept(this);
             }

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -1457,6 +1457,15 @@ public:
     {
         buf.writestring(ti.name.toChars());
         tiargsToBuffer(ti);
+
+        if (ti.aliasdecl)
+        {
+            buf.writenl();
+            if (hgs.fullDump)
+            {
+                ti.aliasdecl.accept(this);
+            }
+        }
     }
 
     override void visit(TemplateMixin tm)

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -169,6 +169,7 @@ Where:
   -transition=?    list all language changes
   -unittest        compile in unit tests
   -v               verbose
+  -vcg-ast         generates .d.cg file with the ast right before obj-file generation
   -vcolumns        print character (column) numbers in diagnostics
   -verrors=<num>   limit the number of error messages (0 means unlimited)
   -verrors=spec    show errors from speculative compiles such as __traits(compiles,...)
@@ -529,6 +530,8 @@ private int tryMain(size_t argc, const(char)** argv)
             }
             else if (strcmp(p + 1, "v") == 0)
                 global.params.verbose = true;
+            else if (strcmp(p + 1, "vcg-ast") == 0)
+                global.params.vcg_ast = true;
             else if (strcmp(p + 1, "vtls") == 0)
                 global.params.vtls = true;
             else if (strcmp(p + 1, "vcolumns") == 0)
@@ -1573,6 +1576,28 @@ Language changes listed by -transition=id:
         {
             Module m = modules[i];
             gendocfile(m);
+        }
+    }
+    if(global.params.vcg_ast)
+    {
+        import ddmd.hdrgen;
+        foreach(mod;modules)
+        {
+            auto buf = new OutBuffer;
+            buf.doindent = 1;
+            scope HdrGenState hgs;
+            hgs.fullDump = 1;
+            scope PrettyPrintVisitor ppv = new PrettyPrintVisitor(buf, &hgs);
+            mod.accept(ppv);
+
+            auto modFilename = mod.srcfile.toChars();
+            auto modFilenameLength = strlen(modFilename);
+            auto cgFilename = cast(char*)allocmemory(modFilenameLength + 4);
+            strcpy(cgFilename, modFilename);
+            cgFilename[modFilenameLength .. modFilenameLength + 4] = ".cg\0";
+            auto cgFile = File(cgFilename);
+            cgFile.setbuffer(buf.data, buf.offset);
+            cgFile.write();
         }
     }
     if (!global.params.obj)

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -169,7 +169,6 @@ Where:
   -transition=?    list all language changes
   -unittest        compile in unit tests
   -v               verbose
-  -vcg-ast         generates .d.cg file with the ast right before obj-file generation
   -vcolumns        print character (column) numbers in diagnostics
   -verrors=<num>   limit the number of error messages (0 means unlimited)
   -verrors=spec    show errors from speculative compiles such as __traits(compiles,...)
@@ -1578,10 +1577,10 @@ Language changes listed by -transition=id:
             gendocfile(m);
         }
     }
-    if(global.params.vcg_ast)
+    if (global.params.vcg_ast)
     {
         import ddmd.hdrgen;
-        foreach(mod;modules)
+        foreach (mod; modules)
         {
             auto buf = new OutBuffer;
             buf.doindent = 1;

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1589,10 +1589,11 @@ Language changes listed by -transition=id:
             scope PrettyPrintVisitor ppv = new PrettyPrintVisitor(buf, &hgs);
             mod.accept(ppv);
 
+            // write the output to $(filename).cg
             auto modFilename = mod.srcfile.toChars();
             auto modFilenameLength = strlen(modFilename);
             auto cgFilename = cast(char*)allocmemory(modFilenameLength + 4);
-            strcpy(cgFilename, modFilename);
+            memcpy(cgFilename, modFilename, modFilenameLength);
             cgFilename[modFilenameLength .. modFilenameLength + 4] = ".cg\0";
             auto cgFile = File(cgFilename);
             cgFile.setbuffer(buf.data, buf.offset);


### PR DESCRIPTION
In order to debug the inliner I found a need to print the write-out AST after all semantic steps have been done (akin to `gcc -E`).

This is a developer tool and is therefore not covered by the test-suite.