### PR TITLE
WIP: Fix CPP mangling #1

### DIFF
--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -48,6 +48,11 @@ extern (C++) abstract class Condition : RootObject
         this.loc = loc;
     }
 
+    override const(char)* toCharsFull()
+    {
+        return loc.toChars();
+    }
+
     abstract Condition syntaxCopy();
 
     abstract int include(Scope* sc, ScopeDsymbol sds);
@@ -77,6 +82,11 @@ extern (C++) class DVCondition : Condition
         this.mod = mod;
         this.level = level;
         this.ident = ident;
+    }
+
+    override const(char)* toCharsFull()
+    {
+        return ident.toChars();
     }
 
     override final Condition syntaxCopy()
@@ -200,6 +210,11 @@ extern (C++) final class DebugCondition : DVCondition
     override const(char)* toChars()
     {
         return ident ? ident.toChars() : "debug".ptr;
+    }
+
+    override const(char)* toCharsFull()
+    {
+        return toChars();
     }
 }
 
@@ -478,6 +493,11 @@ extern (C++) final class VersionCondition : DVCondition
     {
         return ident ? ident.toChars() : "version".ptr;
     }
+
+    override const(char)* toCharsFull()
+    {
+        return toChars();
+    }
 }
 
 /***********************************************************
@@ -576,6 +596,11 @@ extern (C++) final class StaticIfCondition : Condition
     override const(char)* toChars()
     {
         return exp ? exp.toChars() : "static if".ptr;
+    }
+
+    override const(char)* toCharsFull()
+    {
+        return toChars();
     }
 }
 

--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -314,6 +314,7 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                 if (exist(p.isTemplateInstance().tempdecl))
                     dont_write_prefix = true;
                 p = p.toParent();
+                store(s);
             }
             if (p && !p.isModule())
             {

--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -28,6 +28,7 @@ import ddmd.target;
 import ddmd.tokens;
 import ddmd.visitor;
 
+
 /* Do mangling for C++ linkage.
  * No attempt is made to support mangling of templates, operator
  * overloading, or special functions.
@@ -118,6 +119,8 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
             {
                 if (!skipname && !substitute(ti.tempdecl))
                 {
+                    if (!exist(ti.tempdecl.toAlias().ident))
+                        store(ti.tempdecl.toAlias().ident);
                     const(char)* name = ti.tempdecl.toAlias().ident.toChars();
                     buf.printf("%d%s", strlen(name), name);
                 }
@@ -280,8 +283,6 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                     else
                         prefix_name(p);
                 }
-                if (!(s.ident == Id.std && is_initial_qualifier(s)))
-                    store(s);
                 source_name(s);
             }
         }
@@ -314,7 +315,6 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                 if (exist(p.isTemplateInstance().tempdecl))
                     dont_write_prefix = true;
                 p = p.toParent();
-                store(s);
             }
             if (p && !p.isModule())
             {
@@ -499,6 +499,7 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                 assert(tf.ty == Tfunction);
                 argsCppMangle(tf.parameters, tf.varargs);
             }
+
         }
 
         void argsCppMangle(Parameters* parameters, int varargs)

--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -283,6 +283,8 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                     else
                         prefix_name(p);
                 }
+                if (!(s.ident == Id.std && is_initial_qualifier(s)) && !s.isTemplateInstance())
+                    store(s);
                 source_name(s);
             }
         }

--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -68,16 +68,16 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
 
         bool substitute(RootObject p)
         {
-            //printf("substitute %s\n", p ? p.toChars() : null);
+            printf("substitute %s\n", p ? p.toChars() : null);
             if (components_on)
                 for (size_t i = 0; i < components.dim; i++)
                 {
-                    //printf("    component[%d] = %s %s\n", i, components[i] ? components[i].toChars() : null, components[i] ? components[i].toCharsFull() : null);
+                    printf("    component[%d] = %s %s\n", i, components[i] ? components[i].toChars() : null, components[i] ? components[i].toCharsFull() : null);
                     import core.stdc.string : strcmp;
                     //if (p && components[i] && (p == components[i] || (strcmp(p.toChars(), components[i].toChars()) == 0 && strcmp(p.toCharsFull(), components[i].toCharsFull()) == 0)))
                     if (p && components[i] && (strcmp(p.toChars(), components[i].toChars()) == 0 && strcmp(p.toCharsFull(), components[i].toCharsFull()) == 0))
                     {
-                        //printf("\tmatch\n");
+                        printf("\tmatch\n");
                         /* Sequence is S_, S0_, .., S9_, SA_, ..., SZ_, S10_, ...
                          */
                         buf.writeByte('S');
