### PR TITLE
emit better code for try-finally when function does not throw

### DIFF
--- a/src/ddmd/backend/cc.d
+++ b/src/ddmd/backend/cc.d
@@ -408,8 +408,8 @@ enum
     BFLnostackopt    = 8,       // set when stack elimination should not
                                 // be done
     // NTEXCEPTIONS
-    BFLehcode        = 0x10,    // set when we need to load exception code
-    BFLunwind        = 0x1000,  // do local_unwind following block
+    BFLehcode        = 0x10,    // BC_filter: need to load exception code
+    BFLunwind        = 0x1000,  // do local_unwind following block (unused)
 
     BFLnomerg        = 0x20,    // do not merge with other blocks
     BFLprolog        = 0x80,    // generate function prolog
@@ -668,6 +668,7 @@ enum
     Fnotailrecursion = 0x4000,  // no tail recursion optimizations
     Ffakeeh          = 0x8000,  // allocate space for NT EH context sym anyway
     Fnothrow         = 0x10000, // function does not throw (even if not marked 'nothrow')
+    Feh_none         = 0x20000, // ehmethod==EH_NONE for this function only
 }
 
 struct func_t

--- a/src/ddmd/backend/cc.h
+++ b/src/ddmd/backend/cc.h
@@ -418,8 +418,8 @@ enum
     BFLnostackopt    = 8,       // set when stack elimination should not
                                 // be done
 #if NTEXCEPTIONS
-    BFLehcode        = 0x10,    // set when we need to load exception code
-    BFLunwind        = 0x1000,  // do local_unwind following block
+    BFLehcode        = 0x10,    // BC_filter: need to load exception code
+    BFLunwind        = 0x1000,  // do local_unwind following block (unused)
 #endif
     BFLnomerg        = 0x20,    // do not merge with other blocks
     BFLprolog        = 0x80,    // generate function prolog
@@ -709,6 +709,7 @@ enum
     Fnotailrecursion = 0x4000,  // no tail recursion optimizations
     Ffakeeh          = 0x8000,  // allocate space for NT EH context sym anyway
     Fnothrow         = 0x10000, // function does not throw (even if not marked 'nothrow')
+    Feh_none         = 0x20000, // ehmethod==EH_NONE for this function only
 };
 
 struct func_t
@@ -1411,6 +1412,18 @@ struct Aliassym : Symbol { };
 #else
     inline char *prettyident(Symbol *s) { return s->Sident; }
 #endif
+
+/************************
+ * Params:
+ *      f = function symbol
+ * Returns:
+ *      exception method for f
+ */
+inline EHmethod ehmethod(Symbol *f)
+{
+    return f->Sfunc->Fflags3 & Feh_none ? EH_NONE : config.ehmethod;
+}
+
 
 
 /**********************************

--- a/src/ddmd/backend/dwarf.c
+++ b/src/ddmd/backend/dwarf.c
@@ -6,6 +6,7 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/dwarf.c, backend/dwarf.c)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/ddmd/backend/dwarf.c
  */
 
 // Emit Dwarf symbolic debug info
