### PR TITLE
Make header generation for this() and ~this() symmetrical.

### DIFF
--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -2019,14 +2019,18 @@ public:
 
     override void visit(StaticDtorDeclaration d)
     {
-        if (hgs.hdrgen)
-            return;
         if (stcToBuffer(buf, d.storage_class & ~STCstatic))
             buf.writeByte(' ');
         if (d.isSharedStaticDtorDeclaration())
             buf.writestring("shared ");
         buf.writestring("static ~this()");
-        bodyToBuffer(d);
+        if (hgs.hdrgen && !hgs.tpltMember)
+        {
+            buf.writeByte(';');
+            buf.writenl();
+        }
+        else
+            bodyToBuffer(d);
     }
 
     override void visit(InvariantDeclaration d)

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -143,10 +143,15 @@ template Foo(T, int V)
 	}
 }
 static this();
+static ~this();
 nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe static ~this();
 nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe static ~this();
 nothrow pure @nogc @safe shared static this();
+nothrow pure @nogc @safe shared static ~this();
 nothrow pure @nogc @safe shared static this();
+nothrow pure @nogc @safe shared static ~this();
 interface iFoo
 {
 }

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -178,10 +178,15 @@ template Foo(T, int V)
 	}
 }
 static this();
+static ~this();
 nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe static ~this();
 nothrow pure @nogc @safe static this();
+nothrow pure @nogc @safe static ~this();
 nothrow pure @nogc @safe shared static this();
+nothrow pure @nogc @safe shared static ~this();
 nothrow pure @nogc @safe shared static this();
+nothrow pure @nogc @safe shared static ~this();
 interface iFoo
 {
 }


### PR DESCRIPTION
Given the following code in tracemodule.d:
```D
module tracemodule;
import std.stdio;

mixin template traceModule(string moduleName = __MODULE__)
{
  import std.stdio;

  static this()
  {
    writeln("init " ~ moduleName);
  }

  static ~this()
  {
    writeln("deinit " ~ moduleName);
  }
}
```
Compiling it with `dmd -H -c tracemodule.d` yields the following header:
```D
// D import file generated from 'tracemodule.d'
module tracemodule;
import std.stdio;
template traceModule(string moduleName = __MODULE__)
{
	import std.stdio;
	static this()
	{
		writeln("init " ~ moduleName);
	}
}
```
Note the different treatment between the static ctor and dtor. This PR fixes it. After applying:
```D
// D import file generated from 'tracemodule.d'
module tracemodule;
import std.stdio;
template traceModule(string moduleName = __MODULE__)
{
	import std.stdio;
	static this()
	{
		writeln("init " ~ moduleName);
	}
	static ~this()
	{
		writeln("deinit " ~ moduleName);
	}
}
```
