### PR TITLE
[WIP] Solve most spurious forward/circular referencing errors

### DIFF
--- a/src/ddmd/access.d
+++ b/src/ddmd/access.d
@@ -558,7 +558,7 @@ private Dsymbol mostVisibleOverload(Dsymbol s)
         {
             assert(ad.isOverloadable, "Non overloadable Aliasee in overload list");
             // Yet unresolved aliases store overloads in overnext.
-            if (ad.semanticRun < PASSsemanticdone)
+            if (ad.aliasState != SemState.Done)
                 next = ad.overnext;
             else
             {

--- a/src/ddmd/aggregate.d
+++ b/src/ddmd/aggregate.d
@@ -110,9 +110,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      * Create a new scope from sc.
      * semantic, semantic2 and semantic3 will use this for aggregate members.
      */
-    override Scope* newScope(Scope* sc)
+    override Scope* newScope()
     {
-        auto sc2 = sc.push(this);
+        auto sc2 = _scope.push(this);
         sc2.stc &= STCsafe | STCtrusted | STCsystem;
         sc2.parent = this;
         if (isUnionDeclaration())

--- a/src/ddmd/aggregate.d
+++ b/src/ddmd/aggregate.d
@@ -255,7 +255,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             if (v.aliassym)
                 return 0;   // If this variable was really a tuple, skip it.
 
-            if (v.storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCctfe | STCtemplateparameter))
+            if (v.storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCctfe | STCtemplateparameter)) // FWDREF FIXME: we should skip static variables, but part of semantic should have run to know that
                 return 0;
             if (!v.isField() || v.semanticRun < PASSsemanticdone)
                 return 1;   // unresolvable forward reference
@@ -320,7 +320,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         }
 
         if (_scope)
-            semantic(null);
+            importAll(_scope);
 
         // Determine the instance size of base class first.
         if (auto cd = isClassDeclaration())

--- a/src/ddmd/aggregate.d
+++ b/src/ddmd/aggregate.d
@@ -246,8 +246,8 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
             auto ad = cast(AggregateDeclaration)param;
 
-            if (v.semanticRun < PASSsemanticdone)
-                v.semantic(null);
+            if (v.semanticRun < PASSmembersdone)
+                v.importAll(null);
             // Return in case a recursive determineFields triggered by v.semantic already finished
             if (ad.sizeok != SIZEOKnone)
                 return 1;
@@ -257,7 +257,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
             if (v.storage_class & (STCstatic | STCextern | STCtls | STCgshared | STCmanifest | STCctfe | STCtemplateparameter)) // FWDREF FIXME: we should skip static variables, but part of semantic should have run to know that
                 return 0;
-            if (!v.isField() || v.semanticRun < PASSsemanticdone)
+            if (!v.isField() || v.semanticRun < PASSmembersdone)
                 return 1;   // unresolvable forward reference
 
             ad.fields.push(v);

--- a/src/ddmd/aggregate.d
+++ b/src/ddmd/aggregate.d
@@ -103,7 +103,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         super(id);
         this.loc = loc;
         protection = Prot(PROTpublic);
-        sizeok = SIZEOKnone; // size not determined yet
     }
 
     /***************************************
@@ -142,8 +141,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 sc3.stc |= STCdeprecated;
 
             ti.semantic(sc3);
-            ti.semantic2(sc3);
-            ti.semantic3(sc3);
             auto e = DsymbolExp.resolve(Loc(), sc3, ti.toAlias(), false);
 
             sc3.endCTFE();
@@ -321,7 +318,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     final bool checkOverlappedFields()
     {
         //printf("AggregateDeclaration::checkOverlappedFields() %s\n", toChars());
-        assert(sizeok == SIZEOKdone);
+        assert(sizeState == SemState.Done);
         size_t nfields = fields.dim;
         if (isNested())
         {
@@ -396,7 +393,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     final bool fill(Loc loc, Expressions* elements, bool ctorinit)
     {
         //printf("AggregateDeclaration::fill() %s\n", toChars());
-        assert(sizeok == SIZEOKdone);
+        assert(sizeState == SemState.Done);
         assert(elements);
         size_t nfields = fields.dim - isNested();
         bool errors = false;
@@ -684,7 +681,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             vthis.parent = this;
             vthis.protection = Prot(PROTpublic);
             vthis.alignment = t.alignment();
-            vthis.semanticRun = PASSsemanticdone;
+            vthis.typeState = SemState.Done;
+            vthis.initializerState = SemState.Done;
+            vthis.semanticState = SemState.Done;
 
             if (fieldsState == SemState.Done)
                 fields.push(vthis);
@@ -724,7 +723,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 {
                     auto f = s.isCtorDeclaration();
                     if (f && f.semanticRun == PASSinit)
-                        f.semantic(null);
+                        f.semantic();
                     return 0;
                 }
             }

--- a/src/ddmd/aggregate.h
+++ b/src/ddmd/aggregate.h
@@ -58,13 +58,6 @@ enum StructPOD
     ISPODfwd,           // POD not yet computed
 };
 
-enum Abstract
-{
-    ABSfwdref = 0,      // whether an abstract class is not yet computed
-    ABSyes,             // is abstract class
-    ABSno,              // is not abstract class
-};
-
 FuncDeclaration *hasIdentityOpAssign(AggregateDeclaration *ad, Scope *sc);
 FuncDeclaration *buildOpAssign(StructDeclaration *sd, Scope *sc);
 bool needOpEquals(StructDeclaration *sd);
@@ -277,9 +270,8 @@ public:
     bool cpp;                           // true if this is a C++ interface
     bool isobjc;                        // true if this is an Objective-C class/interface
     bool isscope;                       // true if this is a scope class
-    Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
+    bool isabstract;                // true if this is an abstract class
     int inuse;                          // to prevent recursive attempts
-    Baseok baseok;                      // set the progress of base classes resolving
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -297,7 +289,7 @@ public:
     void finalizeSize();
     bool isFuncHidden(FuncDeclaration *fd);
     FuncDeclaration *findFunc(Identifier *ident, TypeFunction *tf);
-    void interfaceSemantic(Scope *sc);
+    void initVtblInterfaces();
     bool isCOMclass() const;
     virtual bool isCOMinterface() const;
     bool isCPPclass() const;

--- a/src/ddmd/arrayop.d
+++ b/src/ddmd/arrayop.d
@@ -79,10 +79,9 @@ extern (C++) FuncDeclaration buildArrayOp(Identifier ident, BinExp exp, Scope* s
     sc.parent = sc._module.importedFrom;
     sc.stc = 0;
     sc.linkage = LINKc;
-    fd.semantic(sc);
-    fd.semantic2(sc);
+    fd.setScope(sc);
     uint errors = global.startGagging();
-    fd.semantic3(sc);
+    fd.semanticBody(); // FWDREF NOTE not sure if correct, but master got rid of compiler-generated array op so it doesn't matter much
     if (global.endGagging(errors))
     {
         fd.type = Type.terror;

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -155,18 +155,22 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
     {
         if (semanticRun >= PASSmembersdone || ininc)
             return;
-        if (semanticRun == PASSinit)
+
+        if (semanticRun == PASSinit ||
+                (semanticRun == PASSmembersdeferred && !membersNest))
             semanticRun = PASSmembers;
+
         ininc = true;
         Dsymbols* d = include(sc, null);
         ininc = false;
-        if (!d && semanticRun == PASSmembersdeferred)
-            return; // might be too soon for the static if cond
         //printf("\tAttribDeclaration::importAll '%s', d = %p\n", toChars(), d);
+
         if (d)
         {
+            if (!membersNest)
+                nextMember = 0;
+
             Scope* sc2 = newScope(sc);
-            auto oldnextMember = nextMember;
             ++membersNest;
             while (nextMember < d.dim)
             {
@@ -177,7 +181,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
                 ++nextMember;
             }
             --membersNest;
-            nextMember = oldnextMember;
+
             if (sc2 != sc)
                 sc2.pop();
         }

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -1329,13 +1329,12 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
             return;
         includeState = SemState.In;
 
+        void defer() { includeState = SemState.Defer; }
+
         auto e = semanticString(_scope, exp, "argument to mixin");
         if (e.op == TOKdefer)
-        {
-            includeState = SemState.Defer;
-            return:
-        }
-        assert(e.op == TOKstring)
+            return defer();
+        assert(e.op == TOKstring);
         auto se = cast(StringExp) e;
         if (!se)
             return;

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -148,21 +148,29 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         }
     }
 
+    bool ininc;
+    size_t nextMember;
     override void importAll(Scope* sc)
     {
+        if (semanticRun >= PASSmembersdone || ininc)
+            return;
+        ininc = true;
         Dsymbols* d = include(sc, null);
+        ininc = false;
         //printf("\tAttribDeclaration::importAll '%s', d = %p\n", toChars(), d);
         if (d)
         {
             Scope* sc2 = newScope(sc);
-            for (size_t i = 0; i < d.dim; i++)
+            while (nextMember < d.dim)
             {
-                Dsymbol s = (*d)[i];
+                auto s = (*d)[nextMember];
                 s.importAll(sc2);
+                ++nextMember;
             }
             if (sc2 != sc)
                 sc2.pop();
         }
+        semanticRun = PASSmembersdone;
     }
 
     override void semantic(Scope* sc)

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -1614,9 +1614,13 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
 
     override void importAll(Scope* sc)
     {
+        if (semanticRun >= PASSmembersdone || ininc)
+            return;
         if (!compiled)
         {
+            ininc = true;
             compileIt(sc);
+            ininc = false;
             AttribDeclaration.addMember(sc, scopesym);
             compiled = true;
 

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -167,7 +167,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void semantic(Scope* sc)
     {
-        if (semanticRun != PASSinit)
+        if (semanticRun >= PASSsemantic)
             return;
         semanticRun = PASSsemantic;
         Dsymbols* d = include(sc, null);
@@ -1364,7 +1364,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
 
     override void importAll(Scope* sc)
     {
-        // do not evaluate condition before semantic pass
+        AttribDeclaration.importAll(sc);
     }
 
     override void semantic(Scope* sc)
@@ -1477,7 +1477,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
 
     override void importAll(Scope* sc)
     {
-        // do not evaluate aggregate before semantic pass
+        AttribDeclaration.importAll(sc);
     }
 
     override void semantic(Scope* sc)
@@ -1601,6 +1601,26 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
             assert(global.errors != errors);
             decl = null;
         }
+    }
+
+    override void importAll(Scope* sc)
+    {
+        if (!compiled)
+        {
+            compileIt(sc);
+            AttribDeclaration.addMember(sc, scopesym);
+            compiled = true;
+
+            if (_scope && decl)
+            {
+                for (size_t i = 0; i < decl.dim; i++)
+                {
+                    Dsymbol s = (*decl)[i];
+                    s.setScope(_scope);
+                }
+            }
+        }
+        AttribDeclaration.importAll(sc);
     }
 
     override void semantic(Scope* sc)

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -1207,10 +1207,11 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
     Condition condition;
     Dsymbols* elsedecl;     // array of Dsymbol's for else block
 
-    final extern (D) this(Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
+    final extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
     {
         super(decl);
         //printf("ConditionalDeclaration::ConditionalDeclaration()\n");
+        this.loc = loc;
         this.condition = condition;
         this.elsedecl = elsedecl;
     }
@@ -1218,7 +1219,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        return new ConditionalDeclaration(condition.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl), Dsymbol.arraySyntaxCopy(elsedecl));
+        return new ConditionalDeclaration(loc, condition.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl), Dsymbol.arraySyntaxCopy(elsedecl));
     }
 
     override final bool oneMember(Dsymbol* ps, Identifier ident)
@@ -1298,16 +1299,16 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
     ScopeDsymbol scopesym;
     bool addisdone;
 
-    extern (D) this(Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
+    extern (D) this(Loc loc, Condition condition, Dsymbols* decl, Dsymbols* elsedecl)
     {
-        super(condition, decl, elsedecl);
+        super(loc, condition, decl, elsedecl);
         //printf("StaticIfDeclaration::StaticIfDeclaration()\n");
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        return new StaticIfDeclaration(condition.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl), Dsymbol.arraySyntaxCopy(elsedecl));
+        return new StaticIfDeclaration(loc, condition.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl), Dsymbol.arraySyntaxCopy(elsedecl));
     }
 
     /****************************************

--- a/src/ddmd/canthrow.d
+++ b/src/ddmd/canthrow.d
@@ -242,7 +242,7 @@ extern (C++) bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNot
     ad = s.isAttribDeclaration();
     if (ad)
     {
-        Dsymbols* decl = ad.include(null, null);
+        Dsymbols* decl = ad.include(null);
         if (decl && decl.dim)
         {
             for (size_t i = 0; i < decl.dim; i++)

--- a/src/ddmd/clone.d
+++ b/src/ddmd/clone.d
@@ -308,15 +308,14 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
     fop.addMember(sc, sd);
     sd.hasIdentityAssign = true; // temporary mark identity assignable
     uint errors = global.startGagging(); // Do not report errors, even if the
-    Scope* sc2 = sc.push();
-    sc2.stc = 0;
-    sc2.linkage = LINKd;
-    fop.semantic(sc2);
-    fop.semantic2(sc2);
+//     Scope* sc2 = sc.push();
+//     sc2.stc = 0;
+//     sc2.linkage = LINKd;
+    fop.semanticBody(); // FWDREF FIXME?! isn't determineMembers a bit early for this?
     // https://issues.dlang.org/show_bug.cgi?id=15044
     // fop.semantic3 isn't run here for lazy forward reference resolution.
 
-    sc2.pop();
+//     sc2.pop();
     if (global.endGagging(errors)) // if errors happened
     {
         // Disable generated opAssign, because some members forbid identity assignment.

--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -760,8 +760,8 @@ extern (C++) final class StaticIfCondition : Condition
             sc.sds = sds; // sds gets any addMember()
 
             import ddmd.staticcond;
-            bool errors;
-            bool result = evalStaticCondition(sc, exp, exp, errors);
+            bool errors, defer;
+            bool result = evalStaticCondition(sc, exp, exp, errors, defer);
             sc.pop();
             --nest;
             // Prevent repeated condition evaluation.
@@ -770,6 +770,11 @@ extern (C++) final class StaticIfCondition : Condition
                 return (inc == 1);
             if (errors)
                 return errorReturn();
+            if (defer)
+            {
+                assert(inc == 0); // FWDREF TODO check fail7815?
+                return 0;
+            }
             if (result)
                 inc = 1;
             else

--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -757,14 +757,13 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     // Initialize the vtbl before running any FuncDeclaration.semantic() on virtual methods
     final void initVtbl(Scope *sc)
     {
-        if (vtbl.dim)
+        if (baseok >= BASEOKsemanticdone)
             return;
+        assert(baseok == BASEOKdone);
 
         if (_scope)
             sc = _scope;
         assert(sc);
-
-        assert(semanticRun == PASSmembersdone || semanticRun == PASSsemantic);
 
         for (size_t i = 0; i < baseclasses.dim; i++)
         {

--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -473,6 +473,16 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                 parent = sc.parent;
             }
 
+            if (this.errors)
+                type = Type.terror;
+            type = type.semantic(loc, sc);
+            if (type.ty == Tclass && (cast(TypeClass)type).sym != this)
+            {
+                auto ti = (cast(TypeClass)type).sym.isInstantiated();
+                if (ti && isError(ti))
+                    (cast(TypeClass)type).sym = this;
+            }
+
             protection = sc.protection;
 
             storage_class |= sc.stc;
@@ -845,16 +855,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             sc = _scope;
             scx = _scope; // save so we don't make redundant copies
             _scope = null;
-        }
-
-        if (this.errors)
-            type = Type.terror;
-        type = type.semantic(loc, sc);
-        if (type.ty == Tclass && (cast(TypeClass)type).sym != this)
-        {
-            auto ti = (cast(TypeClass)type).sym.isInstantiated();
-            if (ti && isError(ti))
-                (cast(TypeClass)type).sym = this;
         }
 
         // Ungag errors when not speculative

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -1800,6 +1800,81 @@ extern (C++) class VarDeclaration : Declaration
         }
 
     Ldone:
+        if (_init && !toParent().isFuncDeclaration())
+        {
+            inuse++;
+            version (none)
+            {
+                ExpInitializer ei = _init.isExpInitializer();
+                if (ei)
+                {
+                    ei.exp.print();
+                    printf("type = %p\n", ei.exp.type);
+                }
+            }
+            // https://issues.dlang.org/show_bug.cgi?id=14166
+            // Don't run CTFE for the temporary variables inside typeof
+            _init = _init.semantic(sc, type, sc.intypeof == 1 ? INITnointerpret : INITinterpret);
+            inuse--;
+        }
+        if (_init && storage_class & STCmanifest)
+        {
+            /* Cannot initializer enums with CTFE classreferences and addresses of struct literals.
+             * Scan initializer looking for them. Issue error if found.
+             */
+            if (ExpInitializer ei = _init.isExpInitializer())
+            {
+                static bool hasInvalidEnumInitializer(Expression e)
+                {
+                    static bool arrayHasInvalidEnumInitializer(Expressions* elems)
+                    {
+                        foreach (e; *elems)
+                        {
+                            if (e && hasInvalidEnumInitializer(e))
+                                return true;
+                        }
+                        return false;
+                    }
+
+                    if (e.op == TOKclassreference)
+                        return true;
+                    if (e.op == TOKaddress && (cast(AddrExp)e).e1.op == TOKstructliteral)
+                        return true;
+                    if (e.op == TOKarrayliteral)
+                        return arrayHasInvalidEnumInitializer((cast(ArrayLiteralExp)e).elements);
+                    if (e.op == TOKstructliteral)
+                        return arrayHasInvalidEnumInitializer((cast(StructLiteralExp)e).elements);
+                    if (e.op == TOKassocarrayliteral)
+                    {
+                        AssocArrayLiteralExp ae = cast(AssocArrayLiteralExp)e;
+                        return arrayHasInvalidEnumInitializer(ae.values) ||
+                               arrayHasInvalidEnumInitializer(ae.keys);
+                    }
+                    return false;
+                }
+
+                if (hasInvalidEnumInitializer(ei.exp))
+                    error(": Unable to initialize enum with class or pointer to struct. Use static const variable instead.");
+            }
+        }
+        else if (_init && isThreadlocal())
+        {
+            if ((type.ty == Tclass) && type.isMutable() && !type.isShared())
+            {
+                ExpInitializer ei = _init.isExpInitializer();
+                if (ei && ei.exp.op == TOKclassreference)
+                    error("is mutable. Only const or immutable class thread local variable are allowed, not %s", type.toChars());
+            }
+            else if (type.ty == Tpointer && type.nextOf().ty == Tstruct && type.nextOf().isMutable() && !type.nextOf().isShared())
+            {
+                ExpInitializer ei = _init.isExpInitializer();
+                if (ei && ei.exp.op == TOKaddress && (cast(AddrExp)ei.exp).e1.op == TOKstructliteral)
+                {
+                    error("is a pointer to mutable struct. Only pointers to const, immutable or shared struct thread local variable are allowed, not %s", type.toChars());
+                }
+            }
+        }
+
         initializerState = SemState.Done;
     }
 
