### PR TITLE
refactor: add printast.d

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -56,6 +56,7 @@ import ddmd.nspace;
 import ddmd.opover;
 import ddmd.optimize;
 import ddmd.parse;
+import ddmd.printast;
 import ddmd.root.ctfloat;
 import ddmd.root.file;
 import ddmd.root.filename;
@@ -2601,18 +2602,6 @@ extern (C++) abstract class Expression : RootObject
         HdrGenState hgs;
         toCBuffer(this, &buf, &hgs);
         return buf.extractString();
-    }
-
-    /********************
-     * Print AST data structure in a nice format.
-     * Params:
-     *  indent = indentation level
-     */
-    void printAST(int indent = 0)
-    {
-        foreach (i; 0 .. indent)
-            printf(" ");
-        printf("%s %s\n", Token.toChars(op), type ? type.toChars() : "");
     }
 
     final void error(const(char)* format, ...) const
@@ -6468,14 +6457,6 @@ extern (C++) class SymbolExp : Expression
     {
         v.visit(this);
     }
-
-    override void printAST(int indent)
-    {
-        Expression.printAST(indent);
-        foreach (i; 0 .. indent + 2)
-            printf(" ");
-        printf(".var: %s\n", var ? var.toChars() : "");
-    }
 }
 
 /***********************************************************
@@ -7878,12 +7859,6 @@ extern (C++) class UnaExp : Expression
     {
         v.visit(this);
     }
-
-    override void printAST(int indent)
-    {
-        Expression.printAST(indent);
-        e1.printAST(indent + 2);
-    }
 }
 
 extern (C++) alias fp_t = UnionExp function(Loc loc, Type, Expression, Expression);
@@ -8204,13 +8179,6 @@ extern (C++) abstract class BinExp : Expression
     override void accept(Visitor v)
     {
         v.visit(this);
-    }
-
-    override void printAST(int indent)
-    {
-        Expression.printAST(indent);
-        e1.printAST(indent + 2);
-        e2.printAST(indent + 2);
     }
 }
 
@@ -9527,14 +9495,6 @@ extern (C++) final class DelegateExp : UnaExp
     override void accept(Visitor v)
     {
         v.visit(this);
-    }
-
-    override void printAST(int indent)
-    {
-        UnaExp.printAST(indent);
-        foreach (i; 0 .. indent + 2)
-            printf(" ");
-        printf(".func: %s\n", func ? func.toChars() : "");
     }
 }
 

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -144,7 +144,6 @@ public:
 
     void print();
     const char *toChars();
-    virtual void printAST(int ident = 0);
     void error(const char *format, ...) const;
     void warning(const char *format, ...) const;
     void deprecation(const char *format, ...) const;
@@ -704,7 +703,6 @@ public:
     Expression *resolveLoc(Loc loc, Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
-    void printAST(int ident);
 };
 
 typedef UnionExp (*fp_t)(Type *, Expression *, Expression *);
@@ -731,7 +729,6 @@ public:
     Expression *reorderSettingAAElem(Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
-    void printAST(int ident);
 };
 
 class BinAssignExp : public BinExp

--- a/src/ddmd/printast.d
+++ b/src/ddmd/printast.d
@@ -1,0 +1,90 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC _printast.d)
+ */
+
+module ddmd.printast;
+
+import core.stdc.stdio;
+
+import ddmd.expression;
+import ddmd.tokens;
+import ddmd.visitor;
+
+/********************
+ * Print AST data structure in a nice format.
+ * Params:
+ *  e = expression AST to print
+ *  indent = indentation level
+ */
+void printAST(Expression e, int indent = 0)
+{
+    scope PrintASTVisitor pav = new PrintASTVisitor(indent);
+    e.accept(pav);
+}
+
+private:
+
+extern (C++) final class PrintASTVisitor : Visitor
+{
+    alias visit = super.visit;
+
+    int indent;
+
+    extern (D) this(int indent)
+    {
+        this.indent = indent;
+    }
+
+    override void visit(Expression e)
+    {
+        printIndent(indent);
+        printf("%s %s\n", Token.toChars(e.op), e.type ? e.type.toChars() : "");
+    }
+
+    override void visit(StructLiteralExp e)
+    {
+        printIndent(indent);
+        printf("%s %s, %s\n", Token.toChars(e.op), e.type ? e.type.toChars() : "", e.toChars());
+    }
+
+    override void visit(SymbolExp e)
+    {
+        visit(cast(Expression)e);
+        printIndent(indent + 2);
+        printf(".var: %s\n", e.var ? e.var.toChars() : "");
+    }
+
+    override void visit(UnaExp e)
+    {
+        visit(cast(Expression)e);
+        printAST(e.e1, indent + 2);
+    }
+
+    override void visit(BinExp e)
+    {
+        visit(cast(Expression)e);
+        printAST(e.e1, indent + 2);
+        printAST(e.e2, indent + 2);
+    }
+
+    override void visit(DelegateExp e)
+    {
+        visit(cast(Expression)e);
+        printIndent(indent + 2);
+        printf(".func: %s\n", e.func ? e.func.toChars() : "");
+    }
+
+    static void printIndent(int indent)
+    {
+        foreach (i; 0 .. indent)
+            putc(' ', stdout);
+    }
+}
+
+

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -230,7 +230,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	hdrgen impcnvtab imphint init inline inlinecost intrange	\
 	json lib link mars mtype nogc nspace objc opover optimize parse sapply	\
 	sideeffect statement staticassert target traits visitor	\
-	typinf utils statement_rewrite_walker statementsem staticcond safe blockexit asttypename))
+	typinf utils statement_rewrite_walker statementsem staticcond safe blockexit asttypename printast))
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors globals id identifier lexer tokens utf))
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -163,7 +163,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/impcnvtab.d $D/init.d $D/inline.d $D/inlinecost.d $D/intrange.d $D/json.d $D/lib.d $D/link.d	\
 	$D/mars.d $D/mtype.d $D/nogc.d $D/nspace.d $D/objc.d $D/opover.d $D/optimize.d $D/parse.d	\
 	$D/sapply.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d	\
-	$D/safe.d $D/blockexit.d $D/asttypename.d \
+	$D/safe.d $D/blockexit.d $D/asttypename.d $D/printast.d \
 	$D/traits.d $D/utils.d $D/visitor.d $D/libomf.d $D/scanomf.d $D/typinf.d \
 	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d
 


### PR DESCRIPTION
This pulls the `printAST()` code out of `expression.d` and puts it all in its own file, `printast.d`. This makes it easier to manage and much better encapsulated.