### PR TITLE
refactor: explicitly list flags

### DIFF
--- a/src/ddmd/backend/cgcod.c
+++ b/src/ddmd/backend/cgcod.c
@@ -693,7 +693,7 @@ Lagain:
     spoff = 0;
     char guessneedframe = needframe;
     int cfa_offset = 0;
-//    if (needframe && config.exe & (EX_LINUX | EX_FREEBSD | EX_SOLARIS) && !(usednteh & ~NTEHjmonitor))
+//    if (needframe && config.exe & (EX_LINUX | EX_FREEBSD | EX_SOLARIS) && !(usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru)))
 //      usednteh |= NTEHpassthru;
 
     /* Compute BP offsets for variables on stack.
@@ -882,7 +882,7 @@ Lagain:
                 farfunc ||
                 config.flags & CFGstack ||
                 xlocalsize >= 0x1000 ||
-                (usednteh & ~NTEHjmonitor) ||
+                (usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru)) ||
                 anyiasm ||
                 Alloca.size
                )
@@ -1257,7 +1257,7 @@ void stackoffsets(int flags)
              */
             if (// Don't share because could stomp on variables
                 // used in finally blocks
-                !(usednteh & ~NTEHjmonitor) &&
+                !(usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru)) &&
                 s->Srange && !(s->Sflags & SFLspill))
             {
                 for (size_t i = 0; i < si; i++)
@@ -2906,8 +2906,6 @@ void scodelem(CodeBuilder& cdb, elem *e,regm_t *pretregs,regm_t keepmsk,bool con
  * Turn register mask into a string suitable for printing.
  */
 
-#ifdef DEBUG
-
 const char *regm_str(regm_t rm)
 {
     #define NUM 10
@@ -2946,8 +2944,6 @@ const char *regm_str(regm_t rm)
     assert(strlen(p) <= SMAX);
     return strdup(p);
 }
-
-#endif
 
 /*********************************
  * Scan down comma-expressions.

--- a/src/ddmd/backend/cod1.c
+++ b/src/ddmd/backend/cod1.c
@@ -2947,7 +2947,7 @@ void cdfunc(CodeBuilder& cdb,elem *e,regm_t *pretregs)
     bool usefuncarg = FALSE;
 #if 0
     printf("test1 %d %d %d %d %d %d %d %d\n", (config.flags4 & CFG4speed)!=0, !Alloca.size,
-        !(usednteh & ~NTEHjmonitor),
+        !(usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru)),
         (int)numpara, !stackpush,
         (cgstate.funcargtos == ~0 || numpara < cgstate.funcargtos),
         (!typfunc(tyf) || sf && sf->Sflags & SFLexit), !I16);

--- a/src/ddmd/backend/cod3.c
+++ b/src/ddmd/backend/cod3.c
@@ -2209,7 +2209,7 @@ regm_t cod3_useBP()
             tyfarfunc(tym) ||
             config.flags & CFGstack ||
             localsize >= 0x100 ||       // arbitrary value < 0x1000
-            (usednteh & ~NTEHjmonitor) ||
+            (usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru)) ||
             Alloca.size
            )
             goto Lcant;
@@ -3010,7 +3010,7 @@ void prolog_frame(CodeBuilder& cdb, unsigned farfunc, unsigned* xlocalsize, bool
         (*xlocalsize >= 0x1000 && config.exe & EX_flat) ||
         localsize >= 0x10000 ||
 #if NTEXCEPTIONS == 2
-        (usednteh & ~NTEHjmonitor && (config.ehmethod == EH_WIN32 && !(funcsym_p->Sfunc->Fflags3 & Feh_none) || config.ehmethod == EH_SEH)) ||
+        (usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru) && (config.ehmethod == EH_WIN32 && !(funcsym_p->Sfunc->Fflags3 & Feh_none) || config.ehmethod == EH_SEH)) ||
 #endif
         (config.target_cpu >= TARGET_80386 &&
          config.flags4 & CFG4speed)
@@ -3024,7 +3024,7 @@ void prolog_frame(CodeBuilder& cdb, unsigned farfunc, unsigned* xlocalsize, bool
             // Don't reorder instructions, as dwarf CFA relies on it
             code_orflag(cdb.last(), CFvolatile);
 #if NTEXCEPTIONS == 2
-        if (usednteh & ~NTEHjmonitor && (config.ehmethod == EH_WIN32 && !(funcsym_p->Sfunc->Fflags3 & Feh_none) || config.ehmethod == EH_SEH))
+        if (usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru) && (config.ehmethod == EH_WIN32 && !(funcsym_p->Sfunc->Fflags3 & Feh_none) || config.ehmethod == EH_SEH))
         {
             nteh_prolog(cdb);
             int sz = nteh_contextsym_size();
@@ -3849,7 +3849,7 @@ void epilog(block *b)
         useregs((ALLREGS | mBP | mES) & ~s->Sregsaved);
     }
 
-    if (usednteh & ~NTEHjmonitor && (config.exe == EX_WIN32 || MARS))
+    if (usednteh & (NTEH_try | NTEH_except | NTEHcpp | EHcleanup | EHtry | NTEHpassthru) && (config.exe == EX_WIN32 || MARS))
     {
         nteh_epilog(cdbx);
     }

--- a/src/ddmd/backend/code.h
+++ b/src/ddmd/backend/code.h
@@ -162,14 +162,16 @@ enum
 {
     NTEH_try        = 1,      // used _try statement
     NTEH_except     = 2,      // used _except statement
+
     NTEHexcspec     = 4,      // had C++ exception specification
     NTEHcleanup     = 8,      // destructors need to be called
     NTEHtry         = 0x10,   // had C++ try statement
     NTEHcpp         = (NTEHexcspec | NTEHcleanup | NTEHtry),
+
     EHcleanup       = 0x20,   // has destructors in the 'code' instructions
     EHtry           = 0x40,   // has BCtry or BC_try blocks
-    NTEHjmonitor    = 0x80,   // uses Mars monitor
-    NTEHpassthru    = 0x100,
+    NTEHjmonitor    = 0x80,   // uses D class monitor
+    NTEHpassthru    = 0x100,  // skip this frame when unwinding
 };
 
 /********************** Code Generator State ***************/
@@ -490,7 +492,7 @@ void push87(CodeBuilder& cdb);
 void save87(CodeBuilder& cdb);
 void save87regs(CodeBuilder& cdb, unsigned n);
 void gensaverestore87(regm_t, CodeBuilder& cdbsave, CodeBuilder& cdbrestore);
-code *genfltreg(code *c,unsigned opcode,unsigned reg,targ_size_t offset);
+//code *genfltreg(code *c,unsigned opcode,unsigned reg,targ_size_t offset);
 void genfwait(CodeBuilder& cdb);
 void comsub87(CodeBuilder& cdb, elem *e, regm_t *pretregs);
 void fixresult87(CodeBuilder& cdb, elem *e, regm_t retregs, regm_t *pretregs);

--- a/src/ddmd/backend/var.c
+++ b/src/ddmd/backend/var.c
@@ -198,12 +198,10 @@ unsigned
 GlobalOptimizer go;
 
 /* From debug.c */
-#if DEBUG
 const char *regstring[32] = {"AX","CX","DX","BX","SP","BP","SI","DI",
                              "R8","R9","R10","R11","R12","R13","R14","R15",
                              "XMM0","XMM1","XMM2","XMM3","XMM4","XMM5","XMM6","XMM7",
                              "ES","PSW","STACK","ST0","ST01","NOREG","RMload","RMstore"};
-#endif
 
 /* From nwc.c */
 


### PR DESCRIPTION
These ad-hoc flags are wretched enough without the confusing bit inversions.