### PR TITLE
Reassign copyright from Digital Mars to D Language Foundation

### DIFF
--- a/docs/man/man1/dmd.1
+++ b/docs/man/man1/dmd.1
@@ -1,4 +1,4 @@
-.TH DMD 1 "2011-02-22" "Digital Mars" "Digital Mars D"
+.TH DMD 1 "2011-02-22" "The D Language Foundation" "The D Language Foundation"
 .SH NAME
 dmd \- Digital Mars D2.x Compiler
 .SH SYNOPSIS
@@ -239,10 +239,10 @@ does it. I don't know if this is an issue or not.
 .PP
 The compiler sometimes gets the line number wrong on an error.
 .SH AUTHOR
-Copyright (c) 1999-2016 by Digital Mars written by Walter Bright
+Copyright (c) 1999-2017 by The D Language Foundation written by Walter Bright
 .SH "ONLINE DOCUMENTATION"
-.UR http://www.digitalmars.com/d/index.html
-http://www.digitalmars.com/d/index.html
+.UR https://dlang.org/dmd.html
+https://dlang.org/dmd.html
 .UE
 .SH "SEE ALSO"
 .BR dmd.conf (5)

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,7 +1,7 @@
 name "dmd"
 description "The DMD compiler"
 authors "Walter Bright"
-copyright "Copyright © 1999-2017, Digital Mars"
+copyright "Copyright © 1999-2017, The D Language Foundation"
 license "BSL-1.0"
 
 targetType "none"

--- a/src/ddmd/access.d
+++ b/src/ddmd/access.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/access.d, _access.d)

--- a/src/ddmd/aggregate.d
+++ b/src/ddmd/aggregate.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/aggregate.d, _aggregate.d)

--- a/src/ddmd/aggregate.h
+++ b/src/ddmd/aggregate.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/aliasthis.d
+++ b/src/ddmd/aliasthis.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/aliasthis.d, _aliasthis.d)

--- a/src/ddmd/aliasthis.h
+++ b/src/ddmd/aliasthis.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 2009-2014 by Digital Mars
+ * Copyright (c) 2009-2014 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/apply.d
+++ b/src/ddmd/apply.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/apply.d, _apply.d)

--- a/src/ddmd/argtypes.d
+++ b/src/ddmd/argtypes.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/argtypes.d, _argtypes.d)

--- a/src/ddmd/arrayop.d
+++ b/src/ddmd/arrayop.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/arrayop.d, _arrayop.d)

--- a/src/ddmd/arraytypes.d
+++ b/src/ddmd/arraytypes.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/arraytypes.d, _arraytypes.d)

