### PR TITLE
switch to expressionSemantic() from semantic()

### DIFF
--- a/src/ddmd/aliasthis.d
+++ b/src/ddmd/aliasthis.d
@@ -17,6 +17,7 @@ import ddmd.aggregate;
 import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.globals;
 import ddmd.identifier;
 import ddmd.mtype;
@@ -70,7 +71,7 @@ extern (C++) Expression resolveAliasThis(Scope* sc, Expression e, bool gag = fal
         Loc loc = e.loc;
         Type tthis = (e.op == TOKtype ? e.type : null);
         e = new DotIdExp(loc, e, ad.aliasthis.ident);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         if (tthis && ad.aliasthis.needThis())
         {
             if (e.op == TOKvar)
@@ -102,7 +103,7 @@ extern (C++) Expression resolveAliasThis(Scope* sc, Expression e, bool gag = fal
             }
         L1:
             e = new TypeExp(loc, new TypeTypeof(loc, e));
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         }
         e = resolveProperties(sc, e);
         if (gag && global.endGagging(olderrors))

--- a/src/ddmd/arrayop.d
+++ b/src/ddmd/arrayop.d
@@ -18,6 +18,7 @@ import ddmd.declaration;
 import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.id;
@@ -134,7 +135,7 @@ extern (C++) Expression arrayOp(BinExp e, Scope* sc)
         Expression id = new IdentifierExp(e.loc, Id.empty);
         id = new DotIdExp(e.loc, id, Id.object);
         id = new DotIdExp(e.loc, id, Identifier.idPool("_arrayOp"));
-        id = id.semantic(sc);
+        id = id.expressionSemantic(sc);
         if (id.op != TOKtemplate)
             ObjectNotFound(Identifier.idPool("_arrayOp"));
         arrayOp = (cast(TemplateExp)id).td;
@@ -143,7 +144,7 @@ extern (C++) Expression arrayOp(BinExp e, Scope* sc)
     auto fd = resolveFuncCall(e.loc, sc, arrayOp, tiargs, null, args);
     if (!fd || fd.errors)
         return new ErrorExp();
-    return new CallExp(e.loc, new VarExp(e.loc, fd, false), args).semantic(sc);
+    return new CallExp(e.loc, new VarExp(e.loc, fd, false), args).expressionSemantic(sc);
 }
 
 /// ditto
@@ -220,7 +221,7 @@ extern (C++) void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Express
                 buf.writestring("u");
                 buf.writestring(Token.toString(e.op));
                 e.e1.accept(this);
-                tiargs.push(new StringExp(Loc(), buf.extractString()).semantic(sc));
+                tiargs.push(new StringExp(Loc(), buf.extractString()).expressionSemantic(sc));
             }
         }
 
@@ -236,7 +237,7 @@ extern (C++) void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Express
                 // RPN
                 e.e1.accept(this);
                 e.e2.accept(this);
-                tiargs.push(new StringExp(Loc(), cast(char*) Token.toChars(e.op)).semantic(sc));
+                tiargs.push(new StringExp(Loc(), cast(char*) Token.toChars(e.op)).expressionSemantic(sc));
             }
         }
     }

--- a/src/ddmd/clone.d
+++ b/src/ddmd/clone.d
@@ -21,6 +21,7 @@ import ddmd.dstruct;
 import ddmd.dsymbol;
 import ddmd.dtemplate;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.id;
@@ -501,7 +502,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
         Expression e = new IdentifierExp(sd.loc, Id.empty);
         e = new DotIdExp(sd.loc, e, Id.object);
         e = new DotIdExp(sd.loc, e, id);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         Dsymbol s = getDsymbol(e);
         assert(s);
         sd.xerreq = s.isFuncDeclaration();
@@ -621,7 +622,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
         Expression e = new IdentifierExp(sd.loc, Id.empty);
         e = new DotIdExp(sd.loc, e, Id.object);
         e = new DotIdExp(sd.loc, e, id);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         Dsymbol s = getDsymbol(e);
         assert(s);
         sd.xerrcmp = s.isFuncDeclaration();

--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -19,6 +19,7 @@ import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.globals;
 import ddmd.identifier;
 import ddmd.mtype;
@@ -134,7 +135,7 @@ extern (C++) final class StaticForeach : RootObject
         auto aggr = aggrfe.aggr;
         Expression el = new ArrayLengthExp(aggr.loc, aggr);
         sc = sc.startCTFE();
-        el = el.semantic(sc);
+        el = el.expressionSemantic(sc);
         sc = sc.endCTFE();
         el = el.optimize(WANTvalue);
         el = el.ctfeInterpret();
@@ -149,7 +150,7 @@ extern (C++) final class StaticForeach : RootObject
                 es.push(value);
             }
             aggrfe.aggr = new TupleExp(aggr.loc, es);
-            aggrfe.aggr = aggrfe.aggr.semantic(sc);
+            aggrfe.aggr = aggrfe.aggr.expressionSemantic(sc);
             aggrfe.aggr = aggrfe.aggr.optimize(WANTvalue);
         }
         else
@@ -326,9 +327,9 @@ extern (C++) final class StaticForeach : RootObject
         if (rangefe)
         {
             sc = sc.startCTFE();
-            rangefe.lwr = rangefe.lwr.semantic(sc);
+            rangefe.lwr = rangefe.lwr.expressionSemantic(sc);
             rangefe.lwr = resolveProperties(sc, rangefe.lwr);
-            rangefe.upr = rangefe.upr.semantic(sc);
+            rangefe.upr = rangefe.upr.expressionSemantic(sc);
             rangefe.upr = resolveProperties(sc, rangefe.upr);
             sc = sc.endCTFE();
             rangefe.lwr = rangefe.lwr.optimize(WANTvalue);
@@ -353,7 +354,7 @@ extern (C++) final class StaticForeach : RootObject
         s2.push(new ReturnStatement(aloc, new IdentifierExp(aloc, idres)));
         auto aggr = wrapAndCall(aloc, new CompoundStatement(aloc, s2));
         sc = sc.startCTFE();
-        aggr = aggr.semantic(sc);
+        aggr = aggr.expressionSemantic(sc);
         aggr = resolveProperties(sc, aggr);
         sc = sc.endCTFE();
         aggr = aggr.optimize(WANTvalue);
@@ -382,7 +383,7 @@ extern (C++) final class StaticForeach : RootObject
         if (aggrfe)
         {
             sc = sc.startCTFE();
-            aggrfe.aggr = aggrfe.aggr.semantic(sc);
+            aggrfe.aggr = aggrfe.aggr.expressionSemantic(sc);
             sc = sc.endCTFE();
             aggrfe.aggr = aggrfe.aggr.optimize(WANTvalue);
             auto tab = aggrfe.aggr.type.toBasetype();

--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -1519,7 +1519,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 TypeVector tv = cast(TypeVector)tob;
                 result = new CastExp(e.loc, e, tv.elementType());
                 result = new VectorExp(e.loc, result, tob);
-                result = result.semantic(sc);
+                result = result.expressionSemantic(sc);
                 return;
             }
             else if (tob.ty != Tvector && t1b.ty == Tvector)
@@ -2015,7 +2015,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 {
                     f.tookAddressOf++;
                     auto se = new SymOffExp(e.loc, f, 0, false);
-                    se.semantic(sc);
+                    se.expressionSemantic(sc);
                     // Let SymOffExp::castTo() do the heavy lifting
                     visit(se);
                     return;
@@ -2178,7 +2178,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     (*ae.elements)[i] = ex;
                 }
                 Expression ev = new VectorExp(e.loc, ae, tb);
-                ev = ev.semantic(sc);
+                ev = ev.expressionSemantic(sc);
                 result = ev;
                 return;
             }
@@ -2258,12 +2258,12 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                         if (f.needThis() && hasThis(sc))
                         {
                             result = new DelegateExp(e.loc, new ThisExp(e.loc), f, false);
-                            result = result.semantic(sc);
+                            result = result.expressionSemantic(sc);
                         }
                         else if (f.isNested())
                         {
                             result = new DelegateExp(e.loc, new IntegerExp(0), f, false);
-                            result = result.semantic(sc);
+                            result = result.expressionSemantic(sc);
                         }
                         else if (f.needThis())
                         {

--- a/src/ddmd/delegatize.d
+++ b/src/ddmd/delegatize.d
@@ -18,6 +18,7 @@ import ddmd.declaration;
 import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.initsem;
@@ -49,7 +50,7 @@ extern (C++) Expression toDelegate(Expression e, Type t, Scope* sc)
         s = new ReturnStatement(loc, e);
     fld.fbody = s;
     e = new FuncExp(loc, fld);
-    e = e.semantic(sc);
+    e = e.expressionSemantic(sc);
     return e;
 }
 

--- a/src/ddmd/denum.d
+++ b/src/ddmd/denum.d
@@ -17,6 +17,7 @@ import ddmd.declaration;
 import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.globals;
 import ddmd.id;
 import ddmd.identifier;
@@ -230,7 +231,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
                  */
                 Expression ec = new CmpExp(id == Id.max ? TOKgt : TOKlt, em.loc, e, *pval);
                 inuse++;
-                ec = ec.semantic(em._scope);
+                ec = ec.expressionSemantic(em._scope);
                 inuse--;
                 ec = ec.ctfeInterpret();
                 if (ec.toInteger())
@@ -365,7 +366,7 @@ extern (C++) final class EnumMember : VarDeclaration
         if (errors)
             return new ErrorExp();
         Expression e = new VarExp(loc, this);
-        return e.semantic(sc);
+        return e.expressionSemantic(sc);
     }
 
     override inout(EnumMember) isEnumMember() inout

--- a/src/ddmd/dinterpret.d
+++ b/src/ddmd/dinterpret.d
@@ -27,6 +27,7 @@ import ddmd.dsymbol;
 import ddmd.dtemplate;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.id;
@@ -2415,7 +2416,7 @@ public:
             e = s.dsym.type.defaultInitLiteral(loc);
             if (e.op == TOKerror)
                 error(loc, "CTFE failed because of previous errors in %s.init", s.toChars());
-            e = e.semantic(null);
+            e = e.expressionSemantic(null);
             if (e.op == TOKerror)
                 e = CTFEExp.cantexp;
             else // Convert NULL to CTFEExp

--- a/src/ddmd/dsymbol.d
+++ b/src/ddmd/dsymbol.d
@@ -33,6 +33,7 @@ import ddmd.dsymbolsem;
 import ddmd.dtemplate;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.id;
@@ -1912,7 +1913,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                         }
                         auto tiargs = new Objects();
                         Expression edim = new IntegerExp(Loc(), dim, Type.tsize_t);
-                        edim = edim.semantic(sc);
+                        edim = edim.expressionSemantic(sc);
                         tiargs.push(edim);
                         e = new DotTemplateInstanceExp(loc, ce, td.ident, tiargs);
                     }
@@ -1932,7 +1933,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                         assert(d);
                         e = new DotVarExp(loc, ce, d);
                     }
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     if (!e.type)
                         exp.error("%s has no value", e.toChars());
                     t = e.type.toBasetype();

--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -29,6 +29,7 @@ import ddmd.dsymbol;
 import ddmd.dsymbolsem;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.hdrgen;
@@ -1544,7 +1545,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                     // Deduce prmtype from the defaultArg.
                     farg = fparam.defaultArg.syntaxCopy();
-                    farg = farg.semantic(paramscope);
+                    farg = farg.expressionSemantic(paramscope);
                     farg = resolveProperties(paramscope, farg);
                 }
                 else
@@ -3904,7 +3905,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                             // (it may be from a parent template, for example)
                         }
 
-                        e2 = e2.semantic(sc); // https://issues.dlang.org/show_bug.cgi?id=13417
+                        e2 = e2.expressionSemantic(sc); // https://issues.dlang.org/show_bug.cgi?id=13417
                         e2 = e2.ctfeInterpret();
 
                         //printf("e1 = %s, type = %s %d\n", e1.toChars(), e1.type.toChars(), e1.type.ty);
@@ -4509,7 +4510,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     e.fd.treq = tparam;
 
                 auto ti = new TemplateInstance(e.loc, e.td, tiargs);
-                Expression ex = (new ScopeExp(e.loc, ti)).semantic(e.td._scope);
+                Expression ex = (new ScopeExp(e.loc, ti)).expressionSemantic(e.td._scope);
 
                 // Reset inference target for the later re-semantic
                 e.fd.treq = null;
