### PR TITLE
Fix Issue 15896 - private ignored when import bindings are used

### DIFF
--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -13,6 +13,7 @@ module ddmd.dimport;
 import core.stdc.string;
 import core.stdc.stdio;
 
+import ddmd.access;
 import ddmd.arraytypes;
 import ddmd.declaration;
 import ddmd.dmodule;
@@ -244,7 +245,7 @@ extern (C++) final class Import : Dsymbol
         if (mod)
         {
             // Modules need a list of each imported module
-            //printf("%s imports %s\n", sc.module.toChars(), mod.toChars());
+            //printf("%s imports %s\n", sc._module.toChars(), mod.toChars());
             sc._module.aimports.push(mod);
 
             if (sc.explicitProtection)
@@ -295,10 +296,15 @@ extern (C++) final class Import : Dsymbol
             for (size_t i = 0; i < aliasdecls.dim; i++)
             {
                 AliasDeclaration ad = aliasdecls[i];
-                //printf("\tImport %s alias %s = %s, scope = %p\n", toPrettyChars(), aliases[i].toChars(), names[i].toChars(), ad._scope);
-                if (mod.search(loc, names[i]))
+                //printf("\tImport %s alias %s = %s, scope = %p\n", toPrettyChars(), aliasdecls[i].toChars(), names[i].toChars(), ad._scope);
+                Dsymbol importedSymbol = mod.search(loc, names[i]);
+                if (importedSymbol)
                 {
-                    ad.semantic(sc);
+                    // BUGZILLA 15896 : if symbol is private then it shouldn't be accessed
+                    if(importedSymbol.prot().kind == PROTprivate)
+                        mod.error(loc, "member '%s' is private", names[i].toChars());
+                    else
+                        ad.semantic(sc);
                     // If the import declaration is in non-root module,
                     // analysis of the aliased symbol is deferred.
                     // Therefore, don't see the ad.aliassym or ad.type here.
@@ -307,7 +313,9 @@ extern (C++) final class Import : Dsymbol
                 {
                     Dsymbol s = mod.search_correct(names[i]);
                     if (s)
+                    {
                         mod.error(loc, "import '%s' not found, did you mean %s '%s'?", names[i].toChars(), s.kind(), s.toChars());
+                    }
                     else
                         mod.error(loc, "import '%s' not found", names[i].toChars());
                     ad.type = Type.terror;

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -6584,7 +6584,7 @@ extern (C++) final class VarExp : SymbolExp
          * problems when instantiating imported templates passing private
          * variables as alias template parameters.
          */
-        //checkAccess(loc, sc, NULL, var);
+        //checkAccess(loc, sc, null, var);
 
         if (auto vd = var.isVarDeclaration())
         {

--- a/test/fail_compilation/fail15896.d
+++ b/test/fail_compilation/fail15896.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail15896.d(8): Error: module imports.imp15896 member 'thebar' is private
+---
+*/
+
+import imports.imp15896 : thebar;
+
+int func()
+{
+    thebar +=1;
+    return 0;
+}

--- a/test/fail_compilation/imports/imp15896.d
+++ b/test/fail_compilation/imports/imp15896.d
@@ -1,0 +1,3 @@
+module imports.imp15896;
+
+private int thebar=4;


### PR DESCRIPTION
A module member which is declared private should not be accessible from another module. While this is true for most members, it is false in the case of variables which are selectively imported. See example in the filed bug report [1]. Although the simplest fix would have been to add a call to the checkAccess function from access.d, this is not possible (see [2]).

When a selective import occurs, the compiler just checks if the selected symbol exists in the imported module; the protection attribute is verified later, when the symbol is used. I think this is a design flaw since you can import a symbol, use it 10 times and have 10 errors, basically stating the same thing. It makes a lot more sense to check if the symbol is private when the existence lookup occurs (and that is what this PR does).

[1] https://issues.dlang.org/show_bug.cgi?id=15896
[2] https://issues.dlang.org/show_bug.cgi?id=1161