### PR TITLE
debian x-www-browser -> Freedesktop xdg-open

### DIFF
--- a/src/ddmd/root/man.d
+++ b/src/ddmd/root/man.d
@@ -79,7 +79,7 @@ else version (Posix)
         if (browser)
             browser = strdup(browser);
         else
-            browser = "x-www-browser";
+            browser = "xdg-open";
         args[0] = browser;
         args[1] = url;
         args[2] = null;


### PR DESCRIPTION
- use more portable xdg-open to open websites
- in accordance with std.process.browse