### PR TITLE
Add initital codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,43 @@
+# See also:
+# - https://github.com/blog/2392-introducing-code-owners
+# - https://help.github.com/articles/about-codeowners/
+
+# Each line is a file pattern followed by one or more owners (sorted alphabetically).
+# Please feel free to add yourself to a module or create a new mapping.
+# Ideally each module should have two or more owners.
+
+# Code owners are automatically requested for review
+# when someone opens a pull request that modifies code that they own.
+# Later matches take precedence.
+
+src/ddmd/access.d @MartinNowak
+src/ddmd/astbase* @RazvanN7
+src/ddmd/astcodegen.d @RazvanN7
+src/ddmd/asttypename.d @UplinkCoder
+src/ddmd/builtin.d @klickvebot @WalterBright
+src/ddmd/cond.d @mathias-lang-sociomantic @Geod24
+src/ddmd/console.d @CyberShadow
+src/ddmd/cppmangle.d @ibuclaw
+src/ddmd/ctfeexpr.d @UplinkCoder
+src/ddmd/doc.d @andralex @jacob-carlborg
+src/ddmd/hdrgen.d @UplinkCoder @WalterBright
+src/ddmd/mars.d @MartinNowak @mathias-lang-sociomantic @Geod24 @rainers @UplinkCoder @WalterBright
+src/ddmd/objc* @jacob-carlborg
+src/ddmd/permissivevisitor.d @RazvanN7
+src/ddmd/target.d @ibuclaw @MartinNowak
+src/ddmd/transitivevisitor.d @RazvanN7
+src/ddmd/vcbuild @rainers
+
+# GitHub's implementation of the CODEOWNERS format is buggy, so this might not work
+src/ddmd/*.h @ibuclaw
+
+src/ddmd/* @WalterBright
+src/ddmd/backend/* @WalterBright
+src/ddmd/root/* @WalterBright
+src/ddmd/tk/* @WalterBright
+
+# CI & automation
+posix.mak @CyberShadow @MartinNowak @wilzbach
+src/posix.mak @CyberShadow @MartinNowak @wilzbach
+circle.sh @CyberShadow @MartinNowak @wilzbach
+travis.sh @CyberShadow @MartinNowak @wilzbach


### PR DESCRIPTION
Similarly to https://github.com/dlang/phobos/pull/5573

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. When someone with admin permissions has enabled required reviews, they can optionally require approval from a code owner.

Moreover, it's a simple plain-text format:

> A CODEOWNERS file uses a pattern that follows the same rules used in gitignore files. The pattern is followed by one or more GitHub usernames or team names using the standard @username or @org/team-name format. 

For more information, the [help page](https://help.github.com/articles/about-codeowners/) goes into more details.

I tried to use some insights from [@MartinNowak's git blame analyzer](https://github.com/dlang/phobos/pull/5573#issuecomment-314227208), but this isn't perfect and your feedback and input would be very welcome: what are files in the DMD codebase that you feel comfortable with? Are there mappings that I add that don't reflect the status quo?

We [had some troubles with GitHub at Phobos](https://github.com/dlang/phobos/pull/5604), but [here's an example on how it will look in live](https://github.com/dlang/phobos/pull/5605).

CC @dlang/team-dmd  @Geod24 @LemonBoy @kinke @redstar @rainers @mathias-lang-sociomantic @thewilsonator @luismarques  @JohanEngelen and all other awesome DMD contributors

(I will wait a few days and if you don't confirm that you are ok with being pinged on a PR,  I will remove you from the file for now).