--- a/src/ddmd/arraytypes.h
+++ b/src/ddmd/arraytypes.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 2006-2014 by Digital Mars
+ * Copyright (c) 2006-2014 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/asttypename.d
+++ b/src/ddmd/asttypename.d
@@ -1,6 +1,6 @@
 /**
  * Part of the Compiler implementation of the D programming language
- * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The The D Language Foundation, All Rights Reserved
  * Authors:     Stefan Koch
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/asttypename.d, _asttypename.d)

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/attrib.d, _attrib.d)

--- a/src/ddmd/attrib.h
+++ b/src/ddmd/attrib.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/backend/aa.c
+++ b/src/ddmd/backend/aa.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/aa.c, backend/aa.c)

--- a/src/ddmd/backend/aa.h
+++ b/src/ddmd/backend/aa.h
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/aa.h, backend/aa.h)

--- a/src/ddmd/backend/backconfig.c
+++ b/src/ddmd/backend/backconfig.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/backconfig.c, backend/backconfig.c)

--- a/src/ddmd/backend/blockopt.c
+++ b/src/ddmd/backend/blockopt.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1986-1997 by Symantec
- *              Copyright (c) 2000-2012 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2012 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/blockopt.c, backend/blockopt.c)

--- a/src/ddmd/backend/cc.d
+++ b/src/ddmd/backend/cc.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2012 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2012 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cc.d, backend/_cc.d)

--- a/src/ddmd/backend/cc.h
+++ b/src/ddmd/backend/cc.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cc.h, backend/cc.h)

--- a/src/ddmd/backend/cdef.d
+++ b/src/ddmd/backend/cdef.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cdef.d, backend/_cdef.d)
@@ -362,18 +362,18 @@ alias SYMIDX = int;    // symbol table index
 //#ifndef COPYRIGHT_SYMBOL
 //#define COPYRIGHT_SYMBOL "\xA9"
 //#endif
-//#define COPYRIGHT "Copyright " COPYRIGHT_SYMBOL " 2001 Digital Mars"
+//#define COPYRIGHT "Copyright " COPYRIGHT_SYMBOL " 2001 The D Language Foundation"
 //#else
 //#ifdef DEBUG
-//#define COPYRIGHT "Copyright (C) Digital Mars 2000-2017.  All Rights Reserved.\n\
+//#define COPYRIGHT "Copyright (C) The D Language Foundation 2000-2017.  All Rights Reserved.\n\
 //Written by Walter Bright\n\
 //*****BETA TEST VERSION*****"
 //#else
 //#if __linux__
-//#define COPYRIGHT "Copyright (C) Digital Mars 2000-2017.  All Rights Reserved.\n\
+//#define COPYRIGHT "Copyright (C) The D Language Foundation 2000-2017.  All Rights Reserved.\n\
 //Written by Walter Bright, Linux version by Pat Nelson"
 //#else
-//#define COPYRIGHT "Copyright (C) Digital Mars 2000-2017.  All Rights Reserved.\n\
+//#define COPYRIGHT "Copyright (C) The D Language Foundation 2000-2017.  All Rights Reserved.\n\
 //Written by Walter Bright"
 //#endif
 //#endif

--- a/src/ddmd/backend/cdef.h
+++ b/src/ddmd/backend/cdef.h
@@ -599,18 +599,18 @@ typedef int             SYMIDX;         // symbol table index
 #ifndef COPYRIGHT_SYMBOL
 #define COPYRIGHT_SYMBOL "\xA9"
 #endif
-#define COPYRIGHT "Copyright " COPYRIGHT_SYMBOL " 2001 Digital Mars"
+#define COPYRIGHT "Copyright " COPYRIGHT_SYMBOL " 2001-2017 The D Language Foundation"
 #else
 #ifdef DEBUG
-#define COPYRIGHT "Copyright (C) Digital Mars 2000-2016.  All Rights Reserved.\n\
+#define COPYRIGHT "Copyright (C) The D Language Foundation 2000-2017.  All Rights Reserved.\n\
 Written by Walter Bright\n\
 *****BETA TEST VERSION*****"
 #else
 #if __linux__
-#define COPYRIGHT "Copyright (C) Digital Mars 2000-2016.  All Rights Reserved.\n\
+#define COPYRIGHT "Copyright (C) The D Language Foundation 2000-2017.  All Rights Reserved.\n\
 Written by Walter Bright, Linux version by Pat Nelson"
 #else
-#define COPYRIGHT "Copyright (C) Digital Mars 2000-2016.  All Rights Reserved.\n\
+#define COPYRIGHT "Copyright (C) The D Language Foundation Mars 2000-2017.  All Rights Reserved.\n\
 Written by Walter Bright"
 #endif
 #endif

--- a/src/ddmd/backend/cdef.h
+++ b/src/ddmd/backend/cdef.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cdef.h, backend/cdef.h)

--- a/src/ddmd/backend/cg.c
+++ b/src/ddmd/backend/cg.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1995 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cg.c, backend/cg.c)

--- a/src/ddmd/backend/cg87.c
+++ b/src/ddmd/backend/cg87.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1987-1995 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cg87.c, backend/cg87.c)

--- a/src/ddmd/backend/cgcod.c
+++ b/src/ddmd/backend/cgcod.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgcod.c, backend/cgcod.c)

--- a/src/ddmd/backend/cgcs.c
+++ b/src/ddmd/backend/cgcs.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1995 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgcs.c, backend/cgcs.c)

--- a/src/ddmd/backend/cgcv.c
+++ b/src/ddmd/backend/cgcv.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1995 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgcv.c, backend/cgcv.c)

--- a/src/ddmd/backend/cgcv.d
+++ b/src/ddmd/backend/cgcv.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgcv.c, backend/cgcv.c)

--- a/src/ddmd/backend/cgcv.h
+++ b/src/ddmd/backend/cgcv.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgcv.h, backend/cgcv.h)

--- a/src/ddmd/backend/cgelem.c
+++ b/src/ddmd/backend/cgelem.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgelem.c, backend/cgelem.c)

--- a/src/ddmd/backend/cgen.c
+++ b/src/ddmd/backend/cgen.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgen.c, backend/cgen.c)

--- a/src/ddmd/backend/cgobj.c
+++ b/src/ddmd/backend/cgobj.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgobj.c, backend/cgobj.c)

--- a/src/ddmd/backend/cgreg.c
+++ b/src/ddmd/backend/cgreg.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgreg.c, backend/cgreg.c)

--- a/src/ddmd/backend/cgsched.c
+++ b/src/ddmd/backend/cgsched.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1995-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgsched.c, backend/cgsched.c)

--- a/src/ddmd/backend/cgxmm.c
+++ b/src/ddmd/backend/cgxmm.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2011-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2011-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgxmm.c, backend/cgxmm.c)

--- a/src/ddmd/backend/cod1.c
+++ b/src/ddmd/backend/cod1.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cod1.c, backend/cod1.c)

--- a/src/ddmd/backend/cod2.c
+++ b/src/ddmd/backend/cod2.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cod2.c, backend/cod2.c)

--- a/src/ddmd/backend/cod3.c
+++ b/src/ddmd/backend/cod3.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cod3.c, backend/cod3.c)

--- a/src/ddmd/backend/cod4.c
+++ b/src/ddmd/backend/cod4.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cod4.c, backend/cod4.c)

--- a/src/ddmd/backend/cod5.c
+++ b/src/ddmd/backend/cod5.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1995-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cod5.c, backend/cod5.c)

--- a/src/ddmd/backend/code.c
+++ b/src/ddmd/backend/code.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1987-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/code.c, backend/code.c)

--- a/src/ddmd/backend/code.d
+++ b/src/ddmd/backend/code.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/code.d, backend/_code.d)

--- a/src/ddmd/backend/code.h
+++ b/src/ddmd/backend/code.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     Distributed under the Boost Software License, Version 1.0.
  *              http://www.boost.org/LICENSE_1_0.txt

--- a/src/ddmd/backend/code_x86.d
+++ b/src/ddmd/backend/code_x86.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/code_x86.c, backend/code_x86.c)

--- a/src/ddmd/backend/code_x86.h
+++ b/src/ddmd/backend/code_x86.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/code_x86.h, backend/code_x86.h)

--- a/src/ddmd/backend/compress.c
+++ b/src/ddmd/backend/compress.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/compress.c, backend/compress.c)

--- a/src/ddmd/backend/cv8.c
+++ b/src/ddmd/backend/cv8.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:    Copyright (c) 2012-2017 by Digital Mars, All Rights Reserved
+ * Copyright:    Copyright (c) 2012-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/code.c, backend/code.c)

--- a/src/ddmd/backend/debug.c
+++ b/src/ddmd/backend/debug.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/debug.c, backend/debug.c)

--- a/src/ddmd/backend/divcoeff.c
+++ b/src/ddmd/backend/divcoeff.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2013-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2013-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/divcoeff.c, backend/divcoeff.c)

--- a/src/ddmd/backend/dt.c
+++ b/src/ddmd/backend/dt.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/dt.c, backend/dt.c)

--- a/src/ddmd/backend/dt.d
+++ b/src/ddmd/backend/dt.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/dt.d, backend/dt.d)

--- a/src/ddmd/backend/dwarf.c
+++ b/src/ddmd/backend/dwarf.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/dwarf.c, backend/dwarf.c)

--- a/src/ddmd/backend/dwarf2.d
+++ b/src/ddmd/backend/dwarf2.d
@@ -1,5 +1,5 @@
 
-/* Reflects declarations from the Dwarf 3 spec, not the Digital Mars
+/* Reflects declarations from the Dwarf 3 spec, not the The D Language Foundation
  * dwarf implementation
  *
  * Source: $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/dwarf2.d, backend/_dwarf2.d)

--- a/src/ddmd/backend/dwarfeh.c
+++ b/src/ddmd/backend/dwarfeh.c
@@ -3,7 +3,7 @@
  * Implements LSDA (Language Specific Data Area) table generation
  * for Dwarf Exception Handling.
  *
- * Copyright: Copyright (c) 2015 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 2015 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/dwarfeh.c, backend/dwarfeh.c)

--- a/src/ddmd/backend/ee.c
+++ b/src/ddmd/backend/ee.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1995-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/ee.c, backend/ee.c)

--- a/src/ddmd/backend/el.c
+++ b/src/ddmd/backend/el.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/el.c, backend/el.c)

--- a/src/ddmd/backend/el.d
+++ b/src/ddmd/backend/el.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/el.d, backend/el.d)

--- a/src/ddmd/backend/el.h
+++ b/src/ddmd/backend/el.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/el.h, backend/el.h)

--- a/src/ddmd/backend/elfobj.c
+++ b/src/ddmd/backend/elfobj.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) ?-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/elfobj.c, backend/elfobj.c)

--- a/src/ddmd/backend/evalu8.c
+++ b/src/ddmd/backend/evalu8.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/evalu8.c, backend/evalu8.c)

--- a/src/ddmd/backend/exh.d
+++ b/src/ddmd/backend/exh.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1993-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/exh.d, backend/exh.d)

--- a/src/ddmd/backend/exh.h
+++ b/src/ddmd/backend/exh.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1993-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/exh.h, backend/exh.h)

--- a/src/ddmd/backend/gdag.c
+++ b/src/ddmd/backend/gdag.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1986-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/gdag.c, backend/gdag.c)

--- a/src/ddmd/backend/gflow.c
+++ b/src/ddmd/backend/gflow.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/gflow.c, backend/gflow.c)

--- a/src/ddmd/backend/global.d
+++ b/src/ddmd/backend/global.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/global.d, backend/global.d)

--- a/src/ddmd/backend/global.h
+++ b/src/ddmd/backend/global.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/global.h, backend/global.h)

--- a/src/ddmd/backend/glocal.c
+++ b/src/ddmd/backend/glocal.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1993-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/glocal.c, backend/glocal.c)

--- a/src/ddmd/backend/gloop.c
+++ b/src/ddmd/backend/gloop.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/gloop.c, backend/gloop.c)

--- a/src/ddmd/backend/go.c
+++ b/src/ddmd/backend/go.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1986-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/go.c, backend/go.c)

--- a/src/ddmd/backend/go.h
+++ b/src/ddmd/backend/go.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/go.h, backend/go.h)

--- a/src/ddmd/backend/gother.c
+++ b/src/ddmd/backend/gother.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1986-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/gother.c, backend/gother.c)

--- a/src/ddmd/backend/gsroa.c
+++ b/src/ddmd/backend/gsroa.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2016-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2016-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/gslice.c, backend/gslice.c)

--- a/src/ddmd/backend/iasm.d
+++ b/src/ddmd/backend/iasm.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1982-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     Mike Cote, John Micco, $(LINK2 http://www.digitalmars.com, Walter Bright),
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/iasm.d, backend/iasm.d)

--- a/src/ddmd/backend/iasm.h
+++ b/src/ddmd/backend/iasm.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1992-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     Mike Cote, John Micco, $(LINK2 http://www.digitalmars.com, Walter Bright),
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/iasm.h, backend/iasm.h)

--- a/src/ddmd/backend/machobj.c
+++ b/src/ddmd/backend/machobj.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2009-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2009-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/machobj.c, backend/machobj.c)

--- a/src/ddmd/backend/mscoffobj.c
+++ b/src/ddmd/backend/mscoffobj.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2009-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2009-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/mscoffobj.c, backend/mscoffobj.c)

--- a/src/ddmd/backend/newman.c
+++ b/src/ddmd/backend/newman.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1992-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/newman.c, backend/newman.c)

--- a/src/ddmd/backend/nteh.c
+++ b/src/ddmd/backend/nteh.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/nteh.c, backend/nteh.c)

--- a/src/ddmd/backend/obj.d
+++ b/src/ddmd/backend/obj.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/obj.d, backend/obj.d)

--- a/src/ddmd/backend/obj.h
+++ b/src/ddmd/backend/obj.h
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2012-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2012-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/obj.d, backend/obj.d)

--- a/src/ddmd/backend/oper.d
+++ b/src/ddmd/backend/oper.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/oper.d, backend/oper.d)

--- a/src/ddmd/backend/oper.h
+++ b/src/ddmd/backend/oper.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/oper.h, backend/oper.h)

--- a/src/ddmd/backend/optabgen.c
+++ b/src/ddmd/backend/optabgen.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/optabgen.c, backend/optabgen.c)

--- a/src/ddmd/backend/os.c
+++ b/src/ddmd/backend/os.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/os.c, backend/os.c)

--- a/src/ddmd/backend/out.c
+++ b/src/ddmd/backend/out.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/out.c, backend/out.c)

--- a/src/ddmd/backend/outbuf.c
+++ b/src/ddmd/backend/outbuf.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/outbuf.c, backend/outbuf.c)

--- a/src/ddmd/backend/outbuf.d
+++ b/src/ddmd/backend/outbuf.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/outbuf.d, backend/outbuf.d)

--- a/src/ddmd/backend/outbuf.h
+++ b/src/ddmd/backend/outbuf.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/outbuf.h, backend/outbuf.h)

--- a/src/ddmd/backend/pdata.c
+++ b/src/ddmd/backend/pdata.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2012-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2012-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/pdata.c, backend/pdata.c)

--- a/src/ddmd/backend/ph2.c
+++ b/src/ddmd/backend/ph2.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/ph2.c, backend/ph2.c)

--- a/src/ddmd/backend/platform_stub.c
+++ b/src/ddmd/backend/platform_stub.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2011-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2011-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     Brad Roberts
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/platform_stub.c, backend/platform_stub.c)

--- a/src/ddmd/backend/ptrntab.c
+++ b/src/ddmd/backend/ptrntab.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/ptrntab.c, backend/ptrntab.c)
  */

