### PR TITLE
Make struct dtors work in -betterC via hack on Linux

### DIFF
--- a/src/ddmd/backend/dwarf.c
+++ b/src/ddmd/backend/dwarf.c
@@ -1503,7 +1503,9 @@ void dwarf_func_term(Symbol *sfunc)
 {
    //printf("dwarf_func_term(sfunc = '%s')\n", sfunc->Sident);
 
-    if (config.ehmethod == EH_DWARF)
+    // Temporarily disabling EH generation for betterC so scope(exit) and
+    // struct dtors work. This is a filthy hack.
+    if (config.ehmethod == EH_DWARF && !global.params.betterC)
     {
         bool ehunwind = doUnwindEhFrame();
 

--- a/test/runnable/cdtor.d
+++ b/test/runnable/cdtor.d
@@ -1,0 +1,27 @@
+/* REQUIRED_ARGS: -betterC
+   PERMUTE_ARGS:
+   DISABLED: win32
+ */
+
+__gshared bool dtorRan;
+
+struct S
+{
+    ~this()
+    {
+        dtorRan = true;
+    }
+
+    void m() {}
+}
+
+extern(C) int main()
+{
+    dtorRan = false;
+    {
+        S s;
+        s.m();
+    }
+    assert(dtorRan);
+    return 0;
+}


### PR DESCRIPTION
They currently fail because they output a reference to druntime personality function. This hacks it out. Follow-up to my other PR: https://github.com/dlang/dmd/pull/6922

These together with Walter's at https://github.com/dlang/dmd/pull/6918 achieve the goal I set out in October to make -betterC actually usable.

Still a filthy hack, especially this one, but a *usable* filthy hack. We can go back and add stuff back in like EH later.

Note: I have not tested betterC on Windows yet. I *think* the struct dtor already works there though.