### PR TITLE
Fix make clean to remove stale backend/cdxxx.c .

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -384,6 +384,7 @@ endif
 clean:
 	rm -R $(GENERATED)
 	rm -f dmd $(idgen_output)
+	rm -f $(addprefix $D/backend/, $(optabgen_output))
 	@[ ! -d ${PGO_DIR} ] || echo You should issue manually: rm -rf ${PGO_DIR}
 
 ######## Download and install the last dmd buildable without dmd


### PR DESCRIPTION
Otherwise it may cause compile errors when updating from older builds of dmd.

Followup to: #6769 