### PR TITLE
Added bugtracker keyword links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,11 @@ Before submitting a PR there are some things you can check which will hopefully 
   - Descriptive commit messages ease review and catching bugs
   - Keep pull requests focused on one single topic or bug.  For example, if your fix requires a refactoring, then the refactoring should be submitted as a separate pull request.
 
-### Finding bugs to work on
+### Find bugs to work on
 
-For first time contributers, we suggest to look for issues categorized as [trivial](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=trivial&product=D). You may continue with issues categorized [bootcamp](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=bootcamp&product=D).
+For first-time contributers, we suggest to look for issues categorized as [trivial](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=trivial&product=D). You may continue with issues categorized [bootcamp](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=bootcamp&product=D).
 
-If you want a hassle free contribution look for issues categorized as [preapproved](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=preapproved&product=D).
+If you want a hassle-free contribution look for issues categorized as [preapproved](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=preapproved&product=D).
 
 ## dmd-internals mailing list
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,11 @@ Before submitting a PR there are some things you can check which will hopefully 
   - Descriptive commit messages ease review and catching bugs
   - Keep pull requests focused on one single topic or bug.  For example, if your fix requires a refactoring, then the refactoring should be submitted as a separate pull request.
 
+### Finding bugs to work on
+
+For first time contributers, we suggest to look for issues categorized as [trivial](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=trivial&product=D). You may continue with issues categorized [bootcamp](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=bootcamp&product=D).
+
+If you want a hassle free contribution look for issues categorized as [preapproved](https://issues.dlang.org/buglist.cgi?component=dmd&keywords=preapproved&product=D).
 
 ## dmd-internals mailing list
 


### PR DESCRIPTION
* added categories `trivial`, `bootcamp` and `preapproved` as direct links to encourage a good start for new contributors.