### PR TITLE
refactor: make TemplateParameterSemanticVisitor private

### DIFF
--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -62,6 +62,7 @@ import ddmd.utils;
 import ddmd.semantic;
 import ddmd.statement;
 import ddmd.target;
+import ddmd.templateparamsem;
 import ddmd.visitor;
 
 enum LOG = false;
@@ -3633,7 +3634,7 @@ extern(C++) final class DsymbolSemanticVisitor : Visitor
                 error(tp.loc, "parameter '%s' multiply defined", tp.ident.toChars());
                 tempdecl.errors = true;
             }
-            if (!tp.semantic(paramscope, tempdecl.parameters))
+            if (!tp.tpsemantic(paramscope, tempdecl.parameters))
             {
                 tempdecl.errors = true;
             }

--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -79,23 +79,6 @@ extern(C++) Type semantic(Type t, Loc loc, Scope* sc)
 }
 
 
-/************************************************
- * Performs semantic on TemplateParameter AST nodes.
- *
- * Params:
- *      tp = element of `parameters` to be semantically analyzed
- *      sc = context
- *      parameters = array of `TemplateParameters` supplied to the `TemplateDeclaration`
- * Returns:
- *      `true` if no errors
- */
-extern(C++) bool semantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
-{
-    scope v = new TemplateParameterSemanticVisitor(sc, parameters);
-    tp.accept(v);
-    return v.result;
-}
-
 void semantic(Catch c, Scope* sc)
 {
     semanticWrapper(c, sc);

--- a/src/ddmd/templateparamsem.d
+++ b/src/ddmd/templateparamsem.d
@@ -21,11 +21,29 @@ import ddmd.dtemplate;
 import ddmd.globals;
 import ddmd.expression;
 import ddmd.root.rootobject;
-import ddmd.mtype;
 import ddmd.semantic;
+import ddmd.mtype;
 import ddmd.visitor;
 
-extern (C++) final class TemplateParameterSemanticVisitor : Visitor
+/************************************************
+ * Performs semantic on TemplateParameter AST nodes.
+ *
+ * Params:
+ *      tp = element of `parameters` to be semantically analyzed
+ *      sc = context
+ *      parameters = array of `TemplateParameters` supplied to the `TemplateDeclaration`
+ * Returns:
+ *      `true` if no errors
+ */
+extern(C++) bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters* parameters)
+{
+    scope v = new TemplateParameterSemanticVisitor(sc, parameters);
+    tp.accept(v);
+    return v.result;
+}
+
+
+private extern (C++) final class TemplateParameterSemanticVisitor : Visitor
 {
     alias visit = super.visit;
 


### PR DESCRIPTION
Makes most of the code private, hence better encapsulated. Also renamed `semantic` to `tpsemantic` because of excessive and pointless overloading of `semantic`, making things impractical to grep.