### PR TITLE
refactor: convert #define's to enum's

### DIFF
--- a/src/ddmd/backend/cgobj.c
+++ b/src/ddmd/backend/cgobj.c
@@ -66,90 +66,100 @@ static char __file__[] = __FILE__;      // for tassert.h
  * Record types:
  */
 
-#define RHEADR  0x6E
-#define REGINT  0x70
-#define REDATA  0x72
-#define RIDATA  0x74
-#define OVLDEF  0x76
-#define ENDREC  0x78
-#define BLKDEF  0x7A
-#define BLKEND  0x7C
-//#define DEBSYM        0x7E
-#define THEADR  0x80
-#define LHEADR  0x82
-#define PEDATA  0x84
-#define PIDATA  0x86
-#define COMENT  0x88
-#define MODEND  0x8A
-#define EXTDEF  0x8C
-#define TYPDEF  0x8E
-#define PUBDEF  0x90
-#define PUB386  0x91
-#define LOCSYM  0x92
-#define LINNUM  0x94
-#define LNAMES  0x96
-#define SEGDEF  0x98
-#define SEG386  0x99
-#define GRPDEF  0x9A
-#define FIXUPP  0x9C
-#define FIX386  0x9D
-#define LEDATA  0xA0
-#define LED386  0xA1
-#define LIDATA  0xA2
-#define LID386  0xA3
-#define LIBHED  0xA4
-#define LIBNAM  0xA6
-#define LIBLOC  0xA8
-#define LIBDIC  0xAA
-#define COMDEF  0xB0
-#define LEXTDEF 0xB4
-#define LPUBDEF 0xB6
-#define LCOMDEF 0xB8
-#define CEXTDEF 0xBC
-#define COMDAT  0xC2
-#define LINSYM  0xC4
-#define ALIAS   0xC6
-#define LLNAMES 0xCA
+enum
+{
+    RHEADR  = 0x6E,
+    REGINT  = 0x70,
+    REDATA  = 0x72,
+    RIDATA  = 0x74,
+    OVLDEF  = 0x76,
+    ENDREC  = 0x78,
+    BLKDEF  = 0x7A,
+    BLKEND  = 0x7C,
+//  DEBSYM  = 0x7E,
+    THEADR  = 0x80,
+    LHEADR  = 0x82,
+    PEDATA  = 0x84,
+    PIDATA  = 0x86,
+    COMENT  = 0x88,
+    MODEND  = 0x8A,
+    EXTDEF  = 0x8C,
+    TYPDEF  = 0x8E,
+    PUBDEF  = 0x90,
+    PUB386  = 0x91,
+    LOCSYM  = 0x92,
+    LINNUM  = 0x94,
+    LNAMES  = 0x96,
+    SEGDEF  = 0x98,
+    SEG386  = 0x99,
+    GRPDEF  = 0x9A,
+    FIXUPP  = 0x9C,
+    FIX386  = 0x9D,
+    LEDATA  = 0xA0,
+    LED386  = 0xA1,
+    LIDATA  = 0xA2,
+    LID386  = 0xA3,
+    LIBHED  = 0xA4,
+    LIBNAM  = 0xA6,
+    LIBLOC  = 0xA8,
+    LIBDIC  = 0xAA,
+    COMDEF  = 0xB0,
+    LEXTDEF = 0xB4,
+    LPUBDEF = 0xB6,
+    LCOMDEF = 0xB8,
+    CEXTDEF = 0xBC,
+    COMDAT  = 0xC2,
+    LINSYM  = 0xC4,
+    ALIAS   = 0xC6,
+    LLNAMES = 0xCA,
+};
 
 // Some definitions for .OBJ files. Trial and error to determine which
 // one to use when. Page #s refer to Intel spec on .OBJ files.
 
 // Values for LOCAT byte: (pg. 71)
