### PR TITLE
make -vcg-ast print all instantiated template

### DIFF
--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -164,7 +164,7 @@ public:
 
     override void visit(UnrolledLoopStatement s)
     {
-        buf.writestring("unrolled {");
+        buf.writestring("/*unrolled*/ {");
         buf.writenl();
         buf.level++;
         foreach (sx; *s.statements)
@@ -1461,12 +1461,7 @@ public:
         if (hgs.fullDump)
         {
             buf.writenl();
-            if (ti.aliasdecl)
-            {
-                // the ti.aliasDecl is the instantiated body
-                // if we have it, print it.
-                ti.aliasdecl.accept(this);
-            }
+            dumpTemplateInstance(ti);
         }
     }
 
@@ -1482,6 +1477,31 @@ public:
         }
         buf.writeByte(';');
         buf.writenl();
+        if (hgs.fullDump)
+            dumpTemplateInstance(tm);
+    }
+
+    void dumpTemplateInstance(TemplateInstance ti)
+    {
+        buf.writeByte('{');
+        buf.writenl();
+        buf.level++;
+
+        if (ti.aliasdecl)
+        {
+            ti.aliasdecl.accept(this);
+            buf.writenl();
+        }
+        else if (ti.members)
+        {
+            foreach(m;*ti.members)
+                m.accept(this);
+        }
+
+        buf.level--;
+        buf.writeByte('}');
+        buf.writenl();
+
     }
 
     void tiargsToBuffer(TemplateInstance ti)

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1598,6 +1598,7 @@ Language changes listed by -transition=id:
             cgFilename[modFilenameLength .. modFilenameLength + 4] = ".cg\0";
             auto cgFile = File(cgFilename);
             cgFile.setbuffer(buf.data, buf.offset);
+            cgFile._ref = 1;
             cgFile.write();
         }
     }

--- a/test/compilable/vcg-ast.d
+++ b/test/compilable/vcg-ast.d
@@ -1,0 +1,18 @@
+module vcg;
+// REQUIRED_ARGS: -vcg-ast -o-
+// PERMUTE_ARGS:
+
+template Seq(A...)
+{
+    alias Seq = A;
+}
+
+auto a = Seq!(1,2,3);
+
+
+template R(T)
+{
+  struct _R { T elem; }
+}
+
+typeof(R!int._R.elem) x;


### PR DESCRIPTION
This PR enables -vcg-ast to print the instancied versions of templates and mixin templates in fullDump mode (vcg-ast)