### PR TITLE
[D1] Fix parsing nested final class declaration

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3364,8 +3364,8 @@ Statement *Parser::parseStatement(int flags)
         case TOKfinal:
             nextToken();
             if (token.value != TOKswitch)
-                error("found '%s' when expecting 'switch' following final", token.toChars());
-            // Implicit fallthrough on purpose
+                goto Ldeclaration;
+            // else fallthrough
 
         case TOKswitch:
         {


### PR DESCRIPTION
Minor regression introduced by 4f703abb5677e491752d8cf137c4163b5accf977 (compiler
start to reject nested final class declaration while previously it was ignored).