### PR TITLE
set e.f in the CallExp's for _d_critical*

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3482,7 +3482,7 @@ else
         Expression genCall(Identifier id, Expression argexp, STC stc)
         {
             FuncDeclaration fd = FuncDeclaration.genCfunc(args, Type.tvoid, id, stc);
-            CallExp e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), argexp);
+            CallExp e = new CallExp(ss.loc, new VarExp(ss.loc, fd, false), argexp);
             e.f = fd;
             e.type = Type.tvoid; // do not run semantic on e
             return e;
@@ -3499,7 +3499,6 @@ else
 
         // set the explicit __critsecNNN alignment after semantic()
         if (!ss.exp) tmp.alignment = Target.ptrsize;
-
     }
 
     override void visit(WithStatement ws)

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3499,7 +3499,7 @@ else
 
         // set the explicit __critsecNNN alignment after semantic()
         if (!ss.exp) tmp.alignment = Target.ptrsize;
-        }
+
     }
 
     override void visit(WithStatement ws)

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3479,7 +3479,7 @@ else
             if (ss.exp) return new VarExp(ss.loc, tmp);
             else        return new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
         }
-        Expression genCall(Identifier id, Expression argexp, STC stc = STC.undefined_)
+        Expression genCall(Identifier id, Expression argexp, STC stc)
         {
             FuncDeclaration fd = FuncDeclaration.genCfunc(args, Type.tvoid, id, stc);
             CallExp e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), argexp);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3480,7 +3480,7 @@ else
                 return new VarExp(ss.loc, tmp);
             else
             {
-                auto e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
+                Expression e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
                 e = e.expressionSemantic(sc);
                 return e;
             }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3464,7 +3464,7 @@ else
         
         cs.push(new ExpStatement(ss.loc, tmp));
         
