### PR TITLE
Base class condition in ClassDeclaration.isAbstract only applies to classes

### DIFF
--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -872,7 +872,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         /* If the base class is not abstract, then this class cannot
          * be abstract.
          */
-        if (!baseClass || !baseClass.isAbstract())
+        if (!isInterfaceDeclaration() && (!baseClass || !baseClass.isAbstract()))
             return no();
 
         /* If any abstract functions are inherited, but not overridden,


### PR DESCRIPTION
Fixes logic bug introduced by #7198 - sorry, no tests, as it only affects gdc being able to compile simple code that uses interfaces.

It is triggered because `ClassDeclaration.fillVtbl` is called during the data layout of TypeInfo for interfaces too.