### PR TITLE
add backticks to dcast.d error messages

### DIFF
--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -90,14 +90,14 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
             {
                 if (!t.deco)
                 {
-                    e.error("forward reference to type %s", t.toChars());
+                    e.error("forward reference to type `%s`", t.toChars());
                 }
                 else
                 {
                     //printf("type %p ty %d deco %p\n", type, type.ty, type.deco);
                     //type = type.semantic(loc, sc);
                     //printf("type %s t %s\n", type.deco, t.deco);
-                    e.error("cannot implicitly convert expression (%s) of type %s to %s",
+                    e.error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
                         e.toChars(), e.type.toChars(), t.toChars());
                 }
             }
@@ -197,7 +197,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 return;
             if (!e.type)
             {
-                e.error("%s is not an expression", e.toChars());
+                e.error("`%s` is not an expression", e.toChars());
                 e.type = Type.terror;
             }
 
@@ -1553,7 +1553,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             {
                 if (t1b.size(e.loc) == tob.size(e.loc))
                     goto Lok;
-                e.error("cannot cast expression %s of type %s to %s because of different sizes", e.toChars(), e.type.toChars(), t.toChars());
+                e.error("cannot cast expression `%s` of type `%s` to `%s` because of different sizes", e.toChars(), e.type.toChars(), t.toChars());
                 result = new ErrorExp();
                 return;
             }
@@ -1578,7 +1578,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     if (((cast(TypeSArray)t1b).dim.toInteger() * fsize) % tsize != 0)
                     {
                         // copied from sarray_toDarray() in e2ir.c
-                        e.error("cannot cast expression %s of type %s to %s since sizes don't line up", e.toChars(), e.type.toChars(), t.toChars());
+                        e.error("cannot cast expression `%s` of type `%s` to `%s` since sizes don't line up", e.toChars(), e.type.toChars(), t.toChars());
                         result = new ErrorExp();
                         return;
                     }
@@ -1629,7 +1629,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             if (t1b.ty == Tvoid && tob.ty != Tvoid)
             {
             Lfail:
-                e.error("cannot cast expression %s of type %s to %s", e.toChars(), e.type.toChars(), t.toChars());
+                e.error("cannot cast expression `%s` of type `%s` to `%s`", e.toChars(), e.type.toChars(), t.toChars());
                 result = new ErrorExp();
                 return;
             }
@@ -1708,7 +1708,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
             {
-                e.error("cannot convert string literal to void*");
+                e.error("cannot convert string literal to `void*`");
                 result = new ErrorExp();
                 return;
             }
@@ -2263,7 +2263,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                         }
                         else if (f.needThis())
                         {
-                            e.error("no 'this' to create delegate for %s", f.toChars());
+                            e.error("no `this` to create delegate for `%s`", f.toChars());
                             result = new ErrorExp();
                             return;
                         }
@@ -2462,7 +2462,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     return;
                 }
             }
-            e.error("cannot cast expression %s of type %s to %s", e.toChars(), tsa ? tsa.toChars() : e.type.toChars(), t.toChars());
+            e.error("cannot cast expression `%s` of type `%s` to `%s`", e.toChars(), tsa ? tsa.toChars() : e.type.toChars(), t.toChars());
             result = new ErrorExp();
         }
     }
@@ -3439,7 +3439,7 @@ extern (C++) bool arrayTypeCompatible(Loc loc, Type t1, Type t2)
     {
         if (t1.nextOf().implicitConvTo(t2.nextOf()) < MATCHconst && t2.nextOf().implicitConvTo(t1.nextOf()) < MATCHconst && (t1.nextOf().ty != Tvoid && t2.nextOf().ty != Tvoid))
         {
-            error(loc, "array equality comparison type mismatch, %s vs %s", t1.toChars(), t2.toChars());
+            error(loc, "array equality comparison type mismatch, `%s` vs `%s`", t1.toChars(), t2.toChars());
         }
         return true;
     }

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -7124,7 +7124,7 @@ extern (C++) final class FuncExp : Expression
         }
         else if (!flag)
         {
-            error("cannot implicitly convert expression (%s) of type %s to %s", toChars(), tx.toChars(), to.toChars());
+            error("cannot implicitly convert expression `%s` of type `%s` to `%s`", toChars(), tx.toChars(), to.toChars());
         }
         return m;
     }

--- a/test/compilable/verrors_spec.d
+++ b/test/compilable/verrors_spec.d
@@ -3,7 +3,7 @@ PERMUTE_ARGS:
 REQUIRED_ARGS: -verrors=spec
 TEST_OUTPUT:
 ---
-(spec:1) compilable/verrors_spec.d(13): Error: cannot implicitly convert expression (& i) of type int* to int
+(spec:1) compilable/verrors_spec.d(13): Error: cannot implicitly convert expression `& i` of type `int*` to `int`
 ---
 */
 

--- a/test/fail_compilation/ctfe14731.d
+++ b/test/fail_compilation/ctfe14731.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ctfe14731.d(16): Error: cannot implicitly convert expression (["a b"]) of type string[] to string
-fail_compilation/ctfe14731.d(17): Error: cannot implicitly convert expression (split("a b")) of type string[] to string
+fail_compilation/ctfe14731.d(16): Error: cannot implicitly convert expression `["a b"]` of type `string[]` to `string`
+fail_compilation/ctfe14731.d(17): Error: cannot implicitly convert expression `split("a b")` of type `string[]` to `string`
 ---
 */
 

--- a/test/fail_compilation/diag10221.d
+++ b/test/fail_compilation/diag10221.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10221.d(10): Error: cannot implicitly convert expression (256) of type int to ubyte
+fail_compilation/diag10221.d(10): Error: cannot implicitly convert expression `256` of type `int` to `ubyte`
 ---
 */
 

--- a/test/fail_compilation/diag10221a.d
+++ b/test/fail_compilation/diag10221a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10221a.d(10): Error: cannot implicitly convert expression (257) of type int to ubyte
+fail_compilation/diag10221a.d(10): Error: cannot implicitly convert expression `257` of type `int` to `ubyte`
 ---
 */
 

--- a/test/fail_compilation/diag12380.d
+++ b/test/fail_compilation/diag12380.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag12380.d(12): Error: cannot implicitly convert expression (cast(E)0) of type E to void*
+fail_compilation/diag12380.d(12): Error: cannot implicitly convert expression `cast(E)0` of type `E` to `void*`
 ---
 */
 

--- a/test/fail_compilation/diag13142.d
+++ b/test/fail_compilation/diag13142.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13142.d(25): Error: cannot implicitly convert expression (3) of type int to TYPE
+fail_compilation/diag13142.d(25): Error: cannot implicitly convert expression `3` of type `int` to `TYPE`
 ---
 */
 

