### PR TITLE
[WIP] Move parser imports to another file

### DIFF
--- a/src/ddmd/astcodegen.d
+++ b/src/ddmd/astcodegen.d
@@ -81,7 +81,7 @@ struct ASTCodegen
     alias PROTundefined             = ddmd.dsymbol.PROTundefined;
     alias Prot                      = ddmd.dsymbol.Prot;
 
-    alias typeDotIdExp              = ddmd.expression.typeDotIdExp;
+//    alias typeDotIdExp              = ddmd.expression.typeDotIdExp;
 
     alias deprecation               = ddmd.errors.deprecation;
     alias warning                   = ddmd.errors.warning;

--- a/src/ddmd/astcodegen.d
+++ b/src/ddmd/astcodegen.d
@@ -16,7 +16,6 @@ struct ASTCodegen
     import ddmd.dsymbol;
     import ddmd.dtemplate;
     import ddmd.dversion;
-    import ddmd.errors;
     import ddmd.expression;
     import ddmd.func;
     import ddmd.hdrgen;
@@ -80,11 +79,6 @@ struct ASTCodegen
     alias PROTexport                = ddmd.dsymbol.PROTexport;
     alias PROTundefined             = ddmd.dsymbol.PROTundefined;
     alias Prot                      = ddmd.dsymbol.Prot;
-
-//    alias typeDotIdExp              = ddmd.expression.typeDotIdExp;
-
-    alias deprecation               = ddmd.errors.deprecation;
-    alias warning                   = ddmd.errors.warning;
 
     alias stcToBuffer               = ddmd.hdrgen.stcToBuffer;
     alias linkageToChars            = ddmd.hdrgen.linkageToChars;

--- a/src/ddmd/astcodegen.d
+++ b/src/ddmd/astcodegen.d
@@ -1,0 +1,92 @@
+module ddmd.astcodegen;
+
+struct ASTCodegen
+{
+    import ddmd.aggregate;
+    import ddmd.aliasthis;
+    import ddmd.arraytypes;
+    import ddmd.attrib;
+    import ddmd.cond;
+    import ddmd.dclass;
+    import ddmd.declaration;
+    import ddmd.denum;
+    import ddmd.dimport;
+    import ddmd.dmodule;
+    import ddmd.dstruct;
+    import ddmd.dsymbol;
+    import ddmd.dtemplate;
+    import ddmd.dversion;
+    import ddmd.errors;
+    import ddmd.expression;
+    import ddmd.func;
+    import ddmd.hdrgen;
+    import ddmd.init;
+    import ddmd.mtype;
+    import ddmd.nspace;
+    import ddmd.statement;
+    import ddmd.staticassert;
+
+    alias UserAttributeDeclaration  = ddmd.attrib.UserAttributeDeclaration;
+
+    alias MODconst                  = ddmd.mtype.MODconst;
+    alias MODimmutable              = ddmd.mtype.MODimmutable;
+    alias MODshared                 = ddmd.mtype.MODshared;
+    alias MODwild                   = ddmd.mtype.MODwild;
+    alias Type                      = ddmd.mtype.Type;
+    alias Tident                    = ddmd.mtype.Tident;
+    alias Tfunction                 = ddmd.mtype.Tfunction;
+    alias Parameter                 = ddmd.mtype.Parameter;
+    alias Taarray                   = ddmd.mtype.Taarray;
+    alias Tsarray                   = ddmd.mtype.Tsarray;
+
+    alias STCconst                  = ddmd.declaration.STCconst;
+    alias STCimmutable              = ddmd.declaration.STCimmutable;
+    alias STCshared                 = ddmd.declaration.STCshared;
+    alias STCwild                   = ddmd.declaration.STCwild;
+    alias STCin                     = ddmd.declaration.STCin;
+    alias STCout                    = ddmd.declaration.STCout;
+    alias STCref                    = ddmd.declaration.STCref;
+    alias STClazy                   = ddmd.declaration.STClazy;
+    alias STCscope                  = ddmd.declaration.STCscope;
+    alias STCfinal                  = ddmd.declaration.STCfinal;
+    alias STCauto                   = ddmd.declaration.STCauto;
+    alias STCreturn                 = ddmd.declaration.STCreturn;
+    alias STCmanifest               = ddmd.declaration.STCmanifest;
+    alias STCgshared                = ddmd.declaration.STCgshared;
+    alias STCtls                    = ddmd.declaration.STCtls;
+    alias STCsafe                   = ddmd.declaration.STCsafe;
+    alias STCsystem                 = ddmd.declaration.STCsystem;
+    alias STCtrusted                = ddmd.declaration.STCtrusted;
+    alias STCnothrow                = ddmd.declaration.STCnothrow;
+    alias STCpure                   = ddmd.declaration.STCpure;
+    alias STCproperty               = ddmd.declaration.STCproperty;
+    alias STCnogc                   = ddmd.declaration.STCnogc;
+    alias STCdisable                = ddmd.declaration.STCdisable;
+    alias STCundefined              = ddmd.declaration.STCundefined;
+    alias STC_TYPECTOR              = ddmd.declaration.STC_TYPECTOR;
+    alias STCoverride               = ddmd.declaration.STCoverride;
+    alias STCabstract               = ddmd.declaration.STCabstract;
+    alias STCsynchronized           = ddmd.declaration.STCsynchronized;
+    alias STCdeprecated             = ddmd.declaration.STCdeprecated;
+    alias STCstatic                 = ddmd.declaration.STCstatic;
+    alias STCextern                 = ddmd.declaration.STCextern;
+
+    alias Dsymbol                   = ddmd.dsymbol.Dsymbol;
+    alias Dsymbols                  = ddmd.dsymbol.Dsymbols;
+    alias PROTprivate               = ddmd.dsymbol.PROTprivate;
+    alias PROTpackage               = ddmd.dsymbol.PROTpackage;
+    alias PROTprotected             = ddmd.dsymbol.PROTprotected;
+    alias PROTpublic                = ddmd.dsymbol.PROTpublic;
+    alias PROTexport                = ddmd.dsymbol.PROTexport;
+    alias PROTundefined             = ddmd.dsymbol.PROTundefined;
+    alias Prot                      = ddmd.dsymbol.Prot;
+
+    alias typeDotIdExp              = ddmd.expression.typeDotIdExp;
+
+    alias deprecation               = ddmd.errors.deprecation;
+    alias warning                   = ddmd.errors.warning;
+
+    alias stcToBuffer               = ddmd.hdrgen.stcToBuffer;
+    alias linkageToChars            = ddmd.hdrgen.linkageToChars;
+    alias protectionToChars         = ddmd.hdrgen.protectionToChars;
+}

