### PR TITLE
[Trivial] More precise error message for TypeInfo mismatch

### DIFF
--- a/src/ddmd/todt.d
+++ b/src/ddmd/todt.d
@@ -966,7 +966,8 @@ extern (C++) class TypeInfoDtVisitor : Visitor
                 printf("expected = x%x, %s.structsize = x%x\n", cast(uint)expected,
                     typeclass.toChars(), cast(uint)typeclass.structsize);
             }
-            error(typeclass.loc, "mismatch between compiler and object.d or object.di found. Check installation and import paths with -v compiler switch.");
+            error(typeclass.loc, "`%s`: mismatch between compiler (%d bytes) and object.d or object.di (%d bytes) found. Check installation and import paths with -v compiler switch.",
+                typeclass.toChars(), cast(uint)expected, cast(uint)typeclass.structsize);
             fatal();
         }
     }


### PR DESCRIPTION
Current error message emitted by the compiler reads:  "mismatch between compiler and object.d or object.di found. Check installation and import paths with -v compiler switch."

This pull request changes it to (for example):  "TypeInfo_Struct: mismatch between compiler (136 bytes) and object.d or object.di (16 bytes) found. Check installation and import paths with -v compiler switch."
