### PR TITLE
Actually fix path of generated DMD

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -61,6 +61,7 @@
 # fixed model for win32.mak, overridden by win64.mak
 MODEL=32
 BUILD=release
+OS=windows
 
 ##### Directories
 


### PR DESCRIPTION
As `OS` was never defined, it was substituted as an empty string in the `G` variable.

This is a fixup for #6873.

I don't see where `OS` is being set by the autotester (if anywhere) - if it's not, then it's still using the current path hierarchy instead of the intended POSIX one. Let's see what the autotester says.