### PR TITLE
Add prototype for 'error(Loc, const char*, ...)' to headers.

### DIFF
--- a/src/ddmd/errors.h
+++ b/src/ddmd/errors.h
@@ -32,6 +32,7 @@ D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(const Loc& loc, const char *fo
 D_ATTRIBUTE_FORMAT(2, 3) void deprecation(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void error(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 3) void error(Loc loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void errorSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 0) void verror(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
 D_ATTRIBUTE_FORMAT(2, 0) void verrorSupplemental(const Loc& loc, const char *format, va_list ap);


### PR DESCRIPTION
I seem to have missed this from the list of problems encountered when linking gdc.

This function was added during the transition from C++ to D if I understand correctly - so that passing a const literal worked.