### PR TITLE
VRP for and,or,xor + Refactoring intrange.d + Fix Issue 10310

### DIFF
--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -3516,81 +3516,6 @@ extern (C++) IntRange getIntRange(Expression e)
     extern (C++) final class IntRangeVisitor : Visitor
     {
         alias visit = super.visit;
-    private:
-        static uinteger_t getMask(uinteger_t v)
-        {
-            // Ref: http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-            v |= v >> 1;
-            v |= v >> 2;
-            v |= v >> 4;
-            v |= v >> 8;
-            v |= v >> 16;
-            v |= v >> 32;
-            return v;
-        }
-
-        // The algorithms for &, |, ^ are not yet the best! Sometimes they will produce
-        //  not the tightest bound. See
-        //      https://github.com/dlang/dmd/pull/116
-        //  for detail.
-        static IntRange unsignedBitwiseAnd(ref const(IntRange) a, ref const(IntRange) b)
-        {
-            // the DiffMasks stores the mask of bits which are variable in the range.
-            uinteger_t aDiffMask = getMask(a.imin.value ^ a.imax.value);
-            uinteger_t bDiffMask = getMask(b.imin.value ^ b.imax.value);
-
-            // Since '&' computes the digitwise-minimum, the we could set all varying
-            //  digits to 0 to get a lower bound, and set all varying digits to 1 to get
-            //  an upper bound.
-            IntRange result;
-            result.imin.value = (a.imin.value & ~aDiffMask) & (b.imin.value & ~bDiffMask);
-            result.imax.value = (a.imax.value | aDiffMask) & (b.imax.value | bDiffMask);
-
-            // Sometimes the upper bound is overestimated. The upper bound will never
-            //  exceed the input.
-            if (result.imax.value > a.imax.value)
-                result.imax.value = a.imax.value;
-            if (result.imax.value > b.imax.value)
-                result.imax.value = b.imax.value;
-
-            result.imin.negative = result.imax.negative = a.imin.negative && b.imin.negative;
-            return result;
-        }
-
-        static IntRange unsignedBitwiseOr(ref const(IntRange) a, ref const(IntRange) b)
-        {
-            // the DiffMasks stores the mask of bits which are variable in the range.
-            uinteger_t aDiffMask = getMask(a.imin.value ^ a.imax.value);
-            uinteger_t bDiffMask = getMask(b.imin.value ^ b.imax.value);
-
-            // The imax algorithm by Adam D. Ruppe.
-            // http://www.digitalmars.com/pnews/read.php?server=news.digitalmars.com&group=digitalmars.D&artnum=108796
-            IntRange result;
-            result.imin.value = (a.imin.value & ~aDiffMask) | (b.imin.value & ~bDiffMask);
-            result.imax.value = a.imax.value | b.imax.value | getMask(a.imax.value & b.imax.value);
-
-            // Sometimes the lower bound is underestimated. The lower bound will never
-            //  less than the input.
-            if (result.imin.value < a.imin.value)
-                result.imin.value = a.imin.value;
-            if (result.imin.value < b.imin.value)
-                result.imin.value = b.imin.value;
-
-            result.imin.negative = result.imax.negative = a.imin.negative || b.imin.negative;
-            return result;
-        }
-
-        static IntRange unsignedBitwiseXor(ref const(IntRange) a, ref const(IntRange) b)
-        {
-            // the DiffMasks stores the mask of bits which are variable in the range.
-            uinteger_t aDiffMask = getMask(a.imin.value ^ a.imax.value);
-            uinteger_t bDiffMask = getMask(b.imin.value ^ b.imax.value);
-            IntRange result;
-            result.imin.value = (a.imin.value ^ b.imin.value) & ~(aDiffMask | bDiffMask);
-            result.imax.value = (a.imax.value ^ b.imax.value) | (aDiffMask | bDiffMask);
-            result.imin.negative = result.imax.negative = a.imin.negative != b.imin.negative;
-            return result;
-        }
 
     public:
         IntRange range;
@@ -3686,7 +3611,7 @@ extern (C++) IntRange getIntRange(Expression e)
                 return;
             }
 
-            ++irDen.imin;
+            irDen.imin = irDen.imin + SignExtendedNumber(1);
             irDen.imax = -irDen.imin;
 
             if (!irNum.imin.negative)
