### PR TITLE
refactor: make ExpressionSemanticVisitor private

### DIFF
--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -66,7 +66,7 @@ import ddmd.visitor;
 
 enum LOGSEMANTIC = false;
 
-extern (C++) final class ExpressionSemanticVisitor : Visitor
+private extern (C++) final class ExpressionSemanticVisitor : Visitor
 {
     alias visit = super.visit;
 
@@ -8215,6 +8215,14 @@ Expression binSemanticProp(BinExp e, Scope* sc)
     e.e1 = e1x;
     e.e2 = e2x;
     return null;
+}
+
+// entrypoint for semantic ExpressionSemanticVisitor
+extern (C++) Expression expressionSemantic(Expression e, Scope* sc)
+{
+    scope v = new ExpressionSemanticVisitor(sc);
+    e.accept(v);
+    return v.result;
 }
 
 Expression semanticX(DotIdExp exp, Scope* sc)

--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -24,7 +24,6 @@ import ddmd.statement;
 
 import ddmd.initsem;
 import ddmd.dsymbolsem;
-import ddmd.expressionsem;
 import ddmd.statementsem;
 import ddmd.templateparamsem;
 import ddmd.typesem;
@@ -38,12 +37,10 @@ extern(C++) void semantic(Dsymbol dsym, Scope* sc)
     dsym.accept(v);
 }
 
-// entrypoint for semantic ExpressionSemanticVisitor
 extern(C++) Expression semantic(Expression e, Scope* sc)
 {
-    scope v = new ExpressionSemanticVisitor(sc);
-    e.accept(v);
-    return v.result;
+    import ddmd.expressionsem;
+    return expressionSemantic(e, sc);
 }
 
 /******************************************


### PR DESCRIPTION
Makes a huge chunk of code private.

Also, now that `semantic` is no longer a virtual function, there is entirely too much overloading of the name going on. This is a start at fixing that.