### PR TITLE
Fix Issue 12496: __traits(parent, x) returns incorrect symbol

### DIFF
--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -637,6 +637,25 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto s = getDsymbol(o);
         if (s)
         {
+            // https://issues.dlang.org/show_bug.cgi?id=12496
+            // Consider:
+            // class T1
+            // {
+            //     class C(uint value) { }
+            // }
+            // __traits(parent, T1.C!2)
+            if (auto ad = s.isAggregateDeclaration())  // `s` is `C`
+            {
+                if (ad.isNested())                     // `C` is nested
+                {
+                    if (auto p = s.toParent())         // `C`'s parent is `C!2`, believe it or not
+                    {
+                        if (p.isTemplateInstance())    // `C!2` is a template instance
+                            s = p;                     // `C!2`'s parent is `T1`
+                    }
+                }
+            }
+
             if (auto fd = s.isFuncDeclaration()) // https://issues.dlang.org/show_bug.cgi?id=8943
                 s = fd.toAliasFunc();
             if (!s.isImport()) // https://issues.dlang.org/show_bug.cgi?id=8922

--- a/test/compilable/test12496.d
+++ b/test/compilable/test12496.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=12496
+
+final abstract class T1
+{
+    final abstract class C(uint value) { }
+
+    alias Child = C!2;
+}
+
+void main()
+{
+    static assert(__traits(isSame, __traits(parent, T1.Child), T1));
+}


### PR DESCRIPTION
~This is the 2nd of 3 pull requests to fix issue 12496.  They must be done in order to ensure the test suite is green with each step.~

~Step 1: https://github.com/dlang/phobos/pull/5709 - Deletes an incorrect Phobos unittest that is preventing Step 2 (this PR) from passing its test suite.~
~Step 2: (This PR) the actual fix for issue 11246.  This should pass its test suite after Step 1 is pulled.~
~Step 3: https://github.com/dlang/phobos/pull/5704 - Repairs the unittest that was deleted in Step 1 so it properly tests for correct behavior.~

This pull request is on its own now; it does not depend on any other pull requests.