### PR TITLE
Fix Issue 17307 - [REG2.072.0][ICE] TypeBasic::implicitConvTo

### DIFF
--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -55,6 +55,9 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     Dsymbols* include(Scope* sc, ScopeDsymbol sds)
     {
+        if (errors)
+            return null;
+
         return decl;
     }
 
@@ -802,6 +805,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
         if (!ad)
         {
             .error(loc, "%s can only be a part of an aggregate, not %s `%s`", kind(), p.kind(), p.toChars());
+            errors = true;
             return;
         }
 
@@ -1241,6 +1245,10 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
     override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
     {
         //printf("ConditionalDeclaration::include(sc = %p) scope = %p\n", sc, scope);
+
+        if (errors)
+            return null;
+
         assert(condition);
         return condition.include(_scope ? _scope : sc, sds) ? decl : elsedecl;
     }
@@ -1317,6 +1325,10 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
     override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
     {
         //printf("StaticIfDeclaration::include(sc = %p) scope = %p\n", sc, scope);
+
+        if (errors)
+            return null;
+
         if (condition.inc == 0)
         {
             assert(scopesym); // addMember is already done
@@ -1442,6 +1454,9 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
 
     override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
     {
+        if (errors)
+            return null;
+
         if (cached)
         {
             return cache;

--- a/test/fail_compilation/test17307.d
+++ b/test/fail_compilation/test17307.d
@@ -1,0 +1,12 @@
+/* 
+TEST_OUTPUT:
+---
+fail_compilation/test17307.d(9): Error: anonymous struct can only be a part of an aggregate, not module `test17307`
+---
+ * https://issues.dlang.org/show_bug.cgi?id=17307
+ */
+
+struct { enum bitsPerWord = size_t; }
+
+void main()
+{ }


### PR DESCRIPTION
This fixes the ICE, but there may still be an underlying problem with the semantics.

Output for...
```
struct { enum bitsPerWord = size_t; }

void main()
{ }
```
... is now...
```
main.d(1): Error: anonymous struct can only be a part of an aggregate, not module main
main.d(1): Error: cannot interpret ulong at compile time
```
I'd be happy to add a test case, but I first need confirmation that that is the expected output.