### PR TITLE
Fix test17868 post script for Darwin_64_32 auto-test failures

### DIFF
--- a/test/runnable/extra-files/test17868-postscript.sh
+++ b/test/runnable/extra-files/test17868-postscript.sh
@@ -9,4 +9,4 @@ if [ $? -ne 0 ]; then
     exit 1;
 fi
 
-rm ${RESULTS_DIR}/runnable/test17868.d.out.2
+rm -f ${RESULTS_DIR}/runnable/test17868.d.out.2


### PR DESCRIPTION
I'm seeing periodic failures from DARWIN_64_32 in the auto-tester.  Sometimes it succeeds, sometimes it doesn't

https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=2955137&isPull=true
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=2957010&isPull=true

The `rm` command fails because it can't find one of the intermediate files.  Why it can't find it, I don't know, but it doesn't seem to be crucial to the test; it's just cleanup.

If the file doesn't exist and it's trying to delete it, I don't see that there's anything to complain about.

cc @braddr, @wilzbach 