--- a/test/fail_compilation/diag13281.d
+++ b/test/fail_compilation/diag13281.d
@@ -1,19 +1,19 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13281.d(20): Error: cannot implicitly convert expression (123) of type int to string
-fail_compilation/diag13281.d(21): Error: cannot implicitly convert expression (123u) of type uint to string
-fail_compilation/diag13281.d(22): Error: cannot implicitly convert expression (123L) of type long to string
-fail_compilation/diag13281.d(23): Error: cannot implicitly convert expression (123LU) of type ulong to string
-fail_compilation/diag13281.d(24): Error: cannot implicitly convert expression (123.4) of type double to int
-fail_compilation/diag13281.d(25): Error: cannot implicitly convert expression (123.4F) of type float to int
-fail_compilation/diag13281.d(26): Error: cannot implicitly convert expression (123.4L) of type real to int
-fail_compilation/diag13281.d(27): Error: cannot implicitly convert expression (123.4i) of type idouble to int
-fail_compilation/diag13281.d(28): Error: cannot implicitly convert expression (123.4Fi) of type ifloat to int
-fail_compilation/diag13281.d(29): Error: cannot implicitly convert expression (123.4Li) of type ireal to int
-fail_compilation/diag13281.d(30): Error: cannot implicitly convert expression ((123.4+5.6i)) of type cdouble to int
-fail_compilation/diag13281.d(31): Error: cannot implicitly convert expression ((123.4F+5.6Fi)) of type cfloat to int
-fail_compilation/diag13281.d(32): Error: cannot implicitly convert expression ((123.4L+5.6Li)) of type creal to int
+fail_compilation/diag13281.d(20): Error: cannot implicitly convert expression `123` of type `int` to `string`
+fail_compilation/diag13281.d(21): Error: cannot implicitly convert expression `123u` of type `uint` to `string`
+fail_compilation/diag13281.d(22): Error: cannot implicitly convert expression `123L` of type `long` to `string`
+fail_compilation/diag13281.d(23): Error: cannot implicitly convert expression `123LU` of type `ulong` to `string`
+fail_compilation/diag13281.d(24): Error: cannot implicitly convert expression `123.4` of type `double` to `int`
+fail_compilation/diag13281.d(25): Error: cannot implicitly convert expression `123.4F` of type `float` to `int`
+fail_compilation/diag13281.d(26): Error: cannot implicitly convert expression `123.4L` of type `real` to `int`
+fail_compilation/diag13281.d(27): Error: cannot implicitly convert expression `123.4i` of type `idouble` to `int`
+fail_compilation/diag13281.d(28): Error: cannot implicitly convert expression `123.4Fi` of type `ifloat` to `int`
+fail_compilation/diag13281.d(29): Error: cannot implicitly convert expression `123.4Li` of type `ireal` to `int`
+fail_compilation/diag13281.d(30): Error: cannot implicitly convert expression `(123.4+5.6i)` of type `cdouble` to `int`
+fail_compilation/diag13281.d(31): Error: cannot implicitly convert expression `(123.4F+5.6Fi)` of type `cfloat` to `int`
+fail_compilation/diag13281.d(32): Error: cannot implicitly convert expression `(123.4L+5.6Li)` of type `creal` to `int`
 ---
 */
 

--- a/test/fail_compilation/diag16977.d
+++ b/test/fail_compilation/diag16977.d
@@ -2,10 +2,10 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag16977.d(22): Error: undefined identifier `undefined`, did you mean function `undefinedId`?
-fail_compilation/diag16977.d(23): Error: cannot implicitly convert expression ("\x01string") of type string to int
+fail_compilation/diag16977.d(23): Error: cannot implicitly convert expression `"\x01string"` of type `string` to `int`
 fail_compilation/diag16977.d(24): Error: template diag16977.templ cannot deduce function from argument types !()(int), candidates are:
 fail_compilation/diag16977.d(17):        diag16977.templ(S)(S s) if (false)
-fail_compilation/diag16977.d(25): Error: cannot implicitly convert expression (5) of type int to string
+fail_compilation/diag16977.d(25): Error: cannot implicitly convert expression `5` of type `int` to `string`
 fail_compilation/diag16977.d(27): Error: template instance diag16977.test.funcTemplate!string error instantiating
 ---
 */

--- a/test/fail_compilation/diag6796.d
+++ b/test/fail_compilation/diag6796.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag6796.d(11): Error: cannot implicitly convert expression (0) of type int to int[]
-fail_compilation/diag6796.d(11): Error: cannot implicitly convert expression (1) of type int to int[]
+fail_compilation/diag6796.d(11): Error: cannot implicitly convert expression `0` of type `int` to `int[]`
+fail_compilation/diag6796.d(11): Error: cannot implicitly convert expression `1` of type `int` to `int[]`
 ---
 */
 

--- a/test/fail_compilation/diag7477.d
+++ b/test/fail_compilation/diag7477.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7477.d(13): Error: cannot implicitly convert expression (0) of type int to Foo
-fail_compilation/diag7477.d(20): Error: cannot implicitly convert expression (0) of type int to string
+fail_compilation/diag7477.d(13): Error: cannot implicitly convert expression `0` of type `int` to `Foo`
+fail_compilation/diag7477.d(20): Error: cannot implicitly convert expression `0` of type `int` to `string`
 ---
 */
 

--- a/test/fail_compilation/diag8892.d
+++ b/test/fail_compilation/diag8892.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8892.d(14): Error: cannot implicitly convert expression (['A']) of type char[] to char[2]
+fail_compilation/diag8892.d(14): Error: cannot implicitly convert expression `['A']` of type `char[]` to `char[2]`
 ---
 */
 struct Foo

--- a/test/fail_compilation/diag9250.d
+++ b/test/fail_compilation/diag9250.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9250.d(19): Error: cannot implicitly convert expression (10u) of type uint to Foo
-fail_compilation/diag9250.d(22): Error: cannot implicitly convert expression (10u) of type uint to void*
+fail_compilation/diag9250.d(19): Error: cannot implicitly convert expression `10u` of type `uint` to `Foo`
+fail_compilation/diag9250.d(22): Error: cannot implicitly convert expression `10u` of type `uint` to `void*`
 ---
 */
 

--- a/test/fail_compilation/diag9357.d
+++ b/test/fail_compilation/diag9357.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9357.d(14): Error: cannot implicitly convert expression (1.00000) of type double to int
-fail_compilation/diag9357.d(15): Error: cannot implicitly convert expression (10.0000) of type double to int
-fail_compilation/diag9357.d(16): Error: cannot implicitly convert expression (11.0000) of type double to int
-fail_compilation/diag9357.d(17): Error: cannot implicitly convert expression (99.0000) of type double to int
-fail_compilation/diag9357.d(18): Error: cannot implicitly convert expression (1.04858e+06L) of type real to int
-fail_compilation/diag9357.d(19): Error: cannot implicitly convert expression (1.04858e+06L) of type real to int
+fail_compilation/diag9357.d(14): Error: cannot implicitly convert expression `1.00000` of type `double` to `int`
+fail_compilation/diag9357.d(15): Error: cannot implicitly convert expression `10.0000` of type `double` to `int`
+fail_compilation/diag9357.d(16): Error: cannot implicitly convert expression `11.0000` of type `double` to `int`
+fail_compilation/diag9357.d(17): Error: cannot implicitly convert expression `99.0000` of type `double` to `int`
+fail_compilation/diag9357.d(18): Error: cannot implicitly convert expression `1.04858e+06L` of type `real` to `int`
+fail_compilation/diag9357.d(19): Error: cannot implicitly convert expression `1.04858e+06L` of type `real` to `int`
 ---
 */
 void main()

--- a/test/fail_compilation/diag9765.d
+++ b/test/fail_compilation/diag9765.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9765.d(9): Error: cannot implicitly convert expression ('x') of type char to char[]
+fail_compilation/diag9765.d(9): Error: cannot implicitly convert expression `'x'` of type `char` to `char[]`
 ---
 */
 

--- a/test/fail_compilation/diag9961.d
+++ b/test/fail_compilation/diag9961.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9961.d(11): Error: cannot implicitly convert expression ("") of type string to int
+fail_compilation/diag9961.d(11): Error: cannot implicitly convert expression `""` of type `string` to `int`
 fail_compilation/diag9961.d(14): Error: template instance diag9961.foo!int error instantiating
-fail_compilation/diag9961.d(11): Error: cannot implicitly convert expression ("") of type string to int
+fail_compilation/diag9961.d(11): Error: cannot implicitly convert expression `""` of type `string` to `int`
 fail_compilation/diag9961.d(15): Error: template instance diag9961.foo!char error instantiating
 ---
 */

--- a/test/fail_compilation/fail100.d
+++ b/test/fail_compilation/fail100.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail100.d(24): Error: cannot implicitly convert expression (f) of type Class[] to I[]
+fail_compilation/fail100.d(24): Error: cannot implicitly convert expression `f` of type `Class[]` to `I[]`
 ---
 */
 

--- a/test/fail_compilation/fail101.d
+++ b/test/fail_compilation/fail101.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail101.d(8): Error: cannot implicitly convert expression (1) of type int to creal
+fail_compilation/fail101.d(8): Error: cannot implicitly convert expression `1` of type `int` to `creal`
 ---
 */
 

--- a/test/fail_compilation/fail11163.d
+++ b/test/fail_compilation/fail11163.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11163.d(12): Error: cannot implicitly convert expression (foo()) of type int[] to immutable(int[])
+fail_compilation/fail11163.d(12): Error: cannot implicitly convert expression `foo()` of type `int[]` to `immutable(int[])`
 fail_compilation/fail11163.d(13):        while evaluating pragma(msg, a)
 ---
 */

