### PR TITLE
Fix coverage reports with the new src/ddmd layout

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1708,9 +1708,9 @@ int main()
             return path;
         }
         version (Windows)
-            enum sourcePath = dirName(__FILE_FULL_PATH__, `\`);
+            enum sourcePath = dirName(dirName(__FILE_FULL_PATH__, `\`), `\`);
         else
-            enum sourcePath = dirName(__FILE_FULL_PATH__, '/');
+            enum sourcePath = dirName(dirName(__FILE_FULL_PATH__, '/'), '/');
 
         dmd_coverSourcePath(sourcePath);
         dmd_coverDestPath(sourcePath);


### PR DESCRIPTION
I had a quick look at the broken CodeCov reporting. It turns out that empty .lst files are written. This is due to the changed DMD source layout. This simple change should fix it. However, it's a bit ugly for now as this is just an initial test.
CC @MartinNowak @WalterBright 