### PR TITLE
Generate id.d and id.h using "dmd -run idgen.d" instead of compiling

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -446,11 +446,9 @@ optabgen.out : $G/optabgen
 ######## idgen generates some source
 
 idgen_output = $D/id.h $D/id.d
-$(idgen_output) : $G/idgen
 
-$G/idgen: $D/idgen.d $(HOST_DMD_PATH)
-	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $<
-	$G/idgen
+$(idgen_output): $D/idgen.d $(HOST_DMD_PATH)
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -run $<
 
 #########
 # STRING_IMPORT_FILES

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -415,8 +415,7 @@ $(OPTABGENOUTPUT) : \
 	$(DEL) *.c
 
 $(IDGENOUTPUT) : $D\idgen.d
-	$(HOST_DC) -of$G\idgen $D\idgen.d
-	$G/idgen
+	$(HOST_DC) -run $D\idgen.d
 
 $G\verstr.h : ..\VERSION
 	echo "$(..\VERSION)" >$G\verstr.h


### PR DESCRIPTION
Simple build simplification.  Run idgen.d directly using "dmd -run" instead of compiling and running in 2 seperate steps.