--- a/src/ddmd/backend/rtlsym.c
+++ b/src/ddmd/backend/rtlsym.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1996-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/rtlsym.c, backend/rtlsym.c)

--- a/src/ddmd/backend/rtlsym.d
+++ b/src/ddmd/backend/rtlsym.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/rtlsym.d, backend/_rtlsym.d)

--- a/src/ddmd/backend/rtlsym.h
+++ b/src/ddmd/backend/rtlsym.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/rtlsym.h, backend/rtlsym.h)

--- a/src/ddmd/backend/strtold.c
+++ b/src/ddmd/backend/strtold.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/strtold.c, backend/strtold.c)

--- a/src/ddmd/backend/symbol.c
+++ b/src/ddmd/backend/symbol.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/symbol.c, backend/symbol.c)

--- a/src/ddmd/backend/tassert.h
+++ b/src/ddmd/backend/tassert.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1989-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/tassert.h, backend/tassert.h)

--- a/src/ddmd/backend/ti_achar.c
+++ b/src/ddmd/backend/ti_achar.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2006-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2006-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/ti_achar.c, backend/ti_achar.c)

--- a/src/ddmd/backend/ti_pvoid.c
+++ b/src/ddmd/backend/ti_pvoid.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2011-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2011-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/ti_pvoid.c, backend/ti_pvoid.c)

