### PR TITLE
fix Issue 17339 - ambiguous mangling with const alias argument

### DIFF
--- a/src/ddmd/backend/elfobj.c
+++ b/src/ddmd/backend/elfobj.c
@@ -1736,13 +1736,9 @@ STATIC void setup_comdat(Symbol *s)
         const char *p = cpp_mangle(s);
         // Create a section for the comdat symbol with the SHF_GROUP bit set
         s->Sseg = ElfObj::getsegment(".text.", p, SHT_PROGBITS, SHF_ALLOC|SHF_EXECINSTR|SHF_GROUP, align);
-        /* Workaround https://issues.dlang.org/show_bug.cgi?id=17339, there was
-         * a previous instance with the same mangling.  Leave the section group
-         * empty and reuse the existing one. */
-        const bool issue17339 = MAP_SEG2SECIDX(s->Sseg) < groupsecidx;
+        assert(MAP_SEG2SECIDX(s->Sseg) > groupsecidx); // no existing section with identical mangling
         // add to section group
-        if (!issue17339)
-            SegData[groupseg]->SDbuf->write32(MAP_SEG2SECIDX(s->Sseg));
+        SegData[groupseg]->SDbuf->write32(MAP_SEG2SECIDX(s->Sseg));
 
         // Create a weak symbol for the comdat
         IDXSTR namidx = Obj::addstr(symtab_strings, p);
@@ -1757,17 +1753,8 @@ STATIC void setup_comdat(Symbol *s)
 
         if (s->Salignment > align)
             SegData[s->Sseg]->SDalignment = s->Salignment;
-        if (issue17339)
-        {
-            // existing section symbol and associated group
-            assert(SegData[s->Sseg]->SDsym);
-            assert(SegData[s->Sseg]->SDassocseg);
-        }
-        else
-        {
-            SegData[s->Sseg]->SDsym = s;
-            SegData[s->Sseg]->SDassocseg = groupseg;
-        }
+        SegData[s->Sseg]->SDsym = s;
+        SegData[s->Sseg]->SDassocseg = groupseg;
         return;
 #endif
     }

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -8246,8 +8246,10 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             }
             else if (ea)
             {
-                // Don't interpret it yet, it might actually be an alias
-                ea = ea.optimize(WANTvalue);
+                // Don't interpret it yet, it might actually be an alias template parameter.
+                // Only constfold manifest constants, not const/immutable lvalues, see https://issues.dlang.org/show_bug.cgi?id=17339.
+                enum keepLvalue = true;
+                ea = ea.optimize(WANTvalue, keepLvalue);
                 if (ea.op == TOKvar)
                 {
                     sa = (cast(VarExp)ea).var;

--- a/test/compilable/test17339.d
+++ b/test/compilable/test17339.d
@@ -1,0 +1,19 @@
+void foo(alias param)()
+{
+}
+
+const CONST1 = 1;
+const CONST2 = 1;
+static assert(&foo!CONST1 !is &foo!CONST2);
+static assert(foo!CONST1.mangleof != foo!CONST2.mangleof);
+
+immutable IMM1 = 1;
+immutable IMM2 = 1;
+static assert(&foo!IMM1 !is &foo!IMM2);
+static assert(foo!IMM1.mangleof != foo!IMM2.mangleof);
+
+// Behaves different for manifest constants!
+enum ENUM1 = 1;
+enum ENUM2 = 1;
+static assert(&foo!ENUM1 is &foo!ENUM2);
+static assert(foo!ENUM1.mangleof == foo!ENUM2.mangleof);


### PR DESCRIPTION
- don't constfold const/immutable variables to generate
  the mangling for alias template arguments

This already generated different instances (see `!is` and `is` assertions), just the mangling was wrong.