### PR TITLE
spelling fixes (just comments)

### DIFF
--- a/docs/man/man1/obj2asm.1
+++ b/docs/man/man1/obj2asm.1
@@ -55,7 +55,7 @@ obj2asm test.o
 
 .SH BUGS
 Although the output of obj2asm is in MASM format, it
-usually requires a little editting before MASM will accept
+usually requires a little editing before MASM will accept
 it.
 
 .SH AUTHOR

--- a/samples/chello.d
+++ b/samples/chello.d
@@ -62,7 +62,7 @@ protected:
 
     extern (Windows) :
     /*
-     *  Performs any intialization of a CHello that's prone to failure
+     *  Performs any initialization of a CHello that's prone to failure
      *  that we also use internally before exposing the object outside.
      * Return Value:
      *  BOOL            true if the function is successful,

--- a/src/ddmd/backend/backend.txt
+++ b/src/ddmd/backend/backend.txt
@@ -62,8 +62,8 @@ oper.h          operators for expression tree
 optabgen.c      generate tables for back end
 os.c            some operating system specific support
 out.c           write data definitions to object file
-outbuf.c        resizeable buffer
-outbuf.h        API for resizeable buffer
+outbuf.c        resizable buffer
+outbuf.h        API for resizable buffer
 ptrntab.c       instruction tables for inline assembler
 rtlsym.c        initialize for compiler 'helper' runtime functions
 rtlsym.h        compiler 'helper' runtime functions

--- a/src/ddmd/backend/cc.d
+++ b/src/ddmd/backend/cc.d
@@ -1269,7 +1269,7 @@ struct Symbol
     }
     version (MARS)
     {
-        const(char)* prettyIdent;   // the symbol identifer as the user sees it
+        const(char)* prettyIdent;   // the symbol identifier as the user sees it
     }
 
 //#if TARGET_OSX

--- a/src/ddmd/backend/cc.h
+++ b/src/ddmd/backend/cc.h
@@ -1320,7 +1320,7 @@ struct Symbol
     unsigned Ssequence;         // sequence number (used for 2 level lookup)
                                 // also used as 'parameter number' for SCTtemparg
 #elif MARS
-    const char *prettyIdent;    // the symbol identifer as the user sees it
+    const char *prettyIdent;    // the symbol identifier as the user sees it
 #endif
 
 //#if TARGET_OSX

--- a/src/ddmd/backend/cdef.h
+++ b/src/ddmd/backend/cdef.h
@@ -55,7 +55,7 @@ One and only one of these macros must be set by the makefile:
 /* Windows/DOS/DOSX Version
  * ------------------------
  * There are two main issues: hosting the compiler on windows,
- * and generating (targetting) windows/dos/dosx executables.
+ * and generating (targeting) windows/dos/dosx executables.
  * The "_WIN32" and "__DMC__" macros control hosting issues
  * for operating system and compiler dependencies, respectively.
  * To target linux executables, use OMFOBJ for things specific to the
@@ -70,7 +70,7 @@ One and only one of these macros must be set by the makefile:
 /* Linux Version
  * -------------
  * There are two main issues: hosting the compiler on linux,
- * and generating (targetting) linux executables.
+ * and generating (targeting) linux executables.
  * The "linux" and "__GNUC__" macros control hosting issues
  * for operating system and compiler dependencies, respectively.
  * To target linux executables, use ELFOBJ for things specific to the
@@ -85,7 +85,7 @@ One and only one of these macros must be set by the makefile:
 /* OSX Version
  * -------------
  * There are two main issues: hosting the compiler on OSX,
- * and generating (targetting) OSX executables.
+ * and generating (targeting) OSX executables.
  * The "__APPLE__" and "__GNUC__" macros control hosting issues
  * for operating system and compiler dependencies, respectively.
  * To target OSX executables, use MACHOBJ for things specific to the
@@ -100,7 +100,7 @@ One and only one of these macros must be set by the makefile:
 /* FreeBSD Version
  * -------------
  * There are two main issues: hosting the compiler on FreeBSD,
- * and generating (targetting) FreeBSD executables.
+ * and generating (targeting) FreeBSD executables.
  * The "__FreeBSD__" and "__GNUC__" macros control hosting issues
  * for operating system and compiler dependencies, respectively.
  * To target FreeBSD executables, use ELFOBJ for things specific to the
@@ -115,7 +115,7 @@ One and only one of these macros must be set by the makefile:
 /* OpenBSD Version
  * -------------
  * There are two main issues: hosting the compiler on OpenBSD,
- * and generating (targetting) OpenBSD executables.
+ * and generating (targeting) OpenBSD executables.
  * The "__OpenBSD__" and "__GNUC__" macros control hosting issues
  * for operating system and compiler dependencies, respectively.
  * To target OpenBSD executables, use ELFOBJ for things specific to the
@@ -130,7 +130,7 @@ One and only one of these macros must be set by the makefile:
 /* Solaris Version
  * -------------
  * There are two main issues: hosting the compiler on Solaris,
- * and generating (targetting) Solaris executables.
+ * and generating (targeting) Solaris executables.
  * The "__sun" and "__GNUC__" macros control hosting issues
  * for operating system and compiler dependencies, respectively.
  * To target Solaris executables, use ELFOBJ for things specific to the

--- a/src/ddmd/backend/cgcod.c
+++ b/src/ddmd/backend/cgcod.c
@@ -740,11 +740,11 @@ Lagain:
     /* Despite what the comment above says, aligning Fast section to size greater
      * than REGSIZE does not break contract implementation. Fast.offset and
      * Fast.alignment must be the same for the overriding and
-     * the overriden function, since they have the same parameters. Fast.size
+     * the overridden function, since they have the same parameters. Fast.size
      * must be the same because otherwise, contract inheritance wouldn't work
      * even if we didn't align Fast section to size greater than REGSIZE. Therefore,
      * the only way aligning the section could cause problems with contract
-     * inheritance is if bias (declared below) differed for the overriden
+     * inheritance is if bias (declared below) differed for the overridden
      * and the overriding function.
      *
      * Bias depends on Para.size and needframe. The value of Para.size depends on
@@ -757,7 +757,7 @@ Lagain:
      * during backend's initialization and on function flag Ffakeeh. On Windows,
      * that flag is always set for virtual functions, for which contracts are
      * defined and on other platforms, it is never set. Because of that
-     * the value of neadframe should always be the same for the overriden
+     * the value of neadframe should always be the same for the overridden
      * and the overriding function, and so bias should be the same too.
     */
 

