### PR TITLE
fix Issue 16301 - CTFE execution of opApply keeps wrong "this" context in foreach's body

### DIFF
--- a/test/compilable/ctfeNestedDelegate.d
+++ b/test/compilable/ctfeNestedDelegate.d
@@ -1,0 +1,32 @@
+void opApply(void delegate() dlg) { dlg(); }
+
+struct Foo {
+    int i;
+
+    int abc() {
+        void dg() { i = 0; }
+        opApply(&dg);
+        return 0;
+    }
+}
+
+void bar() {
+    enum x = Foo().abc();
+}
+
+struct OpApply {
+    int opApply(scope int delegate(int) dlg) {
+        return dlg(1);
+    }
+}
+
+struct Foo2 {
+    int i;
+    this(int x) {
+        foreach(_; OpApply()) {
+            i = 0; // Error: couldn't find field i of type int in OpApply()
+        }
+    }
+}
+
+enum x = Foo2(1);


### PR DESCRIPTION
Fixes issue 16301 by walking up the stack of previous this-pointers and looking for a match.
This will allow delegates to properly work at ctfe.