### PR TITLE
Provide STCfuture to string conversion

### DIFF
--- a/src/ddmd/astbase.d
+++ b/src/ddmd/astbase.d
@@ -6286,6 +6286,7 @@ struct ASTBase
             SCstring(STCtrusted, TOKat, "@trusted"),
             SCstring(STCsystem, TOKat, "@system"),
             SCstring(STCdisable, TOKat, "@disable"),
+            SCstring(STCfuture, TOKat, "@__future"),
             SCstring(0, TOKreserved)
         ];
         for (int i = 0; table[i].stc; i++)

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -3165,6 +3165,7 @@ extern (C++) const(char)* stcToChars(ref StorageClass stc)
         SCstring(STCtrusted, TOKat, "@trusted"),
         SCstring(STCsystem, TOKat, "@system"),
         SCstring(STCdisable, TOKat, "@disable"),
+        SCstring(STCfuture, TOKat, "@__future"),
         SCstring(0, TOKreserved)
     ];
     for (int i = 0; table[i].stc; i++)

--- a/test/compilable/futurexf.d
+++ b/test/compilable/futurexf.d
@@ -1,0 +1,12 @@
+/* PERMUTE_ARGS:
+   REQUIRED_ARGS: -Xffuture.json
+ */
+
+class A
+{
+    @__future char msg();
+}
+
+void main()
+{
+}


### PR DESCRIPTION
In case there's a need to render the @__future storage class to a string
(for example, in case of a json output), there should be translation
provided between storage class and a string representation.