--- a/src/ddmd/backend/tinfo.h
+++ b/src/ddmd/backend/tinfo.h
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/tinfo.h, backend/tinfo.h)

--- a/src/ddmd/backend/tk.c
+++ b/src/ddmd/backend/tk.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/tk.c, backend/tk.c)

--- a/src/ddmd/backend/token.h
+++ b/src/ddmd/backend/token.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/token.h, backend/token.h)

--- a/src/ddmd/backend/ty.d
+++ b/src/ddmd/backend/ty.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1983-1998 by Symantec
- *              Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/ty.d, backend/_ty.d)

--- a/src/ddmd/backend/ty.h
+++ b/src/ddmd/backend/ty.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1983-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/ty.h, backend/ty.h)

--- a/src/ddmd/backend/type.c
+++ b/src/ddmd/backend/type.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/type.c, backend/type.c)

--- a/src/ddmd/backend/type.d
+++ b/src/ddmd/backend/type.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/type.d, backend/_type.d)

--- a/src/ddmd/backend/type.h
+++ b/src/ddmd/backend/type.h
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/type.h, backend/type.h)

--- a/src/ddmd/backend/util2.c
+++ b/src/ddmd/backend/util2.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1984-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/util2.c, backend/util2.c)

--- a/src/ddmd/backend/var.c
+++ b/src/ddmd/backend/var.c
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1985-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/var.c, backend/var.c)