--- a/test/fail_compilation/fail11426.d
+++ b/test/fail_compilation/fail11426.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11426.d(15): Error: cannot implicitly convert expression (udarr) of type uint[] to int[]
-fail_compilation/fail11426.d(16): Error: cannot implicitly convert expression (usarr) of type uint[1] to int[]
-fail_compilation/fail11426.d(18): Error: cannot implicitly convert expression (udarr) of type uint[] to int[]
-fail_compilation/fail11426.d(19): Error: cannot implicitly convert expression (usarr) of type uint[1] to int[]
+fail_compilation/fail11426.d(15): Error: cannot implicitly convert expression `udarr` of type `uint[]` to `int[]`
+fail_compilation/fail11426.d(16): Error: cannot implicitly convert expression `usarr` of type `uint[1]` to `int[]`
+fail_compilation/fail11426.d(18): Error: cannot implicitly convert expression `udarr` of type `uint[]` to `int[]`
+fail_compilation/fail11426.d(19): Error: cannot implicitly convert expression `usarr` of type `uint[1]` to `int[]`
 ---
 */
 void main()

--- a/test/fail_compilation/fail11746.d
+++ b/test/fail_compilation/fail11746.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11746.d(18): Error: cannot implicitly convert expression (1) of type int to string
-fail_compilation/fail11746.d(25): Error: cannot implicitly convert expression (1) of type int to string
-fail_compilation/fail11746.d(26): Error: cannot implicitly convert expression (2) of type int to string
+fail_compilation/fail11746.d(18): Error: cannot implicitly convert expression `1` of type `int` to `string`
+fail_compilation/fail11746.d(25): Error: cannot implicitly convert expression `1` of type `int` to `string`
+fail_compilation/fail11746.d(26): Error: cannot implicitly convert expression `2` of type `int` to `string`
 ---
 */
 

--- a/test/fail_compilation/fail12604.d
+++ b/test/fail_compilation/fail12604.d
@@ -5,8 +5,8 @@ fail_compilation/fail12604.d(14): Error: mismatched array lengths, 1 and 3
 fail_compilation/fail12604.d(15): Error: mismatched array lengths, 1 and 3
 fail_compilation/fail12604.d(17): Error: mismatched array lengths, 1 and 3
 fail_compilation/fail12604.d(18): Error: mismatched array lengths, 1 and 3
-fail_compilation/fail12604.d(20): Error: cannot implicitly convert expression ([65536]) of type int[] to short[]
-fail_compilation/fail12604.d(21): Error: cannot implicitly convert expression ([65536, 2, 3]) of type int[] to short[]
+fail_compilation/fail12604.d(20): Error: cannot implicitly convert expression `[65536]` of type `int[]` to `short[]`
+fail_compilation/fail12604.d(21): Error: cannot implicitly convert expression `[65536, 2, 3]` of type `int[]` to `short[]`
 ---
 */
 void main()

--- a/test/fail_compilation/fail13434_m32.d
+++ b/test/fail_compilation/fail13434_m32.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13434_m32.d(13): Error: cannot implicitly convert expression (()) of type () to uint
+fail_compilation/fail13434_m32.d(13): Error: cannot implicitly convert expression `()` of type `()` to `uint`
 ---
 */
 

--- a/test/fail_compilation/fail13434_m64.d
+++ b/test/fail_compilation/fail13434_m64.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13434_m64.d(13): Error: cannot implicitly convert expression (()) of type () to ulong
+fail_compilation/fail13434_m64.d(13): Error: cannot implicitly convert expression `()` of type `()` to `ulong`
 ---
 */
 

--- a/test/fail_compilation/fail13498.d
+++ b/test/fail_compilation/fail13498.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13498.d(11): Error: cannot implicitly convert expression ("foo") of type string to int
+fail_compilation/fail13498.d(11): Error: cannot implicitly convert expression `"foo"` of type `string` to `int`
 fail_compilation/fail13498.d(16): Error: template instance fail13498.foo!() error instantiating
 ---
 */

--- a/test/fail_compilation/fail13775.d
+++ b/test/fail_compilation/fail13775.d
@@ -2,10 +2,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13775.d(17): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to ubyte[1]
-fail_compilation/fail13775.d(18): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to ubyte[3]
-fail_compilation/fail13775.d(19): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to byte[1]
-fail_compilation/fail13775.d(20): Error: cannot cast expression ubytes[0..2] of type ubyte[2] to byte[3]
+fail_compilation/fail13775.d(17): Error: cannot cast expression `ubytes[0..2]` of type `ubyte[2]` to `ubyte[1]`
+fail_compilation/fail13775.d(18): Error: cannot cast expression `ubytes[0..2]` of type `ubyte[2]` to `ubyte[3]`
+fail_compilation/fail13775.d(19): Error: cannot cast expression `ubytes[0..2]` of type `ubyte[2]` to `byte[1]`
+fail_compilation/fail13775.d(20): Error: cannot cast expression `ubytes[0..2]` of type `ubyte[2]` to `byte[3]`
 ---
 */
 

--- a/test/fail_compilation/fail15089.d
+++ b/test/fail_compilation/fail15089.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15089.d(10): Error: cannot implicitly convert expression (130) of type int to byte
+fail_compilation/fail15089.d(10): Error: cannot implicitly convert expression `130` of type `int` to `byte`
 ---
 */
 

--- a/test/fail_compilation/fail163.d
+++ b/test/fail_compilation/fail163.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(11): Error: cannot implicitly convert expression (q) of type const(char)[] to char[]
+fail_compilation/fail163.d(11): Error: cannot implicitly convert expression `q` of type `const(char)[]` to `char[]`
 ---
 */
 void test1()
@@ -14,7 +14,7 @@ void test1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(24): Error: cannot implicitly convert expression (p) of type const(int***) to const(int)***
+fail_compilation/fail163.d(24): Error: cannot implicitly convert expression `p` of type `const(int***)` to `const(int)***`
 ---
 */
 void test2()
@@ -40,7 +40,7 @@ void test3()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(50): Error: cannot implicitly convert expression (cp) of type const(int)***[] to const(uint***)[]
+fail_compilation/fail163.d(50): Error: cannot implicitly convert expression `cp` of type `const(int)***[]` to `const(uint***)[]`
 ---
 */
 void test4()
@@ -66,7 +66,7 @@ void test5()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(76): Error: cannot implicitly convert expression (& x) of type int* to immutable(int)*
+fail_compilation/fail163.d(76): Error: cannot implicitly convert expression `& x` of type `int*` to `immutable(int)*`
 fail_compilation/fail163.d(77): Error: cannot modify immutable expression *p
 ---
 */
@@ -80,7 +80,7 @@ void test6()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail163.d(89): Error: cannot implicitly convert expression (& x) of type const(int)* to int*
+fail_compilation/fail163.d(89): Error: cannot implicitly convert expression `& x` of type `const(int)*` to `int*`
 ---
 */
 void test7()

--- a/test/fail_compilation/fail238_m32.d
+++ b/test/fail_compilation/fail238_m32.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail238_m32.d(21): Error: cannot implicitly convert expression ("a") of type string to uint
+fail_compilation/fail238_m32.d(21): Error: cannot implicitly convert expression `"a"` of type `string` to `uint`
 fail_compilation/fail238_m32.d(24): Error: cannot interpret X!() at compile time
 fail_compilation/fail238_m32.d(29): Error: template instance fail238_m32.A!"a" error instantiating
 fail_compilation/fail238_m32.d(35):        instantiated from here: M!(q)

--- a/test/fail_compilation/fail238_m64.d
+++ b/test/fail_compilation/fail238_m64.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail238_m64.d(21): Error: cannot implicitly convert expression ("a") of type string to ulong
+fail_compilation/fail238_m64.d(21): Error: cannot implicitly convert expression `"a"` of type `string` to `ulong`
 fail_compilation/fail238_m64.d(24): Error: cannot interpret X!() at compile time
 fail_compilation/fail238_m64.d(29): Error: template instance fail238_m64.A!"a" error instantiating
 fail_compilation/fail238_m64.d(35):        instantiated from here: M!(q)

