### PR TITLE
Change error(Loc) override to extern (D)

### DIFF
--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -43,7 +43,7 @@ extern (C++) void error(const ref Loc loc, const(char)* format, ...)
     va_end(ap);
 }
 
-extern (C++) void error(Loc loc, const(char)* format, ...)
+extern (D) void error(Loc loc, const(char)* format, ...)
 {
     va_list ap;
     va_start(ap, format);


### PR DESCRIPTION
I don't like this, but given the choice between linker errors or C++ compiler errors.  Neither is any good.