### PR TITLE
Remove invalid file existence stat before dmd.conf

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -518,7 +518,7 @@ endef
 export DEFAULT_DMD_CONF
 
 $G/dmd.conf: $(SRC_MAKE)
-	[ -f $@ ] || echo "$$DEFAULT_DMD_CONF" > $@
+	echo "$$DEFAULT_DMD_CONF" > $@
 
 ######## REMOVE ME after the ddmd -> dmd transition
 dmd.conf:


### PR DESCRIPTION
dmd.conf solely depends on posix.mak and should always be regenerated if
the Makefile changes