### PR TITLE
fix Issue 17237 - Wrong alignment for 256-bit vectors.

### DIFF
--- a/src/aggregate.d
+++ b/src/aggregate.d
@@ -629,15 +629,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         if (!isunion)
             *nextoffset = ofs;
 
-        if (alignment == STRUCTALIGN_DEFAULT)
-        {
-            if ((global.params.is64bit || global.params.isOSX) && memalignsize == 16)
-            {
-            }
-            else if (8 < memalignsize)
-                memalignsize = 8;
-        }
-        else
+        if (alignment != STRUCTALIGN_DEFAULT)
         {
             if (memalignsize < alignment)
                 memalignsize = alignment;

--- a/src/target.d
+++ b/src/target.d
@@ -153,7 +153,12 @@ struct Target
      */
     extern (C++) static uint fieldalign(Type type)
     {
-        return type.alignsize();
+        const size = type.alignsize();
+
+        if ((global.params.is64bit || global.params.isOSX) && (size == 16 || size == 32))
+            return size;
+
+        return (8 < size) ? 8 : size;
     }
 
     /***********************************

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1834,6 +1834,23 @@ void test10447()
 }
 
 /*****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=17237
+
+struct S17237
+{
+    bool a;
+    struct
+    {
+        bool b;
+        int8 c;
+    }
+}
+
+static assert(S17237.a.offsetof == 0);
+static assert(S17237.b.offsetof == 32);
+static assert(S17237.c.offsetof == 64);
+
+/*****************************************/
 
 int main()
 {


### PR DESCRIPTION
Relaxed the condition to allow 256-bit vector alignment, but I won't change the logic of anything else incase it affects something, you can do this in a much better way, but it's not my place to say.

Moved alignment adjusting code to `Target::fieldalign`, as the frontend should adhere to the result returned from this function, unless some explicit alignment was requested, and not overwrite it in frontend-only code.