### PR TITLE
Add ScopeDsymbol::symtabLookup to vtable

### DIFF
--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -313,6 +313,7 @@ public:
     const char *kind();
     FuncDeclaration *findGetMembers();
     virtual Dsymbol *symtabInsert(Dsymbol *s);
+    virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     bool hasStaticCtorOrDtor();
 
     static size_t dim(Dsymbols *members);


### PR DESCRIPTION
Found vtable mismatch when calling `cd->isBaseOf()` from C++.

This function was added by #6760, and I added the function to headers in #7087, but missed that it was a virtual function, first declared in another class.