### PR TITLE
Fix Issue 17522 - win64.mak broken

### DIFF
--- a/src/win64.mak
+++ b/src/win64.mak
@@ -7,6 +7,8 @@
 MAKE=make
 HOST_DC=dmd
 MODEL=64
+BUILD=release
+OS=windows
 
 ################################### Rules ####################################
 
@@ -15,11 +17,11 @@ MODEL=64
 
 D=ddmd
 GEN = ..\generated
-G = $(GEN)\$(OS)$(MODEL)
+G = $(GEN)\$(OS)\$(BUILD)\$(MODEL)
 OBJ_MSVC=$G/strtold.obj $G\longdouble.obj $G\ldfpu.obj
 DEPENDENCIES=vcbuild\msvc-dmc.exe vcbuild\msvc-lib.exe
 
-MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" MODEL=$(MODEL) HOST_DC=$(HOST_DC) GEN="$(GEN)" G="$G" OBJ_MSVC="$(OBJ_MSVC)" CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
+MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" BUILD=$(BUILD) MODEL=$(MODEL) HOST_DC=$(HOST_DC) GEN="$(GEN)" G="$G" OBJ_MSVC="$(OBJ_MSVC)" CC=vcbuild\msvc-dmc LIB=vcbuild\msvc-lib
 
 ################################## Targets ###################################
 


### PR DESCRIPTION
CC @RazvanN7

This is still not enough to build Druntime/Phobos - another regression is blocking that, which I will file shortly.