### PR TITLE
Windows: fix range error in dmd with empty configuration file

### DIFF
--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -194,7 +194,7 @@ nothrow:
             // work around Windows file path length limitation
             // (see documentation for extendedPathThen).
             HANDLE h = name.extendedPathThen!
-                (p => CreateFileW(&p[0],
+                (p => CreateFileW(p,
                                   GENERIC_READ,
                                   FILE_SHARE_READ,
                                   null,
@@ -271,7 +271,7 @@ nothrow:
             // work around Windows file path length limitation
             // (see documentation for extendedPathThen).
             HANDLE h = name.extendedPathThen!
-                (p => CreateFileW(&p[0],
+                (p => CreateFileW(p,
                                   GENERIC_WRITE,
                                   0,
                                   null,


### PR DESCRIPTION
current debug version of dmd fails to build druntime due to "-conf=" causing a range error.

This removes unnecessary conversion wchar* -> wstring -> const(wchar)*

cc @atilaneves 