### PR TITLE
Fix signature of Port::memicmp to match D declaration

### DIFF
--- a/src/ddmd/root/port.d
+++ b/src/ddmd/root/port.d
@@ -38,7 +38,7 @@ extern (C++) struct Port
     {
         int result = 0;
 
-        for (int i = 0; i < n; i++)
+        foreach (i; 0 .. n)
         {
             char c1 = s1[i];
             char c2 = s2[i];

--- a/src/ddmd/root/port.h
+++ b/src/ddmd/root/port.h
@@ -29,7 +29,7 @@ typedef unsigned char utf8_t;
 
 struct Port
 {
-    static int memicmp(const char *s1, const char *s2, int n);
+    static int memicmp(const char *s1, const char *s2, size_t n);
     static char *strupr(char *s);
 
     static bool isFloat32LiteralOutOfRange(const char *s);


### PR DESCRIPTION
A case of `int` vs. `size_t`.