### PR TITLE
BetterC: make try-finally work without exceptions

### DIFF
--- a/src/ddmd/backend/backconfig.c
+++ b/src/ddmd/backend/backconfig.c
@@ -74,7 +74,7 @@ void out_config_init(
     {   config.exe = EX_WIN64;
         config.fpxmmregs = TRUE;
         config.avx = avx;
-        config.ehmethod = EH_DM;
+        config.ehmethod = betterC ? EH_NONE : EH_DM;
 
         // Not sure we really need these two lines, try removing them later
         config.flags |= CFGnoebp;
@@ -85,7 +85,7 @@ void out_config_init(
     else
     {
         config.exe = EX_WIN32;
-        config.ehmethod = EH_WIN32;
+        config.ehmethod = betterC ? EH_NONE : EH_WIN32;
         config.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
     }
 
@@ -96,14 +96,14 @@ void out_config_init(
 #if TARGET_LINUX
     if (model == 64)
     {   config.exe = EX_LINUX64;
-        config.ehmethod = EH_DWARF;
+        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
         config.fpxmmregs = TRUE;
         config.avx = avx;
     }
     else
     {
         config.exe = EX_LINUX;
-        config.ehmethod = EH_DWARF;
+        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
         if (!exe)
             config.flags |= CFGromable; // put switch tables in code segment
     }
@@ -121,12 +121,12 @@ void out_config_init(
     if (model == 64)
     {   config.exe = EX_OSX64;
         config.fpxmmregs = TRUE;
-        config.ehmethod = EH_DWARF;
+        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
     }
     else
     {
         config.exe = EX_OSX;
-        config.ehmethod = EH_DWARF;
+        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
     }
     config.flags |= CFGnoebp;
     if (!exe)
@@ -140,14 +140,14 @@ void out_config_init(
 #if TARGET_FREEBSD
     if (model == 64)
     {   config.exe = EX_FREEBSD64;
-        config.ehmethod = EH_DWARF;
+        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
         config.fpxmmregs = TRUE;
         config.avx = avx;
     }
     else
     {
         config.exe = EX_FREEBSD;
-        config.ehmethod = EH_DWARF;
+        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
         if (!exe)
             config.flags |= CFGromable; // put switch tables in code segment
     }
@@ -176,7 +176,7 @@ void out_config_init(
     if (!exe)
         config.flags3 |= CFG3pic;
     config.objfmt = OBJ_ELF;
-    config.ehmethod = EH_DM;
+    config.ehmethod = betterC ? EH_NONE : EH_DM;
 #endif
 #if TARGET_SOLARIS
     if (model == 64)
@@ -195,7 +195,7 @@ void out_config_init(
     if (!exe)
         config.flags3 |= CFG3pic;
     config.objfmt = OBJ_ELF;
-    config.ehmethod = EH_DM;
+    config.ehmethod = betterC ? EH_NONE : EH_DM;
 #endif
     config.flags2 |= CFG2nodeflib;      // no default library
     config.flags3 |= CFG3eseqds;

--- a/src/ddmd/backend/nteh.c
+++ b/src/ddmd/backend/nteh.c
@@ -7,6 +7,7 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/nteh.c, backend/nteh.c)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/ddmd/backend/nteh.c
  */
 
 // Support for NT exception handling
@@ -542,9 +543,14 @@ code *nteh_patchindex(code* c, int sindex)
 
 void nteh_gensindex(CodeBuilder& cdb, int sindex)
 {
+#if MARS
+    if (config.ehmethod != EH_WIN32)
+        return;
+#endif
+#if SCPP
     if (config.exe != EX_WIN32)
         return;
-
+#endif
     // Generate:
     //  MOV     -4[EBP],sindex
 

--- a/test/runnable/bcraii2.d
+++ b/test/runnable/bcraii2.d
@@ -1,0 +1,49 @@
+/* REQUIRED_ARGS: -betterC
+ * PERMUTE_ARGS:
+ */
+
+import core.stdc.stdio;
+
+extern (C) int main()
+{
+    auto j = test(1);
+    assert(j == 3);
+    assert(Sdtor == 1);
+    return 0;
+}
+
+int test(int i) nothrow
+{
+  {
+    S s = S(3);
+    printf("inside\n");
+    assert(Sctor == 1);
+    assert(Sdtor == 0);
+    return s.i;
+  }
+  printf("done\n");
+  return -1;
+}
+
+__gshared int Sctor;
+__gshared int Sdtor;
+
+struct S
+{
+    int i;
+    this(int i) nothrow
+    {
+        this.i += i;
+        printf("S.this()\n");
+        ++Sctor;
+    }
+
+    ~this() nothrow
+    {
+        assert(i == 3);
+        i = 0;
+        printf("S.~this()\n");
+        ++Sdtor;
+    }
+}
+


### PR DESCRIPTION
Instead of relying on the exception unwinding mechanism, this just calls the finally block. Since destructors and scope statements are rewritten to use try-finally, they'll work with this.