### PR TITLE
Lower dynamic array comparison to __equals template

### DIFF
--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -7859,16 +7859,47 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
+        Type t1 = exp.e1.type.toBasetype();
+        Type t2 = exp.e2.type.toBasetype();
+
+
+        bool needsDirectEq()
+        {
+            Type t1n = t1.nextOf().toBasetype();
+            Type t2n = t2.nextOf().toBasetype();
+            if (((t1n.ty == Tchar || t1n.ty == Twchar || t1n.ty == Tdchar) &&
+                 (t2n.ty == Tchar || t2n.ty == Twchar || t2n.ty == Tdchar)) ||
+                (t1n.ty == Tvoid || t2n.ty == Tvoid))
+            {
+                return false;
+            }
+            if (t1n.constOf() != t2n.constOf())
+                return true;
+
+            Type t = t1n;
+            while (t.toBasetype().nextOf())
+                t = t.nextOf().toBasetype();
+            if (t.ty != Tstruct)
+                return false;
+
+            semanticTypeInfo(sc, t);
+            return (cast(TypeStruct)t).sym.hasIdentityEquals;
+        }
+
         if (auto e = exp.op_overload(sc))
         {
             result = e;
             return;
         }
 
-        if (auto e = typeCombine(exp, sc))
+
+        if (!(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq()))
         {
-            result = e;
-            return;
+            if (auto e = typeCombine(exp, sc))
+                {
+                    result = e;
+                    return;
+                }
         }
 
         auto f1 = checkNonAssignmentArrayOp(exp.e1);
@@ -7879,20 +7910,52 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = Type.tbool;
 
         // Special handling for array comparisons
-        if (!arrayTypeCompatible(exp.loc, exp.e1.type, exp.e2.type))
+        if (!(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq()))
         {
-            if (exp.e1.type != exp.e2.type && exp.e1.type.isfloating() && exp.e2.type.isfloating())
+            if (!arrayTypeCompatible(exp.loc, exp.e1.type, exp.e2.type))
             {
-                // Cast both to complex
-                exp.e1 = exp.e1.castTo(sc, Type.tcomplex80);
-                exp.e2 = exp.e2.castTo(sc, Type.tcomplex80);
+                if (exp.e1.type != exp.e2.type && exp.e1.type.isfloating() && exp.e2.type.isfloating())
+                {
+                    // Cast both to complex
+                    exp.e1 = exp.e1.castTo(sc, Type.tcomplex80);
+                    exp.e2 = exp.e2.castTo(sc, Type.tcomplex80);
+                }
             }
         }
+
+        if (t1.ty == Tarray && t2.ty == Tarray)
+        {
+            Type telement  = t1.nextOf().toBasetype();
+            Type telement2 = t2.nextOf().toBasetype();
+
+            //printf("Lowering to __equals %s %s\n", e1.toChars(), e2.toChars());
+
+            // For e1 and e2 of struct type, lowers e1 == e2 to object.__equals(e1, e2)
+            // and e1 != e2 to !(object.__equals(e1, e2)).
+
+            Expression __equals = new IdentifierExp(exp.loc, Id.empty);
+            Identifier id = Identifier.idPool("__equals");
+            __equals = new DotIdExp(exp.loc, __equals, Id.object);
+            __equals = new DotIdExp(exp.loc, __equals, id);
+
+            auto arguments = new Expressions();
+            arguments.push(exp.e1);
+            arguments.push(exp.e2);
+
+            __equals = new CallExp(exp.loc, __equals, arguments);
+            if (exp.op == TOKnotequal)
+            {
+                __equals = new NotExp(exp.loc, __equals);
+            }
+            __equals = __equals.expressionSemantic(sc);
+
+            result = __equals;
+            return;
+        }
+
         if (exp.e1.type.toBasetype().ty == Taarray)
             semanticTypeInfo(sc, exp.e1.type.toBasetype());
 
