### PR TITLE
Make the Visitor class inherit the ParseTimeVisitor

### DIFF
--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -19,115 +19,112 @@ import dmd.root.rootobject;
 
 // Online documentation: https://dlang.org/phobos/dmd_visitor.html
 
-
-/** Visitor instantianted with the code generation AST family
+/**
+ * Classic Visitor class which implements visit methods for all the AST
+ * nodes present in the compiler. The visit methods for AST nodes
+ * created at parse time are inherited while the visiting methods
+ * for AST nodes created at semantic time are implemented.
  */
-alias Visitor = GenericVisitor!ASTCodegen;
-
-// Generic visitor which implements a visit method for all the AST nodes.
-private extern (C++) class GenericVisitor(AST) : ParseTimeVisitor!AST
+extern (C++) class Visitor : ParseTimeVisitor!ASTCodegen
 {
-    alias visit = ParseTimeVisitor!AST.visit;
+    alias visit = ParseTimeVisitor!ASTCodegen.visit;
 public:
-    void visit(AST.ErrorStatement s) { visit(cast(AST.Statement)s); }
-    void visit(AST.PeelStatement s) { visit(cast(AST.Statement)s); }
-    void visit(AST.UnrolledLoopStatement s) { visit(cast(AST.Statement)s); }
-    void visit(AST.SwitchErrorStatement s) { visit(cast(AST.Statement)s); }
-    void visit(AST.DebugStatement s) { visit(cast(AST.Statement)s); }
-    void visit(AST.DtorExpStatement s) { visit(cast(AST.ExpStatement)s); }
-    void visit(AST.ForwardingStatement s)
+    void visit(ASTCodegen.ErrorStatement s) { visit(cast(ASTCodegen.Statement)s); }
+    void visit(ASTCodegen.PeelStatement s) { visit(cast(ASTCodegen.Statement)s); }
+    void visit(ASTCodegen.UnrolledLoopStatement s) { visit(cast(ASTCodegen.Statement)s); }
+    void visit(ASTCodegen.SwitchErrorStatement s) { visit(cast(ASTCodegen.Statement)s); }
+    void visit(ASTCodegen.DebugStatement s) { visit(cast(ASTCodegen.Statement)s); }
+    void visit(ASTCodegen.DtorExpStatement s) { visit(cast(ASTCodegen.ExpStatement)s); }
+    void visit(ASTCodegen.ForwardingStatement s)
     {
         if(s.statement)
             s.statement.accept(this);
     }
-    void visit(AST.OverloadSet s) { visit(cast(AST.Dsymbol)s); }
-    void visit(AST.LabelDsymbol s) { visit(cast(AST.Dsymbol)s); }
-    void visit(AST.WithScopeSymbol s) { visit(cast(AST.ScopeDsymbol)s); }
-    void visit(AST.ArrayScopeSymbol s) { visit(cast(AST.ScopeDsymbol)s); }
-    void visit(AST.OverDeclaration s) { visit(cast(AST.Declaration)s); }
-    void visit(AST.SymbolDeclaration s) { visit(cast(AST.Declaration)s); }
-    void visit(AST.ThisDeclaration s) { visit(cast(AST.VarDeclaration)s); }
-    void visit(AST.TypeInfoDeclaration s) { visit(cast(AST.VarDeclaration)s); }
-    void visit(AST.TypeInfoStructDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoClassDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoInterfaceDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoPointerDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoArrayDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoStaticArrayDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoAssociativeArrayDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoEnumDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoFunctionDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoDelegateDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoTupleDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoConstDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoInvariantDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoSharedDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoWildDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.TypeInfoVectorDeclaration s) { visit(cast(AST.TypeInfoDeclaration)s); }
-    void visit(AST.FuncAliasDeclaration s) { visit(cast(AST.FuncDeclaration)s); }
-    void visit(AST.ErrorInitializer i) { visit(cast(AST.Initializer)i); }
-    void visit(AST.ErrorExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.ComplexExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.StructLiteralExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.SymOffExp e) { visit(cast(AST.SymbolExp)e); }
-    void visit(AST.OverExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.HaltExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.DotTemplateExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.DotVarExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.DelegateExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.DotTypeExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.VectorExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.SliceExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.ArrayLengthExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.DelegatePtrExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.DelegateFuncptrExp e) { visit(cast(AST.UnaExp)e); }
-    void visit(AST.DotExp e) { visit(cast(AST.BinExp)e); }
-    void visit(AST.IndexExp e) { visit(cast(AST.BinExp)e); }
-    void visit(AST.ConstructExp e) { visit(cast(AST.AssignExp)e); }
-    void visit(AST.BlitExp e) { visit(cast(AST.AssignExp)e); }
-    void visit(AST.RemoveExp e) { visit(cast(AST.BinExp)e); }
-    void visit(AST.ClassReferenceExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.VoidInitExp e) { visit(cast(AST.Expression)e); }
-    void visit(AST.ThrownExceptionExp e) { visit(cast(AST.Expression)e); }
+    void visit(ASTCodegen.OverloadSet s) { visit(cast(ASTCodegen.Dsymbol)s); }
+    void visit(ASTCodegen.LabelDsymbol s) { visit(cast(ASTCodegen.Dsymbol)s); }
+    void visit(ASTCodegen.WithScopeSymbol s) { visit(cast(ASTCodegen.ScopeDsymbol)s); }
+    void visit(ASTCodegen.ArrayScopeSymbol s) { visit(cast(ASTCodegen.ScopeDsymbol)s); }
+    void visit(ASTCodegen.OverDeclaration s) { visit(cast(ASTCodegen.Declaration)s); }
+    void visit(ASTCodegen.SymbolDeclaration s) { visit(cast(ASTCodegen.Declaration)s); }
+    void visit(ASTCodegen.ThisDeclaration s) { visit(cast(ASTCodegen.VarDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoDeclaration s) { visit(cast(ASTCodegen.VarDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoStructDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoClassDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoInterfaceDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoPointerDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoArrayDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoStaticArrayDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoAssociativeArrayDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoEnumDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoFunctionDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoDelegateDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoTupleDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoConstDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoInvariantDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoSharedDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoWildDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoVectorDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.FuncAliasDeclaration s) { visit(cast(ASTCodegen.FuncDeclaration)s); }
+    void visit(ASTCodegen.ErrorInitializer i) { visit(cast(ASTCodegen.Initializer)i); }
+    void visit(ASTCodegen.ErrorExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.ComplexExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.StructLiteralExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.SymOffExp e) { visit(cast(ASTCodegen.SymbolExp)e); }
+    void visit(ASTCodegen.OverExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.HaltExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.DotTemplateExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.DotVarExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.DelegateExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.DotTypeExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.VectorExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.SliceExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.ArrayLengthExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.DelegatePtrExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.DelegateFuncptrExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.DotExp e) { visit(cast(ASTCodegen.BinExp)e); }
+    void visit(ASTCodegen.IndexExp e) { visit(cast(ASTCodegen.BinExp)e); }
+    void visit(ASTCodegen.ConstructExp e) { visit(cast(ASTCodegen.AssignExp)e); }
+    void visit(ASTCodegen.BlitExp e) { visit(cast(ASTCodegen.AssignExp)e); }
+    void visit(ASTCodegen.RemoveExp e) { visit(cast(ASTCodegen.BinExp)e); }
+    void visit(ASTCodegen.ClassReferenceExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.VoidInitExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.ThrownExceptionExp e) { visit(cast(ASTCodegen.Expression)e); }
 }
 
-/** Permissive visitor instantiated with the code generation AST family
+/**
+ * The PermissiveVisitor overrides the root AST nodes with
+ * empty visiting methods.
  */
-alias SemanticTimePermissiveVisitor = GenericPermissiveVisitor!ASTCodegen;
-
-// Generic permissive visitor where all the nodes do nothing
-private extern (C++) class GenericPermissiveVisitor(AST) : GenericVisitor!AST
+extern (C++) class SemanticTimePermissiveVisitor : Visitor
 {
-    alias visit = GenericVisitor!AST.visit;
+    alias visit = Visitor.visit;
 
-    override void visit(AST.Dsymbol){}
-    override void visit(AST.Parameter){}
-    override void visit(AST.Statement){}
-    override void visit(AST.Type){}
-    override void visit(AST.Expression){}
-    override void visit(AST.TemplateParameter){}
-    override void visit(AST.Condition){}
-    override void visit(AST.Initializer){}
+    override void visit(ASTCodegen.Dsymbol){}
+    override void visit(ASTCodegen.Parameter){}
+    override void visit(ASTCodegen.Statement){}
+    override void visit(ASTCodegen.Type){}
+    override void visit(ASTCodegen.Expression){}
+    override void visit(ASTCodegen.TemplateParameter){}
+    override void visit(ASTCodegen.Condition){}
+    override void visit(ASTCodegen.Initializer){}
 }
 
-/** Transitive visitor instantiated with the code generation AST family
+/**
+ * The TransitiveVisitor implements the AST traversal logic for all AST nodes.
  */
-alias SemanticTimeTransitiveVisitor = GenericTransitiveVisitor!ASTCodegen;
-
-// The generic TransitiveVisitor implements all the AST nodes traversal logic
-private extern (C++) class GenericTransitiveVisitor(AST) : GenericPermissiveVisitor!AST
+extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
 {
-    alias visit = GenericPermissiveVisitor!AST.visit;
+    alias visit = SemanticTimePermissiveVisitor.visit;
 
-    mixin ParseVisitMethods!AST;
+    mixin ParseVisitMethods!ASTCodegen;
 
-    override void visit(AST.PeelStatement s)
+    override void visit(ASTCodegen.PeelStatement s)
     {
         if (s.s)
             s.s.accept(this);
     }
 
-    override void visit(AST.UnrolledLoopStatement s)
+    override void visit(ASTCodegen.UnrolledLoopStatement s)
     {
         foreach(sx; *s.statements)
         {
@@ -136,19 +133,19 @@ private extern (C++) class GenericTransitiveVisitor(AST) : GenericPermissiveVisi
         }
     }
 
-    override void visit(AST.DebugStatement s)
+    override void visit(ASTCodegen.DebugStatement s)
     {
         if (s.statement)
             s.statement.accept(this);
     }
 
-    override void visit(AST.ForwardingStatement s)
+    override void visit(ASTCodegen.ForwardingStatement s)
     {
         if (s.statement)
             s.statement.accept(this);
     }
 
-    override void visit(AST.StructLiteralExp e)
+    override void visit(ASTCodegen.StructLiteralExp e)
     {
         // CTFE can generate struct literals that contain an AddrExp pointing to themselves,
         // need to avoid infinite recursion.
@@ -163,34 +160,34 @@ private extern (C++) class GenericTransitiveVisitor(AST) : GenericPermissiveVisi
         }
     }
 
-    override void visit(AST.DotTemplateExp e)
+    override void visit(ASTCodegen.DotTemplateExp e)
     {
         e.e1.accept(this);
     }
 
-    override void visit(AST.DotVarExp e)
+    override void visit(ASTCodegen.DotVarExp e)
     {
         e.e1.accept(this);
     }
 
-    override void visit(AST.DelegateExp e)
+    override void visit(ASTCodegen.DelegateExp e)
     {
         if (!e.func.isNested())
             e.e1.accept(this);
     }
 
-    override void visit(AST.DotTypeExp e)
+    override void visit(ASTCodegen.DotTypeExp e)
     {
         e.e1.accept(this);
     }
 
-    override void visit(AST.VectorExp e)
+    override void visit(ASTCodegen.VectorExp e)
     {
         visitType(e.to);
         e.e1.accept(this);
     }
 
-    override void visit(AST.SliceExp e)
+    override void visit(ASTCodegen.SliceExp e)
     {
         e.e1.accept(this);
         if (e.upr)
@@ -199,34 +196,34 @@ private extern (C++) class GenericTransitiveVisitor(AST) : GenericPermissiveVisi
             e.lwr.accept(this);
     }
 
-    override void visit(AST.ArrayLengthExp e)
+    override void visit(ASTCodegen.ArrayLengthExp e)
     {
         e.e1.accept(this);
     }
 
-    override void visit(AST.DelegatePtrExp e)
+    override void visit(ASTCodegen.DelegatePtrExp e)
     {
         e.e1.accept(this);
     }
 
-    override void visit(AST.DelegateFuncptrExp e)
+    override void visit(ASTCodegen.DelegateFuncptrExp e)
     {
         e.e1.accept(this);
     }
 
-    override void visit(AST.DotExp e)
-    {
-        e.e1.accept(this);
-        e.e2.accept(this);
-    }
-
-    override void visit(AST.IndexExp e)
+    override void visit(ASTCodegen.DotExp e)
     {
         e.e1.accept(this);
         e.e2.accept(this);
     }
 
-    override void visit(AST.RemoveExp e)
+    override void visit(ASTCodegen.IndexExp e)
+    {
+        e.e1.accept(this);
+        e.e2.accept(this);
+    }
+
+    override void visit(ASTCodegen.RemoveExp e)
     {
         e.e1.accept(this);
         e.e2.accept(this);


### PR DESCRIPTION
@ibuclaw Is there anything else that should be done in order to make the visitor compatible with gdc? Should the header files be updated so that the inheritance is visible?