### PR TITLE
[D1] Backport of -profile=gc

### DIFF
--- a/src/e2ir.c
+++ b/src/e2ir.c
@@ -62,6 +62,8 @@ elem *ElemsToStaticArray(Loc loc, Type *telem, Elems *elems, symbol **psym);
 
 Symbol *toStringSymbol(const char *str, size_t len, size_t sz);
 Symbol *toStringDarraySymbol(const char *str, size_t len, size_t sz);
+elem *filelinefunction(IRState *irs, Expression *e);
+void toTraceGC(IRState *irs, elem *e, Loc *loc);
 
 #define el_setLoc(e,loc)        ((e)->Esrcpos.Sfilename = (char *)(loc).filename, \
                                  (e)->Esrcpos.Slinnum = (loc).linnum)
@@ -1286,6 +1288,7 @@ elem *NewExp::toElem(IRState *irs)
         {
             csym = cd->toSymbol();
             ex = el_bin(OPcall,TYnptr,el_var(getRtlsym(RTLSYM_NEWCLASS)),el_ptr(csym));
+            toTraceGC(irs, ex, &this->loc);
             ectype = NULL;
 
             if (cd->isNested())
@@ -1463,6 +1466,7 @@ elem *NewExp::toElem(IRState *irs)
 
             int rtl = t->isZeroInit() ? RTLSYM_NEWARRAYT : RTLSYM_NEWARRAYIT;
             e = el_bin(OPcall,TYdarray,el_var(getRtlsym(rtl)),e);
+            toTraceGC(irs, ex, &this->loc);
 
             // The new functions return an array, so convert to a pointer
             // ex -> (unsigned)(e >> 32)
@@ -1520,6 +1524,7 @@ elem *NewExp::toElem(IRState *irs)
             e = el_param(e, type->getTypeInfo(NULL)->toElem(irs));
             int rtl = tda->next->isZeroInit() ? RTLSYM_NEWARRAYT : RTLSYM_NEWARRAYIT;
             e = el_bin(OPcall,TYdarray,el_var(getRtlsym(rtl)),e);
+            toTraceGC(irs, e, &this->loc);
         }
         else
         {   // Multidimensional array allocations
@@ -1542,6 +1547,7 @@ elem *NewExp::toElem(IRState *irs)
             e = el_param(e, type->getTypeInfo(NULL)->toElem(irs));
             int rtl = t->isZeroInit() ? RTLSYM_NEWARRAYMTX : RTLSYM_NEWARRAYMITX;
             e = el_bin(OPcall,TYdarray,el_var(getRtlsym(rtl)),e);
+            toTraceGC(irs, e, &this->loc);
             e = el_combine(earray, e);
         }
     }
@@ -1558,6 +1564,7 @@ elem *NewExp::toElem(IRState *irs)
 
         int rtl = tp->next->isZeroInit() ? RTLSYM_NEWARRAYT : RTLSYM_NEWARRAYIT;
         e = el_bin(OPcall,TYdarray,el_var(getRtlsym(rtl)),e);
+        toTraceGC(irs, e, &this->loc);
 
         // The new functions return an array, so convert to a pointer
         // e -> (unsigned)(e >> 32)
@@ -1941,6 +1948,7 @@ elem *CatExp::toElem(IRState *irs)
         elem *ep = el_pair(TYdarray, el_long(TYsize_t, elems.dim), el_ptr(sdata));
         ep = el_param(ep, ta->getTypeInfo(NULL)->toElem(irs));
         e = el_bin(OPcall, TYdarray, el_var(rtlsym[RTLSYM_ARRAYCATNTX]), ep);
+        toTraceGC(irs, e, &this->loc);
         e = el_combine(earr, e);
     }
     else
@@ -1953,6 +1961,7 @@ elem *CatExp::toElem(IRState *irs)
         e2 = eval_Darray(irs, this->e2);
         ep = el_params(e2, e1, ta->getTypeInfo(NULL)->toElem(irs), NULL);
         e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYCATT)), ep);
+        toTraceGC(irs, e, &this->loc);
     }
     el_setLoc(e,loc);
     return e;
@@ -2404,6 +2413,7 @@ elem *AssignExp::toElem(IRState *irs)
 
         e = el_bin(OPcall, type->totym(), el_var(getRtlsym(r)), ep);
         el_setLoc(e, loc);
+        toTraceGC(irs, e, &this->loc);
         return e;
     }
 
@@ -2804,6 +2814,7 @@ elem *CatAssignExp::toElem(IRState *irs)
                 ? RTLSYM_ARRAYAPPENDCD
                 : RTLSYM_ARRAYAPPENDWD;
         e = el_bin(OPcall, TYdarray, el_var(getRtlsym(rtl)), ep);
