### PR TITLE
fix issue 17853 - Switch statement without braces only works with one case

### DIFF
--- a/src/ddmd/lexer.d
+++ b/src/ddmd/lexer.d
@@ -262,7 +262,7 @@ class Lexer
         {
             scan(&token);
         }
-        //token.print();
+        //printf(token.toChars());
         return token.value;
     }
 

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -5672,7 +5672,9 @@ final class Parser(AST) : Lexer
                     s = new AST.CompoundStatement(loc, statements);
                 }
                 else
-                    s = parseStatement(PSsemi | PScurlyscope);
+                {
+                    s = parseStatement(PSsemi);
+                }
                 s = new AST.ScopeStatement(loc, s, token.loc);
 
                 if (last)
@@ -5705,7 +5707,7 @@ final class Parser(AST) : Lexer
                     s = new AST.CompoundStatement(loc, statements);
                 }
                 else
-                    s = parseStatement(PSsemi | PScurlyscope);
+                    s = parseStatement(PSsemi);
                 s = new AST.ScopeStatement(loc, s, token.loc);
                 s = new AST.DefaultStatement(loc, s);
                 break;

--- a/test/compilable/test17853.d
+++ b/test/compilable/test17853.d
@@ -1,0 +1,11 @@
+// Switch with no braces & empty case should compile
+
+int main() {
+	int ob = 1;
+
+    final switch (ob)
+    case 0: case 1:
+        break;
+
+    return ob;
+}


### PR DESCRIPTION
Passing ```PScurlyscope``` made the parser think there was a ```{ }``` block there.