### PR TITLE
Split TOKcatass into TOKcatass, TOKcatelemass, TOKcatdcharass

### DIFF
--- a/src/ddmd/ctfeexpr.d
+++ b/src/ddmd/ctfeexpr.d
@@ -279,6 +279,8 @@ extern (C++) bool needToCopyLiteral(Expression expr)
         case TOKcat:
             return needToCopyLiteral((cast(BinExp)expr).e1) || needToCopyLiteral((cast(BinExp)expr).e2);
         case TOKcatass:
+        case TOKcatelemass:
+        case TOKcatdcharass:
             expr = (cast(BinExp)expr).e2;
             continue;
         default:

--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -3728,7 +3728,7 @@ public:
             if (e.e1.type.ty != Tpointer)
             {
                 // ~= can create new values (see bug 6052)
-                if (e.op == TOKcatass)
+                if (e.op == TOKcatass || e.op == TOKcatelemass || e.op == TOKcatdcharass)
                 {
                     // We need to dup it and repaint the type. For a dynamic array
                     // we can skip duplication, because it gets copied later anyway.
@@ -4497,6 +4497,8 @@ public:
             return;
 
         case TOKcatass:
+        case TOKcatelemass:
+        case TOKcatdcharass:
             interpretAssignCommon(e, &ctfeCat);
             return;
 

--- a/src/ddmd/escape.d
+++ b/src/ddmd/escape.d
@@ -178,7 +178,8 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 {
     enum log = false;
     if (log) printf("checkAssignEscape(e: %s)\n", e.toChars());
-    if (e.op != TOKassign && e.op != TOKblit && e.op != TOKconstruct && e.op != TOKcatass)
+    if (e.op != TOKassign && e.op != TOKblit && e.op != TOKconstruct &&
+        e.op != TOKcatass && e.op != TOKcatelemass && e.op != TOKcatdcharass)
         return false;
     auto ae = cast(BinExp)e;
     Expression e1 = ae.e1;

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -7664,6 +7664,14 @@ extern (C++) final class UshrAssignExp : BinAssignExp
 }
 
 /***********************************************************
+ * The ~= operator. It can have one of the following operators:
+ *
+ * TOKcatass      - appending T[] to T[]
+ * TOKcatelemass  - appending T to T[]
+ * TOKcatdcharass - appending dchar to T[]
+ *
+ * The parser initially sets it to TOKcatass, and semantic() later decides which
+ * of the three it will be set to.
  */
 extern (C++) final class CatAssignExp : BinAssignExp
 {

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -172,6 +172,8 @@ __gshared PREC[TOKMAX] precedence =
     TOKaddass : PREC.assign,
     TOKminass : PREC.assign,
     TOKcatass : PREC.assign,
+    TOKcatelemass : PREC.assign,
+    TOKcatdcharass : PREC.assign,
     TOKmulass : PREC.assign,
     TOKdivass : PREC.assign,
     TOKmodass : PREC.assign,

--- a/src/ddmd/sideeffect.d
+++ b/src/ddmd/sideeffect.d
@@ -156,6 +156,8 @@ extern (C++) bool lambdaHasSideEffect(Expression e)
     case TOKaddass:
     case TOKminass:
     case TOKcatass:
+    case TOKcatelemass:
+    case TOKcatdcharass:
     case TOKmulass:
     case TOKdivass:
     case TOKmodass:

--- a/src/ddmd/tokens.d
+++ b/src/ddmd/tokens.d
@@ -114,7 +114,9 @@ enum TOK : int
     TOKushr,
     TOKushrass,
     TOKcat,
-    TOKcatass, // ~ ~=
+    TOKcatass, // ~=
+    TOKcatelemass,
+    TOKcatdcharass,
     TOKadd,
     TOKmin,
     TOKaddass,
@@ -147,7 +149,7 @@ enum TOK : int
     TOKpreplusplus,
     TOKpreminusminus,
 
-    // 111
+    // 113
     // Numeric literals
     TOKint32v,
     TOKuns32v,
@@ -162,13 +164,13 @@ enum TOK : int
     TOKimaginary64v,
     TOKimaginary80v,
 
-    // 123
+    // 125
     // Char constants
     TOKcharv,
     TOKwcharv,
     TOKdcharv,
 
-    // 126
+    // 128
     // Leaf operators
     TOKidentifier,
     TOKstring,
@@ -179,7 +181,7 @@ enum TOK : int
     TOKtuple,
     TOKerror,
 
-    // 134
+    // 136
     // Basic types
     TOKvoid,
     TOKint8,
@@ -206,7 +208,7 @@ enum TOK : int
     TOKdchar,
     TOKbool,
 
-    // 158
+    // 160
     // Aggregates
     TOKstruct,
     TOKclass,
@@ -240,7 +242,7 @@ enum TOK : int
     TOKmanifest,
     TOKimmutable,
 
-    // 189
+    // 191
     // Statements
     TOKif,
     TOKelse,
@@ -267,7 +269,7 @@ enum TOK : int
     TOKon_scope_failure,
     TOKon_scope_success,
 
-    // 213
+    // 215
     // Contracts
     TOKinvariant,
 
@@ -279,7 +281,7 @@ enum TOK : int
     TOKref,
     TOKmacro,
 
-    // 219
+    // 221
     TOKparameters,
     TOKtraits,
     TOKoverloadset,
@@ -300,7 +302,7 @@ enum TOK : int
     TOKvector,
     TOKpound,
 
-    // 237
+    // 239
     TOKinterval,
     TOKvoidexp,
     TOKcantexp,
@@ -388,6 +390,8 @@ alias TOKushr = TOK.TOKushr;
 alias TOKushrass = TOK.TOKushrass;
 alias TOKcat = TOK.TOKcat;
 alias TOKcatass = TOK.TOKcatass;
+alias TOKcatelemass = TOK.TOKcatelemass;
+alias TOKcatdcharass = TOK.TOKcatdcharass;
 alias TOKadd = TOK.TOKadd;
 alias TOKmin = TOK.TOKmin;
 alias TOKaddass = TOK.TOKaddass;
@@ -768,6 +772,8 @@ extern (C++) struct Token
         TOKandass: "&=",
         TOKorass: "|=",
         TOKcatass: "~=",
+        TOKcatelemass: "~=",
+        TOKcatdcharass: "~=",
         TOKcat: "~",
         TOKcall: "call",
         TOKidentity: "is",

--- a/src/ddmd/tokens.h
+++ b/src/ddmd/tokens.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2017 by Digital Mars
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com
@@ -90,7 +90,7 @@ enum TOK
         TOKshl,         TOKshr,
         TOKshlass,      TOKshrass,
         TOKushr,        TOKushrass,
-        TOKcat,         TOKcatass,      // ~ ~=
+        TOKcat,         TOKcatass,      TOKcatelemass,  TOKcatdcharass,     // ~ ~=
         TOKadd,         TOKmin,         TOKaddass,      TOKminass,
         TOKmul,         TOKdiv,         TOKmod,
         TOKmulass,      TOKdivass,      TOKmodass,


### PR DESCRIPTION
This is a refactor, it makes the code significantly easier to follow, and exposed a couple harmless bugs in e2ir.d