### PR TITLE
enable test case for dip1008

### DIFF
--- a/test/compilable/testdip1008.d
+++ b/test/compilable/testdip1008.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// won't work until druntime is updated, so disable XXXEQUIRED_ARGS: -dip1008
+// REQUIRED_ARGS: -dip1008
 
 int bar()
 {


### PR DESCRIPTION
Now that https://github.com/dlang/druntime/pull/1804 is pulled, we can enable the test case from https://github.com/dlang/dmd/pull/6681