### PR TITLE
Suppress duplicate errors in divide by zero during constfolding

### DIFF
--- a/src/ddmd/constfold.d
+++ b/src/ddmd/constfold.d
@@ -431,7 +431,8 @@ extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
         if (n2 == 0)
         {
             e2.error("divide by 0");
-            n2 = 1;
+            emplaceExp!(ErrorExp)(&ue);
+            return ue;
         }
         if (n2 == -1 && !type.isunsigned())
         {
@@ -495,7 +496,8 @@ extern (C++) UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
         if (n2 == 0)
         {
             e2.error("divide by 0");
-            n2 = 1;
+            emplaceExp!(ErrorExp)(&ue);
+            return ue;
         }
         if (n2 == -1 && !type.isunsigned())
         {

--- a/test/fail_compilation/test4682a.d
+++ b/test/fail_compilation/test4682a.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+----
+fail_compilation/test4682a.d(10): Error: divide by 0
+fail_compilation/test4682a.d(11): Error: divide by 0
+fail_compilation/test4682a.d(12): Error: divide by 0
+fail_compilation/test4682a.d(13): Error: divide by 0
+----
+*/
+auto a = int.min / 0;
+auto b = long.min / 0;
+auto c = int.min % 0;
+auto d = long.min % 0;


### PR DESCRIPTION
A continuation of #6579.  Checked other places where there are errors in constfold.d, and all look OK.