### PR TITLE
add noeh RAII optimizations at expression level

### DIFF
--- a/src/ddmd/glue.d
+++ b/src/ddmd/glue.d
@@ -977,11 +977,10 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             break;
     }
 
-    IRState irs = IRState(m, fd);
     Dsymbols deferToObj;                   // write these to OBJ file later
-    irs.deferToObj = &deferToObj;
+    Array!(elem*) varsInScope;
     Label*[void*] labels = null;
-    irs.labels = &labels;
+    IRState irs = IRState(m, fd, &varsInScope, &deferToObj, &labels);
 
     Symbol *shidden = null;
     Symbol *sthis = null;


### PR DESCRIPTION
When temporaries are generated while evaluating an expression, the destructors for them must be called at the end of that expression. This PR checks the expression to see if it is nothrow, and if so, generates much more efficient code for RAII destruction.

It also resolves a memory leak in `varsInScope` by allocating it on the stack.