### PR TITLE
refactor: add staticcond.evalStaticCondition() to merge 3 almost-the-same implementations 

### DIFF
--- a/src/ddmd/staticcond.d
+++ b/src/ddmd/staticcond.d
@@ -1,0 +1,76 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC _staticcond.d)
+ */
+
+module ddmd.staticcond;
+
+import ddmd.arraytypes;
+import ddmd.dmodule;
+import ddmd.dscope;
+import ddmd.dsymbol;
+import ddmd.errors;
+import ddmd.expression;
+import ddmd.globals;
+import ddmd.identifier;
+import ddmd.mtype;
+import ddmd.tokens;
+import ddmd.utils;
+
+
+
+/********************************************
+ * Semantically analyze and then evaluate a static condition at compile time.
+ * This is special because short circuit operators &&, || and ?: at the top
+ * level are not semantically analyzed if the result of the expression is not
+ * necessary.
+ * Params:
+ *      exp = original expression, for error messages
+ * Returns:
+ *      true if evaluates to true
+ */
+
+bool evalStaticCondition(Scope* sc, Expression exp, Expression e, ref bool errors)
+{
+    uint nerrors = global.errors;
+
+    sc = sc.startCTFE();
+    sc.flags |= SCOPEcondition;
+
+    e = e.semantic(sc);
+    e = resolveProperties(sc, e);
+
+    sc = sc.endCTFE();
+    e = e.optimize(WANTvalue);
+
+    if (nerrors != global.errors ||
+        e.op == TOKerror ||
+        e.type.toBasetype() == Type.terror)
+    {
+        errors = true;
+        return false;
+    }
+
+    if (!e.type.isBoolean())
+    {
+        exp.error("expression %s of type %s does not have a boolean value", exp.toChars(), e.type.toChars());
+        errors = true;
+        return false;
+    }
+
+    e = e.ctfeInterpret();
+
+    if (e.isBool(true))
+        return true;
+    else if (e.isBool(false))
+        return false;
+
+    e.error("expression %s is not constant", e.toChars());
+    errors = true;
+    return false;
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -230,7 +230,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	hdrgen impcnvtab imphint init inline inlinecost intrange	\
 	json lib link mars mtype nogc nspace opover optimize parse sapply	\
 	sideeffect statement staticassert target traits visitor	\
-	typinf utils statement_rewrite_walker statementsem safe blockexit asttypename))
+	typinf utils statement_rewrite_walker statementsem staticcond safe blockexit asttypename))
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, entity errors globals id identifier lexer tokens utf))
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -155,7 +155,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 # D front end
 FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
 	$D/arraytypes.d $D/astcodegen.d $D/astnull.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/clone.d $D/complex.d		\
-	$D/cond.d $D/constfold.d $D/cppmangle.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d		\
+	$D/cond.d $D/constfold.d $D/cppmangle.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d	\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d		\
 	$D/dtemplate.d $D/dversion.d $D/escape.d			\
@@ -165,7 +165,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/sapply.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d	\
 	$D/safe.d $D/blockexit.d $D/asttypename.d \
 	$D/traits.d $D/utils.d $D/visitor.d $D/libomf.d $D/scanomf.d $D/typinf.d \
-	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d
+	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d
 
 LEXER_SRCS=$D/entity.d $D/errors.d $D/globals.d $D/id.d $D/identifier.d \
 	$D/lexer.d $D/tokens.d $D/utf.d

--- a/test/fail_compilation/checkimports2a.d
+++ b/test/fail_compilation/checkimports2a.d
@@ -2,13 +2,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/checkimports2a.d(24): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2a.X
-fail_compilation/checkimports2a.d(30): Deprecation: local import search method found variable imports.imp2.X instead of nothing
-fail_compilation/checkimports2a.d(30): Error: no property 'X' for type 'checkimports2a.B'
-fail_compilation/checkimports2a.d(31): Deprecation: local import search method found variable imports.imp2.Y instead of nothing
-fail_compilation/checkimports2a.d(31): Error: no property 'Y' for type 'checkimports2a.B'
-fail_compilation/checkimports2a.d(33): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2a.X
-fail_compilation/checkimports2a.d(34): Deprecation: local import search method found variable imports.imp2.Y instead of variable imports.imp1.Y
+fail_compilation/checkimports2a.d(26): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2a.X
+fail_compilation/checkimports2a.d(32): Deprecation: local import search method found variable imports.imp2.X instead of nothing
+fail_compilation/checkimports2a.d(32): Error: no property 'X' for type 'checkimports2a.B'
+fail_compilation/checkimports2a.d(32):        while evaluating: static assert((B).X == 0)
+fail_compilation/checkimports2a.d(33): Deprecation: local import search method found variable imports.imp2.Y instead of nothing
+fail_compilation/checkimports2a.d(33): Error: no property 'Y' for type 'checkimports2a.B'
+fail_compilation/checkimports2a.d(33):        while evaluating: static assert((B).Y == 2)
+fail_compilation/checkimports2a.d(35): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2a.X
+fail_compilation/checkimports2a.d(36): Deprecation: local import search method found variable imports.imp2.Y instead of variable imports.imp1.Y
 ---
 */
 