@@ -5310,7 +5311,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
         if (e)
         {
             e = e.syntaxCopy();
-            if ((e = e.semantic(sc)) is null)
+            if ((e = e.expressionSemantic(sc)) is null)
                 return null;
             if ((e = resolveProperties(sc, e)) is null)
                 return null;
@@ -5344,7 +5345,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
                 goto Lnomatch;
 
             ei = new VarExp(loc, f);
-            ei = ei.semantic(sc);
+            ei = ei.expressionSemantic(sc);
 
             /* If a function is really property-like, and then
              * it's CTFEable, ei will be a literal expression.
@@ -5405,7 +5406,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
             Expression e = specValue;
 
             sc = sc.startCTFE();
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             e = resolveProperties(sc, e);
             sc = sc.endCTFE();
             e = e.implicitCastTo(sc, vt);
@@ -5413,7 +5414,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
 
             ei = ei.syntaxCopy();
             sc = sc.startCTFE();
-            ei = ei.semantic(sc);
+            ei = ei.expressionSemantic(sc);
             sc = sc.endCTFE();
             ei = ei.implicitCastTo(sc, vt);
             ei = ei.ctfeInterpret();
@@ -6604,7 +6605,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 //printf("+[%d] ea = %s %s\n", j, Token.toChars(ea.op), ea.toChars());
                 if (flags & 1) // only used by __traits
                 {
-                    ea = ea.semantic(sc);
+                    ea = ea.expressionSemantic(sc);
 
                     // must not interpret the args, excepting template parameters
                     if (ea.op != TOKvar || ((cast(VarExp)ea).var.storage_class & STCtemplateparameter))
@@ -6615,7 +6616,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 else
                 {
                     sc = sc.startCTFE();
-                    ea = ea.semantic(sc);
+                    ea = ea.expressionSemantic(sc);
                     sc = sc.endCTFE();
 
                     if (ea.op == TOKvar)

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -147,10 +147,10 @@ L1:
                     e1.type = s.isClassDeclaration().type;
                     e1.type = e1.type.addMod(t.mod);
                     if (n > 1)
-                        e1 = e1.semantic(sc);
+                        e1 = e1.expressionSemantic(sc);
                 }
                 else
-                    e1 = e1.semantic(sc);
+                    e1 = e1.expressionSemantic(sc);
                 goto L1;
             }
 
@@ -238,7 +238,7 @@ Lagain:
             }
             e = v.expandInitializer(loc);
             v.inuse++;
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             v.inuse--;
             return e;
         }
@@ -251,14 +251,14 @@ Lagain:
             e = new DotVarExp(loc, new ThisExp(loc), v);
         else
             e = new VarExp(loc, v);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
     if (auto fld = s.isFuncLiteralDeclaration())
     {
         //printf("'%s' is a function literal\n", fld.toChars());
         e = new FuncExp(loc, fld);
-        return e.semantic(sc);
+        return e.expressionSemantic(sc);
     }
     if (auto f = s.isFuncDeclaration())
     {
@@ -293,27 +293,27 @@ Lagain:
             return new ErrorExp();
         }
         auto ie = new ScopeExp(loc, imp.pkg);
-        return ie.semantic(sc);
+        return ie.expressionSemantic(sc);
     }
     if (Package pkg = s.isPackage())
     {
         auto ie = new ScopeExp(loc, pkg);
-        return ie.semantic(sc);
+        return ie.expressionSemantic(sc);
     }
     if (Module mod = s.isModule())
     {
         auto ie = new ScopeExp(loc, mod);
-        return ie.semantic(sc);
+        return ie.expressionSemantic(sc);
     }
     if (Nspace ns = s.isNspace())
     {
         auto ie = new ScopeExp(loc, ns);
-        return ie.semantic(sc);
+        return ie.expressionSemantic(sc);
     }
 
     if (Type t = s.getType())
     {
-        return (new TypeExp(loc, t)).semantic(sc);
+        return (new TypeExp(loc, t)).expressionSemantic(sc);
     }
 
     if (TupleDeclaration tup = s.isTupleDeclaration())
@@ -322,7 +322,7 @@ Lagain:
             e = new DotVarExp(loc, new ThisExp(loc), tup);
         else
             e = new TupleExp(loc, tup);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -335,7 +335,7 @@ Lagain:
         if (!s.isTemplateInstance())
             goto Lagain;
         e = new ScopeExp(loc, ti);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
     if (TemplateDeclaration td = s.isTemplateDeclaration())
@@ -349,7 +349,7 @@ Lagain:
         }
         else
             e = new TemplateExp(loc, td);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -484,7 +484,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
         FuncDeclaration fd = null;
         if (e2)
         {
-            e2 = e2.semantic(sc);
+            e2 = e2.expressionSemantic(sc);
             if (e2.op == TOKerror)
                 return new ErrorExp();
             e2 = resolveProperties(sc, e2);
@@ -507,7 +507,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
             if (fd)
             {
                 Expression e = new CallExp(loc, e1, e2);
-                return e.semantic(sc);
+                return e.expressionSemantic(sc);
             }
         }
         {
@@ -530,7 +530,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
                 Expression e = new CallExp(loc, e1);
                 if (e2)
                     e = new AssignExp(loc, e, e2);
-                return e.semantic(sc);
+                return e.expressionSemantic(sc);
             }
         }
         if (e2)
@@ -599,7 +599,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
         assert(s);
         if (e2)
         {
-            e2 = e2.semantic(sc);
+            e2 = e2.expressionSemantic(sc);
             if (e2.op == TOKerror)
                 return new ErrorExp();
             e2 = resolveProperties(sc, e2);
@@ -615,7 +615,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
                 assert(fd.type.ty == Tfunction);
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 Expression e = new CallExp(loc, e1, e2);
-                return e.semantic(sc);
+                return e.expressionSemantic(sc);
             }
         }
         {
@@ -631,7 +631,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
                     Expression e = new CallExp(loc, e1);
                     if (e2)
                         e = new AssignExp(loc, e, e2);
-                    return e.semantic(sc);
+                    return e.expressionSemantic(sc);
                 }
             }
         }
@@ -641,7 +641,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
             assert(fd.type.ty == Tfunction);
             TypeFunction tf = cast(TypeFunction)fd.type;
             Expression e = new CallExp(loc, e1, e2);
-            return e.semantic(sc);
+            return e.expressionSemantic(sc);
         }
         if (e2)
             goto Leprop;
@@ -666,7 +666,7 @@ extern (C++) Expression resolvePropertiesX(Scope* sc, Expression e1, Expression 
             if (ve.var.storage_class & STClazy)
             {
                 Expression e = new CallExp(loc, e1);
-                return e.semantic(sc);
+                return e.expressionSemantic(sc);
             }
         }
         else if (e1.op == TOKdotvar)
@@ -1023,7 +1023,7 @@ extern (C++) Expression resolveUFCS(Scope* sc, CallExp ce)
                     return new ErrorExp();
                 }
                 Expression key = (*ce.arguments)[0];
-                key = key.semantic(sc);
+                key = key.expressionSemantic(sc);
                 key = resolveProperties(sc, key);
 
                 TypeAArray taa = cast(TypeAArray)t;
@@ -1047,7 +1047,7 @@ extern (C++) Expression resolveUFCS(Scope* sc, CallExp ce)
                 if (isDotOpDispatch(ey))
                 {
                     uint errors = global.startGagging();
-                    e = ce.syntaxCopy().semantic(sc);
+                    e = ce.syntaxCopy().expressionSemantic(sc);
                     if (!global.endGagging(errors))
                         return e;
                     /* fall down to UFCS */
@@ -1113,7 +1113,7 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
     if (e2)
     {
         // run semantic without gagging
-        e2 = e2.semantic(sc);
+        e2 = e2.expressionSemantic(sc);
 
         /* f(e1) = e2
          */
@@ -1139,13 +1139,13 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
             {
                 checkPropertyCall(ex, e1);
                 ex = new AssignExp(loc, ex, e2);
-                return ex.semantic(sc);
+                return ex.expressionSemantic(sc);
             }
         }
         else
         {
             // strict setter prints errors if fails
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         }
         checkPropertyCall(e, e1);
         return e;
@@ -1158,9 +1158,9 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
         arguments.setDim(1);
         (*arguments)[0] = eleft;
         e = new CallExp(loc, e, arguments);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         checkPropertyCall(e, e1);
-        return e.semantic(sc);
+        return e.expressionSemantic(sc);
     }
 }
 
@@ -1177,7 +1177,7 @@ extern (C++) bool arrayExpressionSemantic(Expressions* exps, Scope* sc, bool pre
             Expression e = (*exps)[i];
             if (e)
             {
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 if (e.op == TOKerror)
                     err = true;
                 if (preserveErrors || e.op != TOKerror)
@@ -1377,7 +1377,7 @@ extern (C++) bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type
             condexp.e1 = e0;
             condexp.e2 = e;
             condexp.loc = e.loc;
-            Expression ex = condexp.semantic(sc);
+            Expression ex = condexp.expressionSemantic(sc);
             if (ex.op == TOKerror)
                 e = ex;
             else
@@ -1783,7 +1783,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                     }
                     break;
                 }
-                arg = arg.semantic(sc);
+                arg = arg.expressionSemantic(sc);
                 //printf("\targ = '%s'\n", arg.toChars());
                 arguments.setDim(i + 1);
                 (*arguments)[i] = arg;
@@ -2087,7 +2087,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
             gate.semantic(sc);
 
             auto ae = new DeclarationExp(loc, gate);
-            eprefix = ae.semantic(sc);
+            eprefix = ae.expressionSemantic(sc);
         }
 
         for (ptrdiff_t i = start; i != end; i += step)
@@ -2137,21 +2137,21 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                     assert(tmp.edtor);
                     Expression e = tmp.edtor;
                     e = new LogicalExp(e.loc, TOKoror, new VarExp(e.loc, gate), e);
-                    tmp.edtor = e.semantic(sc);
+                    tmp.edtor = e.expressionSemantic(sc);
                     //printf("edtor: %s\n", tmp.edtor.toChars());
                 }
 
                 // eprefix => (eprefix, auto __pfx/y = arg)
                 auto ae = new DeclarationExp(loc, tmp);
-                eprefix = Expression.combine(eprefix, ae.semantic(sc));
+                eprefix = Expression.combine(eprefix, ae.expressionSemantic(sc));
 
                 // arg => __pfx/y
                 arg = new VarExp(loc, tmp);
