### PR TITLE
fix Issue 17432 - scope delegates change type, but not mangling

### DIFF
--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -128,6 +128,7 @@ enum STCautoref             = (1L << 45);   // Mark for the already deduced 'aut
 enum STCinference           = (1L << 46);   // do attribute inference
 enum STCexptemp             = (1L << 47);   // temporary variable that has lifetime restricted to an expression
 enum STCmaybescope          = (1L << 48);   // parameter might be 'scope'
+enum STCscopeinferred       = (1L << 49);   // 'scope' has been inferred and should not be part of mangling
 
 enum STC_TYPECTOR = (STCconst | STCimmutable | STCshared | STCwild);
 enum STC_FUNCATTR = (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem);

--- a/src/ddmd/dmangle.d
+++ b/src/ddmd/dmangle.d
@@ -287,7 +287,7 @@ public:
                 buf.writestring("Ni");
             if (ta.isreturn)
                 buf.writestring("Nj");
-            if (ta.isscope && !ta.isreturn)
+            if (ta.isscope && !ta.isreturn && !ta.isscopeinferred)
                 buf.writestring("Nl");
             switch (ta.trust)
             {

--- a/src/ddmd/escape.d
+++ b/src/ddmd/escape.d
@@ -255,7 +255,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
             {
                 if (!va.isScope() && inferScope)
                 {   //printf("inferring scope for %s\n", va.toChars());
-                    va.storage_class |= STCscope;
+                    va.storage_class |= STCscope | STCscopeinferred;
                     va.storage_class |= v.storage_class & STCreturn;
                 }
                 continue;
@@ -276,7 +276,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
                 {
                     if (!va.isScope() && inferScope)
                     {   //printf("inferring scope for %s\n", va.toChars());
-                        va.storage_class |= STCscope;
+                        va.storage_class |= STCscope | STCscopeinferred;
                     }
                     continue;
                 }
@@ -326,7 +326,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
                 if (!va.isScope() && inferScope &&
                     va.type.toBasetype().ty != Tclass)  // scope classes are special
                 {   //printf("inferring scope for %s\n", va.toChars());
-                    va.storage_class |= STCscope;
+                    va.storage_class |= STCscope | STCscopeinferred;
                 }
                 continue;
             }
@@ -364,7 +364,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
                      * won't be generated for sc.func.
                      */
                     //if (!va.isScope() && inferScope)
-                        //va.storage_class |= STCscope;
+                        //va.storage_class |= STCscope | STCscopeinferred;
                     continue;
                 }
                 if (sc.func.setUnsafe())
@@ -384,7 +384,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
         {
             if (!va.isScope() && inferScope)
             {   //printf("inferring scope for %s\n", va.toChars());
-                va.storage_class |= STCscope;
+                va.storage_class |= STCscope | STCscopeinferred;
             }
             continue;
         }

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -507,6 +507,7 @@ extern (C++) class FuncDeclaration : Declaration
             TypeFunction tfx = type.toTypeFunction();
             tfo.mod = tfx.mod;
             tfo.isscope = tfx.isscope;
+            tfo.isscopeinferred = tfx.isscopeinferred;
             tfo.isref = tfx.isref;
             tfo.isnothrow = tfx.isnothrow;
             tfo.isnogc = tfx.isnogc;
@@ -2015,8 +2016,8 @@ extern (C++) class FuncDeclaration : Declaration
                     //printf("Inferring scope for %s\n", v.toChars());
                     Parameter p = Parameter.getNth(f.parameters, u);
                     v.storage_class &= ~STCmaybescope;
-                    v.storage_class |= STCscope;
-                    p.storageClass |= STCscope;
+                    v.storage_class |= STCscope | STCscopeinferred;
+                    p.storageClass |= STCscope | STCscopeinferred;
                     assert(!(p.storageClass & STCmaybescope));
                 }
             }
@@ -2025,8 +2026,9 @@ extern (C++) class FuncDeclaration : Declaration
         if (vthis && vthis.storage_class & STCmaybescope)
         {
             vthis.storage_class &= ~STCmaybescope;
-            vthis.storage_class |= STCscope;
+            vthis.storage_class |= STCscope | STCscopeinferred;
             f.isscope = true;
+            f.isscopeinferred = true;
         }
 
         // reset deco to apply inference result to mangled name

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -2972,7 +2972,7 @@ public:
         StorageClass stc = p.storageClass;
         if (p.type && p.type.mod & MODshared)
             stc &= ~STCshared;