--- a/src/ddmd/backend/cgelem.c
+++ b/src/ddmd/backend/cgelem.c
@@ -3755,7 +3755,7 @@ STATIC elem * elopass(elem *e, goal_t goal)
                             e->E2 = el_una(OPc_i, e1->Ety, e->E2);
                         return optelem(e, GOALvalue);
                     }
-                    // Repace x/=y with x=x/y
+                    // Replace x/=y with x=x/y
                     if (OPTIMIZER &&
                         tyintegral(e->E1->Ety) &&
                         e->E1->Eoper == OPvar &&
@@ -3769,7 +3769,7 @@ STATIC elem * elopass(elem *e, goal_t goal)
                     break;
 
                 case OPmodass:
-                    // Repace x%=y with x=x%y
+                    // Replace x%=y with x=x%y
                     if (OPTIMIZER &&
                         tyintegral(e->E1->Ety) &&
                         e->E1->Eoper == OPvar &&

--- a/src/ddmd/backend/cgen.c
+++ b/src/ddmd/backend/cgen.c
@@ -726,7 +726,7 @@ code *gencodelem(code *c,elem *e,regm_t *pretregs,bool constflag)
         c = cat(c,codelem(e,pretregs,constflag));
         assert(cgstate.stackclean == 0);
         cgstate.stackclean = stackcleansave;
-        c = genstackclean(c,stackpush - stackpushsave,*pretregs);       // do defered cleaning
+        c = genstackclean(c,stackpush - stackpushsave,*pretregs);       // do deferred cleaning
     }
     return c;
 }

