### PR TITLE
bug 8858 - Switch to analyze dependencies without printing them

### DIFF
--- a/src/ddmd/cond.d
+++ b/src/ddmd/cond.d
@@ -923,9 +923,9 @@ extern (C++) bool findCondition(Identifiers* ids, Identifier ident)
 // Helper for printing dependency information
 private void printDepsConditional(Scope* sc, DVCondition condition, const(char)[] depType)
 {
-    if (!global.params.moduleDeps || global.params.moduleDepsFile)
+    if (!global.params.moduleDepsOut || global.params.moduleDepsFile)
         return;
-    OutBuffer* ob = global.params.moduleDeps;
+    OutBuffer* ob = global.params.moduleDepsOut;
     Module imod = sc ? sc.instantiatingModule() : condition.mod;
     if (!imod)
         return;

--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -2783,7 +2783,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // don't list pseudo modules __entrypoint.d, __main.d
         // https://issues.dlang.org/show_bug.cgi?id=11117
         // https://issues.dlang.org/show_bug.cgi?id=11164
-        if (global.params.moduleDeps !is null && !(imp.id == Id.object && sc._module.ident == Id.object) &&
+        if (global.params.moduleDepsOut && !(imp.id == Id.object && sc._module.ident == Id.object) &&
             sc._module.ident != Id.entrypoint &&
             strcmp(sc._module.ident.toChars(), "__main") != 0)
         {
@@ -2799,8 +2799,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              *      FilePath
              *          - any string with '(', ')' and '\' escaped with the '\' character
              */
-            OutBuffer* ob = global.params.moduleDeps;
             Module imod = sc.instantiatingModule();
+            OutBuffer* ob = global.params.moduleDepsOut;
             if (!global.params.moduleDepsFile)
                 ob.writestring("depsImport ");
             ob.writestring(imod.toPrettyChars());
@@ -2968,9 +2968,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 name[se.len] = 0;
                 if (global.params.verbose)
                     fprintf(global.stdmsg, "library   %s\n", name);
-                if (global.params.moduleDeps && !global.params.moduleDepsFile)
+                if (global.params.moduleDepsOut && !global.params.moduleDepsFile)
                 {
-                    OutBuffer* ob = global.params.moduleDeps;
+                    OutBuffer* ob = global.params.moduleDepsOut;
                     Module imod = sc.instantiatingModule();
                     ob.writestring("depsLib ");
                     ob.writestring(imod.toPrettyChars());

--- a/src/ddmd/expressionsem.d
+++ b/src/ddmd/expressionsem.d
@@ -4291,9 +4291,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (global.params.verbose)
             fprintf(global.stdmsg, "file      %.*s\t(%s)\n", cast(int)se.len, se.string, name);
-        if (global.params.moduleDeps !is null)
+        if (global.params.moduleDepsOut !is null)
         {
-            OutBuffer* ob = global.params.moduleDeps;
+            OutBuffer* ob = global.params.moduleDepsOut;
             Module imod = sc.instantiatingModule();
 
             if (!global.params.moduleDepsFile)

--- a/src/ddmd/globals.d
+++ b/src/ddmd/globals.d
@@ -189,8 +189,9 @@ struct Param
     const(char)* debuglibname;          // default library for debug builds
     const(char)* mscrtlib;              // MS C runtime library
 
+    bool moduleDepsEnabled;             // true if compiler is to load all module dependencies
     const(char)* moduleDepsFile;        // filename for deps output
-    OutBuffer* moduleDeps;              // contents to be written to deps file
+    OutBuffer* moduleDepsOut;           // contents to be written to deps file, this can only be set if moduleDepsEnabled is true
 
     // Hidden debug switches
     bool debugb;

--- a/src/ddmd/globals.h
+++ b/src/ddmd/globals.h
@@ -174,8 +174,9 @@ struct Param
     const char *debuglibname;   // default library for debug builds
     const char *mscrtlib;       // MS C runtime library
 
+    bool moduleDepsEnabled;     // true if compiler is to load all module dependencies
     const char *moduleDepsFile; // filename for deps output
-    OutBuffer *moduleDeps;      // contents to be written to deps file
+    OutBuffer *moduleDepsOut;   // contents to be written to deps file, this can only be set if moduleDepsEnabled is true
 
     // Hidden debug switches
     bool debugb;


### PR DESCRIPTION
…or to a file.

This is in response to (https://issues.dlang.org/show_bug.cgi?id=8858).  It allows the option `-deps-` which causes the compiler to analyze dependencies without printing them to stderr or to a file.  The typical use case for this would be when a tool like rdmd needs to know all the dependencies but is using the verbose output instead of the dependency specific output.