### PR TITLE
use 0x8B instead of 0x89 so it isn't optimized away

### DIFF
--- a/src/ddmd/backend/cgxmm.c
+++ b/src/ddmd/backend/cgxmm.c
@@ -404,7 +404,8 @@ void xmmcnvt(CodeBuilder& cdb,elem *e,regm_t *pretregs)
     else if (zx)
     {   assert(I64);
         getregs(cdb,regs);
-        genregs(cdb,STO,reg,reg); // MOV reg,reg to zero upper 32-bit
+        genregs(cdb,0x8B,reg,reg); // MOV reg,reg to zero upper 32-bit
+                                   // Don't use x89 because that will get optimized away
         code_orflag(cdb.last(),CFvolatile);
     }
 

--- a/src/ddmd/backend/cod4.c
+++ b/src/ddmd/backend/cod4.c
@@ -2884,7 +2884,8 @@ void cdshtlng(CodeBuilder& cdb,elem *e,regm_t *pretregs)
                 // Zero high 32 bits
                 getregs(cdb,retregs);
                 reg = findreg(retregs);
-                genregs(cdb,0x89,reg,reg);  // MOV Ereg,Ereg
+                // Don't use x89 because that will get optimized away
+                genregs(cdb,0x8B,reg,reg);  // MOV Ereg,Ereg
             }
         }
         fixresult(cdb,e,retregs,pretregs);


### PR DESCRIPTION
@rainers discovered this. No known test case. The peephole optimizer removes `MOV reg,reg` when the 0x89 op is used.