### PR TITLE
Remove outdated math headers

### DIFF
--- a/src/root/ctfloat.c
+++ b/src/root/ctfloat.c
@@ -387,10 +387,6 @@ size_t CTFloat::hash(real_t a)
 #if __linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__
 
 #include <math.h>
-#if __linux__
-#include <bits/nan.h>
-#include <bits/mathdef.h>
-#endif
 #if __FreeBSD__ && __i386__
 #include <ieeefp.h>
 #endif


### PR DESCRIPTION
These glibc headers say not to use them for something like 20 years, so I'm not sure when they were actually used.  [As I noted in the forum earlier, this breaks the compile for me](http://forum.dlang.org/thread/xgtbpcvbikxlilanrzqa@forum.dlang.org) on Arch linux, which is why [I took it out of ldc last year](https://github.com/ldc-developers/ldc/pull/1447/files#diff-2268700876655bdfa9d178b9cc466277).

With all @ibuclaw's other recent commits, dmd from dmd-cxx builds for me again with this commit, though I haven't run the tests.  One issue I noticed is that this dmd says the version is 2.069-devel-*, but Iain said it's up to the 2.071 frontend in his commits.  @braddr, do you think we can get the auto-tester to build dmd master using this dmd-cxx branch, once we're sure it's working well?

Also, I'm not sure what Iain's plan is with this branch, I thought it was just to get the last mostly C++ frontend, 2.068.2, building again, to always be able to bootstrap with it, wheareas he seems to be updating it to newer backported frontends?  When is that going to stop, whenever gdc finally switches over to the ddmd frontend fully?