### PR TITLE
Add -requireinit compiler switch to emit errors for uninitialized variables

### DIFF
--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -142,6 +142,8 @@ struct Param
      * before becoming default.
      */
 
+    bool requireinit;      // emit error for any uninitialized variables
+
     bool showGaggedErrors;  // print gagged errors anyway
     bool manual;            // open browser on compiler manual
     bool usage;             // print usage and exit

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -143,7 +143,6 @@ Where:
   --help           print help and exit
   -I=<directory>   look for imports also in directory
   -ignore          ignore unsupported pragmas
-  -requireinit     emit error for any uninitialized variables
   -inline          do function inlining
   -J=<directory>   look for string imports also in directory
   -L=<linkerflag>  pass linkerflag to link
@@ -167,6 +166,7 @@ Where:
   -profile         profile runtime performance of generated code
   -profile=gc      profile runtime allocations
   -release         compile release version
+  -requireinit     emit error for any uninitialized variables
   -shared          generate shared library (DLL)
   -transition=<id> help with language change identified by 'id'
   -transition=?    list all language changes

--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -143,6 +143,7 @@ Where:
   --help           print help and exit
   -I=<directory>   look for imports also in directory
   -ignore          ignore unsupported pragmas
+  -requireinit     emit error for any uninitialized variables
   -inline          do function inlining
   -J=<directory>   look for string imports also in directory
   -L=<linkerflag>  pass linkerflag to link
@@ -2159,6 +2160,8 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lnoarg;
                 }
             }
+            else if (strcmp(p + 1, "requireinit") == 0) // https://dlang.org/dmd-windows.html#switch-requireinit
+                params.requireinit = true;
             else if (p[1] == '\0')
                 files.push("__stdin.d");
             else

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -4495,7 +4495,7 @@ final class Parser(AST) : Lexer
                 else
                 {
                     if (global.params.requireinit)
-                        error("`%s` was not iniitialized", ident.toChars());
+                        error("`%s` was not initialized", ident.toChars());
                 }
 
 

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -4492,6 +4492,12 @@ final class Parser(AST) : Lexer
                     nextToken();
                     _init = parseInitializer();
                 }
+                else
+                {
+                    if (global.params.requireinit)
+                        error("`%s` was not iniitialized", ident.toChars());
+                }
+
 
                 auto v = new AST.VarDeclaration(loc, t, ident, _init);
                 v.storage_class = storage_class;

--- a/test/compilable/requireinit.d
+++ b/test/compilable/requireinit.d
@@ -2,8 +2,38 @@
 REQUIRED_ARGS: -requireinit
 */
 
-class TestClass {}
-struct TestStruct {}
+class TestClass
+{
+    // Test class fields
+    TestClass tc = null;
+    TestStruct ts = TestStruct();
+    string s = "";
+    int i = 0;
+    int[] a = [1,2,3];
+
+    // Test class fields with void initializations
+    TestClass tc2 = void;
+    TestStruct ts2 = void;
+    string s2= void;
+    int i2 = void;
+    int[] a2 = void;
+}
+struct TestStruct
+{
+    // Test struct filds
+    TestClass tc = null;
+    TestStruct ts = TestStruct();
+    string s = "";
+    int i = 0;
+    int[] a = [1,2,3];
+
+    // Test struct fields with void initializations
+    TestClass tc2 = void;
+    TestStruct ts2 = void;
+    string s2= void;
+    int i2 = void;
+    int[] a2 = void;
+}
 
 // Test global declarations
 TestClass tc = null;

--- a/test/compilable/requireinit.d
+++ b/test/compilable/requireinit.d
@@ -1,0 +1,37 @@
+/*
+REQUIRED_ARGS: -requireinit
+*/
+
+class TestClass {}
+struct TestStruct {}
+
+// Test global declarations
+TestClass tc = null;
+TestStruct ts = TestStruct();
+string s = "";
+int i = 0;
+int[] a = [1,2,3];
+
+// Test global void initializations
+TestClass tc2 = void;
+TestStruct ts2 = void;
+string s2= void;
+int i2 = void;
+int[] a2 = void;
+
+void main()
+{
+    // Test local declarations
+    TestClass ltc = null;
+    TestStruct lts = TestStruct();
+    string ls = "";
+    int li = 0;
+    int[] la = [1,2,3];
+
+    // Test local void initializations
+    TestClass tc2 = void;
+    TestStruct ts2 = void;
+    string s2= void;
+    int i2 = void;
+    int[] a2 = void;
+}

