### PR TITLE
fix issue 18093: [Reg 2.071] MSCOFF: dmd crashes when overriding a C+…

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -614,12 +614,14 @@ extern (C++) class FuncDeclaration : Declaration
      */
     final BaseClass* overrideInterface()
     {
-        ClassDeclaration cd = parent.isClassDeclaration();
-        foreach (b; cd.interfaces)
+        if (ClassDeclaration cd = parent.isClassDeclaration())
         {
-            auto v = findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
-            if (v >= 0)
-                return b;
+            foreach (b; cd.interfaces)
+            {
+                auto v = findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
+                if (v >= 0)
+                    return b;
+            }
         }
         return null;
     }

--- a/test/fail_compilation/fail18093.d
+++ b/test/fail_compilation/fail18093.d
@@ -1,0 +1,27 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail18093.d(19): Error: function fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen).visit does not override any function, did you mean to override 'extern (C++) fail18093.ParseTimeVisitor!(ASTCodegen).ParseTimeVisitor.visit'?
+fail_compilation/fail18093.d(24): Error: mixin fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen) error instantiating
+fail_compilation/fail18093.d(27): Error: template instance fail18093.GenericTransitiveVisitor!(ASTCodegen) error instantiating
+---
+ * https://issues.dlang.org/show_bug.cgi?id=18093
+ */
+
+
+struct ASTCodegen {}
+
+extern (C++) class ParseTimeVisitor(AST)
+{
+    void visit() {}
+}
+template ParseVisitMethods(AST)
+{
+    override void visit() {}
+}
+
+class GenericTransitiveVisitor(AST) : ParseTimeVisitor!AST
+{
+    mixin ParseVisitMethods!AST;
+}
+
+alias SemanticTimeTransitiveVisitor = GenericTransitiveVisitor!ASTCodegen;


### PR DESCRIPTION
…+ method in a mixin template

Latest dmd no longer builds against VC...