### PR TITLE
Fix warnings about uninitialized variables

### DIFF
--- a/src/dmd/backend/cg87.c
+++ b/src/dmd/backend/cg87.c
@@ -680,7 +680,7 @@ __body
     targ_float f;
     targ_double d;
     targ_ldouble ld;
-    int sz;
+    int sz = -1;
     int zero;
     void *p;
     static char zeros[sizeof(longdouble)];
@@ -1955,7 +1955,7 @@ ret0:   return 0;
 void eq87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
         code cs;
-        unsigned op1;
+        unsigned op1 = -1;
         unsigned op2;
 
         //printf("+eq87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
@@ -2180,8 +2180,8 @@ void complex_eq87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 static void cnvteq87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
         code cs;
-        unsigned op1;
-        unsigned op2;
+        unsigned op1 = -1;
+        unsigned op2 = -1;
 
         assert(e->Eoper == OPeq);
         assert(!*pretregs);
@@ -2232,7 +2232,7 @@ void opass87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         code cs;
         unsigned op;
         unsigned opld;
-        unsigned op1;
+        unsigned op1 = -1;
         unsigned op2;
         tym_t ty1 = tybasic(e->E1->Ety);
 
@@ -2732,8 +2732,9 @@ static void opass_complex87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
  */
 
 void cdnegass87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
