### PR TITLE
Fix Issue 17676 - bad inlining of functions with multiple return statements

### DIFF
--- a/src/ddmd/inlinecost.d
+++ b/src/ddmd/inlinecost.d
@@ -240,7 +240,8 @@ public:
     override void visit(ReturnStatement s)
     {
         // Can't handle return statements nested in if's
-        if (nested)
+        // Or is they are not the last statement in the function
+        if (fd.fbody.last() !is s || nested)
         {
             cost = COST_MAX;
         }

--- a/src/ddmd/inlinecost.d
+++ b/src/ddmd/inlinecost.d
@@ -240,7 +240,7 @@ public:
     override void visit(ReturnStatement s)
     {
         // Can't handle return statements nested in if's
-        // Or is they are not the last statement in the function
+        // Or if it's not the last statement in the function
         if (fd.fbody.last() !is s || nested)
         {
             cost = COST_MAX;

--- a/test/runnable/issue17676.d
+++ b/test/runnable/issue17676.d
@@ -1,0 +1,35 @@
+import core.stdc.stdio;
+
+__gshared bool bgEnable = 1;
+
+void smallAlloc() nothrow
+{
+    fullcollect();
+}
+
+size_t fullcollect() nothrow
+{
+    if(bgEnable)
+       return fullcollectTrigger();
+
+    return fullcollectNow();
+}
+
+size_t fullcollectNow() nothrow
+{
+    if (bgEnable)
+        assert(0);
+    pragma(inline, false);
+    return 1;
+}
+
+size_t fullcollectTrigger() nothrow
+{
+    pragma(inline, false);
+    return 0;
+}
+
+void main()
+{
+    smallAlloc();
+}


### PR DESCRIPTION
This is fixed by making sure that we only inline the return statement if it is the last statement in the function.
and leave the return there if this is not the last statement.

@andralex @WalterBright ready to pull!