### PR TITLE
 fix issue 17619:  [REG2.072] Wrong debug line information with single line loops

### DIFF
--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -187,6 +187,7 @@ class Lexer
     __gshared OutBuffer stringbuffer;
 
     Loc scanloc;            // for error messages
+    Loc prevloc;            // location of token before current
 
     const(char)* base;      // pointer to start of buffer
     const(char)* end;       // pointer to last element of buffer
@@ -252,6 +253,7 @@ class Lexer
 
     final TOK nextToken()
     {
+        prevloc = token.loc;
         if (token.next)
         {
             Token* t = token.next;

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -5016,7 +5016,7 @@ final class Parser(AST) : Lexer
      * Input:
      *      flags   PSxxxx
      * Output:
-     *      pEndloc if { ... statements ... }, store location of closing brace, otherwise loc of first token of next statement
+     *      pEndloc if { ... statements ... }, store location of closing brace, otherwise loc of last token of statement
      */
     AST.Statement parseStatement(int flags, const(char)** endPtr = null, Loc* pEndloc = null)
     {
@@ -6015,7 +6015,7 @@ final class Parser(AST) : Lexer
             break;
         }
         if (pEndloc)
-            *pEndloc = token.loc;
+            *pEndloc = prevloc;
         return s;
     }
 

--- a/test/runnable/extra-files/test17619.d
+++ b/test/runnable/extra-files/test17619.d
@@ -1,0 +1,7 @@
+void foo()
+{
+    foreach (i; 0 .. 3)
+        i++;
+
+    int bad; // shown during loop
+}

--- a/test/runnable/test17619.sh
+++ b/test/runnable/test17619.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+src=runnable${SEP}extra-files
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/test17619.sh.out
+
+if [ ${OS} != "linux" ]; then
+    echo "Skipping test17619 on ${OS}."
+    touch ${output_file}
+    exit 0
+fi 
+
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}test17619${OBJ} -c ${src}${SEP}test17619.d || exit 1
+# error out if there is an advance by 0 for a non.zero address
+objdump -Wl ${RESULTS_DIR}/runnable/test17619${OBJ} | grep "advance Address by 0 to 0x[1-9]" && exit 1
+
+rm ${dir}/test17619${OBJ}
+
+echo Success >${output_file}


### PR DESCRIPTION
for statements without curly braces, default endloc to location of last token, not next token.