--- a/src/ddmd/astnull.d
+++ b/src/ddmd/astnull.d
@@ -1,0 +1,1790 @@
+module ddmd.astnull;
+
+struct ASTNull
+{
+    import ddmd.root.file;
+    import ddmd.root.array;
+    import ddmd.root.rootobject;
+    import ddmd.tokens;
+    import ddmd.identifier;
+    import ddmd.globals;
+
+    alias Dsymbols              = Array!(Dsymbol);
+    alias Objects               = Array!(RootObject);
+    alias Expressions           = Array!(Expression);
+    alias TemplateParameters    = Array!(TemplateParameter);
+    alias BaseClasses           = Array!(BaseClass*);
+    alias Parameters            = Array!(Parameter);
+    alias Statements            = Array!(Statement);
+    alias Catches               = Array!(Catch);
+    alias Identifiers           = Array!(Identifier);
+
+    enum PROTKIND : int
+    {
+        PROTundefined,
+        PROTnone,           // no access
+        PROTprivate,
+        PROTpackage,
+        PROTprotected,
+        PROTpublic,
+        PROTexport,
+    }
+
+    alias PROTprivate       = PROTKIND.PROTprivate;
+    alias PROTpackage       = PROTKIND.PROTpackage;
+    alias PROTprotected     = PROTKIND.PROTprotected;
+    alias PROTpublic        = PROTKIND.PROTpublic;
+    alias PROTexport        = PROTKIND.PROTexport;
+    alias PROTundefined     = PROTKIND.PROTundefined;
+
+    static int MODconst            = 0;
+    static int MODimmutable        = 0;
+    static int MODshared           = 0;
+    static int MODwild             = 0;
+
+    static int STCconst                  = 0;
+    static int STCimmutable              = 0;
+    static int STCshared                 = 0;
+    static int STCwild                   = 0;
+    static int STCin                     = 0;
+    static int STCout                    = 0;
+    static int STCref                    = 0;
+    static int STClazy                   = 0;
+    static int STCscope                  = 0;
+    static int STCfinal                  = 0;
+    static int STCauto                   = 0;
+    static int STCreturn                 = 0;
+    static int STCmanifest               = 0;
+    static int STCgshared                = 0;
+    static int STCtls                    = 0;
+    static int STCsafe                   = 0;
+    static int STCsystem                 = 0;
+    static int STCtrusted                = 0;
+    static int STCnothrow                = 0;
+    static int STCpure                   = 0;
+    static int STCproperty               = 0;
+    static int STCnogc                   = 0;
+    static int STCdisable                = 0;
+    static int STCundefined              = 0;
+    static int STC_TYPECTOR              = 0;
+    static int STCoverride               = 0;
+    static int STCabstract               = 0;
+    static int STCsynchronized           = 0;
+    static int STCdeprecated             = 0;
+    static int STCstatic                 = 0;
+    static int STCextern                 = 0;
+
+    static int Tident                    = 0;
+    static int Tfunction                 = 0;
+    static int Taarray                   = 0;
+    static int Tsarray                   = 0;
+
+    extern (C++) class Dsymbol
+    {
+        Loc loc;
+        Identifier ident;
+        UnitTestDeclaration ddocUnittest;
+        UserAttributeDeclaration userAttribDecl;
+
+        final extern (D) this() {}
+
+        void addComment(const(char)* comment) {}
+        AttribDeclaration isAttribDeclaration()
+        {
+            return null;
+        }
+    }
+
+    extern (C++) class AliasThis : Dsymbol
+    {
+        final extern (D) this(A, B)(A a, B b) {}
+    }
+
+    extern (C++) class Declaration : Dsymbol
+    {
+        StorageClass storage_class;
+
+        final extern (D) this(A)(A a) {}
+    }
+
+    extern (C++) class ScopeDsymbol : Dsymbol
+    {
+        Dsymbols* members;
+        final extern (D) this() {}
+    }
+
+    extern (C++) class Import : Dsymbol
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e) {}
+        void addAlias(A, B)(A a, B b) {}
+    }
+
+    extern (C++) abstract class AttribDeclaration : Dsymbol
+    {
+        final extern (D) this(A)(A a) {}
+    }
+
+    extern (C++) final class StaticAssert : Dsymbol
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c) {}
+    }
+
+    extern (C++) final class DebugSymbol : Dsymbol
+    {
+        final extern (D) this(A, B)(A a, B b) {}
+    }
+
+    extern (C++) final class VersionSymbol : Dsymbol
+    {
+        final extern (D) this(A, B)(A a, B b) {}
+    }
+
+    extern (C++) class VarDeclaration : Declaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d, StorageClass st = STCundefined)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) class FuncDeclaration : Declaration
+    {
+        Statement fbody;
+        Statement frequire;
+        Statement fensure;
+        Loc endloc;
+        Identifier outId;
+
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0);
+        }
+
+        FuncLiteralDeclaration* isFuncLiteralDeclaration()
+        {
+            return null;
+        }
+    }
+
+    extern (C++) final class AliasDeclaration : Declaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class PostBlitDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CtorDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class DtorDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class InvariantDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class UnitTestDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class NewDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class DeleteDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class StaticCtorDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class StaticDtorDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class SharedStaticCtorDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class SharedStaticDtorDeclaration : FuncDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) class Package : ScopeDsymbol
+    {
+        final extern (D) this() {}
+    }
+
+    extern (C++) class EnumDeclaration : ScopeDsymbol
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c) {}
+    }
+
+    extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
+    {
+        final extern (D) this(A, B)(A a, B b) {}
+    }
+
+    extern (C++) class TemplateDeclaration : ScopeDsymbol
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e, bool f=false, bool g=false) {}
+    }
+
+    extern (C++) class TemplateInstance : ScopeDsymbol
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c) {}
+    }
+
+    extern (C++) class Nspace : ScopeDsymbol
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c) {}
+    }
+
+    extern (C++) class CompileDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class UserAttributeDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+        static Expressions* concat(Expressions* a, Expressions* b)
+        {
+            return null;
+        }
+    }
+
+    extern (C++) final class LinkDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class AnonDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class AlignDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class CPPMangleDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ProtDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class PragmaDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) class StorageClassDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) class ConditionalDeclaration : AttribDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class DeprecatedDeclaration : StorageClassDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class StaticIfDeclaration : ConditionalDeclaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0);
+        }
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class EnumMember : VarDeclaration
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) class Module : Package
+    {
+        File* srcfile;
+        const(char)* srcfilePath;
+
+        final extern (D) this() {}
+        const(char)* toChars() const
+        {
+            return "";
+        }
+    }
+
+    extern (C++) class StructDeclaration : AggregateDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class UnionDeclaration : StructDeclaration
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class ClassDeclaration : AggregateDeclaration
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0);
+        }
+
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class InterfaceDeclaration : ClassDeclaration
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class TemplateMixin : TemplateInstance
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class Parameter : RootObject
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d) {}
+
+        static size_t dim(Parameters* parameters)
+        {
+            return 0;
+        }
+    }
+
+    extern (C++) abstract class Statement : RootObject
+    {
+        final extern (D) this(A)(A a) {}
+    }
+
+    extern (C++) final class ImportStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ScopeStatement : Statement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ReturnStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class LabelStatement : Statement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class StaticAssertStatement : Statement
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class CompileStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class WhileStatement : Statement
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ForStatement : Statement
+    {
+        final extern (D) this(A, B, C, D, E, F)(A a, B b, C c, D d, E e, F f)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class DoStatement : Statement
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ForeachRangeStatement : Statement
+    {
+        final extern (D) this(A, B, C, D, E, F, G)(A a, B b, C c, D d, E e, F f, G g)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ForeachStatement : Statement
+    {
+        final extern (D) this(A, B, C, D, E, F)(A a, B b, C c, D d, E e, F f)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class IfStatement : Statement
+    {
+        final extern (D) this(A, B, C, D, E, F)(A a, B b, C c, D d, E e, F f)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class OnScopeStatement : Statement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ConditionalStatement : Statement
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class PragmaStatement : Statement
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class SwitchStatement : Statement
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class CaseRangeStatement : Statement
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class CaseStatement : Statement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class DefaultStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class BreakStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ContinueStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class GotoDefaultStatement : Statement
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class GotoCaseStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class GotoStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class SynchronizedStatement : Statement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class WithStatement : Statement
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class TryCatchStatement : Statement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class TryFinallyStatement : Statement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class ThrowStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class AsmStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) class ExpStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) class CompoundStatement : Statement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class CompoundDeclarationStatement : CompoundStatement
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class CompoundAsmStatement : CompoundStatement
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class Catch : RootObject
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d) {}
+    }
+    extern (C++) abstract class Type : RootObject
+    {
+        ubyte ty;
+
+        extern (C++) static __gshared Type tvoid;
+        extern (C++) static __gshared Type tint8;
+        extern (C++) static __gshared Type tuns8;
+        extern (C++) static __gshared Type tint16;
+        extern (C++) static __gshared Type tuns16;
+        extern (C++) static __gshared Type tint32;
+        extern (C++) static __gshared Type tuns32;
+        extern (C++) static __gshared Type tint64;
+        extern (C++) static __gshared Type tuns64;
+        extern (C++) static __gshared Type tint128;
+        extern (C++) static __gshared Type tuns128;
+        extern (C++) static __gshared Type tfloat32;
+        extern (C++) static __gshared Type tfloat64;
+        extern (C++) static __gshared Type tfloat80;
+        extern (C++) static __gshared Type timaginary32;
+        extern (C++) static __gshared Type timaginary64;
+        extern (C++) static __gshared Type timaginary80;
+        extern (C++) static __gshared Type tcomplex32;
+        extern (C++) static __gshared Type tcomplex64;
+        extern (C++) static __gshared Type tcomplex80;
+        extern (C++) static __gshared Type tbool;
+        extern (C++) static __gshared Type tchar;
+        extern (C++) static __gshared Type twchar;
+        extern (C++) static __gshared Type tdchar;
+
+        extern (C++) static __gshared Type terror;
+
+        final extern (D) this(A)(A a) {}
+
+        final Type addSTC(B)(B b)
+        {
+            return null;
+        }
+        Expression toExpression()
+        {
+            return null;
+        }
+        Type syntaxCopy()
+        {
+            return null;
+        }
+        final Type addMod(T)(T...)
+        {
+            return null;
+        }
+    }
+
+    extern (C++) class TypeVector : Type
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) abstract class TypeNext : Type
+    {
+        Type next;
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class TypeSlice : TypeNext
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TypeDelegate : TypeNext
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class TypePointer : TypeNext
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0 ,0);
+        }
+    }
+
+    extern (C++) class TypeFunction : TypeNext
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TypeArray : TypeNext
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TypeDArray : TypeArray
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TypeAArray : TypeArray
+    {
+        Type index;
+
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TypeSArray : TypeArray
+    {
+        Expression dim;
+
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) abstract class TypeQualified : Type
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+
+        final void addIdent(Identifier id) {}
+        final void addInst(TemplateInstance ti) {}
+        final void addIndex(RootObject e) {}
+    }
+
+    extern (C++) class TypeIdentifier : TypeQualified
+    {
+        Identifier ident;
+
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TypeReturn : TypeQualified
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class TypeTypeof : TypeQualified
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TypeInstance : TypeQualified
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) abstract class Expression : RootObject
+    {
+        TOK op;
+        Loc loc;
+        ubyte parens;
+
+        final extern (D) this(A, B, C)(A a, B b, C c) {}
+
+        Expression syntaxCopy()
+        {
+            return null;
+        }
+    }
+
+    extern (C++) final class IntegerExp : Expression
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class NewAnonClassExp : Expression
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class IsExp : Expression
+    {
+        final extern (D) this(A, B, C, D, E, F, G)(A a, B b, C c, D d, E e, F f, G g)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class RealExp : Expression
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class NullExp : Expression
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class TypeidExp : Expression
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class TraitsExp : Expression
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class StringExp : Expression
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class NewExp : Expression
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AssocArrayLiteralExp : Expression
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ArrayLiteralExp : Expression
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class FuncExp : Expression
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class IntervalExp : Expression
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class TypeExp : Expression
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class ScopeExp : Expression
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class IdentifierExp : Expression
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class UnaExp : Expression
+    {
+        Expression e1;
+
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class DefaultInitExp : Expression
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) abstract class BinExp : Expression
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+
+    extern (C++) final class DollarExp : IdentifierExp
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class ThisExp : IdentifierExp
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class SuperExp : IdentifierExp
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class AddrExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class PreExp : UnaExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class PtrExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class NegExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class UAddExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class NotExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ComExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class DeleteExp : UnaExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CastExp : UnaExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CallExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class DotIdExp : UnaExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AssertExp : UnaExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CompileExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ImportExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class DotTemplateInstanceExp : UnaExp
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ArrayExp : UnaExp
+    {
+        final extern (D) this(A, B)(A a, B b, Expression index = null)
+        {
+            super(0, 0, 0, 0);
+        }
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class FuncInitExp : DefaultInitExp
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class PrettyFuncInitExp : DefaultInitExp
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class FileInitExp : DefaultInitExp
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class LineInitExp : DefaultInitExp
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ModuleInitExp : DefaultInitExp
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CommaExp : BinExp
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class PostExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class PowExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class MulExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class DivExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ModExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AddExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class MinExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CatExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ShlExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ShrExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class UshrExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class EqualExp : BinExp
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class InExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class IdentityExp : BinExp
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CmpExp : BinExp
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AndExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class XorExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class OrExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AndAndExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class OrOrExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CondExp : BinExp
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AddAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class MinAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class MulAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class DivAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ModAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class PowAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class AndAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class OrAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class XorAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ShlAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class ShrAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class UshrAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) final class CatAssignExp : BinExp
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) class TemplateParameter
+    {
+        final extern (D) this(A, B)(A a, B b) {}
+        void foo() {}
+    }
+
+    extern (C++) final class TemplateAliasParameter : TemplateParameter
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) class TemplateTypeParameter : TemplateParameter
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class TemplateTupleParameter : TemplateParameter
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class TemplateValueParameter : TemplateParameter
+    {
+        final extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e)
+        {
+            super(0, 0);
+        }
+    }
+
+    extern (C++) final class TemplateThisParameter : TemplateTypeParameter
+    {
+        final extern (D) this(A, B, C, D)(A a, B b, C c, D d)
+        {
+            super(0, 0, 0, 0);
+        }
+    }
+
+    extern (C++) abstract class Condition : RootObject
+    {
+        final extern (D) this(A)(A a) {}
+    }
+
+    extern (C++) final class StaticIfCondition : Condition
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) class DVCondition : Condition
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class DebugCondition : DVCondition
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) final class VersionCondition : DVCondition
+    {
+        final extern (D) this(A, B, C)(A a, B b, C c)
+        {
+            super(0, 0, 0);
+        }
+    }
+
+    extern (C++) class Initializer : RootObject
+    {
+        final extern (D) this(A)(A a) {}
+
+        Expression toExpression(Type t = null);
+    }
+
+    extern (C++) final class ExpInitializer : Initializer
+    {
+        final extern (D) this(A, B)(A a, B b)
+        {
+            super(0);
+        }
+    }
+
+    extern (C++) final class StructInitializer : Initializer
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0);
+        }
+
+        void addInit(Identifier id, Initializer init) {}
+    }
+
+    extern (C++) final class ArrayInitializer : Initializer
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0);
+        }
+
+        void addInit(Expression e, Initializer i) {}
+    }
+
+    extern (C++) final class VoidInitializer : Initializer
+    {
+        final extern (D) this(A)(A a)
+        {
+            super(0);
+        }
+    }
+
+    struct BaseClass
+    {
+        Type t;
+    }
+
+    struct ModuleDeclaration
+    {
+        Identifier id;
+        Identifiers *packages;
+
+        extern (D) this(A, B, C, D, E)(A a, B b, C c, D d, E e) {}
+
+        extern (C++) const(char)* toChars()
+        {
+            return "";
+        }
+    }
+
+    struct Prot
+    {
+        PROTKIND kind;
+    }
+
+    extern (C++) static const(char)* protectionToChars(PROTKIND kind)
+    {
+        return null;
+    }
+
+    extern (C++) static bool stcToBuffer(A, B)(A a, B b)
+    {
+        return false;
+    }
+
+    extern (C++) static bool linkageToChars(A)(A a)
+    {
+        return false;
+    }
+
+    extern (C++) static void deprecation(const ref Loc loc, const(char)* format, ...) {}
+    extern (C++) static void warning(const ref Loc loc, const(char)* format, ...) {}
+}

