### PR TITLE
Add field to give struct used in testing issue 13089 a size.

### DIFF
--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -3511,6 +3511,7 @@ void test12686()
 struct S13089
 {
     @disable this(this);    // non nothrow
+    int val;
 }
 
 void* p13089;


### PR DESCRIPTION
Types with no size are never passed in memory in the x86_64 ABI at least.