### PR TITLE
Fix Issue 12385 - Enum member should not be modifiable when the member is immutable

### DIFF
--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -3547,7 +3547,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                 if (!em.ed.isAnonymous())
                 {
-                    e = e.castTo(sc, em.ed.type);
+                    e = e.castTo(sc, em.ed.type.addMod(e.type.mod)); // https://issues.dlang.org/show_bug.cgi?id=12385
                     e = e.ctfeInterpret();
                 }
             }

--- a/test/compilable/test16570.d
+++ b/test/compilable/test16570.d
@@ -5,4 +5,4 @@ enum Regression
     a = _a,
 }
 
-static assert(is(typeof(Regression.a) == Regression));
+static assert(is(typeof(Regression.a) == immutable(Regression)));

--- a/test/fail_compilation/test12385.d
+++ b/test/fail_compilation/test12385.d
@@ -1,0 +1,30 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test12385.d(29): Error: cannot modify immutable expression BundledState("bla", 3).x
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=12385
+
+class BundledState
+{
+    string m_State;
+
+    int x = 3;
+
+    this(string state) immutable
+    {
+        m_State = state;
+    }
+}
+
+enum States : immutable(BundledState)
+{
+    unbundled = new immutable BundledState("bla"),
+}
+
+void main()
+{
+    States.unbundled.x = 6; // Modifies x.
+}


### PR DESCRIPTION
Revival of #5200
Thanks to @AndrejMitrovic and @9rnsr