### PR TITLE
Fix Issue 17748 - extern(C) do nothing on struct methods

### DIFF
--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -439,7 +439,20 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
     {
         super(decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", p, decl);
+
         linkage = (p == LINKsystem) ? Target.systemLinkage() : p;
+
+        if (linkage == LINKc)
+        {
+            if (decl)
+            {
+                foreach (d; *decl)
+                {
+                    if (d.isAggregateDeclaration)
+                        d.deprecation("cannot be marked as \"extern (C)\".");
+                }
+            }
+        }
     }
 
     static LinkDeclaration create(LINK p, Dsymbols* decl)

--- a/src/ddmd/dmangle.d
+++ b/src/ddmd/dmangle.d
@@ -537,6 +537,12 @@ public:
 
     static const(char)* externallyMangledIdentifier(Declaration d)
     {
+        if (d.isFuncDeclaration && d.linkage == LINKc &&
+           (d.parent !is null && !d.parent.isModule && !d.isStatic))
+        {
+            d.deprecation("is declared \"extern (C)\" and it is neither static nor defined at top level.");
+        }
+
         if (!d.parent || d.parent.isModule() || d.linkage == LINKcpp) // if at global scope
         {
             switch (d.linkage)
@@ -565,6 +571,7 @@ public:
     {
         //printf("Declaration.mangle(this = %p, '%s', parent = '%s', linkage = %d)\n",
         //        d, d.toChars(), d.parent ? d.parent.toChars() : "null", d.linkage);
+
         if (auto id = externallyMangledIdentifier(d))
         {
             buf.writestring(id);
@@ -854,7 +861,7 @@ public:
             mangleIdentifier(s.ident, s);
         else
             toBuffer(s.toChars(), s);
-        //printf("Dsymbol.mangle() %s = %s\n", s.toChars(), id);
+        //printf("Dsymbol.mangle() %s = %s\n", s.toChars(), s.ident);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/test/fail_compilation/fail17748a.d
+++ b/test/fail_compilation/fail17748a.d
@@ -1,0 +1,20 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/fail17748a.d(11): Deprecation: function fail17748a.S.foo is declared "extern (C)" and it is neither static nor defined at top level.
+---
+*/
+
+struct S
+{
+    extern (C) void foo() {}
+}
+
+struct S2
+{
+    static extern (C) void foo() {}
+}
+
+void main()
+{}

--- a/test/fail_compilation/fail17748b.d
+++ b/test/fail_compilation/fail17748b.d
@@ -1,0 +1,12 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/fail17748b.d(9): Deprecation: class LeClass cannot be marked as "extern (C)".
+---
+*/
+
+extern (C) class LeClass {}
+
+void main()
+{}

--- a/test/fail_compilation/fail17748b.d
+++ b/test/fail_compilation/fail17748b.d
@@ -2,11 +2,14 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail17748b.d(9): Deprecation: class LeClass cannot be marked as "extern (C)".
+fail_compilation/fail17748b.d(10): Deprecation: class LeClass cannot be marked as "extern (C)".
+fail_compilation/fail17748b.d(12): Deprecation: struct LeStruct cannot be marked as "extern (C)".
 ---
 */
 
 extern (C) class LeClass {}
+
+extern (C) struct LeStruct {}
 
 void main()
 {}


### PR DESCRIPTION
This is just a starting point implementation. The problem is that classes defined with extern (C) can be identified at parsing time, while nested functions can be excluded (from what I've seen) only during semantic.