@@ -92,6 +93,11 @@ static char __file__[] = __FILE__;      // for tassert.h
  */
 bool doUnwindEhFrame()
 {
+    if (funcsym_p->Sfunc->Fflags3 & Feh_none)
+    {
+        return (config.exe & (EX_FREEBSD | EX_FREEBSD64)) != 0;
+    }
+
     /* FreeBSD fails when having some frames as having unwinding info and some not.
      * (It hangs in unittests for std.datetime.)
      * g++ on FreeBSD does not generate mixed frames, while g++ on OSX and Linux does.
@@ -1530,7 +1536,7 @@ void dwarf_func_term(Symbol *sfunc)
 
     unsigned funcabbrevcode;
 
-    if (config.ehmethod == EH_DM)
+    if (ehmethod(sfunc) == EH_DM)
     {
         IDXSEC dfseg = dwarf_getsegment(debug_frame_name, 1);
         writeDebugFrameFDE(dfseg, sfunc);

--- a/src/ddmd/backend/nteh.c
+++ b/src/ddmd/backend/nteh.c
@@ -541,7 +541,7 @@ code *nteh_patchindex(code* c, int sindex)
 
 void nteh_gensindex(CodeBuilder& cdb, int sindex)
 {
-    if (!(config.ehmethod == EH_WIN32 || config.ehmethod == EH_SEH))
+    if (!(config.ehmethod == EH_WIN32 || config.ehmethod == EH_SEH) || funcsym_p->Sfunc->Fflags3 & Feh_none)
         return;
     // Generate:
     //  MOV     -4[EBP],sindex

--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -481,6 +481,7 @@ void builtin_init();
 #define FUNCFLAGreturnInprocess 0x10    // working on inferring 'return' for parameters
 #define FUNCFLAGinlineScanned   0x20    // function has been scanned for inline possibilities
 #define FUNCFLAGinferScope      0x40    // infer 'scope' for parameters
+#define FUNCFLAGhasCatches      0x80    // function has try-catch statements
 
 class FuncDeclaration : public Declaration
 {
@@ -523,6 +524,8 @@ public:
     CompiledCtfeFunction *ctfeCode;     // Compiled code for interpreter
     int inlineNest;                     // !=0 if nested inline
     bool isArrayOp;                     // true if array operation
+    bool eh_none;                       /// true if no exception unwinding is needed
+
     // true if errors in semantic3 this function's frame ptr
     bool semantic3Errors;
     ForeachStatement *fes;              // if foreach body, this is the foreach

--- a/src/ddmd/eh.d
+++ b/src/ddmd/eh.d
@@ -45,14 +45,14 @@ private @property @nogc nothrow auto NPTRSIZE() { return _tysize[TYnptr]; }
 Symbol *except_gentables()
 {
     //printf("except_gentables()\n");
-    if (config.ehmethod == EHmethod.EH_DM)
+    if (config.ehmethod == EHmethod.EH_DM && !(funcsym_p.Sfunc.Fflags3 & Feh_none))
     {
         // BUG: alloca() changes the stack size, which is not reflected
         // in the fixed eh tables.
         if (Alloca.size)
             error(null, 0, 0, "cannot mix core.std.stdlib.alloca() and exception handling in %s()", &funcsym_p.Sident[0]);
 
-        char[13+5+1] name;
+        char[13+5+1] name = void;
         __gshared int tmpnum;
         sprintf(name.ptr,"_HandlerTable%d",tmpnum++);
 

--- a/src/ddmd/func.d
+++ b/src/ddmd/func.d
@@ -1,4 +1,4 @@
-/**
+/***
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -136,6 +136,7 @@ public:
             catches.push(ctch);
 
             Statement s2 = new TryCatchStatement(Loc(), s._body, catches);
+            fd.eh_none = false;
             replaceCurrent(s2);
             s2.accept(this);
         }
@@ -153,6 +154,7 @@ enum FUNCFLAG : uint
     returnInprocess  = 0x10,   /// working on inferring 'return' for parameters
     inlineScanned    = 0x20,   /// function has been scanned for inline possibilities
     inferScope       = 0x40,   /// infer 'scope' for parameters
+    hasCatches       = 0x80,   /// function has try-catch statements
 }
 
 /***********************************************************
@@ -198,6 +200,7 @@ extern (C++) class FuncDeclaration : Declaration
     CompiledCtfeFunction* ctfeCode;     /// Compiled code for interpreter (not actually)
     int inlineNest;                     /// !=0 if nested inline
     bool isArrayOp;                     /// true if array operation
+    bool eh_none;                       /// true if no exception unwinding is needed
 
     bool semantic3Errors;               /// true if errors in semantic3 this function's frame ptr
     ForeachStatement fes;               /// if foreach body, this is the foreach

--- a/src/ddmd/glue.d
+++ b/src/ddmd/glue.d
@@ -827,6 +827,10 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (fd.isVirtual() && (fd.fensure || fd.frequire))
         f.Fflags3 |= Ffakeeh;
 
+    if (fd.eh_none)
+        // Same as config.ehmethod==EH_NONE, but only for this function
+        f.Fflags3 |= Feh_none;
+
     s.Sclass = global.params.isOSX ? SCcomdat : SCglobal;
     for (Dsymbol p = fd.parent; p; p = p.parent)
     {
@@ -1246,7 +1250,8 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
                 }
             }
         }
-        insertFinallyBlockCalls(f.Fstartblock);
+        if (!(f.Fflags3 & Feh_none))
+            insertFinallyBlockCalls(f.Fstartblock);
     }
 
     // If static constructor

--- a/src/ddmd/irstate.d
+++ b/src/ddmd/irstate.d
@@ -258,6 +258,8 @@ struct IRState
          * the best we can do.
          * Nothrow needs to be tracked at the Statement level.
          */
-        return !global.params.useExceptions;
+        FuncDeclaration fd;
+        return !global.params.useExceptions ||
+                (fd = getFunc()) !is null && fd.eh_none;
     }
 }

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -3605,6 +3605,7 @@ else
         result = ws;
     }
 
