### PR TITLE
refactor: use static allocation for some arrays

### DIFF
--- a/src/ddmd/doc.d
+++ b/src/ddmd/doc.d
@@ -379,7 +379,7 @@ extern (C++) void gendocfile(Module m)
         // Override with the ddoc macro files from the command line
         for (size_t i = 0; i < global.params.ddocfiles.dim; i++)
         {
-            auto f = FileName((*global.params.ddocfiles)[i]);
+            auto f = FileName(global.params.ddocfiles[i]);
             auto file = File(&f);
             readFile(m.loc, &file);
             // BUG: convert file contents to UTF-8 before use

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -162,7 +162,7 @@ struct Param
     bool doDocComments;                 // process embedded documentation comments
     const(char)* docdir;                // write documentation file to docdir directory
     const(char)* docname;               // write documentation file to docname
-    Array!(const(char)*)* ddocfiles;    // macro include files for Ddoc
+    Array!(const(char)*) ddocfiles;     // macro include files for Ddoc
 
     bool doHdrGeneration;               // process embedded documentation comments
     const(char)* hdrdir;                // write 'header' file to docdir directory
@@ -197,10 +197,10 @@ struct Param
     Strings runargs; // arguments for executable
 
     // Linker stuff
-    Array!(const(char)*)* objfiles;
-    Array!(const(char)*)* linkswitches;
-    Array!(const(char)*)* libfiles;
-    Array!(const(char)*)* dllfiles;
+    Array!(const(char)*) objfiles;
+    Array!(const(char)*) linkswitches;
+    Array!(const(char)*) libfiles;
+    Array!(const(char)*) dllfiles;
     const(char)* deffile;
     const(char)* resfile;
     const(char)* exefile;

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -143,7 +143,7 @@ struct Param
     bool doDocComments;  // process embedded documentation comments
     const char *docdir;  // write documentation file to docdir directory
     const char *docname; // write documentation file to docname
-    Array<const char *> *ddocfiles;  // macro include files for Ddoc
+    Array<const char *> ddocfiles;  // macro include files for Ddoc
 
     bool doHdrGeneration;  // process embedded documentation comments
     const char *hdrdir;    // write 'header' file to docdir directory
@@ -178,10 +178,10 @@ struct Param
     Strings runargs;    // arguments for executable
 
     // Linker stuff
-    Array<const char *> *objfiles;
-    Array<const char *> *linkswitches;
-    Array<const char *> *libfiles;
-    Array<const char *> *dllfiles;
+    Array<const char *> objfiles;
+    Array<const char *> linkswitches;
+    Array<const char *> libfiles;
+    Array<const char *> dllfiles;
     const char *deffile;
     const char *resfile;
     const char *exefile;

--- a/src/ddmd/lib.d
+++ b/src/ddmd/lib.d
@@ -88,7 +88,7 @@ class Library
         if (!arg || !*arg)
         {
             // Generate lib file name from first obj name
-            const(char)* n = (*global.params.objfiles)[0];
+            const(char)* n = global.params.objfiles[0];
             n = FileName.name(n);
             arg = FileName.forceExt(n, global.lib_ext);
         }

--- a/src/ddmd/link.d
+++ b/src/ddmd/link.d
@@ -166,7 +166,7 @@ public int runLINK()
             {
                 if (i)
                     cmdbuf.writeByte(' ');
-                const(char)* p = (*global.params.objfiles)[i];
+                const(char)* p = global.params.objfiles[i];
                 const(char)* basename = FileName.removeExt(FileName.name(p));
                 const(char)* ext = FileName.ext(p);
                 if (ext && !strchr(basename, '.'))
@@ -194,7 +194,7 @@ public int runLINK()
                 /* Generate exe file name from first obj name.
                  * No need to add it to cmdbuf because the linker will default to it.
                  */
-                const(char)* n = (*global.params.objfiles)[0];
+                const(char)* n = global.params.objfiles[0];
                 n = FileName.name(n);
                 global.params.exefile = cast(char*)FileName.forceExt(n, "exe");
             }
@@ -222,7 +222,7 @@ public int runLINK()
             {
                 cmdbuf.writeByte(' ');
                 cmdbuf.writestring("/DEFAULTLIB:");
-                writeFilename(&cmdbuf, (*global.params.libfiles)[i]);
+                writeFilename(&cmdbuf, global.params.libfiles[i]);
             }
             if (global.params.deffile)
             {
@@ -246,7 +246,7 @@ public int runLINK()
             for (size_t i = 0; i < global.params.linkswitches.dim; i++)
             {
                 cmdbuf.writeByte(' ');
-                cmdbuf.writestring((*global.params.linkswitches)[i]);
+                cmdbuf.writestring(global.params.linkswitches[i]);
             }
             /* Append the path to the VC lib files, and then the SDK lib files
              */
@@ -350,7 +350,7 @@ public int runLINK()
             {
                 if (i)
                     cmdbuf.writeByte('+');
-                const(char)* p = (*global.params.objfiles)[i];
+                const(char)* p = global.params.objfiles[i];
                 const(char)* basename = FileName.removeExt(FileName.name(p));
                 const(char)* ext = FileName.ext(p);
                 if (ext && !strchr(basename, '.'))
@@ -370,7 +370,7 @@ public int runLINK()
                 /* Generate exe file name from first obj name.
                  * No need to add it to cmdbuf because the linker will default to it.
                  */
-                const(char)* n = (*global.params.objfiles)[0];
+                const(char)* n = global.params.objfiles[0];
                 n = FileName.name(n);
                 global.params.exefile = cast(char*)FileName.forceExt(n, "exe");
             }
@@ -397,7 +397,7 @@ public int runLINK()
             {
                 if (i)
                     cmdbuf.writeByte('+');
-                writeFilename(&cmdbuf, (*global.params.libfiles)[i]);
+                writeFilename(&cmdbuf, global.params.libfiles[i]);
             }
             if (global.params.deffile)
             {
@@ -438,7 +438,7 @@ public int runLINK()
             cmdbuf.writestring("/noi");
             for (size_t i = 0; i < global.params.linkswitches.dim; i++)
             {
-                cmdbuf.writestring((*global.params.linkswitches)[i]);
+                cmdbuf.writestring(global.params.linkswitches[i]);
             }
             cmdbuf.writeByte(';');
             char* p = cmdbuf.peekString();
@@ -490,7 +490,7 @@ public int runLINK()
             }
             free(arg);
         }
-        argv.append(global.params.objfiles);
+        argv.append(&global.params.objfiles);
         version (OSX)
         {
             // If we are on Mac OS X and linking a dynamic library,
@@ -547,7 +547,7 @@ public int runLINK()
         else
         {
             // Generate exe file name from first obj name
-            const(char)* n = (*global.params.objfiles)[0];
+            const(char)* n = global.params.objfiles[0];
             char* ex;
             n = FileName.name(n);
             const(char)* e = FileName.ext(n);
@@ -637,7 +637,7 @@ public int runLINK()
         }
         for (size_t i = 0; i < global.params.linkswitches.dim; i++)
         {
-            const(char)* p = (*global.params.linkswitches)[i];
+            const(char)* p = global.params.linkswitches[i];
             if (!p || !p[0] || !(p[0] == '-' && (p[1] == 'l' || p[1] == 'L')))
             {
                 // Don't need -Xlinker if switch starts with -l or -L.
@@ -657,7 +657,7 @@ public int runLINK()
          */
         for (size_t i = 0; i < global.params.libfiles.dim; i++)
         {
-            const(char)* p = (*global.params.libfiles)[i];
+            const(char)* p = global.params.libfiles[i];
             size_t plen = strlen(p);
             if (plen > 2 && p[plen - 2] == '.' && p[plen - 1] == 'a')
                 argv.push(p);
@@ -672,7 +672,7 @@ public int runLINK()
         }
         for (size_t i = 0; i < global.params.dllfiles.dim; i++)
         {
-            const(char)* p = (*global.params.dllfiles)[i];
+            const(char)* p = global.params.dllfiles[i];
             argv.push(p);
         }
         /* D runtime libraries must go after user specified libraries

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -310,11 +310,6 @@ private int tryMain(size_t argc, const(char)** argv)
     global.params.obj = true;
     global.params.useDeprecated = 2;
     global.params.hdrStripPlainFunctions = true;
-    global.params.linkswitches = new Strings();
-    global.params.libfiles = new Strings();
-    global.params.dllfiles = new Strings();
-    global.params.objfiles = new Strings();
-    global.params.ddocfiles = new Strings();
     // Default to -m32 for 32 bit dmd, -m64 for 64 bit dmd
     global.params.is64bit = (size_t.sizeof == 8);
     global.params.mscoff = false;
@@ -796,7 +791,7 @@ Language changes listed by -transition=id:
             // Remove m's object file from list of object files
             for (size_t j = 0; j < global.params.objfiles.dim; j++)
             {
-                if (m.objfile.name.str == (*global.params.objfiles)[j])
+                if (m.objfile.name.str == global.params.objfiles[j])
                 {
                     global.params.objfiles.remove(j);
                     break;
@@ -961,7 +956,7 @@ Language changes listed by -transition=id:
             else
             {
                 // Generate json file name from first obj name
-                const(char)* n = (*global.params.objfiles)[0];
+                const(char)* n = global.params.objfiles[0];
                 n = FileName.name(n);
                 //if (!FileName::absolute(name))
                 //    name = FileName::combine(dir, name);


### PR DESCRIPTION
Since they are always allocated, might as well statically allocate them.