### PR TITLE
Fix issue 17502: Allow no parameters in out contract for auto methods

### DIFF
--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -1766,9 +1766,6 @@ extern (C++) class FuncDeclaration : Declaration
                 if (f.next.ty == Tvoid && outId)
                     error("void functions have no result");
 
-                if (fensure && f.next.ty != Tvoid)
-                    buildResultVar(scout, f.next);
-
                 sc2 = scout; //push
                 sc2.flags = (sc2.flags & ~SCOPEcontract) | SCOPEensure;
 
@@ -1777,9 +1774,17 @@ extern (C++) class FuncDeclaration : Declaration
                 if (inferRetType && fdensure && fdensure.type.toTypeFunction().parameters)
                 {
                     // Return type was unknown in the first semantic pass
-                    Parameter p = (*(cast(TypeFunction)fdensure.type).parameters)[0];
-                    p.type = f.next;
+                    auto out_params = (cast(TypeFunction)fdensure.type).parameters;
+                    if (out_params.dim > 0)
+                    {
+                        Parameter p = (*out_params)[0];
+                        p.type = f.next;
+                    }
                 }
+
+                if (fensure && f.next.ty != Tvoid)
+                    buildResultVar(scout, f.next);
+
                 fens = fens.semantic(sc2);
                 fens.blockExit(this, false);
 

--- a/test/compilable/test17502.d
+++ b/test/compilable/test17502.d
@@ -1,0 +1,30 @@
+class Foo
+{
+    auto foo()
+    out {}
+    body {}
+
+    auto bar()
+    out { assert (__result > 5); }
+    body { return 6; }
+
+    auto bar_2()
+    out (res) { assert (res > 5); }
+    body { return 6; }
+
+    int concrete()
+    out { assert(__result > 5); }
+    body { return 6; }
+
+    int concrete_2()
+    out(res) { assert (res > 5); }
+    body { return 6; }
+
+    void void_foo()
+    out {}
+    body {}
+
+    auto void_auto()
+    out {}
+    body {}
+}


### PR DESCRIPTION
Even in case of non-void methods, their out contract should
be able to accept no arguments. For the methods with auto return type,
there was oversight where one argument to `out` was always assumed.