### PR TITLE
fix building with version=GC

### DIFF
--- a/src/ddmd/root/rmem.d
+++ b/src/ddmd/root/rmem.d
@@ -27,6 +27,7 @@ version (GC)
 
         static void xfree(void* p) nothrow
         {
+            return GC.free(p);
         }
 
         static void* xmalloc(size_t n) nothrow
@@ -42,6 +43,14 @@ version (GC)
         static void* xrealloc(void* p, size_t size) nothrow
         {
             return GC.realloc(p, size);
+        }
+        static void error() nothrow
+        {
+            import core.stdc.stdlib : exit, EXIT_FAILURE;
+            import core.stdc.stdio : printf;
+
+            printf("Error: out of memory\n");
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/src/ddmd/root/rmem.d
+++ b/src/ddmd/root/rmem.d
@@ -44,6 +44,7 @@ version (GC)
         {
             return GC.realloc(p, size);
         }
+
         static void error() nothrow
         {
             import core.stdc.stdlib : exit, EXIT_FAILURE;


### PR DESCRIPTION
When adding GC.disable before the code generation, building phobos unittests with the split build in win64.mak works with the GC version, but is about 20% slower.

As a touchstone compiling all phobos unittests with a single compiler invocation still doesn't work completely. It finishes semantic analysis within about 8GB of memory, but later fails after using a lot more memory during code generation.

It seems using the front end as a library with the GC enabled is feasable.