### PR TITLE
enable runnable/testxmm for Win64

### DIFF
--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1,5 +1,4 @@
 // REQUIRED_ARGS:
-// DISABLED: win64
 // PERMUTE_ARGS: -mcpu=native
 
 version (D_SIMD)


### PR DESCRIPTION
This test is disabled for Win64, but has been working for quite a while.