### PR TITLE
Treating import paths the same for posix&windows

### DIFF
--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -524,12 +524,11 @@ nothrow:
             for (const(char)* p = name; *p; p++)
             {
                 char c = *p;
-                if (c == '\\' || c == ':' || c == '%' || (c == '.' && p[1] == '.') || (c == '/' && p[1] == '/'))
+                if (c == '\\' || c == ':' || c == '%' || (c == '/' && p[1] == '/'))
                 {
                     return null;
                 }
             }
-            return FileName.searchPath(path, name, false);
         }
         else version (Posix)
         {
@@ -543,47 +542,47 @@ nothrow:
                     return null;
                 }
             }
-            if (path)
-            {
-                /* Each path is converted to a cannonical name and then a check is done to see
-                 * that the searched name is really a child one of the the paths searched.
-                 */
-                for (size_t i = 0; i < path.dim; i++)
-                {
-                    const(char)* cname = null;
-                    const(char)* cpath = canonicalName((*path)[i]);
-                    //printf("FileName::safeSearchPath(): name=%s; path=%s; cpath=%s\n",
-                    //      name, (char *)path.data[i], cpath);
-                    if (cpath is null)
-                        goto cont;
-                    cname = canonicalName(combine(cpath, name));
-                    //printf("FileName::safeSearchPath(): cname=%s\n", cname);
-                    if (cname is null)
-                        goto cont;
-                    //printf("FileName::safeSearchPath(): exists=%i "
-                    //      "strncmp(cpath, cname, %i)=%i\n", exists(cname),
-                    //      strlen(cpath), strncmp(cpath, cname, strlen(cpath)));
-                    // exists and name is *really* a "child" of path
-                    if (exists(cname) && strncmp(cpath, cname, strlen(cpath)) == 0)
-                    {
-                        .free(cast(void*)cpath);
-                        const(char)* p = mem.xstrdup(cname);
-                        .free(cast(void*)cname);
-                        return p;
-                    }
-                cont:
-                    if (cpath)
-                        .free(cast(void*)cpath);
-                    if (cname)
-                        .free(cast(void*)cname);
-                }
-            }
-            return null;
         }
         else
         {
             assert(0);
         }
+        if (path)
+        {
+            /* Each path is converted to a cannonical name and then a check is done to see
+             * that the searched name is really a child one of the the paths searched.
+             */
+            for (size_t i = 0; i < path.dim; i++)
+            {
+                const(char)* cname = null;
+                const(char)* cpath = canonicalName((*path)[i]);
+                //printf("FileName::safeSearchPath(): name=%s; path=%s; cpath=%s\n",
+                //      name, (char *)path.data[i], cpath);
+                if (cpath is null)
+                    goto cont;
+                cname = canonicalName(combine(cpath, name));
+                //printf("FileName::safeSearchPath(): cname=%s\n", cname);
+                if (cname is null)
+                    goto cont;
+                //printf("FileName::safeSearchPath(): exists=%i "
+                //      "strncmp(cpath, cname, %i)=%i\n", exists(cname),
+                //      strlen(cpath), strncmp(cpath, cname, strlen(cpath)));
+                // exists and name is *really* a "child" of path
+                if (exists(cname) && strncmp(cpath, cname, strlen(cpath)) == 0)
+                {
+                    .free(cast(void*)cpath);
+                    const(char)* p = mem.xstrdup(cname);
+                    .free(cast(void*)cname);
+                    return p;
+                }
+            cont:
+                if (cpath)
+                    .free(cast(void*)cpath);
+                if (cname)
+                    .free(cast(void*)cname);
+            }
+        }
+        return null;
     }
 
     extern (C++) static int exists(const(char)* name)

--- a/test/runnable/test37.d
+++ b/test/runnable/test37.d
@@ -9,4 +9,7 @@ void main()
     // also want to ensure that we can access
     // imports in a subdirectory of the -J path
     writefln(import("std14198/uni.d"));
+    // and also that paths can be dealt with properly
+	// regardless of how stupid they are
+    writefln(import("std14198/../std14198/uni.d"));
 }


### PR DESCRIPTION
Besides special blacklisting of forbidden path elements, there should be no reason to treat windows differently from posix when determining if a program should be allowed to perform a string import.

Current windows-specific blacklisting:

- No leading `/` ([here](https://github.com/DrInfiniteExplorer/dmd/blob/ce1e74ee9a31004e5d00a86125b58b2467af2dad/src/ddmd/root/filename.d#L507))
- No `\` allowed at all (why though?)
- No `:` allowed
- No `%` allowed
- No `//` allowed

This PR unifies the way that import paths are checked for validity. The main purpose of this is to make sure that things which are passed to `import(...)` do not escape the folders specified with `-J <path>`.
I can't see why one should disallow absolute paths, as long as those paths point to objects within the `-J` paths.

If one wants to import a file which is relative to the current module with help of `__FILE__` or `__FILE_FULL_PATH__` and one is doing an out-of-source build on windows, then `__FILE__` can contain `..` which was previously illegal. With `__FILE_FULL_PATH__` (when it works) you get an absolute path, which was similarly illegal. But it shouldn't really matter, as long as the pointed-to-file is within the `-J` paths.

I don't know why `%` is illegal though. Can someone clarify this?

`:` is possibly illegal to "detect" absolute windows paths which include a drive letter followed with a colon. This is kind of flawed for two reasons, one being the absolute-path-issue mentioned above. The other issue is that this makes paths to alternate data streams illegal.