### PR TITLE
[Trivial] Fix constness of DSymbol::kind() in C++ headers

### DIFF
--- a/src/ddmd/aggregate.h
+++ b/src/ddmd/aggregate.h
@@ -191,7 +191,7 @@ public:
     void semantic(Scope *sc);
     void semanticTypeInfoMembers();
     Dsymbol *search(Loc, Identifier *ident, int flags = SearchLocalsOnly);
-    const char *kind();
+    const char *kind() const;
     void finalizeSize();
     bool fit(Loc loc, Scope *sc, Expressions *elements, Type *stype);
     bool isPOD();
@@ -204,7 +204,7 @@ class UnionDeclaration : public StructDeclaration
 {
 public:
     Dsymbol *syntaxCopy(Dsymbol *s);
-    const char *kind();
+    const char *kind() const;
 
     UnionDeclaration *isUnionDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -316,7 +316,7 @@ public:
     virtual bool isCPPinterface() const;
     bool isAbstract();
     virtual int vtblOffset() const;
-    const char *kind();
+    const char *kind() const;
 
     void addLocalClass(ClassDeclarations *);
 
@@ -335,7 +335,7 @@ public:
     void semantic(Scope *sc);
     bool isBaseOf(ClassDeclaration *cd, int *poffset);
     bool isBaseOf(BaseClass *bc, int *poffset);
-    const char *kind();
+    const char *kind() const;
     int vtblOffset() const;
     bool isCPPinterface() const;
     bool isCOMinterface() const;

--- a/src/ddmd/aliasthis.h
+++ b/src/ddmd/aliasthis.h
@@ -28,7 +28,7 @@ public:
     Identifier *ident;
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     AliasThis *isAliasThis() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/ddmd/declaration.h
+++ b/src/ddmd/declaration.h
@@ -129,7 +129,7 @@ public:
     int inuse;                  // used to detect cycles
     const char *mangleOverride;      // overridden symbol with pragma(mangle, "...")
 
-    const char *kind();
+    const char *kind() const;
     d_uns64 size(Loc loc);
     int checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int flag);
 
@@ -178,7 +178,7 @@ public:
     TypeTuple *tupletype;       // !=NULL if this is a type tuple
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     Type *getType();
     Dsymbol *toAlias2();
     bool needThis();
@@ -200,7 +200,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void aliasSemantic(Scope *sc);
     bool overloadInsert(Dsymbol *s);
-    const char *kind();
+    const char *kind() const;
     Type *getType();
     Dsymbol *toAlias();
     Dsymbol *toAlias2();
@@ -219,7 +219,7 @@ public:
     Dsymbol *aliassym;
     bool hasOverloads;
 
-    const char *kind();
+    const char *kind() const;
     bool equals(RootObject *o);
     bool overloadInsert(Dsymbol *s);
 
@@ -262,7 +262,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    const char *kind();
+    const char *kind() const;
     AggregateDeclaration *isThis();
     bool needThis();
     bool isExport();
@@ -626,7 +626,7 @@ public:
     virtual bool isFinalFunc();
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
-    const char *kind();
+    const char *kind() const;
     FuncDeclaration *isUnique();
     bool checkNestedReference(Scope *sc, Loc loc);
     bool needsClosure();
@@ -660,7 +660,7 @@ public:
     bool hasOverloads;
 
     FuncAliasDeclaration *isFuncAliasDeclaration() { return this; }
-    const char *kind();
+    const char *kind() const;
 
     FuncDeclaration *toAliasFunc();
     void accept(Visitor *v) { v->visit(this); }
@@ -685,7 +685,7 @@ public:
     void modifyReturns(Scope *sc, Type *tret);
 
     FuncLiteralDeclaration *isFuncLiteralDeclaration() { return this; }
