### PR TITLE
Extend the common Makefile between DMD, DRuntime, Phobos etc.

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -7,7 +7,7 @@ CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
 CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-dmd}
-BUILD="debug"
+BUILD="release"
 
 case $CIRCLE_NODE_INDEX in
     0) MODEL=64 ;;

--- a/src/common.mak
+++ b/src/common.mak
@@ -147,7 +147,7 @@ ifeq (,$(findstring win,$(OS)))
 else
 	DOTOBJ:=.obj
 	DOTEXE:=.exe
-	PATHSEP:=$(shell echo "\\")
+	PATHSEP:=$(subst /,/,\)
 endif
 
 ifeq (osx,$(OS))

--- a/src/common.mak
+++ b/src/common.mak
@@ -7,13 +7,13 @@
 # Common directories
 ################################################################################
 
-DMD_DIR = $(D_HOME)/dmd
-DRUNTIME_DIR = $(D_HOME)/druntime
-PHOBOS_DIR = $(D_HOME)/phobos
-DLANG_ORG_DIR = $(D_HOME)/dlang.org
-TOOLS_DIR = $(D_HOME)/tools
-INSTALL_DIR = $(D_HOME)/install
-INSTALLER_DIR = $(D_HOME)/installer
+DMD_DIR=$(D_HOME)/dmd
+DRUNTIME_DIR=$(D_HOME)/druntime
+PHOBOS_DIR=$(D_HOME)/phobos
+DLANG_ORG_DIR=$(D_HOME)/dlang.org
+TOOLS_DIR=$(D_HOME)/tools
+INSTALL_DIR=$(D_HOME)/install
+INSTALLER_DIR=$(D_HOME)/installer
 TMP?=/tmp
 GIT_HOME=https://github.com/dlang
 
@@ -55,7 +55,7 @@ ifneq ($(BUILD),release)
     ifneq ($(BUILD),debug)
         $(error Unrecognized BUILD=$(BUILD), must be 'debug' or 'release')
     endif
-    ENABLE_DEBUG := 1
+    ENABLE_DEBUG:=1
 endif
 
 ################################################################################
@@ -94,16 +94,16 @@ ifneq (,$(DRUNTIME))
 endif
 
 ifeq (,$(findstring win,$(OS)))
-   LIB_DRUNTIME = $(DRUNTIME_BUILD_DIR)/libdruntime.a
-   LIB_DRUNTIMESO = $(basename $(LIB_DRUNTIME)).so.a
+   LIB_DRUNTIME=$(DRUNTIME_BUILD_DIR)/libdruntime.a
+   LIB_DRUNTIMESO=$(basename $(LIB_DRUNTIME)).so.a
 else
-   LIB_DRUNTIME = $(DRUNTIME_PATH)/lib/druntime.lib
+   LIB_DRUNTIME=$(DRUNTIME_PATH)/lib/druntime.lib
 endif
 
 # Set PHOBOS name and full path
 ifeq (,$(findstring win,$(OS)))
-	LIB_PHOBOS = $(PHOBOS_BUILD_DIR)/libphobos2.a
-	LIB_PHOBOSSO = $(PHOBOS_BUILD_DIR)/libphobos2.so
+	LIB_PHOBOS=$(PHOBOS_BUILD_DIR)/libphobos2.a
+	LIB_PHOBOSSO=$(PHOBOS_BUILD_DIR)/libphobos2.so
 endif
 
 # build with shared library support
@@ -116,15 +116,15 @@ LINKDL=$(if $(findstring $(OS),linux),-L-ldl,)
 ################################################################################
 
 ifeq ($(OS),win32wine)
-	CC = wine dmc.exe
-	DMD = wine dmd.exe
-	RUN = wine
+	CC=wine dmc.exe
+	DMD=wine dmd.exe
+	RUN=wine
 else
 	DMD = $(DMD_BUILD_DIR)/dmd
 	ifeq ($(OS),win32)
-		CC = dmc
+		CC=dmc
 	else
-		CC = cc
+		CC=cc
 	endif
 	RUN =
 endif
@@ -171,19 +171,16 @@ endif
 # Default DUB FLAGS
 ################################################################################
 
-DUBFLAGS = --arch=$(subst 32,x86,$(subst 64,x86_64,$(MODEL)))
+DUBFLAGS=--arch=$(subst 32,x86,$(subst 64,x86_64,$(MODEL)))
 
 ################################################################################
 # Automatically create dlang/tools repository if non-existent
 ################################################################################
 
-_all: all
-
 $(TOOLS_DIR):
 	git clone --depth=1 ${GIT_HOME}/$(@F) $@
 
 $(TOOLS_DIR)/checkwhitespace.d: | $(TOOLS_DIR)
-
 
 ################################################################################
 # Common build rules

