### PR TITLE
 Enable C++ warnings by default

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -98,7 +98,7 @@ coverage()
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
     # build dmd, druntime, and phobos
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD ENABLE_WARNINGS=1 all
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
 

--- a/posix.mak
+++ b/posix.mak
@@ -8,7 +8,7 @@ all:
 	$(QUIET)$(MAKE) -C src -f posix.mak all
 
 auto-tester-build: toolchain-info
-	$(QUIET)$(MAKE) -C src -f posix.mak auto-tester-build ENABLE_RELEASE=1
+	$(QUIET)$(MAKE) -C src -f posix.mak auto-tester-build ENABLE_RELEASE=1 ENABLE_WARNINGS=1
 
 auto-tester-test: test
 

--- a/src/dmd/backend/blockopt.c
+++ b/src/dmd/backend/blockopt.c
@@ -727,7 +727,7 @@ void brcombine()
                     {
                         if (EOP(b3->Belem))
                             continue;
-                        tym_t ty = (bc2 == BCretexp) ? b2->Belem->Ety : TYvoid;
+                        tym_t ty = (bc2 == BCretexp) ? b2->Belem->Ety : static_cast<regm_t>(TYvoid);
                         e = el_bin(OPcolon2,ty,b2->Belem,b3->Belem);
                         b->Belem = el_bin(OPcond,ty,b->Belem,e);
                     }

