### PR TITLE
win64: speed up test suite by more than 15 minutes

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -556,6 +556,11 @@ int main(string[] args)
                 (testArgs.mode == TestMode.FAIL_COMPILE ? "-verrors=0 " : null) ~
                 testArgs.requiredArgs;
 
+            // https://issues.dlang.org/show_bug.cgi?id=10664: exceptions don't work reliably with COMDAT folding
+            // it also slows down some tests drastically, e.g. runnable/test17338.d
+            if (msc)
+                reqArgs ~= " -L/OPT:NOICF";
+
             string compile_output;
             if (!testArgs.compileSeparately)
             {


### PR DESCRIPTION
runnable/test17338.d added in https://github.com/dlang/dmd/pull/6718 triggers pretty bad identical comdat folding performance by the MS linker.

As this is known to have problems anyway (e.g. https://issues.dlang.org/show_bug.cgi?id=10664) and is disabled in sc.ini (https://github.com/dlang/dmd/blob/master/ini/windows/bin/sc.ini#L23), we can disable it in the tests, too.
