### PR TITLE
[scope] fix Issue 17422 - class reference not initialized as scope variable

### DIFF
--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -2241,7 +2241,7 @@ extern (C++) class VarDeclaration : Declaration
                     // Destructors are not supported on extern(C++) classes
                     break;
                 }
-                if (mynew || onstack || cd.dtors.dim) // if any destructors
+                if (mynew || onstack) // if any destructors
                 {
                     // delete this;
                     Expression ec;

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -2236,9 +2236,10 @@ extern (C++) class VarDeclaration : Declaration
                 //if (cd.isInterfaceDeclaration())
                 //    error("interface %s cannot be scope", cd.toChars());
 
+                // Destroying C++ scope classes crashes currently. Since C++ class dtors are not currently supported, simply do not run dtors for them.
+                // See https://issues.dlang.org/show_bug.cgi?id=13182
                 if (cd.cpp)
                 {
-                    // Destructors are not supported on extern(C++) classes
                     break;
                 }
                 if (mynew || onstack) // if any destructors

--- a/src/ddmd/escape.d
+++ b/src/ddmd/escape.d
@@ -323,8 +323,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
         {
             if (va && !va.isDataseg() && !va.doNotInferScope)
             {
-                if (!va.isScope() && inferScope &&
-                    va.type.toBasetype().ty != Tclass)  // scope classes are special
+                if (!va.isScope() && inferScope)
                 {   //printf("inferring scope for %s\n", va.toChars());
                     va.storage_class |= STCscope;
                 }

--- a/test/fail_compilation/test17422.d
+++ b/test/fail_compilation/test17422.d
@@ -1,0 +1,24 @@
+/*
+REQUIRED_ARGS: -dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test17422.d(23): Error: scope variable p may not be returned
+---
+*/
+struct RC
+{
+    Object get() return scope @trusted
+    {
+        return cast(Object) &store[0];
+    }
+
+private:
+    ubyte[__traits(classInstanceSize, Object)] store;
+}
+
+Object test() @safe
+{
+    RC rc;
+    auto p = rc.get; // p must be inferred as scope variable, works for int*
+    return p;
+}

--- a/test/runnable/fix17429.d
+++ b/test/runnable/fix17429.d
@@ -1,0 +1,17 @@
+class Klazz
+{
+    __gshared size_t count;
+    ~this()
+    {
+        ++count;
+    }
+}
+
+void main()
+{
+    auto s = new Klazz;
+    {
+        scope s2 = s; // calls delete even though it does not own s
+    }
+    assert(Klazz.count == 0);
+}


### PR DESCRIPTION
- infer scope for class references to prevent escaping
- those are just normal class references with scope to prevent escaping (copying)
- only `scope o = new Object` remains special, because it uses the fact
  that the class ref cannot be escaped to allocate the instance on the stack