### PR TITLE
fix issue 17940 - always set REX for 1-byte CSE moves on x86_64

### DIFF
--- a/src/ddmd/backend/cgcod.c
+++ b/src/ddmd/backend/cgcod.c
@@ -2407,6 +2407,8 @@ if (regcon.cse.mval & 1) elem_print(regcon.cse.value[0]);
                         allocreg(cdb,&retregs,&reg,tym);
                         code *cr = &csextab[i].csimple;
                         cr->setReg(reg);
+                        if (I64 && reg >= 4 && tysize(csextab[i].e->Ety) == 1)
+                            cr->Irex |= REX;
                         cdb.gen(cr);
                         goto L10;
                     }

--- a/src/ddmd/backend/cod3.c
+++ b/src/ddmd/backend/cod3.c
@@ -2236,8 +2236,6 @@ bool cse_simple(code *c, elem *e)
         if (I64)
         {   if (sz == 8)
                 c->Irex |= REX_W;
-            else if (sz == 1 && reg >= 4)
-                c->Irex |= REX;
         }
 
         return true;
@@ -2260,8 +2258,6 @@ bool cse_simple(code *c, elem *e)
         else if (I64)
         {   if (sz == 8)
                 c->Irex |= REX_W;
-            else if (sz == 1 && reg >= 4)
-                c->Irex |= REX;
         }
 
         return true;

--- a/test/runnable/test17940.d
+++ b/test/runnable/test17940.d
@@ -1,0 +1,46 @@
+// PERMUTE_ARGS: -O
+
+// https://issues.dlang.org/show_bug.cgi?id=17940
+
+struct Array
+{
+    long length;
+    long ptr;
+}
+
+struct Struct
+{
+    bool b = true;
+}
+
+void fun1(int)
+{
+}
+
+void fun2(Array arr, int, int)
+{
+    assert(!arr.length);
+}
+
+void fn(Struct* str)
+{
+    Array arr;
+    if (!str)
+    {
+        return;
+    }
+    if (str)
+    {
+        fun1(str.b);
+    }
+    if (str.b)
+    {
+        fun2(arr, str.b, 0);
+    }
+}
+
+void main()
+{
+    Struct s;
+    fn(&s);
+}


### PR DESCRIPTION
When generating a 1-byte mov in cse_simple on x86_64, we should always set rex,
not just when it's a register >= 4.
The reason is that our cse may be rewritten to mov into a reg >= 4 later.
This fixes https://issues.dlang.org/show_bug.cgi?id=17940 .

Thanks @belka-ew for helping minimize the testcase and testing the patch!
