### PR TITLE
Fix warnings about uninitialized variables

### DIFF
--- a/src/dmd/backend/tassert.h
+++ b/src/dmd/backend/tassert.h
@@ -24,7 +24,7 @@
 
 void util_assert(const char * , int) __attribute__((noreturn));
 
-static void local_assert(int line)
+__attribute__((noreturn)) static void local_assert(int line)
 {
     util_assert(__file__,line);
     __builtin_unreachable();


### PR DESCRIPTION
These warnings occur if the `ENABLE_WARNINGS` environment variable is set when compiling.

The fix is to properly annotate the custom assert implementation in the backend to make the compiler understand that function will never return.

I tried to use the system provided assert implementation but that caused new errors because of how the `_VEX_ASSERT0` [1] macro is used. For example:

```
dmd/backend/ptrntab.c:1218:11: error: predefined identifier is only valid inside function [-Werror,-Wpredefined-identifier-outside-function]
        { VEX_128_WIG(LODD), _r, _xmm, _rm32 },
          ^
dmd/backend/iasm.h:75:36: note: expanded from macro 'VEX_128_WIG'
#define VEX_128_WIG(op)            VEX_128_W0(op)
                                   ^
dmd/backend/iasm.h:73:36: note: expanded from macro 'VEX_128_W0'
#define VEX_128_W0(op)            (_VEX(op)|_VEX_NOO)
                                   ^
dmd/backend/iasm.h:114:32: note: expanded from macro '_VEX'
#define _VEX(op) (0xC4 << 24 | _VEX_MM(op >> 8) | (op & 0xFF))
                               ^
note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
dmd/backend/iasm.h:130:9: note: expanded from macro '_VEX_PP'
        _VEX_ASSERT0                                    \
        ^
dmd/backend/iasm.h:135:27: note: expanded from macro '_VEX_ASSERT0'
    #define _VEX_ASSERT0 (assert(0))
                          ^
/usr/include/assert.h:93:47: note: expanded from macro 'assert'
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __FILE__, __LINE__, #e) : (void)0)
```

[1] https://github.com/dlang/dmd/blob/master/src/dmd/backend/iasm.h#L135