### PR TITLE
Make more Phobos math primitives CTFE-able

### DIFF
--- a/src/ddmd/builtin.d
+++ b/src/ddmd/builtin.d
@@ -101,6 +101,28 @@ extern (C++) Expression eval_ldexp(Loc loc, FuncDeclaration fd, Expressions* arg
     return new RealExp(loc, CTFloat.ldexp(arg0.toReal(), cast(int) arg1.toInteger()), arg0.type);
 }
 
+extern (C++) Expression eval_isnan(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    return new IntegerExp(loc, CTFloat.isNaN(arg0.toReal()), Type.tbool);
+}
+
+extern (C++) Expression eval_isinfinity(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    return new IntegerExp(loc, CTFloat.isInfinity(arg0.toReal()), Type.tbool);
+}
+
+extern (C++) Expression eval_isfinite(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    const value = !CTFloat.isNaN(arg0.toReal()) && !CTFloat.isInfinity(arg0.toReal());
+    return new IntegerExp(loc, value, Type.tbool);
+}
+
 extern (C++) Expression eval_bsf(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
@@ -281,6 +303,17 @@ public extern (C++) void builtin_init()
     add_builtin("_D3std4math5ldexpFNaNbNiNfeiZe", &eval_ldexp);
     add_builtin("_D3std4math5ldexpFNaNbNiNfdiZd", &eval_ldexp);
     add_builtin("_D3std4math5ldexpFNaNbNiNffiZf", &eval_ldexp);
+
+    // @trusted @nogc pure nothrow bool function(T)
+    add_builtin("_D3std4math12__T5isNaNTeZ5isNaNFNaNbNiNeeZb", &eval_isnan);
+    add_builtin("_D3std4math12__T5isNaNTdZ5isNaNFNaNbNiNedZb", &eval_isnan);
+    add_builtin("_D3std4math12__T5isNaNTfZ5isNaNFNaNbNiNefZb", &eval_isnan);
+    add_builtin("_D3std4math18__T10isInfinityTeZ10isInfinityFNaNbNiNeeZb", &eval_isinfinity);
+    add_builtin("_D3std4math18__T10isInfinityTdZ10isInfinityFNaNbNiNedZb", &eval_isinfinity);
+    add_builtin("_D3std4math18__T10isInfinityTfZ10isInfinityFNaNbNiNefZb", &eval_isinfinity);
+    add_builtin("_D3std4math15__T8isFiniteTeZ8isFiniteFNaNbNiNeeZb", &eval_isfinite);
+    add_builtin("_D3std4math15__T8isFiniteTdZ8isFiniteFNaNbNiNedZb", &eval_isfinite);
+    add_builtin("_D3std4math15__T8isFiniteTfZ8isFiniteFNaNbNiNefZb", &eval_isfinite);
 
     // @safe @nogc pure nothrow int function(uint)
     add_builtin("_D4core5bitop3bsfFNaNbNiNfkZi", &eval_bsf);

--- a/src/ddmd/builtin.d
+++ b/src/ddmd/builtin.d
@@ -92,6 +92,15 @@ extern (C++) Expression eval_fabs(Loc loc, FuncDeclaration fd, Expressions* argu
     return new RealExp(loc, CTFloat.fabs(arg0.toReal()), arg0.type);
 }
 
+extern (C++) Expression eval_ldexp(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOKfloat64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOKint64);
+    return new RealExp(loc, CTFloat.ldexp(arg0.toReal(), cast(int) arg1.toInteger()), arg0.type);
+}
+
 extern (C++) Expression eval_bsf(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
@@ -266,6 +275,13 @@ public extern (C++) void builtin_init()
     }
     // @safe @nogc pure nothrow long function(real)
     add_builtin("_D3std4math6rndtolFNaNbNiNfeZl", &eval_unimp);
