### PR TITLE
Improve error syntax highlighting colors

### DIFF
--- a/src/ddmd/console.d
+++ b/src/ddmd/console.d
@@ -21,14 +21,23 @@ extern (C) int isatty(int);
 
 enum Color : int
 {
-    black     = 0,
-    red       = 1,
-    green     = 2,
-    blue      = 4,
-    yellow    = red | green,
-    magenta   = red | blue,
-    cyan      = green | blue,
-    white     = red | green | blue,
+    black         = 0,
+    red           = 1,
+    green         = 2,
+    blue          = 4,
+    yellow        = red | green,
+    magenta       = red | blue,
+    cyan          = green | blue,
+    lightGray     = red | green | blue,
+    bright        = 8,
+    darkGray      = bright | black,
+    brightRed     = bright | red,
+    brightGreen   = bright | green,
+    brightBlue    = bright | blue,
+    brightYellow  = bright | yellow,
+    brightMagenta = bright | magenta,
+    brightCyan    = bright | cyan,
+    white         = bright | lightGray,
 }
 
 struct Console
@@ -107,17 +116,16 @@ struct Console
          * Set color and intensity.
          * Params:
          *      color = the color
-         *      bright = turn intensity on
          */
-        void setColor(Color color, bool bright)
+        void setColor(Color color)
         {
             enum FOREGROUND_WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
             WORD attr = sbi.wAttributes;
             attr = (attr & ~(FOREGROUND_WHITE | FOREGROUND_INTENSITY)) |
-                   ((color & Color.red)   ? FOREGROUND_RED   : 0) |
-                   ((color & Color.green) ? FOREGROUND_GREEN : 0) |
-                   ((color & Color.blue)  ? FOREGROUND_BLUE  : 0) |
-                   (bright ? FOREGROUND_INTENSITY : 0);
+                   ((color & Color.red)    ? FOREGROUND_RED   : 0) |
+                   ((color & Color.green)  ? FOREGROUND_GREEN : 0) |
+                   ((color & Color.blue)   ? FOREGROUND_BLUE  : 0) |
+                   ((color & Color.bright) ? FOREGROUND_INTENSITY : 0);
             SetConsoleTextAttribute(handle, attr);
         }
 
@@ -175,9 +183,9 @@ struct Console
             fprintf(_fp, "\033[%dm", bright);
         }
 
-        void setColor(Color color, bool bright)
+        void setColor(Color color)
         {
-            fprintf(_fp, "\033[%d;%dm", bright, 30 + cast(int)color);
+            fprintf(_fp, "\033[%d;%dm", color & Color.bright ? 1 : 0, 30 + (color & ~Color.bright));
         }
 
         void resetColor()
@@ -199,7 +207,7 @@ struct Console
             assert(0);
         }
 
-        void setColor(Color color, bool bright)
+        void setColor(Color color)
         {
             assert(0);
         }

