### PR TITLE
deprecate mixing AVX-256 usage and legacy SSE instructions

### DIFF
--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -4432,12 +4432,18 @@ extern (C++) final class TypeVector : Type
             error(loc, "SIMD vector types not supported on this platform");
             return terror;
         case 2:
-            // invalid size
-            error(loc, "%d byte vector type %s is not supported on this platform", sz, toChars());
-            return terror;
-        case 3:
             // invalid base type
             error(loc, "vector type %s is not supported on this platform", toChars());
+            return terror;
+        case 3:
+            // invalid size
+            if (sz == 32)
+            {
+                deprecation(loc, "%d byte vector types are only supported with -mcpu=avx", sz, toChars());
+                return merge();
+            }
+            else
+                error(loc, "%d byte vector type %s is not supported on this platform", sz, toChars());
             return terror;
         default:
             assert(0);

--- a/src/ddmd/target.d
+++ b/src/ddmd/target.d
@@ -254,15 +254,13 @@ struct Target
      * (in bytes) and element type `type`.
      *
      * Returns: 0 if the type is supported, or else: 1 if vector types are not
-     *     supported on the target at all, 2 if the given size isn't, or 3 if
-     *     the element type isn't.
+     *     supported on the target at all, 2 if the element type isn't, or 3 if
+     *     the given size isn't.
      */
     extern (C++) static int isVectorTypeSupported(int sz, Type type)
     {
         if (!global.params.is64bit && !global.params.isOSX)
             return 1; // not supported
-        if (sz != 16 && sz != 32)
-            return 2; // wrong size
         switch (type.ty)
         {
         case Tvoid:
@@ -278,8 +276,10 @@ struct Target
         case Tfloat64:
             break;
         default:
-            return 3; // wrong base type
+            return 2; // wrong base type
         }
+        if (sz != 16 && !(global.params.cpu >= CPU.avx && sz == 32))
+            return 3; // wrong size
         return 0;
     }
 

--- a/test/compilable/vector_types.d
+++ b/test/compilable/vector_types.d
@@ -1,0 +1,27 @@
+/*
+REQUIRED_ARGS: -o-
+PERMUTE_ARGS:
+TEST_OUTPUT:
+DISABLED: freebsd32 linux32 osx32 win32
+---
+compilable/vector_types.d(22): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(22): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(23): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(23): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(24): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(24): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(25): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(25): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(26): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(26): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(27): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+compilable/vector_types.d(27): Deprecation: 32 byte vector types are only supported with -mcpu=avx
+---
+*/
+version (D_SIMD):
+alias a = __vector(double[4]);
+alias b = __vector(float[8]);
+alias c = __vector(ulong[4]);
+alias d = __vector(uint[8]);
+alias e = __vector(ushort[16]);
+alias f = __vector(ubyte[32]);

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -37,29 +37,32 @@ static assert(uint4.sizeof == 16);
 static assert(long2.sizeof == 16);
 static assert(ulong2.sizeof == 16);
 
