### PR TITLE
[CodeCov] Don't wait for other CIs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,16 @@ codecov:
   notify:
     after_n_builds: 1  # send notifications after the first upload
   bot: dlang-bot
+  ci:
+    # https://docs.codecov.io/docs/detecting-ci-services
+    # Only CircleCi generates coverages files atm.
+    # Don't wait for the other CIs
+    - ci/circleci
+    - !CyberShadow/DAutoTest
+    - !auto-tester
+    - !continuous-integration/appveyor/pr
+    - !continuous-integration/jenkins/pr-merge
+    - !continuous-integration/travis-ci/pr
 
 coverage:
   precision: 3


### PR DESCRIPTION
I have repeatedly observed that the CodeCov statuses only appear once the slowest CI is finished (usually the auto-tester).
So it seems that the setting `after_n_builds` has zero effect. According to the documentation, we can set CIs to ignored.
That's what this PR is trying to do.

See also:
https://docs.codecov.io/docs/detecting-ci-services