### PR TITLE
refactor: Replace 'extern(C++) static' with 'extern(D) private'

### DIFF
--- a/src/ddmd/access.d
+++ b/src/ddmd/access.d
@@ -89,7 +89,7 @@ extern (C++) Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
  *      false   is not accessible
  *      true    is accessible
  */
-extern (C++) static bool isAccessible(Dsymbol smember, Dsymbol sfunc, AggregateDeclaration dthis, AggregateDeclaration cdscope)
+private bool isAccessible(Dsymbol smember, Dsymbol sfunc, AggregateDeclaration dthis, AggregateDeclaration cdscope)
 {
     assert(dthis);
     version (none)

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -1311,7 +1311,7 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
     }
 }
 
-extern (C++) static uint setMangleOverride(Dsymbol s, char* sym)
+uint setMangleOverride(Dsymbol s, char* sym)
 {
     AttribDeclaration ad = s.isAttribDeclaration();
     if (ad)

--- a/src/ddmd/doc.d
+++ b/src/ddmd/doc.d
@@ -329,7 +329,7 @@ extern (C++) bool isCVariadicParameter(Dsymbols* a, const(char)* p, size_t len)
     return false;
 }
 
-extern (C++) static Dsymbol getEponymousMember(TemplateDeclaration td)
+private Dsymbol getEponymousMember(TemplateDeclaration td)
 {
     if (!td.onemember)
         return null;
@@ -344,7 +344,7 @@ extern (C++) static Dsymbol getEponymousMember(TemplateDeclaration td)
     return null;
 }
 
-extern (C++) static TemplateDeclaration getEponymousParent(Dsymbol s)
+private TemplateDeclaration getEponymousParent(Dsymbol s)
 {
     if (!s.parent)
         return null;
@@ -636,14 +636,14 @@ extern (C++) void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start)
 
 // Basically, this is to skip over things like private{} blocks in a struct or
 // class definition that don't add any components to the qualified name.
-extern (C++) static Scope* skipNonQualScopes(Scope* sc)
+private Scope* skipNonQualScopes(Scope* sc)
 {
     while (sc && !sc.scopesym)
         sc = sc.enclosing;
     return sc;
 }
 
