### PR TITLE
Fix alignment/size of packed aggregates (issue #17277)

### DIFF
--- a/test/compilable/aggr_alignment.d
+++ b/test/compilable/aggr_alignment.d
@@ -1,0 +1,28 @@
+struct S1 // overall alignment: max(1, 1) = 1
+{
+    byte[5] bytes;
+    struct // overall alignment: max(1, 1) = 1
+    {
+        byte byte1;
+        align(1) int int1;
+    }
+}
+
+static assert(S1.int1.offsetof == 6);
+static assert(S1.alignof == 1);
+static assert(S1.sizeof == 10);
+
+class C2 // overall alignment: max(vtbl.alignof, monitor.alignof, 1, 2)
+{
+    byte[5] bytes;
+    struct // overall alignment: max(1, 2) = 2
+    {
+        byte byte1;
+        align(2) int int1;
+    }
+}
+
+enum payloadOffset = C2.bytes.offsetof;
+static assert(C2.int1.offsetof == payloadOffset + 8);
+static assert(C2.alignof == size_t.sizeof);
+static assert(__traits(classInstanceSize, C2) == payloadOffset + 12);

--- a/test/runnable/cabi1.d
+++ b/test/runnable/cabi1.d
@@ -209,6 +209,36 @@ void test15()
 
 /******************************************/
 
+// see https://issues.dlang.org/show_bug.cgi?id=17277
+struct S16 {
+  char[5] a;
+  struct {
+    char b;
+    align(1) int c;
+  }
+}
+
+extern (C) S16 ctest16(ubyte x, S16, ubyte y);
+
+void test16()
+{
+  version (X86) // misaligned field
+  {
+  S16 t;
+  assert(S16.sizeof == 10);
+  assert(S16.alignof == 1);
+  t.a = "hello";
+  t.b = 3;
+  t.c = 0x11223344;
+  auto s = ctest16(1, t, 5);
+  assert(s.a == "hello");
+  assert(s.b == 3);
+  assert(s.c == 0x11223344);
+  }
+}
+
+/******************************************/
+
 int main()
 {
     test1();
@@ -226,6 +256,7 @@ else
     test13();
     test14();
     test15();
+    test16();
 
     return 0;
 }

--- a/test/runnable/extra-files/cabi2.cpp
+++ b/test/runnable/extra-files/cabi2.cpp
@@ -217,6 +217,37 @@ S15 ctest15(char x, S15 s, char y) {
 }
 
 
+/**********************************************/
+
+typedef struct S16 {
+  char a[5];
+#ifdef __GNUC__
+  struct __attribute__((packed))
+#else
+  #pragma pack(push, 1)
+  struct
+#endif
+  {
+    char b;
+    int c;
+  };
+#ifndef __GNUC__
+  #pragma pack(pop)
+#endif
+} S16;
+
+S16 ctest16(char x, S16 s, char y) {
+  printf("C sz = %d\n", (int)sizeof(S16));
+  assert(sizeof(S16) == 10);
+  printf("x   = %d\n", (int)x);
+  printf("s.a = %.*s\n", 5, s.a);
+  printf("s.b = %d\n", (int)s.b);
+  printf("s.c = %d\n", s.c);
+  printf("y   = %d\n", (int)y);
+  return s;
+}
+
+
 
 #if __cplusplus
 }


### PR DESCRIPTION
Change the definition of an aggregate's overall alignment from maximum of each field's `max(natural type alignment, optional alignment attribute)` to maximum of each field's actual alignment (which may be less than its type's natural alignment).

See [issue 17277](https://issues.dlang.org/show_bug.cgi?id=17277).