### PR TITLE
fix Issue 17807 - Spurious dead code warnings on enum and static variables.

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -3594,6 +3594,11 @@ extern (C++) abstract class Expression : RootObject
         return .op_overload(this, sc);
     }
 
+    bool hasCode()
+    {
+        return true;
+    }
+
     void accept(Visitor v)
     {
         v.visit(this);
@@ -5711,6 +5716,15 @@ extern (C++) final class DeclarationExp : Expression
     override Expression syntaxCopy()
     {
         return new DeclarationExp(loc, declaration.syntaxCopy(null));
+    }
+
+    override bool hasCode()
+    {
+        if (auto vd = declaration.isVarDeclaration())
+        {
+            return !(vd.storage_class & (STCmanifest | STCstatic));
+        }
+        return false;
     }
 
     override void accept(Visitor v)

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -214,6 +214,11 @@ public:
         return ::op_overload(this, sc);
     }
 
+    virtual bool hasCode()
+    {
+        return true;
+    }
+
     virtual void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -611,6 +616,8 @@ public:
     Dsymbol *declaration;
 
     Expression *syntaxCopy();
+
+    bool hasCode();
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -272,7 +272,10 @@ extern (C++) abstract class Statement : RootObject
 
             override void visit(ExpStatement s)
             {
-                stop = s.exp !is null;
+                if (s.exp !is null)
+                {
+                    stop = s.exp.hasCode();
+                }
             }
 
             override void visit(CompoundStatement s)

--- a/test/compilable/test17807.d
+++ b/test/compilable/test17807.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -o- -w
+
+int bug17807(){
+    int y=0;
+    Lswitch: switch(2){
+        { case 0: break; }
+        enum x=0;
+        struct S{ enum x=0; }
+        int foo(){
+            return 0;
+        }
+        default: y=x+S.x+foo();
+        static foreach(i;1..5)
+            case i: break Lswitch;
+    }
+    return y;
+}


### PR DESCRIPTION
Local declarations (except variable declarations that are neither `enum` nor `static`) have no associated code, and therefore should not give dead code warnings.