### PR TITLE
traits.d: fix error messages to use syntax highlighting

### DIFF
--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -127,7 +127,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
     const sz_size_t = Type.tsize_t.size(loc);
     if (sz > sz.max - sz_size_t)
     {
-        error(loc, "size overflow for type %s", t.toChars());
+        error(loc, "size overflow for type `%s`", t.toChars());
         return d_uns64.max;
     }
 
@@ -348,7 +348,7 @@ extern (C++) Expression pointerBitmap(TraitsExp e)
     Type t = getType((*e.args)[0]);
     if (!t)
     {
-        error(e.loc, "%s is not a type", (*e.args)[0].toChars());
+        error(e.loc, "`%s` is not a type", (*e.args)[0].toChars());
         return new ErrorExp();
     }
 
@@ -386,7 +386,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
     Expression dimError(int expected)
     {
-        e.error("expected %d arguments for %s but had %d", expected, e.ident.toChars(), cast(int)dim);
+        e.error("expected %d arguments for `%s` but had %d", expected, e.ident.toChars(), cast(int)dim);
         return new ErrorExp();
     }
 
@@ -490,7 +490,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto t = isType(o);
         if (!t)
         {
-            e.error("type expected as second argument of __traits %s instead of %s",
+            e.error("type expected as second argument of __traits `%s` instead of `%s`",
                 e.ident.toChars(), o.toChars());
             return new ErrorExp();
         }
@@ -521,7 +521,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return fd.isNested() ? True() : False();
         }
 
-        e.error("aggregate or function expected instead of '%s'", o.toChars());
+        e.error("aggregate or function expected instead of `%s`", o.toChars());
         return new ErrorExp();
     }
     if (e.ident == Id.isAbstractFunction)
@@ -584,7 +584,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             Dsymbol s = getDsymbol(o);
             if (!s || !s.ident)
             {
-                e.error("argument %s has no identifier", o.toChars());
+                e.error("argument `%s` has no identifier", o.toChars());
                 return new ErrorExp();
             }
             id = s.ident;
@@ -610,7 +610,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         if (!s)
         {
             if (!isError(o))
-                e.error("argument %s has no protection", o.toChars());
+                e.error("argument `%s` has no protection", o.toChars());
             return new ErrorExp();
         }
         if (s.semanticRun == PASSinit)
@@ -637,7 +637,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         if (!s || s.isImport())
         {
-            e.error("argument %s has no parent", o.toChars());
+            e.error("argument `%s` has no parent", o.toChars());
             return new ErrorExp();
         }
 
@@ -673,7 +673,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto ex = isExpression((*e.args)[1]);
         if (!ex)
         {
-            e.error("expression expected as second argument of __traits %s", e.ident.toChars());
+            e.error("expression expected as second argument of __traits `%s`", e.ident.toChars());
             return new ErrorExp();
         }
         ex = ex.ctfeInterpret();
@@ -681,7 +681,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         StringExp se = ex.toStringExp();
         if (!se || se.len == 0)
         {
-            e.error("string expected as second argument of __traits %s instead of %s", e.ident.toChars(), ex.toChars());
+            e.error("string expected as second argument of __traits `%s` instead of `%s`", e.ident.toChars(), ex.toChars());
             return new ErrorExp();
         }
         se = se.toUTF8(sc);
@@ -742,7 +742,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             Expression eorig = ex;
             ex = ex.semantic(scx);
             if (errors < global.errors)