--- a/test/fail_compilation/fail27.d
+++ b/test/fail_compilation/fail27.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail27.d(15): Error: cannot implicitly convert expression (-32769) of type int to short
-fail_compilation/fail27.d(16): Error: cannot implicitly convert expression (-129) of type int to byte
-fail_compilation/fail27.d(17): Error: cannot implicitly convert expression (-1) of type int to char
-fail_compilation/fail27.d(18): Error: cannot implicitly convert expression (65536) of type int to wchar
-fail_compilation/fail27.d(19): Error: cannot implicitly convert expression (-1) of type int to wchar
-fail_compilation/fail27.d(21): Error: cannot implicitly convert expression (-1) of type int to dchar
+fail_compilation/fail27.d(15): Error: cannot implicitly convert expression `-32769` of type `int` to `short`
+fail_compilation/fail27.d(16): Error: cannot implicitly convert expression `-129` of type `int` to `byte`
+fail_compilation/fail27.d(17): Error: cannot implicitly convert expression `-1` of type `int` to `char`
+fail_compilation/fail27.d(18): Error: cannot implicitly convert expression `65536` of type `int` to `wchar`
+fail_compilation/fail27.d(19): Error: cannot implicitly convert expression `-1` of type `int` to `wchar`
+fail_compilation/fail27.d(21): Error: cannot implicitly convert expression `-1` of type `int` to `dchar`
 ---
 */
 

--- a/test/fail_compilation/fail290.d
+++ b/test/fail_compilation/fail290.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail290.d(15): Error: no 'this' to create delegate for foo
+fail_compilation/fail290.d(15): Error: no `this` to create delegate for `foo`
 ---
 */
 

--- a/test/fail_compilation/fail298.d
+++ b/test/fail_compilation/fail298.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail298.d(12): Error: cannot implicitly convert expression (num1 / cast(ulong)num2) of type ulong to int
+fail_compilation/fail298.d(12): Error: cannot implicitly convert expression `num1 / cast(ulong)num2` of type `ulong` to `int`
 ---
 */
 

--- a/test/fail_compilation/fail302.d
+++ b/test/fail_compilation/fail302.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail302.d(21): Error: cannot implicitly convert expression (1) of type int to Bar
+fail_compilation/fail302.d(21): Error: cannot implicitly convert expression `1` of type `int` to `Bar`
 ---
 */
 

--- a/test/fail_compilation/fail304.d
+++ b/test/fail_compilation/fail304.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail304.d(15): Error: cannot cast expression foo() of type Small to Large because of different sizes
+fail_compilation/fail304.d(15): Error: cannot cast expression `foo()` of type `Small` to `Large` because of different sizes
 ---
 */
 

--- a/test/fail_compilation/fail307.d
+++ b/test/fail_compilation/fail307.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail307.d(11): Error: cannot implicitly convert expression (cast(int)(cast(double)cast(int)b + 6.1)) of type int to short
+fail_compilation/fail307.d(11): Error: cannot implicitly convert expression `cast(int)(cast(double)cast(int)b + 6.1)` of type `int` to `short`
 ---
 */
 

--- a/test/fail_compilation/fail80_m32.d
+++ b/test/fail_compilation/fail80_m32.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail80_m32.d(28): Error: cannot implicitly convert expression ("progress_rem") of type string to uint
-fail_compilation/fail80_m32.d(29): Error: cannot implicitly convert expression ("redo") of type string to uint
+fail_compilation/fail80_m32.d(28): Error: cannot implicitly convert expression `"progress_rem"` of type `string` to `uint`
+fail_compilation/fail80_m32.d(29): Error: cannot implicitly convert expression `"redo"` of type `string` to `uint`
 ---
 */
 

--- a/test/fail_compilation/fail80_m64.d
+++ b/test/fail_compilation/fail80_m64.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail80_m64.d(28): Error: cannot implicitly convert expression ("progress_rem") of type string to ulong
-fail_compilation/fail80_m64.d(29): Error: cannot implicitly convert expression ("redo") of type string to ulong
+fail_compilation/fail80_m64.d(28): Error: cannot implicitly convert expression `"progress_rem"` of type `string` to `ulong`
+fail_compilation/fail80_m64.d(29): Error: cannot implicitly convert expression `"redo"` of type `string` to `ulong`
 ---
 */
 

--- a/test/fail_compilation/fail8179b.d
+++ b/test/fail_compilation/fail8179b.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8179b.d(10): Error: cannot cast expression [1, 2] of type int[] to int[2][1]
+fail_compilation/fail8179b.d(10): Error: cannot cast expression `[1, 2]` of type `int[]` to `int[2][1]`
 ---
 */
 void foo(int[2][1]) {}

--- a/test/fail_compilation/fail98.d
+++ b/test/fail_compilation/fail98.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail98.d(17): Error: cannot implicitly convert expression (256) of type int to E
+fail_compilation/fail98.d(17): Error: cannot implicitly convert expression `256` of type `int` to `E`
 ---
 */
 

--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(12): Error: cannot cast expression x of type short[2] to int[2] because of different sizes
+fail_compilation/fail_casting.d(12): Error: cannot cast expression `x` of type `short[2]` to `int[2]` because of different sizes
 ---
 */
 void test3133()
@@ -15,10 +15,10 @@ void test3133()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(28): Error: cannot cast expression null of type typeof(null) to S1
-fail_compilation/fail_casting.d(29): Error: cannot cast expression null of type typeof(null) to S2
-fail_compilation/fail_casting.d(30): Error: cannot cast expression s1 of type S1 to typeof(null)
-fail_compilation/fail_casting.d(31): Error: cannot cast expression s2 of type S2 to typeof(null)
+fail_compilation/fail_casting.d(28): Error: cannot cast expression `null` of type `typeof(null)` to `S1`
+fail_compilation/fail_casting.d(29): Error: cannot cast expression `null` of type `typeof(null)` to `S2`
+fail_compilation/fail_casting.d(30): Error: cannot cast expression `s1` of type `S1` to `typeof(null)`
+fail_compilation/fail_casting.d(31): Error: cannot cast expression `s2` of type `S2` to `typeof(null)`
 ---
 */
 void test9904()
@@ -34,10 +34,10 @@ void test9904()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(46): Error: cannot cast expression x of type Object[] to object.Object
-fail_compilation/fail_casting.d(47): Error: cannot cast expression x of type Object[2] to object.Object
-fail_compilation/fail_casting.d(49): Error: cannot cast expression x of type object.Object to Object[]
-fail_compilation/fail_casting.d(50): Error: cannot cast expression x of type object.Object to Object[2]
+fail_compilation/fail_casting.d(46): Error: cannot cast expression `x` of type `Object[]` to `object.Object`
+fail_compilation/fail_casting.d(47): Error: cannot cast expression `x` of type `Object[2]` to `object.Object`
+fail_compilation/fail_casting.d(49): Error: cannot cast expression `x` of type `object.Object` to `Object[]`
+fail_compilation/fail_casting.d(50): Error: cannot cast expression `x` of type `object.Object` to `Object[2]`
 ---
 */
 void test10646()
@@ -53,14 +53,14 @@ void test10646()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(69): Error: cannot cast expression x of type int[1] to int
-fail_compilation/fail_casting.d(70): Error: cannot cast expression x of type int to int[1]
-fail_compilation/fail_casting.d(71): Error: cannot cast expression x of type float[1] to int
-fail_compilation/fail_casting.d(72): Error: cannot cast expression x of type int to float[1]
-fail_compilation/fail_casting.d(75): Error: cannot cast expression x of type int[] to int
-fail_compilation/fail_casting.d(76): Error: cannot cast expression x of type int to int[]
-fail_compilation/fail_casting.d(77): Error: cannot cast expression x of type float[] to int
-fail_compilation/fail_casting.d(78): Error: cannot cast expression x of type int to float[]
+fail_compilation/fail_casting.d(69): Error: cannot cast expression `x` of type `int[1]` to `int`
+fail_compilation/fail_casting.d(70): Error: cannot cast expression `x` of type `int` to `int[1]`
+fail_compilation/fail_casting.d(71): Error: cannot cast expression `x` of type `float[1]` to `int`
+fail_compilation/fail_casting.d(72): Error: cannot cast expression `x` of type `int` to `float[1]`
+fail_compilation/fail_casting.d(75): Error: cannot cast expression `x` of type `int[]` to `int`
+fail_compilation/fail_casting.d(76): Error: cannot cast expression `x` of type `int` to `int[]`
+fail_compilation/fail_casting.d(77): Error: cannot cast expression `x` of type `float[]` to `int`
+fail_compilation/fail_casting.d(78): Error: cannot cast expression `x` of type `int` to `float[]`
 ---
 */
 void test11484()
