### PR TITLE
refactor: use Identifiers for findCondition() instead of strings

### DIFF
--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -453,20 +453,6 @@ extern (C++) class DVCondition : Condition
 extern (C++) final class DebugCondition : DVCondition
 {
     /**
-     * Set the global debug level
-     *
-     * Only called from the driver
-     *
-     * Params:
-     *   level = Integer literal to set the global version to
-     */
-    static void setGlobalLevel(uint level)
-    {
-        global.params.debuglevel = level;
-    }
-
-
-    /**
      * Add an user-supplied identifier to the list of global debug identifiers
      *
      * Can be called from either the driver or a `debug = Ident;` statement.
@@ -493,9 +479,9 @@ extern (C++) final class DebugCondition : DVCondition
     /// Ditto
     extern(D) static void addGlobalIdent(const(char)[] ident)
     {
-        if (!global.params.debugids)
-            global.params.debugids = new Strings();
-        global.params.debugids.push(cast(char*)ident);
+        if (!global.debugids)
+            global.debugids = new Identifiers();
+        global.debugids.push(Identifier.idPool(ident));
     }
 
 
@@ -528,13 +514,13 @@ extern (C++) final class DebugCondition : DVCondition
                     inc = 1;
                     definedInModule = true;
                 }
-                else if (findCondition(global.params.debugids, ident))
+                else if (findCondition(global.debugids, ident))
                     inc = 1;
                 else
                 {
                     if (!mod.debugidsNot)
-                        mod.debugidsNot = new Strings();
-                    mod.debugidsNot.push(ident.toChars());
+                        mod.debugidsNot = new Identifiers();
+                    mod.debugidsNot.push(ident);
                 }
             }
             else if (level <= global.params.debuglevel || level <= mod.debuglevel)
@@ -574,19 +560,6 @@ extern (C++) final class DebugCondition : DVCondition
  */
 extern (C++) final class VersionCondition : DVCondition
 {
-    /**
-     * Set the global version level
-     *
-     * Only called from the driver
-     *
-     * Params:
-     *   level = Integer literal to set the global version to
-     */
-    static void setGlobalLevel(uint level)
-    {
-        global.params.versionlevel = level;
-    }
-
     /**
      * Check if a given version identifier is reserved.
      *
@@ -777,9 +750,9 @@ extern (C++) final class VersionCondition : DVCondition
     /// Ditto
     extern(D) static void addPredefinedGlobalIdent(const(char)[] ident)
     {
-        if (!global.params.versionids)
-            global.params.versionids = new Strings();
-        global.params.versionids.push(cast(char*)ident);
+        if (!global.versionids)
+            global.versionids = new Identifiers();
+        global.versionids.push(Identifier.idPool(ident));
     }
 
     /**
@@ -812,13 +785,13 @@ extern (C++) final class VersionCondition : DVCondition
                     inc = 1;
                     definedInModule = true;
                 }
-                else if (findCondition(global.params.versionids, ident))
+                else if (findCondition(global.versionids, ident))
                     inc = 1;
                 else
                 {
                     if (!mod.versionidsNot)
-                        mod.versionidsNot = new Strings();
-                    mod.versionidsNot.push(ident.toChars());
+                        mod.versionidsNot = new Identifiers();
+                    mod.versionidsNot.push(ident);
                 }
             }
             else if (level <= global.params.versionlevel || level <= mod.versionlevel)
@@ -927,14 +900,22 @@ extern (C++) final class StaticIfCondition : Condition
     }
 }
 
-extern (C++) int findCondition(Strings* ids, Identifier ident)
+
+/****************************************
+ * Find `ident` in an array of identifiers.
+ * Params:
+ *      ids = array of identifiers
+ *      ident = identifier to search for
+ * Returns:
+ *      true if found
+ */
+extern (C++) bool findCondition(Identifiers* ids, Identifier ident)
 {
     if (ids)
     {
-        for (size_t i = 0; i < ids.dim; i++)
+        foreach (id; *ids)
         {
-            const(char)* id = (*ids)[i];
-            if (strcmp(id, ident.toChars()) == 0)
+            if (id == ident)
                 return true;
         }
     }

--- a/src/ddmd/dmodule.d
+++ b/src/ddmd/dmodule.d
@@ -388,12 +388,12 @@ extern (C++) final class Module : Package
     Modules aimports;           // all imported modules
 
     uint debuglevel;            // debug level
-    Strings* debugids;          // debug identifiers
-    Strings* debugidsNot;       // forward referenced debug identifiers
+    Identifiers* debugids;      // debug identifiers
+    Identifiers* debugidsNot;   // forward referenced debug identifiers
 
     uint versionlevel;          // version level
-    Strings* versionids;        // version identifiers
-    Strings* versionidsNot;     // forward referenced version identifiers
+    Identifiers* versionids;    // version identifiers
+    Identifiers* versionidsNot; // forward referenced version identifiers
 
     Macro* macrotable;          // document comment macros
     Escape* escapetable;        // document comment escapes

--- a/src/ddmd/dversion.d
+++ b/src/ddmd/dversion.d
@@ -85,8 +85,8 @@ extern (C++) final class DebugSymbol : Dsymbol
                     errors = true;
                 }
                 if (!m.debugids)
-                    m.debugids = new Strings();
-                m.debugids.push(ident.toChars());
+                    m.debugids = new Identifiers();
+                m.debugids.push(ident);
             }
         }
         else
