### PR TITLE
Disallow empty statements made by semicolons

### DIFF
--- a/changelog/disallowSemiEmpty.dd
+++ b/changelog/disallowSemiEmpty.dd
@@ -1,0 +1,5 @@
+Deprecate empty statements made by semicolon
+
+Creating empty statements using semicolons, for which
+was previously issued a warning is now causing a deprecation
+hint.

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -5113,7 +5113,7 @@ final class Parser(AST) : Lexer
             if (!(flags & PSsemi_ok))
             {
                 if (flags & PSsemi)
-                    warning(loc, "use '{ }' for an empty statement, not a ';'");
+                    deprecation("use '{ }' for an empty statement, not a ';'");
                 else
                     error("use '{ }' for an empty statement, not a ';'");
             }

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -93,7 +93,7 @@ template Foo(T, int V)
         break;
     }
 
-        enum Label { A, B, C };
+        enum Label { A, B, C }
         void fswitch(Label l)
         {
             final switch (l)

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -88,7 +88,6 @@ template Foo(T, int V)
 			B,
 			C,
 		}
-		;
 		void fswitch(Label l);
 		loop:
 		while (x)

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -106,7 +106,6 @@ template Foo(T, int V)
 			B,
 			C,
 		}
-		;
 		void fswitch(Label l)
 		{
 			final switch (l)

--- a/test/fail_compilation/fail4559.d
+++ b/test/fail_compilation/fail4559.d
@@ -1,0 +1,22 @@
+/*
+REQUIRED_ARGS: -o- -de
+TEST_OUTPUT:
+---
+fail_compilation/fail4559.d(13): Deprecation: use '{ }' for an empty statement, not a ';'
+fail_compilation/fail4559.d(19): Deprecation: use '{ }' for an empty statement, not a ';'
+fail_compilation/fail4559.d(21): Deprecation: use '{ }' for an empty statement, not a ';'
+---
+*/
+
+void foo()
+{
+    int x;;
+    enum A
+    {
+        a,
+        b,
+        c
+    };
+
+    void bar() {};
+}

--- a/test/fail_compilation/fail9368.d
+++ b/test/fail_compilation/fail9368.d
@@ -43,7 +43,7 @@ void test286()
         case G.A:
 //      case G.B:
         case G.C:
-            ;
+            {}
     }
 }
 

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -1125,7 +1125,7 @@ void test12421()
     // This is problematic case, and should be disallowed in the future.
     alias f = x => y;
     int y = 10;
-    assert(f(1) == 10);;
+    assert(f(1) == 10);
 }
 
 /***************************************************/

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -3146,7 +3146,7 @@ void func48(void delegate () callback)
 
 void test48()
 {
-    func48(() { asm{ mov EAX,EAX; }; });
+    func48(() { asm{ mov EAX,EAX; } });
 }
 
 /****************************************************/

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -3125,7 +3125,7 @@ void func48(void delegate () callback)
 
 void test48()
 {
-    func48(() { asm{ mov EAX,EAX; }; });
+    func48(() { asm{ mov EAX,EAX; } });
 }
 
 /****************************************************/

--- a/test/runnable/imports/argufile.d
+++ b/test/runnable/imports/argufile.d
@@ -119,12 +119,12 @@ while (1)
                             continue;
 
                         default:
-;
+                            {}
                     }
                     return;
                 }
             default:
-;
+                {}
         }
 
     Lnumber:

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -1884,7 +1884,7 @@ char[] func95(immutable char[] s)
 
 void test95()
 {
-    mixin(func95(";"));
+    mixin(func95("{}"));
 }
 
 /************************************************/
@@ -1899,7 +1899,7 @@ char[] func96(string s)
 
 void test96()
 {
-    mixin(func96(";"));
+    mixin(func96("{}"));
 }
 
 /************************************************/
@@ -2524,7 +2524,6 @@ int bugzilla1790(Types...)()
 {
     foreach (T; Types)
     {
-        ;
     }
     return 0;
 }

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -1515,7 +1515,7 @@ alias void delegate() dg_t;
 
 void Y(dg_t delegate (dg_t) y)
 {
-    struct F { void delegate(F) f; };
+    struct F { void delegate(F) f; }
 
   version (all)
   { // generates error

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -772,7 +772,7 @@ int getRefNonref(T)(    T s){ return 2; }
 
 int getAutoRef(T)(auto ref T s){ return __traits(isRef, s) ? 1 : 2; }
 
-void getOut(T)(out T s){ ; }
+void getOut(T)(out T s){ {} }
 
 void getLazy1(T=int)(lazy void s){ s(), s(); }
 void getLazy2(T)(lazy T s){  s(), s(); }
@@ -1545,7 +1545,7 @@ struct Bar7755
 {
     void qux()
     {
-        if (is(typeof(to7755!string(Foo7755!int)))){};
+        if (is(typeof(to7755!string(Foo7755!int)))){}
     }
 }
 

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -698,7 +698,7 @@ void test46()
 
 void test47()
 {
-    enum { _P_WAIT, _P_NOWAIT, _P_OVERLAY };
+    enum { _P_WAIT, _P_NOWAIT, _P_OVERLAY }
 
     alias _P_WAIT P_WAIT;
     alias _P_NOWAIT P_NOWAIT;

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1176,7 +1176,7 @@ void test72()
 {
     int a;
     const int b;
-    enum { int c = 0 };
+    enum { int c = 0 }
     immutable int d = 0;
 
     assert(__traits(isSame, a, a));

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -367,8 +367,8 @@ extern(C++) interface F : E {}
 @safe
 void classcast()
 {
-    class A {};
-    class B : A {};
+    class A {}
+    class B : A {}
 
     A a;
     B b;
@@ -391,8 +391,8 @@ void classcast()
     static assert(!__traits(compiles, cast(A)cb));
     static assert(!__traits(compiles, cast(B)cb));
 
-    interface C {};
-    interface D : C {};
+    interface C {}
+    interface D : C {}
 
     C c;
     D d;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -710,7 +710,7 @@ void test36()
 
 void test6685()
 {
-    struct S { int x; };
+    struct S { int x; }
     with({ return S(); }())
     {
         x++;
@@ -2736,7 +2736,7 @@ void test129()
 /***************************************************/
 // 6169
 
-auto ctfefunc6169() { return ";"; }
+auto ctfefunc6169() { return "{}"; }
 enum ctfefptr6169 = &ctfefunc6169;
 int ctfefunc6169a() { return 1; }
 template x6169(string c) { alias int x6169; }
@@ -4126,7 +4126,7 @@ void test4963()
 {
     struct Value {
         byte a;
-    };
+    }
     Value single()
     {
         return Value();
@@ -4430,7 +4430,7 @@ void test4392()
 // 6220
 
 void test6220() {
-    struct Foobar { real x; real y; real z;};
+    struct Foobar { real x; real y; real z;}
     switch("x") {
         foreach(i,member; __traits(allMembers, Foobar)) {
             case member : break;


### PR DESCRIPTION
This turns the previous warning when using a semicolon
for an empty statement to a compilation error.
