### PR TITLE
[trivial] Use backticks instead of brackets in error messages

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -3246,7 +3246,7 @@ public:
             if (cmp == -1)
             {
                 char dir = (e.op == TOKgt || e.op == TOKge) ? '<' : '>';
-                e.error("the ordering of pointers to unrelated memory blocks is indeterminate in CTFE. To check if they point to the same memory block, use both > and < inside && or ||, eg (%s && %s %c= %s + 1)", e.toChars(), e.e1.toChars(), dir, e.e2.toChars());
+                e.error("the ordering of pointers to unrelated memory blocks is indeterminate in CTFE. To check if they point to the same memory block, use both > and < inside && or ||, eg `%s && %s %c= %s + 1`", e.toChars(), e.e1.toChars(), dir, e.e2.toChars());
                 result = CTFEExp.cantexp;
                 return;
             }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4749,11 +4749,11 @@ extern (C++) class UnaExp : Expression
 
         if (e1.op == TOKtype)
         {
-            error("incompatible type for (%s(%s)): cannot use '%s' with types", Token.toChars(op), e1.toChars(), Token.toChars(op));
+            error("incompatible type for `%s(%s)`: cannot use '%s' with types", Token.toChars(op), e1.toChars(), Token.toChars(op));
         }
         else
         {
-            error("incompatible type for (%s(%s)): '%s'", Token.toChars(op), e1.toChars(), e1.type.toChars());
+            error("incompatible type for `%s(%s)`: '%s'", Token.toChars(op), e1.toChars(), e1.type.toChars());
         }
         return new ErrorExp();
     }
