### PR TITLE
Implement initial version of lambda comparison

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4342,7 +4342,15 @@ extern (C++) final class FuncExp : Expression
             if (fd.fes)
                 s = "__foreachbody";
             else if (fd.tok == TOK.reserved)
+            {
+                import dmd.lambdacomp;
+
                 s = "__lambda";
+                auto serVisitor = new SerializeVisitor(sc);
+                fd.accept(serVisitor);
+                fd.serialization = serVisitor.buf.offset == 0 ? "uncomparable" : serVisitor.buf.extractString();
+                //printf("serialization: %s\n", fd.serialization);
+            }
             else if (fd.tok == TOK.delegate_)
                 s = "__dgliteral";
             else

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2918,6 +2918,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
 
     // backend
     bool deferToObj;
+    const(char)* serialization;
 
     extern (D) this(Loc loc, Loc endloc, Type type, TOK tok, ForeachStatement fes, Identifier id = null)
     {

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -1,0 +1,227 @@
+module dmd.lambdacomp;
+
+import core.stdc.stdio;
+import core.stdc.string;
+
+import dmd.declaration;
+import dmd.denum;
+import dmd.dsymbol;
+import dmd.expression;
+import dmd.func;
+import dmd.dmangle;
+import dmd.mtype;
+import dmd.root.outbuffer;
+import dmd.root.stringtable;
+import dmd.dscope;
+import dmd.statement;
+import dmd.tokens;
+import dmd.visitor;
+
+enum ExpType
+{
+    None,
+    EnumDecl,
+    Arg
+}
+
+extern (C++) class SerializeVisitor : SemanticTimeTransitiveVisitor
+{
+    alias visit = SemanticTimeTransitiveVisitor.visit;
+    OutBuffer buf;
+    StringTable arg_hash;
+    Scope* sc;
+    ExpType et;
+    Dsymbol d;
+
+    this(Scope* sc)
+    {
+        this.sc = sc;
+    }
+
+    override void visit(FuncLiteralDeclaration fld)
+    {
+        if (fld.type.ty == Terror)
+            return;
+
+        TypeFunction tf = cast(TypeFunction)fld.type;
+        uint dim = cast(uint)Parameter.dim(tf.parameters);
+        buf.printf("%d:", dim);
+
+        arg_hash._init(dim + 1);
+        foreach (i; 0 .. dim)
+        {
+            auto fparam = Parameter.getNth(tf.parameters, i);
+            if (fparam.ident !is null)
+            {
+                auto key = fparam.ident.toString().ptr;
+                OutBuffer value;
+                value.writestring("arg");
+                value.print(i);
+                arg_hash.insert(key, strlen(key), value.extractString);
+                fparam.accept(this);
+            }
+        }
+
+        CompoundStatement cs = fld.fbody.isCompoundStatement();
+        Statement s = !cs ? fld.fbody : null;
+        ReturnStatement rs = s ? s.isReturnStatement() : null;
+        if (rs && rs.exp)
+        {
+            rs.exp.accept(this);
+        }
+    }
+
+    override void visit(DotIdExp exp)
+    {
+        if (buf.offset == 0)
+            return;
+
+        exp.e1.accept(this);
+        if (buf.offset == 0)
+            return;
+
+        if (et == ExpType.EnumDecl)
+        {
+            Dsymbol s = d.search(exp.loc, exp.ident);
+            if (s)
+            {
+                if (auto em = s.isEnumMember())
+                {
+                    em.value.accept(this);
+                }
+                et = ExpType.None;
+                d = null;
+            }
+        }
+
+        else if (et == ExpType.Arg)
+        {
+            buf.setsize(buf.offset -1);
+            buf.writeByte('.');
+            buf.writestring(exp.ident.toString());
+            buf.writeByte('_');
+        }
+    }
+
+    override void visit(IdentifierExp exp)
+    {
+        if (buf.offset == 0)
+            return;
+
+        auto id = exp.ident.toChars;
+        auto stringtable_value = arg_hash.lookup(id, strlen(id));
+        if (stringtable_value)
+        {
+            const(char)* gen_id = cast(const(char)*)stringtable_value.ptrvalue;
+            buf.writestring(gen_id);
+            buf.writeByte('_');
+            et = ExpType.Arg;
+        }
+        else
+        {
+            Dsymbol scopesym;
+            Dsymbol s = sc.search(exp.loc, exp.ident, &scopesym);
+            if (s)
+            {
+                if (auto v = s.isVarDeclaration)
+                {
+                    if (v.storage_class & STC.manifest)
+                    {
+                        v.getConstInitializer.accept(this);
+                    }
+                    else
+                        buf.reset();
+                }
+                else if (auto em = s.isEnumDeclaration)
+                {
+                    d = em;
+                    et = ExpType.EnumDecl;
+                }
+                else
+                {
+                    buf.reset();
+                }
+            }
+        }
+    }
+
+    override void visit(UnaExp exp)
+    {
+        if (buf.offset == 0)
+            return;
+
+        buf.writeByte('(');
+        buf.writestring(Token.toString(exp.op));
+        exp.e1.accept(this);
+        if (buf.offset != 0)
+            buf.writestring(")_");
+    }
+
+    override void visit(IntegerExp exp)
+    {
+        if (buf.offset == 0)
+            return;
+
+        exp.normalize();
+        auto val = exp.value;
+        buf.print(val);
+        buf.writeByte('_');
+    }
+
+    override void visit(BinExp exp)
+    {
+        if (buf.offset == 0)
+            return;
+
+        buf.writeByte('(');
+        buf.writestring(Token.toChars(exp.op));
+
+        exp.e1.accept(this);
+        if (buf.offset == 0)
+            return;
+
+        exp.e2.accept(this);
+        if (buf.offset == 0)
+            return;
+
+        buf.writeByte(')');
+    }
+
+    override void visit(TypeBasic t)
+    {
+        buf.writestring(t.dstring);
+        buf.writeByte('_');
+    }
+
+    override void visit(TypeIdentifier t)
+    {
+        Dsymbol scopesym;
+        Dsymbol s = sc.search(t.loc, t.ident, &scopesym);
+        if (s && s.semanticRun == PASS.semantic3done)
+        {
+            OutBuffer mangledName;
+            mangleToBuffer(s, &mangledName);
+            buf.writestring(mangledName.peekSlice);
+            buf.writeByte('_');
+        }
+        else
+            buf.reset();
+    }
+
+    override void visit(TypeInstance t)
+    {
+        buf.reset();
+    }
+
+    override void visit(Parameter p)
+    {
+        if (p.type.ty == Tident
+            && (cast(TypeIdentifier)p.type).ident.toString().length > 3
+            && strncmp((cast(TypeIdentifier)p.type).ident.toChars(), "__T", 3) == 0)
+        {
+            buf.writestring("none_");
+        }
+        else
+            visitType(p.type);
+    }
+}

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -1068,12 +1068,6 @@ package mixin template ParseVisitMethods(AST)
         e.e1.accept(this);
     }
 
