### PR TITLE
Don't generate ModuleInfo if it's not declared in druntime

### DIFF
--- a/changelog/optional_ModuleInfo.dd
+++ b/changelog/optional_ModuleInfo.dd
@@ -1,0 +1,11 @@
+Optional `ModuleInfo`
+
+$(LINK2 $(ROOT_DIR)phobos/object.html#.ModuleInfo, `ModuleInfo`) is not a necessary feature of D.  There are use cases where the program author may choose to provide an alternate implementation of the D runtime that does not include `ModuleInfo`.  This could be for interoperability with other software or to reduce the footprint of D programs in resource constrained platforms.
+
+Prior to this release, the compiler would emit an error if `ModuleInfo` was not declared in the D runtime.
+
+Platform support is provided by the D runtime. `ModuleInfo` is declared in object.d. Therefore, the compiler can see, at compile-time, whether or not the platform has provided support for `ModuleInfo` and generate object code accordingly.
+
+Starting with this release, if `ModuleInfo` is not delared in the D runtime, the compiler will simply not generate `ModuleInfo` instances.
+
+This should reduce friction for those wishing to incrementally port D to new platforms and use D in a more pay-as-you-go fashion.

--- a/src/ddmd/glue.d
+++ b/src/ddmd/glue.d
@@ -504,10 +504,11 @@ void genObjFile(Module m, bool multiobj)
         return;
     }
 
-    /* Always generate module info, because of templates and -cov.
-     * But module info needs the runtime library, so disable it for betterC.
+     /* Generate module info for templates and -cov.
+     *  Don't generate ModuleInfo if `object.ModuleInfo` is not declared or
+     *  explicitly disabled through compiler switches such as `-betterC`.
      */
-    if (global.params.useModuleInfo /*|| needModuleInfo()*/)
+    if (global.params.useModuleInfo && Module.moduleinfo /*|| needModuleInfo()*/)
         genModuleInfo(m);
 
     objmod.termfile();

--- a/test/runnable/extra-files/no_object_ModuleInfo/object.d
+++ b/test/runnable/extra-files/no_object_ModuleInfo/object.d
@@ -1,0 +1,1 @@
+module object;

--- a/test/runnable/extra-files/no_object_ModuleInfo/verify_symbols.sh
+++ b/test/runnable/extra-files/no_object_ModuleInfo/verify_symbols.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if ! nm "$1" | grep -q ModuleInfo ; then
+    exit 0
+fi
+
+exit 1

--- a/test/runnable/no_object_ModuleInfo.d
+++ b/test/runnable/no_object_ModuleInfo.d
@@ -1,0 +1,8 @@
+// PERMUTE_ARGS:
+// POST_SCRIPT: runnable/extra-files/no_object_ModuleInfo/verify_symbols.sh
+// REQUIRED_ARGS: -Irunnable/extra-files/no_object_ModuleInfo/
+
+extern(C) int main()
+{
+    return 0;
+}


### PR DESCRIPTION
In response to http://forum.dlang.org/post/onn8vi$tgs$1@digitalmars.com and http://forum.dlang.org/post/p0280p$29t$1@digitalmars.com

## Rationale
The compiler shouldn't require `ModuleInfo` to exist if the platform doesn't support it or the program author wishes to provide an alternate druntime implementation that doesn't support it.

Platform support is provided by druntime.  `ModuleInfo` is declared in object.d.  Therefore, the compiler can see, at compile-time, whether or not the platform engineer has provided support for `ModuleInfo` and generate object code accordingly. (i.e. Design by Introspection)

There are also use cases where, although the platform could support `ModuleInfo`, the program author  may choose to provide an alternate implementation of druntime features just for their program.  That alternate implementation may not support `ModuleInfo`.  

The current compiler implementation will emit errors if `ModuleInfo` is not declared.  It is an unnecessary restriction to require the author to workaround this constraint when they don't wish to support `ModuleInfo`.

Current workarounds are to define a stub `ModuleInfo` and have it discarded through LTO, `--gc-sections`, or a custom linker script. 

## Benefits
- Eliminate the need for hackish workarounds due to arbitrary constraints imposed by the compiler
- Reduce friction for platform engineers wishing to incrementally port D to new platforms
- A step in the right direction for using D in a more pay-as-you-go fashion.
- Broaden D's relevance in new, interesting, and niche use cases currently dominated by minimal runtime languages such as Rust and C.
