### PR TITLE
Fix Issue 17684 - [REG 2.062] static alias this (Part 2)

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -7916,6 +7916,13 @@ extern (C++) abstract class BinExp : Expression
         }
         Expression e1x = e1.semantic(sc);
         Expression e2x = e2.semantic(sc);
+
+        // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
+        if (e1x.op == TOKtype)
+            e1x = resolveAliasThis(sc, e1x);
+        if (e2x.op == TOKtype)
+            e2x = resolveAliasThis(sc, e2x);
+
         if (e1x.op == TOKerror)
             return e1x;
         if (e2x.op == TOKerror)

--- a/test/runnable/test17684.d
+++ b/test/runnable/test17684.d
@@ -1,12 +1,117 @@
-private struct StaticStruct
+struct IntFieldTest
 {
-    static int value;
-    static alias value this;
+    static int Field;	
+    static alias Field this;
+}
+
+struct IntPropertyTest
+{
+    static int Field;
+	
+	static @property int property()
+	{
+		return Field;	
+	}
+	
+	static @property void property(int value)
+	{
+		Field = value;	
+	}
+	
+    static alias property this;
+}
+
+struct BoolFieldTest
+{
+    static bool Field;	
+    static alias Field this;
+}
+
+struct BoolPropertyTest
+{
+    static bool Field;
+	
+	static @property bool property()
+	{
+		return Field;	
+	}
+	
+	static @property void property(bool value)
+	{
+		Field = value;	
+	}
+	
+    static alias property this;
 }
 
 void main()
 {
-    StaticStruct = 42;
-    immutable int a = StaticStruct;
-    assert(a == 42);
+    // Test `static alias this` to a field of boolean type
+    BoolFieldTest = false;
+    assert(BoolFieldTest == false);
+
+    bool boolValue = BoolFieldTest;
+    assert(boolValue == false);
+
+    BoolFieldTest = !BoolFieldTest;
+    assert(BoolFieldTest == true);
+
+    boolValue = BoolFieldTest;
+    assert(boolValue == true);
+
+    // Test `static alias this` to a property of boolean type
+    BoolPropertyTest = false;
+    assert(BoolPropertyTest == false);
+
+    boolValue = BoolPropertyTest;
+    assert(boolValue == false);
+
+    BoolPropertyTest = !BoolPropertyTest;
+    assert(BoolPropertyTest == true);
+
+    boolValue = BoolPropertyTest;
+    assert(boolValue == true);
+
+    // Test `static alias this` to a field of int type
+    IntFieldTest = 42;           // test assignment
+    assert(IntFieldTest == 42);
+
+    int intValue = IntFieldTest;
+    assert(intValue == 42);
+
+    IntFieldTest++;              // test a few unary and binary operators
+    assert(IntFieldTest == 43);
+
+    IntFieldTest += 1;
+    assert(IntFieldTest == 44);
+
+    IntFieldTest--;
+    assert(IntFieldTest == 43);
+
+    IntFieldTest -= 1;
+    assert(IntFieldTest == 42);
+
+    assert(~IntFieldTest == ~42);
+
+    // Test `static alias this` to a property of int type
+    IntPropertyTest = 42;           // test assignment
+    assert(IntPropertyTest == 42);
+
+    intValue = IntPropertyTest;
+    assert(intValue == 42);
+
+    // These currently don't work due to https://issues.dlang.org/show_bug.cgi?id=8006
+    // IntPropertyTest++;
+    // assert(IntPropertyTest == 43);
+
+    // IntPropertyTest += 1;
+    // assert(IntPropertyTest == 44);
+
+    // IntPropertyTest--;
+    // assert(IntPropertyTest == 43);
+
+    // IntPropertyTest -= 1;
+    // assert(IntPropertyTest == 42);
+
+    assert(~IntPropertyTest == ~42);
 }


### PR DESCRIPTION
Follow up to https://github.com/dlang/dmd/pull/7055.

I discovered that the implementation was still incomplete, and `static alias this` would not work with binary expressions (e.g. `==`).  This attempts to fix that.

I also added more tests in an attempt to be more thorough.