+    // https://dlang.org/spec/statement.html#TryStatement
     override void visit(TryCatchStatement tcs)
     {
         //printf("TryCatchStatement.semantic()\n");
@@ -3652,6 +3653,7 @@ else
 
         if (sc.func)
         {
+            sc.func.flags |= FUNCFLAG.hasCatches;
             if (flags == (FLAGcpp | FLAGd))
             {
                 tcs.error("cannot mix catching D and C++ exceptions in the same try-catch");
@@ -3679,7 +3681,8 @@ else
 
                 /* If catch exception type is derived from Exception
                  */
-                if (c.type.toBasetype().implicitConvTo(ClassDeclaration.exception.type) && (!c.handler || !c.handler.comeFrom()))
+                if (c.type.toBasetype().implicitConvTo(ClassDeclaration.exception.type) &&
+                    (!c.handler || !c.handler.comeFrom()))
                 {
                     // Remove c from the array of catches
                     tcs.catches.remove(i);

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -836,6 +836,68 @@ void test17481()
 
 /****************************************************/
 
+// a nothrow function, even though it is not marked as nothrow
+void test12()
+{
+    int i = 3;
+    try
+    {
+        try
+        {
+            ++i;
+            goto L10;
+        }
+        finally
+        {
+            i *= 2;
+            printf("f1\n");
+        }
+    }
+    finally
+    {
+        i += 5;
+        printf("f2\n");
+    }
+
+L10:
+    printf("3\n");
+    assert(i == (3 + 1) * 2 + 5);
+}
+
+/****************************************************/
+
+void foo13() { }
+
+void test13()
+{
+    int i = 3;
+    try
+    {
+        try
+        {
+            foo13(); // compiler assumes it throws
+            ++i;
+            goto L10;
+        }
+        finally
+        {
+            i *= 2;
+            printf("f1\n");
+        }
+    }
+    finally
+    {
+        i += 5;
+        printf("f2\n");
+    }
+
+L10:
+    printf("3\n");
+    assert(i == (3 + 1) * 2 + 5);
+}
+
+/****************************************************/
+
 int main()
 {
     printf("start\n");
@@ -860,6 +922,8 @@ int main()
     test10();
     test11();
     test17481();
+    test12();
+    test13();
 
     printf("finish\n");
     return 0;


### PR DESCRIPTION
Even if a function is marked `nothrow`, the exception unwind tables must still be there because a try-catch could still be there that absorbs the exception. This PR marks a function internally if it does not throw and does not have a try-catch. This knowledge is then used to omit building exception unwind tables, and the code gen does not have to assume that an external unwinder is calling the `finally` blocks. The code emitted (at least for Windows) is substantially less.