### PR TITLE
Add Dyncast.condition

### DIFF
--- a/src/asttypename.d
+++ b/src/asttypename.d
@@ -62,6 +62,8 @@ string astTypeName(RootObject node)
             return astTypeName(cast(Parameter) node);
         case DYNCAST_STATEMENT:
             return astTypeName(cast(Statement) node);
+        case DYNCAST.condition:
+            return astTypeName(cast(Condition) node);
     }
 }
 

--- a/src/cond.d
+++ b/src/cond.d
@@ -38,6 +38,11 @@ extern (C++) abstract class Condition : RootObject
     // 2: do not include
     int inc;
 
+    override final DYNCAST dyncast() const
+    {
+        return DYNCAST.condition;
+    }
+
     final extern (D) this(Loc loc)
     {
         this.loc = loc;

--- a/src/root/rootobject.d
+++ b/src/root/rootobject.d
@@ -27,6 +27,7 @@ enum DYNCAST : int
     tuple,
     parameter,
     statement,
+    condition,
 }
 
 alias DYNCAST_OBJECT = DYNCAST.object;


### PR DESCRIPTION
Dyncast.condition is needed for the asttypename utilty and for further improvement of the header-generator. 
@yebblies I think you'll merge this.    