### PR TITLE
Fix DDoc warnings and add a CI check to avoid regressions

### DIFF
--- a/src/dmd/backend/oper.d
+++ b/src/dmd/backend/oper.d
@@ -272,7 +272,9 @@ int rel_unord(int op)     { return _rel_unord    [op - RELOPMIN]; }
 /****************************************
  * Conversion operators.
  * Convert from conversion operator to conversion index
- * parallel array invconvtab[] in cgelem.c)
+ * parallel array invconvtab[] in cgelem.c
+ * Params:
+ *   op = conversion operator
  */
 int convidx(OPER op) { return op - CNVOPMIN; }
 

--- a/src/dmd/dinifile.d
+++ b/src/dmd/dinifile.d
@@ -169,8 +169,9 @@ void updateRealEnvironment(StringTable* environment)
  *      environment = our own cache of the program environment
  *      filename = name of the file being parsed
  *      path = what @P will expand to
- *      buffer[len] = contents of configuration file
- *      sections[] = section names
+ *      length = length of the configuration file buffer
+ *      buffer = contents of configuration file
+ *      sections = section names
  */
 void parseConfFile(StringTable* environment, const(char)* filename, const(char)* path, size_t length, ubyte* buffer, Strings* sections)
 {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6116,7 +6116,6 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      * Compare proposed template instantiation with existing template instantiation.
      * Note that this is not commutative because of the auto ref check.
      * Params:
-     *  this = proposed template instantiation
      *  o = existing template instantiation
      * Returns:
      *  0 for match, 1 for no match

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5784,7 +5784,7 @@ private elem *appendDtors(IRState *irs, elem *er, size_t starti, size_t endi)
  * temporaries created in elem.
  * Params:
  *      e = Expression to convert
- *      irstate = context
+ *      irs = context
  * Returns:
  *      generated elem tree
  */
@@ -5825,8 +5825,6 @@ elem *toElemDtor(Expression e, IRState *irs)
  *      str = string
  *      len = number of code units in string
  *      sz = number of bytes per code unit
- *      comdat = emit string in its own comdat (default is read-only segment).
- *          Comdats are useful when linker does not coalesce redundant strings.
  * Returns:
  *      Symbol
  */

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -83,9 +83,12 @@ void emplaceExp(T : UnionExp)(T* p, Expression e)
  * right `this` pointer if var is in an outer class, but our
  * existing `this` pointer is in an inner class.
  * Params:
- *      e1 = existing `this`
+ *      loc = location to use for error messages
+ *      sc = context
  *      ad = struct or class we need the correct `this` for
+ *      e1 = existing `this`
  *      var = the specific member of ad we're accessing
+ *      flag = if true, return `null` instead of throwing an error
  * Returns:
  *      Expression representing the `this` for the var
  */

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -519,6 +519,8 @@ extern (C++) class FuncDeclaration : Declaration
      * this function overrides.
      * Prefer an exact match to a covariant one.
      * Params:
+     *      vtbl     = vtable to use
+     *      dim      = maximal vtable dimension
      *      fix17349 = enable fix https://issues.dlang.org/show_bug.cgi?id=17349
      * Returns:
      *      -1      didn't find one
@@ -607,8 +609,6 @@ extern (C++) class FuncDeclaration : Declaration
     /*********************************
      * If function a function in a base class,
      * return that base class.
-     * Params:
-     *  cd = class that function is in
      * Returns:
      *  base class if overriding, null if not
      */
@@ -2446,6 +2446,7 @@ private const(char)* prependSpace(const(char)* str)
  * Params:
  *      loc =           instantiation location
  *      sc =            instantiation scope
+ *      s =             instantiation symbol
  *      tiargs =        initial list of template arguments
  *      tthis =         if !NULL, the `this` argument type
  *      fargs =         arguments to function

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -76,6 +76,8 @@ int inlineCostExpression(Expression e)
  * Determine cost of inlining function
  * Params:
  *      fd = function to determine cost of
+ *      hasthis = if the function call has explicit 'this' expression
+ *      hdrscan = if generating a header file
  * Returns:
  *      cost of inlining fd
  */

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2583,6 +2583,9 @@ extern (C++) abstract class Type : RootObject
     /***************************************
      * Access the members of the object e. This type is same as e.type.
      * Params:
+     *  sc = instantiating scope
+     *  e = expression to convert
+     *  ident = identifier being used
      *  flag = DotExpFlag bit flags
      * Returns:
      *  resulting expression with e.ident resolved
@@ -9104,6 +9107,7 @@ extern (C++) final class Parameter : RootObject
      * Compute covariance of parameters `this` and `p`
      * as determined by the storage classes of both.
      * Params:
+     *  returnByRef = true if the function returns by ref
      *  p = Parameter to compare with
      * Returns:
      *  true = `this` can be used in place of `p`

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6318,6 +6318,7 @@ final class Parser(AST) : Lexer
             error(e.loc, "`%s` must be parenthesized when next to operator `%s`", e.toChars(), Token.toChars(value));
     }
 
+    ///
     enum NeedDeclaratorId
     {
         no,             // Declarator part must have no identifier
@@ -6329,9 +6330,12 @@ final class Parser(AST) : Lexer
     /************************************
      * Determine if the scanner is sitting on the start of a declaration.
      * Params:
-     *      needId
+     *      t       = current token of the scanner
+     *      needId  = flag with additional requirements for a declaration
+     *      endtok  = ending token
+     *      pt      = will be set ending token (if not null)
      * Output:
-     *      if *pt is not NULL, it is set to the ending token, which would be endtok
+     *      true if the token `t` is a declaration, false otherwise
      */
     bool isDeclaration(Token* t, NeedDeclaratorId needId, TOK endtok, Token** pt)
     {

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -828,7 +828,7 @@ extern (C++) class CompoundStatement : Statement
      *
      * Params:
      *   loc = Instantiation information
-     *   s   = A variadic array of `Statement`s, that will copied in this class
+     *   sts   = A variadic array of `Statement`s, that will copied in this class
      *         The entries themselves will not be copied.
      */
     final extern (D) this(Loc loc, Statement[] sts...)

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -34,7 +34,10 @@ import dmd.utils;
  * level are not semantically analyzed if the result of the expression is not
  * necessary.
  * Params:
+ *      sc  = instantiating scope
  *      exp = original expression, for error messages
+ *      e =  resulting expression
+ *      errors = set to `true` if errors occurred
  * Returns:
  *      true if evaluates to true
  */

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -628,6 +628,7 @@ extern (C++) void StructDeclaration_toDt(StructDeclaration sd, DtBuilder dtb)
  * to the C++ RTTI symbol for cd.
  * Params:
  *      cd = C++ class
+ *      dtb = data table builder
  */
 extern (C++) void cpp_type_info_ptr_toDt(ClassDeclaration cd, DtBuilder dtb)
 {

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -609,8 +609,8 @@ HTMLS=$(addprefix $(DOC_OUTPUT_DIR)/, \
 # For each module, define a rule e.g.:
 # ../web/phobos/dmd_mars.html : dmd/mars.d $(STDDOC) ; ...
 $(foreach p,$(SRC_DOCUMENTABLES),$(eval \
-$(DOC_OUTPUT_DIR)/$(call D2HTML,$p) : $p $(STDDOC) $(HOST_DMD_PATH) ;\
-  $(HOST_DMD_RUN) -of- $(MODEL_FLAG) -J$G -J../res -c -Dd$(DOCSRC) -Idmd\
+$(DOC_OUTPUT_DIR)/$(call D2HTML,$p) : $p $(STDDOC) $(DMD) ;\
+  $(DMD) -o- $(MODEL_FLAG) -J$G -J../res -c -w -Dd$(DOCSRC) -Idmd\
   $(DFLAGS) project.ddoc $(STDDOC) -Df$$@ $$<))
 
 $(DOC_OUTPUT_DIR) :


### PR DESCRIPTION
Individual commits:
- Remove duplicated id.d from FRONT_SRCS (It's already part of LEXER_SRCS)
- Add new 'style' target to check for Ddoc errors
- Run style target on CircleCi
- Fix DDoc warnings