### PR TITLE
Don't set ModuleInfo unless currently parsing object.d

### DIFF
--- a/src/ddmd/astbase.d
+++ b/src/ddmd/astbase.d
@@ -1497,14 +1497,17 @@ struct ASTBase
         int zeroInit;
         StructPOD ispod;
 
-        final extern (D) this(Loc loc, Identifier id)
+        final extern (D) this(Loc loc, Identifier id, bool inObject)
         {
             super(loc, id);
             zeroInit = 0;
             ispod = ISPODfwd;
             type = new TypeStruct(this);
-            if (id == Id.ModuleInfo && !Module.moduleinfo)
-                Module.moduleinfo = this;
+            if (inObject)
+            {
+                if (id == Id.ModuleInfo && !Module.moduleinfo)
+                    Module.moduleinfo = this;
+            }
         }
 
         override void accept(Visitor v)
@@ -1517,7 +1520,7 @@ struct ASTBase
     {
         extern (D) this(Loc loc, Identifier id)
         {
-            super(loc, id);
+            super(loc, id, false);
         }
 
         override void accept(Visitor v)

--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -226,7 +226,7 @@ extern (C++) final class StaticForeach : RootObject
     private extern(D) TypeStruct createTupleType(Loc loc, Expressions* e, Scope* sc)
     {   // TODO: move to druntime?
         auto sid = Identifier.generateId("Tuple");
-        auto sdecl = new StructDeclaration(loc, sid);
+        auto sdecl = new StructDeclaration(loc, sid, false);
         sdecl.storage_class |= STCstatic;
         sdecl.members = new Dsymbols();
         auto fid = Identifier.idPool(tupleFieldName.ptr, tupleFieldName.length);

--- a/src/ddmd/dstruct.d
+++ b/src/ddmd/dstruct.d
@@ -252,27 +252,31 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
 
-    final extern (D) this(Loc loc, Identifier id)
+    final extern (D) this(Loc loc, Identifier id, bool inObject)
     {
         super(loc, id);
         zeroInit = 0; // assume false until we do semantic processing
         ispod = ISPODfwd;
         // For forward references
         type = new TypeStruct(this);
-        if (id == Id.ModuleInfo && !Module.moduleinfo)
-            Module.moduleinfo = this;
+
+        if (inObject)
+        {
+            if (id == Id.ModuleInfo && !Module.moduleinfo)
+                Module.moduleinfo = this;
+        }
     }
 
-    static StructDeclaration create(Loc loc, Identifier id)
+    static StructDeclaration create(Loc loc, Identifier id, bool inObject)
     {
-        return new StructDeclaration(loc, id);
+        return new StructDeclaration(loc, id, inObject);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         StructDeclaration sd =
             s ? cast(StructDeclaration)s
-              : new StructDeclaration(loc, ident);
+              : new StructDeclaration(loc, ident, false);
         return ScopeDsymbol.syntaxCopy(sd);
     }
 
@@ -793,7 +797,7 @@ extern (C++) final class UnionDeclaration : StructDeclaration
 {
     extern (D) this(Loc loc, Identifier id)
     {
-        super(loc, id);
+        super(loc, id, false);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -3140,7 +3140,8 @@ final class Parser(AST) : Lexer
         case TOKstruct:
             if (id)
             {
-                a = new AST.StructDeclaration(loc, id);
+                bool inObject = md && !md.packages && md.id == Id.object;
+                a = new AST.StructDeclaration(loc, id, inObject);
                 a.members = members;
             }
             else


### PR DESCRIPTION
This is taken from gdc's implementation.  The type declaration is used directly when building module information (e.g: for debug), so shouldn't allow some other module to override its implementation.