### PR TITLE
[Revive PR 6297] - Remove usage of deprecated features 

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -15721,8 +15721,8 @@ extern (C++) final class IdentityExp : BinExp
         if (e1.type.toBasetype().ty == Tsarray ||
             e2.type.toBasetype().ty == Tsarray)
             deprecation("identity comparison of static arrays "
-                "implicitly coerces them to slices, "
-                "which are compared by reference");
+                ~ "implicitly coerces them to slices, "
+                ~ "which are compared by reference");
 
         return this;
     }

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -2870,7 +2870,9 @@ final class Parser : Lexer
                             //error("scope cannot be ref or out");
 
                         Token* t;
-                        if (tpl && token.value == TOKidentifier && (t = peek(&token), (t.value == TOKcomma || t.value == TOKrparen || t.value == TOKdotdotdot)))
+                        if (tpl && token.value == TOKidentifier
+                            && (t = peek(&token)) !is null
+                            && (t.value == TOKcomma || t.value == TOKrparen || t.value == TOKdotdotdot))
                         {
                             Identifier id = Identifier.generateId("__T");
                             const loc = token.loc;

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -2869,24 +2869,29 @@ final class Parser : Lexer
                         //if ((storageClass & STCscope) && (storageClass & (STCref | STCout)))
                             //error("scope cannot be ref or out");
 
-                        Token* t;
-                        if (tpl && token.value == TOKidentifier
-                            && (t = peek(&token)) !is null
-                            && (t.value == TOKcomma || t.value == TOKrparen || t.value == TOKdotdotdot))
+                        if (tpl && token.value == TOKidentifier)
                         {
-                            Identifier id = Identifier.generateId("__T");
-                            const loc = token.loc;
-                            at = new TypeIdentifier(loc, id);
-                            if (!*tpl)
-                                *tpl = new TemplateParameters();
-                            TemplateParameter tp = new TemplateTypeParameter(loc, id, null, null);
-                            (*tpl).push(tp);
+                            Token* t = peek(&token);
+                            if (t.value == TOKcomma || t.value == TOKrparen || t.value == TOKdotdotdot)
+                            {
+                                Identifier id = Identifier.generateId("__T");
+                                const loc = token.loc;
+                                at = new TypeIdentifier(loc, id);
+                                if (!*tpl)
+                                    *tpl = new TemplateParameters();
+                                TemplateParameter tp = new TemplateTypeParameter(loc, id, null, null);
+                                (*tpl).push(tp);
 
-                            ai = token.ident;
-                            nextToken();
+                                ai = token.ident;
+                                nextToken();
+                            }
+                            else goto _else;
                         }
                         else
+                        {
+                        _else:
                             at = parseType(&ai);
+                        }
                         ae = null;
                         if (token.value == TOKassign) // = defaultArg
                         {

--- a/test/runnable/extra-files/runnable-sieve.lst
+++ b/test/runnable/extra-files/runnable-sieve.lst
@@ -6,9 +6,9 @@
        |/* Eratosthenes Sieve prime number calculation. */
        |
        |import std.stdio;
-       | 
-       |bool flags[8191];
-       | 
+       |
+       |bool[8191] flags;
+       |
        |int sieve()
        |{
       1|    int count;

--- a/test/runnable/sieve.d
+++ b/test/runnable/sieve.d
@@ -6,9 +6,9 @@
 /* Eratosthenes Sieve prime number calculation. */
 
 import std.stdio;
- 
-bool flags[8191];
- 
+
+bool[8191] flags;
+
 int sieve()
 {
     int count;


### PR DESCRIPTION
Seeing the deprecation messages for months on the __reference__ compile doesn't depict the best image.

> If the compiler devs can't fix their own deprecations messages, how do they expect it from other projects? 

As https://github.com/dlang/dmd/pull/6297 got stalled, this is a revival of it.