### PR TITLE
fix 17868 - add pragma(crt_con-/destructor)

### DIFF
--- a/changelog/crt-constructor.dd
+++ b/changelog/crt-constructor.dd
@@ -1,0 +1,33 @@
+pragma(crt_constructor) and pragma(crt_destructor) were added
+
+This allows programs to run initialization code before or cleanup code after C
+main.
+
+In particular those pragmas can be used in $(TT -betterC) code as substitutes
+for $(LINK2 $(ROOT_DIR)spec/class.html#shared_static_constructors, `shared static this()`) and
+$(LINK2 $(ROOT_DIR)spec/class.html#shared_static_destructors, `shared static ~this()`).
+
+$(RED Note:) At the time of execution druntime is not initialized.
+
+$(RED Note:) The order in which constructors are executed is unspecified.
+
+---
+import core.stdc.stdio;
+
+pragma(crt_constructor)
+void init()
+{
+    puts("init");
+}
+
+pragma(crt_destructor)
+void fini()
+{
+    puts("fini");
+}
+
+extern(C) int main()
+{
+    puts("main");
+}
+---

--- a/src/ddmd/backend/melf.h
+++ b/src/ddmd/backend/melf.h
@@ -108,6 +108,9 @@ typedef struct
         #define SHT_REL          9          /* Relocations no addends */
         #define SHT_RESTYPE      10         /* Reserved section type*/
         #define SHT_DYNTAB       11         /* Dynamic linker symbol table */
+        #define SHT_INIT_ARRAY   14         /* Array of constructors */
+        #define SHT_FINI_ARRAY   15         /* Array of destructors */
+        #define SHT_PREINIT_ARRAY 16        /* Array of pre-constructors */
         #define SHT_GROUP        17         /* Section group (COMDAT) */
         #define SHT_SYMTAB_SHNDX 18         /* Extended section indices */
   Elf32_Word   sh_flags;               /* Section attribute flags */

--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -3048,6 +3048,12 @@ extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
             }
         }
+        else if (pd.ident == Id.crt_constructor || pd.ident == Id.crt_destructor)
+        {
+            if (pd.args && pd.args.dim != 0)
+                pd.error("takes no argument");
+            goto Ldecl;
+        }
         else if (global.params.ignoreUnsupportedPragmas)
         {
             if (global.params.verbose)

--- a/src/ddmd/id.d
+++ b/src/ddmd/id.d
@@ -298,6 +298,8 @@ immutable Msgtable[] msgtable =
     { "mangle" },
     { "msg" },
     { "startaddress" },
+    { "crt_constructor" },
+    { "crt_destructor" },
 
     // For special functions
     { "tohash", "toHash" },

--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -1115,7 +1115,41 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 Symbol *s = toSymbol(f);
                 obj_startaddress(s);
             }
+
             visit(cast(AttribDeclaration)pd);
+
+            if (pd.ident == Id.crt_constructor || pd.ident == Id.crt_destructor)
+            {
+                immutable isCtor = pd.ident == Id.crt_constructor;
+
+                static uint recurse(Dsymbol s, bool isCtor)
+                {
+                    if (auto ad = s.isAttribDeclaration())
+                    {
+                        uint nestedCount;
+                        auto decls = ad.include(null, null);
+                        if (decls)
+                        {
+                            for (size_t i = 0; i < decls.dim; ++i)
+                                nestedCount += recurse((*decls)[i], isCtor);
+                        }
+                        return nestedCount;
+                    }
+                    else if (auto f = s.isFuncDeclaration())
+                    {
+                        objmod.setModuleCtorDtor(s.csym, isCtor);
+                        if (f.linkage != LINKc)
+                            f.error("must be extern(C) for pragma %s", isCtor ? "crt_constructor".ptr : "crt_destructor".ptr);
+                        return 1;
+                    }
+                    else
+                        return 0;
+                    assert(0);
+                }
+
+                if (recurse(pd, isCtor) > 1)
+                    pd.error("can only apply to a single declaration");
+            }
         }
 
         override void visit(TemplateInstance ti)
@@ -1482,5 +1516,3 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass *b, ref FuncDeclarations bv
     }
     return id_vtbl_dim * Target.ptrsize;
 }