-#define LOCATselfrel    0x8000
-#define LOCATsegrel     0xC000
+enum
+{
+    LOCATselfrel            = 0x8000,
+    LOCATsegrel             = 0xC000,
+
 // OR'd with one of the following:
-#define LOClobyte               0x0000
-#define LOCbase                 0x0800
-#define LOChibyte               0x1000
-#define LOCloader_resolved      0x1400
+    LOClobyte               = 0x0000,
+    LOCbase                 = 0x0800,
+    LOChibyte               = 0x1000,
+    LOCloader_resolved      = 0x1400,
 
 // Unfortunately, the fixup stuff is different for EASY OMF and Microsoft
-#define EASY_LOCoffset          0x1400          // 32 bit offset
-#define EASY_LOCpointer         0x1800          // 48 bit seg/offset
+    EASY_LOCoffset          = 0x1400,          // 32 bit offset
+    EASY_LOCpointer         = 0x1800,          // 48 bit seg/offset
 
-#define LOC32offset             0x2400
-#define LOC32tlsoffset          0x2800
-#define LOC32pointer            0x2C00
+    LOC32offset             = 0x2400,
+    LOC32tlsoffset          = 0x2800,
+    LOC32pointer            = 0x2C00,
 
-#define LOC16offset             0x0400
-#define LOC16pointer            0x0C00
+    LOC16offset             = 0x0400,
+    LOC16pointer            = 0x0C00,
 
-#define LOCxx                   0x3C00
+    LOCxx                   = 0x3C00
+};
 
 // FDxxxx are constants for the FIXDAT byte in fixup records (pg. 72)
 