+        toTraceGC(irs, e, &this->loc);
         el_setLoc(e,loc);
     }
     else if (tb1->ty == Tarray || tb2->ty == Tsarray)
@@ -2825,6 +2836,7 @@ elem *CatAssignExp::toElem(IRState *irs)
             }
             elem *ep = el_params(e2, e1, this->e1->type->getTypeInfo(NULL)->toElem(irs), NULL);
             e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYAPPENDT)), ep);
+            toTraceGC(irs, e, &this->loc);
         }
         else if (I64)
         {   // Append element
@@ -2858,6 +2870,7 @@ elem *CatAssignExp::toElem(IRState *irs)
             elem *ep = el_param(e1, this->e1->type->getTypeInfo(NULL)->toElem(irs));
             ep = el_param(el_long(TYsize_t, 1), ep);
             e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYAPPENDCTX)), ep);
+            toTraceGC(irs, e, &this->loc);
             symbol *stmp = symbol_genauto(tb1->toCtype());
             e = el_bin(OPeq, TYdarray, el_var(stmp), e);
 
@@ -4413,6 +4426,7 @@ elem *ArrayLiteralExp::toElem(IRState *irs)
             e = el_param(e, type->getTypeInfo(NULL)->toElem(irs));
             // call _d_arrayliteralTX(ti, dim)
             e = el_bin(OPcall,TYnptr,el_var(getRtlsym(RTLSYM_ARRAYLITERALTX)),e);
+            toTraceGC(irs, e, &this->loc);
             Symbol *stmp = symbol_genauto(Type::tvoid->pointerTo()->toCtype());
             e = el_bin(OPeq,TYnptr,el_var(stmp),e);
 
@@ -4578,6 +4592,7 @@ elem *AssocArrayLiteralExp::toElem(IRState *irs)
 
         // call _d_assocarrayliteralTX(ti, keys, values)
         e = el_bin(OPcall,TYnptr,el_var(getRtlsym(RTLSYM_ASSOCARRAYLITERALTX)),e);
+        toTraceGC(irs, e, &this->loc);
         el_setLoc(e,loc);
 
         e = el_combine(evalues, e);
@@ -4912,4 +4927,100 @@ Symbol *toStringDarraySymbol(const char *str, size_t len, size_t sz)
     out_readonly(sida);
     outdata(sida);
     return sida;
+}
+
+/******************************************************
+ * Return an elem that is the file, line, and function suitable
+ * for insertion into the parameter list.
+ */
+
+elem *filelinefunction(IRState *irs, Loc *loc)
+{
+    const char *id = loc->filename;
+    size_t len = strlen(id);
+    Symbol *si = toStringSymbol(id, len, 1);
+    elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
+    if (config.exe == EX_WIN64)
+        efilename = addressElem(efilename, Type::tstring, true);
+
+    elem *elinnum = el_long(TYint, loc->linnum);
+
+    const char *s = "";
+    FuncDeclaration *fd = irs->getFunc();
+    if (fd)
+    {
+        s = fd->toPrettyChars();
+    }
+
+    len = strlen(s);
+    si = toStringSymbol(s, len, 1);
+    elem *efunction = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
+    if (config.exe == EX_WIN64)
+        efunction = addressElem(efunction, Type::tstring, true);
+
+    return el_params(efunction, elinnum, efilename, NULL);
+}
+
+
+/******************************************************
+ * Replace call to GC allocator with call to tracing GC allocator.
+ * Params:
+ *      irs = to get function from
+ *      e = elem to modify
+ *      eloc = to get file/line from
+ */
+
+void toTraceGC(IRState *irs, elem *e, Loc *loc)
+{
+    static const int map[][2] =
+    {
+        { RTLSYM_NEWCLASS, RTLSYM_TRACENEWCLASS },
+        { RTLSYM_NEWITEMT, RTLSYM_TRACENEWITEMT },
+        { RTLSYM_NEWITEMIT, RTLSYM_TRACENEWITEMIT },
+        { RTLSYM_NEWARRAYT, RTLSYM_TRACENEWARRAYT },
+        { RTLSYM_NEWARRAYIT, RTLSYM_TRACENEWARRAYIT },
+        { RTLSYM_NEWARRAYMTX, RTLSYM_TRACENEWARRAYMTX },
+        { RTLSYM_NEWARRAYMITX, RTLSYM_TRACENEWARRAYMITX },
+
+        { RTLSYM_DELCLASS, RTLSYM_TRACEDELCLASS },
+        { RTLSYM_CALLFINALIZER, RTLSYM_TRACECALLFINALIZER },
+        { RTLSYM_CALLINTERFACEFINALIZER, RTLSYM_TRACECALLINTERFACEFINALIZER },
+        { RTLSYM_DELINTERFACE, RTLSYM_TRACEDELINTERFACE },
+        { RTLSYM_DELARRAYT, RTLSYM_TRACEDELARRAYT },
+        { RTLSYM_DELMEMORY, RTLSYM_TRACEDELMEMORY },
+        { RTLSYM_DELSTRUCT, RTLSYM_TRACEDELSTRUCT },
+
+        { RTLSYM_ARRAYLITERALTX, RTLSYM_TRACEARRAYLITERALTX },
+        { RTLSYM_ASSOCARRAYLITERALTX, RTLSYM_TRACEASSOCARRAYLITERALTX },
+
+        { RTLSYM_ARRAYCATT, RTLSYM_TRACEARRAYCATT },
+        { RTLSYM_ARRAYCATNTX, RTLSYM_TRACEARRAYCATNTX },
+
+        { RTLSYM_ARRAYAPPENDCD, RTLSYM_TRACEARRAYAPPENDCD },
+        { RTLSYM_ARRAYAPPENDWD, RTLSYM_TRACEARRAYAPPENDWD },
+        { RTLSYM_ARRAYAPPENDT, RTLSYM_TRACEARRAYAPPENDT },
+        { RTLSYM_ARRAYAPPENDCTX, RTLSYM_TRACEARRAYAPPENDCTX },
+
+        { RTLSYM_ARRAYSETLENGTHT, RTLSYM_TRACEARRAYSETLENGTHT },
+        { RTLSYM_ARRAYSETLENGTHIT, RTLSYM_TRACEARRAYSETLENGTHIT },
+
+        { RTLSYM_ALLOCMEMORY, RTLSYM_TRACEALLOCMEMORY },
+    };
+
+    if (global.params.tracegc && loc->filename)
+    {
+        assert(e->Eoper == OPcall);
+        elem *e1 = e->E1;
+        assert(e1->Eoper == OPvar);
+        for (size_t i = 0; 1; ++i)
+        {
+            assert(i < sizeof(map)/sizeof(map[0]));
+            if (e1->EV.sp.Vsym == rtlsym[map[i][0]])
+            {
+                e1->EV.sp.Vsym = rtlsym[map[i][1]];
+                break;
+            }
+        }
+        e->E2 = el_param(e->E2, filelinefunction(irs, loc));
+    }
 }

