### PR TITLE
cleanup and print @trusted or @safe on function-literals

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1953,7 +1953,7 @@ public:
             buf.writeByte(' ');
         }
         TypeFunction tf = cast(TypeFunction)f.type;
-        // only print tf.next if we have a tf.next and are not infering it
+        // only print tf.next if we have a tf.next and are not inferring it
         if (!f.inferRetType && tf.next)
             typeToBuffer(tf.next, null);
 
@@ -1963,7 +1963,7 @@ public:
         {
             // we need to print the trust attribute if we are outputing a header
             // since the header-output will be done w/o runnung semantic3 this
-            // will not include infered attributes
+            // will not include inferred attributes
             if (tf.trust)
             {
                 buf.writeByte(' ');

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -456,7 +456,7 @@ class TestClass
 	{
 		return aa;
 	}
-	@trusted @nogc @disable ~this();
+	@nogc @trusted @disable ~this();
 }
 class FooA
 {

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -573,7 +573,7 @@ class TestClass
 	{
 		return aa;
 	}
-	@trusted @nogc @disable ~this()
+	@nogc @trusted @disable ~this()
 	{
 	}
 }

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -9,7 +9,7 @@ void foo2(const C2 c);
 struct Foo3
 {
 	int k;
-	@trusted @nogc @disable ~this();
+	@nogc @trusted @disable ~this();
 	this(this);
 }
 class C3

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -13,7 +13,7 @@ void foo2(const C2 c);
 struct Foo3
 {
 	int k;
-	@trusted @nogc @disable ~this()
+	@nogc @trusted @disable ~this()
 	{
 		k = 1;
 	}


### PR DESCRIPTION
just a little cleanup and a fix for missing @trusted @safe. 