### PR TITLE
Moved "tochars" validation from RUNTIME to COMPILE-TIME

### DIFF
--- a/src/ddmd/tokens.d
+++ b/src/ddmd/tokens.d
@@ -834,6 +834,12 @@ extern (C++) struct Token
         TOKcantexp: "cantexp",
     ];
 
+    static assert(() {
+        foreach (s; tochars)
+            assert(s.length);
+        return true;
+    }());
+
     static this()
     {
         Identifier.initTable();
@@ -841,11 +847,6 @@ extern (C++) struct Token
         {
             //printf("keyword[%d] = '%s'\n",kw, tochars[kw].ptr);
             Identifier.idPool(tochars[kw].ptr, tochars[kw].length, cast(uint)kw);
-        }
-
-        foreach (i, s; tochars)
-        {
-            assert(s.length);
         }
     }
 


### PR DESCRIPTION
I removed the runtime foreach loop inside the `static this()` constructor in the "tokens.d" module.  I replaced it with a static assert so the validation would be done at "compile-time" instead.