--- a/src/ddmd/backend/varstats.c
+++ b/src/ddmd/backend/varstats.c
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2015-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2015-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     Rainer Schuetze
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/varstats.c, backend/varstats.c)

--- a/src/ddmd/backend/varstats.h
+++ b/src/ddmd/backend/varstats.h
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 2015-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 2015-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     Rainer Schuetze
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/varstats.h, backend/varstats.h)

--- a/src/ddmd/backend/xmm.d
+++ b/src/ddmd/backend/xmm.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) ?-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) ?-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/xmm.d, backend/_xmm.d)

--- a/src/ddmd/blockexit.d
+++ b/src/ddmd/blockexit.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/blockexit.d, _blockexit.d)

--- a/src/ddmd/builtin.d
+++ b/src/ddmd/builtin.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/builtin.d, _builtin.d)

--- a/src/ddmd/canthrow.d
+++ b/src/ddmd/canthrow.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/canthrow.d, _canthrow.d)

--- a/src/ddmd/clone.d
+++ b/src/ddmd/clone.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/clone.d, _clone.d)

--- a/src/ddmd/complex.d
+++ b/src/ddmd/complex.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/complex.d, _complex.d)

--- a/src/ddmd/complex_t.h
+++ b/src/ddmd/complex_t.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/cond.d, _cond.d)

--- a/src/ddmd/cond.h
+++ b/src/ddmd/cond.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/console.d
+++ b/src/ddmd/console.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/console.d, _console.d)

--- a/src/ddmd/constfold.d
+++ b/src/ddmd/constfold.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/constfold.d, _constfold.d)

