### PR TITLE
Enable to build debug dmd from win64.mak

### DIFF
--- a/src/vcbuild/msvc-dmc.d
+++ b/src/vcbuild/msvc-dmc.d
@@ -35,6 +35,9 @@ int main(string[] args)
             case "-cpp": // "source files are C++"
                 newArgs ~= "/TP";
                 break;
+            case "-D": // "define macro DEBUG"
+                newArgs ~= "/DDEBUG";
+                break;
             case "-e": // "show results of preprocessor"
                 break;
             case "-g": // "generate debug info"


### PR DESCRIPTION
`-D` option of dmc must be handled well.