### PR TITLE
Support latest g++ when ENABLE_WARNINGS is on

### DIFF
--- a/src/dmd/backend/blockopt.c
+++ b/src/dmd/backend/blockopt.c
@@ -713,7 +713,7 @@ void brcombine()
                     {
                         if (EOP(b3->Belem))
                             continue;
-                        tym_t ty = (bc2 == BCretexp) ? b2->Belem->Ety : TYvoid;
+                        tym_t ty = (bc2 == BCretexp) ? b2->Belem->Ety : (tym_t) TYvoid;
                         elem *e = el_bin(OPcolon2,ty,b2->Belem,b3->Belem);
                         b->Belem = el_bin(OPcond,ty,b->Belem,e);
                     }

--- a/src/dmd/backend/cgcod.c
+++ b/src/dmd/backend/cgcod.c
@@ -595,7 +595,7 @@ tryagain:
 
     // Mask of regs saved
     // BUG: do interrupt functions save BP?
-    sfunc->Sregsaved = (functy == TYifunc) ? mBP : (mfuncreg | fregsaved);
+    sfunc->Sregsaved = (functy == TYifunc) ? (regm_t) mBP : (mfuncreg | fregsaved);
 
     util_free(csextab);
     csextab = NULL;
@@ -2365,10 +2365,11 @@ static void comsub(CodeBuilder& cdb,elem *e,regm_t *pretregs)
   /* create mask of what's in csextab[] */
   csemask = 0;
   for (size_t i = 0; i < cstop; i++)
-  {     if (csextab[i].e)
-            elem_debug(csextab[i].e);
-        if (csextab[i].e == e)
-                csemask |= csextab[i].regm;
+  {
+      if (csextab[i].e)
+          elem_debug(csextab[i].e);
+      if (csextab[i].e == e)
+          csemask |= csextab[i].regm;
   }
   csemask &= ~emask;            /* stuff already in registers   */
 

--- a/src/dmd/backend/cod1.c
+++ b/src/dmd/backend/cod1.c
@@ -4803,7 +4803,7 @@ void loaddata(CodeBuilder& cdb,elem *e,regm_t *pretregs)
             loadea(cdb,e,&cs,op,reg,0,0,0);     // MOV regL,data
         }
         else
-        {   nregm = tyuns(tym) ? BYTEREGS : mAX;
+        {   nregm = tyuns(tym) ? BYTEREGS : (regm_t) mAX;
             if (*pretregs & nregm)
                 nreg = reg;                             // already allocated
             else

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -4403,7 +4403,7 @@ void cdneg(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         }
         else
         {
-            unsigned reg = (sz == 8) ? AX : findregmsw(retregs);
+            unsigned reg = (sz == 8) ? (unsigned) AX : findregmsw(retregs);
             cdb.genc2(0x81,modregrm(3,6,reg),0x8000);     // XOR AX,0x8000
         }
         fixresult(cdb,e,retregs,pretregs);
@@ -4476,7 +4476,7 @@ void cdabs(CodeBuilder& cdb,elem *e, regm_t *pretregs)
         }
         else
         {
-            int reg = (sz == 8) ? AX : findregmsw(retregs);
+            int reg = (sz == 8) ? (int) AX : findregmsw(retregs);
             cdb.genc2(0x81,modregrm(3,4,reg),0x7FFF);     // AND AX,0x7FFF
         }
         fixresult(cdb,e,retregs,pretregs);
@@ -4486,7 +4486,7 @@ void cdabs(CodeBuilder& cdb,elem *e, regm_t *pretregs)
     unsigned byte = sz == 1;
     assert(byte == 0);
     byte = 0;
-    regm_t possregs = (sz <= REGSIZE) ? mAX : allregs;
+    regm_t possregs = (sz <= REGSIZE) ? (regm_t) mAX : allregs;
     if (!I16 && sz == REGSIZE)
         possregs = allregs;
     regm_t retregs = *pretregs & possregs;

--- a/src/dmd/backend/cod3.c
+++ b/src/dmd/backend/cod3.c
@@ -624,7 +624,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
 
         case TYllong:
         case TYullong:
-            return I64 ? mAX : (I32 ? mDX | mAX : DOUBLEREGS);
+            return I64 ? (regm_t) mAX : (I32 ? mDX | mAX : DOUBLEREGS);
 
         case TYldouble:
         case TYildouble:

--- a/src/dmd/backend/cod4.c
+++ b/src/dmd/backend/cod4.c
@@ -3299,7 +3299,7 @@ void cdport(CodeBuilder& cdb,elem *e,regm_t *pretregs)
     {
         sz = tysize(e->E2->Ety);
         regm_t retregs = mAX;           // byte/word to output is in AL/AX
-        scodelem(cdb,e->E2,&retregs,((op & 0x08) ? mDX : (regm_t) 0),TRUE);
+        scodelem(cdb,e->E2,&retregs,((op & 0x08) ? mDX : 0),TRUE);
         op |= 0x02;                     // OUT opcode
     }
     else // OPinp

--- a/src/dmd/backend/el.c
+++ b/src/dmd/backend/el.c
@@ -2375,7 +2375,7 @@ elem *el_ctor_dtor(elem *ec, elem *ed, elem **pedtor)
         union eve c;
         memset(&c, 0, sizeof(c));
         elem *e_flag_0 = el_bin(OPeq, TYvoid, el_var(sflag), el_const(TYbool, &c));  // __flag = 0
-        er = el_bin(OPinfo, ec ? ec->Ety : TYvoid, ector, el_combine(e_flag_0, ec));
+        er = el_bin(OPinfo, ec ? ec->Ety : (tym_t) TYvoid, ector, el_combine(e_flag_0, ec));
 
         /* A destructor always executes code, or we wouldn't need
          * eh for it.

--- a/src/dmd/backend/symbol.c
+++ b/src/dmd/backend/symbol.c
@@ -413,7 +413,7 @@ void symbol_func(symbol *s)
     // Interrupt functions modify all registers
     // BUG: do interrupt functions really save BP?
     // Note that fregsaved may not be set yet
-    s->Sregsaved = (s->Stype && tybasic(s->Stype->Tty) == TYifunc) ? mBP : fregsaved;
+    s->Sregsaved = (s->Stype && tybasic(s->Stype->Tty) == TYifunc) ? (regm_t) mBP : fregsaved;
     s->Sseg = UNKNOWN;          // don't know what segment it is in
     if (!s->Sfunc)
         s->Sfunc = func_calloc();

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -174,7 +174,9 @@ WARNINGS += \
 	-Wno-logical-op \
 	-Wno-narrowing \
 	-Wno-unused-but-set-variable \
-	-Wno-uninitialized
+	-Wno-uninitialized \
+	-Wno-class-memaccess \
+	-Wno-implicit-fallthrough
 endif
 # Clang Specific
 ifeq ($(HOST_CXX_KIND), clang++)


### PR DESCRIPTION
Minimum changes needed to build.  Slightly borrowed from #7475.