### PR TITLE
fix Issue 17688 - ICE with static foreach directly inside switch

### DIFF
--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -5145,6 +5145,8 @@ final class Parser(AST) : Lexer
                 else if(t.value == TOKforeach || t.value == TOKforeach_reverse)
                 {
                     s = parseForeach!(true,false)(loc);
+                    if (flags & PSscope)
+                        s = new AST.ScopeStatement(loc, s, token.loc);
                     break;
                 }
                 if (t.value == TOKimport)

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -356,10 +356,13 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         result = ss;
     }
 
-    override void visit(ForwardingStatement ss)
-    {
+    override void visit(ForwardingStatement ss){
         assert(ss.sym);
-        ss.sym.forward = sc.scopesym;
+        for (Scope* csc = sc; !ss.sym.forward; csc = csc.enclosing)
+        {
+            assert(csc);
+            ss.sym.forward = csc.scopesym;
+        }
         sc = sc.push(ss.sym);
         sc.sbreak = ss;
         sc.scontinue = ss;

--- a/test/compilable/staticforeach.d
+++ b/test/compilable/staticforeach.d
@@ -685,3 +685,8 @@ void testToStatement(){
     static assert(x0==0 && x1==1);
     static assert(y0==0 && y1==1);
 }
+
+void bug17688(){
+    final switch(1) static foreach(x;0..1){ int y=3; case 1: return; }
+    static assert(!is(typeof(y)));
+}


### PR DESCRIPTION
1. The parser needs to respect PSscope when parsing a StaticForeachStatement.
2. If the current scope has no scopesym, need to search enclosing scopes to find the scopesym to forward symbols to. (This is not necessary to fix the ICE given that fix 1 is applied, but it is consistent with how identifier lookup is implemented.)