### PR TITLE
fix Issue 16013 - [REG2.072a] ICE with mutually dependent structs and…

### DIFF
--- a/test/compilable/test16013a.d
+++ b/test/compilable/test16013a.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=16013
+
+struct Impl { S _payload; } /* Only this line has changed from above. */
+
+struct RefCounted
+{
+    void opAssign(RefCounted rhs) {}
+    void opAssign(S rhs) {}
+    S refCountedPayload() { return S.init; }
+    alias refCountedPayload this;
+}
+
+struct S { RefCounted s; }

--- a/test/compilable/test16013b.d
+++ b/test/compilable/test16013b.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=16013
+
+S s; /* Only this line has changed from above. */
+
+struct RefCounted
+{
+    void opAssign(RefCounted rhs) {}
+    void opAssign(S rhs) {}
+    S refCountedPayload() { return S.init; }
+    alias refCountedPayload this;
+}
+
+struct S { RefCounted s; }


### PR DESCRIPTION
… alias this

This just adds the test cases from the bug report to make sure it is working now.