### PR TITLE
Issue 12929 - Empty union followed by field causes ICE due to offset of 0(Tests Only)

### DIFF
--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7283,6 +7283,21 @@ void test12900()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=12929
+
+struct Foo12929
+{
+    union { }
+    int var;
+}
+
+struct Bar12929
+{
+    struct { }
+    int var;
+}
+
+/***************************************************/
 // 12937
 
 void test12937()


### PR DESCRIPTION
This is a partial revival of #4107.

The test cases in both the issue and the PR pass in the current compiler implementation.  This PR just adds the test cases to keep it that way.