### PR TITLE
Add static create methods for frequently used types and declarations.

### DIFF
--- a/src/ddmd/aggregate.h
+++ b/src/ddmd/aggregate.h
@@ -188,6 +188,7 @@ public:
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
 
+    static StructDeclaration *create(Loc loc, Identifier *id);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
     void semanticTypeInfoMembers();
@@ -282,6 +283,7 @@ public:
     Baseok baseok;                      // set the progress of base classes resolving
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
+    static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void semantic(Scope *sc);

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -538,6 +538,11 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
         linkage = (p == LINKsystem) ? Target.systemLinkage() : p;
     }
 
+    static LinkDeclaration create(LINK p, Dsymbols* decl)
+    {
+        return new LinkDeclaration(p, decl);
+    }
+
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);

--- a/src/ddmd/attrib.h
+++ b/src/ddmd/attrib.h
@@ -89,6 +89,7 @@ class LinkDeclaration : public AttribDeclaration
 public:
     LINK linkage;
 
+    static LinkDeclaration *create(LINK p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *toChars();

--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -400,6 +400,11 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         baseok = BASEOKnone;
     }
 
+    static ClassDeclaration create(Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
+    {
+        return new ClassDeclaration(loc, id, baseclasses, members, inObject);
+    }
+
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         //printf("ClassDeclaration.syntaxCopy('%s')\n", toChars());

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -526,6 +526,11 @@ extern (C++) final class AliasDeclaration : Declaration
         assert(s);
     }
 
+    static AliasDeclaration create(Loc loc, Identifier id, Type type)
+    {
+        return new AliasDeclaration(loc, id, type);
+    }
+
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         //printf("AliasDeclaration::syntaxCopy()\n");

--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -194,6 +194,7 @@ public:
     Dsymbol *overnext;          // next in overload list
     Dsymbol *_import;           // !=NULL if unresolved internal alias for selective import
 
+    static AliasDeclaration *create(Loc loc, Identifier *id, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     void aliasSemantic(Scope *sc);
@@ -571,6 +572,7 @@ public:
 
     unsigned flags;                     // FUNCFLAGxxxxx
 
+    static FuncDeclaration *create(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);
     void semantic(Scope *sc);
     void semantic2(Scope *sc);

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -263,6 +263,11 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             Module.moduleinfo = this;
     }
 
+    static StructDeclaration create(Loc loc, Identifier id)
+    {
+        return new StructDeclaration(loc, id);
+    }
+
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         StructDeclaration sd =

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -3634,6 +3634,11 @@ extern (C++) final class IntegerExp : Expression
         this.value = cast(d_int32)value;
     }
 
+    static IntegerExp create(Loc loc, dinteger_t value, Type type)
+    {
+        return new IntegerExp(loc, value, type);
+    }
+
     override bool equals(RootObject o)
     {
         if (this == o)
@@ -3806,6 +3811,11 @@ extern (C++) final class RealExp : Expression
         this.type = type;
     }
 
+    static RealExp create(Loc loc, real_t value, Type type)
+    {
+        return new RealExp(loc, value, type);
+    }
+
     override bool equals(RootObject o)
     {
         if (this == o)
@@ -3869,6 +3879,11 @@ extern (C++) final class ComplexExp : Expression
         this.value = value;
         this.type = type;
         //printf("ComplexExp::ComplexExp(%s)\n", toChars());
+    }
+
+    static ComplexExp create(Loc loc, complex_t value, Type type)
+    {
+        return new ComplexExp(loc, value, type);
     }
 
     override bool equals(RootObject o)
@@ -4154,6 +4169,11 @@ extern (C++) final class StringExp : Expression
     static StringExp create(Loc loc, char* s)
     {
         return new StringExp(loc, s);
+    }
+
+    static StringExp create(Loc loc, void* string, size_t len)
+    {
+        return new StringExp(loc, string, len);
     }
 
     override bool equals(RootObject o)
@@ -4604,6 +4624,11 @@ extern (C++) final class ArrayLiteralExp : Expression
         super(loc, TOKarrayliteral, __traits(classInstanceSize, ArrayLiteralExp));
         this.basis = basis;
         this.elements = elements;
+    }
+
+    static ArrayLiteralExp create(Loc loc, Expressions* elements)
+    {
+        return new ArrayLiteralExp(loc, elements);
     }
 
     override Expression syntaxCopy()
@@ -5185,6 +5210,11 @@ extern (C++) final class NewExp : Expression
         this.newargs = newargs;
         this.newtype = newtype;
         this.arguments = arguments;
+    }
+
+    static NewExp create(Loc loc, Expression thisexp, Expressions* newargs, Type newtype, Expressions* arguments)
+    {
+        return new NewExp(loc, thisexp, newargs, newtype, arguments);
     }
 
     override Expression syntaxCopy()
