### PR TITLE
port longdouble.* to D to allow building dmd with LDC on Windows

### DIFF
--- a/src/dmd/backend/bcomplex.d
+++ b/src/dmd/backend/bcomplex.d
@@ -11,6 +11,8 @@ module dmd.backend.bcomplex;
 
 // Online documentation: https://dlang.org/phobos/dmd_backend_bcomplex.html
 
+import dmd.backend.cdef;
+
 extern (C++):
 @nogc:
 nothrow:
@@ -24,7 +26,7 @@ struct Complex_f
 
     static Complex_f div(ref Complex_f x, ref Complex_f y);
     static Complex_f mul(ref Complex_f x, ref Complex_f y);
-    static real abs(ref Complex_f z);
+    static targ_ldouble abs(ref Complex_f z);
     static Complex_f sqrtc(ref Complex_f z);
 }
 
@@ -34,16 +36,16 @@ struct Complex_d
 
     static Complex_d div(ref Complex_d x, ref Complex_d y);
     static Complex_d mul(ref Complex_d x, ref Complex_d y);
-    static real abs(ref Complex_d z);
+    static targ_ldouble abs(ref Complex_d z);
     static Complex_d sqrtc(ref Complex_d z);
 }
 
 struct Complex_ld
 {
-    real re, im;
+    targ_ldouble re, im;
 
     static Complex_ld div(ref Complex_ld x, Complex_ld y);
     static Complex_ld mul(ref Complex_ld x, ref Complex_ld y);
-    static real abs(ref Complex_ld z);
+    static targ_ldouble abs(ref Complex_ld z);
     static Complex_ld sqrtc(ref Complex_ld z);
 }

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -245,7 +245,7 @@ alias targ_llong = long;
 alias targ_ullong = ulong;
 alias targ_float = float;
 alias targ_double = double;
-alias targ_ldouble = real;
+public import dmd.root.longdouble : targ_ldouble = longdouble;
 
 // Extract most significant register from constant
 //#define MSREG(p)        ((REGSIZE == 2) ? (p) >> 16 : ((sizeof(targ_llong) == 8) ? (p) >> 32 : 0))

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1386,7 +1386,7 @@ elem *toElem(Expression e, IRState *irs)
                     /* This assignment involves a conversion, which
                      * unfortunately also converts SNAN to QNAN.
                      */
