### PR TITLE
fix Issue 17335 - Function calls in conjunctions do not short circuit…

### DIFF
--- a/src/ddmd/staticcond.d
+++ b/src/ddmd/staticcond.d
@@ -37,6 +37,39 @@ import ddmd.utils;
 
 bool evalStaticCondition(Scope* sc, Expression exp, Expression e, ref bool errors)
 {
+    if (e.op == TOKandand)
+    {
+        AndAndExp aae = cast(AndAndExp)e;
+        bool result = evalStaticCondition(sc, exp, aae.e1, errors);
+        if (errors || !result)
+            return false;
+        result = evalStaticCondition(sc, exp, aae.e2, errors);
+        return !errors && result;
+    }
+
+    if (e.op == TOKoror)
+    {
+        OrOrExp ooe = cast(OrOrExp)e;
+        bool result = evalStaticCondition(sc, exp, ooe.e1, errors);
+        if (errors)
+            return false;
+        if (result)
+            return true;
+        result = evalStaticCondition(sc, exp, ooe.e2, errors);
+        return !errors && result;
+    }
+
+    if (e.op == TOKquestion)
+    {
+        CondExp ce = cast(CondExp)e;
+        bool result = evalStaticCondition(sc, exp, ce.econd, errors);
+        if (errors)
+            return false;
+        Expression leg = result ? ce.e1 : ce.e2;
+        result = evalStaticCondition(sc, exp, leg, errors);
+        return !errors && result;
+    }
+
     uint nerrors = global.errors;
 
     sc = sc.startCTFE();

--- a/test/compilable/fix17335.d
+++ b/test/compilable/fix17335.d
@@ -1,0 +1,28 @@
+/*
+ * PERMUTE_ARGS:
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=17335
+
+bool alwaysFalse() { return false; }
+void main()
+{
+	static if (false && a == 1)
+	{
+	}
+	static if ("a" == "b" && b == 1)
+	{
+	}
+	static if (alwaysFalse() && c == 1)
+	{
+	}
+	static if (!alwaysFalse() || d == 1)
+	{
+	}
+	static if (alwaysFalse() ? e == 1 : 1)
+	{
+	}
+	static if (!alwaysFalse() ? 1 : f == 1)
+	{
+	}
+}

--- a/test/fail_compilation/ice10949.d
+++ b/test/fail_compilation/ice10949.d
@@ -4,9 +4,9 @@ TEST_OUTPUT:
 fail_compilation/ice10949.d(12): Deprecation: Using the result of a comma expression is deprecated
 fail_compilation/ice10949.d(12): Error: array index 3 is out of bounds [5, 5][0 .. 2]
 fail_compilation/ice10949.d(12): Error: array index 17 is out of bounds [2, 3][0 .. 2]
-fail_compilation/ice10949.d(12): Error: array index 9 is out of bounds [3, 3, 3][0 .. 3]
-fail_compilation/ice10949.d(12):        while evaluating: static assert((__error) || (__error))
+fail_compilation/ice10949.d(12):        while evaluating: static assert((((([5, 5][3] + global - global) * global / global % global >> global & global | global) ^ global) == 9 , [2, 3][17]) || [3, 3, 3][9] is 4 && [[1, 2, 3]][4].length)
 ---
 */
+
 int global;
 static assert((((((([5,5][3] + global - global)*global/global%global)>>global) &global|global)^global) == 9, [2,3][17]) || ([3,3,3][9] is 4) && ([[1,2,3]][4]).length);


### PR DESCRIPTION
… when evaluated during compilation

Also fix https://issues.dlang.org/show_bug.cgi?id=17334