### PR TITLE
Use a proper fallback when `git describe` fails

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -470,10 +470,7 @@ $G/idgen: $D/idgen.d $(HOST_DMD_PATH)
 
 VERSION := $(shell cat ../VERSION) # default to checked-in VERSION file
 ifneq (1,$(RELEASE)) # unless building a release
-	VERSION_GIT := $(shell printf "`$(GIT) describe --dirty`") # use git describe
-	ifneq (,$(VERSION_GIT)) # check for git failures
-		VERSION := $(VERSION_GIT)
-	endif
+	VERSION := $(shell printf "`$(GIT) describe --dirty || cat ../VERSION`") # use git describe
 endif
 
 # only update $G/VERSION when it differs to avoid unnecessary rebuilds


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/6935 broke CircleCi on Phobos, because now `git describe` failures lead to hard errors and abortion of the build process.
The fix even removes two lines :)

CC @CyberShadow @MartinNowak 