### PR TITLE
Mark the error Loc override as extern(D)

### DIFF
--- a/src/ddmd/errors.d
+++ b/src/ddmd/errors.d
@@ -43,7 +43,8 @@ extern (C++) void error(const ref Loc loc, const(char)* format, ...)
     va_end(ap);
 }
 
-extern (C++) void error(Loc loc, const(char)* format, ...)
+// This override allows Loc() literals to be passed.
+extern (D) void error(Loc loc, const(char)* format, ...)
 {
     va_list ap;
     va_start(ap, format);

--- a/src/ddmd/errors.h
+++ b/src/ddmd/errors.h
@@ -32,6 +32,7 @@ D_ATTRIBUTE_FORMAT(2, 3) void warningSupplemental(const Loc& loc, const char *fo
 D_ATTRIBUTE_FORMAT(2, 3) void deprecation(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void deprecationSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void error(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(4, 5) void error(const char *filename, unsigned linnum, unsigned charnum, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 3) void errorSupplemental(const Loc& loc, const char *format, ...);
 D_ATTRIBUTE_FORMAT(2, 0) void verror(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL, const char *header = "Error: ");
 D_ATTRIBUTE_FORMAT(2, 0) void verrorSupplemental(const Loc& loc, const char *format, va_list ap);


### PR DESCRIPTION
If in the future there will be some automatic translation of D -> C++, this should not be picked up.

Of course, if D ever gets support for rvalue references like C++ then the override can be removed entirely.

Also adds the third error override to C++ headers.