### PR TITLE
Rename `D_betterC` to `D_BetterC` in order to keep the naming consistency

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1404,7 +1404,7 @@ private void addDefaultVersionIdentifiers()
     if (global.params.useArrayBounds == BOUNDSCHECKoff)
         VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
     if (global.params.betterC)
-        VersionCondition.addPredefinedGlobalIdent("D_betterC");
+        VersionCondition.addPredefinedGlobalIdent("D_BetterC");
 
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
 

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -17,7 +17,7 @@ int foo(int[] a, int i)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=17787
-version (D_betterC)
+version (D_BetterC)
 {
 }
 else


### PR DESCRIPTION
with other predefined version identifiers, like `D_NoBoundsChecks`. As discussed in https://github.com/dlang/dmd/pull/7132#issuecomment-339444578.

Spec pull request: https://github.com/dlang/dlang.org/pull/1919