### PR TITLE
fix issue 17559 - [REG2.073.0] Wrong line number in stack trace

### DIFF
--- a/src/ddmd/backend/cgcod.c
+++ b/src/ddmd/backend/cgcod.c
@@ -2621,15 +2621,15 @@ void codelem(CodeBuilder& cdb,elem *e,regm_t *pretregs,bool constflag)
   if (!constflag && *pretregs & (mES | ALLREGS | mBP | XMMREGS) & ~regcon.mvar)
         *pretregs &= ~regcon.mvar;                      /* can't use register vars */
 
-    if (configv.addlinenumbers && e->Esrcpos.Slinnum)
-        cdb.genlinnum(e->Esrcpos);
-
     unsigned op = e->Eoper;
     if (e->Ecount && e->Ecount != e->Ecomsub)     // if common subexp
     {
         comsub(cdb,e,pretregs);
         goto L1;
     }
+
+    if (configv.addlinenumbers && e->Esrcpos.Slinnum)
+        cdb.genlinnum(e->Esrcpos);
 
   switch (op)
   {

--- a/test/runnable/test17559.d
+++ b/test/runnable/test17559.d
@@ -1,5 +1,7 @@
-// REQUIRED_ARGS: -g -L-export-dynamic
+// REQUIRED_ARGS: -g
+// REQUIRED_ARGS(linux freebsd): -L-export-dynamic
 // PERMUTE_ARGS:
+// DISABLED: osx
 
 import core.stdc.stdio;
 

--- a/test/runnable/test17559.d
+++ b/test/runnable/test17559.d
@@ -1,0 +1,82 @@
+// REQUIRED_ARGS: -g -L-export-dynamic
+// PERMUTE_ARGS:
+
+import core.stdc.stdio;
+
+void main()
+{
+    fun(1);
+    fun(2);
+    fun(3);
+#line 30
+    fun(4);
+
+    foo(1, 10);
+    foo(2, 10);
+    foo(3, 10);
+#line 40
+    foo(4, 10);
+}
+
+void fun(int n, int defParam = 10)
+{
+    try
+    {
+        if (n == 4)
+            throw new Exception("fun");
+    }
+    catch(Exception e)
+    {
+        string s = e.toString();
+        printf("%.*s\n", cast(int)s.length, s.ptr);
+        int line = lineInMain(e.toString());
+        assert(line >= 30 && line <= 32); // return address might be next statement
+    }
+}
+
+void foo(int n, int m)
+{
+    try
+    {
+        if (n == 4)
+            throw new Exception("foo");
+    }
+    catch(Exception e)
+    {
+        string s = e.toString();
+        printf("%.*s\n", cast(int)s.length, s.ptr);
+        int line = lineInMain(e.toString());
+        assert(line >= 40 && line <= 41); // return address might be next statement
+    }
+}
+
+int lineInMain(string msg)
+{
+    // find line number of _Dmain in stack trace
+    // on linux:   file.d:line _Dmain [addr]
+    // on windows: addr in _Dmain at file.d(line)
+    int line = 0;
+    bool mainFound = false;
+    for (size_t pos = 0; pos + 6 < msg.length; pos++)
+    {
+        if (msg[pos] == '\n')
+        {
+            line = 0;
+            mainFound = false;
+        }
+        else if ((msg[pos] == ':' || msg[pos] == '(') && line == 0)
+        {
+            for (pos++; pos < msg.length && msg[pos] >= '0' && msg[pos] <= '9'; pos++)
+                line = line * 10 + msg[pos] - '0';
+            if (line > 0 && mainFound)
+                return line;
+        }
+        else if (msg[pos .. pos + 6] == "_Dmain" || msg[pos .. pos + 6] == "D main")
+        {
+            mainFound = true;
+            if (line > 0 && mainFound)
+                return line;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Do not generate debug line information for reuse of common sub expressions.

This also adds new syntax to d_do_test to enable OS specific command line arguments: if the test variable is followed by '(', a list of targets terminated by ')' can be specified to not apply the variable on other targets, e.g.:
```// REQUIRED_ARGS(linux freebsd): -L-export-dynamic```


~~This disables any optimizations in non-optimized builds. They badly effect the debug experience.~~

~~I measured the impact on build phobos unittests without optimizations (not the same system as for the demangling benchmarks):~~

|             | master | this PR
|---------|--------|--------
build time | 2min32s | 2min29s
exec time | 38.0s | 38.2s