@@ -1836,6 +1911,7 @@ extern (C++) class VarDeclaration : Declaration
             /* Templates cannot add fields to aggregates // FWDREF FIXME: What??? How is that even supposed to happen?
              */
             TemplateInstance ti = parent.isTemplateInstance();
+            assert(!ti); // FWDREF
             if (ti)
             {
                 // Take care of nested templates
@@ -1989,95 +2065,6 @@ extern (C++) class VarDeclaration : Declaration
 
         //printf("\t%s: memalignsize = %d\n", toChars(), memalignsize);
         //printf(" addField '%s' to '%s' at offset %d, size = %d\n", toChars(), ad.toChars(), offset, memsize);
-    }
-
-    override final void semantic2(Scope* sc)
-    {
-        if (semanticRun < PASSsemanticdone && inuse)
-            return;
-        assert(semanticRun >= PASSsemanticdone);
-
-        //printf("VarDeclaration::semantic2('%s')\n", toChars());
-
-        if (_scope)
-            sc = _scope;
-        assert(sc);
-
-        if (_init && !toParent().isFuncDeclaration())
-        {
-            inuse++;
-            version (none)
-            {
-                ExpInitializer ei = _init.isExpInitializer();
-                if (ei)
-                {
-                    ei.exp.print();
-                    printf("type = %p\n", ei.exp.type);
-                }
-            }
-            // https://issues.dlang.org/show_bug.cgi?id=14166
-            // Don't run CTFE for the temporary variables inside typeof
-            _init = _init.semantic(sc, type, sc.intypeof == 1 ? INITnointerpret : INITinterpret);
-            inuse--;
-        }
-        if (_init && storage_class & STCmanifest)
-        {
-            /* Cannot initializer enums with CTFE classreferences and addresses of struct literals.
-             * Scan initializer looking for them. Issue error if found.
-             */
-            if (ExpInitializer ei = _init.isExpInitializer())
-            {
-                static bool hasInvalidEnumInitializer(Expression e)
-                {
-                    static bool arrayHasInvalidEnumInitializer(Expressions* elems)
-                    {
-                        foreach (e; *elems)
-                        {
-                            if (e && hasInvalidEnumInitializer(e))
-                                return true;
-                        }
-                        return false;
-                    }
-
-                    if (e.op == TOKclassreference)
-                        return true;
-                    if (e.op == TOKaddress && (cast(AddrExp)e).e1.op == TOKstructliteral)
-                        return true;
-                    if (e.op == TOKarrayliteral)
-                        return arrayHasInvalidEnumInitializer((cast(ArrayLiteralExp)e).elements);
-                    if (e.op == TOKstructliteral)
-                        return arrayHasInvalidEnumInitializer((cast(StructLiteralExp)e).elements);
-                    if (e.op == TOKassocarrayliteral)
-                    {
-                        AssocArrayLiteralExp ae = cast(AssocArrayLiteralExp)e;
-                        return arrayHasInvalidEnumInitializer(ae.values) ||
-                               arrayHasInvalidEnumInitializer(ae.keys);
-                    }
-                    return false;
-                }
-
-                if (hasInvalidEnumInitializer(ei.exp))
-                    error(": Unable to initialize enum with class or pointer to struct. Use static const variable instead.");
-            }
-        }
-        else if (_init && isThreadlocal())
-        {
-            if ((type.ty == Tclass) && type.isMutable() && !type.isShared())
-            {
-                ExpInitializer ei = _init.isExpInitializer();
-                if (ei && ei.exp.op == TOKclassreference)
-                    error("is mutable. Only const or immutable class thread local variable are allowed, not %s", type.toChars());
-            }
-            else if (type.ty == Tpointer && type.nextOf().ty == Tstruct && type.nextOf().isMutable() && !type.nextOf().isShared())
-            {
-                ExpInitializer ei = _init.isExpInitializer();
-                if (ei && ei.exp.op == TOKaddress && (cast(AddrExp)ei.exp).e1.op == TOKstructliteral)
-                {
-                    error("is a pointer to mutable struct. Only pointers to const, immutable or shared struct thread local variable are allowed, not %s", type.toChars());
-                }
-            }
-        }
-        semanticRun = PASSsemantic2done;
     }
 
     override const(char)* kind() const

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -857,7 +857,7 @@ extern (C++) final class AliasDeclaration : Declaration
                 /* If this is an internal alias for selective/renamed import,
                  * load the module first.
                  */
-                _import.semantic(null);
+                _import.importAll(null);
             }
             if (_scope)
             {

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -1331,7 +1331,7 @@ extern (C++) class VarDeclaration : Declaration
         }
     }
 
-    final void semanticType()
+    override void semanticType()
     {
         if (typeState == SemState.Done)
             return;

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -2048,6 +2048,7 @@ extern (C++) class VarDeclaration : Declaration
     {
         if (semanticRun < PASSsemanticdone && inuse)
             return;
+        assert(semanticRun >= PASSsemanticdone);
 
         //printf("VarDeclaration::semantic2('%s')\n", toChars());
 
@@ -2370,8 +2371,6 @@ extern (C++) class VarDeclaration : Declaration
      */
     final Expression getConstInitializer(bool needFullType = true)
     {
-        assert(type && _init);
-
         // Ungag errors when not speculative
         uint oldgag = global.gag;
         if (global.gag)
@@ -2386,6 +2385,7 @@ extern (C++) class VarDeclaration : Declaration
             semantic(null);
             semantic2(null);
         }
+        assert(type && _init);
 
         auto vinit = _init;
 
@@ -2602,6 +2602,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         protection = Prot(PROTpublic);
         linkage = LINKc;
         alignment = Target.ptrsize;
+        semanticRun = PASSsemanticdone;
     }
 
     static TypeInfoDeclaration create(Type tinfo)

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -172,7 +172,7 @@ extern (C++) abstract class Declaration : Dsymbol
         linkage = LINKdefault;
     }
 
-    override void semantic(Scope* sc)
+    override void semantic()
     {
     }
 

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -2416,15 +2416,19 @@ extern (C++) class VarDeclaration : Declaration
                 global.gag = 0;
         }
 
+        auto vinit = _init;
+
         if (_scope)
         {
             inuse++;
-            _init = _init.semantic(_scope, type, INITinterpret);
-            _scope = null;
+            vinit = _init.semantic(_scope, type, INITinterpret);
+            if (!vinit.isDeferInitializer())
+                _init = vinit;
+//             _scope = null; // FWDREF FIXME?: this whole parallel initializer affair doesn't seem right to me, what's wrong with semantic()?
             inuse--;
         }
 
-        Expression e = _init.toExpression(needFullType ? type : null);
+        Expression e = vinit.toExpression(needFullType ? type : null);
         global.gag = oldgag;
         return e;
     }

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -1385,6 +1385,7 @@ extern (C++) class VarDeclaration : Declaration
                     storage_class |= arg.storageClass;
                 auto v = new VarDeclaration(loc, arg.type, id, ti, storage_class);
                 //printf("declaring field %s of type %s\n", v.toChars(), v.type.toChars());
+                v.setScope(sc);
                 v.importAll(sc);
 
                 if (sc.scopesym)
@@ -2050,6 +2051,10 @@ extern (C++) class VarDeclaration : Declaration
 
         //printf("VarDeclaration::semantic2('%s')\n", toChars());
 
+        if (_scope)
+            sc = _scope;
+        assert(sc);
+
         if (_init && !toParent().isFuncDeclaration())
         {
             inuse++;
@@ -2376,9 +2381,15 @@ extern (C++) class VarDeclaration : Declaration
                 global.gag = 0;
         }
 
+        if (_scope && semanticRun < PASSsemantic2done)
+        {
+            semantic(null);
+            semantic2(null);
+        }
+
         auto vinit = _init;
 
-        if (_scope)
+        if (_scope && semanticRun < PASSsemantic2done)
         {
             inuse++;
             vinit = _init.semantic(_scope, type, INITinterpret);

--- a/src/ddmd/denum.d
+++ b/src/ddmd/denum.d
@@ -334,21 +334,21 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         return "enum";
     }
 
-    override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
-    {
-        //printf("%s.EnumDeclaration::search('%s')\n", toChars(), ident.toChars());
-        importAll(_scope);
-
-        if (!members || !symtab || _scope)
-        {
-            error("is forward referenced when looking for `%s`", ident.toChars());
-            //*(char*)0=0;
-            return null;
-        }
-
-        Dsymbol s = ScopeDsymbol.search(loc, ident, flags);
-        return s;
-    }
+//     override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
+//     {
+//         //printf("%s.EnumDeclaration::search('%s')\n", toChars(), ident.toChars());
+//         importAll(_scope);
+//
+//         if (!members || !symtab || _scope)
+//         {
+//             error("is forward referenced when looking for `%s`", ident.toChars());
+//             //*(char*)0=0;
+//             return null;
+//         }
+//
+//         Dsymbol s = ScopeDsymbol.search(loc, ident, flags);
+//         return s;
+//     }
 
     // is Dsymbol deprecated?
     override bool isDeprecated()

