### PR TITLE
use GROUP for Elf code COMDATs for FreeBSD

### DIFF
--- a/changelog/freebsd-version.dd
+++ b/changelog/freebsd-version.dd
@@ -1,0 +1,6 @@
+FreeBSD 10.3 is new minimum supported version
+
+This is because in order to support Elf common blocks, the linker
+ld 2.17.50 version or later is required. Although FreeBSD 9.2
+introduced ld 2.17.50, and may work, FreeBSD versions prior to 10.3
+are not officially supported.

--- a/src/dmd/backend/elfobj.c
+++ b/src/dmd/backend/elfobj.c
@@ -92,7 +92,7 @@ void addSegmentToComdat(segidx_t seg, segidx_t comdatseg);
  * For the time being, just stick with Linux.
  */
 
-#define ELF_COMDAT      TARGET_LINUX
+#define ELF_COMDAT      1
 
 /***************************************************
  * Correspondence of relocation types


### PR DESCRIPTION
This extends https://github.com/dlang/dmd/pull/6564 for FreeBSD. It currently fails because the autotester is at FreeBSD 8.4, and needs upgrading.