@@ -109,18 +109,18 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
 
         void store(RootObject p)
         {
-            //printf("store %s\n", p ? p.toChars() : "null");
+            printf("store %s\n", p ? p.toChars() : "null");
             if (components_on)
             {
                 components.push(p);
-                //for (size_t i = 0; i < components.dim; i++)
-                //    printf("    component[%d] = %s\n", i, components[i].toCharsFull());
+                for (size_t i = 0; i < components.dim; i++)
+                    printf("    component[%d] = %s\n", i, components[i].toCharsFull());
             }
         }
 
         void source_name(Dsymbol s, bool skipname = false, bool skipname2 = false)
         {
-            //printf("source_name(%s)\n", s.toChars());
+            printf("source_name(%s)\n", s.toChars());
             TemplateInstance ti = s.isTemplateInstance();
             if (ti)
             {
@@ -196,11 +196,11 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                         Type t = isType(o);
                         assert(t);
                         t.accept(this);
-                        if (s && s.isTemplateInstance()) {
-                            if (!(s.ident == Id.std && is_initial_qualifier(s)) && !exist(s)) {
-                                store(s);
-                            }
-                        }
+                        //if (s && s.isTemplateInstance()) {
+                        //    if (!(s.ident == Id.std && is_initial_qualifier(s)) && !exist(s)) {
+                        //        store(s);
+                        //    }
+                        //}
                     }
                     else if (tp.isTemplateAliasParameter())
                     {
@@ -253,6 +253,8 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                     buf.writeByte('E');
                 }
                 buf.writeByte('E');
+                if(!exist(ti))
+                    store(ti);
                 return;
             }
             else
@@ -269,7 +271,7 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
 
         void prefix_name(Dsymbol s)
         {
-            //printf("prefix_name(%s)\n", s.toChars());
+            printf("prefix_name(%s)\n", s.toChars());
             if (!substitute(s))
             {
                 Dsymbol p = s.toParent();
@@ -294,7 +296,9 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
                         prefix_name(p);
                 }
                 if (!(s.ident == Id.std && is_initial_qualifier(s)) && !s.isTemplateInstance())
+                //if (!(s.ident == Id.std && is_initial_qualifier(s)))
                     store(s);
+                //source_name(s, false, true);
                 source_name(s, false, true);
             }
         }
@@ -307,6 +311,7 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
             if (p && p.isTemplateInstance())
             {
                 if (exist(p.isTemplateInstance().tempdecl))
+                //if (exist(p.isTemplateInstance()))
                 {
                     return true;
                 }
@@ -317,7 +322,7 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
 
         void cpp_mangle_name(Dsymbol s, bool qualified)
         {
-            //printf("cpp_mangle_name(%s, %d)\n", s.toChars(), qualified);
+            printf("cpp_mangle_name(%s, %d)\n", s.toChars(), qualified);
             Dsymbol p = s.toParent();
             Dsymbol se = s;
             bool dont_write_prefix = false;
@@ -325,6 +330,7 @@ static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TAR
             {
                 se = p;
                 if (exist(p.isTemplateInstance().tempdecl))
+                //if (exist(p.isTemplateInstance()))
                     dont_write_prefix = true;
                 p = p.toParent();
             }

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -231,6 +231,20 @@ extern (C++) class Dsymbol : RootObject
         return ident ? ident.toChars() : "__anonymous";
     }
 
+    override const(char)* toCharsFull()
+    {
+        import std.conv : to;
+        import std.string : toStringz;
+        if (parent)
+        {
+            //string r = format("%s.%s", to!string(parent.toCharsFull()), to!string(toChars));
+            string r = to!string(parent.toCharsFull()) ~ '.' ~ to!string(toChars);
+            return toStringz(r);
+        }
+        return toChars();
+    }
+
+
     // helper to print fully qualified (template) arguments
     const(char)* toPrettyCharsHelper()
     {

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -478,6 +478,11 @@ extern (C++) final class Tuple : RootObject
     {
         return objects.toChars();
     }
+
+    override const(char)* toCharsFull()
+    {
+        return toChars();
+    }
 }
 
 struct TemplatePrevious
@@ -6871,6 +6876,32 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         toCBufferInstance(this, &buf, true);
         return buf.extractString();
     }