--- a/src/ddmd/astnull.d
+++ b/src/ddmd/astnull.d
@@ -5,6 +5,7 @@ struct ASTNull
     import ddmd.root.file;
     import ddmd.root.array;
     import ddmd.root.rootobject;
+
     import ddmd.tokens;
     import ddmd.identifier;
     import ddmd.globals;
@@ -22,7 +23,7 @@ struct ASTNull
     enum PROTKIND : int
     {
         PROTundefined,
-        PROTnone,           // no access
+        PROTnone,
         PROTprivate,
         PROTpackage,
         PROTprotected,
@@ -1708,7 +1709,10 @@ struct ASTNull
     {
         final extern (D) this(A)(A a) {}
 
-        Expression toExpression(Type t = null);
+        Expression toExpression(Type t = null)
+        {
+            return null;
+        }
     }
 
     extern (C++) final class ExpInitializer : Initializer
@@ -1785,6 +1789,4 @@ struct ASTNull
         return false;
     }
 
-    extern (C++) static void deprecation(const ref Loc loc, const(char)* format, ...) {}
-    extern (C++) static void warning(const ref Loc loc, const(char)* format, ...) {}
 }

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -14,6 +14,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 import ddmd.aggregate;
 import ddmd.arraytypes;
+import ddmd.astcodegen;
 import ddmd.cond;
 import ddmd.declaration;
 import ddmd.dinterpret;