@@ -6856,6 +6886,11 @@ extern (C++) final class VectorExp : UnaExp
         super(loc, TOKvector, __traits(classInstanceSize, VectorExp), e);
         assert(t.ty == Tvector);
         to = cast(TypeVector)t;
+    }
+
+    static VectorExp create(Loc loc, Expression e, Type t)
+    {
+        return new VectorExp(loc, e, t);
     }
 
     override Expression syntaxCopy()

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -227,6 +227,7 @@ class IntegerExp : public Expression
 public:
     dinteger_t value;
 
+    static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
     bool equals(RootObject *o);
     dinteger_t toInteger();
     real_t toReal();
@@ -254,6 +255,7 @@ class RealExp : public Expression
 public:
     real_t value;
 
+    static RealExp *create(Loc loc, real_t value, Type *type);
     bool equals(RootObject *o);
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -269,6 +271,7 @@ class ComplexExp : public Expression
 public:
     complex_t value;
 
+    static ComplexExp *create(Loc loc, complex_t value, Type *type);
     bool equals(RootObject *o);
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -348,6 +351,7 @@ public:
     OwnedBy ownedByCtfe;
 
     static StringExp *create(Loc loc, char *s);
+    static StringExp *create(Loc loc, void *s, size_t len);
     bool equals(RootObject *o);
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
@@ -391,6 +395,7 @@ public:
     Expressions *elements;
     OwnedBy ownedByCtfe;
 
+    static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     Expression *syntaxCopy();
     bool equals(RootObject *o);
     Expression *getElement(d_size_t i);
@@ -517,6 +522,7 @@ public:
     NewDeclaration *allocator;  // allocator function
     int onstack;                // allocate on stack
 
+    static NewExp *create(Loc loc, Expression *thisexp, Expressions *newargs, Type *newtype, Expressions *arguments);
     Expression *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }
@@ -888,6 +894,7 @@ public:
     TypeVector *to;             // the target vector type before semantic()
     unsigned dim;               // number of elements in the vector
 
+    static VectorExp *create(Loc loc, Expression *e, Type *t);
     Expression *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -269,6 +269,11 @@ extern (C++) class FuncDeclaration : Declaration
         inferRetType = (type && type.nextOf() is null);
     }
 
+    static FuncDeclaration create(Loc loc, Loc endloc, Identifier id, StorageClass storage_class, Type type)
+    {
+        return new FuncDeclaration(loc, endloc, id, storage_class, type);
+    }
+
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         //printf("FuncDeclaration::syntaxCopy('%s')\n", toChars());

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -4392,6 +4392,11 @@ extern (C++) final class TypeVector : Type
         this.basetype = basetype;
     }
 
+    static TypeVector create(Loc loc, Type basetype)
+    {
+        return new TypeVector(loc, basetype);
+    }
+
     override const(char)* kind() const
     {
         return "vector";
@@ -5635,6 +5640,11 @@ extern (C++) final class TypePointer : TypeNext
     extern (D) this(Type t)
     {
         super(Tpointer, t);
+    }
+
+    static TypePointer create(Type t)
+    {
+        return new TypePointer(t);
     }
 
     override const(char)* kind() const
@@ -7095,6 +7105,11 @@ extern (C++) final class TypeDelegate : TypeNext
         ty = Tdelegate;
     }
 
+    static TypeDelegate create(Type t)
+    {
+        return new TypeDelegate(t);
+    }
+
     override const(char)* kind() const
     {
         return "delegate";
@@ -8169,6 +8184,11 @@ extern (C++) final class TypeStruct : Type
     {
         super(Tstruct);
         this.sym = sym;
+    }
+
+    static TypeStruct create(StructDeclaration sym)
+    {
+        return new TypeStruct(sym);
     }
 
     override const(char)* kind() const

--- a/src/ddmd/mtype.h
+++ b/src/ddmd/mtype.h
@@ -418,6 +418,7 @@ class TypeVector : public Type
 public:
     Type *basetype;
 
+    static TypeVector *create(Loc loc, Type *basetype);
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
@@ -521,6 +522,7 @@ public:
 class TypePointer : public TypeNext
 {
 public:
+    static TypePointer *create(Type *t);
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
@@ -631,6 +633,7 @@ class TypeDelegate : public TypeNext
 public:
     // .next is a TypeFunction
 
+    static TypeDelegate *create(Type *t);
     const char *kind();
     Type *syntaxCopy();
     Type *semantic(Loc loc, Scope *sc);
@@ -743,6 +746,7 @@ public:
     AliasThisRec att;
     CPPMANGLE cppmangle;
 
+    static TypeStruct *create(StructDeclaration *sym);
     const char *kind();
     d_uns64 size(Loc loc);
     unsigned alignsize();


### PR DESCRIPTION
In GDC, these are used in the C++ parts of the compiler for:
 - Building types and function declarations for the gcc.builtins module.
 - Implement CTFE-able builtins.

Though I guess ideally there should be a create for all front-end AST types.  Or some generic way to request a new class from C++ to D.