### PR TITLE
Fix Issue 17908 - Can't alias an overload set with disabled function

### DIFF
--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -6510,7 +6510,7 @@ extern (C++) abstract class TypeQualified : Type
             if (d && (d.storage_class & STCtemplateparameter))
                 s = s.toAlias();
             else
-                s.checkDeprecated(loc, sc); // check for deprecated aliases
+                s.checkDeprecated(loc, sc, true); // check for deprecated or disabled aliases
             s = s.toAlias();
             //printf("\t2: s = '%s' %p, kind = '%s'\n",s.toChars(), s, s.kind());
             for (size_t i = 0; i < idents.dim; i++)

--- a/test/compilable/test17908.d
+++ b/test/compilable/test17908.d
@@ -1,0 +1,17 @@
+// PERMUTE ARGS:
+
+@disable void foo() {}
+void foo(int) {}
+alias g = foo;
+
+// make sure the order of declaration
+// doesn't change anything
+void bar(int) {}
+@disable void bar() {}
+alias h = bar;
+
+void main()
+{
+    g(10);
+    h(10);
+}

--- a/test/fail_compilation/test17908a.d
+++ b/test/fail_compilation/test17908a.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test17908a.d(10): Error: function test17908a.foo is not callable because it is annotated with @disable
+---
+*/
+
+@disable void foo();
+@disable void foo(int) {}
+alias g = foo;
+
+void main()
+{
+    g(10);
+}

--- a/test/fail_compilation/test17908b.d
+++ b/test/fail_compilation/test17908b.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test17908b.d(13): Error: function test17908b.foobar is not callable because it is annotated with @disable
+---
+*/
+void foobar() {}
+@disable void foobar(int) {}
+alias i = foobar;
+
+void main()
+{
+    i(10);
+}


### PR DESCRIPTION
Checking a disabled aliased symbol was done by calling the checkDeprecated function from the Dsymbol class. If the symbol was disabled, then an error was issued. I added the checking for functions in the same overload set. If an overload which is not disabled is found, then we're good, otherwise, issue error.