### PR TITLE
refactor: better encapsulate parseCommandLine()

### DIFF
--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -136,6 +136,11 @@ struct Param
      */
 
     bool showGaggedErrors;  // print gagged errors anyway
+    bool manual;            // open browser on compiler manual
+    bool usage;             // print usage and exit
+    bool mcpuUsage;         // print help on -mcpu switch
+    bool transitionUsage;   // print help on -transition switch
+    bool logo;              // print logo;
 
     CPU cpu;                // CPU instruction set to target
     BOUNDSCHECK useArrayBounds;

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -117,6 +117,11 @@ struct Param
     bool bug10378;      // use pre-bugzilla 10378 search strategy
     bool vsafe;         // use enhanced @safe checking
     bool showGaggedErrors;  // print gagged errors anyway
+    bool manual;            // open browser on compiler manual
+    bool usage;             // print usage and exit
+    bool mcpuUsage;         // print help on -mcpu switch
+    bool transitionUsage;   // print help on -transition switch
+    bool logo;              // print logo;
 
     CPU cpu;                // CPU instruction set to target
     BOUNDSCHECK useArrayBounds;

--- a/test/fail_compilation/diag6743.d
+++ b/test/fail_compilation/diag6743.d
@@ -3,6 +3,7 @@ REQUIRED_ARGS: -run test.exe
 TEST_OUTPUT:
 ---
 Error: -run must be followed by a source file, not 'test.exe'
+       run 'dmd -man' to open browser on manual
 ---
 */
 


### PR DESCRIPTION
This moves towards making `parseCommandLine()` into a more pure, encapsulated function by:

1. pushing decisions about exiting the compiler up to the caller

2. pushing some requested actions up to the caller

3. detecting the existence of errors with return value rather than a global

Error messages are consolidated into a single nested function.

Error messages about command line are followed by a supplemental message about how to open a browser on the manual.

There are remaining problems with setting `debuglevel` and `versionlevel` via globals that should be addressed separately.