### PR TITLE
Removed repo-specific mailmap in favor of dlang/tools/.mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,0 @@
-Daniel Murphy <yebblies@gmail.com> yebblies <yebblies@gmail.com>
-Hara Kenji <k.hara.pg+dev@gmail.com> k-hara <k.hara.pg@gmail.com>
-Iain Buclaw <ibuclaw@gdcproject.org> ibuclaw <ibuclaw@ubuntu.com>
-Kai Nacke <kai@redstar.de> kai <kai@redstar.de>
-Martin Nowak <code@dawg.eu> dawg <dawg@dawgfoto.de>
-Mathias Lang <mathias.lang@sociomantic.com> Geod24 <pro.mathias.lang@gmail.com>


### PR DESCRIPTION
For the new [contributors listing](https://dlang.org/contributors.html) on dlang.org we use a more complete `.mailmap` file at the [tools](https://github.com/dlang/tools/blob/master/.mailmap) repo. Let's make this the single source of truth.

See also: https://github.com/dlang/tools/pull/253#discussion_r157349799