### PR TITLE
Fix fail4611 test for 64-bit platforms

### DIFF
--- a/test/fail_compilation/fail4611.d
+++ b/test/fail_compilation/fail4611.d
@@ -1,6 +1,6 @@
 /*
 ---
-fail_compilation/fail4611.d(15): Error: Vec[1000000000] size 4 * 1000000000 exceeds 0x7fffffff size limit for static array
+fail_compilation/fail4611.d(15): Error: Vec[2147483647] size 4 * 2147483647 exceeds 0x7fffffff size limit for static array
 ---
 */
 
@@ -11,5 +11,5 @@ struct Vec
 
 void main()
 {
-    Vec[1000_000_000] a;
+    Vec[ptrdiff_t.max] a;
 }


### PR DESCRIPTION
Since the addition of `Target.maxStaticDataSize`.

GDC allows data sizes up to half of the address space, so on 64-bit this compiles as `4000_000_000 < 9223_372_036_854_775_807`