### PR TITLE
Use -fPIC by default

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -417,7 +417,7 @@ endif
 
 define DEFAULT_DMD_CONF
 [Environment32]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic) -fPIC
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic)
 
 [Environment64]
 DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic) -fPIC
@@ -436,7 +436,7 @@ define DEFAULT_DMD_CONF_LEGACY
 DFLAGS=-I%@P%/../../druntime/import -I%@P%/../../phobos -L-L%@P%/../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic)
 
 [Environment64]
-DFLAGS=-I%@P%/../../druntime/import -I%@P%/../../phobos -L-L%@P%/../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic)
+DFLAGS=-I%@P%/../../druntime/import -I%@P%/../../phobos -L-L%@P%/../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic) -fPIC
 endef
 
 export DEFAULT_DMD_CONF_LEGACY

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -168,7 +168,7 @@ CXXFLAGS += \
     -std=gnu++98
 endif
 # Default D compiler flags for all source files
-DFLAGS= -version=MARS
+DFLAGS= -version=MARS -fPIC
 # Enable D warnings
 DFLAGS += -wi
 
@@ -417,10 +417,10 @@ endif
 
 define DEFAULT_DMD_CONF
 [Environment32]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic)
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/32$(if $(filter $(OS),osx),, -L--export-dynamic) -fPIC
 
 [Environment64]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic)
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/release/64$(if $(filter $(OS),osx),, -L--export-dynamic) -fPIC
 endef
 
 export DEFAULT_DMD_CONF

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -29,6 +29,21 @@ ifneq ($(BUILD),release)
     endif
 endif
 
+# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+# Note that shared libraries and C files are always compiled with PIC.
+ifeq ($(PIC),)
+    ifeq ($(MODEL),64) # x86_64
+        PIC:=1
+    else
+        PIC:=0
+    endif
+endif
+ifeq ($(PIC),1)
+    override PIC:=-fPIC
+else
+    override PIC:=
+endif
+
 GIT_HOME=https://github.com/dlang
 TOOLS_DIR=../../tools
 
@@ -161,14 +176,13 @@ MMD=-MMD -MF $(basename $@).deps
 CXXFLAGS := $(WARNINGS) \
 	-fno-exceptions -fno-rtti \
 	-D__pascal= -DMARS=1 -DTARGET_$(OS_UPCASE)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 \
-	$(MODEL_FLAG)
+	$(MODEL_FLAG) $(PIC)
 # GCC Specific
 ifeq ($(CXX_KIND), g++)
 CXXFLAGS += \
     -std=gnu++98
 endif
-# Default D compiler flags for all source files
-DFLAGS= -version=MARS -fPIC
+DFLAGS := -version=MARS $(PIC)
 # Enable D warnings
 DFLAGS += -wi
 


### PR DESCRIPTION
The [release dmd.conf](https://github.com/dlang/dmd/blob/master/ini/linux/bin64/dmd.conf#L5) already contains `-fPIC`, but the default generated one doesn't.
This requires `libphobos2.a` to be built with `-fPIC`, but that one is already in the queue: https://github.com/dlang/phobos/pull/5586

Other PRs:

- [x] https://github.com/dlang/druntime/pull/1880
- [x] https://github.com/dlang/phobos/pull/5586