### PR TITLE
String Switch Lowering

### DIFF
--- a/src/ddmd/id.d
+++ b/src/ddmd/id.d
@@ -314,6 +314,7 @@ immutable Msgtable[] msgtable =
     { "rt_init" },
     { "__cmp" },
     { "__equals"},
+    { "__switch"},
 
     // varargs implementation
     { "va_start" },


### PR DESCRIPTION
Paired with https://github.com/dlang/druntime/pull/1952

We replace a switch with string labels with a switch with integer case labels. The new label for each string is the index of the string in the sorted array of labels.

The switch condition is determined through a call to the druntime template object.__switch. Previous implementation generated a call to the druntime functions from rt/switch__.d .

The new integer switch goes to s2ir and gets generated based on the same rules as before.

This PR only eliminates special processing for string switches in IR + calls to druntime functions.