-    override void visit(AST.PreExp e)
-    {
-        //printf("Visiting PreExp\n");
-        e.e1.accept(this);
-    }
-
     override void visit(AST.CondExp e)
     {
         //printf("Visiting CondExp\n");

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -296,7 +296,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\
 	hdrgen id impcnvtab imphint init initsem inline inlinecost intrange	\
-	json lib libelf libmach link mars mtype nogc nspace objc opover optimize parse permissivevisitor sapply templateparamsem	\
+	json lambdacomp lib libelf libmach link mars mtype nogc nspace objc opover optimize parse permissivevisitor sapply templateparamsem	\
 	sideeffect statement staticassert target typesem traits transitivevisitor parsetimevisitor visitor	\
 	typinf utils scanelf scanmach statement_rewrite_walker statementsem staticcond safe blockexit printast \
 	semantic2 semantic3))

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -153,7 +153,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d $D/dsymbolsem.d		\
-	$D/dtemplate.d $D/dversion.d $D/escape.d			\
+	$D/lambdacomp.d $D/dtemplate.d $D/dversion.d $D/escape.d			\
 	$D/expression.d $D/expressionsem.d $D/func.d $D/hdrgen.d $D/id.d $D/imphint.d	\
 	$D/impcnvtab.d $D/init.d $D/initsem.d $D/inline.d $D/inlinecost.d $D/intrange.d $D/json.d $D/lib.d $D/link.d	\
 	$D/mars.d $D/mtype.d $D/nogc.d $D/nspace.d $D/objc.d $D/opover.d $D/optimize.d $D/parse.d	\

