### PR TITLE
CircleCi/CodeCov: Don't use multiple threads for the DMD testsuite

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -114,7 +114,7 @@ coverage()
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd clean
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_COVERAGE=1
 
-    make -j$N -C test MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1
+    make -j1 -C test MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1
 }
 
 codecov()


### PR DESCRIPTION
I am trying to remove the unrelated coverage changes from the CodeCov output and it seems like running the test suite in multiple threads might be problematic.
I don't know yet how the running time of CircleCi will be with this change, but given that we have __4__ parallel builds and we just run coverage tests there (i.e. all other CI take longer), it shouldn't matter if this fixes the problem.

CC @CyberShadow 

Original thread: https://github.com/dlang/dmd/pull/6879#issuecomment-307535894