-                e.error("%s cannot be resolved", eorig.toChars());
+                e.error("`%s` cannot be resolved", eorig.toChars());
             //ex.print();
 
             /* Create tuple of functions of ex
@@ -810,7 +810,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         if (cd.sizeok != SIZEOKdone)
         {
-            e.error("%s %s is forward referenced", cd.kind(), cd.toChars());
+            e.error("%s `%s` is forward referenced", cd.kind(), cd.toChars());
             return new ErrorExp();
         }
 
@@ -932,7 +932,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto sds = s.isScopeDsymbol();
         if (!sds || sds.isTemplateDeclaration())
         {
-            e.error("%s %s has no members", s.kind(), s.toChars());
+            e.error("%s `%s` has no members", s.kind(), s.toChars());
             return new ErrorExp();
         }
 
@@ -1149,7 +1149,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto s = getDsymbol(o);
         if (!s)
         {
-            e.error("argument %s to __traits(getUnitTests) must be a module or aggregate",
+            e.error("argument `%s` to __traits(getUnitTests) must be a module or aggregate",
                 o.toChars());
             return new ErrorExp();
         }
@@ -1159,7 +1159,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto sds = s.isScopeDsymbol();
         if (!sds)
         {
-            e.error("argument %s to __traits(getUnitTests) must be a module or aggregate, not a %s",
+            e.error("argument `%s` to __traits(getUnitTests) must be a module or aggregate, not a %s",
                 s.toChars(), s.kind());
             return new ErrorExp();
         }
@@ -1236,8 +1236,8 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     }
 
     if (auto sub = cast(const(char)*)speller(e.ident.toChars(), &trait_search_fp, idchars))
-        e.error("unrecognized trait '%s', did you mean '%s'?", e.ident.toChars(), sub);
+        e.error("unrecognized trait `%s`, did you mean `%s`?", e.ident.toChars(), sub);
     else
-        e.error("unrecognized trait '%s'", e.ident.toChars());
+        e.error("unrecognized trait `%s`", e.ident.toChars());
     return new ErrorExp();
 }

--- a/test/fail_compilation/diag11819a.d
+++ b/test/fail_compilation/diag11819a.d
@@ -1,27 +1,27 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11819a.d(30): Error: unrecognized trait 'DoesNotExist'
-fail_compilation/diag11819a.d(31): Error: unrecognized trait 'IsAbstractClass', did you mean 'isAbstractClass'?
-fail_compilation/diag11819a.d(32): Error: unrecognized trait 'IsArithmetic', did you mean 'isArithmetic'?
-fail_compilation/diag11819a.d(33): Error: unrecognized trait 'IsAssociativeArray', did you mean 'isAssociativeArray'?
-fail_compilation/diag11819a.d(34): Error: unrecognized trait 'IsFinalClass', did you mean 'isFinalClass'?
-fail_compilation/diag11819a.d(35): Error: unrecognized trait 'IsPOD', did you mean 'isPOD'?
-fail_compilation/diag11819a.d(36): Error: unrecognized trait 'IsNested', did you mean 'isNested'?
-fail_compilation/diag11819a.d(37): Error: unrecognized trait 'IsFloating', did you mean 'isFloating'?
-fail_compilation/diag11819a.d(38): Error: unrecognized trait 'IsIntegral', did you mean 'isIntegral'?
-fail_compilation/diag11819a.d(39): Error: unrecognized trait 'IsScalar', did you mean 'isScalar'?
-fail_compilation/diag11819a.d(40): Error: unrecognized trait 'IsStaticArray', did you mean 'isStaticArray'?
-fail_compilation/diag11819a.d(41): Error: unrecognized trait 'IsUnsigned', did you mean 'isUnsigned'?
-fail_compilation/diag11819a.d(42): Error: unrecognized trait 'IsVirtualFunction', did you mean 'isVirtualFunction'?
-fail_compilation/diag11819a.d(43): Error: unrecognized trait 'IsVirtualMethod', did you mean 'isVirtualMethod'?
-fail_compilation/diag11819a.d(44): Error: unrecognized trait 'IsAbstractFunction', did you mean 'isAbstractFunction'?
-fail_compilation/diag11819a.d(45): Error: unrecognized trait 'IsFinalFunction', did you mean 'isFinalFunction'?
-fail_compilation/diag11819a.d(46): Error: unrecognized trait 'IsOverrideFunction', did you mean 'isOverrideFunction'?
-fail_compilation/diag11819a.d(47): Error: unrecognized trait 'IsStaticFunction', did you mean 'isStaticFunction'?
-fail_compilation/diag11819a.d(48): Error: unrecognized trait 'IsRef', did you mean 'isRef'?
-fail_compilation/diag11819a.d(49): Error: unrecognized trait 'IsOut', did you mean 'isOut'?
-fail_compilation/diag11819a.d(50): Error: unrecognized trait 'IsLazy', did you mean 'isLazy'?
+fail_compilation/diag11819a.d(30): Error: unrecognized trait `DoesNotExist`
+fail_compilation/diag11819a.d(31): Error: unrecognized trait `IsAbstractClass`, did you mean `isAbstractClass`?
+fail_compilation/diag11819a.d(32): Error: unrecognized trait `IsArithmetic`, did you mean `isArithmetic`?
+fail_compilation/diag11819a.d(33): Error: unrecognized trait `IsAssociativeArray`, did you mean `isAssociativeArray`?
+fail_compilation/diag11819a.d(34): Error: unrecognized trait `IsFinalClass`, did you mean `isFinalClass`?
+fail_compilation/diag11819a.d(35): Error: unrecognized trait `IsPOD`, did you mean `isPOD`?
+fail_compilation/diag11819a.d(36): Error: unrecognized trait `IsNested`, did you mean `isNested`?
+fail_compilation/diag11819a.d(37): Error: unrecognized trait `IsFloating`, did you mean `isFloating`?
+fail_compilation/diag11819a.d(38): Error: unrecognized trait `IsIntegral`, did you mean `isIntegral`?
+fail_compilation/diag11819a.d(39): Error: unrecognized trait `IsScalar`, did you mean `isScalar`?
+fail_compilation/diag11819a.d(40): Error: unrecognized trait `IsStaticArray`, did you mean `isStaticArray`?
+fail_compilation/diag11819a.d(41): Error: unrecognized trait `IsUnsigned`, did you mean `isUnsigned`?
+fail_compilation/diag11819a.d(42): Error: unrecognized trait `IsVirtualFunction`, did you mean `isVirtualFunction`?
+fail_compilation/diag11819a.d(43): Error: unrecognized trait `IsVirtualMethod`, did you mean `isVirtualMethod`?
+fail_compilation/diag11819a.d(44): Error: unrecognized trait `IsAbstractFunction`, did you mean `isAbstractFunction`?
+fail_compilation/diag11819a.d(45): Error: unrecognized trait `IsFinalFunction`, did you mean `isFinalFunction`?
+fail_compilation/diag11819a.d(46): Error: unrecognized trait `IsOverrideFunction`, did you mean `isOverrideFunction`?
+fail_compilation/diag11819a.d(47): Error: unrecognized trait `IsStaticFunction`, did you mean `isStaticFunction`?
+fail_compilation/diag11819a.d(48): Error: unrecognized trait `IsRef`, did you mean `isRef`?
+fail_compilation/diag11819a.d(49): Error: unrecognized trait `IsOut`, did you mean `isOut`?
+fail_compilation/diag11819a.d(50): Error: unrecognized trait `IsLazy`, did you mean `isLazy`?
 ---
 */
 

