### PR TITLE
[do not merge] ELF: generate information for mutable pointers in DATA and TLS

### DIFF
--- a/src/dmd/backend/elfobj.c
+++ b/src/dmd/backend/elfobj.c
@@ -141,6 +141,7 @@ STATIC void obj_tlssections();
 static void obj_rtinit();
 #endif
 static void addSectionToComdat(IDXSEC secidx, segidx_t comdatseg);
+STATIC void objflush_pointerRefs();
 
 static IDXSYM elf_addsym(IDXSTR sym, targ_size_t val, unsigned sz,
                          unsigned typ,unsigned bind,IDXSEC sec,
@@ -1155,6 +1156,7 @@ void Obj::term(const char *objfilename)
     if (!errcnt)
 #endif
     {
+        objflush_pointerRefs();
         outfixlist();           // backpatches
     }
 
@@ -3259,6 +3261,8 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
                 outrel:
                     //printf("\t\t************* adding relocation\n");
                     const size_t nbytes = ElfObj::writerel(seg, offset, relinfo, refseg, val);
+                    //if(nbytes != retsize)
+                    //    printf("nbytes=%d retsize=%d, reltype=%d, s=%s\n", nbytes, retsize, relinfo, s->Sident);
                     assert(nbytes == retsize);
                 }
             }
@@ -3733,8 +3737,80 @@ symbol *Obj::tlv_bootstrap()
     return NULL;
 }
 