-extern (C++) static bool emitAnchorName(OutBuffer* buf, Dsymbol s, Scope* sc, bool includeParent)
+private bool emitAnchorName(OutBuffer* buf, Dsymbol s, Scope* sc, bool includeParent)
 {
     if (!s || s.isPackage() || s.isModule())
         return false;
@@ -674,7 +674,7 @@ extern (C++) static bool emitAnchorName(OutBuffer* buf, Dsymbol s, Scope* sc, bo
     return true;
 }
 
-extern (C++) static void emitAnchor(OutBuffer* buf, Dsymbol s, Scope* sc, bool forHeader = false)
+private void emitAnchor(OutBuffer* buf, Dsymbol s, Scope* sc, bool forHeader = false)
 {
     Identifier ident;
     {
@@ -733,7 +733,7 @@ extern (C++) static void emitAnchor(OutBuffer* buf, Dsymbol s, Scope* sc, bool f
 /******************************* emitComment **********************************/
 
 /** Get leading indentation from 'src' which represents lines of code. */
-extern (C++) static size_t getCodeIndent(const(char)* src)
+private size_t getCodeIndent(const(char)* src)
 {
     while (src && (*src == '\r' || *src == '\n'))
         ++src; // skip until we find the first non-empty line
@@ -747,7 +747,7 @@ extern (C++) static size_t getCodeIndent(const(char)* src)
 }
 
 /** Recursively expand template mixin member docs into the scope. */
-extern (C++) static void expandTemplateMixinComments(TemplateMixin tm, OutBuffer* buf, Scope* sc)
+private void expandTemplateMixinComments(TemplateMixin tm, OutBuffer* buf, Scope* sc)
 {
     if (!tm.semanticRun)
         tm.semantic(sc);

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -2179,7 +2179,7 @@ extern (C++) int overloadApply(Dsymbol fstart, void* param, int function(void*, 
     return overloadApply(fstart, s => (*fp)(param, s));
 }
 
-extern (C++) static void MODMatchToBuffer(OutBuffer* buf, ubyte lhsMod, ubyte rhsMod)
+void MODMatchToBuffer(OutBuffer* buf, ubyte lhsMod, ubyte rhsMod)
 {
     bool bothMutable = ((lhsMod & rhsMod) == 0);
     bool sharedMismatch = ((lhsMod ^ rhsMod) & MODshared) != 0;
@@ -3160,7 +3160,7 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
  * Generate unique unittest function Id so we can have multiple
  * instances per module.
  */
-extern (C++) static Identifier unitTestId(Loc loc)
+private Identifier unitTestId(Loc loc)
 {
     OutBuffer buf;
     buf.printf("__unittestL%u_", loc.linnum);

--- a/src/ddmd/libomf.d
+++ b/src/ddmd/libomf.d
@@ -521,7 +521,7 @@ enum BUCKETSIZE = (BUCKETPAGE - HASHMOD - 1);
  * Returns:
  *      false   failure
  */
-extern (C++) static bool EnterDict(ubyte* bucketsP, ushort ndicpages, ubyte* entry, uint entrylen)
+private bool EnterDict(ubyte* bucketsP, ushort ndicpages, ubyte* entry, uint entrylen)
 {
     ushort uStartIndex;
     ushort uStep;

--- a/src/ddmd/opover.d
+++ b/src/ddmd/opover.d
@@ -66,7 +66,7 @@ extern (C++) bool isCommutative(TOK op)
 /***********************************
  * Get Identifier for operator overload.
  */
-extern (C++) static Identifier opId(Expression e)
+private Identifier opId(Expression e)
 {
     extern (C++) final class OpIdVisitor : Visitor
     {
@@ -274,7 +274,7 @@ extern (C++) static Identifier opId(Expression e)
  * Get Identifier for reverse operator overload,
  * NULL if not supported for this operator.
  */
-extern (C++) static Identifier opId_r(Expression e)
+private Identifier opId_r(Expression e)
 {
     extern (C++) final class OpIdRVisitor : Visitor
     {
@@ -1950,7 +1950,7 @@ extern (C++) bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbo
     return true;
 }
 
-extern (C++) static Dsymbol inferApplyArgTypesX(Expression ethis, FuncDeclaration fstart, Parameters* parameters)
+private Dsymbol inferApplyArgTypesX(Expression ethis, FuncDeclaration fstart, Parameters* parameters)
 {
     MOD mod = ethis.type.mod;
     MATCH match = MATCHnomatch;
@@ -2004,7 +2004,7 @@ extern (C++) static Dsymbol inferApplyArgTypesX(Expression ethis, FuncDeclaratio
  *      1 match for this function
  *      0 no match for this function
  */
-extern (C++) static int inferApplyArgTypesY(TypeFunction tf, Parameters* parameters, int flags = 0)
+private int inferApplyArgTypesY(TypeFunction tf, Parameters* parameters, int flags = 0)
 {
     size_t nparams;
     Parameter p;

--- a/src/ddmd/scanomf.d
+++ b/src/ddmd/scanomf.d
@@ -85,7 +85,7 @@ extern (C++) void parseName(const(ubyte)** pp, char* name)
     *pp = p + len;
 }
 
-extern (C++) static ushort parseIdx(const(ubyte)** pp)
+private ushort parseIdx(const(ubyte)** pp)
 {
     auto p = *pp;
     const c = *p++;
@@ -95,7 +95,7 @@ extern (C++) static ushort parseIdx(const(ubyte)** pp)
 }
 
 // skip numeric field of a data type of a COMDEF record
-extern (C++) static void skipNumericField(const(ubyte)** pp)
+private void skipNumericField(const(ubyte)** pp)
 {
     const(ubyte)* p = *pp;
     const c = *p++;
@@ -111,7 +111,7 @@ extern (C++) static void skipNumericField(const(ubyte)** pp)
 }
 
 // skip data type of a COMDEF record
-extern (C++) static void skipDataType(const(ubyte)** pp)
+private void skipDataType(const(ubyte)** pp)
 {
     auto p = *pp;
     const c = *p++;

--- a/src/ddmd/target.d
+++ b/src/ddmd/target.d
@@ -476,7 +476,7 @@ struct Target
  * Private helpers for Target::paintAsType.
  */
 // Write the integer value of 'e' into a unsigned byte buffer.
-extern (C++) static void encodeInteger(Expression e, ubyte* buffer)
+private void encodeInteger(Expression e, ubyte* buffer)
 {
     dinteger_t value = e.toInteger();
     int size = cast(int)e.type.size();
@@ -489,7 +489,7 @@ extern (C++) static void encodeInteger(Expression e, ubyte* buffer)
 
 // Write the bytes encoded in 'buffer' into an integer and returns
 // the value as a new IntegerExp.
-extern (C++) static Expression decodeInteger(Loc loc, Type type, ubyte* buffer)
+private Expression decodeInteger(Loc loc, Type type, ubyte* buffer)
 {
     dinteger_t value = 0;
     int size = cast(int)type.size();
@@ -502,7 +502,7 @@ extern (C++) static Expression decodeInteger(Loc loc, Type type, ubyte* buffer)
 }
 
 // Write the real_t value of 'e' into a unsigned byte buffer.
-extern (C++) static void encodeReal(Expression e, ubyte* buffer)
+private void encodeReal(Expression e, ubyte* buffer)
 {
     switch (e.type.ty)
     {
@@ -525,7 +525,7 @@ extern (C++) static void encodeReal(Expression e, ubyte* buffer)
 
 // Write the bytes encoded in 'buffer' into a real_t and returns
 // the value as a new RealExp.
-extern (C++) static Expression decodeReal(Loc loc, Type type, ubyte* buffer)
+private Expression decodeReal(Loc loc, Type type, ubyte* buffer)
 {
     real_t value;
     switch (type.ty)

--- a/src/ddmd/typinf.d
+++ b/src/ddmd/typinf.d
@@ -233,7 +233,7 @@ extern (C++) bool isSpeculativeType(Type t)
 /* These decide if there's an instance for them already in std.typeinfo,
  * because then the compiler doesn't need to build one.
  */
-extern (C++) static bool builtinTypeInfo(Type t)
+private bool builtinTypeInfo(Type t)
 {
     if (t.isTypeBasic() || t.ty == Tclass || t.ty == Tnull)
         return !t.mod;


### PR DESCRIPTION
In the C++ -> D conversion, global `static` functions got translated into `extern (C++) static`, however they are all effectively private/internal to the module they are defined in.

Only a couple are not marked private here due to the split-up of `semantic` that is currently going on.