--- a/src/mars.c
+++ b/src/mars.c
@@ -681,8 +681,23 @@ int main(int iargc, const char *argv[])
                 global.params.is64bit = 0;
             else if (strcmp(p + 1, "m64") == 0)
                 global.params.is64bit = 1;
-            else if (strcmp(p + 1, "profile") == 0)
-                global.params.trace = 1;
+            else if (memcmp(p + 1, "profile", 7) == 0)
+            {
+                // Parse:
+                //      -profile
+                //      -profile=gc
+                if (p[8] == '=')
+                {
+                    if (strcmp(p + 9, "gc") == 0)
+                        global.params.tracegc = true;
+                    else
+                        goto Lerror;
+                }
+                else if (p[8])
+                    goto Lerror;
+                else
+                    global.params.trace = true;
+            }
             else if (strcmp(p + 1, "v") == 0)
                 global.params.verbose = 1;
 #if DMDV2

--- a/src/mars.h
+++ b/src/mars.h
@@ -158,6 +158,7 @@ struct Param
     char multiobj;      // break one object file into multiple ones
     char oneobj;        // write one object file instead of multiple ones
     bool trace;         // insert profiling hooks
+    bool tracegc;       // instrument calls to 'new'
     char quiet;         // suppress non-error messages
     char verbose;       // verbose compile
     char vtls;          // identify thread local variables

--- a/src/toir.c
+++ b/src/toir.c
@@ -47,6 +47,8 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
+void toTraceGC(IRState *irs, elem *e, Loc *loc);
+
 /*********************************************
  * Produce elem which increments the usage count for a particular line.
  * Used to implement -cov switch (coverage analysis).
@@ -648,6 +650,7 @@ void FuncDeclaration::buildClosure(IRState *irs)
         elem *e;
         e = el_long(TYsize_t, offset);
         e = el_bin(OPcall, TYnptr, el_var(getRtlsym(RTLSYM_ALLOCMEMORY)), e);
+        toTraceGC(irs, e, &fd->loc);
 
         // Assign block of memory to sclosure
         //    sclosure = allocmemory(sz);


### PR DESCRIPTION
Please don't merge.

Background: there are some application that suffer from minor performance/memory degradation after switching to D2, which too subtle to track manually so far but is a deal breaker for live depolyment. Intent is to backport GC profiling feature so that we can compare logs between D1 and D2 versions under large throughput and check differences.

(matching tangort PR https://github.com/sociomantic-tsunami/tangort/pull/7)