### PR TITLE
Move import of ddmd.lib behind version blocks

### DIFF
--- a/src/ddmd/gluelayer.d
+++ b/src/ddmd/gluelayer.d
@@ -15,13 +15,14 @@ module ddmd.gluelayer;
 import ddmd.dmodule;
 import ddmd.dscope;
 import ddmd.dsymbol;
-import ddmd.lib;
 import ddmd.mtype;
 import ddmd.statement;
 import ddmd.root.file;
 
 version (NoBackend)
 {
+    import ddmd.lib : Library;
+
     struct Symbol;
     struct code;
     struct block;
@@ -54,6 +55,8 @@ version (NoBackend)
 }
 else
 {
+    import ddmd.lib : Library;
+
     public import ddmd.backend.cc : block, Blockx, Symbol;
     public import ddmd.backend.type : type;
     public import ddmd.backend.el : elem;


### PR DESCRIPTION
The `ddmd.lib` module does not exist in gdc's source tree.  No need to add it as a dependency (although the gluelayer module as a whole should probably be re-thought).