### PR TITLE
Implement visitor for TemplateParameter AST nodes

### DIFF
--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -1,15 +1,19 @@
 module ddmd.semantic;
 
+import ddmd.arraytypes;
 import ddmd.dsymbol;
-import ddmd.dsymbolsem;
 import ddmd.dscope;
+import ddmd.dtemplate;
 import ddmd.expression;
-import ddmd.expressionsem;
 import ddmd.init;
-import ddmd.initsem;
 import ddmd.mtype;
 import ddmd.statement;
+
+import ddmd.initsem;
+import ddmd.dsymbolsem;
+import ddmd.expressionsem;
 import ddmd.statementsem;
+import ddmd.templateparamsem;
 
 /*************************************
  * Does semantic analysis on the public face of declarations.
@@ -52,6 +56,14 @@ extern (C++) Statement semantic(Statement s, Scope* sc)
 {
     scope v = new StatementSemanticVisitor(sc);
     s.accept(v);
+    return v.result;
+}
+
+// Performs semantic on TemplateParamter AST nodes
+extern (C++) bool semantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
+{
+    scope v = new TemplateParameterSemanticVisitor(sc, parameters);
+    tp.accept(v);
     return v.result;
 }
 

--- a/src/ddmd/template.h
+++ b/src/ddmd/template.h
@@ -146,7 +146,6 @@ public:
 
     virtual TemplateParameter *syntaxCopy() = 0;
     virtual bool declareParameter(Scope *sc) = 0;
-    virtual bool semantic(Scope *sc, TemplateParameters *parameters) = 0;
     virtual void print(RootObject *oarg, RootObject *oded) = 0;
     virtual RootObject *specialization() = 0;
     virtual RootObject *defaultArg(Loc instLoc, Scope *sc) = 0;
@@ -177,7 +176,6 @@ public:
     TemplateTypeParameter *isTemplateTypeParameter();
     TemplateParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
-    bool semantic(Scope *sc, TemplateParameters *parameters);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
     RootObject *defaultArg(Loc instLoc, Scope *sc);
@@ -213,7 +211,6 @@ public:
     TemplateValueParameter *isTemplateValueParameter();
     TemplateParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
-    bool semantic(Scope *sc, TemplateParameters *parameters);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
     RootObject *defaultArg(Loc instLoc, Scope *sc);
@@ -238,7 +235,6 @@ public:
     TemplateAliasParameter *isTemplateAliasParameter();
     TemplateParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
-    bool semantic(Scope *sc, TemplateParameters *parameters);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
     RootObject *defaultArg(Loc instLoc, Scope *sc);
@@ -257,7 +253,6 @@ public:
     TemplateTupleParameter *isTemplateTupleParameter();
     TemplateParameter *syntaxCopy();
     bool declareParameter(Scope *sc);
-    bool semantic(Scope *sc, TemplateParameters *parameters);
     void print(RootObject *oarg, RootObject *oded);
     RootObject *specialization();
     RootObject *defaultArg(Loc instLoc, Scope *sc);

--- a/src/ddmd/templateparamsem.d
+++ b/src/ddmd/templateparamsem.d
@@ -1,0 +1,125 @@
+module ddmd.templateparamsem;
+
+import ddmd.arraytypes;
+import ddmd.dsymbol;
+import ddmd.dscope;
+import ddmd.dtemplate;
+import ddmd.globals;
+import ddmd.expression;
+import ddmd.root.rootobject;
+import ddmd.mtype;
+import ddmd.semantic;
+import ddmd.visitor;
+
+extern (C++) final class TemplateParameterSemanticVisitor : Visitor
+{
+    alias visit = super.visit;
+
+    Scope* sc;
+    TemplateParameters* parameters;
+    bool result;
+
+    this(Scope* sc, TemplateParameters* parameters)
+    {
+        this.sc = sc;
+        this.parameters = parameters;
+    }
+
+    override void visit(TemplateTypeParameter ttp)
+    {
+        //printf("TemplateTypeParameter.semantic('%s')\n", ident.toChars());
+        if (ttp.specType && !reliesOnTident(ttp.specType, parameters))
+        {
+            ttp.specType = ttp.specType.semantic(ttp.loc, sc);
+        }
+        version (none)
+        {
+            // Don't do semantic() until instantiation
+            if (ttp.defaultType)
+            {
+                ttp.defaultType = ttp.defaultType.semantic(ttp.loc, sc);
+            }
+        }
+        result = !(ttp.specType && isError(ttp.specType));
+    }
+
+    override void visit(TemplateValueParameter tvp)
+    {
+        tvp.valType = tvp.valType.semantic(tvp.loc, sc);
+        version (none)
+        {
+            // defer semantic analysis to arg match
+            if (tvp.specValue)
+            {
+                Expression e = tvp.specValue;
+                sc = sc.startCTFE();
+                e = e.semantic(sc);
+                sc = sc.endCTFE();
+                e = e.implicitCastTo(sc, tvp.valType);
+                e = e.ctfeInterpret();
+                if (e.op == TOKint64 || e.op == TOKfloat64 ||
+                    e.op == TOKcomplex80 || e.op == TOKnull || e.op == TOKstring)
+                    tvp.specValue = e;
+            }
+
+            if (tvp.defaultValue)
+            {
+                Expression e = defaultValue;
+                sc = sc.startCTFE();
+                e = e.semantic(sc);
+                sc = sc.endCTFE();
+                e = e.implicitCastTo(sc, tvp.valType);
+                e = e.ctfeInterpret();
+                if (e.op == TOKint64)
+                    tvp.defaultValue = e;
+            }
+        }
+        result = !isError(tvp.valType);
+    }
+
+    override void visit(TemplateAliasParameter tap)
+    {
+        if (tap.specType && !reliesOnTident(tap.specType, parameters))
+        {
+            tap.specType = tap.specType.semantic(tap.loc, sc);
+        }
+        tap.specAlias = aliasParameterSemantic(tap.loc, sc, tap.specAlias, parameters);
+        version (none)
+        {
+            // Don't do semantic() until instantiation
+            if (tap.defaultAlias)
+                tap.defaultAlias = tap.defaultAlias.semantic(tap.loc, sc);
+        }
+        result = !(tap.specType && isError(tap.specType)) && !(tap.specAlias && isError(tap.specAlias));
+    }
+
+    override void visit(TemplateTupleParameter ttp)
+    {
+        result = true;
+    }
+}
+
+RootObject aliasParameterSemantic(Loc loc, Scope* sc, RootObject o, TemplateParameters* parameters)
+{
+    if (o)
+    {
+        Expression ea = isExpression(o);
+        Type ta = isType(o);
+        if (ta && (!parameters || !reliesOnTident(ta, parameters)))
+        {
+            Dsymbol s = ta.toDsymbol(sc);
+            if (s)
+                o = s;
+            else
+                o = ta.semantic(loc, sc);
+        }
+        else if (ea)
+        {
+            sc = sc.startCTFE();
+            ea = ea.semantic(sc);
+            sc = sc.endCTFE();
+            o = ea.ctfeInterpret();
+        }
+    }
+    return o;
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -258,7 +258,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\
 	hdrgen id impcnvtab imphint init initsem inline inlinecost intrange	\
-	json lib link mars mtype nogc nspace objc opover optimize parse sapply	\
+	json lib link mars mtype nogc nspace objc opover optimize parse sapply templateparamsem	\
 	semantic sideeffect statement staticassert target typesem traits visitor	\
 	typinf utils statement_rewrite_walker statementsem staticcond safe blockexit asttypename printast))
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -166,7 +166,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/mars.d $D/mtype.d $D/nogc.d $D/nspace.d $D/objc.d $D/opover.d $D/optimize.d $D/parse.d	\
 	$D/sapply.d $D/semantic.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d	\
 	$D/safe.d $D/blockexit.d $D/asttypename.d $D/printast.d $D/typesem.d \
-	$D/traits.d $D/utils.d $D/visitor.d $D/libomf.d $D/scanomf.d $D/typinf.d \
+	$D/traits.d $D/utils.d $D/visitor.d $D/libomf.d $D/scanomf.d $D/templateparamsem.d $D/typinf.d \
 	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d
 
 LEXER_SRCS=$D/console.d $D/entity.d $D/errors.d $D/globals.d $D/id.d $D/identifier.d \


### PR DESCRIPTION
This PR finalizes moving all the `semantic` routines from the AST nodes. I am thinking of doing next the `resolve` functions from mtype.d. They seem fit to be implemented via a visitor. What do you guys think abut this?