### PR TITLE
Remove C++ constructors for File from headers

### DIFF
--- a/src/ddmd/root/file.h
+++ b/src/ddmd/root/file.h
@@ -30,9 +30,7 @@ struct File
 
     FileName *name;             // name of our file
 
-    File(const char *);
     static File *create(const char *);
-    File(const FileName *);
     ~File();
 
     const char *toChars();


### PR DESCRIPTION
As per #7147, maybe these should be inlined for the benefit of C++ implementations.  It is certainly nice *not* to have to allocate via `File::create` in order to use this type.