### PR TITLE
Fix issue 17392 - Add Dub file for the lexer and parser

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,0 +1,50 @@
+name "dmd"
+description "The DMD compiler"
+authors "Walter Bright"
+copyright "Copyright © 1999-2017, Digital Mars"
+license "BSL-1.0"
+
+targetType "none"
+dependency ":parser" version="*"
+
+subPackage {
+  name "root"
+  targetType "library"
+  sourcePaths "src/ddmd/root"
+}
+
+subPackage {
+  name "lexer"
+  targetType "library"
+  sourcePaths
+
+  sourceFiles \
+    "src/ddmd/console.d" \
+    "src/ddmd/entity.d" \
+    "src/ddmd/errors.d" \
+    "src/ddmd/globals.d" \
+    "src/ddmd/id.d" \
+    "src/ddmd/identifier.d" \
+    "src/ddmd/lexer.d" \
+    "src/ddmd/tokens.d" \
+    "src/ddmd/utf.d"
+
+  // stringImportPaths cannot be used because it will make Dub extremely slow
+  // https://github.com/dlang/dub/issues/1199
+  dflags "-J$PACKAGE_DIR"
+
+  dependency "dmd:root" version="*"
+}
+
+subPackage {
+  name "parser"
+  targetType "library"
+  sourcePaths
+
+  sourceFiles \
+    "src/ddmd/astbase.d" \
+    "src/ddmd/astbasevisitor.d" \
+    "src/ddmd/parse.d"
+
+  dependency "dmd:lexer" version="*"
+}

--- a/test/dub_package/.gitignore
+++ b/test/dub_package/.gitignore
@@ -1,0 +1,5 @@
+.dub
+docs.json
+__dummy.html
+*.o
+*.obj

--- a/test/dub_package/dub.sdl
+++ b/test/dub_package/dub.sdl
@@ -1,0 +1,5 @@
+name "dmd-dub-test"
+description "Test of the DMD Dub package"
+license "BSL 1.0"
+
+dependency "dmd" path="../../"

--- a/test/dub_package/source/app.d
+++ b/test/dub_package/source/app.d
@@ -1,0 +1,45 @@
+// The tests in this module are highlevel and mostly indented to make sure all
+// necessary modules are included in the Dub package.
+
+void main()
+{
+}
+
+// lexer
+unittest
+{
+    import ddmd.lexer;
+    import ddmd.tokens;
+
+    immutable expected = [
+        TOKvoid,
+        TOKidentifier,
+        TOKlparen,
+        TOKrparen,
+        TOKlcurly,
+        TOKrcurly
+    ];
+
+    immutable sourceCode = "void test() {} // foobar";
+    scope lexer = new Lexer("test", sourceCode.ptr, 0, sourceCode.length, 0, 0);
+    lexer.nextToken;
+
+    TOK[] result;
+
+    do
+    {
+        result ~= lexer.token.value;
+    } while (lexer.nextToken != TOKeof);
+
+    assert(result == expected);
+}
+
+// parser
+unittest
+{
+    import ddmd.astbase;
+    import ddmd.parse;
+
+    scope parser = new Parser!ASTBase(null, null, false);
+    assert(parser !is null);
+}

--- a/travis.sh
+++ b/travis.sh
@@ -54,6 +54,7 @@ rebuild() {
 
 # test druntime, phobos, dmd
 test() {
+    test_dub_package
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL unittest
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL unittest
     test_dmd
@@ -67,6 +68,13 @@ test_dmd() {
     else
         make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release"
     fi
+}
+
+# test dub package
+test_dub_package() {
+    pushd test/dub_package
+    dub test
+    popd
 }
 
 for proj in druntime phobos; do


### PR DESCRIPTION
The Dub file is intended to make the the compiler available as a library through Dub.

Currently the Dub package is only tested in Travis CI. I don't know if Dub is available in the autotester or not.