### PR TITLE
Fix issue18076: allow -run to work with - (stdin)

### DIFF
--- a/src/ddmd/mars.d
+++ b/src/ddmd/mars.d
@@ -2156,7 +2156,10 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                         error("-run must be followed by a source file, not '%s'", arguments[i + 1]);
                         break;
                     }
-                    files.push(arguments[i + 1]);
+                    if (strcmp(arguments[i + 1], "-") == 0)
+                        files.push("__stdin.d");
+                    else
+                        files.push(arguments[i + 1]);
                     params.runargs.setDim(length - 1);
                     for (size_t j = 0; j < length - 1; ++j)
                     {

--- a/test/runnable/test18076.sh
+++ b/test/runnable/test18076.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+dir=${RESULTS_DIR}${SEP}runnable
+output_file=${dir}/test18076.sh.out
+
+echo 'import std.stdio; void main() { writeln("Success"); }' | \
+	$DMD -m${MODEL} -run - > ${output_file} || exit 1
+grep -q '^Success$' ${output_file} || exit 1


### PR DESCRIPTION
Turns out, only a trivial change is needed to make this work, by hooking into the code implemented in #6880 for reading source code from stdin.

With this change, dmd acquires the functionality:
````
$ echo 'import std.stdio; void main() { writeln("Hello, World!"); }' | dmd -run -
Hello, World!
$
````
which compiles and runs standard input without the user needing to specify any intermediate filenames.

The above is a trivial example, of course.  A more pertinent use case would be executing the source code in an editor's buffer via stdin, and having the output captured by the editor as stdout, without needing to specify intermediate temporary files.  Another use case would be code generation tools that can instantly produce output without needing to manage temporary files.