--- a/src/ddmd/cppmangle.d
+++ b/src/ddmd/cppmangle.d
@@ -1,7 +1,7 @@
 /**
  * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/cppmangle.d, _cppmangle.d)

--- a/src/ddmd/cppmanglewin.d
+++ b/src/ddmd/cppmanglewin.d
@@ -1,7 +1,7 @@
 /**
  * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/cppmanglewin.d, _cppmanglewin.d)

--- a/src/ddmd/ctfe.h
+++ b/src/ddmd/ctfe.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/ctfeexpr.d
+++ b/src/ddmd/ctfeexpr.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/ctfeexpr.d, _ctfeexpr.d)

--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dcast.d, _dcast.d)

--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dclass.d, _dclass.d)

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/declaration.d, _declaration.d)

--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/delegatize.d
+++ b/src/ddmd/delegatize.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/delegatize.d, _delegatize.d)

--- a/src/ddmd/denum.d
+++ b/src/ddmd/denum.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/denum.d, _denum.d)

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dimport.d, _dimport.d)

--- a/src/ddmd/dinifile.d
+++ b/src/ddmd/dinifile.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dinifile.d, _dinifile.d)

--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dinterpret.d, _dinterpret.d)

--- a/src/ddmd/dmacro.d
+++ b/src/ddmd/dmacro.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dmacro.d, _dmacro.d)

--- a/src/ddmd/dmangle.d
+++ b/src/ddmd/dmangle.d
@@ -1,7 +1,7 @@
 /**
  * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dmangle.d, _dmangle.d)

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dmodule.d, _dmodule.d)

--- a/src/ddmd/dmsc.d
+++ b/src/ddmd/dmsc.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dmsc.d, _dmsc.d)

--- a/src/ddmd/doc.d
+++ b/src/ddmd/doc.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/doc.d, _doc.d)

--- a/src/ddmd/dscope.d
+++ b/src/ddmd/dscope.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dscope.d, _dscope.d)

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dstruct.d, _dstruct.d)

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dsymbol.d, _dsymbol.d)

--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dsymbolsem.d, _dsymbolsem.d)

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -4,7 +4,7 @@
  *
  * Template implementation.
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dtemplate.d, _dtemplate.d)

--- a/src/ddmd/dversion.d
+++ b/src/ddmd/dversion.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/dversion.d, _dversion.d)

--- a/src/ddmd/e2ir.d
+++ b/src/ddmd/e2ir.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/e2ir.d, _e2ir.d)

--- a/src/ddmd/eh.d
+++ b/src/ddmd/eh.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
- *              Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 2000-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/eh.d, _eh.d)

--- a/src/ddmd/entity.d
+++ b/src/ddmd/entity.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/entity.d, _entity.d)

--- a/src/ddmd/enum.h
+++ b/src/ddmd/enum.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/errors.d, _errors.d)

--- a/src/ddmd/errors.h
+++ b/src/ddmd/errors.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/escape.d
+++ b/src/ddmd/escape.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/escape.d, _escape.d)

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/expression.d, _expression.d)

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(DMDSRC _expression.d)

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/func.d, _func.d)

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/globals.d, _globals.d)

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -355,7 +355,7 @@ struct Global
         {
             static assert(0, "fix this");
         }
-        copyright = "Copyright (c) 1999-2017 by Digital Mars";
+        copyright = "Copyright (c) 1999-2017 by The D Language Foundation";
         written = "written by Walter Bright";
         _version = (import("VERSION") ~ '\0').ptr;
         compiler.vendor = "Digital Mars D";

--- a/src/ddmd/glue.d
+++ b/src/ddmd/glue.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/glue.d, _glue.d)

--- a/src/ddmd/gluelayer.d
+++ b/src/ddmd/gluelayer.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/gluelayer.d, _gluelayer.d)

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/hdrgen.d, _hdrgen.d)

--- a/src/ddmd/hdrgen.h
+++ b/src/ddmd/hdrgen.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Dave Fladebo
  * http://www.digitalmars.com

--- a/src/ddmd/iasm.d
+++ b/src/ddmd/iasm.d
@@ -3,7 +3,7 @@
  * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (c) 1992-1999 by Symantec
- *              Copyright (c) 1999-2017 by Digital Mars
+ *              Copyright (c) 1999-2017 by The D Language Foundation
  *              All Rights Reserved
  * Authors:     Mike Cote, John Micco and $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/ddmd/id.d
+++ b/src/ddmd/id.d
@@ -5,7 +5,7 @@
  * This module contains the `Id` struct with a list of predefined symbols the
  * compiler knows about.
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/id.d, _id.d)

--- a/src/ddmd/identifier.d
+++ b/src/ddmd/identifier.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/identifier.d, _identifier.d)

--- a/src/ddmd/identifier.h
+++ b/src/ddmd/identifier.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/impcnvtab.d
+++ b/src/ddmd/impcnvtab.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/impcnvtab.d, _impcnvtab.d)

--- a/src/ddmd/imphint.d
+++ b/src/ddmd/imphint.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/imphint.d, _imphint.d)

--- a/src/ddmd/import.h
+++ b/src/ddmd/import.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/init.d
+++ b/src/ddmd/init.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/init.d, _init.d)

--- a/src/ddmd/init.h
+++ b/src/ddmd/init.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/initsem.d
+++ b/src/ddmd/initsem.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/initsem.d, _initsem.d)

--- a/src/ddmd/inline.d
+++ b/src/ddmd/inline.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/inline.d, _inline.d)

--- a/src/ddmd/inlinecost.d
+++ b/src/ddmd/inlinecost.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/inlinecost.d, _inlinecost.d)

--- a/src/ddmd/intrange.d
+++ b/src/ddmd/intrange.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/intrange.d, _intrange.d)

--- a/src/ddmd/intrange.h
+++ b/src/ddmd/intrange.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by KennyTM
  * http://www.digitalmars.com

--- a/src/ddmd/irstate.d
+++ b/src/ddmd/irstate.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/irstate.d, _irstate.d)

--- a/src/ddmd/json.d
+++ b/src/ddmd/json.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/json.d, _json.d)

--- a/src/ddmd/json.h
+++ b/src/ddmd/json.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/lexer.d, _lexer.d)

--- a/src/ddmd/lib.d
+++ b/src/ddmd/lib.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/lib.d, _lib.d)

--- a/src/ddmd/libelf.d
+++ b/src/ddmd/libelf.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/libelf.d, _libelf.d)

--- a/src/ddmd/libmach.d
+++ b/src/ddmd/libmach.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/libmach.d, _libmach.d)

--- a/src/ddmd/libmscoff.d
+++ b/src/ddmd/libmscoff.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/libmscoff.d, _libmscoff.d)

--- a/src/ddmd/libomf.d
+++ b/src/ddmd/libomf.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/libomf.d, _libomf.d)

--- a/src/ddmd/link.d
+++ b/src/ddmd/link.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/link.d, _link.d)

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -7,7 +7,7 @@
  * utilities needed for arguments parsing, path manipulation, etc...
  * This file is not shared with other compilers which use the DMD front-end.
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/mars.d, _mars.d)

--- a/src/ddmd/mars.h
+++ b/src/ddmd/mars.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/mtype.d, _mtype.d)

--- a/src/ddmd/mtype.h
+++ b/src/ddmd/mtype.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/nogc.d
+++ b/src/ddmd/nogc.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/nogc.d, _nogc.d)

--- a/src/ddmd/nspace.d
+++ b/src/ddmd/nspace.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/nspace.d, _nspace.d)

--- a/src/ddmd/nspace.h
+++ b/src/ddmd/nspace.h
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  */

--- a/src/ddmd/objc.d
+++ b/src/ddmd/objc.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/objc.d, _objc.d)

--- a/src/ddmd/objc.h
+++ b/src/ddmd/objc.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 2015 by Digital Mars
+ * Copyright (c) 2015 by The D Language Foundation
  * All Rights Reserved
  * written by Michel Fortin
  * http://www.digitalmars.com

--- a/src/ddmd/objc_glue.d
+++ b/src/ddmd/objc_glue.d
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 2015 by Digital Mars
+ * Copyright (c) 2015 by The D Language Foundation
  * All Rights Reserved
  * written by Michel Fortin
  * http://www.digitalmars.com

