### PR TITLE
Struct array lowering to __equals template call

### DIFF
--- a/changelog/stack-allocation-for-array-literals.dd
+++ b/changelog/stack-allocation-for-array-literals.dd
@@ -1,0 +1,26 @@
+Stack Allocation for Array Literals
+
+When the '==' operator is used on an array literal and another array, the array
+literal is placed on the stack. Previous behavior allocated memory on the heap
+for the array literal.
+
+In the case of an array literal of structs, the struct dtors are called at the end of
+full expression, rather than at an unknown moment in time when GC occurs.
+
+-------
+string op;
+
+struct S
+{
+    char x = 'x';
+    this(this) { op ~= x-0x20; }    // upper case
+    ~this()    { op ~= x; }         // lower case
+}
+
+
+assert(op == "");
+{
+    S[3] sx = [S('a'), S('b'), S('c')];
+}
+assert(op == "cba");
+-------

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -15638,6 +15638,7 @@ extern (C++) final class EqualExp : BinExp
 
         if (auto e = binSemanticProp(sc))
             return e;
+
         if (e1.op == TOKtype || e2.op == TOKtype)
             return incompatibleTypes();
 
@@ -15689,6 +15690,38 @@ extern (C++) final class EqualExp : BinExp
 
         if (e1.type.toBasetype().ty == Tvector)
             return incompatibleTypes();
+
+        Type t1 = e1.type.toBasetype();
+        Type t2 = e2.type.toBasetype();
+
+        if ((t1.ty == Tarray || t1.ty == Tsarray) &&
+            (t2.ty == Tarray || t2.ty == Tsarray))
+        {
+            Type telement  = t1.nextOf().toBasetype();
+            Type telement2 = t2.nextOf().toBasetype();
+
+            // For e1 and e2 of struct type, lowers e1 == e2 to object.__equals(e1, e2)
+            // and e1 != e2 to !(object.__equals(e1, e2)).
+            if (telement.ty == Tstruct && telement2.ty == Tstruct)
+            {
+                Expression __equals = new IdentifierExp(loc, Id.empty);
+                Identifier id = Identifier.idPool("__equals");
+                __equals = new DotIdExp(loc, __equals, Id.object);
+                __equals = new DotIdExp(loc, __equals, id);
+
+                auto arguments = new Expressions();
+                arguments.push(e1);
+                arguments.push(e2);
+
+                __equals = new CallExp(loc, __equals, arguments);
+                if (op == TOKnotequal)
+                {
+                    __equals = new NotExp(loc, __equals);
+                }
+                __equals = __equals.semantic(sc);
+                return __equals;
+            }
+        }
 
         return this;
     }

--- a/src/ddmd/idgen.d
+++ b/src/ddmd/idgen.d
@@ -291,6 +291,7 @@ Msgtable[] msgtable =
     { "entrypoint", "__entrypoint" },
     { "rt_init" },
     { "__cmp" },
+    { "__equals"},
 
     // varargs implementation
     { "va_start" },

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -2778,7 +2778,7 @@ void test9907()
 struct S9985
 {
     ubyte* b;
-    ubyte buf[128];
+    ubyte[128] buf;
     this(this) { assert(0); }
 
     static void* ptr;
@@ -3870,6 +3870,7 @@ bool test14022()
             this.sb = sa;   // TOKconstruct
             assert(op == "BC", op);
             assert(sb == [S('b'), S('c')]);
+            assert(op == "BCcb");
         }
         void test(ref S[2] sa)
         {
@@ -3882,7 +3883,7 @@ bool test14022()
     {
         S[2] sa = [S('a'), S('b')];
         T t;    t.sb[0].x = 'x';
-                t.sb[1].x = 'y';
+        t.sb[1].x = 'y';
         assert(op == "");
         t.sb = sa;
         assert(op == "AxBy");
@@ -3899,20 +3900,22 @@ bool test14022()
         t.sb[1].x = 'y';
         assert(sa == [S('a'), S('b'), S('c')]);
         assert(t.sb == [S('x'), S('y')]);
-        assert(op == "BC");
+        // Array literals destroyed at the end of scope
+        assert(op == "BCcbcbayx");
     }
-    assert(op == "BCyxcba");
+    assert(op == "BCcbcbayxyxcba");
 
     op = null;
     {
         S[3] sx = [S('a'), S('b'), S('c')];
         T t;    t.sb[0].x = 'x';
-                t.sb[1].x = 'y';
+        t.sb[1].x = 'y';
         t.test(sx[1..3]);
         assert(op == "BxCy");
         assert(t.sb == [S('b'), S('c')]);
+        assert(op == "BxCycb");
     }
-    assert(op == "BxCycbcba");
+    assert(op == "BxCycbcbcba");
 
     return true;
 }
@@ -3952,6 +3955,8 @@ bool test14023()
         a[0] = sa;      // index <-- resolveSlice(newva)
         assert(op == "BxCx");
         assert(a[0] == [S('b'), S('c')]);
+        // Array literals destroyed at the end of scope
+        assert(op == "BxCxcb");
     }
 
     op = null;
@@ -3981,9 +3986,9 @@ bool test14023()
     {
         S[3] sa = [S('a'), S('b'), S('c')];
         test(sa[1..3]);
-        assert(op == "BxCx");
+        assert(op == "BxCxcb");
     }
-    assert(op == "BxCxcba");
+    assert(op == "BxCxcbcba");
 
     return true;
 }


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/6634 got closed.

Fixed the issue with GC. I tried creating special ```__equals``` template overloads for array literals and this seems to put the array literals on the stack, rather than on the heap.

For this reason, the arrays are cleared from the memory at the end of scope. I adjusted some failing tests to reflect this.

Let me know what you think. Thanks!