### PR TITLE
fix Issue 17721 - Wrong expression type using vector extensions with shift operands

### DIFF
--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -3329,7 +3329,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (shift)
         {
-            exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
+            if (exp.e2.type.toBasetype().ty != Tvector)
+                exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
         }
 
         if (!Target.isVectorOpSupported(exp.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
@@ -7659,7 +7660,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
+        if (exp.e2.type.toBasetype().ty != Tvector)
+            exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
         result = exp;
@@ -7696,7 +7698,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
+        if (exp.e2.type.toBasetype().ty != Tvector)
+            exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
         result = exp;
@@ -7733,7 +7736,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
+        if (exp.e2.type.toBasetype().ty != Tvector)
+            exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
         result = exp;


### PR DESCRIPTION
GCC supports many kinds of [vector extensions](https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html) that could also be supported, but aren't handled by the semantic in D.

i.e:
```
int4 f1 = [1,2,3,4];
int4 f2 = [5,6,7,8];
int4 f3 = f1 << f2;      // [32, 128, 384, 1024]
```

This covers the following operations to return a type vector:
- vector << vector  (integral only)
- vector >> vector  (integral only)
- vector >>> vector (integral only)

DMD doesn't support these, but is this OK from a language POV? -> Needs discussion.

~Could add support for vector `!`, `&&` and `||` also.~

--------
Update:  After some discussion, it seems best that all logical and comparison operators should not be included in the language.

I've removed semantic support for all except shift operators (on x86_64 these can be compiled down to `vpsravd` and `vpsllvd` respectively).