### PR TITLE
Call vdeprecationSupplemental from deprecationSupplemental

### DIFF
--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -99,7 +99,7 @@ extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format
 {
     va_list ap;
     va_start(ap, format);
-    vdeprecation(loc, format, ap);
+    vdeprecationSupplemental(loc, format, ap);
     va_end(ap);
 }
 

--- a/test/fail_compilation/diag3438.d
+++ b/test/fail_compilation/diag3438.d
@@ -5,9 +5,9 @@ TEST_OUTPUT:
 fail_compilation/diag3438.d(16): Deprecation: constructor diag3438.F1.this all parameters have default arguments, but structs cannot have default constructors.
 fail_compilation/diag3438.d(17): Deprecation: constructor diag3438.F2.this all parameters have default arguments, but structs cannot have default constructors.
 fail_compilation/diag3438.d(20): Deprecation: constructor diag3438.F5.this @disable'd constructor cannot have default arguments for all parameters.
-fail_compilation/diag3438.d(20): Deprecation: Use @disable this(); if you want to disable default initialization.
+fail_compilation/diag3438.d(20):        Use @disable this(); if you want to disable default initialization.
 fail_compilation/diag3438.d(21): Deprecation: constructor diag3438.F6.this @disable'd constructor cannot have default arguments for all parameters.
-fail_compilation/diag3438.d(21): Deprecation: Use @disable this(); if you want to disable default initialization.
+fail_compilation/diag3438.d(21):        Use @disable this(); if you want to disable default initialization.
 ---
 */
 


### PR DESCRIPTION
Seems like it should do this to be consistent with `errorSupplemental` and `warningSupplemental`.