### PR TITLE
Fix Issue 17660 - ICE with `static foreach`: AssertError@ddmd/visitor.d(39)

### DIFF
--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -415,12 +415,6 @@ public:
             ctfeCompile(s.statement);
     }
 
-    override void visit(ForwardingStatement s)
-    {
-        assert(!!s.statement);
-        s.statement.accept(this);
-    }
-
     override void visit(OnScopeStatement s)
     {
         debug (LOGCOMPILE)
@@ -1242,12 +1236,6 @@ public:
             istate.start = null;
 
         result = interpret(s.statement, istate);
-    }
-
-    override void visit(ForwardingStatement s)
-    {
-        assert(!!s.statement);
-        s.statement.accept(this);
     }
 
     /**

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -189,14 +189,6 @@ public:
         buf.writenl();
     }
 
-    override void visit(ForwardingStatement s)
-    {
-        if (s.statement)
-        {
-            s.statement.accept(this);
-        }
-    }
-
     override void visit(WhileStatement s)
     {
         buf.writestring("while (");

--- a/src/ddmd/s2ir.d
+++ b/src/ddmd/s2ir.d
@@ -983,15 +983,6 @@ extern (C++) class S2irVisitor : Visitor
     /***************************************
      */
 
-    override void visit(ForwardingStatement s)
-    {
-        assert(!!s.statement);
-        s.statement.accept(this);
-    }
-
-    /***************************************
-     */
-
     override void visit(WithStatement s)
     {
         Symbol *sp;

--- a/src/ddmd/visitor.d
+++ b/src/ddmd/visitor.d
@@ -86,7 +86,10 @@ extern (C++) class Visitor
 
     void visit(ForwardingStatement s)
     {
-        visit(cast(Statement)s);
+        if (s.statement)
+        {
+            s.statement.accept(this);
+        }
     }
 
     void visit(WhileStatement s)

--- a/test/compilable/staticforeach.d
+++ b/test/compilable/staticforeach.d
@@ -632,3 +632,9 @@ void testEmpty(){
     static foreach(i;0..0) { }
 }
 
+auto bug17660(){
+    int x;
+    static foreach (i; 0 .. 1) { return 3; }
+    return x;
+}
+static assert(bug17660()==3);


### PR DESCRIPTION
This adds a default implementation for ForwardingStatement to the Statement visitor.