--- a/src/ddmd/denum.d
+++ b/src/ddmd/denum.d
@@ -111,7 +111,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
 
     override void importAll(Scope* sc)
     {
-        if (semanticRun >= PASSmembersdone)
+        if (semanticRun >= PASSmembers) // since there's no members.importAll calls (which is strange, can't enums contain static if?), no need to support recursive calls
             return;
         semanticRun = PASSmembers;
 
@@ -145,7 +145,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         {
             EnumMember em = (*members)[i].isEnumMember();
             if (em)
-                em._scope = sce; // FWDREF WARNING: can't enum contain more than just EnumMembers at this point?
+                em._scope = sce; // FWDREF WARNING: can't enum contain more than just EnumMembers at this point e.g attributes?
         }
 
         if (!added)

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -202,6 +202,9 @@ extern (C++) final class Import : Dsymbol
 
     override void importAll(Scope* sc)
     {
+        if (_scope)
+            sc = _scope;
+
         if (!mod)
         {
             load(sc);

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -271,10 +271,11 @@ extern (C++) final class Import : Dsymbol
             else
                 mod.deprecation(loc, "is deprecated");
         }
+
+        auto sc = _scope;
+
         if (!isstatic && !aliasId && !names.dim)
-        {
             sc.scopesym.importScope(mod, protection);
-        }
 
         if (aliasdecls.dim)
         {
@@ -291,6 +292,15 @@ extern (C++) final class Import : Dsymbol
 
         if (!aliasId && !names.dim) // neither a selective nor a renamed import
         {
+            ScopeDsymbol scopesym;
+            for (Scope* scd = sc; scd; scd = scd.enclosing)
+            {
+                if (!scd.scopesym)
+                    continue;
+                scopesym = scd.scopesym;
+                break;
+            }
+
             // Mark the imported packages as accessible from the current
             // scope. This access check is necessary when using FQN b/c
             // we're using a single global package tree.

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -229,7 +229,7 @@ extern (C++) final class Import : Dsymbol
     override void semantic(Scope* sc)
     {
         //printf("Import::semantic('%s') %s\n", toPrettyChars(), id.toChars());
-        if (semanticRun > PASSinit)
+        if (semanticRun >= PASSsemantic)
             return;
 
         if (_scope)

--- a/src/ddmd/dimport.d
+++ b/src/ddmd/dimport.d
@@ -224,6 +224,15 @@ extern (C++) final class Import : Dsymbol
                 }
             }
         }
+
+        if (aliasdecls.dim)
+        {
+            sc = sc.push(mod);
+            sc.protection = protection;
+            foreach (ad; aliasdecls)
+                ad.setScope(sc);
+            sc = sc.pop();
+        }
     }
 
     override void semantic(Scope* sc)
@@ -450,22 +459,6 @@ extern (C++) final class Import : Dsymbol
             ad._import = this;
             ad.addMember(sc, sd);
             aliasdecls.push(ad);
-        }
-    }
-
-    override void setScope(Scope* sc)
-    {
-        Dsymbol.setScope(sc);
-        if (aliasdecls.dim)
-        {
-            if (!mod)
-                importAll(sc);
-
-            sc = sc.push(mod);
-            sc.protection = protection;
-            foreach (ad; aliasdecls)
-                ad.setScope(sc);
-            sc = sc.pop();
         }
     }
 

--- a/src/ddmd/dmangle.d
+++ b/src/ddmd/dmangle.d
@@ -93,6 +93,7 @@ private immutable char[TMAX] mangleChar =
     // '@' shouldn't appear anywhere in the deco'd names
     Tinstance    : '@',
     Terror       : '@',
+    Tdefer       : '@',
     Ttypeof      : '@',
     Tslice       : '@',
     Treturn      : '@',

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -1309,7 +1309,8 @@ extern (C++) final class Module : Package
             if (todoalloc)
                 free(todoalloc);
         }
-        while (deferredM.dim < len/+ || dprogress+/); // while making progress
+        while (true);
+//         while (deferredM.dim < len || dprogress); // while making progress
         nested--;
         //printf("-Module::runDeferredSemantic(), len = %d\n", deferredM.dim);
 /+
@@ -1361,6 +1362,8 @@ extern (C++) final class Module : Package
             {
                 Dsymbol s = todo[i];
                 s.semantic(null);
+                if (s.semanticRun == PASSsemanticdeferred) // FWDREF FIXME? most is still not PASSsemanticdeferred
+                    s.semanticRun = PASSmembersdone;
                 //printf("deferred: %s, parent = %s\n", s.toChars(), s.parent.toChars());
             }
             //printf("\tdeferred.dim = %d, len = %d, dprogress = %d\n", deferred.dim, len, dprogress);

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -1300,8 +1300,7 @@ extern (C++) final class Module : Package
             for (size_t i = 0; i < len; i++)
             {
                 Dsymbol s = todo[i];
-                assert(s.semanticRun == PASSmembersdeferred);
-                s.semanticRun = PASSmembers;
+                assert(s.semanticRun >= PASSmembersdeferred);
                 s.importAll(null);
                 //printf("deferredM: %s, parent = %s\n", s.toChars(), s.parent.toChars());
             }
@@ -1361,9 +1360,9 @@ extern (C++) final class Module : Package
             for (size_t i = 0; i < len; i++)
             {
                 Dsymbol s = todo[i];
-                s.semantic(null);
                 if (s.semanticRun == PASSsemanticdeferred) // FWDREF FIXME? most is still not PASSsemanticdeferred
                     s.semanticRun = PASSmembersdone;
+                s.semantic(null);
                 //printf("deferred: %s, parent = %s\n", s.toChars(), s.parent.toChars());
             }
             //printf("\tdeferred.dim = %d, len = %d, dprogress = %d\n", deferred.dim, len, dprogress);

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -254,10 +254,9 @@ extern (C++) class Package : ScopeDsymbol
         return isAncestorPackageOf(pkg.parent.isPackage());
     }
 
-    override void semantic(Scope* sc)
+    override void semantic()
     {
-        if (semanticRun < PASSsemanticdone)
-            semanticRun = PASSsemanticdone;
+        semanticState = SemState.Done;
     }
 
     override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
@@ -1002,7 +1001,7 @@ extern (C++) final class Module : Package
         return _scope;
     }
 
-    override void detemineMembers()
+    override void determineMembers()
     {
         //printf("+Module::detemineMembers(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
         if (membersState == SemState.Done)

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -126,10 +126,10 @@ void semantic3OnDependencies(Module m)
     if (!m)
         return;
 
-    if (m.semanticRun > PASSsemantic3)
+    if (m.semanticState == SemState.Done)
         return;
 
-    m.semantic3(null);
+    m.semantic();
 
     foreach (i; 1 .. m.aimports.dim)
         semantic3OnDependencies(m.aimports[i]);

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -1165,15 +1165,15 @@ extern (C++) final class Module : Package
 
     override Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
+        importAll(_scope);
+
         /* Since modules can be circularly referenced,
          * need to stop infinite recursive searches.
          * This is done with the cache.
          */
         //printf("%s Module.search('%s', flags = x%x) insearch = %d\n", toChars(), ident.toChars(), flags, insearch);
-        if (insearch)
+        if (insearch) // FWDREF FIXME!: this should go
             return null;
-
-        importAll(_scope);
 
         /* Qualified module searches always search their imports,
          * even if SearchLocalsOnly

--- a/src/ddmd/doc.d
+++ b/src/ddmd/doc.d
@@ -746,8 +746,8 @@ extern (C++) static size_t getCodeIndent(const(char)* src)
 /** Recursively expand template mixin member docs into the scope. */
 extern (C++) static void expandTemplateMixinComments(TemplateMixin tm, OutBuffer* buf, Scope* sc)
 {
-    if (!tm.semanticRun)
-        tm.semantic(sc);
+    if (tm.semanticState != SemState.Done) // FWDREF TODO check if doc generation doesn't break?
+        tm.semantic();
     TemplateDeclaration td = (tm && tm.tempdecl) ? tm.tempdecl.isTemplateDeclaration() : null;
     if (td && td.members)
     {
@@ -1037,7 +1037,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
              * (only template instantiations).
              * Hence, Ddoc omits attributes from template members.
              */
-            Dsymbols* d = ad.include(null, null);
+            Dsymbols* d = ad.include(null);
             if (d)
             {
                 for (size_t i = 0; i < d.dim; i++)

--- a/src/ddmd/dscope.d
+++ b/src/ddmd/dscope.d
@@ -513,7 +513,7 @@ struct Scope
                         *pscopesym = sc.scopesym;
                     return s;
                 }
-                else if (confident && (sc.scopesym.semanticRun == PASSmembersdeferred || sc.scopesym.membersNest >= 2))
+                else if (confident && (sc.scopesym.semanticRun == PASSmembersdeferred || sc.scopesym.membersNest >= 1))
                     *confident = false;
 
                 // Stop when we hit a module, but keep going if that is not just under the global scope

--- a/src/ddmd/dscope.d
+++ b/src/ddmd/dscope.d
@@ -513,7 +513,7 @@ struct Scope
                         *pscopesym = sc.scopesym;
                     return s;
                 }
-                else if (confident && sc.scopesym.membersNest >= 2)
+                else if (confident && (sc.scopesym.semanticRun == PASSmembersdeferred || sc.scopesym.membersNest >= 2))
                     *confident = false;
 
                 // Stop when we hit a module, but keep going if that is not just under the global scope

--- a/src/ddmd/dscope.d
+++ b/src/ddmd/dscope.d
@@ -441,7 +441,7 @@ struct Scope
      * Returns:
      *  symbol if found, null if not
      */
-    extern (C++) Dsymbol search(Loc loc, Identifier ident, Dsymbol* pscopesym, int flags = IgnoreNone)
+    extern (C++) Dsymbol search(Loc loc, Identifier ident, Dsymbol* pscopesym, int flags = IgnoreNone, bool* confident = null)
     {
         version (LOGSEARCH)
         {
@@ -487,6 +487,9 @@ struct Scope
 
         Dsymbol searchScopes(int flags)
         {
+            if (confident)
+                *confident = true;
+
             for (Scope* sc = &this; sc; sc = sc.enclosing)
             {
                 assert(sc != sc.enclosing);
@@ -510,6 +513,9 @@ struct Scope
                         *pscopesym = sc.scopesym;
                     return s;
                 }
+                else if (confident && sc.scopesym.membersNest >= 2)
+                    *confident = false;
+
                 // Stop when we hit a module, but keep going if that is not just under the global scope
                 if (sc.scopesym.isModule() && !(sc.enclosing && !sc.enclosing.enclosing))
                     break;

--- a/src/ddmd/dscope.d
+++ b/src/ddmd/dscope.d
@@ -513,7 +513,7 @@ struct Scope
                         *pscopesym = sc.scopesym;
                     return s;
                 }
-                else if (confident && (sc.scopesym.semanticRun == PASSmembersdeferred || sc.scopesym.membersNest >= 1))
+                else if (confident && (sc.scopesym.membersState == SemState.Defer || sc.scopesym.membersNest >= 1))
                     *confident = false;
 
                 // Stop when we hit a module, but keep going if that is not just under the global scope

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -278,17 +278,20 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             sc = _scope;
         assert(sc);
 
+        assert(symtab || semanticRun < PASSmembers);
+        semanticRun = PASSmembers;
+
         auto sc2 = newScope(sc);
 
-        if (!parent) // FWDREF WARNING: shouldn't this be done once?
+        if (!symtab)
         {
-            assert(sc.parent && sc.func);
-            parent = sc.parent;
-        }
-        assert(parent && !isAnonymous());
+            if (!parent)
+            {
+                assert(sc.parent && sc.func);
+                parent = sc.parent;
+            }
+            assert(parent && !isAnonymous());
 
-        if (semanticRun < PASSmembers)
-        {
             protection = sc.protection;
 
             alignment = sc.alignment();
@@ -306,16 +309,14 @@ extern (C++) class StructDeclaration : AggregateDeclaration
                 semanticRun = PASSmembersdone;
                 return;
             }
-            if (!symtab)
-            {
-                symtab = new DsymbolTable();
 
-                for (size_t i = 0; i < members.dim; i++)
-                {
-                    auto s = (*members)[i];
-                    //printf("adding member '%s' to '%s'\n", s.toChars(), this.toChars());
-                    s.addMember(sc, this);
-                }
+            symtab = new DsymbolTable();
+
+            for (size_t i = 0; i < members.dim; i++)
+            {
+                auto s = (*members)[i];
+                //printf("adding member '%s' to '%s'\n", s.toChars(), this.toChars());
+                s.addMember(sc, this);
             }
 
             /* Set scope so if there are forward references, we still might be able to

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -279,7 +279,6 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         assert(sc);
 
         assert(symtab || semanticRun < PASSmembers);
-        semanticRun = PASSmembers;
 
         auto sc2 = newScope(sc);
 
@@ -549,20 +548,20 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         }
     }
 
-    override final Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
-    {
-        //printf("%s.StructDeclaration::search('%s', flags = x%x)\n", toChars(), ident.toChars(), flags);
-        if (_scope && !symtab)
-            semantic(_scope);
-
-        if (!members || !symtab) // opaque or semantic() is not yet called
-        {
-            error("is forward referenced when looking for '%s'", ident.toChars());
-            return null;
-        }
-
-        return ScopeDsymbol.search(loc, ident, flags);
-    }
+//     override final Dsymbol search(Loc loc, Identifier ident, int flags = SearchLocalsOnly)
+//     {
+//         //printf("%s.StructDeclaration::search('%s', flags = x%x)\n", toChars(), ident.toChars(), flags);
+//         if (_scope && !symtab)
+//             semantic(_scope);
+//
+//         if (!members || !symtab) // opaque or semantic() is not yet called
+//         {
+//             error("is forward referenced when looking for '%s'", ident.toChars());
+//             return null;
+//         }
+//
+//         return ScopeDsymbol.search(loc, ident, flags);
+//     }
 
     override const(char)* kind() const
     {

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -291,6 +291,18 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
             assert(parent && !isAnonymous());
 
+            if (this.errors)
+                type = Type.terror;
+            if (semanticRun < PASSsemantic)
+                type = type.addSTC(sc.stc | storage_class);
+            type = type.semantic(loc, sc);
+            if (type.ty == Tstruct && (cast(TypeStruct)type).sym != this)
+            {
+                auto ti = (cast(TypeStruct)type).sym.isInstantiated();
+                if (ti && isError(ti))
+                    (cast(TypeStruct)type).sym = this;
+            }
+
             protection = sc.protection;
 
             alignment = sc.alignment();
@@ -357,18 +369,6 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             sc = _scope;
             scx = _scope; // save so we don't make redundant copies
             _scope = null;
-        }
-
-        if (this.errors)
-            type = Type.terror;
-        if (semanticRun < PASSsemantic)
-            type = type.addSTC(sc.stc | storage_class);
-        type = type.semantic(loc, sc);
-        if (type.ty == Tstruct && (cast(TypeStruct)type).sym != this)
-        {
-            auto ti = (cast(TypeStruct)type).sym.isInstantiated();
-            if (ti && isError(ti))
-                (cast(TypeStruct)type).sym = this;
         }
 
         // Ungag errors when not speculative

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -1315,7 +1315,11 @@ public:
         //printf("%s.ScopeDsymbol::search(ident='%s', flags=x%x)\n", toChars(), ident.toChars(), flags);
         //if (strcmp(ident.toChars(),"c") == 0) *(char*)0=0;
 
-        if (_scope)
+//         if (!(flags & 0x100))
+//             if (auto result = search(loc, ident, flags | 0x100))
+//                 return result;
+
+        if (_scope && !(flags & 0x100))
             importAll(_scope);
 
         // Look in symbols declared in this module
@@ -1732,8 +1736,9 @@ public:
         semanticRun = PASSmembers;
         while (nextMember < members.dim)
         {
-            auto s = (*members)[nextMember++];
+            auto s = (*members)[nextMember];
             s.importAll(sc);
+            ++nextMember;
         }
         semanticRun = PASSmembersdone;
     }

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -676,9 +676,13 @@ extern (C++) class Dsymbol : RootObject
             case PASSmembers:
                 deferMembers();
                 break;
+            case PASSmembersdone:
             case PASSsemantic:
                 deferSemantic();
                 break;
+            case PASSmembersdeferred:
+            case PASSsemanticdeferred:
+                return;
             default:
                 assert(0);
         }

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -697,6 +697,10 @@ extern (C++) class Dsymbol : RootObject
     {
     }
 
+    void semanticInitializer()
+    {
+    }
+
     /*************************************
      * Does semantic analysis on the public face of declarations.
      */
@@ -2213,7 +2217,7 @@ extern (C++) final class ForwardingScopeDsymbol : ScopeDsymbol
         forward.importScope(s, protection);
     }
 
-    override void semantic(Scope* sc){ }
+    override void semantic() { }
 
     override const(char)* kind()const{ return "local scope"; }
 

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -1343,7 +1343,8 @@ public:
         //printf("%s.ScopeDsymbol::search(ident='%s', flags=x%x)\n", toChars(), ident.toChars(), flags);
         //if (strcmp(ident.toChars(),"c") == 0) *(char*)0=0;
 
-        determineMembers();
+        if (membersState != SemState.Done)
+            determineMembers();
 
         // Look in symbols declared in this module
         if (symtab && !(flags & SearchImportsOnly))

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -693,6 +693,10 @@ extern (C++) class Dsymbol : RootObject
     {
     }
 
+    void semanticType()
+    {
+    }
+
     /*************************************
      * Does semantic analysis on the public face of declarations.
      */

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -1799,16 +1799,22 @@ public:
     uint membersNest;
     override void importAll(Scope* sc)
     {
+        if (semanticRun >= PASSmembersdone)
+            return;
+
         if (!members)
         {
             semanticRun = PASSmembersdone;
             return;
         }
 
-        if (semanticRun == PASSinit)
+        if (semanticRun == PASSinit ||
+                (semanticRun == PASSmembersdeferred && !membersNest))
             semanticRun = PASSmembers;
 
-        auto oldnextMember = nextMember;
+        if (!membersNest)
+            nextMember = 0;
+
         ++membersNest;
         while (nextMember < members.dim)
         {
@@ -1817,16 +1823,9 @@ public:
             ++nextMember;
         }
         --membersNest;
-        nextMember = oldnextMember;
 
         if (!membersNest && semanticRun != PASSmembersdeferred)
             semanticRun = PASSmembersdone;
-
-        if (!membersNest && isModule())
-        {
-            Module.runDeferredMembers(); // TODO move to dmodule
-            assert(semanticRun >= PASSmembersdone);
-        }
     }
 
     override void semantic(Scope* sc) { }

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -229,15 +229,25 @@ extern (C++) class Dsymbol : RootObject
         @property SemState initializerState() { return (semanticRun & (0x3<<4)) >> 4; }
         @property SemState initializerState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<4)) | (value << 4); }
         alias bodyState = initializerState;
+        alias aliasState = initializerState;
 
         @property SemState sizeState() { return (semanticRun & (0x3<<6)) >> 6; }
         @property SemState sizeState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<6)) | (value << 6); }
 
         @property SemState baseClassState() { return (semanticRun & (0x3<<8)) >> 8; }
         @property SemState baseClassState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<8)) | (value << 8); }
