### PR TITLE
Fix Issue 17371 -  [REG 2.074.0] di generation broken for anonymous classes

### DIFF
--- a/src/ddmd/aggregate.h
+++ b/src/ddmd/aggregate.h
@@ -247,6 +247,18 @@ struct ClassFlags
     };
 };
 
+enum ClassKind
+{
+    /// the class is a d(efault) class
+    d,
+    /// the class is a C++ interface
+    cpp,
+    /// the class is an Objective-C class/interface
+    objc,
+    /// the class is anonymous
+    anonymous,
+};
+
 class ClassDeclaration : public AggregateDeclaration
 {
 public:
@@ -273,11 +285,10 @@ public:
 
     TypeInfoClassDeclaration *vclassinfo;       // the ClassInfo object for this ClassDeclaration
     bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
-    bool cpp;                           // true if this is a C++ interface
-    bool isobjc;                        // true if this is an Objective-C class/interface
-    bool isscope;                       // true if this is a scope class
+    bool stack;                       // true if this is a scope class
+    ClassKind classKind;               // specifies the linkage type
+
     Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
-    int inuse;                          // to prevent recursive attempts
     Baseok baseok;                      // set the progress of base classes resolving
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 

--- a/src/ddmd/declaration.d
+++ b/src/ddmd/declaration.d
@@ -1343,7 +1343,7 @@ extern (C++) class VarDeclaration : Declaration
 
                 // Destroying C++ scope classes crashes currently. Since C++ class dtors are not currently supported, simply do not run dtors for them.
                 // See https://issues.dlang.org/show_bug.cgi?id=13182
-                if (cd.cpp)
+                if (cd.classKind == ClassKind.cpp)
                 {
                     break;
                 }

--- a/src/ddmd/e2ir.d
+++ b/src/ddmd/e2ir.d
@@ -4179,9 +4179,9 @@ elem *toElem(Expression e, IRState *irs)
                         // Casting from derived class to base class is a no-op
                     }
                 }
-                else if (cdfrom.cpp)
+                else if (cdfrom.classKind == ClassKind.cpp)
                 {
-                    if (cdto.cpp)
+                    if (cdto.classKind == ClassKind.cpp)
                     {
                         /* Casting from a C++ interface to a C++ interface
                          * is always a 'paint' operation

--- a/src/ddmd/hdrgen.d
+++ b/src/ddmd/hdrgen.d
@@ -1754,7 +1754,7 @@ public:
 
     override void visit(ClassDeclaration d)
     {
-        if (!d.isAnonymous())
+        if (d.classKind != ClassKind.anonymous)
         {
             buf.writestring(d.kind());
             buf.writeByte(' ');
@@ -1781,7 +1781,8 @@ public:
     {
         if (!d || !d.baseclasses.dim)
             return;
-        buf.writestring(" : ");
+        if (d.classKind != ClassKind.anonymous)
+            buf.writestring(" : ");
         foreach (i, b; *d.baseclasses)
         {
             if (i)

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -8534,7 +8534,7 @@ extern (C++) final class TypeClass : Type
 
     override bool isscope() const
     {
-        return sym.isscope;
+        return sym.stack;
     }
 
     override bool isBoolean() const

--- a/src/ddmd/objc.d
+++ b/src/ddmd/objc.d
@@ -188,12 +188,12 @@ extern(C++) private final class Supported : Objc
 
     override void setObjc(ClassDeclaration cd)
     {
-        cd.isobjc = true;
+        cd.classKind = ClassKind.objc;
     }
 
     override void setObjc(InterfaceDeclaration id)
     {
-        id.isobjc = true;
+        id.classKind = ClassKind.objc;
     }
 
     override void setSelector(FuncDeclaration fd, Scope* sc)

--- a/src/ddmd/opover.d
+++ b/src/ddmd/opover.d
@@ -1145,7 +1145,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
             {
                 ClassDeclaration cd1 = t1.isClassHandle();
                 ClassDeclaration cd2 = t2.isClassHandle();
-                if (!(cd1.cpp || cd2.cpp))
+                if (!(cd1.classKind == ClassKind.cpp || cd2.classKind == ClassKind.cpp))
                 {
                     /* Rewrite as:
                      *      .object.opEquals(e1, e2)

--- a/src/ddmd/tocvdebug.d
+++ b/src/ddmd/tocvdebug.d
@@ -538,7 +538,7 @@ void toDebug(ClassDeclaration cd)
     //printf("ClassDeclaration::toDebug('%s')\n", cd.toChars());
 
     assert(config.fulltypes >= CV4);
-    if (cd.isAnonymous())
+    if (cd.classKind == ClassKind.anonymous)
         return /*0*/;
 
     if (typidx)                 // if reference already generated

--- a/src/ddmd/todt.d
+++ b/src/ddmd/todt.d
@@ -719,7 +719,7 @@ private void membersToDt(AggregateDeclaration ad, DtBuilder dtb,
         {
             dtb.xoff(toVtblSymbol(concreteType), 0);  // __vptr
             offset = Target.ptrsize;
-            if (!cd.cpp)
+            if (!cd.classKind == ClassKind.cpp)
             {
                 dtb.size(0);              // __monitor
                 offset += Target.ptrsize;

--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -421,7 +421,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             dtb.size(0);                        // monitor
 
             // m_init[]
-            assert(cd.structsize >= 8 || (cd.cpp && cd.structsize >= 4));
+            assert(cd.structsize >= 8 || (cd.classKind == ClassKind.cpp && cd.structsize >= 4));
             dtb.size(cd.structsize);           // size
             dtb.xoff(sinit, 0, TYnptr);         // initializer
 

--- a/test/compilable/extra-files/header2.d
+++ b/test/compilable/extra-files/header2.d
@@ -158,3 +158,15 @@ void leFoo()()
     sign = a == 2 ? false : sign ^ (y < 0);
     sign = 2 + 3 | 7 + 5;
 }
+
+// 17371
+interface LeInterface
+{}
+class LeClass
+{
+    this()
+    {
+        auto foo = new class () LeInterface {};
+    }
+}
+const levar = new class LeClass, LeInterface {};

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -114,3 +114,20 @@ void leFoo()()
 	sign = a == 2 ? false : sign ^ (y < 0);
 	sign = 2 + 3 | 7 + 5;
 }
+interface LeInterface
+{
+}
+class LeClass
+{
+	this()
+	{
+		auto foo = new class LeInterface
+		{
+		}
+		;
+	}
+}
+const levar = new class LeClass, LeInterface
+{
+}
+;

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -216,3 +216,20 @@ void leFoo()()
 	sign = a == 2 ? false : sign ^ (y < 0);
 	sign = 2 + 3 | 7 + 5;
 }
+interface LeInterface
+{
+}
+class LeClass
+{
+	this()
+	{
+		auto foo = new class LeInterface
+		{
+		}
+		;
+	}
+}
+const levar = new class LeClass, LeInterface
+{
+}
+;


### PR DESCRIPTION
The header generation takes into account if a class is anonymous by invoking the final method Dsymbol.isAnonymous. The specified method verifies if a symbol is anonymous by checking if the id is null, but when a class is instantiated with a null id, it generates one [1] making isAnonymous to report a wrong answer. The easiest way to fix this is to declare a new bool field (isanon) which is set to true when a null id is passed to the instantiation of a class declaration and the header generation can check for that field instead of the wrong isAnonymous method.

[1] https://github.com/dlang/dmd/pull/5565/files#diff-ddbaa5e9ca3d5c90a425a9dfafaf1734R225