-#define FD_F0   0x00            // segment index
-#define FD_F1   0x10            // group index
-#define FD_F2   0x20            // external index
-#define FD_F4   0x40            // canonic frame of LSEG that contains Location
-#define FD_F5   0x50            // Target determines the frame
+enum
+{
+    FD_F0 = 0x00,            // segment index
+    FD_F1 = 0x10,            // group index
+    FD_F2 = 0x20,            // external index
+    FD_F4 = 0x40,            // canonic frame of LSEG that contains Location
+    FD_F5 = 0x50,            // Target determines the frame
 
-#define FD_T0   0               // segment index
-#define FD_T1   1               // group index
-#define FD_T2   2               // external index
-#define FD_T4   4               // segment index, 0 displacement
-#define FD_T5   5               // group index, 0 displacement
-#define FD_T6   6               // external index, 0 displacement
+    FD_T0 = 0,               // segment index
+    FD_T1 = 1,               // group index
+    FD_T2 = 2,               // external index
+    FD_T4 = 4,               // segment index, 0 displacement
+    FD_T5 = 5,               // group index, 0 displacement
+    FD_T6 = 6,               // external index, 0 displacement
+};
 
 /***************
  * Fixup list.
@@ -198,26 +208,29 @@ struct Ledatarec
 
 #define SEG_ATTR(A,C,B,P)       (((A) << 5) | ((C) << 2) | ((B) << 1) | (P))
 
+enum
+{
 // Segment alignment A
-#define SEG_ALIGN0      0       // absolute segment
-#define SEG_ALIGN1      1       // byte align
-#define SEG_ALIGN2      2       // word align
-#define SEG_ALIGN16     3       // paragraph align
-#define SEG_ALIGN4K     4       // 4Kb page align
-#define SEG_ALIGN4      5       // dword align
+    SEG_ALIGN0    = 0,       // absolute segment
+    SEG_ALIGN1    = 1,       // byte align
+    SEG_ALIGN2    = 2,       // word align
+    SEG_ALIGN16   = 3,       // paragraph align
+    SEG_ALIGN4K   = 4,       // 4Kb page align
+    SEG_ALIGN4    = 5,       // dword align
 
 // Segment combine types C
-#define SEG_C_ABS       0
-#define SEG_C_PUBLIC    2
-#define SEG_C_STACK     5
-#define SEG_C_COMMON    6
+    SEG_C_ABS     = 0,
+    SEG_C_PUBLIC  = 2,
+    SEG_C_STACK   = 5,
+    SEG_C_COMMON  = 6,
 
 // Segment type P
-#define USE16   0
-#define USE32   1
+    USE16 = 0,
+    USE32 = 1,
 
-#define USE32_CODE      (4+2)           // use32 + execute/read
-#define USE32_DATA      (4+3)           // use32 + read/write
+    USE32_CODE    = (4+2),          // use32 + execute/read
+    USE32_DATA    = (4+3),          // use32 + read/write
+};
 
 /*****************************
  * Line number support.

--- a/src/ddmd/backend/elfobj.c
+++ b/src/ddmd/backend/elfobj.c
@@ -249,19 +249,22 @@ Outbuffer  *SECbuf;             // Buffer to build section table in
 // not used.
 static int section_cnt; // Number of sections in table
 
-#define SHN_TEXT        1
-#define SHN_RELTEXT     2
-#define SHN_DATA        3
-#define SHN_RELDATA     4
-#define SHN_BSS         5
-#define SHN_RODAT       6
-#define SHN_STRINGS     7
-#define SHN_SYMTAB      8
-#define SHN_SECNAMES    9
-#define SHN_COM         10
-#define SHN_NOTE        11
-#define SHN_GNUSTACK    12
-#define SHN_CDATAREL    13
+enum
+{
+    SHN_TEXT        = 1,
+    SHN_RELTEXT     = 2,
+    SHN_DATA        = 3,
+    SHN_RELDATA     = 4,
+    SHN_BSS         = 5,
+    SHN_RODAT       = 6,
+    SHN_STRINGS     = 7,
+    SHN_SYMTAB      = 8,
+    SHN_SECNAMES    = 9,
+    SHN_COM         = 10,
+    SHN_NOTE        = 11,
+    SHN_GNUSTACK    = 12,
+    SHN_CDATAREL    = 13,
+};
 
 IDXSYM *mapsec2sym;
 #define S2S_INC 20
@@ -271,15 +274,18 @@ IDXSYM *mapsec2sym;
 static int symbol_idx;          // Number of symbols in symbol table
 static int local_cnt;           // Number of symbols with STB_LOCAL
 
-#define STI_FILE 1              // Where file symbol table entry is
-#define STI_TEXT 2
-#define STI_DATA 3
-#define STI_BSS  4
-#define STI_GCC  5              // Where "gcc2_compiled" symbol is */
-#define STI_RODAT 6             // Symbol for readonly data
-#define STI_NOTE 7              // Where note symbol table entry is
-#define STI_COM  8
-#define STI_CDATAREL 9          // Symbol for readonly data with relocations
+enum
+{
+    STI_FILE     = 1,       // Where file symbol table entry is
+    STI_TEXT     = 2,
+    STI_DATA     = 3,
+    STI_BSS      = 4,
+    STI_GCC      = 5,       // Where "gcc2_compiled" symbol is */
+    STI_RODAT    = 6,       // Symbol for readonly data
+    STI_NOTE     = 7,       // Where note symbol table entry is
+    STI_COM      = 8,
+    STI_CDATAREL = 9,       // Symbol for readonly data with relocations
+};
 
 // NOTE: There seems to be a requirement that the read-only data have the
 // same symbol table index and section index. Use section NOTE as a place
@@ -314,19 +320,23 @@ static const char compiler[] = "\0Digital Mars C/C++"
 //      be continuous when adding data. Fix-ups anywhere withing existing data.
 
 #define COMD CDATAREL+1
-#define OB_SEG_SIZ      10              // initial number of segments supported
-#define OB_SEG_INC      10              // increment for additional segments
 
-#define OB_CODE_STR     100000          // initial size for code
-#define OB_CODE_INC     100000          // increment for additional code
-#define OB_DATA_STR     100000          // initial size for data
-#define OB_DATA_INC     100000          // increment for additional data
-#define OB_CDATA_STR      1024          // initial size for data
-#define OB_CDATA_INC      1024          // increment for additional data
-#define OB_COMD_STR        256          // initial size for comments
-                                        // increment as needed
-#define OB_XTRA_STR        250          // initial size for extra segments
-#define OB_XTRA_INC      10000          // increment size
+enum
+{
+    OB_SEG_SIZ      = 10,          // initial number of segments supported
+    OB_SEG_INC      = 10,          // increment for additional segments
+
+    OB_CODE_STR     = 100000,      // initial size for code
+    OB_CODE_INC     = 100000,      // increment for additional code
+    OB_DATA_STR     = 100000,      // initial size for data
+    OB_DATA_INC     = 100000,      // increment for additional data
+    OB_CDATA_STR    =   1024,      // initial size for data
+    OB_CDATA_INC    =   1024,      // increment for additional data
+    OB_COMD_STR     =    256,      // initial size for comments
+                                   // increment as needed
+    OB_XTRA_STR     =    250,      // initial size for extra segments
+    OB_XTRA_INC     =  10000,      // increment size
+};
 
 #define MAP_SEG2SECIDX(seg) (SegData[seg]->SDshtidx)
 #define MAP_SEG2SYMIDX(seg) (SegData[seg]->SDsymidx)
