### PR TITLE
fix issue 17782 - The identifier delimiter of a delimited string can not begin with '_'

### DIFF
--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -1530,7 +1530,7 @@ class Lexer
                 }
                 else if (c == delimright)
                     goto Ldone;
-                if (startline && isalpha(c) && hereid)
+                if (startline && (isalpha(c) || c == '_' || (c >= 0x80 && isUniAlpha(c))) && hereid)
                 {
                     Token tok;
                     auto psave = p;

--- a/test/compilable/test17782.d
+++ b/test/compilable/test17782.d
@@ -1,0 +1,6 @@
+void main() {
+    string str = q"_DLANG
+123
+_DLANG";
+    assert( str == "123\n" );
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=17782