### PR TITLE
outbuf: modernize buffer reallocation strategy

### DIFF
--- a/src/ddmd/backend/outbuf.d
+++ b/src/ddmd/backend/outbuf.d
@@ -26,16 +26,16 @@ struct Outbuffer
     ubyte *buf;         // the buffer itself
     ubyte *pend;        // pointer past the end of the buffer
     ubyte *p;           // current position in buffer
-    uint len;           // size of buffer
-    uint inc;           // default increment size
     ubyte *origbuf;     // external buffer
 
     //this();
 
-    this(size_t incx); // : buf(null), pend(null), p(null), len(0), inc(incx), origbuf(null) { }
+    this(size_t initialSize); // : buf(null), pend(null), p(null), origbuf(null) { }
 
-    this(ubyte *bufx, size_t bufxlen, uint incx);
-        //: buf(bufx), pend(bufx + bufxlen), p(bufx), len(bufxlen), inc(incx), origbuf(bufx) { }
+    this(ubyte *bufx, size_t bufxlen, uint incx)
+    {
+        buf = bufx; pend = bufx + bufxlen; p = bufx; origbuf = bufx;
+    }
 
     //~this();
 
@@ -169,15 +169,15 @@ struct Outbuffer
      */
     void writeDouble(double v);
 
-    void write(const char *s);
+    void write(const(char)* s);
 
-    void write(const ubyte *s);
+    void write(const(ubyte)* s);
 
-    void writeString(const char *s);
+    void writeString(const(char)* s);
 
-    void prependBytes(const char *s);
+    void prependBytes(const(char)* s);
 
-    void prepend(const void *b, size_t len);
+    void prepend(const(void)* b, size_t len);
 
     void bracket(char c1,char c2);
 

--- a/src/ddmd/backend/outbuf.h
+++ b/src/ddmd/backend/outbuf.h
@@ -33,16 +33,14 @@ struct Outbuffer
     unsigned char *buf;         // the buffer itself
     unsigned char *pend;        // pointer past the end of the buffer
     unsigned char *p;           // current position in buffer
-    unsigned len;               // size of buffer
-    unsigned inc;               // default increment size
     unsigned char *origbuf;     // external buffer
 
     Outbuffer();
 
-    Outbuffer(d_size_t incx) : buf(NULL), pend(NULL), p(NULL), len(0), inc(incx), origbuf(NULL) { }
+    Outbuffer(d_size_t initialSize);
 
     Outbuffer(unsigned char *bufx, d_size_t bufxlen, unsigned incx) :
-        buf(bufx), pend(bufx + bufxlen), p(bufx), len(bufxlen), inc(incx), origbuf(bufx) { }
+        buf(bufx), pend(bufx + bufxlen), p(bufx), origbuf(bufx) { }
 
     ~Outbuffer();
 

--- a/src/ddmd/glue.d
+++ b/src/ddmd/glue.d
@@ -293,8 +293,6 @@ void obj_end(Library library, File *objfile)
     }
     objbuf.pend = null;
     objbuf.p = null;
-    objbuf.len = 0;
-    objbuf.inc = 0;
 }
 
 bool obj_includelib(const(char)* name)


### PR DESCRIPTION
This changes the reallocation strategy to using a 1.5x growth factor rather than a constant increment.