### PR TITLE
Fix .di function literal using `body` instead of `do`

### DIFF
--- a/changelog/body.dd
+++ b/changelog/body.dd
@@ -1,0 +1,6 @@
+Generate header files using `do` instead of `body` as per DIP1003
+
+Support for
+[DIP1003](https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md)
+was added in release 2.075.0. Use of `body` in an error message and
+header file generation has been fixed in this release.

--- a/src/ddmd/parse.d
+++ b/src/ddmd/parse.d
@@ -4761,7 +4761,7 @@ final class Parser(AST) : Lexer
         default:
             if (literal)
             {
-                const(char)* sbody = (f.frequire || f.fensure) ? "body " : "";
+                const(char)* sbody = (f.frequire || f.fensure) ? "do " : "";
                 error("missing `%s{ ... }` for function literal", sbody);
             }
             else if (!f.frequire && !f.fensure) // allow these even with no body

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -10,6 +10,8 @@ static assert(true, "message");
 
 alias double mydbl;
 
+alias fl = function () in {} body {};
+
 int testmain()
 in
 {

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -5,6 +5,14 @@ pragma (lib, "test");
 pragma (msg, "Hello World");
 static assert(true, "message");
 alias mydbl = double;
+alias fl = function ()
+in
+{
+}
+do
+{
+}
+;
 int testmain();
 struct S
 {

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -5,6 +5,14 @@ pragma (lib, "test");
 pragma (msg, "Hello World");
 static assert(true, "message");
 alias mydbl = double;
+alias fl = function ()
+in
+{
+}
+do
+{
+}
+;
 int testmain()
 in
 {


### PR DESCRIPTION
Follow up from #7347.
Use do instead of body in generated header files.
Adds changelog item.