--- a/src/ddmd/objc_glue_stubs.d
+++ b/src/ddmd/objc_glue_stubs.d
@@ -1,7 +1,7 @@
 
 /**
  * Compiler implementation of the D programming language
- * Copyright (c) 2015 by Digital Mars
+ * Copyright (c) 2015 by The D Language Foundation
  * All Rights Reserved
  * written by Michel Fortin
  * http://www.digitalmars.com

--- a/src/ddmd/opover.d
+++ b/src/ddmd/opover.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/opover.d, _opover.d)

--- a/src/ddmd/optimize.d
+++ b/src/ddmd/optimize.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/optimize.d, _optimize.d)

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/parse.d, _parse.d)

--- a/src/ddmd/printast.d
+++ b/src/ddmd/printast.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/printast.d, _printast.d)

--- a/src/ddmd/root/aav.d
+++ b/src/ddmd/root/aav.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/aav.d, root/_aav.d)

--- a/src/ddmd/root/array.d
+++ b/src/ddmd/root/array.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/array.d, root/_array.d)

--- a/src/ddmd/root/array.h
+++ b/src/ddmd/root/array.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2011-2014 by Digital Mars
+/* Copyright (c) 2011-2014 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/ctfloat.d
+++ b/src/ddmd/root/ctfloat.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/ctfloat.d, root/_ctfloat.d)

--- a/src/ddmd/root/ctfloat.h
+++ b/src/ddmd/root/ctfloat.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/file.d
+++ b/src/ddmd/root/file.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/file.d, root/_file.d)

--- a/src/ddmd/root/file.h
+++ b/src/ddmd/root/file.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/filename.d
+++ b/src/ddmd/root/filename.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/filename.d, root/_filename.d)

--- a/src/ddmd/root/filename.h
+++ b/src/ddmd/root/filename.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/hash.d
+++ b/src/ddmd/root/hash.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Martin Nowak, Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/hash.d, root/_hash.d)

--- a/src/ddmd/root/longdouble.c
+++ b/src/ddmd/root/longdouble.c
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Rainer Schuetze
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/longdouble.h
+++ b/src/ddmd/root/longdouble.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Rainer Schuetze
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/man.d
+++ b/src/ddmd/root/man.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/man.d, root/_man.d)

--- a/src/ddmd/root/newdelete.c
+++ b/src/ddmd/root/newdelete.c
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 2000-2014 by Digital Mars
+/* Copyright (c) 2000-2014 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/object.h
+++ b/src/ddmd/root/object.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/outbuffer.d
+++ b/src/ddmd/root/outbuffer.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/outbuffer.d, root/_outbuffer.d)

--- a/src/ddmd/root/outbuffer.h
+++ b/src/ddmd/root/outbuffer.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/port.d
+++ b/src/ddmd/root/port.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/port.d, root/_port.d)

--- a/src/ddmd/root/port.h
+++ b/src/ddmd/root/port.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/response.d
+++ b/src/ddmd/root/response.d
@@ -3,7 +3,7 @@
  * http://dlang.org
  * This file is not shared with other compilers which use the DMD front-end.
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  *              Some portions copyright (c) 1994-1995 by Symantec
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/ddmd/root/rmem.d
+++ b/src/ddmd/root/rmem.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/rmem.d, root/_rmem.d)

--- a/src/ddmd/root/rmem.h
+++ b/src/ddmd/root/rmem.h
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  */

--- a/src/ddmd/root/root.h
+++ b/src/ddmd/root/root.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/rootobject.d
+++ b/src/ddmd/root/rootobject.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/rootobject.d, root/_rootobject.d)

--- a/src/ddmd/root/speller.d
+++ b/src/ddmd/root/speller.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/speller.d, root/_speller.d)

--- a/src/ddmd/root/stringtable.d
+++ b/src/ddmd/root/stringtable.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the D programming language
  * http://dlang.org
  *
- * Copyright: Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright: Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:   Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/root/stringtable.d, root/_stringtable.d)

