### PR TITLE
Replace `body` keyword with its replacement: `do`

### DIFF
--- a/src/ddmd/astbase.d
+++ b/src/ddmd/astbase.d
@@ -5924,7 +5924,7 @@ struct ASTBase
         {
             assert(!!aggrfe ^ !!rangefe);
         }
-        body
+        do
         {
             this.loc = loc;
             this.aggrfe = aggrfe;

--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -107,7 +107,7 @@ extern (C++) final class StaticForeach : RootObject
     {
         assert(!!aggrfe ^ !!rangefe);
     }
-    body
+    do
     {
         this.loc = loc;
         this.aggrfe = aggrfe;
@@ -378,7 +378,7 @@ extern (C++) final class StaticForeach : RootObject
     {
         assert(sc);
     }
-    body
+    do
     {
         if (aggrfe)
         {

--- a/src/ddmd/root/man.d
+++ b/src/ddmd/root/man.d
@@ -25,7 +25,7 @@ version (Windows)
     {
         assert(strncmp(url, "http://", 7) == 0 || strncmp(url, "https://", 8) == 0);
     }
-    body
+    do
     {
         ShellExecuteA(null, "open", url, null, null, SW_SHOWNORMAL);
     }
@@ -37,7 +37,7 @@ else version (OSX)
     {
         assert(strncmp(url, "http://", 7) == 0 || strncmp(url, "https://", 8) == 0);
     }
-    body
+    do
     {
         pid_t childpid;
         const(char)*[5] args;
@@ -71,7 +71,7 @@ else version (Posix)
     {
         assert(strncmp(url, "http://", 7) == 0 || strncmp(url, "https://", 8) == 0);
     }
-    body
+    do
     {
         pid_t childpid;
         const(char)*[3] args;


### PR DESCRIPTION
Automatic replacement with

    sed -i "s/^\([ ]*\)body/\1do/" -i **/*.d

See also: https://github.com/dlang/phobos/pull/5869, https://github.com/dlang/druntime/pull/1975
I left the `test` files untouched for now as they should probably be changed once the use of `body` triggers a deprecation warning.