### PR TITLE
Fix Issue 17489 - ICE in ddmd/argtypes.d

### DIFF
--- a/src/ddmd/argtypes.d
+++ b/src/ddmd/argtypes.d
@@ -341,6 +341,8 @@ extern (C++) TypeTuple toArgTypes(Type t)
                     {
                         VarDeclaration f = t.sym.fields[i];
                         //printf("  [%d] %s f.type = %s\n", cast(int)i, f.toChars(), f.type.toChars());
+                        if (f.type.ty == Terror)
+                            goto Lmemory;
                         TypeTuple tup = toArgTypes(f.type);
                         if (!tup)
                             goto Lmemory;

--- a/test/fail_compilation/extra-files/fail17489_file.d
+++ b/test/fail_compilation/extra-files/fail17489_file.d
@@ -1,0 +1,11 @@
+struct Path {
+		immutable()m_nodes;
+}
+
+enum DirectoryChangeType {}
+
+
+struct DirectoryChange {
+	DirectoryChangeType type;
+	Path path;
+}

--- a/test/fail_compilation/fail17489.d
+++ b/test/fail_compilation/fail17489.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -Ifail_compilation/extra-files
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/extra-files/fail17489_file.d(2): Error: basic type expected, not )
+fail_compilation/extra-files/fail17489_file.d(5): Error: enum fail17489_file.DirectoryChangeType enum `DirectoryChangeType` must have at least one member
+---
+*/
+class VibedScheduler {
+	import fail17489_file;
+}


### PR DESCRIPTION
Funny thing - the ICE in Vibe.d  0.7.31-rc.2 was fixed  #6875 and can't be observed anymore, but in the dustmited example (it just took quite a bit for dustmite too reduce it).