### PR TITLE
Move functions from statement.d to statementsem.d and make them private

### DIFF
--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -49,44 +49,6 @@ import ddmd.staticassert;
 import ddmd.tokens;
 import ddmd.visitor;
 
-/*******************************************
- * Check to see if statement is the innermost labeled statement.
- * Params:
- *      sc = context
- *      statement = Statement to check
- * Returns:
- *      if `true`, then the `LabelStatement`, otherwise `null`
- */
-extern (C++) LabelStatement checkLabeledLoop(Scope* sc, Statement statement)
-{
-    if (sc.slabel && sc.slabel.statement == statement)
-    {
-        return sc.slabel;
-    }
-    return null;
-}
-
-/***********************************************************
- * Check an assignment is used as a condition.
- * Intended to be use before the `semantic` call on `e`.
- * Params:
- *  e = condition expression which is not yet run semantic analysis.
- * Returns:
- *  `e` or ErrorExp.
- */
-Expression checkAssignmentAsCondition(Expression e)
-{
-    auto ec = e;
-    while (ec.op == TOKcomma)
-        ec = (cast(CommaExp)ec).e2;
-    if (ec.op == TOKassign)
-    {
-        ec.error("assignment cannot be used as a condition, perhaps `==` was meant?");
-        return new ErrorExp();
-    }
-    return e;
-}
-
 /**
  * Returns:
  *     `TypeIdentifier` corresponding to `object.Throwable`

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -49,31 +49,6 @@ import ddmd.staticassert;
 import ddmd.tokens;
 import ddmd.visitor;
 
-/*****************************************
- * CTFE requires FuncDeclaration::labtab for the interpretation.
- * So fixing the label name inside in/out contracts is necessary
- * for the uniqueness in labtab.
- * Params:
- *      sc = context
- *      ident = statement label name to be adjusted
- * Returns:
- *      adjusted label name
- */
-extern (C++) Identifier fixupLabelName(Scope* sc, Identifier ident)
-{
-    uint flags = (sc.flags & SCOPEcontract);
-    const id = ident.toChars();
-    if (flags && flags != SCOPEinvariant && !(id[0] == '_' && id[1] == '_'))
-    {
-        const(char)* prefix = flags == SCOPErequire ? "__in_" : "__out_";
-        OutBuffer buf;
-        buf.printf("%s%s", prefix, ident.toChars());
-
-        ident = Identifier.idPool(buf.peekSlice());
-    }
-    return ident;
-}
-
 /*******************************************
  * Check to see if statement is the innermost labeled statement.
  * Params:

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -97,6 +97,27 @@ private LabelStatement checkLabeledLoop(Scope* sc, Statement statement)
     return null;
 }
 
+/***********************************************************
+ * Check an assignment is used as a condition.
+ * Intended to be use before the `semantic` call on `e`.
+ * Params:
+ *  e = condition expression which is not yet run semantic analysis.
+ * Returns:
+ *  `e` or ErrorExp.
+ */
+private Expression checkAssignmentAsCondition(Expression e)
+{
+    auto ec = e;
+    while (ec.op == TOKcomma)
+        ec = (cast(CommaExp)ec).e2;
+    if (ec.op == TOKassign)
+    {
+        ec.error("assignment cannot be used as a condition, perhaps `==` was meant?");
+        return new ErrorExp();
+    }
+    return e;
+}
+
 // Performs semantic analysis in Statement AST nodes
 extern(C++) Statement statementSemantic(Statement s, Scope* sc)
 {

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -80,6 +80,23 @@ private Identifier fixupLabelName(Scope* sc, Identifier ident)
     return ident;
 }
 
+/*******************************************
+ * Check to see if statement is the innermost labeled statement.
+ * Params:
+ *      sc = context
+ *      statement = Statement to check
+ * Returns:
+ *      if `true`, then the `LabelStatement`, otherwise `null`
+ */
+private LabelStatement checkLabeledLoop(Scope* sc, Statement statement)
+{
+    if (sc.slabel && sc.slabel.statement == statement)
+    {
+        return sc.slabel;
+    }
+    return null;
+}
+
 // Performs semantic analysis in Statement AST nodes
 extern(C++) Statement statementSemantic(Statement s, Scope* sc)
 {


### PR DESCRIPTION
After moving the semantic methods outside the statement AST nodes and in different files, a lot of helper methods were left in the statement.d file which are not called there at all. This PR moves those functions to statementsem and makes them private.