### PR TITLE
Add Type.tambig and make ready to use.

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -335,6 +335,7 @@ public:
     {
         //printf("TypeFunction.toDecoBuffer() t = %p %s\n", t, t.toChars());
         //static int nest; if (++nest == 50) *(char*)0=0;
+        assert(!t.isAmbiguous());
         mangleFuncType(t, t, t.mod, t.next);
     }
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -619,6 +619,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (needctfe)
                 sc = sc.endCTFE();
 
+            if (dsym.type.isAmbiguous())
+            {
+                dsym.type = Type.terror;
+                return;
+            }
+
             dsym.inuse--;
             inferred = 1;
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -848,6 +848,7 @@ public:
     override void visit(TypeFunction t)
     {
         //printf("TypeFunction::toCBuffer2() t = %p, ref = %d\n", t, t.isref);
+        assert(!t.isAmbiguous());
         visitFuncIdentWithPostfix(t, null);
     }
 
@@ -979,6 +980,7 @@ public:
 
     override void visit(TypeDelegate t)
     {
+        assert(!t.isAmbiguous());
         visitFuncIdentWithPostfix(cast(TypeFunction)t.next, "delegate");
     }
 
@@ -3441,6 +3443,7 @@ extern (C++) const(char)* protectionToChars(Prot.Kind kind)
 extern (C++) void functionToBufferFull(TypeFunction tf, OutBuffer* buf, Identifier ident, HdrGenState* hgs, TemplateDeclaration td)
 {
     //printf("TypeFunction::toCBuffer() this = %p\n", this);
+    assert(!tf.isAmbiguous());
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     v.visitFuncIdentWithPrefix(tf, ident, td);
 }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -198,6 +198,7 @@ public:
     static Type *twstring;              // immutable(wchar)[]
     static Type *tdstring;              // immutable(dchar)[]
     static Type *tvalist;               // va_list alias
+    static Type *tambig;                // for ambiguous function overloads
     static Type *terror;                // for error recovery
     static Type *tnull;                 // for null type
 
@@ -263,6 +264,7 @@ public:
     virtual bool isscope();
     virtual bool isString();
     virtual bool isAssignable();
+    virtual bool isAmbiguous();
     virtual bool isBoolean();
     virtual void checkDeprecated(const Loc &loc, Scope *sc);
     bool isConst() const       { return (mod & MODconst) != 0; }
@@ -356,6 +358,7 @@ class TypeNext : public Type
 public:
     Type *next;
 
+    bool isAmbiguous();
     void checkDeprecated(const Loc &loc, Scope *sc);
     int hasWild() const;
     Type *nextOf();
@@ -573,6 +576,7 @@ public:
     static TypeFunction *create(Parameters *parameters, Type *treturn, int varargs, LINK linkage, StorageClass stc = 0);
     const char *kind();
     Type *syntaxCopy();
+    bool isAmbiguous();
     void purityLevel();
     bool hasLazyParameters();
     bool parameterEscapes(Parameter *p);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3091,7 +3091,13 @@ else
             {
                 if (!tret)
                 {
-                    tf.next = rs.exp.type;
+                    if (rs.exp.type.isAmbiguous())
+                    {
+                        rs.error("cannot infer return type from ambiguous expression `%s`", rs.exp.toChars());
+                        tf.next = Type.terror;
+                    }
+                    else
+                        tf.next = rs.exp.type;
                 }
                 else if (tret.ty != Terror && !rs.exp.type.equals(tret))
                 {


### PR DESCRIPTION
First commit of #2130.  I've checked the PR, and fixing all mentioned issues ([1983](https://issues.dlang.org/show_bug.cgi?id=1983), [7322](https://issues.dlang.org/show_bug.cgi?id=7322), [7549](https://issues.dlang.org/show_bug.cgi?id=7549), [8868](https://issues.dlang.org/show_bug.cgi?id=8868), [9027](https://issues.dlang.org/show_bug.cgi?id=9027)) depends on this first if we are to take on the original patch.

I've replaced the handling of `isAmbiguous` in dmangle and hdrgen with asserts, as I do not know whether they are reachable.  See that the type is only used for generating errors, I would suspect not.