### PR TITLE
adjust hardcoded index of Error.bypassException

### DIFF
--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -1808,20 +1808,27 @@ public:
         }
         // Little sanity check to make sure it's really a Throwable
         ClassReferenceExp boss = oldest.thrown;
-        assert((*boss.value.elements)[4].type.ty == Tclass); // Throwable.next
+        const next = 4;                         // index of Throwable.next
+        assert((*boss.value.elements)[next].type.ty == Tclass); // Throwable.next
         ClassReferenceExp collateral = newest.thrown;
         if (isAnErrorException(collateral.originalClass()) && !isAnErrorException(boss.originalClass()))
         {
+            /* Find the index of the Error.bypassException field
+             */
+            auto bypass = next + 1;
+            if ((*collateral.value.elements)[bypass].type.ty == Tuns32)
+                bypass += 1;  // skip over _refcount field
+            assert((*collateral.value.elements)[bypass].type.ty == Tclass);
+
             // The new exception bypass the existing chain
-            assert((*collateral.value.elements)[5].type.ty == Tclass);
-            (*collateral.value.elements)[5] = boss;
+            (*collateral.value.elements)[bypass] = boss;
             return newest;
         }
-        while ((*boss.value.elements)[4].op == TOKclassreference)
+        while ((*boss.value.elements)[next].op == TOKclassreference)
         {
-            boss = cast(ClassReferenceExp)(*boss.value.elements)[4];
+            boss = cast(ClassReferenceExp)(*boss.value.elements)[next];
         }
-        (*boss.value.elements)[4] = collateral;
+        (*boss.value.elements)[next] = collateral;
         return oldest;
     }
 


### PR DESCRIPTION
It turns out that `dinterpret.d` has a hardcoded dependency on the layout of `Throwable` and `Error`. While this doesn't fix that, it does accommodate the addition of the `Throwable._refcount` field, as it is blocking https://github.com/dlang/druntime/pull/1804