### PR TITLE
Issue 9631 - Error message not using fully qualified name (part 2)

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4827,11 +4827,19 @@ extern (C++) abstract class BinExp : Expression
         TOK thisOp = (op == TOKquestion) ? TOKcolon : op;
         if (e1.op == TOKtype || e2.op == TOKtype)
         {
-            error("incompatible types for ((%s) %s (%s)): cannot use '%s' with types", e1.toChars(), Token.toChars(thisOp), e2.toChars(), Token.toChars(op));
+            error("incompatible types for ((%s) %s (%s)): cannot use '%s' with types",
+                e1.toChars(), Token.toChars(thisOp), e2.toChars(), Token.toChars(op));
+        }
+        else if (e1.type.equals(e2.type))
+        {
+            error("incompatible types for ((%s) %s (%s)): both operands are of type '%s'",
+                e1.toChars(), Token.toChars(thisOp), e2.toChars(), e1.type.toChars());
         }
         else
         {
-            error("incompatible types for ((%s) %s (%s)): '%s' and '%s'", e1.toChars(), Token.toChars(thisOp), e2.toChars(), e1.type.toChars(), e2.type.toChars());
+            auto ts = toAutoQualChars(e1.type, e2.type);
+            error("incompatible types for ((%s) %s (%s)): '%s' and '%s'",
+                e1.toChars(), Token.toChars(thisOp), e2.toChars(), ts[0], ts[1]);
         }
         return new ErrorExp();
     }

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -1,32 +1,42 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(17): Error: cannot implicitly convert expression `F()` of type `bug9631.tem!().F` to `bug9631.F`
+fail_compilation/bug9631.d(20): Error: cannot implicitly convert expression `F()` of type `bug9631.T1!().F` to `bug9631.T2!().F`
 ---
 */
 
-struct F { }
-
-template tem()
+template T1()
 {
     struct F { }
 }
 
-void convert()
+template T2()
 {
-    F x = tem!().F();
+    struct F { }
+}
+
+void main()
+{
+    T2!().F x = T1!().F();
 }
 
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(31): Error: incompatible types for ((x) == (y)): 'bug9631.F' and 'bug9631.tem!().F'
+fail_compilation/bug9631.d(41): Error: incompatible types for ((x) == (y)): 'bug9631.S' and 'bug9631.tem!().S'
 ---
 */
 
+struct S { char c; }
+
+template tem()
+{
+    struct S { int i; }
+}
+
 void equal()
 {
-    F x;
-    auto y = tem!().F();
+    S x;
+    auto y = tem!().S();
     bool b = x == y;
 }

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -1,21 +1,32 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(20): Error: cannot implicitly convert expression `F()` of type `bug9631.T1!().F` to `bug9631.T2!().F`
+fail_compilation/bug9631.d(17): Error: cannot implicitly convert expression `F()` of type `bug9631.tem!().F` to `bug9631.F`
 ---
 */
 
-template T1()
+struct F { }
+
+template tem()
 {
     struct F { }
 }
 
-template T2()
+void convert()
 {
-    struct F { }
+    F x = tem!().F();
 }
 
-void main()
+/*
+TEST_OUTPUT:
+---
+fail_compilation/bug9631.d(31): Error: incompatible types for ((x) == (y)): 'bug9631.F' and 'bug9631.tem!().F'
+---
+*/
+
+void equal()
 {
-    T2!().F x = T1!().F();
+    F x;
+    auto y = tem!().F();
+    bool b = x == y;
 }

--- a/test/fail_compilation/fail11445.d
+++ b/test/fail_compilation/fail11445.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11445.d(11): Error: incompatible types for ((a) + (b)): 'double[string]' and 'double[string]'
+fail_compilation/fail11445.d(11): Error: incompatible types for ((a) + (b)): both operands are of type 'double[string]'
 ---
 */
 

--- a/test/fail_compilation/fail3.d
+++ b/test/fail_compilation/fail3.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3.d(40): Error: incompatible types for ((a) + (b)): 'vec2' and 'vec2'
+fail_compilation/fail3.d(33): Error: incompatible types for ((a) + (b)): both operands are of type 'vec2'
 ---
 */
 
@@ -14,20 +14,13 @@ template vector(T)
         T x, y;
     }
 
+    // not struct member
     vec2 opAdd(vec2 a, vec2 b)
     {
         vec2 r;
         r.x = a.x + b.x;
         r.y = a.y + b.y;
         return r;
-    }
-
-    vec2 make2(T x, T y)
-    {
-        vec2 a;
-        a.x = x;
-        a.y = y;
-        return a;
     }
 }
 

--- a/test/fail_compilation/fail3.d
+++ b/test/fail_compilation/fail3.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3.d(33): Error: incompatible types for ((a) + (b)): both operands are of type 'vec2'
+fail_compilation/fail3.d(41): Error: incompatible types for ((a) + (b)): both operands are of type 'vec2'
 ---
 */
 
@@ -21,6 +21,14 @@ template vector(T)
         r.x = a.x + b.x;
         r.y = a.y + b.y;
         return r;
+    }
+
+    vec2 make2(T x, T y)
+    {
+        vec2 a;
+        a.x = x;
+        a.y = y;
+        return a;
     }
 }
 

--- a/test/fail_compilation/fail79.d
+++ b/test/fail_compilation/fail79.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail79.d(13): Error: incompatible types for ((& a) + (& b)): 'int*' and 'int*'
+fail_compilation/fail79.d(13): Error: incompatible types for ((& a) + (& b)): both operands are of type 'int*'
 ---
 */
 


### PR DESCRIPTION
@JinShil Following on from #7405.

* Disambiguate incompatible type errors.
* Add "both operands are of type '%s'" error message case.

The latter saves the programmer time reading the error when there are two types with long qualification.