### PR TITLE
display overload type mismatches as highlighted comments

### DIFF
--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -4177,14 +4177,18 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                 //printf("tf = %s, args = %s\n", tf.deco, (*fargs)[0].type.deco);
                 if (hasOverloads)
                 {
-                    .error(loc, "none of the overloads of '%s' are callable using argument types %s, candidates are:",
+                    .error(loc, "none of the overloads of `%s` are callable using argument types `%s`, candidates are:",
                         fd.ident.toChars(), fargsBuf.peekString());
                 }
                 else
                 {
-                    fd.error(loc, "%s%s is not callable using argument types %s",
-                        parametersTypeToChars(tf.parameters, tf.varargs),
-                        tf.modToChars(), fargsBuf.peekString());
+                    fd.error(loc, "is not callable using argument types `%s`, the signature is:",
+                        fargsBuf.peekString());
+
+                    .errorSupplemental(fd.loc, "`%s%s%s`", 
+                        fd.toPrettyChars(),
+                        parametersTypeToChars(tf.parameters, tf.varargs, fargs),
+                        tf.modToChars());
                 }
             }
 
@@ -4200,12 +4204,12 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                         return 0;
 
                     auto tf = cast(TypeFunction)fd.type;
-                    .errorSupplemental(fd.loc, "%s%s", fd.toPrettyChars(),
-                        parametersTypeToChars(tf.parameters, tf.varargs));
+                    .errorSupplemental(fd.loc, "`%s%s`", fd.toPrettyChars(),
+                        parametersTypeToChars(tf.parameters, tf.varargs, fargs));
                 }
                 else
                 {
-                    .errorSupplemental(td.loc, "%s", td.toPrettyChars());
+                    .errorSupplemental(td.loc, "`%s`", td.toPrettyChars());
                 }
 
                 if (global.params.verbose || --numToDisplay != 0 || !fd)

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -2975,7 +2975,7 @@ public:
         }
     }
 
-    void parametersToBuffer(Parameters* parameters, int varargs)
+    void parametersToBuffer(Parameters* parameters, int varargs, Expressions* fargs = null)
     {
         buf.writeByte('(');
         if (parameters)
@@ -2986,6 +2986,25 @@ public:
                 if (i)
                     buf.writestring(", ");
                 Parameter fparam = Parameter.getNth(parameters, i);
+
+                if (fargs)
+                {
+                    if (i < (*fargs).dim && !(*fargs)[i].type.implicitConvTo(fparam.type))
+                    {
+                        /*
+                            Type mismatch with given arguments, add the
+                            type given as a comment to the output for
+                            easier visual comparison by the reader.
+                        */
+                        buf.writestring("/* ");
+                        buf.writestring((*fargs)[i].type.toPrettyChars());
+                        buf.writestring(" */ ");
+                    }
+                    else if (i >= (*fargs).dim)
+                    {
+                        buf.writestring("/* missing */ ");
+                    }
+                }
                 fparam.accept(this);
             }
             if (varargs)
@@ -3306,11 +3325,11 @@ extern (C++) void arrayObjectsToBuffer(OutBuffer* buf, Objects* objects)
     }
 }
 
-extern (C++) const(char)* parametersTypeToChars(Parameters* parameters, int varargs)
+extern (C++) const(char)* parametersTypeToChars(Parameters* parameters, int varargs, Expressions* fargs = null)
 {
     OutBuffer buf;
     HdrGenState hgs;
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(&buf, &hgs);
-    v.parametersToBuffer(parameters, varargs);
+    v.parametersToBuffer(parameters, varargs, fargs);
     return buf.extractString();
 }

--- a/test/fail_compilation/ice14923.d
+++ b/test/fail_compilation/ice14923.d
@@ -1,10 +1,11 @@
-/*
+/+
 TEST_OUTPUT:
 ---
-fail_compilation/ice14923.d(21): Error: function ice14923.parse (C a) is not callable using argument types (A)
-fail_compilation/ice14923.d(21):        instantiated from here: bar!((b) => parse(b))
+fail_compilation/ice14923.d(22): Error: function ice14923.parse is not callable using argument types `(A)`, the signature is:
+fail_compilation/ice14923.d(20):        ice14923.parse(/* A */ C a)
+fail_compilation/ice14923.d(22):        instantiated from here: bar!((b) => parse(b))
 ---
-*/
++/
 
 auto bar(alias fun)()
 {


### PR DESCRIPTION
One of the things that I dislike about D's error messages is not giving information the compiler knows in an easy-to-read way. For example, in a no overload matches message, lining up what you passed with what the compiler expects is a huge pain for non-trivial functions.

I was thinking of coloring the matches green and mismatches red, but I have an even better idea now: print the mismatched type as a comment in the overload. Then, when you look down the candidates, you can easily see "oh I passed a `string[]` when it was expecting a `string`" without needing try to count commas yourself. See the following picture:

![test.d(1):        test.foo(int _param_0, /* string[] */string _param_1)](http://arsdnet.net/better_error.png)

With syntax highlighting, the rare comment in an error message can stand out making it easy to scan for them - helping mitigate my objection to syntax highlighting in the first place - and without syntax highlighting or color support in general, an inline comment is still readable by the user. Everybody wins. If lines become too long, we can even run this through something akin to `dfmt`... but that's a future idea.

If this works, I'd like to do something similar for template constraints.