### PR TITLE
Fix #6821 changelog entry

### DIFF
--- a/changelog/b6227.dd
+++ b/changelog/b6227.dd
@@ -1,5 +1,4 @@
-Comparison that takes into account the enumerated type improves code correctness by
-disallowing comparison of unrelated enumerated types. 
+Comparison of values belonging to different enums is deprecated.
 
 This change does not affect anonymous enumerations.
 


### PR DESCRIPTION
This is a partial revert of 0d40de43e9fbe41817a9ace030260a94fd211cc1. This commit introduced a number of problems:

1. The title was two lines, which did not conform to the syntax as described in README.md, and caused the generated changelog to be misformed (see http://dlang.org/changelog/2.075.0_pre.html)

2. There was trailing whitespace on the second line, causing dlang.org's test target to fail

3. Subjectively, I'm having trouble understanding the new wording. The old wording was much more concise, and if it was factually incorrect, I don't see how.

CC @UplinkCoder @wilzbach 