### PR TITLE
use UD2 instead of HLT instruction

### DIFF
--- a/src/ddmd/backend/cod2.c
+++ b/src/ddmd/backend/cod2.c
@@ -7,6 +7,7 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/ddmd/backend/cod2.c, backend/cod2.c)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/ddmd/backend/cod2.c
  */
 
 #if !SPP
@@ -5202,7 +5203,7 @@ void cdvoid(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 void cdhalt(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
     assert(*pretregs == 0);
-    cdb.gen1(0xF4);            // HLT
+    cdb.gen1(config.target_cpu >= TARGET_80286 ? UD2 : INT3);
 }
 
 #endif // !SPP

--- a/src/ddmd/backend/code_x86.h
+++ b/src/ddmd/backend/code_x86.h
@@ -219,6 +219,8 @@ enum
     LES     = 0xC4,
     LEA     = 0x8D,
     LOCK    = 0xF0,
+    INT3    = 0xCC,
+    HLT     = 0xF4,
 
     STO     = 0x89,
     LOD     = 0x8B,
@@ -241,6 +243,8 @@ enum
     JGE     = 0x7D,
     JLE     = 0x7E,
     JG      = 0x7F,
+
+    UD2     = 0x0F0B,
 
     // NOP is used as a placeholder in the linked list of instructions, no
     // actual code will be generated for it.


### PR DESCRIPTION
Adam Ruppe suggested it:

http://www.digitalmars.com/d/archives/digitalmars/D/Thoughts_about_D_308441.html#N308711

```
hlt kinda bothers me because it actually has a meaning. You're 
just abusing the fact that it is privileged so it traps on 
operating systems, but on bare metal, it just pauses until the 
next interrupt.
int 3, on the other hand, is explicitly for debugging - which is 
what we want asserts to be.
```