@@ -81,10 +81,10 @@ void test11484()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(97): Error: cannot cast expression x of type int to fail_casting.test11485.C
-fail_compilation/fail_casting.d(98): Error: cannot cast expression x of type int to fail_casting.test11485.I
-fail_compilation/fail_casting.d(101): Error: cannot cast expression x of type fail_casting.test11485.C to int
-fail_compilation/fail_casting.d(102): Error: cannot cast expression x of type fail_casting.test11485.I to int
+fail_compilation/fail_casting.d(97): Error: cannot cast expression `x` of type `int` to `fail_casting.test11485.C`
+fail_compilation/fail_casting.d(98): Error: cannot cast expression `x` of type `int` to `fail_casting.test11485.I`
+fail_compilation/fail_casting.d(101): Error: cannot cast expression `x` of type `fail_casting.test11485.C` to `int`
+fail_compilation/fail_casting.d(102): Error: cannot cast expression `x` of type `fail_casting.test11485.I` to `int`
 ---
 */
 
@@ -105,8 +105,8 @@ void test11485()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(114): Error: cannot cast expression x of type typeof(null) to int[2]
-fail_compilation/fail_casting.d(115): Error: cannot cast expression x of type int[2] to typeof(null)
+fail_compilation/fail_casting.d(114): Error: cannot cast expression `x` of type `typeof(null)` to `int[2]`
+fail_compilation/fail_casting.d(115): Error: cannot cast expression `x` of type `int[2]` to `typeof(null)`
 ---
 */
 void test8179()
@@ -118,8 +118,8 @@ void test8179()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(128): Error: cannot cast expression x of type S to int*
-fail_compilation/fail_casting.d(130): Error: cannot cast expression x of type void* to S
+fail_compilation/fail_casting.d(128): Error: cannot cast expression `x` of type `S` to `int*`
+fail_compilation/fail_casting.d(130): Error: cannot cast expression `x` of type `void*` to `S`
 ---
 */
 void test13959()
@@ -133,7 +133,7 @@ void test13959()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(144): Error: cannot cast expression mi.x of type int to MyUbyte14154
+fail_compilation/fail_casting.d(144): Error: cannot cast expression `mi.x` of type `int` to `MyUbyte14154`
 ---
 */
 struct MyUbyte14154 { ubyte x; alias x this; }
@@ -147,8 +147,8 @@ void test14154()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup$n$.__expand_field_0 of type int to object.Object
-fail_compilation/fail_casting.d(179): Error: cannot cast expression __tup$n$.__expand_field_1 of type int to object.Object
+fail_compilation/fail_casting.d(179): Error: cannot cast expression `__tup$n$.__expand_field_0` of type `int` to `object.Object`
+fail_compilation/fail_casting.d(179): Error: cannot cast expression `__tup$n$.__expand_field_1` of type `int` to `object.Object`
 ---
 */
 alias TypeTuple14093(T...) = T;
@@ -182,8 +182,8 @@ void test14093()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(192): Error: cannot cast expression p of type void* to char[]
-fail_compilation/fail_casting.d(193): Error: cannot cast expression p of type void* to char[2]
+fail_compilation/fail_casting.d(192): Error: cannot cast expression `p` of type `void*` to `char[]`
+fail_compilation/fail_casting.d(193): Error: cannot cast expression `p` of type `void*` to `char[2]`
 ---
 */
 void test14596()
@@ -196,12 +196,12 @@ void test14596()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(217): Error: cannot cast expression c of type fail_casting.test14629.C to typeof(null)
-fail_compilation/fail_casting.d(218): Error: cannot cast expression p of type int* to typeof(null)
-fail_compilation/fail_casting.d(219): Error: cannot cast expression da of type int[] to typeof(null)
-fail_compilation/fail_casting.d(220): Error: cannot cast expression aa of type int[int] to typeof(null)
-fail_compilation/fail_casting.d(221): Error: cannot cast expression fp of type int function() to typeof(null)
-fail_compilation/fail_casting.d(222): Error: cannot cast expression dg of type int delegate() to typeof(null)
+fail_compilation/fail_casting.d(217): Error: cannot cast expression `c` of type `fail_casting.test14629.C` to `typeof(null)`
+fail_compilation/fail_casting.d(218): Error: cannot cast expression `p` of type `int*` to `typeof(null)`
+fail_compilation/fail_casting.d(219): Error: cannot cast expression `da` of type `int[]` to `typeof(null)`
+fail_compilation/fail_casting.d(220): Error: cannot cast expression `aa` of type `int[int]` to `typeof(null)`
+fail_compilation/fail_casting.d(221): Error: cannot cast expression `fp` of type `int function()` to `typeof(null)`
+fail_compilation/fail_casting.d(222): Error: cannot cast expression `dg` of type `int delegate()` to `typeof(null)`
 ---
 */
 void test14629()

--- a/test/fail_compilation/fail_casting1.d
+++ b/test/fail_compilation/fail_casting1.d
@@ -20,18 +20,18 @@ struct S {}                 S s;
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting1.d(39): Error: cannot cast expression p of type int* to int[1]
-fail_compilation/fail_casting1.d(40): Error: cannot cast expression fp of type int function() to int[1]
-fail_compilation/fail_casting1.d(41): Error: cannot cast expression dg of type int delegate() to int[1]
-fail_compilation/fail_casting1.d(42): Error: cannot cast expression da of type int[] to int[1]
-fail_compilation/fail_casting1.d(43): Error: cannot cast expression aa of type int[int] to int[1]
-fail_compilation/fail_casting1.d(44): Error: cannot cast expression c of type fail_casting1.C to int[1]
-fail_compilation/fail_casting1.d(45): Error: cannot cast expression n of type typeof(null) to int[1]
-fail_compilation/fail_casting1.d(49): Error: cannot cast expression sa of type int[1] to int delegate()
-fail_compilation/fail_casting1.d(51): Error: cannot cast expression sa of type int[1] to double[] since sizes don't line up
-fail_compilation/fail_casting1.d(52): Error: cannot cast expression sa of type int[1] to int[int]
-fail_compilation/fail_casting1.d(53): Error: cannot cast expression sa of type int[1] to fail_casting1.C
-fail_compilation/fail_casting1.d(54): Error: cannot cast expression sa of type int[1] to typeof(null)
+fail_compilation/fail_casting1.d(39): Error: cannot cast expression `p` of type `int*` to `int[1]`
+fail_compilation/fail_casting1.d(40): Error: cannot cast expression `fp` of type `int function()` to `int[1]`
+fail_compilation/fail_casting1.d(41): Error: cannot cast expression `dg` of type `int delegate()` to `int[1]`
+fail_compilation/fail_casting1.d(42): Error: cannot cast expression `da` of type `int[]` to `int[1]`
+fail_compilation/fail_casting1.d(43): Error: cannot cast expression `aa` of type `int[int]` to `int[1]`
+fail_compilation/fail_casting1.d(44): Error: cannot cast expression `c` of type `fail_casting1.C` to `int[1]`
+fail_compilation/fail_casting1.d(45): Error: cannot cast expression `n` of type `typeof(null)` to `int[1]`
+fail_compilation/fail_casting1.d(49): Error: cannot cast expression `sa` of type `int[1]` to `int delegate()`
+fail_compilation/fail_casting1.d(51): Error: cannot cast expression `sa` of type `int[1]` to `double[]` since sizes don't line up
+fail_compilation/fail_casting1.d(52): Error: cannot cast expression `sa` of type `int[1]` to `int[int]`
+fail_compilation/fail_casting1.d(53): Error: cannot cast expression `sa` of type `int[1]` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(54): Error: cannot cast expression `sa` of type `int[1]` to `typeof(null)`
 ---
 */
 void test1()
