### PR TITLE
Replace C++ syntax check with dummy frontend

### DIFF
--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -188,18 +188,6 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             result = blockExit(s.statement, func, mustNotThrow);
         }
 
-        override void visit(ForwardingStatement s)
-        {
-            if (s.statement)
-            {
-                s.statement.accept(this);
-            }
-            else
-            {
-                result = BE.fallthru;
-            }
-        }
-
         override void visit(WhileStatement s)
         {
             assert(global.errors);

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -34,7 +34,7 @@ struct Id
      * An identifier that corresponds to each static field in this struct will
      * be placed in the identifier pool.
      */
-    void initialize()
+    extern(C++) void initialize()
     {
         mixin(msgtable.generate(&initializer));
     }

--- a/src/dmd/id.h
+++ b/src/dmd/id.h
@@ -1,0 +1,24 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (c) 2017 by The D Language Foundation
+ * All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/id.h
+ */
+
+#ifndef DMD_ID_H
+#define DMD_ID_H
+
+#ifdef __DMC__
+#pragma once
+#endif /* __DMC__ */
+
+struct Id
+{
+    static void initialize();
+};
+
+#endif /* DMD_ID_H */

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1052,54 +1052,6 @@ extern (C++) final class ForwardingStatement : Statement
         return new ForwardingStatement(loc, statement.syntaxCopy());
     }
 