-
-

--- a/test/fail_compilation/test17868.d
+++ b/test/fail_compilation/test17868.d
@@ -1,0 +1,24 @@
+/*
+TEST_OUTPUT:
+----
+fail_compilation/test17868.d(10): Error: pragma crt_constructor takes no argument
+fail_compilation/test17868.d(11): Error: pragma crt_constructor takes no argument
+fail_compilation/test17868.d(12): Error: pragma crt_constructor takes no argument
+fail_compilation/test17868.d(13): Error: pragma crt_constructor takes no argument
+----
+ */
+pragma(crt_constructor, ctfe())
+pragma(crt_constructor, 1.5f)
+pragma(crt_constructor, "foobar")
+pragma(crt_constructor, S())
+void foo()
+{
+}
+
+int ctfe()
+{
+    __gshared int val;
+    return val;
+}
+
+struct S {}

--- a/test/fail_compilation/test17868b.d
+++ b/test/fail_compilation/test17868b.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+----
+fail_compilation/test17868b.d(10): Error: function test17868b.foo must be extern(C) for pragma crt_constructor
+fail_compilation/test17868b.d(14): Error: function test17868b.bar must be extern(C) for pragma crt_constructor
+fail_compilation/test17868b.d(9): Error: pragma crt_constructor can only apply to a single declaration
+----
+ */
+pragma(crt_constructor):
+void foo()
+{
+}
+
+void bar()
+{
+}

--- a/test/runnable/extra-files/test17868-postscript.sh
+++ b/test/runnable/extra-files/test17868-postscript.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# trim off the first line which contains the path of the file which differs between windows and non-windows
+# also trim off compiler debug message
+grep -v 'runnable\|DEBUG' $1 > ${RESULTS_DIR}/runnable/test17868.d.out.2
+
+diff --strip-trailing-cr runnable/extra-files/test17868.d.out ${RESULTS_DIR}/runnable/test17868.d.out.2
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
+rm ${RESULTS_DIR}/runnable/test17868.d.out.2

--- a/test/runnable/extra-files/test17868.d.out
+++ b/test/runnable/extra-files/test17868.d.out
@@ -1,0 +1,5 @@
+init
+init
+main
+fini
+fini

--- a/test/runnable/test17868.d
+++ b/test/runnable/test17868.d
@@ -1,0 +1,35 @@
+// REQUIRED_ARGS: -betterC
+// POST_SCRIPT: runnable/extra-files/test17868-postscript.sh
+import core.stdc.stdio;
+
+extern(C):
+
+pragma(crt_constructor)
+void init()
+{
+    puts("init");
+}
+
+pragma(crt_destructor)
+void fini2()
+{
+    puts("fini");
+}
+
+pragma(crt_constructor)
+void foo()
+{
+    puts("init");
+}
+
+pragma(crt_destructor)
+void bar()
+{
+    puts("fini");
+}
+
+int main()
+{
+    puts("main");
+    return 0;
+}

--- a/test/runnable/test17868b.d
+++ b/test/runnable/test17868b.d
@@ -1,0 +1,42 @@
+// REQUIRED_ARGS: -betterC
+// POST_SCRIPT: runnable/extra-files/test17868-postscript.sh
+import core.stdc.stdio;
+
+extern(C):
+
+pragma(crt_constructor)
+pragma(crt_destructor)
+void ctor_dtor_1()
+{
+    __gshared bool initialized;
+    puts(initialized ? "fini" : "init");
+    initialized = true;
+}
+
+pragma(crt_constructor)
+__gshared int var; // ignored for anything but functions
+
+pragma(crt_constructor)
+{
+    version (all) void init()
+    {
+        puts("init");
+    }
+}
+
+template fini()
+{
+    pragma(crt_destructor)
+    void fini()
+    {
+        puts("fini");
+    }
+}
+
+alias instantiate = fini!();
+
+int main()
+{
+    puts("main");
+    return 0;
+}


### PR DESCRIPTION
- allows to run con-/destructors before/after CRT startup/shutdown
- primary use-case is implementing modular startup in druntime itself

required for https://github.com/dlang/dmd/pull/6956