### PR TITLE
Fix issue 7184 - parse error on *(x)++

### DIFF
--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -7966,6 +7966,13 @@ final class Parser(AST) : Lexer
                                     e = new AST.TypeExp(loc, t);
                                     e = parsePostExp(e);
                                 }
+                                else if (token.value == TOKplusplus || token.value == TOKminusminus)
+                                {
+                                    // if ()++
+                                    // or ()--
+                                    e = new AST.TypeExp(loc, t);
+                                    e = parsePostExp(e);
+                                }
                                 else
                                 {
                                     e = parseUnaryExp();

--- a/test/runnable/test7184.d
+++ b/test/runnable/test7184.d
@@ -1,0 +1,8 @@
+// Tests for 7184
+
+void main() {
+    auto a = 0;
+    auto b = (a)++;
+    assert(a == 1);
+    assert(b == 0);
+}


### PR DESCRIPTION
The test for C style casts was too aggressive and didn't take into account postfix ++ and --.
It also triggers when the item inside parentheses is a callable. This could potentially be reported at a later point, when the compiler knows whether the contents of the parentheses is a type. This PR does not fix that problem in any way.