+        alias includeState = baseClassState;
 
         @property SemState tiargsState() { return (semanticRun & (0x3<<10)) >> 10; }
         @property SemState tiargsState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<10)) | (value << 10); }
+        alias fieldsState = tiargsState;
+
+        @property SemState addMemberState() { return (semanticRun & (0x3<<12)) >> 12; }
+        @property SemState addMemberState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<12)) | (value << 12); }
+
+        @property SemState semanticState() { return (semanticRun & (0x3<<14)) >> 14; }
+        @property SemState semanticState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<14)) | (value << 14); }
+
 
         // vtbl?
     }
@@ -645,6 +655,9 @@ extern (C++) class Dsymbol : RootObject
             return;
 
         setScope(sc);
+
+        if (auto decl = isDeclaration()) // FWDREF TODO move to Declaration.addMember? (this was originally in StorageClassDeclaration.addMember)
+            decl.storage_class |= sc.stc & STClocal;
 
         //printf("Dsymbol::addMember('%s')\n", toChars());
         //printf("Dsymbol::addMember(this = %p, '%s' scopesym = '%s')\n", this, toChars(), sds.toChars());

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -241,6 +241,7 @@ extern (C++) class Dsymbol : RootObject
         @property SemState tiargsState() { return (semanticRun & (0x3<<10)) >> 10; }
         @property SemState tiargsState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<10)) | (value << 10); }
         alias fieldsState = tiargsState;
+        alias vtblState = tiargsState;
 
         @property SemState addMemberState() { return (semanticRun & (0x3<<12)) >> 12; }
         @property SemState addMemberState(SemState value) { return semanticRun = (semanticRun & ~(0x3<<12)) | (value << 12); }

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -689,14 +689,14 @@ extern (C++) class Dsymbol : RootObject
             userAttribDecl = sc.userAttribDecl;
     }
 
-    void determineMembers(Scope* sc)
+    void determineMembers()
     {
     }
 
     /*************************************
      * Does semantic analysis on the public face of declarations.
      */
-    void semantic(Scope* sc)
+    void semantic()
     {
         error("%p has no semantic routine", this);
     }

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -900,8 +900,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         assert(ti.inst is null);
         ti.inst = ti; // temporary instantiation to enable genIdent()
         scx.flags |= SCOPEconstraint;
-        bool errors;
-        bool result = evalStaticCondition(scx, constraint, e, errors);
+        bool errors, defer;
+        bool result = evalStaticCondition(scx, constraint, e, errors, defer);
         ti.inst = null;
         ti.symtab = null;
         scx = scx.pop();

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -6578,137 +6578,137 @@ extern (C++) class TemplateInstance : ScopeDsymbol
          * on them due to forward references, we cannot run semantic2()
          * or semantic3() yet.
          */
-        {
-            bool found_deferred_ad = false;
-            for (size_t i = 0; i < Module.deferred.dim; i++)
-            {
-                Dsymbol sd = Module.deferred[i];
-                AggregateDeclaration ad = sd.isAggregateDeclaration();
-                if (ad && ad.parent && ad.parent.isTemplateInstance())
-                {
-                    //printf("deferred template aggregate: %s %s\n",
-                    //        sd.parent.toChars(), sd.toChars());
-                    found_deferred_ad = true;
-                    if (ad.parent == this)
-                    {
-                        ad.deferred = this;
-                        break;
-                    }
-                }
-            }
-            if (found_deferred_ad || Module.deferred.dim)
-                goto Laftersemantic;
-        }
+//         {
+//             bool found_deferred_ad = false;
+//             for (size_t i = 0; i < Module.deferred.dim; i++)
+//             {
+//                 Dsymbol sd = Module.deferred[i];
+//                 AggregateDeclaration ad = sd.isAggregateDeclaration();
+//                 if (ad && ad.parent && ad.parent.isTemplateInstance())
+//                 {
+//                     //printf("deferred template aggregate: %s %s\n",
+//                     //        sd.parent.toChars(), sd.toChars());
+//                     found_deferred_ad = true;
+//                     if (ad.parent == this)
+//                     {
+//                         ad.deferred = this;
+//                         break;
+//                     }
+//                 }
+//             }
+//             if (found_deferred_ad || Module.deferred.dim)
+//                 goto Laftersemantic;
+//         }
 
         /* The problem is when to parse the initializer for a variable.
          * Perhaps VarDeclaration.semantic() should do it like it does
          * for initializers inside a function.
          */
         //if (sc.parent.isFuncDeclaration())
-        {
+//         {
             /* https://issues.dlang.org/show_bug.cgi?id=782
              * this has problems if the classes this depends on
              * are forward referenced. Find a way to defer semantic()
              * on this template.
              */
-            semantic2(sc2);
-        }
-        if (global.errors != errorsave)
-            goto Laftersemantic;
+//             semantic2(sc2);
+//         }
+//         if (global.errors != errorsave)
+//             goto Laftersemantic;
 
-        if ((inFunc || requiresFullInst) && !tinst)
-        {
-            /* If a template is instantiated inside function, the whole instantiation
-             * should be done at that position. But, immediate running semantic3 of
-             * dependent templates may cause unresolved forward reference.
-             * https://issues.dlang.org/show_bug.cgi?id=9050
-             * To avoid the issue, don't run semantic3 until semantic and semantic2 done.
-             */
-            TemplateInstances deferred;
-            this.deferred = &deferred;
+//         if ((inFunc || requiresFullInst) && !tinst)
+//         {
+//             /* If a template is instantiated inside function, the whole instantiation
+//              * should be done at that position. But, immediate running semantic3 of
+//              * dependent templates may cause unresolved forward reference.
+//              * https://issues.dlang.org/show_bug.cgi?id=9050
+//              * To avoid the issue, don't run semantic3 until semantic and semantic2 done.
+//              */
+//             TemplateInstances deferred;
+//             this.deferred = &deferred;
+//
+//             //printf("Run semantic3 on %s\n", toChars());
+//             trySemantic3(sc2);
+//
+//             for (size_t i = 0; i < deferred.dim; i++)
+//             {
+//                 //printf("+ run deferred semantic3 on %s\n", deferred[i].toChars());
+//                 deferred[i].semantic3(null);
+//             }
+//
+//             this.deferred = null;
+//         }
+//         else if (tinst)
+//         {
+//             bool doSemantic3 = false;
+//             if (inFunc && aliasdecl && aliasdecl.toAlias().isFuncDeclaration())
+//             {
+//                 /* Template function instantiation should run semantic3 immediately
+//                  * for attribute inference.
+//                  */
+//                 doSemantic3 = true;
+//             }
+//             else if (inFunc)
+//             {
+//                 /* A lambda function in template arguments might capture the
+//                  * instantiated scope context. For the correct context inference,
+//                  * all instantiated functions should run the semantic3 immediately.
+//                  * See also compilable/test14973.d
+//                  */
+//                 foreach (oarg; tdtypes)
+//                 {
+//                     auto s = getDsymbol(oarg);
+//                     if (!s)
+//                         continue;
+//
+//                     if (auto td = s.isTemplateDeclaration())
+//                     {
+//                         if (!td.literal)
+//                             continue;
+//                         assert(td.members && td.members.dim == 1);
+//                         s = (*td.members)[0];
+//                     }
+//                     if (auto fld = s.isFuncLiteralDeclaration())
+//                     {
+//                         if (fld.tok == TOKreserved)
+//                         {
+//                             doSemantic3 = true;
+//                             break;
+//                         }
+//                     }
+//                 }
+//                 //printf("[%s] %s doSemantic3 = %d\n", loc.toChars(), toChars(), doSemantic3);
+//             }
+//             if (doSemantic3)
+//                 trySemantic3(sc2);
 
-            //printf("Run semantic3 on %s\n", toChars());
-            trySemantic3(sc2);
-
-            for (size_t i = 0; i < deferred.dim; i++)
-            {
-                //printf("+ run deferred semantic3 on %s\n", deferred[i].toChars());
-                deferred[i].semantic3(null);
-            }
-
-            this.deferred = null;
-        }
-        else if (tinst)
-        {
-            bool doSemantic3 = false;
-            if (inFunc && aliasdecl && aliasdecl.toAlias().isFuncDeclaration())
-            {
-                /* Template function instantiation should run semantic3 immediately
-                 * for attribute inference.
-                 */
-                doSemantic3 = true;
-            }
-            else if (inFunc)
-            {
-                /* A lambda function in template arguments might capture the
-                 * instantiated scope context. For the correct context inference,
-                 * all instantiated functions should run the semantic3 immediately.
-                 * See also compilable/test14973.d
-                 */
-                foreach (oarg; tdtypes)
-                {
-                    auto s = getDsymbol(oarg);
-                    if (!s)
-                        continue;
-
-                    if (auto td = s.isTemplateDeclaration())
-                    {
-                        if (!td.literal)
-                            continue;
-                        assert(td.members && td.members.dim == 1);
-                        s = (*td.members)[0];
-                    }
-                    if (auto fld = s.isFuncLiteralDeclaration())
-                    {
-                        if (fld.tok == TOKreserved)
-                        {
-                            doSemantic3 = true;
-                            break;
-                        }
-                    }
-                }
-                //printf("[%s] %s doSemantic3 = %d\n", loc.toChars(), toChars(), doSemantic3);
-            }
-            if (doSemantic3)
-                trySemantic3(sc2);
-
-            TemplateInstance ti = tinst;
-            int nest = 0;
-            while (ti && !ti.deferred && ti.tinst)
-            {
-                ti = ti.tinst;
-                if (++nest > 500)
-                {
-                    global.gag = 0; // ensure error message gets printed
-                    error("recursive expansion");
-                    fatal();
-                }
-            }
-            if (ti && ti.deferred)
-            {
-                //printf("deferred semantic3 of %p %s, ti = %s, ti.deferred = %p\n", this, toChars(), ti.toChars());
-                for (size_t i = 0;; i++)
-                {
-                    if (i == ti.deferred.dim)
-                    {
-                        ti.deferred.push(this);
-                        break;
-                    }
-                    if ((*ti.deferred)[i] == this)
-                        break;
-                }
-            }
-        }
+//             TemplateInstance ti = tinst;
+//             int nest = 0;
+//             while (ti && !ti.deferred && ti.tinst)
+//             {
+//                 ti = ti.tinst;
+//                 if (++nest > 500)
+//                 {
+//                     global.gag = 0; // ensure error message gets printed
+//                     error("recursive expansion");
+//                     fatal();
+//                 }
+//             }
+//             if (ti && ti.deferred)
+//             {
+//                 //printf("deferred semantic3 of %p %s, ti = %s, ti.deferred = %p\n", this, toChars(), ti.toChars());
+//                 for (size_t i = 0;; i++)
+//                 {
+//                     if (i == ti.deferred.dim)
+//                     {
+//                         ti.deferred.push(this);
+//                         break;
+//                     }
+//                     if ((*ti.deferred)[i] == this)
+//                         break;
+//                 }
+//             }
+//         }
 
         if (aliasdecl)
         {

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -571,6 +571,11 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         return new TemplateDeclaration(loc, ident, p, constraint ? constraint.syntaxCopy() : null, Dsymbol.arraySyntaxCopy(members), ismixin, literal);
     }
 
