### PR TITLE
test42: Don't run (1 / real.epsilon) -> double -> ulong test if too large to fit

### DIFF
--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5562,22 +5562,25 @@ void testdbl_to_ulong()
     //writeln(u);
     assert(u == 12345);
 
-    real adjust = 1.0L/real.epsilon;
-    u = d2ulong(adjust);
-    //writefln("%s %s", adjust, u);
-    static if(real.mant_dig == 64)
-        assert(u == 9223372036854775808UL);
-    else static if(real.mant_dig == 53)
-        assert(u == 4503599627370496UL);
-    else
-        static assert(false, "Test not implemented for this architecture");
+    static if (real.mant_dig <= 64)
+    {
+        real adjust = 1.0L/real.epsilon;
+        u = d2ulong(adjust);
+        //writefln("%s %s", adjust, u);
+        static if(real.mant_dig == 64)
+            assert(u == 9223372036854775808UL);
+        else static if(real.mant_dig == 53)
+            assert(u == 4503599627370496UL);
+        else
+            static assert(false, "Test not implemented for this architecture");
 
-    auto v = d2ulong(adjust * 1.1);
-    //writefln("%s %s %s", adjust, v, u + u/10);
+        auto v = d2ulong(adjust * 1.1);
+        //writefln("%s %s %s", adjust, v, u + u/10);
 
-    // The following can vary in the last bits with different optimization settings,
-    // i.e. the conversion from real to double may not happen.
-    //assert(v == 10145709240540254208UL);
+        // The following can vary in the last bits with different optimization settings,
+        // i.e. the conversion from real to double may not happen.
+        //assert(v == 10145709240540254208UL);
+    }
 }
 
 /***************************************************/


### PR DESCRIPTION
This is the case with quadruple-precision reals, e.g. on ARM64/AAPCS64.