### PR TITLE
remove c++ style DYNCAST_*

### DIFF
--- a/src/asttypename.d
+++ b/src/asttypename.d
@@ -45,22 +45,22 @@ string astTypeName(RootObject node)
 {
     final switch (node.dyncast())
     {
-        case DYNCAST_OBJECT:
+        case DYNCAST.object:
             return "RootObject";
-        case DYNCAST_IDENTIFIER:
+        case DYNCAST.identifier:
             return "Identifier";
 
-        case DYNCAST_EXPRESSION:
+        case DYNCAST.expression:
             return astTypeName(cast(Expression) node);
-        case DYNCAST_DSYMBOL:
+        case DYNCAST.dsymbol:
             return astTypeName(cast(Dsymbol) node);
-        case DYNCAST_TYPE:
+        case DYNCAST.type:
             return astTypeName(cast(Type) node);
-        case DYNCAST_TUPLE:
+        case DYNCAST.tuple:
             return astTypeName(cast(Tuple) node);
-        case DYNCAST_PARAMETER:
+        case DYNCAST.parameter:
             return astTypeName(cast(Parameter) node);
-        case DYNCAST_STATEMENT:
+        case DYNCAST.statement:
             return astTypeName(cast(Statement) node);
     }
 }

--- a/src/canthrow.d
+++ b/src/canthrow.d
@@ -294,7 +294,7 @@ extern (C++) bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNot
         for (size_t i = 0; i < td.objects.dim; i++)
         {
             RootObject o = (*td.objects)[i];
-            if (o.dyncast() == DYNCAST_EXPRESSION)
+            if (o.dyncast() == DYNCAST.expression)
             {
                 Expression eo = cast(Expression)o;
                 if (eo.op == TOKdsymbol)

--- a/src/declaration.d
+++ b/src/declaration.d
@@ -393,7 +393,7 @@ extern (C++) final class TupleDeclaration : Declaration
             for (size_t i = 0; i < objects.dim; i++)
             {
                 RootObject o = (*objects)[i];
-                if (o.dyncast() != DYNCAST_TYPE)
+                if (o.dyncast() != DYNCAST.type)
                 {
                     //printf("\tnot[%d], %p, %d\n", i, o, o.dyncast());
                     return null;
@@ -456,7 +456,7 @@ extern (C++) final class TupleDeclaration : Declaration
         for (size_t i = 0; i < objects.dim; i++)
         {
             RootObject o = (*objects)[i];
-            if (o.dyncast() == DYNCAST_EXPRESSION)
+            if (o.dyncast() == DYNCAST.expression)
             {
                 Expression e = cast(Expression)o;
                 if (e.op == TOKdsymbol)
@@ -1857,7 +1857,7 @@ extern (C++) class VarDeclaration : Declaration
             for (size_t i = 0; i < v2.objects.dim; i++)
             {
                 RootObject o = (*v2.objects)[i];
-                assert(o.dyncast() == DYNCAST_EXPRESSION);
+                assert(o.dyncast() == DYNCAST.expression);
                 Expression e = cast(Expression)o;
                 assert(e.op == TOKdsymbol);
                 DsymbolExp se = cast(DsymbolExp)e;

--- a/src/denum.d
+++ b/src/denum.d
@@ -586,7 +586,7 @@ extern (C++) final class EnumMember : VarDeclaration
         if (value)
         {
             Expression e = value;
-            assert(e.dyncast() == DYNCAST_EXPRESSION);
+            assert(e.dyncast() == DYNCAST.expression);
             e = e.semantic(sc);
             e = resolveProperties(sc, e);
             e = e.ctfeInterpret();

--- a/src/dsymbol.d
+++ b/src/dsymbol.d
@@ -484,7 +484,7 @@ extern (C++) class Dsymbol : RootObject
     // kludge for template.isSymbol()
     override final DYNCAST dyncast() const
     {
-        return DYNCAST_DSYMBOL;
+        return DYNCAST.dsymbol;
     }
 
     /*************************************
@@ -740,10 +740,10 @@ extern (C++) class Dsymbol : RootObject
         }
         switch (id.dyncast())
         {
-        case DYNCAST_IDENTIFIER:
+        case DYNCAST.identifier:
             sm = s.search(loc, cast(Identifier)id);
             break;
-        case DYNCAST_DSYMBOL:
+        case DYNCAST.dsymbol:
             {
                 // It's a template instance
                 //printf("\ttemplate instance id\n");
@@ -772,8 +772,8 @@ extern (C++) class Dsymbol : RootObject
                 sm = ti.toAlias();
                 break;
             }
-        case DYNCAST_TYPE:
-        case DYNCAST_EXPRESSION:
+        case DYNCAST.type:
+        case DYNCAST.expression:
         default:
             assert(0);
         }

--- a/src/dtemplate.d
+++ b/src/dtemplate.d
@@ -53,7 +53,7 @@ enum IDX_NOTFOUND = 0x12345678;
 extern (C++) Expression isExpression(RootObject o)
 {
     //return dynamic_cast<Expression *>(o);
-    if (!o || o.dyncast() != DYNCAST_EXPRESSION)
+    if (!o || o.dyncast() != DYNCAST.expression)
         return null;
     return cast(Expression)o;
 }
@@ -61,7 +61,7 @@ extern (C++) Expression isExpression(RootObject o)
 extern (C++) Dsymbol isDsymbol(RootObject o)
 {
     //return dynamic_cast<Dsymbol *>(o);
-    if (!o || o.dyncast() != DYNCAST_DSYMBOL)
+    if (!o || o.dyncast() != DYNCAST.dsymbol)
         return null;
     return cast(Dsymbol)o;
 }
@@ -69,7 +69,7 @@ extern (C++) Dsymbol isDsymbol(RootObject o)
 extern (C++) Type isType(RootObject o)
 {
     //return dynamic_cast<Type *>(o);
-    if (!o || o.dyncast() != DYNCAST_TYPE)
+    if (!o || o.dyncast() != DYNCAST.type)
         return null;
     return cast(Type)o;
 }
@@ -77,7 +77,7 @@ extern (C++) Type isType(RootObject o)
 extern (C++) Tuple isTuple(RootObject o)
 {
     //return dynamic_cast<Tuple *>(o);
-    if (!o || o.dyncast() != DYNCAST_TUPLE)
+    if (!o || o.dyncast() != DYNCAST.tuple)
         return null;
     return cast(Tuple)o;
 }
@@ -85,7 +85,7 @@ extern (C++) Tuple isTuple(RootObject o)
 extern (C++) Parameter isParameter(RootObject o)
 {
     //return dynamic_cast<Parameter *>(o);
-    if (!o || o.dyncast() != DYNCAST_PARAMETER)
+    if (!o || o.dyncast() != DYNCAST.parameter)
         return null;
     return cast(Parameter)o;
 }
@@ -466,7 +466,7 @@ extern (C++) final class Tuple : RootObject
     // kludge for template.isType()
     override DYNCAST dyncast() const
     {
-        return DYNCAST_TUPLE;
+        return DYNCAST.tuple;
     }
 
     override const(char)* toChars()
@@ -3334,7 +3334,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     for (size_t j = tident.idents.dim; j-- > 0;)
                     {
                         RootObject id = tident.idents[j];
-                        if (id.dyncast() == DYNCAST_IDENTIFIER)
+                        if (id.dyncast() == DYNCAST.identifier)
                         {
                             if (!s || !s.parent)
                                 goto Lnomatch;
@@ -4113,7 +4113,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 if (tpi.idents.dim)
                 {
                     RootObject id = tpi.idents[tpi.idents.dim - 1];
-                    if (id.dyncast() == DYNCAST_IDENTIFIER && t.sym.ident.equals(cast(Identifier)id))
+                    if (id.dyncast() == DYNCAST.identifier && t.sym.ident.equals(cast(Identifier)id))
                     {
                         Type tparent = t.sym.parent.getType();
                         if (tparent)
@@ -4253,7 +4253,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 if (tpi.idents.dim)
                 {
                     RootObject id = tpi.idents[tpi.idents.dim - 1];
-                    if (id.dyncast() == DYNCAST_IDENTIFIER && t.sym.ident.equals(cast(Identifier)id))
+                    if (id.dyncast() == DYNCAST.identifier && t.sym.ident.equals(cast(Identifier)id))
                     {
                         Type tparent = t.sym.parent.getType();
                         if (tparent)

--- a/src/e2ir.d
+++ b/src/e2ir.d
@@ -5087,7 +5087,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 for (size_t i = 0; i < td.objects.dim; i++)
                 {   RootObject o = (*td.objects)[i];
-                    if (o.dyncast() == DYNCAST_EXPRESSION)
+                    if (o.dyncast() == DYNCAST.expression)
                     {   Expression eo = cast(Expression)o;
                         if (eo.op == TOKdsymbol)
                         {   DsymbolExp se = cast(DsymbolExp)eo;

--- a/src/expression.d
+++ b/src/expression.d
@@ -2582,7 +2582,7 @@ extern (C++) abstract class Expression : RootObject
     // kludge for template.isExpression()
     override final DYNCAST dyncast() const
     {
-        return DYNCAST_EXPRESSION;
+        return DYNCAST.expression;
     }
 
     override final void print()
@@ -4424,7 +4424,7 @@ extern (C++) final class NullExp : Expression
 
     override bool equals(RootObject o)
     {
-        if (o && o.dyncast() == DYNCAST_EXPRESSION)
+        if (o && o.dyncast() == DYNCAST.expression)
         {
             Expression e = cast(Expression)o;
             if (e.op == TOKnull && type.equals(e.type))
@@ -4519,7 +4519,7 @@ extern (C++) final class StringExp : Expression
     override bool equals(RootObject o)
     {
         //printf("StringExp::equals('%s') %s\n", o.toChars(), toChars());
-        if (o && o.dyncast() == DYNCAST_EXPRESSION)
+        if (o && o.dyncast() == DYNCAST.expression)
         {
             Expression e = cast(Expression)o;
             if (e.op == TOKstring)
@@ -4957,13 +4957,13 @@ extern (C++) final class TupleExp : Expression
                 Expression e = new DsymbolExp(loc, s);
                 this.exps.push(e);
             }
-            else if (o.dyncast() == DYNCAST_EXPRESSION)
+            else if (o.dyncast() == DYNCAST.expression)
             {
                 auto e = (cast(Expression)o).copy();
                 e.loc = loc;    // Bugzilla 15669
                 this.exps.push(e);
             }
-            else if (o.dyncast() == DYNCAST_TYPE)
+            else if (o.dyncast() == DYNCAST.type)
             {
                 Type t = cast(Type)o;
                 Expression e = new TypeExp(loc, t);
@@ -5094,7 +5094,7 @@ extern (C++) final class ArrayLiteralExp : Expression
     {
         if (this == o)
             return true;
-        if (o && o.dyncast() == DYNCAST_EXPRESSION && (cast(Expression)o).op == TOKarrayliteral)
+        if (o && o.dyncast() == DYNCAST.expression && (cast(Expression)o).op == TOKarrayliteral)
         {
             ArrayLiteralExp ae = cast(ArrayLiteralExp)o;
             if (elements.dim != ae.elements.dim)
@@ -5300,7 +5300,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
     {
         if (this == o)
             return true;
-        if (o && o.dyncast() == DYNCAST_EXPRESSION && (cast(Expression)o).op == TOKassocarrayliteral)
+        if (o && o.dyncast() == DYNCAST.expression && (cast(Expression)o).op == TOKassocarrayliteral)
         {
             AssocArrayLiteralExp ae = cast(AssocArrayLiteralExp)o;
             if (keys.dim != ae.keys.dim)
@@ -5440,7 +5440,7 @@ extern (C++) final class StructLiteralExp : Expression
     {
         if (this == o)
             return true;
-        if (o && o.dyncast() == DYNCAST_EXPRESSION && (cast(Expression)o).op == TOKstructliteral)
+        if (o && o.dyncast() == DYNCAST.expression && (cast(Expression)o).op == TOKstructliteral)
         {
             StructLiteralExp se = cast(StructLiteralExp)o;
             if (!type.equals(se.type))
@@ -6728,7 +6728,7 @@ extern (C++) final class FuncExp : Expression
     {
         if (this == o)
             return true;
-        if (o.dyncast() != DYNCAST_EXPRESSION)
+        if (o.dyncast() != DYNCAST.expression)
             return false;
         if ((cast(Expression)o).op == TOKfunction)
         {
@@ -9017,7 +9017,7 @@ extern (C++) final class DotVarExp : UnaExp
             {
                 RootObject o = (*tup.objects)[i];
                 Expression e;
-                if (o.dyncast() == DYNCAST_EXPRESSION)
+                if (o.dyncast() == DYNCAST.expression)
                 {
                     e = cast(Expression)o;
                     if (e.op == TOKdsymbol)
@@ -9026,11 +9026,11 @@ extern (C++) final class DotVarExp : UnaExp
                         e = new DotVarExp(loc, ev, s.isDeclaration());
                     }
                 }
-                else if (o.dyncast() == DYNCAST_DSYMBOL)
+                else if (o.dyncast() == DYNCAST.dsymbol)
                 {
                     e = new DsymbolExp(loc, cast(Dsymbol)o);
                 }
-                else if (o.dyncast() == DYNCAST_TYPE)
+                else if (o.dyncast() == DYNCAST.type)
                 {
                     e = new TypeExp(loc, cast(Type)o);
                 }

--- a/src/hdrgen.d
+++ b/src/hdrgen.d
@@ -915,19 +915,19 @@ public:
     {
         foreach (id; t.idents)
         {
-            if (id.dyncast() == DYNCAST_DSYMBOL)
+            if (id.dyncast() == DYNCAST.dsymbol)
             {
                 buf.writeByte('.');
                 TemplateInstance ti = cast(TemplateInstance)id;
                 ti.accept(this);
             }
-            else if (id.dyncast() == DYNCAST_EXPRESSION)
+            else if (id.dyncast() == DYNCAST.expression)
             {
                 buf.writeByte('[');
                 (cast(Expression)id).accept(this);
                 buf.writeByte(']');
             }
-            else if (id.dyncast() == DYNCAST_TYPE)
+            else if (id.dyncast() == DYNCAST.type)
             {
                 buf.writeByte('[');
                 (cast(Type)id).accept(this);

--- a/src/iasm.d
+++ b/src/iasm.d
@@ -2098,12 +2098,12 @@ ILLEGAL_ADDRESS_ERROR:
         else
         {
             RootObject o = (*tup.objects)[index];
-            if (o.dyncast() == DYNCAST_DSYMBOL)
+            if (o.dyncast() == DYNCAST.dsymbol)
             {
                 o1.s = cast(Dsymbol)o;
                 return;
             }
-            else if (o.dyncast() == DYNCAST_EXPRESSION)
+            else if (o.dyncast() == DYNCAST.expression)
             {
                 Expression e = cast(Expression)o;
                 if (e.op == TOKvar)

--- a/src/identifier.d
+++ b/src/identifier.d
@@ -116,7 +116,7 @@ public:
 
     override DYNCAST dyncast() const
     {
-        return DYNCAST_IDENTIFIER;
+        return DYNCAST.identifier;
     }
 
     extern (C++) static __gshared StringTable stringtable;

--- a/src/mtype.d
+++ b/src/mtype.d
@@ -641,7 +641,7 @@ extern (C++) abstract class Type : RootObject
     // kludge for template.isType()
     override final DYNCAST dyncast() const
     {
-        return DYNCAST_TYPE;
+        return DYNCAST.type;
     }
 
     /*******************************
@@ -4735,7 +4735,7 @@ extern (C++) final class TypeSArray : TypeArray
             }
 
             RootObject o = (*tup.objects)[cast(size_t)d];
-            if (o.dyncast() != DYNCAST_TYPE)
+            if (o.dyncast() != DYNCAST.type)
             {
                 error(loc, "%s is not a type", toChars());
                 return Type.terror;
@@ -4877,12 +4877,12 @@ extern (C++) final class TypeSArray : TypeArray
                 }
 
                 RootObject o = (*tup.objects)[cast(size_t)d];
-                if (o.dyncast() == DYNCAST_DSYMBOL)
+                if (o.dyncast() == DYNCAST.dsymbol)
                 {
                     *ps = cast(Dsymbol)o;
                     return;
                 }
-                if (o.dyncast() == DYNCAST_EXPRESSION)
+                if (o.dyncast() == DYNCAST.expression)
                 {
                     Expression e = cast(Expression)o;
                     if (e.op == TOKdsymbol)
@@ -4897,7 +4897,7 @@ extern (C++) final class TypeSArray : TypeArray
                     }
                     return;
                 }
-                if (o.dyncast() == DYNCAST_TYPE)
+                if (o.dyncast() == DYNCAST.type)
                 {
                     *ps = null;
                     *pt = (cast(Type)o).addMod(this.mod);
@@ -7313,19 +7313,19 @@ extern (C++) abstract class TypeQualified : Type
         for (size_t i = 0; i < idents.dim; i++)
         {
             RootObject id = t.idents[i];
-            if (id.dyncast() == DYNCAST_DSYMBOL)
+            if (id.dyncast() == DYNCAST.dsymbol)
             {
                 TemplateInstance ti = cast(TemplateInstance)id;
                 ti = cast(TemplateInstance)ti.syntaxCopy(null);
                 id = ti;
             }
-            else if (id.dyncast() == DYNCAST_EXPRESSION)
+            else if (id.dyncast() == DYNCAST.expression)
             {
                 Expression e = cast(Expression)id;
                 e = e.syntaxCopy();
                 id = e;
             }
-            else if (id.dyncast() == DYNCAST_TYPE)
+            else if (id.dyncast() == DYNCAST.type)
             {
                 Type tx = cast(Type)id;
                 tx = tx.syntaxCopy();
@@ -7432,24 +7432,24 @@ extern (C++) abstract class TypeQualified : Type
             switch (id.dyncast())
             {
                 // ... '. ident'
-                case DYNCAST_IDENTIFIER:
+                case DYNCAST.identifier:
                     e = new DotIdExp(e.loc, e, cast(Identifier)id);
                     break;
 
                 // ... '. name!(tiargs)'
-                case DYNCAST_DSYMBOL:
+                case DYNCAST.dsymbol:
                     auto ti = (cast(Dsymbol)id).isTemplateInstance();
                     assert(ti);
                     e = new DotTemplateInstanceExp(e.loc, e, ti.name, ti.tiargs);
                     break;
 
                 // ... '[type]'
-                case DYNCAST_TYPE:          // Bugzilla 1215
+                case DYNCAST.type:          // Bugzilla 1215
                     e = new ArrayExp(loc, e, new TypeExp(loc, cast(Type)id));
                     break;
 
                 // ... '[expr]'
-                case DYNCAST_EXPRESSION:    // Bugzilla 1215
+                case DYNCAST.expression:    // Bugzilla 1215
                     e = new ArrayExp(loc, e, cast(Expression)id);
                     break;
 
@@ -7492,8 +7492,8 @@ extern (C++) abstract class TypeQualified : Type
             for (size_t i = 0; i < idents.dim; i++)
             {
                 RootObject id = idents[i];
-                if (id.dyncast() == DYNCAST_EXPRESSION ||
-                    id.dyncast() == DYNCAST_TYPE)
+                if (id.dyncast() == DYNCAST.expression ||
+                    id.dyncast() == DYNCAST.type)
                 {
                     Type tx;
                     Expression ex;
@@ -7559,7 +7559,7 @@ extern (C++) abstract class TypeQualified : Type
                     if (t)
                     {
                         sm = t.toDsymbol(sc);
-                        if (sm && id.dyncast() == DYNCAST_IDENTIFIER)
+                        if (sm && id.dyncast() == DYNCAST.identifier)
                         {
                             sm = sm.search(loc, cast(Identifier)id);
                             if (sm)
@@ -7581,14 +7581,14 @@ extern (C++) abstract class TypeQualified : Type
                     }
                     else
                     {
-                        if (id.dyncast() == DYNCAST_DSYMBOL)
+                        if (id.dyncast() == DYNCAST.dsymbol)
                         {
                             // searchX already handles errors for template instances
                             assert(global.errors);
                         }
                         else
                         {
-                            assert(id.dyncast() == DYNCAST_IDENTIFIER);
+                            assert(id.dyncast() == DYNCAST.identifier);
                             sm = s.search_correct(cast(Identifier)id);
                             if (sm)
                                 error(loc, "identifier '%s' of '%s' is not defined, did you mean %s '%s'?", id.toChars(), toChars(), sm.kind(), sm.toChars());
@@ -10130,7 +10130,7 @@ extern (C++) final class Parameter : RootObject
     // kludge for template.isType()
     override DYNCAST dyncast() const
     {
-        return DYNCAST_PARAMETER;
+        return DYNCAST.parameter;
     }
 
     void accept(Visitor v)

--- a/src/root/rootobject.d
+++ b/src/root/rootobject.d
@@ -29,15 +29,6 @@ enum DYNCAST : int
     statement,
 }
 
-alias DYNCAST_OBJECT = DYNCAST.object;
-alias DYNCAST_EXPRESSION = DYNCAST.expression;
-alias DYNCAST_DSYMBOL = DYNCAST.dsymbol;
-alias DYNCAST_TYPE = DYNCAST.type;
-alias DYNCAST_IDENTIFIER = DYNCAST.identifier;
-alias DYNCAST_TUPLE = DYNCAST.tuple;
-alias DYNCAST_PARAMETER = DYNCAST.parameter;
-alias DYNCAST_STATEMENT = DYNCAST.statement;
-
 /***********************************************************
  */
 
@@ -74,6 +65,6 @@ extern (C++) class RootObject
 
     DYNCAST dyncast() const
     {
-        return DYNCAST_OBJECT;
+        return DYNCAST.object;
     }
 }

--- a/src/statement.d
+++ b/src/statement.d
@@ -110,7 +110,7 @@ extern (C++) abstract class Statement : RootObject
 
     override final DYNCAST dyncast() const
     {
-        return DYNCAST_STATEMENT;
+        return DYNCAST.statement;
     }
 
     final extern (D) this(Loc loc)


### PR DESCRIPTION
as per title.
removes the c++ legacy names of dyncast.
waiting for the day where we can get rid of dyncast all-together and have a type-field in rootObejct.