### PR TITLE
fix Issue 17491 - Compiles on invalid: *&s.init.var is not an lvalue

### DIFF
--- a/src/ddmd/optimize.d
+++ b/src/ddmd/optimize.d
@@ -1203,7 +1203,14 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
     }
 
     scope OptimizeVisitor v = new OptimizeVisitor(result, keepLvalue);
+    Expression ex = null;
     v.ret = e;
-    e.accept(v);
-    return v.ret;
+
+    // Optimize the expression until it can no longer be simplified.
+    while (ex != v.ret)
+    {
+        ex = v.ret;
+        ex.accept(v);
+    }
+    return ex;
 }

--- a/test/fail_compilation/fail17491.d
+++ b/test/fail_compilation/fail17491.d
@@ -1,0 +1,41 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail17491.d(24): Error: (S17491).init is not an lvalue
+fail_compilation/fail17491.d(25): Error: S17491(0) is not an lvalue
+fail_compilation/fail17491.d(27): Error: constant S17491(0).field is not an lvalue
+fail_compilation/fail17491.d(28): Error: constant *&S17491(0).field is not an lvalue
+fail_compilation/fail17491.d(33): Error: S17491(0) is not an lvalue
+fail_compilation/fail17491.d(34): Error: S17491(0) is not an lvalue
+fail_compilation/fail17491.d(36): Error: constant S17491(0).field is not an lvalue
+fail_compilation/fail17491.d(37): Error: constant *&S17491(0).field is not an lvalue
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=17491
+
+struct S17491
+{
+    int field;
+    static int var;
+}
+
+void test17491()
+{
+    S17491.init = S17491(42);       // NG
+    *&S17491.init = S17491(42);     // NG
+
+    S17491.init.field = 42;         // NG
+    *&S17491.init.field = 42;       // Should be NG
+
+    S17491.init.var = 42;           // OK
+    *&S17491.init.var = 42;         // OK
+
+    S17491(0) = S17491(42);         // NG
+    *&S17491(0) = S17491(42);       // NG
+
+    S17491(0).field = 42;           // NG
+    *&S17491(0).field = 42;         // Should be NG
+
+    S17491(0).var = 42;             // OK
+    *&S17491(0).var = 42;           // OK
+}


### PR DESCRIPTION
Same as #6892, but with added test case.

The idea here is that, the optimizer can simplify:
- `S(42).var` -> `42`, and
- `*&S(42).var` -> `S(42).var`

But it is not able to (in one pass) go from:
- `*&S(42).var` -> `42`

Because of this, the compiler accepts an assignment to non-lvalue as valid code because it hasn't sufficiently determined that the LHS is infact a constant literal.

The first commit is a prerequisite for this fix. `PowExp.optimize` is code that I wrote a few years back, and fixing 17491 exposed a hidden bug in them.

Fixes dmd bug: https://issues.dlang.org/show_bug.cgi?id=17491
Fixes gdc bug: https://bugzilla.gdcproject.org/show_bug.cgi?id=151