### PR TITLE
Fix Lexer memory access beyond the given buffer when malformed input is passed.

### DIFF
--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -129,8 +129,8 @@ unittest
     //printf("lexer.unittest\n");
     /* Not much here, just trying things out.
      */
-    string text = "int";
-    scope Lexer lex1 = new Lexer(null, text.ptr, 0, text.length, 0, 0);
+    string text = "int"; // We rely on the implicit null-terminator
+    scope Lexer lex1 = new Lexer(null, text.ptr, 0, text.length+1, 0, 0);
     TOK tok;
     tok = lex1.nextToken();
     //printf("tok == %s, %d, %d\n", Token::toChars(tok), tok, TOKint32);
@@ -178,10 +178,11 @@ class Lexer
 
     /*********************
      * Creates a Lexer for the source code base[begoffset..endoffset].
+     * The last character, base[endoffset-1], must be null (0) or EOF (0x1A).
      *
      * Params:
      *  filename = used for error messages
-     *  base = source code
+     *  base = source code, must be terminated by a null (0) or EOF (0x1A) character
      *  begoffset = starting offset into base[]
      *  endoffset = one past the last offset to read into base[]
      *  doDocComment = handle documentation comments
@@ -268,14 +269,16 @@ class Lexer
         Loc startLoc;
         t.blockComment = null;
         t.lineComment = null;
+
+        // Return EOF token when end of buffer is already reached
+        if (p >= end) {
+            t.value = TOKeof;
+            t.loc = loc();
+            return;
+        }
+
         while (1)
         {
-            // Return error token when end of buffer is reached unexpectedly.
-            if (p >= end) {
-                t.value = TOKeof;
-                return;
-            }
-
             t.ptr = p;
             //printf("p = %p, *p = '%c'\n",p,*p);
             t.loc = loc();

--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -145,16 +145,33 @@ unittest
 
 unittest
 {
-    // Test malformed input
-    char[2] text = ['\'', 0];
-    scope Lexer lex2 = new Lexer(null, text.ptr, 0, text.length-1, 0, 0);
-    TOK tok;
-    tok = lex2.nextToken();
-    assert(tok == TOKcharv);
-    tok = lex2.nextToken();
-    assert(tok == TOKeof);
-    tok = lex2.nextToken();
-    assert(tok == TOKeof);
+    // Test malformed input: even malformed input should end in a TOKeof.
+    static immutable char[][] testcases =
+    [   // Testcase must end with 0 or 0x1A.
+        [0], // not malformed, but pathological
+        ['\'', 0],
+        ['\'', 0x1A],
+        ['{', '{', 'q', '{', 0],
+        [0xFF, 0],
+        [0xFF, 0x80, 0],
+        [0xFF, 0xFF, 0],
+        [0xFF, 0xFF, 0],
+        ['x', '"', 0x1A],
+    ];
+
+    foreach (i, testcase; testcases)
+    {
+        scope Lexer lex2 = new Lexer(null, testcase.ptr, 0, testcase.length-1, 0, 0);
+        TOK tok = lex2.nextToken();
+        size_t iterations = 1;
+        while ((tok != TOKeof) && (iterations++ < testcase.length))
+        {
+            tok = lex2.nextToken();
+        }
+        assert(tok == TOKeof);
+        tok = lex2.nextToken();
+        assert(tok == TOKeof);
+    }
 }
 
 /***********************************************************

--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -129,8 +129,8 @@ unittest
     //printf("lexer.unittest\n");
     /* Not much here, just trying things out.
      */
-    string text = "int"; // the test relies on this string begin null-terminated
-    scope Lexer lex1 = new Lexer(null, text.ptr, 0, text.length+1, 0, 0);
+    string text = "int";
+    scope Lexer lex1 = new Lexer(null, text.ptr, 0, text.length, 0, 0);
     TOK tok;
     tok = lex1.nextToken();
     //printf("tok == %s, %d, %d\n", Token::toChars(tok), tok, TOKint32);
@@ -152,9 +152,9 @@ unittest
     tok = lex2.nextToken();
     assert(tok == TOKcharv);
     tok = lex2.nextToken();
-    assert(tok == TOKerror);
+    assert(tok == TOKeof);
     tok = lex2.nextToken();
-    assert(tok == TOKerror);
+    assert(tok == TOKeof);
 }
 
 /***********************************************************
@@ -177,11 +177,11 @@ class Lexer
     bool errors;            // errors occurred during lexing or parsing
 
     /*********************
-     * Creates a Lexer for the (null- or EOF-terminated) source code base[begoffset..endoffset].
+     * Creates a Lexer for the source code base[begoffset..endoffset].
      *
      * Params:
      *  filename = used for error messages
-     *  base = source code, ending in a null- or EOF-byte
+     *  base = source code
      *  begoffset = starting offset into base[]
      *  endoffset = one past the last offset to read into base[]
      *  doDocComment = handle documentation comments
@@ -272,7 +272,7 @@ class Lexer
         {
             // Return error token when end of buffer is reached unexpectedly.
             if (p >= end) {
-                t.value = TOKerror;
+                t.value = TOKeof;
                 return;
             }
 
@@ -1566,7 +1566,6 @@ class Lexer
                 }
                 continue;
             case TOKeof:
-            case TOKerror:
                 error("unterminated token string constant starting at %s", start.toChars());
                 t.setString();
                 return TOKstring;

--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -1566,6 +1566,7 @@ class Lexer
                 }
                 continue;
             case TOKeof:
+            case TOKerror:
                 error("unterminated token string constant starting at %s", start.toChars());
                 t.setString();
                 return TOKstring;

--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -159,7 +159,7 @@ unittest
         ['x', '"', 0x1A],
     ];
 
-    foreach (i, testcase; testcases)
+    foreach (testcase; testcases)
     {
         scope Lexer lex2 = new Lexer(null, testcase.ptr, 0, testcase.length-1, 0, 0);
         TOK tok = lex2.nextToken();


### PR DESCRIPTION
Let me know what token value you want to return upon errors.

This change also enforces that the buffer is really null-terminated (or EOF), and that the terminating null character is included in the buffer interval that the Lexer should lex.
When a string is passed, the implicit null-terminator is necessary and the code must be modified:
```diff
    string text = "int"; // the test relies on this string begin null-terminated
-    scope Lexer lex1 = new Lexer(null, text.ptr, 0, text.length, 0, 0);
+    scope Lexer lex1 = new Lexer(null, text.ptr, 0, text.length+1, 0, 0);
```
Without including the null terminator in the length (the `+1`), `nextToken` would return `TOKerror` instead of `TOKeof`.
