### PR TITLE
refactor: make StatementSemanticVisitor private

### DIFF
--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -65,12 +65,10 @@ extern(C++) Initializer semantic(Initializer init, Scope* sc, Type t, NeedInterp
     return v.result;
 }
 
-// Performs semantic analisys in Statement AST nodes
+// Performs semantic analysis in Statement AST nodes
 extern(C++) Statement semantic(Statement s, Scope* sc)
 {
-    scope v = new StatementSemanticVisitor(sc);
-    s.accept(v);
-    return v.result;
+    return statementSemantic(s, sc);
 }
 
 /******************************************

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -51,7 +51,15 @@ import ddmd.tokens;
 import ddmd.semantic;
 import ddmd.visitor;
 
-extern (C++) final class StatementSemanticVisitor : Visitor
+// Performs semantic analysis in Statement AST nodes
+extern(C++) Statement statementSemantic(Statement s, Scope* sc)
+{
+    scope v = new StatementSemanticVisitor(sc);
+    s.accept(v);
+    return v.result;
+}
+
+private extern (C++) final class StatementSemanticVisitor : Visitor
 {
     alias visit = super.visit;
 


### PR DESCRIPTION
Makes a huge chunk of code private.

Also, now that semantic is no longer a virtual function, there is entirely too much overloading of the name going on. This is a start at fixing that.