### PR TITLE
Revert "refactor: Move struct ClassFlags to toobj.d and make it private"

### DIFF
--- a/src/ddmd/aggregate.h
+++ b/src/ddmd/aggregate.h
@@ -230,6 +230,23 @@ struct BaseClass
     void copyBaseInterfaces(BaseClasses *);
 };
 
+struct ClassFlags
+{
+    typedef unsigned Type;
+    enum Enum
+    {
+        isCOMclass = 0x1,
+        noPointers = 0x2,
+        hasOffTi = 0x4,
+        hasCtor = 0x8,
+        hasGetMembers = 0x10,
+        hasTypeInfo = 0x20,
+        isAbstract = 0x40,
+        isCPPclass = 0x80,
+        hasDtor = 0x100,
+    };
+};
+
 enum ClassKind
 {
     /// the class is a d(efault) class

--- a/src/ddmd/dclass.d
+++ b/src/ddmd/dclass.d
@@ -151,6 +151,34 @@ struct BaseClass
     }
 }
 
+struct ClassFlags
+{
+    alias Type = uint;
+
+    enum Enum : int
+    {
+        isCOMclass = 0x1,
+        noPointers = 0x2,
+        hasOffTi = 0x4,
+        hasCtor = 0x8,
+        hasGetMembers = 0x10,
+        hasTypeInfo = 0x20,
+        isAbstract = 0x40,
+        isCPPclass = 0x80,
+        hasDtor = 0x100,
+    }
+
+    alias isCOMclass = Enum.isCOMclass;
+    alias noPointers = Enum.noPointers;
+    alias hasOffTi = Enum.hasOffTi;
+    alias hasCtor = Enum.hasCtor;
+    alias hasGetMembers = Enum.hasGetMembers;
+    alias hasTypeInfo = Enum.hasTypeInfo;
+    alias isAbstract = Enum.isAbstract;
+    alias isCPPclass = Enum.isCPPclass;
+    alias hasDtor = Enum.hasDtor;
+}
+
 /**
  * The ClassKind enum is used in ClassDeclaration AST nodes
  * to specify the linkage type of the class or if it is an

--- a/src/ddmd/toobj.d
+++ b/src/ddmd/toobj.d
@@ -75,33 +75,6 @@ extern (C++):
 alias toSymbol = ddmd.tocsym.toSymbol;
 alias toSymbol = ddmd.glue.toSymbol;
 
-private struct ClassFlags
-{
-    alias Type = uint;
-
-    enum Enum : int
-    {
-        isCOMclass = 0x1,
-        noPointers = 0x2,
-        hasOffTi = 0x4,
-        hasCtor = 0x8,
-        hasGetMembers = 0x10,
-        hasTypeInfo = 0x20,
-        isAbstract = 0x40,
-        isCPPclass = 0x80,
-        hasDtor = 0x100,
-    }
-
-    alias isCOMclass = Enum.isCOMclass;
-    alias noPointers = Enum.noPointers;
-    alias hasOffTi = Enum.hasOffTi;
-    alias hasCtor = Enum.hasCtor;
-    alias hasGetMembers = Enum.hasGetMembers;
-    alias hasTypeInfo = Enum.hasTypeInfo;
-    alias isAbstract = Enum.isAbstract;
-    alias isCPPclass = Enum.isCPPclass;
-    alias hasDtor = Enum.hasDtor;
-}
 
 /* ================================================================== */
 


### PR DESCRIPTION
Reverts dlang/dmd#7372 - as it was merged despite @kinke and @ibuclaw's objections.
Also CC @JinShil.
By reverting the change we buy ourselves more time to create a PR that works for everybody.