### PR TITLE
Fix Issue 17646 dmd segfaults on missing [tuple] foreach body in import

### DIFF
--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -739,7 +739,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 }
                 st.push(new ExpStatement(loc, var));
 
-                st.push(fs._body.syntaxCopy());
+                if (fs._body)
+                    st.push(fs._body.syntaxCopy());
                 s = new CompoundStatement(loc, st);
                 s = new ScopeStatement(loc, s, fs.endloc);
                 statements.push(s);


### PR DESCRIPTION
As per title the reason this happens is because an `UnrolledLoopStatement` (which is what Tuple-foreach becomes) is not technically required to have statements in it's body.
However it seems so far  this was not trigged. 