### PR TITLE
Use platform-independent CLI documentation links

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1541,17 +1541,17 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
         const(char)* p = arguments[i];
         if (*p == '-')
         {
-            if (strcmp(p + 1, "allinst") == 0) // https://dlang.org/dmd-windows.html#switch-allinst
+            if (strcmp(p + 1, "allinst") == 0) // https://dlang.org/dmd.html#switch-allinst
                 params.allInst = true;
-            else if (strcmp(p + 1, "de") == 0) // https://dlang.org/dmd-windows.html#switch-de
+            else if (strcmp(p + 1, "de") == 0) // https://dlang.org/dmd.html#switch-de
                 params.useDeprecated = 0;
-            else if (strcmp(p + 1, "d") == 0)  // https://dlang.org/dmd-windows.html#switch-d
+            else if (strcmp(p + 1, "d") == 0)  // https://dlang.org/dmd.html#switch-d
                 params.useDeprecated = 1;
-            else if (strcmp(p + 1, "dw") == 0) // https://dlang.org/dmd-windows.html#switch-dw
+            else if (strcmp(p + 1, "dw") == 0) // https://dlang.org/dmd.html#switch-dw
                 params.useDeprecated = 2;
-            else if (strcmp(p + 1, "c") == 0)  // https://dlang.org/dmd-windows.html#switch-c
+            else if (strcmp(p + 1, "c") == 0)  // https://dlang.org/dmd.html#switch-c
                 params.link = false;
-            else if (memcmp(p + 1, cast(char*)"color", 5) == 0) // https://dlang.org/dmd-windows.html#switch-color
+            else if (memcmp(p + 1, cast(char*)"color", 5) == 0) // https://dlang.org/dmd.html#switch-color
             {
                 params.color = true;
                 // Parse:
@@ -1567,11 +1567,11 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else if (p[6])
                     goto Lerror;
             }
-            else if (memcmp(p + 1, cast(char*)"conf=", 5) == 0) // https://dlang.org/dmd-windows.html#switch-conf
+            else if (memcmp(p + 1, cast(char*)"conf=", 5) == 0) // https://dlang.org/dmd.html#switch-conf
             {
                 // ignore, already handled above
             }
-            else if (memcmp(p + 1, cast(char*)"cov", 3) == 0) // https://dlang.org/dmd-windows.html#switch-cov
+            else if (memcmp(p + 1, cast(char*)"cov", 3) == 0) // https://dlang.org/dmd.html#switch-cov
             {
                 params.cov = true;
                 // Parse:
@@ -1618,13 +1618,13 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (strcmp(p + 1, "map") == 0) // https://dlang.org/dmd-windows.html#switch-map
+            else if (strcmp(p + 1, "map") == 0) // https://dlang.org/dmd.html#switch-map
                 params.map = true;
             else if (strcmp(p + 1, "multiobj") == 0)
                 params.multiobj = true;
-            else if (strcmp(p + 1, "g") == 0) // https://dlang.org/dmd-windows.html#switch-g
+            else if (strcmp(p + 1, "g") == 0) // https://dlang.org/dmd.html#switch-g
                 params.symdebug = 1;
-            else if (strcmp(p + 1, "gc") == 0)  // https://dlang.org/dmd-windows.html#switch-gc
+            else if (strcmp(p + 1, "gc") == 0)  // https://dlang.org/dmd.html#switch-gc
             {
                 Loc loc;
                 deprecation(loc, "use -g instead of -gc");
@@ -1636,21 +1636,21 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     params.symdebug = 1;
                 params.symdebugref = true;
             }
-            else if (strcmp(p + 1, "gs") == 0)  // https://dlang.org/dmd-windows.html#switch-gs
+            else if (strcmp(p + 1, "gs") == 0)  // https://dlang.org/dmd.html#switch-gs
                 params.alwaysframe = true;
-            else if (strcmp(p + 1, "gx") == 0)  // https://dlang.org/dmd-windows.html#switch-gx
+            else if (strcmp(p + 1, "gx") == 0)  // https://dlang.org/dmd.html#switch-gx
                 params.stackstomp = true;
             else if (strcmp(p + 1, "gt") == 0)
             {
                 error("use -profile instead of -gt");
                 params.trace = true;
             }
-            else if (strcmp(p + 1, "m32") == 0) // https://dlang.org/dmd-windows.html#switch-m32
+            else if (strcmp(p + 1, "m32") == 0) // https://dlang.org/dmd.html#switch-m32
             {
                 params.is64bit = false;
                 params.mscoff = false;
             }
-            else if (strcmp(p + 1, "m64") == 0) // https://dlang.org/dmd-windows.html#switch-m64
+            else if (strcmp(p + 1, "m64") == 0) // https://dlang.org/dmd.html#switch-m64
             {
                 params.is64bit = true;
                 static if (TARGET_WINDOS)
@@ -1658,7 +1658,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     params.mscoff = true;
                 }
             }
-            else if (strcmp(p + 1, "m32mscoff") == 0) // https://dlang.org/dmd-windows.html#switch-m32mscoff
+            else if (strcmp(p + 1, "m32mscoff") == 0) // https://dlang.org/dmd.html#switch-m32mscoff
             {
                 static if (TARGET_WINDOS)
                 {
@@ -1681,7 +1681,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     error("-mscrtlib");
                 }
             }
-            else if (memcmp(p + 1, cast(char*)"profile", 7) == 0) // https://dlang.org/dmd-windows.html#switch-profile
+            else if (memcmp(p + 1, cast(char*)"profile", 7) == 0) // https://dlang.org/dmd.html#switch-profile
             {
                 // Parse:
                 //      -profile
@@ -1698,17 +1698,17 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     params.trace = true;
             }
-            else if (strcmp(p + 1, "v") == 0) // https://dlang.org/dmd-windows.html#switch-v
+            else if (strcmp(p + 1, "v") == 0) // https://dlang.org/dmd.html#switch-v
                 params.verbose = true;
             else if (strcmp(p + 1, "vcg-ast") == 0)
                 params.vcg_ast = true;
-            else if (strcmp(p + 1, "vtls") == 0) // https://dlang.org/dmd-windows.html#switch-vtls
+            else if (strcmp(p + 1, "vtls") == 0) // https://dlang.org/dmd.html#switch-vtls
                 params.vtls = true;
-            else if (strcmp(p + 1, "vcolumns") == 0) // https://dlang.org/dmd-windows.html#switch-vcolumns
+            else if (strcmp(p + 1, "vcolumns") == 0) // https://dlang.org/dmd.html#switch-vcolumns
                 params.showColumns = true;
-            else if (strcmp(p + 1, "vgc") == 0) // https://dlang.org/dmd-windows.html#switch-vgc
+            else if (strcmp(p + 1, "vgc") == 0) // https://dlang.org/dmd.html#switch-vgc
                 params.vgc = true;
-            else if (memcmp(p + 1, cast(char*)"verrors", 7) == 0) // https://dlang.org/dmd-windows.html#switch-verrors
+            else if (memcmp(p + 1, cast(char*)"verrors", 7) == 0) // https://dlang.org/dmd.html#switch-verrors
             {
                 if (p[8] == '=' && isdigit(cast(char)p[9]))
                 {
@@ -1724,7 +1724,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (memcmp(p + 1, "mcpu".ptr, 4) == 0) // https://dlang.org/dmd-windows.html#switch-mcpu
+            else if (memcmp(p + 1, "mcpu".ptr, 4) == 0) // https://dlang.org/dmd.html#switch-mcpu
             {
                 // Parse:
                 //      -mcpu=identifier
@@ -1762,7 +1762,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (memcmp(p + 1, cast(char*)"transition", 10) == 0) // https://dlang.org/dmd-windows.html#switch-transition
+            else if (memcmp(p + 1, cast(char*)"transition", 10) == 0) // https://dlang.org/dmd.html#switch-transition
             {
                 // Parse:
                 //      -transition=number
@@ -1836,21 +1836,21 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (strcmp(p + 1, "w") == 0)   // https://dlang.org/dmd-windows.html#switch-w
+            else if (strcmp(p + 1, "w") == 0)   // https://dlang.org/dmd.html#switch-w
                 params.warnings = 1;
-            else if (strcmp(p + 1, "wi") == 0)  // https://dlang.org/dmd-windows.html#switch-wi
+            else if (strcmp(p + 1, "wi") == 0)  // https://dlang.org/dmd.html#switch-wi
                 params.warnings = 2;
-            else if (strcmp(p + 1, "O") == 0)   // https://dlang.org/dmd-windows.html#switch-O
+            else if (strcmp(p + 1, "O") == 0)   // https://dlang.org/dmd.html#switch-O
                 params.optimize = true;
             else if (p[1] == 'o')
             {
                 const(char)* path;
                 switch (p[2])
                 {
-                case '-':                       // https://dlang.org/dmd-windows.html#switch-o-
+                case '-':                       // https://dlang.org/dmd.html#switch-o-
                     params.obj = false;
                     break;
-                case 'd':                       // https://dlang.org/dmd-windows.html#switch-od
+                case 'd':                       // https://dlang.org/dmd.html#switch-od
                     if (!p[3])
                         goto Lnoarg;
                     path = p + 3 + (p[3] == '=');
@@ -1860,7 +1860,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     }
                     params.objdir = path;
                     break;
-                case 'f':                       // https://dlang.org/dmd-windows.html#switch-of
+                case 'f':                       // https://dlang.org/dmd.html#switch-of
                     if (!p[3])
                         goto Lnoarg;
                     path = p + 3 + (p[3] == '=');
@@ -1870,7 +1870,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     }
                     params.objname = path;
                     break;
-                case 'p':                       // https://dlang.org/dmd-windows.html#switch-op
+                case 'p':                       // https://dlang.org/dmd.html#switch-op
                     if (p[3])
                         goto Lerror;
                     params.preservePaths = true;
@@ -1882,17 +1882,17 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (p[1] == 'D')       // https://dlang.org/dmd-windows.html#switch-D
+            else if (p[1] == 'D')       // https://dlang.org/dmd.html#switch-D
             {
                 params.doDocComments = true;
                 switch (p[2])
                 {
-                case 'd':               // https://dlang.org/dmd-windows.html#switch-Dd
+                case 'd':               // https://dlang.org/dmd.html#switch-Dd
                     if (!p[3])
                         goto Lnoarg;
                     params.docdir = p + 3 + (p[3] == '=');
                     break;
-                case 'f':               // https://dlang.org/dmd-windows.html#switch-Df
+                case 'f':               // https://dlang.org/dmd.html#switch-Df
                     if (!p[3])
                         goto Lnoarg;
                     params.docname = p + 3 + (p[3] == '=');
@@ -1903,17 +1903,17 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (p[1] == 'H')       // https://dlang.org/dmd-windows.html#switch-H
+            else if (p[1] == 'H')       // https://dlang.org/dmd.html#switch-H
             {
                 params.doHdrGeneration = true;
                 switch (p[2])
                 {
-                case 'd':               // https://dlang.org/dmd-windows.html#switch-Hd
+                case 'd':               // https://dlang.org/dmd.html#switch-Hd
                     if (!p[3])
                         goto Lnoarg;
                     params.hdrdir = p + 3 + (p[3] == '=');
                     break;
-                case 'f':               // https://dlang.org/dmd-windows.html#switch-Hf
+                case 'f':               // https://dlang.org/dmd.html#switch-Hf
                     if (!p[3])
                         goto Lnoarg;
                     params.hdrname = p + 3 + (p[3] == '=');
@@ -1924,12 +1924,12 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (p[1] == 'X')       // https://dlang.org/dmd-windows.html#switch-X
+            else if (p[1] == 'X')       // https://dlang.org/dmd.html#switch-X
             {
                 params.doJsonGeneration = true;
                 switch (p[2])
                 {
-                case 'f':               // https://dlang.org/dmd-windows.html#switch-Xf
+                case 'f':               // https://dlang.org/dmd.html#switch-Xf
                     if (!p[3])
                         goto Lnoarg;
                     params.jsonfilename = p + 3 + (p[3] == '=');
@@ -1940,16 +1940,16 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (strcmp(p + 1, "ignore") == 0)      // https://dlang.org/dmd-windows.html#switch-ignore
+            else if (strcmp(p + 1, "ignore") == 0)      // https://dlang.org/dmd.html#switch-ignore
                 params.ignoreUnsupportedPragmas = true;
             else if (strcmp(p + 1, "property") == 0)
                 params.enforcePropertySyntax = true;
-            else if (strcmp(p + 1, "inline") == 0) // https://dlang.org/dmd-windows.html#switch-inline
+            else if (strcmp(p + 1, "inline") == 0) // https://dlang.org/dmd.html#switch-inline
             {
                 params.useInline = true;
                 params.hdrStripPlainFunctions = false;
             }
-            else if (strcmp(p + 1, "dip25") == 0)       // https://dlang.org/dmd-windows.html#switch-dip25
+            else if (strcmp(p + 1, "dip25") == 0)       // https://dlang.org/dmd.html#switch-dip25
                 params.useDIP25 = true;
             else if (strcmp(p + 1, "dip1000") == 0)
             {
@@ -1960,7 +1960,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             {
                 params.ehnogc = true;
             }
-            else if (strcmp(p + 1, "lib") == 0) // https://dlang.org/dmd-windows.html#switch-lib
+            else if (strcmp(p + 1, "lib") == 0) // https://dlang.org/dmd.html#switch-lib
                 params.lib = true;
             else if (strcmp(p + 1, "nofloat") == 0)
                 params.nofloat = true;
@@ -1968,15 +1968,15 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             {
                 // Ignore
             }
-            else if (strcmp(p + 1, "release") == 0) // https://dlang.org/dmd-windows.html#switch-release
+            else if (strcmp(p + 1, "release") == 0) // https://dlang.org/dmd.html#switch-release
                 params.release = true;
-            else if (strcmp(p + 1, "betterC") == 0) // https://dlang.org/dmd-windows.html#switch-betterC
+            else if (strcmp(p + 1, "betterC") == 0) // https://dlang.org/dmd.html#switch-betterC
                 params.betterC = true;
-            else if (strcmp(p + 1, "noboundscheck") == 0) // https://dlang.org/dmd-windows.html#switch-noboundscheck
+            else if (strcmp(p + 1, "noboundscheck") == 0) // https://dlang.org/dmd.html#switch-noboundscheck
             {
                 params.useArrayBounds = CHECKENABLE.off;
             }
-            else if (memcmp(p + 1, cast(char*)"boundscheck", 11) == 0) // https://dlang.org/dmd-windows.html#switch-boundscheck
+            else if (memcmp(p + 1, cast(char*)"boundscheck", 11) == 0) // https://dlang.org/dmd.html#switch-boundscheck
             {
                 // Parse:
                 //      -boundscheck=[on|safeonly|off]
@@ -2002,13 +2002,13 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             }
             else if (strcmp(p + 1, "unittest") == 0)
                 params.useUnitTests = true;
-            else if (p[1] == 'I') // https://dlang.org/dmd-windows.html#switch-I
+            else if (p[1] == 'I') // https://dlang.org/dmd.html#switch-I
             {
                 if (!params.imppath)
                     params.imppath = new Strings();
                 params.imppath.push(p + 2 + (p[2] == '='));
             }
-            else if (p[1] == 'm' && p[2] == 'v' && p[3] == '=') // https://dlang.org/dmd-windows.html#switch-mv
+            else if (p[1] == 'm' && p[2] == 'v' && p[3] == '=') // https://dlang.org/dmd.html#switch-mv
             {
                 if (p[4] && strchr(p + 5, '='))
                 {
@@ -2019,13 +2019,13 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (p[1] == 'J') // https://dlang.org/dmd-windows.html#switch-J
+            else if (p[1] == 'J') // https://dlang.org/dmd.html#switch-J
             {
                 if (!params.fileImppath)
                     params.fileImppath = new Strings();
                 params.fileImppath.push(p + 2 + (p[2] == '='));
             }
-            else if (memcmp(p + 1, cast(char*)"debug", 5) == 0 && p[6] != 'l') // https://dlang.org/dmd-windows.html#switch-debug
+            else if (memcmp(p + 1, cast(char*)"debug", 5) == 0 && p[6] != 'l') // https://dlang.org/dmd.html#switch-debug
             {
                 // Parse:
                 //      -debug
@@ -2055,7 +2055,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     params.debuglevel = 1;
             }
-            else if (memcmp(p + 1, cast(char*)"version", 7) == 0) // https://dlang.org/dmd-windows.html#switch-version
+            else if (memcmp(p + 1, cast(char*)"version", 7) == 0) // https://dlang.org/dmd.html#switch-version
             {
                 // Parse:
                 //      -version=number
@@ -2103,19 +2103,19 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 params.debugx = true;
             else if (strcmp(p + 1, "-y") == 0)
                 params.debugy = true;
-            else if (p[1] == 'L')       // https://dlang.org/dmd-windows.html#switch-L
+            else if (p[1] == 'L')       // https://dlang.org/dmd.html#switch-L
             {
                 params.linkswitches.push(p + 2 + (p[2] == '='));
             }
-            else if (memcmp(p + 1, cast(char*)"defaultlib=", 11) == 0) // https://dlang.org/dmd-windows.html#switch-defaultlib
+            else if (memcmp(p + 1, cast(char*)"defaultlib=", 11) == 0) // https://dlang.org/dmd.html#switch-defaultlib
             {
                 params.defaultlibname = p + 1 + 11;
             }
-            else if (memcmp(p + 1, cast(char*)"debuglib=", 9) == 0)     // https://dlang.org/dmd-windows.html#switch-debuglib
+            else if (memcmp(p + 1, cast(char*)"debuglib=", 9) == 0)     // https://dlang.org/dmd.html#switch-debuglib
             {
                 params.debuglibname = p + 1 + 9;
             }
-            else if (memcmp(p + 1, cast(char*)"deps", 4) == 0) // https://dlang.org/dmd-windows.html#switch-deps
+            else if (memcmp(p + 1, cast(char*)"deps", 4) == 0) // https://dlang.org/dmd.html#switch-deps
             {
                 if (params.moduleDeps)
                 {
@@ -2135,16 +2135,16 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 }
                 params.moduleDeps = new OutBuffer();
             }
-            else if (strcmp(p + 1, "main") == 0)        // https://dlang.org/dmd-windows.html#switch-main
+            else if (strcmp(p + 1, "main") == 0)        // https://dlang.org/dmd.html#switch-main
             {
                 params.addMain = true;
             }
-            else if (memcmp(p + 1, cast(char*)"man", 3) == 0)   // https://dlang.org/dmd-windows.html#switch-man
+            else if (memcmp(p + 1, cast(char*)"man", 3) == 0)   // https://dlang.org/dmd.html#switch-man
             {
                 params.manual = true;
                 return false;
             }
-            else if (strcmp(p + 1, "run") == 0)         // https://dlang.org/dmd-windows.html#switch-run
+            else if (strcmp(p + 1, "run") == 0)         // https://dlang.org/dmd.html#switch-run
             {
                 params.run = true;
                 size_t length = argc - i - 1;


### PR DESCRIPTION
The redirect magic [exists since quite a while](https://github.com/dlang/dlang.org/commit/b67e39b47e915528771a3378e0249c7e84c7877c#diff-8052c42ab3b8aa06a3f5f788a4ddccc2) and is already frequently used on dlang.org