### PR TITLE
Fix OSX build after changed C++ mangling

### DIFF
--- a/src/dmd/backend/dt.c
+++ b/src/dmd/backend/dt.c
@@ -325,7 +325,7 @@ void DtBuilder::dword(int value)
 /***********************
  * Write a size_t value.
  */
-void DtBuilder::size(d_ulong value)
+void DtBuilder::size(unsigned long value)
 {
     if (value == 0)
     {

--- a/src/dmd/backend/dt.h
+++ b/src/dmd/backend/dt.h
@@ -5,16 +5,6 @@
 
 #include <stddef.h>     // for size_t
 
-#if __APPLE__ && __i386__
-    /* size_t is 'unsigned long', which makes it mangle differently
-     * than D's 'uint'
-     */
-    typedef unsigned d_size_t;
-#else
-    typedef size_t d_size_t;
-#endif
-
-
 struct dt_t;
 struct Symbol;
 typedef unsigned        tym_t;          // data type big enough for type masks
@@ -29,12 +19,6 @@ dt_t **dtend(dt_t** pdt);
 bool dtallzeros(const dt_t *dt);
 bool dtpointers(const dt_t *dt);
 void dt2common(dt_t **pdt);
-
-#if __LP64__
-#define d_ulong unsigned long
-#else
-#define d_ulong unsigned long long
-#endif
 
 class DtBuilder
 {
@@ -51,7 +35,7 @@ public:
     void abytes(tym_t ty, unsigned offset, unsigned size, const char *ptr, unsigned nzeros);
     void abytes(unsigned offset, unsigned size, const char *ptr, unsigned nzeros);
     void dword(int value);
-    void size(d_ulong value);
+    void size(unsigned long value);
     void nzeros(unsigned size);
     void xoff(Symbol *s, unsigned offset, tym_t ty);
     dt_t *xoffpatch(Symbol *s, unsigned offset, tym_t ty);
@@ -60,7 +44,7 @@ public:
     void coff(unsigned offset);
     void cat(dt_t *dt);
     void cat(DtBuilder *dtb);
-    void repeat(dt_t *dt, d_size_t count);
+    void repeat(dt_t *dt, size_t count);
     unsigned length();
     bool isZeroLength();
 };

--- a/src/dmd/backend/outbuf.h
+++ b/src/dmd/backend/outbuf.h
@@ -15,15 +15,6 @@
 
 #include <stddef.h>     // for size_t
 
-#if __APPLE__ && __i386__
-    /* size_t is 'unsigned long', which makes it mangle differently
-     * than D's 'uint'
-     */
-    typedef unsigned d_size_t;
-#else
-    typedef size_t d_size_t;
-#endif
-
 // Output buffer
 
 // (This used to be called OutBuffer, we renamed it to avoid name conflicts with Mars.)
@@ -47,14 +38,14 @@ struct Outbuffer
     void reset();
 
     // Reserve nbytes in buffer
-    void reserve(d_size_t nbytes)
+    void reserve(size_t nbytes)
     {
         if (pend - p < nbytes)
             enlarge(nbytes);
     }
 
     // Reserve nbytes in buffer
-    void enlarge(d_size_t nbytes);
+    void enlarge(size_t nbytes);
 
     // Write n zeros; return pointer to start of zeros
     void *writezeros(d_size_t n);

--- a/src/dmd/tk/mem.c
+++ b/src/dmd/tk/mem.c
@@ -614,7 +614,7 @@ L1:
 
 /***************************/
 
-void *mem_malloc(d_size_t numbytes)
+void *mem_malloc(size_t numbytes)
 {       void *p;
 
         if (numbytes == 0)

--- a/src/dmd/tk/mem.h
+++ b/src/dmd/tk/mem.h
@@ -12,15 +12,6 @@
 
 #include <stdio.h> // for size_t
 
-#if __APPLE__ && __i386__
-    /* size_t is 'unsigned long', which makes it mangle differently
-     * than D's 'uint'
-     */
-    typedef unsigned d_size_t;
-#else
-    typedef size_t d_size_t;
-#endif
-
 /*
  * Memory management routines.
  *
@@ -156,7 +147,7 @@ void mem_checkptr(void *ptr);
  *              return NULL
  */
 
-void *mem_malloc(d_size_t);
+void *mem_malloc(size_t);
 void *mem_calloc(size_t);
 
 /*****************************


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/7416 and https://github.com/dlang/dmd/pull/7505

Still missing are these:

```
Undefined symbols for architecture x86_64:
  "symboldata(unsigned long, unsigned int)", referenced from:
      el_ptr(Symbol*) in backend.a(el.o)
      el_convstring(elem*) in backend.a(el.o)
      out_readonly_sym(unsigned int, void*, int) in backend.a(out.o)
      Obj::sym_cdata(unsigned int, char*, int) in backend.a(machobj.o)
  "_align(unsigned long, unsigned long)", referenced from:
      codgen(Symbol*) in backend.a(cgcod.o)
      stackoffsets(int) in backend.a(cgcod.o)
      outjmptab(block*) in backend.a(cod3.o)
      outswitab(block*) in backend.a(cod3.o)
      type_paramsize(TYPE*) in backend.a(type.o)
      alignOffset(int, unsigned long) in backend.a(out.o)
      out_readonly_sym(unsigned int, void*, int) in backend.a(out.o)
      ...
  "ispow2(unsigned long long)", referenced from:
      asmSemantic(AsmStatement*, Scope*) in dmd.o
  "outthunk(Symbol*, Symbol*, unsigned int, unsigned int, unsigned long long, int, unsigned long long)", referenced from:
      toThunkSymbol(FuncDeclaration*, int) in dmd.o
  "Obj::ehtables(Symbol*, unsigned long long, Symbol*)", referenced from:
      except_gentables() in dmd.o
```

But I'm without OSX, so I first wanted to see whether I'm on the right road here.