### PR TITLE
generate TypeInfo for structs only on demand

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1469,31 +1469,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         sc2.pop();
 
-        // don't do it for unused deprecated types
-        // or error ypes
-        if (!ad.getRTInfo && Type.rtinfo && (!ad.isDeprecated() || global.params.useDeprecated != DiagnosticReporting.error) && (ad.type && ad.type.ty != Terror))
-        {
-            // Evaluate: RTinfo!type
-            auto tiargs = new Objects();
-            tiargs.push(ad.type);
-            auto ti = new TemplateInstance(ad.loc, Type.rtinfo, tiargs);
-
-            Scope* sc3 = ti.tempdecl._scope.startCTFE();
-            sc3.tinst = sc.tinst;
-            sc3.minst = sc.minst;
-            if (ad.isDeprecated())
-                sc3.stc |= STC.deprecated_;
-
-            ti.dsymbolSemantic(sc3);
-            ti.semantic2(sc3);
-            ti.semantic3(sc3);
-            auto e = symbolToExp(ti.toAlias(), Loc.initial, sc3, false);
-
-            sc3.endCTFE();
-
-            e = e.ctfeInterpret();
-            ad.getRTInfo = e;
-        }
+//      ad.setGetRTInfo(sc);
         if (sd)
             sd.semanticTypeInfoMembers();
         ad.semanticRun = PASS.semantic3done;

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1342,6 +1342,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         }
 
         // xgetRTInfo
+        if (!sd.getRTInfo)
+             error(sd.loc, "ICE: RTInfo not evaluated for %s", sd.toChars());
         if (sd.getRTInfo)
         {
             Expression_toDt(sd.getRTInfo, *dtb);

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -491,8 +491,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 else if (global.params.symdebug)
                     toDebug(sd);
 
-                if (global.params.useTypeInfo && Type.dtypeinfo)
-                    genTypeInfo(sd.loc, sd.type, null);
+                //if (global.params.useTypeInfo && Type.dtypeinfo)
+                    //genTypeInfo(sd.loc, sd.type, null);
 
                 // Generate static initializer
                 auto sinit = toInitializer(sd);


### PR DESCRIPTION
The original code always generates them when a struct declaration was found. But they were also generated again by other object modules whenever the typeinfo was needed. This relied on COMDATs to cull the duplicates. But with such, the typeinfo does not need to be generated just because the struct is declared - only when it is actually used.