### PR TITLE
spelling fixes - might fix bugs and/or might break stuff..

### DIFF
--- a/src/ddmd/attrib.h
+++ b/src/ddmd/attrib.h
@@ -36,7 +36,7 @@ public:
     int apply(Dsymbol_apply_ft_t fp, void *param);
     static Scope *createNewScope(Scope *sc,
         StorageClass newstc, LINK linkage, CPPMANGLE cppmangle, Prot protection,
-        int explictProtection, AlignDeclaration *aligndecl, PINLINE inlining);
+        int explicitProtection, AlignDeclaration *aligndecl, PINLINE inlining);
     virtual Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);

--- a/src/ddmd/ctfeexpr.d
+++ b/src/ddmd/ctfeexpr.d
@@ -1982,7 +1982,7 @@ extern (C++) void showCtfeExpr(Expression e, int level = 0)
                 {
                     for (int j = level; --j;)
                         printf(" ");
-                    printf(" field: block initalized static array\n");
+                    printf(" field: block initialized static array\n");
                     continue;
                 }
             }

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -384,9 +384,9 @@ extern (C++) class FuncDeclaration : Declaration
                  * then this function defaults to pure too.
                  *
                  *  auto foo() pure {
-                 *    auto bar() {}     // become a weak purity funciton
+                 *    auto bar() {}     // become a weak purity function
                  *    class C {         // nested class
-                 *      auto baz() {}   // become a weak purity funciton
+                 *      auto baz() {}   // become a weak purity function
                  *    }
                  *
                  *    static auto boo() {}   // typed as impure
@@ -1165,7 +1165,7 @@ extern (C++) class FuncDeclaration : Declaration
                 FuncDeclaration fdv = foverrides[i];
                 if (fdv.fbody && !fdv.frequire)
                 {
-                    error("cannot have an in contract when overriden function %s does not have an in contract", fdv.toPrettyChars());
+                    error("cannot have an in contract when overridden function %s does not have an in contract", fdv.toPrettyChars());
                     break;
                 }
             }
@@ -1797,7 +1797,7 @@ extern (C++) class FuncDeclaration : Declaration
                             ExpInitializer ie = v._init.isExpInitializer();
                             assert(ie);
                             if (ie.exp.op == TOKconstruct)
-                                ie.exp.op = TOKassign; // construction occured in parameter processing
+                                ie.exp.op = TOKassign; // construction occurred in parameter processing
                             a.push(new ExpStatement(Loc(), ie.exp));
                         }
                     }
@@ -2527,7 +2527,7 @@ extern (C++) class FuncDeclaration : Declaration
                 if (f.needThis())
                     match = f.isCtorDeclaration() ? MATCHexact : MODmethodConv(tthis.mod, tf.mod);
                 else
-                    match = MATCHconst; // keep static funciton in overload candidates
+                    match = MATCHconst; // keep static function in overload candidates
             }
             else // static functions are preferred than non-static ones
             {
@@ -3412,7 +3412,7 @@ extern (C++) class FuncDeclaration : Declaration
                         requiresClosure = true;
 
                     /* Bugzilla 12406: Iterate all closureVars to mark all descendant
-                     * nested functions that access to the closing context of this funciton.
+                     * nested functions that access to the closing context of this function.
                      */
                 }
             }

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -3771,7 +3771,7 @@ final class Parser(AST) : Lexer
             if (pident)
                 *pident = token.ident;
             else
-                error("unexpected identifer '%s' in declarator", token.ident.toChars());
+                error("unexpected identifier '%s' in declarator", token.ident.toChars());
             ts = t;
             nextToken();
             break;
@@ -4375,7 +4375,7 @@ final class Parser(AST) : Lexer
                 v.storage_class = storage_class;
                 if (pAttrs)
                 {
-                    /* AliasDeclaration distinguish @safe, @system, @trusted atttributes
+                    /* AliasDeclaration distinguish @safe, @system, @trusted attributes
                      * on prefix and postfix.
                      *   @safe alias void function() FP1;
                      *   alias @safe void function() FP2;    // FP2 is not @safe

--- a/test/fail_compilation/ice13835.d
+++ b/test/fail_compilation/ice13835.d
@@ -1,5 +1,5 @@
 /*
-TEST_OUPUT:
+TEST_OUTPUT:
 ---
 fail_compilation/ice13835.d(15): Error: value of 'this' is not known at compile time
 fail_compilation/ice13835.d(21): Error: template instance ice13835.Foo!int error instantiating

--- a/test/runnable/functype.d
+++ b/test/runnable/functype.d
@@ -107,7 +107,7 @@ void testda()
     static assert(!is(typeof(fpda[0]() == 1)));     // cannot call with using defArgs
     static assert(!is(typeof(fpda[1]() == 2)));     // cannot call with using defArgs
     static assert(typeof(fpda).stringof == "int function(int)[]");
-    static assert(typeof(fpda).stringof != "int funciton(int n = 1)[]");
+    static assert(typeof(fpda).stringof != "int function(int n = 1)[]");
 
     int delegate(int n = 1)[] dgda = [n => n + 1, n => n+2];
     assert(dgda[0](1) == 2);
@@ -120,7 +120,7 @@ void testda()
 
 template StringOf(T)
 {
-    // template type parameter cannot have redundant informations
+    // template type parameter cannot have redundant information
     enum StringOf = T.stringof;
 }
 


### PR DESCRIPTION
patch contains some spelling fixes as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.

some of the findings might be "bugs" (like the one in src/ddmd/attrib.h , test/runnable/functype.d ), some might break stuff. ( changed printf() output which might confuse other tools )

"I hereby assign copyright in my contributions to DMD to the D Language Foundation" - email sent.