### PR TITLE
enable runtime tests

### DIFF
--- a/test/runnable/evalorder.d
+++ b/test/runnable/evalorder.d
@@ -47,7 +47,7 @@ void add()
     static assert(test1(1) == (1 + 8 + 3));
 
     static int test2(int val) { val = val + add8ret3(val); return val; }
-    // FIXME: assert(test2(1) == (1 + 3));
+    assert(test2(1) == (1 + 3));
     static assert(test2(1) == (1 + 3));
 
     static int test3(int val) { (val += 7) += mul11ret3(val); return val; }
@@ -62,7 +62,7 @@ void min()
     static assert(test1(1) == (1 + 8 - 3));
 
     static int test2(int val) { val = val - add8ret3(val); return val; }
-    // FIXME: assert(test2(1) == (1 - 3));
+    assert(test2(1) == (1 - 3));
     static assert(test2(1) == (1 - 3));
 
     static int test3(int val) { (val -= 7) -= mul11ret3(val); return val; }
@@ -77,7 +77,7 @@ void mul()
     static assert(test1(7) == ((7 + 8) * 3));
 
     static int test2(int val) { val = val * add8ret3(val); return val; }
-    // FIXME: assert(test2(7) == (7 * 3));
+    assert(test2(7) == (7 * 3));
     static assert(test2(7) == (7 * 3));
 
     static int test3(int val) { (val *= 7) *= add8ret3(val); return val; }
@@ -92,7 +92,7 @@ void xor()
     static assert(test1(1) == ((1 + 8) ^ 3));
 
     static int test2(int val) { val = val ^ add8ret3(val); return val; }
-    // FIXME: assert(test2(1) == (1 ^ 3));
+    assert(test2(1) == (1 ^ 3));
     static assert(test2(1) == (1 ^ 3));
 
     static int test3(int val) { (val ^= 7) ^= add8ret3(val); return val; }
@@ -106,7 +106,7 @@ void addptr()
     assert(test1(cast(int*)4) == ((cast(int*)4) + 8 + 3));
 
     static int* test2(int* val) { val = val + add8ret3(val); return val; }
-    // FIXME: assert(test2(cast(int*)4) == ((cast(int*)4) + 3));
+    assert(test2(cast(int*)4) == ((cast(int*)4) + 3));
 
     static int* test3(int* val) { (val += 7) += add8ret3(val); return val; }
     assert(test3(cast(int*)16) == ((cast(int*)16) + 7 + 8 + 3));


### PR DESCRIPTION
enable the tests in evalorder.
why were they disabled in the first place ?