### PR TITLE
Unify comment header and expose module with Ddox

### DIFF
--- a/src/ddmd/backend/dwarf.d
+++ b/src/ddmd/backend/dwarf.d
@@ -1,4 +1,4 @@
-/* Dwarf debug
+/** Dwarf debug
  *
  * Source: $(DMDSRC backend/_dwarf.d)
  */

--- a/src/ddmd/backend/mscoff.d
+++ b/src/ddmd/backend/mscoff.d
@@ -1,4 +1,4 @@
-/* Microsoft COFF object file format
+/** Microsoft COFF object file format
  *
  * Source: $(DMDSRC backend/_mscoff.d)
  */

--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -1,10 +1,12 @@
-// Compiler implementation of the D programming language
-// Copyright (c) 1999-2017 by Digital Mars
-// All Rights Reserved
-// written by Walter Bright
-// http://www.digitalmars.com
-// Distributed under the Boost Software License, Version 1.0.
-// http://www.boost.org/LICENSE_1_0.txt
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC _dinterpret.d)
+ */
 
 module ddmd.dinterpret;
 

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -1,10 +1,12 @@
-// Compiler implementation of the D programming language
-// Copyright (c) 1999-2017 by Digital Mars
-// All Rights Reserved
-// written by Walter Bright
-// http://www.digitalmars.com
-// Distributed under the Boost Software License, Version 1.0.
-// http://www.boost.org/LICENSE_1_0.txt
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC _dstruct.d)
+ */
 
 module ddmd.dstruct;
 

--- a/src/ddmd/nspace.h
+++ b/src/ddmd/nspace.h
@@ -1,10 +1,11 @@
-
-// Compiler implementation of the D programming language
-// Copyright: Copyright (c) 2014 by Digital Mars, All Rights Reserved
-// Authors: Walter Bright, http://www.digitalmars.com
-// License: http://boost.org/LICENSE_1_0.txt
-// Source: https://github.com/dlang/dmd/blob/master/src/nspace.h
-
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ */
 
 #ifndef DMD_NSPACE_H
 #define DMD_NSPACE_H

--- a/src/ddmd/root/array.d
+++ b/src/ddmd/root/array.d
@@ -1,10 +1,12 @@
-// Compiler implementation of the D programming language
-// Copyright (c) 1999-2017 by Digital Mars
-// All Rights Reserved
-// written by Walter Bright
-// http://www.digitalmars.com
-// Distributed under the Boost Software License, Version 1.0.
-// http://www.boost.org/LICENSE_1_0.txt
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC root/_array.d)
+ */
 
 module ddmd.root.array;
 

--- a/src/ddmd/root/ctfloat.d
+++ b/src/ddmd/root/ctfloat.d
@@ -1,10 +1,12 @@
-// Compiler implementation of the D programming language
-// Copyright (c) 1999-2017 by Digital Mars
-// All Rights Reserved
-// written by Walter Bright
-// http://www.digitalmars.com
-// Distributed under the Boost Software License, Version 1.0.
-// http://www.boost.org/LICENSE_1_0.txt
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(DMDSRC root/_ctfloat.d)
+ */
 
 module ddmd.root.ctfloat;
 

--- a/src/ddmd/root/rmem.h
+++ b/src/ddmd/root/rmem.h
@@ -1,11 +1,11 @@
-// Compiler implementation of the D programming language
-// Copyright (c) 2000-2015 by Digital Mars
-// All Rights Reserved
-// written by Walter Bright
-// http://www.digitalmars.com
-// Distributed under the Boost Software License, Version 1.0.
-// http://www.boost.org/LICENSE_1_0.txt
-// https://github.com/dlang/dmd/blob/master/src/root/rmem.h
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ */
 
 #ifndef ROOT_MEM_H
 #define ROOT_MEM_H


### PR DESCRIPTION
I noticed in https://github.com/dlang/dmd/pull/6866 that a few modules aren't visible on the DDoX build.
It turns out that Ddox only shows modules with a DDoc module header (e.g. `/**` instead `/*`). I used this opportunity to unify the comment format to the Ddoc style.