### PR TITLE
Delete dmd/src/dmd

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -339,9 +339,9 @@ STRING_IMPORT_FILES = $G/verstr.h $G/SYSCONFDIR.imp ../res/default_ddoc_theme.dd
 
 DEPS = $(patsubst %.o,%.deps,$(DMD_OBJS) $(GLUE_OBJS) $(BACK_OBJS))
 
-all: dmd
+all: $G/dmd $G/dmd.conf
 
-auto-tester-build: dmd checkwhitespace $G/dmd_frontend
+auto-tester-build: $G/dmd checkwhitespace $G/dmd_frontend $G/dmd.conf
 .PHONY: auto-tester-build
 
 toolchain-info:
@@ -369,9 +369,6 @@ $G/lexer.a: $(LEXER_SRCS) $(LEXER_ROOT)
 $G/dmd_frontend: $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
 	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^) -version=NoBackend
 
-dmd: $G/dmd $G/dmd.conf
-	cp $< .
-
 ifdef ENABLE_LTO
 $G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_GLUE_OBJS) $(G_OBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
 	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
@@ -383,7 +380,7 @@ endif
 
 clean:
 	rm -R $(GENERATED)
-	rm -f dmd $(idgen_output)
+	rm -f $(idgen_output)
 	@[ ! -d ${PGO_DIR} ] || echo You should issue manually: rm -rf ${PGO_DIR}
 
 ######## Download and install the last dmd buildable without dmd
@@ -518,7 +515,7 @@ $G/newdelete.o: $G/%.o: $(ROOT)/%.c posix.mak
 install: all
 	$(eval bin_dir=$(if $(filter $(OS),osx), bin, bin$(MODEL)))
 	mkdir -p $(INSTALL_DIR)/$(OS)/$(bin_dir)
-	cp dmd $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd
+	cp $G/dmd $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd
 	cp ../ini/$(OS)/$(bin_dir)/dmd.conf $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd.conf
 	cp $D/boostlicense.txt $(INSTALL_DIR)/dmd-boostlicense.txt
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -60,6 +60,9 @@
 
 # fixed model for win32.mak, overridden by win64.mak
 MODEL=32
+OS=windows
+BUILD=release
+
 
 ##### Directories
 
@@ -80,7 +83,7 @@ SCPDIR=..\backup
 
 # Generated files directory
 GEN = ..\generated
-G = $(GEN)\$(OS)$(MODEL)
+G = $(GEN)\$(OS)\$(BUILD)\$(MODEL)
 
 ##### Tools
 
@@ -323,11 +326,9 @@ DMDFRONTENDEXE = $G\dmd_frontend.exe
 
 $(DMDFRONTENDEXE): $(FRONT_SRCS) $D\gluelayer.d $(ROOT_SRCS) $G\newdelete.obj $G\liblexer.lib $(STRING_IMPORT_FILES)
 	$(HOST_DC) $(DSRC) -of$@ -vtls -J$G -J../res -L/STACK:8388608 $(DFLAGS) $(LFLAGS) $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) newdelete.obj -version=NoBackend
-	copy $(DMDFRONTENDEXE) .
 
 $(TARGETEXE): $(DMD_SRCS) $(ROOT_SRCS) $G\newdelete.obj $(LIBS) $(STRING_IMPORT_FILES)
 	$(HOST_DC) $(DSRC) -of$@ -vtls -J$G -J../res -L/STACK:8388608 $(DFLAGS) $(LFLAGS) $(DMD_SRCS) $(ROOT_SRCS) $G\newdelete.obj $(LIBS)
-	copy $(TARGETEXE) .
 
 ############################ Maintenance Targets #############################
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -94,7 +94,7 @@ export REQUIRED_ARGS=
 
 ifeq ($(findstring win,$(OS)),win)
 export ARGS=-inline -release -g -O
-export DMD=../src/dmd.exe
+export DMD=../generated/$(OS)/release/$(MODEL)/dmd.exe
 export EXE=.exe
 export OBJ=.obj
 export DSEP=\\
@@ -106,7 +106,7 @@ export DFLAGS=-I$(DRUNTIME_PATH)\import -I$(PHOBOS_PATH)
 export LIB=$(PHOBOS_PATH)
 else
 export ARGS=-inline -release -g -O -fPIC
-export DMD=../src/dmd
+export DMD=../generated/$(OS)/release/$(MODEL)/dmd
 export EXE=
 export OBJ=.o
 export DSEP=/


### PR DESCRIPTION
After modifying all the scrips to use dmd/generated/os/build/model/dmd instead of dmd/src/dmd, we can delete the dmd/src/dmd binary.