-                arg = arg.semantic(sc);
+                arg = arg.expressionSemantic(sc);
                 if (isRef)
                 {
                     arg = new PtrExp(loc, arg);
-                    arg = arg.semantic(sc);
+                    arg = arg.expressionSemantic(sc);
                 }
 
                 /* Last throwing arg? Then finalize eprefix => (eprefix, gate = true),
@@ -2165,7 +2165,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
                 if (i == lastthrow)
                 {
                     auto e = new AssignExp(gate.loc, new VarExp(gate.loc, gate), new IntegerExp(gate.loc, 1, Type.tbool));
-                    eprefix = Expression.combine(eprefix, e.semantic(sc));
+                    eprefix = Expression.combine(eprefix, e.expressionSemantic(sc));
                     gate = null;
                 }
             }
@@ -2199,7 +2199,7 @@ extern (C++) bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type t
         }
         auto tup = new TypeTuple(args);
         Expression e = new TypeidExp(loc, tup);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         arguments.insert(0, e);
     }
 
@@ -2552,14 +2552,14 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
         ae.lengthVar = null; // Create it only if required
         ae.currentDimension = i; // Dimension for $, if required
 
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         e = resolveProperties(sc, e);
 
         if (ae.lengthVar && sc.func)
         {
             // If $ was used, declare it now
             Expression de = new DeclarationExp(ae.loc, ae.lengthVar);
-            de = de.semantic(sc);
+            de = de.expressionSemantic(sc);
             *pe0 = Expression.combine(*pe0, de);
         }
         sc = sc.pop();
@@ -2570,7 +2570,7 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
 
             auto tiargs = new Objects();
             Expression edim = new IntegerExp(ae.loc, i, Type.tsize_t);
-            edim = edim.semantic(sc);
+            edim = edim.expressionSemantic(sc);
             tiargs.push(edim);
 
             auto fargs = new Expressions();
@@ -2587,7 +2587,7 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
 
             e = new DotTemplateInstanceExp(ae.loc, ae.e1, slice.ident, tiargs);
             e = new CallExp(ae.loc, e, fargs);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         }
 
         if (!e.type)
@@ -2624,7 +2624,7 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, 
     for (size_t i = 0; i < 2; ++i)
     {
         Expression e = i == 0 ? ie.lwr : ie.upr;
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         e = resolveProperties(sc, e);
         if (!e.type)
         {
@@ -2638,7 +2638,7 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, 
     {
         // If $ was used, declare it now
         Expression de = new DeclarationExp(ae.loc, ae.lengthVar);
-        de = de.semantic(sc);
+        de = de.expressionSemantic(sc);
         *pe0 = Expression.combine(*pe0, de);
     }
 
@@ -2659,7 +2659,7 @@ extern (C++) Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, 
 StringExp semanticString(Scope *sc, Expression exp, const char* s)
 {
     sc = sc.startCTFE();
-    exp = exp.semantic(sc);
+    exp = exp.expressionSemantic(sc);
     exp = resolveProperties(sc, exp);
     sc = sc.endCTFE();
 
@@ -3512,7 +3512,7 @@ extern (C++) abstract class Expression : RootObject
             if (fd)
             {
                 e = new CastExp(loc, e, Type.tbool);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
 
@@ -5049,7 +5049,7 @@ extern (C++) final class StructLiteralExp : Expression
             auto tmp = copyToTemp(0, buf.ptr, this);
             Expression ae = new DeclarationExp(loc, tmp);
             Expression e = new CommaExp(loc, ae, new VarExp(loc, tmp));
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
         return this;
@@ -5627,7 +5627,7 @@ extern (C++) final class FuncExp : Expression
                 fd.treq = to;
 
             auto ti = new TemplateInstance(loc, td, tiargs);
-            Expression ex = (new ScopeExp(loc, ti)).semantic(td._scope);
+            Expression ex = (new ScopeExp(loc, ti)).expressionSemantic(td._scope);
 
             // Reset inference target for the later re-semantic
             fd.treq = null;
@@ -6462,7 +6462,7 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
             return true;
 
         Expression e = new DotIdExp(loc, e1, ti.name);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         if (e.op == TOKdot)
             e = (cast(DotExp)e).e2;
 
@@ -6649,7 +6649,7 @@ extern (C++) final class CallExp : UnaExp
                 auto de = new DeclarationExp(loc, tmp);
                 auto ve = new VarExp(loc, tmp);
                 Expression e = new CommaExp(loc, de, ve);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
         }
@@ -8177,7 +8177,7 @@ extern (C++) final class CondExp : BinExp
                             vcond.semantic(sc);
 
                             Expression de = new DeclarationExp(ce.econd.loc, vcond);
-                            de = de.semantic(sc);
+                            de = de.expressionSemantic(sc);
 
                             Expression ve = new VarExp(ce.econd.loc, vcond);
                             ce.econd = Expression.combine(de, ve);
@@ -8189,7 +8189,7 @@ extern (C++) final class CondExp : BinExp
                             v.edtor = new LogicalExp(v.edtor.loc, TOKandand, ve, v.edtor);
                         else
                             v.edtor = new LogicalExp(v.edtor.loc, TOKoror, ve, v.edtor);
-                        v.edtor = v.edtor.semantic(sc);
+                        v.edtor = v.edtor.expressionSemantic(sc);
                         //printf("\t--v = %s, v.edtor = %s\n", v.toChars(), v.edtor.toChars());
                     }
                 }
@@ -8245,7 +8245,7 @@ extern (C++) final class FileInitExp : DefaultInitExp
         if (subop == TOKfilefullpath)
             s = FileName.combine(sc._module.srcfilePath, s);
         Expression e = new StringExp(loc, cast(char*)s);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         e = e.castTo(sc, type);
         return e;
     }
@@ -8295,7 +8295,7 @@ extern (C++) final class ModuleInitExp : DefaultInitExp
         else
             s = sc._module.toPrettyChars();
         Expression e = new StringExp(loc, cast(char*)s);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         e = e.castTo(sc, type);
         return e;
     }
@@ -8325,7 +8325,7 @@ extern (C++) final class FuncInitExp : DefaultInitExp
         else
             s = "";
         Expression e = new StringExp(loc, cast(char*)s);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         e = e.castTo(sc, type);
         return e;
     }
@@ -8367,7 +8367,7 @@ extern (C++) final class PrettyFuncInitExp : DefaultInitExp
         }
 
         Expression e = new StringExp(loc, cast(char*)s);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         e = e.castTo(sc, type);
         return e;
     }

--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -182,7 +182,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 //  The redudancy should be removed.
                 e = new VarExp(exp.loc, withsym.withstate.wthis);
                 e = new DotIdExp(exp.loc, e, exp.ident);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
             }
             else
             {
@@ -205,7 +205,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         if (td.overroot) // if not start of overloaded list of TemplateDeclaration's
                             td = td.overroot; // then get the start
                         e = new TemplateExp(exp.loc, td, f);
-                        e = e.semantic(sc);
+                        e = e.expressionSemantic(sc);
                         result = e;
                         return;
                     }
@@ -248,7 +248,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             vd.storage_class |= STCtemp;
             vd.semanticRun = PASSsemanticdone;
             Expression e = new VarExp(exp.loc, vd);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -559,14 +559,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (exp.e0)
-            exp.e0 = exp.e0.semantic(sc);
+            exp.e0 = exp.e0.expressionSemantic(sc);
 
         // Run semantic() on each argument
         bool err = false;
         for (size_t i = 0; i < exp.exps.dim; i++)
         {
             Expression e = (*exp.exps)[i];
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             if (!e.type)
             {
                 exp.error("%s has no value", e.toChars());
@@ -604,7 +604,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
 
         if (e.basis)
-            e.basis = e.basis.semantic(sc);
+            e.basis = e.basis.expressionSemantic(sc);
         if (arrayExpressionSemantic(e.elements, sc) || (e.basis && e.basis.op == TOKerror))
             return setError();
 
@@ -739,7 +739,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (e)
         {
             //printf("e = %s %s\n", Token::toChars(e.op), e.toChars());
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         }
         else if (t)
         {
@@ -784,7 +784,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 Expression e = new VarExp(exp.loc, withsym.withstate.wthis);
                 e = new DotTemplateInstanceExp(exp.loc, e, ti);
-                result = e.semantic(sc);
+                result = e.expressionSemantic(sc);
                 return;
             }
             if (ti.needsTypeInference(sc))
@@ -797,7 +797,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (fdthis && ad && isAggregate(fdthis.vthis.type) == ad && (td._scope.stc & STCstatic) == 0)
                     {
                         Expression e = new DotTemplateInstanceExp(exp.loc, new ThisExp(exp.loc), ti.name, ti.tiargs);
-                        result = e.semantic(sc);
+                        result = e.expressionSemantic(sc);
                         return;
                     }
                 }
@@ -808,7 +808,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (fdthis && ad && isAggregate(fdthis.vthis.type) == ad)
                     {
                         Expression e = new DotTemplateInstanceExp(exp.loc, new ThisExp(exp.loc), ti.name, ti.tiargs);
-                        result = e.semantic(sc);
+                        result = e.expressionSemantic(sc);
                         return;
                     }
                 }
@@ -868,7 +868,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
                     auto e = v.expandInitializer(exp.loc);
                     ti.inuse++;
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     ti.inuse--;
                     result = e;
                     return;
@@ -889,13 +889,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // (Aggregate|Enum)Declaration
         if (auto t = sds2.getType())
         {
-            result = (new TypeExp(exp.loc, t)).semantic(sc);
+            result = (new TypeExp(exp.loc, t)).expressionSemantic(sc);
             return;
         }
 
         if (auto td = sds2.isTemplateDeclaration())
         {
-            result = (new TemplateExp(exp.loc, td)).semantic(sc);
+            result = (new TemplateExp(exp.loc, td)).expressionSemantic(sc);
             return;
         }
 
@@ -934,7 +934,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         ClassDeclaration cdthis = null;
         if (exp.thisexp)
         {
-            exp.thisexp = exp.thisexp.semantic(sc);
+            exp.thisexp = exp.thisexp.expressionSemantic(sc);
             if (exp.thisexp.op == TOKerror)
                 return setError();
 
@@ -1066,7 +1066,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             exp.thisexp = new DotIdExp(exp.loc, exp.thisexp, Id.outer);
                         }
 
-                        exp.thisexp = exp.thisexp.semantic(sc);
+                        exp.thisexp = exp.thisexp.expressionSemantic(sc);
                         if (exp.thisexp.op == TOKerror)
                             return setError();
                         cdthis = exp.thisexp.type.isClassHandle();
@@ -1356,7 +1356,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression d = new DeclarationExp(e.loc, e.cd);
         sc = sc.push(); // just create new scope
         sc.flags &= ~SCOPEctfe; // temporary stop CTFE
-        d = d.semantic(sc);
+        d = d.expressionSemantic(sc);
         sc = sc.pop();
 
         if (!e.cd.errors && sc.intypeof && !sc.parent.inNonRoot())
@@ -1368,7 +1368,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression n = new NewExp(e.loc, e.thisexp, e.newargs, e.cd.type, e.arguments);
 
         Expression c = new CommaExp(e.loc, d, n);
-        result = c.semantic(sc);
+        result = c.expressionSemantic(sc);
     }
 
     override void visit(SymOffExp e)
@@ -1603,12 +1603,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
 
                 auto ti = new TemplateInstance(exp.loc, exp.td, tiargs);
-                return (new ScopeExp(exp.loc, ti)).semantic(sc);
+                return (new ScopeExp(exp.loc, ti)).expressionSemantic(sc);
             }
             exp.error("cannot infer function literal type");
             return new ErrorExp();
         }
-        return exp.semantic(sc);
+        return exp.expressionSemantic(sc);
     }
 
     override void visit(CallExp exp)
@@ -1646,7 +1646,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto ce = cast(CommaExp)exp.e1;
             exp.e1 = ce.e2;
             ce.e2 = exp;
-            result = ce.semantic(sc);
+            result = ce.expressionSemantic(sc);
             return;
         }
         if (exp.e1.op == TOKdelegate)
@@ -1713,7 +1713,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 else
                 {
-                    Expression e1x = exp.e1.semantic(sc);
+                    Expression e1x = exp.e1.expressionSemantic(sc);
                     if (e1x.op == TOKerror)
                     {
                         result = e1x;
@@ -1755,7 +1755,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 else
                 {
-                    Expression e1x = exp.e1.semantic(sc);
+                    Expression e1x = exp.e1.expressionSemantic(sc);
                     if (e1x.op == TOKerror)
                     {
                         result = e1x;
@@ -1778,7 +1778,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (exp.e1.op == TOKdotid)
             {
                 DotIdExp die = cast(DotIdExp)exp.e1;
-                exp.e1 = die.semantic(sc);
+                exp.e1 = die.expressionSemantic(sc);
                 /* Look for e1 having been rewritten to expr.opDispatch!(string)
                  * We handle such earlier, so go back.
                  * Note that in the rewrite, we carefully did not run semantic() on e1
@@ -1830,7 +1830,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 SymOffExp se = cast(SymOffExp)exp.e1;
                 exp.e1 = new VarExp(se.loc, se.var, true);
-                exp.e1 = exp.e1.semantic(sc);
+                exp.e1 = exp.e1.expressionSemantic(sc);
             }
             else if (exp.e1.op == TOKdot)
             {
@@ -1909,7 +1909,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     else
                         assert(0);
                     e = new CallExp(exp.loc, e, exp.arguments);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     result = e;
                     return;
                 }
@@ -1934,7 +1934,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  */
             Lx:
                 Expression e = new StructLiteralExp(exp.loc, sd, exp.arguments, exp.e1.type);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 result = e;
                 return;
             }
@@ -1944,7 +1944,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // Rewrite as e1.call(arguments)
                 Expression e = new DotIdExp(exp.loc, exp.e1, Id.call);
                 e = new CallExp(exp.loc, e, exp.arguments);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 result = e;
                 return;
             }
@@ -1975,7 +1975,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.error("more than one argument for construction of %s", t1.toChars());
                     return setError();
                 }
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 result = e;
                 return;
             }
@@ -2053,7 +2053,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 auto b = exp.f.interfaceVirtual;
                 auto ad2 = b.sym;
                 ue.e1 = ue.e1.castTo(sc, ad2.type.addMod(ue.e1.type.mod));
-                ue.e1 = ue.e1.semantic(sc);
+                ue.e1 = ue.e1.expressionSemantic(sc);
                 ue1 = ue.e1;
                 auto vi = exp.f.findVtblIndex(&ad2.vtbl, cast(int)ad2.vtbl.dim);
                 assert(vi >= 0);
@@ -2108,7 +2108,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 else
                 {
                     exp.e1 = new DotVarExp(exp.loc, dte.e1, exp.f, false);
-                    exp.e1 = exp.e1.semantic(sc);
+                    exp.e1 = exp.e1.expressionSemantic(sc);
                     if (exp.e1.op == TOKerror)
                         return setError();
                     ue = cast(UnaExp)exp.e1;
@@ -2140,7 +2140,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (ad != cd)
                     {
                         ue.e1 = ue.e1.castTo(sc, ad.type.addMod(ue.e1.type.mod));
-                        ue.e1 = ue.e1.semantic(sc);
+                        ue.e1 = ue.e1.expressionSemantic(sc);
                     }
                 }
             }
@@ -2197,7 +2197,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             checkAccess(exp.loc, sc, null, exp.f);
 
             exp.e1 = new DotVarExp(exp.e1.loc, exp.e1, exp.f, false);
-            exp.e1 = exp.e1.semantic(sc);
+            exp.e1 = exp.e1.expressionSemantic(sc);
             t1 = exp.e1.type;
         }
         else if (exp.e1.op == TOKthis)
@@ -2237,7 +2237,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             //checkAccess(loc, sc, NULL, f);    // necessary?
 
             exp.e1 = new DotVarExp(exp.e1.loc, exp.e1, exp.f, false);
-            exp.e1 = exp.e1.semantic(sc);
+            exp.e1 = exp.e1.expressionSemantic(sc);
             t1 = exp.e1.type;
 
             // BUG: this should really be done by checking the static
@@ -2310,7 +2310,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 exp.e1 = new VarExp(dve.loc, exp.f, false);
                 Expression e = new CommaExp(exp.loc, dve.e1, exp);
-                result = e.semantic(sc);
+                result = e.expressionSemantic(sc);
                 return;
             }
             else if (exp.e1.op == TOKvar && (cast(VarExp)exp.e1).var.isOverDeclaration())
@@ -2331,7 +2331,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     {
                         // Supply an implicit 'this', as in
                         //    this.ident
-                        exp.e1 = new DotVarExp(exp.loc, (new ThisExp(exp.loc)).semantic(sc), exp.f, false);
+                        exp.e1 = new DotVarExp(exp.loc, (new ThisExp(exp.loc)).expressionSemantic(sc), exp.f, false);
                         goto Lagain;
                     }
                     else if (isNeedThisScope(sc, exp.f))
