### PR TITLE
ddoc: avoid generating hardcoded characters

### DIFF
--- a/res/default_ddoc_theme.ddoc
+++ b/res/default_ddoc_theme.ddoc
@@ -2,6 +2,8 @@ LPAREN = (
 RPAREN = )
 BACKTICK = `
 DOLLAR = $
+LF =
+$(LF)
 
 ESCAPES =
   /</&lt;/
@@ -528,22 +530,22 @@ DDOC =
       </article>
     </div>
   </body>
-</html>
+</html>$(LF)
 
 DDOC_MODULE_MEMBERS = <section class="section ddoc_module_members_section">
   <div class="ddoc_module_members">
     $(DDOC_MEMBERS $0)
   </div>
-</section>
+</section>$(LF)
 
-DDOC_CLASS_MEMBERS = $(DDOC_MEMBERS $0)
-DDOC_STRUCT_MEMBERS = $(DDOC_MEMBERS $0)
-DDOC_ENUM_MEMBERS = $(DDOC_MEMBERS $0)
-DDOC_TEMPLATE_MEMBERS = $(DDOC_MEMBERS $0)
+DDOC_CLASS_MEMBERS = $(DDOC_MEMBERS $0)$(LF)
+DDOC_STRUCT_MEMBERS = $(DDOC_MEMBERS $0)$(LF)
+DDOC_ENUM_MEMBERS = $(DDOC_MEMBERS $0)$(LF)
+DDOC_TEMPLATE_MEMBERS = $(DDOC_MEMBERS $0)$(LF)
 
 DDOC_MEMBERS = <ul class="ddoc_members">
   $0
-</ul>
+</ul>$(LF)
 
 DDOC_MEMBER = <li class="ddoc_member">
   $0
@@ -580,13 +582,13 @@ DDOC_DECL_DD = <div class="ddoc_decl">
 
 DDOC_SECTIONS = <section class="section ddoc_sections">
   $0
-</section>
+</section>$(LF)
 
 DDOC_SUMMARY = <div class="ddoc_summary">
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_DESCRIPTION = <div class="ddoc_description">
   <h4>Discussion</h4>
@@ -600,14 +602,14 @@ DDOC_EXAMPLES = <div class="ddoc_examples">
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_RETURNS = <div class="ddoc_returns">
   <h4>Return Value</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_PARAMS = <div class="ddoc_params">
   <h4>Parameters</h4>
@@ -616,17 +618,17 @@ DDOC_PARAMS = <div class="ddoc_params">
       $0
     </tbody>
   </table>
-</div>
+</div>$(LF)
 
 DDOC_PARAM_ROW = <tr class="ddoc_param_row">
   $0
-</tr>
+</tr>$(LF)
 
 DDOC_PARAM_ID = <td scope="ddoc_param_id">
   <code class="code">
     <em class="term">$0</em>
   </code>
-</td>
+</td>$(LF)
 
 DDOC_PARAM_DESC = <td>
   <div class="ddoc_param_desc">
@@ -641,85 +643,85 @@ DDOC_LICENSE = <div class="ddoc_license">
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_AUTHORS = <div class="ddoc_authors">
   <h4>Authors</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_BUGS = <div class="ddoc_bugs">
   <h4>Bugs</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_COPYRIGHT = <div class="ddoc_copyright">
   <h4>Copyright</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_DATE = <div class="ddoc_date">
   <h4>Date</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_DEPRECATED = <div class="ddoc_deprecated">
   <h4>Deprecated</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_HISTORY = <div class="ddoc_history">
   <h4>History</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_SEE_ALSO = <div class="ddoc_see_also">
   <h4>See Also</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_STANDARDS = <div class="ddoc_standards">
   <h4>Standards</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_THROWS = <div class="ddoc_throws">
   <h4>Throws</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_VERSION = <div class="ddoc_version">
   <h4>Version</h4>
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
 DDOC_SECTION = <div class="ddoc_section">
   <p class="para">
     $0
   </p>
-</div>
+</div>$(LF)
 
-DDOC_SECTION_H = <span class="ddoc_section_h">$0</span>
+DDOC_SECTION_H = <span class="ddoc_section_h">$0:</span>$(LF)
 
 DDOC_DITTO = <br>
 $0

--- a/src/ddmd/doc.d
+++ b/src/ddmd/doc.d
@@ -134,7 +134,7 @@ extern (C++) class Section
                 buf.writeByte((c == '_') ? ' ' : c);
             }
             escapeStrayParenthesis(loc, buf, o);
-            buf.writestring(":)\n");
+            buf.writestring(")");
         }
         else
         {
@@ -145,7 +145,7 @@ extern (C++) class Section
         buf.write(_body, bodylen);
         escapeStrayParenthesis(loc, buf, o);
         highlightText(sc, a, buf, o);
-        buf.writestring(")\n");
+        buf.writestring(")");
     }
 }
 
@@ -252,7 +252,7 @@ extern (C++) final class ParamSection : Section
                         escapeStrayParenthesis(loc, buf, o);
                         highlightCode(sc, a, buf, o);
                     }
-                    buf.writestring(")\n");
+                    buf.writestring(")");
                     buf.writestring("$(DDOC_PARAM_DESC ");
                     {
                         size_t o = buf.offset;
@@ -262,7 +262,7 @@ extern (C++) final class ParamSection : Section
                     }
                     buf.writestring(")");
                 }
-                buf.writestring(")\n");
+                buf.writestring(")");
                 namelen = 0;
                 if (p >= pend)
                     break;
@@ -288,7 +288,7 @@ extern (C++) final class ParamSection : Section
         if (namelen)
             goto L1;
         // write out last one
-        buf.writestring(")\n");
+        buf.writestring(")");
         TypeFunction tf = a.dim == 1 ? isTypeFunction(s) : null;
         if (tf)
         {
@@ -438,7 +438,7 @@ extern (C++) void gendocfile(Module m)
     //printf("BODY= '%.*s'\n", buf.offset, buf.data);
     Macro.define(&m.macrotable, "BODY", buf.peekSlice());
     OutBuffer buf2;
-    buf2.writestring("$(DDOC)\n");
+    buf2.writestring("$(DDOC)");
     size_t end = buf2.offset;
     m.macrotable.expand(&buf2, 0, &end, null, 0);
     version (all)
@@ -801,7 +801,7 @@ extern (C++) void emitMemberComments(ScopeDsymbol sds, OutBuffer* buf, Scope* sc
         buf.offset = offset1;
     }
     else
-        buf.writestring(")\n");
+        buf.writestring(")");
 }
 
 extern (C++) void emitProtection(OutBuffer* buf, Prot prot)
@@ -1737,7 +1737,7 @@ struct DocComment
                 buf.write(sec._body, sec.bodylen);
                 escapeStrayParenthesis(loc, buf, o);
                 highlightText(sc, a, buf, o);
-                buf.writestring(")\n");
+                buf.writestring(")");
             }
             else
                 sec.write(loc, &this, sc, a, buf);
@@ -1780,7 +1780,7 @@ struct DocComment
             buf.writestring("\n");
         }
         else
-            buf.writestring(")\n");
+            buf.writestring(")");
     }
 }
 


### PR DESCRIPTION
ddoc generates a few spurious newlines and such that are annoying to deal with if precise output is to be generated. This PR moves the hardcoded characters into the macro definitions, thus improving flexibility.

This will fail at building documentation because of small differences. A follow-up PR will add the extra characters to the macros in dlang.org.