### PR TITLE
fix Issue 17800 - [2.076] "static foreach" allocates closures in GC without reason

### DIFF
--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -323,6 +323,19 @@ extern (C++) final class StaticForeach : RootObject
         }
         // generate remaining code for the new aggregate which is an
         // array (see documentation comment).
+        if (rangefe)
+        {
+            sc = sc.startCTFE();
+            rangefe.lwr = rangefe.lwr.semantic(sc);
+            rangefe.lwr = resolveProperties(sc, rangefe.lwr);
+            rangefe.upr = rangefe.upr.semantic(sc);
+            rangefe.upr = resolveProperties(sc, rangefe.upr);
+            sc = sc.endCTFE();
+            rangefe.lwr = rangefe.lwr.optimize(WANTvalue);
+            rangefe.lwr = rangefe.lwr.ctfeInterpret();
+            rangefe.upr = rangefe.upr.optimize(WANTvalue);
+            rangefe.upr = rangefe.upr.ctfeInterpret();
+        }
         auto s1 = new Statements();
         auto sfe = new Statements();
         if (tplty) sfe.push(new ExpStatement(loc, tplty.sym));

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -1067,7 +1067,7 @@ extern (C++) class VarDeclaration : Declaration
         {
             if (!type && !_init)
             {
-                printf("VarDeclaration('%s')\n", id.toChars());
+                //printf("VarDeclaration('%s')\n", id.toChars());
                 //*(char*)0=0;
             }
         }

--- a/test/compilable/staticforeach.d
+++ b/test/compilable/staticforeach.d
@@ -690,3 +690,13 @@ void bug17688(){
     final switch(1) static foreach(x;0..1){ int y=3; case 1: return; }
     static assert(!is(typeof(y)));
 }
+
+struct T{ enum n = 1; }
+T foo(T v)@nogc{
+    static foreach(x;0..v.n){ }
+    return T.init;
+}
+T foo(T v)@nogc{
+    static foreach(_;0..typeof(return).n){ }
+    return T.init;
+}


### PR DESCRIPTION
The foreach ranges should be semantically analyzed and interpreted before lowering.