### PR TITLE
Enable debug mode on BUILD=debug

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -1,3 +1,31 @@
+################################################################################
+# Important variables:
+# --------------------
+#
+# HOST_CSS:				Host C++ compiler to use (g++,clang++)
+# HOST_DMD: 			Host D compiler to use for bootstrapping
+# AUTO_BOOTSTRAP:		Enable auto-boostrapping by download a stable DMD binary
+# INSTALL_DIR:			Installation folder to use
+#
+################################################################################
+# Build modes:
+# ------------
+# BUILD: release (default) | debug (enabled a build with debug symbols)
+#
+# Opt-in build features:
+#
+# ENABLE_RELEASE:		Optimized release built (set by BUILD=release)
+# ENABLE_DEBUG:			Add debug instructions and symbols (set by BUILD=debug)
+# ENABLE_WARNINGS: 		Enable C++ build warnings
+# ENABLE_PROFILING:		Build dmd with a profiling recorder (C++)
+# ENABLE_PGO_USE:		Build dmd with existing profiling information (C++)
+# 	PGO_DIR:			Directory for profile-guided optimization (PGO) logs
+# ENABLE_LTO:			Enable link-time optimizations
+# ENABLE_UNITTEST:		Build dmd with unittests (sets ENABLE_COVERAGE=1)
+# ENABLE_PROFILE:		Build dmd with a profiling recorder (D)
+# ENABLE_COVERAGE		Build dmd with coverage counting
+################################################################################
+
 # get OS and MODEL
 include osmodel.mak
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -27,6 +27,7 @@ ifneq ($(BUILD),release)
     ifneq ($(BUILD),debug)
         $(error Unrecognized BUILD=$(BUILD), must be 'debug' or 'release')
     endif
+    ENABLE_DEBUG := 1
 endif
 
 GIT_HOME=https://github.com/dlang


### PR DESCRIPTION
I expected `make -f posix.mak BUILD=debug` to work out of the box and generate a debug build of the compiler (with debug info!).