### PR TITLE
Fix issue 17167 - handle long filepaths on Windows

### DIFF
--- a/src/ddmd/root/filename.d
+++ b/src/ddmd/root/filename.d
@@ -734,23 +734,28 @@ nothrow:
 
 version(Windows)
 {
-    /*
-      The code before used the POSIX function `mkdir` on Windows. That
-      function is now deprecated and fails with long paths, so instead
-      we use the newer `CreateDirectoryW`.
-
-      `CreateDirectoryW` is the unicode version of the generic macro
-      `CreateDirectory`.  `CreateDirectoryA` has a file path
-      limitation of 248 characters, `mkdir` fails with less and might
-      fail due to the number of consecutive `..`s in the
-      path. `CreateDirectoryW` also normally has a 248 character
-      limit, unless the path is absolute and starts with `\\?\`. Note
-      that this is different from starting with the almost identical
-      `\\?`.
-
-      Please consult
-      https://msdn.microsoft.com/en-us/library/windows/desktop/aa363855(v=vs.85).aspx
-    */
+    /****************************************************************
+     * The code before used the POSIX function `mkdir` on Windows. That
+     * function is now deprecated and fails with long paths, so instead
+     * we use the newer `CreateDirectoryW`.
+     *
+     * `CreateDirectoryW` is the unicode version of the generic macro
+     * `CreateDirectory`.  `CreateDirectoryA` has a file path
+     *  limitation of 248 characters, `mkdir` fails with less and might
+     *  fail due to the number of consecutive `..`s in the
+     *  path. `CreateDirectoryW` also normally has a 248 character
+     * limit, unless the path is absolute and starts with `\\?\`. Note
+     * that this is different from starting with the almost identical
+     * `\\?`.
+     *
+     * Params:
+     *  path = The path to create.
+     * Returns:
+     *  0 on success, 1 on failure.
+     *
+     * References:
+     *  https://msdn.microsoft.com/en-us/library/windows/desktop/aa363855(v=vs.85).aspx
+     */
     private int _mkdir(const(char)* path) nothrow
     {
         import core.stdc.errno: errno, EEXIST, ENOENT;
@@ -787,11 +792,17 @@ version(Windows)
         return createRet == 0 ? 1 : 0;
     }
 
-    // Converts a path to one suitable to be passed to Win32 API
-    // functions that can deal with paths longer than 248
-    // characters then calls the supplied function on it.
-    // For more information:
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+    /**************************************
+     * Converts a path to one suitable to be passed to Win32 API
+     * functions that can deal with paths longer than 248
+     * characters then calls the supplied function on it.
+     * Params:
+     *  path = The Path to call F on.
+     * Returns:
+     *  The result of calling F on path.
+     * References:
+     *  https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+     */
     package auto extendedPathThen(alias F)(const(char*) path)
     {
         wchar[1024] wpathBuf;
@@ -837,10 +848,17 @@ version(Windows)
         return F(extendedPath);
     }
 
-    // Converts a null-terminated string to an array of wchar that's null
-    // terminated so it can be passed to Win32 APIs.
-    // buf is passed as a scratch space to store the result. If more memory
-    // is needed then toWstringz allocates on the GC heap instead.
+    /**********************************
+     * Converts a null-terminated string to an array of wchar that's null
+     * terminated so it can be passed to Win32 APIs.
+     * buf is passed as a scratch space to store the result. If more memory
+     * is needed then toWstringz allocates on the GC heap instead.
+     * Params:
+     *  str = The string to convert.
+     *  buf = The scratch space to use to store the new string.
+     * Returns:
+     *  A UTF16 string.
+     */
     private wchar[] toWStringz(const(char*) str, wchar[] buf = []) nothrow
     {
         import core.stdc.string: strlen;

--- a/test/compilable/issue17167.sh
+++ b/test/compilable/issue17167.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Test that file paths larger than 248 characters can be used
+# Test CRLF and mixed line ending handling in D lexer.
+
+name=$(basename "$0" .sh)
+dir=${RESULTS_DIR}/compilable/
+
+test_dir=${dir}/${name}/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+[[ -d $test_dir ]] || mkdir -p "$test_dir"
+bin_base=${test_dir}/${name}
+bin="$bin_base$OBJ"
+src="$bin_base.d"
+
+echo 'void main() {}' > "${src}"
+
+# Only compile, not link, since optlink can't handle long file names
+$DMD -m"${MODEL}" "${DFLAGS}" -c -of"${bin}" "${src}" || exit 1
+
+rm -rf "${dir:?}"/"$name"
+
+echo Success >"${dir}"/"$(basename $0)".out


### PR DESCRIPTION
This issue is made more grave by the fact that dub uses relative file paths for any package dependencies. This means that if your project is in `C:\foo\bar\baz\quux`, it'll try writing to `C:\foo\bar\baz\quux\..\..\..\..\Users\%USERNAME%\AppData\Roaming\dub\packages\%PACKAGE_VERSION%\%PACKAGE%\.dub\%HASH%`. This gets big quite quickly and goes over Windows's 260 character file path limit, meaning that dub build fails with a message saying that it can't write to a certain directory.

This PR fixes the issue by using the newer unicode-aware Win32 APIs, which don't have the limitation.