--- a/src/common.mak
+++ b/src/common.mak
@@ -1,0 +1,204 @@
+# Common Makefile variables (shared between DMD, DRuntime and Phobos)
+# Be careful when updating
+# This file expects the following variables to be defined in the including Makefile:
+# - D_HOME        Root of all D repositories
+
+###############################################################################
+# Common directories
+################################################################################
+
+DMD_DIR = $(D_HOME)/dmd
+DRUNTIME_DIR = $(D_HOME)/druntime
+PHOBOS_DIR = $(D_HOME)/phobos
+DLANG_ORG_DIR = $(D_HOME)/dlang.org
+TOOLS_DIR = $(D_HOME)/tools
+INSTALL_DIR = $(D_HOME)/install
+INSTALLER_DIR = $(D_HOME)/installer
+TMP?=/tmp
+GIT_HOME=https://github.com/dlang
+
+# get OS and MODEL
+include $(D_HOME)/dmd/src/osmodel.mak
+
+###############################################################################
+# Common variables
+################################################################################
+
+# Set VERSION, where the file is that contains the version string
+VERSION=$(DMD_DIR)/VERSION
+MAKEFILE = $(firstword $(MAKEFILE_LIST))
+
+################################################################################
+# Output directories
+################################################################################
+
+DMD_GENERATED=$(DMD_DIR)/generated
+DRUNTIME_GENERATED=$(DRUNTIME_DIR)/generated
+PHOBOS_GENERATED=$(PHOBOS_DIR)/generated
+
+BUILD_TRIPLE=$(OS)/$(BUILD)/$(MODEL)
+
+DMD_BUILD_DIR=$(DMD_GENERATED)/$(BUILD_TRIPLE)
+DRUNTIME_BUILD_DIR=$(DRUNTIME_GENERATED)/$(BUILD_TRIPLE)
+PHOBOS_BUILD_DIR=$(PHOBOS_GENERATED)/$(BUILD_TRIPLE)
+
+################################################################################
+# Detect build mode (default: release)
+################################################################################
+
+# Default to a release built, override with BUILD=debug
+ifeq (,$(BUILD))
+BUILD=release
+endif
+
+ifneq ($(BUILD),release)
+    ifneq ($(BUILD),debug)
+        $(error Unrecognized BUILD=$(BUILD), must be 'debug' or 'release')
+    endif
+    ENABLE_DEBUG := 1
+endif
+
+################################################################################
+# Target-specific flags
+################################################################################
+
+# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+# Note that shared libraries and C files are always compiled with PIC.
+ifeq ($(PIC),)
+    ifeq ($(MODEL),64) # x86_64
+        PIC:=1
+    else
+        PIC:=0
+    endif
+endif
+ifeq ($(PIC),1)
+    override PIC:=-fPIC
+else
+    override PIC:=
+endif
+
+
+ifeq (osx,$(OS))
+    export MACOSX_DEPLOYMENT_TARGET=10.7
+endif
+
+################################################################################
+# Define library files and import paths
+################################################################################
+
+DRUNTIME_IMPORT_DIR=$(DRUNTIME_DIR)/import
+PHOBOS_IMPORT_DIR=$(PHOBOS_DIR)
+
+ifneq (,$(DRUNTIME))
+	CUSTOM_DRUNTIME=1
+endif
+
+ifeq (,$(findstring win,$(OS)))
+   LIB_DRUNTIME = $(DRUNTIME_BUILD_DIR)/libdruntime.a
+   LIB_DRUNTIMESO = $(basename $(LIB_DRUNTIME)).so.a
+else
+   LIB_DRUNTIME = $(DRUNTIME_PATH)/lib/druntime.lib
+endif
+
+# Set PHOBOS name and full path
+ifeq (,$(findstring win,$(OS)))
+	LIB_PHOBOS = $(PHOBOS_BUILD_DIR)/libphobos2.a
+	LIB_PHOBOSSO = $(PHOBOS_BUILD_DIR)/libphobos2.so
+endif
+
+# build with shared library support
+# (defaults to true on supported platforms, can be overridden w/ make SHARED=0)
+SHARED=$(if $(findstring $(OS),linux freebsd),1,)
+LINKDL=$(if $(findstring $(OS),linux),-L-ldl,)
+
+################################################################################
+# Set CC and DMD
+################################################################################
+
+ifeq ($(OS),win32wine)
+	CC = wine dmc.exe
+	DMD = wine dmd.exe
+	RUN = wine
+else
+	DMD = $(DMD_BUILD_DIR)/dmd
+	ifeq ($(OS),win32)
+		CC = dmc
+	else
+		CC = cc
+	endif
+	RUN =
+endif
+
+################################################################################
+# Commonly used binaries
+################################################################################
+
+DUB=dub
+
+################################################################################
+# Platform-specific variables
+################################################################################
+
+# Set DOTOBJ and DOTEXE
+ifeq (,$(findstring win,$(OS)))
+	DOTOBJ:=.o
+	DOTEXE:=
+	PATHSEP:=/
+else
+	DOTOBJ:=.obj
+	DOTEXE:=.exe
+	PATHSEP:=$(shell echo "\\")
+endif
+
+ifeq (osx,$(OS))
+	DOTDLL:=.dylib
+	DOTLIB:=.a
+else
+	DOTDLL:=.so
+	DOTLIB:=.a
+endif
+
+################################################################################
+# Phobos DFLAGS (for linking with the currently built Phobos)
+################################################################################
+
+PHOBOS_DFLAGS=-conf= $(MODEL_FLAG) -I$(DRUNTIME_IMPORT_DIR) -I$(PHOBOS_IMPORT_DIR) -L-L$(PHOBOS_BUILD_DIR) $(PIC)
+ifeq (1,$(SHARED))
+PHOBOS_DFLAGS+=-defaultlib=libphobos2.so -L-rpath=$(PHOBOS_BUILD_DIR)
+endif
+
+################################################################################
+# Default DUB FLAGS
+################################################################################
+
+DUBFLAGS = --arch=$(subst 32,x86,$(subst 64,x86_64,$(MODEL)))
+
+################################################################################
+# Automatically create dlang/tools repository if non-existent
+################################################################################
+
+_all: all
+
+$(TOOLS_DIR):
+	git clone --depth=1 ${GIT_HOME}/$(@F) $@
+
+$(TOOLS_DIR)/checkwhitespace.d: | $(TOOLS_DIR)
+
+
+################################################################################
+# Common build rules
+#
+# Use _build to avoid conflicts with their real rules
+################################################################################
+
+$(DMD)_build: $(DMD)
+	make -C $(DMD_DIR)/src -f posix.mak BUILD=$(BUILD) OS=$(OS) MODEL=$(MODEL)
+	touch $@
+
+$(LIB_DRUNTIME)_build: $(LIB_DRUNTIME)
+	make -C $(DRUNTIME_DIR) -f posix.mak BUILD=$(BUILD) OS=$(OS) MODEL=$(MODEL)
+	touch $@
+
+ifeq (,$(findstring win,$(OS)))
+$(LIB_DRUNTIMESO)_build: $(LIB_DRUNTIME)_build
+endif

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -27,47 +27,16 @@
 # ENABLE_SANITIZERS     Build dmd with sanitizer (e.g. ENABLE_SANITIZERS=address,undefined)
 ################################################################################
 
