### PR TITLE
Fix dyncast in C++ headers.

### DIFF
--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -188,7 +188,7 @@ public:
     Ungag ungagSpeculative();
 
     // kludge for template.isSymbol()
-    int dyncast() { return DYNCAST_DSYMBOL; }
+    int dyncast() const { return DYNCAST_DSYMBOL; }
 
     static Dsymbols *arraySyntaxCopy(Dsymbols *a);
 

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -136,7 +136,7 @@ public:
     Expression *trySemantic(Scope *sc);
 
     // kludge for template.isExpression()
-    int dyncast() { return DYNCAST_EXPRESSION; }
+    int dyncast() const { return DYNCAST_EXPRESSION; }
 
     void print();
     const char *toChars();

--- a/src/ddmd/identifier.h
+++ b/src/ddmd/identifier.h
@@ -34,7 +34,7 @@ public:
     const char *toChars();
     int getValue() const;
     const char *toHChars2();
-    int dyncast();
+    int dyncast() const;
 
     static StringTable stringtable;
     static Identifier *generateId(const char *prefix);

--- a/src/ddmd/mtype.h
+++ b/src/ddmd/mtype.h
@@ -236,7 +236,7 @@ public:
     bool equals(RootObject *o);
     bool equivalent(Type *t);
     // kludge for template.isType()
-    int dyncast() { return DYNCAST_TYPE; }
+    int dyncast() const { return DYNCAST_TYPE; }
     int covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars();
     char *toPrettyChars(bool QualifyTypes = false);
@@ -896,7 +896,7 @@ public:
     Parameter *syntaxCopy();
     Type *isLazyArray();
     // kludge for template.isType()
-    int dyncast() { return DYNCAST_PARAMETER; }
+    int dyncast() const { return DYNCAST_PARAMETER; }
     virtual void accept(Visitor *v) { v->visit(this); }
 
     static Parameters *arraySyntaxCopy(Parameters *parameters);

--- a/src/ddmd/template.h
+++ b/src/ddmd/template.h
@@ -47,7 +47,7 @@ public:
     Objects objects;
 
     // kludge for template.isType()
-    int dyncast() { return DYNCAST_TUPLE; }
+    int dyncast() const { return DYNCAST_TUPLE; }
 
     const char *toChars() { return objects.toChars(); }
 };


### PR DESCRIPTION
All overrides should have been marked `const` too, otherwise they don't get put in the vtable.