### PR TITLE
fix -c -inline ddmd/mars.d

### DIFF
--- a/src/ddmd/gluelayer.d
+++ b/src/ddmd/gluelayer.d
@@ -47,10 +47,7 @@ version (NoBackend)
         RET retStyle(TypeFunction tf)               { return RETregs; }
         void toObjFile(Dsymbol ds, bool multiobj)   {}
 
-        version (OSX)
-        {
-            void objc_initSymbols() {}
-        }
+        void objc_initSymbols() {}
     }
 }
 else
@@ -75,9 +72,6 @@ else
         RET retStyle(TypeFunction tf);
         void toObjFile(Dsymbol ds, bool multiobj);
 
-        version (OSX)
-        {
-            void objc_initSymbols();
-        }
+        void objc_initSymbols();
     }
 }

--- a/src/ddmd/objc_glue_stubs.d
+++ b/src/ddmd/objc_glue_stubs.d
@@ -19,6 +19,11 @@ import ddmd.backend.el;
 
 extern (C++):
 
+void objc_initSymbols()
+{
+    // noop
+}
+
 void objc_callfunc_setupEp(elem *esel, elem **ep, int reverse)
 {
     // noop


### PR DESCRIPTION
- fails when compiling because ddmd/mars.d imports ddmd.objc and the
  modulename != filename hack doesn't work for single file
  compilation, so ddmd/objc.d (instead of ddmd/objc_stub.d) gets
  imported and fails on a OSX-only symbol
- fixed by always defining objc_initSymbols and adding it to the stubs