### PR TITLE
Alternative fix to issue 17548 - [REG2.072.0] Forward reference error with scope function parameters

### DIFF
--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -323,10 +323,8 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             userAttribDecl = sc.userAttribDecl;
         }
         else if (symtab && !scx)
-        {
-            semanticRun = PASSsemanticdone;
             return;
-        }
+
         semanticRun = PASSsemantic;
 
         if (!members) // if opaque declaration
@@ -374,6 +372,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         {
             assert(type.ty == Terror);
             sc2.pop();
+            semanticRun = PASSsemanticdone;
             return;
         }
         /* Following special member functions creation needs semantic analysis

--- a/test/compilable/imports/fwdref2_test17548.d
+++ b/test/compilable/imports/fwdref2_test17548.d
@@ -1,0 +1,9 @@
+module fwdref2_test17548;
+
+import test17548;
+
+struct S2 {
+    void bar(int arg = .test17548.cnst) {}
+    S1 s;
+    import fwdref2_test17548;
+}

--- a/test/compilable/test17548.d
+++ b/test/compilable/test17548.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -c
+
+module test17548;
+
+struct S1 {
+    void foo(scope S2 arg) {}
+    int myField;
+}
+
+enum cnst = 4321;
+
+import imports.fwdref2_test17548;


### PR DESCRIPTION
Previous PR: #6934

This one line fix ensures that if a `StructDeclaration.semantic()` call has to defer itself, `semanticRun` is set to `PASSsemantic`, because it may already have been set to `PASSsemanticdone` if a second `StructDeclaration.semantic()` call on the same struct happened while semantic'ing its members (see how in the Bugzilla issue) and then the deferred call would immediately return.