### PR TITLE
Make Target floating-point properties static.

### DIFF
--- a/src/ddmd/root/ctfloat.h
+++ b/src/ddmd/root/ctfloat.h
@@ -4,7 +4,7 @@
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
- * https://github.com/D-Programming-Language/dmd/blob/master/src/root/port.h
+ * https://github.com/dlang/dmd/blob/master/src/root/ctfloat.h
  */
 
 #ifndef CTFLOAT_H

--- a/src/ddmd/target.d
+++ b/src/ddmd/target.d
@@ -34,32 +34,29 @@ struct Target
     extern (C++) static __gshared int classinfosize;        // size of 'ClassInfo'
     extern (C++) static __gshared ulong maxStaticDataSize;  // maximum size of static data
 
-    template FPTypeProperties(T)
+    extern (C++) struct FPTypeProperties(T)
     {
-        enum : real_t
+        static __gshared
         {
-            max = T.max,
-            min_normal = T.min_normal,
-            nan = T.nan,
-            snan = T.init,
-            infinity = T.infinity,
-            epsilon = T.epsilon
-        }
+            real_t max = T.max;
+            real_t min_normal = T.min_normal;
+            real_t nan = T.nan;
+            real_t snan = T.init;
+            real_t infinity = T.infinity;
+            real_t epsilon = T.epsilon;
 
-        enum : long
-        {
-            dig = T.dig,
-            mant_dig = T.mant_dig,
-            max_exp = T.max_exp,
-            min_exp = T.min_exp,
-            max_10_exp = T.max_10_exp,
-            min_10_exp = T.min_10_exp
+            d_int64 dig = T.dig;
+            d_int64 mant_dig = T.mant_dig;
+            d_int64 max_exp = T.max_exp;
+            d_int64 min_exp = T.min_exp;
+            d_int64 max_10_exp = T.max_10_exp;
+            d_int64 min_10_exp = T.min_10_exp;
         }
     }
 
     alias FloatProperties = FPTypeProperties!float;
     alias DoubleProperties = FPTypeProperties!double;
-    alias RealProperties = FPTypeProperties!real;
+    alias RealProperties = FPTypeProperties!real_t;
 
     extern (C++) static void _init()
     {

--- a/src/ddmd/target.h
+++ b/src/ddmd/target.h
@@ -35,6 +35,28 @@ struct Target
     static int classinfosize;        // size of 'ClassInfo'
     static unsigned long long maxStaticDataSize;  // maximum size of static data
 
+    template <typename T>
+    struct FPTypeProperties
+    {
+        static real_t max;
+        static real_t min_normal;
+        static real_t nan;
+        static real_t snan;
+        static real_t infinity;
+        static real_t epsilon;
+
+        static d_int64 dig;
+        static d_int64 mant_dig;
+        static d_int64 max_exp;
+        static d_int64 min_exp;
+        static d_int64 max_10_exp;
+        static d_int64 min_10_exp;
+    };
+
+    typedef FPTypeProperties<float> FloatProperties;
+    typedef FPTypeProperties<double> DoubleProperties;
+    typedef FPTypeProperties<real_t> RealProperties;
+
     static void _init();
     // Type sizes and support.
     static unsigned alignsize(Type* type);


### PR DESCRIPTION
Also add their definitions in the C++ headers.

Allows these to be runtime-initialized in gdc, and still be referenced from the D code.

i.e:
```
template <typename T> real_t Target::FPTypeProperties<T>::max;
// Declare others...

template <typename T>
static void define_float_constants (tree type)
{
  T::max = get_max_value(type);
  // Initialize others...
}
```

@kinke @klickverbot - Does this affect you?