### PR TITLE
Common type between character types should be another character type.

### DIFF
--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -2701,7 +2701,7 @@ extern (C++) bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expres
     Type t1b = e1.type.toBasetype();
     Type t2b = e2.type.toBasetype();
 
-    if (op != TOKquestion || t1b.ty != t2b.ty && (t1b.isTypeBasic() && t2b.isTypeBasic()))
+    if (op != TOKquestion && t1b.ty != t2b.ty && (t1b.isTypeBasic() && t2b.isTypeBasic()))
     {
         e1 = integralPromotions(e1, sc);
         e2 = integralPromotions(e2, sc);

--- a/src/ddmd/impcnvtab.d
+++ b/src/ddmd/impcnvtab.d
@@ -75,6 +75,18 @@ ImpCnvTab generateImpCnvTab()
 
     /* ======================= */
 
+    X(Tchar,Tchar,        Tchar,Tchar,           Tchar);
+    X(Tchar,Twchar,       Tchar,Twchar,          Twchar);
+    X(Tchar,Tdchar,       Tchar,Tdchar,          Tdchar);
+    X(Twchar,Tchar,       Twchar,Tchar,          Twchar);
+    X(Twchar,Twchar,      Twchar,Twchar,         Twchar);
+    X(Twchar,Tdchar,      Twchar,Tdchar,         Tdchar);
+    X(Tdchar,Tchar,       Tdchar,Tchar,          Tdchar);
+    X(Tdchar,Twchar,      Tdchar,Twchar,         Tdchar);
+    X(Tdchar,Tdchar,      Tdchar,Tdchar,         Tdchar);
+
+    /* ======================= */
+
     X(Tint8,Tint8,   Tint32,Tint32,  Tint32);
     X(Tint8,Tuns8,   Tint32,Tint32,  Tint32);
     X(Tint8,Tint16,  Tint32,Tint32,  Tint32);


### PR DESCRIPTION
This is my hamfisted fix for [issue 17141](https://issues.dlang.org/show_bug.cgi?id=17141). I'm pretty sure it breaks something out there, but at least it worked for the use case described in the bug! (The reason for submitting it here is really so that the autotester can tell me what I've broken.)