### PR TITLE
Fix Issue 16640 - __FILE_FULL_PATH__ doesn't return relative path when used as default parameter

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -16065,6 +16065,8 @@ extern (C++) final class FileInitExp : DefaultInitExp
     {
         //printf("FileInitExp::resolve() %s\n", toChars());
         const(char)* s = loc.filename ? loc.filename : sc._module.ident.toChars();
+        if (subop == TOKfilefullpath)
+            s = FileName.combine(sc._module.srcfilePath, s);
         Expression e = new StringExp(loc, cast(char*)s);
         e = e.semantic(sc);
         e = e.castTo(sc, type);

--- a/test/runnable/test16640.d
+++ b/test/runnable/test16640.d
@@ -1,0 +1,11 @@
+// PERMUTE_ARGS:
+
+void testFileFullPathAsDefaultArgument(string preBakedFileFullPath, string fileFullPath = __FILE_FULL_PATH__)
+{
+    assert(preBakedFileFullPath == fileFullPath);
+}
+
+void main()
+{
+    testFileFullPathAsDefaultArgument(__FILE_FULL_PATH__);
+}


### PR DESCRIPTION
The resolveLoc function of the FileInitExp class, which is responsible for assigning the right path to the symbol used treats only the case of  __File__. I added an if to test if the symbol used is __FILE_FULL_PATH__ so that the right path is assigned