### PR TITLE
Add Target.cppTypeMangle hook for vendor types.

### DIFF
--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -699,9 +699,18 @@ public:
         }
         if (t.isConst())
             buf.writeByte('K');
-        if (p)
-            buf.writeByte(p);
-        buf.writeByte(c);
+
+        // Handle any target-specific basic types.
+        if (auto tm = Target.cppTypeMangle(t))
+        {
+            buf.writestring(tm);
+        }
+        else
+        {
+            if (p)
+                buf.writeByte(p);
+            buf.writeByte(c);
+        }
     }
 
     override void visit(TypeVector t)
@@ -716,11 +725,20 @@ public:
         }
         if (t.isConst())
             buf.writeByte('K');
-        assert(t.basetype && t.basetype.ty == Tsarray);
-        assert((cast(TypeSArray)t.basetype).dim);
-        //buf.printf("Dv%llu_", ((TypeSArray *)t.basetype).dim.toInteger());// -- Gnu ABI v.4
-        buf.writestring("U8__vector"); //-- Gnu ABI v.3
-        t.basetype.nextOf().accept(this);
+
+        // Handle any target-specific vector types.
+        if (auto tm = Target.cppTypeMangle(t))
+        {
+            buf.writestring(tm);
+        }
+        else
+        {
+            assert(t.basetype && t.basetype.ty == Tsarray);
+            assert((cast(TypeSArray)t.basetype).dim);
+            //buf.printf("Dv%llu_", ((TypeSArray *)t.basetype).dim.toInteger());// -- Gnu ABI v.4
+            buf.writestring("U8__vector"); //-- Gnu ABI v.3
+            t.basetype.nextOf().accept(this);
+        }
     }
 
     override void visit(TypeSArray t)
@@ -859,13 +877,22 @@ public:
         }
         if (t.isConst())
             buf.writeByte('K');
-        if (!substitute(t.sym))
+
+        // Handle any target-specific struct types.
+        if (auto tm = Target.cppTypeMangle(t))
         {
-            cpp_mangle_name(t.sym, t.isConst());
+            buf.writestring(tm);
         }
-        if (t.isImmutable() || t.isShared())
+        else
         {
-            visit(cast(Type)t);
+            if (!substitute(t.sym))
+            {
+                cpp_mangle_name(t.sym, t.isConst());
+            }
+            if (t.isImmutable() || t.isShared())
+            {
+                visit(cast(Type)t);
+            }
         }
         if (t.isConst())
             store(t);

--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -638,7 +638,7 @@ public:
             c = 'd';
             break;
         case Tfloat80:
-            c = Target.realislongdouble ? 'e' : 'g';
+            c = 'e';
             break;
         case Tbool:
             c = 'b';

--- a/src/ddmd/target.d
+++ b/src/ddmd/target.d
@@ -30,7 +30,6 @@ struct Target
     extern (C++) static __gshared int realsize;             // size a real consumes in memory
     extern (C++) static __gshared int realpad;              // 'padding' added to the CPU real size to bring it up to realsize
     extern (C++) static __gshared int realalignsize;        // alignment for reals
-    extern (C++) static __gshared bool realislongdouble;    // distinguish between C 'long double' and '__float128'
     extern (C++) static __gshared bool reverseCppOverloads; // with dmc and cl, overloaded functions are grouped and in reverse order
     extern (C++) static __gshared bool cppExceptions;       // set if catching C++ exceptions is supported
     extern (C++) static __gshared int c_longsize;           // size of a C 'long' or 'unsigned long' type
@@ -127,7 +126,6 @@ struct Target
                 c_longsize = 8;
             }
         }
-        realislongdouble = true;
         c_long_doublesize = realsize;
         if (global.params.is64bit && global.params.isWindows)
             c_long_doublesize = 8;

--- a/src/ddmd/target.d
+++ b/src/ddmd/target.d
@@ -451,6 +451,15 @@ struct Target
     }
 
     /**
+     * For a vendor-specific type, return a string containing the C++ mangling.
+     * In all other cases, return null.
+     */
+    extern (C++) static const(char)* cppTypeMangle(Type t)
+    {
+        return null;
+    }
+
+    /**
      * Return the default system linkage for the target.
      */
     extern (C++) static LINK systemLinkage()

--- a/src/ddmd/target.h
+++ b/src/ddmd/target.h
@@ -17,6 +17,8 @@
 // most or all target machine and target O/S specific information.
 #include "globals.h"
 
+class ClassDeclaration;
+class Dsymbol;
 class Expression;
 class Type;
 class Module;
@@ -70,6 +72,9 @@ struct Target
     // ABI and backend.
     static void loadModule(Module *m);
     static void prefixName(OutBuffer *buf, LINK linkage);
+    static const char *toCppMangle(Dsymbol *s);
+    static const char *cppTypeInfoMangle(ClassDeclaration *cd);
+    static const char *cppTypeMangle(Type *t);
     static LINK systemLinkage();
 };
 


### PR DESCRIPTION
This patch adds `Target.cppMangleType`, which returns a pointer to statically allocated string containing the target/vendor-specific mangling for the given type.

While this could apply for any type, have only added it to the basic, vector, and struct type visitor passes for now.  DMD does nothing with this, however these specific places should catch all of the following:

- `real` may be a `__float128` type mangled as `g` (alpha, ia64, ppc, systemz, sparc, x86)
- `real` may be mangled as a vendor type `U10__float128` (ppc) or `u9__float80` (ia64)
- `va_list` may be mangled as if it is in the "std" namespace `St9__va_list` (arm, aarch64)
- `__vector()` may differ depending on the default C++ ABI `Dv` (abi >= 4)

This replaces `Target.realislongdouble`.

See https://github.com/dlang/dmd/pull/6887/files?w=1 to read diff without whitespace changes.

Fixes the frontend part of bug reported against gdc: https://bugzilla.gdcproject.org/show_bug.cgi?id=247

FYI: @redstar / @klickverbot - this would affect you.