@@ -57,20 +57,20 @@ void test1()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting1.d(78): Error: cannot cast expression p of type int* to S
-fail_compilation/fail_casting1.d(79): Error: cannot cast expression fp of type int function() to S
-fail_compilation/fail_casting1.d(80): Error: cannot cast expression dg of type int delegate() to S
-fail_compilation/fail_casting1.d(81): Error: cannot cast expression da of type int[] to S
-fail_compilation/fail_casting1.d(82): Error: cannot cast expression aa of type int[int] to S
-fail_compilation/fail_casting1.d(83): Error: cannot cast expression c of type fail_casting1.C to S
-fail_compilation/fail_casting1.d(84): Error: cannot cast expression n of type typeof(null) to S
-fail_compilation/fail_casting1.d(85): Error: cannot cast expression s of type S to int*
-fail_compilation/fail_casting1.d(86): Error: cannot cast expression s of type S to int function()
-fail_compilation/fail_casting1.d(87): Error: cannot cast expression s of type S to int delegate()
-fail_compilation/fail_casting1.d(88): Error: cannot cast expression s of type S to int[]
-fail_compilation/fail_casting1.d(89): Error: cannot cast expression s of type S to int[int]
-fail_compilation/fail_casting1.d(90): Error: cannot cast expression s of type S to fail_casting1.C
-fail_compilation/fail_casting1.d(91): Error: cannot cast expression s of type S to typeof(null)
+fail_compilation/fail_casting1.d(78): Error: cannot cast expression `p` of type `int*` to `S`
+fail_compilation/fail_casting1.d(79): Error: cannot cast expression `fp` of type `int function()` to `S`
+fail_compilation/fail_casting1.d(80): Error: cannot cast expression `dg` of type `int delegate()` to `S`
+fail_compilation/fail_casting1.d(81): Error: cannot cast expression `da` of type `int[]` to `S`
+fail_compilation/fail_casting1.d(82): Error: cannot cast expression `aa` of type `int[int]` to `S`
+fail_compilation/fail_casting1.d(83): Error: cannot cast expression `c` of type `fail_casting1.C` to `S`
+fail_compilation/fail_casting1.d(84): Error: cannot cast expression `n` of type `typeof(null)` to `S`
+fail_compilation/fail_casting1.d(85): Error: cannot cast expression `s` of type `S` to `int*`
+fail_compilation/fail_casting1.d(86): Error: cannot cast expression `s` of type `S` to `int function()`
+fail_compilation/fail_casting1.d(87): Error: cannot cast expression `s` of type `S` to `int delegate()`
+fail_compilation/fail_casting1.d(88): Error: cannot cast expression `s` of type `S` to `int[]`
+fail_compilation/fail_casting1.d(89): Error: cannot cast expression `s` of type `S` to `int[int]`
+fail_compilation/fail_casting1.d(90): Error: cannot cast expression `s` of type `S` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(91): Error: cannot cast expression `s` of type `S` to `typeof(null)`
 ---
 */
 void test2()
@@ -94,28 +94,28 @@ void test2()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting1.d(125): Error: cannot cast expression p of type int* to int delegate()
-fail_compilation/fail_casting1.d(126): Error: cannot cast expression p of type int* to int[]
-fail_compilation/fail_casting1.d(129): Error: cannot cast expression p of type int* to typeof(null)
-fail_compilation/fail_casting1.d(133): Error: cannot cast expression fp of type int function() to int delegate()
-fail_compilation/fail_casting1.d(134): Error: cannot cast expression fp of type int function() to int[]
-fail_compilation/fail_casting1.d(137): Error: cannot cast expression fp of type int function() to typeof(null)
+fail_compilation/fail_casting1.d(125): Error: cannot cast expression `p` of type `int*` to `int delegate()`
+fail_compilation/fail_casting1.d(126): Error: cannot cast expression `p` of type `int*` to `int[]`
+fail_compilation/fail_casting1.d(129): Error: cannot cast expression `p` of type `int*` to `typeof(null)`
+fail_compilation/fail_casting1.d(133): Error: cannot cast expression `fp` of type `int function()` to `int delegate()`
+fail_compilation/fail_casting1.d(134): Error: cannot cast expression `fp` of type `int function()` to `int[]`
+fail_compilation/fail_casting1.d(137): Error: cannot cast expression `fp` of type `int function()` to `typeof(null)`
 fail_compilation/fail_casting1.d(139): Deprecation: casting from int delegate() to int* is deprecated
 fail_compilation/fail_casting1.d(140): Deprecation: casting from int delegate() to int function() is deprecated
-fail_compilation/fail_casting1.d(142): Error: cannot cast expression dg of type int delegate() to int[]
-fail_compilation/fail_casting1.d(143): Error: cannot cast expression dg of type int delegate() to int[int]
-fail_compilation/fail_casting1.d(144): Error: cannot cast expression dg of type int delegate() to fail_casting1.C
-fail_compilation/fail_casting1.d(145): Error: cannot cast expression dg of type int delegate() to typeof(null)
-fail_compilation/fail_casting1.d(157): Error: cannot cast expression da of type int[] to int delegate()
-fail_compilation/fail_casting1.d(159): Error: cannot cast expression da of type int[] to int[int]
-fail_compilation/fail_casting1.d(160): Error: cannot cast expression da of type int[] to fail_casting1.C
-fail_compilation/fail_casting1.d(161): Error: cannot cast expression da of type int[] to typeof(null)
-fail_compilation/fail_casting1.d(165): Error: cannot cast expression aa of type int[int] to int delegate()
-fail_compilation/fail_casting1.d(166): Error: cannot cast expression aa of type int[int] to int[]
-fail_compilation/fail_casting1.d(169): Error: cannot cast expression aa of type int[int] to typeof(null)
-fail_compilation/fail_casting1.d(173): Error: cannot cast expression c of type fail_casting1.C to int delegate()
-fail_compilation/fail_casting1.d(174): Error: cannot cast expression c of type fail_casting1.C to int[]
-fail_compilation/fail_casting1.d(177): Error: cannot cast expression c of type fail_casting1.C to typeof(null)
+fail_compilation/fail_casting1.d(142): Error: cannot cast expression `dg` of type `int delegate()` to `int[]`
+fail_compilation/fail_casting1.d(143): Error: cannot cast expression `dg` of type `int delegate()` to `int[int]`
+fail_compilation/fail_casting1.d(144): Error: cannot cast expression `dg` of type `int delegate()` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(145): Error: cannot cast expression `dg` of type `int delegate()` to `typeof(null)`
+fail_compilation/fail_casting1.d(157): Error: cannot cast expression `da` of type `int[]` to `int delegate()`
+fail_compilation/fail_casting1.d(159): Error: cannot cast expression `da` of type `int[]` to `int[int]`
+fail_compilation/fail_casting1.d(160): Error: cannot cast expression `da` of type `int[]` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(161): Error: cannot cast expression `da` of type `int[]` to `typeof(null)`
+fail_compilation/fail_casting1.d(165): Error: cannot cast expression `aa` of type `int[int]` to `int delegate()`
+fail_compilation/fail_casting1.d(166): Error: cannot cast expression `aa` of type `int[int]` to `int[]`
+fail_compilation/fail_casting1.d(169): Error: cannot cast expression `aa` of type `int[int]` to `typeof(null)`
+fail_compilation/fail_casting1.d(173): Error: cannot cast expression `c` of type `fail_casting1.C` to `int delegate()`
+fail_compilation/fail_casting1.d(174): Error: cannot cast expression `c` of type `fail_casting1.C` to `int[]`
+fail_compilation/fail_casting1.d(177): Error: cannot cast expression `c` of type `fail_casting1.C` to `typeof(null)`
 ---
 */
 void test3()    // between reference types
