### PR TITLE
refactor: improve console.d encapsulation

### DIFF
--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -236,6 +236,8 @@ struct Global
 
     uint errorLimit;
 
+    void* console;         // opaque pointer to console for controlling text attributes
+
     /* Start gagging. Return the current number of gagged errors
      */
     extern (C++) uint startGagging()

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -218,6 +218,8 @@ struct Global
 
     unsigned errorLimit;
 
+    void* console;         // opaque pointer to console for controlling text attributes
+
     /* Start gagging. Return the current number of gagged errors
      */
     unsigned startGagging();

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -291,7 +291,7 @@ private int tryMain(size_t argc, const(char)** argv)
     files.reserve(arguments.dim - 1);
     // Set default values
     global.params.argv0 = arguments[0];
-    global.params.color = isConsoleColorSupported();
+    global.params.color = true;
     global.params.link = true;
     global.params.useAssert = true;
     global.params.useInvariants = true;
@@ -1051,6 +1051,10 @@ Language changes listed by -transition=id:
             files.push(p);
         }
     }
+
+    if (global.params.color)
+        global.console = Console.create(core.stdc.stdio.stderr);
+
     global.params.cpu = setTargetCPU(global.params.cpu);
     if (global.params.is64bit != is64bit)
         error(Loc(), "the architecture must not be changed in the %s section of %s", envsection.ptr, global.inifilename);


### PR DESCRIPTION
1. encapsulated state in a `struct Console`
2. eliminated random global variables
3. removed hardcoding of `stderr`
4. added documentation
5. removed grossly excessive number of system calls (on Windows version)
6. provide reasonable fallback if console fails to initialize
7. reduce messy interleaved `version` declarations
8. remove ugly C++ conversion detritus
9. fix incorrect error checking of `GetConsoleScreenBufferInfo()`
10. use `fputs` instead of `fprintf` where possible
11. put initialization of console *after* command line processing, not before. Doing it before could mean it was turned on even if it failed.