### PR TITLE
Revive #3531 - Adding support for __traits(documentation, ...)

### DIFF
--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -816,7 +816,9 @@ extern (C++) final class Module : Package
             return this;
         }
         {
-            scope p = new Parser!ASTCodegen(this, buf[0 .. buflen], docfile !is null);
+            // Always lex comments; __traits(documentation, ...) might require it.
+            bool doDocComment = true;
+            scope p = new Parser!ASTCodegen(this, buf[0 .. buflen], doDocComment);
             p.nextToken();
             members = p.parseModule();
             md = p.md;

--- a/src/ddmd/idgen.d
+++ b/src/ddmd/idgen.d
@@ -357,6 +357,7 @@ Msgtable[] msgtable =
     { "getUnitTests" },
     { "getVirtualIndex" },
     { "getPointerBitmap" },
+    { "documentation" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -80,6 +80,7 @@ static this()
         "isLazy",
         "hasMember",
         "identifier",
+        "documentation",
         "getProtection",
         "parent",
         "getLinkage",
@@ -594,6 +595,21 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         auto se = new StringExp(e.loc, cast(char*)id.toChars());
+        return se.semantic(sc);
+    }
+    if (e.ident == Id.documentation)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        auto o = (*e.args)[0];
+        auto s = getDsymbol(o);
+        if (!s)
+        {
+            e.error("argument %s is not a symbol", o.toChars());
+            return new ErrorExp();
+        }
+        StringExp se = new StringExp(e.loc, cast(char*)s.comment);
         return se.semantic(sc);
     }
     if (e.ident == Id.getProtection)

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -316,6 +316,7 @@
    {
     "name" : "bar",
     "kind" : "function",
+    "comment" : " Documentation test\n",
     "line" : 52,
     "char" : 16,
     "deco" : "FNeKkC4json4Bar2Zi",
@@ -397,6 +398,7 @@
     "members" : [
      {
       "kind" : "template",
+      "comment" : " Issue 9480 - Template name should be stripped of parameters\n",
       "line" : 85,
       "char" : 5,
       "name" : "this",
@@ -429,6 +431,7 @@
    {
     "kind" : "template",
     "protection" : "private",
+    "comment" : " Issue 9755 - Protection not emitted properly for Templates.\n",
     "line" : 89,
     "char" : 9,
     "name" : "S1_9755",
@@ -503,6 +506,7 @@
    {
     "name" : "c_10011",
     "kind" : "variable",
+    "comment" : " Issue 10011 - init property is wrong for object initializer.\n",
     "line" : 98,
     "char" : 14,
     "storageClass" : [
@@ -515,6 +519,7 @@
    {
     "name" : "Numbers",
     "kind" : "enum",
+    "comment" : "\n",
     "line" : 101,
     "char" : 1,
     "baseDeco" : "i",

--- a/test/runnable/traits_documentation.d
+++ b/test/runnable/traits_documentation.d
@@ -1,0 +1,38 @@
+/**
+ * Module documentation.
+ */
+module traits_documentation;
+
+/**
+ * Function documentation.
+ */
+void documentedFunc() {}
+/++
+ + Enum documentation.
+ +/
+enum documentedEnum = 1;
+auto documentedVar = 2; /// Some unicode: Σ σ Π π.
+
+auto emptyVar  = 2; ///
+
+///
+auto emptyVar2  = 2;
+
+void main()
+{
+    enum funcDoc = __traits(documentation, documentedFunc);
+    enum enumDoc = __traits(documentation, documentedEnum);
+    enum varDoc = __traits(documentation, documentedVar);
+    enum modDoc = __traits(documentation, traits_documentation);
+
+    static assert(funcDoc == " Function documentation.\n");
+    static assert(enumDoc == " Enum documentation.\n");
+    static assert(varDoc == "Some unicode: Σ σ Π π.\n");
+    static assert(modDoc == " Module documentation.\n");
+
+    static assert(!__traits(compiles, __traits(documentation, 3)));
+    static assert(!__traits(compiles, __traits(documentation, "4")));
+
+    static assert(__traits(documentation, emptyVar) == "\n");
+    static assert(__traits(documentation, emptyVar2) == "\n");
+}


### PR DESCRIPTION
So I took the liberty to revive #3531, but unfortunately there hasn't been a clear consensus on how to move forward. The most important bits from the discussion:

> I object to turning this on by default [`doDocComment = true`] - it also affects memory consumption, which is currently a significant problem with dmd.

The discussion circled around adding a special flag for this as `-D` always produces an html file.

> - I think the newline should be stripped before returning it as a __traits(), otherwise user code will constantly have to strip it manually.

I share this opinion, but I wanted to wait on feedback before investing more work on this PR (same for adding more tests).

The PR to dlang.org is still [open](https://github.com/dlang/dlang.org/pull/574).

So three years later, what's your opinion on being able to query DDoc comments during CTFE?