### PR TITLE
betterC: add nothrow RAII for destructors in expressions

### DIFF
--- a/src/ddmd/e2ir.d
+++ b/src/ddmd/e2ir.d
@@ -5,12 +5,12 @@
  * Copyright:   Copyright (c) 1999-2017 by Digital Mars, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tocsym.d, _e2ir.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/e2ir.d, _e2ir.d)
+ * Documentation: https://dlang.org/phobos/ddmd_e2ir.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/ddmd/e2ir.d
  */
 
 module ddmd.e2ir;
-
-// Online documentation: https://dlang.org/phobos/ddmd_e2ir.html
 
 import core.stdc.stdio;
 import core.stdc.stddef;
@@ -5160,8 +5160,17 @@ elem *toElem(Expression e, IRState *irs)
                      */
                     if (vd.needsScopeDtor())
                     {
+                        elem *edtor = toElem(vd.edtor, irs);
                         elem *ed = null;
-                        e = el_ctor_dtor(e, toElem(vd.edtor, irs), &ed);
+                        if (irs.isNothrow())
+                        {
+                            ed = edtor;
+                        }
+                        else
+                        {
+                            // Construct special elems to deal with exceptions
+                            e = el_ctor_dtor(e, edtor, &ed);
+                        }
 
                         // ed needs to be inserted into the code later
                         if (!irs.varsInScope)

--- a/src/ddmd/irstate.d
+++ b/src/ddmd/irstate.d
@@ -6,11 +6,11 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/irstate.d, _irstate.d)
+ * Documentation: https://dlang.org/phobos/ddmd_irstate.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/ddmd/irstate.d
  */
 
 module ddmd.irstate;
-
-// Online documentation: https://dlang.org/phobos/ddmd_irstate.html
 
 import ddmd.root.array;
 
@@ -39,7 +39,7 @@ extern (C++) struct Label
 
 /***********************************************************
  */
-struct IRState
+extern (C++) struct IRState
 {
     IRState* prev;
     Statement statement;
@@ -262,5 +262,19 @@ struct IRState
             assert(0);
         }
         return result;
+    }
+
+    /****************************
+     * Returns:
+     *  true if in a nothrow section of code
+     */
+    bool isNothrow()
+    {
+        /* Note that even nothrow functions can have throwing parts,
+         * so until we do a better job tracking that, this is
+         * the best we can do.
+         * Nothrow needs to be tracked at the Statement level.
+         */
+        return global.params.betterC;
     }
 }

--- a/test/runnable/bcraii.d
+++ b/test/runnable/bcraii.d
@@ -1,0 +1,47 @@
+/* REQUIRED_ARGS: -betterC
+ * PERMUTE_ARGS:
+ */
+
+import core.stdc.stdio;
+
+extern (C) int main()
+{
+    auto j = test(1);
+    assert(j == 3);
+    return 0;
+}
+
+int test(int i) nothrow
+{
+  {
+    int j = i ? S(3).i : 3;
+    printf("inside\n");
+    assert(Sctor == 1);
+    assert(Sdtor == 1);
+    return j;
+  }
+  printf("done\n");
+  return -1;
+}
+
+__gshared int Sctor;
+__gshared int Sdtor;
+
+struct S
+{
+    int i;
+    this(int i) nothrow
+    {
+        this.i += i;
+        printf("S.this()\n");
+        ++Sctor;
+    }
+
+    ~this() nothrow
+    {
+        assert(i == 3);
+        i = 0;
+        printf("S.~this()\n");
+        ++Sdtor;
+    }
+}


### PR DESCRIPTION
This is a start on adding RAII support for -betterC by doing it the old-fashioned way - assume a nothrow environment. It's the way C++ worked before exceptions were added to the language.

Adding this support for statement level RAII comes later.

This also suggests a significant optimization for regular D if nothrow is tracked at the statement level rather than at the function level.