### PR TITLE
skip typeinfo for struct/enum in betterC mode

### DIFF
--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -831,7 +831,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 if (global.params.symdebug)
                     toDebug(sd);
 
-                genTypeInfo(sd.type, null);
+                if (!global.params.betterC)
+                    genTypeInfo(sd.type, null);
 
                 // Generate static initializer
                 toInitializer(sd);
@@ -990,7 +991,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
             if (global.params.symdebug)
                 toDebug(ed);
 
-            genTypeInfo(ed.type, null);
+            if (!global.params.betterC)
+                genTypeInfo(ed.type, null);
 
             TypeEnum tc = cast(TypeEnum)ed.type;
             if (!tc.sym.members || ed.type.isZeroInit())


### PR DESCRIPTION
Currently, if you try to compile a -betterC thing with a struct, it gives a linker error. This skips typeinfo letting them work in the simple case.

Whereas -betterC is a "rip stuff out" hack in the first place, this little change fits right in with it. And with this, I consider -betterC to actually live up to its name - the C subset of D is actually usable now, out of the box, given the switch.

