### PR TITLE
Fix issue 7184 - parse error on *(x)++

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7973,6 +7973,13 @@ final class Parser(AST) : Lexer
                                     e = new AST.TypeExp(loc, t);
                                     e = parsePostExp(e);
                                 }
+                                else if (token.value == TOKplusplus || token.value == TOKminusminus)
+                                {
+                                    // if ()++
+                                    // or ()--
+                                    e = new AST.TypeExp(loc, t);
+                                    e = parsePostExp(e);
+                                }
                                 else
                                 {
                                     e = parseUnaryExp();

--- a/test/runnable/test7184.d
+++ b/test/runnable/test7184.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=7184
+
+void main()
+{
+    auto a = 0;
+    auto b = (a)++;
+    assert(a == 1);
+    assert(b == 0);
+
+    a = 1;
+    b = 1;
+    b = (a)--;
+    assert(a == 0);
+    assert(b == 1);
+}


### PR DESCRIPTION
Revival of #7281

@WalterBright Added test for `(x)--`

@ibuclaw  `(int)++x` will result in _Error: semicolon expected, not x_
