### PR TITLE
Move Compiler structure to own module.

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -1,0 +1,16 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 1999-2017 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/compiler.d, _compiler.d)
+ */
+
+module dmd.compiler;
+
+struct Compiler
+{
+    const(char)* vendor; // Compiler backend name
+}

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -1,0 +1,23 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 1999-2017 by The D Language Foundation
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/compiler.h
+ */
+
+#ifndef DMD_COMPILER_H
+#define DMD_COMPILER_H
+
+// This file contains a data structure that describes a back-end compiler
+// and implements compiler-specific actions.
+
+struct Compiler
+{
+    const char *vendor;     // Compiler backend name
+};
+
+#endif /* DMD_COMPILER_H */

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -19,6 +19,7 @@ import core.stdc.stdio;
 import dmd.root.array;
 import dmd.root.filename;
 import dmd.root.outbuffer;
+import dmd.compiler;
 import dmd.identifier;
 
 template xversion(string s)
@@ -213,11 +214,6 @@ struct Param
     const(char)* resfile;
     const(char)* exefile;
     const(char)* mapfile;
-}
-
-struct Compiler
-{
-    const(char)* vendor; // Compiler backend name
 }
 
 alias structalign_t = uint;

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -19,6 +19,7 @@
 #include "ctfloat.h"
 #include "outbuffer.h"
 #include "filename.h"
+#include "compiler.h"
 
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
@@ -198,11 +199,6 @@ struct Param
     const char *resfile;
     const char *exefile;
     const char *mapfile;
-};
-
-struct Compiler
-{
-    const char *vendor;     // Compiler backend name
 };
 
 typedef unsigned structalign_t;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -283,7 +283,7 @@ endif
 ######## DMD frontend source files
 
 FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes arrayop	\
-	arraytypes astcodegen attrib builtin canthrow clone complex cond constfold		\
+	arraytypes astcodegen attrib builtin canthrow clone compiler complex cond constfold	\
 	cppmangle cppmanglewin ctfeexpr dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\
@@ -401,7 +401,7 @@ TK_SRC = \
 ######## CXX header files (only needed for checkcxxheaders)
 
 SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
-	attrib.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
+	attrib.h compiler.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
 	enum.h errors.h expression.h globals.h hdrgen.h identifier.h \
 	import.h init.h intrange.h json.h \
 	mars.h module.h mtype.h nspace.h objc.h                         \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -150,7 +150,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 
 # D front end
 FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
-	$D/arraytypes.d $D/astcodegen.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/clone.d $D/complex.d		\
+	$D/arraytypes.d $D/astcodegen.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/clone.d $D/compiler.d $D/complex.d	\
 	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d $D/dsymbolsem.d		\
@@ -208,7 +208,7 @@ ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 
 # D front end
 SRCS = $D/aggregate.h $D/aliasthis.h $D/arraytypes.h	\
-	$D/attrib.h $D/complex_t.h $D/cond.h $D/ctfe.h $D/ctfe.h $D/declaration.h $D/dsymbol.h	\
+	$D/attrib.h $D/compiler.h $D/complex_t.h $D/cond.h $D/ctfe.h $D/ctfe.h $D/declaration.h $D/dsymbol.h	\
 	$D/enum.h $D/errors.h $D/expression.h $D/globals.h $D/hdrgen.h $D/identifier.h	\
 	$D/import.h $D/init.h $D/intrange.h $D/json.h	\
 	$D/mars.h $D/module.h $D/mtype.h $D/nspace.h $D/objc.h                         \


### PR DESCRIPTION
And I propose that this should be the home of `genCmain` (which closes [issue 15374](https://issues.dlang.org/show_bug.cgi?id=15374)), as well as other free functions called by the frontend, but implemented by the driver/backend in a way that isn't compatible across compiler implementations.