### PR TITLE
fix Travis-CI tests

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -647,7 +647,10 @@ int main(string[] args)
                     auto script = test_app_dmd_base ~ to!string(i) ~ ".gdb";
                     toCleanup ~= script;
                     with (File(script, "w"))
+                    {
+                        writeln("set disable-randomization off");
                         write(testArgs.gdbScript);
+                    }
                     string command = "gdb "~test_app_dmd~" --batch -x "~script;
                     auto gdb_output = execute(fThisRun, command, true, result_path);
                     if (testArgs.gdbMatch !is null)


### PR DESCRIPTION
- run gdb tests with ASLR
- turning off ASLR is not permitted is some test contexts (e.g. Travis-CI)