### PR TITLE
Fix Issue 11714 - Improve error message for wrongly initialized thread-local class and pointer to struct instances

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -321,19 +321,19 @@ extern(C++) final class Semantic2Visitor : Visitor
         }
         else if (vd._init && vd.isThreadlocal())
         {
+            // Cannot initialize a thread-local class or pointer to struct variable with a literal
+            // that itself is a thread-local reference and would need dynamic initialization also.
             if ((vd.type.ty == Tclass) && vd.type.isMutable() && !vd.type.isShared())
             {
                 ExpInitializer ei = vd._init.isExpInitializer();
                 if (ei && ei.exp.op == TOKclassreference)
-                    vd.error("is mutable. Only const or immutable class thread local variable are allowed, not %s", vd.type.toChars());
+                    vd.error("is a thread-local class and cannot have a static initializer. Use `static this()` to initialize instead.");
             }
             else if (vd.type.ty == Tpointer && vd.type.nextOf().ty == Tstruct && vd.type.nextOf().isMutable() && !vd.type.nextOf().isShared())
             {
                 ExpInitializer ei = vd._init.isExpInitializer();
                 if (ei && ei.exp.op == TOKaddress && (cast(AddrExp)ei.exp).e1.op == TOKstructliteral)
-                {
-                    vd.error("is a pointer to mutable struct. Only pointers to const, immutable or shared struct thread local variable are allowed, not %s", vd.type.toChars());
-                }
+                    vd.error("is a thread-local pointer to struct and cannot have a static initializer. Use `static this()` to initialize instead.");
             }
         }
         vd.semanticRun = PASSsemantic2done;

--- a/test/fail_compilation/fail11714.d
+++ b/test/fail_compilation/fail11714.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11714.d(14): Error: variable fail11714.c is a thread-local class and cannot have a static initializer. Use `static this()` to initialize instead.
+fail_compilation/fail11714.d(21): Error: variable fail11714.s is a thread-local pointer to struct and cannot have a static initializer. Use `static this()` to initialize instead.
+---
+*/
+
+class C11714
+{
+    int data;
+};
+
+C11714 c = new C11714;  // mutable class reference.
+
+struct S11714
+{
+    int data;
+};
+
+S11714* s = new S11714; // mutable pointer to struct.


### PR DESCRIPTION
My attempt to take a stab at #2943