### PR TITLE
fix Issue 17049 - [scope] member methods not escape checked like free…

### DIFF
--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -443,6 +443,13 @@ extern (C++) class FuncDeclaration : Declaration
             if (ad && ad.isClassDeclaration() && (tf.isreturn || sc.stc & STCreturn) && !(sc.stc & STCstatic))
                 sc.stc |= STCscope;
 
+            // If 'this' has no pointers, remove 'scope' as it has no meaning
+            if (sc.stc & STCscope && ad && ad.isStructDeclaration() && !ad.type.hasPointers())
+            {
+                sc.stc &= ~STCscope;
+                tf.isscope = false;
+            }
+
             sc.linkage = linkage;
 
             if (!tf.isNaked() && !(isThis() || isNested()))

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -111,4 +111,38 @@ fail_compilation/retscope2.d(614): Error: template instance retscope2.test600!(i
     test600(p, q);
 }
 
+/*************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope2.d(719): Error: escaping reference to local variable s
+fail_compilation/retscope2.d(721): Error: escaping reference to local variable s
+---
+*/
+
+#line 700
+// https://issues.dlang.org/show_bug.cgi?id=17049
+
+@safe S700* get2(return ref scope S700 _this)
+{
+    return &_this;
+}
+
+struct S700
+{
+    @safe S700* get1() return scope
+    {
+        return &this;
+    }
+}
+
+S700* escape700(int i) @safe
+{
+    S700 s;
+    if (i)
+        return s.get2(); // 719
+    else
+        return s.get1(); // 721
+}
 


### PR DESCRIPTION
… functions

Member functions must behave the same way as free functions.