+    override void importAll(Scope* sc)
+    {
+        // FWDREF FIXME: ScopeDsymbol.importAll is here as a safety net, but it should eventually be turned into a helper method?
+    }
+
     override void semantic(Scope* sc)
     {
         static if (LOG)
@@ -579,7 +584,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             printf("sc.stc = %llx\n", sc.stc);
             printf("sc.module = %s\n", sc._module.toChars());
         }
-        if (semanticRun != PASSinit)
+        if (semanticRun >= PASSsemantic)
             return; // semantic() already run
 
         // Remember templates defined in module object that we need to know about
@@ -2624,13 +2629,13 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         if (!sc)
             sc = td._scope; // workaround for Type.aliasthisOf
 
-        if (td.semanticRun == PASSinit && td._scope)
+        if (td.semanticRun < PASSsemantic && td._scope)
         {
             // Try to fix forward reference. Ungag errors while doing so.
             Ungag ungag = td.ungagSpeculative();
             td.semantic(td._scope);
         }
-        if (td.semanticRun == PASSinit)
+        if (td.semanticRun < PASSsemantic)
         {
             .error(loc, "forward reference to template %s", td.toChars());
         Lerror:
@@ -2649,7 +2654,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
             auto ti = new TemplateInstance(loc, td, tiargs);
             Objects dedtypes;
             dedtypes.setDim(td.parameters.dim);
-            assert(td.semanticRun != PASSinit);
+            assert(td.semanticRun >= PASSsemantic);
             MATCH mta = td.matchWithInstance(sc, ti, &dedtypes, fargs, 0);
             //printf("matchWithInstance = %d\n", mta);
             if (mta <= MATCHnomatch || mta < ta_last)   // no match or less match
@@ -6141,9 +6146,25 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return ti;
     }
 
