### PR TITLE
Add convenience function for Identifier::idPool

### DIFF
--- a/src/ddmd/identifier.h
+++ b/src/ddmd/identifier.h
@@ -40,6 +40,12 @@ public:
     static Identifier *generateId(const char *prefix);
     static Identifier *generateId(const char *prefix, size_t i);
     static Identifier *idPool(const char *s, size_t len);
+
+    static inline Identifier *idPool(const char *s)
+    {
+        return idPool(s, strlen(s));
+    }
+
     static bool isValidIdentifier(const char *p);
     static Identifier *lookup(const char *s, size_t len);
     static void initTable();


### PR DESCRIPTION
GDC uses `Identifier::idPool("some const string");` in many places.  Though this convenient function was removed on the D side in favour of using `string`.  It's still useful on the C++ side to have this.

If this is ok, then I'll add a few more methods like this which are lacking for GDC.