### PR TITLE
Fix up headers after ExpressionVisitor refactor

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -170,7 +170,7 @@ L1:
  *          true:  it's overloaded and will be resolved later.
  *          false: it's exact function symbol.
  */
-static Expression resolve(Loc loc, Scope *sc, Dsymbol s, bool hasOverloads)
+Expression resolve(Loc loc, Scope *sc, Dsymbol s, bool hasOverloads)
 {
     static if (LOGSEMANTIC)
     {

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -232,8 +232,6 @@ public:
     void accept(Visitor *v) { v->visit(this); }
     dinteger_t getInteger() { return value; }
     void setInteger(dinteger_t value);
-
-private:
     void normalize();
 };
 
@@ -299,7 +297,6 @@ public:
     Dsymbol *s;
     bool hasOverloads;
 
-    static Expression *resolve(Loc loc, Scope *sc, Dsymbol *s, bool hasOverloads);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
@@ -689,8 +686,6 @@ public:
     Type *att2; // Save alias this type to detect recursion
 
     Expression *syntaxCopy();
-    Expression *binSemantic(Scope *sc);
-    Expression *binSemanticProp(Scope *sc);
     Expression *incompatibleTypes();
     Expression *checkOpAssignTypes(Scope *sc);
     bool checkIntegralBin();
@@ -862,8 +857,8 @@ public:
 
 class DeleteExp : public UnaExp
 {
-    bool isRAII;
 public:
+    bool isRAII;
     Expression *toBoolean(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
- A few methods that are no more.
- `DeleteExp::isRAII` and `IntegerExp::normalize` aren't *really* private, as they are accessed from the visitor in expressionsem (this is only for the benefit of the C++ backport).
- Remove redundant static from `resolve` in D code.