-        if (ss.exp)
+        if (!ss.exp)
         {
             /* This is just a dummy variable for "goto skips declaration" error.
              * Backend optimizer could remove this unused variable.
@@ -3476,8 +3476,14 @@ else
         
         Expression argExp()
         {
-            if (ss.exp) return new VarExp(ss.loc, tmp);
-            else        return new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
+            if (ss.exp)
+                return new VarExp(ss.loc, tmp);
+            else
+            {
+                auto e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
+                e = e.expressionSemantic(sc);
+                return e;
+            }
         }
         Expression genCall(Identifier id, Expression argexp, STC stc)
         {

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3437,7 +3437,7 @@ else
          *  _d_monitorenter(tmp);
          *  try { foo(); } finally { _d_monitorexit(tmp); }
          *
-         *  Rewrite synchonized() { foo(); } as:
+         *  Rewrite synchonized { foo(); } as:
          *  // NNN == line number
          *  __gshared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsecNNN;
          *  _d_criticalenter(__critsecNNN.ptr);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3430,88 +3430,75 @@ else
                 ss.exp = new CastExp(ss.loc, ss.exp, t);
                 ss.exp = ss.exp.expressionSemantic(sc);
             }
-            version (all)
-            {
-                /* Rewrite as:
-                 *  auto tmp = exp;
-                 *  _d_monitorenter(tmp);
-                 *  try { body } finally { _d_monitorexit(tmp); }
-                 */
-                auto tmp = copyToTemp(0, "__sync", ss.exp);
-                tmp.dsymbolSemantic(sc);
-
-                auto cs = new Statements();
-                cs.push(new ExpStatement(ss.loc, tmp));
-
-                auto args = new Parameters();
-                args.push(new Parameter(0, ClassDeclaration.object.type, null, null));
-
-                FuncDeclaration fdenter = FuncDeclaration.genCfunc(args, Type.tvoid, Id.monitorenter);
-                Expression e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), new VarExp(ss.loc, tmp));
-                (cast(CallExp)e).f = fdenter;
-                e.type = Type.tvoid; // do not run semantic on e
-
-                cs.push(new ExpStatement(ss.loc, e));
-                FuncDeclaration fdexit = FuncDeclaration.genCfunc(args, Type.tvoid, Id.monitorexit);
-                e = new CallExp(ss.loc, new VarExp(ss.loc, fdexit, false), new VarExp(ss.loc, tmp));
-                (cast(CallExp)e).f = fdexit;
-                e.type = Type.tvoid; // do not run semantic on e
-                Statement s = new ExpStatement(ss.loc, e);
-                s = new TryFinallyStatement(ss.loc, ss._body, s);
-                cs.push(s);
-
-                s = new CompoundStatement(ss.loc, cs);
-                result = s.statementSemantic(sc);
-            }
+        }
+        /*
+         * Rewrite synchonized(exp) { foo(); } as:
+         *  auto tmp = exp;
+         *  _d_monitorenter(tmp);
+         *  try { foo(); } finally { _d_monitorexit(tmp); }
+         *
+         *  Rewrite synchonized() { foo(); } as:
+         *  // NNN == line number
+         *  __gshared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsecNNN;
+         *  _d_criticalenter(__critsecNNN.ptr);
+         *  try { foo(); } finally { _d_criticalexit(__critsec.ptr); }
+         */
+        VarDeclaration tmp;
+        auto cs = new Statements();
+        auto args = new Parameters();
+        if (ss.exp)
+        {
+            tmp = copyToTemp(0, "__sync", ss.exp);
+            tmp.dsymbolSemantic(sc);
+            args.push(new Parameter(0, ClassDeclaration.object.type, null, null));
         }
         else
         {
-            /* Generate our own critical section, then rewrite as:
-             *  __gshared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsec;
-             *  _d_criticalenter(__critsec.ptr);
-             *  try { body } finally { _d_criticalexit(__critsec.ptr); }
-             */
             auto id = Identifier.generateId("__critsec");
             auto t = Type.tint8.sarrayOf(Target.ptrsize + Target.critsecsize());
-            auto tmp = new VarDeclaration(ss.loc, t, id, null);
+            tmp = new VarDeclaration(ss.loc, t, id, null);
             tmp.storage_class |= STC.temp | STC.gshared | STC.static_;
-
-            auto cs = new Statements();
-            cs.push(new ExpStatement(ss.loc, tmp));
-
+            args.push(new Parameter(0, t.pointerTo(), null, null));
+            // Assignment of the alignment is delayed until after semantic
+        }
+        
+        cs.push(new ExpStatement(ss.loc, tmp));
+        
+        if (ss.exp)
+        {
             /* This is just a dummy variable for "goto skips declaration" error.
              * Backend optimizer could remove this unused variable.
              */
             auto v = new VarDeclaration(ss.loc, Type.tvoidptr, Identifier.generateId("__sync"), null);
             v.dsymbolSemantic(sc);
             cs.push(new ExpStatement(ss.loc, v));
-
-            auto args = new Parameters();
-            args.push(new Parameter(0, t.pointerTo(), null, null));
-
-            FuncDeclaration fdenter = FuncDeclaration.genCfunc(args, Type.tvoid, Id.criticalenter, STC.nothrow_);
-            Expression e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
-            e = e.expressionSemantic(sc);
-            e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), e);
-            (cast(CallExp)e).f = fdenter;
+        }
+        
+        Expression argExp()
+        {
+            if (ss.exp) return new VarExp(ss.loc, tmp);
+            else        return new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
+        }
+        Expression genCall(Identifier id, Expression argexp, STC stc = STC.undefined_)
+        {
+            FuncDeclaration fd = FuncDeclaration.genCfunc(args, Type.tvoid, id, stc);
+            CallExp e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), argexp);
+            e.f = fd;
             e.type = Type.tvoid; // do not run semantic on e
-            cs.push(new ExpStatement(ss.loc, e));
+            return e;
+        }
+        auto stc    = ss.exp ? STC.undefined_  : STC.nothrow_;
+        auto ienter = ss.exp ? Id.monitorenter : Id.criticalenter;
+        auto iexit  = ss.exp ? Id.monitorexit  : Id.criticalexit;
 
