### PR TITLE
fix travis-ci linux 64-bit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ d:
   - gdc
   - ldc
 
-script: ./travis.sh
+script:
+  - deactivate # deactivate d compiler
+  - ./travis.sh
 
 sudo: false
 addons:

--- a/travis.sh
+++ b/travis.sh
@@ -2,10 +2,6 @@
 
 set -uexo pipefail
 
-# add missing cc link in gdc-4.9.3 download
-if [ $DC = gdc ] && [ ! -f $(dirname $(which gdc))/cc ]; then
-    ln -s gcc $(dirname $(which gdc))/cc
-fi
 N=2
 
 # use faster ld.gold linker on linux
@@ -34,9 +30,11 @@ clone() {
 
 # build dmd, druntime, phobos
 build() {
+    source ~/dlang/*/activate # activate host compiler
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD ENABLE_RELEASE=1 all
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
+    deactivate # deactivate host compiler
 }
 
 # self-compile dmd


### PR DESCRIPTION
- the dmd/tests are using a shared phobos library but did link against
  the one that comes with the host compiler (installed by
  travis/install.sh) due to LD_LIBRARY_PATH being set
- wasn't noticed before cause dmd tests hardly rely on phobos and the
  parts used where ABI stable enough with the last release
- didn't happen for gdc/ldc with their gphobos/phobos-ldc libs