### PR TITLE
Fix Travis & let it use dmd from generated

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -41,9 +41,15 @@ build() {
 
 # self-compile dmd
 rebuild() {
-    mv src/dmd src/host_dmd
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd clean
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=./host_dmd ENABLE_RELEASE=1 all
+    local build_path=generated/$TRAVIS_OS_NAME/release/$MODEL
+    # `generated` gets cleaned in the next step, so we create another _generated
+    # The nested folder hierarchy is needed to conform to those specified in
+    # the generated dmd.conf
+    mkdir -p _${build_path}
+    cp $build_path/dmd _${build_path}/host_dmd
+    cp $build_path/dmd.conf _${build_path}
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd clean
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_RELEASE=1 all
 }
 
 # test druntime, phobos, dmd


### PR DESCRIPTION
The Travis scripts still depend on `dmd` and `dmd.conf` being in `src`.

(the currently failing status is partially due to https://github.com/dlang/dmd/pull/6586)

This applies the same trick that is used for CircleCi as well.

CC @RazvanN7 