### PR TITLE
fix calling win makefiles w/ MODEL=32

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -58,6 +58,9 @@
 
 ############################### Configuration ################################
 
+# fixed model for win32.mak, overriden by win64.mak
+MODEL=32
+
 ##### Directories
 
 # DMC directory
@@ -128,7 +131,7 @@ BFLAGS=
 # D Optimizer flags
 DOPT=
 # D Model flags
-DMODEL=
+DMODEL=-m$(MODEL)
 # D Debug flags
 DDEBUG=-debug -g -unittest
 
@@ -142,7 +145,7 @@ MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARG
 DFLAGS=$(DOPT) $(DMODEL) $(DDEBUG) -wi -version=MARS
 
 # Recursive make
-DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$(HOST_DC)" DMODEL=$(DMODEL) CC="$(CC)" LIB="$(LIB)" OBJ_MSVC="$(OBJ_MSVC)"
+DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$(HOST_DC)" MODEL=$(MODEL) CC="$(CC)" LIB="$(LIB)" OBJ_MSVC="$(OBJ_MSVC)"
 
 ############################### Rule Variables ###############################
 

--- a/src/win64.mak
+++ b/src/win64.mak
@@ -6,7 +6,7 @@
 
 MAKE=make
 HOST_DC=dmd
-DMODEL=-m64
+MODEL=64
 
 ################################### Rules ####################################
 
@@ -17,7 +17,7 @@ D=ddmd
 OBJ_MSVC=$D\strtold.obj $D\longdouble.obj $D\ldfpu.obj
 DEPENDENCIES=$D\vcbuild\msvc-dmc.exe $D\vcbuild\msvc-lib.exe
 
-MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" DMODEL=$(DMODEL) HOST_DC=$(HOST_DC) OBJ_MSVC="$(OBJ_MSVC)" CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
+MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" MODEL=$(MODEL) HOST_DC=$(HOST_DC) OBJ_MSVC="$(OBJ_MSVC)" CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
 
 ################################## Targets ###################################
 


### PR DESCRIPTION
- calling submake didn't forward MODEL, thus used a different
  generated folder, and failed w/ a missing target rule
- as MODEL was undefined, the generated folders were actually
  the same between win32.mak and win64.mak
- fixed by using/forwarding MODEL