### PR TITLE
Refactor cgelem.c: split elmemxxx() into 3 functions

### DIFF
--- a/src/ddmd/backend/optabgen.c
+++ b/src/ddmd/backend/optabgen.c
@@ -450,11 +450,11 @@ void dotab()
         case OPrndtol:  X("rndtol",     evalu8, cdrndtol);
         case OPstrlen:  X("strlen",     elzot,  cdstrlen);
         case OPstrcpy:  X("strcpy",     elstrcpy,cdstrcpy);
-        case OPmemcpy:  X("memcpy",     elmemxxx,cdmemcpy);
-        case OPmemset:  X("memset",     elmemxxx,cdmemset);
+        case OPmemcpy:  X("memcpy",     elmemcpy,cdmemcpy);
+        case OPmemset:  X("memset",     elmemset,cdmemset);
         case OPstrcat:  X("strcat",     elzot,  cderr);
         case OPstrcmp:  X("strcmp",     elstrcmp,cdstrcmp);
-        case OPmemcmp:  X("memcmp",     elmemxxx,cdmemcmp);
+        case OPmemcmp:  X("memcmp",     elmemcmp,cdmemcmp);
         case OPsetjmp:  X("setjmp",     elzot,  cdsetjmp);
         case OPnegass:  X("negass",     elnegass, cdaddass);
         case OPpreinc:  X("U++",        elzot,  cderr);


### PR DESCRIPTION
This is a simple cut&paste refactor job. There is hardly any overlap in what these functions do, they should never have been combined into one.