### PR TITLE
refactor: checkNestedRef() to ensureStaticLinkTo()

### DIFF
--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -50,7 +50,7 @@ extern (C++) bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, 
     {
         //printf("ad = %p %s [%s], parent:%p\n", ad, ad.toChars(), ad.loc.toChars(), ad.parent);
         //printf("sparent = %p %s [%s], parent: %s\n", sparent, sparent.toChars(), sparent.loc.toChars(), sparent.parent,toChars());
-        if (checkNestedRef(s, sparent))
+        if (!ensureStaticLinkTo(s, sparent))
         {
             error(loc, "cannot access frame pointer of %s", ad.toPrettyChars());
             return true;
@@ -2329,7 +2329,7 @@ extern (C++) class VarDeclaration : Declaration
         Dsymbol p = toParent2();
 
         // Function literals from fdthis to p must be delegates
-        checkNestedRef(fdthis, p);
+        ensureStaticLinkTo(fdthis, p);
 
         // The function that this variable is in
         FuncDeclaration fdv = p.isFuncDeclaration();

--- a/src/ddmd/delegatize.d
+++ b/src/ddmd/delegatize.d
@@ -170,12 +170,25 @@ extern (C++) bool lambdaCheckForNestedRef(Expression e, Scope* sc)
     return v.result;
 }
 
-bool checkNestedRef(Dsymbol s, Dsymbol p)
+/*****************************************
+ * See if context `s` is nested within context `p`, meaning
+ * it `p` is reachable at runtime by walking the static links.
+ * If any of the intervening contexts are function literals,
+ * make sure they are delegates.
+ * Params:
+ *      s = inner context
+ *      p = outer context
+ * Returns:
+ *      true means it is accessible by walking the context pointers at runtime
+ * References:
+ *      for static links see https://en.wikipedia.org/wiki/Call_stack#Functions_of_the_call_stack
+ */
+bool ensureStaticLinkTo(Dsymbol s, Dsymbol p)
 {
     while (s)
     {
         if (s == p) // hit!
-            return false;
+            return true;
 
         if (auto fd = s.isFuncDeclaration())
         {
@@ -193,5 +206,5 @@ bool checkNestedRef(Dsymbol s, Dsymbol p)
         }
         s = s.toParent2();
     }
-    return true;
+    return false;
 }

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -122,7 +122,7 @@ L1:
                 e1 = new DotVarExp(loc, e1, tcd.vthis);
                 e1.type = tcd.vthis.type;
                 e1.type = e1.type.addMod(t.mod);
-                // Do not call checkNestedRef()
+                // Do not call ensureStaticLinkTo()
                 //e1 = e1.semantic(sc);
 
                 // Skip up over nested functions, and get the enclosing
@@ -6146,7 +6146,7 @@ extern (C++) final class NewExp : Expression
                 else if (auto fdn = s.isFuncDeclaration())
                 {
                     // make sure the parent context fdn of cd is reachable from sc
-                    if (checkNestedRef(sc.parent, fdn))
+                    if (!ensureStaticLinkTo(sc.parent, fdn))
                     {
                         error("outer function context of %s is needed to 'new' nested class %s",
                             fdn.toPrettyChars(), cd.toPrettyChars());

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -3296,7 +3296,7 @@ extern (C++) class FuncDeclaration : Declaration
         Dsymbol p = toParent2();
 
         // Function literals from fdthis to p must be delegates
-        checkNestedRef(fdthis, p);
+        ensureStaticLinkTo(fdthis, p);
 
         if (isNested())
         {

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -9539,7 +9539,7 @@ extern (C++) final class TypeClass : Type
                         e1 = new DotVarExp(e.loc, e1, tcd.vthis);
                         e1.type = tcd.vthis.type;
                         e1.type = e1.type.addMod(t.mod);
-                        // Do not call checkNestedRef()
+                        // Do not call ensureStaticLinkTo()
                         //e1 = e1.semantic(sc);
 
                         // Skip up over nested functions, and get the enclosing


### PR DESCRIPTION
A better name, and less confusing use of true/false/not.