### PR TITLE
Enable automatic compiling of imports

### DIFF
--- a/changelog/includeimports.dd
+++ b/changelog/includeimports.dd
@@ -1,0 +1,10 @@
+Automatically include imports via -i command line option
+
+Added the command line option -i which causes the compiler to treat imported modules as if they were given on the command line.  The option also accepts "module patterns" that include/exclude modules based on their name.  For example, the following will include all modules whose names start with "foo", except for those that start with "foo.bar":
+---
+dmd -i=foo,-foo.bar
+---
+The option -i by itself is equivalent to:
+---
+dmd -i=-std,-core,-etc,-object
+---

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -190,6 +190,12 @@ struct Usage
         Option("I=<directory>",
             "look for imports also in directory"
         ),
+        Option("i",
+            "same as -i=-std,-core,-etc,-object"
+        ),
+        Option("i=[-]<pkg>,...",
+            "include/exclude imported modules whose name matches one of <pkg>"
+        ),
         Option("ignore",
             "ignore unsupported pragmas"
         ),

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -327,6 +327,7 @@ immutable Msgtable[] msgtable =
     // Builtin functions
     { "std" },
     { "core" },
+    { "etc" },
     { "attribute" },
     { "math" },
     { "sin" },

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -63,6 +63,12 @@ public:
     static Dsymbols deferred2;  // deferred Dsymbol's needing semantic2() run on them
     static Dsymbols deferred3;  // deferred Dsymbol's needing semantic3() run on them
     static unsigned dprogress;  // progress resolving the deferred list
+    /**
+     * A callback function that is called once an imported module is
+     * parsed. If the callback returns true, then it tells the
+     * frontend that the driver intends on compiling the import.
+     */
+    static bool (*onImport)(Module);
     static void _init();
 
     static AggregateDeclaration *moduleinfo;

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -253,3 +253,63 @@ private:
     size_t len;
     size_t *ptr;
 }
