### PR TITLE
betterC on Win32: execute shared static ctors+dtors

### DIFF
--- a/changelog/betterC-STI-STD.dd
+++ b/changelog/betterC-STI-STD.dd
@@ -1,0 +1,36 @@
+-betterC switch now redirects shared static constructors and shared static destructors
+to the C library implementation of how this is done for C and C++ code. This is not
+guaranteed to work on all platforms, as this capability is not required by the C Standard.
+This implementation is for Win32 only. Other platforms will be supported in due course.
+
+Although D guarantees that static construction for imports occurs first,
+no such ordering guarantee is available with -betterC. Typically, however, the order
+matches the order in which object files are presente to the linker.
+
+Example:
+
+---
+import core.stdc.stdio;
+
+shared static this() {
+    printf("hello\n");
+}
+
+shared static ~this() {
+    printf("goodbye\n");
+}
+
+extern (C) int main() {
+    printf("main\n");
+    return 0;
+}
+---
+
+dmd test -betterC
+./test
+
+prints:
+
+hello
+main
+goodbye

--- a/src/ddmd/glue.d
+++ b/src/ddmd/glue.d
@@ -177,9 +177,16 @@ void obj_write_deferred(Library library)
 
 /***********************************************
  * Generate function that calls array of functions and gates.
+ * Params:
+ *      m = module symbol (for name mangling purposes)
+ *      sctors = array of functions
+ *      ectorgates = array of gates
+ *      id = identifier string for generator function
+ * Returns:
+ *      function Symbol generated
  */
 
-Symbol *callFuncsAndGates(Module m, symbols *sctors, StaticDtorDeclarations *ectorgates,
+private Symbol *callFuncsAndGates(Module m, symbols *sctors, StaticDtorDeclarations *ectorgates,
         const(char)* id)
 {
     Symbol *sctor = null;
@@ -198,6 +205,7 @@ Symbol *callFuncsAndGates(Module m, symbols *sctors, StaticDtorDeclarations *ect
         }
 
         localgot = null;
+
         sctor = toSymbolX(m, id, SCglobal, t, "FZv");
         cstate.CSpsymtab = &sctor.Sfunc.Flocsym;
         elem *ector = null;
@@ -483,6 +491,14 @@ void genObjFile(Module m, bool multiobj)
         m.ssharedctor = callFuncsAndGates(m, &ssharedctors, cast(StaticDtorDeclarations *)&esharedctorgates, "__modsharedctor");
         m.sshareddtor = callFuncsAndGates(m, &sshareddtors, null, "__modshareddtor");
         m.stest = callFuncsAndGates(m, &stests, null, "__modtest");
+
+        if (global.params.betterC)
+        {
+            if (m.ssharedctor)
+                objmod.setModuleCtorDtor(m.ssharedctor, true);
+            if (m.sshareddtor)
+                objmod.setModuleCtorDtor(m.sshareddtor, false);
+        }
 
         if (m.doppelganger)
             genModuleInfo(m);

--- a/test/runnable/betterCsharedctor.d
+++ b/test/runnable/betterCsharedctor.d
@@ -1,0 +1,21 @@
+/* REQUIRED_ARGS: -betterC
+ * PERMUTE_ARGS:
+ */
+
+import core.stdc.stdio;
+
+shared static this()
+{
+    printf("hello\n");
+}
+
+shared static ~this()
+{
+    printf("goodbye\n");
+}
+
+extern (C) int main()
+{
+    printf("main()\n");
+    return 0;
+}

--- a/test/runnable/betterCsharedctor2.d
+++ b/test/runnable/betterCsharedctor2.d
@@ -1,0 +1,16 @@
+/* REQUIRED_ARGS: -betterC
+ * PERMUTE_ARGS:
+ */
+
+import core.stdc.stdio;
+
+shared static ~this()
+{
+    printf("goodbye\n");
+}
+
+extern (C) int main()
+{
+    printf("main()\n");
+    return 0;
+}

--- a/test/runnable/betterCsharedctor3.d
+++ b/test/runnable/betterCsharedctor3.d
@@ -1,0 +1,16 @@
+/* REQUIRED_ARGS: -betterC
+ * PERMUTE_ARGS:
+ */
+
+import core.stdc.stdio;
+
+shared static this()
+{
+    printf("hello\n");
+}
+
+extern (C) int main()
+{
+    printf("main()\n");
+    return 0;
+}


### PR DESCRIPTION
This uses the mechanism Digital Mars C++ uses to call C++ static constructors and destructors to call D shared static constructors and destructors in `-betterC` mode.

Each C compiler does it differently, so some research is necessary to figure it out for other platforms.