### PR TITLE
Fix Issue 15094 - __traits(getMember) fails when the source is a struct/class field

### DIFF
--- a/src/ddmd/dtemplate.d
+++ b/src/ddmd/dtemplate.d
@@ -6559,7 +6559,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             {
                 //printf("type %s\n", ta.toChars());
                 // It might really be an Expression or an Alias
-                ta.resolve(loc, sc, &ea, &ta, &sa);
+                ta.resolve(loc, sc, &ea, &ta, &sa, (flags & 1) != 0);
                 if (ea)
                     goto Lexpr;
                 if (sa)
@@ -6691,7 +6691,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                         //goto Ldsym;
                     }
                 }
-                if (ea.op == TOKdotvar)
+                if (ea.op == TOKdotvar && !(flags & 1))
                 {
                     // translate expression to dsymbol.
                     sa = (cast(DotVarExp)ea).var;
@@ -6702,7 +6702,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     sa = (cast(TemplateExp)ea).td;
                     goto Ldsym;
                 }
-                if (ea.op == TOKdottd)
+                if (ea.op == TOKdottd && !(flags & 1))
                 {
                     // translate expression to dsymbol.
                     sa = (cast(DotTemplateExp)ea).td;

--- a/src/ddmd/traits.d
+++ b/src/ddmd/traits.d
@@ -60,17 +60,24 @@ struct PushAttributes
 }
 
 /**************************************
- * Convert `Expression` or `Type` to corresponding `Dsymbol`,
- * additionally strip off expression contexts.
+ * Convert `Expression` or `Type` to corresponding `Dsymbol`, additionally
+ * stripping off expression contexts.
  *
  * Some symbol related `__traits` ignore arguments expression contexts.
  * For example:
+ * ----
  *  struct S { void f() {} }
  *  S s;
  *  pragma(msg, __traits(isNested, s.f));
- *  // s.f is DotVarExp, but __traits(isNested) needs a FuncDeclaration.
+ *  // s.f is `DotVarExp`, but `__traits(isNested)`` needs a `FuncDeclaration`.
+ * ----
  *
  * This is used for that common `__traits` behavior.
+ *
+ * Input:
+ *      oarg     object to get the symbol for
+ * Returns:
+ *      Dsymbol  the corresponding symbol for oarg
  */
 private Dsymbol getDsymbolWithoutExpCtx(RootObject oarg)
 {

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1526,6 +1526,19 @@ void async(ARGS...)(ARGS)
 alias test17495 = async!(int, int);
 
 /********************************************************/
+// 15094
+
+void test15094()
+{
+    static struct Foo { int i; }
+    static struct Bar { Foo foo; }
+
+    Bar bar;
+    auto n = __traits(getMember, bar.foo, "i");
+    assert(n == bar.foo.i);
+}
+
+/********************************************************/
 
 int main()
 {
@@ -1566,6 +1579,7 @@ int main()
     test_getFunctionAttributes();
     test_isOverrideFunction();
     test12237();
+    test15094();
 
     writeln("Success");
     return 0;


### PR DESCRIPTION
Revival of #5215
Special thanks to @9rnsr 