### PR TITLE
Fix Issue 9433 - Deprecate delete

### DIFF
--- a/changelog/deprecate_delete.dd
+++ b/changelog/deprecate_delete.dd
@@ -1,0 +1,8 @@
+The `delete` keyword has been deprecated.
+
+See the $(LINK2 $(ROOT_DIR)deprecate.html#delete, Deprecated Features) for more information.
+
+Starting with this release, using the `delete` keyword will result in a deprecation warning.
+
+As a replacement, users are encouraged to use $(REF1 destroy, object)
+if feasible, or $(REF __delete, core,memory) as a last resort.

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7768,6 +7768,11 @@ final class Parser(AST) : Lexer
         case TOK.delete_:
             nextToken();
             e = parseUnaryExp();
+            // @@@DEPRECATED_2019-02@@@
+            // 1. Deprecation for 1 year
+            // 2. Error for 1 year
+            // 3. Removal, "delete" can be used for other identities
+            deprecation("The `delete` keyword has been deprecated.  Use `object.destroy()` instead.");
             e = new AST.DeleteExp(loc, e, false);
             break;
 

--- a/test/compilable/vgc1.d
+++ b/test/compilable/vgc1.d
@@ -1,6 +1,15 @@
 // REQUIRED_ARGS: -vgc -o-
 // PERMUTE_ARGS:
 
+/*
+TEST_OUTPUT:
+---
+compilable/vgc1.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+compilable/vgc1.d(94): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+compilable/vgc1.d(95): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+---
+*/
+
 /***************** NewExp *******************/
 
 struct S1 { }
@@ -12,13 +21,13 @@ struct S5 { @nogc new(size_t); }
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(27): vgc: `new` causes a GC allocation
-compilable/vgc1.d(29): vgc: `new` causes a GC allocation
-compilable/vgc1.d(30): vgc: `new` causes a GC allocation
-compilable/vgc1.d(32): vgc: `new` causes a GC allocation
-compilable/vgc1.d(33): vgc: `new` causes a GC allocation
-compilable/vgc1.d(34): vgc: `new` causes a GC allocation
+compilable/vgc1.d(36): vgc: `new` causes a GC allocation
 compilable/vgc1.d(38): vgc: `new` causes a GC allocation
+compilable/vgc1.d(39): vgc: `new` causes a GC allocation
+compilable/vgc1.d(41): vgc: `new` causes a GC allocation
+compilable/vgc1.d(42): vgc: `new` causes a GC allocation
+compilable/vgc1.d(43): vgc: `new` causes a GC allocation
+compilable/vgc1.d(47): vgc: `new` causes a GC allocation
 ---
 */
 
@@ -41,12 +50,12 @@ void testNew()
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(55): vgc: `new` causes a GC allocation
-compilable/vgc1.d(57): vgc: `new` causes a GC allocation
-compilable/vgc1.d(58): vgc: `new` causes a GC allocation
-compilable/vgc1.d(60): vgc: `new` causes a GC allocation
-compilable/vgc1.d(61): vgc: `new` causes a GC allocation
-compilable/vgc1.d(62): vgc: `new` causes a GC allocation
+compilable/vgc1.d(64): vgc: `new` causes a GC allocation
+compilable/vgc1.d(66): vgc: `new` causes a GC allocation
+compilable/vgc1.d(67): vgc: `new` causes a GC allocation
+compilable/vgc1.d(69): vgc: `new` causes a GC allocation
+compilable/vgc1.d(70): vgc: `new` causes a GC allocation
+compilable/vgc1.d(71): vgc: `new` causes a GC allocation
 ---
 */
 
@@ -74,9 +83,9 @@ void testNewScope()
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(84): vgc: `delete` requires the GC
-compilable/vgc1.d(85): vgc: `delete` requires the GC
-compilable/vgc1.d(86): vgc: `delete` requires the GC
+compilable/vgc1.d(93): vgc: `delete` requires the GC
+compilable/vgc1.d(94): vgc: `delete` requires the GC
+compilable/vgc1.d(95): vgc: `delete` requires the GC
 ---
 */
 void testDelete(int* p, Object o, S1* s)

--- a/test/fail_compilation/fail14486.d
+++ b/test/fail_compilation/fail14486.d
@@ -1,5 +1,41 @@
 // REQUIRED_ARGS: -o-
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14486.d(81): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(82): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(83): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(84): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(85): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(99): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(100): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(101): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(102): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(103): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(123): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(124): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(125): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(126): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(127): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(141): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(142): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(143): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(144): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(145): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(164): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(165): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(166): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(167): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(168): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(181): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(182): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(183): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(184): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail14486.d(185): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+---
+*/
+
 class  C0a { }
 class  C1a {                  ~this() {} }
 class  C2a {                  ~this() {}  @nogc pure @safe delete(void* p) {} }
@@ -27,18 +63,19 @@ struct S4b {          nothrow ~this() {}           nothrow delete(void* p) {} }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(44): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
-fail_compilation/fail14486.d(45): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(45): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(45): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(46): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(46): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(46): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(47): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(47): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(47): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(48): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
----*/
+fail_compilation/fail14486.d(81): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
+fail_compilation/fail14486.d(82): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(82): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(82): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(83): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(83): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(83): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(84): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(84): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(84): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(85): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
+---
+*/
 void test1a() @nogc pure @safe
 {
     C0a   c0;  delete c0;   // error
@@ -51,10 +88,10 @@ void test1a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(63): Error: destructor `fail14486.C1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(64): Error: destructor `fail14486.C2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(65): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(60): Error: `nothrow` function `fail14486.test1b` may throw
+fail_compilation/fail14486.d(100): Error: destructor `fail14486.C1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(101): Error: destructor `fail14486.C2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(102): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(97): Error: `nothrow` function `fail14486.test1b` may throw
 ---
 */
 void test1b() nothrow
@@ -69,16 +106,16 @@ void test1b() nothrow
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(86): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
-fail_compilation/fail14486.d(87): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(87): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(87): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(88): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(88): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(88): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(89): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(89): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(89): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(123): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
+fail_compilation/fail14486.d(124): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(124): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(124): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(125): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(125): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(125): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(126): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(126): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(126): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
 ---
 */
 void test2a() @nogc pure @safe
@@ -93,10 +130,10 @@ void test2a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(105): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(106): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(107): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(102): Error: `nothrow` function `fail14486.test2b` may throw
+fail_compilation/fail14486.d(142): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(143): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(144): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(139): Error: `nothrow` function `fail14486.test2b` may throw
 ---
 */
 void test2b() nothrow
@@ -111,15 +148,15 @@ void test2b() nothrow
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(127): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(128): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(128): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(128): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(129): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(129): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(129): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(130): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(131): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(164): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(165): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(165): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(165): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(166): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(166): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(166): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(167): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(168): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
 ---
 */
 void test3a() @nogc pure @safe
@@ -134,9 +171,9 @@ void test3a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(145): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(146): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(142): Error: `nothrow` function `fail14486.test3b` may throw
+fail_compilation/fail14486.d(182): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(183): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(179): Error: `nothrow` function `fail14486.test3b` may throw
 ---
 */
 void test3b() nothrow

--- a/test/fail_compilation/fail2361.d
+++ b/test/fail_compilation/fail2361.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2361.d(13): Error: cannot modify `immutable` expression `c`
+fail_compilation/fail2361.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail2361.d(14): Error: cannot modify `immutable` expression `c`
 ---
 */
 

--- a/test/fail_compilation/fail_arrayop2.d
+++ b/test/fail_compilation/fail_arrayop2.d
@@ -3,8 +3,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(12): Error: array operation `[1, 2, 3] - [1, 2, 3]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(15): Error: invalid array operation `"a" - "b"` (possible missing [])
+fail_compilation/fail_arrayop2.d(281): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail_arrayop2.d(13): Error: array operation `[1, 2, 3] - [1, 2, 3]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(16): Error: invalid array operation `"a" - "b"` (possible missing [])
 ---
 */
 void test2603() // Issue 2603 - ICE(cgcs.c) on subtracting string literals
@@ -18,17 +19,17 @@ void test2603() // Issue 2603 - ICE(cgcs.c) on subtracting string literals
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(37): Error: array operation `-a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(38): Error: array operation `~a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(40): Error: array operation `a[] + a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(41): Error: array operation `a[] - a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(42): Error: array operation `a[] * a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(43): Error: array operation `a[] / a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(44): Error: array operation `a[] % a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(45): Error: array operation `a[] ^ a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(46): Error: array operation `a[] & a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(47): Error: array operation `a[] | a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(48): Error: array operation `a[] ^^ a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(38): Error: array operation `-a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(39): Error: array operation `~a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(41): Error: array operation `a[] + a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(42): Error: array operation `a[] - a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(43): Error: array operation `a[] * a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(44): Error: array operation `a[] / a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(45): Error: array operation `a[] % a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(46): Error: array operation `a[] ^ a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(47): Error: array operation `a[] & a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(48): Error: array operation `a[] | a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(49): Error: array operation `a[] ^^ a[]` without destination memory not allowed (possible missing [])
 ---
 */
 void test9459()
@@ -51,19 +52,19 @@ void test9459()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(74): Error: array operation `a[] + a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(75): Error: array operation `a[] - a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(76): Error: array operation `a[] * a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(77): Error: array operation `a[] / a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(78): Error: array operation `a[] % a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(79): Error: array operation `a[] ^ a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(80): Error: array operation `a[] & a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(81): Error: array operation `a[] | a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(82): Error: array operation `a[] ^^ 10` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(83): Error: array operation `-a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(84): Error: array operation `~a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(89): Error: array operation `[1] + a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(75): Error: array operation `a[] + a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(76): Error: array operation `a[] - a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(77): Error: array operation `a[] * a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(78): Error: array operation `a[] / a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(79): Error: array operation `a[] % a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(80): Error: array operation `a[] ^ a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(81): Error: array operation `a[] & a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(82): Error: array operation `a[] | a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(83): Error: array operation `a[] ^^ 10` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(84): Error: array operation `-a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(85): Error: array operation `~a[]` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(90): Error: array operation `[1] + a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(91): Error: array operation `[1] + a[]` without destination memory not allowed
 ---
 */
 void test12179()
@@ -93,7 +94,7 @@ void test12179()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(104): Error: array operation `h * y[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(105): Error: array operation `h * y[]` without destination memory not allowed
 ---
 */
 void test12381()
@@ -107,8 +108,8 @@ void test12381()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(117): Error: array operation `-a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(119): Error: array operation `(-a[])[0..4]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(118): Error: array operation `-a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(120): Error: array operation `(-a[])[0..4]` without destination memory not allowed
 ---
 */
 float[] test12769(float[] a)
@@ -122,11 +123,11 @@ float[] test12769(float[] a)
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(136): Error: array operation `a[] - a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(138): Error: array operation `a[] - a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(137): Error: array operation `a[] - a[]` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(139): Error: array operation `a[] - a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(142): Error: array operation `a[] - a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(144): Error: array operation `a[] - a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(140): Error: array operation `a[] - a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(143): Error: array operation `a[] - a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(145): Error: array operation `a[] - a[]` without destination memory not allowed
 ---
 */
 void test13208()
@@ -147,10 +148,10 @@ void test13208()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(159): Error: array operation `a[] * a[]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(160): Error: array operation `(a[] * a[])[0..1]` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(163): Error: array operation `a[] * a[]` without destination memory not allowed (possible missing [])
-fail_compilation/fail_arrayop2.d(164): Error: array operation `(a[] * a[])[0..1]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(160): Error: array operation `a[] * a[]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(161): Error: array operation `(a[] * a[])[0..1]` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(164): Error: array operation `a[] * a[]` without destination memory not allowed (possible missing [])
+fail_compilation/fail_arrayop2.d(165): Error: array operation `(a[] * a[])[0..1]` without destination memory not allowed (possible missing [])
 ---
 */
 void test13497()
@@ -167,7 +168,7 @@ void test13497()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(180): Error: array operation `data[segmentId][28..29] & cast(ubyte)(1 << 0)` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(181): Error: array operation `data[segmentId][28..29] & cast(ubyte)(1 << 0)` without destination memory not allowed
 ---
 */
 void test13910()
@@ -184,8 +185,8 @@ void test13910()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(194): Error: array operation `a[] + 1` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(194): Error: array operation `a[] * 2` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(195): Error: array operation `a[] + 1` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(195): Error: array operation `a[] * 2` without destination memory not allowed
 ---
 */
 void test14895()
@@ -197,40 +198,40 @@ void test14895()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(245): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(246): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(247): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(252): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(255): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(264): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(267): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(268): Error: array operation `"abc"[] + '\x01'` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(271): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(274): Error: `([1] * 6)[0..2]` is not an lvalue
-fail_compilation/fail_arrayop2.d(277): Error: can only `*` a pointer, not a `int[]`
-fail_compilation/fail_arrayop2.d(280): Error: `[1] * 6` is not an lvalue
-fail_compilation/fail_arrayop2.d(283): Error: array operation `da[] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(286): Error: array operation `da[] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(289): Error: `[1] * 6` is not an lvalue
-fail_compilation/fail_arrayop2.d(290): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(293): Error: `[1] * 6` is not an lvalue
-fail_compilation/fail_arrayop2.d(294): Error: `([1] * 6)[]` is not an lvalue
-fail_compilation/fail_arrayop2.d(297): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(248): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(253): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(256): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(265): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(268): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(269): Error: array operation `"abc"[] + '\x01'` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(272): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(275): Error: `([1] * 6)[0..2]` is not an lvalue
+fail_compilation/fail_arrayop2.d(278): Error: can only `*` a pointer, not a `int[]`
+fail_compilation/fail_arrayop2.d(281): Error: `[1] * 6` is not an lvalue
+fail_compilation/fail_arrayop2.d(284): Error: array operation `da[] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(287): Error: array operation `da[] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(290): Error: `[1] * 6` is not an lvalue
+fail_compilation/fail_arrayop2.d(291): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(294): Error: `[1] * 6` is not an lvalue
+fail_compilation/fail_arrayop2.d(295): Error: `([1] * 6)[]` is not an lvalue
 fail_compilation/fail_arrayop2.d(298): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(299): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(302): Error: `[1] * 6` is not an lvalue
+fail_compilation/fail_arrayop2.d(300): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(303): Error: `[1] * 6` is not an lvalue
-fail_compilation/fail_arrayop2.d(306): Error: `[1] * 6` is not of integral type, it is a `int[]`
+fail_compilation/fail_arrayop2.d(304): Error: `[1] * 6` is not an lvalue
 fail_compilation/fail_arrayop2.d(307): Error: `[1] * 6` is not of integral type, it is a `int[]`
 fail_compilation/fail_arrayop2.d(308): Error: `[1] * 6` is not of integral type, it is a `int[]`
-fail_compilation/fail_arrayop2.d(311): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(309): Error: `[1] * 6` is not of integral type, it is a `int[]`
 fail_compilation/fail_arrayop2.d(312): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(315): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(313): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(316): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(317): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(320): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(320): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(320): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(318): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(321): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(321): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(321): Error: array operation `[1] * 6` without destination memory not allowed
 ---
 */
 // Test all expressions, which can take arrays as their operands but cannot be a part of array operation.
@@ -323,15 +324,15 @@ void test15407exp()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(341): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(344): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(347): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(342): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(345): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(348): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(349): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(352): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(355): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(358): Error: array operation `"str"[] + cast(immutable(char))1` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(366): Error: CTFE internal error: non-constant value `"uvt"[]`
+fail_compilation/fail_arrayop2.d(350): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(353): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(356): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(359): Error: array operation `"str"[] + cast(immutable(char))1` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(367): Error: CTFE internal error: non-constant value `"uvt"[]`
 ---
 */
 // Test all statements, which can take arrays as their operands.

--- a/test/fail_compilation/faildeleteaa.d
+++ b/test/fail_compilation/faildeleteaa.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/faildeleteaa.d(11): Error: cannot delete type `int`
+fail_compilation/faildeleteaa.d(12): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/faildeleteaa.d(12): Error: cannot delete type `int`
 ---
 */
 

--- a/test/fail_compilation/nogc1.d
+++ b/test/fail_compilation/nogc1.d
@@ -1,6 +1,15 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/nogc1.d(91): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/nogc1.d(92): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/nogc1.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+---
+*/
+
 /***************** NewExp *******************/
 
 struct S1 { }
@@ -12,14 +21,14 @@ struct S5 { @nogc new(size_t); }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(27): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(29): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(30): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(32): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(33): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(34): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(35): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc allocator `nogc1.S4.new`
+fail_compilation/nogc1.d(36): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
 fail_compilation/nogc1.d(38): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(39): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(41): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(42): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(43): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(44): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc allocator `nogc1.S4.new`
+fail_compilation/nogc1.d(47): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
 ---
 */
 @nogc void testNew()
@@ -41,13 +50,13 @@ fail_compilation/nogc1.d(38): Error: cannot use `new` in `@nogc` function `nogc1
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(55): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(57): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(58): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(60): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(61): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(62): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(63): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc allocator `nogc1.S4.new`
+fail_compilation/nogc1.d(64): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(66): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(67): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(69): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(70): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(71): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(72): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc allocator `nogc1.S4.new`
 ---
 */
 @nogc void testNewScope()
@@ -72,9 +81,9 @@ fail_compilation/nogc1.d(63): Error: `@nogc` function `nogc1.testNewScope` canno
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(82): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(83): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(84): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(91): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(92): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(93): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
 ---
 */
 @nogc void testDelete(int* p, Object o, S1* s)

--- a/test/fail_compilation/test16195.d
+++ b/test/fail_compilation/test16195.d
@@ -1,7 +1,8 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/test16195.d(13): Error: `delete p` is not `@safe` but is used in `@safe` function `test`
+fail_compilation/test16195.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/test16195.d(14): Error: `delete p` is not `@safe` but is used in `@safe` function `test`
 ---
  */
 


### PR DESCRIPTION
See:
https://dlang.org/deprecate.html
https://dlang.org/deprecate.html#delete
http://forum.dlang.org/post/jzldqlkxgewtxjyffekb@forum.dlang.org
http://forum.dlang.org/post/gqgnquwhmykvpafwpemr@forum.dlang.org

Spec and Documentation Update: https://github.com/dlang/dlang.org/pull/1941.

There are only 5 lines of code change in this PR, and 4 of them are comments. The rest are mostly line number changes for the test suite, as many of the tests now emit a deprecation warning in addition to their other output. 