### PR TITLE
fix Issue 17545 - [REG2.072] __traits(getAttributes, name) evaluates …

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -8520,6 +8520,7 @@ extern (C++) final class DotIdExp : UnaExp
 {
     Identifier ident;
     bool noderef;       // true if the result of the expression will never be dereferenced
+    bool wantsym;       // do not replace Symbol with its initializer during semantic()
 
     extern (D) this(Loc loc, Expression e, Identifier ident)
     {
@@ -8772,8 +8773,12 @@ extern (C++) final class DotIdExp : UnaExp
                     if (v.type.ty == Terror)
                         return new ErrorExp();
 
-                    if ((v.storage_class & STCmanifest) && v._init)
+                    if ((v.storage_class & STCmanifest) && v._init && !wantsym)
                     {
+                        /* Normally, the replacement of a symbol with its initializer is supposed to be in semantic2().
+                         * Introduced by https://github.com/dlang/dmd/pull/5588 which should probably
+                         * be reverted. `wantsym` is the hack to work around the problem.
+                         */
                         if (v.inuse)
                         {
                             .error(loc, "circular initialization of %s '%s'", v.kind(), v.toPrettyChars());

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -773,6 +773,8 @@ class DotIdExp : public UnaExp
 {
 public:
     Identifier *ident;
+    bool noderef;       // true if the result of the expression will never be dereferenced
+    bool wantsym;       // do not replace Symbol with its initializer during semantic()
 
     static DotIdExp *create(Loc loc, Expression *e, Identifier *ident);
     Expression *semantic(Scope *sc);

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -734,6 +734,9 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         else if (e.ident == Id.getMember)
         {
+            if (ex.op == TOKdotid)
+                // Prevent semantic() from replacing Symbol with its initializer
+                (cast(DotIdExp)ex).wantsym = true;
             ex = ex.semantic(scx);
             return ex;
         }

--- a/test/compilable/test17545.d
+++ b/test/compilable/test17545.d
@@ -1,0 +1,16 @@
+/* TEST_OUTPUT:
+---
+tuple((Attrib))
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=17545
+
+module example;
+
+struct Attrib {}
+
+@Attrib enum TEST = 123;
+
+pragma(msg, __traits(getAttributes, 
+                     __traits(getMember, example, "TEST")));


### PR DESCRIPTION
…name to value prematurely

I hate adding flags like this, but it seemed the least disruptive way.