### PR TITLE
refactor: remove cseg global dependency from Obj::linnum()

### DIFF
--- a/src/ddmd/backend/cgcod.c
+++ b/src/ddmd/backend/cgcod.c
@@ -291,7 +291,7 @@ tryagain:
         cstop--;
 
     if (configv.addlinenumbers)
-        objmod->linnum(funcsym_p->Sfunc->Fstartline,Coffset);
+        objmod->linnum(funcsym_p->Sfunc->Fstartline,cseg,Offset(cseg));
 
     // Otherwise, jmp's to startblock will execute the prolog again
     assert(!startblock->Bpred);
@@ -511,7 +511,7 @@ tryagain:
            start of the last instruction
          */
         /* Instead, try offset to cleanup code  */
-        objmod->linnum(funcsym_p->Sfunc->Fendline,funcoffset + retoffset);
+        objmod->linnum(funcsym_p->Sfunc->Fendline,cseg,funcoffset + retoffset);
 
 #if TARGET_WINDOS && MARS
     if (config.exe == EX_WIN64)

--- a/src/ddmd/backend/cod3.c
+++ b/src/ddmd/backend/cod3.c
@@ -6101,7 +6101,7 @@ unsigned codout(code *c)
                 switch (op & 0xFFFF00)
                 {   case ESClinnum:
                         /* put out line number stuff    */
-                        objmod->linnum(c->IEV1.Vsrcpos,ggen.getOffset());
+                        objmod->linnum(c->IEV1.Vsrcpos,cseg,ggen.getOffset());
                         break;
 #if SCPP
 #if 1

--- a/src/ddmd/backend/elfobj.c
+++ b/src/ddmd/backend/elfobj.c
@@ -1409,18 +1409,20 @@ void Obj::term(const char *objfilename)
 /***************************
  * Record file and line number at segment and offset.
  * The actual .debug_line segment is put out by dwarf_termfile().
- * Input:
- *      cseg    current code segment
+ * Params:
+ *      srcpos = source file position
+ *      seg = segment it corresponds to
+ *      offset = offset within seg
  */
 
-void Obj::linnum(Srcpos srcpos, targ_size_t offset)
+void Obj::linnum(Srcpos srcpos, int seg, targ_size_t offset)
 {
     if (srcpos.Slinnum == 0)
         return;
 
 #if 0
 #if MARS || SCPP
-    printf("Obj::linnum(cseg=%d, offset=0x%lx) ", cseg, offset);
+    printf("Obj::linnum(seg=%d, offset=0x%lx) ", seg, offset);
 #endif
     srcpos.print("");
 #endif
@@ -1437,42 +1439,42 @@ void Obj::linnum(Srcpos srcpos, targ_size_t offset)
 #endif
 
     size_t i;
-    seg_data *seg = SegData[cseg];
+    seg_data *pseg = SegData[seg];
 
     // Find entry i in SDlinnum_data[] that corresponds to srcpos filename
     for (i = 0; 1; i++)
     {
-        if (i == seg->SDlinnum_count)
+        if (i == pseg->SDlinnum_count)
         {   // Create new entry
-            if (seg->SDlinnum_count == seg->SDlinnum_max)
+            if (pseg->SDlinnum_count == pseg->SDlinnum_max)
             {   // Enlarge array
-                unsigned newmax = seg->SDlinnum_max * 2 + 1;
+                unsigned newmax = pseg->SDlinnum_max * 2 + 1;
                 //printf("realloc %d\n", newmax * sizeof(linnum_data));
-                seg->SDlinnum_data = (linnum_data *)mem_realloc(
-                    seg->SDlinnum_data, newmax * sizeof(linnum_data));
-                memset(seg->SDlinnum_data + seg->SDlinnum_max, 0,
-                    (newmax - seg->SDlinnum_max) * sizeof(linnum_data));
-                seg->SDlinnum_max = newmax;
+                pseg->SDlinnum_data = (linnum_data *)mem_realloc(
+                    pseg->SDlinnum_data, newmax * sizeof(linnum_data));
+                memset(pseg->SDlinnum_data + pseg->SDlinnum_max, 0,
+                    (newmax - pseg->SDlinnum_max) * sizeof(linnum_data));
+                pseg->SDlinnum_max = newmax;
             }
-            seg->SDlinnum_count++;
+            pseg->SDlinnum_count++;
 #if MARS
-            seg->SDlinnum_data[i].filename = srcpos.Sfilename;
+            pseg->SDlinnum_data[i].filename = srcpos.Sfilename;
 #endif
 #if SCPP
-            seg->SDlinnum_data[i].filptr = sf;
+            pseg->SDlinnum_data[i].filptr = sf;
 #endif
             break;
         }
 #if MARS
-        if (seg->SDlinnum_data[i].filename == srcpos.Sfilename)
+        if (pseg->SDlinnum_data[i].filename == srcpos.Sfilename)
 #endif
 #if SCPP
-        if (seg->SDlinnum_data[i].filptr == sf)
+        if (pseg->SDlinnum_data[i].filptr == sf)
 #endif
             break;
     }
 
-    linnum_data *ld = &seg->SDlinnum_data[i];
+    linnum_data *ld = &pseg->SDlinnum_data[i];
 //    printf("i = %d, ld = x%x\n", i, ld);
     if (ld->linoff_count == ld->linoff_max)
     {

--- a/src/ddmd/backend/mscoffobj.c
+++ b/src/ddmd/backend/mscoffobj.c
@@ -1018,11 +1018,13 @@ void MsCoffObj::term(const char *objfilename)
 
 /***************************
  * Record file and line number at segment and offset.
- * Input:
- *      cseg    current code segment
+ * Params:
+ *      srcpos = source file position
+ *      seg = segment it corresponds to
+ *      offset = offset within seg
  */
 
-void MsCoffObj::linnum(Srcpos srcpos, targ_size_t offset)
+void MsCoffObj::linnum(Srcpos srcpos, int seg, targ_size_t offset)
 {
     if (srcpos.Slinnum == 0 || !srcpos.Sfilename)
         return;

--- a/src/ddmd/backend/obj.d
+++ b/src/ddmd/backend/obj.d
@@ -34,7 +34,7 @@ class Obj
 
     size_t mangle(Symbol *s,char *dest);
     void _import(elem *e);
-    void linnum(Srcpos srcpos, targ_size_t offset);
+    void linnum(Srcpos srcpos, int seg, targ_size_t offset);
     int codeseg(char *name,int suffix);
     void dosseg();
     void startaddress(Symbol *);
@@ -110,7 +110,7 @@ class MsCoffObj : Obj
 
 //    size_t mangle(Symbol *s,char *dest);
 //    void _import(elem *e);
-    override void linnum(Srcpos srcpos, targ_size_t offset);
+    override void linnum(Srcpos srcpos, int seg, targ_size_t offset);
     override int codeseg(char *name,int suffix);
 //    void dosseg();
     override void startaddress(Symbol *);
@@ -202,7 +202,7 @@ class Obj
 
     static size_t mangle(Symbol *s,char *dest);
     static void _import(elem *e);
-    static void linnum(Srcpos srcpos, targ_size_t offset);
+    static void linnum(Srcpos srcpos, int seg, targ_size_t offset);
     static int codeseg(char *name,int suffix);
     static void dosseg();
     static void startaddress(Symbol *);

--- a/src/ddmd/backend/obj.h
+++ b/src/ddmd/backend/obj.h
@@ -33,7 +33,7 @@ class Obj
 
     VIRTUAL size_t mangle(Symbol *s,char *dest);
     VIRTUAL void _import(elem *e);
-    VIRTUAL void linnum(Srcpos srcpos, targ_size_t offset);
+    VIRTUAL void linnum(Srcpos srcpos, int seg, targ_size_t offset);
     VIRTUAL int codeseg(char *name,int suffix);
     VIRTUAL void dosseg(void);
     VIRTUAL void startaddress(Symbol *);
@@ -143,7 +143,7 @@ class MsCoffObj : public Obj
 
 //    VIRTUAL size_t mangle(Symbol *s,char *dest);
 //    VIRTUAL void _import(elem *e);
-    VIRTUAL void linnum(Srcpos srcpos, targ_size_t offset);
+    VIRTUAL void linnum(Srcpos srcpos, int seg, targ_size_t offset);
     VIRTUAL int codeseg(char *name,int suffix);
 //    VIRTUAL void dosseg(void);
     VIRTUAL void startaddress(Symbol *);


### PR DESCRIPTION
Because global variables are bad.