### PR TITLE
allow $(test_results) to specify an absolute path

### DIFF
--- a/test/runnable/test44.sh
+++ b/test/runnable/test44.sh
@@ -13,7 +13,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-./${dir}/test44_1 >> ${output_file}
+${dir}/test44_1 >> ${output_file}
 if [ $? -ne 0 ]; then
     cat ${output_file}
     rm -f ${output_file}
@@ -27,7 +27,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-./${dir}/test44_2 >> ${output_file}
+${dir}/test44_2 >> ${output_file}
 if [ $? -ne 0 ]; then
     cat ${output_file}
     rm -f ${output_file}


### PR DESCRIPTION
I stumbled across this when trying to run the tests and the dmd directory was mounted through a network share.