+
+    // @safe @nogc pure nothrow T function(T, int)
+    add_builtin("_D4core4math5ldexpFNaNbNiNfeiZe", &eval_ldexp);
+    add_builtin("_D3std4math5ldexpFNaNbNiNfeiZe", &eval_ldexp);
+    add_builtin("_D3std4math5ldexpFNaNbNiNfdiZd", &eval_ldexp);
+    add_builtin("_D3std4math5ldexpFNaNbNiNffiZf", &eval_ldexp);
+
     // @safe @nogc pure nothrow int function(uint)
     add_builtin("_D4core5bitop3bsfFNaNbNiNfkZi", &eval_bsf);
     add_builtin("_D4core5bitop3bsrFNaNbNiNfkZi", &eval_bsr);

--- a/src/ddmd/root/ctfloat.d
+++ b/src/ddmd/root/ctfloat.d
@@ -106,7 +106,7 @@ extern (C++) struct CTFloat
 
     static bool isInfinity(real_t r)
     {
-        return r is real_t.infinity || r is -real_t.infinity;
+        return isIdentical(fabs(r), real_t.infinity);
     }
 
     static real_t parse(const(char)* literal, bool* isOutOfRange = null)

--- a/src/ddmd/root/ctfloat.d
+++ b/src/ddmd/root/ctfloat.d
@@ -66,6 +66,7 @@ extern (C++) struct CTFloat
     static real_t tan(real_t x) { return core.stdc.math.tanl(x); }
     static real_t sqrt(real_t x) { return core.math.sqrt(x); }
     static real_t fabs(real_t x) { return core.math.fabs(x); }
+    static real_t ldexp(real_t n, int exp) { return core.math.ldexp(n, exp); }
 
     static bool isIdentical(real_t a, real_t b)
     {

--- a/src/ddmd/root/ctfloat.h
+++ b/src/ddmd/root/ctfloat.h
@@ -29,6 +29,7 @@ struct CTFloat
     static real_t tan(real_t x);
     static real_t sqrt(real_t x);
     static real_t fabs(real_t x);
+    static real_t ldexp(real_t n, int exp);
 
     static bool isIdentical(real_t a, real_t b);
     static bool isNaN(real_t r);

--- a/test/compilable/ctfe_math.d
+++ b/test/compilable/ctfe_math.d
@@ -1,0 +1,25 @@
+// Test CTFE builtins for std.math functions.
+
+import std.math;
+
+void main()
+{
+    static assert(approxEqual(sin(2.0L), 0.9092974L));
+    static assert(approxEqual(cos(2.0), -0.4161468));
+    static assert(approxEqual(tan(2.0f), -2.185040f));
+    static assert(approxEqual(sqrt(2.0L), 1.414214L));
+    static assert(fabs(-2.0) == 2.0);
+    static assert(ldexp(2.5f, 3) == 20.0f);
+
+    static assert(isNaN(real.init));
+    static assert(isNaN(double.nan));
+    static assert(!isNaN(float.infinity));
+
+    static assert(isInfinity(real.infinity));
+    static assert(isInfinity(-double.infinity));
+    static assert(!isInfinity(float.nan));
+
+    static assert(isFinite(1.0L));
+    static assert(!isFinite(double.infinity));
+    static assert(!isFinite(float.nan));
+}


### PR DESCRIPTION
These, in combination with a [CTFE-able std.math.exp2](https://github.com/ldc-developers/phobos/commit/823fc05bffbe614d9373b966b91b48d3189b5649) implementation, make the [most common math functions CTFE-able for LDC](https://github.com/ldc-developers/ldc/pull/2259#issuecomment-320461243), incl. `pow()` and the `^^` operator, [DMD issue #16474](https://issues.dlang.org/show_bug.cgi?id=16474).

[Some more builtins or CTFE-friendly Phobos implementations may still be needed for DMD. LDC's Phobos diverges where it can use LLVM intrinsics. These intrinsics are detected as CTFE builtins and have appropriate implementations in `CTFloat`.]