### PR TITLE
disable OSX-32 self-hosting test on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
   include:
     - os: osx
       d: dmd
-      env: MODEL=32
-    - os: osx
-      d: dmd
       env: MODEL=64
   exclude:
     # gdc doesn't neither comes w/ multilib support nor picks up system-wide -lstdc++ lgcc_s

--- a/travis.sh
+++ b/travis.sh
@@ -52,8 +52,9 @@ rebuild() {
     cp $build_path/dmd.conf _${build_path}
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd clean
     make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd ENABLE_RELEASE=1 all
-    # build reproducibility is currently broken for unknown reasons on osx-32
-    if [ $compare -eq 1 ] && [ "$TRAVIS_OS_NAME-$MODEL" != osx-32 ]; then
+
+    # compare binaries to test reproducibile build
+    if [ $compare -eq 1 ]; then
         if ! diff _${build_path}/host_dmd $build_path/dmd; then
             $NM _${build_path}/host_dmd > a
             $NM $build_path/dmd > b


### PR DESCRIPTION
- stop testing OSX-32 self-hosting on Travis-CI
- target isn't too well maintained
- osx-32 binaries haven't been reproducible and we only ship
  64-bit dmd binaries, so testing self-hosting on OSX-32 is not
  necessary
- there is a new self-hosted OSX-32-only regression that produces
  incorrect binaries, fixing this would be laborious and fruitless
  (see e.g. https://travis-ci.org/dlang/dmd/jobs/309247634)
- we still have the auto-tester to test OSX-32 cross-compilation