### PR TITLE
fixup #7447 - reintroduced Wconstant-logical-operand on older clangs

### DIFF
--- a/src/dmd/backend/cod1.c
+++ b/src/dmd/backend/cod1.c
@@ -1321,7 +1321,7 @@ void getlvalue(CodeBuilder& cdb,code *pcs,elem *e,regm_t keepmsk)
             }
 #endif
         }
-        if (s->ty() & mTYcs && LARGECODE)
+        if (s->ty() & mTYcs && (bool) LARGECODE)
             goto Lfardata;
         goto L3;
     case FLdata:


### PR DESCRIPTION
- original fix https://github.com/dlang/dmd/pull/7430
- reintroduced here https://github.com/dlang/dmd/commit/4a195a70d349bd0c5807ced4779ad7ca1edb250b#r26333985, maybe because of an outdated source file