### PR TITLE
Use SSL for AUTO_BOOSTRAP

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -90,11 +90,12 @@ else
   # Auto-bootstrapping, will download dmd automatically
   # Keep var below in sync with other occurrences of that variable, e.g. in circleci.sh
   HOST_DMD_VER=2.072.2
+  HOST_DMD_YEAR=2016
   HOST_DMD_ROOT=$(TMP)/.host_dmd-$(HOST_DMD_VER)
   # dmd.2.072.2.osx.zip or dmd.2.072.2.linux.tar.xz
   HOST_DMD_BASENAME=dmd.$(HOST_DMD_VER).$(OS)$(if $(filter $(OS),freebsd),-$(MODEL),)
   # http://downloads.dlang.org/releases/2.x/2.072.2/dmd.2.072.2.linux.tar.xz
-  HOST_DMD_URL=http://downloads.dlang.org/releases/2.x/$(HOST_DMD_VER)/$(HOST_DMD_BASENAME)
+  HOST_DMD_URL=https://s3-us-west-2.amazonaws.com/downloads.dlang.org/releases/$(HOST_DMD_YEAR)/$(HOST_DMD_BASENAME)
   HOST_DMD=$(HOST_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))/dmd
   HOST_DMD_PATH=$(HOST_DMD)
   HOST_DMD_RUN=$(HOST_DMD) -conf=$(dir $(HOST_DMD))dmd.conf


### PR DESCRIPTION
I believe this doesn't matter, because on a modern system a D compiler should be present and package maintainers use source tarballs (or digger) to do the bootstrapping.

Unfortunately, the year needs to be set as well as the release layout is a bit weird.

See also:
- https://github.com/dlang/installer/pull/211
- https://trello.com/c/mWHZxwo5/89-https-for-s3-downloadsdlangorg