### PR TITLE
Avoid temporary files created by the testsuite

### DIFF
--- a/test/compilable/futurexf.d
+++ b/test/compilable/futurexf.d
@@ -1,5 +1,5 @@
 /* PERMUTE_ARGS:
-   REQUIRED_ARGS: -Xffuture.json
+   REQUIRED_ARGS: -Xf${RESULTS_DIR}/compilable/futurexf.out
  */
 
 class A

--- a/test/compilable/vcg-ast.d
+++ b/test/compilable/vcg-ast.d
@@ -1,6 +1,7 @@
 module vcg;
 // REQUIRED_ARGS: -vcg-ast -o-
 // PERMUTE_ARGS:
+// POST_SCRIPT: rm -f compilable/vcg-ast.d.cg && cat
 
 template Seq(A...)
 {


### PR DESCRIPTION
Output files should be stored in `test_results` ...