### PR TITLE
refactor: convert cdxxx[] to CodeBuilder

### DIFF
--- a/src/ddmd/backend/cg87.c
+++ b/src/ddmd/backend/cg87.c
@@ -519,7 +519,7 @@ code *comsub87(elem *e,regm_t *pretregs)
         }
         else
             // Reload
-            cdb.append(loaddata(e,pretregs));
+            loaddata(cdb,e,pretregs);
     }
     else
     {
@@ -534,7 +534,7 @@ code *comsub87(elem *e,regm_t *pretregs)
         }
         else
             // Reload
-            cdb.append(loaddata(e,pretregs));
+            loaddata(cdb,e,pretregs);
     }
 
     freenode(e);
@@ -1908,7 +1908,7 @@ code *load87(elem *e,unsigned eoffset,regm_t *pretregs,elem *eleft,int op)
                     cdb.append(load87(e, 0, &retregs, NULL, -1));
                 }
                 else
-                    cdb.append((*cdxxx[e->Eoper])(e,&retregs));
+                    (*cdxxx[e->Eoper])(cdb,e,&retregs);
 #else
                 codelem(cdb,e,&retregs,FALSE);
 #endif
@@ -3328,7 +3328,8 @@ code *cnvt87(elem *e,regm_t *pretregs)
  * Do OPrndtol.
  */
 
