### PR TITLE
Fix Issue 17548 - [REG2.072.0] Forward reference error with scope function parameters

### DIFF
--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -292,7 +292,7 @@ extern (C++) final class Import : Dsymbol
                 scopesym.addAccessiblePackage(mod, protection); // d
             }
 
-            mod.semantic(null);
+            mod.semantic();
             if (mod.needmoduleinfo)
             {
                 //printf("module4 %s because of %s\n", sc.module.toChars(), mod.toChars());
@@ -409,7 +409,7 @@ extern (C++) final class Import : Dsymbol
         //printf("Import::semantic2('%s')\n", toChars());
         if (mod)
         {
-            mod.semantic2(null);
+            mod.semantic2();
             if (mod.needmoduleinfo)
             {
                 //printf("module5 %s because of %s\n", sc.module.toChars(), mod.toChars());
@@ -476,7 +476,7 @@ extern (C++) final class Import : Dsymbol
         {
             load(null);
             mod.importAll(null);
-            mod.semantic(null);
+            mod.semantic();
         }
         // Forward it to the package/module
         return pkg.search(loc, ident, flags);

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -292,7 +292,7 @@ extern (C++) final class Import : Dsymbol
                 scopesym.addAccessiblePackage(mod, protection); // d
             }
 
-            mod.semantic();
+            mod.doSemanticPass1();
             if (mod.needmoduleinfo)
             {
                 //printf("module4 %s because of %s\n", sc.module.toChars(), mod.toChars());
@@ -409,7 +409,7 @@ extern (C++) final class Import : Dsymbol
         //printf("Import::semantic2('%s')\n", toChars());
         if (mod)
         {
-            mod.semantic2();
+            mod.doSemanticPass2();
             if (mod.needmoduleinfo)
             {
                 //printf("module5 %s because of %s\n", sc.module.toChars(), mod.toChars());
@@ -476,7 +476,7 @@ extern (C++) final class Import : Dsymbol
         {
             load(null);
             mod.importAll(null);
-            mod.semantic();
+            mod.doSemanticPass1();
         }
         // Forward it to the package/module
         return pkg.search(loc, ident, flags);

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -246,7 +246,7 @@ extern (C++) class Package : ScopeDsymbol
         return isAncestorPackageOf(pkg.parent.isPackage());
     }
 
-    override void semantic(Scope* sc)
+    override final void semantic(Scope* sc)
     {
         if (semanticRun < PASSsemanticdone)
             semanticRun = PASSsemanticdone;
@@ -1047,7 +1047,7 @@ extern (C++) final class Module : Package
     }
 
     // semantic analysis
-    override void semantic(Scope*)
+    void semantic()
     {
         if (semanticRun != PASSinit)
             return;
@@ -1084,7 +1084,7 @@ extern (C++) final class Module : Package
     }
 
     // pass 2 semantic analysis
-    override void semantic2(Scope*)
+    void semantic2()
     {
         //printf("Module::semantic2('%s'): parent = %p\n", toChars(), parent);
         if (semanticRun != PASSsemanticdone) // semantic() not completed yet - could be recursive call
@@ -1112,7 +1112,7 @@ extern (C++) final class Module : Package
     }
 
     // pass 3 semantic analysis
-    override void semantic3(Scope*)
+    void semantic3()
     {
         //printf("Module::semantic3('%s'): parent = %p\n", toChars(), parent);
         if (semanticRun != PASSsemantic2done)

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -112,7 +112,7 @@ extern (C++) const(char)* lookForSourceFile(const(char)** path, const(char)* fil
     return null;
 }
 
-// function used to call semantic3 on a module's dependencies
+// function used to call doSemanticPass3 on a module's dependencies
 void semantic3OnDependencies(Module m)
 {
     if (!m)
@@ -121,7 +121,7 @@ void semantic3OnDependencies(Module m)
     if (m.semanticRun > PASSsemantic3)
         return;
 
-    m.semantic3();
+    m.doSemanticPass3();
 
     foreach (i; 1 .. m.aimports.dim)
         semantic3OnDependencies(m.aimports[i]);
@@ -1047,11 +1047,11 @@ extern (C++) final class Module : Package
     }
 
     // semantic analysis
-    void semantic()
+    void doSemanticPass1()
     {
         if (semanticRun != PASSinit)
             return;
-        //printf("+Module::semantic(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
+        //printf("+Module::doSemanticPass1(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
         semanticRun = PASSsemantic;
         // Note that modules get their own scope, from scratch.
         // This is so regardless of where in the syntax a module
@@ -1080,13 +1080,13 @@ extern (C++) final class Module : Package
             sc.pop(); // 2 pops because Scope::createGlobal() created 2
         }
         semanticRun = PASSsemanticdone;
-        //printf("-Module::semantic(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
+        //printf("-Module::doSemanticPass1(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
     }
 
     // pass 2 semantic analysis
-    void semantic2()
+    void doSemanticPass2()
     {
-        //printf("Module::semantic2('%s'): parent = %p\n", toChars(), parent);
+        //printf("Module::doSemanticPass2('%s'): parent = %p\n", toChars(), parent);
         if (semanticRun != PASSsemanticdone) // semantic() not completed yet - could be recursive call
             return;
         semanticRun = PASSsemantic2;
@@ -1108,13 +1108,13 @@ extern (C++) final class Module : Package
         sc = sc.pop();
         sc.pop();
         semanticRun = PASSsemantic2done;
-        //printf("-Module::semantic2('%s'): parent = %p\n", toChars(), parent);
+        //printf("-Module::doSemanticPass2('%s'): parent = %p\n", toChars(), parent);
     }
 
     // pass 3 semantic analysis
-    void semantic3()
+    void doSemanticPass3()
     {
-        //printf("Module::semantic3('%s'): parent = %p\n", toChars(), parent);
+        //printf("Module::doSemanticPass3('%s'): parent = %p\n", toChars(), parent);
         if (semanticRun != PASSsemantic2done)
             return;
         semanticRun = PASSsemantic3;

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -121,7 +121,7 @@ void semantic3OnDependencies(Module m)
     if (m.semanticRun > PASSsemantic3)
         return;
 
-    m.semantic3(null);
+    m.semantic3();
 
     foreach (i; 1 .. m.aimports.dim)
         semantic3OnDependencies(m.aimports[i]);

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -14912,7 +14912,7 @@ extern (C++) Module loadStdMath()
         if (s.mod)
         {
             s.mod.importAll(null);
-            s.mod.semantic(null);
+            s.mod.semantic();
         }
         impStdMath = s;
     }

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -14912,7 +14912,7 @@ extern (C++) Module loadStdMath()
         if (s.mod)
         {
             s.mod.importAll(null);
-            s.mod.semantic();
+            s.mod.doSemanticPass1();
         }
         impStdMath = s;
     }

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -237,9 +237,9 @@ extern (C++) void genCmain(Scope* sc)
     global.params.verbose = false;
     m.importedFrom = m;
     m.importAll(null);
-    m.semantic(null);
-    m.semantic2(null);
-    m.semantic3(null);
+    m.semantic();
+    m.semantic2();
+    m.semantic3();
     global.params.verbose = v;
     entrypoint = m;
     rootHasMain = sc._module;
@@ -1455,7 +1455,7 @@ Language changes listed by -transition=id:
         Module m = modules[i];
         if (global.params.verbose)
             fprintf(global.stdmsg, "semantic  %s\n", m.toChars());
-        m.semantic(null);
+        m.semantic();
     }
     //if (global.errors)
     //    fatal();
@@ -1477,7 +1477,7 @@ Language changes listed by -transition=id:
         Module m = modules[i];
         if (global.params.verbose)
             fprintf(global.stdmsg, "semantic2 %s\n", m.toChars());
-        m.semantic2(null);
+        m.semantic2();
     }
     Module.runDeferredSemantic2();
     if (global.errors)
@@ -1489,7 +1489,7 @@ Language changes listed by -transition=id:
         Module m = modules[i];
         if (global.params.verbose)
             fprintf(global.stdmsg, "semantic3 %s\n", m.toChars());
-        m.semantic3(null);
+        m.semantic3();
     }
     Module.runDeferredSemantic3();
     if (global.errors)

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -237,9 +237,9 @@ extern (C++) void genCmain(Scope* sc)
     global.params.verbose = false;
     m.importedFrom = m;
     m.importAll(null);