-void Obj::write_pointerRef(Symbol* s, unsigned off)
+static Outbuffer *ptrref_buf;           // buffer for pointer references
+
+/*****************************************
+ * write a reference to a mutable pointer into the object file
+ * Params:
+ *      s    = symbol that contains the pointer
+ *      soff = offset of the pointer inside the Symbol's memory
+ */
+void Obj::write_pointerRef(Symbol* s, unsigned soff)
 {
+    if (!ptrref_buf)
+        ptrref_buf = new Outbuffer;
+
+    // defer writing pointer references until the symbols are written out
+    ptrref_buf->write(&s, sizeof(s));
+    ptrref_buf->write32(soff);
+}
+
+/*****************************************
+ * flush a single pointer reference saved by write_pointerRef
+ * to the object file
+ * Params:
+ *      ptrseg = segment that stores the pointer reference
+ *      s      = symbol that contains the pointer
+ *      soff   = offset of the pointer inside the Symbol's memory
+ */
+static void objflush_pointerRef(int ptrseg, Symbol* s, unsigned soff)
+{
+    targ_size_t& offset = SegData[ptrseg]->SDoffset;
+    unsigned relinfo = (I64 ? R_X86_64_PC32 : R_386_PC32);
+    offset += ElfObj::writerel(ptrseg, offset, relinfo, MAP_SEG2SYMIDX(s->Sseg), s->Soffset + soff);
+}
+
+/*****************************************
+ * flush all pointer references to segment dat_ptr or tls_ptr
+ * Params:
+ *      tls = select which references to flush
+ */
+STATIC void objflush_pointerRefs(bool tls)
+{
+    unsigned char *p = ptrref_buf->buf;
+    unsigned char *end = ptrref_buf->p;
+    int seg = -1;
+    while (p < end)
+    {
+        Symbol* s = *(Symbol**)p;
+        p += sizeof(s);
+        unsigned soff = *(unsigned*)p;
+        p += sizeof(soff);
+        if ((s->Sfl == FLtlsdata) == tls)
+        {
+            if (seg == -1)
+            {
+                const char* segname = tls ? "tls_ptr" : "dat_ptr";
+                seg = ElfObj::getsegment(segname, NULL, SHT_PROGBITS, SHF_ALLOC | SHF_WRITE, 4);
+            }
+            objflush_pointerRef(seg, s, soff);
+        }
+    }
+}
+
+/*****************************************
+ * flush all pointer references saved by write_pointerRef
+ * to the object file
+ */
+STATIC void objflush_pointerRefs()
+{
+    if (!ptrref_buf)
+        return;
+
+    objflush_pointerRefs(false);
+    objflush_pointerRefs(true);
+
+    ptrref_buf->reset();
 }
 
 /******************************************

--- a/test/runnable/imports/testptrref_tmpl.d
+++ b/test/runnable/imports/testptrref_tmpl.d
@@ -1,0 +1,8 @@
+module imports.testptrref_tmpl;
+
+struct TStruct(T)
+{
+    static T tlsInstance;
+    __gshared T gsharedInstance;
+}
+

--- a/test/runnable/imports/testptrref_usetmpl.d
+++ b/test/runnable/imports/testptrref_usetmpl.d
@@ -1,0 +1,8 @@
+module imports.testptrref_usetmpl;
+import imports.testptrref_tmpl;
+
+void* intPtrInstance()
+{
+    return &TStruct!(int*).gsharedInstance;
+}
+

--- a/test/runnable/testptrref.d
+++ b/test/runnable/testptrref.d
@@ -1,3 +1,13 @@
+// EXTRA_SOURCES: imports/testptrref_tmpl.d imports/testptrref_usetmpl.d
+// COMPILE_SEPARATELY
+
+module testptrref;
+import imports.testptrref_tmpl : TStruct;
+import imports.testptrref_usetmpl;
+
+version (CRuntime_Glibc) version = UseELF;
+else version (FreeBSD) version = UseELF;
+else version (NetBSD) version = UseELF;
 
 version(CRuntime_Microsoft)
 {
@@ -25,7 +35,7 @@ version(CRuntime_Microsoft)
                                               void[] function(string name) nothrow @nogc);
         dataSection = findImageSection(".data");
     }
-    
+
     version = ptrref_supported;
 }
 else version(Win32)
@@ -39,6 +49,67 @@ else version(Win32)
         extern int _tlsstart;
         extern int _tlsend;
     }
+    version = ptrref_supported;
+}
+else version(UseELF)
+{
+    version(linux)
+    {
+        import core.sys.linux.elf;
+        import core.sys.linux.link;
+    }
+    else version (FreeBSD)
+    {
+        import core.sys.freebsd.sys.elf;
+        import core.sys.freebsd.sys.link_elf;
+    }
+    else version (NetBSD)
+    {
+        import core.sys.netbsd.sys.elf;
+        import core.sys.netbsd.sys.link_elf;
+    }
+    else
+    {
+        static assert(0, "unimplemented");
+    }
+
+    extern extern(C) __gshared int __start_dat_ptr;
+    extern extern(C) __gshared int __stop_dat_ptr;
+    extern extern(C) __gshared int __start_tls_ptr;
+    extern extern(C) __gshared int __stop_tls_ptr;
+
+    alias _DPbegin = __start_dat_ptr;
+    alias _DPend = __stop_dat_ptr;
+    alias _TPbegin = __start_tls_ptr;
+    alias _TPend = __stop_tls_ptr;
+
+    extern extern(C) int _tlsstart;
+    extern extern(C) int _tlsend;
+
+    __gshared void[] imgTlsRange;
+    __gshared size_t dlpi_tls_modid;
+
+    import core.internal.traits : externDFunc;
+    alias getTLSRange = externDFunc!("rt.sections_elf_shared.getTLSRange",
+                                     void[] function(size_t mod, size_t sz) nothrow @nogc);
+
+    shared static this()
+    {
+        alias fnFindDSOInfoForAddr = bool function(in void* addr, dl_phdr_info* result=null) nothrow @nogc;
+        alias findDSOInfoForAddr = externDFunc!("rt.sections_elf_shared.findDSOInfoForAddr",
+                                                fnFindDSOInfoForAddr);
+
+        size_t tlsSize;
+        dl_phdr_info info = void;
+        findDSOInfoForAddr(&imgTlsRange, &info) || assert(0);
+        debug(PRINT) printf("dlpi_tls_modid=%p\n", info.dlpi_tls_modid);
+        dlpi_tls_modid = info.dlpi_tls_modid;
+
+        foreach (ref phdr; info.dlpi_phdr[0 .. info.dlpi_phnum])
+            if (phdr.p_type == PT_TLS)
+                imgTlsRange = (cast(void*)(info.dlpi_addr + phdr.p_vaddr))[0..phdr.p_memsz];
+    }
+
     version = ptrref_supported;
 }
 
@@ -91,13 +162,23 @@ void main()
 version(ptrref_supported):
 
 bool findTlsPtr(const(void)* ptr)
-{    
+{
+    version(UseELF) auto tlsRange = getTLSRange(dlpi_tls_modid, imgTlsRange.length);
+
     debug(PRINT) printf("findTlsPtr %p\n", ptr);
-    for (uint* p = &_TPbegin; p < &_TPend; p++)
+    for (auto p = &_TPbegin; p < &_TPend; p++)
     {
-        void* addr = cast(void*) &_tlsstart + *p;
-        debug(PRINT) printf("  try %p\n", addr);
-        assert(addr < &_tlsend);
+        version(UseELF)
+            void* addr = cast(void*) p + *p + (tlsRange.ptr - imgTlsRange.ptr);
+        else
+            void* addr = cast(void*) &_tlsstart + *p;
+        debug(PRINTTRY) printf("  try %p -> %p\n", cast(void*) cast(size_t) *p, addr);
+
+        // for ELF, _tlsstart doesn't point at the actual start of TLS, and there's
+        //  even a variable before it (strArr in this file)
+        version(UseELF) assert(tlsRange.ptr <= addr && addr < tlsRange.ptr + tlsRange.length);
+        else            assert(&_tlsstart <= addr && addr < &_tlsend);
+
         if (addr == ptr)
             return true;
     }
@@ -109,12 +190,14 @@ bool findDataPtr(const(void)* ptr)
     debug(PRINT) printf("findDataPtr %p\n", ptr);
     for (auto p = &_DPbegin; p < &_DPend; p++)
     {
-        debug(PRINT) printf("  try %p\n", cast(void*) cast(size_t) *p);
-        version(CRuntime_Microsoft)
+        version(UseELF)
+            void* addr = cast(void*)p + *p;
+        else version(CRuntime_Microsoft)
             void* addr = dataSection.ptr + *p;
         else
             void* addr = *p;
-        
+
+        debug(PRINTTRY) printf("  try %p -> %p\n", cast(void*) cast(size_t) *p, addr);
         if (addr == ptr)
             return true;
     }
@@ -125,25 +208,36 @@ void testRefPtr()
 {
     debug(PRINT) printf("&_DPbegin %p\n", &_DPbegin);
     debug(PRINT) printf("&_DPend   %p\n", &_DPend);
+    debug(PRINT) printf("&_tlsstart %p\n", &_tlsstart);
+    debug(PRINT) printf("&_tlsend   %p\n", &_tlsend);
+    version(UseELF)
+        debug(PRINT) printf("_tlsRange  [%p,%p]\n", imgTlsRange.ptr, imgTlsRange.ptr + imgTlsRange.length);
 
     assert(!findDataPtr(cast(void*)&sharedInt));
-    assert(!findTlsPtr(&tlsInt));
 
     assert(findDataPtr(cast(void*)&sharedVar));
     assert(findDataPtr(&gsharedVar));
     assert(findDataPtr(&gsharedStrct.next));
     assert(findDataPtr(&(gsharedClss)));
     assert(findDataPtr(&(gsharedClss.ptr)));
+    assert(findDataPtr(&(TStruct!Class.gsharedInstance)));
+    assert(findDataPtr(&(TStruct!(int*).gsharedInstance)));
+    assert(!findDataPtr(&(TStruct!long.gsharedInstance)));
+    assert(&(TStruct!(int*).gsharedInstance) is intPtrInstance());
 
+    assert(!findTlsPtr(&tlsInt));
     assert(findTlsPtr(&tlsVar));
     assert(findTlsPtr(&tlsClss));
     assert(findTlsPtr(&tlsStrcArr[0].next));
     assert(findTlsPtr(&tlsStrcArr[1].next));
     assert(findTlsPtr(&tlsStrcArr[2].next));
+    assert(findTlsPtr(&(TStruct!Class.tlsInstance)));
+    assert(findTlsPtr(&(TStruct!(int*).tlsInstance)));
+    assert(!findTlsPtr(&(TStruct!long.tlsInstance)));
 
     assert(!findTlsPtr(cast(size_t*)&tlsStr)); // length
     assert(findTlsPtr(cast(size_t*)&tlsStr + 1)); // ptr
-    
+
     // monitor is manually managed
     assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
     assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
@@ -152,7 +246,8 @@ void testRefPtr()
     assert(!findTlsPtr(&arr));
     assert(!findDataPtr(cast(size_t*)&arr + 1));
     assert(!findTlsPtr(cast(size_t*)&arr + 1));
-    
+
+    assert(findTlsPtr(cast(size_t*)&strArr + 1));
     assert(findDataPtr(cast(size_t*)&strArr[0] + 1)); // ptr in _DATA!
     assert(findDataPtr(cast(size_t*)&strArr[1] + 1)); // ptr in _DATA!
     strArr[1] = "c";


### PR DESCRIPTION
This extends https://github.com/dlang/dmd/pull/6534 to ELF object files. It generates PC relative offsets into segments dat_ptr and tls_ptr.

The additional test cases also triggered failures for the Windows implementation, hopefully resolving why https://github.com/dlang/druntime/pull/1763 failed the auto-tester.