### PR TITLE
refactor: make TypeSemanticVisitor private

### DIFF
--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -85,9 +85,7 @@ extern(C++) Statement semantic(Statement s, Scope* sc)
  */
 extern(C++) Type semantic(Type t, Loc loc, Scope* sc)
 {
-    scope v = new TypeSemanticVisitor(loc, sc);
-    t.accept(v);
-    return  v.result;
+    return typeSemantic(t, loc, sc);
 }
 
 

--- a/src/ddmd/typesem.d
+++ b/src/ddmd/typesem.d
@@ -42,6 +42,23 @@ import ddmd.semantic;
 import ddmd.target;
 import ddmd.tokens;
 
+/******************************************
+ * Perform semantic analysis on a type.
+ * Params:
+ *      t = Type AST node
+ *      loc = the location of the type
+ *      sc = context
+ * Returns:
+ *      `Type` with completed semantic analysis, `Terror` if errors
+ *      were encountered
+ */
+extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
+{
+    scope v = new TypeSemanticVisitor(loc, sc);
+    t.accept(v);
+    return  v.result;
+}
+
 private extern (C++) final class TypeToExpressionVisitor : Visitor
 {
     alias visit = super.visit;
@@ -148,7 +165,7 @@ extern (C++) Expression typeToExpressionHelper(TypeQualified t, Expression e, si
     return e;
 }
 
-extern (C++) final class TypeSemanticVisitor : Visitor
+private extern (C++) final class TypeSemanticVisitor : Visitor
 {
     alias visit = super.visit;
     Loc loc;


### PR DESCRIPTION
Makes a huge chunk of code private.

Also, now that semantic is no longer a virtual function, there is entirely too much overloading of the name going on. This is a start at fixing that.