### PR TITLE
fix clang warnings

### DIFF
--- a/src/ddmd/backend/cgelem.c
+++ b/src/ddmd/backend/cgelem.c
@@ -7,6 +7,7 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cgelem.c, backend/cgelem.c)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/ddmd/backend/cgelem.c
  */
 
 #if !SPP
@@ -1406,18 +1407,14 @@ STATIC elem * elbitwise(elem *e, goal_t goal)
          */
         if (e1->Eoper == OPshl &&
             ELCONST(e1->E1,1) &&
-            ((e12 = e1->E2), 1) &&
-            ((e12->Eoper == OP64_32 && ((e12 = e12->E1),1)),
-            e12->Eoper == OPand) &&
+            (((e12 = e1->E2)->Eoper == OP64_32 ? (e12 = e12->E1) : e12)->Eoper == OPand) &&
             ELCONST(e12->E2,sz * 8 - 1) &&
 
             e2->Eoper == OPind &&
             e2->E1->Eoper == OPadd &&
             e2->E1->E1->Eoper == OPshl &&
             ELCONST(e2->E1->E1->E2,pow2sz) &&
-            ((e2111 = e2->E1->E1->E1), 1) &&
-            ((e2111->Eoper == OPu32_64 && ((e2111 = e2111->E1),1)),
-            e2111->Eoper == OPshr) &&
+            (((e2111 = e2->E1->E1->E1)->Eoper == OPu32_64 ? (e2111 = e2111->E1) : e2111)->Eoper == OPshr) &&
             ELCONST(e2111->E2,pow2sz + 3)
            )
         {

--- a/src/ddmd/backend/outbuf.d
+++ b/src/ddmd/backend/outbuf.d
@@ -85,7 +85,7 @@ struct Outbuffer
     /**
      * Writes an 8 bit byte, no reserve check.
      */
-    void writeByten(char v)
+    void writeByten(ubyte v)
     {
         *p++ = v;
     }

--- a/src/ddmd/backend/outbuf.h
+++ b/src/ddmd/backend/outbuf.h
@@ -90,7 +90,7 @@ struct Outbuffer
     /**
      * Writes an 8 bit byte, no reserve check.
      */
-    void writeByten(char v)
+    void writeByten(unsigned char v)
     {
         *p++ = v;
     }

--- a/src/ddmd/tk/mem.c
+++ b/src/ddmd/tk/mem.c
@@ -74,7 +74,7 @@ void err_message(const char *,...);
 
 /*******************************/
 
-void mem_setexception(enum MEM_E flag,...)
+void mem_setexception(MEM_E flag,...)
 {   va_list ap;
     typedef int (*fp_t)(void);
 

--- a/src/ddmd/tk/mem.h
+++ b/src/ddmd/tk/mem.h
@@ -89,8 +89,9 @@ extern int mem_inited;          /* != 0 if mem package is initialized.  */
 
 #if !MEM_NONE
 #if __SC__ || __DMC__ || __GNUC__
-enum MEM_E { MEM_ABORTMSG, MEM_ABORT, MEM_RETNULL, MEM_CALLFP, MEM_RETRY };
-void mem_setexception(enum MEM_E,...);
+typedef int MEM_E;
+enum { MEM_ABORTMSG, MEM_ABORT, MEM_RETNULL, MEM_CALLFP, MEM_RETRY };
+void mem_setexception(MEM_E,...);
 #else
 #define MEM_ABORTMSG    0
 #define MEM_ABORT       1


### PR DESCRIPTION
The warnings are:
```
ddmd/tk/mem.c:82:17: warning: passing an object that undergoes default argument promotion
to 'va_start' has undefined behavior [-Wvarargs]
    va_start(ap,flag);
                ^
ddmd/tk/mem.c:77:34: note: parameter of type 'enum MEM_E' is declared here
void mem_setexception(enum MEM_E flag,...)
                                 ^
```
```
ddmd/backend/dwarf.c:786:39: warning: implicit conversion from 'int' to 'char' changes value
from 144 to -112 [-Wconstant-conversion]
        buf->writeByten(DW_CFA_offset + 16);    // OFFSET r16,1   RIP is at -8*1[RSP]
             ~~~~~~~~~~ ~~~~~~~~~~~~~~^~~~
ddmd/backend/dwarf.c:795:39: warning: implicit conversion from 'int' to 'char' changes value
from 136 to -120 [-Wconstant-conversion]
        buf->writeByten(DW_CFA_offset + 8);     // OFFSET r8,1
             ~~~~~~~~~~ ~~~~~~~~~~~~~~^~~
```
```
ddmd/backend/cgelem.c:1410:37: warning: expression result unused [-Wunused-value]
            ((e12->Eoper == OP64_32 && ((e12 = e12->E1),1)),
              ~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~
ddmd/backend/cgelem.c:1419:40: warning: expression result unused [-Wunused-value]
            ((e2111->Eoper == OPu32_64 && ((e2111 = e2111->E1),1)),
              ~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~
```