-    m.semantic();
-    m.semantic2();
-    m.semantic3();
+    m.doSemanticPass1();
+    m.doSemanticPass2();
+    m.doSemanticPass3();
     global.params.verbose = v;
     entrypoint = m;
     rootHasMain = sc._module;
@@ -1454,8 +1454,8 @@ Language changes listed by -transition=id:
     {
         Module m = modules[i];
         if (global.params.verbose)
-            fprintf(global.stdmsg, "semantic  %s\n", m.toChars());
-        m.semantic();
+            fprintf(global.stdmsg, "doSemanticPass1  %s\n", m.toChars());
+        m.doSemanticPass1();
     }
     //if (global.errors)
     //    fatal();
@@ -1476,8 +1476,8 @@ Language changes listed by -transition=id:
     {
         Module m = modules[i];
         if (global.params.verbose)
-            fprintf(global.stdmsg, "semantic2 %s\n", m.toChars());
-        m.semantic2();
+            fprintf(global.stdmsg, "doSemanticPass2 %s\n", m.toChars());
+        m.doSemanticPass2();
     }
     Module.runDeferredSemantic2();
     if (global.errors)
@@ -1488,8 +1488,8 @@ Language changes listed by -transition=id:
     {
         Module m = modules[i];
         if (global.params.verbose)
-            fprintf(global.stdmsg, "semantic3 %s\n", m.toChars());
-        m.semantic3();
+            fprintf(global.stdmsg, "doSemanticPass3 %s\n", m.toChars());
+        m.doSemanticPass3();
     }
     Module.runDeferredSemantic3();
     if (global.errors)

