### PR TITLE
fix issue 17969 - crash when computing mangling of erroneous function type

### DIFF
--- a/src/ddmd/dmangle.d
+++ b/src/ddmd/dmangle.d
@@ -503,20 +503,25 @@ public:
         //printf("fd.type = %s\n", fd.type.toChars());
         if (fd.needThis() || fd.isNested())
             buf.writeByte('M');
-        if (inParent)
+
+        if (!fd.type || fd.type.ty == Terror)
+        {
+            // never should have gotten here, but could be the result of
+            // failed speculative compilation
+            buf.writestring("9__error__FZ");
+
+            //printf("[%s] %s no type\n", fd.loc.toChars(), fd.toChars());
+            //assert(0); // don't mangle function until semantic3 done.
+        }
+        else if (inParent)
         {
             TypeFunction tf = cast(TypeFunction)fd.type;
             TypeFunction tfo = cast(TypeFunction)fd.originalType;
             mangleFuncType(tf, tfo, 0, null);
         }
-        else if (fd.type)
-        {
-            visitWithMask(fd.type, 0);
-        }
         else
         {
-            printf("[%s] %s no type\n", fd.loc.toChars(), fd.toChars());
-            assert(0); // don't mangle function until semantic3 done.
+            visitWithMask(fd.type, 0);
         }
     }
 

--- a/test/fail_compilation/fail17969.d
+++ b/test/fail_compilation/fail17969.d
@@ -1,0 +1,18 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail17969.d(9): Error: no property 'sum' for type 'MapResult2!((b) => b)'
+---
+ * https://issues.dlang.org/show_bug.cgi?id=17969
+ */
+ 
+
+alias fun = a => MapResult2!(b => b).sum;
+
+int[] e;
+static assert(!is(typeof(fun(e)) == void));
+void foo() { fun(e); }
+
+struct MapResult2(alias fun)
+{
+    int[] _input;
+}


### PR DESCRIPTION
be more permissive mangling functions that failed semantic analysis and have type TypeError