@@ -4827,18 +4827,18 @@ extern (C++) abstract class BinExp : Expression
         TOK thisOp = (op == TOKquestion) ? TOKcolon : op;
         if (e1.op == TOKtype || e2.op == TOKtype)
         {
-            error("incompatible types for ((%s) %s (%s)): cannot use '%s' with types",
+            error("incompatible types for `(%s) %s (%s)`: cannot use '%s' with types",
                 e1.toChars(), Token.toChars(thisOp), e2.toChars(), Token.toChars(op));
         }
         else if (e1.type.equals(e2.type))
         {
-            error("incompatible types for ((%s) %s (%s)): both operands are of type '%s'",
+            error("incompatible types for `(%s) %s (%s)`: both operands are of type '%s'",
                 e1.toChars(), Token.toChars(thisOp), e2.toChars(), e1.type.toChars());
         }
         else
         {
             auto ts = toAutoQualChars(e1.type, e2.type);
-            error("incompatible types for ((%s) %s (%s)): '%s' and '%s'",
+            error("incompatible types for `(%s) %s (%s)`: '%s' and '%s'",
                 e1.toChars(), Token.toChars(thisOp), e2.toChars(), ts[0], ts[1]);
         }
         return new ErrorExp();

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4249,7 +4249,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (p.token.value != TOKeof)
         {
-            exp.error("incomplete mixin expression (%s)", se.toChars());
+            exp.error("incomplete mixin expression `%s`", se.toChars());
             return setError();
         }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7010,7 +7010,7 @@ extern (C++) final class TypeTypeof : TypeQualified
         Type t = exp.type;
         if (!t)
         {
-            error(loc, "expression (%s) has no type", exp.toChars());
+            error(loc, "expression `%s` has no type", exp.toChars());
             goto Lerr;
         }
         if (t.ty == Ttypeof)

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -23,7 +23,7 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/bug9631.d(41): Error: incompatible types for ((x) == (y)): 'bug9631.S' and 'bug9631.tem!().S'
+fail_compilation/bug9631.d(41): Error: incompatible types for `(x) == (y)`: 'bug9631.S' and 'bug9631.tem!().S'
 ---
 */
 

--- a/test/fail_compilation/diag12063.d
+++ b/test/fail_compilation/diag12063.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag12063.d(11): Error: no property 'max' for type 'Foo'
-fail_compilation/diag12063.d(14): Error: incompatible types for ((Foo()) + (1)): 'Bar' and 'int'
+fail_compilation/diag12063.d(14): Error: incompatible types for `(Foo()) + (1)`: 'Bar' and 'int'
 ---
 */
 

--- a/test/fail_compilation/diag16499.d
+++ b/test/fail_compilation/diag16499.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag16499.d(22): Error: incompatible types for ((2) in (foo)): 'int' and 'A'
-fail_compilation/diag16499.d(24): Error: incompatible types for ((1.00000) in (bar)): 'double' and 'B'
+fail_compilation/diag16499.d(22): Error: incompatible types for `(2) in (foo)`: 'int' and 'A'
+fail_compilation/diag16499.d(24): Error: incompatible types for `(1.00000) in (bar)`: 'double' and 'B'
 ---
 */
 

--- a/test/fail_compilation/diag9398.d
+++ b/test/fail_compilation/diag9398.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9398.d(11): Error: incompatible types for ((f) : (s)): 'float' and 'string'
+fail_compilation/diag9398.d(11): Error: incompatible types for `(f) : (s)`: 'float' and 'string'
 ---
 */
 void main()

--- a/test/fail_compilation/diag_err1.d
+++ b/test/fail_compilation/diag_err1.d
@@ -8,7 +8,7 @@ fail_compilation/diag_err1.d(22): Error: undefined identifier `y`
 fail_compilation/diag_err1.d(22):        while evaluating pragma(msg, (x + y).sizeof)
 fail_compilation/diag_err1.d(23): Error: undefined identifier `x`
 fail_compilation/diag_err1.d(23):        while evaluating pragma(msg, (n += x).sizeof)
-fail_compilation/diag_err1.d(24): Error: incompatible types for ((s) ~ (n)): 'string' and 'int'
+fail_compilation/diag_err1.d(24): Error: incompatible types for `(s) ~ (n)`: 'string' and 'int'
 fail_compilation/diag_err1.d(24):        while evaluating pragma(msg, (s ~ n).sizeof)
 ---
 */

--- a/test/fail_compilation/fail11445.d
+++ b/test/fail_compilation/fail11445.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11445.d(11): Error: incompatible types for ((a) + (b)): both operands are of type 'double[string]'
+fail_compilation/fail11445.d(11): Error: incompatible types for `(a) + (b)`: both operands are of type 'double[string]'
 ---
 */
 

--- a/test/fail_compilation/fail209.d
+++ b/test/fail_compilation/fail209.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail209.d(20): Error: incompatible types for ((a) -= (x)): 'float' and 'fail209.X'
+fail_compilation/fail209.d(20): Error: incompatible types for `(a) -= (x)`: 'float' and 'fail209.X'
 ---
 */
 

--- a/test/fail_compilation/fail256.d
+++ b/test/fail_compilation/fail256.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail256.d(8): Error: incompatible types for (("foo"d) ~ ("bar"c)): 'dstring' and 'string'
+fail_compilation/fail256.d(8): Error: incompatible types for `("foo"d) ~ ("bar"c)`: 'dstring' and 'string'
 ---
 */
 

--- a/test/fail_compilation/fail297.d
+++ b/test/fail_compilation/fail297.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail297.d(30): Error: incompatible types for ((Bar()) + (baz())): 'Bar' and 'const(Bar)'
+fail_compilation/fail297.d(30): Error: incompatible types for `(Bar()) + (baz())`: 'Bar' and 'const(Bar)'
 ---
 */
 

--- a/test/fail_compilation/fail3.d
+++ b/test/fail_compilation/fail3.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3.d(41): Error: incompatible types for ((a) + (b)): both operands are of type 'vec2'
+fail_compilation/fail3.d(41): Error: incompatible types for `(a) + (b)`: both operands are of type 'vec2'
 ---
 */
 

--- a/test/fail_compilation/fail312.d
+++ b/test/fail_compilation/fail312.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail312.d(13): Error: incompatible types for ((a[]) == (b)): 'int[]' and 'short'
-fail_compilation/fail312.d(14): Error: incompatible types for ((a[]) <= (b)): 'int[]' and 'short'
+fail_compilation/fail312.d(13): Error: incompatible types for `(a[]) == (b)`: 'int[]' and 'short'
+fail_compilation/fail312.d(14): Error: incompatible types for `(a[]) <= (b)`: 'int[]' and 'short'
 ---
 */
 

--- a/test/fail_compilation/fail54.d
+++ b/test/fail_compilation/fail54.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail54.d(22): Error: incompatible types for ((0) == (Exception)): cannot use '==' with types
+fail_compilation/fail54.d(22): Error: incompatible types for `(0) == (Exception)`: cannot use '==' with types
 ---
 */
 

--- a/test/fail_compilation/fail79.d
+++ b/test/fail_compilation/fail79.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail79.d(13): Error: incompatible types for ((& a) + (& b)): both operands are of type 'int*'
+fail_compilation/fail79.d(13): Error: incompatible types for `(& a) + (& b)`: both operands are of type 'int*'
 ---
 */
 

--- a/test/fail_compilation/ice11850.d
+++ b/test/fail_compilation/ice11850.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11850.d(14): Error: incompatible types for ((a) < ([0])): 'uint[]' and 'int[]'
+fail_compilation/ice11850.d(14): Error: incompatible types for `(a) < ([0])`: 'uint[]' and 'int[]'
 fail_compilation/imports/a11850.d(9):        instantiated from here: FilterResult!(__lambda1, uint[][])
 fail_compilation/ice11850.d(14):        instantiated from here: filter!(uint[][])
 ---

--- a/test/fail_compilation/ice13382.d
+++ b/test/fail_compilation/ice13382.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice13382.d(18): Error: incompatible types for ((a) == (0)): 'int[]' and 'int'
-fail_compilation/ice13382.d(19): Error: incompatible types for ((a) >= (0)): 'int[]' and 'int'
-fail_compilation/ice13382.d(20): Error: incompatible types for ((0) == (a)): 'int' and 'int[]'
-fail_compilation/ice13382.d(21): Error: incompatible types for ((0) >= (a)): 'int' and 'int[]'
-fail_compilation/ice13382.d(22): Error: incompatible types for ((a) is (0)): 'int[]' and 'int'
-fail_compilation/ice13382.d(23): Error: incompatible types for ((a) !is (0)): 'int[]' and 'int'
-fail_compilation/ice13382.d(24): Error: incompatible types for ((0) is (a)): 'int' and 'int[]'
-fail_compilation/ice13382.d(25): Error: incompatible types for ((0) !is (a)): 'int' and 'int[]'
+fail_compilation/ice13382.d(18): Error: incompatible types for `(a) == (0)`: 'int[]' and 'int'
+fail_compilation/ice13382.d(19): Error: incompatible types for `(a) >= (0)`: 'int[]' and 'int'
+fail_compilation/ice13382.d(20): Error: incompatible types for `(0) == (a)`: 'int' and 'int[]'
+fail_compilation/ice13382.d(21): Error: incompatible types for `(0) >= (a)`: 'int' and 'int[]'
+fail_compilation/ice13382.d(22): Error: incompatible types for `(a) is (0)`: 'int[]' and 'int'
+fail_compilation/ice13382.d(23): Error: incompatible types for `(a) !is (0)`: 'int[]' and 'int'
+fail_compilation/ice13382.d(24): Error: incompatible types for `(0) is (a)`: 'int' and 'int[]'
+fail_compilation/ice13382.d(25): Error: incompatible types for `(0) !is (a)`: 'int' and 'int[]'
 ---
 */
 

--- a/test/fail_compilation/ice2843.d
+++ b/test/fail_compilation/ice2843.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice2843.d(22): Error: incompatible types for ((1) is (typeid(int))): 'int' and 'object.TypeInfo'
+fail_compilation/ice2843.d(22): Error: incompatible types for `(1) is (typeid(int))`: 'int' and 'object.TypeInfo'
 ---
 */
 

--- a/test/fail_compilation/ice8309.d
+++ b/test/fail_compilation/ice8309.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8309.d(10): Error: incompatible types for ((__lambda1) : (__lambda2)): 'double function() pure nothrow @nogc @safe' and 'int function() pure nothrow @nogc @safe'
+fail_compilation/ice8309.d(10): Error: incompatible types for `(__lambda1) : (__lambda2)`: 'double function() pure nothrow @nogc @safe' and 'int function() pure nothrow @nogc @safe'
 ---
 */
 

--- a/test/fail_compilation/ice8511.d
+++ b/test/fail_compilation/ice8511.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice8511.d(11): Error: enum ice8511.hypot.SQRTMAX is forward referenced looking for base type
-fail_compilation/ice8511.d(12): Error: incompatible types for ((SQRTMAX) / (2)): cannot use '/' with types
+fail_compilation/ice8511.d(12): Error: incompatible types for `(SQRTMAX) / (2)`: cannot use '/' with types
 ---
 */
 

--- a/test/fail_compilation/test16116.d
+++ b/test/fail_compilation/test16116.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -m64
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/test16116.d(15): Error: incompatible types for ((v) * (i)): '__vector(short[8])' and 'int'
+fail_compilation/test16116.d(15): Error: incompatible types for `(v) * (i)`: '__vector(short[8])' and 'int'
 ---
 */
 


### PR DESCRIPTION
Change some uses of `(expression)` to use backtick quoting.