--- a/test/compilable/testlambdacomp.d
+++ b/test/compilable/testlambdacomp.d
@@ -1,0 +1,95 @@
+void test1()
+{
+    static assert(__traits(isSame, (a, b) => a + b, (c, d) => c + d));
+    static assert(__traits(isSame, a => ++a, b => ++b));
+    static assert(!__traits(isSame, (int a, int b) => a + b, (a, b) => a + b));
+    static assert(__traits(isSame, (a, b) => a + b + 10, (c, d) => c + d + 10));
+}
+
+void test2()
+{
+
+    int b;
+    static assert(!__traits(isSame, a => a + b, a => a + b));
+
+    int f() { return 3;}
+    static assert(!__traits(isSame, a => a + f(), a => a + f()));
+
+    class A
+    {
+        int a;
+        this(int a)
+        {
+            this.a = a;
+        }
+    }
+
+    class B
+    {
+        int a;
+        this(int a)
+        {
+            this.a = a;
+        }
+    }
+
+    static assert(__traits(isSame, (A a) => ++a.a, (A b) => ++b.a));
+    static assert(!__traits(isSame, (A a) => ++a.a, (B a) => ++a.a));
+
+    A cl = new A(7);
+    static assert(!__traits(isSame, a => a + cl.a, c => c + cl.a));
+
+    struct T(G)
+    {
+        G a;
+    }
+
+    static assert(!__traits(isSame, (T!int a) => ++a.a, (T!int a) => ++a.a));
+}
+
+void test3()
+{
+    enum q = 10;
+    static assert(__traits(isSame, (a, b) => a + b + q, (c, d) => c + d + 10));
+
+    struct Bar
+    {
+        int a;
+    }
+    enum r1 = Bar(1);
+    enum r2 = Bar(1);
+    static assert(__traits(isSame, a => a + r1.a, b => b + r2.a));
+
+    enum X { A, B, C}
+    static assert(__traits(isSame, a => a + X.A, a => a + 0));
+}
+
+void foo(alias pred)()
+{
+    static assert(__traits(isSame, pred, (c, d) => c + d));
+    static assert(__traits(isSame, (c, d) => c + d, pred));
+}
+
+void bar(alias pred)()
+{
+    static assert(__traits(isSame, pred, (c, d) => c < d + 7));
+
+    enum q = 7;
+    static assert(__traits(isSame, pred, (c, d) => c < d + q));
+
+    int r = 7;
+    static assert(!__traits(isSame, pred, (c, d) => c < d + r));
+}
+void test4()
+{
+    foo!((a, b) => a + b)();
+    bar!((a, b) => a < b + 7);
+}
+
+void main()
+{
+    test1();
+    test2();
+    test3();
+    test4();
+}


### PR DESCRIPTION
This PR implements the first draft of the lambda comparison project. For the moment, it is possible to compare lambda functions :

-> which use in their body only parameters, IntegerExps and enums (no runtime variables)
-> that have user defined types as parameter types

A lambda function which has runtime variables or function calls in its body will be considered uncomparable for the moment. I plan on working on that case.

The current PR is just a proof of concept and I am sure that there are a lot of corner cases that I've missed and if you identify such cases please report them. I plan an adding some tests in the next commit and also try to see if function calls can be supported by putting the mangled name of the function in the lambda serialization.