-# get OS and MODEL
-include osmodel.mak
+D_HOME=../../
+# Load common Makefile variables
+include common.mak
 
 ifeq (,$(TARGET_CPU))
     $(info no cpu specified, assuming X86)
     TARGET_CPU=X86
 endif
 
-# Default to a release built, override with BUILD=debug
-ifeq (,$(BUILD))
-BUILD=release
-endif
-
-ifneq ($(BUILD),release)
-    ifneq ($(BUILD),debug)
-        $(error Unrecognized BUILD=$(BUILD), must be 'debug' or 'release')
-    endif
-    ENABLE_DEBUG := 1
-endif
-
-# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
-# Note that shared libraries and C files are always compiled with PIC.
-ifeq ($(PIC),)
-    ifeq ($(MODEL),64) # x86_64
-        PIC:=1
-    else
-        PIC:=0
-    endif
-endif
-ifeq ($(PIC),1)
-    override PIC:=-fPIC
-else
-    override PIC:=
-endif
-
-GIT_HOME=https://github.com/dlang
-TOOLS_DIR=../../tools
-
-INSTALL_DIR=../../install
 SYSCONFDIR=/etc
-TMP?=/tmp
 PGO_DIR=$(abspath pgo)
 
 D = dmd
@@ -77,8 +46,7 @@ TK=$D/tk
 ROOT=$D/root
 EX=examples
 
-GENERATED = ../generated
-G = $(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
+G = $(DMD_BUILD_DIR)
 $(shell mkdir -p $G)
 
 ifeq (osx,$(OS))
@@ -477,7 +445,7 @@ build-examples: $(EXAMPLES)
 ######## Manual cleanup
 
 clean:
-	rm -R $(GENERATED)
+	rm -R $(DMD_GENERATED)
 	rm -f $(addprefix $D/backend/, $(optabgen_output))
 	@[ ! -d ${PGO_DIR} ] || echo You should issue manually: rm -rf ${PGO_DIR}
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -528,9 +528,6 @@ install: all
 checkwhitespace: $(HOST_DMD_PATH) $(TOOLS_DIR)/checkwhitespace.d
 	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -run $(TOOLS_DIR)/checkwhitespace.d $(SRC) $(GLUE_SRC) $(ROOT_SRCS)
 
-$(TOOLS_DIR)/checkwhitespace.d:
-	git clone --depth=1 ${GIT_HOME}/tools $(TOOLS_DIR)
-
 ######################################################
 
 # See https://github.com/dlang/dmd/pull/7358 for why -xc++ is used here


### PR DESCRIPTION
I'm tired of keeping all the Makefile in sync. The repositories are already interdependent (e.g. we do include `osmodel.mak` and call their respective Makefile targets.

Using a common Makefile has the following advantages:
- automatically keeping everything in sync with _one_ source of truth (don't underestimate this point)
- using a consistent naming scheme (e.g. `DRUNTIME_DIR` vs. `DRUNTIME_PATH`)
- makes the individual Makefiles thinner (DRY!)
- reduces the overhead in maintaining so many Makefiles (e.g. the ddmd -> dmd transition would have been one change in the new `common.mak` file)
- allows to slowly move to target of having _one_ Makefile for Posix & Windows (per repository)