### PR TITLE
Remove prelude assert from ctors & dtors

### DIFF
--- a/changelog/removePreludeAssert.dd
+++ b/changelog/removePreludeAssert.dd
@@ -1,0 +1,5 @@
+Removed prelude assert for constructors & destructors
+
+The compiler used to insert an `assert(this, "null this");` at the start of constructors & destructors.
+To trigger these asserts one needed to construct or destruct an aggregate at the null memory location.
+This would crash upon any data member access, which is required for a constructor or destructor to do anything useful.


### PR DESCRIPTION
Removes prelude `assert(this !is null, "null this");` from constructors & destructors.
Trying to assign or access any members would crash anyway.


