### PR TITLE
Remove C++ constructors and operators for Prot from headers

### DIFF
--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -108,11 +108,7 @@ struct Prot
     PROTKIND kind;
     Package *pkg;
 
-    Prot();
-    Prot(PROTKIND kind);
-
     bool isMoreRestrictiveThan(const Prot other) const;
-    bool operator==(const Prot& other) const;
     bool isSubsetOf(const Prot& other) const;
 };
 


### PR DESCRIPTION
Though maybe these should be inline implementations.