@@ -2445,7 +2445,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     // Supply an implicit 'this', as in
                     //    this.ident
-                    exp.e1 = new DotVarExp(exp.loc, (new ThisExp(exp.loc)).semantic(sc), ve.var);
+                    exp.e1 = new DotVarExp(exp.loc, (new ThisExp(exp.loc)).expressionSemantic(sc), ve.var);
                     // Note: we cannot use f directly, because further overload resolution
                     // through the supplied 'this' may cause different result.
                     goto Lagain;
@@ -2646,7 +2646,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (auto sym = getDsymbol(ea))
                 ea = resolve(exp.loc, sc, sym, false);
             else
-                ea = ea.semantic(sc);
+                ea = ea.expressionSemantic(sc);
             ea = resolveProperties(sc, ea);
             ta = ea.type;
             if (ea.op == TOKtype)
@@ -2668,7 +2668,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             /* Get the dynamic type, which is .classinfo
              */
-            ea = ea.semantic(sc);
+            ea = ea.expressionSemantic(sc);
             e = new TypeidExp(ea.loc, ea);
             e.type = Type.typeinfoclass.type;
         }
@@ -2687,7 +2687,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (ea)
             {
                 e = new CommaExp(exp.loc, ea, e); // execute ea
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
             }
         }
         result = e;
@@ -3043,7 +3043,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             // arr.length op= e2;
             e = ArrayLengthExp.rewriteOpAssign(exp);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -3071,7 +3071,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        exp.e1 = exp.e1.semantic(sc);
+        exp.e1 = exp.e1.expressionSemantic(sc);
         exp.e1 = exp.e1.optimize(WANTvalue);
         exp.e1 = exp.e1.modifiableLvalue(sc, exp.e1);
         exp.type = exp.e1.type;
@@ -3159,7 +3159,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        result = e.semantic(sc);
+        result = e.expressionSemantic(sc);
     }
 
     override void visit(ImportExp e)
@@ -3228,7 +3228,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 se = new StringExp(e.loc, f.buffer, f.len);
             }
         }
-        result = se.semantic(sc);
+        result = se.expressionSemantic(sc);
     }
 
     override void visit(AssertExp exp)
@@ -3250,7 +3250,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (exp.msg)
         {
-            exp.msg = exp.msg.semantic(sc);
+            exp.msg = exp.msg.expressionSemantic(sc);
             exp.msg = resolveProperties(sc, exp.msg);
             exp.msg = exp.msg.implicitCastTo(sc, Type.tchar.constOf().arrayOf());
             exp.msg = exp.msg.optimize(WANTvalue);
@@ -3287,7 +3287,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (!global.params.useAssert)
             {
                 Expression e = new HaltExp(exp.loc);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 result = e;
                 return;
             }
@@ -3352,7 +3352,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         exp.var = exp.var.toAlias().isDeclaration();
 
-        exp.e1 = exp.e1.semantic(sc);
+        exp.e1 = exp.e1.expressionSemantic(sc);
 
         if (auto tup = exp.var.isTupleDeclaration())
         {
@@ -3396,7 +3396,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             Expression e = new TupleExp(exp.loc, e0, exps);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -3451,7 +3451,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* Later checkRightThis will report correct error for invalid field variable access.
                  */
                 Expression e = new VarExp(exp.loc, exp.var);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 result = e;
                 return;
             }
@@ -3474,7 +3474,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 checkAccess(exp.loc, sc, exp.e1, v);
                 Expression e = new VarExp(exp.loc, v);
                 e = new CommaExp(exp.loc, exp.e1, e);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 result = e;
                 return;
             }
@@ -3508,7 +3508,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        e.e1 = e.e1.semantic(sc);
+        e.e1 = e.e1.expressionSemantic(sc);
 
         e.type = new TypeDelegate(e.func.type);
         e.type = e.type.semantic(e.loc, sc);
@@ -3535,7 +3535,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // A downcast is required for interfaces
             // https://issues.dlang.org/show_bug.cgi?id=3706
             e.e1 = new CastExp(e.loc, e.e1, ad.type);
-            e.e1 = e.e1.semantic(sc);
+            e.e1 = e.e1.expressionSemantic(sc);
         }
         result = e;
     }
@@ -3597,7 +3597,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (f)
                 {
                     exp.e1 = new DotVarExp(exp.e1.loc, dti.e1, f);
-                    exp.e1 = exp.e1.semantic(sc);
+                    exp.e1 = exp.e1.expressionSemantic(sc);
                 }
             }
         }
@@ -3616,7 +3616,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (f)
                 {
                     exp.e1 = new VarExp(exp.e1.loc, f);
-                    exp.e1 = exp.e1.semantic(sc);
+                    exp.e1 = exp.e1.expressionSemantic(sc);
                 }
             }
         }
@@ -3673,7 +3673,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     e = new DelegateExp(exp.loc, dve.e1, f, dve.hasOverloads);
                 else // It is a function pointer. Convert &v.f() --> (v, &V.f())
                     e = new CommaExp(exp.loc, dve.e1, new AddrExp(exp.loc, new VarExp(exp.loc, f, dve.hasOverloads)));
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 result = e;
                 return;
             }
@@ -3732,13 +3732,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             /* Supply a 'null' for a this pointer if no this is available
                              */
                             Expression e = new DelegateExp(exp.loc, new NullExp(exp.loc, Type.tnull), f, ve.hasOverloads);
-                            e = e.semantic(sc);
+                            e = e.expressionSemantic(sc);
                             result = e;
                             return;
                         }
                     }
                     Expression e = new DelegateExp(exp.loc, exp.e1, f, ve.hasOverloads);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     result = e;
                     return;
                 }
@@ -3751,7 +3751,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                          */
                         Expression ethis = new ThisExp(exp.loc);
                         Expression e = new DelegateExp(exp.loc, ethis, f, ve.hasOverloads);
-                        e = e.semantic(sc);
+                        e = e.expressionSemantic(sc);
                         result = e;
                         return;
                     }
@@ -3824,9 +3824,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // Re-run semantic on the address expressions only
             ce.e1.type = null;
-            ce.e1 = ce.e1.semantic(sc);
+            ce.e1 = ce.e1.expressionSemantic(sc);
             ce.e2.type = null;
-            ce.e2 = ce.e2.semantic(sc);
+            ce.e2 = ce.e2.expressionSemantic(sc);
         }
         result = exp.optimize(WANTvalue);
     }
@@ -4101,14 +4101,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     Expression e = ea ? new VarExp(exp.loc, v) : exp.e1;
                     e = new DotVarExp(Loc(), e, fd, false);
                     eb = new CallExp(exp.loc, e);
-                    eb = eb.semantic(sc);
+                    eb = eb.expressionSemantic(sc);
                 }
                 if (f)
                 {
                     Type tpv = Type.tvoid.pointerTo();
                     Expression e = ea ? new VarExp(exp.loc, v) : exp.e1.castTo(sc, tpv);
                     e = new CallExp(exp.loc, new VarExp(exp.loc, f, false), e);
-                    ec = e.semantic(sc);
+                    ec = e.expressionSemantic(sc);
                 }
                 ea = Expression.combine(ea, eb);
                 ea = Expression.combine(ea, ec);
@@ -4311,7 +4311,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        exp.e1 = exp.e1.semantic(sc);
+        exp.e1 = exp.e1.expressionSemantic(sc);
         exp.type = exp.to.semantic(exp.loc, sc);
         if (exp.e1.op == TOKerror || exp.type.ty == Terror)
         {
@@ -4377,7 +4377,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
             Expression e = new TypeExp(exp.loc, exp.e1.type.arrayOf());
-            result = e.semantic(sc);
+            result = e.expressionSemantic(sc);
             return;
         }
         if (!exp.lwr && !exp.upr)
@@ -4526,7 +4526,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (t1b.ty == Ttuple)
                 sc = sc.startCTFE();
-            exp.lwr = exp.lwr.semantic(sc);
+            exp.lwr = exp.lwr.expressionSemantic(sc);
             exp.lwr = resolveProperties(sc, exp.lwr);
             if (t1b.ty == Ttuple)
                 sc = sc.endCTFE();
@@ -4536,7 +4536,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (t1b.ty == Ttuple)
                 sc = sc.startCTFE();
-            exp.upr = exp.upr.semantic(sc);
+            exp.upr = exp.upr.expressionSemantic(sc);
             exp.upr = resolveProperties(sc, exp.upr);
             if (t1b.ty == Ttuple)
                 sc = sc.endCTFE();
@@ -4602,7 +4602,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 e = new TypeExp(exp.e1.loc, new TypeTuple(args));
             }
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -4623,7 +4623,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (t1b.ty == Tsarray || t1b.ty == Tarray)
             {
                 Expression el = new ArrayLengthExp(exp.loc, exp.e1);
-                el = el.semantic(sc);
+                el = el.expressionSemantic(sc);
                 el = el.optimize(WANTvalue);
                 if (el.op == TOKint64)
                 {
@@ -4699,8 +4699,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (exp.type)
                 printf("\ttype = %s\n", exp.type.toChars());
         }
-        exp.e1 = exp.e1.semantic(sc);
-        exp.e2 = exp.e2.semantic(sc);
+        exp.e1 = exp.e1.expressionSemantic(sc);
+        exp.e2 = exp.e2.expressionSemantic(sc);
 
         if (exp.e1.op == TOKtype)
         {
@@ -4716,7 +4716,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             auto td = (cast(TemplateExp)exp.e2).td;
             Expression e = new DotTemplateExp(exp.loc, exp.e1, td);
-            result = e.semantic(sc);
+            result = e.expressionSemantic(sc);
             return;
         }
         if (!exp.type)
@@ -4768,11 +4768,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Expression le = e.lwr;
-        le = le.semantic(sc);
+        le = le.expressionSemantic(sc);
         le = resolveProperties(sc, le);
 
         Expression ue = e.upr;
-        ue = ue.semantic(sc);
+        ue = ue.expressionSemantic(sc);
         ue = resolveProperties(sc, ue);
 
         if (le.op == TOKerror)
@@ -4848,11 +4848,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         // operator overloading should be handled in ArrayExp already.
         if (!exp.e1.type)
-            exp.e1 = exp.e1.semantic(sc);
+            exp.e1 = exp.e1.expressionSemantic(sc);
         assert(exp.e1.type); // semantic() should already be run on it
         if (exp.e1.op == TOKtype && exp.e1.type.ty != Ttuple)
         {
-            exp.e2 = exp.e2.semantic(sc);
+            exp.e2 = exp.e2.expressionSemantic(sc);
             exp.e2 = resolveProperties(sc, exp.e2);
             Type nt;
             if (exp.e2.op == TOKtype)
@@ -4860,7 +4860,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             else
                 nt = new TypeSArray(exp.e1.type, exp.e2);
             Expression e = new TypeExp(exp.loc, nt);
-            result = e.semantic(sc);
+            result = e.expressionSemantic(sc);
             return;
         }
         if (exp.e1.op == TOKerror)
@@ -4897,7 +4897,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (t1b.ty == Ttuple)
             sc = sc.startCTFE();
-        exp.e2 = exp.e2.semantic(sc);
+        exp.e2 = exp.e2.expressionSemantic(sc);
         exp.e2 = resolveProperties(sc, exp.e2);
         if (t1b.ty == Ttuple)
             sc = sc.endCTFE();
@@ -5024,7 +5024,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (t1b.ty == Tsarray || t1b.ty == Tarray)
         {
             Expression el = new ArrayLengthExp(exp.loc, exp.e1);
-            el = el.semantic(sc);
+            el = el.expressionSemantic(sc);
             el = el.optimize(WANTvalue);
             if (el.op == TOKint64)
             {
@@ -5119,7 +5119,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 ea = new CommaExp(exp.loc, de, ea);
             e = new CommaExp(exp.loc, ea, eb);
             e = new CommaExp(exp.loc, e, ec);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -5155,7 +5155,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             e = new AddAssignExp(exp.loc, exp.e1, new IntegerExp(exp.loc, 1, Type.tint32));
         else
             e = new MinAssignExp(exp.loc, exp.e1, new IntegerExp(exp.loc, 1, Type.tint32));
-        result = e.semantic(sc);
+        result = e.expressionSemantic(sc);
     }
 
     override void visit(AssignExp exp)
@@ -5183,12 +5183,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Expression e0;
             exp.e2 = Expression.extractLast(exp.e2, &e0);
             Expression e = Expression.combine(e0, exp);
-            result = e.semantic(sc);
+            result = e.expressionSemantic(sc);
             return;
         }
 
         /* Look for operator overloading of a[arguments] = e2.
-         * Do it before e1.semantic() otherwise the ArrayExp will have been
+         * Do it before e1.expressionSemantic() otherwise the ArrayExp will have been
          * converted to unary operator overloading already.
          */
         if (exp.e1.op == TOKarray)
@@ -5196,7 +5196,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Expression res;
 
             ArrayExp ae = cast(ArrayExp)exp.e1;
-            ae.e1 = ae.e1.semantic(sc);
+            ae.e1 = ae.e1.expressionSemantic(sc);
             ae.e1 = resolveProperties(sc, ae.e1);
             Expression ae1old = ae.e1;
 
@@ -5237,7 +5237,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         return;
                     }
 
