### PR TITLE
Issue 9287 - Implement -stdin.

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1033,6 +1033,8 @@ Language changes listed by -transition=id:
                     goto Lnoarg;
                 }
             }
+            else if (p[1] == '\0')
+                files.push("__stdin.d");
             else
             {
             Lerror:

--- a/src/ddmd/root/file.d
+++ b/src/ddmd/root/file.d
@@ -77,12 +77,65 @@ nothrow:
     {
         if (len)
             return false; // already read the file
+
+        import core.stdc.string : strcmp;
+        const(char)* name = this.name.toChars();
+        if (strcmp(name, "__stdin.d") == 0)
+        {
+            /* Read from stdin */
+            enum bufIncrement = 128 * 1024;
+            size_t pos = 0;
+            size_t sz = bufIncrement;
+
+            if (!_ref)
+                .free(buffer);
+
+            buffer = null;
+            L1: for (;;)
+            {
+                buffer = cast(ubyte*).realloc(buffer, sz + 2); // +2 for sentinel
+                if (!buffer)
+                {
+                    printf("\tmalloc error, errno = %d\n", errno);
+                    break L1;
+                }
+
+                // Fill up buffer
+                do
+                {
+                    assert(sz > pos);
+                    size_t rlen = fread(buffer + pos, 1, sz - pos, stdin);
+                    pos += rlen;
+                    if (ferror(stdin))
+                    {
+                        printf("\tread error, errno = %d\n", errno);
+                        break L1;
+                    }
+                    if (feof(stdin))
+                    {
+                        // We're done
+                        assert(pos < sz + 2);
+                        len = pos;
+                        buffer[pos] = '\0';
+                        buffer[pos + 1] = '\0';
+                        return false;
+                    }
+                } while (pos < sz);
+
+                // Buffer full, expand
+                sz += bufIncrement;
+            }
+            .free(buffer);
+            buffer = null;
+            len = 0;
+            return true;
+        }
+
         version (Posix)
         {
             size_t size;
             stat_t buf;
             ssize_t numread;
-            const(char)* name = this.name.toChars();
             //printf("File::read('%s')\n",name);
             int fd = open(name, O_RDONLY);
             if (fd == -1)
@@ -135,7 +188,6 @@ nothrow:
         {
             DWORD size;
             DWORD numread;
-            const(char)* name = this.name.toChars();
             HANDLE h = CreateFileA(name, GENERIC_READ, FILE_SHARE_READ, null, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, null);
             if (h == INVALID_HANDLE_VALUE)
                 goto err1;

--- a/test/runnable/test9287.sh
+++ b/test/runnable/test9287.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/test9287.sh.out
+
+echo 'import std.stdio; void main() { writeln("Success"); }' | \
+	$DMD -m${MODEL} -of${dir}${SEP}test9287a${EXE} - || exit 1
+
+${RESULTS_DIR}/runnable/test9287a${EXE} > ${output_file}
+
+\rm -f ${dir}/test9287a{${OBJ},${EXE}}


### PR DESCRIPTION
It's nice to be able to pipe source code into dmd via standard input, e.g., in code generation programs so that you don't have to create a temporary file just to be able to compile the code.

Based on the bug notes in the original bug, using `-` to mean stdin is probably a problematic idea, so I have chosen a different route, i.e., use `-stdin` to indicate that dmd should read source code from stdin. I think this is clearer, and less *nix-specific.