@@ -3707,25 +3632,9 @@ extern (C++) IntRange getIntRange(Expression e)
 
         override void visit(AndExp e)
         {
-            IntRange ir1 = getIntRange(e.e1);
-            IntRange ir2 = getIntRange(e.e2);
-
-            IntRange ir1neg, ir1pos, ir2neg, ir2pos;
-            bool has1neg, has1pos, has2neg, has2pos;
-
-            ir1.splitBySign(ir1neg, has1neg, ir1pos, has1pos);
-            ir2.splitBySign(ir2neg, has2neg, ir2pos, has2pos);
-
             IntRange result;
             bool hasResult = false;
-            if (has1pos && has2pos)
-                result.unionOrAssign(unsignedBitwiseAnd(ir1pos, ir2pos), hasResult);
-            if (has1pos && has2neg)
-                result.unionOrAssign(unsignedBitwiseAnd(ir1pos, ir2neg), hasResult);
-            if (has1neg && has2pos)
-                result.unionOrAssign(unsignedBitwiseAnd(ir1neg, ir2pos), hasResult);
-            if (has1neg && has2neg)
-                result.unionOrAssign(unsignedBitwiseAnd(ir1neg, ir2neg), hasResult);
+            result.unionOrAssign(getIntRange(e.e1) & getIntRange(e.e2), hasResult);
 
             assert(hasResult);
             range = result._cast(e.type);
@@ -3733,25 +3642,9 @@ extern (C++) IntRange getIntRange(Expression e)
 
         override void visit(OrExp e)
         {
-            IntRange ir1 = getIntRange(e.e1);
-            IntRange ir2 = getIntRange(e.e2);
-
-            IntRange ir1neg, ir1pos, ir2neg, ir2pos;
-            bool has1neg, has1pos, has2neg, has2pos;
-
-            ir1.splitBySign(ir1neg, has1neg, ir1pos, has1pos);
-            ir2.splitBySign(ir2neg, has2neg, ir2pos, has2pos);
-
             IntRange result;
             bool hasResult = false;
-            if (has1pos && has2pos)
-                result.unionOrAssign(unsignedBitwiseOr(ir1pos, ir2pos), hasResult);
-            if (has1pos && has2neg)
-                result.unionOrAssign(unsignedBitwiseOr(ir1pos, ir2neg), hasResult);
-            if (has1neg && has2pos)
-                result.unionOrAssign(unsignedBitwiseOr(ir1neg, ir2pos), hasResult);
-            if (has1neg && has2neg)
-                result.unionOrAssign(unsignedBitwiseOr(ir1neg, ir2neg), hasResult);
+            result.unionOrAssign(getIntRange(e.e1) | getIntRange(e.e2), hasResult);
 
             assert(hasResult);
             range = result._cast(e.type);
@@ -3759,25 +3652,9 @@ extern (C++) IntRange getIntRange(Expression e)
 
         override void visit(XorExp e)
         {
-            IntRange ir1 = getIntRange(e.e1);
-            IntRange ir2 = getIntRange(e.e2);
-
-            IntRange ir1neg, ir1pos, ir2neg, ir2pos;
-            bool has1neg, has1pos, has2neg, has2pos;
-
-            ir1.splitBySign(ir1neg, has1neg, ir1pos, has1pos);
-            ir2.splitBySign(ir2neg, has2neg, ir2pos, has2pos);
-
             IntRange result;
             bool hasResult = false;
-            if (has1pos && has2pos)
-                result.unionOrAssign(unsignedBitwiseXor(ir1pos, ir2pos), hasResult);
-            if (has1pos && has2neg)
-                result.unionOrAssign(unsignedBitwiseXor(ir1pos, ir2neg), hasResult);
-            if (has1neg && has2pos)
-                result.unionOrAssign(unsignedBitwiseXor(ir1neg, ir2pos), hasResult);
-            if (has1neg && has2neg)
-                result.unionOrAssign(unsignedBitwiseXor(ir1neg, ir2neg), hasResult);
+            result.unionOrAssign(getIntRange(e.e1) ^ getIntRange(e.e2), hasResult);
 
             assert(hasResult);
             range = result._cast(e.type);

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -329,3 +329,9 @@ void test13001(bool unknown)
         static assert(!__traits(compiles, b = i + 254));
     }
 }
+
+void test10310()
+{
+    int y;
+    ubyte x = ((y & 252) ^ 2) + 1;
+}


### PR DESCRIPTION
As per discussions with @andralex @WalterBright and @tgehr , this PR is the first step to improving VRP in dmd. Reimplemented ```and```, ```or```, ```xor``` over ```IntRange``` using the algorithms designed by @tgehr : 
 https://github.com/tgehr/d-compiler/blob/master/vrange.d

Refactored ```intrange.d``` to use DMD2 style op overloads. Moved implementation for ```and```, ```or```, ```xor``` from ```dcast.d```. This is a first step, the other operators will follow - this PR is quite big already.

Also fixing bug related to imprecise ```xor``` bounds:
https://issues.dlang.org/show_bug.cgi?id=10310