### PR TITLE
[Trivial] fix C++ header for StaticForeachDeclaration

### DIFF
--- a/src/ddmd/attrib.h
+++ b/src/ddmd/attrib.h
@@ -199,10 +199,10 @@ public:
     Dsymbols *cache;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    bool oneMember(Dsymbol *ps, Identifier *ident);
+    bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    void addComment(const char *comment);
+    void addComment(const utf8_t *comment);
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     const char *kind() const;


### PR DESCRIPTION
This fixes the types of functions overridden by `StaticForeachDeclaration`, such that they actually override the base functions.

Can we use C++11 in ddmd's C++ headers? (LDC already requires C++11, @ibuclaw how about GDC?)  Marking such overrides with `override` would help in avoiding these unintended errors in overriding.