--- a/src/ddmd/backend/cod3.c
+++ b/src/ddmd/backend/cod3.c
@@ -7187,7 +7187,7 @@ void code_dehydrate(code **pc)
 #endif
 
 /***************************
- * Debug code to dump code stucture.
+ * Debug code to dump code structure.
  */
 
 void WRcodlst(code *c)

--- a/src/ddmd/backend/code.h
+++ b/src/ddmd/backend/code.h
@@ -109,7 +109,7 @@ struct CSE
         regm_t  regm;           // mask of register stored there
         char    flags;          // flag bytes
 #define CSEload         1       // set if the CSE was ever loaded
-#define CSEsimple       2       // CSE can be regenerated easilly
+#define CSEsimple       2       // CSE can be regenerated easily
 
 // != 0 if CSE was ever loaded
 #define CSE_loaded(i)   (csextab[i].flags & CSEload)

--- a/src/ddmd/backend/divcoeff.c
+++ b/src/ddmd/backend/divcoeff.c
@@ -94,7 +94,7 @@ void u128Div(ullong xh, ullong xl, ullong yh, ullong yl, ullong *pqh, ullong *pq
 }
 
 /************************************
- * Implemement Algorithm 6.2: Selection of multiplier and shift count
+ * Implement Algorithm 6.2: Selection of multiplier and shift count
  * Input:
  *      N       32 or 64
  *      d       divisor (must not be 0 or a power of 2)

--- a/src/ddmd/backend/glocal.c
+++ b/src/ddmd/backend/glocal.c
@@ -675,7 +675,7 @@ STATIC void local_ambigref()
 }
 
 //////////////////////////////////////
-// Ambigous definition. Remove all with ambiguous refs.
+// Ambiguous definition. Remove all with ambiguous refs.
 //
 
 STATIC void local_ambigdef()

--- a/src/ddmd/backend/gother.c
+++ b/src/ddmd/backend/gother.c
@@ -1716,7 +1716,7 @@ void verybusyexp()
 
                         /* Mark all the vbe elems found but one (the    */
                         /* go.expnod[j] one) so that the expression will   */
-                        /* only be hoisted again if other occurrances   */
+                        /* only be hoisted again if other occurrences   */
                         /* of the expression are found later. This      */
                         /* will substitute for the fact that the        */
                         /* el_copytree() expression does not appear in go.expnod[]. */

--- a/src/ddmd/backend/melf.h
+++ b/src/ddmd/backend/melf.h
@@ -109,7 +109,7 @@ typedef struct
         #define SHT_RESTYPE      10         /* Reserved section type*/
         #define SHT_DYNTAB       11         /* Dynamic linker symbol table */
         #define SHT_GROUP        17         /* Section group (COMDAT) */
-        #define SHT_SYMTAB_SHNDX 18         /* Extended section indeces */
+        #define SHT_SYMTAB_SHNDX 18         /* Extended section indices */
   Elf32_Word   sh_flags;               /* Section attribute flags */
         #define SHF_WRITE       (1 << 0)    /* Writable during execution */
         #define SHF_ALLOC       (1 << 1)    /* In memory during execution */

--- a/src/ddmd/backend/type.c
+++ b/src/ddmd/backend/type.c
@@ -579,7 +579,7 @@ STATIC type * type_allocbasic(tym_t ty)
 
     t = type_alloc(ty);
     t->Tmangle = mTYman_c;
-    t->Tcount = 1;              /* so it is not inadvertantly free'd    */
+    t->Tcount = 1;              /* so it is not inadvertently free'd    */
     return t;
 }
 