-    void semantic(Scope* sc, Expressions* fargs)
+    final void updateAliasDecl()
     {
-        //printf("[%s] TemplateInstance.semantic('%s', this=%p, gag = %d, sc = %p)\n", loc.toChars(), toChars(), this, global.gag, sc);
+        if (members.dim)
+        {
+            Dsymbol s;
+            if (Dsymbol.oneMembers(members, &s, tempdecl.ident) && s)
+            {
+                if (!aliasdecl || aliasdecl != s)
+                {
+                    //printf("tempdecl.ident = %s, s = '%s'\n", tempdecl.ident.toChars(), s.kind(), s.toPrettyChars());
+                    //printf("setting aliasdecl 2\n");
+                    aliasdecl = s;
+                }
+            }
+        }
+    }
+
+    void importAll(Scope* sc, Expressions* fargs)
+    {
         version (none)
         {
             for (Dsymbol s = this; s; s = s.parent)
@@ -6166,6 +6187,19 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             static if (LOG)
             {
                 printf("-TemplateInstance.semantic('%s', this=%p) already run\n", inst.toChars(), inst);
+            }
+            if (semanticRun < PASSmembersdone)
+            {
+                sc = tempdecl._scope; // FWDREF TODO: this is purposedly ugly, since ideally it's shouldn't be needed after setScope, neither here nor in semantic2/3
+                sc = sc.push(argsym);
+                sc = sc.push(this);
+                sc.parent = this;
+                sc.tinst = this;
+                sc.minst = minst;
+                ScopeDsymbol.importAll(sc);
+                sc = sc.pop();
+                sc.pop();
+                updateAliasDecl();
             }
             return;
         }
@@ -6202,7 +6236,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
         gagged = (global.gag > 0);
 
-        semanticRun = PASSsemantic;
+        semanticRun = PASSmembers;
 
         static if (LOG)
         {
@@ -6244,7 +6278,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
          * implements the typeargs. If so, just refer to that one instead.
          */
         inst = tempdecl.findExistingInstance(this, fargs);
-        TemplateInstance errinst = null;
         if (!inst)
         {
             // So, we need to implement 'this' instance.
@@ -6253,7 +6286,19 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         {
             // If the first instantiation had failed, re-run semantic,
             // so that error messages are shown.
-            errinst = inst;
+
+            /* https://issues.dlang.org/show_bug.cgi?id=14541
+             * If the previous gagged instance had failed by
+             * circular references, currrent "error reproduction instantiation"
+             * might succeed, because of the difference of instantiated context.
+             * On such case, the cached error instance needs to be overridden by the
+             * succeeded instance.
+             */
+            //printf("replaceInstance()\n");
+            assert(inst.errors);
+            auto ti1 = TemplateInstanceBox(inst);
+            tempdecl.instances.remove(ti1);
+            inst = null;
         }
         else
         {
@@ -6323,6 +6368,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             {
                 printf("\tit's a match with instance %p, %d\n", inst, inst.semanticRun);
             }
+            semanticRun = PASSmembersdone;
             return;
         }
         static if (LOG)
@@ -6330,23 +6376,27 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             printf("\timplement template instance %s '%s'\n", tempdecl.parent.toChars(), toChars());
             printf("\ttempdecl %s\n", tempdecl.toChars());
         }
-        uint errorsave = global.errors;
 
         inst = this;
         parent = enclosing ? enclosing : tempdecl.parent;
         //printf("parent = '%s'\n", parent.kind());
 
-        TemplateInstance tempdecl_instance_idx = tempdecl.addInstance(this);
+        tempdecl.addInstance(this);
 
         //getIdent();
 
         // Store the place we added it to in target_symbol_list(_idx) so we can
         // remove it later if we encounter an error.
-        Dsymbols* target_symbol_list = appendToModuleMember();
-        size_t target_symbol_list_idx = target_symbol_list ? target_symbol_list.dim - 1 : 0;
+        target_symbol_list = appendToModuleMember();
+        target_symbol_list_idx = target_symbol_list ? target_symbol_list.dim - 1 : 0;
+
+        inFunc = sc.func !is null; // FWDREF UGLY
+        requiresFullInst = (sc.flags & SCOPEfullinst) != 0;
 
         // Copy the syntax trees from the TemplateDeclaration
         members = Dsymbol.arraySyntaxCopy(tempdecl.members);
+
+        uint errorsave = global.errors;
 
         // resolve TemplateThisParameter
         for (size_t i = 0; i < tempdecl.parameters.dim; i++)
@@ -6367,7 +6417,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
         // Create our own scope for the template parameters
         Scope* _scope = tempdecl._scope;
-        if (tempdecl.semanticRun == PASSinit)
+        if (tempdecl.semanticRun < PASSsemantic)
         {
             error("template instantiation %s forward references template declaration %s", toChars(), tempdecl.toChars());
             return;
@@ -6414,16 +6464,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
          * If so, this template instance becomes an alias for that member.
          */
         //printf("members.dim = %d\n", members.dim);
-        if (members.dim)
-        {
-            Dsymbol s;
-            if (Dsymbol.oneMembers(members, &s, tempdecl.ident) && s)
-            {
-                //printf("tempdecl.ident = %s, s = '%s'\n", tempdecl.ident.toChars(), s.kind(), s.toPrettyChars());
-                //printf("setting aliasdecl\n");
-                aliasdecl = s;
-            }
-        }
+        updateAliasDecl();
 
         /* If function template declaration
          */
@@ -6453,28 +6494,77 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         sc2.tinst = this;
         sc2.minst = minst;
 
-        tryExpandMembers(sc2);
+        for (size_t i = 0; i < members.dim; i++)
+        {
+            Dsymbol s = (*members)[i];
+            s.setScope(sc2);
+        }
 
-        semanticRun = PASSsemanticdone;
+        ScopeDsymbol.importAll(sc2);
+
+        sc2.pop();
 
         /* ConditionalDeclaration may introduce eponymous declaration,
          * so we should find it once again after semantic.
          */
-        if (members.dim)
+        updateAliasDecl();
+
+        checkErrorCount(errorsave);
+    }
+
+    override void importAll(Scope* sc)
+    {
+        importAll(sc, null);
+    }
+
+    Dsymbols* target_symbol_list; // FWDREF temporary, this is non-ideal
+    size_t target_symbol_list_idx;
+
+    bool inFunc; // FWDREF FIXME ugly, but TemplateInstance.semantic may be deferred and called with sc=null
+    bool requiresFullInst;
+
+    void semantic(Scope* sc, Expressions* fargs)
+    {
+        //printf("[%s] TemplateInstance.semantic('%s', this=%p, gag = %d, sc = %p)\n", loc.toChars(), toChars(), this, global.gag, sc);
+
+        if (semanticRun >= PASSsemantic)
+            return;
+
+        importAll(sc, fargs);
+
+        if (semanticRun < PASSmembersdone)
         {
-            Dsymbol s;
-            if (Dsymbol.oneMembers(members, &s, tempdecl.ident) && s)
-            {
-                if (!aliasdecl || aliasdecl != s)
-                {
-                    //printf("tempdecl.ident = %s, s = '%s'\n", tempdecl.ident.toChars(), s.kind(), s.toPrettyChars());
-                    //printf("setting aliasdecl 2\n");
-                    aliasdecl = s;
-                }
-            }
+            error("template instance fwd ref");
+            return;
         }
 
-        if (global.errors != errorsave)
+        if (inst != this)
+        {
+            Module.dprogress++;
+            semanticRun = PASSsemanticdone;
+            return;
+        }
+
+        uint errorsave = global.errors;
+
+        semanticRun = PASSsemantic;
+
+        Scope* _scope = tempdecl._scope; // FWDREF TODO members should already have their _scope set, this shouldn't be needed
+        _scope = _scope.push(argsym);
+
+        Scope* sc2;
+        sc2 = _scope.push(this);
+        //printf("enclosing = %d, sc.parent = %s\n", enclosing, sc.parent.toChars());
+        sc2.parent = this;
+        sc2.tinst = this;
+        sc2.minst = minst;
+
+        trySemanticMembers(sc2);
+
+        Module.dprogress++;
+        semanticRun = PASSsemanticdone;
+
+        if (errors || global.errors != errorsave)
             goto Laftersemantic;
 
         /* If any of the instantiation members didn't get semantic() run
@@ -6519,7 +6609,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (global.errors != errorsave)
             goto Laftersemantic;
 
-        if ((sc.func || (sc.flags & SCOPEfullinst)) && !tinst)
+        if ((inFunc || requiresFullInst) && !tinst)
         {
             /* If a template is instantiated inside function, the whole instantiation
              * should be done at that position. But, immediate running semantic3 of
@@ -6544,14 +6634,14 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         else if (tinst)
         {
             bool doSemantic3 = false;
-            if (sc.func && aliasdecl && aliasdecl.toAlias().isFuncDeclaration())
+            if (inFunc && aliasdecl && aliasdecl.toAlias().isFuncDeclaration())
             {
                 /* Template function instantiation should run semantic3 immediately
                  * for attribute inference.
                  */
                 doSemantic3 = true;
             }
-            else if (sc.func)
+            else if (inFunc)
             {
                 /* A lambda function in template arguments might capture the
                  * instantiated scope context. For the correct context inference,
@@ -6631,6 +6721,19 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         sc2.pop();
         _scope.pop();
 
+        checkErrorCount(errorsave);
+
+        static if (LOG)
+        {
+            printf("-TemplateInstance.semantic('%s', this=%p)\n", toChars(), this);
+        }
+    }
+
+    final void checkErrorCount(uint errorsave)
+    {
+        assert(tempdecl.isTemplateDeclaration());
+        TemplateDeclaration tempdecl = cast(TemplateDeclaration) this.tempdecl;
+
         // Give additional context info if error occurred during instantiation
         if (global.errors != errorsave)
         {
@@ -6648,7 +6751,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 // instance/symbol lists we added it to and reset our state to
                 // finish clean and so we can try to instantiate it again later
                 // (see https://issues.dlang.org/show_bug.cgi?id=4302 and https://issues.dlang.org/show_bug.cgi?id=6602).
-                tempdecl.removeInstance(tempdecl_instance_idx);
+                tempdecl.removeInstance(this);
                 if (target_symbol_list)
                 {
                     // Because we added 'this' in the last position above, we
@@ -6662,28 +6765,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 symtab = null;
             }
         }
-        else if (errinst)
-        {
-            /* https://issues.dlang.org/show_bug.cgi?id=14541
-             * If the previous gagged instance had failed by
-             * circular references, currrent "error reproduction instantiation"
-             * might succeed, because of the difference of instantiated context.
-             * On such case, the cached error instance needs to be overridden by the
-             * succeeded instance.
-             */
-            //printf("replaceInstance()\n");
-            assert(errinst.errors);
-            auto ti1 = TemplateInstanceBox(errinst);
-            tempdecl.instances.remove(ti1);
-
-            auto ti2 = TemplateInstanceBox(this);
-            tempdecl.instances[ti2] = this;
-        }
-
-        static if (LOG)
-        {
-            printf("-TemplateInstance.semantic('%s', this=%p)\n", toChars(), this);
-        }
     }
 
     override void semantic(Scope* sc)
@@ -6693,6 +6774,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
     override void semantic2(Scope* sc)
     {
+        if (!errors && semanticRun < PASSsemanticdone)
+            semantic(sc);
         if (semanticRun >= PASSsemantic2)
             return;
         semanticRun = PASSsemantic2;
@@ -6760,6 +6843,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             printf("TemplateInstance.semantic3('%s'), semanticRun = %d\n", toChars(), semanticRun);
         }
         //if (toChars()[0] == 'D') *(char*)0=0;
+        if (semanticRun < PASSsemantic2done)
+            semantic2(sc);
         if (semanticRun >= PASSsemantic3)
             return;
         semanticRun = PASSsemantic3;
@@ -7293,7 +7378,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 if (!td)
                     return 0;
 
-                if (td.semanticRun == PASSinit)
+                if (td.semanticRun < PASSsemantic)
                 {
                     if (td._scope)
                     {
@@ -7301,7 +7386,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                         Ungag ungag = td.ungagSpeculative();
                         td.semantic(td._scope);
                     }
-                    if (td.semanticRun == PASSinit)
+                    if (td.semanticRun < PASSsemantic)
                     {
                         error("%s forward references template declaration %s",
                             toChars(), td.toChars());
@@ -7631,7 +7716,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 (*tiargs)[j] = sa;
 
                 TemplateDeclaration td = sa.isTemplateDeclaration();
-                if (td && td.semanticRun == PASSinit && td.literal)
+                if (td && td.semanticRun < PASSsemantic && td.literal)
                 {
                     td.semantic(sc);
                 }
@@ -7743,7 +7828,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
                 dedtypes.setDim(td.parameters.dim);
                 dedtypes.zero();
-                assert(td.semanticRun != PASSinit);
+                assert(td.semanticRun >= PASSsemantic);
 
                 MATCH m = td.matchWithInstance(sc, this, &dedtypes, fargs, 0);
                 //printf("matchWithInstance = %d\n", m);
@@ -7881,7 +7966,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     final bool needsTypeInference(Scope* sc, int flag = 0)
     {
         //printf("TemplateInstance.needsTypeInference() %s\n", toChars());
-        if (semanticRun != PASSinit)
+        if (semanticRun >= PASSsemantic)
             return false;
 
         uint olderrs = global.errors;
@@ -7957,7 +8042,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                      */
                     dedtypes.setDim(td.parameters.dim);
                     dedtypes.zero();
-                    if (td.semanticRun == PASSinit)
+                    if (td.semanticRun < PASSsemantic)
                     {
                         if (td._scope)
                         {
@@ -7965,7 +8050,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                             Ungag ungag = td.ungagSpeculative();
                             td.semantic(td._scope);
                         }
-                        if (td.semanticRun == PASSinit)
+                        if (td.semanticRun < PASSsemantic)
                         {
                             error("%s forward references template declaration %s", toChars(), td.toChars());
                             return 1;
@@ -8188,6 +8273,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         Dsymbols* a = mi.members;
         a.push(this);
         memberOf = mi;
+//         if (mi.semanticRun >= PASSsemanticdone)
+//             Module.addDeferredSemantic(this);
         if (mi.semanticRun >= PASSsemantic2done && mi.isRoot())
             Module.addDeferredSemantic2(this);
         if (mi.semanticRun >= PASSsemantic3done && mi.isRoot())
@@ -8344,20 +8431,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return Identifier.idPool(buf.peekSlice());
     }
 
-    final void expandMembers(Scope* sc2)
+    final void semanticMembers(Scope *sc)
     {
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            Dsymbol s = (*members)[i];
-            s.setScope(sc2);
-        }
-
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            Dsymbol s = (*members)[i];
-            s.importAll(sc2);
-        }
-
         for (size_t i = 0; i < members.dim; i++)
         {
             Dsymbol s = (*members)[i];
@@ -8366,13 +8441,13 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             //if (enclosing)
             //    s.parent = sc.parent;
             //printf("test3: enclosing = %d, s.parent = %s\n", enclosing, s.parent.toChars());
-            s.semantic(sc2);
+            s.semantic(sc);
             //printf("test4: enclosing = %d, s.parent = %s\n", enclosing, s.parent.toChars());
             Module.runDeferredSemantic();
         }
     }
 
-    final void tryExpandMembers(Scope* sc2)
+    final void trySemanticMembers(Scope *sc)
     {
         static __gshared int nest;
         // extracted to a function to allow windows SEH to work without destructors in the same function
@@ -8384,7 +8459,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             fatal();
         }
 
-        expandMembers(sc2);
+        semanticMembers(sc);
 
         nest--;
     }
@@ -8555,6 +8630,204 @@ extern (C++) final class TemplateMixin : TemplateInstance
         return TemplateInstance.syntaxCopy(tm);
     }
 
+    override void importAll(Scope* sc)
+    {
+        if (_scope)
+            sc = _scope;
+
+        if (semanticRun < PASSmembers)
+        {
+            /* Run semantic on each argument, place results in tiargs[],
+            * then find best match template with tiargs
+            */
+            if (!findTempDecl(sc) || !semanticTiargs(sc) || !findBestMatch(sc, null))
+            {
+                if (semanticRun == PASSinit) // forward reference had occurred
+                {
+                    //printf("forward reference - deferring\n");
+                    _scope.setNoFree();
+                    _scope._module.addDeferredSemantic(this);
+                    return;
+                }
+
+                inst = this;
+                errors = true;
+                semanticRun = PASSmembersdone;
+                return; // error recovery
+            }
+
+            if (!ident)
+            {
+                /* Assign scope local unique identifier, as same as lambdas.
+                */
+                const(char)* s = "__mixin";
+
+                DsymbolTable symtab;
+                if (FuncDeclaration func = sc.parent.isFuncDeclaration())
+                {
+                    symtab = func.localsymtab;
+                    if (symtab)
+                    {
+                        // Inside template constraint, symtab is not set yet.
+                        goto L1;
+                    }
+                }
+                else
+                {
+                    symtab = sc.parent.isScopeDsymbol().symtab;
+                L1:
+                    assert(symtab);
+                    ident = Identifier.generateId(s, symtab.len + 1);
+                    symtab.insert(this);
+                }
+            }
+
+            inst = this;
+            parent = sc.parent;
+
+            auto tempdecl = this.tempdecl.isTemplateDeclaration();
+            assert(tempdecl);
+
+            /* Detect recursive mixin instantiations.
+            */
+            for (Dsymbol s = parent; s; s = s.parent)
+            {
+                //printf("\ts = '%s'\n", s.toChars());
+                TemplateMixin tm = s.isTemplateMixin();
+                if (!tm || tempdecl != tm.tempdecl)
+                    continue;
+
+                /* Different argument list lengths happen with variadic args
+                */
+                if (tiargs.dim != tm.tiargs.dim)
+                    continue;
+
+                for (size_t i = 0; i < tiargs.dim; i++)
+                {
+                    RootObject o = (*tiargs)[i];
+                    Type ta = isType(o);
+                    Expression ea = isExpression(o);
+                    Dsymbol sa = isDsymbol(o);
+                    RootObject tmo = (*tm.tiargs)[i];
+                    if (ta)
+                    {
+                        Type tmta = isType(tmo);
+                        if (!tmta)
+                            goto Lcontinue;
+                        if (!ta.equals(tmta))
+                            goto Lcontinue;
+                    }
+                    else if (ea)
+                    {
+                        Expression tme = isExpression(tmo);
+                        if (!tme || !ea.equals(tme))
+                            goto Lcontinue;
+                    }
+                    else if (sa)
+                    {
+                        Dsymbol tmsa = isDsymbol(tmo);
+                        if (sa != tmsa)
+                            goto Lcontinue;
+                    }
+                    else
+                        assert(0);
+                }
+                error("recursive mixin instantiation");
+                return;
+
+            Lcontinue:
+                continue;
+            }
+
+            // Copy the syntax trees from the TemplateDeclaration
+            members = Dsymbol.arraySyntaxCopy(tempdecl.members);
+            if (!members)
+            {
+                semanticRun = PASSmembersdone;
+                return;
+            }
+
+            symtab = new DsymbolTable();
+
+            for (Scope* sce = sc; 1; sce = sce.enclosing)
+            {
+                ScopeDsymbol sds = sce.scopesym;
+                if (sds)
+                {
+                    sds.importScope(this, Prot(PROTpublic));
+                    break;
+                }
+            }
+
+            static if (LOG)
+            {
+                printf("\tcreate scope for template parameters '%s'\n", toChars());
+            }
+
+            argsym = new ScopeDsymbol();
+            argsym.parent = this;
+        }
+
+        Scope* scy = sc.push(this);
+        scy.parent = this;
+
+        Scope* argscope = scy.push(argsym);
+        Scope* sc2 = argscope.push(this);
+
+        uint errorsave = global.errors;
+
+        if (semanticRun < PASSmembers)
+        {
+            // Declare each template parameter as an alias for the argument type
+            declareParameters(argscope);
+
+            // Add members to enclosing scope, as well as this scope
+            for (size_t i = 0; i < members.dim; i++)
+            {
+                Dsymbol s = (*members)[i];
+                s.addMember(argscope, this);
+                //printf("sc.parent = %p, sc.scopesym = %p\n", sc.parent, sc.scopesym);
+                //printf("s.parent = %s\n", s.parent.toChars());
+            }
+
+            // Do semantic() analysis on template instance members
+            static if (LOG)
+            {
+                printf("\tdo semantic() on template instance members '%s'\n", toChars());
+            }
+
+            //size_t deferred_dim = Module.deferred.dim;
+
+            for (size_t i = 0; i < members.dim; i++)
+            {
+                Dsymbol s = (*members)[i];
+                s.setScope(sc2);
+            }
+        }
+
+        static __gshared int nest;
+        //printf("%d\n", nest);
+        if (++nest > 500)
+        {
+            global.gag = 0; // ensure error message gets printed
+            error("recursive expansion");
+            fatal();
+        }
+        ScopeDsymbol.importAll(sc2);
+        nest--;
+
+        // Give additional context info if error occurred during instantiation
+        if (global.errors != errorsave)
+        {
+            error("error instantiating");
+            errors = true;
+        }
+
+        sc2.pop();
+        argscope.pop();
+        scy.pop();
+    }
+
     override void semantic(Scope* sc)
     {
         static if (LOG)
@@ -8562,7 +8835,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
             printf("+TemplateMixin.semantic('%s', this=%p)\n", toChars(), this);
             fflush(stdout);
         }
-        if (semanticRun != PASSinit)
+        if (semanticRun >= PASSsemantic)
         {
             // When a class/struct contains mixin members, and is done over
             // because of forward references, never reach here so semanticRun
@@ -8573,6 +8846,20 @@ extern (C++) final class TemplateMixin : TemplateInstance
             }
             return;
         }
+
+        importAll(sc);
+        if (semanticRun < PASSmembersdone)
+        {
+            error("template mixin forward ref");
+            return;
+        }
+
+        if (errors)
+        {
+            semanticRun = PASSsemanticdone;
+            return;
+        }
+
         semanticRun = PASSsemantic;
         static if (LOG)
         {
@@ -8587,186 +8874,19 @@ extern (C++) final class TemplateMixin : TemplateInstance
             _scope = null;
         }
 
