### PR TITLE
Suppress duplicate errors on integer division overflow during constfolding

### DIFF
--- a/src/ddmd/constfold.d
+++ b/src/ddmd/constfold.d
@@ -439,12 +439,14 @@ extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
             if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Tint64)
             {
                 e2.error("integer overflow: int.min / -1");
-                n2 = 1;
+                emplaceExp!(ErrorExp)(&ue);
+                return ue;
             }
             else if (n1 == 0x8000000000000000L) // long.min / -1
             {
                 e2.error("integer overflow: long.min / -1");
-                n2 = 1;
+                emplaceExp!(ErrorExp)(&ue);
+                return ue;
             }
         }
         if (e1.type.isunsigned() || e2.type.isunsigned())
@@ -501,12 +503,14 @@ extern (C++) UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
             if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Tint64)
             {
                 e2.error("integer overflow: int.min %% -1");
-                n2 = 1;
+                emplaceExp!(ErrorExp)(&ue);
+                return ue;
             }
             else if (n1 == 0x8000000000000000L) // long.min % -1
             {
                 e2.error("integer overflow: long.min %% -1");
-                n2 = 1;
+                emplaceExp!(ErrorExp)(&ue);
+                return ue;
             }
         }
         if (e1.type.isunsigned() || e2.type.isunsigned())

--- a/src/ddmd/init.d
+++ b/src/ddmd/init.d
@@ -884,6 +884,8 @@ extern (C++) final class ExpInitializer : Initializer
             {
                 exp = exp.implicitCastTo(sc, t);
             }
+            if (!global.gag && olderrors != global.errors)
+                return this;
             exp = exp.ctfeInterpret();
         }
         else

--- a/test/fail_compilation/test4682.d
+++ b/test/fail_compilation/test4682.d
@@ -1,18 +1,10 @@
 /*
 TEST_OUTPUT:
 ----
-fail_compilation/test4682.d(18): Error: integer overflow: int.min / -1
-fail_compilation/test4682.d(18): Error: integer overflow: int.min / -1
-fail_compilation/test4682.d(18): Error: integer overflow: int.min / -1
-fail_compilation/test4682.d(19): Error: integer overflow: long.min / -1
-fail_compilation/test4682.d(19): Error: integer overflow: long.min / -1
-fail_compilation/test4682.d(19): Error: integer overflow: long.min / -1
-fail_compilation/test4682.d(20): Error: integer overflow: int.min % -1
-fail_compilation/test4682.d(20): Error: integer overflow: int.min % -1
-fail_compilation/test4682.d(20): Error: integer overflow: int.min % -1
-fail_compilation/test4682.d(21): Error: integer overflow: long.min % -1
-fail_compilation/test4682.d(21): Error: integer overflow: long.min % -1
-fail_compilation/test4682.d(21): Error: integer overflow: long.min % -1
+fail_compilation/test4682.d(10): Error: integer overflow: int.min / -1
+fail_compilation/test4682.d(11): Error: integer overflow: long.min / -1
+fail_compilation/test4682.d(12): Error: integer overflow: int.min % -1
+fail_compilation/test4682.d(13): Error: integer overflow: long.min % -1
 ----
 */
 auto a = int.min / -1;


### PR DESCRIPTION
Noticed in the test added by #6511 - other const-folding methods return `ErrorExp` on error to prevent re-evaluation.