### PR TITLE
fix issue 17676:  [REG 2.075] bad inlining of functions with multiple return statements

### DIFF
--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -543,6 +543,7 @@ public:
     // 2 if there's a throw statement
     // 4 if there's an assert(0)
     // 8 if there's inline asm
+    // 16 if there are multiple return statements
     int hasReturnExp;
 
     // Support for NRVO (named return value optimization)

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -217,6 +217,7 @@ extern (C++) class FuncDeclaration : Declaration
     /// 2 if there's a throw statement
     /// 4 if there's an assert(0)
     /// 8 if there's inline asm
+    /// 16 if there are multiple return statements
     int hasReturnExp;
 
     // Support for NRVO (named return value optimization)
@@ -1607,7 +1608,7 @@ extern (C++) class FuncDeclaration : Declaration
                         Statement s = new ReturnStatement(loc, null);
                         s = s.semantic(sc2);
                         fbody = new CompoundStatement(loc, fbody, s);
-                        hasReturnExp |= 1;
+                        hasReturnExp |= (hasReturnExp & 1 ? 16 : 1);
                     }
                 }
                 else if (fes)
@@ -1618,7 +1619,7 @@ extern (C++) class FuncDeclaration : Declaration
                         Expression e = new IntegerExp(0);
                         Statement s = new ReturnStatement(Loc(), e);
                         fbody = new CompoundStatement(Loc(), fbody, s);
-                        hasReturnExp |= 1;
+                        hasReturnExp |= (hasReturnExp & 1 ? 16 : 1);
                     }
                     assert(!returnLabel);
                 }

--- a/src/ddmd/inline.d
+++ b/src/ddmd/inline.d
@@ -1553,7 +1553,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         }
 
         /* Don't inline a function that returns non-void, but has
-         * no return expression.
+         * no or multiple return expression.
          * When inlining as a statement:
          * 1. don't inline array operations, because the order the arguments
          *    get evaluated gets reversed. This is the same issue that e2ir.callfunc()
@@ -1601,6 +1601,17 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         static if (CANINLINE_LOG)
         {
             printf("\t4: no %s\n", fd.toChars());
+        }
+        goto Lno;
+    }
+
+    // cannot inline functions as statement if they have multiple
+    //  return statements
+    if ((fd.hasReturnExp & 16) && statementsToo)
+    {
+        static if (CANINLINE_LOG)
+        {
+            printf("\t5: no %s\n", fd.toChars());
         }
         goto Lno;
     }

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -2505,7 +2505,7 @@ else
         }
         else if (rs.exp)
         {
-            fd.hasReturnExp |= 1;
+            fd.hasReturnExp |= (fd.hasReturnExp & 1 ? 16 : 1);
 
             FuncLiteralDeclaration fld = fd.isFuncLiteralDeclaration();
             if (tret)

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -1065,6 +1065,37 @@ void test15296c()
 }
 
 /**********************************/
+// https://issues.dlang.org/show_bug.cgi?id=17676
+__gshared bool bgEnable = 1;
+
+void test17676() nothrow
+{
+    fullcollect();
+}
+
+size_t fullcollect() nothrow
+{
+    if(bgEnable)
+       return fullcollectTrigger();
+
+    return fullcollectNow();
+}
+
+size_t fullcollectNow() nothrow
+{
+    if (bgEnable)
+        assert(0);
+    pragma(inline, false);
+    return 1;
+}
+
+size_t fullcollectTrigger() nothrow
+{
+    pragma(inline, false);
+    return 0;
+}
+
+/**********************************/
 
 int main()
 {
@@ -1100,7 +1131,8 @@ int main()
     test15296();
     test15296b();
     test15296c();
-
+    test17676();
+    
     printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
do not inline function with multiple return statements as statements