-                    res = exp.e2.semantic(sc);
+                    res = exp.e2.expressionSemantic(sc);
                     if (res.op == TOKerror)
                     {
                         result = res;
@@ -5255,7 +5255,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (maybeSlice) // a[] = e2 might be: a.opSliceAssign(e2)
                         res = res.trySemantic(sc);
                     else
-                        res = res.semantic(sc);
+                        res = res.expressionSemantic(sc);
                     if (res)
                     {
                         res = Expression.combine(e0, res);
@@ -5275,7 +5275,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         return;
                     }
 
-                    res = exp.e2.semantic(sc);
+                    res = exp.e2.expressionSemantic(sc);
                     if (res.op == TOKerror)
                     {
                         result = res;
@@ -5295,7 +5295,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
                     res = new DotIdExp(exp.loc, ae.e1, Id.sliceass);
                     res = new CallExp(exp.loc, res, a);
-                    res = res.semantic(sc);
+                    res = res.expressionSemantic(sc);
                     res = Expression.combine(e0, res);
                     result = res;
                     return;
@@ -5371,7 +5371,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (e1x.op == TOKslice)
                     (cast(SliceExp)e1x).arrayop = true;
 
-                e1x = e1x.semantic(sc);
+                e1x = e1x.expressionSemantic(sc);
             }
 
             /* We have f = value.
@@ -5398,7 +5398,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         {
             Expression e2x = inferType(exp.e2, t1.baseElemOf());
-            e2x = e2x.semantic(sc);
+            e2x = e2x.expressionSemantic(sc);
             e2x = resolveProperties(sc, e2x);
             if (e2x.op == TOKtype)
                 e2x = resolveAliasThis(sc, e2x); //https://issues.dlang.org/show_bug.cgi?id=17684
@@ -5447,7 +5447,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
                     e = new TupleExp(exp.loc, Expression.combine(tup1.e0, tup2.e0), exps);
                 }
-                result = e.semantic(sc);
+                result = e.expressionSemantic(sc);
                 return;
             }
 
@@ -5490,7 +5490,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
                 }
                 e2x = new TupleExp(e2x.loc, e0, iexps);
-                e2x = e2x.semantic(sc);
+                e2x = e2x.expressionSemantic(sc);
                 if (e2x.op == TOKerror)
                 {
                     result = e2x;
@@ -5612,7 +5612,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                         auto e = Expression.combine(ae, cx);
                         e = Expression.combine(e0, e);
-                        e = e.semantic(sc);
+                        e = e.expressionSemantic(sc);
                         result = e;
                         return;
                     }
@@ -5629,7 +5629,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             Expression ea1 = new ConstructExp(econd.e1.loc, e1x, econd.e1);
                             Expression ea2 = new ConstructExp(econd.e1.loc, e1x, econd.e2);
                             Expression e = new CondExp(exp.loc, econd.econd, ea1, ea2);
-                            result = e.semantic(sc);
+                            result = e.expressionSemantic(sc);
                             return;
                         }
 
@@ -5653,7 +5653,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             e = new BlitExp(exp.loc, e, e2x);
                             e = new DotVarExp(exp.loc, e, sd.postblit, false);
                             e = new CallExp(exp.loc, e);
-                            result = e.semantic(sc);
+                            result = e.expressionSemantic(sc);
                             return;
                         }
                         else
@@ -5687,7 +5687,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         e = new DotIdExp(exp.loc, e1x, Id.ctor);
                         e = new CallExp(exp.loc, e, e2x);
                         e = new CommaExp(exp.loc, einit, e);
-                        e = e.semantic(sc);
+                        e = e.expressionSemantic(sc);
                         result = e;
                         return;
                     }
@@ -5701,7 +5701,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         e2x = typeDotIdExp(e2x.loc, e1x.type, Id.call);
                         e2x = new CallExp(exp.loc, e2x, exp.e2);
 
-                        e2x = e2x.semantic(sc);
+                        e2x = e2x.expressionSemantic(sc);
                         e2x = resolveProperties(sc, e2x);
                         if (e2x.op == TOKerror)
                         {
@@ -5723,7 +5723,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                          *      (e1 op e2.aliasthis)
                          */
                         exp.e2 = new DotIdExp(exp.e2.loc, exp.e2, ad2.aliasthis.ident);
-                        result = exp.semantic(sc);
+                        result = exp.expressionSemantic(sc);
                         return;
                     }
                 }
@@ -5753,7 +5753,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                     AssignExp ae = cast(AssignExp)exp.copy();
                     ae.e1 = new IndexExp(exp.loc, ea, ek);
-                    ae.e1 = ae.e1.semantic(sc);
+                    ae.e1 = ae.e1.expressionSemantic(sc);
                     ae.e1 = ae.e1.optimize(WANTvalue);
                     ae.e2 = ev;
                     Expression e = ae.op_overload(sc);
@@ -5777,12 +5777,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         {
                             Expression ex;
                             ex = new IndexExp(exp.loc, ea, ek);
-                            ex = ex.semantic(sc);
+                            ex = ex.expressionSemantic(sc);
                             ex = ex.optimize(WANTvalue);
                             ex = ex.modifiableLvalue(sc, ex); // allocate new slot
 
                             ey = new ConstructExp(exp.loc, ex, ey);
-                            ey = ey.semantic(sc);
+                            ey = ey.expressionSemantic(sc);
                             if (ey.op == TOKerror)
                             {
                                 result = ey;
@@ -5803,7 +5803,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                             e = new CondExp(exp.loc, new InExp(exp.loc, ek, ea), ex, ey);
                         }
                         e = Expression.combine(e0, e);
-                        e = e.semantic(sc);
+                        e = e.expressionSemantic(sc);
                         result = e;
                         return;
                     }
@@ -5859,7 +5859,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // e.g. e1[] = a[] + b[];
                     auto sle = new SliceExp(e1x.loc, e1x, null, null);
                     sle.arrayop = true;
-                    e1x = sle.semantic(sc);
+                    e1x = sle.expressionSemantic(sc);
                 }
                 else
                 {
@@ -5909,7 +5909,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 auto sle = new SliceExp(e1x.loc, e1x, null, null);
                 sle.arrayop = true;
-                e1x = sle.semantic(sc);
+                e1x = sle.expressionSemantic(sc);
             }
             if (e1x.op == TOKerror)
             {
@@ -6268,7 +6268,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 e = new CommaExp(exp.loc, de, e);
             }
             e = Expression.combine(e0, e);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -6900,7 +6900,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.e1.type = exp.type;
                     exp.e2.type = exp.type;
                     e = new NegExp(exp.loc, exp);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     result = e;
                     return;
                 }
@@ -6974,7 +6974,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // x/iv = i(-x/v)
                     exp.e2.type = t1;
                     e = new NegExp(exp.loc, exp);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     result = e;
                     return;
                 }
@@ -7134,7 +7134,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e = exp.optimize(WANTvalue);
         if (e.op != TOKpow)
         {
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -7161,7 +7161,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (intpow == 3)
                 me = new MulExp(exp.loc, me, ve);
             e = new CommaExp(exp.loc, de, me);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             result = e;
             return;
         }
@@ -7193,7 +7193,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // Replace e1 ^^ e2 with .std.math.pow(e1, e2)
             e = new CallExp(exp.loc, new DotIdExp(exp.loc, e, Id._pow), exp.e1, exp.e2);
         }
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         result = e;
         return;
     }
@@ -7482,7 +7482,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         exp.setNoderefOperands();
 
-        Expression e1x = exp.e1.semantic(sc);
+        Expression e1x = exp.e1.expressionSemantic(sc);
 
         // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
         if (e1x.op == TOKtype)
@@ -7504,7 +7504,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        Expression e2x = exp.e2.semantic(sc);
+        Expression e2x = exp.e2.expressionSemantic(sc);
         sc.mergeCallSuper(exp.loc, cs1);
 
         // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
@@ -7588,7 +7588,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (e.op == TOKcall)
             {
                 e = new CmpExp(exp.op, exp.loc, e, new IntegerExp(exp.loc, 0, Type.tint32));
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
             }
             result = e;
             return;
@@ -7626,7 +7626,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression al = new IdentifierExp(exp.loc, Id.empty);
                 al = new DotIdExp(exp.loc, al, Id.object);
                 al = new DotIdExp(exp.loc, al, Id.__cmp);
-                al = al.semantic(sc);
+                al = al.expressionSemantic(sc);
 
                 auto arguments = new Expressions();
                 arguments.push(exp.e1);
@@ -7738,7 +7738,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         //printf("CmpExp: %s, type = %s\n", e.toChars(), e.type.toChars());
         if (arrayLowering)
         {
-            arrayLowering = arrayLowering.semantic(sc);
+            arrayLowering = arrayLowering.expressionSemantic(sc);
             result = arrayLowering;
             return;
         }
@@ -7970,20 +7970,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.econd.op == TOKdotid)
             (cast(DotIdExp)exp.econd).noderef = true;
 
-        Expression ec = exp.econd.semantic(sc);
+        Expression ec = exp.econd.expressionSemantic(sc);
         ec = resolveProperties(sc, ec);
         ec = ec.toBoolean(sc);
 
         uint cs0 = sc.callSuper;
         uint* fi0 = sc.saveFieldInit();
-        Expression e1x = exp.e1.semantic(sc);
+        Expression e1x = exp.e1.expressionSemantic(sc);
         e1x = resolveProperties(sc, e1x);
 
         uint cs1 = sc.callSuper;
         uint* fi1 = sc.fieldinit;
         sc.callSuper = cs0;
         sc.fieldinit = fi0;
-        Expression e2x = exp.e2.semantic(sc);
+        Expression e2x = exp.e2.expressionSemantic(sc);
         e2x = resolveProperties(sc, e2x);
 
         sc.mergeCallSuper(exp.loc, cs1);
@@ -8148,7 +8148,7 @@ Expression trySemantic(Expression exp, Scope* sc)
 {
     //printf("+trySemantic(%s)\n", toChars());
     uint errors = global.startGagging();
-    Expression e = semantic(exp, sc);
+    Expression e = expressionSemantic(exp, sc);
     if (global.endGagging(errors))
     {
         e = null;
@@ -8167,7 +8167,7 @@ Expression unaSemantic(UnaExp e, Scope* sc)
     {
         printf("UnaExp::semantic('%s')\n", e.toChars());
     }
-    Expression e1x = e.e1.semantic(sc);
+    Expression e1x = e.e1.expressionSemantic(sc);
     if (e1x.op == TOKerror)
         return e1x;
     e.e1 = e1x;
@@ -8184,8 +8184,8 @@ Expression binSemantic(BinExp e, Scope* sc)
     {
         printf("BinExp::semantic('%s')\n", e.toChars());
     }
-    Expression e1x = e.e1.semantic(sc);
-    Expression e2x = e.e2.semantic(sc);
+    Expression e1x = e.e1.expressionSemantic(sc);
+    Expression e2x = e.e2.expressionSemantic(sc);
 
     // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
     if (e1x.op == TOKtype)
@@ -8268,7 +8268,7 @@ Expression semanticX(DotIdExp exp, Scope* sc)
                 mangleToBuffer(ds, &buf);
                 const s = buf.peekSlice();
                 Expression e = new StringExp(exp.loc, buf.extractString(), s.length);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
         default:
@@ -8299,13 +8299,13 @@ Expression semanticX(DotIdExp exp, Scope* sc)
         for (size_t i = 0; i < exps.dim; i++)
         {
             Expression e = (*te.exps)[i];
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             e = new DotIdExp(e.loc, e, Id.offsetof);
             (*exps)[i] = e;
         }
         // Don't evaluate te.e0 in runtime
         Expression e = new TupleExp(exp.loc, null, exps);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
     if (exp.e1.op == TOKtuple && exp.ident == Id.length)
@@ -8450,7 +8450,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                     }
                     e = v.expandInitializer(exp.loc);
                     v.inuse++;
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     v.inuse--;
                     return e;
                 }
@@ -8460,7 +8460,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                     if (!eleft)
                         eleft = new ThisExp(exp.loc);
                     e = new DotVarExp(exp.loc, eleft, v);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                 }
                 else
                 {
@@ -8472,7 +8472,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                     }
                 }
                 e = e.deref();
-                return e.semantic(sc);
+                return e.expressionSemantic(sc);
             }
 
             FuncDeclaration f = s.isFuncDeclaration();
