### PR TITLE
Fix up C++ headers

### DIFF
--- a/src/ddmd/attrib.h
+++ b/src/ddmd/attrib.h
@@ -24,6 +24,7 @@ class LabelDsymbol;
 class Initializer;
 class Module;
 class Condition;
+class StaticForeach;
 
 /**************************************************************/
 
@@ -65,6 +66,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
+    void addMember(Scope *sc, ScopeDsymbol *sds);
     StorageClassDeclaration *isStorageClassDeclaration() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
@@ -199,12 +201,16 @@ public:
 class StaticForeachDeclaration : public ConditionalDeclaration
 {
 public:
+    StaticForeach *sfe;
     ScopeDsymbol *scopesym;
-    bool addisdone;
+    bool cached;
+    Dsymbols *cache;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
+    bool oneMember(Dsymbol *ps, Identifier *ident);
     Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     void addMember(Scope *sc, ScopeDsymbol *sds);
+    void addComment(const char *comment);
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     void semantic(Scope *sc);
@@ -212,14 +218,14 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class ForwardingAttribDeclaration: AttribDeclaration
+class ForwardingAttribDeclaration : AttribDeclaration
 {
 public:
-        ForwardingScopeDsymbol *sym;
+    ForwardingScopeDsymbol *sym;
 
-        Scope* newScope(Scope *sc);
-        void addMember(Scope *sc, ScopeDsymbol *sds);
-        ForwardingAttribDeclaration *isForwardingAttribDeclaration() { return this; }
+    Scope *newScope(Scope *sc);
+    void addMember(Scope *sc, ScopeDsymbol *sds);
+    ForwardingAttribDeclaration *isForwardingAttribDeclaration() { return this; }
 };
 
 // Mixin declarations

--- a/src/ddmd/cond.h
+++ b/src/ddmd/cond.h
@@ -52,7 +52,7 @@ public:
 
     bool needExpansion;
 
-    Condition *syntaxCopy();
+    StaticForeach *syntaxCopy();
 };
 
 class DVCondition : public Condition

--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -94,12 +94,14 @@ enum PINLINE;
 #define STCexptemp       0x800000000000LL // temporary variable that has lifetime restricted to an expression
 #define STCmaybescope    0x1000000000000LL // parameter might be 'scope'
 #define STCscopeinferred 0x2000000000000LL // 'scope' has been inferred and should not be part of mangling
+#define STCfuture        0x4000000000000LL // introducing new base class function
+#define STClocal         0x8000000000000LL // do not forward (see ddmd.dsymbol.ForwardingScopeDsymbol).
 
 const StorageClass STCStorageClass = (STCauto | STCscope | STCstatic | STCextern | STCconst | STCfinal |
-    STCabstract | STCsynchronized | STCdeprecated | STCoverride | STClazy | STCalias |
+    STCabstract | STCsynchronized | STCdeprecated | STCfuture | STCoverride | STClazy | STCalias |
     STCout | STCin |
     STCmanifest | STCimmutable | STCshared | STCwild | STCnothrow | STCnogc | STCpure | STCref | STCtls |
-    STCgshared | STCproperty | STCsafe | STCtrusted | STCsystem | STCdisable);
+    STCgshared | STCproperty | STCsafe | STCtrusted | STCsystem | STCdisable | STClocal);
 
 struct Match
 {
@@ -158,6 +160,8 @@ public:
     bool isIn()    { return (storage_class & STCin) != 0; }
     bool isOut()   { return (storage_class & STCout) != 0; }
     bool isRef()   { return (storage_class & STCref) != 0; }
+
+    bool isFuture() { return (storage_class & STCfuture) != 0; }
 
     Prot prot();
 

--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -320,6 +320,7 @@ public:
     static Dsymbol *getNth(Dsymbols *members, size_t nth, size_t *pn = NULL);
 
     ScopeDsymbol *isScopeDsymbol() { return this; }
+    void semantic(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/ddmd/expression.h
+++ b/src/ddmd/expression.h
@@ -905,6 +905,7 @@ public:
     VarDeclaration *lengthVar;
     bool upperIsInBounds;       // true if upr <= e1.length
     bool lowerIsLessThanUpper;  // true if lwr <= upr
+    bool arrayop;               // an array operation, rather than a slice
 
     Expression *syntaxCopy();
     int checkModifiable(Scope *sc, int flag);

--- a/src/ddmd/init.h
+++ b/src/ddmd/init.h
@@ -108,7 +108,7 @@ public:
 
     Initializer *syntaxCopy();
 
-    virtual ExpInitializer *isExpInitializer() { return this; }
+    ExpInitializer *isExpInitializer() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/ddmd/scope.h
+++ b/src/ddmd/scope.h
@@ -153,6 +153,7 @@ struct Scope
     Dsymbol *search(Loc loc, Identifier *ident, Dsymbol **pscopesym, int flags = IgnoreNone);
     static void deprecation10378(Loc loc, Dsymbol *sold, Dsymbol *snew);
     Dsymbol *search_correct(Identifier *ident);
+    static const char *search_correct_C(Identifier *ident);
     Dsymbol *insert(Dsymbol *s);
 
     ClassDeclaration *getClassScope();

--- a/src/ddmd/statement.h
+++ b/src/ddmd/statement.h
@@ -225,9 +225,16 @@ public:
 
 class ForwardingStatement : public Statement
 {
-    Statement *statement;
     ForwardingScopeDsymbol *sym;
+    Statement *statement;
 
+    Statement *syntaxCopy();
+    Statement *getRelatedLabeled();
+    bool hasBreak();
+    bool hasContinue();
+    Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexception, Statement **sfinally);
+    Statement *last();
+    Statements *flatten(Scope *sc);
     ForwardingStatement *isForwardingStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/ddmd/visitor.h
+++ b/src/ddmd/visitor.h
@@ -393,8 +393,8 @@ public:
     virtual void visit(PragmaDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ConditionalDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(StaticIfDeclaration *s) { visit((ConditionalDeclaration *)s); }
-    virtual void visit(CompileDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(StaticForeachDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(CompileDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(UserAttributeDeclaration *s) { visit((AttribDeclaration *)s); }
 
     virtual void visit(ScopeDsymbol *s) { visit((Dsymbol *)s); }


### PR DESCRIPTION
Resulting from upgrading LDC to v2.076.0. I only checked the diffs from 2.075.1 which are relevant for LDC (i.e., only a subset of the .d files); that was very tedious already, and I cannot guarantee that I caught all
spots where the D implementation and the C++ headers diverged.

Pinging @ibuclaw.