### PR TITLE
[WIP] Add AppVeyor config to test Visual Studio builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,40 @@
+platform: x64
+environment:
+ matrix:
+  #- DC: dmd
+    #DVersion: nightly
+    #arch: x64
+  - DC: dmd
+    DVersion: nightly
+    arch: x86
+skip_tags: false
+build_script:
+ - ps: wget https://raw.githubusercontent.com/wilzbach/installer/appveyor-script/script/install.ps1 -OutFile install.ps1
+ - ps: .\install.ps1
+ - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %compilersetupargs%
+ - ps: function InstallDMC
+        {
+            pushd c:\\;
+            Invoke-WebRequest "https://github.com/wilzbach/dmc-mirror/raw/master/dm857c.zip" -OutFile "dmc.zip";
+            7z x dmc.zip > $null;
+            $env:PATH = "C:\dm\bin;$($env:PATH)";
+            popd;
+        }
+ - ps: InstallDMC
+
+test_script:
+ - git clone --branch %APPVEYOR_REPO_BRANCH% https://github.com/dlang/druntime ..\druntime
+ - git clone https://github.com/dlang/tools ..\tools
+ - echo %PLATFORM%
+ - echo %Darch%
+ - echo %DC%
+ - echo %PATH%
+ - '%DC% --version'
+ - ps: $env:HOST_DC = "dmd";
+ - ps: if($env:arch -eq "x86"){
+            cd src;
+            make -f win32.mak HOST_DC="dmd";
+        }elseif($env:arch -eq "x64"){
+            cd src;
+            make -f win64.mak HOST_DC="dmd";
+        }

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -139,7 +139,7 @@ DDEBUG=-debug -g -unittest
 # Compile flags
 CFLAGS=-I$(INCLUDE) $(OPT) $(CFLAGS) $(DEBUG) -cpp -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
 # Compile flags for modules with backend/toolkit dependencies
-MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -e -wx -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
+MFLAGS=-I$C;$(TK) $(OPT) -DMARS -cpp $(DEBUG) -DTARGET_WINDOS=1 -DDM_TARGET_CPU_X86=1
 # D compile flags
 DFLAGS=$(DOPT) $(DMODEL) $(DDEBUG) -wi -version=MARS
 


### PR DESCRIPTION
To avoid issues like https://github.com/dlang/dmd/pull/7408 in the future

I added AppVeyor to the list of CIs to be able to test this PR. Of course, I will remove it if we decide to not go with this.