### PR TITLE
Fix issue 16995 - __traits(getUnitTests) works with separate compilation

### DIFF
--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -319,6 +319,11 @@ extern (C++) final class Module : Package
     int isDocFile;              // if it is a documentation input file, not D source
     bool isPackageFile;         // if it is a package.d
     int needmoduleinfo;
+    /**
+       How many unit tests have been seen so far in this module. Makes it so the
+       unit test name is reproducible regardless of whether it's compiled
+       separately or all at once.
+     */
     uint unitTestCounter;       // how many unittests have been seen so far
     int selfimports;            // 0: don't know, 1: does not, 2: does
 

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -319,7 +319,7 @@ extern (C++) final class Module : Package
     int isDocFile;              // if it is a documentation input file, not D source
     bool isPackageFile;         // if it is a package.d
     int needmoduleinfo;
-
+    uint unitTestCounter;       // how many unittests have been seen so far
     int selfimports;            // 0: don't know, 1: does not, 2: does
 
     /*************************************

--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -5144,10 +5144,11 @@ extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(UnitTestDeclaration utd)
     {
-        // the identifier has to be generated here in order to be able to link
-        // or not the files are compiled separately or all at once.
-        // See bugzilla #16995
-        utd.setIdentifier;
+        // The identifier has to be generated here in order for it to be possible
+        // to link regardless of whether the files were compiled separately
+        // or all at once. See:
+        // https://issues.dlang.org/show_bug.cgi?id=16995
+        utd.setIdentifier();
 
         if (utd.semanticRun >= PASSsemanticdone)
             return;

--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -5144,6 +5144,11 @@ extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(UnitTestDeclaration utd)
     {
+        // the identifier has to be generated here in order to be able to link
+        // or not the files are compiled separately or all at once.
+        // See bugzilla #16995
+        utd.setIdentifier;
+
         if (utd.semanticRun >= PASSsemanticdone)
             return;
         if (utd._scope)

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -3182,6 +3182,12 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
         return FuncDeclaration.syntaxCopy(utd);
     }
 
+    /**
+       Sets the "real" identifier, replacing the one created in the contructor.
+       The reason for this is that the "real" identifier can only be generated
+       properly in the semantic pass. See:
+       https://issues.dlang.org/show_bug.cgi?id=16995
+     */
     final void setIdentifier()
     {
         ident = createIdentifier(loc, _scope);
@@ -3193,7 +3199,6 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
      */
     private static Identifier createIdentifier(Loc loc, Scope* sc)
     {
-
         OutBuffer buf;
         auto index = sc ? sc._module.unitTestCounter++ : 0;
         buf.printf("__unittest_%s_%u_%d", loc.filename, loc.linnum, index);
@@ -3203,7 +3208,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
         for(int i = 0; str[i] != 0; ++i)
             if(str[i] == '/' || str[i] == '\\' || str[i] == '.') str[i] = '_';
 
-        return Identifier.idPool(buf.peekSlice);
+        return Identifier.idPool(buf.peekSlice());
     }
 
     override AggregateDeclaration isThis()

--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -81,7 +81,7 @@ public:
     int isDocFile;      // if it is a documentation input file, not D source
     bool isPackageFile; // if it is a package.d
     int needmoduleinfo;
-
+    unsigned unitTestCounter;       // how many unittests have been seen so far
     int selfimports;            // 0: don't know, 1: does not, 2: does
     bool selfImports();         // returns true if module imports itself
 

--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -81,7 +81,12 @@ public:
     int isDocFile;      // if it is a documentation input file, not D source
     bool isPackageFile; // if it is a package.d
     int needmoduleinfo;
-    unsigned unitTestCounter;       // how many unittests have been seen so far
+    /**
+       How many unit tests have been seen so far in this module. Makes it so the
+       unit test name is reproducible regardless of whether it's compiled
+       separately or all at once.
+     */
+    unsigned unitTestCounter;
     int selfimports;            // 0: don't know, 1: does not, 2: does
     bool selfImports();         // returns true if module imports itself
 

--- a/test/compilable/imports/module_with_tests.d
+++ b/test/compilable/imports/module_with_tests.d
@@ -1,0 +1,1 @@
+unittest {} unittest {}

--- a/test/compilable/issue16995.d
+++ b/test/compilable/issue16995.d
@@ -1,0 +1,13 @@
+// EXTRA_SOURCES: imports/module_with_tests.d
+// REQUIRED_ARGS: -unittest
+// COMPILE_SEPARATELY
+
+
+import imports.module_with_tests;
+
+void main() {
+    import module_with_tests;
+    foreach(ut; __traits(getUnitTests, module_with_tests)) {
+        ut();
+    }
+}

--- a/test/fail_compilation/fail7848.d
+++ b/test/fail_compilation/fail7848.d
@@ -3,16 +3,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7848.d(35): Error: pure function 'fail7848.C.__unittestL33_$n$' cannot call impure function 'fail7848.func'
-fail_compilation/fail7848.d(35): Error: @safe function 'fail7848.C.__unittestL33_$n$' cannot call @system function 'fail7848.func'
-fail_compilation/fail7848.d(35): Error: @nogc function 'fail7848.C.__unittestL33_$n$' cannot call non-@nogc function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: pure function 'fail7848.C.__unittest_fail_compilation_fail7848_d_33_0' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: @safe function 'fail7848.C.__unittest_fail_compilation_fail7848_d_33_0' cannot call @system function 'fail7848.func'
+fail_compilation/fail7848.d(35): Error: @nogc function 'fail7848.C.__unittest_fail_compilation_fail7848_d_33_0' cannot call non-@nogc function 'fail7848.func'
 fail_compilation/fail7848.d(35): Error: function `fail7848.func` is not nothrow
-fail_compilation/fail7848.d(33): Error: nothrow function `fail7848.C.__unittestL33_$n$` may throw
-fail_compilation/fail7848.d(40): Error: pure function 'fail7848.C.__invariant2' cannot call impure function 'fail7848.func'
-fail_compilation/fail7848.d(40): Error: @safe function 'fail7848.C.__invariant2' cannot call @system function 'fail7848.func'
-fail_compilation/fail7848.d(40): Error: @nogc function 'fail7848.C.__invariant2' cannot call non-@nogc function 'fail7848.func'
+fail_compilation/fail7848.d(33): Error: nothrow function `fail7848.C.__unittest_fail_compilation_fail7848_d_33_0` may throw
+fail_compilation/fail7848.d(40): Error: pure function 'fail7848.C.__invariant1' cannot call impure function 'fail7848.func'
+fail_compilation/fail7848.d(40): Error: @safe function 'fail7848.C.__invariant1' cannot call @system function 'fail7848.func'
+fail_compilation/fail7848.d(40): Error: @nogc function 'fail7848.C.__invariant1' cannot call non-@nogc function 'fail7848.func'
 fail_compilation/fail7848.d(40): Error: function `fail7848.func` is not nothrow
-fail_compilation/fail7848.d(38): Error: nothrow function `fail7848.C.__invariant2` may throw
+fail_compilation/fail7848.d(38): Error: nothrow function `fail7848.C.__invariant1` may throw
 fail_compilation/fail7848.d(45): Error: pure allocator 'fail7848.C.new' cannot call impure function 'fail7848.func'
 fail_compilation/fail7848.d(45): Error: @safe allocator 'fail7848.C.new' cannot call @system function 'fail7848.func'
 fail_compilation/fail7848.d(45): Error: @nogc allocator 'fail7848.C.new' cannot call non-@nogc function 'fail7848.func'

--- a/test/fail_compilation/ice14424.d
+++ b/test/fail_compilation/ice14424.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14424.d(12): Error: `tuple` has no effect in expression `tuple(__unittestL3_$n$)`
+fail_compilation/ice14424.d(12): Error: `tuple` has no effect in expression `tuple(__unittest_fail_compilation_imports_a14424_d_3_0)`
 ---
 */
 


### PR DESCRIPTION
Before this patch, `__traits(getUnitTests)` only worked when compiling all source files at once. This fix enables it to work for separate compilation as well.