### PR TITLE
Fix issue 16746 - Please output Makefile-style depfiles for ninja and make

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -377,6 +377,18 @@ dmd -cov -unittest myprog.d
             source module to be compiled. This name can be overridden with
             the $(SWLINK -of) switch.`,
         ),
+        Option("M",
+            "generate make-style dependencies"
+        ),
+        Option("Mf<filename>",
+            "write make-style dependencies to filename"
+        ),
+        Option("Md<directory>",
+            "write make-style dependencies to directory"
+        ),
+        Option("Mt<name>",
+            "specifies the name of the target rule in the make depfile"
+        ),
         Option("m32",
             "generate 32 bit code",
             `$(UNIX Compile a 32 bit executable. This is the default for the 32 bit dmd.)

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -382,6 +382,7 @@ extern (C++) final class Module : Package
     Dsymbols* decldefs;         // top level declarations for this Module
 
     Modules aimports;           // all imported modules
+    Strings astringImports;     // all string-imported files
 
     uint debuglevel;            // debug level
     Identifiers* debugids;      // debug identifiers

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5302,6 +5302,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             ob.writestring(")");
             ob.writenl();
         }
+        sc.instantiatingModule().astringImports.push(name);
+
 
         {
             auto f = File(name);

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -208,6 +208,11 @@ struct Param
     const(char)* moduleDepsFile;        // filename for deps output
     OutBuffer* moduleDeps;              // contents to be written to deps file
 
+    bool doMakeDeps;                    /// generate make-style dependencies file
+    const(char)* makeDepsFile;          /// filename for make-style dependencies output
+    const(char)* makeDepsDir;           /// directory for make-style dependencies output
+    const(char)* makeDepsTarget;        /// the make target name
+
     // Hidden debug switches
     bool debugb;
     bool debugc;

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -180,6 +180,11 @@ struct Param
     const char *moduleDepsFile; // filename for deps output
     OutBuffer *moduleDeps;      // contents to be written to deps file
 
+    bool doMakeDeps;                  // generate make-style dependencies file
+    const char *makeDepsFile;         // filename for make-style dependencies output
+    const char *makeDepsDir;          // directory for make-style dependencies output
+    const char *makeDepsTarget;       // the generated make target name
+
     // Hidden debug switches
     bool debugb;
     bool debugc;

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -105,6 +105,7 @@ public:
     Dsymbols *decldefs;         // top level declarations for this Module
 
     Modules aimports;             // all imported modules
+    Strings astringImports;     // all string-imported files
 
     unsigned debuglevel;        // debug level
     Strings *debugids;      // debug identifiers

--- a/test/compilable/extra-files/makedeps.sh
+++ b/test/compilable/extra-files/makedeps.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+GDEPFILE=${RESULTS_DIR}/compilable/makedeps.dep
+GDEPFILE_a=${RESULTS_DIR}/compilable/makedeps_a.dep
+grep  'makedeps_[0-9]*.o:' ${GDEPFILE} || # some platforms use .obj instead of .o for object files.
+grep  'makedeps_[0-9]*.obj:' ${GDEPFILE}
+# The test runner will generate a single object file from both source files, hence the same target name
+grep  'makedeps_[0-9]*.o:'  ${GDEPFILE_a} ||
+grep  'makedeps_[0-9]*.obj:'  ${GDEPFILE_a}
+grep  'makedeps.d'  ${GDEPFILE}
+grep  'makedeps.sh'  ${GDEPFILE}
+grep  'makedeps_a.d'  ${GDEPFILE}
+grep  'object.d'  ${GDEPFILE}
+! grep  '__entrypoint'  ${GDEPFILE}
+rm -f ${GDEPFILE} ${GDEPFILE_a}

--- a/test/compilable/extra-files/makedeps2.sh
+++ b/test/compilable/extra-files/makedeps2.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+grep  "make\\ deps:"  ${RESULTS_DIR}/compilable/makedeps2.dep
+grep  'makedeps2.d'  ${RESULTS_DIR}/compilable/makedeps2.dep
+grep  'makedeps.sh'  ${RESULTS_DIR}/compilable/makedeps2.dep
+grep  'makedeps_a.d'  ${RESULTS_DIR}/compilable/makedeps2.dep
+grep  'object.d'  ${RESULTS_DIR}/compilable/makedeps2.dep
+! grep  '__entrypoint'  ${RESULTS_DIR}/compilable/makedeps2.dep
+rm -f ${RESULTS_DIR}/compilable/makedeps2.dep

--- a/test/compilable/extra-files/makedeps_a.d
+++ b/test/compilable/extra-files/makedeps_a.d
@@ -1,0 +1,5 @@
+module makedeps_a;
+
+void a_func()
+{
+}

--- a/test/compilable/makedeps.d
+++ b/test/compilable/makedeps.d
@@ -1,0 +1,17 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -Md${RESULTS_DIR}/compilable/ -Jcompilable/extra-files
+// POST_SCRIPT: compilable/extra-files/makedeps.sh
+// EXTRA_SOURCES: /extra-files/makedeps_a.d
+
+module makedeps;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum SH_TEXT = import("makedeps.sh");
+
+void main()
+{
+    a_func();
+}

--- a/test/compilable/makedeps2.d
+++ b/test/compilable/makedeps2.d
@@ -1,0 +1,17 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -M -Mf${RESULTS_DIR}/compilable/makedeps2.dep "-Mtmake deps" -Jcompilable/extra-files
+// POST_SCRIPT: compilable/extra-files/makedeps2.sh
+// EXTRA_SOURCES: /extra-files/makedeps_a.d
+
+module makedeps;
+
+// Test import statement
+import makedeps_a;
+
+// Test import expression
+enum SH_TEXT = import("makedeps.sh");
+
+void main()
+{
+    a_func();
+}


### PR DESCRIPTION
This adds `-M`, `-Mffile`, `-Mddirectory`, `-Mttarget` commandline options akin to C(++) compilers, and implements generation of make depfiles which can be used by buildsystems such as Ninja, Make or Meson.

Link to issue: https://issues.dlang.org/show_bug.cgi?id=16746