-code *cdrndtol(elem *e,regm_t *pretregs)
+CDXXX(cdrndtol)
+code *cdrndtolx(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
     if (*pretregs == 0)
@@ -3388,7 +3389,8 @@ code *cdrndtol(elem *e,regm_t *pretregs)
  * Do OPscale, OPyl2x, OPyl2xp1.
  */
 
-code *cdscale(elem *e,regm_t *pretregs)
+CDXXX(cdscale)
+code *cdscalex(elem *e,regm_t *pretregs)
 {
     assert(*pretregs != 0);
 
@@ -3766,7 +3768,8 @@ code *fixresult_complex87(elem *e,regm_t retregs,regm_t *pretregs)
  * Operators OPc_r and OPc_i
  */
 
-code *cdconvt87(elem *e, regm_t *pretregs)
+CDXXX(cdconvt87)
+code *cdconvt87x(elem *e, regm_t *pretregs)
 {
     regm_t retregs = mST01;
     CodeBuilder cdb;

--- a/src/ddmd/backend/cgxmm.c
+++ b/src/ddmd/backend/cgxmm.c
@@ -1004,7 +1004,8 @@ static unsigned xmmoperator(tym_t tym, unsigned oper)
     return op;
 }
 
-code *cdvector(elem *e, regm_t *pretregs)
+CDXXX(cdvector)
+code *cdvectorx(elem *e, regm_t *pretregs)
 {
     /* e should look like one of:
      *    vector
@@ -1200,7 +1201,8 @@ code *cdvector(elem *e, regm_t *pretregs)
  *  (op1 OPvecsto (op OPparam op2))
  * where op is the store instruction STOxxxx.
  */
-code *cdvecsto(elem *e, regm_t *pretregs)
+CDXXX(cdvecsto)
+code *cdvecstox(elem *e, regm_t *pretregs)
 {
     //printf("cdvecsto()\n");
     //elem_print(e);
@@ -1219,7 +1221,8 @@ code *cdvecsto(elem *e, regm_t *pretregs)
  * OPvecfill takes the single value in e1 and
  * fills the vector type with it.
  */
-code *cdvecfill(elem *e, regm_t *pretregs)
+CDXXX(cdvecfill)
+code *cdvecfillx(elem *e, regm_t *pretregs)
 {
     //printf("cdvecfill(e = %p, *pretregs = %s)\n",e,regm_str(*pretregs));
 

--- a/src/ddmd/backend/cod1.c
+++ b/src/ddmd/backend/cod1.c
@@ -2836,7 +2836,8 @@ int FuncParamRegs::alloc(type *t, tym_t ty, reg_t *preg1, reg_t *preg2)
  * Generate code sequence for function call.
  */
 
-code *cdfunc(elem *e,regm_t *pretregs)
+CDXXX(cdfunc)
+code *cdfuncx(elem *e,regm_t *pretregs)
 {
     //printf("cdfunc()\n"); elem_print(e);
     assert(e);
@@ -3263,7 +3264,8 @@ code *cdfunc(elem *e,regm_t *pretregs)
 /***********************************
  */
 
-code *cdstrthis(elem *e,regm_t *pretregs)
+CDXXX(cdstrthis)
+code *cdstrthisx(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
 
@@ -3359,7 +3361,7 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,
             retregs = allregs & ~keepmsk;
             s->Sflags &= ~GTregcand;
             s->Sflags |= SFLread;
-            cdbe.append(cdrelconst(e1,&retregs));
+            cdrelconst(cdbe,e1,&retregs);
             if (farfunc)
             {
                 unsigned reg = findregmsw(retregs);
@@ -3984,7 +3986,7 @@ code *pushParams(elem *e,unsigned stackalign)
                         {   seg = CFes;
                             retregs |= mES;
                         }
-                        cdb.append(cdrelconst(e1,&retregs));
+                        cdrelconst(cdb,e1,&retregs);
                         // Reverse the effect of the previous add
                         if (doneoff)
                             e1->EV.sp.Voffset -= sz - pushsize;
@@ -4491,7 +4493,8 @@ L3:
  * Generate code to load data into registers.
  */
 
-code *loaddata(elem *e,regm_t *pretregs)
+CDXXX(loaddata);
+code *loaddatax(elem *e,regm_t *pretregs)
 { unsigned reg,nreg,op,sreg;
   tym_t tym;
   code cs;
@@ -4508,7 +4511,11 @@ code *loaddata(elem *e,regm_t *pretregs)
         return CNIL;
   tym = tybasic(e->Ety);
   if (tym == TYstruct)
-        return cdrelconst(e,pretregs);
+  {
+        CodeBuilder cdb;
+        cdrelconst(cdb,e,pretregs);
+        return cdb.finish();
+  }
   if (tyfloating(tym))
   {     objmod->fltused();
         if (config.inline8087)

--- a/src/ddmd/backend/cod2.c
+++ b/src/ddmd/backend/cod2.c
@@ -161,7 +161,8 @@ code *opdouble(elem *e,regm_t *pretregs,unsigned clib)
  * ( + - & | ^ )
  */
 
-code *cdorth(elem *e,regm_t *pretregs)
+CDXXX(cdorth)
+code *cdorthx(elem *e,regm_t *pretregs)
 {
     //printf("cdorth(e = %p, *pretregs = %s)\n",e,regm_str(*pretregs));
     elem *e1 = e->E1;
@@ -866,7 +867,8 @@ code *cdorth(elem *e,regm_t *pretregs)
  * Note that modulo isn't defined for doubles.
  */
 
-code *cdmul(elem *e,regm_t *pretregs)
+CDXXX(cdmul)
+code *cdmulx(elem *e,regm_t *pretregs)
 {   unsigned rreg,op,lib;
     regm_t resreg,retregs,rretregs;
     tym_t tyml;
@@ -1676,7 +1678,8 @@ code *cdmul(elem *e,regm_t *pretregs)
  *      cnop:   nop
  */
 
-code *cdnot(elem *e,regm_t *pretregs)
+CDXXX(cdnot)
+code *cdnotx(elem *e,regm_t *pretregs)
 {   unsigned reg;
     tym_t forflags;
     regm_t retregs;
@@ -1852,7 +1855,8 @@ code *cdnot(elem *e,regm_t *pretregs)
  * Complement operator
  */
 
-code *cdcom(elem *e,regm_t *pretregs)
+CDXXX(cdcom)
+code *cdcomx(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
     if (*pretregs == 0)
@@ -1899,7 +1903,8 @@ code *cdcom(elem *e,regm_t *pretregs)
  * Bswap operator
  */
 
-code *cdbswap(elem *e,regm_t *pretregs)
+CDXXX(cdbswap)
+code *cdbswapx(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
     if (*pretregs == 0)
@@ -1927,7 +1932,8 @@ code *cdbswap(elem *e,regm_t *pretregs)
  * ?: operator
  */
 
-code *cdcond(elem *e,regm_t *pretregs)
+CDXXX(cdcond)
+code *cdcondx(elem *e,regm_t *pretregs)
 {
   con_t regconold,regconsave;
   unsigned stackpushold,stackpushsave;
@@ -2195,7 +2201,8 @@ code *cdcond(elem *e,regm_t *pretregs)
  * Comma operator OPcomma
  */
 
-code *cdcomma(elem *e,regm_t *pretregs)
+CDXXX(cdcomma)
+code *cdcommax(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
     regm_t retregs = 0;
@@ -2225,7 +2232,8 @@ code *cdcomma(elem *e,regm_t *pretregs)
  *      cnop2:  NOP                     ;mark end of code
  */
 
-code *cdloglog(elem *e,regm_t *pretregs)
+CDXXX(cdloglog)
+code *cdloglogx(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
 
@@ -2337,7 +2345,8 @@ code *cdloglog(elem *e,regm_t *pretregs)
  * Generate code for shift left or shift right (OPshl,OPshr,OPashr,OProl,OPror).
  */
 
-code *cdshift(elem *e,regm_t *pretregs)
+CDXXX(cdshift)
+code *cdshiftx(elem *e,regm_t *pretregs)
 { unsigned resreg,shiftcnt;
   regm_t retregs,rretregs;
 
@@ -2828,7 +2837,8 @@ code *cdshift(elem *e,regm_t *pretregs)
  * Perform a 'star' reference (indirection).
  */
 
-code *cdind(elem *e,regm_t *pretregs)
+CDXXX(cdind)
+code *cdindx(elem *e,regm_t *pretregs)
 {
   regm_t retregs;
   unsigned reg,nreg;
@@ -3141,7 +3151,8 @@ STATIC code *cod2_setES(tym_t ty)
  * Generate code for intrinsic strlen().
  */
 
-code *cdstrlen( elem *e, regm_t *pretregs)
+CDXXX(cdstrlen)
+code *cdstrlenx( elem *e, regm_t *pretregs)
 {
     /* Generate strlen in CX:
         LES     DI,e1
@@ -3191,7 +3202,8 @@ code *cdstrlen( elem *e, regm_t *pretregs)
  * Generate code for strcmp(s1,s2) intrinsic.
  */
 
-code *cdstrcmp( elem *e, regm_t *pretregs)
+CDXXX(cdstrcmp);
+code *cdstrcmpx(elem *e, regm_t *pretregs)
 {
     char need_DS;
     int segreg;
@@ -3298,7 +3310,8 @@ code *cdstrcmp( elem *e, regm_t *pretregs)
  * Generate code for memcmp(s1,s2,n) intrinsic.
  */
 
-code *cdmemcmp(elem *e,regm_t *pretregs)
+CDXXX(cdmemcmp)
+code *cdmemcmpx(elem *e,regm_t *pretregs)
 {
     char need_DS;
     int segreg;
@@ -3409,7 +3422,8 @@ code *cdmemcmp(elem *e,regm_t *pretregs)
  * Generate code for strcpy(s1,s2) intrinsic.
  */
 
-code *cdstrcpy(elem *e,regm_t *pretregs)
+CDXXX(cdstrcpy)
+code *cdstrcpyx(elem *e,regm_t *pretregs)
 {
     char need_DS;
     int segreg;
@@ -3521,7 +3535,8 @@ code *cdstrcpy(elem *e,regm_t *pretregs)
  *      s2    n
  */
 
-code *cdmemcpy(elem *e,regm_t *pretregs)
+CDXXX(cdmemcpy)
+code *cdmemcpyx(elem *e,regm_t *pretregs)
 {
     char need_DS;
     int segreg;
@@ -3659,7 +3674,8 @@ code *cdmemcpy(elem *e,regm_t *pretregs)
  *      (s OPmemset (n OPparam val))
  */
 
-code *cdmemset(elem *e,regm_t *pretregs)
+CDXXX(cdmemset)
+code *cdmemsetx(elem *e,regm_t *pretregs)
 {
     regm_t retregs1;
     regm_t retregs2;
@@ -3870,7 +3886,8 @@ fixres:
  * Mebbe call cdstreq() for double assignments???
  */
 
-code *cdstreq(elem *e,regm_t *pretregs)
+CDXXX(cdstreq)
+code *cdstreqx(elem *e,regm_t *pretregs)
 {
     char need_DS = FALSE;
     elem *e1 = e->E1;
@@ -3920,11 +3937,10 @@ code *cdstreq(elem *e,regm_t *pretregs)
         if (e2->EV.sp.Vsym->ty() & mTYfar) // if e2 is in a far segment
         {   srcregs |= mCX;             // get segment also
             need_DS = TRUE;
-            cdb.append(cdrelconst(e2,&srcregs));
+            cdrelconst(cdb,e2,&srcregs);
         }
         else
         {
-            code *c1a = cdrelconst(e2,&srcregs);
             segreg = segfl[el_fl(e2)];
             if ((config.wflags & WFssneds) && segreg == SEG_SS || // if source is on stack
                 segreg == SEG_CS)               // if source is in CS
@@ -3936,7 +3952,7 @@ code *cdstreq(elem *e,regm_t *pretregs)
                 cdb.gen2(0x8C,                // MOV CX,[SS|CS]
                     modregrm(3,segreg,CX));
             }
-            cdb.append(c1a);
+            cdrelconst(cdb,e2,&srcregs);
         }
         freenode(e2);
     }
@@ -3959,7 +3975,7 @@ code *cdstreq(elem *e,regm_t *pretregs)
         scodelem(cdb,e1->E1,&dstregs,srcregs,FALSE);
     }
     else
-        cdb.append(cdrelconst(e1,&dstregs));
+        cdrelconst(cdb,e1,&dstregs);
     freenode(e1);
 
     cdb.append(getregs((srcregs | dstregs) & (mLSW | mDI)));
@@ -4034,7 +4050,8 @@ code *cdstreq(elem *e,regm_t *pretregs)
  * Is also called by cdstreq() to set up pointer to a structure.
  */
 
-code *cdrelconst(elem *e,regm_t *pretregs)
+CDXXX(cdrelconst)
+code *cdrelconstx(elem *e,regm_t *pretregs)
 {
     //printf("cdrelconst(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
     CodeBuilder cdb;
@@ -4383,7 +4400,8 @@ code *getoffset(elem *e,unsigned reg)
  * Negate, sqrt operator
  */
 
-code *cdneg(elem *e,regm_t *pretregs)
+CDXXX(cdneg)
+code *cdnegx(elem *e,regm_t *pretregs)
 {
     //printf("cdneg()\n");
     //elem_print(e);
@@ -4461,7 +4479,9 @@ code *cdneg(elem *e,regm_t *pretregs)
  * Absolute value operator
  */
 
-code *cdabs( elem *e, regm_t *pretregs)
+
+CDXXX(cdabs)
+code *cdabsx(elem *e, regm_t *pretregs)
 {
     //printf("cdabs(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
     if (*pretregs == 0)
@@ -4578,14 +4598,19 @@ code *cdabs( elem *e, regm_t *pretregs)
  * Post increment and post decrement.
  */
 
-code *cdpost(elem *e,regm_t *pretregs)
+CDXXX(cdpost)
+code *cdpostx(elem *e,regm_t *pretregs)
 {
   //printf("cdpost(pretregs = %s)\n", regm_str(*pretregs));
   code cs;
   regm_t retregs = *pretregs;
   unsigned op = e->Eoper;                       // OPxxxx
   if (retregs == 0)                             // if nothing to return
-        return cdaddass(e,pretregs);
+  {
+        CodeBuilder cdb;
+        cdaddass(cdb,e,pretregs);
+        return cdb.finish();
+  }
   tym_t tyml = tybasic(e->E1->Ety);
   int sz = _tysize[tyml];
   elem *e2 = e->E2;
@@ -4961,8 +4986,9 @@ code *cdpost(elem *e,regm_t *pretregs)
   }
 }
 
+CDXXX(cderr)
 
-code *cderr(elem *e,regm_t *pretregs)
+code *cderrx(elem *e,regm_t *pretregs)
 {
 #if DEBUG
         elem_print(e);
@@ -4974,7 +5000,8 @@ code *cderr(elem *e,regm_t *pretregs)
         return 0;
 }
 
-code *cdinfo(elem *e,regm_t *pretregs)
+CDXXX(cdinfo)
+code *cdinfox(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
     code cs;
@@ -4991,7 +5018,7 @@ code *cdinfo(elem *e,regm_t *pretregs)
 #endif
 #if SCPP
         case OPdtor:
-            cdb.append(cdcomma(e,pretregs));
+            cdcomma(cdb,e,pretregs);
             break;
         case OPctor:
             codelem(cdb,e->E2,pretregs,FALSE);
@@ -5034,7 +5061,8 @@ code *cdinfo(elem *e,regm_t *pretregs)
  * D constructor.
  */
 
-code *cddctor(elem *e,regm_t *pretregs)
+CDXXX(cddctor)
+code *cddctorx(elem *e,regm_t *pretregs)
 {
     /* Generate:
         ESCAPE | ESCdctor
@@ -5063,7 +5091,8 @@ code *cddctor(elem *e,regm_t *pretregs)
  * D destructor.
  */
 
-code *cdddtor(elem *e,regm_t *pretregs)
+CDXXX(cdddtor)
+code *cdddtorx(elem *e,regm_t *pretregs)
 {
     if (config.ehmethod == EH_DWARF)
     {
@@ -5159,7 +5188,8 @@ code *cdddtor(elem *e,regm_t *pretregs)
  * C++ constructor.
  */
 
-code *cdctor(elem *e,regm_t *pretregs)
+CDXXX(cdctor)
+code *cdctorx(elem *e,regm_t *pretregs)
 {
 #if SCPP
     code cs;
@@ -5181,7 +5211,8 @@ code *cdctor(elem *e,regm_t *pretregs)
 #endif
 }
 
-code *cddtor(elem *e,regm_t *pretregs)
+CDXXX(cddtor)
+code *cddtorx(elem *e,regm_t *pretregs)
 {
 #if SCPP
     code cs;
@@ -5203,13 +5234,15 @@ code *cddtor(elem *e,regm_t *pretregs)
 #endif
 }
 
-code *cdmark(elem *e,regm_t *pretregs)
+CDXXX(cdmark)
+code *cdmarkx(elem *e,regm_t *pretregs)
 {
     return NULL;
 }
 
 #if !NTEXCEPTIONS
-code *cdsetjmp(elem *e,regm_t *pretregs)
+CDXXX(cdsetjmp)
+code *cdsetjmpx(elem *e,regm_t *pretregs)
 {
     assert(0);
     return NULL;
@@ -5219,7 +5252,8 @@ code *cdsetjmp(elem *e,regm_t *pretregs)
 /*****************************************
  */
 
-code *cdvoid(elem *e,regm_t *pretregs)
+CDXXX(cdvoid)
+code *cdvoidx(elem *e,regm_t *pretregs)
 {
     assert(*pretregs == 0);
     CodeBuilder cdb;
@@ -5230,7 +5264,8 @@ code *cdvoid(elem *e,regm_t *pretregs)
 /*****************************************
  */
 
-code *cdhalt(elem *e,regm_t *pretregs)
+CDXXX(cdhalt)
+code *cdhaltx(elem *e,regm_t *pretregs)
 {
     assert(*pretregs == 0);
     return gen1(NULL, 0xF4);            // HLT

--- a/src/ddmd/backend/cod3.c
+++ b/src/ddmd/backend/cod3.c
@@ -2278,7 +2278,8 @@ code* gen_loadcse(code *c, unsigned reg, targ_uns i)
  * Gen code for OPframeptr
  */
 
-code *cdframeptr(elem *e, regm_t *pretregs)
+CDXXX(cdframeptr)
+code *cdframeptrx(elem *e, regm_t *pretregs)
 {
     CodeBuilder cdb;
 
@@ -2304,7 +2305,8 @@ code *cdframeptr(elem *e, regm_t *pretregs)
  * This value gets cached in the local variable 'localgot'.
  */
 
-code *cdgot(elem *e, regm_t *pretregs)
+CDXXX(cdgot)
+code *cdgotx(elem *e, regm_t *pretregs)
 {
 #if TARGET_OSX
     CodeBuilder cdb;

--- a/src/ddmd/backend/cod4.c
+++ b/src/ddmd/backend/cod4.c
@@ -313,7 +313,8 @@ STATIC code * opnegassdbl(elem *e,regm_t *pretregs)
  * Generate code for an assignment.
  */
 
-code *cdeq(elem *e,regm_t *pretregs)
+CDXXX(cdeq)
+code *cdeqx(elem *e,regm_t *pretregs)
 {
   tym_t tymll;
   unsigned reg;
@@ -787,7 +788,8 @@ Lp:
  * Generate code for += -= &= |= ^= negass
  */
 
-code *cdaddass(elem *e,regm_t *pretregs)
+CDXXX(cdaddass)
+code *cdaddassx(elem *e,regm_t *pretregs)
 {
     //printf("cdaddass(e=%p, *pretregs = %s)\n",e,regm_str(*pretregs));
     unsigned op = e->Eoper;
@@ -1293,7 +1295,8 @@ code *cdaddass(elem *e,regm_t *pretregs)
  * Generate code for *= /= %=
  */
 
-code *cdmulass(elem *e,regm_t *pretregs)
+CDXXX(cdmulass)
+code *cdmulassx(elem *e,regm_t *pretregs)
 {
     code cs;
     regm_t retregs;
@@ -1538,7 +1541,8 @@ code *cdmulass(elem *e,regm_t *pretregs)
  * Generate code for <<= and >>=
  */
 
-code *cdshass(elem *e,regm_t *pretregs)
+CDXXX(cdshass)
+code *cdshassx(elem *e,regm_t *pretregs)
 {
     code cs;
     regm_t retregs;
@@ -1782,7 +1786,8 @@ code *cdshass(elem *e,regm_t *pretregs)
  * Handles lt,gt,le,ge,eqeq,ne for all data types.
  */
 
-code *cdcmp(elem *e,regm_t *pretregs)
+CDXXX(cdcmp)
+code *cdcmpx(elem *e,regm_t *pretregs)
 { regm_t retregs,rretregs;
   unsigned reg,rreg;
   int fl;
@@ -2592,7 +2597,8 @@ code *longcmp(elem *e,bool jcond,unsigned fltarg,code *targ)
  * Depends on OPd_s32 and CLIBdbllng being in sequence.
  */
 
-code *cdcnvt(elem *e, regm_t *pretregs)
+CDXXX(cdcnvt)
+code *cdcnvtx(elem *e, regm_t *pretregs)
 {
     //printf("cdcnvt: *pretregs = %s\n", regm_str(*pretregs));
     //elem_print(e);
@@ -2780,7 +2786,8 @@ L1:
  * OPu64_128, OPs64_128
  */
 
-code *cdshtlng(elem *e,regm_t *pretregs)
+CDXXX(cdshtlng)
+code *cdshtlngx(elem *e,regm_t *pretregs)
 {
     unsigned reg;
     regm_t retregs;
@@ -3015,7 +3022,8 @@ code *cdshtlng(elem *e,regm_t *pretregs)
  * For OPu8_16 and OPs8_16.
  */
 
-code *cdbyteint(elem *e,regm_t *pretregs)
+CDXXX(cdbyteint)
+code *cdbyteintx(elem *e,regm_t *pretregs)
 {
     regm_t retregs;
     char size;
@@ -3153,7 +3161,8 @@ code *cdbyteint(elem *e,regm_t *pretregs)
  * OP128_64
  */
 
-code *cdlngsht(elem *e,regm_t *pretregs)
+CDXXX(cdlngsht)
+code *cdlngshtx(elem *e,regm_t *pretregs)
 {
 #ifdef DEBUG
     switch (e->Eoper)
@@ -3221,7 +3230,8 @@ code *cdlngsht(elem *e,regm_t *pretregs)
  * OPmsw
  */
 
-code *cdmsw(elem *e,regm_t *pretregs)
+CDXXX(cdmsw)
+code *cdmswx(elem *e,regm_t *pretregs)
 {
     assert(e->Eoper == OPmsw);
 
@@ -3257,7 +3267,8 @@ code *cdmsw(elem *e,regm_t *pretregs)
  * Handle operators OPinp and OPoutp.
  */
 
-code *cdport(elem *e,regm_t *pretregs)
+CDXXX(cdport)
+code *cdportx(elem *e,regm_t *pretregs)
 {
     //printf("cdport\n");
     unsigned char op = 0xE4;            // root of all IN/OUT opcodes
@@ -3309,7 +3320,8 @@ code *cdport(elem *e,regm_t *pretregs)
  * Generate code for an asm elem.
  */
 
-code *cdasm(elem *e,regm_t *pretregs)
+CDXXX(cdasm)
+code *cdasmx(elem *e,regm_t *pretregs)
 {
     CodeBuilder cdb;
     // Assume only regs normally destroyed by a function are destroyed
@@ -3323,7 +3335,8 @@ code *cdasm(elem *e,regm_t *pretregs)
  * Generate code for OPnp_f16p and OPf16p_np.
  */
 
-code *cdfar16( elem *e, regm_t *pretregs)
+CDXXX(cdfar16)
+code *cdfar16x( elem *e, regm_t *pretregs)
 {
     code *cnop;
     code cs;
@@ -3398,7 +3411,8 @@ code *cdfar16( elem *e, regm_t *pretregs)
  * Generate code for OPbtst
  */
 
-code *cdbtst(elem *e, regm_t *pretregs)
+CDXXX(cdbtst)
+code *cdbtstx(elem *e, regm_t *pretregs)
 {
     regm_t retregs;
     unsigned reg;
@@ -3525,7 +3539,8 @@ code *cdbtst(elem *e, regm_t *pretregs)
  * Generate code for OPbt, OPbtc, OPbtr, OPbts
  */
 
-code *cdbt(elem *e, regm_t *pretregs)
+CDXXX(cdbt)
+code *cdbtx(elem *e, regm_t *pretregs)
 {
     //printf("cdbt(%p, %s)\n", e, regm_str(*pretregs));
     regm_t retregs;
@@ -3643,7 +3658,8 @@ code *cdbt(elem *e, regm_t *pretregs)
  * Generate code for OPbsf and OPbsr.
  */
 
-code *cdbscan(elem *e, regm_t *pretregs)
+CDXXX(cdbscan)
+code *cdbscanx(elem *e, regm_t *pretregs)
 {
     //printf("cdbscan()\n");
     //elem_print(e);
@@ -3700,7 +3716,8 @@ code *cdbscan(elem *e, regm_t *pretregs)
  * OPpopcnt operator
  */
 
-code *cdpopcnt(elem *e,regm_t *pretregs)
+CDXXX(cdpopcnt)
+code *cdpopcntx(elem *e,regm_t *pretregs)
 {
     //printf("cdpopcnt()\n");
     //elem_print(e);
@@ -3761,7 +3778,8 @@ code *cdpopcnt(elem *e,regm_t *pretregs)
  * Generate code for OPpair, OPrpair.
  */
 
-code *cdpair(elem *e, regm_t *pretregs)
+CDXXX(cdpair)
+code *cdpairx(elem *e, regm_t *pretregs)
 {
     if (*pretregs == 0)                         // if don't want result
     {
@@ -3831,7 +3849,8 @@ code *cdpair(elem *e, regm_t *pretregs)
  * Generate code for OPcmpxchg
  */
 
-code *cdcmpxchg(elem *e, regm_t *pretregs)
+CDXXX(cdcmpxchg)
+code *cdcmpxchgx(elem *e, regm_t *pretregs)
 {
     /* The form is:
      *     OPcmpxchg
@@ -3931,7 +3950,8 @@ code *cdcmpxchg(elem *e, regm_t *pretregs)
  * Generate code for OPprefetch
  */
 
-code *cdprefetch(elem *e, regm_t *pretregs)
+CDXXX(cdprefetch)
+code *cdprefetchx(elem *e, regm_t *pretregs)
 {
     /* Generate the following based on e2:
      *    0: prefetch0

--- a/src/ddmd/backend/code.h
+++ b/src/ddmd/backend/code.h
@@ -192,8 +192,6 @@ extern CGstate cgstate;
 
 extern regm_t msavereg,mfuncreg,allregs;
 
-typedef code *cd_t (elem *e , regm_t *pretregs );
-
 extern  int BPRM;
 extern  regm_t FLOATREGS;
 extern  regm_t FLOATREGS2;
@@ -238,7 +236,7 @@ extern  int refparam;
 extern  int reflocal;
 extern  bool anyiasm;
 extern  char calledafunc;
-extern  code *(*cdxxx[])(elem *,regm_t *);
+extern  void(*cdxxx[])(CodeBuilder&,elem *,regm_t *);
 
 void stackoffsets(int);
 void codgen(Symbol *);
@@ -274,6 +272,85 @@ void scodelem(CodeBuilder& cdb, elem *e, regm_t *pretregs, regm_t keepmsk, bool 
 const char *regm_str(regm_t rm);
 int numbitsset(regm_t);
 
+/* cdxxx.c: functions that go into cdxxx[] table */
+typedef code *cd_t (elem *e , regm_t *pretregs); // old way
+
+typedef void cdxxx_t (CodeBuilder& cdb, elem *e, regm_t *pretregs);
+
+cdxxx_t
+        cdabs,
+        cdaddass,
+        cdasm,
+        cdbscan,
+        cdbswap,
+        cdbt,
+        cdbtst,
+        cdbyteint,
+        cdcmp,
+        cdcmpxchg,
+        cdcnvt,
+        cdcom,
+        cdcomma,
+        cdcond,
+        cdconvt87,
+        cdctor,
+        cddctor,
+        cdddtor,
+        cddtor,
+        cdeq,
+        cderr,
+        cdfar16,
+        cdframeptr,
+        cdfunc,
+        cdgot,
+        cdhalt,
+        cdind,
+        cdinfo,
+        cdlngsht,
+        cdloglog,
+        cdmark,
+        cdmemcmp,
+        cdmemcpy,
+        cdmemset,
+        cdmsw,
+        cdmul,
+        cdmulass,
+        cdneg,
+        cdnot,
+        cdorth,
+        cdpair,
+        cdpopcnt,
+        cdport,
+        cdpost,
+        cdprefetch,
+        cdrelconst,
+        cdrndtol,
+        cdscale,
+        cdsetjmp,
+        cdshass,
+        cdshift,
+        cdshtlng,
+        cdstrcmp,
+        cdstrcpy,
+        cdstreq,
+        cdstrlen,
+        cdstrthis,
+        cdvecfill,
+        cdvecsto,
+        cdvector,
+        cdvoid,
+        loaddata;
+
+#define CDX(cd) cd##x
+#define CDXXX(cd) \
+  void cd(CodeBuilder& cdb, elem *e, regm_t *pretregs) \
+  {                                                    \
+    extern cd_t CDX(cd);                               \
+    code *c = CDX(cd)(e, pretregs);                    \
+    cdb.append(c);                                     \
+  }
+
+
 /* cod1.c */
 extern int clib_inited;
 
@@ -294,11 +371,8 @@ code *fltregs (code *pcs , tym_t tym );
 code *tstresult (regm_t regm , tym_t tym , unsigned saveflag );
 code *fixresult (elem *e , regm_t retregs , regm_t *pretregs );
 code *callclib (elem *e , unsigned clib , regm_t *pretregs , regm_t keepmask );
-cd_t cdfunc;
-cd_t cdstrthis;
 code *pushParams(elem *, unsigned);
 code *offsetinreg (elem *e , regm_t *pretregs );
-code *loaddata (elem *e , regm_t *pretregs );
 
 /* cod2.c */
 int movOnly(elem *e);
@@ -306,43 +380,9 @@ regm_t idxregm(code *c);
 #if TARGET_WINDOS
 code *opdouble (elem *e , regm_t *pretregs , unsigned clib );
 #endif
-cd_t cdorth;
-cd_t cdmul;
-cd_t cdnot;
-cd_t cdcom;
-cd_t cdbswap;
-cd_t cdpopcnt;
-cd_t cdcond;
 void WRcodlst (code *c );
-cd_t cdcomma;
-cd_t cdloglog;
-cd_t cdshift;
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-cd_t cdindpic;
-#endif
-cd_t cdind;
-cd_t cdstrlen;
-cd_t cdstrcmp;
-cd_t cdstrcpy;
-cd_t cdmemchr;
-cd_t cdmemcmp;
-cd_t cdmemcpy;
-cd_t cdmemset;
-cd_t cdstreq;
-cd_t cdrelconst;
+code *cdmemchr(elem *e, regm_t *pretregs);
 code *getoffset (elem *e , unsigned reg );
-cd_t cdneg;
-cd_t cdabs;
-cd_t cdpost;
-cd_t cdcmpxchg;
-cd_t cderr;
-cd_t cdinfo;
-cd_t cddctor;
-cd_t cdddtor;
-cd_t cdctor;
-cd_t cddtor;
-cd_t cdmark;
-cd_t cdclassinit;
 
 /* cod3.c */
 
@@ -378,8 +418,6 @@ code *genjmp (code *c , unsigned op , unsigned fltarg , block *targ );
 code *prolog (void );
 void epilog (block *b);
 code *gen_spill_reg(Symbol *s, bool toreg);
-cd_t cdframeptr;
-cd_t cdgot;
 code *load_localgot();
 targ_size_t cod3_spoff();
 code *cod3_load_got();
@@ -433,27 +471,6 @@ extern int cdcmp_flag;
 
 int doinreg(symbol *s, elem *e);
 code *modEA(code *c);
-cd_t cdeq;
-cd_t cdaddass;
-cd_t cdmulass;
-cd_t cdshass;
-cd_t cdcmp;
-cd_t cdcnvt;
-cd_t cdshtlng;
-cd_t cdbyteint;
-cd_t cdlngsht;
-cd_t cdmsw;
-cd_t cdport;
-cd_t cdasm;
-cd_t cdsetjmp;
-cd_t cdvoid;
-cd_t cdhalt;
-cd_t cdfar16;
-cd_t cdbtst;
-cd_t cdbt;
-cd_t cdbscan;
-cd_t cdpair;
-cd_t cdprefetch;
 code *longcmp (elem *,bool,unsigned,code *);
 
 /* cod5.c */
@@ -471,9 +488,6 @@ code *xmmpost(elem *e, regm_t *pretregs);
 code *xmmneg(elem *e, regm_t *pretregs);
 unsigned xmmload(tym_t tym, bool aligned = true);
 unsigned xmmstore(tym_t tym, bool aligned = true);
-code *cdvector(elem *e, regm_t *pretregs);
-code *cdvecsto(elem *e, regm_t *pretregs);
-code *cdvecfill(elem *e, regm_t *pretregs);
 bool xmmIsAligned(elem *e);
 void checkSetVex3(code *c);
 void checkSetVex(code *c, tym_t ty);
@@ -505,15 +519,12 @@ code *cdnegass87 (elem *e , regm_t *pretregs );
 code *post87 (elem *e , regm_t *pretregs );
 code *cnvt87 (elem *e , regm_t *pretregs );
 code *cnvteq87 (elem *e , regm_t *pretregs );
-cd_t cdrndtol;
-cd_t cdscale;
 code *neg87 (elem *e , regm_t *pretregs );
 code *neg_complex87(elem *e, regm_t *pretregs);
 code *cdind87(elem *e,regm_t *pretregs);
 #if TX86
 extern int stackused;
 #endif
-code *cdconvt87(elem *e, regm_t *pretregs);
 code *cload87(elem *e, regm_t *pretregs);
 code *cdd_u64(elem *e, regm_t *pretregs);
 code *cdd_u32(elem *e, regm_t *pretregs);

--- a/src/ddmd/backend/nteh.c
+++ b/src/ddmd/backend/nteh.c
@@ -572,7 +572,8 @@ code *nteh_gensindex(int sindex)
  * Generate code for setjmp().
  */
 
-code *cdsetjmp(elem *e,regm_t *pretregs)
+CDXXX(cdsetjmp)
+code *cdsetjmpx(elem *e,regm_t *pretregs)
 {   code cs;
     regm_t retregs;
     unsigned stackpushsave;

--- a/src/ddmd/backend/optabgen.c
+++ b/src/ddmd/backend/optabgen.c
@@ -599,7 +599,7 @@ void dotab()
   fprintf(fdeb,"\t\"%s\"\n\t};\n",debtab[i]);
 
   f = fopen("cdxxx.c","w");
-  fprintf(f,"code *(*cdxxx[OPMAX]) (elem *,regm_t *) = \n\t{\n");
+  fprintf(f,"void (*cdxxx[OPMAX]) (CodeBuilder&,elem *,regm_t *) = \n\t{\n");
   for (i = 0; i < OPMAX - 1; i++)
         fprintf(f,"\t%s,\n",cdxxx[i]);
   fprintf(f,"\t%s\n\t};\n",cdxxx[i]);


### PR DESCRIPTION
Switching the array is tedious, but repetitive. Rather than change all the functions at once, which is error-prone, I used a temporary macro CDXXX() to build wrappers. On a subsequent PR, I'll remove the wrappers and change the functions.

After that's done, we should see a performance increase in the code generator as it removes the quadratic performance of continually walking the linked list of instructions (making it linear).