### PR TITLE
Issue 9631 - Error message not using fully qualified name

### DIFF
--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -102,8 +102,9 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                     //printf("type %p ty %d deco %p\n", type, type.ty, type.deco);
                     //type = type.typeSemantic(loc, sc);
                     //printf("type %s t %s\n", type.deco, t.deco);
+                    auto ts = Type.toAutoQualChars(e.type, t);
                     e.error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
-                        e.toChars(), e.type.toChars(), t.toChars());
+                        e.toChars(), ts[0], ts[1]);
                 }
             }
             result = new ErrorExp();

--- a/src/ddmd/dcast.d
+++ b/src/ddmd/dcast.d
@@ -102,7 +102,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                     //printf("type %p ty %d deco %p\n", type, type.ty, type.deco);
                     //type = type.typeSemantic(loc, sc);
                     //printf("type %s t %s\n", type.deco, t.deco);
-                    auto ts = Type.toAutoQualChars(e.type, t);
+                    auto ts = toAutoQualChars(e.type, t);
                     e.error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
                         e.toChars(), ts[0], ts[1]);
                 }

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -4529,7 +4529,7 @@ extern (C++) final class FuncExp : Expression
         }
         else if (!flag)
         {
-            auto ts = Type.toAutoQualChars(tx, to);
+            auto ts = toAutoQualChars(tx, to);
             error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
                 toChars(), ts[0], ts[1]);
         }

--- a/src/ddmd/expression.d
+++ b/src/ddmd/expression.d
@@ -4529,7 +4529,9 @@ extern (C++) final class FuncExp : Expression
         }
         else if (!flag)
         {
-            error("cannot implicitly convert expression `%s` of type `%s` to `%s`", toChars(), tx.toChars(), to.toChars());
+            auto ts = Type.toAutoQualChars(tx, to);
+            error("cannot implicitly convert expression `%s` of type `%s` to `%s`",
+                toChars(), ts[0], ts[1]);
         }
         return m;
     }

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -899,6 +899,7 @@ extern (C++) abstract class Type : RootObject
         return buf.extractString();
     }
 
+    /// ditto
     final char* toPrettyChars(bool QualifyTypes = false)
     {
         OutBuffer buf;
@@ -9172,9 +9173,14 @@ extern (C++) final class Parameter : RootObject
     extern (D) static immutable bool[SR.max + 1][SR.max + 1] covariant = covariantInit();
 }
 
-/***********************************************************
+/**
  * For printing two types with qualification when necessary.
- * Disambiguates the case where toChars() on each type match.
+ * Params:
+ *    t1 = The first type to receive the type name for
+ *    t2 = The second type to receive the type name for
+ * Returns:
+ *    The fully-qualified names of both types if the two type names are not the same,
+ *    or the unqualified names of both types if the two type names are the same.
  */
 const(char*)[2] toAutoQualChars(Type t1, Type t2)
 {

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -910,18 +910,6 @@ extern (C++) abstract class Type : RootObject
         return buf.extractString();
     }
 
-    static const(char*)[2] toAutoQualChars(Type t1, Type t2)
-    {
-        auto s1 = t1.toChars();
-        auto s2 = t2.toChars();
-        if (strcmp(s1, s2) == 0)
-        {
-            s1 = t1.toPrettyChars(true);
-            s2 = t2.toPrettyChars(true);
-        }
-        return [s1, s2];
-    }
-
     static void _init()
     {
         stringtable._init(14000);
@@ -9182,4 +9170,20 @@ extern (C++) final class Parameter : RootObject
     }
 
     extern (D) static immutable bool[SR.max + 1][SR.max + 1] covariant = covariantInit();
+}
+
+/***********************************************************
+ * For printing two types with qualification when necessary.
+ * Disambiguates the case where toChars() on each type match.
+ */
+const(char*)[2] toAutoQualChars(Type t1, Type t2)
+{
+    auto s1 = t1.toChars();
+    auto s2 = t2.toChars();
+    if (strcmp(s1, s2) == 0)
+    {
+        s1 = t1.toPrettyChars(true);
+        s2 = t2.toPrettyChars(true);
+    }
+    return [s1, s2];
 }

--- a/src/ddmd/mtype.d
+++ b/src/ddmd/mtype.d
@@ -910,6 +910,18 @@ extern (C++) abstract class Type : RootObject
         return buf.extractString();
     }
 
+    static const(char*)[2] toAutoQualChars(Type t1, Type t2)
+    {
+        auto s1 = t1.toChars();
+        auto s2 = t2.toChars();
+        if (strcmp(s1, s2) == 0)
+        {
+            s1 = t1.toPrettyChars(true);
+            s2 = t2.toPrettyChars(true);
+        }
+        return [s1, s2];
+    }
+
     static void _init()
     {
         stringtable._init(14000);

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/bug9631.d(20): Error: cannot implicitly convert expression `F()` of type `bug9631.T1!().F` to `bug9631.T2!().F`
+---
+*/
+
+template T1()
+{
+    struct F { }
+}
+
+template T2()
+{
+    struct F { }
+}
+
+void main()
+{
+    T2!().F x = T1!().F();
+}


### PR DESCRIPTION
Fix *cannot implicitly convert expression of type T to T* ambiguous errors.
Add `Type.toAutoQualChars()`.

There are other related errors that could use this fix, this only addresses the first test case in bugzilla.