### PR TITLE
ASTBase: add missing overrides and fix constructor's parameter name

### DIFF
--- a/src/ddmd/astbase.d
+++ b/src/ddmd/astbase.d
@@ -493,6 +493,11 @@ struct ASTBase
             return null;
         }
 
+        override final DYNCAST dyncast() const
+        {
+            return DYNCAST.dsymbol;
+        }
+
         void accept(Visitor v)
         {
             v.visit(this);
@@ -1132,7 +1137,7 @@ struct ASTBase
         bool havetempdecl;
         TemplateInstance inst;
 
-        final extern (D) this(Loc loc, Identifier ident, Objects* tiards)
+        final extern (D) this(Loc loc, Identifier ident, Objects* tiargs)
         {
             super(null);
             this.loc = loc;
@@ -4273,6 +4278,11 @@ struct ASTBase
             }
             e = cast(Expression)mem.xmalloc(size);
             return cast(Expression)memcpy(cast(void*)e, cast(void*)this, size);
+        }
+
+        override final DYNCAST dyncast() const
+        {
+            return DYNCAST.expression;
         }
 
         void accept(Visitor v)


### PR DESCRIPTION
I added the overriding dyncast methods and fixed a typo which pruned ast subtrees corresponding to template instances parameters.  