### PR TITLE
[WIP] Provide a mechanism to add extra library search paths for OPTLINK

### DIFF
--- a/test/compilable/extra-files/foolib.d
+++ b/test/compilable/extra-files/foolib.d
@@ -1,0 +1,2 @@
+module foolib;
+void foolibfunc() { }

--- a/test/compilable/extra-files/libpath.d
+++ b/test/compilable/extra-files/libpath.d
@@ -1,0 +1,2 @@
+import foolib;
+void main() { foolibfunc(); }

--- a/test/compilable/libpath.sh
+++ b/test/compilable/libpath.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+TEMP_LIB_PATH=${RESULTS_DIR}${SEP}compilable${SEP}templibpath
+
+function echorun() {
+    echo $@
+    $@
+}
+
+if [ $OS == "win32" -o  $OS == "win64" ]; then
+    LIB_ARGS=
+    FOOLIB_OUT=foolib.lib
+    FOOLIB_ARG=foolib.lib
+    # TODO: if MSVC; then
+    #    LINKER_FLAG=/LIBPATH:${TEMP_LIB_PATH}
+    LINKER_FLAG="-L+${TEMP_LIB_PATH}\\"
+else
+    LIB_ARGS=-fPIC
+    FOOLIB_OUT=libfoolib.a
+    FOOLIB_ARG=-L-lfoolib
+    LINKER_FLAG=-L-L${TEMP_LIB_PATH}
+fi
+
+mkdir -p ${TEMP_LIB_PATH}
+
+echorun ${DMD} -m${MODEL} -conf= -lib ${LIB_ARGS} -od${TEMP_LIB_PATH} -of${FOOLIB_OUT} compilable/extra-files/foolib.d
+
+# TODO: remove -v before merging
+echorun ${DMD} -v -m${MODEL} -conf= -od${TEMP_LIB_PATH} -of${TEMP_LIB_PATH}/libpath -Icompilable/extra-files compilable/extra-files/libpath.d ${LINKER_FLAG} ${FOOLIB_ARG}
+
+rm -rf ${TEMP_LIB_PATH}


### PR DESCRIPTION
Currently there's no mechanism to add library search paths when using dmd with optlink on windows.

This change allows you to use the following command line to prepend/append library search paths for optlink.
```
dmd -L:libMyHighPriorityPath\ -L:-libMyLowPriorityPath\
```

To explain a bit more.  The problem is that you cannot add library search paths to optlink via command line switches.  The only way to add search paths is to modify the config file, or add them to the `lib` location on the command line:
```
LINK obj[,out[,map[,lib[,def[,res]]]]]
                    ^
     must be added here, and paths must end with a trailing backslash \
```

The problem is that all the `-L<linker-option>` options are added to the end of the command, which does not allow you to add library search paths.  This change treats optlink options prefixed with `:lib` and `:-lib` special by inserting them into the front/back of the `lib` command line location.