### PR TITLE
Fix compiler-inserted destructor call on shared objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/dmd.exe
 -.DS_Store
 -trace.def
 -trace.log
+*.lst
 
 # Visual Studio files
 *.exe

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -2192,6 +2192,11 @@ extern (C++) class VarDeclaration : Declaration
                  */
                 e.type = e.type.mutableOf();
 
+                // Enable calling destructors on shared objects.
+                // The destructor is always a single, non-overloaded function,
+                // and must serve both shared and non-shared objects.
+                e.type = e.type.unSharedOf;
+
                 e = new DotVarExp(loc, e, sd.dtor, false);
                 e = new CallExp(loc, e);
             }

--- a/test/compilable/shared_destructor.d
+++ b/test/compilable/shared_destructor.d
@@ -1,0 +1,21 @@
+struct MaybeShared
+{
+    this(this T)()
+    {
+
+    }
+
+    ~this()
+    {
+
+    }
+}
+
+void main() {
+    {
+        auto aboutToDie = MaybeShared();
+    }
+    {
+        auto aboutToDie = shared MaybeShared();
+    }
+}


### PR DESCRIPTION
Currently, a struct can be used as both shared and not when the constructor (and other functions) are templated on this. Defining a destructor breaks this because destructors can't be templated, and the non-shared destructor call on a shared `this` fails. This patch fixes this in a manner similar to how the compiler already treats destructor calls on `immutable` and `const` objects: by casting it away.

Since the compiler-generated destructor call is always scoped, only one thread is destroying it anyway.