### PR TITLE
call semantic() after copyToTemp()

### DIFF
--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -1277,6 +1277,7 @@ extern (C++) class VarDeclaration : Declaration
                     else if (isAliasThisTuple(e))
                     {
                         auto v = copyToTemp(0, "__tup", e);
+                        v.semantic(sc);
                         auto ve = new VarExp(loc, v);
                         ve.type = e.type;
 

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -1933,6 +1933,7 @@ extern (C++) final class OnScopeStatement : Statement
                  *  sfinally: if (!x) statement;
                  */
                 auto v = copyToTemp(0, "__os", new IntegerExp(Loc(), 0, Type.tbool));
+                v.semantic(sc);
                 *sentry = new ExpStatement(loc, v);
 
                 Expression e = new IntegerExp(Loc(), 1, Type.tbool);

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -1046,6 +1046,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 else
                 {
                     r = copyToTemp(0, "__r", fs.aggr);
+                    r.semantic(sc);
                     _init = new ExpStatement(loc, r);
                     if (vinit)
                         _init = new CompoundStatement(loc, new ExpStatement(loc, vinit), _init);
@@ -1078,6 +1079,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 else
                 {
                     auto vd = copyToTemp(STCref, "__front", einit);
+                    vd.semantic(sc);
                     makeargs = new ExpStatement(loc, vd);
 
                     Type tfront;
@@ -2955,6 +2957,7 @@ else
                  *  try { body } finally { _d_monitorexit(tmp); }
                  */
                 auto tmp = copyToTemp(0, "__sync", ss.exp);
+                tmp.semantic(sc);
 
                 auto cs = new Statements();
                 cs.push(new ExpStatement(ss.loc, tmp));
@@ -3095,6 +3098,7 @@ else
                      * }
                      */
                     auto tmp = copyToTemp(0, "__withtmp", ws.exp);
+                    tmp.semantic(sc);
                     auto es = new ExpStatement(ws.loc, tmp);
                     ws.exp = new VarExp(ws.loc, tmp);
                     Statement ss = new ScopeStatement(ws.loc, new CompoundStatement(ws.loc, es, ws), ws.endloc);

--- a/test/fail_compilation/ice15441.d
+++ b/test/fail_compilation/ice15441.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice15441.d(22): Error: s1.front is void and has no value
-fail_compilation/ice15441.d(25): Error: cannot infer argument types, expected 1 argument, not 2
+fail_compilation/ice15441.d(24): Error: variable ice15441.main.__front62 type void is inferred from initializer __r61.front(), and variables cannot be of type void
+fail_compilation/ice15441.d(24): Error: expression __r61.front() is void and has no value
+fail_compilation/ice15441.d(24): Error: s1.front is void and has no value
+fail_compilation/ice15441.d(27): Error: cannot infer argument types, expected 1 argument, not 2
 ---
 */
 


### PR DESCRIPTION
Not doing this was an oversight, even though it appears to work.