### PR TITLE
Sync up renames of init functions in C++ headers.

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -129,7 +129,7 @@ public:
     unsigned char size;         // # of bytes in Expression so we can copy() it
     unsigned char parens;       // if this is a parenthesized expression
 
-    static void init();
+    static void _init();
     Expression *copy();
     virtual Expression *syntaxCopy();
     virtual Expression *semantic(Scope *sc);

--- a/src/globals.h
+++ b/src/globals.h
@@ -232,7 +232,7 @@ struct Global
      */
     void increaseErrorCount();
 
-    void init();
+    void _init();
 };
 
 extern Global global;

--- a/src/module.h
+++ b/src/module.h
@@ -65,7 +65,7 @@ public:
     static Dsymbols deferred2;  // deferred Dsymbol's needing semantic2() run on them
     static Dsymbols deferred3;  // deferred Dsymbol's needing semantic3() run on them
     static unsigned dprogress;  // progress resolving the deferred list
-    static void init();
+    static void _init();
 
     static AggregateDeclaration *moduleinfo;
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -240,7 +240,7 @@ public:
     int covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars();
     char *toPrettyChars(bool QualifyTypes = false);
-    static void init();
+    static void _init();
 
     d_uns64 size();
     virtual d_uns64 size(Loc loc);

--- a/src/target.h
+++ b/src/target.h
@@ -34,7 +34,7 @@ struct Target
     static int c_long_doublesize;    // size of a C 'long double'
     static int classinfosize;        // size of 'ClassInfo'
 
-    static void init();
+    static void _init();
     // Type sizes and support.
     static unsigned alignsize(Type* type);
     static unsigned fieldalign(Type* type);


### PR DESCRIPTION
Though these may be implemented on D side, gdc's main function is in C++, and so needs to be able to call them.