### PR TITLE
Only consider an identifier followed by a colon a tag if a newline follows the colon

### DIFF
--- a/changelog/ddoc-tag-deduction.dd
+++ b/changelog/ddoc-tag-deduction.dd
@@ -1,0 +1,38 @@
+Ddoc: tightening the conditions under which the sequence "identifier:" is deduced as a tag
+
+Previously, ddoc would deduce that an identifier occurring at the beginning of a
+line and followed by a colon (":") is a tag. The predefined tags (introducing
+the so-called $(HTTPS dlang.org/spec/ddoc.html#standard_srction, "Standard
+Sections")) are formatted with the `DDOC_SECTION` macro and have each one
+dedicated macro. All other detected tags are formatted with the `DDOC_SECTION_H`
+macro.
+
+A known problem with the previous tag detection mechanism was that it would be
+overactive, detecting tags where they were simply meant as regular text using
+":" as punctuation. Consider:
+
+----
+/**
+Lorem ipsum dolor sit amet, nam risus, sodales orci tempus sociis vel  lacinia,
+adipiscing vestibulum viverra ipsum, consequat vestibulum dolor quam in, ante
+accumsan amet tristique est sit. Depending on the input, the function frobnicate
+returns: (a) junk, (b) meh, or (c) something awesome.
+
+Returns:
+The result of frobnication.
+*/
+----
+
+The first occurence of "returns:" is in lowercase and part of regular text. It
+is sheer happenstance (e.g. a combination of text content and editor
+settings/author preference) whether the literal use of "returns:" occurs at the
+beginning of a line. The second occurrence of "Returns:", however, is a tag
+meant to highlight the homonym section of the documentation.
+
+Other examples of undesired tag detection include the use of hyperlinks
+("http:", "mailto:" etc) in text.
+
+To distinguish between textual use and the use as a tag, the new rule is: a tag
+is detected if (a) it is an identifier at the beginning of a line; (b) it is
+followed by a colon and a whitespace; and (c) it starts with an uppercase
+letter.

--- a/src/ddmd/doc.d
+++ b/src/ddmd/doc.d
@@ -1643,13 +1643,10 @@ struct DocComment
                     const(char)* q = p + utfStride(p);
                     while (isIdTail(q))
                         q += utfStride(q);
-                    if (*q == ':' &&            // 'identifier:' ends it
-                                                // but not 'http://' or 'https://'
-                        !(q[1] == '/' && q[2] == '/' &&
-                          (q - p == 4 && Port.memicmp(p, "http".ptr, 4) == 0 ||
-                           q - p == 5 && Port.memicmp(p, "https".ptr, 5) == 0)
-                         )
-                       )
+
+                    // Detected tag ends it
+                    if (*q == ':' && isupper(*p)
+                            && (isspace(q[1]) || q[1] == 0))
                     {
                         idlen = q - p;
                         idstart = p;

--- a/test/compilable/ddoc17697.d
+++ b/test/compilable/ddoc17697.d
@@ -11,6 +11,19 @@
  *    $(LINK2 http://www.food.com/test1, test1)
  */
 
+/**
+Also piggyback a few tests for https://github.com/dlang/dmd/pull/6989
+
+not_a_tag_because_it_does_not_start_with_uppercase:
+
+not_a_tag_because_no_whitespace_after_colon:x
+
+TagGalore: yes this is a tag
+
+MoreTag:
+yes the above is also a tag
+*/
+
 module test1;
 
 int a;

--- a/test/compilable/ddoc4899.d
+++ b/test/compilable/ddoc4899.d
@@ -4,8 +4,8 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/ddoc4899.d(16): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
-compilable/ddoc4899.d(16): Warning: Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.
+compilable/ddoc4899.d(18): Warning: Ddoc: Stray '('. This may cause incorrect Ddoc output. Use $(LPAREN) instead for unpaired left parentheses.
+compilable/ddoc4899.d(19): Warning: Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.
 ---
 */
 
@@ -14,6 +14,9 @@ compilable/ddoc4899.d(16): Warning: Ddoc: Stray ')'. This may cause incorrect Dd
         foo:)
 +/
 module d;
+
+/** ( */ int a;
+/** ) */ int b;
 
 void main()
 {

--- a/test/compilable/extra-files/ddoc17697.html
+++ b/test/compilable/extra-files/ddoc17697.html
@@ -473,6 +473,28 @@
     <a href="https://www.foob.com/test1">https://www.foob.com/test1</a>
     <a href="http://www.fooc.com/test1">http://www.fooc.com/test1</a>
     <a href="http://www.food.com/test1"><code class="code">test1</code></a>
+<br><br>
+Also piggyback a few tests for <a href="https://github.com/dlang/dmd/pull/6989">https://github.com/dlang/dmd/pull/6989</a>
+<br><br>
+not_a_tag_because_it_does_not_start_with_uppercase:
+<br><br>
+not_a_tag_because_no_whitespace_after_colon:x
+
+
+  </p>
+</div>
+<div class="ddoc_section">
+  <p class="para">
+    <span class="ddoc_section_h">TagGalore:</span>
+yes this is a tag
+
+
+  </p>
+</div>
+<div class="ddoc_section">
+  <p class="para">
+    <span class="ddoc_section_h">MoreTag:</span>
+yes the above is also a tag
   </p>
 </div>
 


### PR DESCRIPTION
This solves a number of annoying problems when ddoc confuses the use of ":" in running text with the intent to insert a tag. The matter can happen after text is reflown with no intent or knowledge that a tag will be generated.

Among the most annoying: if a link `http://...` happens to fall at the start of a line the `http` is converted to a tag. 

I suspect this will expose a few cases when people do want to insert tags but don't insert a newline.