### PR TITLE
fix Issue 17399 - core.checkedint.addu cannot inline function

### DIFF
--- a/test/compilable/extra-files/c6815.d
+++ b/test/compilable/extra-files/c6815.d
@@ -1,0 +1,5 @@
+void c()
+{
+    import d6815 : d;
+    d();
+}

--- a/test/compilable/extra-files/d6815.d
+++ b/test/compilable/extra-files/d6815.d
@@ -1,0 +1,5 @@
+void d()
+{
+    import e6815 : e;
+    static if (e("")) { }
+}

--- a/test/compilable/extra-files/e6815.d
+++ b/test/compilable/extra-files/e6815.d
@@ -1,0 +1,7 @@
+bool e(T)(T)
+{
+    f(true);
+    return true;
+}
+
+void f(lazy bool) {}

--- a/test/compilable/pull6815.d
+++ b/test/compilable/pull6815.d
@@ -1,0 +1,8 @@
+/* REQUIRED_ARGS: -inline -Icompilable/extra-files
+ */
+
+void b()
+{
+    import e6815 : e;
+    e("");
+}

--- a/test/compilable/test17399.d
+++ b/test/compilable/test17399.d
@@ -1,0 +1,18 @@
+/* REQUIRED_ARGS: -inline
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=17399
+
+pragma(inline, true)
+uint addu(uint x, uint y, ref bool overflow) {
+    uint r = x + y;
+    if (r < x || r < y)
+        overflow = true;
+    return r;
+}
+
+void foo() {
+    uint a, b;
+    bool over;
+    addu(a, b, over);
+}


### PR DESCRIPTION
This could use a refactoring to get rid of the `goto`, but I wanted to keep the diff small. Refactorings should happen separately.