--- a/test/fail_compilation/checkimports2b.d
+++ b/test/fail_compilation/checkimports2b.d
@@ -2,11 +2,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/checkimports2b.d(22): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2b.X
-fail_compilation/checkimports2b.d(28): Deprecation: local import search method found variable imports.imp2.X instead of nothing
-fail_compilation/checkimports2b.d(29): Deprecation: local import search method found variable imports.imp2.Y instead of nothing
-fail_compilation/checkimports2b.d(31): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2b.X
-fail_compilation/checkimports2b.d(32): Deprecation: local import search method found variable imports.imp2.Y instead of variable imports.imp1.Y
+fail_compilation/checkimports2b.d(27): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2b.X
+fail_compilation/checkimports2b.d(27):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2b.d(33): Deprecation: local import search method found variable imports.imp2.X instead of nothing
+fail_compilation/checkimports2b.d(33):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2b.d(34): Deprecation: local import search method found variable imports.imp2.Y instead of nothing
+fail_compilation/checkimports2b.d(34):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2b.d(36): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2b.X
+fail_compilation/checkimports2b.d(36):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2b.d(37): Deprecation: local import search method found variable imports.imp2.Y instead of variable imports.imp1.Y
+fail_compilation/checkimports2b.d(37):        while evaluating: static assert(2 == 2)
 ---
 */
 

--- a/test/fail_compilation/checkimports2c.d
+++ b/test/fail_compilation/checkimports2c.d
@@ -2,11 +2,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/checkimports2c.d(22): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2c.X
-fail_compilation/checkimports2c.d(28): Deprecation: local import search method found variable imports.imp2.X instead of nothing
-fail_compilation/checkimports2c.d(29): Deprecation: local import search method found variable imports.imp2.Y instead of nothing
-fail_compilation/checkimports2c.d(31): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2c.X
-fail_compilation/checkimports2c.d(32): Deprecation: local import search method found variable imports.imp2.Y instead of variable imports.imp1.Y
+
+fail_compilation/checkimports2c.d(28): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2c.X
+fail_compilation/checkimports2c.d(28):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2c.d(34): Deprecation: local import search method found variable imports.imp2.X instead of nothing
+fail_compilation/checkimports2c.d(34):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2c.d(35): Deprecation: local import search method found variable imports.imp2.Y instead of nothing
+fail_compilation/checkimports2c.d(35):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2c.d(37): Deprecation: local import search method found variable imports.imp2.X instead of variable checkimports2c.X
+fail_compilation/checkimports2c.d(37):        while evaluating: static assert(2 == 2)
+fail_compilation/checkimports2c.d(38): Deprecation: local import search method found variable imports.imp2.Y instead of variable imports.imp1.Y
+fail_compilation/checkimports2c.d(38):        while evaluating: static assert(2 == 2)
 ---
 */
 

--- a/test/fail_compilation/fail237.d
+++ b/test/fail_compilation/fail237.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail237.d(10): Error: undefined identifier 'a' in module 'fail237'
+fail_compilation/fail237.d(11): Error: undefined identifier 'a' in module 'fail237'
+fail_compilation/fail237.d(11):        while evaluating: static assert(module fail237.a!().b)
 ---
 */
 

--- a/test/fail_compilation/fail310.d
+++ b/test/fail_compilation/fail310.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail310.d(9): Error: undefined identifier 'Foo', did you mean function 'foo'?
-fail_compilation/fail310.d(13): Error: template instance fail310.foo!(1, 2) error instantiating
+fail_compilation/fail310.d(10): Error: undefined identifier 'Foo', did you mean function 'foo'?
+fail_compilation/fail310.d(14): Error: template instance fail310.foo!(1, 2) error instantiating
+fail_compilation/fail310.d(14):        while evaluating: static assert(foo!(1, 2)())
 ---
 */
 

--- a/test/fail_compilation/fail340.d
+++ b/test/fail_compilation/fail340.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail340.d(17): Error: variable fail340.w of type struct const(CopyTest) uses this(this), which is not allowed in static initialization
+fail_compilation/fail340.d(18): Error: variable fail340.w of type struct const(CopyTest) uses this(this), which is not allowed in static initialization
+fail_compilation/fail340.d(19):        while evaluating: static assert(w.x == 55.0000)
 ---
 */
 

--- a/test/fail_compilation/failoffset.d
+++ b/test/fail_compilation/failoffset.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/failoffset.d(11): Error: no property 'offset' for type 'int'
+fail_compilation/failoffset.d(12): Error: no property 'offset' for type 'int'
+fail_compilation/failoffset.d(12):        while evaluating: static assert(b.offset == 4)
 ---
 */
 

