### PR TITLE
set semanticRun in semantic()

### DIFF
--- a/src/ddmd/aliasthis.d
+++ b/src/ddmd/aliasthis.d
@@ -41,14 +41,25 @@ extern (C++) final class AliasThis : Dsymbol
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        /* Since there is no semantic information stored here,
-         * we don't need to copy it.
-         */
-        return this;
+        return new AliasThis(loc, ident);
     }
 
     override void semantic(Scope* sc)
     {
+        if (semanticRun != PASSinit)
+            return;
+
+        if (_scope)
+        {
+            sc = _scope;
+            _scope = null;
+        }
+
+        if (!sc)
+            return;
+
+        semanticRun = PASSsemantic;
+
         Dsymbol p = sc.parent.pastMixin();
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
@@ -94,6 +105,7 @@ extern (C++) final class AliasThis : Dsymbol
         }
 
         ad.aliasthis = s;
+        semanticRun = PASSsemanticdone;
     }
 
     override const(char)* kind() const

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -165,6 +165,9 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void semantic(Scope* sc)
     {
+        if (semanticRun != PASSinit)
+            return;
+        semanticRun = PASSsemantic;
         Dsymbols* d = include(sc, null);
         //printf("\tAttribDeclaration::semantic '%s', d = %p\n",toChars(), d);
         if (d)
@@ -178,6 +181,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
             if (sc2 != sc)
                 sc2.pop();
         }
+        semanticRun = PASSsemanticdone;
     }
 
     override void semantic2(Scope* sc)

--- a/src/ddmd/denum.d
+++ b/src/ddmd/denum.d
@@ -447,13 +447,14 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             goto Lerrors;
         }
 
-        for (size_t i = 0; i < members.dim; i++)
+        foreach (const i; 0 .. members.dim)
         {
             EnumMember em = (*members)[i].isEnumMember();
-            if (!em)
-                continue;
-            defaultval = em.value;
-            return defaultval;
+            if (em)
+            {
+                defaultval = em.value;
+                return defaultval;
+            }
         }
 
     Lerrors:
@@ -568,13 +569,15 @@ extern (C++) final class EnumMember : VarDeclaration
 
         if (_scope)
             sc = _scope;
+        if (!sc)
+            return;
+
+        semanticRun = PASSsemantic;
 
         protection = ed.isAnonymous() ? ed.protection : Prot(PROTpublic);
         linkage = LINKd;
         storage_class = STCmanifest;
         userAttribDecl = ed.isAnonymous() ? ed.userAttribDecl : null;
-
-        semanticRun = PASSsemantic;
 
         // The first enum member is special
         bool first = (this == (*ed.members)[0]);

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -232,6 +232,8 @@ extern (C++) class Package : ScopeDsymbol
 
     override void semantic(Scope* sc)
     {
+        if (semanticRun < PASSsemanticdone)
+            semanticRun = PASSsemanticdone;
     }
 
     override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -581,7 +581,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         }
         if (semanticRun != PASSinit)
             return; // semantic() already run
-        semanticRun = PASSsemantic;
 
         // Remember templates defined in module object that we need to know about
         if (sc._module && sc._module.ident == Id.object)
@@ -598,6 +597,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             this._scope = sc.copy();
             this._scope.setNoFree();
         }
+
+        semanticRun = PASSsemantic;
 
         parent = sc.parent;
         protection = sc.protection;

--- a/src/ddmd/dversion.d
+++ b/src/ddmd/dversion.d
@@ -101,6 +101,8 @@ extern (C++) final class DebugSymbol : Dsymbol
     override void semantic(Scope* sc)
     {
         //printf("DebugSymbol::semantic() %s\n", toChars());
+        if (semanticRun < PASSsemanticdone)
+            semanticRun = PASSsemanticdone;
     }
 
     override const(char)* kind() const
@@ -138,8 +140,8 @@ extern (C++) final class VersionSymbol : Dsymbol
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        auto ds = new VersionSymbol(loc, ident);
-        ds.level = level;
+        auto ds = ident ? new VersionSymbol(loc, ident)
+                        : new VersionSymbol(loc, level);
         return ds;
     }
 
@@ -195,6 +197,8 @@ extern (C++) final class VersionSymbol : Dsymbol
 
     override void semantic(Scope* sc)
     {
+        if (semanticRun < PASSsemanticdone)
+            semanticRun = PASSsemanticdone;
     }
 
     override const(char)* kind() const

--- a/src/ddmd/nspace.d
+++ b/src/ddmd/nspace.d
@@ -90,9 +90,8 @@ extern (C++) final class Nspace : ScopeDsymbol
 
     override void semantic(Scope* sc)
     {
-        if (semanticRun >= PASSsemantic)
+        if (semanticRun != PASSinit)
             return;
-        semanticRun = PASSsemantic;
         static if (LOG)
         {
             printf("+Nspace::semantic('%s')\n", toChars());
@@ -102,6 +101,10 @@ extern (C++) final class Nspace : ScopeDsymbol
             sc = _scope;
             _scope = null;
         }
+        if (!sc)
+            return;
+
+        semanticRun = PASSsemantic;
         parent = sc.parent;
         if (members)
         {
@@ -123,6 +126,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             }
             sc.pop();
         }
+        semanticRun = PASSsemanticdone;
         static if (LOG)
         {
             printf("-Nspace::semantic('%s')\n", toChars());


### PR DESCRIPTION
`semanticRun` needs to be set properly in all `semantic()` routines.