### PR TITLE
Fix changelog: it's Ddoc, not Markdown

### DIFF
--- a/changelog/body.dd
+++ b/changelog/body.dd
@@ -1,6 +1,6 @@
 Generate header files using `do` instead of `body` as per DIP1003
 
 Support for
-[DIP1003](https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md)
+$(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/DIP1003.md, DIP1003)
 was added in release 2.075.0. Use of `body` in an error message and
 header file generation has been fixed in this release.


### PR DESCRIPTION
The current changelog can be previewed at https://dlang.org/changelog/pending.html

@ reviewers DAutotest builds the pending changelog too, s.t. changes to it can be conveniently previewed.