### PR TITLE
Mention individual test file target in the test Makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,7 @@
 # Execute the dmd test suite
 #
-# Targets:
+# Targets
+# -------
 #
 #    default | all:      run all unit tests that haven't been run yet
 #
@@ -14,8 +15,11 @@
 #
 #    clean:              remove all temporary or result files from prevous runs
 #
-#
-# In-test variables:
+#    test_results/compilable/json.d.out      runs an individual test
+#                                            (run log of the test is stored)
+
+# In-test variables
+# -----------------
 #
 #   COMPILE_SEPARATELY:  if present, forces each .d file to compile separately and linked
 #                        together in an extra setp.


### PR DESCRIPTION
I guess everyone has found his favorite solution over the years, but why not adding a good "out-of-the-box" solution?

I re-open the Makefile as imho that's cleaner than duplicating the build commands (AFAIK there's no nice way in Make to force re-execution of dependencies).