### PR TITLE
fix Issue 6856 - Use in contract from base class if not specified in derived

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -279,9 +279,6 @@ private extern(C++) final class Semantic3Visitor : Visitor
         }
 
         uint oldErrors = global.errors;
-        auto fds = FuncDeclSem3(funcdecl,sc);
-
-        fds.checkInContractOverrides();
 
         // Remember whether we need to generate an 'out' contract.
         immutable bool needEnsure = FuncDeclaration.needsFensure(funcdecl);
@@ -882,6 +879,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
             funcdecl.frequire = funcdecl.mergeFrequire(funcdecl.frequire);
             funcdecl.fensure = funcdecl.mergeFensure(funcdecl.fensure, Id.result);
+
+            auto fds = FuncDeclSem3(funcdecl,sc);
+            fds.checkInContractOverrides();
 
             Statement freq = funcdecl.frequire;
             Statement fens = funcdecl.fensure;

--- a/test/fail_compilation/fail6856.d
+++ b/test/fail_compilation/fail6856.d
@@ -1,0 +1,37 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail6856.d(30): Error: function `fail6856.EvenMoreDerived.foo` cannot have an in contract when overridden function `fail6856.Derived.foo` does not have an in contract
+---
+*/
+
+class Base
+{
+    void foo(int x)
+    in
+    {
+        assert(false);
+    }
+    body
+    {
+
+    }
+}
+
+class Derived : Base
+{
+    override void foo(int x)
+    {
+    }
+}
+
+class EvenMoreDerived : Derived
+{
+    override void foo(int x)
+    in
+    {
+    }
+    body
+    {
+    }
+}

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -634,8 +634,6 @@ void test7517()
         static C self;
 
         void setEnable()
-        in {}       // supply in-contract to invoke I.setEnable.in
-        do
         {
             assert(self is this);
             result ~= "C.setEnable/";
@@ -668,7 +666,7 @@ void test7517()
 
     result = null;
     i.setDisable();
-    assert(result == "C.setDisable/I.setDisable.out/C.enabled/");
+    assert(result == "I.setDisable.in/C.enabled/C.setDisable/I.setDisable.out/C.enabled/");
 }
 
 /*******************************************/

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -481,7 +481,7 @@ class Base6856
     void foo(int x)
     in
     {
-        printf("[%d] in Base(%x)\n", data, this);
+        printf("[%d] in Base(%p, %d)\n", data, this, x);
         data += 1;
         assert(false);
     }
@@ -496,7 +496,7 @@ class Derived6856 : Base6856
     override void foo(int x)
     in
     {
-        printf("[%d] in Derived(%x)\n", data, this);
+        printf("[%d] in Derived(%p, %d)\n", data, this, x);
         data += 1;
         assert(x > 5);
     }
@@ -516,7 +516,7 @@ class EvenMoreDerived6856a : Derived6856
     override void foo(int x)
     in
     {
-        printf("[%d] in EvenMoreDerived(%x)\n", data, this);
+        printf("[%d] in EvenMoreDerived(%p, %d)\n", data, this, x);
         data += 1;
     }
     do


### PR DESCRIPTION
Supersedes #4200.