### PR TITLE
[Trivial] test/runnable/testpdb: Fix compile error on Win32

### DIFF
--- a/test/runnable/testpdb.d
+++ b/test/runnable/testpdb.d
@@ -792,7 +792,7 @@ Line[] findSymbolLineNumbers(IDiaSession session, IDiaSymbol sym, ubyte[]* funcR
     scope(exit) dialines.Release();
 
     ubyte* rvabase = &__ImageBase;
-    *funcRange = rvabase[rva .. rva+length];
+    *funcRange = rvabase[rva .. rva + cast(size_t)length];
 
     Line[] lines;
     IDiaLineNumber line;


### PR DESCRIPTION
`length` is a 64-bit integer.

Pinging @rainers.