--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -127,9 +127,9 @@ public:
     bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.
     Module *parse();    // syntactic parse
     void importAll(Scope *sc);
-    void semantic(Scope *);    // semantic analysis
-    void semantic2(Scope *);   // pass 2 semantic analysis
-    void semantic3(Scope *);   // pass 3 semantic analysis
+    void semantic();    // semantic analysis
+    void semantic2();   // pass 2 semantic analysis
+    void semantic3();   // pass 3 semantic analysis
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
     bool isPackageAccessible(Package *p, Prot protection, int flags = 0);

--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -127,9 +127,9 @@ public:
     bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.
     Module *parse();    // syntactic parse
     void importAll(Scope *sc);
-    void semantic();    // semantic analysis
-    void semantic2();   // pass 2 semantic analysis
-    void semantic3();   // pass 3 semantic analysis
+    void doSemanticPass1();   // pass 1 semantic analysis
+    void doSemanticPass2();   // pass 2 semantic analysis
+    void doSemanticPass3();   // pass 3 semantic analysis
     int needModuleInfo();
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
     bool isPackageAccessible(Package *p, Prot protection, int flags = 0);

--- a/test/compilable/imports/fwdref2_test17548.d
+++ b/test/compilable/imports/fwdref2_test17548.d
@@ -1,0 +1,8 @@
+module fwdref2_test17548;
+
+import test17548;
+
+struct S2 {
+    void bar(int arg = .test17548.cnst) {}
+    S1 s;
+}

--- a/test/compilable/test17548.d
+++ b/test/compilable/test17548.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -c
+
+module test17548;
+
+struct S1 {
+    void foo(scope S2 arg) {}
+    int myField;
+}
+
+enum cnst = 4321;
+
+import imports.fwdref2_test17548;


### PR DESCRIPTION
This PR
- reverts #6001 and #6038 , because #6001  caused a regression : https://issues.dlang.org/show_bug.cgi?id=17548 .
- adds the testcase from dlang issue 17548
- renames Module.semantic*, such that it is clear that it is not accidental that Dsymbol.semantic* are not overridden (this was the original intent of #6001).
