### PR TITLE
Small clean-ups in word count samples

### DIFF
--- a/samples/wc.d
+++ b/samples/wc.d
@@ -1,9 +1,7 @@
-
 import std.stdio;
 import std.file;
-import std.conv;
 
-int main(string[] args)
+void main(string[] args)
 {
     int w_total;
     int l_total;
@@ -13,11 +11,10 @@ int main(string[] args)
 
     foreach (arg; args[1 .. $])
     {
-        string input;
         int w_cnt, l_cnt, c_cnt;
-        int inword;
+        bool inword;
 
-        input = to!string(std.file.read(arg));
+        string input = readText(arg);
 
         foreach (char c; input)
         {
@@ -28,12 +25,12 @@ int main(string[] args)
             {
                 if (!inword)
                 {
-                    inword = 1;
+                    inword = true;
                     ++w_cnt;
                 }
             }
             else
-                inword = 0;
+                inword = false;
 
             ++c_cnt;
         }
@@ -49,6 +46,4 @@ int main(string[] args)
         writefln("--------------------------------------\n%8s%8s%8s total",
                  l_total, w_total, c_total);
     }
-
-    return 0;
 }

--- a/samples/wc2.d
+++ b/samples/wc2.d
@@ -1,12 +1,13 @@
 import std.stdio;
 import std.file;
+import std.algorithm.sorting;
 
-int main (string[] args)
+void main (string[] args)
 {
     int w_total;
     int l_total;
     ulong c_total;
-    int[string] dictionary;
+    size_t[string] dictionary;
 
     writefln("   lines   words   bytes file");
     foreach (arg; args[1 .. $])
@@ -18,7 +19,7 @@ int main (string[] args)
         if (c_cnt < 10_000_000)
         {
             size_t wstart;
-            auto input = cast(string)std.file.read(arg);
+            auto input = readText(arg);
 
             foreach (j, c; input)
             {
@@ -109,10 +110,8 @@ int main (string[] args)
 
     writefln("--------------------------------------");
 
-    import std.algorithm;
     foreach (word1; dictionary.keys.sort())
     {
         writefln("%3s %s", dictionary[word1], word1);
     }
-    return 0;
 }


### PR DESCRIPTION
Makes things a bit cleaner and uses the modern `readText` function, which is generally safer than raw reading to `void[]` and casting.