### PR TITLE
Cleanup PR 6864: scope delegates change type, but not mangling

### DIFF
--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -93,6 +93,7 @@ enum PINLINE;
 #define STCinference     0x400000000000LL // do attribute inference
 #define STCexptemp       0x800000000000LL // temporary variable that has lifetime restricted to an expression
 #define STCmaybescope    0x1000000000000LL // parameter might be 'scope'
+#define STCscopeinferred 0x2000000000000LL // 'scope' has been inferred and should not be part of mangling
 
 const StorageClass STCStorageClass = (STCauto | STCscope | STCstatic | STCextern | STCconst | STCfinal |
     STCabstract | STCsynchronized | STCdeprecated | STCoverride | STClazy | STCalias |

--- a/src/ddmd/dmangle.d
+++ b/src/ddmd/dmangle.d
@@ -820,7 +820,7 @@ public:
 
     override void visit(Parameter p)
     {
-        if (p.storageClass & STCscope)
+        if (p.storageClass & STCscope && !(p.storageClass & STCscopeinferred))
             buf.writeByte('M');
         // 'return inout ref' is the same as 'inout ref'
         if ((p.storageClass & (STCreturn | STCwild)) == STCreturn)

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -1328,7 +1328,7 @@ extern (C++) class FuncDeclaration : Declaration
                     stc |= STCparameter;
                     if (f.varargs == 2 && i + 1 == nparams)
                         stc |= STCvariadic;
-                    if (flags & FUNCFLAGinferScope)
+                    if (flags & FUNCFLAGinferScope && !(fparam.storageClass & STCscope))
                         stc |= STCmaybescope;
                     stc |= fparam.storageClass & (STCin | STCout | STCref | STCreturn | STCscope | STClazy | STCfinal | STC_TYPECTOR | STCnodtor);
                     v.storage_class = stc;
@@ -2195,7 +2195,7 @@ extern (C++) class FuncDeclaration : Declaration
                 if (tf.isscope)
                     v.storage_class |= STCscope;
             }
-            if (flags & FUNCFLAGinferScope)
+            if (flags & FUNCFLAGinferScope && !(v.storage_class & STCscope))
                 v.storage_class |= STCmaybescope;
 
             v.semantic(sc);
@@ -2220,7 +2220,7 @@ extern (C++) class FuncDeclaration : Declaration
                 if (tf.isscope)
                     v.storage_class |= STCscope;
             }
-            if (flags & FUNCFLAGinferScope)
+            if (flags & FUNCFLAGinferScope && !(v.storage_class & STCscope))
                 v.storage_class |= STCmaybescope;
 
             v.semantic(sc);

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -6035,7 +6035,7 @@ extern (C++) final class TypeFunction : TypeNext
     bool isref;                 // true: returns a reference
     bool isreturn;              // true: 'this' is returned by ref
     bool isscope;               // true: 'this' is scope
-    bool isscopeinferred;       // true: 'this' is scope from inferrence
+    bool isscopeinferred;       // true: 'this' is scope from inference
     LINK linkage;               // calling convention
     TRUST trust;                // level of trust
     PURE purity = PUREimpure;

--- a/src/ddmd/mtype.h
+++ b/src/ddmd/mtype.h
@@ -598,7 +598,7 @@ public:
     bool isref;         // true: returns a reference
     bool isreturn;      // true: 'this' is returned by ref
     bool isscope;       // true: 'this' is scope
-    bool isscopeinferred; // true: 'this' is scope from inferrence
+    bool isscopeinferred; // true: 'this' is scope from inference
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust
     PURE purity;   // PURExxxx

--- a/test/runnable/testscope.d
+++ b/test/runnable/testscope.d
@@ -316,11 +316,16 @@ template Parameters(alias func)
 
 alias op = Parameters!(test17432)[0];
 enum typeString = op.stringof;
+static assert(typeString == "int delegate()"); // no scope added?
 mixin(typeString ~ " dg;");
 alias ty = typeof(dg);
 
 static assert(op.stringof == ty.stringof);
 static assert(op.mangleof == ty.mangleof);
+
+void test17432_2()(scope void delegate () dg) { dg(); }
+
+static assert(typeof(&test17432_2!()).stringof == "void function(scope void delegate() dg) @system");
 
 /********************************************/
 


### PR DESCRIPTION
#6864 was not complete, a few more issues showed up:

- do not emit "scope" in mangling if inferred on a parameter
- do not infer scope if explicitly specified (this might omit it later in mangling)

Also fixed typo and updated C++ header.
