### PR TITLE
better error messages for better C

### DIFF
--- a/src/ddmd/dscope.d
+++ b/src/ddmd/dscope.d
@@ -29,6 +29,7 @@ import ddmd.root.outbuffer;
 import ddmd.root.rmem;
 import ddmd.root.speller;
 import ddmd.statement;
+import ddmd.tokens;
 
 //version=LOGSEARCH;
 
@@ -644,6 +645,30 @@ struct Scope
         }
 
         return cast(Dsymbol)speller(ident.toChars(), &scope_search_fp, idchars);
+    }
+
+    /************************************
+     * Maybe `ident` was a C or C++ name. Check for that,
+     * and suggest the D equivalent.
+     * Params:
+     *  ident = unknown identifier
+     * Returns:
+     *  D identifier string if found, null if not
+     */
+    extern (C++) static const(char)* search_correct_C(Identifier ident)
+    {
+        TOK tok;
+        if (ident == Id.NULL)
+            tok = TOKnull;
+        else if (ident == Id.TRUE)
+            tok = TOKtrue;
+        else if (ident == Id.FALSE)
+            tok = TOKfalse;
+        else if (ident == Id.unsigned)
+            tok = TOKuns32;
+        else
+            return null;
+        return Token.toChars(tok);
     }
 
     extern (C++) Dsymbol insert(Dsymbol s)

--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -281,17 +281,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        const(char)* n = importHint(exp.ident.toChars());
-        if (n)
+        /* Look for what user might have meant
+         */
+        if (const n = importHint(exp.ident.toChars()))
             exp.error("`%s` is not defined, perhaps `import %s;` is needed?", exp.ident.toChars(), n);
+        else if (auto s2 = sc.search_correct(exp.ident))
+            exp.error("undefined identifier `%s`, did you mean %s `%s`?", exp.ident.toChars(), s2.kind(), s2.toChars());
+        else if (const p = Scope.search_correct_C(exp.ident))
+            exp.error("undefined identifier `%s`, did you mean `%s`?", exp.ident.toChars(), p);
         else
-        {
-            s = sc.search_correct(exp.ident);
-            if (s)
-                exp.error("undefined identifier `%s`, did you mean %s `%s`?", exp.ident.toChars(), s.kind(), s.toChars());
-            else
-                exp.error("undefined identifier `%s`", exp.ident.toChars());
-        }
+            exp.error("undefined identifier `%s`", exp.ident.toChars());
+
         result = new ErrorExp();
     }
 

--- a/src/ddmd/id.d
+++ b/src/ddmd/id.d
@@ -393,6 +393,12 @@ immutable Msgtable[] msgtable =
 
     // Compiler recognized UDA's
     { "udaSelector", "selector" },
+
+    // C names, for undefined identifier error messages
+    { "NULL" },
+    { "TRUE" },
+    { "FALSE" },
+    { "unsigned" },
 ];
 
 

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -7615,19 +7615,19 @@ extern (C++) abstract class TypeQualified : Type
         }
         if (!s)
         {
-            const(char)* p = mutableOf().unSharedOf().toChars();
-            const(char)* n = importHint(p);
-            if (n)
-                error(loc, "'%s' is not defined, perhaps you need to import %s; ?", p, n);
+            /* Look for what user might have intended
+             */
+            const p = mutableOf().unSharedOf().toChars();
+            auto id = Identifier.idPool(p, strlen(p));
+            if (const n = importHint(p))
+                error(loc, "`%s` is not defined, perhaps `import %s;` ?", p, n);
+            else if (auto s2 = sc.search_correct(id))
+                error(loc, "undefined identifier `%s`, did you mean %s `%s`?", p, s2.kind(), s2.toChars());
+            else if (const q = Scope.search_correct_C(id))
+                error(loc, "undefined identifier `%s`, did you mean `%s`?", p, q);
             else
-            {
-                auto id = new Identifier(p);
-                s = sc.search_correct(id);
-                if (s)
-                    error(loc, "undefined identifier `%s`, did you mean %s `%s`?", p, s.kind(), s.toChars());
-                else
-                    error(loc, "undefined identifier `%s`", p);
-            }
+                error(loc, "undefined identifier `%s`", p);
+
             *pt = Type.terror;
         }
     }

--- a/test/fail_compilation/cwords.d
+++ b/test/fail_compilation/cwords.d
@@ -1,0 +1,17 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/cwords.d(13): Error: undefined identifier `FALSE`, did you mean `false`?
+fail_compilation/cwords.d(14): Error: undefined identifier `TRUE`, did you mean `true`?
+fail_compilation/cwords.d(15): Error: undefined identifier `NULL`, did you mean `null`?
+fail_compilation/cwords.d(16): Error: undefined identifier `unsigned`, did you mean `uint`?
+---
+*/
+
+
+void foo()
+{
+    bool a = FALSE;
+    bool b = TRUE;
+    int* p = NULL;
+    unsigned u;
+}


### PR DESCRIPTION
In converting C code to D, these identifiers crop up constantly, justifying a better error message.