-            FuncDeclaration fdexit = FuncDeclaration.genCfunc(args, Type.tvoid, Id.criticalexit, STC.nothrow_);
-            e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
-            e = e.expressionSemantic(sc);
-            e = new CallExp(ss.loc, new VarExp(ss.loc, fdexit, false), e);
-            (cast(CallExp)e).f = fdexit;
-            e.type = Type.tvoid; // do not run semantic on e
-            Statement s = new ExpStatement(ss.loc, e);
-            s = new TryFinallyStatement(ss.loc, ss._body, s);
-            cs.push(s);
+        cs.push(new ExpStatement(ss.loc, genCall(ienter,argExp(), stc)));
+        Statement fin = new ExpStatement(ss.loc, genCall(iexit ,argExp(), stc));
+        cs.push(new TryFinallyStatement(ss.loc, ss._body, fin));
+        
+        result = new CompoundStatement(ss.loc, cs).statementSemantic(sc);
 
-            s = new CompoundStatement(ss.loc, cs);
-            result = s.statementSemantic(sc);
-
-            // set the explicit __critsec alignment after semantic()
-            tmp.alignment = Target.ptrsize;
+        // set the explicit __critsecNNN alignment after semantic()
+        if (!ss.exp) tmp.alignment = Target.ptrsize;
         }
     }
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3448,11 +3448,13 @@ else
 
                 FuncDeclaration fdenter = FuncDeclaration.genCfunc(args, Type.tvoid, Id.monitorenter);
                 Expression e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), new VarExp(ss.loc, tmp));
+                (cast(CallExp)e).f = fdenter;
                 e.type = Type.tvoid; // do not run semantic on e
 
                 cs.push(new ExpStatement(ss.loc, e));
                 FuncDeclaration fdexit = FuncDeclaration.genCfunc(args, Type.tvoid, Id.monitorexit);
                 e = new CallExp(ss.loc, new VarExp(ss.loc, fdexit, false), new VarExp(ss.loc, tmp));
+                (cast(CallExp)e).f = fdexit;
                 e.type = Type.tvoid; // do not run semantic on e
                 Statement s = new ExpStatement(ss.loc, e);
                 s = new TryFinallyStatement(ss.loc, ss._body, s);
@@ -3491,6 +3493,7 @@ else
             Expression e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
             e = e.expressionSemantic(sc);
             e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), e);
+            (cast(CallExp)e).f = fdenter;
             e.type = Type.tvoid; // do not run semantic on e
             cs.push(new ExpStatement(ss.loc, e));
 
@@ -3498,6 +3501,7 @@ else
             e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
             e = e.expressionSemantic(sc);
             e = new CallExp(ss.loc, new VarExp(ss.loc, fdexit, false), e);
+            (cast(CallExp)e).f = fdexit;
             e.type = Type.tvoid; // do not run semantic on e
             Statement s = new ExpStatement(ss.loc, e);
             s = new TryFinallyStatement(ss.loc, ss._body, s);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3461,9 +3461,9 @@ else
             args.push(new Parameter(0, t.pointerTo(), null, null));
             // Assignment of the alignment is delayed until after semantic
         }
-        
+
         cs.push(new ExpStatement(ss.loc, tmp));
-        
+
         if (!ss.exp)
         {
             /* This is just a dummy variable for "goto skips declaration" error.
@@ -3473,7 +3473,7 @@ else
             v.dsymbolSemantic(sc);
             cs.push(new ExpStatement(ss.loc, v));
         }
-        
+
         Expression argExp()
         {
             if (ss.exp)
@@ -3500,7 +3500,7 @@ else
         cs.push(new ExpStatement(ss.loc, genCall(ienter,argExp(), stc)));
         Statement fin = new ExpStatement(ss.loc, genCall(iexit ,argExp(), stc));
         cs.push(new TryFinallyStatement(ss.loc, ss._body, fin));
-        
+
         result = new CompoundStatement(ss.loc, cs).statementSemantic(sc);
 
         // set the explicit __critsecNNN alignment after semantic()


### PR DESCRIPTION
e.f is null otherwise and will speed up semantic validation and simplify logic rather than having to go through `(cast(FuncDeclaration)(cast(VarExp)e.e1).var)`.