### PR TITLE
fix Issue 17388 - [scope] e[] should be treated like &e as far as sco…

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -6851,9 +6851,11 @@ extern (C++) final class SliceExp : UnaExp
 {
     Expression upr;             // null if implicit 0
     Expression lwr;             // null if implicit [length - 1]
+
     VarDeclaration lengthVar;
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
+    bool arrayop;               // an array operation, rather than a slice
 
     /************************************************************/
     extern (D) this(Loc loc, Expression e1, IntervalExp ie)

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -164,26 +164,26 @@ void foo800()
 }
 
 /*************************************************/
+/+
+/*
+XEST_OUTPUT:
 
+fail_compilation/retscope2.d(907): Error: address of variable `this` assigned to `p17568` with longer lifetime
 
+*/
 
+#line 900
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+int* p17568;
+struct T17568
+{
+    int a;
+    void escape() @safe scope
+    {
+        p17568 = &a;
+    }
+}
++/
 /*************************************************/
 
 /*
@@ -243,5 +243,53 @@ void delegate() test17430() @safe
     auto dg = &s.foo; // infer dg as scope
     return dg;
 }
+
+/****************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope2.d(1216): Error: returning `s.foo()` escapes a reference to local variable `s`
+fail_compilation/retscope2.d(1233): Error: returning `t.foo()` escapes a reference to local variable `t`
+---
+*/
+
+#line 1200
+// https://issues.dlang.org/show_bug.cgi?id=17388
+
+struct S17388
+{
+    //int*
+    auto
+        foo() return @safe
+    {
+        return &x;
+    }
+    int x;
+}
+
+@safe int* f17388()
+{
+    S17388 s;
+    return s.foo();
+}
+
+struct T17388
+{
+    //int[]
+    auto
+        foo() return @safe
+    {
+        return x[];
+    }
+    int[4] x;
+}
+
+@safe int[] g17388()
+{
+    T17388 t;
+    return t.foo();
+}
+
 
 


### PR DESCRIPTION
…pe goes

`&e` was working correctly, so the fix was to make slicing a static array follow the same logic.

Had to make checkAddressVar() a global function so it can be called by both AddrExp and SliceExp.