@@ -8486,7 +8486,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                     if (!eleft)
                         eleft = new ThisExp(exp.loc);
                     e = new DotVarExp(exp.loc, eleft, f, true);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                 }
                 else
                 {
@@ -8505,7 +8505,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                     e = new DotTemplateExp(exp.loc, eleft, td);
                 else
                     e = new TemplateExp(exp.loc, td);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
             if (OverDeclaration od = s.isOverDeclaration())
@@ -8527,7 +8527,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
 
             if (auto t = s.getType())
             {
-                return (new TypeExp(exp.loc, t)).semantic(sc);
+                return (new TypeExp(exp.loc, t)).expressionSemantic(sc);
             }
 
             TupleDeclaration tup = s.isTupleDeclaration();
@@ -8536,11 +8536,11 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                 if (eleft)
                 {
                     e = new DotVarExp(exp.loc, eleft, tup);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     return e;
                 }
                 e = new TupleExp(exp.loc, tup);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
 
@@ -8549,7 +8549,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             {
                 //printf("it's a ScopeDsymbol %s\n", ident.toChars());
                 e = new ScopeExp(exp.loc, sds);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 if (eleft)
                     e = new DotExp(exp.loc, eleft, e);
                 return e;
@@ -8559,7 +8559,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             if (imp)
             {
                 ie = new ScopeExp(exp.loc, imp.pkg);
-                return ie.semantic(sc);
+                return ie.expressionSemantic(sc);
             }
             // BUG: handle other cases like in IdentifierExp::semantic()
             debug
@@ -8572,7 +8572,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         {
             const p = ie.toChars();
             e = new StringExp(exp.loc, cast(char*)p, strlen(p));
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
         if (ie.sds.isPackage() || ie.sds.isImport() || ie.sds.isModule())
@@ -8606,7 +8606,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         if (flag && t1bn.ty == Tvoid)
             return null;
         e = new PtrExp(exp.loc, exp.e1);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e.type.dotExp(sc, e, exp.ident, flag | (exp.noderef ? Type.DotExpFlag.noDeref : 0));
     }
     else
@@ -8615,7 +8615,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             flag = 0;
         e = exp.e1.type.dotExp(sc, exp.e1, exp.ident, flag | (exp.noderef ? Type.DotExpFlag.noDeref : 0));
         if (e)
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         return e;
     }
 }
@@ -8669,7 +8669,7 @@ L1:
             if (td)
             {
                 e = new DotTemplateExp(dve.loc, dve.e1, td);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
             }
         }
         else if (OverDeclaration od = dve.var.isOverDeclaration())
@@ -8691,12 +8691,12 @@ L1:
                 if (v.type && !v.type.deco)
                     v.type = v.type.semantic(v.loc, sc);
                 e = new DotVarExp(exp.loc, exp.e1, v);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
             e = new ScopeExp(exp.loc, exp.ti);
             e = new DotExp(exp.loc, exp.e1, e);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
     }
@@ -8709,14 +8709,14 @@ L1:
             if (td)
             {
                 e = new TemplateExp(ve.loc, td);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
             }
         }
         else if (OverDeclaration od = ve.var.isOverDeclaration())
         {
             exp.ti.tempdecl = od;
             e = new ScopeExp(exp.loc, exp.ti);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
     }
@@ -8739,19 +8739,19 @@ L1:
         if (v && (v.isFuncDeclaration() || v.isVarDeclaration()))
         {
             e = new DotVarExp(exp.loc, exp.e1, v);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
         e = new ScopeExp(exp.loc, exp.ti);
         e = new DotExp(exp.loc, exp.e1, e);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
     else if (e.op == TOKtemplate)
     {
         exp.ti.tempdecl = (cast(TemplateExp)e).td;
         e = new ScopeExp(exp.loc, exp.ti);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
     else if (e.op == TOKdot)
@@ -8777,12 +8777,12 @@ L1:
                 if (v.type && !v.type.deco)
                     v.type = v.type.semantic(v.loc, sc);
                 e = new DotVarExp(exp.loc, exp.e1, v);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
             e = new ScopeExp(exp.loc, exp.ti);
             e = new DotExp(exp.loc, exp.e1, e);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
     }
@@ -8791,7 +8791,7 @@ L1:
         OverExp oe = cast(OverExp)e;
         exp.ti.tempdecl = oe.vars;
         e = new ScopeExp(exp.loc, exp.ti);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
 

--- a/src/ddmd/iasm.d
+++ b/src/ddmd/iasm.d
@@ -28,6 +28,7 @@ import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.id;
@@ -3473,7 +3474,7 @@ code *asm_db_parse(OP *pop)
             {
                 Expression e = IdentifierExp.create(asmstate.loc, asmstate.tok.ident);
                 Scope *sc = asmstate.sc.startCTFE();
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 sc.endCTFE();
                 e = e.ctfeInterpret();
                 if (e.op == TOKint64)
@@ -3564,7 +3565,7 @@ int asm_getnum()
         {
             Expression e = IdentifierExp.create(asmstate.loc, asmstate.tok.ident);
             Scope *sc = asmstate.sc.startCTFE();
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             sc.endCTFE();
             e = e.ctfeInterpret();
             i = e.toInteger();
@@ -4241,7 +4242,7 @@ void asm_primary_exp(out OPND o1)
                         }
                     }
                     Scope *sc = asmstate.sc.startCTFE();
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     sc.endCTFE();
                     e = e.ctfeInterpret();
                     if (e.isConst())

--- a/src/ddmd/initsem.d
+++ b/src/ddmd/initsem.d
@@ -284,7 +284,7 @@ extern(C++) final class InitializerSemanticVisitor : Visitor
             if (idx)
             {
                 sc = sc.startCTFE();
-                idx = idx.semantic(sc);
+                idx = idx.expressionSemantic(sc);
                 sc = sc.endCTFE();
                 idx = idx.ctfeInterpret();
                 i.index[j] = idx;
@@ -366,7 +366,7 @@ extern(C++) final class InitializerSemanticVisitor : Visitor
         //printf("ExpInitializer::semantic(%s), type = %s\n", exp.toChars(), t.toChars());
         if (needInterpret)
             sc = sc.startCTFE();
-        i.exp = i.exp.semantic(sc);
+        i.exp = i.exp.expressionSemantic(sc);
         i.exp = resolveProperties(sc, i.exp);
         if (needInterpret)
             sc = sc.endCTFE();
@@ -458,7 +458,7 @@ extern(C++) final class InitializerSemanticVisitor : Visitor
                 e = new StructLiteralExp(i.loc, sd, null);
                 e = new DotIdExp(i.loc, e, Id.ctor);
                 e = new CallExp(i.loc, e, i.exp);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 if (needInterpret)
                     i.exp = e.ctfeInterpret();
                 else
@@ -625,7 +625,7 @@ private extern(C++) final class InferTypeVisitor : Visitor
     override void visit(ExpInitializer init)
     {
         //printf("ExpInitializer::inferType() %s\n", toChars());
-        init.exp = init.exp.semantic(sc);
+        init.exp = init.exp.expressionSemantic(sc);
         init.exp = resolveProperties(sc, init.exp);
         if (init.exp.op == TOKscope)
         {

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -329,7 +329,7 @@ Expression semanticLength(Scope* sc, TupleDeclaration tup, Expression exp)
 
     sc = sc.push(sym);
     sc = sc.startCTFE();
-    exp = exp.semantic(sc);
+    exp = exp.expressionSemantic(sc);
     sc = sc.endCTFE();
     sc.pop();
 
@@ -348,14 +348,14 @@ Expression semanticLength(Scope* sc, Type t, Expression exp)
         sym.parent = sc.scopesym;
         sc = sc.push(sym);
         sc = sc.startCTFE();
-        exp = exp.semantic(sc);
+        exp = exp.expressionSemantic(sc);
         sc = sc.endCTFE();
         sc.pop();
     }
     else
     {
         sc = sc.startCTFE();
-        exp = exp.semantic(sc);
+        exp = exp.expressionSemantic(sc);
         sc = sc.endCTFE();
     }
     return exp;
@@ -2536,7 +2536,7 @@ extern (C++) abstract class Type : RootObject
             {
                 e = new StringExp(loc, deco);
                 Scope sc;
-                e = e.semantic(&sc);
+                e = e.expressionSemantic(&sc);
             }
         }
         else if (ident == Id.stringof)
@@ -2544,7 +2544,7 @@ extern (C++) abstract class Type : RootObject
             const s = toChars();
             e = new StringExp(loc, cast(char*)s);
             Scope sc;
-            e = e.semantic(&sc);
+            e = e.expressionSemantic(&sc);
         }
         else if (flag && this != Type.terror)
         {
@@ -2645,7 +2645,7 @@ extern (C++) abstract class Type : RootObject
 
     Lreturn:
         if (e)
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -2709,7 +2709,7 @@ extern (C++) abstract class Type : RootObject
                  */
                 e = build_overload(e.loc, sc, e, null, fd);
                 e = new DotIdExp(e.loc, e, ident);
-                return returnExp(e.semantic(sc));
+                return returnExp(e.expressionSemantic(sc));
             }
 
             /* Look for overloaded opDispatch to see if we should forward request
@@ -4121,7 +4121,7 @@ extern (C++) final class TypeBasic : Type
             return Type.dotExp(sc, e, ident, flag);
         }
         if (!(flag & 1) || e)
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -4378,7 +4378,7 @@ extern (C++) final class TypeVector : Type
              * __vector(float[4]), and a type paint won't do.
              */
             e = new AddrExp(e.loc, e);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             e = e.castTo(sc, basetype.nextOf().pointerTo());
             return e;
         }
@@ -4499,7 +4499,7 @@ extern (C++) class TypeArray : TypeNext
         e = Type.dotExp(sc, e, ident, flag);
 
         if (!(flag & 1) || e)
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -4680,7 +4680,7 @@ extern (C++) final class TypeSArray : TypeArray
             e = TypeArray.dotExp(sc, e, ident, flag);
         }
         if (!(flag & 1) || e)
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -6322,7 +6322,7 @@ extern (C++) final class TypeDelegate : TypeNext
         if (ident == Id.ptr)
         {
             e = new DelegatePtrExp(e.loc, e);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         }
         else if (ident == Id.funcptr)
         {
@@ -6332,7 +6332,7 @@ extern (C++) final class TypeDelegate : TypeNext
                 return new ErrorExp();
             }
             e = new DelegateFuncptrExp(e.loc, e);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
         }
         else
         {
@@ -6441,7 +6441,7 @@ extern (C++) abstract class TypeQualified : Type
             else if (sindex)
                 eindex = .resolve(loc, sc, sindex, false);
             Expression e = new IndexExp(loc, .resolve(loc, sc, s, false), eindex);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             resolveExp(e, pt, pe, ps);
             return;
         }
@@ -6532,7 +6532,7 @@ extern (C++) abstract class TypeQualified : Type
                     assert(ex);
 
                     ex = typeToExpressionHelper(this, ex, i + 1);
-                    ex = ex.semantic(sc);
+                    ex = ex.expressionSemantic(sc);
                     resolveExp(ex, pt, pe, ps);
                     return;
                 }
@@ -6599,7 +6599,7 @@ extern (C++) abstract class TypeQualified : Type
                             e = new VarExp(loc, s.isDeclaration(), true);
 
                         e = typeToExpressionHelper(this, e, i);
-                        e = e.semantic(sc);
+                        e = e.expressionSemantic(sc);
                         resolveExp(e, pt, pe, ps);
                         return;
                     }
@@ -6665,7 +6665,7 @@ extern (C++) abstract class TypeQualified : Type
             {
                 //printf("'%s' is a function literal\n", fld.toChars());
                 *pe = new FuncExp(loc, fld);
-                *pe = (*pe).semantic(sc);
+                *pe = (*pe).expressionSemantic(sc);
                 return;
             }
             version (none)
@@ -6968,7 +6968,7 @@ extern (C++) final class TypeTypeof : TypeQualified
          */
         Scope* sc2 = sc.push();
         sc2.intypeof = 1;
-        auto exp2 = exp.semantic(sc2);
+        auto exp2 = exp.expressionSemantic(sc2);
         exp2 = resolvePropertiesOnly(sc2, exp2);
         sc2.pop();
 
@@ -7025,7 +7025,7 @@ extern (C++) final class TypeTypeof : TypeQualified
             else
             {
                 auto e = typeToExpressionHelper(this, new TypeExp(loc, t));
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 resolveExp(e, pt, pe, ps);
             }
         }
@@ -7113,7 +7113,7 @@ extern (C++) final class TypeReturn : TypeQualified
             else
             {
                 auto e = typeToExpressionHelper(this, new TypeExp(loc, t));
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 resolveExp(e, pt, pe, ps);
             }
         }
@@ -7215,7 +7215,7 @@ extern (C++) final class TypeStruct : Type
             /* Create a TupleExp out of the fields of the struct e:
              * (e.field0, e.field1, e.field2, ...)
              */
-            e = e.semantic(sc); // do this before turning on noaccesscheck
+            e = e.expressionSemantic(sc); // do this before turning on noaccesscheck
 
             sym.size(e.loc); // do semantic of type
 
@@ -7243,7 +7243,7 @@ extern (C++) final class TypeStruct : Type
             e = new TupleExp(e.loc, e0, exps);
             Scope* sc2 = sc.push();
             sc2.flags = sc.flags | SCOPEnoaccesscheck;
-            e = e.semantic(sc2);
+            e = e.expressionSemantic(sc2);
             sc2.pop();
             return e;
         }
@@ -7313,14 +7313,14 @@ extern (C++) final class TypeStruct : Type
                 }
                 checkAccess(e.loc, sc, null, v);
                 Expression ve = new VarExp(e.loc, v);
-                ve = ve.semantic(sc);
+                ve = ve.expressionSemantic(sc);
                 return ve;
             }
         }
 
         if (auto t = s.getType())
         {
-            return (new TypeExp(e.loc, t)).semantic(sc);
+            return (new TypeExp(e.loc, t)).expressionSemantic(sc);
         }
 
         TemplateMixin tm = s.isTemplateMixin();
@@ -7338,7 +7338,7 @@ extern (C++) final class TypeStruct : Type
                 e = new TemplateExp(e.loc, td);
             else
                 e = new DotTemplateExp(e.loc, e, td);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
 
