### PR TITLE
More fixing up missing fields and virtual functions in C++ headers

### DIFF
--- a/src/ddmd/hdrgen.h
+++ b/src/ddmd/hdrgen.h
@@ -17,6 +17,7 @@ struct HdrGenState
 {
     bool hdrgen;        // true if generating header file
     bool ddoc;          // true if generating Ddoc file
+    bool fullDump;      // true if generating a full AST dump file
     bool fullQual;      // fully qualify types when printing
     int tpltMember;
     int autoMember;

--- a/src/ddmd/mtype.h
+++ b/src/ddmd/mtype.h
@@ -637,6 +637,7 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
+    Type *addStorageClass(StorageClass stc);
     d_uns64 size(Loc loc) /*const*/;
     unsigned alignsize() /*const*/;
     MATCH implicitConvTo(Type *to);
@@ -904,7 +905,8 @@ public:
     static size_t dim(Parameters *parameters);
     static Parameter *getNth(Parameters *parameters, d_size_t nth, d_size_t *pn = NULL);
     const char *toChars();
-    bool isCovariant(const Parameter *p) const;
+    bool isCovariant(bool returnByRef, const Parameter *p) const;
+    static bool isCovariantScope(bool returnByRef, StorageClass from, StorageClass to);
 };
 
 bool arrayTypeCompatible(Loc loc, Type *t1, Type *t2);

--- a/src/ddmd/target.h
+++ b/src/ddmd/target.h
@@ -66,7 +66,7 @@ struct Target
     static unsigned critsecsize();
     static Type *va_listType();  // get type of va_list
     static int isVectorTypeSupported(int sz, Type *type);
-    static bool isVectorOpSupported(Type *type, TOK op, Type *t2)
+    static bool isVectorOpSupported(Type *type, TOK op, Type *t2 = NULL);
     // CTFE support for cross-compilation.
     static Expression *paintAsType(Expression *e, Type *type);
     // ABI and backend.


### PR DESCRIPTION
fullDump added in #6556, TypeDelegate::addStorageClass added in #6495.

Fixed up missing default initializer and `;` in Target::isVectorOpSupported.