### PR TITLE
fix Issue 17494 - Do not execute scope(...) if an Error exception has…

### DIFF
--- a/compiler/src/dmd/statementsem.d
+++ b/compiler/src/dmd/statementsem.d
@@ -323,7 +323,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                      * As:
                      *      s;
                      *      try { s1; s2; }
-                     *      catch (Throwable __o)
+                     *      catch (Exception __o)
                      *      { sexception; throw __o; }
                      */
                     auto a = new Statements();
@@ -344,7 +344,7 @@ package (dmd) extern (C++) final class StatementSemanticVisitor : Visitor
                     }
 
                     auto catches = new Catches();
-                    auto ctch = new Catch(Loc.initial, getThrowable(), id, handler);
+                    auto ctch = new Catch(Loc.initial, getException(), id, handler);
                     ctch.internalCatch = true;
                     catches.push(ctch);
 

--- a/compiler/test/compilable/test17493.d
+++ b/compiler/test/compilable/test17493.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=17493
+
+struct S {
+    ~this() {}
+}
+
+class C {
+    S s;
+
+    this() nothrow {}
+}


### PR DESCRIPTION
… been thrown

fix 17494

This is an enhancement, see https://issues.dlang.org/show_bug.cgi?id=17494

It's also a regression fix.