### PR TITLE
use linkonce for Elf data COMDATs

### DIFF
--- a/src/ddmd/backend/elfobj.c
+++ b/src/ddmd/backend/elfobj.c
@@ -1714,8 +1714,8 @@ STATIC void setup_comdat(Symbol *s)
         if (I64)
             align = 16;
         s->Sfl = FLdata;
-        //prefix = ".gnu.linkonce.d.";
-        prefix = ".data.";
+        prefix = ".gnu.linkonce.d.";
+        //prefix = ".data.";
         type = SHT_PROGBITS;
         flags = SHF_ALLOC|SHF_WRITE;
     }


### PR DESCRIPTION
This is a bit of a mystery. The comments in elfobj.c say that linkonce doesn't work, and .data does. But .data does not work, it concatenates the COMDATs instead of picking one. I can't get clang++ or g++ to generate linkonce sections. I wonder what is going on. So let's try it.