--- a/test/fail_compilation/diag11819b.d
+++ b/test/fail_compilation/diag11819b.d
@@ -1,25 +1,25 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag11819b.d(28): Error: unrecognized trait 'HasMember', did you mean 'hasMember'?
-fail_compilation/diag11819b.d(29): Error: unrecognized trait 'Identifier', did you mean 'identifier'?
-fail_compilation/diag11819b.d(30): Error: unrecognized trait 'GetProtection', did you mean 'getProtection'?
-fail_compilation/diag11819b.d(31): Error: unrecognized trait 'Parent', did you mean 'parent'?
-fail_compilation/diag11819b.d(32): Error: unrecognized trait 'GetMember', did you mean 'getMember'?
-fail_compilation/diag11819b.d(33): Error: unrecognized trait 'GetOverloads', did you mean 'getOverloads'?
-fail_compilation/diag11819b.d(34): Error: unrecognized trait 'GetVirtualFunctions', did you mean 'getVirtualFunctions'?
-fail_compilation/diag11819b.d(35): Error: unrecognized trait 'GetVirtualMethods', did you mean 'getVirtualMethods'?
-fail_compilation/diag11819b.d(36): Error: unrecognized trait 'ClassInstanceSize', did you mean 'classInstanceSize'?
-fail_compilation/diag11819b.d(37): Error: unrecognized trait 'AllMembers', did you mean 'allMembers'?
-fail_compilation/diag11819b.d(38): Error: unrecognized trait 'DerivedMembers', did you mean 'derivedMembers'?
-fail_compilation/diag11819b.d(39): Error: unrecognized trait 'IsSame', did you mean 'isSame'?
-fail_compilation/diag11819b.d(40): Error: unrecognized trait 'Compiles', did you mean 'compiles'?
-fail_compilation/diag11819b.d(41): Error: unrecognized trait 'Parameters', did you mean 'parameters'?
-fail_compilation/diag11819b.d(42): Error: unrecognized trait 'GetAliasThis', did you mean 'getAliasThis'?
-fail_compilation/diag11819b.d(43): Error: unrecognized trait 'GetAttributes', did you mean 'getAttributes'?
-fail_compilation/diag11819b.d(44): Error: unrecognized trait 'GetFunctionAttributes', did you mean 'getFunctionAttributes'?
-fail_compilation/diag11819b.d(45): Error: unrecognized trait 'GetUnitTests', did you mean 'getUnitTests'?
-fail_compilation/diag11819b.d(46): Error: unrecognized trait 'GetVirtualIndex', did you mean 'getVirtualIndex'?
+fail_compilation/diag11819b.d(28): Error: unrecognized trait `HasMember`, did you mean `hasMember`?
+fail_compilation/diag11819b.d(29): Error: unrecognized trait `Identifier`, did you mean `identifier`?
+fail_compilation/diag11819b.d(30): Error: unrecognized trait `GetProtection`, did you mean `getProtection`?
+fail_compilation/diag11819b.d(31): Error: unrecognized trait `Parent`, did you mean `parent`?
+fail_compilation/diag11819b.d(32): Error: unrecognized trait `GetMember`, did you mean `getMember`?
+fail_compilation/diag11819b.d(33): Error: unrecognized trait `GetOverloads`, did you mean `getOverloads`?
+fail_compilation/diag11819b.d(34): Error: unrecognized trait `GetVirtualFunctions`, did you mean `getVirtualFunctions`?
+fail_compilation/diag11819b.d(35): Error: unrecognized trait `GetVirtualMethods`, did you mean `getVirtualMethods`?
+fail_compilation/diag11819b.d(36): Error: unrecognized trait `ClassInstanceSize`, did you mean `classInstanceSize`?
+fail_compilation/diag11819b.d(37): Error: unrecognized trait `AllMembers`, did you mean `allMembers`?
+fail_compilation/diag11819b.d(38): Error: unrecognized trait `DerivedMembers`, did you mean `derivedMembers`?
+fail_compilation/diag11819b.d(39): Error: unrecognized trait `IsSame`, did you mean `isSame`?
+fail_compilation/diag11819b.d(40): Error: unrecognized trait `Compiles`, did you mean `compiles`?
+fail_compilation/diag11819b.d(41): Error: unrecognized trait `Parameters`, did you mean `parameters`?
+fail_compilation/diag11819b.d(42): Error: unrecognized trait `GetAliasThis`, did you mean `getAliasThis`?
+fail_compilation/diag11819b.d(43): Error: unrecognized trait `GetAttributes`, did you mean `getAttributes`?
+fail_compilation/diag11819b.d(44): Error: unrecognized trait `GetFunctionAttributes`, did you mean `getFunctionAttributes`?
+fail_compilation/diag11819b.d(45): Error: unrecognized trait `GetUnitTests`, did you mean `getUnitTests`?
+fail_compilation/diag11819b.d(46): Error: unrecognized trait `GetVirtualIndex`, did you mean `getVirtualIndex`?
 ---
 */
 

--- a/test/fail_compilation/ice14844.d
+++ b/test/fail_compilation/ice14844.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14844.d(20): Error: template opDispatch(string name) has no members
+fail_compilation/ice14844.d(20): Error: template `opDispatch(string name)` has no members
 ---
 */
 


### PR DESCRIPTION
Using backticks enables color syntax highlighting.