### PR TITLE
Build compiler as a library

### DIFF
--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -33,7 +33,7 @@ import ddmd.hdrgen;
 import ddmd.id;
 import ddmd.identifier;
 import ddmd.init;
-import ddmd.mars;
+import ddmd.gencmain;
 import ddmd.mtype;
 import ddmd.nogc;
 import ddmd.objc;

--- a/src/ddmd/gencmain.d
+++ b/src/ddmd/gencmain.d
@@ -1,0 +1,71 @@
+module ddmd.gencmain;
+
+import ddmd.dmodule;
+import ddmd.dscope;
+import ddmd.parse;
+import ddmd.astcodegen;
+
+import ddmd.globals;
+import ddmd.id;
+import ddmd.identifier;
+import ddmd.tokens;
+
+/// DMD-generated module `__entrypoint` where the C main resides
+extern (C++) __gshared Module entrypoint = null;
+/// Module in which the D main is
+extern (C++) __gshared Module rootHasMain = null;
+
+
+/**
+ * Generate C main() in response to seeing D main().
+ *
+ * This function will generate a module called `__entrypoint`,
+ * and set the globals `entrypoint` and `rootHasMain`.
+ *
+ * This used to be in druntime, but contained a reference to _Dmain
+ * which didn't work when druntime was made into a dll and was linked
+ * to a program, such as a C++ program, that didn't have a _Dmain.
+ *
+ * Params:
+ *   sc = Scope which triggered the generation of the C main,
+ *        used to get the module where the D main is.
+ */
+extern (C++) void genCmain(Scope* sc)
+{
+    if (entrypoint)
+        return;
+    /* The D code to be generated is provided as D source code in the form of a string.
+     * Note that Solaris, for unknown reasons, requires both a main() and an _main()
+     */
+    immutable cmaincode =
+    q{
+        extern(C)
+        {
+            int _d_run_main(int argc, char **argv, void* mainFunc);
+            int _Dmain(char[][] args);
+            int main(int argc, char **argv)
+            {
+                return _d_run_main(argc, argv, &_Dmain);
+            }
+            version (Solaris) int _main(int argc, char** argv) { return main(argc, argv); }
+        }
+    };
+    Identifier id = Id.entrypoint;
+    auto m = new Module("__entrypoint.d", id, 0, 0);
+    scope p = new Parser!ASTCodegen(m, cmaincode, false);
+    p.scanloc = Loc();
+    p.nextToken();
+    m.members = p.parseModule();
+    assert(p.token.value == TOKeof);
+    assert(!p.errors); // shouldn't have failed to parse it
+    bool v = global.params.verbose;
+    global.params.verbose = false;
+    m.importedFrom = m;
+    m.importAll(null);
+    m.semantic(null);
+    m.semantic2(null);
+    m.semantic3(null);
+    global.params.verbose = v;
+    entrypoint = m;
+    rootHasMain = sc._module;
+}

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -35,6 +35,7 @@ import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.gencmain;
 import ddmd.globals;
 import ddmd.hdrgen;
 import ddmd.id;
@@ -185,67 +186,6 @@ Where:
   -Xf=<filename>   write JSON file to filename
 ", FileName.canonicalName(global.inifilename), fpic, m32mscoff, mscrtlib);
 }
-
-/// DMD-generated module `__entrypoint` where the C main resides
-extern (C++) __gshared Module entrypoint = null;
-/// Module in which the D main is
-extern (C++) __gshared Module rootHasMain = null;
-
-
-/**
- * Generate C main() in response to seeing D main().
- *
- * This function will generate a module called `__entrypoint`,
- * and set the globals `entrypoint` and `rootHasMain`.
- *
- * This used to be in druntime, but contained a reference to _Dmain
- * which didn't work when druntime was made into a dll and was linked
- * to a program, such as a C++ program, that didn't have a _Dmain.
- *
- * Params:
- *   sc = Scope which triggered the generation of the C main,
- *        used to get the module where the D main is.
- */
-extern (C++) void genCmain(Scope* sc)
-{
-    if (entrypoint)
-        return;
-    /* The D code to be generated is provided as D source code in the form of a string.
-     * Note that Solaris, for unknown reasons, requires both a main() and an _main()
-     */
-    immutable cmaincode =
-    q{
-        extern(C)
-        {
-            int _d_run_main(int argc, char **argv, void* mainFunc);
-            int _Dmain(char[][] args);
-            int main(int argc, char **argv)
-            {
-                return _d_run_main(argc, argv, &_Dmain);
-            }
-            version (Solaris) int _main(int argc, char** argv) { return main(argc, argv); }
-        }
-    };
-    Identifier id = Id.entrypoint;
-    auto m = new Module("__entrypoint.d", id, 0, 0);
-    scope p = new Parser!ASTCodegen(m, cmaincode, false);
-    p.scanloc = Loc();
-    p.nextToken();
-    m.members = p.parseModule();
-    assert(p.token.value == TOKeof);
-    assert(!p.errors); // shouldn't have failed to parse it
-    bool v = global.params.verbose;
-    global.params.verbose = false;
-    m.importedFrom = m;
-    m.importAll(null);
-    m.semantic(null);
-    m.semantic2(null);
-    m.semantic3(null);
-    global.params.verbose = v;
-    entrypoint = m;
-    rootHasMain = sc._module;
-}
-
 
 /**
  * DMD's real entry point

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -227,7 +227,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	arraytypes astcodegen attrib builtin canthrow clone complex cond constfold		\
 	cppmangle ctfeexpr dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol	\
-	dtemplate dversion escape expression expressionsem func			\
+	dtemplate dversion escape expression expressionsem func gencmain			\
 	hdrgen id impcnvtab imphint init initsem inline inlinecost intrange	\
 	json lib link mars mtype nogc nspace objc opover optimize parse sapply	\
 	sideeffect statement staticassert target traits visitor	\
@@ -388,8 +388,11 @@ ifdef ENABLE_LTO
 $G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_GLUE_OBJS) $(G_OBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
 	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
 else
-$G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/backend.a $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
-	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT),$^)
+$G/dmd: $G/dmd.a $D/mars.d $(STRING_IMPORT_FILES)
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -I$D -L-lstdc++ -J$G -J../res $(DFLAGS) $G/dmd.a $D/mars.d
+
+$G/dmd.a: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/backend.a $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -lib -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT) $D/mars.d,$^)
 endif
 
 


### PR DESCRIPTION
At the moment, I had to exclude ddmd/backend/outbuf.d from the library since the compilation would fail with the message : 

..\generated\windows\release\32\dmd.lib: Error: multiple definition of outbuf_829_3b2: ?reserve@Outbuffer@@QAEXI@Z and cgobj: ?reserve@Outbuffer@@QAEXI@Z
..\generated\windows\release\32\dmd.lib: Error: multiple definition of outbuf_829_3b2: ?clearn@Outbuffer@@QAEXI@Z and mscoffobj: ?clearn@Outbuffer@@QAEXI@Z
..\generated\windows\release\32\dmd.lib: Error: multiple definition of outbuf_829_3b2: ?writeByte@Outbuffer@@QAEXH@Z and outbuf: ?writeByte@Outbuffer@@QAEXH@Z
..\generated\windows\release\32\dmd.lib: Error: multiple definition of outbuf_829_3b2: ?writeShort@Outbuffer@@QAEXH@Z and cv8: ?writeShort@Outbuffer@@QAEXH@Z

In order to compile the library I had to exclude outbuf.d from the library and add it when the binary is built. I know this is not a solution, but I have no idea how to workaround this.