### PR TITLE
fix Issue 17215 -  ICE(cgcod.c:findreg) with SIMD and -O -inline

### DIFF
--- a/src/backend/cgelem.c
+++ b/src/backend/cgelem.c
@@ -3511,7 +3511,7 @@ STATIC elem * eleq(elem *e, goal_t goal)
             e1->Eoper == OPvar &&
             e2->Eoper == OPvar &&
             goal == GOALnone &&
-            !tyfloating(e1->Ety)
+            !tyfloating(e1->Ety) && !tyvector(e1->Ety)
            )
         {
             tym_t ty = (REGSIZE == 8) ? TYllong : TYint;

--- a/test/compilable/test17215.d
+++ b/test/compilable/test17215.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -O
+version (X86_64):
+alias vec = __vector(int[4]);
+
+vec binop(vec a)
+{
+    vec b = a;
+    return b;
+}


### PR DESCRIPTION
- caused by assigning 2*REGSIZE XMM vectors partially
- only triggers since SROA sees this 8 bytes access