-        /* Run semantic on each argument, place results in tiargs[],
-         * then find best match template with tiargs
-         */
-        if (!findTempDecl(sc) || !semanticTiargs(sc) || !findBestMatch(sc, null))
-        {
-            if (semanticRun == PASSinit) // forward reference had occurred
-            {
-                //printf("forward reference - deferring\n");
-                _scope = scx ? scx : sc.copy();
-                _scope.setNoFree();
-                _scope._module.addDeferredSemantic(this);
-                return;
-            }
-
-            inst = this;
-            errors = true;
-            return; // error recovery
-        }
-
-        auto tempdecl = this.tempdecl.isTemplateDeclaration();
-        assert(tempdecl);
-
-        if (!ident)
-        {
-            /* Assign scope local unique identifier, as same as lambdas.
-             */
-            const(char)* s = "__mixin";
-
-            DsymbolTable symtab;
-            if (FuncDeclaration func = sc.parent.isFuncDeclaration())
-            {
-                symtab = func.localsymtab;
-                if (symtab)
-                {
-                    // Inside template constraint, symtab is not set yet.
-                    goto L1;
-                }
-            }
-            else
-            {
-                symtab = sc.parent.isScopeDsymbol().symtab;
-            L1:
-                assert(symtab);
-                ident = Identifier.generateId(s, symtab.len + 1);
-                symtab.insert(this);
-            }
-        }
-
-        inst = this;
-        parent = sc.parent;
-
-        /* Detect recursive mixin instantiations.
-         */
-        for (Dsymbol s = parent; s; s = s.parent)
-        {
-            //printf("\ts = '%s'\n", s.toChars());
-            TemplateMixin tm = s.isTemplateMixin();
-            if (!tm || tempdecl != tm.tempdecl)
-                continue;
-
-            /* Different argument list lengths happen with variadic args
-             */
-            if (tiargs.dim != tm.tiargs.dim)
-                continue;
-
-            for (size_t i = 0; i < tiargs.dim; i++)
-            {
-                RootObject o = (*tiargs)[i];
-                Type ta = isType(o);
-                Expression ea = isExpression(o);
-                Dsymbol sa = isDsymbol(o);
-                RootObject tmo = (*tm.tiargs)[i];
-                if (ta)
-                {
-                    Type tmta = isType(tmo);
-                    if (!tmta)
-                        goto Lcontinue;
-                    if (!ta.equals(tmta))
-                        goto Lcontinue;
-                }
-                else if (ea)
-                {
-                    Expression tme = isExpression(tmo);
-                    if (!tme || !ea.equals(tme))
-                        goto Lcontinue;
-                }
-                else if (sa)
-                {
-                    Dsymbol tmsa = isDsymbol(tmo);
-                    if (sa != tmsa)
-                        goto Lcontinue;
-                }
-                else
-                    assert(0);
-            }
-            error("recursive mixin instantiation");
-            return;
-
-        Lcontinue:
-            continue;
-        }
-
-        // Copy the syntax trees from the TemplateDeclaration
-        members = Dsymbol.arraySyntaxCopy(tempdecl.members);
-        if (!members)
-            return;
-
-        symtab = new DsymbolTable();
-
-        for (Scope* sce = sc; 1; sce = sce.enclosing)
-        {
-            ScopeDsymbol sds = sce.scopesym;
-            if (sds)
-            {
-                sds.importScope(this, Prot(PROTpublic));
-                break;
-            }
-        }
-
-        static if (LOG)
-        {
-            printf("\tcreate scope for template parameters '%s'\n", toChars());
-        }
-        Scope* scy = sc.push(this);
+        Scope* scy = sc.push(this); // FWDREF TODO: passing sc2 to members.semanticN() should ideally not be needed after setScope
         scy.parent = this;
 
-        argsym = new ScopeDsymbol();
-        argsym.parent = scy.parent;
         Scope* argscope = scy.push(argsym);
+        Scope* sc2 = argscope.push(this);
 
         uint errorsave = global.errors;
-
-        // Declare each template parameter as an alias for the argument type
-        declareParameters(argscope);
-
-        // Add members to enclosing scope, as well as this scope
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            Dsymbol s = (*members)[i];
-            s.addMember(argscope, this);
-            //printf("sc.parent = %p, sc.scopesym = %p\n", sc.parent, sc.scopesym);
-            //printf("s.parent = %s\n", s.parent.toChars());
-        }
-
-        // Do semantic() analysis on template instance members
-        static if (LOG)
-        {
-            printf("\tdo semantic() on template instance members '%s'\n", toChars());
-        }
-        Scope* sc2 = argscope.push(this);
-        //size_t deferred_dim = Module.deferred.dim;
-
-        static __gshared int nest;
-        //printf("%d\n", nest);
-        if (++nest > 500)
-        {
-            global.gag = 0; // ensure error message gets printed
-            error("recursive expansion");
-            fatal();
-        }
-
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            Dsymbol s = (*members)[i];
-            s.setScope(sc2);
-        }
-
-        for (size_t i = 0; i < members.dim; i++)
-        {
-            Dsymbol s = (*members)[i];
-            s.importAll(sc2);
-        }
 
         for (size_t i = 0; i < members.dim; i++)
         {
             Dsymbol s = (*members)[i];
             s.semantic(sc2);
         }
-
-        nest--;
 
         /* In DeclDefs scope, TemplateMixin does not have to handle deferred symbols.
          * Because the members would already call Module.addDeferredSemantic() for themselves.

--- a/src/ddmd/dversion.d
+++ b/src/ddmd/dversion.d
@@ -98,11 +98,11 @@ extern (C++) final class DebugSymbol : Dsymbol
         }
     }
 
-    override void semantic(Scope* sc)
+
+    override void semantic()
     {
         //printf("DebugSymbol::semantic() %s\n", toChars());
-        if (semanticRun < PASSsemanticdone)
-            semanticRun = PASSsemanticdone;
+        semanticState = SemState.Done;
     }
 
     override const(char)* kind() const
@@ -195,10 +195,9 @@ extern (C++) final class VersionSymbol : Dsymbol
         }
     }
 
-    override void semantic(Scope* sc)
+    override void semantic()
     {
-        if (semanticRun < PASSsemanticdone)
-            semanticRun = PASSsemanticdone;
+        semanticState = SemState.Done;
     }
 
     override const(char)* kind() const

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -7278,7 +7278,7 @@ extern (C++) final class DeclarationExp : Expression
             // Do semantic() on initializer first, so:
             //      int a = a;
             // will be illegal.
-//             declaration.setScope(sc);
+            declaration.setScope(sc);
             declaration.semantic(sc);
             s.parent = sc.parent;
         }
@@ -7332,7 +7332,7 @@ extern (C++) final class DeclarationExp : Expression
             if (sc2.stc & (STCpure | STCnothrow | STCnogc))
                 sc2 = sc.push();
             sc2.stc &= ~(STCpure | STCnothrow | STCnogc);
-//             declaration.setScope(sc2);
+            declaration.setScope(sc2);
             declaration.semantic(sc2);
             if (sc2 != sc)
                 sc2.pop();

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -2941,6 +2941,8 @@ extern (C++) abstract class Expression : RootObject
 
     final void checkDeprecated(Scope* sc, Dsymbol s)
     {
+        if (auto fd = s.isFuncDeclaration())
+            fd.inferAttributes();
         s.checkDeprecated(loc, sc);
     }
 
@@ -2960,6 +2962,8 @@ extern (C++) abstract class Expression : RootObject
             return false;
         if (sc.flags & (SCOPEctfe | SCOPEdebug))
             return false;
+
+        f.inferAttributes();
 
         /* Given:
          * void f() {
@@ -3190,6 +3194,8 @@ extern (C++) abstract class Expression : RootObject
         if (sc.flags & SCOPEctfe)
             return false;
 
+        f.inferAttributes();
+
         if (!f.isSafe() && !f.isTrusted())
         {
             if (sc.flags & SCOPEcompile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafe())
@@ -3220,6 +3226,8 @@ extern (C++) abstract class Expression : RootObject
             return false;
         if (sc.flags & SCOPEctfe)
             return false;
+
+        f.inferAttributes();
 
         if (!f.isNogc())
         {
@@ -7270,6 +7278,7 @@ extern (C++) final class DeclarationExp : Expression
             // Do semantic() on initializer first, so:
             //      int a = a;
             // will be illegal.
+//             declaration.setScope(sc);
             declaration.semantic(sc);
             s.parent = sc.parent;
         }
@@ -7323,6 +7332,7 @@ extern (C++) final class DeclarationExp : Expression
             if (sc2.stc & (STCpure | STCnothrow | STCnogc))
                 sc2 = sc.push();
             sc2.stc &= ~(STCpure | STCnothrow | STCnogc);
+//             declaration.setScope(sc2);
             declaration.semantic(sc2);
             if (sc2 != sc)
                 sc2.pop();

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -5837,7 +5837,7 @@ extern (C++) final class ScopeExp : Expression
                 type = Type.tvoid;
                 return this;
             }
-            ti.semantic(sc);
+            ti.importAll(sc);
             if (!ti.inst || ti.errors)
                 return new ErrorExp();
 
@@ -5858,7 +5858,7 @@ extern (C++) final class ScopeExp : Expression
 
             if (auto v = s.isVarDeclaration())
             {
-                if (!v.type)
+                if (v.semanticRun == PASSinit)
                 {
                     error("forward reference of %s %s", v.kind(), v.toChars());
                     return new ErrorExp();
@@ -8834,16 +8834,15 @@ extern (C++) final class DotIdExp : UnaExp
                 if (v)
                 {
                     //printf("DotIdExp:: Identifier '%s' is a variable, type '%s'\n", toChars(), v.type.toChars());
-                    if (!v.type ||
-                        !v.type.deco && v.inuse)
+                    if (v.inuse)
                     {
-                        if (v.inuse)
+//                         if (v.inuse)
                             error("circular reference to %s '%s'", v.kind(), v.toPrettyChars());
-                        else
-                            error("forward reference to %s '%s'", v.kind(), v.toPrettyChars());
+//                         else // FWDREF FIXME?
+//                             error("forward reference to %s '%s'", v.kind(), v.toPrettyChars());
                         return new ErrorExp();
                     }
-                    if (v.type.ty == Terror)
+                    if (v.type && v.type.ty == Terror)
                         return new ErrorExp();
 
                     if ((v.storage_class & STCmanifest) && v._init && !wantsym)

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -5891,6 +5891,8 @@ extern (C++) final class ScopeExp : Expression
                     return e;
                 }
             }
+            else if (s.isFuncLiteralDeclaration())
+                ti.semantic3(sc); // FWDREF FIXME: this needs more investigation, this is currently required for test7713 in runnable/funclit.d to prevent FuncExp.semantic() from setting the return type to T, which isn't in _scope
 
             //printf("s = %s, '%s'\n", s.kind(), s.toChars());
             auto e = DsymbolExp.resolve(loc, sc, s, true);

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -5878,7 +5878,7 @@ extern (C++) final class ScopeExp : Expression
             //assert(ti.needsTypeInference(sc));
             if (ti.tempdecl &&
                 ti.semantictiargsdone &&
-                ti.semanticRun == PASSinit)
+                ti.semanticRun < PASSsemantic)
             {
                 error("partial %s %s has no type", sds.kind(), toChars());
                 return true;

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -4073,6 +4073,9 @@ extern (C++) final class DsymbolExp : Expression
         }
         if (auto v = s.isVarDeclaration())
         {
+            if (v._scope)
+                v.semantic(null);
+
             //printf("Identifier '%s' is a variable, type '%s'\n", s.toChars(), v.type.toChars());
             if (!v.type ||                  // during variable type inference
                 !v.type.deco && v.inuse)    // during variable type semantic

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -6535,7 +6535,10 @@ extern (C++) final class SymOffExp : SymbolExp
         {
             printf("SymOffExp::semantic('%s')\n", toChars());
         }
-        //var.semantic(sc);
+//         if (auto v = var.isVarDeclaration())
+//             if (v._scope)
+//                 v.semantic(null);
+
         if (!type)
             type = var.type.pointerTo();
 
@@ -9117,6 +9120,14 @@ extern (C++) final class DotVarExp : UnaExp
         e1 = e1.addDtorHook(sc);
 
         Type t1 = e1.type;
+
+        if (auto vd = var.isVarDeclaration())
+        {
+            if (vd._scope)
+                vd.semantic(null);
+            if (vd.isDeferred())
+                return new DeferExp();
+        }
 
         if (FuncDeclaration fd = var.isFuncDeclaration())
         {

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -628,6 +628,8 @@ extern (C++) class FuncDeclaration : Declaration
             if (type.nextOf() == Type.terror)
                 goto Ldone;
 
+            cd.initVtbl(null);
+
             bool may_override = false;
             for (size_t i = 0; i < cd.baseclasses.dim; i++)
             {

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -278,6 +278,31 @@ extern (C++) class FuncDeclaration : Declaration
         return f;
     }
 
+    override void importAll(Scope* sc)
+    {
+        if (semanticRun >= PASSmembersdone)
+            return;
+
+        if (_scope)
+            sc = _scope;
+
+        if (!sc)
+            return;
+
+        parent = sc.parent;
+
+        AggregateDeclaration ad = isThis();
+        // Don't nest structs b/c of generated methods which should not access the outer scopes.
+        // https://issues.dlang.org/show_bug.cgi?id=16627
+        if (ad && !generated)
+        {
+            storage_class |= ad.storage_class & (STC_TYPECTOR | STCsynchronized);
+            ad.makeNested();
+        }
+
+        semanticRun = PASSmembersdone;
+    }
+
     /// Do the semantic analysis on the external interface to the function.
     override void semantic(Scope* sc)
     {
@@ -294,7 +319,7 @@ extern (C++) class FuncDeclaration : Declaration
             printf("type: %p, %s\n", type, type.toChars());
         }
 
-        if (semanticRun != PASSinit && isFuncLiteralDeclaration())
+        if (semanticRun >= PASSsemantic && isFuncLiteralDeclaration())
         {
             /* Member functions that have return types that are
              * forward references can have semantic() run more than
@@ -306,6 +331,7 @@ extern (C++) class FuncDeclaration : Declaration
 
         if (semanticRun >= PASSsemanticdone)
             return;
+        importAll(sc);
         assert(semanticRun <= PASSsemantic);
         semanticRun = PASSsemantic;
 
@@ -318,20 +344,12 @@ extern (C++) class FuncDeclaration : Declaration
         if (!sc || errors)
             return;
 
-        parent = sc.parent;
         Dsymbol parent = toParent();
 
         foverrides.setDim(0); // reset in case semantic() is being retried for this function
 
         storage_class |= sc.stc & ~STCref;
         ad = isThis();
-        // Don't nest structs b/c of generated methods which should not access the outer scopes.
-        // https://issues.dlang.org/show_bug.cgi?id=16627
-        if (ad && !generated)
-        {
-            storage_class |= ad.storage_class & (STC_TYPECTOR | STCsynchronized);
-            ad.makeNested();
-        }
         if (sc.func)
             storage_class |= sc.func.storage_class & STCdisable;
         // Remove prefix storage classes silently.

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -343,7 +343,7 @@ extern (C++) class FuncDeclaration : Declaration
             return true;
 
         if (storage_class & STCabstract)
-            cd.isabstract = ABSyes; // FWDREF NOTE: couldn't this be moved to setScope?
+            cd.isabstract = true; // FWDREF NOTE: couldn't this be moved to setScope?
 
         // if static function, do not put in vtbl[]
         if (!isVirtual())

--- a/src/ddmd/init.d
+++ b/src/ddmd/init.d
@@ -93,6 +93,11 @@ extern (C++) class Initializer : RootObject
         return null;
     }
 
+    DeferInitializer isDeferInitializer()
+    {
+        return null;
+    }
+
     VoidInitializer isVoidInitializer()
     {
         return null;
@@ -195,6 +200,47 @@ extern (C++) final class ErrorInitializer : Initializer
     }
 
     override ErrorInitializer isErrorInitializer()
+    {
+        return this;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ */
+extern (C++) final class DeferInitializer : Initializer
+{
+    extern (D) this()
+    {
+        super(Loc());
+    }
+
+    override Initializer syntaxCopy()
+    {
+        return this;
+    }
+
+    override Initializer inferType(Scope* sc)
+    {
+        return this;
+    }
+
+    override Initializer semantic(Scope* sc, Type t, NeedInterpret needInterpret)
+    {
+        //printf("DeferInitializer::semantic(t = %p)\n", t);
+        return this;
+    }
+
+    override Expression toExpression(Type t = null)
+    {
+        return new ErrorExp();
+    }
+
+    override DeferInitializer isDeferInitializer()
     {
         return this;
     }
@@ -860,6 +906,8 @@ extern (C++) final class ExpInitializer : Initializer
             return new ErrorInitializer();
         if (!exp.type)
             return new ErrorInitializer();
+        if (exp.op == TOKfinally)
+            return new DeferInitializer();
         return this;
     }
 

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1455,6 +1455,7 @@ Language changes listed by -transition=id:
             fprintf(global.stdmsg, "importall %s\n", m.toChars());
         m.importAll(null);
     }
