### PR TITLE
HdrGen: avoid introducing irritating indentation on  if {} else if {} constructs

### DIFF
--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -322,11 +322,18 @@ public:
         if (s.elsebody)
         {
             buf.writestring("else");
-            buf.writenl();
-            if (!s.elsebody.isScopeStatement())
+            if (!s.elsebody.isIfStatement)
+            {
+                buf.writenl();
+            }
+            else
+            {
+                buf.writeByte(' ');
+            }
+            if (!s.elsebody.isScopeStatement() && !s.elsebody.isIfStatement)
                 buf.level++;
             s.elsebody.accept(this);
-            if (!s.elsebody.isScopeStatement())
+            if (!s.elsebody.isScopeStatement() && !s.elsebody.isIfStatement)
                 buf.level--;
         }
     }

--- a/test/compilable/extra-files/header3.d
+++ b/test/compilable/extra-files/header3.d
@@ -1,0 +1,14 @@
+auto elseifchain()
+{
+    bool a,b,c;
+
+    if (a)
+    {
+    }
+    else if (b)
+    {
+    }
+    else if (c)
+    {
+    }
+}

--- a/test/compilable/extra-files/header3.di
+++ b/test/compilable/extra-files/header3.di
@@ -1,0 +1,13 @@
+auto elseifchain()
+{
+	bool a, b, c;
+	if (a)
+	{
+	}
+	else if (b)
+	{
+	}
+	else if (c)
+	{
+	}
+}

--- a/test/compilable/testheader3.d
+++ b/test/compilable/testheader3.d
@@ -1,0 +1,8 @@
+// EXTRA_SOURCES: extra-files/header3.d
+// REQUIRED_ARGS: -o- -unittest -H -Hf${RESULTS_DIR}/compilable/header3.di
+// PERMUTE_ARGS: -d -dw
+// POST_SCRIPT: compilable/extra-files/header-postscript.sh header3
+
+void main() {}
+
+


### PR DESCRIPTION
before
```
if (a)
{...}
else
    if (b)
    {...}
    else
        if (c)
```
after patch
```
if (a)
{...}
else if (b)
{...}
else if (c)
{...}
```