### PR TITLE
refactor: make DsymbolSemanticVisitor private

### DIFF
--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -69,6 +69,15 @@ import ddmd.visitor;
 
 enum LOG = false;
 
+/*************************************
+ * Does semantic analysis on the public face of declarations.
+ */
+extern(C++) void dsymbolSemantic(Dsymbol dsym, Scope* sc)
+{
+    scope v = new DsymbolSemanticVisitor(sc);
+    dsym.accept(v);
+}
+
 extern(C++) final class Semantic2Visitor : Visitor
 {
     alias visit = super.visit;
@@ -1785,7 +1794,7 @@ extern(C++) final class Semantic3Visitor : Visitor
     }
 }
 
-extern(C++) final class DsymbolSemanticVisitor : Visitor
+private extern(C++) final class DsymbolSemanticVisitor : Visitor
 {
     alias visit = super.visit;
 

--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -34,8 +34,7 @@ import ddmd.typesem;
  */
 extern(C++) void semantic(Dsymbol dsym, Scope* sc)
 {
-    scope v = new DsymbolSemanticVisitor(sc);
-    dsym.accept(v);
+    dsymbolSemantic(dsym, sc);
 }
 
 // entrypoint for semantic ExpressionSemanticVisitor


### PR DESCRIPTION
Makes a huge chunk of code private.

Also, now that semantic is no longer a virtual function, there is entirely too much overloading of the name going on. This is a start at fixing that.