### PR TITLE
CTFECache - caching D compiler

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -101,6 +101,9 @@ struct Usage
         Option("c",
             "do not link"
         ),
+        Option("cache=mmap",
+            "use persistent cache for CTFE evaluations"
+        ),
         Option("color",
             "turn colored console output on"
         ),

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -407,6 +407,8 @@ extern (C++) final class Module : Package
 
     size_t nameoffset;          // offset of module name from start of ModuleInfo
     size_t namelen;             // length of module name in characters
+   
+    ubyte[20] signature;        // A signature of contents, currently SHA1
 
     extern (D) this(const(char)* filename, Identifier ident, int doDocComment, int doHdrGen)
     {

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -16,10 +16,12 @@ import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
 import dmd.attrib;
+import dmd.dcache;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dmodule;
 import dmd.doc;
+import dmd.dimport;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.dtemplate;
@@ -554,7 +556,7 @@ struct Scope
              * checked by the compiler remain usable.  Once the deprecation is over,
              * this should be moved to search_correct instead.
              */
-            if (!s && !(flags & IgnoreSymbolVisibility))
+            if (!cachedSemantics && !s && !(flags & IgnoreSymbolVisibility))
             {
                 s = searchScopes(flags | SearchLocalsOnly | IgnoreSymbolVisibility);
                 if (!s)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -22,6 +22,7 @@ import dmd.aliasthis;
 import dmd.arraytypes;
 import dmd.attrib;
 import dmd.gluelayer;
+import dmd.dcache;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.denum;
@@ -1380,7 +1381,7 @@ public:
                     AliasDeclaration ad = void;
                     // accessing private selective and renamed imports is
                     // deprecated by restricting the symbol visibility
-                    if (s.isImport() || (ad = s.isAliasDeclaration()) !is null && ad._import !is null)
+                    if (cachedSemantics || s.isImport() || (ad = s.isAliasDeclaration()) !is null && ad._import !is null)
                     {}
                     else
                         error(loc, "%s `%s` is `private`", s.kind(), s.toPrettyChars());

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -23,6 +23,7 @@ import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astcodegen;
 import dmd.canthrow;
+import dmd.dcache;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.declaration;
@@ -2962,6 +2963,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (!sd.ctor)
                     sd.ctor = sd.searchCtor();
 
+                // A cached value is a literal
+                if (cachedSemantics) goto Lx;
                 // First look for constructor
                 if (exp.e1.op == TOK.type && sd.ctor)
                 {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -146,6 +146,7 @@ struct Param
      * used to hide a feature that will have to go through deprecate-then-error
      * before becoming default.
      */
+    bool cache;             // use persistent caching of CTFE (DCache)
 
     bool showGaggedErrors;  // print gagged errors anyway
     bool manual;            // open browser on compiler manual

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1530,7 +1530,10 @@ public:
 
     override void visit(TemplateInstance ti)
     {
-        buf.writestring(ti.name.toChars());
+        if (ti.aliasdecl)
+            buf.writestring(ti.aliasdecl.toChars());
+        else
+            buf.writestring(ti.name.toChars());
         tiargsToBuffer(ti);
 
         if (hgs.fullDump)
@@ -2497,7 +2500,7 @@ public:
 
     override void visit(StructLiteralExp e)
     {
-        buf.writestring(e.sd.toChars());
+        buf.writestring(e.sd.type.toChars());
         buf.writeByte('(');
         // CTFE can generate struct literals that contain an AddrExp pointing
         // to themselves, need to avoid infinite recursion:

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -32,6 +32,7 @@ import dmd.dinifile;
 import dmd.dinterpret;
 import dmd.dmodule;
 import dmd.doc;
+import dmd.dcache;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
@@ -478,6 +479,8 @@ private int tryMain(size_t argc, const(char)** argv)
     Expression._init();
     Objc._init();
     builtin_init();
+    if (global.params.cache)
+        dcache.initialize(global._version[0..strlen(global._version)]);
 
     if (global.params.verbose)
     {
@@ -1537,6 +1540,10 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 }
                 else if (p[4])
                     goto Lerror;
+            }
+            else if (strcmp(p + 1, cast(char*)"cache=mmap") == 0)
+            {
+                params.cache = true;
             }
             else if (arg == "-shared")
                 params.dll = true;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -237,7 +237,12 @@ final class Parser(AST) : Lexer
     Loc endloc; // set to location of last right curly
     int inBrackets; // inside [] of array index or slice
     Loc lookingForElse; // location of lonely if looking for an else
-
+    enum withSignature = __traits(hasMember, typeof(mod), "signature");
+    static if (withSignature)
+    {
+        import dmd.root.sha;
+        SHA1 hasher;
+    }
     /*********************
      * Use this constructor for string mixins.
      * Input:
@@ -246,8 +251,14 @@ final class Parser(AST) : Lexer
     extern (D) this(Loc loc, AST.Module _module, const(char)[] input, bool doDocComment)
     {
         super(_module ? _module.srcfile.toChars() : null, input.ptr, 0, input.length, doDocComment, false);
-
         //printf("Parser::Parser()\n");
+        static if (withSignature)
+        {
+            hasher.start();
+            hasher.put(_module.signature[]);
+            hasher.put(cast(ubyte[])input);
+            _module.signature = hasher.finish();
+        }
         scanloc = loc;
 
         if (loc.filename)
@@ -268,7 +279,12 @@ final class Parser(AST) : Lexer
     extern (D) this(AST.Module _module, const(char)[] input, bool doDocComment)
     {
         super(_module ? _module.srcfile.toChars() : null, input.ptr, 0, input.length, doDocComment, false);
-
+        static if (withSignature)
+        {
+            hasher.start();
+            hasher.put(cast(ubyte[])input);
+            _module.signature = hasher.finish();
+        }
         //printf("Parser::Parser()\n");
         mod = _module;
         linkage = LINK.d;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -287,12 +287,16 @@ D_OBJC := 1
 endif
 endif
 
+# Enable stats for DCache
+#DFLAGS += -version=DCACHE_STATS
+# Enable debug for DCache
+#DFLAGS += -debug=DCACHE
 
 ######## DMD frontend source files
 
 FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes arrayop	\
 	arraytypes astcodegen attrib builtin canthrow cli clone compiler complex cond constfold	\
-	cppmangle cppmanglewin ctfeexpr dcast dclass declaration delegatize denum dimport	\
+	cppmangle cppmanglewin ctfeexpr dcache dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\
 	hdrgen id impcnvtab imphint init initsem inline inlinecost intrange	\
@@ -304,7 +308,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors globals id identifier lexer tokens utf))
 
 LEXER_ROOT=$(addsuffix .d, $(addprefix $(ROOT)/, array ctfloat file filename outbuffer port rmem \
-	rootobject stringtable hash))
+	rootobject stringtable hash sha sha_SSSE3))
 
 ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array ctfloat file \
 	filename man outbuffer port response rmem rootobject speller \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -150,7 +150,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 # D front end
 FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
 	$D/arraytypes.d $D/astcodegen.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/cli.d $D/clone.d $D/compiler.d $D/complex.d	\
-	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d		\
+	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/cache.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d $D/dsymbolsem.d		\
 	$D/dtemplate.d $D/dversion.d $D/escape.d			\
@@ -204,7 +204,7 @@ GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.o
 ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 	$(ROOT)/filename.d $(ROOT)/man.d $(ROOT)/outbuffer.d $(ROOT)/port.d \
 	$(ROOT)/response.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
-	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d
+	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d $(ROOT)/sha.d $(ROOT)/sha_SSSE3.d
 
 # D front end
 SRCS = $D/aggregate.h $D/aliasthis.h $D/arraytypes.h	\


### PR DESCRIPTION
A preliminary patch to cache CTFE executions in a persistent store.

This allows to reuse expensive CTFE computations across builds.
Ironically processing huge struct literal is still quite costly but is a fight for another day.

In action:
```bash
▶ cat r*.d
import std.regex;

enum r = regex(`\w`);

void main(){}import std.regex;

enum r = regex(`\w\w`);

void main(){}import std.regex;

enum r = regex(`\w\w\w`);

void main(){}import std.regex;

enum r = regex(`\w\w\w\w`);

void main(){}

▶ cat bench.sh
#!/bin/bash
for f in r*.d ; do
        echo "Compiling $f with dmd $@"
        time dmd $1 $f
done
```
## Recent master version
▶ dmd --version
DMD64 D Compiler v2.077.0-144-gbbca650
Copyright (c) 1999-2017 by Digital Mars written by Walter Bright

▶ ./bench.sh
Compiling r1.d with dmd

real    0m3.047s
user    0m2.808s
sys     0m0.232s
Compiling r2.d with dmd

real    0m4.105s
user    0m3.832s
sys     0m0.264s
Compiling r3.d with dmd

real    0m4.682s
user    0m4.372s
sys     0m0.304s
Compiling r4.d with dmd

real    0m5.457s
user    0m5.128s
sys     0m0.320s
./bench.sh  16.14s user 1.12s system 99% cpu 17.294 total

## DCache version

▶ dmd --version
DMD64 D Compiler v2.077.0-122-g7a50140
Copyright (c) 1999-2017 by Digital Mars written by Walter Bright

▶ ./bench.sh
Compiling r1.d with dmd

real    0m3.358s
user    0m3.004s
sys     0m0.348s
Compiling r2.d with dmd

real    0m3.909s
user    0m3.500s
sys     0m0.404s
Compiling r3.d with dmd

real    0m4.579s
user    0m4.152s
sys     0m0.420s
Compiling r4.d with dmd

real    0m5.332s
user    0m4.836s
sys     0m0.488s
./bench.sh  15.49s user 1.66s system 99% cpu 17.182 total

## Now with caching + cache usage traces
▶ ./bench.sh -cache=mmap
Compiling r1.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Recomputed InversionList!(GcPolicy) memoizeExpr() @trusted in 0.690174
Recomputed InversionList!(GcPolicy) wordCharacter() @property @safe in 0.690408
Recomputed Trie!(BitPacked!(bool, 1LU), dchar, 1114112LU, sliceBits!(8LU, 21LU), sliceBits!(0LU, 8LU)) codepointSetTrie(InversionList!(GcPolicy) set) pure @safe in 0.381241
Recomputed CharMatcher this(InversionList!(GcPolicy) set) ref in 0.418019
Recomputed Regex!char regex(string[] patterns, const(char)[] flags = "") @trusted in 1.111543
Recomputed Regex!char regex(string pattern, const(char)[] flags = "") @trusted in 1.112261

real    0m3.393s
user    0m3.040s
sys     0m0.348s
Compiling r2.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Mixed in InversionList!(GcPolicy) wordCharacter() @property @safe from cache in 0.000605
Mixed in CharMatcher this(InversionList!(GcPolicy) set) ref from cache in 0.001930
Recomputed Regex!char regex(string[] patterns, const(char)[] flags = "") @trusted in 1.750151
Recomputed Regex!char regex(string pattern, const(char)[] flags = "") @trusted in 1.750862

real    0m2.882s
user    0m2.644s
sys     0m0.232s
Compiling r3.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Mixed in InversionList!(GcPolicy) wordCharacter() @property @safe from cache in 0.000705
Mixed in CharMatcher this(InversionList!(GcPolicy) set) ref from cache in 0.001632
Recomputed Regex!char regex(string[] patterns, const(char)[] flags = "") @trusted in 2.486691
Recomputed Regex!char regex(string pattern, const(char)[] flags = "") @trusted in 2.487412

real    0m3.611s
user    0m3.212s
sys     0m0.392s
Compiling r4.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Mixed in InversionList!(GcPolicy) wordCharacter() @property @safe from cache in 0.000636
Mixed in CharMatcher this(InversionList!(GcPolicy) set) ref from cache in 0.001907
Recomputed Regex!char regex(string[] patterns, const(char)[] flags = "") @trusted in 3.138693
Recomputed Regex!char regex(string pattern, const(char)[] flags = "") @trusted in 3.139398

real    0m4.285s
user    0m3.816s
sys     0m0.464s
./bench.sh -cache=mmap  12.72s user 1.44s system 99% cpu 14.176 total

## 2nd run DCache
▶ ./bench.sh -cache=mmap
Compiling r1.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Mixed in InversionList!(GcPolicy) wordCharacter() @property @safe from cache in 0.000619
Mixed in CharMatcher this(InversionList!(GcPolicy) set) ref from cache in 0.001780
Mixed in Regex!char regex(string pattern, const(char)[] flags = "") @trusted from cache in 0.002774

real    0m1.202s
user    0m1.064s
sys     0m0.132s
Compiling r2.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Mixed in InversionList!(GcPolicy) wordCharacter() @property @safe from cache in 0.000714
Mixed in CharMatcher this(InversionList!(GcPolicy) set) ref from cache in 0.001862
Mixed in Regex!char regex(string pattern, const(char)[] flags = "") @trusted from cache in 0.002727

real    0m1.247s
user    0m1.112s
sys     0m0.132s
Compiling r3.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Mixed in InversionList!(GcPolicy) wordCharacter() @property @safe from cache in 0.000631
Mixed in CharMatcher this(InversionList!(GcPolicy) set) ref from cache in 0.001766
Mixed in Regex!char regex(string pattern, const(char)[] flags = "") @trusted from cache in 0.002734

real    0m1.181s
user    0m1.016s
sys     0m0.156s
Compiling r4.d with dmd -cache=mmap
Using DCache at /home/olshanskiy/.cache/dcache-v2.077.0-122-g7a50140
Mixed in InversionList!(GcPolicy) wordCharacter() @property @safe from cache in 0.000617
Mixed in CharMatcher this(InversionList!(GcPolicy) set) ref from cache in 0.001752
Mixed in Regex!char regex(string pattern, const(char)[] flags = "") @trusted from cache in 0.002806

real    0m1.169s
user    0m1.076s
sys     0m0.088s
./bench.sh -cache=mmap  4.27s user 0.51s system 99% cpu 4.804 total