### PR TITLE
refactor: add global.params.useExceptions

### DIFF
--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -125,6 +125,7 @@ struct Param
     bool enforcePropertySyntax;
     bool useModuleInfo = true;   // generate runtime module information
     bool useTypeInfo = true;     // generate runtime type information
+    bool useExceptions = true;   // support exception handling
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -1,6 +1,6 @@
 
 /* Compiler implementation of the D programming language
- * Copyright (c) 1999-2016 by Digital Mars
+ * Copyright (c) 1999-2017 by Digital Mars
  * All Rights Reserved
  * written by Walter Bright
  * http://www.digitalmars.com
@@ -118,6 +118,7 @@ struct Param
     bool enforcePropertySyntax;
     bool useModuleInfo; // generate runtime module information
     bool useTypeInfo;   // generate runtime type information
+    bool useExceptions; // support exception handling
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations

--- a/src/ddmd/irstate.d
+++ b/src/ddmd/irstate.d
@@ -275,6 +275,6 @@ extern (C++) struct IRState
          * the best we can do.
          * Nothrow needs to be tracked at the Statement level.
          */
-        return global.params.betterC;
+        return !global.params.useExceptions;
     }
 }

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -488,6 +488,7 @@ Language changes listed by -transition=id:
         global.params.checkAction = CHECKACTION.C;
         global.params.useModuleInfo = false;
         global.params.useTypeInfo = false;
+        global.params.useExceptions = false;
     }
     if (global.params.useUnitTests)
         global.params.useAssert = CHECKENABLE.on;

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -3609,7 +3609,7 @@ else
     {
         //printf("TryCatchStatement.semantic()\n");
 
-        if (global.params.betterC)
+        if (!global.params.useExceptions)
         {
             tcs.error("Cannot use try-catch statements with -betterC");
             return setError();
@@ -3774,7 +3774,7 @@ else
     {
         //printf("ThrowStatement::semantic()\n");
 
-        if (global.params.betterC)
+        if (!global.params.useExceptions)
         {
             ts.error("Cannot use throw statements with -betterC");
             return setError();


### PR DESCRIPTION
Instead of using `global.params.betterC` at @ibuclaw 's suggestion https://github.com/dlang/dmd/pull/7307#pullrequestreview-75954460