-static assert(void32.alignof == 32);
-static assert(double4.alignof == 32);
-static assert(float8.alignof == 32);
-static assert(byte32.alignof == 32);
-static assert(ubyte32.alignof == 32);
-static assert(short16.alignof == 32);
-static assert(ushort16.alignof == 32);
-static assert(int8.alignof == 32);
-static assert(uint8.alignof == 32);
-static assert(long4.alignof == 32);
-static assert(ulong4.alignof == 32);
+version (D_AVX)
+{
+    static assert(void32.alignof == 32);
+    static assert(double4.alignof == 32);
+    static assert(float8.alignof == 32);
+    static assert(byte32.alignof == 32);
+    static assert(ubyte32.alignof == 32);
+    static assert(short16.alignof == 32);
+    static assert(ushort16.alignof == 32);
+    static assert(int8.alignof == 32);
+    static assert(uint8.alignof == 32);
+    static assert(long4.alignof == 32);
+    static assert(ulong4.alignof == 32);
 
-static assert(void32.sizeof == 32);
-static assert(double4.sizeof == 32);
-static assert(float8.sizeof == 32);
-static assert(byte32.sizeof == 32);
-static assert(ubyte32.sizeof == 32);
-static assert(short16.sizeof == 32);
-static assert(ushort16.sizeof == 32);
-static assert(int8.sizeof == 32);
-static assert(uint8.sizeof == 32);
-static assert(long4.sizeof == 32);
-static assert(ulong4.sizeof == 32);
+    static assert(void32.sizeof == 32);
+    static assert(double4.sizeof == 32);
+    static assert(float8.sizeof == 32);
+    static assert(byte32.sizeof == 32);
+    static assert(ubyte32.sizeof == 32);
+    static assert(short16.sizeof == 32);
+    static assert(ushort16.sizeof == 32);
+    static assert(int8.sizeof == 32);
+    static assert(uint8.sizeof == 32);
+    static assert(long4.sizeof == 32);
+    static assert(ulong4.sizeof == 32);
+}
 
 /*****************************************/
 
@@ -1666,108 +1669,112 @@ void test16448()
 
 /*****************************************/
 
-void foo_byte32(byte t, byte s)
+version (D_AVX)
 {
-    byte32 f = s;
-    auto p = cast(byte*)&f;
-    foreach (i; 0 .. 32)
-        assert(p[i] == s);
-}
+    void foo_byte32(byte t, byte s)
+    {
+        byte32 f = s;
+        auto p = cast(byte*)&f;
+        foreach (i; 0 .. 32)
+            assert(p[i] == s);
+    }
 
-void foo_ubyte32(ubyte t, ubyte s)
+    void foo_ubyte32(ubyte t, ubyte s)
+    {
+        ubyte32 f = s;
+        auto p = cast(ubyte*)&f;
+        foreach (i; 0 .. 32)
+            assert(p[i] == s);
+    }
+
+    void foo_short16(short t, short s)
+    {
+        short16 f = s;
+        auto p = cast(short*)&f;
+        foreach (i; 0 .. 16)
+            assert(p[i] == s);
+    }
+
+    void foo_ushort16(ushort t, ushort s)
+    {
+        ushort16 f = s;
+        auto p = cast(ushort*)&f;
+        foreach (i; 0 .. 16)
+            assert(p[i] == s);
+    }
+
+    void foo_int8(int t, int s)
+    {
+        int8 f = s;
+        auto p = cast(int*)&f;
+        foreach (i; 0 .. 8)
+            assert(p[i] == s);
+    }
+
+    void foo_uint8(uint t, uint s, uint u)
+    {
+        uint8 f = s;
+        auto p = cast(uint*)&f;
+        foreach (i; 0 .. 8)
+            assert(p[i] == s);
+    }
+
+    void foo_long4(long t, long s, long u)
+    {
+        long4 f = s;
+        auto p = cast(long*)&f;
+        foreach (i; 0 .. 4)
+            assert(p[i] == s);
+    }
+
+    void foo_ulong4(ulong t, ulong s)
+    {
+        ulong4 f = s;
+        auto p = cast(ulong*)&f;
+        foreach (i; 0 .. 4)
+            assert(p[i] == s);
+    }
+
+    void foo_float8(float t, float s)
+    {
+        float8 f = s;
+        auto p = cast(float*)&f;
+        foreach (i; 0 .. 8)
+            assert(p[i] == s);
+    }
+
+    void foo_double4(double t, double s, double u)
+    {
+        double4 f = s;
+        auto p = cast(double*)&f;
+        foreach (i; 0 .. 4)
+            assert(p[i] == s);
+    }
+
+    void test16448_32()
+    {
+        foo_byte32(5, -10);
+        foo_ubyte32(5, 11);
+
+        foo_short16(5, -6);
+        foo_short16(5, 7);
+
+        foo_int8(5, -6);
+        foo_uint8(5, 0x12345678, 22);
+
+        foo_long4(5, -6, 1);
+        foo_ulong4(5, 0x12345678_87654321L);
+
+        foo_float8(5, -6);
+        foo_double4(5, -6, 2);
+    }
+}
+else
 {
-    ubyte32 f = s;
-    auto p = cast(ubyte*)&f;
-    foreach (i; 0 .. 32)
-        assert(p[i] == s);
+    void test16448_32()
+    {
+    }
 }
