### PR TITLE
Use a proper fallback when `git describe` fails

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -470,10 +470,7 @@ $G/idgen: $D/idgen.d $(HOST_DMD_PATH)
 
 VERSION := $(shell cat ../VERSION) # default to checked-in VERSION file
 ifneq (1,$(RELEASE)) # unless building a release
-	VERSION_GIT := $(shell printf "`$(GIT) describe --dirty`") # use git describe
-	ifneq (,$(VERSION_GIT)) # check for git failures
-		VERSION := $(VERSION_GIT)
-	endif
+	VERSION := $(shell printf "`$(GIT) describe --dirty || cat ../VERSION`") # use git describe
 endif
 
 # only update $G/VERSION when it differs to avoid unnecessary rebuilds


### PR DESCRIPTION
Due to https://github.com/dlang/dmd/pull/6940 the fix from https://github.com/dlang/dmd/pull/6941 is also needed for `master`, see e.g. https://github.com/dlang/phobos/pull/5514

I cherry-picked the same commit to keep things simple as I would like to get CircleCi working at Phobos.

CC @MartinNowak @CyberShadow 

> Using VERSION without anything else seems a bit more misleading as it can then be confused with a tagged release.

Usually `git describe` shouldn't fail and if it's probably a source ball archive. Anyhow my main focus here is really fixing CircleCi - we can always change the behavior in a follow-up.