### PR TITLE
fix Issue 16540 - Attributes do not propagate correctly in lazy params

### DIFF
--- a/test/compilable/test16540.d
+++ b/test/compilable/test16540.d
@@ -1,0 +1,14 @@
+/* REQUIRED_ARGS:
+   PERMUTE_ARGS:
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=16540
+
+@safe:
+
+void foo(scope lazy int* f) @nogc {
+}
+
+void bar1() @nogc {
+    foo(new int(5)); // It does not understand that the new here is wrapped in an invisible delegate
+}


### PR DESCRIPTION
Actually, it works now, I'm just adding a test case to ensure it continues to work.