### PR TITLE
betterC: send array overflows to C assert

### DIFF
--- a/src/ddmd/s2ir.d
+++ b/src/ddmd/s2ir.d
@@ -761,10 +761,17 @@ extern (C++) class S2irVisitor : Visitor
         Blockx *blx = irs.blx;
 
         //printf("SwitchErrorStatement.toIR()\n");
-
-        elem *efilename = el_ptr(toSymbol(cast(Dsymbol)blx._module));
-        elem *elinnum = el_long(TYint, s.loc.linnum);
-        elem *e = el_bin(OPcall, TYvoid, el_var(getRtlsym(RTLSYM_DSWITCHERR)), el_param(elinnum, efilename));
+        elem *e;
+        if (global.params.betterC)
+        {
+            e = callCAssert(irs, s.loc, null, null, "no switch default");
+        }
+        else
+        {
+            auto efilename = el_ptr(toSymbol(cast(Dsymbol)blx._module));
+            auto elinnum = el_long(TYint, s.loc.linnum);
+            e = el_bin(OPcall, TYvoid, el_var(getRtlsym(RTLSYM_DSWITCHERR)), el_param(elinnum, efilename));
+        }
         block_appendexp(blx.curblock, e);
     }
 

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -1,0 +1,17 @@
+/* REQUIRED_ARGS: -betterC
+   PERMUTE_ARGS:
+*/
+
+import core.stdc.stdio;
+
+extern (C) int main(char** argv, int argc) {
+    printf("hello world\n");
+    int[3] a;
+    foo(a[], 3);
+    return 0;
+}
+
+int foo(int[] a, int i)
+{
+    return a[i];
+}

--- a/test/compilable/betterCswitch.d
+++ b/test/compilable/betterCswitch.d
@@ -1,0 +1,16 @@
+import core.stdc.stdio;
+
+extern (C) int main(char** argv, int argc) {
+    printf("hello world\n");
+    foo(3);
+    return 0;
+}
+
+int foo(int i)
+{
+    final switch (i)
+    {
+	case 1: break;
+    }
+    return i;
+}


### PR DESCRIPTION
So that `betterC` mode can support runtime array overflow detection.