--- a/src/ddmd/constfold.d
+++ b/src/ddmd/constfold.d
@@ -1594,7 +1594,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         StringExp es;
         ubyte sz = es1.sz;
         dinteger_t v = e2.toInteger();
-        // Is it a concatentation of homogenous types?
+        // Is it a concatenation of homogenous types?
         // (char[] ~ char, wchar[]~wchar, or dchar[]~dchar)
         bool homoConcat = (sz == t2.size());
         size_t len = es1.len;

--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -1325,7 +1325,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                         goto Lfdmatch;
 
                     {
-                    // Function type matcing: exact > covariant
+                    // Function type matching: exact > covariant
                     MATCH m1 = tf.equals(fd.type) ? MATCHexact : MATCHnomatch;
                     MATCH m2 = tf.equals(fdmatch.type) ? MATCHexact : MATCHnomatch;
                     if (m1 > m2)

--- a/src/ddmd/dinifile.d
+++ b/src/ddmd/dinifile.d
@@ -131,7 +131,7 @@ private bool writeToEnv(StringTable* environment, char* nameEqValue)
 }
 
 /************************************
- * Update real enviroment with our copy.
+ * Update real environment with our copy.
  * Params:
  *      environment = our copy of the environment
  */
@@ -287,7 +287,7 @@ void parseConfFile(StringTable* environment, const(char)* filename, const(char)*
                 envsection = false;
                 break;
             }
