### PR TITLE
Ignore random coverage changes

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -115,6 +115,10 @@ coverage()
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_COVERAGE=1
 
     make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1
+
+    # Remove coverage information from lines with non-deterministic coverage.
+    # These lines are annotated with a comment containing "nocoverage".
+    sed -i 's/^ *[0-9]*\(|.*nocoverage.*\)$/       \1/' ./src/*.lst
 }
 
 codecov()

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -6963,7 +6963,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (enclosing != ti.enclosing)
         {
             //printf("test2 enclosing %s ti.enclosing %s\n", enclosing ? enclosing.toChars() : "", ti.enclosing ? ti.enclosing.toChars() : "");
-            goto Lnotequals;
+            goto Lnotequals; // nocoverage
         }
         //printf("parent = %s, ti.parent = %s\n", parent.toPrettyChars(), ti.parent.toPrettyChars());
 


### PR DESCRIPTION
We seem to have gotten a non-deterministic behavior into the test suite, which is why the coverage currently changes for non-related changes.
There are quite many recent PR with this behavior (see e.g. https://github.com/dlang/dmd/pull/6871 or https://github.com/dlang/dmd/pull/6878).

This adds a workaround against non-deterministic coverage changes [analogous to Phobos](https://github.com/dlang/phobos/pull/5375/files).

CC @CyberShadow 