### PR TITLE
Fix windows debug build

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -1083,7 +1083,7 @@ Language changes listed by -transition=id:
  * Returns:
  *   Return code of the application
  */
-version(unittest) {} else
+version(NoMain) {} else
 int main()
 {
     import core.memory;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -462,7 +462,7 @@ $G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/backend.a $G/lexer.a $(STRING
 endif
 
 $G/dmd-unittest: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_GLUE_OBJS) $(G_OBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
-	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) -g -unittest -main $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) -g -unittest -main -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
 
 unittest: $G/dmd-unittest
 	$<


### PR DESCRIPTION
Windows debug build is currently broken because dmd does not generate the 'main' function.  I bisected the cause to this commit (https://github.com/dlang/dmd/commit/fed25ec02a5db64b41b661d8c1785bfc023dfd84).  It looks like the `main` method was removed in the `-unittest` build which explains what happened.  I've removed that change so that the `main` method still exists in a unittest build.  I'm not sure why main was removed in the first place, maybe there was a reason so if there was please chime in let me know if another kind of change is needed here.