### PR TITLE
refactor: move towards using semanticRun

### DIFF
--- a/src/ddmd/aggregate.d
+++ b/src/ddmd/aggregate.d
@@ -213,6 +213,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         }
         if (sd)
             sd.semanticTypeInfoMembers();
+        semanticRun = PASSsemantic3done;
     }
 
     /***************************************

--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -613,7 +613,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                 baseClass = tc.sym;
                 b.sym = baseClass;
 
-                if (tc.sym._scope && tc.sym.baseok < BASEOKdone)
+                if (tc.sym.baseok < BASEOKdone)
                     resolveBase(tc.sym.semantic(null)); // Try to resolve forward reference
                 if (tc.sym.baseok < BASEOKdone)
                 {
@@ -663,7 +663,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
                 b.sym = tc.sym;
 
-                if (tc.sym._scope && tc.sym.baseok < BASEOKdone)
+                if (tc.sym.baseok < BASEOKdone)
                     resolveBase(tc.sym.semantic(null)); // Try to resolve forward reference
                 if (tc.sym.baseok < BASEOKdone)
                 {
@@ -1043,10 +1043,10 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         {
             /* cd.baseClass might not be set if cd is forward referenced.
              */
-            if (!cd.baseClass && cd._scope && !cd.isInterfaceDeclaration())
+            if (!cd.baseClass && cd.semanticRun < PASSsemanticdone && !cd.isInterfaceDeclaration())
             {
                 cd.semantic(null);
-                if (!cd.baseClass && cd._scope)
+                if (!cd.baseClass && cd.semanticRun < PASSsemanticdone)
                     cd.error("base class is forward referenced by %s", toChars());
             }
 
@@ -1706,7 +1706,7 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
 
                 b.sym = tc.sym;
 
-                if (tc.sym._scope && tc.sym.baseok < BASEOKdone)
+                if (tc.sym.baseok < BASEOKdone)
                     resolveBase(tc.sym.semantic(null)); // Try to resolve forward reference
                 if (tc.sym.baseok < BASEOKdone)
                 {

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -7558,8 +7558,8 @@ extern (C++) final class IsExp : Expression
                     ClassDeclaration cd = (cast(TypeClass)targ).sym;
                     auto args = new Parameters();
                     args.reserve(cd.baseclasses.dim);
-                    if (cd._scope && !cd.symtab)
-                        cd.semantic(cd._scope);
+                    if (cd.semanticRun < PASSsemanticdone)
+                        cd.semantic(null);
                     for (size_t i = 0; i < cd.baseclasses.dim; i++)
                     {
                         BaseClass* b = (*cd.baseclasses)[i];

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -738,7 +738,7 @@ extern (C++) abstract class Type : RootObject
 
                 // If t1n is forward referenced:
                 ClassDeclaration cd = (cast(TypeClass)t1n).sym;
-                if (cd._scope)
+                if (cd.semanticRun < PASSsemanticdone)
                     cd.semantic(null);
                 if (!cd.isBaseInfoComplete())
                 {
@@ -5452,7 +5452,7 @@ extern (C++) final class TypeAArray : TypeArray
             /* AA's need typeid(index).equals() and getHash(). Issue error if not correctly set up.
              */
             StructDeclaration sd = (cast(TypeStruct)tbase).sym;
-            if (sd._scope)
+            if (sd.semanticRun < PASSsemanticdone)
                 sd.semantic(null);
 
             // duplicate a part of StructDeclaration::semanticTypeInfoMembers
@@ -5514,7 +5514,7 @@ extern (C++) final class TypeAArray : TypeArray
         else if (tbase.ty == Tclass && !(cast(TypeClass)tbase).sym.isInterfaceDeclaration())
         {
             ClassDeclaration cd = (cast(TypeClass)tbase).sym;
-            if (cd._scope)
+            if (cd.semanticRun < PASSsemanticdone)
                 cd.semantic(null);
 
             if (!ClassDeclaration.object)
@@ -9621,9 +9621,9 @@ extern (C++) final class TypeClass : Type
         if (cdto)
         {
             //printf("TypeClass::implicitConvTo(to = '%s') %s, isbase = %d %d\n", to.toChars(), toChars(), cdto.isBaseInfoComplete(), sym.isBaseInfoComplete());
-            if (cdto._scope && !cdto.isBaseInfoComplete())
+            if (cdto.semanticRun < PASSsemanticdone && !cdto.isBaseInfoComplete())
                 cdto.semantic(null);
-            if (sym._scope && !sym.isBaseInfoComplete())
+            if (sym.semanticRun < PASSsemanticdone && !sym.isBaseInfoComplete())
                 sym.semantic(null);
             if (cdto.isBaseOf(sym, null) && MODimplicitConv(mod, to.mod))
             {

--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -329,7 +329,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             if (global.params.symdebug)
                 toDebug(cd);
 
-            assert(!cd._scope);     // semantic() should have been run to completion
+            assert(cd.semanticRun >= PASSsemantic3done);     // semantic() should have been run to completion
 
             enum_SC scclass = SCcomdat;
 

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -990,8 +990,8 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto cd = sds.isClassDeclaration();
         if (cd && e.ident == Id.allMembers)
         {
-            if (cd._scope)
-                cd.semantic(null); // Bugzilla 13668: Try to resolve forward reference
+            if (cd.semanticRun < PASSsemanticdone)
+                cd.semantic(null); // https://issues.dlang.org/show_bug.cgi?id=13668: Try to resolve forward reference
 
             void pushBaseMembersDg(ClassDeclaration cd)
             {


### PR DESCRIPTION
The code uses a confusing mixture of `semanticRun` and `_scope` to determine the state of semantic analysis, mostly because of its history. Start moving towards consolidating it all in `semanticRun`.