### PR TITLE
remove Coffset macro

### DIFF
--- a/src/ddmd/backend/code.h
+++ b/src/ddmd/backend/code.h
@@ -653,9 +653,8 @@ struct linnum_data
 
 extern seg_data **SegData;
 #define Offset(seg) SegData[seg]->SDoffset
-#define Doffset SegData[DATA]->SDoffset
-#define CDoffset SegData[CDATA]->SDoffset
-#define Coffset SegData[cseg]->SDoffset
+#define Doffset Offset(DATA)
+#define CDoffset Offset(CDATA)
 
 /**************************************************/
 


### PR DESCRIPTION
To ensure all `Coffset` have been purged.