### PR TITLE
refactor: split off color handling into console.d

### DIFF
--- a/src/ddmd/console.d
+++ b/src/ddmd/console.d
@@ -1,0 +1,123 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC _console.d)
+ */
+
+module ddmd.console;
+
+import core.stdc.stdio;
+import core.sys.posix.unistd;
+import core.sys.windows.windows;
+
+import core.stdc.string;
+import core.stdc.stdlib;
+
+version (Windows) extern (C) int isatty(int);
+
+enum COLOR : int
+{
+    COLOR_BLACK     = 0,
+    COLOR_RED       = 1,
+    COLOR_GREEN     = 2,
+    COLOR_BLUE      = 4,
+    COLOR_YELLOW    = COLOR_RED | COLOR_GREEN,
+    COLOR_MAGENTA   = COLOR_RED | COLOR_BLUE,
+    COLOR_CYAN      = COLOR_GREEN | COLOR_BLUE,
+    COLOR_WHITE     = COLOR_RED | COLOR_GREEN | COLOR_BLUE,
+}
+
+alias COLOR_BLACK = COLOR.COLOR_BLACK;
+alias COLOR_RED = COLOR.COLOR_RED;
+alias COLOR_GREEN = COLOR.COLOR_GREEN;
+alias COLOR_BLUE = COLOR.COLOR_BLUE;
+alias COLOR_YELLOW = COLOR.COLOR_YELLOW;
+alias COLOR_MAGENTA = COLOR.COLOR_MAGENTA;
+alias COLOR_CYAN = COLOR.COLOR_CYAN;
+alias COLOR_WHITE = COLOR.COLOR_WHITE;
+
+version (Windows)
+{
+    extern (C++) static WORD consoleAttributes(HANDLE h)
+    {
+        static __gshared CONSOLE_SCREEN_BUFFER_INFO sbi;
+        static __gshared bool sbi_inited = false;
+        if (!sbi_inited)
+            sbi_inited = GetConsoleScreenBufferInfo(h, &sbi) != FALSE;
+        return sbi.wAttributes;
+    }
+
+    enum : int
+    {
+        FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE,
+    }
+}
+
+extern (C++) bool isConsoleColorSupported()
+{
+    version (CRuntime_DigitalMars)
+    {
+        return isatty(stderr._file) != 0;
+    }
+    else version (CRuntime_Microsoft)
+    {
+        return isatty(fileno(stderr)) != 0;
+    }
+    else version (Posix)
+    {
+        const(char)* term = getenv("TERM");
+        return isatty(STDERR_FILENO) && term && term[0] && 0 != strcmp(term, "dumb");
+    }
+    else
+    {
+        return false;
+    }
+}
+
+extern (C++) void setConsoleColorBright(bool bright)
+{
+    version (Windows)
+    {
+        HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
+        WORD attr = consoleAttributes(h);
+        SetConsoleTextAttribute(h, attr | (bright ? FOREGROUND_INTENSITY : 0));
+    }
+    else
+    {
+        fprintf(stderr, "\033[%dm", bright ? 1 : 0);
+    }
+}
+
+extern (C++) void setConsoleColor(COLOR color, bool bright)
+{
+    version (Windows)
+    {
+        HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
+        WORD attr = consoleAttributes(h);
+        attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) | ((color & COLOR_RED) ? FOREGROUND_RED : 0) | ((color & COLOR_GREEN) ? FOREGROUND_GREEN : 0) | ((color & COLOR_BLUE) ? FOREGROUND_BLUE : 0) | (bright ? FOREGROUND_INTENSITY : 0);
+        SetConsoleTextAttribute(h, attr);
+    }
+    else
+    {
+        fprintf(stderr, "\033[%d;%dm", bright ? 1 : 0, 30 + cast(int)color);
+    }
+}
+
+extern (C++) void resetConsoleColor()
+{
+    version (Windows)
+    {
+        HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
+        SetConsoleTextAttribute(h, consoleAttributes(h));
+    }
+    else
+    {
+        fprintf(stderr, "\033[m");
+    }
+}
+
+

--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -14,114 +14,11 @@ import core.stdc.stdarg;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
-import core.sys.posix.unistd;
-import core.sys.windows.windows;
 import ddmd.globals;
 import ddmd.root.outbuffer;
 import ddmd.root.rmem;
+import ddmd.console;
 
