### PR TITLE
refactor: rename checkEscape* to checkReturnEscape*

### DIFF
--- a/src/ddmd/escape.d
+++ b/src/ddmd/escape.d
@@ -402,7 +402,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
 /************************************
  * Detect cases where pointers to the stack can 'escape' the
- * lifetime of the stack frame.
+ * lifetime of the stack frame by returning 'e' by value.
  * Print error messages when these are detected.
  * Params:
  *      sc = used to determine current function and module
@@ -411,10 +411,10 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
  * Returns:
  *      true if pointers to the stack can escape
  */
-bool checkEscape(Scope* sc, Expression e, bool gag)
+bool checkReturnEscape(Scope* sc, Expression e, bool gag)
 {
-    //printf("[%s] checkEscape, e = %s\n", e.loc.toChars(), e.toChars());
-    return checkEscapeImpl(sc, e, false, gag);
+    //printf("[%s] checkReturnEscape, e = %s\n", e.loc.toChars(), e.toChars());
+    return checkReturnEscapeImpl(sc, e, false, gag);
 }
 
 /************************************
@@ -428,21 +428,21 @@ bool checkEscape(Scope* sc, Expression e, bool gag)
  * Returns:
  *      true if references to the stack can escape
  */
-bool checkEscapeRef(Scope* sc, Expression e, bool gag)
+bool checkReturnEscapeRef(Scope* sc, Expression e, bool gag)
 {
     version (none)
     {
-        printf("[%s] checkEscapeRef, e = %s\n", e.loc.toChars(), e.toChars());
+        printf("[%s] checkReturnEscapeRef, e = %s\n", e.loc.toChars(), e.toChars());
         printf("current function %s\n", sc.func.toChars());
         printf("parent2 function %s\n", sc.func.toParent2().toChars());
     }
 
-    return checkEscapeImpl(sc, e, true, gag);
+    return checkReturnEscapeImpl(sc, e, true, gag);
 }
 
-private bool checkEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
+private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
 {
-    //printf("[%s] checkEscapeImpl, e = %s\n", e.loc.toChars(), e.toChars());
+    //printf("[%s] checkReturnEscapeImpl, e = %s\n", e.loc.toChars(), e.toChars());
     EscapeByResults er;
 
     if (refs)

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -1676,7 +1676,7 @@ extern (C++) class FuncDeclaration : Declaration
                         {
                             // Function returns a reference
                             exp = exp.toLvalue(sc2, exp);
-                            checkEscapeRef(sc2, exp, false);
+                            checkReturnEscapeRef(sc2, exp, false);
                         }
                         else
                         {
@@ -1689,7 +1689,7 @@ extern (C++) class FuncDeclaration : Declaration
                                 exp = doCopyOrMove(sc2, exp);
 
                             if (tret.hasPointers())
-                                checkEscape(sc2, exp, false);
+                                checkReturnEscape(sc2, exp, false);
                         }
 
                         exp = checkGC(sc2, exp);

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -2597,7 +2597,7 @@ else
                 {
                     /* May return by ref
                      */
-                    if (checkEscapeRef(sc, rs.exp, true))
+                    if (checkReturnEscapeRef(sc, rs.exp, true))
                         tf.isref = false; // return by value
                 }
                 else


### PR DESCRIPTION
This brings the naming into consistency with `checkAssignEscape()` and `checkParamArgumentEscape()`