### PR TITLE
fix Issue 17857 - T.alignof ignores explicit align(N) type alignment

### DIFF
--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -2510,7 +2510,10 @@ extern (C++) abstract class Type : RootObject
         }
         else if (ident == Id.__xalignof)
         {
-            e = new IntegerExp(loc, alignsize(), Type.tsize_t);
+            const explicitAlignment = alignment();
+            const naturalAlignment = alignsize();
+            const actualAlignment = (explicitAlignment == STRUCTALIGN_DEFAULT ? naturalAlignment : explicitAlignment);
+            e = new IntegerExp(loc, actualAlignment, Type.tsize_t);
         }
         else if (ident == Id._init)
         {

--- a/test/compilable/aggr_alignment.d
+++ b/test/compilable/aggr_alignment.d
@@ -26,3 +26,24 @@ enum payloadOffset = C2.bytes.offsetof;
 static assert(C2.int1.offsetof == payloadOffset + 8);
 static assert(C2.alignof == size_t.sizeof);
 static assert(__traits(classInstanceSize, C2) == payloadOffset + 12);
+
+align(8) struct PaddedStruct
+{
+    bool flag;
+    align(2) S1 s1;
+}
+
+static assert(PaddedStruct.s1.offsetof == 2);
+static assert(PaddedStruct.alignof == 8);
+static assert(PaddedStruct.sizeof == 16);
+
+align(1) struct UglyStruct
+{
+    bool flag;
+    int i;
+    ubyte u;
+}
+
+static assert(UglyStruct.i.offsetof == 4);
+static assert(UglyStruct.alignof == 1);
+static assert(UglyStruct.sizeof == 9);


### PR DESCRIPTION
It was previously the natural type alignment, defined as the maximum of the field alignments for an aggregate. Make sure an explicit `align(N)` overrides it.