### PR TITLE
COFF: do not create empty .drectve sections

### DIFF
--- a/src/ddmd/backend/obj.h
+++ b/src/ddmd/backend/obj.h
@@ -310,6 +310,7 @@ class MsCoffObj : public Obj
 //    static void addrel(int seg, targ_size_t offset, unsigned type,
 //                                        unsigned symidx, targ_size_t val);
 
+    static int seg_drectve();
     static int seg_pdata();
     static int seg_xdata();
     static int seg_pdata_comdat(Symbol *sfunc);


### PR DESCRIPTION
As https://github.com/dlang/dmd/pull/7253 this reduces the size of the phobos64.lib by more than 5% (about 2 of 36 MB).

More sections always written but less likely empty are .text, .rdata, .data and .bss