### PR TITLE
use $n$ when matching error message with internal ids

### DIFF
--- a/test/fail_compilation/ice15441.d
+++ b/test/fail_compilation/ice15441.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice15441.d(24): Error: variable ice15441.main.__front62 type void is inferred from initializer __r61.front(), and variables cannot be of type void
-fail_compilation/ice15441.d(24): Error: expression __r61.front() is void and has no value
+fail_compilation/ice15441.d(24): Error: variable ice15441.main.__front$n$ type void is inferred from initializer __r$n$.front(), and variables cannot be of type void
+fail_compilation/ice15441.d(24): Error: expression __r$n$.front() is void and has no value
 fail_compilation/ice15441.d(24): Error: s1.front is void and has no value
 fail_compilation/ice15441.d(27): Error: cannot infer argument types, expected 1 argument, not 2
 ---


### PR DESCRIPTION
$n$ is described in test/d_do_test.d:
"compare output string to reference string, but ignore places
marked by $n$ that contain compiler generated unique numbers"

This should unblock <https://github.com/dlang/druntime/pull/1807>.