### PR TITLE
Deprecate use of private variables from other modules

### DIFF
--- a/changelog/private.dd
+++ b/changelog/private.dd
@@ -1,3 +1,8 @@
-Deprecate the use of private selectively imported members
+Deprecate the use of selectively imported private members
 
-$(LINK2 $(ROOT_DIR)spec/attribute.html#visibility_attributes, The specification states) that a private member is visible only from within the same module. Prior to this release, due to a bug, some imported private members were visible from other modules, violating the specification. Beginning with this release, accessing said private members from outside the module in which they are declared will result in a deprecation message which has been scheduled to be changed to an error in approximately 1 year.
+$(LINK2 $(ROOT_DIR)spec/attribute.html#visibility_attributes, The specification states) that a private member
+is visible only from within the same module.
+Prior to this release, due to a bug, private members
+were visible through selective imports from other modules, violating the specification.
+Beginning with this release, accessing private members from outside the module
+in which they are declared will result in a deprecation message.

--- a/changelog/private.dd
+++ b/changelog/private.dd
@@ -1,0 +1,3 @@
+Deprecate the use of private selectively imported members
+
+$(LINK2 $(ROOT_DIR)spec/attribute.html#visibility_attributes, The specification states) that a private member is visible only from within the same module. Prior to this release, due to a bug, some imported private members were visible from other modules, violating the specification. Beginning with this release, accessing said private members from outside the module in which they are declared will result in a deprecation message which has been scheduled to be changed to an error in approximately 1 year.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1148,9 +1148,17 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 bool flag;
                 AliasDeclaration ad = imp.aliasdecls[i];
                 //printf("\tImport %s alias %s = %s, scope = %p\n", toPrettyChars(), aliases[i].toChars(), names[i].toChars(), ad._scope);
-                if (imp.mod.search(imp.loc, imp.names[i]) /*, IgnorePrivateImports*/)
+                Dsymbol importedSymbol = imp.mod.search(imp.loc, imp.names[i] /*, IgnorePrivateImports */);
+                if (importedSymbol)
                 {
                     flag = true;
+
+                    // Deprecated in 2018-01.
+                    // Change to error in 2019-01.
+                    // @@@DEPRECATED_2019-01@@@.
+                    import dmd.access : symbolIsVisible;
+                    if (!symbolIsVisible(sc, importedSymbol))
+                         imp.mod.deprecation(imp.loc, "member `%s` is not accessible", imp.names[i].toChars());
                     ad.dsymbolSemantic(sc);
                     // If the import declaration is in non-root module,
                     // analysis of the aliased symbol is deferred.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1148,8 +1148,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 bool flag;
                 AliasDeclaration ad = imp.aliasdecls[i];
                 //printf("\tImport %s alias %s = %s, scope = %p\n", toPrettyChars(), aliases[i].toChars(), names[i].toChars(), ad._scope);
-                Dsymbol importedSymbol = imp.mod.search(imp.loc, imp.names[i] /*, IgnorePrivateImports */);
-                if (importedSymbol)
+                Dsymbol sym = imp.mod.search(imp.loc, imp.names[i] /*, IgnorePrivateImports */);
+                if (sym)
                 {
                     flag = true;
 
@@ -1157,8 +1157,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     // Change to error in 2019-01.
                     // @@@DEPRECATED_2019-01@@@.
                     import dmd.access : symbolIsVisible;
-                    if (!symbolIsVisible(sc, importedSymbol))
-                         imp.mod.deprecation(imp.loc, "member `%s` is not accessible", imp.names[i].toChars());
+                    if (!symbolIsVisible(sc, sym))
+                        imp.mod.deprecation(imp.loc, "member `%s` is not visible from module `%s`",
+                            imp.names[i].toChars(), sc._module.toChars());
                     ad.dsymbolSemantic(sc);
                     // If the import declaration is in non-root module,
                     // analysis of the aliased symbol is deferred.

--- a/test/fail_compilation/fail15896.d
+++ b/test/fail_compilation/fail15896.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15896.d(11): Deprecation: module `imports.imp15896` member `thebar` is not accessible
-fail_compilation/fail15896.d(11): Deprecation: module `imports.imp15896` member `packagebar` is not accessible
+fail_compilation/fail15896.d(11): Deprecation: module `imports.imp15896` member `thebar` is not visible from module `fail15896`
+fail_compilation/fail15896.d(11): Deprecation: module `imports.imp15896` member `packagebar` is not visible from module `fail15896`
 ---
 */
 

--- a/test/fail_compilation/fail15896.d
+++ b/test/fail_compilation/fail15896.d
@@ -1,0 +1,18 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail15896.d(11): Deprecation: module `imports.imp15896` member `thebar` is not accessible
+fail_compilation/fail15896.d(11): Deprecation: module `imports.imp15896` member `packagebar` is not accessible
+---
+*/
+
+import imports.imp15896 : thebar, packagebar;
+
+int func()
+{
+    thebar +=1;
+    packagebar += 1;
+    return 0;
+}

--- a/test/fail_compilation/imports/imp15896.d
+++ b/test/fail_compilation/imports/imp15896.d
@@ -1,0 +1,4 @@
+module imports.imp15896;
+
+private int thebar=4;
+package int packagebar=3;


### PR DESCRIPTION
Since #6660 (the work of the devil) was reverted, this PR implements the same feature except this time a deprecation message is issued and not an error