### PR TITLE
Fix win64.mak system

### DIFF
--- a/src/vcbuild/msvc-dmc.d
+++ b/src/vcbuild/msvc-dmc.d
@@ -17,7 +17,7 @@ int main(string[] args)
     string[] newArgs = [cl];
     newArgs ~= "/nologo";
     newArgs ~= `/Ivcbuild`;
-    newArgs ~= `/Iroot`;
+    newArgs ~= `/Iddmd\root`;
     newArgs ~= `/FIwarnings.h`;
     bool compilingOnly;
 
@@ -40,6 +40,9 @@ int main(string[] args)
             case "-g": // "generate debug info"
             case "-gl": // "debug line numbers only"
                 newArgs ~= "/Zi";
+                break;
+            case "-o": // "optimize for program speed"
+                newArgs ~= "/O2";
                 break;
             case "-wx": // "treat warnings as errors"
                 newArgs ~= "/WX";

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -606,7 +606,7 @@ $G\longdouble.obj : $(ROOT)\longdouble.c
 	$(CC) -c -o$@ $(CFLAGS) $(ROOT)\longdouble.c
 
 $G\ldfpu.obj : vcbuild\ldfpu.asm
-	$(ML) -c -o$@ -Zi -Foldfpu.obj vcbuild\ldfpu.asm
+	$(ML) -c -o$@ -Zi -Fo$G\ldfpu.obj vcbuild\ldfpu.asm
 
 ############################## Generated Rules ###############################
 

--- a/src/win64.mak
+++ b/src/win64.mak
@@ -14,10 +14,12 @@ MODEL=64
 	$(HOST_DC) -of$@ $<
 
 D=ddmd
-OBJ_MSVC=$D\strtold.obj $D\longdouble.obj $D\ldfpu.obj
-DEPENDENCIES=$D\vcbuild\msvc-dmc.exe $D\vcbuild\msvc-lib.exe
+GEN = ..\generated
+G = $(GEN)\$(OS)$(MODEL)
+OBJ_MSVC=$G/strtold.obj $G\longdouble.obj $G\ldfpu.obj
+DEPENDENCIES=vcbuild\msvc-dmc.exe vcbuild\msvc-lib.exe
 
-MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" MODEL=$(MODEL) HOST_DC=$(HOST_DC) OBJ_MSVC="$(OBJ_MSVC)" CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
+MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" MODEL=$(MODEL) HOST_DC=$(HOST_DC) GEN="$(GEN)" G="$G" OBJ_MSVC="$(OBJ_MSVC)" CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
 
 ################################## Targets ###################################
 


### PR DESCRIPTION
Follows up to the new directory structure, related to #6562 and #6610. Note `msvc-dmc` and `msvc-lib` binaries are still generated under `vcbuild`.