### PR TITLE
Issue 9631 - Error message not using fully qualified name (part 3)

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1560,7 +1560,9 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             {
                 if (t1b.size(e.loc) == tob.size(e.loc))
                     goto Lok;
-                e.error("cannot cast expression `%s` of type `%s` to `%s` because of different sizes", e.toChars(), e.type.toChars(), t.toChars());
+                auto ts = toAutoQualChars(e.type, t);
+                e.error("cannot cast expression `%s` of type `%s` to `%s` because of different sizes",
+                    e.toChars(), ts[0], ts[1]);
                 result = new ErrorExp();
                 return;
             }
@@ -2469,7 +2471,9 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     return;
                 }
             }
-            e.error("cannot cast expression `%s` of type `%s` to `%s`", e.toChars(), tsa ? tsa.toChars() : e.type.toChars(), t.toChars());
+            auto ts = toAutoQualChars(tsa ? tsa : e.type, t);
+            e.error("cannot cast expression `%s` of type `%s` to `%s`",
+                e.toChars(), ts[0], ts[1]);
             result = new ErrorExp();
         }
     }

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -40,3 +40,21 @@ void equal()
     auto y = tem!().S();
     bool b = x == y;
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/bug9631.d(55): Error: cannot cast expression `x` of type `bug9631.S` to `bug9631.tem!().S` because of different sizes
+fail_compilation/bug9631.d(58): Error: cannot cast expression `ta` of type `bug9631.tem!().S[1]` to `bug9631.S[1]` because of different sizes
+fail_compilation/bug9631.d(59): Error: cannot cast expression `sa` of type `S[1]` to `S[]` since sizes don't line up
+---
+*/
+void test3()
+{
+    S x;
+    auto y = cast(tem!().S)x;
+
+    tem!().S[1] ta;
+    S[1] sa = cast(S[1])ta;
+    auto t2 = cast(tem!().S[])sa;
+}


### PR DESCRIPTION
Disambiguate cast error messages.

@JinShil another follow up from #7405.