--- a/test/fail_compilation/ice10770.d
+++ b/test/fail_compilation/ice10770.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10770.d(12): Error: enum ice10770.E2 is forward referenced looking for base type
+fail_compilation/ice10770.d(13): Error: enum ice10770.E2 is forward referenced looking for base type
+fail_compilation/ice10770.d(13):        while evaluating: static assert(is(E2 e == enum))
 ---
 */
 

--- a/test/fail_compilation/ice10949.d
+++ b/test/fail_compilation/ice10949.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10949.d(11): Deprecation: Using the result of a comma expression is deprecated
-fail_compilation/ice10949.d(11): Error: array index 3 is out of bounds [5, 5][0 .. 2]
-fail_compilation/ice10949.d(11): Error: array index 17 is out of bounds [2, 3][0 .. 2]
-fail_compilation/ice10949.d(11): Error: array index 9 is out of bounds [3, 3, 3][0 .. 3]
+fail_compilation/ice10949.d(12): Deprecation: Using the result of a comma expression is deprecated
+fail_compilation/ice10949.d(12): Error: array index 3 is out of bounds [5, 5][0 .. 2]
+fail_compilation/ice10949.d(12): Error: array index 17 is out of bounds [2, 3][0 .. 2]
+fail_compilation/ice10949.d(12): Error: array index 9 is out of bounds [3, 3, 3][0 .. 3]
+fail_compilation/ice10949.d(12):        while evaluating: static assert((__error) || (__error))
 ---
 */
 int global;

--- a/test/fail_compilation/ice11553.d
+++ b/test/fail_compilation/ice11553.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11553.d(22): Error: recursive template expansion while looking for A!().A()
-fail_compilation/ice11553.d(22): Error: expression A!(B) of type void does not have a boolean value
 ---
 */
+
 
 template A(alias T)
 {

--- a/test/fail_compilation/ice14929.d
+++ b/test/fail_compilation/ice14929.d
@@ -1,10 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14929.d(44): Error: cast(Node)(*this.current).items[this.index] is not an lvalue
-fail_compilation/ice14929.d(87): Error: template instance ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in" error instantiating
-fail_compilation/ice14929.d(91):        instantiated from here: HashmapComponentStorage!int
-fail_compilation/ice14929.d(91): Error: template instance ice14929.isComponentStorage!(HashmapComponentStorage!int, int) error instantiating
+fail_compilation/ice14929.d(45): Error: cast(Node)(*this.current).items[this.index] is not an lvalue
+fail_compilation/ice14929.d(88): Error: template instance ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in" error instantiating
+fail_compilation/ice14929.d(92):        instantiated from here: HashmapComponentStorage!int
+fail_compilation/ice14929.d(92): Error: template instance ice14929.isComponentStorage!(HashmapComponentStorage!int, int) error instantiating
+fail_compilation/ice14929.d(92):        while evaluating: static assert(isComponentStorage!(HashmapComponentStorage!int, int))
 ---
 */
 

--- a/test/fail_compilation/ice9439.d
+++ b/test/fail_compilation/ice9439.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9439.d(11): Error: this for foo needs to be type Derived not type ice9439.Base
-fail_compilation/ice9439.d(18): Error: template instance ice9439.Base.boo!(foo) error instantiating
+fail_compilation/ice9439.d(12): Error: this for foo needs to be type Derived not type ice9439.Base
+fail_compilation/ice9439.d(12):        while evaluating: static assert((__error).foo())
+fail_compilation/ice9439.d(19): Error: template instance ice9439.Base.boo!(foo) error instantiating
 ---
 */
 

--- a/test/fail_compilation/lookup.d
+++ b/test/fail_compilation/lookup.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/lookup.d(21): Error: no property 'X' for type 'lookup.B'
-fail_compilation/lookup.d(22): Error: no property 'Y' for type 'lookup.B'
+fail_compilation/lookup.d(23): Error: no property 'X' for type 'lookup.B'
+fail_compilation/lookup.d(23):        while evaluating: static assert((B).X == 0)
+fail_compilation/lookup.d(24): Error: no property 'Y' for type 'lookup.B'
+fail_compilation/lookup.d(24):        while evaluating: static assert((B).Y == 2)
 ---
 */
 

--- a/test/fail_compilation/test9176.d
+++ b/test/fail_compilation/test9176.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test9176.d(13): Error: forward reference to inferred return type of function call 'get()'
+fail_compilation/test9176.d(14): Error: forward reference to inferred return type of function call 'get()'
+fail_compilation/test9176.d(10):        while evaluating: static assert(!false)
 ---
 */
 


### PR DESCRIPTION
This pulls out common code from 3 places and puts it into a common routine in staticcond.d.