### PR TITLE
Fix regression in condition statements caused by #5293

### DIFF
--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -7155,6 +7155,7 @@ extern (C++) final class CommaExp : BinExp
         if (ex2.op == TOKerror)
             return ex2;
         e2 = ex2;
+        type = e2.type;
         return this;
     }
 

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -986,6 +986,7 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     bool isBool(bool result);
+    Expression *toBoolean(Scope *sc);
     Expression *addDtorHook(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
And add `CommaExp::toBoolean` to C++ headers.

If a comma expression was converted to boolean, the expression type was not updated.  This was a cause of an ICE in gdc backend when using opCast.