### PR TITLE
fixup for - #6717 [Reg 2.075] link failure unsupported symbol section

### DIFF
--- a/test/runnable/test17338.d
+++ b/test/runnable/test17338.d
@@ -1,0 +1,25 @@
+// PERMUTE_ARGS:
+// Generate \sum_{i=0}^{14} 2^i = 32767 template instantiations
+// (each with 3 sections) to use more than 64Ki sections in total.
+version (Win32)
+{
+    // Apparently omf or optlink does not support more than 32767 symbols.
+    void main()
+    {
+    }
+}
+else
+{
+    size_t foo(size_t i, size_t mask)()
+    {
+        static if (i == 14)
+            return mask;
+        else
+            return foo!(i + 1, mask) + foo!(i + 1, mask | (1UL << i));
+    }
+
+    void main()
+    {
+        assert(foo!(0, 0) != 0);
+    }
+}


### PR DESCRIPTION
fixup for #6717 

- add test case for Issue 17338
- add workaround for Issue 17339

Fixing 17339 is out of scope here.