### PR TITLE
fix issue 17291: bad relocations for pointer references

### DIFF
--- a/src/ddmd/backend/cgobj.c
+++ b/src/ddmd/backend/cgobj.c
@@ -756,10 +756,11 @@ void Obj::term(const char *objfilename)
 #if SCPP
         if (!errcnt)
 #endif
-        {   obj_defaultlib();
+        {
+            obj_defaultlib();
+            objflush_pointerRefs();
             outfixlist();               // backpatches
         }
-        objflush_pointerRefs();
 
         if (config.fulltypes)
             cv_term();                  // write out final debug info

--- a/src/ddmd/backend/mscoffobj.c
+++ b/src/ddmd/backend/mscoffobj.c
@@ -683,8 +683,8 @@ void MsCoffObj::term(const char *objfilename)
     if (!errcnt)
 #endif
     {
-        outfixlist();           // backpatches
         objflush_pointerRefs();
+        outfixlist();           // backpatches
     }
 
     if (configv.addlinenumbers)

--- a/test/runnable/testptrref.d
+++ b/test/runnable/testptrref.d
@@ -53,6 +53,12 @@ class Class
     void* ptr;
 }
 
+struct Struc(T)
+{
+	static T vtls;
+	static __gshared T vgshared;
+}
+
 __gshared Struct* gsharedStrctPtr2 = new Struct(7, new Struct(8, null));
 
 int tlsInt;
@@ -154,4 +160,9 @@ void testRefPtr()
     assert(findDataPtr(&gsharedStrctPtr));
     assert(findDataPtr(&gsharedStrctPtr.next));
     assert(findDataPtr(&gsharedStrctPtr.next.next));
+
+    assert(findDataPtr(&(Struc!(int*).vgshared)));
+    assert(!findDataPtr(&(Struc!(int).vgshared)));
+    assert(findTlsPtr(&(Struc!(int*).vtls)));
+    assert(!findTlsPtr(&(Struc!(int).vtls)));
 }


### PR DESCRIPTION
introduced by https://github.com/dlang/dmd/pull/6534

fixes wrong order in object file termination.