@@ -180,23 +180,23 @@ void test3()    // between reference types
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting1.d(206): Error: cannot cast expression 0 of type int to int delegate()
-fail_compilation/fail_casting1.d(207): Error: cannot cast expression 0 of type int to int[]
-fail_compilation/fail_casting1.d(208): Error: cannot cast expression 0 of type int to int[1]
-fail_compilation/fail_casting1.d(209): Error: cannot cast expression 0 of type int to int[int]
-fail_compilation/fail_casting1.d(210): Error: cannot cast expression 0 of type int to fail_casting1.C
-fail_compilation/fail_casting1.d(211): Error: cannot cast expression 0 of type int to typeof(null)
-fail_compilation/fail_casting1.d(215): Error: cannot cast expression i of type int to int delegate()
-fail_compilation/fail_casting1.d(216): Error: cannot cast expression i of type int to int[]
-fail_compilation/fail_casting1.d(217): Error: cannot cast expression i of type int to int[1]
-fail_compilation/fail_casting1.d(218): Error: cannot cast expression i of type int to int[int]
-fail_compilation/fail_casting1.d(219): Error: cannot cast expression i of type int to fail_casting1.C
-fail_compilation/fail_casting1.d(220): Error: cannot cast expression i of type int to typeof(null)
-fail_compilation/fail_casting1.d(224): Error: cannot cast expression dg of type int delegate() to int
-fail_compilation/fail_casting1.d(225): Error: cannot cast expression da of type int[] to int
-fail_compilation/fail_casting1.d(226): Error: cannot cast expression sa of type int[1] to int
-fail_compilation/fail_casting1.d(227): Error: cannot cast expression aa of type int[int] to int
-fail_compilation/fail_casting1.d(228): Error: cannot cast expression c of type fail_casting1.C to int
+fail_compilation/fail_casting1.d(206): Error: cannot cast expression `0` of type `int` to `int delegate()`
+fail_compilation/fail_casting1.d(207): Error: cannot cast expression `0` of type `int` to `int[]`
+fail_compilation/fail_casting1.d(208): Error: cannot cast expression `0` of type `int` to `int[1]`
+fail_compilation/fail_casting1.d(209): Error: cannot cast expression `0` of type `int` to `int[int]`
+fail_compilation/fail_casting1.d(210): Error: cannot cast expression `0` of type `int` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(211): Error: cannot cast expression `0` of type `int` to `typeof(null)`
+fail_compilation/fail_casting1.d(215): Error: cannot cast expression `i` of type `int` to `int delegate()`
+fail_compilation/fail_casting1.d(216): Error: cannot cast expression `i` of type `int` to `int[]`
+fail_compilation/fail_casting1.d(217): Error: cannot cast expression `i` of type `int` to `int[1]`
+fail_compilation/fail_casting1.d(218): Error: cannot cast expression `i` of type `int` to `int[int]`
+fail_compilation/fail_casting1.d(219): Error: cannot cast expression `i` of type `int` to `fail_casting1.C`
+fail_compilation/fail_casting1.d(220): Error: cannot cast expression `i` of type `int` to `typeof(null)`
+fail_compilation/fail_casting1.d(224): Error: cannot cast expression `dg` of type `int delegate()` to `int`
+fail_compilation/fail_casting1.d(225): Error: cannot cast expression `da` of type `int[]` to `int`
+fail_compilation/fail_casting1.d(226): Error: cannot cast expression `sa` of type `int[1]` to `int`
+fail_compilation/fail_casting1.d(227): Error: cannot cast expression `aa` of type `int[int]` to `int`
+fail_compilation/fail_casting1.d(228): Error: cannot cast expression `c` of type `fail_casting1.C` to `int`
 ---
 */
 void test4()
@@ -232,16 +232,16 @@ void test4()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting1.d(249): Error: cannot cast expression 0 of type int to int[1]
-fail_compilation/fail_casting1.d(250): Error: cannot cast expression 0 of type int to S
-fail_compilation/fail_casting1.d(251): Error: cannot cast expression i of type int to int[1]
-fail_compilation/fail_casting1.d(252): Error: cannot cast expression i of type int to S
-fail_compilation/fail_casting1.d(253): Error: cannot cast expression f of type double to int[1]
-fail_compilation/fail_casting1.d(254): Error: cannot cast expression f of type double to S
-fail_compilation/fail_casting1.d(255): Error: cannot cast expression sa of type int[1] to int
-fail_compilation/fail_casting1.d(256): Error: cannot cast expression s of type S to int
-fail_compilation/fail_casting1.d(257): Error: cannot cast expression sa of type int[1] to double
-fail_compilation/fail_casting1.d(258): Error: cannot cast expression s of type S to double
+fail_compilation/fail_casting1.d(249): Error: cannot cast expression `0` of type `int` to `int[1]`
+fail_compilation/fail_casting1.d(250): Error: cannot cast expression `0` of type `int` to `S`
+fail_compilation/fail_casting1.d(251): Error: cannot cast expression `i` of type `int` to `int[1]`
+fail_compilation/fail_casting1.d(252): Error: cannot cast expression `i` of type `int` to `S`
+fail_compilation/fail_casting1.d(253): Error: cannot cast expression `f` of type `double` to `int[1]`
+fail_compilation/fail_casting1.d(254): Error: cannot cast expression `f` of type `double` to `S`
+fail_compilation/fail_casting1.d(255): Error: cannot cast expression `sa` of type `int[1]` to `int`
+fail_compilation/fail_casting1.d(256): Error: cannot cast expression `s` of type `S` to `int`
+fail_compilation/fail_casting1.d(257): Error: cannot cast expression `sa` of type `int[1]` to `double`
+fail_compilation/fail_casting1.d(258): Error: cannot cast expression `s` of type `S` to `double`
 ---
 */
 void test5()

--- a/test/fail_compilation/ice12838.d
+++ b/test/fail_compilation/ice12838.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12838.d(27): Error: cannot implicitly convert expression (1) of type int to string
+fail_compilation/ice12838.d(27): Error: cannot implicitly convert expression `1` of type `int` to `string`
 ---
 */
 

--- a/test/fail_compilation/ice12850.d
+++ b/test/fail_compilation/ice12850.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12850.d(12): Error: cannot implicitly convert expression (0) of type int to string
+fail_compilation/ice12850.d(12): Error: cannot implicitly convert expression `0` of type `int` to `string`
 ---
 */
 alias TypeTuple(TL...) = TL;

--- a/test/fail_compilation/ice13024.d
+++ b/test/fail_compilation/ice13024.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice13024.d(15): Error: cannot implicitly convert expression (t.x) of type A to B
+fail_compilation/ice13024.d(15): Error: cannot implicitly convert expression `t.x` of type `A` to `B`
 ---
 */
 

--- a/test/fail_compilation/ice14185.d
+++ b/test/fail_compilation/ice14185.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14185.d(12): Error: cannot implicitly convert expression (this) of type Mutexed to Mutexed*
+fail_compilation/ice14185.d(12): Error: cannot implicitly convert expression `this` of type `Mutexed` to `Mutexed*`
 ---
 */
 

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -235,10 +235,10 @@ void* funretscope(scope dg_t ptr) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression (__lambda1) of type void* delegate() pure nothrow @nogc return scope @safe to void* delegate() scope @safe
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression (__lambda1) of type void* delegate() pure nothrow @nogc return scope @safe to void* delegate() scope @safe
-fail_compilation/retscope.d(250): Error: cannot implicitly convert expression (__lambda2) of type void* delegate() pure nothrow @nogc return scope @safe to void* delegate() scope @safe
-fail_compilation/retscope.d(250): Error: cannot implicitly convert expression (__lambda2) of type void* delegate() pure nothrow @nogc return scope @safe to void* delegate() scope @safe
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(250): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(250): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
 ---
 */
 
@@ -505,11 +505,11 @@ void foo16() @nogc nothrow
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1701): Error: cannot implicitly convert expression (& func) of type int* function(int* p) to int* function(scope int* p)
-fail_compilation/retscope.d(1702): Error: cannot implicitly convert expression (& func) of type int* function(int* p) to int* function(return scope int* p)
-fail_compilation/retscope.d(1703): Error: cannot implicitly convert expression (& func) of type int* function(int* p) to int* function(return scope int* p)
-fail_compilation/retscope.d(1711): Error: cannot implicitly convert expression (& funcr) of type int* function(return scope int* p) to int* function(scope int* p)
-fail_compilation/retscope.d(1716): Error: cannot implicitly convert expression (& funcrs) of type int* function(return scope int* p) to int* function(scope int* p)
+fail_compilation/retscope.d(1701): Error: cannot implicitly convert expression `& func` of type `int* function(int* p)` to `int* function(scope int* p)`
+fail_compilation/retscope.d(1702): Error: cannot implicitly convert expression `& func` of type `int* function(int* p)` to `int* function(return scope int* p)`
+fail_compilation/retscope.d(1703): Error: cannot implicitly convert expression `& func` of type `int* function(int* p)` to `int* function(return scope int* p)`
+fail_compilation/retscope.d(1711): Error: cannot implicitly convert expression `& funcr` of type `int* function(return scope int* p)` to `int* function(scope int* p)`
+fail_compilation/retscope.d(1716): Error: cannot implicitly convert expression `& funcrs` of type `int* function(return scope int* p)` to `int* function(scope int* p)`
 ---
 */
 