@@ -7358,7 +7358,7 @@ extern (C++) final class TypeStruct : Type
                 e = new ScopeExp(e.loc, ti);
             else
                 e = new DotExp(e.loc, e, new ScopeExp(e.loc, ti));
-            return e.semantic(sc);
+            return e.expressionSemantic(sc);
         }
 
         if (s.isImport() || s.isModule() || s.isPackage())
@@ -7391,7 +7391,7 @@ extern (C++) final class TypeStruct : Type
             if (TupleDeclaration tup = d.isTupleDeclaration())
             {
                 e = new TupleExp(e.loc, tup);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
             if (d.needThis() && sc.intypeof != 1)
@@ -7402,7 +7402,7 @@ extern (C++) final class TypeStruct : Type
                 if (hasThis(sc))
                 {
                     e = new DotVarExp(e.loc, new ThisExp(e.loc), d);
-                    e = e.semantic(sc);
+                    e = e.expressionSemantic(sc);
                     return e;
                 }
             }
@@ -7422,12 +7422,12 @@ extern (C++) final class TypeStruct : Type
             checkAccess(e.loc, sc, e, d);
             Expression ve = new VarExp(e.loc, d);
             e = unreal ? ve : new CommaExp(e.loc, e, ve);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
 
         e = new DotVarExp(e.loc, e, d);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -7812,7 +7812,7 @@ extern (C++) final class TypeEnum : Type
             const s = toChars();
             e = new StringExp(loc, cast(char*)s);
             Scope sc;
-            e = e.semantic(&sc);
+            e = e.expressionSemantic(&sc);
         }
         else if (ident == Id._mangleof)
         {
@@ -8010,7 +8010,7 @@ extern (C++) final class TypeClass : Type
         {
             /* Create a TupleExp
              */
-            e = e.semantic(sc); // do this before turning on noaccesscheck
+            e = e.expressionSemantic(sc); // do this before turning on noaccesscheck
 
             sym.size(e.loc); // do semantic of type
 
@@ -8041,7 +8041,7 @@ extern (C++) final class TypeClass : Type
             e = new TupleExp(e.loc, e0, exps);
             Scope* sc2 = sc.push();
             sc2.flags = sc.flags | SCOPEnoaccesscheck;
-            e = e.semantic(sc2);
+            e = e.expressionSemantic(sc2);
             sc2.pop();
             return e;
         }
@@ -8085,7 +8085,7 @@ extern (C++) final class TypeClass : Type
                 if (e.op == TOKtype)
                     return Type.getProperty(e.loc, ident, 0);
                 e = new DotTypeExp(e.loc, e, sym);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
             if (auto cbase = sym.searchBase(ident))
@@ -8096,7 +8096,7 @@ extern (C++) final class TypeClass : Type
                     e = new CastExp(e.loc, e, ifbase.type);
                 else
                     e = new DotTypeExp(e.loc, e, cbase);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
 
@@ -8154,7 +8154,7 @@ extern (C++) final class TypeClass : Type
                  */
                 e = e.castTo(sc, tvoidptr.immutableOf().pointerTo().pointerTo());
                 e = new PtrExp(e.loc, e);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
 
@@ -8166,7 +8166,7 @@ extern (C++) final class TypeClass : Type
                 e = e.castTo(sc, tvoidptr.pointerTo());
                 e = new AddExp(e.loc, e, new IntegerExp(1));
                 e = new PtrExp(e.loc, e);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
 
@@ -8253,14 +8253,14 @@ extern (C++) final class TypeClass : Type
                 }
                 checkAccess(e.loc, sc, null, v);
                 Expression ve = new VarExp(e.loc, v);
-                ve = ve.semantic(sc);
+                ve = ve.expressionSemantic(sc);
                 return ve;
             }
         }
 
         if (auto t = s.getType())
         {
-            return (new TypeExp(e.loc, t)).semantic(sc);
+            return (new TypeExp(e.loc, t)).expressionSemantic(sc);
         }
 
         TemplateMixin tm = s.isTemplateMixin();
@@ -8278,7 +8278,7 @@ extern (C++) final class TypeClass : Type
                 e = new TemplateExp(e.loc, td);
             else
                 e = new DotTemplateExp(e.loc, e, td);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
 
@@ -8298,7 +8298,7 @@ extern (C++) final class TypeClass : Type
                 e = new ScopeExp(e.loc, ti);
             else
                 e = new DotExp(e.loc, e, new ScopeExp(e.loc, ti));
-            return e.semantic(sc);
+            return e.expressionSemantic(sc);
         }
 
         if (s.isImport() || s.isModule() || s.isPackage())
@@ -8331,7 +8331,7 @@ extern (C++) final class TypeClass : Type
             if (TupleDeclaration tup = d.isTupleDeclaration())
             {
                 e = new TupleExp(e.loc, tup);
-                e = e.semantic(sc);
+                e = e.expressionSemantic(sc);
                 return e;
             }
             if (d.needThis() && sc.intypeof != 1)
@@ -8343,7 +8343,7 @@ extern (C++) final class TypeClass : Type
                 {
                     // This is almost same as getRightThis() in expression.c
                     Expression e1 = new ThisExp(e.loc);
-                    e1 = e1.semantic(sc);
+                    e1 = e1.expressionSemantic(sc);
                 L2:
                     Type t = e1.type.toBasetype();
                     ClassDeclaration cd = e.type.isClassHandle();
@@ -8352,7 +8352,7 @@ extern (C++) final class TypeClass : Type
                     {
                         e = new DotTypeExp(e1.loc, e1, cd);
                         e = new DotVarExp(e.loc, e, d);
-                        e = e.semantic(sc);
+                        e = e.expressionSemantic(sc);
                         return e;
                     }
                     if (tcd && tcd.isNested())
@@ -8364,7 +8364,7 @@ extern (C++) final class TypeClass : Type
                         e1.type = tcd.vthis.type;
                         e1.type = e1.type.addMod(t.mod);
                         // Do not call ensureStaticLinkTo()
-                        //e1 = e1.semantic(sc);
+                        //e1 = e1.expressionSemantic(sc);
 
                         // Skip up over nested functions, and get the enclosing
                         // class type.
@@ -8389,10 +8389,10 @@ extern (C++) final class TypeClass : Type
                             e1.type = s.isClassDeclaration().type;
                             e1.type = e1.type.addMod(t.mod);
                             if (n > 1)
-                                e1 = e1.semantic(sc);
+                                e1 = e1.expressionSemantic(sc);
                         }
                         else
-                            e1 = e1.semantic(sc);
+                            e1 = e1.expressionSemantic(sc);
                         goto L2;
                     }
                 }
@@ -8414,12 +8414,12 @@ extern (C++) final class TypeClass : Type
             checkAccess(e.loc, sc, e, d);
             Expression ve = new VarExp(e.loc, d);
             e = unreal ? ve : new CommaExp(e.loc, e, ve);
-            e = e.semantic(sc);
+            e = e.expressionSemantic(sc);
             return e;
         }
 
         e = new DotVarExp(e.loc, e, d);
-        e = e.semantic(sc);
+        e = e.expressionSemantic(sc);
         return e;
     }
 
@@ -8766,8 +8766,8 @@ extern (C++) final class TypeSlice : TypeNext
                 sym.parent = sc.scopesym;
                 sc = sc.push(sym);
                 sc = sc.startCTFE();
-                lwr = lwr.semantic(sc);
-                upr = upr.semantic(sc);
+                lwr = lwr.expressionSemantic(sc);
+                upr = upr.expressionSemantic(sc);
                 sc = sc.endCTFE();
                 sc = sc.pop();
 

--- a/src/ddmd/opover.d
+++ b/src/ddmd/opover.d
@@ -433,7 +433,7 @@ extern (C++) Objects* opToArg(Scope* sc, TOK op)
         break;
     }
     Expression e = new StringExp(Loc(), cast(char*)Token.toChars(op));
-    e = e.semantic(sc);
+    e = e.expressionSemantic(sc);
     auto tiargs = new Objects();
     tiargs.push(e);
     return tiargs;
@@ -470,7 +470,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
             if (e.e1.op == TOKarray)
             {
                 ArrayExp ae = cast(ArrayExp)e.e1;
-                ae.e1 = ae.e1.semantic(sc);
+                ae.e1 = ae.e1.expressionSemantic(sc);
                 ae.e1 = resolveProperties(sc, ae.e1);
                 Expression ae1old = ae.e1;
                 const(bool) maybeSlice = (ae.arguments.dim == 0 || ae.arguments.dim == 1 && (*ae.arguments)[0].op == TOKinterval);
@@ -512,7 +512,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         if (maybeSlice) // op(a[]) might be: a.opSliceUnary!(op)()
                             result = result.trySemantic(sc);
                         else
-                            result = result.semantic(sc);
+                            result = result.expressionSemantic(sc);
                         if (result)
                         {
                             result = Expression.combine(e0, result);
@@ -538,7 +538,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         Objects* tiargs = opToArg(sc, e.op);
                         result = new DotTemplateInstanceExp(e.loc, ae.e1, Id.opSliceUnary, tiargs);
                         result = new CallExp(e.loc, result, a);
-                        result = result.semantic(sc);
+                        result = result.expressionSemantic(sc);
                         result = Expression.combine(e0, result);
                         return;
                     }
@@ -559,7 +559,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 ae.e1 = ae1old; // recovery
                 ae.lengthVar = null;
             }
-            e.e1 = e.e1.semantic(sc);
+            e.e1 = e.e1.expressionSemantic(sc);
             e.e1 = resolveProperties(sc, e.e1);
             if (e.e1.op == TOKerror)
             {
@@ -593,7 +593,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     Objects* tiargs = opToArg(sc, e.op);
                     result = new DotTemplateInstanceExp(e.loc, e.e1, fd.ident, tiargs);
                     result = new CallExp(e.loc, result);
-                    result = result.semantic(sc);
+                    result = result.expressionSemantic(sc);
                     return;
                 }
                 // Didn't find it. Forward to aliasthis
@@ -617,7 +617,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
         override void visit(ArrayExp ae)
         {
             //printf("ArrayExp::op_overload() (%s)\n", ae.toChars());
-            ae.e1 = ae.e1.semantic(sc);
+            ae.e1 = ae.e1.expressionSemantic(sc);
             ae.e1 = resolveProperties(sc, ae.e1);
             Expression ae1old = ae.e1;
             const(bool) maybeSlice = (ae.arguments.dim == 0 || ae.arguments.dim == 1 && (*ae.arguments)[0].op == TOKinterval);
@@ -650,14 +650,14 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         if (maybeSlice)
                         {
                             result = new SliceExp(ae.loc, ae.e1, ie);
-                            result = result.semantic(sc);
+                            result = result.expressionSemantic(sc);
                             return;
                         }
                         // Convert to IndexExp
                         if (ae.arguments.dim == 1)
                         {
                             result = new IndexExp(ae.loc, ae.e1, (*ae.arguments)[0]);
-                            result = result.semantic(sc);
+                            result = result.expressionSemantic(sc);
                             return;
                         }
                     }
@@ -680,7 +680,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     if (maybeSlice) // a[] might be: a.opSlice()
                         result = result.trySemantic(sc);
                     else
-                        result = result.semantic(sc);
+                        result = result.expressionSemantic(sc);
                     if (result)
                     {
                         result = Expression.combine(e0, result);
@@ -691,7 +691,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 if (maybeSlice && ae.e1.op == TOKtype)
                 {
                     result = new SliceExp(ae.loc, ae.e1, ie);
-                    result = result.semantic(sc);
+                    result = result.expressionSemantic(sc);
                     result = Expression.combine(e0, result);
                     return;
                 }
@@ -712,7 +712,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     }
                     result = new DotIdExp(ae.loc, ae.e1, Id.slice);
                     result = new CallExp(ae.loc, result, a);
-                    result = result.semantic(sc);
+                    result = result.expressionSemantic(sc);
                     result = Expression.combine(e0, result);
                     return;
                 }
@@ -766,7 +766,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     tiargs.push(e.to);
                     result = new DotTemplateInstanceExp(e.loc, e.e1, fd.ident, tiargs);
                     result = new CallExp(e.loc, result);
-                    result = result.semantic(sc);
+                    result = result.expressionSemantic(sc);
                     return;
                 }
                 // Didn't find it. Forward to aliasthis
@@ -1167,7 +1167,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     result = new CallExp(e.loc, result, e1x, e2x);
                     if (e.op == TOKnotequal)
                         result = new NotExp(e.loc, result);
-                    result = result.semantic(sc);
+                    result = result.expressionSemantic(sc);
                     return;
                 }
             }
@@ -1178,7 +1178,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 if (result.op == TOKcall && e.op == TOKnotequal)
                 {
                     result = new NotExp(result.loc, result);
-                    result = result.semantic(sc);
+                    result = result.expressionSemantic(sc);
                 }
                 return;
             }
@@ -1197,7 +1197,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                  */
                 auto op2 = e.op == TOKequal ? TOKidentity : TOKnotidentity;
                 result = new IdentityExp(op2, e.loc, e.e1, e.e2);
-                result = result.semantic(sc);
+                result = result.expressionSemantic(sc);
                 return;
             }
 
