### PR TITLE
refactor: make InitializerSemanticVisitor private

### DIFF
--- a/src/ddmd/initsem.d
+++ b/src/ddmd/initsem.d
@@ -66,11 +66,29 @@ extern (C++) Expression initializerToExpression(Initializer init, Type t = null)
     return v.result;
 }
 
+/******************************************
+ * Perform semantic analysis on init.
+ * Params:
+ *      init = Initializer AST node
+ *      sc = context
+ *      t = type that the initializer needs to become
+ *      needInterpret = if CTFE needs to be run on this,
+ *                      such as if it is the initializer for a const declaration
+ * Returns:
+ *      `Initializer` with completed semantic analysis, `ErrorInitializer` if errors
+ *      were encountered
+ */
+extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t, NeedInterpret needInterpret)
+{
+    scope v = new InitializerSemanticVisitor(sc, t, needInterpret);
+    init.accept(v);
+    return v.result;
+}
 
 /* ****************************** Implementation ************************ */
 
 
-extern(C++) final class InitializerSemanticVisitor : Visitor
+private extern(C++) final class InitializerSemanticVisitor : Visitor
 {
     alias visit = super.visit;
 

--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -22,7 +22,6 @@ import ddmd.init;
 import ddmd.mtype;
 import ddmd.statement;
 
-import ddmd.initsem;
 import ddmd.dsymbolsem;
 import ddmd.statementsem;
 import ddmd.templateparamsem;
@@ -50,9 +49,8 @@ extern(C++) void semantic(Dsymbol dsym, Scope* sc)
  */
 extern(C++) Initializer semantic(Initializer init, Scope* sc, Type t, NeedInterpret needInterpret)
 {
-    scope v = new InitializerSemanticVisitor(sc, t, needInterpret);
-    init.accept(v);
-    return v.result;
+    import ddmd.initsem;
+    return initializerSemantic(init, sc, t, needInterpret);
 }
 
 // Performs semantic analysis in Statement AST nodes


### PR DESCRIPTION
Makes a huge chunk of code private.

Also, now that `semantic` is no longer a virtual function, there is entirely too much overloading of the name going on. This is a start at fixing that.