### PR TITLE
Elf targets: put switch tables in code segment

### DIFF
--- a/src/ddmd/backend/backconfig.c
+++ b/src/ddmd/backend/backconfig.c
@@ -112,6 +112,7 @@ void out_config_init(
         config.flags3 |= CFG3pic;
         config.flags |= CFGalwaysframe; // PIC needs a frame for TLS fixups
     }
+    config.flags |= CFGromable; // put switch tables in code segment
     config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_OSX
@@ -156,6 +157,7 @@ void out_config_init(
         config.flags3 |= CFG3pic;
         config.flags |= CFGalwaysframe; // PIC needs a frame for TLS fixups
     }
+    config.flags |= CFGromable; // put switch tables in code segment
     config.objfmt = OBJ_ELF;
 #endif
 #if TARGET_OPENBSD
@@ -174,6 +176,7 @@ void out_config_init(
     config.flags |= CFGalwaysframe;
     if (!exe)
         config.flags3 |= CFG3pic;
+    config.flags |= CFGromable; // put switch tables in code segment
     config.objfmt = OBJ_ELF;
     config.ehmethod = EH_DM;
 #endif
@@ -193,6 +196,7 @@ void out_config_init(
     config.flags |= CFGalwaysframe;
     if (!exe)
         config.flags3 |= CFG3pic;
+    config.flags |= CFGromable; // put switch tables in code segment
     config.objfmt = OBJ_ELF;
     config.ehmethod = EH_DM;
 #endif


### PR DESCRIPTION
This is so that the tables become part of the COMDAT section they refer to, and don't need to be put in the COMDAT group.