-    override Statement getRelatedLabeled()
-    {
-        if (!statement)
-        {
-            return null;
-        }
-        return statement.getRelatedLabeled();
-    }
-
-    override bool hasBreak()
-    {
-        if (!statement)
-        {
-            return false;
-        }
-        return statement.hasBreak();
-    }
-
-    override bool hasContinue()
-    {
-        if (!statement)
-        {
-            return false;
-        }
-        return statement.hasContinue();
-    }
-
-    override Statement scopeCode(Scope* sc, Statement* sentry, Statement* sexception, Statement* sfinally)
-    {
-        if (!statement)
-        {
-            return this;
-        }
-        sc = sc.push(sym);
-        statement = statement.scopeCode(sc, sentry, sexception, sfinally);
-        sc = sc.pop();
-        return statement ? this : null;
-    }
-
-    override inout(Statement) last() inout nothrow pure
-    {
-        if (!statement)
-        {
-            return null;
-        }
-        return statement.last();
-    }
-
     /***********************
      * ForwardingStatements are distributed over the flattened
      * sequence of statements. This prevents flattening to be

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -229,11 +229,6 @@ class ForwardingStatement : public Statement
     Statement *statement;
 
     Statement *syntaxCopy();
-    Statement *getRelatedLabeled();
-    bool hasBreak();
-    bool hasContinue();
-    Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexception, Statement **sfinally);
-    Statement *last();
     Statements *flatten(Scope *sc);
     ForwardingStatement *isForwardingStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -434,7 +434,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         result = ss;
     }
 
-    override void visit(ForwardingStatement ss){
+    override void visit(ForwardingStatement ss)
+    {
         assert(ss.sym);
         for (Scope* csc = sc; !ss.sym.forward; csc = csc.enclosing)
         {
@@ -446,7 +447,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         sc.scontinue = ss;
         ss.statement = ss.statement.statementSemantic(sc);
         sc = sc.pop();
-        result = ss.statement ? ss : null;
+        result = ss.statement;
     }
 
     override void visit(WhileStatement ws)

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -35,11 +35,7 @@ public:
     void visit(ASTCodegen.SwitchErrorStatement s) { visit(cast(ASTCodegen.Statement)s); }
     void visit(ASTCodegen.DebugStatement s) { visit(cast(ASTCodegen.Statement)s); }
     void visit(ASTCodegen.DtorExpStatement s) { visit(cast(ASTCodegen.ExpStatement)s); }
-    void visit(ASTCodegen.ForwardingStatement s)
-    {
-        if(s.statement)
-            s.statement.accept(this);
-    }
+    void visit(ASTCodegen.ForwardingStatement s) { visit(cast(ASTCodegen.Statement)s); }
     void visit(ASTCodegen.OverloadSet s) { visit(cast(ASTCodegen.Dsymbol)s); }
     void visit(ASTCodegen.LabelDsymbol s) { visit(cast(ASTCodegen.Dsymbol)s); }
     void visit(ASTCodegen.WithScopeSymbol s) { visit(cast(ASTCodegen.ScopeDsymbol)s); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -266,8 +266,7 @@ class UshrExp;
 class AndExp;
 class OrExp;
 class XorExp;
-class OrOrExp;
-class AndAndExp;
+class LogicalExp;
 class CmpExp;
 class InExp;
 class RemoveExp;
@@ -302,126 +301,279 @@ class Parameter;
 class Visitor
 {
 public:
-    virtual void visit(Statement *) { assert(0); }
-    virtual void visit(ErrorStatement *s) { visit((Statement *)s); }
-    virtual void visit(PeelStatement *s) { visit((Statement *)s); }
-    virtual void visit(ExpStatement *s) { visit((Statement *)s); }
-    virtual void visit(DtorExpStatement *s) { visit((ExpStatement *)s); }
-    virtual void visit(CompileStatement *s) { visit((Statement *)s); }
-    virtual void visit(CompoundStatement *s) { visit((Statement *)s); }
-    virtual void visit(CompoundDeclarationStatement *s) { visit((CompoundStatement *)s); }
-    virtual void visit(UnrolledLoopStatement *s) { visit((Statement *)s); }
-    virtual void visit(ScopeStatement *s) { visit((Statement *)s); }
-    virtual void visit(ForwardingStatement *s) { visit((Statement *)s); }
-    virtual void visit(WhileStatement *s) { visit((Statement *)s); }
-    virtual void visit(DoStatement *s) { visit((Statement *)s); }
-    virtual void visit(ForStatement *s) { visit((Statement *)s); }
-    virtual void visit(ForeachStatement *s) { visit((Statement *)s); }
-    virtual void visit(ForeachRangeStatement *s) { visit((Statement *)s); }
-    virtual void visit(StaticForeachStatement *s) { visit((Statement *)s); }
-    virtual void visit(IfStatement *s) { visit((Statement *)s); }
-    virtual void visit(ConditionalStatement *s) { visit((Statement *)s); }
-    virtual void visit(PragmaStatement *s) { visit((Statement *)s); }
-    virtual void visit(StaticAssertStatement *s) { visit((Statement *)s); }
-    virtual void visit(SwitchStatement *s) { visit((Statement *)s); }
-    virtual void visit(CaseStatement *s) { visit((Statement *)s); }
-    virtual void visit(CaseRangeStatement *s) { visit((Statement *)s); }
-    virtual void visit(DefaultStatement *s) { visit((Statement *)s); }
-    virtual void visit(GotoDefaultStatement *s) { visit((Statement *)s); }
-    virtual void visit(GotoCaseStatement *s) { visit((Statement *)s); }
-    virtual void visit(SwitchErrorStatement *s) { visit((Statement *)s); }
-    virtual void visit(ReturnStatement *s) { visit((Statement *)s); }
-    virtual void visit(BreakStatement *s) { visit((Statement *)s); }
-    virtual void visit(ContinueStatement *s) { visit((Statement *)s); }
-    virtual void visit(SynchronizedStatement *s) { visit((Statement *)s); }
-    virtual void visit(WithStatement *s) { visit((Statement *)s); }
-    virtual void visit(TryCatchStatement *s) { visit((Statement *)s); }
-    virtual void visit(TryFinallyStatement *s) { visit((Statement *)s); }
-    virtual void visit(OnScopeStatement *s) { visit((Statement *)s); }
-    virtual void visit(ThrowStatement *s) { visit((Statement *)s); }
-    virtual void visit(DebugStatement *s) { visit((Statement *)s); }
-    virtual void visit(GotoStatement *s) { visit((Statement *)s); }
-    virtual void visit(LabelStatement *s) { visit((Statement *)s); }
-    virtual void visit(AsmStatement *s) { visit((Statement *)s); }
-    virtual void visit(CompoundAsmStatement *s) { visit((CompoundStatement *)s); }
-    virtual void visit(ImportStatement *s) { visit((Statement *)s); }
-
-    virtual void visit(Type *) { assert(0); }
-    virtual void visit(TypeError *t) { visit((Type *)t); }
-    virtual void visit(TypeNext *t) { visit((Type *)t); }
-    virtual void visit(TypeBasic *t) { visit((Type *)t); }
-    virtual void visit(TypeVector *t) { visit((Type *)t); }
-    virtual void visit(TypeArray *t) { visit((TypeNext *)t); }
-    virtual void visit(TypeSArray *t) { visit((TypeArray *)t); }
-    virtual void visit(TypeDArray *t) { visit((TypeArray *)t); }
-    virtual void visit(TypeAArray *t) { visit((TypeArray *)t); }
-    virtual void visit(TypePointer *t) { visit((TypeNext *)t); }
-    virtual void visit(TypeReference *t) { visit((TypeNext *)t); }
-    virtual void visit(TypeFunction *t) { visit((TypeNext *)t); }
-    virtual void visit(TypeDelegate *t) { visit((TypeNext *)t); }
-    virtual void visit(TypeQualified *t) { visit((Type *)t); }
-    virtual void visit(TypeIdentifier *t) { visit((TypeQualified *)t); }
-    virtual void visit(TypeInstance *t) { visit((TypeQualified *)t); }
-    virtual void visit(TypeTypeof *t) { visit((TypeQualified *)t); }
-    virtual void visit(TypeReturn *t) { visit((TypeQualified *)t); }
-    virtual void visit(TypeStruct *t) { visit((Type *)t); }
-    virtual void visit(TypeEnum *t) { visit((Type *)t); }
-    virtual void visit(TypeClass *t) { visit((Type *)t); }
-    virtual void visit(TypeTuple *t) { visit((Type *)t); }
-    virtual void visit(TypeSlice *t) { visit((TypeNext *)t); }
-    virtual void visit(TypeNull *t) { visit((Type *)t); }
-
     virtual void visit(Dsymbol *) { assert(0); }
+    virtual void visit(Parameter *) { assert(0); }
+    virtual void visit(Statement *) { assert(0); }
+    virtual void visit(Type *) { assert(0); }
+    virtual void visit(Expression *) { assert(0); }
+    virtual void visit(TemplateParameter *) { assert(0); }
+    virtual void visit(Condition *) { assert(0); }
+    virtual void visit(Initializer *) { assert(0); }
 
+    // Dsymbols
+    virtual void visit(AliasThis *s) { visit((Dsymbol *)s); }
+    virtual void visit(Declaration *s) { visit((Dsymbol *)s); }
+    virtual void visit(ScopeDsymbol *s) { visit((Dsymbol *)s); }
+    virtual void visit(Import *s) { visit((Dsymbol *)s); }
+    virtual void visit(AttribDeclaration *s) { visit((Dsymbol *)s); }
     virtual void visit(StaticAssert *s) { visit((Dsymbol *)s); }
     virtual void visit(DebugSymbol *s) { visit((Dsymbol *)s); }
     virtual void visit(VersionSymbol *s) { visit((Dsymbol *)s); }
-    virtual void visit(EnumMember *s) { visit((VarDeclaration *)s); }
-    virtual void visit(Import *s) { visit((Dsymbol *)s); }
-    virtual void visit(OverloadSet *s) { visit((Dsymbol *)s); }
-    virtual void visit(LabelDsymbol *s) { visit((Dsymbol *)s); }
-    virtual void visit(AliasThis *s) { visit((Dsymbol *)s); }
 
-    virtual void visit(AttribDeclaration *s) { visit((Dsymbol *)s); }
-    virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(DeprecatedDeclaration *s) { visit((StorageClassDeclaration *)s); }
-    virtual void visit(LinkDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(PragmaDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(ConditionalDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(StaticIfDeclaration *s) { visit((ConditionalDeclaration *)s); }
-    virtual void visit(StaticForeachDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(CompileDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(UserAttributeDeclaration *s) { visit((AttribDeclaration *)s); }
-
-    virtual void visit(ScopeDsymbol *s) { visit((Dsymbol *)s); }
+    // ScopeDsymbols
+    virtual void visit(Package *s) { visit((ScopeDsymbol *)s); }
+    virtual void visit(EnumDeclaration *s) { visit((ScopeDsymbol *)s); }
+    virtual void visit(AggregateDeclaration *s) { visit((ScopeDsymbol *)s); }
     virtual void visit(TemplateDeclaration *s) { visit((ScopeDsymbol *)s); }
     virtual void visit(TemplateInstance *s) { visit((ScopeDsymbol *)s); }
-    virtual void visit(TemplateMixin *s) { visit((TemplateInstance *)s); }
-    virtual void visit(EnumDeclaration *s) { visit((ScopeDsymbol *)s); }
-    virtual void visit(Package *s) { visit((ScopeDsymbol *)s); }
-    virtual void visit(Module *s) { visit((Package *)s); }
-    virtual void visit(WithScopeSymbol *s) { visit((ScopeDsymbol *)s); }
-    virtual void visit(ArrayScopeSymbol *s) { visit((ScopeDsymbol *)s); }
     virtual void visit(Nspace *s) { visit((ScopeDsymbol *)s); }
 
-    virtual void visit(AggregateDeclaration *s) { visit((ScopeDsymbol *)s); }
+    // Declarations
+    virtual void visit(VarDeclaration *s) { visit((Declaration *)s); }
+    virtual void visit(FuncDeclaration *s) { visit((Declaration *)s); }
+    virtual void visit(AliasDeclaration *s) { visit((Declaration *)s); }
+    virtual void visit(TupleDeclaration *s) { visit((Declaration *)s); }
+
+    // FuncDeclarations
+    virtual void visit(FuncLiteralDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(PostBlitDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(CtorDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(DtorDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(InvariantDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(UnitTestDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(NewDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(DeleteDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(StaticCtorDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(StaticDtorDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(SharedStaticCtorDeclaration *s) { visit((StaticCtorDeclaration *)s); }
+    virtual void visit(SharedStaticDtorDeclaration *s) { visit((StaticDtorDeclaration *)s); }
+
+    // AttribDeclarations
+    virtual void visit(CompileDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(UserAttributeDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(LinkDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(PragmaDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(ConditionalDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(StaticForeachDeclaration *s) { visit((AttribDeclaration *)s); }
+
+    // Miscellaneous
+    virtual void visit(DeprecatedDeclaration *s) { visit((StorageClassDeclaration *)s); }
+    virtual void visit(StaticIfDeclaration *s) { visit((ConditionalDeclaration *)s); }
+    virtual void visit(EnumMember *s) { visit((VarDeclaration *)s); }
+    virtual void visit(Module *s) { visit((Package *)s); }
     virtual void visit(StructDeclaration *s) { visit((AggregateDeclaration *)s); }
     virtual void visit(UnionDeclaration *s) { visit((StructDeclaration *)s); }
     virtual void visit(ClassDeclaration *s) { visit((AggregateDeclaration *)s); }
     virtual void visit(InterfaceDeclaration *s) { visit((ClassDeclaration *)s); }
+    virtual void visit(TemplateMixin *s) { visit((TemplateInstance *)s); }
 
-    virtual void visit(Declaration *s) { visit((Dsymbol *)s); }
-    virtual void visit(TupleDeclaration *s) { visit((Declaration *)s); }
-    virtual void visit(AliasDeclaration *s) { visit((Declaration *)s); }
+    // Statements
+    virtual void visit(ImportStatement *s) { visit((Statement *)s); }
+    virtual void visit(ScopeStatement *s) { visit((Statement *)s); }
+    virtual void visit(ReturnStatement *s) { visit((Statement *)s); }
+    virtual void visit(LabelStatement *s) { visit((Statement *)s); }
+    virtual void visit(StaticAssertStatement *s) { visit((Statement *)s); }
+    virtual void visit(CompileStatement *s) { visit((Statement *)s); }
+    virtual void visit(WhileStatement *s) { visit((Statement *)s); }
+    virtual void visit(ForStatement *s) { visit((Statement *)s); }
+    virtual void visit(DoStatement *s) { visit((Statement *)s); }
+    virtual void visit(ForeachRangeStatement *s) { visit((Statement *)s); }
+    virtual void visit(ForeachStatement *s) { visit((Statement *)s); }
+    virtual void visit(IfStatement *s) { visit((Statement *)s); }
+    virtual void visit(OnScopeStatement *s) { visit((Statement *)s); }
+    virtual void visit(ConditionalStatement *s) { visit((Statement *)s); }
+    virtual void visit(StaticForeachStatement *s) { visit((Statement *)s); }
+    virtual void visit(PragmaStatement *s) { visit((Statement *)s); }
+    virtual void visit(SwitchStatement *s) { visit((Statement *)s); }
+    virtual void visit(CaseRangeStatement *s) { visit((Statement *)s); }
+    virtual void visit(CaseStatement *s) { visit((Statement *)s); }
+    virtual void visit(DefaultStatement *s) { visit((Statement *)s); }
+    virtual void visit(BreakStatement *s) { visit((Statement *)s); }
+    virtual void visit(ContinueStatement *s) { visit((Statement *)s); }
+    virtual void visit(GotoDefaultStatement *s) { visit((Statement *)s); }
+    virtual void visit(GotoCaseStatement *s) { visit((Statement *)s); }
+    virtual void visit(GotoStatement *s) { visit((Statement *)s); }
+    virtual void visit(SynchronizedStatement *s) { visit((Statement *)s); }
+    virtual void visit(WithStatement *s) { visit((Statement *)s); }
+    virtual void visit(TryCatchStatement *s) { visit((Statement *)s); }
+    virtual void visit(TryFinallyStatement *s) { visit((Statement *)s); }
+    virtual void visit(ThrowStatement *s) { visit((Statement *)s); }
+    virtual void visit(AsmStatement *s) { visit((Statement *)s); }
+    virtual void visit(ExpStatement *s) { visit((Statement *)s); }
+    virtual void visit(CompoundStatement *s) { visit((Statement *)s); }
+
+    // CompoundStatements
+    virtual void visit(CompoundDeclarationStatement *s) { visit((CompoundStatement *)s); }
+    virtual void visit(CompoundAsmStatement *s) { visit((CompoundStatement *)s); }
+
+    // Types
+    virtual void visit(TypeBasic *t) { visit((Type *)t); }
+    virtual void visit(TypeError *t) { visit((Type *)t); }
+    virtual void visit(TypeNull *t) { visit((Type *)t); }
+    virtual void visit(TypeVector *t) { visit((Type *)t); }
+    virtual void visit(TypeEnum *t) { visit((Type *)t); }
+    virtual void visit(TypeTuple *t) { visit((Type *)t); }
+    virtual void visit(TypeClass *t) { visit((Type *)t); }
+    virtual void visit(TypeStruct *t) { visit((Type *)t); }
+    virtual void visit(TypeNext *t) { visit((Type *)t); }
+    virtual void visit(TypeQualified *t) { visit((Type *)t); }
+
+    // TypeNext
+    virtual void visit(TypeReference *t) { visit((TypeNext *)t); }
+    virtual void visit(TypeSlice *t) { visit((TypeNext *)t); }
+    virtual void visit(TypeDelegate *t) { visit((TypeNext *)t); }
+    virtual void visit(TypePointer *t) { visit((TypeNext *)t); }
+    virtual void visit(TypeFunction *t) { visit((TypeNext *)t); }
+    virtual void visit(TypeArray *t) { visit((TypeNext *)t); }
+
+    // TypeArray
+    virtual void visit(TypeDArray *t) { visit((TypeArray *)t); }
+    virtual void visit(TypeAArray *t) { visit((TypeArray *)t); }
+    virtual void visit(TypeSArray *t) { visit((TypeArray *)t); }
+
+    // TypeQualified
+    virtual void visit(TypeIdentifier *t) { visit((TypeQualified *)t); }
+    virtual void visit(TypeReturn *t) { visit((TypeQualified *)t); }
+    virtual void visit(TypeTypeof *t) { visit((TypeQualified *)t); }
+    virtual void visit(TypeInstance *t) { visit((TypeQualified *)t); }
+
+    // Expressions
+    virtual void visit(DeclarationExp *e) { visit((Expression *)e); }
+    virtual void visit(IntegerExp *e) { visit((Expression *)e); }
+    virtual void visit(NewAnonClassExp *e) { visit((Expression *)e); }
+    virtual void visit(IsExp *e) { visit((Expression *)e); }
+    virtual void visit(RealExp *e) { visit((Expression *)e); }
+    virtual void visit(NullExp *e) { visit((Expression *)e); }
+    virtual void visit(TypeidExp *e) { visit((Expression *)e); }
+    virtual void visit(TraitsExp *e) { visit((Expression *)e); }
+    virtual void visit(StringExp *e) { visit((Expression *)e); }
+    virtual void visit(NewExp *e) { visit((Expression *)e); }
+    virtual void visit(AssocArrayLiteralExp *e) { visit((Expression *)e); }
+    virtual void visit(ArrayLiteralExp *e) { visit((Expression *)e); }
+    virtual void visit(FuncExp *e) { visit((Expression *)e); }
+    virtual void visit(IntervalExp *e) { visit((Expression *)e); }
+    virtual void visit(TypeExp *e) { visit((Expression *)e); }
+    virtual void visit(ScopeExp *e) { visit((Expression *)e); }
+    virtual void visit(IdentifierExp *e) { visit((Expression *)e); }
+    virtual void visit(UnaExp *e) { visit((Expression *)e); }
+    virtual void visit(DefaultInitExp *e) { visit((Expression *)e); }
+    virtual void visit(BinExp *e) { visit((Expression *)e); }
+    virtual void visit(DsymbolExp *e) { visit((Expression *)e); }
+    virtual void visit(TemplateExp *e) { visit((Expression *)e); }
+    virtual void visit(SymbolExp *e) { visit((Expression *)e); }
+    virtual void visit(TupleExp *e) { visit((Expression *)e); }
+    virtual void visit(ThisExp *e) { visit((Expression *)e); }
+
+    // Miscellaneous
+    virtual void visit(VarExp *e) { visit((SymbolExp *)e); }
+    virtual void visit(DollarExp *e) { visit((IdentifierExp *)e); }
+    virtual void visit(SuperExp *e) { visit((ThisExp *)e); }
+
+    // UnaExp
+    virtual void visit(AddrExp *e) { visit((UnaExp *)e); }
+    virtual void visit(PreExp *e) { visit((UnaExp *)e); }
+    virtual void visit(PtrExp *e) { visit((UnaExp *)e); }
+    virtual void visit(NegExp *e) { visit((UnaExp *)e); }
+    virtual void visit(UAddExp *e) { visit((UnaExp *)e); }
+    virtual void visit(NotExp *e) { visit((UnaExp *)e); }
+    virtual void visit(ComExp *e) { visit((UnaExp *)e); }
+    virtual void visit(DeleteExp *e) { visit((UnaExp *)e); }
+    virtual void visit(CastExp *e) { visit((UnaExp *)e); }
+    virtual void visit(CallExp *e) { visit((UnaExp *)e); }
+    virtual void visit(DotIdExp *e) { visit((UnaExp *)e); }
+    virtual void visit(AssertExp *e) { visit((UnaExp *)e); }
+    virtual void visit(CompileExp *e) { visit((UnaExp *)e); }
+    virtual void visit(ImportExp *e) { visit((UnaExp *)e); }
+    virtual void visit(DotTemplateInstanceExp *e) { visit((UnaExp *)e); }
+    virtual void visit(ArrayExp *e) { visit((UnaExp *)e); }
+
+    // DefaultInitExp
+    virtual void visit(FuncInitExp *e) { visit((DefaultInitExp *)e); }
+    virtual void visit(PrettyFuncInitExp *e) { visit((DefaultInitExp *)e); }
+    virtual void visit(FileInitExp *e) { visit((DefaultInitExp *)e); }
+    virtual void visit(LineInitExp *e) { visit((DefaultInitExp *)e); }
+    virtual void visit(ModuleInitExp *e) { visit((DefaultInitExp *)e); }
+
+    // BinExp
+    virtual void visit(CommaExp *e) { visit((BinExp *)e); }
+    virtual void visit(PostExp *e) { visit((BinExp *)e); }
+    virtual void visit(PowExp *e) { visit((BinExp *)e); }
+    virtual void visit(MulExp *e) { visit((BinExp *)e); }
+    virtual void visit(DivExp *e) { visit((BinExp *)e); }
+    virtual void visit(ModExp *e) { visit((BinExp *)e); }
+    virtual void visit(AddExp *e) { visit((BinExp *)e); }
+    virtual void visit(MinExp *e) { visit((BinExp *)e); }
+    virtual void visit(CatExp *e) { visit((BinExp *)e); }
+    virtual void visit(ShlExp *e) { visit((BinExp *)e); }
+    virtual void visit(ShrExp *e) { visit((BinExp *)e); }
+    virtual void visit(UshrExp *e) { visit((BinExp *)e); }
+    virtual void visit(EqualExp *e) { visit((BinExp *)e); }
+    virtual void visit(InExp *e) { visit((BinExp *)e); }
+    virtual void visit(IdentityExp *e) { visit((BinExp *)e); }
+    virtual void visit(CmpExp *e) { visit((BinExp *)e); }
+    virtual void visit(AndExp *e) { visit((BinExp *)e); }
+    virtual void visit(XorExp *e) { visit((BinExp *)e); }
+    virtual void visit(OrExp *e) { visit((BinExp *)e); }
+    virtual void visit(LogicalExp *e) { visit((BinExp *)e); }
+    virtual void visit(CondExp *e) { visit((BinExp *)e); }
+    virtual void visit(AssignExp *e) { visit((BinExp *)e); }
+    virtual void visit(BinAssignExp *e) { visit((BinExp *)e); }
+
+    // BinAssignExp
+    virtual void visit(AddAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(MinAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(MulAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(DivAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(ModAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(PowAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(AndAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(OrAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(XorAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(ShlAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(ShrAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(UshrAssignExp *e) { visit((BinAssignExp *)e); }
+    virtual void visit(CatAssignExp *e) { visit((BinAssignExp *)e); }
+
+    // TemplateParameter
+    virtual void visit(TemplateAliasParameter *tp) { visit((TemplateParameter *)tp); }
+    virtual void visit(TemplateTypeParameter *tp) { visit((TemplateParameter *)tp); }
+    virtual void visit(TemplateTupleParameter *tp) { visit((TemplateParameter *)tp); }
+    virtual void visit(TemplateValueParameter *tp) { visit((TemplateParameter *)tp); }
+
+    virtual void visit(TemplateThisParameter *tp) { visit((TemplateTypeParameter *)tp); }
+
+    // Condition
+    virtual void visit(StaticIfCondition *c) { visit((Condition *)c); }
+    virtual void visit(DVCondition *c) { visit((Condition *)c); }
+    virtual void visit(DebugCondition *c) { visit((DVCondition *)c); }
+    virtual void visit(VersionCondition *c) { visit((DVCondition *)c); }
+
+    // Initializer
+    virtual void visit(ExpInitializer *i) { visit((Initializer *)i); }
+    virtual void visit(StructInitializer *i) { visit((Initializer *)i); }
+    virtual void visit(ArrayInitializer *i) { visit((Initializer *)i); }
+    virtual void visit(VoidInitializer *i) { visit((Initializer *)i); }
+
+    // Miscellaneous
+    virtual void visit(ErrorStatement *s) { visit((Statement *)s); }
+    virtual void visit(PeelStatement *s) { visit((Statement *)s); }
+    virtual void visit(UnrolledLoopStatement *s) { visit((Statement *)s); }
+    virtual void visit(SwitchErrorStatement *s) { visit((Statement *)s); }
+    virtual void visit(DebugStatement *s) { visit((Statement *)s); }
+    virtual void visit(DtorExpStatement *s) { visit((ExpStatement *)s); }
+    virtual void visit(ForwardingStatement *s) { visit((Statement *)s); }
+    virtual void visit(OverloadSet *s) { visit((Dsymbol *)s); }
+    virtual void visit(LabelDsymbol *s) { visit((Dsymbol *)s); }
+    virtual void visit(WithScopeSymbol *s) { visit((ScopeDsymbol *)s); }
+    virtual void visit(ArrayScopeSymbol *s) { visit((ScopeDsymbol *)s); }
     virtual void visit(OverDeclaration *s) { visit((Declaration *)s); }
-    virtual void visit(VarDeclaration *s) { visit((Declaration *)s); }
     virtual void visit(SymbolDeclaration *s) { visit((Declaration *)s); }
     virtual void visit(ThisDeclaration *s) { visit((VarDeclaration *)s); }
-
     virtual void visit(TypeInfoDeclaration *s) { visit((VarDeclaration *)s); }
     virtual void visit(TypeInfoStructDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoClassDeclaration *s) { visit((TypeInfoDeclaration *)s); }
@@ -439,154 +591,31 @@ public:
     virtual void visit(TypeInfoSharedDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoWildDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoVectorDeclaration *s) { visit((TypeInfoDeclaration *)s); }
-
-    virtual void visit(FuncDeclaration *s) { visit((Declaration *)s); }
     virtual void visit(FuncAliasDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(FuncLiteralDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(CtorDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(PostBlitDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(DtorDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(StaticCtorDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(SharedStaticCtorDeclaration *s) { visit((StaticCtorDeclaration *)s); }
-    virtual void visit(StaticDtorDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(SharedStaticDtorDeclaration *s) { visit((StaticDtorDeclaration *)s); }
-    virtual void visit(InvariantDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(UnitTestDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(NewDeclaration *s) { visit((FuncDeclaration *)s); }
-    virtual void visit(DeleteDeclaration *s) { visit((FuncDeclaration *)s); }
-
-    virtual void visit(Initializer *) { assert(0); }
-    virtual void visit(VoidInitializer *i) { visit((Initializer *)i); }
     virtual void visit(ErrorInitializer *i) { visit((Initializer *)i); }
-    virtual void visit(StructInitializer *i) { visit((Initializer *)i); }
-    virtual void visit(ArrayInitializer *i) { visit((Initializer *)i); }
-    virtual void visit(ExpInitializer *i) { visit((Initializer *)i); }
-
-    virtual void visit(Expression *) { assert(0); }
-    virtual void visit(IntegerExp *e) { visit((Expression *)e); }
     virtual void visit(ErrorExp *e) { visit((Expression *)e); }
-    virtual void visit(RealExp *e) { visit((Expression *)e); }
     virtual void visit(ComplexExp *e) { visit((Expression *)e); }
-    virtual void visit(IdentifierExp *e) { visit((Expression *)e); }
-    virtual void visit(DollarExp *e) { visit((IdentifierExp *)e); }
-    virtual void visit(DsymbolExp *e) { visit((Expression *)e); }
-    virtual void visit(ThisExp *e) { visit((Expression *)e); }
-    virtual void visit(SuperExp *e) { visit((ThisExp *)e); }
-    virtual void visit(NullExp *e) { visit((Expression *)e); }
-    virtual void visit(StringExp *e) { visit((Expression *)e); }
-    virtual void visit(TupleExp *e) { visit((Expression *)e); }
-    virtual void visit(ArrayLiteralExp *e) { visit((Expression *)e); }
-    virtual void visit(AssocArrayLiteralExp *e) { visit((Expression *)e); }
     virtual void visit(StructLiteralExp *e) { visit((Expression *)e); }
-    virtual void visit(TypeExp *e) { visit((Expression *)e); }
-    virtual void visit(ScopeExp *e) { visit((Expression *)e); }
-    virtual void visit(TemplateExp *e) { visit((Expression *)e); }
-    virtual void visit(NewExp *e) { visit((Expression *)e); }
-    virtual void visit(NewAnonClassExp *e) { visit((Expression *)e); }
-    virtual void visit(SymbolExp *e) { visit((Expression *)e); }
     virtual void visit(SymOffExp *e) { visit((SymbolExp *)e); }
-    virtual void visit(VarExp *e) { visit((SymbolExp *)e); }
     virtual void visit(OverExp *e) { visit((Expression *)e); }
-    virtual void visit(FuncExp *e) { visit((Expression *)e); }
-    virtual void visit(DeclarationExp *e) { visit((Expression *)e); }
-    virtual void visit(TypeidExp *e) { visit((Expression *)e); }
-    virtual void visit(TraitsExp *e) { visit((Expression *)e); }
     virtual void visit(HaltExp *e) { visit((Expression *)e); }
-    virtual void visit(IsExp *e) { visit((Expression *)e); }
-    virtual void visit(UnaExp *e) { visit((Expression *)e); }
-    virtual void visit(BinExp *e) { visit((Expression *)e); }
-    virtual void visit(BinAssignExp *e) { visit((BinExp *)e); }
-    virtual void visit(CompileExp *e) { visit((UnaExp *)e); }
-    virtual void visit(ImportExp *e) { visit((UnaExp *)e); }
-    virtual void visit(AssertExp *e) { visit((UnaExp *)e); }
-    virtual void visit(DotIdExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotTemplateExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotVarExp *e) { visit((UnaExp *)e); }
-    virtual void visit(DotTemplateInstanceExp *e) { visit((UnaExp *)e); }
     virtual void visit(DelegateExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotTypeExp *e) { visit((UnaExp *)e); }
-    virtual void visit(CallExp *e) { visit((UnaExp *)e); }
-    virtual void visit(AddrExp *e) { visit((UnaExp *)e); }
-    virtual void visit(PtrExp *e) { visit((UnaExp *)e); }
-    virtual void visit(NegExp *e) { visit((UnaExp *)e); }
-    virtual void visit(UAddExp *e) { visit((UnaExp *)e); }
-    virtual void visit(ComExp *e) { visit((UnaExp *)e); }
-    virtual void visit(NotExp *e) { visit((UnaExp *)e); }
-    virtual void visit(DeleteExp *e) { visit((UnaExp *)e); }
-    virtual void visit(CastExp *e) { visit((UnaExp *)e); }
     virtual void visit(VectorExp *e) { visit((UnaExp *)e); }
     virtual void visit(SliceExp *e) { visit((UnaExp *)e); }
     virtual void visit(ArrayLengthExp *e) { visit((UnaExp *)e); }
-    virtual void visit(IntervalExp *e) { visit((Expression *)e); }
     virtual void visit(DelegatePtrExp *e) { visit((UnaExp *)e); }
     virtual void visit(DelegateFuncptrExp *e) { visit((UnaExp *)e); }
-    virtual void visit(ArrayExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotExp *e) { visit((BinExp *)e); }
-    virtual void visit(CommaExp *e) { visit((BinExp *)e); }
     virtual void visit(IndexExp *e) { visit((BinExp *)e); }
-    virtual void visit(PostExp *e) { visit((BinExp *)e); }
-    virtual void visit(PreExp *e) { visit((UnaExp *)e); }
-    virtual void visit(AssignExp *e) { visit((BinExp *)e); }
     virtual void visit(ConstructExp *e) { visit((AssignExp *)e); }
     virtual void visit(BlitExp *e) { visit((AssignExp *)e); }
-    virtual void visit(AddAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(MinAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(MulAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(DivAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(ModAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(AndAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(OrAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(XorAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(PowAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(ShlAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(ShrAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(UshrAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(CatAssignExp *e) { visit((BinAssignExp *)e); }
-    virtual void visit(AddExp *e) { visit((BinExp *)e); }
-    virtual void visit(MinExp *e) { visit((BinExp *)e); }
-    virtual void visit(CatExp *e) { visit((BinExp *)e); }
-    virtual void visit(MulExp *e) { visit((BinExp *)e); }
-    virtual void visit(DivExp *e) { visit((BinExp *)e); }
-    virtual void visit(ModExp *e) { visit((BinExp *)e); }
-    virtual void visit(PowExp *e) { visit((BinExp *)e); }
-    virtual void visit(ShlExp *e) { visit((BinExp *)e); }
-    virtual void visit(ShrExp *e) { visit((BinExp *)e); }
-    virtual void visit(UshrExp *e) { visit((BinExp *)e); }
-    virtual void visit(AndExp *e) { visit((BinExp *)e); }
-    virtual void visit(OrExp *e) { visit((BinExp *)e); }
-    virtual void visit(XorExp *e) { visit((BinExp *)e); }
-    virtual void visit(OrOrExp *e) { visit((BinExp *)e); }
-    virtual void visit(AndAndExp *e) { visit((BinExp *)e); }
-    virtual void visit(CmpExp *e) { visit((BinExp *)e); }
-    virtual void visit(InExp *e) { visit((BinExp *)e); }
     virtual void visit(RemoveExp *e) { visit((BinExp *)e); }
-    virtual void visit(EqualExp *e) { visit((BinExp *)e); }
-    virtual void visit(IdentityExp *e) { visit((BinExp *)e); }
-    virtual void visit(CondExp *e) { visit((BinExp *)e); }
-    virtual void visit(DefaultInitExp *e) { visit((Expression *)e); }
-    virtual void visit(FileInitExp *e) { visit((DefaultInitExp *)e); }
-    virtual void visit(LineInitExp *e) { visit((DefaultInitExp *)e); }
-    virtual void visit(ModuleInitExp *e) { visit((DefaultInitExp *)e); }
-    virtual void visit(FuncInitExp *e) { visit((DefaultInitExp *)e); }
-    virtual void visit(PrettyFuncInitExp *e) { visit((DefaultInitExp *)e); }
     virtual void visit(ClassReferenceExp *e) { visit((Expression *)e); }
     virtual void visit(VoidInitExp *e) { visit((Expression *)e); }
     virtual void visit(ThrownExceptionExp *e) { visit((Expression *)e); }
-
-    virtual void visit(TemplateParameter *) { assert(0); }
-    virtual void visit(TemplateTypeParameter *tp) { visit((TemplateParameter *)tp); }
-    virtual void visit(TemplateThisParameter *tp) { visit((TemplateTypeParameter *)tp); }
-    virtual void visit(TemplateValueParameter *tp) { visit((TemplateParameter *)tp); }
-    virtual void visit(TemplateAliasParameter *tp) { visit((TemplateParameter *)tp); }
-    virtual void visit(TemplateTupleParameter *tp) { visit((TemplateParameter *)tp); }
-
-    virtual void visit(Condition *) { assert(0); }
-    virtual void visit(DVCondition *c) { visit((Condition *)c); }
-    virtual void visit(DebugCondition *c) { visit((DVCondition *)c); }
-    virtual void visit(VersionCondition *c) { visit((DVCondition *)c); }
-    virtual void visit(StaticIfCondition *c) { visit((Condition *)c); }
-
-    virtual void visit(Parameter *) { assert(0); }
 };
 
 class StoppableVisitor : public Visitor

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -266,8 +266,8 @@ endif
 endif
 
 # Unique extra flags if necessary
-DMD_FLAGS  := -I$(ROOT) -Wuninitialized
-GLUE_FLAGS := -I$(ROOT) -I$(TK) -I$(C)
+DMD_FLAGS  := -I$(D) -I$(ROOT) -Wuninitialized
+GLUE_FLAGS := -I$(D) -I$(ROOT) -I$(TK) -I$(C)
 BACK_FLAGS := -I$(ROOT) -I$(TK) -I$(C) -I$G -I$D -DDMDV2=1
 ROOT_FLAGS := -I$(ROOT)
 
@@ -396,7 +396,7 @@ TK_SRC = \
 	$(TK)/filespec.h $(TK)/mem.h $(TK)/list.h $(TK)/vec.h \
 	$(TK)/filespec.c $(TK)/mem.c $(TK)/vec.c $(TK)/list.c
 
-######## CXX header files (only needed for checkcxxheaders)
+######## CXX header files (only needed for cxx-unittest)
 
 SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
 	attrib.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
@@ -423,7 +423,7 @@ DEPS = $(patsubst %.o,%.deps,$(DMD_OBJS) $(GLUE_OBJS) $(BACK_OBJS))
 
 all: $G/dmd
 
-auto-tester-build: $G/dmd checkwhitespace checkcxxheaders $G/dmd_frontend
+auto-tester-build: $G/dmd checkwhitespace cxx-unittest $G/dmd_frontend
 .PHONY: auto-tester-build
 
 toolchain-info:
@@ -569,11 +569,14 @@ $(TOOLS_DIR)/checkwhitespace.d:
 
 ######################################################
 
-# See https://github.com/dlang/dmd/pull/7358 for why -xc++ is used here
-# -O is needed for FreeBSD's compiler to silence "-Wuninitialized is not supported without -O"
-checkcxxheaders: $(ROOT_SRC) $(SRC)
-	$(HOST_CXX) -xc++ -O -fsyntax-only $(ROOT_FLAGS) $(filter %.h,$(ROOT_SRC))
-	$(HOST_CXX) -xc++ -O -fsyntax-only $(DMD_FLAGS) $(filter %.h,$(SRC))
+$G/cxxfrontend.o: $G/%.o: tests/%.c $(SRC) $(ROOT_SRC)
+	$(CXX) -c -o$@ $(CXXFLAGS) $(DMD_FLAGS) $(MMD) $<
+
+$G/cxx-unittest: $G/cxxfrontend.o $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_GLUE_OBJS) $(G_OBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
+
+cxx-unittest: $G/cxx-unittest
+	$<
 
 ######################################################
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -401,7 +401,7 @@ TK_SRC = \
 SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
 	attrib.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
 	enum.h errors.h expression.h globals.h hdrgen.h identifier.h \
-	import.h init.h intrange.h json.h \
+	id.h import.h init.h intrange.h json.h \
 	mars.h module.h mtype.h nspace.h objc.h                         \
 	scope.h statement.h staticassert.h target.h template.h tokens.h	\
 	version.h visitor.h libomf.d scanomf.d libmscoff.d scanmscoff.d)         \

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -1,0 +1,199 @@
+/**
+ * Test the C++ compiler interface of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 2017 by The D Language Foundation, All Rights Reserved
+ * Authors:     Iain Buclaw
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/tests/cxxfrontend.c, _cxxfrontend.c)
+ */
+
+#include "array.h"
+#include "ctfloat.h"
+#include "file.h"
+#include "filename.h"
+#include "longdouble.h"
+#include "object.h"
+#include "outbuffer.h"
+#include "port.h"
+#include "rmem.h"
+#include "root.h"
+#include "stringtable.h"
+#include "thread.h"
+
+#include "aggregate.h"
+#include "aliasthis.h"
+#include "arraytypes.h"
+#include "attrib.h"
+#include "complex_t.h"
+#include "cond.h"
+#include "ctfe.h"
+#include "declaration.h"
+#include "dsymbol.h"
+#include "enum.h"
+#include "errors.h"
+#include "expression.h"
+#include "globals.h"
+#include "hdrgen.h"
+#include "identifier.h"
+#include "id.h"
+#include "import.h"
+#include "init.h"
+#include "intrange.h"
+#include "json.h"
+#include "mars.h"
+#include "module.h"
+#include "mtype.h"
+#include "nspace.h"
+#include "objc.h"
+#include "scope.h"
+#include "statement.h"
+#include "staticassert.h"
+#include "target.h"
+#include "template.h"
+#include "tokens.h"
+#include "version.h"
+#include "visitor.h"
+
+/**********************************/
+
+extern "C" int rt_init();
+extern "C" void gc_disable();
+
+static void frontend_init()
+{
+    rt_init();
+    gc_disable();
+
+    global._init();
+    global.params.isLinux = true;
+
+    Type::_init();
+    Id::initialize();
+    Module::_init();
+    Expression::_init();
+    Objc::_init();
+    Target::_init();
+}
+
+/**********************************/
+
+extern "C" int rt_term();
+extern "C" void gc_enable();
+
+static void frontend_term()
+{
+  gc_enable();
+  rt_term();
+}
+
+/**********************************/
+
+class TestVisitor : public Visitor
+{
+  public:
+    bool expr;
+    bool package;
+    bool stmt;
+    bool type;
+    bool aggr;
+    bool attrib;
+    bool decl;
+    bool typeinfo;
+
+    TestVisitor() : expr(false), package(false), stmt(false), type(false),
+        aggr(false), attrib(false), decl(false), typeinfo(false)
+    {
+    }
+
+    void visit(Expression *)
+    {
+        expr = true;
+    }
+
+    void visit(Package *)
+    {
+        package = true;
+    }
+
+    void visit(Statement *)
+    {
+        stmt = true;
+    }
+
+    void visit(AttribDeclaration *)
+    {
+        attrib = true;
+    }
+
+    void visit(Declaration *)
+    {
+        decl = true;
+    }
+
+    void visit(AggregateDeclaration *)
+    {
+        aggr = true;
+    }
+
+    void visit(TypeNext *)
+    {
+        type = true;
+    }
+
+    void visit(TypeInfoDeclaration *)
+    {
+        typeinfo = true;
+    }
+};
+
+void test_visitors()
+{
+    TestVisitor tv;
+    Loc loc;
+    Identifier *ident = Identifier::idPool("test");
+
+    IntegerExp *ie = IntegerExp::create(loc, 42, Type::tint32);
+    ie->accept(&tv);
+    assert(tv.expr == true);
+
+    Module *mod = Module::create("test", ident, 0, 0);
+    mod->accept(&tv);
+    assert(tv.package == true);
+
+    ExpStatement *es = ExpStatement::create(loc, ie);
+    es->accept(&tv);
+    assert(tv.stmt == true);
+
+    TypePointer *tp = TypePointer::create(Type::tvoid);
+    tp->accept(&tv);
+    assert(tv.type == true);
+
+    LinkDeclaration *ld = LinkDeclaration::create(LINKd, NULL);
+    ld->accept(&tv);
+    assert(tv.attrib == true);
+
+    ClassDeclaration *cd = ClassDeclaration::create(loc, Identifier::idPool("TypeInfo"), NULL, NULL, true);
+    cd->accept(&tv);
+    assert(tv.aggr = true);
+
+    AliasDeclaration *ad = AliasDeclaration::create(loc, ident, tp);
+    ad->accept(&tv);
+    assert(tv.decl == true);
+
+    cd = ClassDeclaration::create(loc, Identifier::idPool("TypeInfo_Pointer"), NULL, NULL, true);
+    TypeInfoPointerDeclaration *ti = TypeInfoPointerDeclaration::create(tp);
+    ti->accept(&tv);
+    assert(tv.typeinfo == true);
+}
+
+/**********************************/
+
+int main(int argc, char **argv)
+{
+    frontend_init();
+
+    test_visitors();
+
+    frontend_term();
+}

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -210,7 +210,7 @@ ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 SRCS = $D/aggregate.h $D/aliasthis.h $D/arraytypes.h	\
 	$D/attrib.h $D/complex_t.h $D/cond.h $D/ctfe.h $D/ctfe.h $D/declaration.h $D/dsymbol.h	\
 	$D/enum.h $D/errors.h $D/expression.h $D/globals.h $D/hdrgen.h $D/identifier.h	\
-	$D/import.h $D/init.h $D/intrange.h $D/json.h	\
+	$D/id.h $D/import.h $D/init.h $D/intrange.h $D/json.h	\
 	$D/mars.h $D/module.h $D/mtype.h $D/nspace.h $D/objc.h                         \
 	$D/scope.h $D/statement.h $D/staticassert.h $D/target.h $D/template.h $D/tokens.h	\
 	$D/version.h $D/visitor.h $D/objc.d $(DMD_SRCS)


### PR DESCRIPTION
On closer inspection the Visitor interface broken by #7397 still wasn't fixed by #7438.

The entire C++ Visitor class has been re-layed out to match the order of virtuals in the D implementation.

Have exported `Id::initialize` to C++ as fundamental components don't work if you can't call it.

Replaced cxxcheckheaders with cxx-unittest, a small program that links against the front-end in the same way that LDC or GDC would to test that interaction works.

I anticipate to build on this test file later.