### PR TITLE
Sync modifiableLvalue from D -> C++

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -12154,16 +12154,6 @@ extern (C++) final class IntervalExp : Expression
         return this;
     }
 
-    override Expression modifiableLvalue(Scope* sc, Expression e)
-    {
-        if (sc.func.setUnsafe())
-        {
-            error("cannot modify delegate pointer in @safe code %s", toChars());
-            return new ErrorExp();
-        }
-        return Expression.modifiableLvalue(sc, e);
-    }
-
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -989,6 +989,7 @@ public:
     Expression *semantic(Scope *sc);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
+    Expression *modifiableLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -998,6 +999,7 @@ public:
     Expression *semantic(Scope *sc);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
+    Expression *modifiableLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
@WalterBright - please confirm.  The addition of `IntervalExp::modifiableLvalue` was a mistake.

My assumption is yes because it is identical to `DelegatePtrExp::modifiableLvalue`.