### PR TITLE
Make deprecation warnings compile errors

### DIFF
--- a/src/ddmd/backend/code.d
+++ b/src/ddmd/backend/code.d
@@ -16,6 +16,7 @@ module ddmd.backend.code;
 import ddmd.backend.cc;
 import ddmd.backend.cdef;
 import ddmd.backend.code_x86;
+import ddmd.backend.el : elem;
 import ddmd.backend.outbuf;
 import ddmd.backend.type;
 

--- a/src/ddmd/iasm.d
+++ b/src/ddmd/iasm.d
@@ -1420,7 +1420,7 @@ code *asm_emit(Loc loc,
             break;
 
         case VEX_NDD:
-            pc.Ivex.vvvv = ~popnd1.base.val;
+            pc.Ivex.vvvv = cast(ubyte) ~int(popnd1.base.val);
 
             asm_make_modrm_byte(
                 auchOpcode.ptr, &usIdx,
@@ -1439,7 +1439,7 @@ code *asm_emit(Loc loc,
 
         case VEX_DDS:
             assert(usNumops == 3);
-            pc.Ivex.vvvv = ~popnd2.base.val;
+            pc.Ivex.vvvv = cast(ubyte) ~int(popnd2.base.val);
 
             asm_make_modrm_byte(
                 auchOpcode.ptr, &usIdx,
@@ -1449,7 +1449,7 @@ code *asm_emit(Loc loc,
             break;
 
         case VEX_NDS:
-            pc.Ivex.vvvv = ~popnd2.base.val;
+            pc.Ivex.vvvv = cast(ubyte) ~int(popnd2.base.val);
 
             if (aoptyTable1 == _m || aoptyTable1 == _rm)
                 asm_make_modrm_byte(

--- a/src/ddmd/scanelf.d
+++ b/src/ddmd/scanelf.d
@@ -149,7 +149,7 @@ void scanElfObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
 
                 const name = &string_tab[sym.st_name];
                 //printf("sym st_name = x%x\n", sym.st_name);
-                const pend = memchr(name, 0, string_tab.length - sym.st_name);
+                const pend = cast(const(char*)) memchr(name, 0, string_tab.length - sym.st_name);
                 if (!pend)       // if didn't find terminating 0 inside the string section
                     return corrupt(__LINE__);
                 pAddSymbol(name[0 .. pend - name], 1);

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -225,7 +225,7 @@ CXXFLAGS += \
 endif
 DFLAGS := -version=MARS $(PIC)
 # Enable D warnings
-DFLAGS += -wi
+DFLAGS += -w -de
 
 ifneq (,$(DEBUG))
 ENABLE_DEBUG := 1


### PR DESCRIPTION
This is already the way we build Phobos + Tools.
See also: https://github.com/dlang/phobos/pull/5546
The idea is that whenever sth. gets deprecated in Druntime or Phobos a replacement needs to exists. By always building with `-de`, we can enforce that the replacement really exists and force the person who submits the deprecation to look after the fallout.

CC @ZombineDev @CyberShadow 