-version (Windows) extern (C) int isatty(int);
-
-enum COLOR : int
-{
-    COLOR_BLACK     = 0,
-    COLOR_RED       = 1,
-    COLOR_GREEN     = 2,
-    COLOR_BLUE      = 4,
-    COLOR_YELLOW    = COLOR_RED | COLOR_GREEN,
-    COLOR_MAGENTA   = COLOR_RED | COLOR_BLUE,
-    COLOR_CYAN      = COLOR_GREEN | COLOR_BLUE,
-    COLOR_WHITE     = COLOR_RED | COLOR_GREEN | COLOR_BLUE,
-}
-
-alias COLOR_BLACK = COLOR.COLOR_BLACK;
-alias COLOR_RED = COLOR.COLOR_RED;
-alias COLOR_GREEN = COLOR.COLOR_GREEN;
-alias COLOR_BLUE = COLOR.COLOR_BLUE;
-alias COLOR_YELLOW = COLOR.COLOR_YELLOW;
-alias COLOR_MAGENTA = COLOR.COLOR_MAGENTA;
-alias COLOR_CYAN = COLOR.COLOR_CYAN;
-alias COLOR_WHITE = COLOR.COLOR_WHITE;
-
-version (Windows)
-{
-    extern (C++) static WORD consoleAttributes(HANDLE h)
-    {
-        static __gshared CONSOLE_SCREEN_BUFFER_INFO sbi;
-        static __gshared bool sbi_inited = false;
-        if (!sbi_inited)
-            sbi_inited = GetConsoleScreenBufferInfo(h, &sbi) != FALSE;
-        return sbi.wAttributes;
-    }
-
-    enum : int
-    {
-        FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE,
-    }
-}
-
-extern (C++) bool isConsoleColorSupported()
-{
-    version (CRuntime_DigitalMars)
-    {
-        return isatty(stderr._file) != 0;
-    }
-    else version (CRuntime_Microsoft)
-    {
-        return isatty(fileno(stderr)) != 0;
-    }
-    else version (Posix)
-    {
-        const(char)* term = getenv("TERM");
-        return isatty(STDERR_FILENO) && term && term[0] && 0 != strcmp(term, "dumb");
-    }
-    else
-    {
-        return false;
-    }
-}
-
-extern (C++) void setConsoleColorBright(bool bright)
-{
-    version (Windows)
-    {
-        HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
-        WORD attr = consoleAttributes(h);
-        SetConsoleTextAttribute(h, attr | (bright ? FOREGROUND_INTENSITY : 0));
-    }
-    else
-    {
-        fprintf(stderr, "\033[%dm", bright ? 1 : 0);
-    }
-}
-
-extern (C++) void setConsoleColor(COLOR color, bool bright)
-{
-    version (Windows)
-    {
-        HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
-        WORD attr = consoleAttributes(h);
-        attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) | ((color & COLOR_RED) ? FOREGROUND_RED : 0) | ((color & COLOR_GREEN) ? FOREGROUND_GREEN : 0) | ((color & COLOR_BLUE) ? FOREGROUND_BLUE : 0) | (bright ? FOREGROUND_INTENSITY : 0);
-        SetConsoleTextAttribute(h, attr);
-    }
-    else
-    {
-        fprintf(stderr, "\033[%d;%dm", bright ? 1 : 0, 30 + cast(int)color);
-    }
-}
-
-extern (C++) void resetConsoleColor()
-{
-    version (Windows)
-    {
-        HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
-        SetConsoleTextAttribute(h, consoleAttributes(h));
-    }
-    else
-    {
-        fprintf(stderr, "\033[m");
-    }
-}
 
 /**************************************
  * Print error message

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -26,6 +26,7 @@ import ddmd.astcodegen;
 import ddmd.gluelayer;
 import ddmd.builtin;
 import ddmd.cond;
+import ddmd.console;
 import ddmd.dinifile;
 import ddmd.dinterpret;
 import ddmd.dmodule;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -232,7 +232,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	sideeffect statement staticassert target traits visitor	\
 	typinf utils statement_rewrite_walker statementsem staticcond safe blockexit asttypename))
 
-LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, entity errors globals id identifier lexer tokens utf))
+LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors globals id identifier lexer tokens utf))
 
 LEXER_ROOT=$(addsyffix .d, $(addprefix $(ROOT)/, array ctfloat file filename outbuffer port rmem \
 	rootobject stringtable hash))

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -167,7 +167,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/traits.d $D/utils.d $D/visitor.d $D/libomf.d $D/scanomf.d $D/typinf.d \
 	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d
 
-LEXER_SRCS=$D/entity.d $D/errors.d $D/globals.d $D/id.d $D/identifier.d \
+LEXER_SRCS=$D/console.d $D/entity.d $D/errors.d $D/globals.d $D/id.d $D/identifier.d \
 	$D/lexer.d $D/tokens.d $D/utf.d
 
 LEXER_ROOT=$(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d $(ROOT)/filename.d \


### PR DESCRIPTION
This moves all the system-dependent color handling code into a separate module. System dependencies should not be in the main compiler logic. For example, main compiler logic should never be importing anything from `core.sys`.

Later on console.d should be refactored to be properly encapsulated. This PR just moves code.