### PR TITLE
Possible improvement to idgen.d

### DIFF
--- a/src/ddmd/idgen.d
+++ b/src/ddmd/idgen.d
@@ -373,14 +373,20 @@ Msgtable[] msgtable =
     { "udaSelector", "selector" },
 ];
 
+const(char)* relativeFile(T)(T name)
+{
+    immutable fileDirectory = __FILE_FULL_PATH__[0..$-8];
+    return (fileDirectory~"/"~name~"\0").ptr;
+}
 
 int main()
 {
     {
-        auto fp = fopen("ddmd/id.h","wb");
+        auto idHeaderFile = relativeFile("id.h");
+        auto fp = fopen(idHeaderFile,"wb");
         if (!fp)
         {
-            printf("can't open ddmd.id.h\n");
+            printf("can't open \"%s\"\n", idHeaderFile);
             exit(EXIT_FAILURE);
         }
 
@@ -405,10 +411,11 @@ int main()
     }
 
     {
-        auto fp = fopen("ddmd/id.d","wb");
+        auto idDFile = relativeFile("id.d");
+        auto fp = fopen(idDFile,"wb");
         if (!fp)
         {
-            printf("can't open ddmd.id.d\n");
+            printf("can't open \"%s\"\n", idDFile);
             exit(EXIT_FAILURE);
         }
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -446,11 +446,8 @@ optabgen.out : $G/optabgen
 ######## idgen generates some source
 
 idgen_output = $D/id.h $D/id.d
-$(idgen_output) : $G/idgen
-
-$G/idgen: $D/idgen.d $(HOST_DMD_PATH)
-	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $<
-	$G/idgen
+$(idgen_output) : $D/idgen.d
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -run $<
 
 #########
 # STRING_IMPORT_FILES

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -415,8 +415,7 @@ $(OPTABGENOUTPUT) : \
 	$(DEL) *.c
 
 $(IDGENOUTPUT) : $D\idgen.d
-	$(HOST_DC) -of$G\idgen $D\idgen.d
-	$G/idgen
+	$(HOST_DC) -run $D\idgen.d
 
 $G\verstr.h : ..\VERSION
 	echo "$(..\VERSION)" >$G\verstr.h


### PR DESCRIPTION
Possibly a good candidate for using the new `__FILE_FULL_PATH__` macro.  Modifies "idgen.d" to be compiled and ran in a single command `dmd -run idgen.d` instead of compiling and running in 2 separate steps.  This removes the need to save the compiled idgen.exe executable somewhere.  Also removes the need to run idgen from a particular directory because it generates the files relative to where idgen.d source lives instead of the current directory.