### PR TITLE
Silence GCC unused-parameter and cast-qual warnings

### DIFF
--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -48,7 +48,7 @@ public:
 
     bool isAncestorPackageOf(const Package * const pkg) const;
 
-    void semantic(Scope *sc) { }
+    void semantic(Scope *) { }
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
     void accept(Visitor *v) { v->visit(this); }
 

--- a/src/ddmd/root/array.h
+++ b/src/ddmd/root/array.h
@@ -148,8 +148,8 @@ struct Array
     #endif
             Array_sort_compare(const void *x, const void *y)
             {
-                RootObject *ox = *(RootObject **)x;
-                RootObject *oy = *(RootObject **)y;
+                RootObject *ox = *(RootObject **)const_cast<void *>(x);
+                RootObject *oy = *(RootObject **)const_cast<void *>(y);
 
                 return ox->compare(oy);
             }


### PR DESCRIPTION
See #2194.

Granted that dmd no longer uses these, previous attempts at changing them may now be unblocked.

@yebblies @ldc-developers.