### PR TITLE
refactor: consolidate handling of various assert errors

### DIFF
--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -1239,7 +1239,7 @@ extern(C++) final class Semantic3Visitor : Visitor
                             funcdecl.error("has no return statement, but is expected to return a value of type %s", f.next.toChars());
                         else
                             funcdecl.error("no return exp; or assert(0); at end of function");
-                        if (global.params.useAssert && !global.params.useInline)
+                        if (global.params.useAssert == CHECKENABLE.on && !global.params.useInline)
                         {
                             /* Add an assert(0, msg); where the missing return
                              * should be.

--- a/src/ddmd/e2ir.d
+++ b/src/ddmd/e2ir.d
@@ -463,7 +463,7 @@ if (!global.params.is64bit) assert(tysize(TYnptr) == 4);
         int ns = ((fd ? callSideEffectLevel(fd)
                       : callSideEffectLevel(t)) == 2 &&
                   retmethod != RETstack &&
-                  !global.params.useAssert && global.params.optimize);
+                  global.params.useAssert == CHECKENABLE.off && global.params.optimize);
         if (ep)
             e = el_bin(ns ? OPcallns : OPcall, tyret, ec, ep);
         else
@@ -1960,9 +1960,9 @@ elem *toElem(Expression e, IRState *irs)
         {
             //printf("AssertExp.toElem() %s\n", toChars());
             elem *e;
-            if (global.params.useAssert)
+            if (global.params.useAssert == CHECKENABLE.on)
             {
-                if (global.params.useCAsserts)
+                if (global.params.checkAction == CHECKACTION.C)
                 {
                     auto econd = toElem(ae.e1, irs);
                     auto ea = callCAssert(irs, ae.e1.loc, ae.e1, ae.msg, null);
@@ -5913,7 +5913,7 @@ elem *filelinefunction(IRState *irs, Loc *loc)
  */
 elem *buildArrayBoundsError(IRState *irs, const ref Loc loc)
 {
-    if (global.params.useCAsserts)
+    if (global.params.checkAction == CHECKACTION.C)
     {
         return callCAssert(irs, loc, null, null, "array overflow");
     }

--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -4380,7 +4380,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     sc.fieldinit[i] |= CSXhalt;
             }
 
-            if (!global.params.useAssert)
+            if (global.params.useAssert == CHECKENABLE.off)
             {
                 Expression e = new HaltExp(exp.loc);
                 e = e.expressionSemantic(sc);

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -33,12 +33,18 @@ enum TARGET_OPENBSD = xversion!`OpenBSD`;
 enum TARGET_SOLARIS = xversion!`Solaris`;
 enum TARGET_WINDOS  = xversion!`Windows`;
 
-enum BOUNDSCHECK : int
+enum CHECKENABLE : ubyte
 {
     _default,     // initial value
-    off,          // never do bounds checking
-    on,           // always do bounds checking
-    safeonly,     // do bounds checking only in @safe functions
+    off,          // never do checking
+    on,           // always do checking
+    safeonly,     // do checking only in @safe functions
+}
+
+enum CHECKACTION : ubyte
+{
+    D,            // call D assert on failure
+    C,            // call C assert on failure
 }
 
 enum CPU
@@ -97,12 +103,10 @@ struct Param
     // 1: silently allow use of deprecated features
     // 2: warn about the use of deprecated features
     byte useDeprecated;
-    bool useAssert;         // generate runtime code for assert()'s
     bool useInvariants;     // generate class invariant checks
     bool useIn;             // generate precondition checks
     bool useOut;            // generate postcondition checks
     bool stackstomp;        // add stack stomping code
-    bool useSwitchError;    // check for switches without a default
     bool useUnitTests;      // generate unittest code
     bool useInline;         // inline expand functions
     bool useDIP25;          // implement http://wiki.dlang.org/DIP25
@@ -119,7 +123,6 @@ struct Param
     bool nofloat;           // code should not pull in floating point support
     bool ignoreUnsupportedPragmas;  // rather than error on them
     bool enforcePropertySyntax;
-    bool useCAsserts;       // use C assert() on bounds and contract failures
     bool useModuleInfo;     // generate runtime module information
     bool useTypeInfo;       // generate runtime type information
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
@@ -144,7 +147,12 @@ struct Param
     bool logo;              // print logo;
 
     CPU cpu;                // CPU instruction set to target
-    BOUNDSCHECK useArrayBounds;
+
+    CHECKENABLE useArrayBounds;    // when to generate code for array bounds checks
+    CHECKENABLE useAssert;         // when to generate code for assert()'s
+    CHECKENABLE useSwitchError;    // check for switches without a default
+    CHECKACTION checkAction;       // action to take when bounds, asserts or switch defaults are violated
+
     uint errorLimit = 20;
 
     const(char)* argv0;                 // program name

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -24,12 +24,20 @@
 template <typename TYPE> struct Array;
 
 // The state of array bounds checking
-enum BOUNDSCHECK
+typedef unsigned char CHECKENABLE;
+enum
 {
-    BOUNDSCHECKdefault, // initial value
-    BOUNDSCHECKoff,     // never do bounds checking
-    BOUNDSCHECKon,      // always do bounds checking
-    BOUNDSCHECKsafeonly // do bounds checking only in @safe functions
+    CHECKENABLEdefault, // initial value
+    CHECKENABLEoff,     // never do bounds checking
+    CHECKENABLEon,      // always do bounds checking
+    CHECKENABLEsafeonly // do bounds checking only in @safe functions
+};
+
+typedef unsigned char CHECKACTION;
+enum
+{
+    CHECKACTION_D,        // call D assert on failure
+    CHECKACTION_C,        // call C assert on failure
 };
 
 enum CPU
@@ -88,12 +96,10 @@ struct Param
     // 1: silently allow use of deprecated features
     // 2: warn about the use of deprecated features
     char useDeprecated;
-    bool useAssert;     // generate runtime code for assert()'s
     bool useInvariants; // generate class invariant checks
     bool useIn;         // generate precondition checks
     bool useOut;        // generate postcondition checks
     bool stackstomp;    // add stack stomping code
-    bool useSwitchError; // check for switches without a default
     bool useUnitTests;  // generate unittest code
     bool useInline;     // inline expand functions
     bool useDIP25;      // implement http://wiki.dlang.org/DIP25
@@ -110,7 +116,6 @@ struct Param
     bool nofloat;       // code should not pull in floating point support
     bool ignoreUnsupportedPragmas;      // rather than error on them
     bool enforcePropertySyntax;
-    bool useCAsserts;   // use C assert() on bounds and contract failures
     bool useModuleInfo; // generate runtime module information
     bool useTypeInfo;   // generate runtime type information
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
@@ -129,7 +134,12 @@ struct Param
     bool logo;              // print logo;
 
     CPU cpu;                // CPU instruction set to target
-    BOUNDSCHECK useArrayBounds;
+
+    CHECKENABLE useArrayBounds;    // when to generate code for array bounds checks
+    CHECKENABLE useAssert;         // when to generate code for assert()'s
+    CHECKENABLE useSwitchError;    // check for switches without a default
+    CHECKACTION checkAction;       // action to take when bounds, asserts or switch defaults are violated
+
     unsigned errorLimit;
 
     const char *argv0;    // program name

--- a/src/ddmd/irstate.d
+++ b/src/ddmd/irstate.d
@@ -238,15 +238,15 @@ struct IRState
     extern (C++) bool arrayBoundsCheck()
     {
         bool result;
-        switch (global.params.useArrayBounds)
+        final switch (global.params.useArrayBounds)
         {
-        case BOUNDSCHECK.off:
+        case CHECKENABLE.off:
             result = false;
             break;
-        case BOUNDSCHECK.on:
+        case CHECKENABLE.on:
             result = true;
             break;
-        case BOUNDSCHECK.safeonly:
+        case CHECKENABLE.safeonly:
             {
                 result = false;
                 FuncDeclaration fd = getFunc();
@@ -258,7 +258,7 @@ struct IRState
                 }
                 break;
             }
-        default:
+        case CHECKENABLE._default:
             assert(0);
         }
         return result;

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -294,12 +294,12 @@ private int tryMain(size_t argc, const(char)** argv)
     global.params.argv0 = arguments[0];
     global.params.color = true;
     global.params.link = true;
-    global.params.useAssert = true;
     global.params.useInvariants = true;
     global.params.useIn = true;
     global.params.useOut = true;
-    global.params.useArrayBounds = BOUNDSCHECK._default; // set correct value later
-    global.params.useSwitchError = true;
+    global.params.useArrayBounds = CHECKENABLE._default; // set correct value later
+    global.params.useAssert      = CHECKENABLE._default;
+    global.params.useSwitchError = CHECKENABLE._default;
     global.params.useModuleInfo = true;
     global.params.useTypeInfo = true;
     global.params.useInline = false;
@@ -486,27 +486,39 @@ Language changes listed by -transition=id:
         if (!global.params.mscrtlib)
             global.params.mscrtlib = "libcmt";
     }
-    if (global.params.useArrayBounds == BOUNDSCHECK._default)
-    {
-        // Set the real default value
-        global.params.useArrayBounds = global.params.release ? BOUNDSCHECK.safeonly : BOUNDSCHECK.on;
-    }
     if (global.params.release)
     {
         global.params.useInvariants = false;
         global.params.useIn = false;
         global.params.useOut = false;
-        global.params.useAssert = false;
-        global.params.useSwitchError = false;
+
+        if (global.params.useArrayBounds == CHECKENABLE._default)
+            global.params.useArrayBounds = CHECKENABLE.safeonly;
+
+        if (global.params.useAssert == CHECKENABLE._default)
+            global.params.useAssert = CHECKENABLE.off;
+
+        if (global.params.useSwitchError == CHECKENABLE._default)
+            global.params.useSwitchError = CHECKENABLE.off;
     }
     if (global.params.betterC)
     {
-        global.params.useCAsserts = true;
+        global.params.checkAction = CHECKACTION.C;
         global.params.useModuleInfo = false;
         global.params.useTypeInfo = false;
     }
     if (global.params.useUnitTests)
-        global.params.useAssert = true;
+        global.params.useAssert = CHECKENABLE.on;
+
+    if (global.params.useArrayBounds == CHECKENABLE._default)
+        global.params.useArrayBounds = CHECKENABLE.on;
+
+    if (global.params.useAssert == CHECKENABLE._default)
+        global.params.useAssert = CHECKENABLE.on;
+
+    if (global.params.useSwitchError == CHECKENABLE._default)
+        global.params.useSwitchError = CHECKENABLE.on;
+
     if (!global.params.obj || global.params.lib)
         global.params.link = false;
     if (global.params.link)
@@ -1408,9 +1420,9 @@ private void addDefaultVersionIdentifiers()
         VersionCondition.addPredefinedGlobalIdent("D_PIC");
     if (global.params.useUnitTests)
         VersionCondition.addPredefinedGlobalIdent("unittest");
-    if (global.params.useAssert)
+    if (global.params.useAssert == CHECKENABLE.on)
         VersionCondition.addPredefinedGlobalIdent("assert");
-    if (global.params.useArrayBounds == BOUNDSCHECK.off)
+    if (global.params.useArrayBounds == CHECKENABLE.off)
         VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
     if (global.params.betterC)
         VersionCondition.addPredefinedGlobalIdent("D_BetterC");
@@ -1967,7 +1979,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 params.betterC = true;
             else if (strcmp(p + 1, "noboundscheck") == 0)
             {
-                params.useArrayBounds = BOUNDSCHECK.off;
+                params.useArrayBounds = CHECKENABLE.off;
             }
             else if (memcmp(p + 1, cast(char*)"boundscheck", 11) == 0)
             {
@@ -1977,15 +1989,15 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 {
                     if (strcmp(p + 13, "on") == 0)
                     {
-                        params.useArrayBounds = BOUNDSCHECK.on;
+                        params.useArrayBounds = CHECKENABLE.on;
                     }
                     else if (strcmp(p + 13, "safeonly") == 0)
                     {
-                        params.useArrayBounds = BOUNDSCHECK.safeonly;
+                        params.useArrayBounds = CHECKENABLE.safeonly;
                     }
                     else if (strcmp(p + 13, "off") == 0)
                     {
-                        params.useArrayBounds = BOUNDSCHECK.off;
+                        params.useArrayBounds = CHECKENABLE.off;
                     }
                     else
                         goto Lerror;

--- a/src/ddmd/s2ir.d
+++ b/src/ddmd/s2ir.d
@@ -686,7 +686,7 @@ extern (C++) class S2irVisitor : Visitor
 
         //printf("SwitchErrorStatement.toIR()\n");
         elem *e;
-        if (global.params.useCAsserts)
+        if (global.params.checkAction == CHECKACTION.C)
         {
             e = callCAssert(irs, s.loc, null, null, "no switch default");
         }

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -2477,7 +2477,7 @@ else
                 needswitcherror = true;
         }
 
-        if (!sc.sw.sdefault && (!ss.isFinal || needswitcherror || global.params.useAssert))
+        if (!sc.sw.sdefault && (!ss.isFinal || needswitcherror || global.params.useAssert == CHECKENABLE.on))
         {
             ss.hasNoDefault = 1;
 
@@ -2489,7 +2489,7 @@ else
             CompoundStatement cs;
             Statement s;
 
-            if (global.params.useSwitchError)
+            if (global.params.useSwitchError == CHECKENABLE.on)
                 s = new SwitchErrorStatement(ss.loc);
             else
                 s = new ExpStatement(ss.loc, new HaltExp(ss.loc));


### PR DESCRIPTION
There are 3 kinds of assert failures in DMD: assert failures, array boundscheck failures, and switch default failures. This refactor doesn't change any behavior, but brings a consistent terminology and pattern to how they are handled, making it practical to add more behavior options (such as halt on assert failures).