@@ -175,8 +175,8 @@ extern (C++) final class VersionSymbol : Dsymbol
                     errors = true;
                 }
                 if (!m.versionids)
-                    m.versionids = new Strings();
-                m.versionids.push(ident.toChars());
+                    m.versionids = new Identifiers();
+                m.versionids.push(ident);
             }
         }
         else

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -17,6 +17,7 @@ import core.stdc.stdio;
 import ddmd.root.array;
 import ddmd.root.filename;
 import ddmd.root.outbuffer;
+import ddmd.identifier;
 
 template xversion(string s)
 {
@@ -247,6 +248,9 @@ struct Global
     uint errorLimit;
 
     void* console;         // opaque pointer to console for controlling text attributes
+
+    Array!Identifier* versionids;    // command line versions and predefined versions
+    Array!Identifier* debugids;      // command line debug versions and predefined versions
 
     /* Start gagging. Return the current number of gagged errors
      */

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -228,6 +228,9 @@ struct Global
 
     void* console;         // opaque pointer to console for controlling text attributes
 
+    Array<class Identifier*>* versionids; // command line versions and predefined versions
+    Array<class Identifier*>* debugids;   // command line debug versions and predefined versions
+
     /* Start gagging. Return the current number of gagged errors
      */
     unsigned startGagging();

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -49,6 +49,7 @@ import ddmd.link;
 import ddmd.mtype;
 import ddmd.objc;
 import ddmd.parse;
+import ddmd.root.array;
 import ddmd.root.file;
 import ddmd.root.filename;
 import ddmd.root.man;
@@ -552,6 +553,14 @@ Language changes listed by -transition=id:
             //fatal();
         }
     }
+
+    // Add in command line versions
+    if (global.params.versionids)
+        foreach (charz; *global.params.versionids)
+            VersionCondition.addGlobalIdent(charz[0 .. strlen(charz)]);
+    if (global.params.debugids)
+        foreach (charz; *global.params.debugids)
+            DebugCondition.addGlobalIdent(charz[0 .. strlen(charz)]);
 
     // Predefined version identifiers
     addDefaultVersionIdentifiers();
@@ -2006,17 +2015,21 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                         const level = strtol(p + 7, &p, 10);
                         if (*p || errno || level > INT_MAX)
                             goto Lerror;
-                        DebugCondition.setGlobalLevel(cast(int)level);
+                        params.debuglevel = cast(uint)level;
                     }
                     else if (Identifier.isValidIdentifier(p + 7))
-                        DebugCondition.addGlobalIdent(p[7 .. p.strlen]);
+                    {
+                        if (!params.debugids)
+                            params.debugids = new Array!(const(char)*);
+                        params.debugids.push(p + 7);
+                    }
                     else
                         goto Lerror;
                 }
                 else if (p[6])
                     goto Lerror;
                 else
-                    DebugCondition.setGlobalLevel(1);
+                    params.debuglevel = 1;
             }
             else if (memcmp(p + 1, cast(char*)"version", 7) == 0)
             {
@@ -2031,10 +2044,14 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                         const level = strtol(p + 9, &p, 10);
                         if (*p || errno || level > INT_MAX)
                             goto Lerror;
-                        VersionCondition.setGlobalLevel(cast(int)level);
+                        params.versionlevel = cast(uint)level;
                     }
                     else if (Identifier.isValidIdentifier(p + 9))
-                        VersionCondition.addGlobalIdent(p[9 .. p.strlen]);
+                    {
+                        if (!params.versionids)
+                            params.versionids = new Array!(const(char)*);
+                        params.versionids.push(p + 9);
+                    }
                     else
                         goto Lerror;
                 }


### PR DESCRIPTION
The idea is that `Identifier`s should be used instead of strings where ever possible, and `parseCommandLine()` should not be setting global variables.