+
+    override const(char)* toCharsFull()
+    {
+        import std.conv : to;
+        import std.string : toStringz;
+
+        string s = to!string(super.toCharsFull());
+        s ~= '[';
+
+        for (size_t j = 0; j < tdtypes.dim; j++)
+        {
+            RootObject o = tdtypes[j];
+            //Type ta = isType(o);
+            //Expression ea = isExpression(o);
+            //Dsymbol sa = isDsymbol(o);
+            //Tuple va = isTuple(o);
+            //printf("\ttiargs[%d] = ta %s, ea %p, sa %s, va %p\n", j, ta, ea, sa, va);
+            if (o)
+                s ~= to!string(o.toCharsFull()) ~ ';';
+        }
+
+        s ~= ']';
+
+        return toStringz(s);
+    }
+
 
     /**************************************
      * Given an error instantiating the TemplateInstance,

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -2600,6 +2600,11 @@ extern (C++) abstract class Expression : RootObject
         return buf.extractString();
     }
 
+    override const(char)* toCharsFull()
+    {
+        return toChars();
+    }
+
     /********************
      * Print AST data structure in a nice format.
      * Params:

--- a/src/ddmd/identifier.d
+++ b/src/ddmd/identifier.d
@@ -71,6 +71,11 @@ public:
         return string;
     }
 
+    override const(char)* toCharsFull()
+    {
+        return toChars();
+    }
+
     extern (D) final const(char)[] toString() const
     {
         return string[0 .. len];

--- a/src/ddmd/init.d
+++ b/src/ddmd/init.d
@@ -88,6 +88,11 @@ extern (C++) class Initializer : RootObject
         return buf.extractString();
     }
 
+    override const(char)* toCharsFull()
+    {
+        return toChars();
+    }
+
     ErrorInitializer isErrorInitializer()
     {
         return null;

--- a/src/ddmd/root/rootobject.d
+++ b/src/ddmd/root/rootobject.d
@@ -59,6 +59,11 @@ extern (C++) class RootObject
         assert(0);
     }
 
+    const(char)* toCharsFull()
+    {
+        assert(0);
+    }
+
     void toBuffer(OutBuffer* buf)
     {
         assert(0);

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -140,6 +140,11 @@ extern (C++) abstract class Statement : RootObject
         return buf.extractString();
     }
 
+    override const(char)* toCharsFull()
+    {
+        return toChars();
+    }
+
     final void error(const(char)* format, ...)
     {
         va_list ap;
@@ -1844,6 +1849,11 @@ extern (C++) final class Catch : RootObject
         auto c = new Catch(loc, type ? type.syntaxCopy() : getThrowable(), ident, (handler ? handler.syntaxCopy() : null));
         c.internalCatch = internalCatch;
         return c;
+    }
+
+    override const(char)* toCharsFull()
+    {
+        return toChars();
     }
 }
 


### PR DESCRIPTION
While trying to interface D with C++ I noticed that most cases will not work due to bugs in the name mangling which causes linking errors. One big problem was the symbol substitution, first of all the way the dmd checked if a symbol was already present in the substitution table was broken for certain cases. The second problem was the way the table was created (order of insertion is relevant here).

For example `std::pair<void*, void*>::swap(std::pair<void*, void*>&)` was mangle as:

-  __ZNSt4pairIPvS0_E4swapERS1_ (gcc)

-  _ZNSt4pairIPvS1_E4swapERStS0_IS1_S1_E (dmd)

Now dmd mangles these cases the same way as gcc. Further tests and fixes are required because currently 

> No attempt is made to support mangling of templates, operator overloading, or special functions

Will add future patches as I stumble upon the issues and fix them.
