### PR TITLE
(Option 1) Cause win32.mak to print error when HOST_DC is not set

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -288,10 +288,17 @@ release:
 $G :
 	if not exist "$G" mkdir $G
 
-debdmd:
+check-host-dc:
+	@cmd /c if "$(HOST_DC)" == "" (echo Error: Environment variable HOST_DC is not set & exit 1)
+
+debdmd: check-host-dc debdmd-make
+
+debdmd-make:
 	$(DMDMAKE) "OPT=" "DEBUG=-D -g -DUNITTEST" "DDEBUG=-debug -g -unittest" "DOPT=" "LFLAGS=-L/ma/co/la" $(TARGETEXE)
 
-reldmd:
+reldmd: check-host-dc reldmd-make
+
+reldmd-make:
 	$(DMDMAKE) "OPT=-o" "DEBUG=" "DDEBUG=" "DOPT=-O -release -inline" "LFLAGS=-L/delexe/la" $(TARGETEXE)
 
 profile:


### PR DESCRIPTION
I spent way too much time on this one.  The limitations of Digital Mars' `make` program made this one quite difficult, this is the best mechanism I could come up with to cause the make file to fail with a nice error messages when `HOST_DC` is not set.