@@ -1392,7 +1393,7 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
         se = se.toUTF8(sc);
 
         uint errors = global.errors;
-        scope Parser p = new Parser(loc, sc._module, se.toStringz(), false);
+        scope p = new Parser!ASTCodegen(loc, sc._module, se.toStringz(), false);
         p.nextToken();
 
         decl = p.parseDeclDefs(0);

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -15,6 +15,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 import ddmd.aggregate;
 import ddmd.arraytypes;
+import ddmd.astcodegen;
 import ddmd.gluelayer;
 import ddmd.dimport;
 import ddmd.dmacro;
@@ -800,7 +801,7 @@ extern (C++) final class Module : Package
             return this;
         }
         {
-            scope Parser p = new Parser(this, buf[0 .. buflen], docfile !is null);
+            scope p = new Parser!ASTCodegen(this, buf[0 .. buflen], docfile !is null);
             p.nextToken();
             members = p.parseModule();
             md = p.md;
@@ -867,29 +868,29 @@ extern (C++) final class Module : Package
             }
             if (arreq)
             {
-                scope Parser p = new Parser(loc, this, code_ArrayEq, false);
+                scope p = new Parser!ASTCodegen(loc, this, code_ArrayEq, false);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             {
-                scope Parser p = new Parser(loc, this, code_ArrayPostblit, false);
+                scope p = new Parser!ASTCodegen(loc, this, code_ArrayPostblit, false);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             {
-                scope Parser p = new Parser(loc, this, code_ArrayDtor, false);
+                scope p = new Parser!ASTCodegen(loc, this, code_ArrayDtor, false);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             if (xopeq)
             {
-                scope Parser p = new Parser(loc, this, code_xopEquals, false);
+                scope p = new Parser!ASTCodegen(loc, this, code_xopEquals, false);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }
             if (xopcmp)
             {
-                scope Parser p = new Parser(loc, this, code_xopCmp, false);
+                scope p = new Parser!ASTCodegen(loc, this, code_xopCmp, false);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -22,6 +22,7 @@ import ddmd.argtypes;
 import ddmd.arrayop;
 import ddmd.arraytypes;
 import ddmd.attrib;
+import ddmd.astcodegen;
 import ddmd.gluelayer;
 import ddmd.canthrow;
 import ddmd.complex;
@@ -8316,7 +8317,7 @@ extern (C++) final class CompileExp : UnaExp
         se = se.toUTF8(sc);
 
         uint errors = global.errors;
-        scope Parser p = new Parser(loc, sc._module, se.toStringz(), false);
+        scope p = new Parser!ASTCodegen(loc, sc._module, se.toStringz(), false);
         p.nextToken();
         //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -22,6 +22,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 import ddmd.arraytypes;
+import ddmd.astcodegen;
 import ddmd.gluelayer;
 import ddmd.builtin;
 import ddmd.cond;
@@ -226,7 +227,7 @@ extern (C++) void genCmain(Scope* sc)
     };
     Identifier id = Id.entrypoint;
     auto m = new Module("__entrypoint.d", id, 0, 0);
-    scope Parser p = new Parser(m, cmaincode, false);
+    scope p = new Parser!ASTCodegen(m, cmaincode, false);
     p.scanloc = Loc();
     p.nextToken();
     m.members = p.parseModule();

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -7320,7 +7320,7 @@ final class Parser(AST) : Lexer
                 error("found '%s' when expecting identifier following '%s.'", token.toChars(), t.toChars());
                 goto Lerr;
             }
-            e = AST.typeDotIdExp(loc, t, token.ident);
+            e = new AST.DotIdExp(loc, new AST.TypeExp(loc, t), token.ident);
             nextToken();
             break;
 
@@ -7697,7 +7697,7 @@ final class Parser(AST) : Lexer
                         error("identifier expected following (type).");
                         return null;
                     }
-                    e = AST.typeDotIdExp(loc, t, token.ident);
+                    e = new AST.DotIdExp(loc, new AST.TypeExp(loc, t), token.ident);
                     nextToken();
                     e = parsePostExp(e);
                 }

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -16,6 +16,7 @@ import ddmd.globals;
 import ddmd.id;
 import ddmd.identifier;
 import ddmd.lexer;
