### PR TITLE
Fix dependency chains in posix.mak

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -83,16 +83,20 @@ coverage() {
 
     # build dmd, druntime, and phobos
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD dmd.conf
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
 
     # rebuild dmd with coverage enabled
     # use the just build dmd as host compiler this time
-    mv src/dmd src/host_dmd
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd clean
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd dmd.conf
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd ENABLE_COVERAGE=1
+    local build_path=generated/linux/release/$MODEL
+    # `generated` gets cleaned in the next step, so we create another _generated
+    # The nested folder hierarchy is needed to conform to those specified in
+    # the generate dmd.conf
+    mkdir -p _${build_path}
+    cp $build_path/dmd _${build_path}/host_dmd
+    cp $build_path/dmd.conf _${build_path}
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd clean
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_COVERAGE=1
 
     make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1
 }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -385,16 +385,32 @@ endif
 
 define DEFAULT_DMD_CONF
 [Environment32]
-DFLAGS=-I%@P%/../../druntime/import -I%@P%/../../phobos -L-L%@P%/../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic)
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic)
 
 [Environment64]
-DFLAGS=-I%@P%/../../druntime/import -I%@P%/../../phobos -L-L%@P%/../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic)
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic)
 endef
 
 export DEFAULT_DMD_CONF
 
 $G/dmd.conf:
 	[ -f $@ ] || echo "$$DEFAULT_DMD_CONF" > $@
+
+######## generate a default dmd.conf (for compatibility)
+######## REMOVE ME after the ddmd -> dmd transition
+
+define DEFAULT_DMD_CONF_LEGACY
+[Environment32]
+DFLAGS=-I%@P%/../../druntime/import -I%@P%/../../phobos -L-L%@P%/../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic)
+
+[Environment64]
+DFLAGS=-I%@P%/../../druntime/import -I%@P%/../../phobos -L-L%@P%/../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic)
+endef
+
+export DEFAULT_DMD_CONF_LEGACY
+
+dmd.conf:
+	[ -f $@ ] || echo "$$DEFAULT_DMD_CONF_LEGACY" > $@
 
 ######## optabgen generates some source
 optabgen_output = debtab.c optab.c cdxxx.c elxxx.c fltables.c tytab.c

--- a/travis.sh
+++ b/travis.sh
@@ -35,7 +35,6 @@ clone() {
 # build dmd, druntime, phobos
 build() {
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD ENABLE_RELEASE=1 all
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD dmd.conf
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
 }
@@ -44,7 +43,6 @@ build() {
 rebuild() {
     mv src/dmd src/host_dmd
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd clean
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd dmd.conf
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd ENABLE_RELEASE=1 all
 }
 


### PR DESCRIPTION
1) The idea of a build system is that only the files that need to be updated, should be. This PR is an attempt to fix this as since the move to `generated` this isn't the case anymore (at the moment every `build` is a _full_ rebuild
2) The generated `dmd.conf` needs to be put into the `generated` folder as well
3) There was an issue with the dependency chain of the C files. An update to the source files _didn't_ trigger the dependency chain. The reason for this problem was that the generated dependency files need to be included _before_ their rule)
4) The optagen output target was completely broken
- the targets didn't exist
- if run in parallel, it would run the tool was well in parallel

For more infos on (4) see [this guide](https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html#Multiple-Outputs) or [this SO question](http://stackoverflow.com/questions/2973445/gnu-makefile-rule-generating-a-few-targets-from-a-single-source-file).

CC @RazvanN7 