### PR TITLE
Remove issue stats badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ DMD
 [![GitHub tag](https://img.shields.io/github/tag/dlang/dmd.svg?maxAge=86400)](#)
 [![Build Status](https://travis-ci.org/dlang/dmd.svg?branch=master)](https://travis-ci.org/dlang/dmd)
 [![Code coverage](https://img.shields.io/codecov/c/github/dlang/dmd.svg?maxAge=86400)](https://codecov.io/gh/dlang/dmd)
-[![Issue Stats](https://img.shields.io/issuestats/p/github/dlang/dmd.svg?maxAge=2592000)](http://www.issuestats.com/github/dlang/dmd)
 
 DMD is the reference compiler for the D programming language.
 


### PR DESCRIPTION
The issue stats badge doesn't work.  The data feeding this badge hasn't been updated in, what appears to be, almost a year, and it appears the repository has been abandoned.  It's conveying incorrect information, so I think it should be removed.