### PR TITLE
array.d: use Tau of 1.5

### DIFF
--- a/src/ddmd/root/array.d
+++ b/src/ddmd/root/array.d
@@ -107,7 +107,12 @@ public:
             }
             else
             {
-                allocdim = dim + nentries;
+                /* Increase size by 1.5x to avoid excessive memory fragmentation
+                 */
+                auto increment = dim / 2;
+                if (nentries > increment)       // if 1.5 is not enough
+                    increment = nentries;
+                allocdim = dim + increment;
                 data = cast(T*)mem.xrealloc(data, allocdim * (*data).sizeof);
             }
         }


### PR DESCRIPTION
Reallocating a growing buffer by an amount of 1.5 minimizes heap fragmentation and allows reuse of earlier sizes. (kudos to Andrei!)