### PR TITLE
Upgrade dub.sdl file

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -43,7 +43,10 @@ subPackage {
   sourceFiles \
     "src/ddmd/astbase.d" \
     "src/ddmd/astbasevisitor.d" \
-    "src/ddmd/parse.d"
+    "src/ddmd/parse.d" \
+    "src/ddmd/transitivevisitor.d" \
+    "src/ddmd/permissivevisitor.d" \
+    "src/ddmd/strictvisitor.d"
 
   dependency "dmd:lexer" version="*"
 }


### PR DESCRIPTION
The parser library contains 3 visitors which were not there when the dub.sdl file was created. I added the dependencies.