-        Type t1 = exp.e1.type.toBasetype();
-        Type t2 = exp.e2.type.toBasetype();
 
         if (!Target.isVectorOpSupported(t1, exp.op, t2))
         {

--- a/src/ddmd/id.d
+++ b/src/ddmd/id.d
@@ -313,6 +313,7 @@ immutable Msgtable[] msgtable =
     { "entrypoint", "__entrypoint" },
     { "rt_init" },
     { "__cmp" },
+    { "__equals"},
 
     // varargs implementation
     { "va_start" },

--- a/src/ddmd/opover.d
+++ b/src/ddmd/opover.d
@@ -1071,13 +1071,14 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
         override void visit(EqualExp e)
         {
             //printf("EqualExp::op_overload() (%s)\n", e.toChars());
+            
             Type t1 = e.e1.type.toBasetype();
             Type t2 = e.e2.type.toBasetype();
 
             /* Check for array equality.
              */
-            if ((t1.ty == Tarray || t1.ty == Tsarray) &&
-                (t2.ty == Tarray || t2.ty == Tsarray))
+            if ((t1.ty == Tarray || t1.ty == Tsarray)
+                && (t2.ty == Tarray || t2.ty == Tsarray))
             {
                 bool needsDirectEq()
                 {
@@ -1102,7 +1103,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     return (cast(TypeStruct)t).sym.hasIdentityEquals;
                 }
 
-                if (needsDirectEq())
+                if (needsDirectEq() && !(t1.ty == Tarray && t2.ty == Tarray))
                 {
                     /* Rewrite as:
                      *      _ArrayEq(e1, e2)
@@ -1183,6 +1184,9 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 }
                 return;
             }
+
+            if (t1.ty == Tarray && t2.ty == Tarray)
+                return;
 
             /* Check for pointer equality.
              */
@@ -1295,13 +1299,14 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 }
                 result = Expression.combine(Expression.combine(tup1.e0, tup2.e0), result);
                 result = result.expressionSemantic(sc);
+
                 return;
             }
         }
 
         override void visit(CmpExp e)
         {
-            //printf("CmpExp::op_overload() (%s)\n", e.toChars());
+            //printf("CmpExp:: () (%s)\n", e.toChars());
             result = compare_overload(e, sc, Id.cmp);
         }
 

--- a/test/fail_compilation/diag7420.d
+++ b/test/fail_compilation/diag7420.d
@@ -2,16 +2,17 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7420.d(20): Error: static variable x cannot be read at compile time
-fail_compilation/diag7420.d(20):        while evaluating: `static assert(x < 4)`
-fail_compilation/diag7420.d(21): Error: static variable y cannot be read at compile time
-fail_compilation/diag7420.d(21):        while evaluating: `static assert(y == "abc")`
+fail_compilation/diag7420.d(21): Error: static variable x cannot be read at compile time
+fail_compilation/diag7420.d(21):        while evaluating: `static assert(x < 4)`
 fail_compilation/diag7420.d(22): Error: static variable y cannot be read at compile time
-fail_compilation/diag7420.d(22):        while evaluating: `static assert(cast(ubyte[])y != null)`
+fail_compilation/diag7420.d(22):        called from here: __equals(y, "abc")
+fail_compilation/diag7420.d(22):        while evaluating: `static assert(y == "abc")`
 fail_compilation/diag7420.d(23): Error: static variable y cannot be read at compile time
-fail_compilation/diag7420.d(23):        while evaluating: `static assert(cast(int)y[0] == 1)`
+fail_compilation/diag7420.d(23):        while evaluating: `static assert(cast(ubyte[])y != null)`
 fail_compilation/diag7420.d(24): Error: static variable y cannot be read at compile time
-fail_compilation/diag7420.d(24):        while evaluating: `static assert(y[0..1].length == 1u)`
+fail_compilation/diag7420.d(24):        while evaluating: `static assert(cast(int)y[0] == 1)`
+fail_compilation/diag7420.d(25): Error: static variable y cannot be read at compile time
+fail_compilation/diag7420.d(25):        while evaluating: `static assert(y[0..1].length == 1u)`
 ---
 */
 


### PR DESCRIPTION
Before this gets approved:
1. Revert old lowering (we don't support static array comparison for the time being) https://github.com/dlang/dmd/pull/6755
2. Wait for https://github.com/dlang/druntime/pull/1824 to be approved to ensure passing tests.