-
-void foo_short16(short t, short s)
-{
-    short16 f = s;
-    auto p = cast(short*)&f;
-    foreach (i; 0 .. 16)
-        assert(p[i] == s);
-}
-
-void foo_ushort16(ushort t, ushort s)
-{
-    ushort16 f = s;
-    auto p = cast(ushort*)&f;
-    foreach (i; 0 .. 16)
-        assert(p[i] == s);
-}
-
-void foo_int8(int t, int s)
-{
-    int8 f = s;
-    auto p = cast(int*)&f;
-    foreach (i; 0 .. 8)
-        assert(p[i] == s);
-}
-
-void foo_uint8(uint t, uint s, uint u)
-{
-    uint8 f = s;
-    auto p = cast(uint*)&f;
-    foreach (i; 0 .. 8)
-        assert(p[i] == s);
-}
-
-void foo_long4(long t, long s, long u)
-{
-    long4 f = s;
-    auto p = cast(long*)&f;
-    foreach (i; 0 .. 4)
-        assert(p[i] == s);
-}
-
-void foo_ulong4(ulong t, ulong s)
-{
-    ulong4 f = s;
-    auto p = cast(ulong*)&f;
-    foreach (i; 0 .. 4)
-        assert(p[i] == s);
-}
-
-void foo_float8(float t, float s)
-{
-    float8 f = s;
-    auto p = cast(float*)&f;
-    foreach (i; 0 .. 8)
-        assert(p[i] == s);
-}
-
-void foo_double4(double t, double s, double u)
-{
-    double4 f = s;
-    auto p = cast(double*)&f;
-    foreach (i; 0 .. 4)
-        assert(p[i] == s);
-}
-
-void test16448_32()
-{
-    import core.cpuid;
-    if (!core.cpuid.avx)
-        return;
-
-    foo_byte32(5, -10);
-    foo_ubyte32(5, 11);
-
-    foo_short16(5, -6);
-    foo_short16(5, 7);
-
-    foo_int8(5, -6);
-    foo_uint8(5, 0x12345678, 22);
-
-    foo_long4(5, -6, 1);
-    foo_ulong4(5, 0x12345678_87654321L);
-
-    foo_float8(5, -6);
-    foo_double4(5, -6, 2);
-}
-
 
 /*****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=16703
@@ -1847,19 +1854,22 @@ void test10447()
 /*****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=17237
 
-struct S17237
+version (D_AVX)
 {
-    bool a;
-    struct
+    struct S17237
     {
-        bool b;
-        int8 c;
+        bool a;
+        struct
+        {
+            bool b;
+            int8 c;
+        }
     }
-}
 
-static assert(S17237.a.offsetof == 0);
-static assert(S17237.b.offsetof == 32);
-static assert(S17237.c.offsetof == 64);
+    static assert(S17237.a.offsetof == 0);
+    static assert(S17237.b.offsetof == 32);
+    static assert(S17237.c.offsetof == 64);
+}
 
 /*****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=17344


### PR DESCRIPTION
- Don't configure the backend with avx=0, while still using AVX-256
  vectors in order to avoid mixing of vex and legacy SSE instructions.
- See https://software.intel.com/en-us/articles/intel-avx-state-transitions-migrating-sse-code-to-avx
  for information on possible penalties. While the backend could carefully
  avoid those it's cleaner to always use vex instructions when AVX-256
  registers are in use.
- check for base type first in isVectorTypeSupported to not produce 
  false hints (e.g. __vector(void*[4]) is only supported with -mcpu=avx)