### PR TITLE
Immediately send CodeCov notifications

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,9 @@ codecov:
   # CodeCov should only wait for CI's that run coverage tests
   # DAutoTester and auto-tester are not in the default list
   ci:
-    - !travis
+    - "circleci.com"
+  notify:
+    after_n_builds: 1  # send notifications after the first upload
   bot: dlang-bot
 
 coverage:


### PR DESCRIPTION
Ideally this should avoid that CodeCov waits with sending the notification.

![image](https://user-images.githubusercontent.com/4370550/27025646-872254f0-4f5b-11e7-9ed7-794265072438.png)

Analogous to https://github.com/dlang/phobos/pull/5455