### PR TITLE
Fix Issue 16273 - [REG2.072a] dmd segfault with inheritance, templates...

### DIFF
--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -739,6 +739,10 @@ extern (C++) class FuncDeclaration : Declaration
 
             default:
                 {
+                    // https://issues.dlang.org/show_bug.cgi?id=16273
+                    if (!cd.vtbl.dim)
+                        return;
+
                     FuncDeclaration fdv = cd.baseClass.vtbl[vi].isFuncDeclaration();
                     FuncDeclaration fdc = cd.vtbl[vi].isFuncDeclaration();
                     // This function is covariant with fdv

--- a/test/compilable/test16273.d
+++ b/test/compilable/test16273.d
@@ -1,0 +1,26 @@
+// REQUIRED_ARGS: -o-
+
+template MixFunc2() { override void func2(); }
+
+class A()
+{
+    alias MyD = D!();
+}
+
+class B
+{
+    void func1() {}
+    void func2() {}
+    alias MyA = A!();
+}
+
+class C : B
+{
+    override void func1() {}
+    mixin MixFunc2;
+}
+
+class D() : A!()
+{
+    void test() { new C; }
+}

--- a/test/fail_compilation/fail16273.d
+++ b/test/fail_compilation/fail16273.d
@@ -1,0 +1,39 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail16273.d(37): Error: cannot create instance of abstract class C
+fail_compilation/fail16273.d(38): Error: cannot create instance of abstract class C2
+fail_compilation/fail16273.d(15): Error: template instance fail16273.D!() error instantiating
+fail_compilation/fail16273.d(22):        instantiated from here: A!()
+---
+*/
+
+template MixFunc2() { abstract override void func2(); }
+
+class A()
+{
+    alias MyD = D!();
+}
+
+class B
+{
+    void func1() {}
+    void func2() {}
+    alias MyA = A!();
+}
+
+class C : B
+{
+    abstract override void func1() {}
+}
+
+class C2 : B
+{
+    mixin MixFunc2;
+}
+
+class D() : A!()
+{
+    void test() { new C; }
+    void test2() { new C2; }
+}


### PR DESCRIPTION
It segfaults, because vtbl is empty at that stage. The two test cases (func1 and func2) are slightly different. FuncDeclaration.semantic() is called from ClassDeclaration.isAbstract() and from MixinTemplate.semantic().

The segfault with mixin was there even before this regression, this fixes both.