--- a/src/dmd/backend/cg87.c
+++ b/src/dmd/backend/cg87.c
@@ -1652,6 +1652,7 @@ void load87(CodeBuilder& cdb,elem *e,unsigned eoffset,regm_t *pretregs,elem *ele
 
             case OPvar:
                 notreg(e);
+                /* FALL-THROUGH */
             case OPind:
             L2:
                 if (op != -1)
@@ -3131,6 +3132,7 @@ void cnvt87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 
             case OPd_u16:
                 szoff = 4;
+                /* FALL-THROUGH */
             case OPd_s32:
                 clib = CLIBdbllng87;
                 mf = ESC(MFlong,1);
@@ -3752,6 +3754,7 @@ __body
     {
         case OPvar:
             notreg(e);                  // never enregister this variable
+            /* FALL-THROUGH */
         case OPind:
             push87(cdb);
             push87(cdb);

--- a/src/dmd/backend/cgcod.c
+++ b/src/dmd/backend/cgcod.c
@@ -595,7 +595,7 @@ tryagain:
 
     // Mask of regs saved
     // BUG: do interrupt functions save BP?
-    sfunc->Sregsaved = (functy == TYifunc) ? mBP : (mfuncreg | fregsaved);
+    sfunc->Sregsaved = (functy == TYifunc) ? static_cast<regm_t>(mBP) : (mfuncreg | fregsaved);
 
     util_free(csextab);
     csextab = NULL;
@@ -2365,10 +2365,11 @@ static void comsub(CodeBuilder& cdb,elem *e,regm_t *pretregs)
   /* create mask of what's in csextab[] */
   csemask = 0;
   for (size_t i = 0; i < cstop; i++)
-  {     if (csextab[i].e)
-            elem_debug(csextab[i].e);
-        if (csextab[i].e == e)
-                csemask |= csextab[i].regm;
+  {
+    if (csextab[i].e)
+        elem_debug(csextab[i].e);
+    if (csextab[i].e == e)
+        csemask |= csextab[i].regm;
   }
   csemask &= ~emask;            /* stuff already in registers   */
 

--- a/src/dmd/backend/cgcod.c
+++ b/src/dmd/backend/cgcod.c
@@ -237,6 +237,7 @@ tryagain:
             {   case SCfastpar:
                 case SCshadowreg:
                     regcon.params |= s->Spregm();
+                    /* FALL-THROUGH */
                 case SCparameter:
                     if (s->Sfl == FLreg)
                         noparams |= s->Sregm;
@@ -337,6 +338,7 @@ tryagain:
                     cdb.genlinnum(b->Bsrcpos);
                     b->Bcode = cdb.finish();
                 }
+                /* FALL-THROUGH */
             case BCretexp:
                 epilog(b);
                 break;
@@ -2677,6 +2679,7 @@ void codelem(CodeBuilder& cdb,elem *e,regm_t *pretregs,bool constflag)
             else
                 *pretregs &= mPSW | s->Sregm;
         }
+        /* FALL-THROUGH */
     case OPconst:
         if (*pretregs == 0 && (e->Ecount >= 3 || e->Ety & mTYvolatile))
         {

--- a/src/dmd/backend/cgcs.c
+++ b/src/dmd/backend/cgcs.c
@@ -212,6 +212,7 @@ STATIC void ecom(elem **pe)
             /* can be done with an INC or DEC instruction.               */
             if (!(OTpost(op) && elemisone(e->E2)))
                 ecom(&e->E2);           /* evaluate 2nd operand first   */
+        /* FALL-THROUGH */
     case OPnegass:
             if (EOP(e->E1))             /* if lvalue is an operator     */
             {
@@ -293,6 +294,7 @@ STATIC void ecom(elem **pe)
     case OPoutp:
 #endif
         ecom(&e->E1);
+        /* FALL-THROUGH */
     case OPinfo:
         ecom(&e->E2);
         return;
@@ -319,6 +321,7 @@ STATIC void ecom(elem **pe)
     case OPmemcpy:
     case OPmemset:
         ecom(&e->E2);
+        /* FALL-THROUGH */
     case OPsetjmp:
         ecom(&e->E1);
         touchfunc(0);
@@ -327,6 +330,7 @@ STATIC void ecom(elem **pe)
         if (!EBIN(e))
            WROP(e->Eoper);
         assert(EBIN(e));
+        /* FALL-THROUGH */
     case OPadd:
     case OPmin:
     case OPmul:
@@ -350,6 +354,7 @@ STATIC void ecom(elem **pe)
         WROP(e->Eoper);
         elem_print(e);
         assert(0);              /* optelem() should have removed these  */
+        /* FALL-THROUGH */
         /* NOTREACHED */
 
     // Explicitly list all the unary ops for speed

--- a/src/dmd/backend/cgelem.c
+++ b/src/dmd/backend/cgelem.c
@@ -2733,6 +2733,7 @@ STATIC bool optim_loglog(elem **pe)
         {
             case 1:
                 ey = el_una(OPu8_16,TYint,ey);
+                /* FALL-THROUGH */
             case 2:
                 ey = el_una(OPu16_32,TYint,ey);
                 break;
@@ -3079,6 +3080,7 @@ STATIC elem * eladdr(elem *e, goal_t goal)
         break;
     case OPnegass:
         assert(0);
+        /* FALL-THROUGH */
     default:
         if (OTassign(e1->Eoper))
         {
@@ -3273,6 +3275,7 @@ elem * elstruct(elem *e, goal_t goal)
             {   tym = TYldouble;
                 goto L1;
             }
+            /* FALL-THROUGH */
         case 9:
         case 11:
         case 13:
@@ -3606,6 +3609,7 @@ STATIC elem * eleq(elem *e, goal_t goal)
                         es->EV.Vllong = 0x8000000000000000LL;
                         break;
                     }
+                    /* FALL-THROUGH */
                 default:
                     el_free(es);
                     goto L8;

--- a/src/dmd/backend/cgsched.c
+++ b/src/dmd/backend/cgsched.c
@@ -1244,6 +1244,7 @@ STATIC void getinfo(Cinfo *ci,code *c)
         case 0x56:
         case 0x57:                              // PUSH reg
             ci->flags |= CIFLpush;
+            /* FALL-THROUGH */
         case 0x54:                              // PUSH ESP
         case 0x6A:                              // PUSH imm8
         case 0x68:                              // PUSH imm

--- a/src/dmd/backend/cgxmm.c
+++ b/src/dmd/backend/cgxmm.c
@@ -1603,6 +1603,7 @@ void checkSetVex(code *c, tym_t ty)
             case STOSD:
                 if ((c->Irm & 0xC0) == 0xC0)
                     break;
+                /* FALL-THROUGH */
             case LODAPS:
             case LODUPS:
             case LODAPD:

--- a/src/dmd/backend/cod1.c
+++ b/src/dmd/backend/cod1.c
@@ -4803,7 +4803,7 @@ void loaddata(CodeBuilder& cdb,elem *e,regm_t *pretregs)
             loadea(cdb,e,&cs,op,reg,0,0,0);     // MOV regL,data
         }
         else
-        {   nregm = tyuns(tym) ? BYTEREGS : mAX;
+        {   nregm = tyuns(tym) ? BYTEREGS : static_cast<regm_t>(mAX);
             if (*pretregs & nregm)
                 nreg = reg;                             // already allocated
             else

--- a/src/dmd/backend/cod1.c
+++ b/src/dmd/backend/cod1.c
@@ -489,6 +489,7 @@ void logexp(CodeBuilder& cdb,elem *e,int jcond,unsigned fltarg,code *targ)
 
             case OPnot:
                 jcond ^= 1;
+                /* FALL-THROUGH */
             case OPbool:
             case OPs8_16:
             case OPu8_16:
@@ -1225,6 +1226,7 @@ void getlvalue(CodeBuilder& cdb,code *pcs,elem *e,regm_t keepmsk)
         pcs->IEVpointer1 = e->EVpointer;
         break;
 #endif
+        /* FALL-THROUGH */
     case FLfltreg:
         reflocal = TRUE;
         pcs->Irm = modregrm(2,0,BPRM);
@@ -1278,6 +1280,7 @@ void getlvalue(CodeBuilder& cdb,code *pcs,elem *e,regm_t keepmsk)
         }
         if (s->Sclass == SCshadowreg)
             goto Lpara;
+        /* FALL-THROUGH */
     case FLbprel:
         reflocal = TRUE;
         pcs->Irm = modregrm(2,0,BPRM);
@@ -3672,6 +3675,7 @@ static void movParams(CodeBuilder& cdb,elem *e,unsigned stackalign, unsigned fun
         case OPstrpar:
         case OPnp_fp:
             assert(0);
+            /* FALL-THROUGH */
         case OPrelconst:
         {
             int fl;

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -4279,6 +4279,7 @@ void getoffset(CodeBuilder& cdb,elem *e,unsigned reg)
         if (I64 && e->EV.sp.Vsym->ty() & mTYthread)
             goto L5;
 #endif
+    /* FALL-THROUGH */
     case FLdata:
     case FLudata:
     case FLgot:

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -4403,7 +4403,7 @@ void cdneg(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         }
         else
         {
-            unsigned reg = (sz == 8) ? AX : findregmsw(retregs);
+            unsigned reg = (sz == 8) ? static_cast<unsigned>(AX) : findregmsw(retregs);
             cdb.genc2(0x81,modregrm(3,6,reg),0x8000);     // XOR AX,0x8000
         }
         fixresult(cdb,e,retregs,pretregs);
@@ -4476,7 +4476,7 @@ void cdabs(CodeBuilder& cdb,elem *e, regm_t *pretregs)
         }
         else
         {
-            int reg = (sz == 8) ? AX : findregmsw(retregs);
+            int reg = (sz == 8) ? static_cast<int>(AX) : findregmsw(retregs);
             cdb.genc2(0x81,modregrm(3,4,reg),0x7FFF);     // AND AX,0x7FFF
         }
         fixresult(cdb,e,retregs,pretregs);
@@ -4486,7 +4486,7 @@ void cdabs(CodeBuilder& cdb,elem *e, regm_t *pretregs)
     unsigned byte = sz == 1;
     assert(byte == 0);
     byte = 0;
-    regm_t possregs = (sz <= REGSIZE) ? mAX : allregs;
+    regm_t possregs = (sz <= REGSIZE) ? static_cast<regm_t>(mAX) : allregs;
     if (!I16 && sz == REGSIZE)
         possregs = allregs;
     regm_t retregs = *pretregs & possregs;

--- a/src/dmd/backend/cod3.c
+++ b/src/dmd/backend/cod3.c
@@ -624,7 +624,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
 
         case TYllong:
         case TYullong:
-            return I64 ? mAX : (I32 ? mDX | mAX : DOUBLEREGS);
+            return I64 ? static_cast<regm_t>(mAX) : (I32 ? static_cast<regm_t>(mDX | mAX) : DOUBLEREGS);
 
         case TYldouble:
         case TYildouble:

--- a/src/dmd/backend/cod3.c
+++ b/src/dmd/backend/cod3.c
@@ -592,6 +592,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
                 return mXMM0;
             if (config.exe & EX_flat)
                 return mST0;
+            /* FALL-THROUGH */
         case TYlong:
         case TYulong:
         case TYdchar:
@@ -635,9 +636,11 @@ regm_t regmask(tym_t tym, tym_t tyf)
             if (I32 && tybasic(tyf) == TYnfunc)
                 return mDX | mAX;
 #endif
+            /* FALL-THROUGH */
         case TYcdouble:
             if (I64)
                 return mXMM0 | mXMM1;
+            /* FALL-THROUGH */
         case TYcldouble:
             return mST01;
 
@@ -4907,6 +4910,7 @@ void assignaddrc(code *c)
             case FLpseudo:
                 assert(0);
                 /* NOTREACHED */
+                /* FALL-THROUGH */
             case FLfast:
                 c->IEVpointer2 += s->Soffset + Fast.size + BPoff;
                 break;
@@ -5466,6 +5470,7 @@ void pinholeopt(code *c,block *b)
                     }
                     if ((op & ~0x0F) != 0x70)
                         break;
+                    /* FALL-THROUGH */
                 case JMP:
                     switch (c->IFL2)
                     {   case FLcode:
@@ -6297,6 +6302,7 @@ unsigned codout(int seg, code *c)
                         if (!(issib(rm) && (c->Isib & 7) == 5 ||
                               (rm & 7) == 5))
                             break;
+                        /* FALL-THROUGH */
                     case 0x80:
                     {   int flags = CFoff;
                         targ_size_t val = 0;
@@ -6337,6 +6343,7 @@ unsigned codout(int seg, code *c)
                     case 0:
                         if ((rm & 7) != 6)
                             break;
+                        /* FALL-THROUGH */
                     case 0x80:
                         do16bit(&ggen, (enum FL)c->IFL1,&c->IEV1,CFoff);
                         break;
@@ -6369,6 +6376,7 @@ unsigned codout(int seg, code *c)
                                 do64bit(&ggen, (enum FL)c->IFL2,&c->IEV2,flags);
                                 break;
                             }
+                            /* FALL-THROUGH */
                         case 0xA0:              /* MOV AL,byte ptr []   */
                         case 0xA2:
                             if (c->Iflags & CFaddrsize && !I64)
@@ -6461,6 +6469,7 @@ unsigned codout(int seg, code *c)
                         case CALL:
                         case JMP:
                             flags |= CFselfrel;
+                            /* FALL-THROUGH */
                         default:
                         case_default16:
                             if (c->Iflags & CFopsize)

--- a/src/dmd/backend/cod4.c
+++ b/src/dmd/backend/cod4.c
@@ -850,10 +850,12 @@ void cdaddass(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 
   switch (op)                   // select instruction opcodes
   {     case OPpostinc: op = OPaddass;                  // i++ => +=
+        /* FALL-THROUGH */
         case OPaddass:  op1 = 0x01; op2 = 0x11;
                         cflags = CFpsw;
                         mode = 0; break;                // ADD, ADC
         case OPpostdec: op = OPminass;                  // i-- => -=
+        /* FALL-THROUGH */
         case OPminass:  op1 = 0x29; op2 = 0x19;
                         cflags = CFpsw;
                         mode = 5; break;                // SUB, SBC

--- a/src/dmd/backend/cod4.c
+++ b/src/dmd/backend/cod4.c
@@ -3299,7 +3299,7 @@ void cdport(CodeBuilder& cdb,elem *e,regm_t *pretregs)
     {
         sz = tysize(e->E2->Ety);
         regm_t retregs = mAX;           // byte/word to output is in AL/AX
-        scodelem(cdb,e->E2,&retregs,((op & 0x08) ? mDX : (regm_t) 0),TRUE);
+        scodelem(cdb,e->E2,&retregs,((op & 0x08) ? static_cast<regm_t>(mDX) : (regm_t) 0),TRUE);
         op |= 0x02;                     // OUT opcode
     }
     else // OPinp

--- a/src/dmd/backend/el.c
+++ b/src/dmd/backend/el.c
@@ -2375,7 +2375,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, elem **pedtor)
         union eve c;
         memset(&c, 0, sizeof(c));
         elem *e_flag_0 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, &c));  // __flag = 0
-        er = el_bin(OPinfo, ec ? ec->Ety : TYvoid, ector, el_combine(e_flag_0, ec));
+        er = el_bin(OPinfo, ec ? ec->Ety : static_cast<tym_t>(TYvoid), ector, el_combine(e_flag_0, ec));
 
         /* A destructor always executes code, or we wouldn't need
          * eh for it.

--- a/src/dmd/backend/el.c
+++ b/src/dmd/backend/el.c
@@ -2240,6 +2240,7 @@ elem *el_convert(elem *e)
                 break;
             }
 #if 1
+            /* FALL-THROUGH */
         case OPdiv:
         case OPadd:
         case OPmin:
@@ -2250,6 +2251,7 @@ elem *el_convert(elem *e)
                 shrinkLongDoubleConstantIfPossible(e->E2);
             // fall through...
 #endif
+            /* FALL-THROUGH */
         default:
             if (OTbinary(op))
             {
@@ -2669,6 +2671,7 @@ L1:
                         {   tym = n1->ET->Tnext->Tty;
                             goto Lagain;
                         }
+                        /* FALL-THROUGH */
                     case TYint:
                     case TYuint:
                         if (intsize == SHORTSIZE)
@@ -2970,6 +2973,7 @@ L1:
             if (NPTRSIZE == LLONGSIZE)
                 goto Ullong;
             assert(0);
+            /* FALL-THROUGH */
 
         case TYuint:
             if (intsize == SHORTSIZE)
@@ -3309,11 +3313,13 @@ case_tym:
             {   tym = e->ET->Tnext->Tty;
                 goto case_tym;
             }
+            /* FALL-THROUGH */
         case TYint:
         case TYuint:
         case TYvoid:        /* in case (void)(1)    */
             if (tysize(TYint) == LONGSIZE)
                 goto L1;
+            /* FALL-THROUGH */
         case TYshort:
         case TYwchar_t:
         case TYushort:

--- a/src/dmd/backend/elfobj.c
+++ b/src/dmd/backend/elfobj.c
@@ -2258,6 +2258,7 @@ char *obj_mangle2(Symbol *s,char *dest, size_t *destlen)
                 len = dlen;
                 break;
             }
+            /* FALL-THROUGH */
         case mTYman_cpp:
         case mTYman_c:
         case mTYman_d:
@@ -3268,6 +3269,7 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
         case SCeinline:
             printf ("Undefined inline value <<fixme>>\n");
             //warerr(WM_undefined_inline,s->Sident);
+            /* FALL-THROUGH */
         case SCinline:
             if (tyfunc(ty))
             {
@@ -3277,6 +3279,7 @@ int Obj::reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val,
             else if (config.flags2 & CFG2comdat)
                 goto case_SCcomdat;     // treat as initialized common block
 
+            /* FALL-THROUGH */
         default:
             //symbol_print(s);
             assert(0);

--- a/src/dmd/backend/evalu8.c
+++ b/src/dmd/backend/evalu8.c
@@ -240,6 +240,7 @@ int boolres(elem *e)
 #else
                     assert(0);
 #endif
+                    /* FALL-THROUGH */
                 case TYvoid:    /* happens if we get syntax errors or
                                        on RHS of && || expressions */
                     b = 0;
@@ -1768,6 +1769,7 @@ elem * evalu8(elem *e, goal_t goal)
         return e;
     case OPngt:
         i++;
+        /* FALL-THROUGH */
     case OPgt:
         if (!tyfloating(tym))
             goto Lnle;
@@ -1778,6 +1780,7 @@ elem * evalu8(elem *e, goal_t goal)
     case OPnle:
     Lnle:
         i++;
+        /* FALL-THROUGH */
     case OPle:
         if (uns)
         {
@@ -1795,6 +1798,7 @@ elem * evalu8(elem *e, goal_t goal)
 
     case OPnge:
         i++;
+        /* FALL-THROUGH */
     case OPge:
         if (!tyfloating(tym))
             goto Lnlt;
@@ -1805,6 +1809,7 @@ elem * evalu8(elem *e, goal_t goal)
     case OPnlt:
     Lnlt:
         i++;
+        /* FALL-THROUGH */
     case OPlt:
         if (uns)
         {
@@ -1822,6 +1827,7 @@ elem * evalu8(elem *e, goal_t goal)
 
     case OPne:
         i++;
+        /* FALL-THROUGH */
     case OPeqeq:
         if (tyfloating(tym))
         {

--- a/src/dmd/backend/gdag.c
+++ b/src/dmd/backend/gdag.c
@@ -691,6 +691,7 @@ STATIC void abewalk(elem *n,vec_t ae,vec_t aeval)
         case OPcolon:
         case OPcolon2:
             assert(0);
+            /* FALL-THROUGH */
 
         case OPandand:
         case OPoror:
@@ -909,6 +910,7 @@ STATIC void abeset(elem *e,vec_t ae,vec_t aeval,int flag)
         switch (e->Eoper)
         {   case OPnot:
                 flag ^= 1;
+                /* FALL-THROUGH */
             case OPbool:
             case OPeq:
                 e = e->E1;

--- a/src/dmd/backend/gflow.c
+++ b/src/dmd/backend/gflow.c
@@ -886,6 +886,7 @@ void main()
                            )
                             break;
 #endif
+                        /* FALL-THROUGH */
                     case OPstrlen:
                     case OPstrcmp:
                     case OPmemcmp:
@@ -1063,6 +1064,7 @@ STATIC void accumaecpx(elem *n)
         case OPeq:
         case OPstreq:
             accumaecpx(n->E2);
+            /* FALL-THROUGH */
         case OPnegass:
             accumaecpx(n->E1);
             t = Elvalue(n);
@@ -1649,6 +1651,7 @@ STATIC void accumvbe(vec_t GEN,vec_t KILL,elem *n)
             case OPcall:
             case OPcallns:
                 accumvbe(GEN,KILL,n->E2);
+                /* FALL-THROUGH */
             case OPucall:
             case OPucallns:
                 t = n->E1;

--- a/src/dmd/backend/glocal.c
+++ b/src/dmd/backend/glocal.c
@@ -298,6 +298,7 @@ Loop:
         case OPcall:
         case OPcallns:
             local_exp(lt,e->E2,1);
+            /* FALL-THROUGH */
         case OPstrctor:
         case OPucall:
         case OPucallns:

--- a/src/dmd/backend/gloop.c
+++ b/src/dmd/backend/gloop.c
@@ -942,6 +942,7 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPvecsto:
         case OPcmpxchg:
                         markinvar(n->E2,rd);
+                        /* FALL-THROUGH */
         case OPnegass:
                         n1 = n->E1;
                         if (n1->Eoper == OPind)
@@ -1978,6 +1979,7 @@ STATIC famlist * newfamlist(tym_t ty)
 
             case TYhptr:
                 ty = TYlong;
+                /* FALL-THROUGH */
             case TYlong:
             case TYulong:
             case TYdchar:

--- a/src/dmd/backend/gother.c
+++ b/src/dmd/backend/gother.c
@@ -1364,6 +1364,7 @@ void elimass(elem *n)
     {
         case OPvecsto:
             n->E2->Eoper = OPcomma;
+            /* FALL-THROUGH */
         case OPeq:
         case OPstreq:
             /* (V=e) => (random constant,e)     */
@@ -1537,6 +1538,7 @@ STATIC void accumda(elem *n,vec_t DEAD, vec_t POSS)
             case OPstrcpy:
             case OPmemset:
                 accumda(n->E2,DEAD,POSS);
+                /* FALL-THROUGH */
             case OPstrlen:
                 accumda(n->E1,DEAD,POSS);
                 vec_subass(POSS,ambigref);      // remove possibly refed

--- a/src/dmd/backend/out.c
+++ b/src/dmd/backend/out.c
@@ -184,6 +184,7 @@ void outdata(symbol *s)
 #endif
                         case mTYthreadData:
                             assert(config.objfmt == OBJ_MACH && I64);
+                            /* FALL-THROUGH */
                         case mTYthread:
                         {   seg_data *pseg = objmod->tlsseg_bss();
                             s->Sseg = pseg->SDseg;
@@ -234,6 +235,7 @@ void outdata(symbol *s)
                     outdata(sb);                // write out data for symbol
 }
             }
+            /* FALL-THROUGH */
             case DT_coff:
                 datasize += size(dt->Dty);
                 break;

--- a/src/dmd/backend/strtold.c
+++ b/src/dmd/backend/strtold.c
@@ -298,6 +298,7 @@ longdouble strtold_dm(const char *p,char **endp)
                 sexp = 0;
                 switch (*++p)
                 {   case '-':    sexp++;
+                    /* FALL-THROUGH */
                     case '+':    p++;
                 }
                 ndigits = 0;
@@ -429,6 +430,7 @@ longdouble strtold_dm(const char *p,char **endp)
             sexp = 0;
             switch (*++p)
             {   case '-':    sexp++;
+                /* FALL-THROUGH */
                 case '+':    p++;
             }
             ndigits = 0;

--- a/src/dmd/backend/symbol.c
+++ b/src/dmd/backend/symbol.c
@@ -413,7 +413,7 @@ void symbol_func(symbol *s)
     // Interrupt functions modify all registers
     // BUG: do interrupt functions really save BP?
     // Note that fregsaved may not be set yet
-    s->Sregsaved = (s->Stype && tybasic(s->Stype->Tty) == TYifunc) ? mBP : fregsaved;
+    s->Sregsaved = (s->Stype && tybasic(s->Stype->Tty) == TYifunc) ? static_cast<int>(mBP) : fregsaved;
     s->Sseg = UNKNOWN;          // don't know what segment it is in
     if (!s->Sfunc)
         s->Sfunc = func_calloc();

--- a/src/dmd/backend/type.c
+++ b/src/dmd/backend/type.c
@@ -197,6 +197,7 @@ L1:
 
             case TYldouble:
                 assert(0);
+                /* FALL-THROUGH */
 
             default:
             err1:                   // let type_size() handle error messages

--- a/src/dmd/tk/vec.c
+++ b/src/dmd/tk/vec.c
@@ -98,10 +98,10 @@ vec_t vec_calloc(size_t numbits)
         v += 2;
         switch (dim)
         {
-            case 5:     v[4] = 0;
-            case 4:     v[3] = 0;
-            case 3:     v[2] = 0;
-            case 2:     v[1] = 0;
+            case 5:     v[4] = 0; /* FALL-THROUGH */
+            case 4:     v[3] = 0; /* FALL-THROUGH */
+            case 3:     v[2] = 0; /* FALL-THROUGH */
+            case 2:     v[1] = 0; /* FALL-THROUGH */
             case 1:     v[0] = 0;
                         break;
             default:    memset(v,0,dim * sizeof(vec_base_t));

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -97,7 +97,7 @@ GIT=git
 
 # determine whether CXX is gcc or clang based
 CXX_VERSION:=$(shell $(CXX) --version)
-ifneq (,$(findstring g++,$(CXX_VERSION))$(findstring gcc,$(CXX_VERSION))$(findstring GCC,$(CXX_VERSION)))
+ifneq (,$(findstring g++,$(CXX_VERSION))$(findstring gcc,$(CXX_VERSION))$(findstring Free Software,$(CXX_VERSION)))
 	CXX_KIND=g++
 endif
 ifneq (,$(findstring clang,$(CXX_VERSION)))


### PR DESCRIPTION
To avoid regressions in the future. 

On the D side this is successfully done with `-w -de`.

What was the motivation for not doing so? Too many warnings?