### PR TITLE
Allow package.d files to have interface file counterparts

### DIFF
--- a/test/compilable/extra-files/pkgDIP37/test17629/common.di
+++ b/test/compilable/extra-files/pkgDIP37/test17629/common.di
@@ -1,0 +1,3 @@
+module pkgDIP37.test17629.common;
+
+void foo17629();

--- a/test/compilable/extra-files/pkgDIP37/test17629/package.di
+++ b/test/compilable/extra-files/pkgDIP37/test17629/package.di
@@ -1,0 +1,2 @@
+module pkgDIP37.test17629;
+public import pkgDIP37.test17629.common;

--- a/test/compilable/testDIP37.d
+++ b/test/compilable/testDIP37.d
@@ -25,7 +25,6 @@ void test4()
     static assert(!__traits(compiles, pkgDIP37.datetime.common.def()));
 }
 
-
 void test7()
 {
     static import pkgDIP37.datetime;
@@ -34,3 +33,9 @@ void test7()
     pkgDIP37.datetime.common.def();
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=17629
+void test17629()
+{
+    import pkgDIP37.test17629;
+    foo17629();
+}


### PR DESCRIPTION
This PR changes package.di files to be scanned prior to package.d files.
This is the same as ordinary modules where .di files are scanned first, and .d files are used if those do not exist.
