### PR TITLE
Remove auto-generated .cg file in test/compilable/vcg-ast

### DIFF
--- a/test/compilable/vcg-ast.d
+++ b/test/compilable/vcg-ast.d
@@ -1,6 +1,7 @@
 module vcg;
 // REQUIRED_ARGS: -vcg-ast -o-
 // PERMUTE_ARGS:
+// POST_SCRIPT: rm compilable/vcg-ast.d.cg && echo
 
 template Seq(A...)
 {


### PR DESCRIPTION
Running the full test suite generated the `test/compilable/vcg-ast.d.cg` which is visible in `git status`.
This file is generated by [test/compilable/vcg-ast.d](https://github.com/dlang/dmd/blob/master/test/compilable/vcg-ast.d)

Thus I guess the simplest solution is to ignore all `*.cg` files?

CC @UplinkCoder 