### PR TITLE
Remove unused ScopeDsymbol parameter from include()

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -44,7 +44,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         this.decl = decl;
     }
 
-    Dsymbols* include(Scope* sc, ScopeDsymbol sds)
+    Dsymbols* include(Scope* sc)
     {
         if (errors)
             return null;
@@ -54,7 +54,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override final int apply(Dsymbol_apply_ft_t fp, void* param)
     {
-        Dsymbols* d = include(_scope, null);
+        Dsymbols* d = include(_scope);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -113,7 +113,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        Dsymbols* d = include(sc, sds);
+        Dsymbols* d = include(sc);
         if (d)
         {
             Scope* sc2 = newScope(sc);
@@ -130,7 +130,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void setScope(Scope* sc)
     {
-        Dsymbols* d = include(sc, null);
+        Dsymbols* d = include(sc);
         //printf("\tAttribDeclaration::setScope '%s', d = %p\n",toChars(), d);
         if (d)
         {
@@ -147,7 +147,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override void importAll(Scope* sc)
     {
-        Dsymbols* d = include(sc, null);
+        Dsymbols* d = include(sc);
         //printf("\tAttribDeclaration::importAll '%s', d = %p\n", toChars(), d);
         if (d)
         {
@@ -167,7 +167,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         //printf("AttribDeclaration::addComment %s\n", comment);
         if (comment)
         {
-            Dsymbols* d = include(null, null);
+            Dsymbols* d = include(null);
             if (d)
             {
                 for (size_t i = 0; i < d.dim; i++)
@@ -187,13 +187,13 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override bool oneMember(Dsymbol* ps, Identifier ident)
     {
-        Dsymbols* d = include(null, null);
+        Dsymbols* d = include(null);
         return Dsymbol.oneMembers(d, ps, ident);
     }
 
     override void setFieldOffset(AggregateDeclaration ad, uint* poffset, bool isunion)
     {
-        Dsymbols* d = include(null, null);
+        Dsymbols* d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -206,7 +206,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override final bool hasPointers()
     {
-        Dsymbols* d = include(null, null);
+        Dsymbols* d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -221,7 +221,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override final bool hasStaticCtorOrDtor()
     {
-        Dsymbols* d = include(null, null);
+        Dsymbols* d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -236,7 +236,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
 
     override final void checkCtorConstInit()
     {
-        Dsymbols* d = include(null, null);
+        Dsymbols* d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -251,7 +251,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
      */
     override final void addLocalClass(ClassDeclarations* aclasses)
     {
-        Dsymbols* d = include(null, null);
+        Dsymbols* d = include(null);
         if (d)
         {
             for (size_t i = 0; i < d.dim; i++)
@@ -342,7 +342,7 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        Dsymbols* d = include(sc, sds);
+        Dsymbols* d = include(sc);
         if (d)
         {
             Scope* sc2 = newScope(sc);
@@ -847,7 +847,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
         //printf("ConditionalDeclaration::oneMember(), inc = %d\n", condition.inc);
         if (condition.inc)
         {
-            Dsymbols* d = condition.include(null, null) ? decl : elsedecl;
+            Dsymbols* d = condition.include(null) ? decl : elsedecl;
             return Dsymbol.oneMembers(d, ps, ident);
         }
         else
@@ -859,7 +859,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
     }
 
     // Decide if 'then' or 'else' code should be included
-    override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
+    override Dsymbols* include(Scope* sc)
     {
         //printf("ConditionalDeclaration::include(sc = %p) scope = %p\n", sc, scope);
 
@@ -867,7 +867,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
             return null;
 
         assert(condition);
-        return condition.include(_scope ? _scope : sc, sds) ? decl : elsedecl;
+        return condition.include(_scope ? _scope : sc) ? decl : elsedecl;
     }
 
     override final void addComment(const(char)* comment)
@@ -898,7 +898,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
 
     override void setScope(Scope* sc)
     {
-        Dsymbols* d = include(sc, null);
+        Dsymbols* d = include(sc);
         //printf("\tConditionalDeclaration::setScope '%s', d = %p\n",toChars(), d);
         if (d)
         {
@@ -939,7 +939,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
      * Different from other AttribDeclaration subclasses, include() call requires
      * the completion of addMember and setScope phases.
      */
-    override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
+    override Dsymbols* include(Scope* sc)
     {
         //printf("StaticIfDeclaration::include(sc = %p) scope = %p\n", sc, scope);
 
@@ -950,7 +950,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
         {
             assert(scopesym); // addMember is already done
             assert(_scope); // setScope is already done
-            Dsymbols* d = ConditionalDeclaration.include(_scope, scopesym);
+            Dsymbols* d = ConditionalDeclaration.include(_scope);
             if (d && !addisdone)
             {
                 // Add members lazily.
@@ -971,7 +971,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
         }
         else
         {
-            return ConditionalDeclaration.include(sc, scopesym);
+            return ConditionalDeclaration.include(sc);
         }
     }
 
@@ -1064,7 +1064,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         return false;
     }
 
-    override Dsymbols* include(Scope* sc, ScopeDsymbol sds)
+    override Dsymbols* include(Scope* sc)
     {
         if (errors)
             return null;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -33,7 +33,7 @@ class AttribDeclaration : public Dsymbol
 public:
     Dsymbols *decl;     // array of Dsymbol's
 
-    virtual Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
+    virtual Dsymbols *include(Scope *sc);
     int apply(Dsymbol_apply_ft_t fp, void *param);
     static Scope *createNewScope(Scope *sc,
         StorageClass newstc, LINK linkage, CPPMANGLE cppmangle, Prot protection,
@@ -169,7 +169,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
+    Dsymbols *include(Scope *sc);
     void addComment(const utf8_t *comment);
     void setScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
@@ -182,7 +182,7 @@ public:
     bool addisdone;
 
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
+    Dsymbols *include(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
     void importAll(Scope *sc);
@@ -200,7 +200,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
+    Dsymbols *include(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void addComment(const utf8_t *comment);
     void setScope(Scope *sc);

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -244,7 +244,7 @@ private bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow
     ad = s.isAttribDeclaration();
     if (ad)
     {
-        Dsymbols* decl = ad.include(null, null);
+        Dsymbols* decl = ad.include(null);
         if (decl && decl.dim)
         {
             for (size_t i = 0; i < decl.dim; i++)

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -59,7 +59,7 @@ extern (C++) abstract class Condition : RootObject
 
     abstract Condition syntaxCopy();
 
-    abstract int include(Scope* sc, ScopeDsymbol sds);
+    abstract int include(Scope* sc);
 
     DebugCondition isDebugCondition()
     {
@@ -502,7 +502,7 @@ extern (C++) final class DebugCondition : DVCondition
         super(mod, level, ident);
     }
 
-    override int include(Scope* sc, ScopeDsymbol sds)
+    override int include(Scope* sc)
     {
         //printf("DebugCondition::include() level = %d, debuglevel = %d\n", level, global.params.debuglevel);
         if (inc == 0)
@@ -768,7 +768,7 @@ extern (C++) final class VersionCondition : DVCondition
         super(mod, level, ident);
     }
 
-    override int include(Scope* sc, ScopeDsymbol sds)
+    override int include(Scope* sc)
     {
         //printf("VersionCondition::include() level = %d, versionlevel = %d\n", level, global.params.versionlevel);
         //if (ident) printf("\tident = '%s'\n", ident.toChars());
@@ -832,16 +832,9 @@ extern (C++) final class StaticIfCondition : Condition
         return new StaticIfCondition(loc, exp.syntaxCopy());
     }
 
-    override int include(Scope* sc, ScopeDsymbol sds)
+    override int include(Scope* sc)
     {
-        version (none)
-        {
-            printf("StaticIfCondition::include(sc = %p, sds = %p) this=%p inc = %d\n", sc, sds, this, inc);
-            if (sds)
-            {
-                printf("\ts = '%s', kind = %s\n", sds.toChars(), sds.kind());
-            }
-        }
+        // printf("StaticIfCondition::include(sc = %p) this=%p inc = %d\n", sc, this, inc);
 
         int errorReturn()
         {
@@ -866,7 +859,6 @@ extern (C++) final class StaticIfCondition : Condition
 
             ++nest;
             sc = sc.push(sc.scopesym);
-            sc.sds = sds; // sds gets any addMember()
 
             import dmd.staticcond;
             bool errors;

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -72,7 +72,7 @@ public:
     static void setGlobalLevel(unsigned level);
     static void addGlobalIdent(const char *ident);
 
-    int include(Scope *sc, ScopeDsymbol *sds);
+    int include(Scope *sc);
     DebugCondition *isDebugCondition() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -84,7 +84,7 @@ public:
     static void addGlobalIdent(const char *ident);
     static void addPredefinedGlobalIdent(const char *ident);
 
-    int include(Scope *sc, ScopeDsymbol *sds);
+    int include(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -95,7 +95,7 @@ public:
     int nest;         // limit circular dependencies
 
     Condition *syntaxCopy();
-    int include(Scope *sc, ScopeDsymbol *sds);
+    int include(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -1041,7 +1041,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
              * (only template instantiations).
              * Hence, Ddoc omits attributes from template members.
              */
-            Dsymbols* d = ad.include(null, null);
+            Dsymbols* d = ad.include(null);
             if (d)
             {
                 for (size_t i = 0; i < d.dim; i++)
@@ -1075,7 +1075,7 @@ extern (C++) void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                 return;
             }
             /* If generating doc comment, be careful because if we're inside
-             * a template, then include(NULL, NULL) will fail.
+             * a template, then include(null) will fail.
              */
             Dsymbols* d = cd.decl ? cd.decl : cd.elsedecl;
             for (size_t i = 0; i < d.dim; i++)

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -117,7 +117,6 @@ struct Scope
 
     Module _module;                 /// Root module
     ScopeDsymbol scopesym;          /// current symbol
-    ScopeDsymbol sds;               /// if in static if, and declaring new symbols, sds gets the addMember()
     FuncDeclaration func;           /// function we are in
     Dsymbol parent;                 /// parent to use
     LabelStatement slabel;          /// enclosing labelled statement
@@ -231,7 +230,6 @@ struct Scope
         //printf("Scope::push(this = %p) new = %p\n", this, s);
         assert(!(flags & SCOPEfree));
         s.scopesym = null;
-        s.sds = null;
         s.enclosing = &this;
         debug
         {
@@ -766,7 +764,6 @@ struct Scope
     {
         this._module = sc._module;
         this.scopesym = sc.scopesym;
-        this.sds = sc.sds;
         this.enclosing = sc.enclosing;
         this.parent = sc.parent;
         this.sw = sc.sw;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1688,7 +1688,7 @@ public:
         {
             Dsymbol s = (*members)[i];
             if (AttribDeclaration a = s.isAttribDeclaration())
-                result = _foreach(sc, a.include(sc, null), dg, &n);
+                result = _foreach(sc, a.include(sc), dg, &n);
             else if (TemplateMixin tm = s.isTemplateMixin())
                 result = _foreach(sc, tm.members, dg, &n);
             else if (s.isTemplateInstance())

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -82,7 +82,7 @@ private uint setMangleOverride(Dsymbol s, char* sym)
     AttribDeclaration ad = s.isAttribDeclaration();
     if (ad)
     {
-        Dsymbols* decls = ad.include(null, null);
+        Dsymbols* decls = ad.include(null);
         uint nestedCount = 0;
         if (decls && decls.dim)
             for (size_t i = 0; i < decls.dim; ++i)
@@ -429,7 +429,7 @@ extern(C++) final class Semantic2Visitor : Visitor
 
     override void visit(AttribDeclaration ad)
     {
-        Dsymbols* d = ad.include(sc, null);
+        Dsymbols* d = ad.include(sc);
         if (d)
         {
             Scope* sc2 = ad.newScope(sc);
@@ -1714,7 +1714,7 @@ extern(C++) final class Semantic3Visitor : Visitor
 
     override void visit(AttribDeclaration ad)
     {
-        Dsymbols* d = ad.include(sc, null);
+        Dsymbols* d = ad.include(sc);
         if (d)
         {
             Scope* sc2 = ad.newScope(sc);
@@ -2860,7 +2860,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (ad.semanticRun != PASSinit)
             return;
         ad.semanticRun = PASSsemantic;
-        Dsymbols* d = ad.include(sc, null);
+        Dsymbols* d = ad.include(sc);
         //printf("\tAttribDeclaration::semantic '%s', d = %p\n",toChars(), d);
         if (d)
         {

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5125,7 +5125,7 @@ elem *toElem(Expression e, IRState *irs)
             //printf("Dsymbol_toElem() %s\n", s.toChars());
             if (AttribDeclaration ad = s.isAttribDeclaration())
             {
-                Dsymbols *decl = ad.include(null, null);
+                Dsymbols *decl = ad.include(null);
                 if (decl && decl.dim)
                 {
                     for (size_t i = 0; i < decl.dim; i++)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4070,9 +4070,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (m <= MATCH.nomatch)
                         goto Lno;
                     s.dsymbolSemantic(sc);
-                    if (sc.sds)
-                        s.addMember(sc, sc.sds);
-                    else if (!sc.insert(s))
+                    if (!sc.insert(s))
                         e.error("declaration %s is already defined", s.toChars());
 
                     unSpeculative(sc, s);
@@ -4105,8 +4103,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              */
             if (!tup && !sc.insert(s))
                 e.error("declaration %s is already defined", s.toChars());
-            if (sc.sds)
-                s.addMember(sc, sc.sds);
 
             unSpeculative(sc, s);
         }

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1400,7 +1400,7 @@ public:
 
     override void visit(AttribDeclaration d)
     {
-        Dsymbols* decls = d.include(null, null);
+        Dsymbols* decls = d.include(null);
         if (decls)
         {
             foreach (i; 0 .. decls.dim)

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -551,7 +551,7 @@ public:
 
     override void visit(AttribDeclaration d)
     {
-        Dsymbols* ds = d.include(null, null);
+        Dsymbols* ds = d.include(null);
         if (ds)
         {
             for (size_t i = 0; i < ds.dim; i++)

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -77,8 +77,6 @@ struct Scope
 
     Module *_module;            // Root module
     ScopeDsymbol *scopesym;     // current symbol
-    ScopeDsymbol *sds;          // if in static if, and declaring new symbols,
-                                // sds gets the addMember()
     FuncDeclaration *func;      // function we are in
     Dsymbol *parent;            // parent to use
     LabelStatement *slabel;     // enclosing labelled statement

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -590,7 +590,7 @@ extern (C++) Statement toStatement(Dsymbol s)
 
         override void visit(ConditionalDeclaration d)
         {
-            result = visitMembers(d.loc, d.include(null, null));
+            result = visitMembers(d.loc, d.include(null));
         }
 
         override void visit(StaticForeachDeclaration d)
@@ -602,7 +602,7 @@ extern (C++) Statement toStatement(Dsymbol s)
 
         override void visit(CompileDeclaration d)
         {
-            result = visitMembers(d.loc, d.include(null, null));
+            result = visitMembers(d.loc, d.include(null));
         }
     }
 
@@ -1471,7 +1471,7 @@ extern (C++) final class ConditionalStatement : Statement
         Statement s;
 
         //printf("ConditionalStatement::flatten()\n");
-        if (condition.include(sc, null))
+        if (condition.include(sc))
         {
             DebugCondition dc = condition.isDebugCondition();
             if (dc)

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2167,7 +2167,7 @@ else
         // If we can short-circuit evaluate the if statement, don't do the
         // semantic analysis of the skipped code.
         // This feature allows a limited form of conditional compilation.
-        if (cs.condition.include(sc, null))
+        if (cs.condition.include(sc))
         {
             DebugCondition dc = cs.condition.isDebugCondition();
             if (dc)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1066,7 +1066,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
         override void visit(AttribDeclaration ad)
         {
-            Dsymbols *d = ad.include(null, null);
+            Dsymbols *d = ad.include(null);
 
             if (d)
             {
@@ -1127,7 +1127,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     if (auto ad = s.isAttribDeclaration())
                     {
                         uint nestedCount;
-                        auto decls = ad.include(null, null);
+                        auto decls = ad.include(null);
                         if (decls)
                         {
                             for (size_t i = 0; i < decls.dim; ++i)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1496,7 +1496,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 {
                     if (auto atd = s.isAttribDeclaration())
                     {
-                        collectUnitTests(atd.include(null, null));
+                        collectUnitTests(atd.include(null));
                         continue;
                     }
                     if (auto ud = s.isUnitTestDeclaration())


### PR DESCRIPTION
Partial revival of #4815

The `ScopeDsymbol sds` parameter to `include` was never used, and almost all calls to it just passed `null`.  Where `null` wasn't passed, it was fruitless.

Also the `Scope.sds` member was simply set to `null` and never actually used.

The benefit of this PR is it reduces some useless noise in the code.

@ibuclaw C++ interface changes