### PR TITLE
use make's sort to remove duplicate documentables

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -602,8 +602,8 @@ DOC_OUTPUT_DIR=$(DOCDIR)
 # Phobos is built
 ifneq ($(DOCSRC),)
 
-# list all files for which documentation should be generated
-SRC_DOCUMENTABLES = $(ROOT_SRCS) $(DMD_SRCS) $(LEXER_SRCS) $(LEXER_ROOT) $(PARSER_SRCS)
+# list all files for which documentation should be generated, use sort to remove duplicates
+SRC_DOCUMENTABLES = $(sort $(ROOT_SRCS) $(DMD_SRCS) $(LEXER_SRCS) $(LEXER_ROOT) $(PARSER_SRCS))
 
 D2HTML=$(foreach p,$1,$(if $(subst package.d,,$(notdir $p)),$(subst /,_,$(subst .d,.html,$p)),$(subst /,_,$(subst /package.d,.html,$p))))
 HTMLS=$(addprefix $(DOC_OUTPUT_DIR)/, \


### PR DESCRIPTION
Cherry-picked https://github.com/dlang/dmd/pull/7466 to master, s.t. the warnings disappear on master too.