+    Module.runDeferredMembers();
     if (global.errors)
         fatal();
 

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -7918,7 +7918,13 @@ extern (C++) final class TypeInstance : TypeQualified
         *ps = null;
 
         //printf("TypeInstance::resolve(sc = %p, tempinst = '%s')\n", sc, tempinst.toChars());
+        tempinst.setScope(sc);
         tempinst.importAll(sc);
+        if (tempinst.isDeferred())
+        {
+            *pt = tdefer;
+            return;
+        }
         if (!global.gag && tempinst.errors)
         {
             *pt = terror;

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -9367,6 +9367,9 @@ extern (C++) final class TypeClass : Type
         }
         if (auto v = s.isVarDeclaration())
         {
+            if (v._scope)
+                v.semantic(null);
+
             if (!v.type ||
                 !v.type.deco && v.inuse)
             {

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -5476,8 +5476,8 @@ extern (C++) final class TypeAArray : TypeArray
         else if (tbase.ty == Tclass && !(cast(TypeClass)tbase).sym.isInterfaceDeclaration())
         {
             ClassDeclaration cd = (cast(TypeClass)tbase).sym;
-            if (cd.semanticRun < PASSsemanticdone)
-                cd.semantic(null);
+            if (cd.semanticRun < PASSmembersdone)
+                cd.importAll(null);
 
             if (!ClassDeclaration.object)
             {

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -7875,7 +7875,7 @@ extern (C++) final class TypeInstance : TypeQualified
         *ps = null;
 
         //printf("TypeInstance::resolve(sc = %p, tempinst = '%s')\n", sc, tempinst.toChars());
-        tempinst.semantic(sc);
+        tempinst.importAll(sc);
         if (!global.gag && tempinst.errors)
         {
             *pt = terror;
@@ -8505,7 +8505,7 @@ extern (C++) final class TypeStruct : Type
                     return e;
                 }
             }
-            if (d.semanticRun == PASSinit)
+            if (d.semanticRun < PASSsemantic) // FWDREF hmm?
                 d.semantic(null);
             checkAccess(e.loc, sc, e, d);
             auto ve = new VarExp(e.loc, d);
@@ -9533,7 +9533,7 @@ extern (C++) final class TypeClass : Type
                 }
             }
             //printf("e = %s, d = %s\n", e.toChars(), d.toChars());
-            if (d.semanticRun == PASSinit)
+            if (d.semanticRun == PASSinit) // FWDREF hmm
                 d.semantic(null);
             checkAccess(e.loc, sc, e, d);
             auto ve = new VarExp(e.loc, d);

--- a/src/ddmd/nspace.d
+++ b/src/ddmd/nspace.d
@@ -237,21 +237,6 @@ extern (C++) final class Nspace : ScopeDsymbol
         return false;
     }
 
-    override void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
-    {
-        //printf("Nspace::setFieldOffset() %s\n", toChars());
-        if (_scope) // if fwd reference
-            semantic(null); // try to resolve it
-        if (members)
-        {
-            foreach (s; *members)
-            {
-                //printf("\t%s\n", s.toChars());
-                s.setFieldOffset(ad, poffset, isunion);
-            }
-        }
-    }
-
     override const(char)* kind() const
     {
         return "namespace";

--- a/src/ddmd/nspace.d
+++ b/src/ddmd/nspace.d
@@ -90,7 +90,7 @@ extern (C++) final class Nspace : ScopeDsymbol
 
     override void semantic(Scope* sc)
     {
-        if (semanticRun != PASSinit)
+        if (semanticRun != PASSinit) // FWDREF FIXME
             return;
         static if (LOG)
         {

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -429,6 +429,7 @@ final class Parser(AST) : Lexer
             AST.Condition condition;
 
             linkage = linksave;
+                const loc2 = token.loc;
 
             switch (token.value)
             {
@@ -629,6 +630,7 @@ final class Parser(AST) : Lexer
                         s = parseStaticAssert();
                     else if (next == TOKif)
                     {
+                        const loc = token.loc;
                         condition = parseStaticIfCondition();
                         AST.Dsymbols* athen;
                         if (token.value == TOKcolon)
@@ -648,7 +650,7 @@ final class Parser(AST) : Lexer
                             aelse = parseBlock(pLastDecl);
                             checkDanglingElse(elseloc);
                         }
-                        s = new AST.StaticIfDeclaration(condition, athen, aelse);
+                        s = new AST.StaticIfDeclaration(loc2, condition, athen, aelse);
                     }
                     else if (next == TOKimport)
                     {
@@ -1117,7 +1119,7 @@ final class Parser(AST) : Lexer
                         aelse = parseBlock(pLastDecl);
                         checkDanglingElse(elseloc);
                     }
-                    s = new AST.ConditionalDeclaration(condition, athen, aelse);
+                    s = new AST.ConditionalDeclaration(loc, condition, athen, aelse);
                     break;
                 }
             case TOKsemicolon:

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -329,6 +329,11 @@ extern (C++) abstract class Statement : RootObject
         return null;
     }
 
+    DeferStatement isDeferStatement()
+    {
+        return null;
+    }
+
     inout(ScopeStatement) isScopeStatement() inout nothrow pure
     {
         return null;
@@ -413,6 +418,32 @@ extern (C++) final class ErrorStatement : Statement
     }
 
     override ErrorStatement isErrorStatement()
+    {
+        return this;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ */
+extern (C++) final class DeferStatement : Statement
+{
+    extern (D) this()
+    {
+        super(Loc());
+        assert(global.gaggedErrors || global.errors);
+    }
+
+    override Statement syntaxCopy()
+    {
+        return this;
+    }
+
+    override DeferStatement isDeferStatement()
     {
         return this;
     }

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -3666,8 +3666,8 @@ else
                 s.aliasdecls.push(ad);
             }
 
-            s.semantic(sc);
-            Module.addDeferredSemantic2(s);     // https://issues.dlang.org/show_bug.cgi?id=14666
+            s.importAll(sc);
+//             Module.addDeferredSemantic2(s);     // https://issues.dlang.org/show_bug.cgi?id=14666
             sc.insert(s);
 
             foreach (aliasdecl; s.aliasdecls)

--- a/src/ddmd/staticassert.d
+++ b/src/ddmd/staticassert.d
@@ -61,8 +61,8 @@ extern (C++) final class StaticAssert : Dsymbol
         sc.minst = null;
 
         import ddmd.staticcond;
-        bool errors;
-        bool result = evalStaticCondition(sc, exp, exp, errors);
+        bool errors, defer;
+        bool result = evalStaticCondition(sc, exp, exp, errors, defer);
         sc = sc.pop();
         if (errors)
         {

--- a/src/ddmd/tokens.d
+++ b/src/ddmd/tokens.d
@@ -1187,3 +1187,5 @@ private immutable TOK[] keywords =
     TOKshared,
     TOKimmutable,
 ];
+
+alias TOKdefer = TOKfinally;

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -518,7 +518,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         else if (auto ad = s.isAggregateDeclaration())
         {
             if (auto cd = ad.isClassDeclaration())
-                assert(cd.baseok == BASEOKdone); // FIXME, shouldn't really be needed
+                assert(cd.baseok >= BASEOKdone); // FIXME, shouldn't really be needed
             return ad.isNested() ? True() : False();
         }
         else if (auto fd = s.isFuncDeclaration())

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -617,7 +617,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return new ErrorExp();
         }
         if (s.semanticRun == PASSinit)
-            s.semantic(null);
+            s.semantic(null); // FWDREF FIXME: so it would probably be better to set the protection in importAll/determineMembers for all Dsymbols, not just ScopeDsymbol
 
         auto protName = protectionToChars(s.prot().kind); // TODO: How about package(names)
         assert(protName);

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -610,7 +610,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
         Scope* sc2 = sc.push();
         sc2.flags = sc.flags | SCOPEnoaccesscheck;
-        bool ok = TemplateInstance.semanticTiargs(e.loc, sc2, e.args, 1);
+        bool ok = TemplateInstance.semanticTiargs(e.loc, sc2, e.args, 1) == SemResult.Done;
         sc2.pop();
         if (!ok)
             return new ErrorExp();

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -517,6 +517,8 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         else if (auto ad = s.isAggregateDeclaration())
         {
+            if (auto cd = ad.isClassDeclaration())
+                assert(cd.baseok == BASEOKdone); // FIXME, shouldn't really be needed
             return ad.isNested() ? True() : False();
         }
         else if (auto fd = s.isFuncDeclaration())


### PR DESCRIPTION
This is the implementation of the solution discussed [here](http://forum.dlang.org/post/auvbfyzmqjxtfhkvmkxu@forum.dlang.org). This PR:
- splits the `semantic()` functions into the part where the `symtab` of a `ScopeDsymbol` gets determined, and the rest. Although instead of adding another function that part is added to `importAll()` since its reason of being has been if I'm not mistaken to get the ScopeDsymbol ready for `search()`.
- makes overrides of `Dsymbol.importAll` callable multiple times recursively each time resuming from where the previous ongoing call left off.
- (todo) renames `importAll` to `determineMembers` to clarify its new role.
- makes `TemplateInstance.semantic3` call `semantic2`, and `TemplateInstance.semantic2` call `semantic` if needed. Every split `semantic` function also calls `importAll` so no additional `importAll` call is needed alongside existing `semantic` calls.

However the re-ordering of `determineMembers/semantic()` calls broke existing code. The reason is that [in some cases](https://github.com/dlang/dmd/pull/7018#issuecomment-318847785), deferring lookups cannot be avoided, which I didn't realize initially. So a large part of this PR is also to implement deferring (instead of error gagging). (will write more details soon). 

This addresses the two issues from the forum thread:

> https://issues.dlang.org/show_bug.cgi?id=17656
> https://issues.dlang.org/show_bug.cgi?id=17194

and probably a lot more cases.

Even @tgehr's code now compiles!:
```d
enum x = "enum xx = q{int y = 123;};";

struct SS{
    mixin(xx);
    mixin(x);
}

void main()
{
    import std.stdio : writeln;
    SS s; writeln(s.y); // prints 123
}
```

**To do:**
- fix the remaining breakages
- special aggregate methods currently generated by clone.d should be added to `.members` during `importAll()`, and their body should be generated not during `Struct/ClassDeclaration.semantic()` but during `FuncDeclaration.semantic()`

Along the way I've spotted possible further improvements.

**Further enhancements:**
- Merge `addMember` into `determineMembers`?
- Is passing `sc` to `semantic1.2.3` really useful once `setScope` has been called? (Was `setScope` historically an afterthought?) Passing sc only seems required if the symbol:
    * is declared inside a function through a DeclarationExp
    * is inside a `typeof()`
    * was added to a `.members` without a setScope call. Only possible case as far as I know: TemplateInstance appended to the members of the instantiating or root module.

    &nbsp;
    The scope has no reason to change and should stay the same between `importAll` and `semantic1,2,3`. Shouldn't `setScope` get called in these few special cases? Ensuring that every symbol about to be semantic'd has its scope set would also avoid having to re-create one or more Scope objects during `AggregateDeclaration/TemplateInstance/AttribDeclaration... .semantic2,3`. (However currently `_scope` is also used in several semantic() functions as a safeguard against recursive semantic calls, but I don't think it should be used that way, checking `semanticRun` would do too.)
- Symbols could retrieve basic info from `sc` during `setScope()`, so `__traits(getProtection/Linkage/...)` may work before `determineMembers`.