### PR TITLE
fix warnings about bad pointer related conversions

### DIFF
--- a/src/dmd/backend/os.c
+++ b/src/dmd/backend/os.c
@@ -80,7 +80,7 @@ void os_error(int line)
 #pragma noreturn(os_error)
 #endif
 
-#if _WIN32
+#if _WIN32 && !_WIN64
 /*********************************
  * Allocate a chunk of memory from the operating system.
  * Bypass malloc and friends.

--- a/src/dmd/tk/vec.c
+++ b/src/dmd/tk/vec.c
@@ -523,8 +523,8 @@ void vec_copy(vec_t to,vec_t from)
     {
 #ifdef DEBUG
         if (!(to && from && vec_numbits(to) == vec_numbits(from)))
-            printf("to = x%lx, from = x%lx, numbits(to) = %d, numbits(from) = %d\n",
-                (long)to,(long)from,to ? (int)vec_numbits(to) : 0, from ? (int)vec_numbits(from): 0);
+            printf("to = x%p, from = x%p, numbits(to) = %d, numbits(from) = %d\n",
+                to,from,to ? (int)vec_numbits(to) : 0, from ? (int)vec_numbits(from): 0);
 #endif
         assert(to && from && vec_numbits(to) == vec_numbits(from));
         memcpy(to,from,sizeof(to[0]) * vec_dim(to));


### PR DESCRIPTION
VC build for Win64: disables Win32 C code that is not used by dmd and is wrong for Win64.