### PR TITLE
Fix test17868 sporadic failures

### DIFF
--- a/test/runnable/extra-files/test17868-postscript.sh
+++ b/test/runnable/extra-files/test17868-postscript.sh
@@ -2,11 +2,11 @@
 
 # trim off the first line which contains the path of the file which differs between windows and non-windows
 # also trim off compiler debug message
-grep -v 'runnable\|DEBUG' $1 > ${RESULTS_DIR}/runnable/test17868.d.out.2
+grep -v 'runnable\|DEBUG' $2 > $1
 
-diff --strip-trailing-cr runnable/extra-files/test17868.d.out ${RESULTS_DIR}/runnable/test17868.d.out.2
+diff --strip-trailing-cr runnable/extra-files/test17868.d.out $1
 if [ $? -ne 0 ]; then
     exit 1;
 fi
 
-rm -f ${RESULTS_DIR}/runnable/test17868.d.out.2
+rm -f $1

--- a/test/runnable/test17868.d
+++ b/test/runnable/test17868.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -betterC
-// POST_SCRIPT: runnable/extra-files/test17868-postscript.sh
+// POST_SCRIPT: runnable/extra-files/test17868-postscript.sh ${RESULTS_DIR}/runnable/test17868.d.out.2
 import core.stdc.stdio;
 
 extern(C):

--- a/test/runnable/test17868b.d
+++ b/test/runnable/test17868b.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -betterC
-// POST_SCRIPT: runnable/extra-files/test17868-postscript.sh
+// POST_SCRIPT: runnable/extra-files/test17868-postscript.sh ${RESULTS_DIR}/runnable/test17868b.d.out.2
 import core.stdc.stdio;
 
 extern(C):


### PR DESCRIPTION
Followup to #7490

This is an attempt to fix some sporadic failures for the test17868 postscript.

For example:
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=2958606&isPull=true
https://travis-ci.org/dlang/dmd/jobs/319656240
https://travis-ci.org/dlang/dmd/jobs/319656246
etc... (there are others)

My Diagnosis.
There are actually two tests `runnable/test17868.d` and `runnable/test17868b.d`, but they both use the same postscript.  The postscript is both creating and removing a file with the same name.  Therefore, if the two tests run at approximately the same time, one can remove the file from the other.

My Solution.
I modified the execution of the post script to take the file name to create as one of its arguments.  `test17868.d` will call the postscript with a file name of `test17868.d.out.2` and `test17868b.d` will call the postscript with a file name of `test17868b.d.out.2`.  Therefore, when the postscript from either test deletes its file, it won't impact the other test.
