### PR TITLE
reset cseg after COMDAT generation

### DIFF
--- a/src/ddmd/backend/cgobj.c
+++ b/src/ddmd/backend/cgobj.c
@@ -2000,6 +2000,7 @@ static int generate_comdat(Obj* objmod, Symbol *s, bool is_readonly_comdat)
     if (s->Sclass == SCstatic)
         lr->flags |= 0x04;      // local bit (make it an "LCOMDAT")
     s->Soffset = 0;
+    s->Sseg = pseg->SDseg;
     return pseg->SDseg;
 }
 

--- a/src/ddmd/backend/elfobj.c
+++ b/src/ddmd/backend/elfobj.c
@@ -1856,6 +1856,7 @@ int ElfObj::getsegment(const char *name, const char *suffix, int type, int flags
 
 void Obj::setcodeseg(int seg)
 {
+    cseg = seg;
 }
 
 /********************************

--- a/src/ddmd/backend/machobj.c
+++ b/src/ddmd/backend/machobj.c
@@ -1931,6 +1931,7 @@ int MachObj::getsegment(const char *sectname, const char *segname,
 
 void Obj::setcodeseg(int seg)
 {
+    cseg = seg;
 }
 
 /********************************


### PR DESCRIPTION
Not doing this results in random code being appended to COMDAT sections.