### PR TITLE
[Makefile] Actually use release flags on BUILD=release

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -59,6 +59,8 @@ ifneq ($(BUILD),release)
         $(error Unrecognized BUILD=$(BUILD), must be 'debug' or 'release')
     endif
     ENABLE_DEBUG := 1
+else
+    ENABLE_RELEASE := 1
 endif
 
 # default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -474,7 +474,7 @@ $G/parser.a: $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS) $G/dmd $G/dmd.conf $(SRC_
 	CC="$(HOST_CXX)" $G/dmd -lib -of$@ $(MODEL_FLAG) -L-lstdc++ -J$G $(DFLAGS) $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS)
 
 $G/examples/%: $(EX)/%.d $G/parser.a $G/dmd
-	CC="$(HOST_CXX)" $G/dmd -of$@ $(MODEL_FLAG) $(DFLAGS) $G/parser.a $<
+	CC="$(HOST_CXX)" $G/dmd -of$@ $(MODEL_FLAG) $(DFLAGS) -J$G $G/parser.a  $<
 
 build-examples: $(EXAMPLES)
 


### PR DESCRIPTION
If we already default to `BUILD=release`, we should actually do so. The README at the top states:

> ENABLE_RELEASE:		Optimized release built (set by BUILD=release)

Before:

```
CC="c++" dmd -of../generated/linux/release/64/dmd -m64 -vtls -J../generated/linux/release/64 -J../res -L-lstdc++ -version=MARS -fPIC -w -de 
```

After:

```
CC="c++" dmd -of../generated/linux/release/64/dmd -m64 -vtls -J../generated/linux/release/64 -J../res -L-lstdc++ -version=MARS -fPIC -w -de -O -release -inline 
```

FYI: I'm not a huge fan of using the release mode by default, but that's a battle for another day.