### PR TITLE
fix using sizeof pointer instead of sizeof buf

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1347,8 +1347,8 @@ Language changes listed by -transition=id:
             Module m = modules[i];
             if (strcmp(m.srcfile.name.str, global.main_d) == 0)
             {
-                static __gshared const(char)* buf = "int main(){return 0;}";
-                m.srcfile.setbuffer(cast(void*)buf, buf.sizeof);
+                string buf = "int main(){return 0;}";
+                m.srcfile.setbuffer(cast(void*)buf.ptr, buf.length);
                 m.srcfile._ref = 1;
                 break;
             }


### PR DESCRIPTION
This problem was apparently introduced by the conversion from C++ to D. The `.sizeof` should have been the length of the string, but instead it was the size of a pointer. The code didn't depend on the length being correct, but this should be fixed anyway.