-            /* Seach sectionnamev[] for p..pn and set envsection to true if it's there
+            /* Search sectionnamev[] for p..pn and set envsection to true if it's there
              */
             for (size_t j = 0; 1; ++j)
             {

--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -751,7 +751,7 @@ extern (C++) Expression ctfeInterpretForPragmaMsg(Expression e)
     if (e.op != TOKtuple)
         return e.ctfeInterpret();
 
-    // Tuples need to be treated seperately, since they are
+    // Tuples need to be treated separately, since they are
     // allowed to contain a TypeExp in this case.
 
     TupleExp tup = cast(TupleExp)e;
@@ -1158,7 +1158,7 @@ public:
         {
             Statement sx = (*s.statements)[i];
             Expression e = interpret(sx, istate);
-            if (!e) // suceeds to interpret, or goto target was not found
+            if (!e) // succeeds to interpret, or goto target was not found
                 continue;
             if (exceptionOrCant(e))
                 return;
@@ -4692,7 +4692,7 @@ public:
             // The valid cases are:
             // p1 > p2 && p3 > p4  (same direction, also for < && <)
             // p1 > p2 && p3 < p4  (different direction, also < && >)
-            // Changing any > into >= doesnt affect the result
+            // Changing any > into >= doesn't affect the result
             if ((dir1 == dir2 && pointToSameMemoryBlock(agg1, agg4) && pointToSameMemoryBlock(agg2, agg3)) || (dir1 != dir2 && pointToSameMemoryBlock(agg1, agg3) && pointToSameMemoryBlock(agg2, agg4)))
             {
                 // it's a legal two-sided comparison

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -52,7 +52,7 @@ extern (C++) FuncDeclaration search_toString(StructDeclaration sd)
 }
 
 /***************************************
- * Request additonal semantic analysis for TypeInfo generation.
+ * Request additional semantic analysis for TypeInfo generation.
  */
 extern (C++) void semanticTypeInfo(Scope* sc, Type t)
 {

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -2487,7 +2487,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
     }
 
     // results
-    int property = 0;   // 0: unintialized
+    int property = 0;   // 0: uninitialized
                         // 1: seen @property
                         // 2: not @property
     size_t ov_index = 0;
@@ -4400,7 +4400,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             // From previous matched expressions to current deduced type
             MATCH match1 = xt ? xt.matchAll(tt) : MATCHnomatch;
 
-            // From current expresssion to previous deduced type
+            // From current expressions to previous deduced type
             Type pt = at.addMod(tparam.mod);
             if (*wm)
                 pt = pt.substWildTo(*wm);
@@ -8592,7 +8592,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
          */
         if (!findTempDecl(sc) || !semanticTiargs(sc) || !findBestMatch(sc, null))
         {
-            if (semanticRun == PASSinit) // forward reference had occured
+            if (semanticRun == PASSinit) // forward reference had occurred
             {
                 //printf("forward reference - deferring\n");
                 _scope = scx ? scx : sc.copy();

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -1361,7 +1361,7 @@ extern (C++) Expression callCpCtor(Scope* sc, Expression e)
             /* Create a variable tmp, and replace the argument e with:
              *      (tmp = e),tmp
              * and let AssignExp() handle the construction.
-             * This is not the most efficent, ideally tmp would be constructed
+             * This is not the most efficient, ideally tmp would be constructed
              * directly onto the stack.
              */
             auto tmp = copyToTemp(STCrvalue, "__copytmp", e);
@@ -2982,7 +2982,7 @@ extern (C++) abstract class Expression : RootObject
             /* Today, static local functions are impure by default, but they cannot
              * violate purity of enclosing functions.
              *
-             *  auto foo() pure {      // non instantiated funciton
+             *  auto foo() pure {      // non instantiated function
              *    static auto bar() {  // static, without pure attribute
              *      impureFunc();      // impure call
              *      // Although impureFunc is called inside bar, f(= impureFunc)
@@ -3064,7 +3064,7 @@ extern (C++) abstract class Expression : RootObject
             /* Today, static local functions are impure by default, but they cannot
              * violate purity of enclosing functions.
              *
-             *  auto foo() pure {      // non instantiated funciton
+             *  auto foo() pure {      // non instantiated function
              *    static auto bar() {  // static, without pure attribute
              *      globalData++;      // impure access
              *      // Although globalData is accessed inside bar,
@@ -5136,7 +5136,7 @@ extern (C++) final class ArrayLiteralExp : Expression
      *      e2  = If it's not `null`, it will be pushed/appended to the new
      *            `Expressions` by the same way with `e1`.
      * Returns:
-     *      Newly allocated `Expresions. Note that it points the original
+     *      Newly allocated `Expressions. Note that it points the original
      *      `Expression` values in e1 and e2.
      */
     static Expressions* copyElements(Expression e1, Expression e2 = null)
@@ -9789,7 +9789,7 @@ extern (C++) final class CallExp : UnaExp
                 VarExp ve = cast(VarExp)e1;
                 if (ve.var.storage_class & STClazy)
                 {
-                    // lazy paramaters can be called without violating purity and safety
+                    // lazy parameters can be called without violating purity and safety
                     Type tw = ve.var.type;
                     Type tc = ve.var.type.substWildTo(MODconst);
                     auto tf = new TypeFunction(null, tc, 0, LINKd, STCsafe | STCpure);

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -252,7 +252,7 @@ struct Global
     }
 
     /* End gagging, restoring the old gagged state.
-     * Return true if errors occured while gagged.
+     * Return true if errors occurred while gagged.
      */
     extern (C++) bool endGagging(uint oldGagged)
     {
@@ -266,7 +266,7 @@ struct Global
     }
 
     /*  Increment the error count to record that an error
-     *  has occured in the current context. An error message
+     *  has occurred in the current context. An error message
      *  may or may not have been printed.
      */
     extern (C++) void increaseErrorCount()

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -223,12 +223,12 @@ struct Global
     unsigned startGagging();
 
     /* End gagging, restoring the old gagged state.
-     * Return true if errors occured while gagged.
+     * Return true if errors occurred while gagged.
      */
     bool endGagging(unsigned oldGagged);
 
     /*  Increment the error count to record that an error
-     *  has occured in the current context. An error message
+     *  has occurred in the current context. An error message
      *  may or may not have been printed.
      */
     void increaseErrorCount();

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -8039,7 +8039,7 @@ extern (C++) final class TypeTypeof : TypeQualified
         }
         inuse++;
 
-        /* Currently we cannot evalute 'exp' in speculative context, because
+        /* Currently we cannot evaluate 'exp' in speculative context, because
          * the type implementation may leak to the final execution. Consider:
          *
          * struct S(T) {

--- a/src/ddmd/opover.d
+++ b/src/ddmd/opover.d
@@ -1408,7 +1408,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
             result = e.binSemanticProp(sc);
             if (result)
                 return;
-            // Don't attempt 'alias this' if an error occured
+            // Don't attempt 'alias this' if an error occurred
             if (e.e1.type.ty == Terror || e.e2.type.ty == Terror)
             {
                 result = new ErrorExp();

--- a/src/ddmd/root/longdouble.h
+++ b/src/ddmd/root/longdouble.h
@@ -76,7 +76,7 @@ struct longdouble
     unsigned short sign:1;
 
     // no constructor to be able to use this class in a union
-    // use ldouble() to explicitely create a longdouble value
+    // use ldouble() to explicitly create a longdouble value
 
     template<typename T> longdouble& operator=(T x) { set(x); return *this; }
 

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -787,7 +787,7 @@ extern (C++) class CompoundStatement : Statement
      * array of `Statement`s
      *
      * Params:
-     *   loc = Instantiation informations
+     *   loc = Instantiation information
      *   s   = An array of `Statement`s, that will referenced by this class
      */
     final extern (D) this(Loc loc, Statements* s)
@@ -800,7 +800,7 @@ extern (C++) class CompoundStatement : Statement
      * Construct a `CompoundStatement` from an array of `Statement`s
      *
      * Params:
-     *   loc = Instantiation informations
+     *   loc = Instantiation information
      *   s   = A variadic array of `Statement`s, that will copied in this class
      *         The entries themselves will not be copied.
      */

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -1215,7 +1215,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return new ErrorExp();
         }
 
-        fd = fd.toAliasFunc(); // Neccessary to support multiple overloads.
+        fd = fd.toAliasFunc(); // Necessary to support multiple overloads.
         return new IntegerExp(e.loc, fd.vtblIndex, Type.tptrdiff_t);
     }
     if (e.ident == Id.getPointerBitmap)

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -209,7 +209,7 @@ ifdef ENABLE_COVERAGE
 DFLAGS  += -cov
 endif
 
-# Uniqe extra flags if necessary
+# Unique extra flags if necessary
 DMD_FLAGS  := -I$(ROOT) -Wuninitialized
 GLUE_FLAGS := -I$(ROOT) -I$(TK) -I$(C)
 BACK_FLAGS := -I$(ROOT) -I$(TK) -I$(C) -I$G -I$D -DDMDV2=1

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -58,7 +58,7 @@
 
 ############################### Configuration ################################
 
-# fixed model for win32.mak, overriden by win64.mak
+# fixed model for win32.mak, overridden by win64.mak
 MODEL=32
 
 ##### Directories

--- a/test/Makefile
+++ b/test/Makefile
@@ -114,7 +114,7 @@ export SEP=/
 
 DRUNTIME_PATH=../../druntime
 PHOBOS_PATH=../../phobos
-# link against shared libraries (defaults to true on supported platforms, can be overriden w/ make SHARED=0)
+# link against shared libraries (defaults to true on supported platforms, can be overridden w/ make SHARED=0)
 SHARED=$(if $(findstring $(OS),linux freebsd),1,)
 DFLAGS=-I$(DRUNTIME_PATH)/import -I$(PHOBOS_PATH) -L-L$(PHOBOS_PATH)/generated/$(OS)/release/$(MODEL)
 ifeq (1,$(SHARED))

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2355,7 +2355,7 @@ static assert(!is(typeof(Compileable!(bug10840(1)))));
 **************************************************/
 
 // Four-pointer relations. Return true if [p1 .. p2] points inside [q1 .. q2]
-// (where the end points dont coincide).
+// (where the end points don't coincide).
 bool ptr4cmp(void* p1, void* p2, void* q1, void* q2)
 {
 // Each compare can be written with <, <=, >, or >=.
@@ -7345,7 +7345,7 @@ string getStr12495()
     s ~= 'a';                               // this should allocate.
     assert(buf.ptr != s.ptr);
     return s.idup;                          // this should allocate again, and
-                                            // definitly point immutable memory.
+                                            // definitely point immutable memory.
 }
 auto indexOf12495(string s)
 {

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -597,7 +597,7 @@ void test10148()
     fb10148!int.fc!int;  // [0] instantiate fb
                          // [3] instantiate fc
 
-    // [6] Afer semantic3 done, fc!int is deduced to @system.
+    // [6] After semantic3 done, fc!int is deduced to @system.
     static assert(is(typeof(&fb10148!int.fc!int) == void delegate() @system));
 }
 

--- a/test/fail_compilation/ice10624.d
+++ b/test/fail_compilation/ice10624.d
@@ -36,8 +36,8 @@ struct Variant
         A* rhsPA;
         {
             return *zis < *rhsPA ? -1 : 1;
-            // Tupple!(Msg) < Tupple!(Msg)
-            // Tupple!(Msg).expand < Tupple!(Msg).expand
+            // Tuple!(Msg) < Tuple!(Msg)
+            // Tuple!(Msg).expand < Tuple!(Msg).expand
             // -> should be error
         }
         return 0;

--- a/test/fail_compilation/ice2843.d
+++ b/test/fail_compilation/ice2843.d
@@ -15,7 +15,7 @@ OLD:
 NEW:
         }else if (e1->isConst() && e2->isConst()) {
         // Comparing a SymExp with a literal, eg typeid(int) is 7.1;
-           cmp=0; // An error has already occured. Prevent an ICE.
+           cmp=0; // An error has already occurred. Prevent an ICE.
         }else
         assert(0);
 */