@@ -547,11 +547,11 @@ void foo17()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1801): Error: cannot implicitly convert expression (&c.func) of type int* delegate() to int* delegate() scope
-fail_compilation/retscope.d(1802): Error: cannot implicitly convert expression (&c.func) of type int* delegate() to int* delegate() return scope
-fail_compilation/retscope.d(1803): Error: cannot implicitly convert expression (&c.func) of type int* delegate() to int* delegate() return scope
-fail_compilation/retscope.d(1811): Error: cannot implicitly convert expression (&c.funcr) of type int* delegate() return scope to int* delegate() scope
-fail_compilation/retscope.d(1816): Error: cannot implicitly convert expression (&c.funcrs) of type int* delegate() return scope to int* delegate() scope
+fail_compilation/retscope.d(1801): Error: cannot implicitly convert expression `&c.func` of type `int* delegate()` to `int* delegate() scope`
+fail_compilation/retscope.d(1802): Error: cannot implicitly convert expression `&c.func` of type `int* delegate()` to `int* delegate() return scope`
+fail_compilation/retscope.d(1803): Error: cannot implicitly convert expression `&c.func` of type `int* delegate()` to `int* delegate() return scope`
+fail_compilation/retscope.d(1811): Error: cannot implicitly convert expression `&c.funcr` of type `int* delegate() return scope` to `int* delegate() scope`
+fail_compilation/retscope.d(1816): Error: cannot implicitly convert expression `&c.funcrs` of type `int* delegate() return scope` to `int* delegate() scope`
 ---
 */
 

--- a/test/fail_compilation/test14538.d
+++ b/test/fail_compilation/test14538.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test14538.d(19): Error: cannot implicitly convert expression (x ? cast(uint)this.fCells[x].code : 32u) of type uint to Cell
+fail_compilation/test14538.d(19): Error: cannot implicitly convert expression `x ? cast(uint)this.fCells[x].code : 32u` of type `uint` to `Cell`
 ---
 */
 

--- a/test/fail_compilation/test16365.d
+++ b/test/fail_compilation/test16365.d
@@ -3,7 +3,7 @@
    TEST_OUTPUT:
 ---
 fail_compilation/test16365.d(21): Error: 'this' reference necessary to take address of member f1 in @safe function main
-fail_compilation/test16365.d(23): Error: cannot implicitly convert expression (&f2) of type void delegate() pure nothrow @nogc @safe to void function() @safe
+fail_compilation/test16365.d(23): Error: cannot implicitly convert expression `&f2` of type `void delegate() pure nothrow @nogc @safe` to `void function() @safe`
 fail_compilation/test16365.d(28): Error: dg.funcptr cannot be used in @safe code
 ---
 */

--- a/test/fail_compilation/testInference.d
+++ b/test/fail_compilation/testInference.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(24): Error: cannot implicitly convert expression (this.a) of type inout(A8998) to immutable(A8998)
+fail_compilation/testInference.d(24): Error: cannot implicitly convert expression `this.a` of type `inout(A8998)` to `immutable(A8998)`
 ---
 */
 
@@ -28,10 +28,10 @@ class C8998
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(39): Error: cannot implicitly convert expression (s) of type const(char[]) to string
-fail_compilation/testInference.d(44): Error: cannot implicitly convert expression (a) of type int[] to immutable(int[])
-fail_compilation/testInference.d(49): Error: cannot implicitly convert expression (a) of type int[] to immutable(int[])
-fail_compilation/testInference.d(54): Error: cannot implicitly convert expression (a) of type int[] to immutable(int[])
+fail_compilation/testInference.d(39): Error: cannot implicitly convert expression `s` of type `const(char[])` to `string`
+fail_compilation/testInference.d(44): Error: cannot implicitly convert expression `a` of type `int[]` to `immutable(int[])`
+fail_compilation/testInference.d(49): Error: cannot implicitly convert expression `a` of type `int[]` to `immutable(int[])`
+fail_compilation/testInference.d(54): Error: cannot implicitly convert expression `a` of type `int[]` to `immutable(int[])`
 ---
 */
 string foo(in char[] s) pure
@@ -58,18 +58,18 @@ immutable(int[]) x3(immutable(int[]) org) /*pure*/
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(94): Error: cannot implicitly convert expression (c) of type testInference.C1 to immutable(C1)
-fail_compilation/testInference.d(95): Error: cannot implicitly convert expression (c) of type testInference.C1 to immutable(C1)
-fail_compilation/testInference.d(96): Error: cannot implicitly convert expression (c) of type testInference.C3 to immutable(C3)
-fail_compilation/testInference.d(97): Error: cannot implicitly convert expression (c) of type testInference.C3 to immutable(C3)
+fail_compilation/testInference.d(94): Error: cannot implicitly convert expression `c` of type `testInference.C1` to `immutable(C1)`
+fail_compilation/testInference.d(95): Error: cannot implicitly convert expression `c` of type `testInference.C1` to `immutable(C1)`
+fail_compilation/testInference.d(96): Error: cannot implicitly convert expression `c` of type `testInference.C3` to `immutable(C3)`
+fail_compilation/testInference.d(97): Error: cannot implicitly convert expression `c` of type `testInference.C3` to `immutable(C3)`
 fail_compilation/testInference.d(100): Error: undefined identifier `X1`, did you mean function `x1`?
-fail_compilation/testInference.d(106): Error: cannot implicitly convert expression (s) of type S1 to immutable(S1)
-fail_compilation/testInference.d(109): Error: cannot implicitly convert expression (a) of type int*[] to immutable(int*[])
-fail_compilation/testInference.d(110): Error: cannot implicitly convert expression (a) of type const(int)*[] to immutable(int*[])
-fail_compilation/testInference.d(114): Error: cannot implicitly convert expression (s) of type S2 to immutable(S2)
-fail_compilation/testInference.d(115): Error: cannot implicitly convert expression (s) of type S2 to immutable(S2)
-fail_compilation/testInference.d(116): Error: cannot implicitly convert expression (s) of type S2 to immutable(S2)
-fail_compilation/testInference.d(118): Error: cannot implicitly convert expression (a) of type const(int)*[] to immutable(int*[])
+fail_compilation/testInference.d(106): Error: cannot implicitly convert expression `s` of type `S1` to `immutable(S1)`
+fail_compilation/testInference.d(109): Error: cannot implicitly convert expression `a` of type `int*[]` to `immutable(int*[])`
+fail_compilation/testInference.d(110): Error: cannot implicitly convert expression `a` of type `const(int)*[]` to `immutable(int*[])`
+fail_compilation/testInference.d(114): Error: cannot implicitly convert expression `s` of type `S2` to `immutable(S2)`
+fail_compilation/testInference.d(115): Error: cannot implicitly convert expression `s` of type `S2` to `immutable(S2)`
+fail_compilation/testInference.d(116): Error: cannot implicitly convert expression `s` of type `S2` to `immutable(S2)`
+fail_compilation/testInference.d(118): Error: cannot implicitly convert expression `a` of type `const(int)*[]` to `immutable(int*[])`
 ---
 */
 immutable(Object) get(inout int*) pure
@@ -122,7 +122,7 @@ immutable(int*[]) bar2c(              S2 prm) pure { immutable(int)*[] a; return
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(134): Error: cannot implicitly convert expression (f10063(cast(inout(void*))p)) of type inout(void)* to immutable(void)*
+fail_compilation/testInference.d(134): Error: cannot implicitly convert expression `f10063(cast(inout(void*))p)` of type `inout(void)*` to `immutable(void)*`
 ---
 */
 inout(void)* f10063(inout void* p) pure

--- a/test/fail_compilation/warn7444.d
+++ b/test/fail_compilation/warn7444.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn7444.d(23): Error: cannot implicitly convert expression (e) of type int to int[]
+fail_compilation/warn7444.d(23): Error: cannot implicitly convert expression `e` of type `int` to `int[]`
 ---
 */
 


### PR DESCRIPTION
So the syntax highlighting will work.