### PR TITLE
Remove calls to _adCmp2 (replaced by object.__cmp in druntime)

### DIFF
--- a/src/ddmd/e2ir.d
+++ b/src/ddmd/e2ir.d
@@ -2319,22 +2319,6 @@ elem *toElem(Expression e, IRState *irs)
                 // Should have already been lowered
                 assert(0);
             }
-            else if (cast(int)eop > 1 &&
-                     (t1.ty == Tarray || t1.ty == Tsarray) &&
-                     (t2.ty == Tarray || t2.ty == Tsarray))
-            {
-                Type telement = t1.nextOf().toBasetype();
-
-                elem *ea1 = eval_Darray(ce.e1);
-                elem *ea2 = eval_Darray(ce.e2);
-
-                elem *ep = el_params(getTypeInfo(telement.arrayOf(), irs),
-                        ea2, ea1, null);
-                int rtlfunc = RTLSYM_ARRAYCMP2;
-                e = el_bin(OPcall, TYint, el_var(getRtlsym(rtlfunc)), ep);
-                e = el_bin(eop, TYint, e, el_long(TYint, 0));
-                elem_setLoc(e,ce.loc);
-            }
             else
             {
                 if (cast(int)eop <= 1)


### PR DESCRIPTION
Doing some cleanup.

The unused RTLSYMS (https://github.com/dlang/dmd/blob/master/src/ddmd/backend/rtlsym.d#L107) need to be removed as well, but there are linking errors when running druntime unittests if I remove them. I made sure they aren't used anywhere before removing them.
Is there something special that needs to be done?

```
../dmd/generated/linux/release/64/dmd -conf= -Isrc -Iimport -w -dip1000 -m64 -fPIC  -g -debug -ofgenerated/linux/debug/64/unittest/test_runner src/test_runner.d -Lgenerated/linux/debug/64/unittest/libdruntime-ut.so -debuglib= -defaultlib=
generated/linux/debug/64/unittest/test_runner.o: In function `_D11test_runner6doTestFPS6object10ModuleInfoKbZv':
/home/teemo/druntime/src/test_runner.d:60: undefined reference to `_local_unwind2'
generated/linux/debug/64/unittest/libdruntime-ut.so: undefined reference to `_d_framehandler'
collect2: error: ld returned 1 exit status
Error: linker exited with status 1
```

