### PR TITLE
fix Issue 16273 - [REG 2.072a] dmd segfault with inheritance, templat…

### DIFF
--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -12,6 +12,7 @@ module ddmd.dclass;
 
 // Online documentation: https://dlang.org/phobos/ddmd_dclass.html
 
+import core.stdc.stdio;
 import core.stdc.string;
 
 import ddmd.aggregate;
@@ -827,8 +828,20 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      */
     final bool isAbstract()
     {
+        enum log = false;
         if (isabstract != ABSfwdref)
             return isabstract == ABSyes;
+
+        if (log) printf("isAbstract(%s)\n", toChars());
+
+        bool no()  { if (log) printf("no\n");  isabstract = ABSno;  return false; }
+        bool yes() { if (log) printf("yes\n"); isabstract = ABSyes; return true;  }
+
+        if (storage_class & STCabstract || _scope && _scope.stc & STCabstract)
+            return yes();
+
+        if (errors)
+            return no();
 
         /* https://issues.dlang.org/show_bug.cgi?id=11169
          * Resolve forward references to all class member functions,
@@ -842,9 +855,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             if (fd.storage_class & STCstatic)
                 return 0;
 
-            if (fd._scope)
-                fd.semantic(null);
-
             if (fd.isAbstract())
                 return 1;
             return 0;
@@ -855,26 +865,59 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             auto s = (*members)[i];
             if (s.apply(&func, cast(void*)this))
             {
-                isabstract = ABSyes;
-                return true;
+                return yes();
             }
         }
 
-        /* Iterate inherited member functions and check their abstract attribute.
+        /* If the base class is not abstract, then this class cannot
+         * be abstract.
          */
-        for (size_t i = 1; i < vtbl.dim; i++)
+        if (!baseClass || !baseClass.isAbstract())
+            return no();
+
+        /* If any abstract functions are inherited, but not overridden,
+         * then the class is abstract. Do this by checking the vtbl[].
+         * Need to do semantic() on class to fill the vtbl[].
+         */
+        this.semantic(null);
+
+        /* The next line should work, but does not because when ClassDeclaration.semantic()
+         * is called recursively it can set PASSsemanticdone without finishing it.
+         */
+        //if (semanticRun < PASSsemanticdone)
+        {
+            /* Could not complete semantic(). Try running semantic() on
+             * each of the virtual functions,
+             * which will fill in the vtbl[] overrides.
+             */
+            extern (C++) static int virtualSemantic(Dsymbol s, void* param)
+            {
+                auto fd = s.isFuncDeclaration();
+                if (fd && !(fd.storage_class & STCstatic))
+                    fd.semantic(null);
+                return 0;
+            }
+
+            for (size_t i = 0; i < members.dim; i++)
+            {
+                auto s = (*members)[i];
+                s.apply(&virtualSemantic, cast(void*)this);
+            }
+        }
+
+        /* Finally, check the vtbl[]
+         */
+        foreach (i; 1 .. vtbl.dim)
         {
             auto fd = vtbl[i].isFuncDeclaration();
-            //if (fd) printf("\tvtbl[%d] = [%s] %s\n", i, fd.loc.toChars(), fd.toChars());
+            //if (fd) printf("\tvtbl[%d] = [%s] %s\n", i, fd.loc.toChars(), fd.toPrettyChars());
             if (!fd || fd.isAbstract())
             {
-                isabstract = ABSyes;
-                return true;
+                return yes();
             }
         }
 
-        isabstract = ABSno;
-        return false;
+        return no();
     }
 
     /****************************************

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -265,7 +265,7 @@ extern (C++) abstract class Declaration : Dsymbol
         return (storage_class & STCfinal) != 0;
     }
 
-    final bool isAbstract()
+    bool isAbstract()
     {
         return (storage_class & STCabstract) != 0;
     }

--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -141,7 +141,7 @@ public:
     virtual bool isCodeseg();
     bool isCtorinit()     { return (storage_class & STCctorinit) != 0; }
     bool isFinal()        { return (storage_class & STCfinal) != 0; }
-    bool isAbstract()     { return (storage_class & STCabstract) != 0; }
+    virtual bool isAbstract()     { return (storage_class & STCabstract) != 0; }
     bool isConst()        { return (storage_class & STCconst) != 0; }
     bool isImmutable()    { return (storage_class & STCimmutable) != 0; }
     bool isWild()         { return (storage_class & STCwild) != 0; }
@@ -596,6 +596,7 @@ public:
     bool isImportedSymbol();
     bool isCodeseg();
     bool isOverloadable();
+    bool isAbstract();
     PURE isPure();
     PURE isPureBypassingInference();
     bool setImpure();

--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -1087,6 +1087,7 @@ extern (C++) final class ExpressionSemanticVisitor : Visitor
                 result = new ErrorExp();
                 return;
             }
+
             if (cd.isAbstract())
             {
                 exp.error("cannot create instance of abstract class %s", cd.toChars());

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -1108,6 +1108,29 @@ extern (C++) class FuncDeclaration : Declaration
         return true; // functions can be overloaded
     }
 
+    /***********************************
+     * Override so it can work even if semantic() hasn't yet
+     * been run.
+     */
+    override final bool isAbstract()
+    {
+        if (storage_class & STCabstract)
+            return true;
+        if (semanticRun >= PASSsemanticdone)
+            return false;
+
+        if (_scope)
+        {
+           if (_scope.stc & STCabstract)
+                return true;
+           parent = _scope.parent;
+           Dsymbol parent = toParent();
+           if (parent.isInterfaceDeclaration())
+                return true;
+        }
+        return false;
+    }
+
     /**********************************
      * Decide if attributes for this function can be inferred from examining
      * the function body.

--- a/test/compilable/test16273.d
+++ b/test/compilable/test16273.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=16273
+
+class A()
+{
+    alias MyD = D!();
+}
+
+class B
+{
+    void f() {}
+    alias MyA = A!();
+}
+
+class C : B
+{
+    override void f() {}
+}
+
+class D() : A!()
+{
+    void g() { new C; }
+}


### PR DESCRIPTION
…es, override

Fixes https://github.com/dlang/dmd/pull/5695 and replaces https://github.com/dlang/dmd/pull/6659

The fix here is to move just enough of `semantic()` into `isAbstract()` to answer the question.