-{   regm_t retregs;
-    unsigned op;
+{
+    regm_t retregs;
+    unsigned op = -1;
 
     //printf("cdnegass87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
     elem *e1 = e->E1;
@@ -2807,8 +2808,8 @@ void cdnegass87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 void post87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
         unsigned op;
-        unsigned op1;
-        unsigned reg;
+        unsigned op1 = -1;
+        unsigned reg = -1;
 
         //printf("post87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
         code cs;
@@ -3113,7 +3114,9 @@ void cdd_u32(CodeBuilder& cdb, elem *e, regm_t *pretregs)
 void cnvt87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
         regm_t retregs;
-        unsigned mf,rf,reg;
+        unsigned mf = -1;
+        unsigned rf = -1;
+        unsigned reg;
         int clib;
 
         //printf("cnvt87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
@@ -3269,7 +3272,8 @@ void cdrndtol(CodeBuilder& cdb,elem *e,regm_t *pretregs)
     regm_t retregs = mST0;
     codelem(cdb,e->E1,&retregs,FALSE);
 
-    unsigned char op1,op2;
+    unsigned char op1 = -1;
+    unsigned char op2 = -1;
     tym_t tym = e->Ety;
     unsigned sz = tysize(tym);
     switch (sz)
@@ -3354,7 +3358,7 @@ void neg87(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         //printf("neg87()\n");
 
         assert(*pretregs);
-        int op;
+        int op = -1;
         switch (e->Eoper)
         {   case OPneg:  op = 0xE0;     break;
             case OPabs:  op = 0xE1;     break;
@@ -3733,7 +3737,7 @@ __body
     unsigned mf;
     unsigned sz;
     unsigned char ldop;
-    regm_t retregs;
+    regm_t retregs = -1;
     int i;
 
     //printf("cload87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));

--- a/src/dmd/backend/cgelem.c
+++ b/src/dmd/backend/cgelem.c
@@ -2319,7 +2319,8 @@ STATIC elem * eldiv(elem *e, goal_t goal)
         e2->Ety = touns(e2->Ety);
         i = ispow2(el_tolong(e2));
         if (i != -1)
-        {   int op;
+        {
+            int op = -1;
 
             switch (e->Eoper)
             {   case OPdiv:

--- a/src/dmd/backend/cgxmm.c
+++ b/src/dmd/backend/cgxmm.c
@@ -640,7 +640,8 @@ void xmmneg(CodeBuilder& cdb,elem *e,regm_t *pretregs)
  */
 
 unsigned xmmload(tym_t tym, bool aligned)
-{   unsigned op;
+{
+    unsigned op = -1;
     if (tysize(tym) == 32)
         aligned = false;
     switch (tybasic(tym))
@@ -691,7 +692,8 @@ unsigned xmmload(tym_t tym, bool aligned)
  */
 
 unsigned xmmstore(tym_t tym, bool aligned)
-{   unsigned op;
+{
+    unsigned op = -1;
     switch (tybasic(tym))
     {
         case TYuint:
@@ -743,7 +745,7 @@ unsigned xmmstore(tym_t tym, bool aligned)
 static unsigned xmmoperator(tym_t tym, unsigned oper)
 {
     tym = tybasic(tym);
-    unsigned op;
+    unsigned op = -1;
     switch (oper)
     {
         case OPadd:
@@ -1049,7 +1051,7 @@ void cdvector(CodeBuilder& cdb, elem *e, regm_t *pretregs)
     unsigned sz1 = _tysize[ty1];
 //    assert(sz1 == 16);       // float or double
 
-    regm_t retregs;
+    regm_t retregs = -1;
     if (n == 3 && ty2 == TYuchar && op2->Eoper == OPconst)
     {   // Handle: op xmm,imm8
 
@@ -1058,7 +1060,7 @@ void cdvector(CodeBuilder& cdb, elem *e, regm_t *pretregs)
             retregs = XMMREGS;
         codelem(cdb,op1,&retregs,FALSE); // eval left leaf
         unsigned reg = findreg(retregs);
-        int r;
+        int r = -1;
         switch (op)
         {
             case PSLLD:  r = 6; op = 0x660F72;  break;

--- a/src/dmd/backend/cod1.c
+++ b/src/dmd/backend/cod1.c
@@ -790,10 +790,11 @@ void getlvalue_lsw(code *c)
 void getlvalue(CodeBuilder& cdb,code *pcs,elem *e,regm_t keepmsk)
 { regm_t idxregs;
   unsigned fl,f,opsave;
-  elem *e1;
+  elem *e1 = NULL;
   elem *e11;
   elem *e12;
-  bool e1isadd,e1free;
+  bool e1isadd = false;
+  bool e1free;
   unsigned reg;
   tym_t e1ty;
   symbol *s;
@@ -3237,7 +3238,8 @@ void cdfunc(CodeBuilder& cdb,elem *e,regm_t *pretregs)
             int preg = parameters[i].reg;
             regm_t retregs = mask[preg];
             if (retregs & XMMREGS)
-            {   int reg;
+            {
+                int reg = -1;
 
                 switch (preg)
                 {   case XMM0: reg = CX; break;
@@ -3625,7 +3627,7 @@ static void funccall(CodeBuilder& cdb,elem *e,unsigned numpara,unsigned numalign
 targ_size_t paramsize(elem *e)
 {
     assert(e->Eoper != OPparam);
-    targ_size_t szb;
+    targ_size_t szb = -1;
     tym_t tym = tybasic(e->Ety);
     if (tyscalar(tym))
         szb = size(tym);
@@ -3778,8 +3780,8 @@ static void movParams(CodeBuilder& cdb,elem *e,unsigned stackalign, unsigned fun
             retregs = tycomplex(tym) ? mST01 : mST0;
             codelem(cdb,e,&retregs,FALSE);
 
-            unsigned op;
-            unsigned r;
+            unsigned op = -1;
+            unsigned r = -1;
             switch (tym)
             {
                 case TYfloat:
@@ -4372,8 +4374,8 @@ void pushParams(CodeBuilder& cdb,elem *e,unsigned stackalign)
             stackpush += sz;
             cdb.genadjesp(sz);
             cod3_stackadj(cdb, sz);
-            unsigned op;
-            unsigned r;
+            unsigned op = -1;
+            unsigned r = -1;
             switch (tym)
             {
                 case TYfloat:

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -209,7 +209,9 @@ void cdorth(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         return;
     }
 
-    unsigned op1,op2,mode;
+    unsigned op1 = -1;
+    unsigned op2;
+    unsigned mode;
     static int nest;
 
   tym_t ty2 = tybasic(e2->Ety);
@@ -3193,7 +3195,7 @@ void cdstrlen(CodeBuilder& cdb, elem *e, regm_t *pretregs)
 
 void cdstrcmp(CodeBuilder& cdb, elem *e, regm_t *pretregs)
 {
-    char need_DS;
+    char need_DS = -1;
     int segreg;
 
     /*
@@ -3298,7 +3300,7 @@ void cdstrcmp(CodeBuilder& cdb, elem *e, regm_t *pretregs)
 
 void cdmemcmp(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
-    char need_DS;
+    char need_DS = -1;
     int segreg;
 
     /*
@@ -3407,7 +3409,7 @@ void cdmemcmp(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 
 void cdstrcpy(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
-    char need_DS;
+    char need_DS = -1;
     int segreg;
 
     /*
@@ -3517,7 +3519,7 @@ void cdstrcpy(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 
 void cdmemcpy(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 {
-    char need_DS;
+    char need_DS = -1;
     int segreg;
 
     /*

--- a/src/dmd/backend/cod3.c
+++ b/src/dmd/backend/cod3.c
@@ -249,7 +249,7 @@ void REGSAVE::restore(CodeBuilder& cdb, int reg, unsigned idx)
 unsigned char vex_inssize(code *c)
 {
     assert(c->Iflags & CFvex && c->Ivex.pfx == 0xC4);
-    unsigned char ins;
+    unsigned char ins = -1;
     if (c->Iflags & CFvex3)
     {
         switch (c->Ivex.mmmm)
@@ -1904,7 +1904,10 @@ void outswitab(block *b)
 
 int jmpopcode(elem *e)
 { tym_t tym;
-  int zero,i,jp,op;
+  int zero;
+  int i = -1;
+  int jp;
+  int op;
   static const char jops[][2][6] =
     {   /* <=  >   <   >=  ==  !=    <=0 >0  <0  >=0 ==0 !=0    */
        { {JLE,JG ,JL ,JGE,JE ,JNE},{JLE,JG ,JS ,JNS,JE ,JNE} }, /* signed   */
@@ -6800,7 +6803,8 @@ static void do16bit(MiniCodeBuf *pbuf, enum FL fl,union evc *uev,int flags)
 }
 
 static void do8bit(MiniCodeBuf *pbuf, enum FL fl,union evc *uev)
-{ char c;
+{
+  char c = -1;
   targ_ptrdiff_t delta;
 
   switch (fl)

--- a/src/dmd/backend/cod4.c
+++ b/src/dmd/backend/cod4.c
@@ -840,7 +840,10 @@ void cdaddass(CodeBuilder& cdb,elem *e,regm_t *pretregs)
     // TRUE if we want the result in a register
     unsigned wantres = forregs || (e1->Ecount && EOP(e1));
 
-    unsigned reg,op1,op2,mode;
+    unsigned reg;
+    unsigned op1 = -1;
+    unsigned op2;
+    unsigned mode;
     code cs;
     elem *e2;
     regm_t varregm;
@@ -2841,7 +2844,8 @@ void cdshtlng(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         if (e1comsub)
             getregs(cdb,retregs);
         if (op == OPnp_fp)
-        {   int segreg;
+        {
+            int segreg = -1;
 
             // BUG: what about pointers to functions?
             switch (tym1)
@@ -3932,8 +3936,8 @@ void cdprefetch(CodeBuilder& cdb, elem *e, regm_t *pretregs)
 
     assert(*pretregs == 0);
     assert(e->E2->Eoper == OPconst);
-    unsigned op;
-    unsigned reg;
+    unsigned op = -1;
+    unsigned reg = -1;
     switch (e->E2->EV.Vuns)
     {
         case 0: op = PREFETCH; reg = 1; break;  // PREFETCH0

--- a/src/dmd/backend/el.c
+++ b/src/dmd/backend/el.c
@@ -1958,7 +1958,7 @@ elem *el_convfloat(elem *e)
     tym_t ty = e->Ety;
     int sz = tysize(ty);
     assert(sz <= sizeof(buffer));
-    void *p;
+    void *p = NULL;
     switch (tybasic(ty))
     {
         case TYfloat:
@@ -2911,7 +2911,8 @@ targ_llong el_tolongt(elem *e)
  */
 
 targ_llong el_tolong(elem *e)
-{   targ_llong result;
+{
+    targ_llong result = -1;
     tym_t ty;
 
     elem_debug(e);

--- a/src/dmd/backend/evalu8.c
+++ b/src/dmd/backend/evalu8.c
@@ -150,7 +150,8 @@ FM1:    // We don't use fprem1 because for some inexplicable
  */
 
 int boolres(elem *e)
-{   int b;
+{
+    int b = -1;
 
     //printf("boolres()\n");
     //elem_print(e);


### PR DESCRIPTION
These warnings occur if the `ENABLE_WARNINGS` environment variable is set when compiling.