### PR TITLE
fix Issue 11847 - sub-pkg not available as qualified name

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -141,6 +141,7 @@ extern (C++) final class Import : Dsymbol
             }
         }
         Dsymbol s = dst.lookup(id);
+        Package pkgmod;
         if (s)
         {
             if (s.isModule())
@@ -161,7 +162,7 @@ extern (C++) final class Import : Dsymbol
                         else
                         {
                             // mod is a package.d, or a normal module which conflicts with the package name.
-                            auto pkgmod = mod.insertIntoPackageTree();
+                            pkgmod = mod.insertIntoPackageTree();
                             if (auto mprev = pkgmod.isModule())
                             {
                                 // https://issues.dlang.org/show_bug.cgi?id=14446
@@ -201,7 +202,7 @@ extern (C++) final class Import : Dsymbol
             mod = Module.load(loc, packages, id);
             if (mod)
             {
-                auto pkgmod = mod.insertIntoPackageTree();
+                pkgmod = mod.insertIntoPackageTree();
                 // https://issues.dlang.org/show_bug.cgi?id=14446
                 // Use previously parsed module to avoid AST duplication ICE.
                 if (auto mprev = pkgmod.isModule())
@@ -214,7 +215,7 @@ extern (C++) final class Import : Dsymbol
         if (mod && !mod.importedFrom)
             mod.importedFrom = sc ? sc._module.importedFrom : Module.rootModule;
         if (!pkg)
-            pkg = mod;
+            pkg = pkgmod ? pkgmod : mod;
         //printf("-Import::load('%s'), pkg = %p\n", toChars(), pkg);
         return global.errors != errors;
     }

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -708,6 +708,10 @@ private int tryMain(size_t argc, const(char)** argv)
             }
         }
         m.parse();
+        // https://issues.dlang.org/show_bug.cgi?id=14446
+        // Use previously parsed module to avoid AST duplication ICE.
+        if (auto mprev = m.insertIntoPackageTree().isModule())
+            m = mprev;
         if (m.isDocFile)
         {
             anydocfiles = true;

--- a/test/compilable/imports/pkg11847/mod.d
+++ b/test/compilable/imports/pkg11847/mod.d
@@ -1,0 +1,2 @@
+module pkg11847.mod;
+enum sym = 0;

--- a/test/compilable/imports/pkg11847/package.d
+++ b/test/compilable/imports/pkg11847/package.d
@@ -1,0 +1,1 @@
+module pkg11847;

--- a/test/compilable/test11847.d
+++ b/test/compilable/test11847.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -Icompilable/imports
+import pkg11847;
+import pkg11847.mod;
+
+void test()
+{
+    auto a = pkg11847.mod.sym;
+}

--- a/test/fail_compilation/extra-files/extra11847.d
+++ b/test/fail_compilation/extra-files/extra11847.d
@@ -1,0 +1,4 @@
+module extra11847;
+
+import pkg11847;
+import pkg11847.mod;

--- a/test/fail_compilation/imports/pkg11847/mod.d
+++ b/test/fail_compilation/imports/pkg11847/mod.d
@@ -1,0 +1,2 @@
+module pkg11847.mod;
+enum sym = 0;

--- a/test/fail_compilation/imports/pkg11847/package.d
+++ b/test/fail_compilation/imports/pkg11847/package.d
@@ -1,0 +1,1 @@
+module pkg11847;

--- a/test/fail_compilation/test11847.d
+++ b/test/fail_compilation/test11847.d
@@ -1,0 +1,14 @@
+/*
+REQUIRED_ARGS: -Ifail_compilation/imports -de
+EXTRA_SOURCES: extra-files/extra11847.d
+TEST_OUTPUT:
+----
+fail_compilation/test11847.d(13): Deprecation: module pkg11847.mod is not accessible here, perhaps add 'static import pkg11847.mod;'
+----
+ */
+import pkg11847;
+
+void test()
+{
+    auto a = pkg11847.mod.sym;
+}


### PR DESCRIPTION
- Change start point for qualified lookups in Import (`pkg`) from
  package.d module to the wrapping Package (package module),
  thus making sub-pkgs available for qualified lookups.

This fix is preceeded by some necessary refactoring as the
wrapping package module wasn't easily accessible to Import.

Targets master as this is quite a big change and beta for 2.077.0 begins today.