### PR TITLE
Fix 17502 (again): Generate contracts after inferring return type.

### DIFF
--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -3669,14 +3669,13 @@ extern (C++) class FuncDeclaration : Declaration
          *     a stack local, allocate that local immediately following the exception
          *     handler block, so it is always at the same offset from EBP.
          */
-        for (size_t i = 0; i < foverrides.dim; i++)
+        foreach (fdv; foverrides)
         {
-            FuncDeclaration fdv = foverrides[i];
-
             /* The semantic pass on the contracts of the overridden functions must
-             * be completed before code generation occurs (bug 3602).
+             * be completed before code generation occurs.
+             * https://issues.dlang.org/show_bug.cgi?id=3602
              */
-            if (fdv.fdrequire && fdv.fdrequire.semanticRun != PASSsemantic3done)
+            if (fdv.frequire && fdv.semanticRun != PASSsemantic3done)
             {
                 assert(fdv._scope);
                 Scope* sc = fdv._scope.push();
@@ -3724,14 +3723,14 @@ extern (C++) class FuncDeclaration : Declaration
          * list for the 'this' pointer, something that would need an unknown amount
          * of tweaking of various parts of the compiler that I'd rather leave alone.
          */
-        for (size_t i = 0; i < foverrides.dim; i++)
+        foreach (fdv; foverrides)
         {
-            FuncDeclaration fdv = foverrides[i];
-
             /* The semantic pass on the contracts of the overridden functions must
-             * be completed before code generation occurs (bug 3602 and 5230).
+             * be completed before code generation occurs.
+             * https://issues.dlang.org/show_bug.cgi?id=3602 and
+             * https://issues.dlang.org/show_bug.cgi?id=5230
              */
-            if (fdv.fdensure && fdv.fdensure.semanticRun != PASSsemantic3done)
+            if (needsFensure(fdv) && fdv.semanticRun != PASSsemantic3done)
             {
                 assert(fdv._scope);
                 Scope* sc = fdv._scope.push();

--- a/test/compilable/imports/test3602a.d
+++ b/test/compilable/imports/test3602a.d
@@ -1,0 +1,14 @@
+module imports.test3602a;
+
+class Base
+{
+   void method(int x, int y)
+   in
+   {
+       assert(x > 0);
+       assert(y > 0);
+   }
+   body
+   {
+   }
+}

--- a/test/compilable/imports/test5230a.d
+++ b/test/compilable/imports/test5230a.d
@@ -1,0 +1,13 @@
+module imports.test5230a;
+
+class Base
+{
+    int method()
+    out (res)
+    {
+    }
+    body
+    {
+        return 42;
+    }
+}

--- a/test/compilable/test17502.d
+++ b/test/compilable/test17502.d
@@ -1,3 +1,4 @@
+// https://issues.dlang.org/show_bug.cgi?id=17502
 class Foo
 {
     auto foo()
@@ -27,4 +28,95 @@ class Foo
     auto void_auto()
     out {}
     body {}
+}
+
+/***************************************************/
+// Order of declaration: (A), (C : B), (B : A)
+
+class A
+{
+    int method(int p)
+    in
+    {
+        assert(p > 5);
+    }
+    out(res)
+    {
+        assert(res > 5);
+    }
+    body
+    {
+        return p;
+    }
+}
+
+class C : B
+{
+    override int method(int p)
+    in
+    {
+        assert(p > 3);
+    }
+    body
+    {
+        return p * 2;
+    }
+}
+
+class B : A
+{
+    override int method(int p)
+    in
+    {
+        assert(p > 2);
+    }
+    body
+    {
+        return p * 3;
+    }
+}
+
+/***************************************************/
+// Order of declaration: (X : Y), (Y : Z), (Z)
+class X : Y
+{
+    override int method(int p)
+    in
+    {
+        assert(p > 3);
+    }
+    body
+    {
+        return p * 2;
+    }
+}
+
+class Y : Z
+{
+    override int method(int p)
+    in
+    {
+        assert(p > 2);
+    }
+    body
+    {
+        return p * 3;
+    }
+}
+
+class Z
+{
+    int method(int p)
+    in
+    {
+        assert(p > 5);
+    }
+    out(res)
+    {
+        assert(res > 5);
+    }
+    body
+    {
+        return p;
+    }
 }

--- a/test/compilable/test3602.d
+++ b/test/compilable/test3602.d
@@ -1,0 +1,17 @@
+// EXTRA_SOURCES: imports/test3602a.d
+// https://issues.dlang.org/show_bug.cgi?id=5230
+
+import imports.test3602a;
+
+class Derived : Base
+{
+   override void method(int x, int y)
+   in
+   {
+       assert(x > 0);
+       assert(y > 0);
+   }
+   body
+   {
+   }
+}

--- a/test/compilable/test5230.d
+++ b/test/compilable/test5230.d
@@ -1,0 +1,12 @@
+// EXTRA_SOURCES: imports/test5230a.d
+// https://issues.dlang.org/show_bug.cgi?id=5230
+
+import imports.test5230a;
+
+class Derived : Base
+{
+    override int method()
+    {
+        return 69;
+    }
+}

--- a/test/fail_compilation/fail17502.d
+++ b/test/fail_compilation/fail17502.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail17502.d(12): Error: function fail17502.Foo.foo void functions have no result
+fail_compilation/fail17502.d(13): Error: cannot have parameter of type const(void)
+fail_compilation/fail17502.d(16): Error: function fail17502.Foo.bar void functions have no result
+fail_compilation/fail17502.d(17): Error: cannot have parameter of type const(void)
+---
+*/
+class Foo
+{
+    void foo()
+    out (res) { assert(res > 5); }
+    body {}
+
+    auto bar()
+    out (res) { assert (res > 5); }
+    body { return; }
+}


### PR DESCRIPTION
 https://issues.dlang.org/show_bug.cgi?id=17502
 Wait until after the return type has been inferred before generating the contracts for this function, and merging contracts from overrides.

 This was originally at the end of the first semantic pass, but required a fix-up to be done here for the `__result` variable type of __ensure() inside auto functions, but this didn't work if the out parameter was implicit.

---

The test-case for this issue was still causing an ICE in gdc because for the following test:
```
class Foo
{
    auto bar()
    out { assert (__result > 5); }
    body { return 6; }
}
```
 it was still generating the following contract.
```
void __ensure ()
{
  assert (__result > 5);
}
__ensure ();
```
With this PR, it now (correctly) generates.
```
void __ensure (const ref __result)
{
  assert (__result > 5)
}
__ensure (&__result);
```

FYI @Burgos as original author. ;-)