### PR TITLE
Fix Issue 17684 - [REG 2.062] static alias this (Part 4)

### DIFF
--- a/src/ddmd/initsem.d
+++ b/src/ddmd/initsem.d
@@ -10,9 +10,11 @@
 
 module ddmd.initsem;
 
+import core.stdc.stdio;
 import core.checkedint;
 
 import ddmd.aggregate;
+import ddmd.aliasthis;
 import ddmd.arraytypes;
 import ddmd.dcast;
 import ddmd.declaration;
@@ -600,6 +602,11 @@ private extern(C++) final class InferTypeVisitor : Visitor
     {
         //printf("ExpInitializer::inferType() %s\n", toChars());
         init.exp = init.exp.semantic(sc);
+
+        // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
+        if (init.exp.op == TOKtype)
+            init.exp = resolveAliasThis(sc, init.exp);
+
         init.exp = resolveProperties(sc, init.exp);
         if (init.exp.op == TOKscope)
         {

--- a/test/runnable/test17684.d
+++ b/test/runnable/test17684.d
@@ -74,6 +74,10 @@ bool boolTest(T)()
     assert(t == boolValue);
     assert(boolValue == t);
 
+    t = true;                     // tests inferType
+    auto inferredValue = t;
+    assert(inferredValue == true);
+
     t = true;
     return t;                     // tests ReturnStatement
 }


### PR DESCRIPTION
Followup to https://github.com/dlang/dmd/pull/7055, https://github.com/dlang/dmd/pull/7070, and https://github.com/dlang/dmd/pull/7106

Fixes expressions like `auto value = T` where `T` is an aggregate with a `static alias this`ed property.