@@ -1215,7 +1215,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     // Use bitwise equality.
                     auto op2 = e.op == TOKequal ? TOKidentity : TOKnotidentity;
                     result = new IdentityExp(op2, e.loc, e.e1, e.e2);
-                    result = result.semantic(sc);
+                    result = result.expressionSemantic(sc);
                     return;
                 }
 
@@ -1237,7 +1237,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 if (!e.att2) e.att2 = t2;
                 e.e1 = new DotIdExp(e.loc, e.e1, Id._tupleof);
                 e.e2 = new DotIdExp(e.loc, e.e2, Id._tupleof);
-                result = e.semantic(sc);
+                result = e.expressionSemantic(sc);
 
                 /* https://issues.dlang.org/show_bug.cgi?id=15292
                  * if the rewrite result is same with the original,
@@ -1293,7 +1293,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     assert(result);
                 }
                 result = Expression.combine(Expression.combine(tup1.e0, tup2.e0), result);
-                result = result.semantic(sc);
+                result = result.expressionSemantic(sc);
                 return;
             }
         }
@@ -1313,7 +1313,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
             if (e.e1.op == TOKarray)
             {
                 ArrayExp ae = cast(ArrayExp)e.e1;
-                ae.e1 = ae.e1.semantic(sc);
+                ae.e1 = ae.e1.expressionSemantic(sc);
                 ae.e1 = resolveProperties(sc, ae.e1);
                 Expression ae1old = ae.e1;
                 const(bool) maybeSlice = (ae.arguments.dim == 0 || ae.arguments.dim == 1 && (*ae.arguments)[0].op == TOKinterval);
@@ -1345,7 +1345,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                             goto Lfallback;
                         if (result.op == TOKerror)
                             return;
-                        result = e.e2.semantic(sc);
+                        result = e.e2.expressionSemantic(sc);
                         if (result.op == TOKerror)
                             return;
                         e.e2 = result;
@@ -1360,7 +1360,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         if (maybeSlice) // (a[] op= e2) might be: a.opSliceOpAssign!(op)(e2)
                             result = result.trySemantic(sc);
                         else
-                            result = result.semantic(sc);
+                            result = result.expressionSemantic(sc);
                         if (result)
                         {
                             result = Expression.combine(e0, result);
@@ -1374,7 +1374,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         result = resolveOpDollar(sc, ae, ie, &e0);
                         if (result.op == TOKerror)
                             return;
-                        result = e.e2.semantic(sc);
+                        result = e.e2.expressionSemantic(sc);
                         if (result.op == TOKerror)
                             return;
                         e.e2 = result;
@@ -1391,7 +1391,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                         Objects* tiargs = opToArg(sc, e.op);
                         result = new DotTemplateInstanceExp(e.loc, ae.e1, Id.opSliceOpAssign, tiargs);
                         result = new CallExp(e.loc, result, a);
-                        result = result.semantic(sc);
+                        result = result.expressionSemantic(sc);
                         result = Expression.combine(e0, result);
                         return;
                     }
@@ -1696,7 +1696,7 @@ extern (C++) Expression build_overload(Loc loc, Scope* sc, Expression ethis, Exp
     else
         e = new DotIdExp(loc, ethis, d.ident);
     e = new CallExp(loc, e, earg);
-    e = e.semantic(sc);
+    e = e.expressionSemantic(sc);
     return e;
 }
 
@@ -1733,7 +1733,7 @@ extern (C++) bool inferAggregate(ForeachStatement fes, Scope* sc, ref Dsymbol sa
     AggregateDeclaration ad;
     while (1)
     {
-        aggr = aggr.semantic(sc);
+        aggr = aggr.expressionSemantic(sc);
         aggr = resolveProperties(sc, aggr);
         aggr = aggr.optimize(WANTvalue);
         if (!aggr.type || aggr.op == TOKerror)

--- a/src/ddmd/optimize.d
+++ b/src/ddmd/optimize.d
@@ -20,6 +20,7 @@ import ddmd.dclass;
 import ddmd.declaration;
 import ddmd.dsymbol;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.globals;
 import ddmd.init;
 import ddmd.mtype;
@@ -107,7 +108,7 @@ extern (C++) Expression expandVar(int result, VarDeclaration v)
                     {
                         // const var initialized with non-const expression
                         ei = ei.implicitCastTo(null, v.type);
-                        ei = ei.semantic(null);
+                        ei = ei.expressionSemantic(null);
                     }
                     else
                         goto L1;

--- a/src/ddmd/semantic.d
+++ b/src/ddmd/semantic.d
@@ -36,12 +36,6 @@ extern(C++) void semantic(Dsymbol dsym, Scope* sc)
     dsymbolSemantic(dsym, sc);
 }
 
-extern(C++) Expression semantic(Expression e, Scope* sc)
-{
-    import ddmd.expressionsem;
-    return expressionSemantic(e, sc);
-}
-
 /******************************************
  * Perform semantic analysis on init.
  * Params:

--- a/src/ddmd/sideeffect.d
+++ b/src/ddmd/sideeffect.d
@@ -16,6 +16,7 @@ import ddmd.apply;
 import ddmd.declaration;
 import ddmd.dscope;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.identifier;
@@ -407,8 +408,8 @@ Expression extractSideEffect(Scope* sc, const char* name,
 
     Expression de = new DeclarationExp(vd.loc, vd);
     Expression ve = new VarExp(vd.loc, vd);
-    de = de.semantic(sc);
-    ve = ve.semantic(sc);
+    de = de.expressionSemantic(sc);
+    ve = ve.expressionSemantic(sc);
 
     e0 = Expression.combine(e0, de);
     return ve;

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -31,6 +31,7 @@ import ddmd.dsymbol;
 import ddmd.dtemplate;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.hdrgen;
@@ -740,7 +741,7 @@ extern (C++) class ExpStatement : Statement
             Dsymbol d = (cast(DeclarationExp)exp).declaration;
             if (TemplateMixin tm = d.isTemplateMixin())
             {
-                Expression e = exp.semantic(sc);
+                Expression e = exp.expressionSemantic(sc);
                 if (e.op == TOKerror || tm.errors)
                 {
                     auto a = new Statements();

--- a/src/ddmd/staticcond.d
+++ b/src/ddmd/staticcond.d
@@ -18,6 +18,7 @@ import ddmd.dscope;
 import ddmd.dsymbol;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.globals;
 import ddmd.identifier;
 import ddmd.mtype;
@@ -76,7 +77,7 @@ bool evalStaticCondition(Scope* sc, Expression exp, Expression e, ref bool error
     sc = sc.startCTFE();
     sc.flags |= SCOPEcondition;
 
-    e = e.semantic(sc);
+    e = e.expressionSemantic(sc);
     e = resolveProperties(sc, e);
 
     sc = sc.endCTFE();

--- a/src/ddmd/templateparamsem.d
+++ b/src/ddmd/templateparamsem.d
@@ -20,6 +20,7 @@ import ddmd.dscope;
 import ddmd.dtemplate;
 import ddmd.globals;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.root.rootobject;
 import ddmd.semantic;
 import ddmd.mtype;
@@ -159,7 +160,7 @@ RootObject aliasParameterSemantic(Loc loc, Scope* sc, RootObject o, TemplatePara
         else if (ea)
         {
             sc = sc.startCTFE();
-            ea = ea.semantic(sc);
+            ea = ea.expressionSemantic(sc);
             sc = sc.endCTFE();
             o = ea.ctfeInterpret();
         }

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -604,7 +604,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         auto se = new StringExp(e.loc, cast(char*)id.toChars());
-        return se.semantic(sc);
+        return se.expressionSemantic(sc);
     }
     if (e.ident == Id.getProtection)
     {
@@ -632,7 +632,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto protName = protectionToChars(s.prot().kind); // TODO: How about package(names)
         assert(protName);
         auto se = new StringExp(e.loc, cast(char*)protName);
-        return se.semantic(sc);
+        return se.expressionSemantic(sc);
     }
     if (e.ident == Id.parent)
     {
@@ -661,14 +661,14 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 if (td.overroot) // if not start of overloaded list of TemplateDeclaration's
                     td = td.overroot; // then get the start
                 Expression ex = new TemplateExp(e.loc, td, f);
-                ex = ex.semantic(sc);
+                ex = ex.expressionSemantic(sc);
                 return ex;
             }
             if (auto fld = f.isFuncLiteralDeclaration())
             {
                 // Directly translate to VarExp instead of FuncExp
                 Expression ex = new VarExp(e.loc, fld, true);
-                return ex.semantic(sc);
+                return ex.expressionSemantic(sc);
             }
         }
         return resolve(e.loc, sc, s, false);
@@ -747,7 +747,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             if (ex.op == TOKdotid)
                 // Prevent semantic() from replacing Symbol with its initializer
                 (cast(DotIdExp)ex).wantsym = true;
-            ex = ex.semantic(scx);
+            ex = ex.expressionSemantic(scx);
             return ex;
         }
         else if (e.ident == Id.getVirtualFunctions ||
@@ -756,7 +756,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             uint errors = global.errors;
             Expression eorig = ex;
-            ex = ex.semantic(scx);
+            ex = ex.expressionSemantic(scx);
             if (errors < global.errors)
                 e.error("`%s` cannot be resolved", eorig.toChars());
             //ex.print();
@@ -802,7 +802,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             });
 
             auto tup = new TupleExp(e.loc, exps);
-            return tup.semantic(scx);
+            return tup.expressionSemantic(scx);
         }
         else
             assert(0);
@@ -850,7 +850,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         if (ad.aliasthis)
             exps.push(new StringExp(e.loc, cast(char*)ad.aliasthis.ident.toChars()));
         Expression ex = new TupleExp(e.loc, exps);
-        ex = ex.semantic(sc);
+        ex = ex.expressionSemantic(sc);
         return ex;
     }
     if (e.ident == Id.getAttributes)
@@ -883,7 +883,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto udad = s.userAttribDecl;
         auto exps = udad ? udad.getAttributes() : new Expressions();
         auto tup = new TupleExp(e.loc, exps);
-        return tup.semantic(sc);
+        return tup.expressionSemantic(sc);
     }
     if (e.ident == Id.getFunctionAttributes)
     {
@@ -924,7 +924,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         tf.attributesApply(&pa, &PushAttributes.fp, TRUSTformatSystem);
 
         auto tup = new TupleExp(e.loc, mods);
-        return tup.semantic(sc);
+        return tup.expressionSemantic(sc);
     }
     if (e.ident == Id.getFunctionVariadicStyle)
     {
@@ -980,7 +980,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 assert(0);
         }
         auto se = new StringExp(e.loc, cast(char*)style);
-        return se.semantic(sc);
+        return se.expressionSemantic(sc);
     }
     if (e.ident == Id.getParameterStorageClasses)
     {
@@ -1083,7 +1083,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             push("scope");
 
         auto tup = new TupleExp(e.loc, exps);
-        return tup.semantic(sc);
+        return tup.expressionSemantic(sc);
     }
     if (e.ident == Id.getLinkage)
     {
@@ -1119,7 +1119,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         auto linkage = linkageToChars(link);
         auto se = new StringExp(e.loc, cast(char*)linkage);
-        return se.semantic(sc);
+        return se.expressionSemantic(sc);
     }
     if (e.ident == Id.allMembers ||
         e.ident == Id.derivedMembers)
@@ -1244,7 +1244,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
          *   [ __traits(allMembers, ...) ]
          */
         Expression ex = new TupleExp(e.loc, exps);
-        ex = ex.semantic(sc);
+        ex = ex.expressionSemantic(sc);
         return ex;
     }
     if (e.ident == Id.compiles)
@@ -1282,7 +1282,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             }
             if (ex)
             {
-                ex = ex.semantic(sc2);
+                ex = ex.expressionSemantic(sc2);
                 ex = resolvePropertiesOnly(sc2, ex);
                 ex = ex.optimize(WANTvalue);
                 if (sc2.func && sc2.func.type.ty == Tfunction)
@@ -1431,7 +1431,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             collectUnitTests(sds.members);
         }
         auto te = new TupleExp(e.loc, exps);
-        return te.semantic(sc);
+        return te.expressionSemantic(sc);
     }
     if (e.ident == Id.getVirtualIndex)
     {

--- a/src/ddmd/typesem.d
+++ b/src/ddmd/typesem.d
@@ -24,6 +24,7 @@ import ddmd.dstruct;
 import ddmd.dsymbol;
 import ddmd.errors;
 import ddmd.expression;
+import ddmd.expressionsem;
 import ddmd.func;
 import ddmd.globals;
 import ddmd.hdrgen;
@@ -938,7 +939,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                     Expression e = fparam.defaultArg;
                     if (fparam.storageClass & (STCref | STCout))
                     {
-                        e = e.semantic(argsc);
+                        e = e.expressionSemantic(argsc);
                         e = resolveProperties(argsc, e);
                     }
                     else
@@ -956,7 +957,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                         // and copying the literal itself is wrong.
                         e = new VarExp(e.loc, fe.fd, false);
                         e = new AddrExp(e.loc, e);
-                        e = e.semantic(argsc);
+                        e = e.expressionSemantic(argsc);
                     }
                     e = e.implicitCastTo(argsc, fparam.type);
 


### PR DESCRIPTION
I hadn't realized there were so many calls. Anyhow, this makes things much more greppable.