-        if (stcToBuffer(buf, stc & (STCconst | STCimmutable | STCwild | STCshared | STCscope)))
+        if (stcToBuffer(buf, stc & (STCconst | STCimmutable | STCwild | STCshared | STCscope | STCscopeinferred)))
             buf.writeByte(' ');
         if (p.storageClass & STCalias)
         {
@@ -3090,6 +3090,8 @@ extern (C++) bool stcToBuffer(OutBuffer* buf, StorageClass stc)
     bool result = false;
     if ((stc & (STCreturn | STCscope)) == (STCreturn | STCscope))
         stc &= ~STCscope;
+    if (stc & STCscopeinferred)
+        stc &= ~(STCscope | STCscopeinferred);
     while (stc)
     {
         const(char)* p = stcToChars(stc);

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -6035,6 +6035,7 @@ extern (C++) final class TypeFunction : TypeNext
     bool isref;                 // true: returns a reference
     bool isreturn;              // true: 'this' is returned by ref
     bool isscope;               // true: 'this' is scope
+    bool isscopeinferred;       // true: 'this' is scope from inferrence
     LINK linkage;               // calling convention
     TRUST trust;                // level of trust
     PURE purity = PUREimpure;
@@ -6067,6 +6068,8 @@ extern (C++) final class TypeFunction : TypeNext
             this.isreturn = true;
         if (stc & STCscope)
             this.isscope = true;
+        if (stc & STCscopeinferred)
+            this.isscopeinferred = true;
 
         this.trust = TRUSTdefault;
         if (stc & STCsafe)
@@ -6100,6 +6103,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isref = isref;
         t.isreturn = isreturn;
         t.isscope = isscope;
+        t.isscopeinferred = isscopeinferred;
         t.iswild = iswild;
         t.trust = trust;
         t.fargs = fargs;
@@ -6146,6 +6150,8 @@ extern (C++) final class TypeFunction : TypeNext
             tf.isreturn = true;
         if (sc.stc & STCscope)
             tf.isscope = true;
+        if (sc.stc & STCscopeinferred)
+            tf.isscopeinferred = true;
 
 //        if (tf.isreturn && !tf.isref)
 //            tf.isscope = true;                                  // return by itself means 'return scope'
@@ -6735,6 +6741,7 @@ extern (C++) final class TypeFunction : TypeNext
             tf.isref = t.isref;
             tf.isreturn = t.isreturn;
             tf.isscope = t.isscope;
+            tf.isscopeinferred = t.isscopeinferred;
             tf.trust = t.trust;
             tf.iswild = t.iswild;
 
@@ -6747,7 +6754,11 @@ extern (C++) final class TypeFunction : TypeNext
             if (stc & STCsafe)
                 tf.trust = TRUSTsafe;
             if (stc & STCscope)
+            {
                 tf.isscope = true;
+                if (stc & STCscopeinferred)
+                    tf.isscopeinferred = true;
+            }
 
             tf.deco = tf.merge().deco;
             t = tf;
@@ -6790,7 +6801,7 @@ extern (C++) final class TypeFunction : TypeNext
         if (res)
             return res;
 
-        if (isscope)
+        if (isscope && !isscopeinferred)
             res = fp(param, "scope");
         if (res)
             return res;
@@ -6847,6 +6858,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isref = isref;
         t.isreturn = isreturn;
         t.isscope = isscope;
+        t.isscopeinferred = isscopeinferred;
         t.iswild = 0;
         t.trust = trust;
         t.fargs = fargs;
@@ -7230,11 +7242,14 @@ extern (C++) final class TypeDelegate : TypeNext
          *  alias dg_t = void* delegate();
          *  scope dg_t dg = ...;
          */
-        auto n = t.next.addStorageClass(stc & STCscope);
-        if (n != t.next)
+        if(stc & STCscope)
         {
-            t.next = n;
-            t.deco = t.merge().deco;
+            auto n = t.next.addStorageClass(STCscope | STCscopeinferred);
+            if (n != t.next)
+            {
+                t.next = n;
+                t.deco = t.merge().deco; // mangling supposed to not be changed due to STCscopeinferrred
+            }
         }
         return t;
     }

--- a/src/ddmd/mtype.h
+++ b/src/ddmd/mtype.h
@@ -598,6 +598,7 @@ public:
     bool isref;         // true: returns a reference
     bool isreturn;      // true: 'this' is returned by ref
     bool isscope;       // true: 'this' is scope
+    bool isscopeinferred; // true: 'this' is scope from inferrence
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust
     PURE purity;   // PURExxxx

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -1066,7 +1066,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             push("inout");
         if (stc & STCshared)
             push("shared");
-        if (stc & STCscope)
+        if (stc & STCscope && !(stc & STCscopeinferred))
             push("scope");
 
         auto tup = new TupleExp(e.loc, exps);

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -235,10 +235,10 @@ void* funretscope(scope dg_t ptr) @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(250): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
-fail_compilation/retscope.d(250): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc return scope @safe` to `void* delegate() scope @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc return @safe` to `void* delegate() @safe`
+fail_compilation/retscope.d(249): Error: cannot implicitly convert expression `__lambda1` of type `void* delegate() pure nothrow @nogc return @safe` to `void* delegate() @safe`
+fail_compilation/retscope.d(250): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc return @safe` to `void* delegate() @safe`
+fail_compilation/retscope.d(250): Error: cannot implicitly convert expression `__lambda2` of type `void* delegate() pure nothrow @nogc return @safe` to `void* delegate() @safe`
 ---
 */
 

--- a/test/runnable/testscope.d
+++ b/test/runnable/testscope.d
@@ -298,6 +298,31 @@ void test11()
 }
 
 /********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=17432
+
+int test17432(scope int delegate() dg)
+{
+	return dg();
+}
+
+// stripped down version of std.traits.Parameters
+template Parameters(alias func)
+{
+    static if (is(typeof(func) P == function))
+        alias Parameters = P;
+    else
+        static assert(0, "unsupported");
+}
+
+alias op = Parameters!(test17432)[0];
+enum typeString = op.stringof;
+mixin(typeString ~ " dg;");
+alias ty = typeof(dg);
+
+static assert(op.stringof == ty.stringof);
+static assert(op.mangleof == ty.mangleof);
+
+/********************************************/
 
 byte typify13(T)(byte val) { return val; }
 alias INT8_C13  = typify13!byte;


### PR DESCRIPTION
This does not add "scope" to .mangleof or .stringof if it was inferred