+import ddmd.errors;
 import ddmd.root.filename;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
@@ -4762,7 +4763,7 @@ final class Parser(AST) : Lexer
     {
         if (token.value != TOKelse && token.value != TOKcatch && token.value != TOKfinally && lookingForElse.linnum != 0)
         {
-            AST.warning(elseloc, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
+            warning(elseloc, "else is dangling, add { } after condition at %s", lookingForElse.toChars());
         }
     }
 
@@ -4776,7 +4777,7 @@ final class Parser(AST) : Lexer
         if (alt & 1) // contains C-style function pointer syntax
             error(loc, "instead of C-style syntax, use D-style '%s%s%s'", t.toChars(), sp, s);
         else
-            AST.deprecation(loc, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
+           ddmd.errors.deprecation(loc, "instead of C-style syntax, use D-style syntax '%s%s%s'", t.toChars(), sp, s);
     }
 
     /*****************************************
@@ -5098,7 +5099,7 @@ final class Parser(AST) : Lexer
             if (!(flags & PSsemi_ok))
             {
                 if (flags & PSsemi)
-                    AST.warning(loc, "use '{ }' for an empty statement, not a ';'");
+                    warning(loc, "use '{ }' for an empty statement, not a ';'");
                 else
                     error("use '{ }' for an empty statement, not a ';'");
             }
@@ -8420,6 +8421,12 @@ final class Parser(AST) : Lexer
         s.addComment(combineComments(blockComment, token.lineComment, true));
         token.lineComment = null;
     }
+}
+
+unittest
+{
+    import ddmd.astnull;
+    scope p = new Parser!ASTNull(null, null, false);
 }
 
 enum PREC : int

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -16,6 +16,7 @@ import core.stdc.stdio;
 import ddmd.aggregate;
 import ddmd.arraytypes;
 import ddmd.attrib;
+import ddmd.astcodegen;
 import ddmd.gluelayer;
 import ddmd.canthrow;
 import ddmd.cond;
@@ -752,7 +753,7 @@ extern (C++) final class CompileStatement : Statement
         se = se.toUTF8(sc);
 
         uint errors = global.errors;
-        scope Parser p = new Parser(loc, sc._module, se.toStringz(), false);
+        scope p = new Parser!ASTCodegen(loc, sc._module, se.toStringz(), false);
         p.nextToken();
 
         auto a = new Statements();

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -223,14 +223,14 @@ endif
 
 
 FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes arrayop	\
-	arraytypes astcodegen attrib builtin canthrow clone complex cond constfold		\
+	arraytypes astcodegen astnull attrib builtin canthrow clone complex cond constfold		\
 	cppmangle ctfeexpr dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol	\
 	dtemplate dversion escape expression func			\
 	hdrgen impcnvtab imphint init inline intrange	\
 	json lib link mars mtype nogc nspace opover optimize parse sapply	\
 	sideeffect statement staticassert target traits visitor	\
-	typinf utils  statement_rewrite_walker statementsem safe blockexit asttypename))
+	typinf utils statement_rewrite_walker statementsem safe blockexit asttypename))
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, entity errors globals id identifier lexer tokens utf))
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -223,7 +223,7 @@ endif
 
 
 FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes arrayop	\
-	arraytypes attrib builtin canthrow clone complex cond constfold		\
+	arraytypes astcodegen attrib builtin canthrow clone complex cond constfold		\
 	cppmangle ctfeexpr dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol	\
 	dtemplate dversion escape expression func			\

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -154,7 +154,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 
 # D front end
 FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
-	$D/arraytypes.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/clone.d $D/complex.d		\
+	$D/arraytypes.d $D/astcodegen.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/clone.d $D/complex.d		\
 	$D/cond.d $D/constfold.d $D/cppmangle.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d		\

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -154,7 +154,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 
 # D front end
 FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
-	$D/arraytypes.d $D/astcodegen.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/clone.d $D/complex.d		\
+	$D/arraytypes.d $D/astcodegen.d $D/astnull.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/clone.d $D/complex.d		\
 	$D/cond.d $D/constfold.d $D/cppmangle.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d		\


### PR DESCRIPTION
The parse.d file creates AST nodes which are passed to the semantic analysis. In the current form, the parser imports 95% of the total compiler code, including semantic analysis code which it doesn't use. In order to break the import cycle and to take a step further into transforming the compiler into a library, it is necessary to offer the possibility of separation between parsing and semantic analysis. This PR is a first step in that direction, by moving the creation of AST nodes (more explicitly the "new" expressions) to a different file and transforming the Parser class into a templated class which receives its AST nodes types through a template. This way anyone can define their own AST nodes and instantiate the parser with them.

This is a work in progress. I only moved the creation of Union and Struct declaration nodes to a file called codegenASTFamily which contains a struct that implements the creation methods.

When this PR will be finished, the CodegenASTFamily struct will contain the creation expressions for all AST nodes and parse.d will have a lot less imports.