--- a/test/fail_compilation/requireinit.d
+++ b/test/fail_compilation/requireinit.d
@@ -1,0 +1,34 @@
+/*
+REQUIRED_ARGS: -requireinit
+TEST_OUTPUT:
+---
+fail_compilation/requireinit.d(21): Error: `tc` was not iniitialized
+fail_compilation/requireinit.d(22): Error: `ts` was not iniitialized
+fail_compilation/requireinit.d(23): Error: `s` was not iniitialized
+fail_compilation/requireinit.d(24): Error: `i` was not iniitialized
+fail_compilation/requireinit.d(25): Error: `a` was not iniitialized
+fail_compilation/requireinit.d(29): Error: `ltc` was not iniitialized
+fail_compilation/requireinit.d(30): Error: `lts` was not iniitialized
+fail_compilation/requireinit.d(31): Error: `ls` was not iniitialized
+fail_compilation/requireinit.d(32): Error: `li` was not iniitialized
+fail_compilation/requireinit.d(33): Error: `la` was not iniitialized
+---
+*/
+
+class TestClass {}
+struct TestStruct {}
+
+TestClass tc;
+TestStruct ts;
+string s;
+int i;
+int[] a;
+
+void main()
+{
+    TestClass ltc;
+    TestStruct lts;
+    string ls;
+    int li;
+    int[] la;
+}

--- a/test/fail_compilation/requireinit.d
+++ b/test/fail_compilation/requireinit.d
@@ -2,21 +2,46 @@
 REQUIRED_ARGS: -requireinit
 TEST_OUTPUT:
 ---
-fail_compilation/requireinit.d(21): Error: `tc` was not iniitialized
-fail_compilation/requireinit.d(22): Error: `ts` was not iniitialized
-fail_compilation/requireinit.d(23): Error: `s` was not iniitialized
-fail_compilation/requireinit.d(24): Error: `i` was not iniitialized
-fail_compilation/requireinit.d(25): Error: `a` was not iniitialized
-fail_compilation/requireinit.d(29): Error: `ltc` was not iniitialized
-fail_compilation/requireinit.d(30): Error: `lts` was not iniitialized
-fail_compilation/requireinit.d(31): Error: `ls` was not iniitialized
-fail_compilation/requireinit.d(32): Error: `li` was not iniitialized
-fail_compilation/requireinit.d(33): Error: `la` was not iniitialized
+fail_compilation/requireinit.d(30): Error: `tc` was not initialized
+fail_compilation/requireinit.d(31): Error: `ts` was not initialized
+fail_compilation/requireinit.d(32): Error: `s` was not initialized
+fail_compilation/requireinit.d(33): Error: `i` was not initialized
+fail_compilation/requireinit.d(34): Error: `a` was not initialized
+fail_compilation/requireinit.d(39): Error: `tc` was not initialized
+fail_compilation/requireinit.d(40): Error: `ts` was not initialized
+fail_compilation/requireinit.d(41): Error: `s` was not initialized
+fail_compilation/requireinit.d(42): Error: `i` was not initialized
+fail_compilation/requireinit.d(43): Error: `a` was not initialized
+fail_compilation/requireinit.d(46): Error: `tc` was not initialized
+fail_compilation/requireinit.d(47): Error: `ts` was not initialized
+fail_compilation/requireinit.d(48): Error: `s` was not initialized
+fail_compilation/requireinit.d(49): Error: `i` was not initialized
+fail_compilation/requireinit.d(50): Error: `a` was not initialized
+fail_compilation/requireinit.d(54): Error: `ltc` was not initialized
+fail_compilation/requireinit.d(55): Error: `lts` was not initialized
+fail_compilation/requireinit.d(56): Error: `ls` was not initialized
+fail_compilation/requireinit.d(57): Error: `li` was not initialized
+fail_compilation/requireinit.d(58): Error: `la` was not initialized
 ---
 */
 
-class TestClass {}
-struct TestStruct {}
+class TestClass
+{
+    TestClass tc;
+    TestStruct ts;
+    string s;
+    int i;
+    int[] a;
+}
+
+struct TestStruct
+{
+    TestClass tc;
+    TestStruct ts;
+    string s;
+    int i;
+    int[] a;
+}
 
 TestClass tc;
 TestStruct ts;


### PR DESCRIPTION
[The D programming language specification](https://dlang.org/spec/function.html#local-variables) clearly states:

>It is an error to use a local variable without first assigning it a value. The implementation may not always be able to detect these cases. Other language compilers sometimes issue a warning for this, but since it is always a bug, it should be an error. 

Surprisingly, this requirement has never been implemented in the D programming language.  Perhaps the reason it was never implemented was due to the high bar required to write sophisticated flow control analysis for catching false positives, as not all uninitialized variables are used. Despite that, it would have been better to require initialization at first, knowing that it would create false positives, and as proper flow control analysis was implemented, relax the enforcement to eliminate the false positives and prevent code breakage along the way.

Unfortunately, here we are years later, with an entire ecosystem of D code that violates this requirement.  It is not feasible to implement strict enforcement out-of-the-box now, this late in the game, but we can provide users with a way to opt into it, so they can have more confidence in the robustness of their D code.

This PR adds a `-requireinit` compiler switch to enable strict enforcement of variable initialization.  When the compiler is executed with this switch, it will emit an error for any variable that is not explicitly initialized.  This will produce false positives, as not all uninitialized variables will be used, but in time, if/when proper flow control analysis is implemented, the enforcement can be relaxed to eliminate false positives, while preventing code breakage along the way.

Changelog entry and documentation will be added after initial reaction to this proposal is received.