### PR TITLE
fix Issue 17831 - [ICE] Internal error: backend/symbol.c 1039

### DIFF
--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -2478,7 +2478,6 @@ else
                     sw.hasVars = 1;
 
                     /* TODO check if v can be uninitialized at that point.
-                     * Also check if the VarExp is declared in a scope outside of this one
                      */
                     if (!v.isConst() && !v.isImmutable())
                     {
@@ -2489,6 +2488,24 @@ else
                     {
                         cs.error("case variables not allowed in final switch statements");
                         errors = true;
+                    }
+
+                    /* Also check if the VarExp is declared in a scope outside of this one
+                     * 'scx' is set to the scope of the switch statement.
+                     */
+                    for (Scope* scx = sc; scx; scx = scx.enclosing)
+                    {
+                        if (scx.enclosing && scx.enclosing.sw == sw)
+                            continue;
+                        assert(scx.sw == sw);
+
+                        if (!scx.search(cs.exp.loc, v.ident, null))
+                        {
+                            cs.error("case variable `%s` declared at %s cannot be declared in switch body",
+                                v.toChars(), v.loc.toChars());
+                            errors = true;
+                        }
+                        break;
                     }
                     goto L1;
                 }

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -2490,8 +2490,8 @@ else
                         errors = true;
                     }
 
-                    /* Also check if the VarExp is declared in a scope outside of this one
-                     * 'scx' is set to the scope of the switch statement.
+                    /* Find the outermost scope `scx` that set `sw`.
+                     * Then search scope `scx` for a declaration of `v`.
                      */
                     for (Scope* scx = sc; scx; scx = scx.enclosing)
                     {

--- a/test/fail_compilation/ice17831.d
+++ b/test/fail_compilation/ice17831.d
@@ -1,0 +1,78 @@
+// REQUIRED_ARGS: -d
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17831.d(19): Error: case variable `i` declared at fail_compilation/ice17831.d(17) cannot be declared in switch body
+fail_compilation/ice17831.d(33): Error: case variable `i` declared at fail_compilation/ice17831.d(31) cannot be declared in switch body
+fail_compilation/ice17831.d(48): Error: case variable `i` declared at fail_compilation/ice17831.d(45) cannot be declared in switch body
+fail_compilation/ice17831.d(61): Error: case variable `i` declared at fail_compilation/ice17831.d(60) cannot be declared in switch body
+fail_compilation/ice17831.d(73): Error: case variable `i` declared at fail_compilation/ice17831.d(72) cannot be declared in switch body
+---
+ */
+
+void test17831a()
+{
+    switch (0)
+    {
+        foreach (i; 0 .. 5)
+        {
+            case i:
+                break;
+        }
+        default:
+            break;
+    }
+}
+
+void test17831b()
+{
+    switch (0)
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            case i:
+                break;
+        }
+        default:
+            break;
+    }
+}
+
+void test17831c()
+{
+    switch (0)
+    {
+        int i = 0;
+        while (i++ < 5)
+        {
+            case i:
+                break;
+        }
+        default:
+            break;
+    }
+}
+
+void test17831d()
+{
+    switch (0)
+    {
+        int i = 0;
+        case i:
+            break;
+        default:
+            break;
+    }
+}
+
+void test17831e()
+{
+    switch (0)
+    {
+        static int i = 0;
+        case i:
+            break;
+        default:
+            break;
+    }
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=17831

ICE was found by compiling a variant of test for #7120.  This causes an ICE in gdc also.  Both code and lowering is just nonsense, e.g:
```
if (i == 0)  // ICE: 'i' is not declared in this scope.
{
    int i = 0;
    ...
}
```
So make it an error.