### PR TITLE
Symbol is a tree_node IN_GCC

### DIFF
--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -53,7 +53,6 @@ class UnitTestDeclaration;
 class NewDeclaration;
 class VarDeclaration;
 class AttribDeclaration;
-struct Symbol;
 class Package;
 class Module;
 class Import;
@@ -74,6 +73,11 @@ class Expression;
 class DeleteDeclaration;
 class OverloadSet;
 struct AA;
+#ifdef IN_GCC
+typedef union tree_node Symbol;
+#else
+struct Symbol;
+#endif
 
 struct Ungag
 {

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -43,13 +43,17 @@ class TemplateInstance;
 class TemplateDeclaration;
 class ClassDeclaration;
 class BinExp;
-struct Symbol;          // back end symbol
 class OverloadSet;
 class Initializer;
 class StringExp;
 class ArrayExp;
 class SliceExp;
 struct UnionExp;
+#ifdef IN_GCC
+typedef union tree_node Symbol;
+#else
+struct Symbol;          // back end symbol
+#endif
 
 void initPrecedence();
 


### PR DESCRIPTION
Last one from #2194.

That leaves only `ExtAsmStatement` - which is undecided - and `WrappedExp` which I plan on removing.

@yebblies - Maybe DMD and GDC would be conceptually sharing the same frontend by the end of the year. :-)