### PR TITLE
refactor isReturnIsolated()

### DIFF
--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -820,7 +820,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             /* Allow the result of strongly pure functions to
              * convert to immutable
              */
-            if (e.f && e.f.isolateReturn())
+            if (e.f && e.f.isReturnIsolated())
             {
                 result = e.type.immutableOf().implicitConvTo(t);
                 if (result > MATCH.constant) // Match level is MATCH.constant at best.

--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -1226,7 +1226,7 @@ extern(C++) final class Semantic3Visitor : Visitor
                             continue;
                         }
 
-                        if (!exp.implicitConvTo(tret) && funcdecl.parametersIntersectIndirect(exp.type))
+                        if (!exp.implicitConvTo(tret) && funcdecl.isTypeIsolated(exp.type))
                         {
                             if (exp.type.immutableOf().implicitConvTo(tret))
                                 exp = exp.castTo(sc2, exp.type.immutableOf());

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -2135,7 +2135,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         if (fd.isCtorDeclaration())
         {
             // For constructors, emitting return type is necessary for
-            // isolateReturn() in functionResolve.
+            // isReturnIsolated() in functionResolve.
             scx.flags |= SCOPEctor;
 
             Dsymbol parent = toParent2();
@@ -2396,10 +2396,10 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         if (isCtorCall)
         {
             //printf("%s tf.mod = x%x tthis_fd.mod = x%x %d\n", tf.toChars(),
-            //        tf.mod, tthis_fd.mod, fd.isolateReturn());
+            //        tf.mod, tthis_fd.mod, fd.isReturnIsolated());
             if (MODimplicitConv(tf.mod, tthis_fd.mod) ||
                 tf.isWild() && tf.isShared() == tthis_fd.isShared() ||
-                fd.isolateReturn())
+                fd.isReturnIsolated())
             {
                 /* && tf.isShared() == tthis_fd.isShared()*/
                 // Uniquely constructed object can ignore shared qualifier.
@@ -2664,7 +2664,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
                 assert(tf.next);
                 if (MODimplicitConv(tf.mod, tthis_fd.mod) ||
                     tf.isWild() && tf.isShared() == tthis_fd.isShared() ||
-                    fd.isolateReturn())
+                    fd.isReturnIsolated())
                 {
                     tthis_fd = null;
                 }

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -2207,13 +2207,13 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
     if (isCtorCall)
     {
         //printf("[%s] fd = %s %s, %d %d %d\n", loc.toChars(), fd.toChars(), fd.type.toChars(),
-        //    wildmatch, tf.isWild(), fd.isolateReturn());
+        //    wildmatch, tf.isWild(), fd.isReturnIsolated());
         if (!tthis)
         {
             assert(sc.intypeof || global.errors);
             tthis = fd.isThis().type.addMod(fd.type.mod);
         }
-        if (tf.isWild() && !fd.isolateReturn())
+        if (tf.isWild() && !fd.isReturnIsolated())
         {
             if (wildmatch)
                 tret = tret.substWildTo(wildmatch);


### PR DESCRIPTION
Do a refactoring of `isolatedReturn()` so the names and logic makes more sense. Inverted the boolean logic of `traverseIndirections()` so it was consistent with `isolatedReturn()`.