### PR TITLE
improve compiletime floatingpoint to behave a little more like runtim…

### DIFF
--- a/src/ddmd/constfold.d
+++ b/src/ddmd/constfold.d
@@ -72,7 +72,13 @@ extern (C++) UnionExp Neg(Type type, Expression e1)
     Loc loc = e1.loc;
     if (e1.type.isreal())
     {
-        emplaceExp!(RealExp)(&ue, loc, -e1.toReal(), type);
+        auto ty = e1.type.ty;
+        if (ty == Tfloat32)
+                emplaceExp!(RealExp)(&ue, loc, { float r = e1.toReal();r = -r; return r; }(), type);
+        else if (ty == Tfloat64)
+            emplaceExp!(RealExp)(&ue, loc, { double r = e1.toReal();r = -r; return r; }(), type);
+        else
+            emplaceExp!(RealExp)(&ue, loc, -e1.toReal(), type);
     }
     else if (e1.type.isimaginary())
     {
@@ -122,7 +128,12 @@ extern (C++) UnionExp Add(Loc loc, Type type, Expression e1, Expression e2)
     }
     if (type.isreal())
     {
-        emplaceExp!(RealExp)(&ue, loc, e1.toReal() + e2.toReal(), type);
+        if (type.ty == Tfloat32)
+            emplaceExp!(RealExp)(&ue, loc, { float r; float a = e1.toReal(); float b = e2.toReal(); r = a + b; return r; }(), type);
+        else if (type.ty == Tfloat64)
+            emplaceExp!(RealExp)(&ue, loc, { double r; double a = e1.toReal(); double b = e2.toReal(); r = a + b; return r; }(), type);
+        else
+            emplaceExp!(RealExp)(&ue, loc, e1.toReal() + e2.toReal(), type);
     }
     else if (type.isimaginary())
     {
@@ -225,7 +236,12 @@ extern (C++) UnionExp Min(Loc loc, Type type, Expression e1, Expression e2)
     UnionExp ue;
     if (type.isreal())
     {
-        emplaceExp!(RealExp)(&ue, loc, e1.toReal() - e2.toReal(), type);
+        if (type.ty == Tfloat32)
+            emplaceExp!(RealExp)(&ue, loc, { float r; float a = e1.toReal(); float b = e2.toReal(); r = a - b; return r; }(), type);
+        else if (type.ty == Tfloat64)
+            emplaceExp!(RealExp)(&ue, loc, { double r; double a = e1.toReal(); double b = e2.toReal(); r = a - b; return r; }(), type);
+        else
+            emplaceExp!(RealExp)(&ue, loc, e1.toReal() - e2.toReal(), type);
     }
     else if (type.isimaginary())
     {
@@ -322,6 +338,19 @@ extern (C++) UnionExp Min(Loc loc, Type type, Expression e1, Expression e2)
 extern (C++) UnionExp Mul(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue;
+
+    if (type.isreal() && e1.type.isreal() && e2.type.isreal())
+    {
+        if (type.ty == Tfloat32)
+            emplaceExp!(RealExp)(&ue, loc, { float r; float a = e1.toReal(); float b = e2.toReal(); r = a * b; return r; }(), type);
+        else if (type.ty == Tfloat64)
+            emplaceExp!(RealExp)(&ue, loc, { double r; double a = e1.toReal(); double b = e2.toReal(); r = a * b; return r; }(), type);
+        else
+            emplaceExp!(RealExp)(&ue, loc, e1.toReal() * e2.toReal(), type);
+
+        return ue;
+    }
+
     if (type.isfloating())
     {
         auto c = complex_t(CTFloat.zero);
@@ -371,6 +400,19 @@ extern (C++) UnionExp Mul(Loc loc, Type type, Expression e1, Expression e2)
 extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue;
+
+    if (type.isreal() && e1.type.isreal() && e2.type.isreal())
+    {
+        if (type.ty == Tfloat32)
+            emplaceExp!(RealExp)(&ue, loc, { float r; float a = e1.toReal(); float b = e2.toReal(); r = a / b; return r; }(), type);
+        else if (type.ty == Tfloat64)
+            emplaceExp!(RealExp)(&ue, loc, { double r; double a = e1.toReal(); double b = e2.toReal(); r = a / b; return r; }(), type);
+        else
+            emplaceExp!(RealExp)(&ue, loc, e1.toReal() / e2.toReal(), type);
+
+        return ue;
+    }
+
     if (type.isfloating())
     {
         auto c = complex_t(CTFloat.zero);
@@ -462,6 +504,19 @@ extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
 extern (C++) UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
 {
     UnionExp ue;
+
+    if (type.isreal() && e1.type.isreal() && e2.type.isreal())
+    {
+        if (type.ty == Tfloat32)
+            emplaceExp!(RealExp)(&ue, loc, { float r; float a = e1.toReal(); float b = e2.toReal(); r = a % b; return r; }(), type);
+        else if (type.ty == Tfloat64)
+            emplaceExp!(RealExp)(&ue, loc, { double r; double a = e1.toReal(); double b = e2.toReal(); r = a % b; return r; }(), type);
+        else
+            emplaceExp!(RealExp)(&ue, loc, e1.toReal() % e2.toReal(), type);
+
+        return ue;
+    }
+
     if (type.isfloating())
     {
         auto c = complex_t(CTFloat.zero);


### PR DESCRIPTION
…e floatingpoint

This pr enforces `cast` to float or double if the result type is float or double.

which makes fp-math in the constant folder and therefore ctfe more like the runtime equivalent.
There are probably cases I have missed but those are not more wrong then before.
The following code used to fail.
```
float fmaddf(float a, float b, float c)
{
    return b + a * c;
}
static assert(fmaddf(6.7, 8.9, 1.3) == 0x1.19c28ep+4);
static assert(fmaddf(0x1.acccccp+2f, 0x1.166666p+3f, 0x1.4cccccp+0f) == 0x1.168f5cp+4f);
static assert(fmaddf(0x1.acccccp+2f, 0x1.166666p+3f, -0x1.4cccccp+0f) == -0x1.47a8p-7f);
```

with this pr it passes.