--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -24,10 +24,10 @@ import ddmd.console;
  */
 enum Classification
 {
-    error = Color.red,          /// for errors
-    gagged = Color.blue,        /// for gagged errors
-    warning = Color.yellow,     /// for warnings
-    deprecation = Color.magenta,/// for deprecations
+    error = Color.brightRed,          /// for errors
+    gagged = Color.brightBlue,        /// for gagged errors
+    warning = Color.brightYellow,     /// for warnings
+    deprecation = Color.brightMagenta,/// for deprecations
 }
 
 /**************************************
@@ -126,7 +126,7 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
         mem.xfree(cast(void*)p);
     }
     if (con)
-        con.setColor(headerColor, true);
+        con.setColor(headerColor);
     fputs(header, stderr);
     if (con)
         con.resetColor();
@@ -294,11 +294,11 @@ enum HIGHLIGHT : ubyte
 {
     Default    = Color.black,           // back to whatever the console is set at
     Escape     = '\xFF',                // highlight Color follows
-    Identifier = Color.magenta,
-    Keyword    = Color.blue,
-    String     = Color.red,
-    Comment    = Color.cyan,
-    Other      = Color.green,           // other tokens
+    Identifier = Color.brightMagenta,
+    Keyword    = Color.brightBlue,
+    String     = Color.brightRed,
+    Comment    = Color.brightCyan,
+    Other      = Color.brightGreen,     // other tokens
 }
 
 /**************************************************
@@ -403,7 +403,7 @@ private void writeHighlights(Console* con, const OutBuffer *buf)
             }
             else
             {
-                con.setColor(cast(Color)color, true);
+                con.setColor(cast(Color)color);
                 colors = true;
             }
         }

--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -25,9 +25,9 @@ import ddmd.console;
 enum Classification
 {
     error = Color.red,          /// for errors
-    gagged = Color.magenta,     /// for gagged errors
+    gagged = Color.blue,        /// for gagged errors
     warning = Color.yellow,     /// for warnings
-    deprecation = Color.blue,  /// for deprecations
+    deprecation = Color.magenta,/// for deprecations
 }
 
 /**************************************

--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -322,7 +322,7 @@ private void colorHighlightCode(OutBuffer* buf)
     ++nested;
 
     auto gaggedErrorsSave = global.startGagging();
-    scope Lexer lex = new Lexer(null, cast(char*)buf.data, 0, buf.offset - 1, 0, 0);
+    scope Lexer lex = new Lexer(null, cast(char*)buf.data, 0, buf.offset - 1, 0, 1);
     OutBuffer res;
     const(char)* lastp = cast(char*)buf.data;
     //printf("colorHighlightCode('%.*s')\n", buf.offset - 1, buf.data);

--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -27,7 +27,7 @@ enum Classification
     error = Color.brightRed,          /// for errors
     gagged = Color.brightBlue,        /// for gagged errors
     warning = Color.brightYellow,     /// for warnings
-    deprecation = Color.brightMagenta,/// for deprecations
+    deprecation = Color.brightCyan,   /// for deprecations
 }
 
 /**************************************
@@ -294,11 +294,11 @@ enum HIGHLIGHT : ubyte
 {
     Default    = Color.black,           // back to whatever the console is set at
     Escape     = '\xFF',                // highlight Color follows
-    Identifier = Color.brightMagenta,
-    Keyword    = Color.brightBlue,
-    String     = Color.brightRed,
-    Comment    = Color.brightCyan,
-    Other      = Color.brightGreen,     // other tokens
+    Identifier = Color.white,
+    Keyword    = Color.white,
+    Literal    = Color.white,
+    Comment    = Color.darkGray,
+    Other      = Color.cyan,           // other tokens
 }
 
 /**************************************************
@@ -343,8 +343,11 @@ private void colorHighlightCode(OutBuffer* buf)
         case TOKcomment:
             highlight = HIGHLIGHT.Comment;
             break;
+        case TOKint32v:
+            ..
+        case TOKdcharv:
         case TOKstring:
-            highlight = HIGHLIGHT.String;
+            highlight = HIGHLIGHT.Literal;
             break;
         default:
             if (tok.isKeyword())
@@ -400,6 +403,13 @@ private void writeHighlights(Console* con, const OutBuffer *buf)
             {
                 con.resetColor();
                 colors = false;
+            }
+            else
+            if (color == Color.white)
+            {
+                con.resetColor();
+                con.setColorBright(true);
+                colors = true;
             }
             else
             {


### PR DESCRIPTION
To [quote](https://github.com/dlang/dmd/pull/6777#issuecomment-301279251) @WalterBright:

> I'll leave it to someone with better color sense to pick better colors.

This is a PR for tweaking the color scheme of the new syntax highlighting in DMD error messages. However, since it's likely there's not going to be consensus on which color scheme is best, I'm going to post a few options, each in their own comment, and let GitHub votes (# of thumbs up) decide on the one to go with.

My goals for choosing colors were:
- Ensure the choice is legible in major terminal emulators for all major platforms;
- Avoid using colors already used elsewhere (e.g. for the Error/Warning/Deprecation message labels);
- Avoid colors that are so bright that they are distracting or annoying;
- It should still be visible at a glance which part of the error message represents D syntax, as in many places the highlighting replaced quote characters that indicated this previously.

In all screenshots, the terminals are (in order): macOS Sierra (10.12) Terminal.app; Ubuntu 16.04 default terminal; Windows 10 console.

If anyone has specific color suggestions, I can render previews and put them up here for voting. 