### PR TITLE
[WIP - Do not merge] Fix issue 16265 - unittest imports should not be counted for cycles

### DIFF
--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -254,6 +254,22 @@ extern (C++) final class Import : Dsymbol
             // Modules need a list of each imported module
             //printf("%s imports %s\n", sc.module.toChars(), mod.toChars());
             sc._module.aimports.push(mod);
+            // determine if import is in a unittest
+            {
+                bool isUnittest = false;
+                for (Scope* utscope = sc; utscope; utscope = utscope.enclosing)
+                {
+                    if(auto scopesym = utscope.scopesym)
+                    {
+                        if(scopesym.isUnitTestDeclaration())
+                        {
+                            isUnittest = true;
+                            break;
+                        }
+                    }
+                }
+                sc._module.utImports.pushBit(isUnittest);
+            }
 
             if (sc.explicitProtection)
                 protection = sc.protection;

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -259,9 +259,9 @@ extern (C++) final class Import : Dsymbol
                 bool isUnittest = false;
                 for (Scope* utscope = sc; utscope; utscope = utscope.enclosing)
                 {
-                    if(auto scopesym = utscope.func)
+                    if (auto scopesym = utscope.func)
                     {
-                        if(scopesym.isUnitTestDeclaration())
+                        if (scopesym.isUnitTestDeclaration())
                         {
                             isUnittest = true;
                             break;

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -252,14 +252,14 @@ extern (C++) final class Import : Dsymbol
         if (mod)
         {
             // Modules need a list of each imported module
-            //printf("%s imports %s\n", sc.module.toChars(), mod.toChars());
+            //printf("%s imports %s\n", sc._module.toChars(), mod.toChars());
             sc._module.aimports.push(mod);
             // determine if import is in a unittest
             {
                 bool isUnittest = false;
                 for (Scope* utscope = sc; utscope; utscope = utscope.enclosing)
                 {
-                    if(auto scopesym = utscope.scopesym)
+                    if(auto scopesym = utscope.func)
                     {
                         if(scopesym.isUnitTestDeclaration())
                         {

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -32,6 +32,7 @@ import ddmd.root.file;
 import ddmd.root.filename;
 import ddmd.root.outbuffer;
 import ddmd.root.port;
+import ddmd.root.array;
 import ddmd.target;
 import ddmd.visitor;
 
@@ -360,6 +361,7 @@ extern (C++) final class Module : Package
     Dsymbols* decldefs;         // top level declarations for this Module
 
     Modules aimports;           // all imported modules
+    BitArray utImports;         // whether the import is inside a unit test
 
     uint debuglevel;            // debug level
     Strings* debugids;          // debug identifiers

--- a/src/ddmd/glue.d
+++ b/src/ddmd/glue.d
@@ -152,6 +152,7 @@ void obj_write_deferred(Library library)
             md.doppelganger = 1;       // identify this module as doppelganger
             md.md = m.md;
             md.aimports.push(m);       // it only 'imports' m
+            md.utImports.pushBit(false); // not a unittest
             md.massert = m.massert;
             md.munittest = m.munittest;
             md.marray = m.marray;

--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -18,6 +18,7 @@
 
 #include "root.h"
 #include "dsymbol.h"
+#include "array.h"
 
 class ClassDeclaration;
 struct ModuleDeclaration;
@@ -102,6 +103,7 @@ public:
     Dsymbols *decldefs;         // top level declarations for this Module
 
     Modules aimports;             // all imported modules
+    BitArray utImports;           // whether import is in unit test
 
     unsigned debuglevel;        // debug level
     Strings *debugids;      // debug identifiers

--- a/src/ddmd/root/array.d
+++ b/src/ddmd/root/array.d
@@ -224,13 +224,20 @@ nothrow:
 
     void opIndexAssign(bool val, size_t idx) pure
     {
-        import core.bitop : btc, bts;
+        import core.bitop : btr, bts;
 
         assert(idx < length);
         if (val)
             bts(ptr, idx);
         else
-            btc(ptr, idx);
+            btr(ptr, idx);
+    }
+
+    // helper to push a bit
+    void pushBit(bool b)
+    {
+        this.length = len + 1;
+        this[len - 1] = b;
     }
 
     @disable this(this);

--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -109,9 +109,11 @@ void genModuleInfo(Module m)
     size_t aimports_dim = m.aimports.dim;
     for (size_t i = 0; i < m.aimports.dim; i++)
     {
-        Module mod = m.aimports[i];
-        if (!mod.needmoduleinfo)
+        Module imported = m.aimports[i];
+
+        if (!imported.needmoduleinfo || m.utImports[i])
             aimports_dim--;
+
     }
 
     FuncDeclaration sgetmembers = m.findGetMembers();
@@ -177,12 +179,12 @@ void genModuleInfo(Module m)
         dtb.size(aimports_dim);
         foreach (i; 0 .. m.aimports.dim)
         {
-            Module mod = m.aimports[i];
+            Module imported = m.aimports[i];
 
-            if (!mod.needmoduleinfo)
+            if (!imported.needmoduleinfo || m.utImports[i])
                 continue;
 
-            Symbol *s = toSymbol(mod);
+            Symbol *s = toSymbol(imported);
 
             /* Weak references don't pull objects in from the library,
              * they resolve to 0 if not pulled in by something else.


### PR DESCRIPTION
The referenced issue contains the details.

This prevents any dependencies based on the fact that it's in a unittest block. The unit test block shouldn't be called from within a static ctor (normally), so there should be no issue.

However, I have had second thoughts on the situation of instantiated templates with static ctors. In that case, the ctor is placed inside the instantiating module, but the ctor can depend on modules imported by the defining module. In this case, I think we should actually add the imported module as a dependency, but I'm not familiar enough with the dmd code to know how to determine this. I will do some more investigation. The module import should be added (or amended to reset the unittest flag) when the instantiation adds the static ctor to the local module. Don't merge for now.

ping @MartinNowak @WalterBright 