--- a/test/fail_compilation/warn7444.d
+++ b/test/fail_compilation/warn7444.d
@@ -16,7 +16,7 @@ void test7444()
 
     {
         // X: Changed accepts-invalid to rejects-invalid by this issue
-        // a: slice assginment
+        // a: slice assignment
         // b: element-wise assignment
         sa   = e;      // X
         sa[] = e;      // b

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -74,7 +74,7 @@ void test2()
     int delegate(int) dg5 = delegate    (int a){ return a*2; };     assert(dg5(2) == 4);
     int delegate(int) dg6 = delegate int(int a){ return a*2; };     assert(dg6(2) == 4);
 
-    // funciton/delegate mismatching always raises an error
+    // function/delegate mismatching always raises an error
     static assert(!__traits(compiles, { int function(int) xfg3 = delegate    (    a){ return a*2; }; }));
     static assert(!__traits(compiles, { int function(int) xfg4 = delegate int(    a){ return a*2; }; }));
     static assert(!__traits(compiles, { int function(int) xfg5 = delegate    (int a){ return a*2; }; }));

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1161,7 +1161,7 @@ static assert(pow10_2550!(0) == 1);
 void foo10a(T   )(T)            { static assert(is(T    == const(int)[])); }
 void foo10b(T...)(T)            { static assert(is(T[0] == const(int)[])); }
 
-// ref paramter doesn't remove top const
+// ref parameter doesn't remove top const
 void boo10a(T   )(ref T)        { static assert(is(T    == const(int[]))); }
 void boo10b(T...)(ref T)        { static assert(is(T[0] == const(int[]))); }
 
@@ -1507,7 +1507,7 @@ void test7684()
 
 void match7694(alias m)()
 {
-    m.foo();    //removing this line supresses ice in both cases
+    m.foo();    //removing this line suppresses ice in both cases
 }
 
 struct T7694


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). 
Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.

"I hereby assign copyright in my contributions to DMD to the D Language Foundation" - email sent.