+
+/**
+ * Exposes the given root Array as a standard D array.
+ * Params:
+ *  array = the array to expose.
+ * Returns:
+ *  The given array exposed to a standard D array.
+ */
+@property T[] asDArray(T)(ref Array!T array)
+{
+    return array.data[0..array.dim];
+}
+
+/**
+ * Splits the array at $(D index) and expands it to make room for $(D length)
+ * elements by shifting everything past $(D index) to the right.
+ * Params:
+ *  array = the array to split.
+ *  index = the index to split the array from.
+ *  length = the number of elements to make room for starting at $(D index).
+ */
+void split(T)(ref Array!T array, size_t index, size_t length)
+{
+    if (length > 0)
+    {
+        auto previousDim = array.dim;
+        array.setDim(array.dim + length);
+        for (size_t i = previousDim; i > index;)
+        {
+            i--;
+            array[i + length] = array[i];
+        }
+    }
+}
+unittest
+{
+    auto array = Array!int();
+    array.split(0, 0);
+    assert([] == array.asDArray);
+    array.push(1);
+    array.push(3);
+    array.split(1, 1);
+    array[1] = 2;
+    assert([1, 2, 3] == array.asDArray);
+    array.split(2, 3);
+    array[2] = 8;
+    array[3] = 20;
+    array[4] = 4;
+    assert([1, 2, 8, 20, 4, 3] == array.asDArray);
+    array.split(0, 0);
+    assert([1, 2, 8, 20, 4, 3] == array.asDArray);
+    array.split(0, 1);
+    array[0] = 123;
+    assert([123, 1, 2, 8, 20, 4, 3] == array.asDArray);
+    array.split(0, 3);
+    array[0] = 123;
+    array[1] = 421;
+    array[2] = 910;
+    assert([123, 421, 910, 123, 1, 2, 8, 20, 4, 3] == array.asDArray);
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -28,6 +28,14 @@
 #   EXECUTE_ARGS:        parameters to add to the execution of the test
 #                        default: (none)
 #
+#   COMPILED_IMPORTS:    list of modules files that are imported by the main source file that
+#                        should be included in compilation; this differs from the EXTRA_SOURCES
+#                        variable in that these files could be compiled by either explicitly
+#                        passing them to the compiler or by using the "-i" option. Using this
+#                        option will cause the test to be compiled twice, once using "-i" and
+#                        once by explicitly passing the modules to the compiler.
+#                        default: (none)
+#
 #   EXTRA_SOURCES:       list of extra files to build and link along with the test
 #                        default: (none)
 #
@@ -38,6 +46,12 @@
 #   PERMUTE_ARGS:        the set of arguments to permute in multiple $(DMD) invocations.
 #                        An empty set means only one permutation with no arguments.
 #                        default: the make variable ARGS (see below)
+#
+#   ARG_SETS:            sets off extra arguments to invoke $(DMD) with (seperated by ';').
+#                        default: (none)
+#
+#   LINK:                enables linking (used for the compilable and fail_compilable tests).
+#                        default: (none)
 #
 #   TEST_OUTPUT:         the output is expected from the compilation (if the
 #                        output of the compilation doesn't match, the test

--- a/test/compilable/a3682.d
+++ b/test/compilable/a3682.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/b3682.d
+// COMPILED_IMPORTS: imports/b3682.d
 // PERMUTE_ARGS:
 
 // 3682

--- a/test/compilable/art4769.d
+++ b/test/compilable/art4769.d
@@ -1,6 +1,6 @@
 // http://www.digitalmars.com/webnews/newsgroups.php?art_group=digitalmars.D.bugs&article_id=4769
 
-// EXTRA_SOURCES: imports/art4769a.d imports/art4769b.d
+// COMPILED_IMPORTS: imports/art4769a.d imports/art4769b.d
 // PERMUTE_ARGS:
 
 module art4769;

--- a/test/compilable/b33.d
+++ b/test/compilable/b33.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/b33a.d
+// COMPILED_IMPORTS: imports/b33a.d
 // PERMUTE_ARGS:
 
 module b33;

--- a/test/compilable/imports/foofunc.d
+++ b/test/compilable/imports/foofunc.d
@@ -1,0 +1,2 @@
+module imports.foofunc;
+void foo() { }

--- a/test/compilable/imports/foofunc2.d
+++ b/test/compilable/imports/foofunc2.d
@@ -1,0 +1,2 @@
+module imports.foofunc2;
+void foo2() { import imports.foofunc; foo(); }

--- a/test/compilable/issue16995.d
+++ b/test/compilable/issue16995.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/module_with_tests.d
+// COMPILED_IMPORTS: imports/module_with_tests.d
 // REQUIRED_ARGS: -unittest
 // COMPILE_SEPARATELY
 

--- a/test/compilable/needsmod.d
+++ b/test/compilable/needsmod.d
@@ -1,0 +1,12 @@
+// ARG_SETS: -i
+// ARG_SETS: -i=.
+// ARG_SETS: -i=imports
+// ARG_SETS: -i=imports.foofunc
+// ARG_SETS: -iimports.foofunc
+// PERMUTE_ARGS:
+// LINK:
+import imports.foofunc;
+void main()
+{
+    foo();
+}

--- a/test/compilable/needsmods.d
+++ b/test/compilable/needsmods.d
@@ -1,0 +1,8 @@
+// ARG_SETS: -i
+// PERMUTE_ARGS:
+// LINK:
+import imports.foofunc2;
+void main()
+{
+    foo2();
+}

--- a/test/compilable/needspkg.d
+++ b/test/compilable/needspkg.d
@@ -1,0 +1,9 @@
+// ARG_SETS: -i=imports.pkgmod313
+// ARG_SETS: -i=imports.pkgmod313.package
+// PERMUTE_ARGS:
+// LINK:
+import imports.pkgmod313;
+void main()
+{
+    foo();
+}

--- a/test/compilable/needspkgmod.d
+++ b/test/compilable/needspkgmod.d
@@ -1,0 +1,11 @@
+// ARG_SETS: -i=imports.pkgmod313
+// ARG_SETS: -i=imports.pkgmod313.mod
+// ARG_SETS: -i=-imports.pkgmod313.package,imports.pkgmod313
+// ARG_SETS: -i=-imports.pkgmod313.package,imports.pkgmod313.mod
+// PERMUTE_ARGS:
+// LINK:
+import imports.pkgmod313.mod;
+void main()
+{
+    bar();
+}

--- a/test/compilable/rdeps7016.d
+++ b/test/compilable/rdeps7016.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -deps=${RESULTS_DIR}/compilable/rdeps7016.deps
+// REQUIRED_ARGS: -deps=${RESULTS_DIR}/compilable/rdeps7016.deps -Icompilable/extra-files
 // POST_SCRIPT: compilable/extra-files/rdepsOutput.sh 
-// EXTRA_SOURCES: extra-files/rdeps7016a.d extra-files/rdeps7016b.d
+// COMPILED_IMPORTS: extra-files/rdeps7016a.d extra-files/rdeps7016b.d
 
 module rdeps7016;
 import rdeps7016a;

--- a/test/compilable/test15177.d
+++ b/test/compilable/test15177.d
@@ -1,6 +1,6 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
-// EXTRA_SOURCES: imports/test15117a.d
+// COMPILED_IMPORTS: imports/test15117a.d
 
 import users = imports.test15117a;
 

--- a/test/compilable/test16080.d
+++ b/test/compilable/test16080.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -lib -Icompilable/imports
-// EXTRA_SOURCES: extra-files/test16080b.d
+// COMPILED_IMPORTS: extra-files/test16080b.d
 // https://issues.dlang.org/show_bug.cgi?id=16080
 
 import imp16080;

--- a/test/compilable/test313d.d
+++ b/test/compilable/test313d.d
@@ -1,5 +1,5 @@
 // first imported as package
-// EXTRA_SOURCES: imports/pkgmod313/mod.d
+// COMPILED_IMPORTS: imports/pkgmod313/mod.d
 // REQUIRED_ARGS: -de
 import imports.pkgmod313; // then as package module
 

--- a/test/compilable/test313e.d
+++ b/test/compilable/test313e.d
@@ -1,5 +1,5 @@
 // first resolved as package, then created as module (with name package)
-// EXTRA_SOURCES: imports/pkgmod313/mod.d imports/pkgmod313/package.d
+// COMPILED_IMPORTS: imports/pkgmod313/mod.d imports/pkgmod313/package.d
 // REQUIRED_ARGS: -de
 import imports.pkgmod313; // then imported as package module
 

--- a/test/compilable/test313g.d
+++ b/test/compilable/test313g.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -de
-// EXTRA_SOURCES: imports/g313.d
+// COMPILED_IMPORTS: imports/g313.d
 import imports.g313;
 
 void test15900()

--- a/test/compilable/test4003.d
+++ b/test/compilable/test4003.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/test4003a.d
+// COMPILED_IMPORTS: imports/test4003a.d
 // PERMUTE_ARGS:
 
 import imports.stdio4003;

--- a/test/compilable/test50.d
+++ b/test/compilable/test50.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/test50a.d
+// COMPILED_IMPORTS: imports/test50a.d
 // PERMUTE_ARGS:
 
 import imports.test50a;

--- a/test/compilable/test55.d
+++ b/test/compilable/test55.d
@@ -1,5 +1,5 @@
 // COMPILE_SEPARATELY
-// EXTRA_SOURCES: imports/test55a.d
+// COMPILED_IMPORT: imports/test55a.d
 // PERMUTE_ARGS: -dw
 // REQUIRED_ARGS: -d
 

--- a/test/compilable/test63.d
+++ b/test/compilable/test63.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/test63a.d
+// COMPILED_IMPORTS: imports/test63a.d
 // PERMUTE_ARGS:
 
 private import imports.test63a;

--- a/test/compilable/testDIP37_10302.d
+++ b/test/compilable/testDIP37_10302.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_SOURCES: extra-files/pkgDIP37_10302/liba.d
-// EXTRA_SOURCES: extra-files/pkgDIP37_10302/libb.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10302/liba.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10302/libb.d
 
 module test;
 import pkgDIP37_10302;

--- a/test/compilable/testDIP37_10421.d
+++ b/test/compilable/testDIP37_10421.d
@@ -1,8 +1,8 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_SOURCES: extra-files/pkgDIP37_10421/algo/package.d
-// EXTRA_SOURCES: extra-files/pkgDIP37_10421/algo/mod.d
-// EXTRA_SOURCES: extra-files/pkgDIP37_10421/except.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10421/algo/package.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10421/algo/mod.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10421/except.d
 
 module testDIP37_10421;
 import pkgDIP37_10421.algo;

--- a/test/compilable/testDIP37a.d
+++ b/test/compilable/testDIP37a.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_SOURCES: extra-files/pkgDIP37/datetime/package.d
-// EXTRA_SOURCES: extra-files/pkgDIP37/datetime/common.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37/datetime/package.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37/datetime/common.d
 
 void main()
 {

--- a/test/compilable/testcontracts.d
+++ b/test/compilable/testcontracts.d
@@ -1,4 +1,4 @@
-// EXTRA_SOURCES: imports/testcontracts.d
+// COMPILED_IMPORTS: imports/testcontracts.d
 
 import imports.testcontracts;
 

--- a/test/compilable/testcov1.d
+++ b/test/compilable/testcov1.d
@@ -1,6 +1,6 @@
-// EXTRA_SOURCES: imports/testcov1a.d imports/testcov1b.d
+// COMPILED_IMPORTS: imports/testcov1a.d imports/testcov1b.d
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -cov
+// REQUIRED_ARGS: -cov -Icompilable/imports
 
 import core.stdc.string;
 import testcov1a;

--- a/test/fail_compilation/imports/foofunc.d
+++ b/test/fail_compilation/imports/foofunc.d
@@ -1,0 +1,2 @@
+module imports.foofunc;
+void foo() { }

--- a/test/fail_compilation/needspkgmod.d
+++ b/test/fail_compilation/needspkgmod.d
@@ -1,0 +1,14 @@
+// ARG_SETS: -i=
+// ARG_SETS: -i=,
+// ARG_SETS: -i=imports.pkgmod313,
+// ARG_SETS: -i=,imports.pkgmod313
+// ARG_SETS: -i=imports.pkgmod313,-imports.pkgmod313.mod
+// ARG_SETS: -i=imports.pkgmod313.package,-imports.pkgmod313.mod
+// REQUIRED_ARGS: -Icompilable
+// PERMUTE_ARGS:
+// LINK:
+import imports.pkgmod313.mod;
+void main()
+{
+    bar();
+}


### PR DESCRIPTION
An implementation of an idea I had (forum discussion here: http://forum.dlang.org/thread/tcrdpvqvwxffnewzohuj@forum.dlang.org)

I added a compiler option `-ci` which stands for "compile imports".

When this option is enabled, the compiler will automatically treat imported modules as if they were specified on the command line so long as it doesn't think they exist in any library.  For now it uses the same logic as rdmd to determine whether a module is in a library (see the `inALibrary` function), which is not full proof, but works well enough for a prototype.  With this change you should now be able to omit all the imported module files from the command line, i.e.

Instead of:
```
dmd prog.d -Isomelib somelib\foo\module1.d somelib\foo\module2.d somelib\foo\module3.d somelib\foo\module4.d somelib\foo\module5.d somelib\foo\module6.d -Ianotherlib anotherlib\bar\module1.d anotherlib\bar\module2.d anotherlib\bar\module3.d anotherlib\bar\module4.d anotherlib\bar\module5.d
```
Use:
```
dmd -ci prog.d -Isomelib -Ianotherlib
```

Should this feature be desirable, I recommend coming up with a more deterministic way of determining what modules exist in object/library files.

Also note that this feature would simplify rdmd and remove the need for it to invoke the compiler twice.  This would fix the current performance problem with rdmd and would have even better performance than the previous solution (https://github.com/dlang/tools/pull/194).