--- a/src/ddmd/root/stringtable.h
+++ b/src/ddmd/root/stringtable.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 1999-2016 by Digital Mars
+/* Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/root/thread.h
+++ b/src/ddmd/root/thread.h
@@ -1,5 +1,5 @@
 
-/* Copyright (c) 2000-2014 by Digital Mars
+/* Copyright (c) 2000-2014 by The D Language Foundation
  * All Rights Reserved, written by Walter Bright
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/ddmd/s2ir.d
+++ b/src/ddmd/s2ir.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _s2ir.d)

--- a/src/ddmd/safe.d
+++ b/src/ddmd/safe.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/safe.d, _safe.d)

--- a/src/ddmd/sapply.d
+++ b/src/ddmd/sapply.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/sparse.d, _sparse.d)

--- a/src/ddmd/scanelf.d
+++ b/src/ddmd/scanelf.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/scanelf.d, _scanelf.d)

--- a/src/ddmd/scanmach.d
+++ b/src/ddmd/scanmach.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/scanmach.d, _scanmach.d)

--- a/src/ddmd/scanmscoff.d
+++ b/src/ddmd/scanmscoff.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/scanmscoff.d, _scanmscoff.d)

--- a/src/ddmd/scanomf.d
+++ b/src/ddmd/scanomf.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/scanomf.d, _scanomf.d)

--- a/src/ddmd/scope.h
+++ b/src/ddmd/scope.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/semantic.d, _semantic.d)

--- a/src/ddmd/sideeffect.d
+++ b/src/ddmd/sideeffect.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/sideeffect.d, _sideeffect.d)

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/statement.d, _statement.d)

--- a/src/ddmd/statement.h
+++ b/src/ddmd/statement.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/statement_rewrite_walker.d
+++ b/src/ddmd/statement_rewrite_walker.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/statement_rewrite_walker.d, _statement_rewrite_walker.d)

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/statementsem.d, _statementsem.d)

--- a/src/ddmd/staticassert.d
+++ b/src/ddmd/staticassert.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/staticassert.d, _staticassert.d)

--- a/src/ddmd/staticassert.h
+++ b/src/ddmd/staticassert.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/staticcond.d
+++ b/src/ddmd/staticcond.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/staticcond.d, _staticcond.d)

--- a/src/ddmd/target.d
+++ b/src/ddmd/target.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/target.d, _target.d)

--- a/src/ddmd/target.h
+++ b/src/ddmd/target.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 2013-2014 by Digital Mars
+ * Copyright (c) 2013-2014 by The D Language Foundation
  * All Rights Reserved
  * written by Iain Buclaw
  * http://www.digitalmars.com

--- a/src/ddmd/template.h
+++ b/src/ddmd/template.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/templateparamsem.d
+++ b/src/ddmd/templateparamsem.d
@@ -4,7 +4,7 @@
  *
  * Template implementation.
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/templateparamsem.d, _templateparamsem.d)

--- a/src/ddmd/tk/dlist.d
+++ b/src/ddmd/tk/dlist.d
@@ -10,7 +10,7 @@
  *         different lists to 'share' a common tail.
  *
  * Copyright:   Copyright (C) 1986-1990 by Northwest Software
- *              Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ *              Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/tk/dlist.d, backend/tk/_dlist.d)

--- a/src/ddmd/tk/vec.c
+++ b/src/ddmd/tk/vec.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 1986-2012 by Digital Mars              */
+/* Copyright (C) 1986-2012 by The D Language Foundation     */
 /* Written by Walter Bright                             */
 /* Bit vector package                                   */
 

--- a/src/ddmd/tocsym.d
+++ b/src/ddmd/tocsym.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _tocsym.d)

--- a/src/ddmd/toctype.d
+++ b/src/ddmd/toctype.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/toctype.d, _toctype.d)

--- a/src/ddmd/tocvdebug.d
+++ b/src/ddmd/tocvdebug.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _tocvdebug.d)

--- a/src/ddmd/todt.d
+++ b/src/ddmd/todt.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/todt.d, _todt.d)

--- a/src/ddmd/toir.d
+++ b/src/ddmd/toir.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/_tocsym.d, _toir.d)

--- a/src/ddmd/tokens.d
+++ b/src/ddmd/tokens.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/tokens.d, _tokens.d)

--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _toobj.d)

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/traits.d, _traits.d)

--- a/src/ddmd/typesem.d
+++ b/src/ddmd/typesem.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(DMDSRC _mtype.d)

--- a/src/ddmd/typinf.d
+++ b/src/ddmd/typinf.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/typeinf.d, _typeinf.d)

--- a/src/ddmd/utf.d
+++ b/src/ddmd/utf.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/utf.d, _utf.d)

--- a/src/ddmd/utils.d
+++ b/src/ddmd/utils.d
@@ -5,7 +5,7 @@
  *
  * This modules defines some utility functions for DMD.
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/utils.d, _utils.d)

--- a/src/ddmd/version.h
+++ b/src/ddmd/version.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2016 by The D Language Foundation
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com

--- a/src/ddmd/visitor.d
+++ b/src/ddmd/visitor.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/visitor.d, _visitor.d)

--- a/src/ddmd/visitor.h
+++ b/src/ddmd/visitor.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 2013-2014 by Digital Mars
+ * Copyright (c) 2013-2014 by The D Language Foundation
  * All Rights Reserved
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.

--- a/src/vcbuild/ldfpu.asm
+++ b/src/vcbuild/ldfpu.asm
@@ -1,5 +1,5 @@
 ;; Compiler implementation of the D programming language
-;; Copyright (c) 1999-2016 by Digital Mars
+;; Copyright (c) 1999-2016 by The D Language Foundation
 ;; All Rights Reserved
 ;; written by Rainer Schuetze
 ;; http://www.digitalmars.com

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -1,6 +1,6 @@
 #_ win32.mak
 #
-# Copyright (c) 1999-2016 by Digital Mars
+# Copyright (c) 1999-2016 by The D Language Foundation
 # All Rights Reserved
 # written by Walter Bright
 # http://www.digitalmars.com

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -1,6 +1,6 @@
 // PERMUTE_ARGS:
 
-// Copyright (c) 1999-2016 by Digital Mars
+// Copyright (c) 1999-2016 by The D Language Foundation
 // All Rights Reserved
 // written by Walter Bright
 // http://www.digitalmars.com

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -1,6 +1,6 @@
 // PERMUTE_ARGS:
 
-// Copyright (c) 1999-2016 by Digital Mars
+// Copyright (c) 1999-2016 by The D Language Foundation
 // All Rights Reserved
 // written by Walter Bright
 // http://www.digitalmars.com


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/6771#discussion_r127611531

> CC @WalterBright @andralex - can we replace/update the copyright notice from Digital Mars to D Language Foundation?
> I'm okay with it. @WalterBright ?