### PR TITLE
Don't add -unittest during DEBUG=1

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -237,7 +237,7 @@ endif
 # Append different flags for debugging, profiling and release.
 ifdef ENABLE_DEBUG
 CXXFLAGS += -g -g3 -DDEBUG=1 -DUNITTEST
-DFLAGS += -g -debug -unittest
+DFLAGS += -g -debug
 endif
 ifdef ENABLE_RELEASE
 CXXFLAGS += -O2


### PR DESCRIPTION
Now that there's the `unittest` target `ENABLE_DEBUG=1` (or simply `DEBUG=1`) should't add `-unittest` when building the main DMD executable.