### PR TITLE
Fix bugs when building with g++-7

### DIFF
--- a/src/ddmd/backend/evalu8.c
+++ b/src/ddmd/backend/evalu8.c
@@ -2209,7 +2209,7 @@ elem * evalu8(elem *e, goal_t goal)
             case TYllong4:
             case TYullong4:
                 for (int i = 0; i < 4; ++i)
-                    e->EV.Vullong2[i] = (targ_ullong)l1;
+                    e->EV.Vullong4[i] = (targ_ullong)l1;
                 break;
 
             default:

--- a/src/ddmd/tk/mem.c
+++ b/src/ddmd/tk/mem.c
@@ -755,8 +755,8 @@ void *mem_fmalloc(size_t numbytes)
 {   void *p;
 
     //printf("fmalloc(%d)\n",numbytes);
-#if defined(__llvm__) && (defined(__GNUC__) || defined(__clang__))
-    // LLVM-GCC and Clang assume some types, notably elem (see DMD issue 6215),
+#if defined(__GNUC__) || defined(__clang__)
+    // GCC and Clang assume some types, notably elem (see DMD issue 6215),
     // to be 16-byte aligned. Because we do not have any type information
     // available here, we have to 16 byte-align everything.
     numbytes = (numbytes + 0xF) & ~0xF;


### PR DESCRIPTION
First is a bug caught by `-Waggressive-loops` - it's pretty obvious that it's an out of bounds error.

Second, ~there seems to be a segfault when doing `esave = *e`, I have no idea why.  Seems like a g++ regression.  Using memcpy and things just work...~ building using g++7, I get the same bug as 6215, aligning memory to 16-bytes fixes the problem - particularly for copying `elem` which uses `movqda`. instruction.