### PR TITLE
Build DMD with BUILD=debug on CircleCi

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -7,6 +7,7 @@ CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
 CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-dmd}
+BUILD="debug"
 
 case $CIRCLE_NODE_INDEX in
     0) MODEL=64 ;;
@@ -98,7 +99,7 @@ coverage()
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
     # build dmd, druntime, and phobos
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
+    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD BUILD=$BUILD all
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL
 


### PR DESCRIPTION
From https://github.com/dlang/dmd/pull/7475#issuecomment-353185711

> For example, since we recently started treating warnings as errors I cannot compile DMD in debug mode without patching it locally.

This shouldn't happen. We should have a CI for this.
Hence, this PR adds `BUILD=debug` to the first build of DMD to CircleCi, s.t. we at least have some CI checking for this build mode...

See also:
- https://github.com/dlang/druntime/pull/2005