### PR TITLE
Add LINKsystem, remove dependency on Target from the parser

### DIFF
--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -33,6 +33,7 @@ import ddmd.mtype;
 import ddmd.parse;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
+import ddmd.target;
 import ddmd.tokens;
 import ddmd.utf;
 import ddmd.utils;
@@ -499,7 +500,7 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
     {
         super(decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", p, decl);
-        linkage = p;
+        linkage = (p == LINKsystem) ? Target.systemLinkage() : p;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -408,6 +408,7 @@ enum LINK : int
     windows,
     pascal,
     objc,
+    system,
 }
 
 alias LINKdefault = LINK.def;
@@ -417,6 +418,7 @@ alias LINKcpp = LINK.cpp;
 alias LINKwindows = LINK.windows;
 alias LINKpascal = LINK.pascal;
 alias LINKobjc = LINK.objc;
+alias LINKsystem = LINK.system;
 
 enum CPPMANGLE : int
 {

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -301,6 +301,7 @@ enum LINK
     LINKwindows,
     LINKpascal,
     LINKobjc,
+    LINKsystem,
 };
 
 enum CPPMANGLE

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -3202,6 +3202,8 @@ extern (C++) const(char)* linkageToChars(LINK linkage)
         return "Pascal";
     case LINKobjc:
         return "Objective-C";
+    case LINKsystem:
+        return "System";
     default:
         assert(0);
     }

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -21,7 +21,6 @@ import ddmd.root.filename;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
 import ddmd.root.rootobject;
-import ddmd.target;
 import ddmd.tokens;
 
 // How multiple declarations are parsed.
@@ -2194,7 +2193,7 @@ final class Parser(AST) : Lexer
             }
             else if (id == Id.System)
             {
-                link = Target.systemLinkage();
+                link = LINKsystem;
             }
             else
             {

--- a/src/ddmd/target.h
+++ b/src/ddmd/target.h
@@ -48,6 +48,7 @@ struct Target
     // ABI and backend.
     static void loadModule(Module *m);
     static void prefixName(OutBuffer *buf, LINK linkage);
+    static LINK systemLinkage();
 };
 
 #endif

--- a/test/fail_compilation/parseStc2.d
+++ b/test/fail_compilation/parseStc2.d
@@ -65,3 +65,13 @@ align(1) align(1) void f12() {}
 align    align(1) void f13() {}
 align(1) align    void f14() {}
 align(1) align(2) void f15() {}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/parseStc2.d(76): Error: redundant linkage extern (System)
+fail_compilation/parseStc2.d(77): Error: conflicting linkage extern (System) and extern (C++)
+---
+*/
+extern(System) extern(System) void f16() {}
+extern(System) extern(C++) void f17() {}


### PR DESCRIPTION
As requested by @yebblies - I don't think this should leak to the glue, if it does, then that should be plugged.