### PR TITLE
refactor cg87.c to use CodeBuilder interfaces

### DIFF
--- a/src/ddmd/backend/cgcod.c
+++ b/src/ddmd/backend/cgcod.c
@@ -2148,10 +2148,11 @@ code *getregs_imm(regm_t r)
 code *cse_flush(int do87)
 {
     //dbg_printf("cse_flush()\n");
-    code* c = cse_save(regcon.cse.mops);      // save any CSEs to memory
+    CodeBuilder cdb;
+    cdb.append(cse_save(regcon.cse.mops));      // save any CSEs to memory
     if (do87)
-        c = cat(c,save87());    // save any 8087 temporaries
-    return c;
+        save87(cdb);    // save any 8087 temporaries
+    return cdb.finish();
 }
 
 /*************************
@@ -2324,7 +2325,11 @@ STATIC code * comsub(elem *e,regm_t *pretregs)
     else if (tyxmmreg(e->Ety) && config.fpxmmregs)
         ;
     else if (tyfloating(e->Ety) && config.inline8087)
-        return comsub87(e,pretregs);
+    {
+        CodeBuilder cdb;
+        comsub87(cdb,e,pretregs);
+        return cdb.finish();
+    }
 
 
   /* create mask of what's in csextab[] */

--- a/src/ddmd/backend/cgxmm.c
+++ b/src/ddmd/backend/cgxmm.c
@@ -387,7 +387,11 @@ code *xmmcnvt(elem *e,regm_t *pretregs)
             break;
         case OPld_d:
             if (e->Eoper == OPd_s64)
-                return cnvt87(e,pretregs); // precision
+            {
+                CodeBuilder cdb;
+                cnvt87(cdb,e,pretregs); // precision
+                return cdb.finish();
+            }
             /* FALL-THROUGH */
         default:
             op = CVTTSD2SI;

--- a/src/ddmd/backend/code.h
+++ b/src/ddmd/backend/code.h
@@ -341,15 +341,6 @@ cdxxx_t
         cdvoid,
         loaddata;
 
-#define CDX(cd) cd##x
-#define CDXXX(cd) \
-  void cd(CodeBuilder& cdb, elem *e, regm_t *pretregs) \
-  {                                                    \
-    extern cd_t CDX(cd);                               \
-    code *c = CDX(cd)(e, pretregs);                    \
-    cdb.append(c);                                     \
-  }
-
 
 /* cod1.c */
 extern int clib_inited;
@@ -499,36 +490,35 @@ void pop87(int, const char *);
 #else
 void pop87();
 #endif
-code *push87 (void );
-code *save87 (void );
-code *save87regs(unsigned n);
+void push87(CodeBuilder& cdb);
+void save87(CodeBuilder& cdb);
+void save87regs(CodeBuilder& cdb, unsigned n);
 void gensaverestore87(regm_t, code **, code **);
 code *genfltreg(code *c,unsigned opcode,unsigned reg,targ_size_t offset);
 code *genxmmreg(code *c,unsigned opcode,unsigned xreg,targ_size_t offset, tym_t tym);
 code *genfwait(code *c);
-code *comsub87(elem *e, regm_t *pretregs);
-code *fixresult87 (elem *e , regm_t retregs , regm_t *pretregs );
-code *fixresult_complex87(elem *e,regm_t retregs,regm_t *pretregs);
-code *orth87 (elem *e , regm_t *pretregs );
-code *load87(elem *e, unsigned eoffset, regm_t *pretregs, elem *eleft, int op);
+void comsub87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void fixresult87(CodeBuilder& cdb, elem *e, regm_t retregs, regm_t *pretregs);
+void fixresult_complex87(CodeBuilder& cdb,elem *e,regm_t retregs,regm_t *pretregs);
+void orth87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void load87(CodeBuilder& cdb, elem *e, unsigned eoffset, regm_t *pretregs, elem *eleft, int op);
 int cmporder87 (elem *e );
-code *eq87 (elem *e , regm_t *pretregs );
-code *complex_eq87 (elem *e , regm_t *pretregs );
-code *opass87 (elem *e , regm_t *pretregs );
-code *cdnegass87 (elem *e , regm_t *pretregs );
-code *post87 (elem *e , regm_t *pretregs );
-code *cnvt87 (elem *e , regm_t *pretregs );
-code *cnvteq87 (elem *e , regm_t *pretregs );
-code *neg87 (elem *e , regm_t *pretregs );
-code *neg_complex87(elem *e, regm_t *pretregs);
-code *cdind87(elem *e,regm_t *pretregs);
+void eq87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void complex_eq87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void opass87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void cdnegass87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void post87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void cnvt87(CodeBuilder& cdb, elem *e , regm_t *pretregs );
+void neg87(CodeBuilder& cdb, elem *e , regm_t *pretregs);
+void neg_complex87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void cdind87(CodeBuilder& cdb,elem *e,regm_t *pretregs);
 #if TX86
 extern int stackused;
 #endif
-code *cload87(elem *e, regm_t *pretregs);
-code *cdd_u64(elem *e, regm_t *pretregs);
-code *cdd_u32(elem *e, regm_t *pretregs);
-code *loadPair87(elem *e, regm_t *pretregs);
+void cload87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void cdd_u64(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void cdd_u32(CodeBuilder& cdb, elem *e, regm_t *pretregs);
+void loadPair87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
 
 #ifdef DEBUG
 #define pop87() pop87(__LINE__,__FILE__)


### PR DESCRIPTION
Lotsa diffs, mostly the same thing over and over, because the return of `code*` was replaced by a parameter of `CodeBuilder& cdb`