-    const char *kind();
+    const char *kind() const;
     const char *toPrettyChars(bool QualifyTypes = false);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -694,7 +694,7 @@ class CtorDeclaration : public FuncDeclaration
 {
 public:
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
@@ -721,7 +721,7 @@ class DtorDeclaration : public FuncDeclaration
 {
 public:
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     const char *toChars();
     bool isVirtual();
     bool addPreInvariant();
@@ -817,7 +817,7 @@ public:
     int varargs;
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     bool isVirtual();
     bool addPreInvariant();
     bool addPostInvariant();
@@ -833,7 +833,7 @@ public:
     Parameters *parameters;
 
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *kind();
+    const char *kind() const;
     bool isDelete();
     bool isVirtual();
     bool addPreInvariant();

--- a/src/ddmd/dsymbol.h
+++ b/src/ddmd/dsymbol.h
@@ -196,7 +196,7 @@ public:
 
     virtual Identifier *getIdent();
     virtual const char *toPrettyChars(bool QualifyTypes = false);
-    virtual const char *kind();
+    virtual const char *kind() const;
     virtual Dsymbol *toAlias();                 // resolve real symbol
     virtual Dsymbol *toAlias2();
     virtual int apply(Dsymbol_apply_ft_t fp, void *param);
@@ -307,7 +307,7 @@ public:
     virtual bool isPackageAccessible(Package *p, Prot protection, int flags = 0);
     bool isforwardRef();
     static void multiplyDefined(Loc loc, Dsymbol *s1, Dsymbol *s2);
-    const char *kind();
+    const char *kind() const;
     FuncDeclaration *findGetMembers();
     virtual Dsymbol *symtabInsert(Dsymbol *s);
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
@@ -359,7 +359,7 @@ public:
 
     void push(Dsymbol *s);
     OverloadSet *isOverloadSet() { return this; }
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -373,7 +373,7 @@ class ForwardingScopeDsymbol : public ScopeDsymbol
     Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     void importScope(Dsymbol *s, Prot protection);
     void semantic(Scope *sc);
-    const char *kind();
+    const char *kind() const;
 
     ForwardingScopeDsymbol *isForwardingScopeDsymbol() { return this; }
 };

--- a/src/ddmd/enum.h
+++ b/src/ddmd/enum.h
@@ -54,7 +54,7 @@ public:
     void setScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Type *getType();
-    const char *kind();
+    const char *kind() const;
     Dsymbol *search(Loc, Identifier *ident, int flags = SearchLocalsOnly);
     bool isDeprecated();                // is Dsymbol deprecated?
     Prot prot();
@@ -88,7 +88,7 @@ public:
     EnumDeclaration *ed;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    const char *kind();
+    const char *kind() const;
     Expression *getVarExp(Loc loc, Scope *sc);
 
     EnumMember *isEnumMember() { return this; }

--- a/src/ddmd/import.h
+++ b/src/ddmd/import.h
@@ -47,7 +47,7 @@ public:
     AliasDeclarations aliasdecls; // corresponding AliasDeclarations for alias=name pairs
 
     void addAlias(Identifier *name, Identifier *alias);
-    const char *kind();
+    const char *kind() const;
     Prot prot();
     Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     void load(Scope *sc);

--- a/src/ddmd/module.h
+++ b/src/ddmd/module.h
@@ -40,7 +40,7 @@ public:
     unsigned tag;       // auto incremented tag, used to mask package tree in scopes
     Module *mod;        // != NULL if isPkgMod == PKGmodule
 
-    const char *kind();
+    const char *kind() const;
 
     static DsymbolTable *resolve(Identifiers *packages, Dsymbol **pparent, Package **ppkg);
 
@@ -125,7 +125,7 @@ public:
 
     static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
 
-    const char *kind();
+    const char *kind() const;
     File *setOutfile(const char *name, const char *dir, const char *arg, const char *ext);
     void setDocfile();
     bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.

--- a/src/ddmd/nspace.h
+++ b/src/ddmd/nspace.h
@@ -29,7 +29,7 @@ class Nspace : public ScopeDsymbol
     int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    const char *kind();
+    const char *kind() const;
     Nspace *isNspace() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/ddmd/staticassert.h
+++ b/src/ddmd/staticassert.h
@@ -29,7 +29,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/ddmd/template.h
+++ b/src/ddmd/template.h
@@ -86,7 +86,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     bool overloadInsert(Dsymbol *s);
     bool hasStaticCtorOrDtor();
-    const char *kind();
+    const char *kind() const;
     const char *toChars();
 
     Prot prot();
@@ -308,7 +308,7 @@ public:
     static Objects *arraySyntaxCopy(Objects *objs);
     Dsymbol *syntaxCopy(Dsymbol *);
     Dsymbol *toAlias();                 // resolve real symbol
-    const char *kind();
+    const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
     const char *toChars();
     const char* toPrettyCharsHelper();
@@ -345,7 +345,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic2(Scope *sc);
-    const char *kind();
+    const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
     int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();

--- a/src/ddmd/version.h
+++ b/src/ddmd/version.h
@@ -27,7 +27,7 @@ public:
 
     const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -40,7 +40,7 @@ public:
 
     const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
-    const char *kind();
+    const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
This fixes constness of all Dsymbol::kind() overrides; some already were defined `const`. Now all overrides should actually override the base virtual function, whereas before they did not.
Note: the base function was lacking `const` aswell.

Tested on LDC master.

Similar to #7401 , C++11 `override` would have helped here.
