### PR TITLE
account for noreturn expressions in Reaching Definitions

### DIFF
--- a/src/ddmd/backend/gloop.c
+++ b/src/ddmd/backend/gloop.c
@@ -1005,15 +1005,34 @@ STATIC void markinvar(elem *n,vec_t rd)
                 markinvar(n->E1,rd);
                 tmp = vec_clone(rd);
                 markinvar(n->E2,tmp);
-                vec_orass(rd,tmp);              /* rd |= tmp            */
+                if (!el_noreturn(n->E2))
+                    vec_orass(rd,tmp);              // rd |= tmp
                 vec_free(tmp);
                 break;
         case OPcolon:
         case OPcolon2:
                 tmp = vec_clone(rd);
-                markinvar(n->E1,rd);
-                markinvar(n->E2,tmp);
-                vec_orass(rd,tmp);              /* rd |= tmp            */
+                switch (el_noreturn(n->E1) * 2 | el_noreturn(n->E2))
+                {
+                    case 0:
+                        markinvar(n->E1,rd);
+                        markinvar(n->E2,tmp);
+                        vec_orass(rd,tmp);              // rd |= tmp
+                        break;
+                    case 1:
+                        markinvar(n->E1,rd);
+                        markinvar(n->E2,tmp);
+                        break;
+                    case 2:
+                        markinvar(n->E1,tmp);
+                        markinvar(n->E2,rd);
+                        break;
+                    case 3:
+                        markinvar(n->E1,tmp);
+                        vec_copy(tmp,rd);
+                        markinvar(n->E2,tmp);
+                        break;
+                }
                 vec_free(tmp);
                 break;
         case OPaddr:            // mark addresses of OPvars as LI


### PR DESCRIPTION
Other flow analyses account for expressions that do not return, so Reaching Definitions should do it, too.