-                    e.EV.Vfloat = re.value;
+                    e.EV.Vfloat = cast(float) re.value;
                     if (CTFloat.isSNaN(re.value))
                     {
                         // Put SNAN back
@@ -1399,7 +1399,7 @@ elem *toElem(Expression e, IRState *irs)
                     /* This assignment involves a conversion, which
                      * unfortunately also converts SNAN to QNAN.
                      */
-                    e.EV.Vdouble = re.value;
+                    e.EV.Vdouble = cast(double) re.value;
                     if (CTFloat.isSNaN(re.value))
                     {
                         // Put SNAN back
@@ -3955,12 +3955,12 @@ elem *toElem(Expression e, IRState *irs)
                     {
                         case Tfloat32:
                             // Must not call toReal directly, to avoid dmd bug 14203 from breaking dmd
-                            e.EV.Vfloat8[i] = complex.re;
+                            e.EV.Vfloat8[i] = cast(float) complex.re;
                             break;
 
                         case Tfloat64:
                             // Must not call toReal directly, to avoid dmd bug 14203 from breaking dmd
-                            e.EV.Vdouble4[i] = complex.re;
+                            e.EV.Vdouble4[i] = cast(double) complex.re;
                             break;
 
                         case Tint64:

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -3392,10 +3392,10 @@ code *asm_db_parse(OP *pop)
                 switch (op)
                 {
                     case OPdf:
-                        dt.f = asmstate.tok.floatvalue;
+                        dt.f = cast(float) asmstate.tok.floatvalue;
                         break;
                     case OPdd:
-                        dt.d = asmstate.tok.floatvalue;
+                        dt.d = cast(double) asmstate.tok.floatvalue;
                         break;
                     case OPde:
                         dt.ld = asmstate.tok.floatvalue;
@@ -3477,10 +3477,10 @@ code *asm_db_parse(OP *pop)
                     switch (op)
                     {
                         case OPdf:
-                            dt.f = e.toReal();
+                            dt.f = cast(float) e.toReal();
                             break;
                         case OPdd:
-                            dt.d = e.toReal();
+                            dt.d = cast(double) e.toReal();
                             break;
                         case OPde:
                             dt.ld = e.toReal();

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -21,7 +21,7 @@ import core.stdc.string;
 nothrow:
 
 // Type used by the front-end for compile-time reals
-alias real_t = real;
+public import dmd.root.longdouble : real_t = longdouble;
 
 private
 {
@@ -29,7 +29,10 @@ private
 
     version(CRuntime_Microsoft) extern (C++)
     {
-        struct longdouble { real_t r; }
+        static if (is(real_t == real))
+            struct longdouble { real_t r; }
+        else
+            import dmd.root.longdouble : longdouble;
         size_t ld_sprint(char* str, int fmt, longdouble x);
         longdouble strtold_dm(const(char)* p, char** endp);
     }
@@ -66,12 +69,24 @@ extern (C++) struct CTFloat
             assert(0);
     }
 
-    static real_t sin(real_t x) { return core.math.sin(x); }
-    static real_t cos(real_t x) { return core.math.cos(x); }
-    static real_t tan(real_t x) { return core.stdc.math.tanl(x); }
-    static real_t sqrt(real_t x) { return core.math.sqrt(x); }
-    static real_t fabs(real_t x) { return core.math.fabs(x); }
-    static real_t ldexp(real_t n, int exp) { return core.math.ldexp(n, exp); }
+    static if (!is(real_t == real))
+    {
+        alias sin = dmd.root.longdouble.sinl;
+        alias cos = dmd.root.longdouble.cosl;
+        alias tan = dmd.root.longdouble.tanl;
+        alias sqrt = dmd.root.longdouble.sqrtl;
+        alias fabs = dmd.root.longdouble.fabsl;
+        alias ldexp = dmd.root.longdouble.ldexpl;
+    }
+    else
+    {
+        static real_t sin(real_t x) { return core.math.sin(x); }
+        static real_t cos(real_t x) { return core.math.cos(x); }
+        static real_t tan(real_t x) { return core.stdc.math.tanl(x); }
+        static real_t sqrt(real_t x) { return core.math.sqrt(x); }
+        static real_t fabs(real_t x) { return core.math.fabs(x); }
+        static real_t ldexp(real_t n, int exp) { return core.math.ldexp(n, exp); }
+    }
 
     static bool isIdentical(real_t a, real_t b)
     {
@@ -103,7 +118,7 @@ extern (C++) struct CTFloat
     // the implementation of longdouble for MSVC is a struct, so mangling
     //  doesn't match with the C++ header.
     // add a wrapper just for isSNaN as this is the only function called from C++
-    version(CRuntime_Microsoft)
+    version(CRuntime_Microsoft) static if (is(real_t == real))
         static bool isSNaN(longdouble ld)
         {
             return isSNaN(ld.r);
@@ -123,7 +138,12 @@ extern (C++) struct CTFloat
             __locale_decpoint = ".";
         }
         version(CRuntime_Microsoft)
-            auto r = strtold_dm(literal, null).r;
+        {
+            version(LDC)
+                auto r = strtold_dm(literal, null);
+            else
+                auto r = strtold_dm(literal, null).r;
+        }
         else
             auto r = strtold(literal, null);
         version(CRuntime_DigitalMars) __locale_decpoint = save;
@@ -159,8 +179,16 @@ extern (C++) struct CTFloat
     }
 
     // Constant real values 0, 1, -1 and 0.5.
-    static __gshared real_t zero = real_t(0);
-    static __gshared real_t one = real_t(1);
-    static __gshared real_t minusone = real_t(-1);
-    static __gshared real_t half = real_t(0.5);
+    static __gshared real_t zero;
+    static __gshared real_t one;
+    static __gshared real_t minusone;
+    static __gshared real_t half;
+
+    shared static this()
+    {
+        zero = real_t(0);
+        one = real_t(1);
+        minusone = real_t(-1);
+        half = real_t(0.5);
+    }
 }

--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -1,0 +1,123 @@
+/* Copyright (c) 1999-2017 by Digital Mars
+ * All Rights Reserved, written by Rainer Schuetze
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+ * https://github.com/dlang/dmd/blob/master/src/root/longdouble.d
+ */
+
+// 80 bit floating point value implementation for LDC compiler targetting MSVC
+
+module dmd.root.longdouble;
+
+enum hasNativeFloat80 = real.sizeof > 8;
+
+static if (hasNativeFloat80)
+{
+    alias longdouble = real;
+}
+
+static if (!hasNativeFloat80):
+extern(C++):
+nothrow:
+
+align(2) struct longdouble
+{
+nothrow:
+    ulong mantissa = 0xC000000000000001UL; // default to snan
+    ushort exp_sign = 0x7fff; // sign is highest bit
+
+    this(ulong m, ushort es) { mantissa = m; exp_sign = es; }
+    this(longdouble ld) { mantissa = ld.mantissa; exp_sign = ld.exp_sign; }
+    this(int i) { ld_set(&this, i); }
+    this(uint i) { ld_set(&this, i); }
+    this(long i) { ld_setll(&this, i); }
+    this(ulong i) { ld_setull(&this, i); }
+    this(float f) { ld_set(&this, f); }
+    this(double d)
+    {
+        // allow zero initialization at compile time
+        if (__ctfe && d == 0)
+        {
+            mantissa = 0;
+            exp_sign = 0;
+        }
+        else
+            ld_set(&this, d);
+    }
+
+    void opAssign(float f) { ld_set(&this, f); }
+    void opAssign(double f) { ld_set(&this, f); }
+    longdouble opNeg() const { return longdouble(mantissa, exp_sign ^ 0x8000); }
+
+    bool opEquals(const longdouble rhs) const { return this.ld_cmpe(rhs); }
+    int  opCmp(longdouble rhs) const { return this.ld_cmp(rhs); }
+    longdouble opAdd(longdouble rhs) const { return this.ld_add(rhs); }
+    longdouble opSub(longdouble rhs) const { return this.ld_sub(rhs); }
+    longdouble opMul(longdouble rhs) const { return this.ld_mul(rhs); }
+    longdouble opDiv(longdouble rhs) const { return this.ld_div(rhs); }
+    longdouble opMod(longdouble rhs) const { return this.ld_mod(rhs); }
+
+    T opCast(T)() const
+    {
+        static      if(is(T == bool))   return mantissa != 0 || (exp_sign & 0x7fff) != 0;
+        else static if(is(T == byte))   return cast(T)ld_read(&this);
+        else static if(is(T == ubyte))  return cast(T)ld_read(&this);
+        else static if(is(T == short))  return cast(T)ld_read(&this);
+        else static if(is(T == ushort)) return cast(T)ld_read(&this);
+        else static if(is(T == int))    return cast(T)ld_read(&this);
+        else static if(is(T == uint))   return cast(T)ld_read(&this);
+        else static if(is(T == float))  return cast(T)ld_read(&this);
+        else static if(is(T == double)) return cast(T)ld_read(&this);
+        else static if(is(T == long))   return ld_readll(&this);
+        else static if(is(T == ulong))  return ld_readull(&this);
+        else static assert(false, "usupported type");
+    }
+
+    static longdouble nan() { return longdouble(0xC000000000000000UL, 0x7fff); }
+    static longdouble infinity() { return longdouble(0x8000000000000000UL, 0x7fff); }
+    static longdouble zero() { return longdouble(0, 0); }
+    static longdouble max() { return longdouble(0xffffffffffffffffUL, 0x7ffe); }
+    static longdouble min_normal() { return longdouble(0x8000000000000000UL, 1); }
+    static longdouble epsilon() { return longdouble(0x8000000000000000UL, 0x3fff - 63); }
+
+    static uint dig() { return 18; }
+    static uint mant_dig() { return 64; }
+    static uint max_exp() { return 16384; }
+    static uint min_exp() { return -16381; }
+    static uint max_10_exp() { return 4932; }
+    static uint min_10_exp() { return -4932; }
+};
+
+extern(C)
+{
+    longdouble ld_add(longdouble ld1, longdouble ld2);
+    longdouble ld_sub(longdouble ld1, longdouble ld2);
+    longdouble ld_mul(longdouble ld1, longdouble ld2);
+    longdouble ld_div(longdouble ld1, longdouble ld2);
+    longdouble ld_mod(longdouble ld1, longdouble ld2);
+
+    int ld_cmp(longdouble ld1, longdouble ld2);
+    bool ld_cmpe(longdouble ld1, longdouble ld2);
+
+    double ld_read(const longdouble* ld);
+    long ld_readll(const longdouble* ld);
+    ulong ld_readull(const longdouble* ld);
+
+    void ld_set(longdouble* ld, double d);
+    void ld_setll(longdouble* ld, long d);
+    void ld_setull(longdouble* ld, ulong d);
+}
+
+
+extern longdouble ld_qnan;
+extern longdouble ld_inf;
+
+longdouble fabsl(longdouble ld);
+longdouble sqrtl(longdouble ld);
+longdouble sinl (longdouble ld);
+longdouble cosl (longdouble ld);
+longdouble tanl (longdouble ld);
+longdouble ldexpl(longdouble ldval, int exp);
+
+longdouble sqrt (longdouble ld) { return sqrtl(ld); }

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -69,12 +69,12 @@ struct Target
     {
         static __gshared
         {
-            real_t max = T.max;                 /// largest representable value that's not infinity
-            real_t min_normal = T.min_normal;   /// smallest representable normalized value that's not 0
-            real_t nan = T.nan;                 /// NaN value
-            real_t snan = T.init;               /// signalling NaN value
-            real_t infinity = T.infinity;       /// infinity value
-            real_t epsilon = T.epsilon;         /// smallest increment to the value 1
+            real_t max;                         /// largest representable value that's not infinity
+            real_t min_normal;                  /// smallest representable normalized value that's not 0
+            real_t nan;                         /// NaN value
+            real_t snan;                        /// signalling NaN value
+            real_t infinity;                    /// infinity value
+            real_t epsilon;                     /// smallest increment to the value 1
 
             d_int64 dig = T.dig;                /// number of decimal digits of precision
             d_int64 mant_dig = T.mant_dig;      /// number of bits in mantissa
@@ -82,6 +82,15 @@ struct Target
             d_int64 min_exp = T.min_exp;        /// minimum int value such that 2$(SUPERSCRIPT `min_exp-1`) is representable as a normalized value
             d_int64 max_10_exp = T.max_10_exp;  /// maximum int value such that 10$(SUPERSCRIPT `max_10_exp` is representable)
             d_int64 min_10_exp = T.min_10_exp;  /// minimum int value such that 10$(SUPERSCRIPT `min_10_exp`) is representable as a normalized value
+        }
+        static void _init()
+        {
+            max = T.max;
+            min_normal = T.min_normal;
+            nan = T.nan;
+            snan = T.init;
+            infinity = T.infinity;
+            epsilon = T.epsilon;
         }
     }
 
@@ -97,6 +106,10 @@ struct Target
      */
     extern (C++) static void _init()
     {
+        FloatProperties._init();
+        DoubleProperties._init();
+        RealProperties._init();
+
         // These have default values for 32 bit code, they get
         // adjusted for 64 bit code.
         ptrsize = 4;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -316,7 +316,7 @@ LEXER_ROOT=$(addsuffix .d, $(addprefix $(ROOT)/, array ctfloat file filename out
 
 ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array ctfloat file \
 	filename man outbuffer port response rmem rootobject speller \
-	stringtable hash))
+	longdouble stringtable hash))
 
 GLUE_OBJS =
 G_GLUE_OBJS = $(addprefix $G/, $(GLUE_OBJS))

--- a/src/vcbuild/ldfpu.asm
+++ b/src/vcbuild/ldfpu.asm
@@ -272,6 +272,25 @@ ld_cmpne PROC
 	ret
 ld_cmpne ENDP
 
+; int ld_cmp(long_double x, long_double y);
+; rcx: &x
+; rdx: &y
+; return -1 if x < y, 0 if x == y or unordered, 1 if x > y
+ld_cmp PROC
+	fld tbyte ptr [rdx]
+	fld tbyte ptr [rcx]
+	fucomip ST(0),ST(1)
+	seta    AL
+	setb    AH
+	setp    DL
+	or      AL,DL
+	or      AH,DL
+	sub     AL,AH
+	movsx   EAX, AL
+	fstp    ST(0)
+	ret
+ld_cmp ENDP
+
 ; long_double ld_sqrt(long_double x);
 ; rcx: &res
 ; rdx: &x

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -252,7 +252,7 @@ TKSRC= $(TK)\filespec.h $(TK)\mem.h $(TK)\list.h $(TK)\vec.h \
 ROOTSRCC=$(ROOT)\newdelete.c
 ROOTSRCD=$(ROOT)\rmem.d $(ROOT)\stringtable.d $(ROOT)\hash.d $(ROOT)\man.d $(ROOT)\port.d \
 	$(ROOT)\response.d $(ROOT)\rootobject.d $(ROOT)\speller.d $(ROOT)\aav.d \
-	$(ROOT)\ctfloat.d $(ROOT)\outbuffer.d $(ROOT)\filename.d \
+	$(ROOT)\ctfloat.d $(ROOT)\longdouble.d $(ROOT)\outbuffer.d $(ROOT)\filename.d \
 	$(ROOT)\file.d $(ROOT)\array.d
 ROOTSRC= $(ROOT)\root.h $(ROOT)\stringtable.h \
 	$(ROOT)\longdouble.h $(ROOT)\outbuffer.h $(ROOT)\object.h $(ROOT)\ctfloat.h \


### PR DESCRIPTION
LDC for MSVC uses 64-bit reals similar to the C runtime, so using the longdouble struct is necessary to compile to 80-bit reals (already used when building the backend with VC).

Building the frontend with LDC (v1.6.0-beta1) has noticable effect on build times, for example the druntime/phobos unittests build about 20% faster (64-bit version with the backend built with VC for both).

Slightly OT: while building the debug version of the dmd frontend with LDC takes almost twice as much time as with DMD, the release is faster with LDC than DMD (1min05 vs. 1min34).