@@ -769,25 +779,29 @@ Obj *Obj::init(Outbuffer *objbuf, const char *filename, const char *csegname)
         SECbuf->setsize(0);
     section_cnt = 0;
 
+    enum
+    {
+        NAMIDX_NONE      =   0,
+        NAMIDX_SYMTAB    =   1,    // .symtab
+        NAMIDX_STRTAB    =   9,    // .strtab
+        NAMIDX_SHSTRTAB  =  17,    // .shstrtab
+        NAMIDX_TEXT      =  27,    // .text
+        NAMIDX_DATA      =  33,    // .data
+        NAMIDX_BSS       =  39,    // .bss
+        NAMIDX_NOTE      =  44,    // .note
+        NAMIDX_COMMENT   =  50,    // .comment
+        NAMIDX_RODATA    =  59,    // .rodata
+        NAMIDX_GNUSTACK  =  67,    // .note.GNU-stack
+        NAMIDX_CDATAREL  =  83,    // .data.rel.ro
+        NAMIDX_RELTEXT   =  96,    // .rel.text and .rela.text
+        NAMIDX_RELDATA   = 106,    // .rel.data
+        NAMIDX_RELDATA64 = 107,    // .rela.data
+    };
+
     if (I64)
     {
         static char section_names_init64[] =
           "\0.symtab\0.strtab\0.shstrtab\0.text\0.data\0.bss\0.note\0.comment\0.rodata\0.note.GNU-stack\0.data.rel.ro\0.rela.text\0.rela.data";
-        #define NAMIDX_NONE      0
-        #define NAMIDX_SYMTAB    1       // .symtab
-        #define NAMIDX_STRTAB    9       // .strtab
-        #define NAMIDX_SHSTRTAB 17      // .shstrtab
-        #define NAMIDX_TEXT     27      // .text
-        #define NAMIDX_DATA     33      // .data
-        #define NAMIDX_BSS      39      // .bss
-        #define NAMIDX_NOTE     44      // .note
-        #define NAMIDX_COMMENT  50      // .comment
-        #define NAMIDX_RODATA   59      // .rodata
-        #define NAMIDX_GNUSTACK 67      // .note.GNU-stack
-        #define NAMIDX_CDATAREL 83      // .data.rel.ro
-        #define NAMIDX_RELTEXT  96      // .rel.text and .rela.text
-        #define NAMIDX_RELDATA  106     // .rel.data
-        #define NAMIDX_RELDATA64 107    // .rela.data
 
         if (section_names)
             section_names->setsize(sizeof(section_names_init64));

--- a/src/ddmd/backend/machobj.c
+++ b/src/ddmd/backend/machobj.c
@@ -51,16 +51,19 @@
 #include        "dwarf.h"
 
 // for x86_64
-#define X86_64_RELOC_UNSIGNED           0
-#define X86_64_RELOC_SIGNED             1
-#define X86_64_RELOC_BRANCH             2
-#define X86_64_RELOC_GOT_LOAD           3
-#define X86_64_RELOC_GOT                4
-#define X86_64_RELOC_SUBTRACTOR         5
-#define X86_64_RELOC_SIGNED_1           6
-#define X86_64_RELOC_SIGNED_2           7
-#define X86_64_RELOC_SIGNED_4           8
-#define X86_64_RELOC_TLV                9 // for thread local variables
+enum
+{
+    X86_64_RELOC_UNSIGNED         = 0,
+    X86_64_RELOC_SIGNED           = 1,
+    X86_64_RELOC_BRANCH           = 2,
+    X86_64_RELOC_GOT_LOAD         = 3,
+    X86_64_RELOC_GOT              = 4,
+    X86_64_RELOC_SUBTRACTOR       = 5,
+    X86_64_RELOC_SIGNED_1         = 6,
+    X86_64_RELOC_SIGNED_2         = 7,
+    X86_64_RELOC_SIGNED_4         = 8,
+    X86_64_RELOC_TLV              = 9, // for thread local variables
+};
 
 static Outbuffer *fobjbuf;
 
@@ -156,13 +159,16 @@ static int pointersSeg;                 // segment index for __pointers
 static IDXSTR extdef;
 
 #if 0
-#define STI_FILE 1              // Where file symbol table entry is
-#define STI_TEXT 2
-#define STI_DATA 3
-#define STI_BSS  4
-#define STI_GCC  5              // Where "gcc2_compiled" symbol is */
-#define STI_RODAT 6             // Symbol for readonly data
-#define STI_COM  8
+enum
+{
+    STI_FILE  = 1,            // Where file symbol table entry is
+    STI_TEXT  = 2,
+    STI_DATA  = 3,
+    STI_BSS   = 4,
+    STI_GCC   = 5,            // Where "gcc2_compiled" symbol is */
+    STI_RODAT = 6,            // Symbol for readonly data
+    STI_COM   = 8,
+};
 #endif
 
 // Each compiler segment is a section
@@ -229,6 +235,12 @@ int seg_tlsseg_data = UNKNOWN;
  * type. Later, translate to Mach-O relocation structure.
  */
 
+enum
+{
+    RELaddr = 0,      // straight address
+    RELrel  = 1,      // relative to location to be fixed up
+};
+
 struct Relocation
 {   // Relocations are attached to the struct seg_data they refer to
     targ_size_t offset; // location in segment to be fixed up
@@ -238,8 +250,6 @@ struct Relocation
     unsigned targseg;   // if !=0, then location is to be fixed up
                         // to address of start of this segment
     unsigned char rtype;   // RELxxxx
-#define RELaddr 0       // straight address
-#define RELrel  1       // relative to location to be fixed up
     unsigned char flag; // 1: emit SUBTRACTOR/UNSIGNED pair
     short val;          // 0, -1, -2, -4
 };

--- a/src/ddmd/backend/mscoffobj.c
+++ b/src/ddmd/backend/mscoffobj.c
@@ -123,6 +123,14 @@ segidx_t seg_tlsseg_bss = UNKNOWN;
  * type. Later, translate to mscoff relocation structure.
  */
 
+enum
+{
+    RELaddr   = 0,     // straight address
+    RELrel    = 1,     // relative to location to be fixed up
+    RELseg    = 2,     // 2 byte section
+    RELaddr32 = 3,     // 4 byte offset
+};
+
 struct Relocation
 {   // Relocations are attached to the struct seg_data they refer to
     targ_size_t offset; // location in segment to be fixed up
@@ -132,10 +140,6 @@ struct Relocation
     unsigned targseg;   // if !=0, then location is to be fixed up
                         // to address of start of this segment
     unsigned char rtype;   // RELxxxx
-#define RELaddr 0       // straight address
-#define RELrel  1       // relative to location to be fixed up
-#define RELseg  2       // 2 byte section
-#define RELaddr32 3     // 4 byte offset
     short val;          // 0, -1, -2, -3, -4, -5
 };
 
@@ -400,10 +404,13 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
 
     seg_count = 0;
 
-#define SHI_DATA        1
-#define SHI_TEXT        2
-#define SHI_UDATA       3
-#define SHI_CDATA       4
+    enum
+    {
+        SHI_DATA       = 1,
+        SHI_TEXT       = 2,
+        SHI_UDATA      = 3,
+        SHI_CDATA      = 4,
+    };
 
     getsegment2(SHI_TEXT);
     assert(SegData[CODE]->SDseg == CODE);


### PR DESCRIPTION
Because macros are so 1990.