### PR TITLE
Fix test11559

### DIFF
--- a/test/compilable/test11559upgradeoptlink.d
+++ b/test/compilable/test11559upgradeoptlink.d
@@ -2,12 +2,28 @@
 
 // If this is failing, you need optlink 8.00.14 or higher
 
+string repeatString(string s, uint repeatCount)
+{
+    char[] result;
+    uint sLength = cast(uint) s.length;
+
+    result.length = sLength * repeatCount;
+    uint p1 = 0;
+    uint p2 = sLength;
+
+    foreach(rc;0 .. repeatCount)
+    {
+        result[p1 .. p2] = s[0 .. sLength];
+        p1 += sLength;
+        p2 += sLength;
+    }
+
+    return cast(string) result;
+}
+
 string gen()
 {
-    string m;
-    foreach(i; 0..4096)
-        m ~= "mixin(\"assert(0);\n\n\n\n\");\n";
-    return m;
+   return repeatString("mixin(\"assert(0);\n\n\n\n\");\n", 4096);
 }
 
 void main()


### PR DESCRIPTION
Replace ~= with slice-assignment into a pre-allocated array.

This way newCTFE will not have a heap-overflow when executing the test.