### PR TITLE
refactor: convert Obj.funcptr() to Obj.setModuleCtorDtor()

### DIFF
--- a/src/ddmd/backend/cgobj.c
+++ b/src/ddmd/backend/cgobj.c
@@ -1724,11 +1724,14 @@ void Obj::staticdtor(Symbol *s)
 
 
 /***************************************
- * Stuff pointer to function in its own segment.
- * Used for static ctor and dtor lists.
+ * Set up function to be called as static constructor on program
+ * startup or static destructor on program shutdown.
+ * Params:
+ *      s = function symbol
+ *      isCtor = true if constructor, false if destructor
  */
 
-void Obj::funcptr(Symbol *s)
+void Obj::setModuleCtorDtor(Symbol *s, bool isCtor)
 {
     // We need to always put out the segments in triples, so that the
     // linker will put them in the correct order.
@@ -1742,16 +1745,15 @@ void Obj::funcptr(Symbol *s)
     static int lnamesize[4] = { 4+3+4,4+3+4,5+4+5,5+4+5 };
 
     int dsegattr;
-    int i;
 
     symbol_debug(s);
-#ifdef DEBUG
+#if defined(DEBUG) && SCPP
     assert(memcmp(s->Sident,"_ST",3) == 0);
 #endif
 
     // Determine if constructor or destructor
     // _STI... is a constructor, _STD... is a destructor
-    i = s->Sident[3] == 'D';
+    int i = !isCtor;
     // Determine if near or far function
     if (tyfarfunc(s->Stype->Tty))
         i += 2;

--- a/src/ddmd/backend/elfobj.c
+++ b/src/ddmd/backend/elfobj.c
@@ -1639,9 +1639,9 @@ void Obj::staticdtor(Symbol *s)
  * Used for static ctor and dtor lists.
  */
 
-void Obj::funcptr(Symbol *s)
+void Obj::setModuleCtorDtor(Symbol *s, bool isCtor)
 {
-    //dbg_printf("Obj::funcptr(%s) \n",s->Sident);
+    //dbg_printf("Obj::setModuleCtorDtor(%s) \n",s->Sident);
 }
 
 

--- a/src/ddmd/backend/machobj.c
+++ b/src/ddmd/backend/machobj.c
@@ -1716,9 +1716,9 @@ void Obj::staticdtor(Symbol *s)
  * Used for static ctor and dtor lists.
  */
 
-void Obj::funcptr(Symbol *s)
+void Obj::setModuleCtorDtor(Symbol *s, bool isCtor)
 {
-    //dbg_printf("Obj::funcptr(%s) \n",s->Sident);
+    //dbg_printf("Obj::setModuleCtorDtor(%s) \n",s->Sident);
 }
 
 

--- a/src/ddmd/backend/mscoffobj.c
+++ b/src/ddmd/backend/mscoffobj.c
@@ -1181,9 +1181,9 @@ void MsCoffObj::staticdtor(Symbol *s)
  * Used for static ctor and dtor lists.
  */
 
-void MsCoffObj::funcptr(Symbol *s)
+void MsCoffObj::setModuleCtorDtor(Symbol *s, bool isCtor)
 {
-    //dbg_printf("MsCoffObj::funcptr(%s) \n",s->Sident);
+    //dbg_printf("MsCoffObj::setModuleCtorDtor(%s) \n",s->Sident);
 }
 
 

--- a/src/ddmd/backend/obj.d
+++ b/src/ddmd/backend/obj.d
@@ -51,7 +51,7 @@ class Obj
     void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
     void staticctor(Symbol *s,int dtor,int seg);
     void staticdtor(Symbol *s);
-    void funcptr(Symbol *s);
+    void setModuleCtorDtor(Symbol *s, bool isCtor);
     void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     void ehsections();
     void moduleinfo(Symbol *scc);
@@ -128,7 +128,7 @@ class MsCoffObj : Obj
 //    void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
     override void staticctor(Symbol *s,int dtor,int seg);
     override void staticdtor(Symbol *s);
-    override void funcptr(Symbol *s);
+    override void setModuleCtorDtor(Symbol *s, bool isCtor);
     override void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     override void ehsections();
     override void moduleinfo(Symbol *scc);
@@ -221,7 +221,7 @@ class Obj
     static void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
     static void staticctor(Symbol *s,int dtor,int seg);
     static void staticdtor(Symbol *s);
-    static void funcptr(Symbol *s);
+    static void setModuleCtorDtor(Symbol *s, bool isCtor);
     static void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     static void ehsections();
     static void moduleinfo(Symbol *scc);

--- a/src/ddmd/backend/obj.h
+++ b/src/ddmd/backend/obj.h
@@ -50,7 +50,7 @@ class Obj
     VIRTUAL void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
     VIRTUAL void staticctor(Symbol *s,int dtor,int seg);
     VIRTUAL void staticdtor(Symbol *s);
-    VIRTUAL void funcptr(Symbol *s);
+    VIRTUAL void setModuleCtorDtor(Symbol *s, bool isCtor);
     VIRTUAL void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     VIRTUAL void ehsections();
     VIRTUAL void moduleinfo(Symbol *scc);
@@ -161,7 +161,7 @@ class MsCoffObj : public Obj
 //    VIRTUAL void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
     VIRTUAL void staticctor(Symbol *s,int dtor,int seg);
     VIRTUAL void staticdtor(Symbol *s);
-    VIRTUAL void funcptr(Symbol *s);
+    VIRTUAL void setModuleCtorDtor(Symbol *s, bool isCtor);
     VIRTUAL void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
     VIRTUAL void ehsections();
     VIRTUAL void moduleinfo(Symbol *scc);

--- a/src/ddmd/backend/out.c
+++ b/src/ddmd/backend/out.c
@@ -1426,7 +1426,7 @@ STATIC void writefunc2(symbol *sfunc)
         if (p[0] == '_' && p[1] == 'S' && p[2] == 'T' &&
             (p[3] == 'I' || p[3] == 'D'))
 #endif
-            objmod->funcptr(sfunc);
+            objmod->setModuleCtorDtor(sfunc, sfunc->Sident[3] == 'I');
     }
 
 Ldone:


### PR DESCRIPTION
Because https://github.com/dlang/dmd/pull/6956 has some controversy, I factored out the uncontroversial bits into this one.

I.e. redo Obj.funcptr() to make its name reflective of what it does, and remove its dependency on the specifics of the identifier so it can be ported to other platforms.