### PR TITLE
use C mangling for unsigned long long for now

### DIFF
--- a/src/dmd/backend/cgobj.c
+++ b/src/dmd/backend/cgobj.c
@@ -1802,7 +1802,7 @@ void Obj::setModuleCtorDtor(Symbol *s, bool isCtor)
  * Used for static ctor and dtor lists.
  */
 
-void Obj::ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym)
+void Obj::ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym)
 {
     // We need to always put out the segments in triples, so that the
     // linker will put them in the correct order.

--- a/src/dmd/backend/dt.c
+++ b/src/dmd/backend/dt.c
@@ -476,7 +476,7 @@ void DtBuilder::cat(DtBuilder *dtb)
 /**************************************
  * Repeat a list of dt_t's count times.
  */
-void DtBuilder::repeat(dt_t *dt, d_size_t count)
+void DtBuilder::repeat(dt_t *dt, unsigned count)
 {
     if (!count)
         return;

--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -52,7 +52,17 @@ final:
     void abytes(tym_t ty, uint offset, uint size, const(char)* ptr, uint nzeros);
     void abytes(uint offset, uint size, const(char)* ptr, uint nzeros);
     void dword(int value);
+version (OSX)
+{
+    void size(ulong value, int dummy = 0)
+    {
+        nbytes(_tysize[TYnptr], cast(char*)&value);
+    }
+}
+else
+{
     void size(ulong value);
+}
     void nzeros(uint size);
     void xoff(Symbol* s, uint offset, tym_t ty);
     dt_t* xoffpatch(Symbol* s, uint offset, tym_t ty);
@@ -61,7 +71,7 @@ final:
     void coff(uint offset);
     void cat(dt_t* dt);
     void cat(DtBuilder dtb);
-    void repeat(dt_t* dt, size_t count);
+    void repeat(dt_t* dt, uint count);
     uint length();
     bool isZeroLength();
 };

--- a/src/dmd/backend/dt.h
+++ b/src/dmd/backend/dt.h
@@ -60,7 +60,7 @@ public:
     void coff(unsigned offset);
     void cat(dt_t *dt);
     void cat(DtBuilder *dtb);
-    void repeat(dt_t *dt, d_size_t count);
+    void repeat(dt_t *dt, unsigned count);
     unsigned length();
     bool isZeroLength();
 };

--- a/src/dmd/backend/elfobj.c
+++ b/src/dmd/backend/elfobj.c
@@ -1678,7 +1678,7 @@ void Obj::setModuleCtorDtor(Symbol *sfunc, bool isCtor)
  *      length of function
  */
 
-void Obj::ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym)
+void Obj::ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym)
 {
     assert(0);                  // converted to Dwarf EH debug format
 }

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -267,7 +267,7 @@ void chkunass(elem *);
 void chknoabstract(type *);
 targ_llong msc_getnum();
 targ_size_t alignmember(type *,targ_size_t,targ_size_t);
-targ_size_t _align(targ_size_t,targ_size_t);
+extern (C) targ_size_t _align(targ_size_t,targ_size_t);
 
 /* nteh.c */
 ubyte *nteh_context_string();
@@ -380,7 +380,7 @@ void cod3_thunk(Symbol *sthunk,Symbol *sfunc,uint p,tym_t thisty,
 /* out.c */
 void outfilename(char *name,int linnum);
 void outcsegname(char *csegname);
-void outthunk(Symbol *sthunk, Symbol *sfunc, uint p, tym_t thisty, targ_size_t d, int i, targ_size_t d2);
+extern (C) void outthunk(Symbol *sthunk, Symbol *sfunc, uint p, tym_t thisty, targ_size_t d, int i, targ_size_t d2);
 void outdata(Symbol *s);
 void outcommon(Symbol *s, targ_size_t n);
 void out_readonly(Symbol *s);
@@ -452,7 +452,7 @@ int elemisone(elem *);
 
 /* msc.c */
 targ_size_t size(tym_t);
-Symbol *symboldata(targ_size_t offset,tym_t ty);
+extern (C) Symbol *symboldata(targ_size_t offset,tym_t ty);
 bool dom(block *A , block *B);
 uint revop(uint op);
 uint invrel(uint op);

--- a/src/dmd/backend/global.h
+++ b/src/dmd/backend/global.h
@@ -259,7 +259,7 @@ void chkunass(elem *);
 void chknoabstract(type *);
 targ_llong msc_getnum();
 targ_size_t alignmember(type *,targ_size_t,targ_size_t);
-targ_size_t _align(targ_size_t,targ_size_t);
+extern "C" { targ_size_t _align(targ_size_t,targ_size_t); }
 
 /* nteh.c */
 unsigned char *nteh_context_string();
@@ -371,7 +371,7 @@ void cod3_thunk(Symbol *sthunk,Symbol *sfunc,unsigned p,tym_t thisty,
 /* out.c */
 void outfilename(char *name,int linnum);
 void outcsegname(char *csegname);
-void outthunk(Symbol *sthunk, Symbol *sfunc, unsigned p, tym_t thisty, targ_size_t d, int i, targ_size_t d2);
+extern "C" { void outthunk(Symbol *sthunk, Symbol *sfunc, unsigned p, tym_t thisty, targ_size_t d, int i, targ_size_t d2); }
 void outdata(Symbol *s);
 void outcommon(Symbol *s, targ_size_t n);
 void out_readonly(Symbol *s);
@@ -439,7 +439,7 @@ int elemisone(elem *);
 
 /* msc.c */
 targ_size_t size(tym_t);
-Symbol *symboldata(targ_size_t offset,tym_t ty);
+extern "C" { Symbol *symboldata(targ_size_t offset,tym_t ty); }
 bool dom(block *A , block *B);
 unsigned revop(unsigned op);
 unsigned invrel(unsigned op);

--- a/src/dmd/backend/machobj.c
+++ b/src/dmd/backend/machobj.c
@@ -1716,7 +1716,7 @@ void Obj::setModuleCtorDtor(Symbol *sfunc, bool isCtor)
  *      length of function
  */
 
-void Obj::ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym)
+void Obj::ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym)
 {
     //dbg_printf("Obj::ehtables(%s) \n",sfunc->Sident);
 

--- a/src/dmd/backend/mscoffobj.c
+++ b/src/dmd/backend/mscoffobj.c
@@ -1166,7 +1166,7 @@ void MsCoffObj::setModuleCtorDtor(Symbol *sfunc, bool isCtor)
  *      length of function
  */
 
-void MsCoffObj::ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym)
+void MsCoffObj::ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym)
 {
     //printf("MsCoffObj::ehtables(func = %s, handler table = %s) \n",sfunc->Sident, ehsym->Sident);
 

--- a/src/dmd/backend/obj.d
+++ b/src/dmd/backend/obj.d
@@ -73,7 +73,7 @@ version (OMF)
         void staticctor(Symbol *s,int dtor,int seg);
         void staticdtor(Symbol *s);
         void setModuleCtorDtor(Symbol *s, bool isCtor);
-        void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
+        void ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
         void ehsections();
         void moduleinfo(Symbol *scc);
       }
@@ -152,7 +152,7 @@ else version (OMFandMSCOFF)
         void staticctor(Symbol *s,int dtor,int seg);
         void staticdtor(Symbol *s);
         void setModuleCtorDtor(Symbol *s, bool isCtor);
-        void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
+        void ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
         void ehsections();
         void moduleinfo(Symbol *scc);
         int comdat(Symbol *);
@@ -228,7 +228,7 @@ else version (OMFandMSCOFF)
         override void staticctor(Symbol *s,int dtor,int seg);
         override void staticdtor(Symbol *s);
         override void setModuleCtorDtor(Symbol *s, bool isCtor);
-        override void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
+        override void ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
         override void ehsections();
         override void moduleinfo(Symbol *scc);
         override int comdat(Symbol *);
@@ -321,7 +321,7 @@ else version (Posix)
         static void staticctor(Symbol *s,int dtor,int seg);
         static void staticdtor(Symbol *s);
         static void setModuleCtorDtor(Symbol *s, bool isCtor);
-        static void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
+        static void ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
         static void ehsections();
         static void moduleinfo(Symbol *scc);
         int comdat(Symbol *);

--- a/src/dmd/backend/obj.h
+++ b/src/dmd/backend/obj.h
@@ -61,7 +61,7 @@ struct seg_data;
         static void staticctor(Symbol *s,int dtor,int seg);
         static void staticdtor(Symbol *s);
         static void setModuleCtorDtor(Symbol *s, bool isCtor);
-        static void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
+        static void ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym);
         static void ehsections();
         static void moduleinfo(Symbol *scc);
         int  comdat(Symbol *);
@@ -147,7 +147,7 @@ class Obj
     VIRTUAL void staticctor(Symbol *s,int dtor,int seg);
     VIRTUAL void staticdtor(Symbol *s);
     VIRTUAL void setModuleCtorDtor(Symbol *s, bool isCtor);
-    VIRTUAL void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
+    VIRTUAL void ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym);
     VIRTUAL void ehsections();
     VIRTUAL void moduleinfo(Symbol *scc);
     virtual int  comdat(Symbol *);
@@ -258,7 +258,7 @@ class MsCoffObj : public Obj
     VIRTUAL void staticctor(Symbol *s,int dtor,int seg);
     VIRTUAL void staticdtor(Symbol *s);
     VIRTUAL void setModuleCtorDtor(Symbol *s, bool isCtor);
-    VIRTUAL void ehtables(Symbol *sfunc,targ_size_t size,Symbol *ehsym);
+    VIRTUAL void ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym);
     VIRTUAL void ehsections();
     VIRTUAL void moduleinfo(Symbol *scc);
     virtual int  comdat(Symbol *);

--- a/src/dmd/backend/out.c
+++ b/src/dmd/backend/out.c
@@ -66,6 +66,7 @@ void outcsegname(char *csegname)
 /***********************************
  * Output function thunk.
  */
+extern "C" {
 void outthunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
         targ_size_t d,int i,targ_size_t d2)
 {
@@ -74,7 +75,7 @@ void outthunk(symbol *sthunk,symbol *sfunc,unsigned p,tym_t thisty,
     sthunk->Sfunc->Fflags &= ~Fpending;
     sthunk->Sfunc->Fflags |= Foutput;   /* mark it as having been output */
 }
-
+}
 
 /***************************
  * Write out statically allocated data.

--- a/src/dmd/backend/outbuf.c
+++ b/src/dmd/backend/outbuf.c
@@ -65,7 +65,7 @@ void Outbuffer::reset()
 }
 
 // Enlarge buffer size so there's at least nbytes available
-void Outbuffer::enlarge(d_size_t nbytes)
+void Outbuffer::enlarge(unsigned nbytes)
 {
     const d_size_t oldlen = pend - buf;
     const d_size_t used = p - buf;
@@ -129,7 +129,7 @@ void Outbuffer::position(d_size_t offset, d_size_t nbytes)
 }
 
 // Write an array to the buffer.
-void Outbuffer::write(const void *b, d_size_t len)
+void Outbuffer::write(const void *b, unsigned len)
 {
     if (pend - p < len)
         reserve(len);

--- a/src/dmd/backend/outbuf.d
+++ b/src/dmd/backend/outbuf.d
@@ -42,14 +42,14 @@ struct Outbuffer
     void reset();
 
     // Reserve nbytes in buffer
-    void reserve(size_t nbytes)
+    void reserve(uint nbytes)
     {
         if (pend - p < nbytes)
             enlarge(nbytes);
     }
 
     // Reserve nbytes in buffer
-    void enlarge(size_t nbytes);
+    void enlarge(uint nbytes);
 
     // Write n zeros; return pointer to start of zeros
     void *writezeros(size_t n);
@@ -72,9 +72,9 @@ struct Outbuffer
     }
 
     // Write an array to the buffer.
-    void write(const(void)* b, size_t len);
+    void write(const(void)* b, uint len);
 
-    void write(Outbuffer *b) { write(b.buf,b.p - b.buf); }
+    void write(Outbuffer *b) { write(b.buf,cast(uint)(b.p - b.buf)); }
 
     /**
      * Flushes the stream. This will write any buffered

--- a/src/dmd/backend/outbuf.h
+++ b/src/dmd/backend/outbuf.h
@@ -47,14 +47,14 @@ struct Outbuffer
     void reset();
 
     // Reserve nbytes in buffer
-    void reserve(d_size_t nbytes)
+    void reserve(unsigned nbytes)
     {
         if (pend - p < nbytes)
             enlarge(nbytes);
     }
 
     // Reserve nbytes in buffer
-    void enlarge(d_size_t nbytes);
+    void enlarge(unsigned nbytes);
 
     // Write n zeros; return pointer to start of zeros
     void *writezeros(d_size_t n);
@@ -77,7 +77,7 @@ struct Outbuffer
     }
 
     // Write an array to the buffer.
-    void write(const void *b, d_size_t len);
+    void write(const void *b, unsigned len);
 
     void write(Outbuffer *b) { write(b->buf,b->p - b->buf); }
 

--- a/src/dmd/backend/util2.c
+++ b/src/dmd/backend/util2.c
@@ -377,3 +377,10 @@ void *util_realloc(void *oldp,unsigned n,unsigned size)
 #endif
 }
 #endif
+
+/*****************************
+ */
+void *mem_malloc2(unsigned size)
+{
+    return mem_malloc(size);
+}

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -139,7 +139,7 @@ void backend_init()
  * Return aligned 'offset' if it is of size 'size'.
  */
 
-targ_size_t _align(targ_size_t size, targ_size_t offset)
+extern (C) targ_size_t _align(targ_size_t size, targ_size_t offset)
 {
     switch (size)
     {
@@ -181,7 +181,7 @@ targ_size_t size(tym_t ty)
  * Generate symbol of type ty at DATA:offset
  */
 
-Symbol *symboldata(targ_size_t offset,tym_t ty)
+extern (C) Symbol *symboldata(targ_size_t offset,tym_t ty)
 {
     Symbol *s = symbol_generate(SClocstat, type_fake(ty));
     s.Sfl = FLdata;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -83,7 +83,7 @@ void objc_callfunc_setupMethodSelector(Type tret, FuncDeclaration fd, Type t, el
 void objc_callfunc_setupMethodCall(elem **ec, elem *ehidden, elem *ethis, TypeFunction tf);
 void objc_callfunc_setupEp(elem *esel, elem **ep, int reverse);
 
-void* mem_malloc(size_t);
+void* mem_malloc2(uint);
 
 
 @property int REGSIZE() { return _tysize[TYnptr]; }
@@ -734,7 +734,7 @@ elem *array_toDarray(Type t, elem *e)
                     es.Eoper = OPstring;
 
                     // freed in el_free
-                    es.EV.Vstring = cast(char*)mem_malloc(len);
+                    es.EV.Vstring = cast(char*)mem_malloc2(cast(uint)len);
                     memcpy(es.EV.Vstring, &e.EV, len);
 
                     es.EV.Vstrlen = len;
@@ -1539,7 +1539,7 @@ elem *toElem(Expression e, IRState *irs)
                 e.Eoper = OPstring;
                 // freed in el_free
                 uint len = cast(uint)((se.numberOfCodeUnits() + 1) * se.sz);
-                e.EV.Vstring = cast(char *)mem_malloc(len);
+                e.EV.Vstring = cast(char *)mem_malloc2(cast(uint)len);
                 se.writeTo(e.EV.Vstring, true);
                 e.EV.Vstrlen = len;
                 e.Ety = TYnptr;

--- a/src/dmd/eh.d
+++ b/src/dmd/eh.d
@@ -64,7 +64,7 @@ Symbol *except_gentables()
 
         outdata(s);                 // output the scope table
 
-        objmod.ehtables(funcsym_p,funcsym_p.Ssize,s);
+        objmod.ehtables(funcsym_p,cast(uint)funcsym_p.Ssize,s);
     }
     return null;
 }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -150,7 +150,8 @@ extern (C++) void Initializer_toDt(Initializer init, DtBuilder dtb)
                         Expression_toDt(edefault, dtb);
                         dtdefault = dtb.finish();
                     }
-                    dtbarray.repeat(dtdefault, n);
+                    assert(n <= uint.max);
+                    dtbarray.repeat(dtdefault, cast(uint)n);
                 }
             }
             switch (tb.ty)
@@ -175,7 +176,9 @@ extern (C++) void Initializer_toDt(Initializer init, DtBuilder dtb)
                                 dtdefault = dtb.finish();
                             }
 
-                            dtbarray.repeat(dtdefault, n * (tadim - ai.dim));
+                            const m = n * (tadim - ai.dim);
+                            assert(m <= uint.max);
+                            dtbarray.repeat(dtdefault, cast(uint)m);
                         }
                     }
                     else if (ai.dim > tadim)
@@ -920,7 +923,8 @@ private void toDtElem(TypeSArray tsa, DtBuilder dtb, Expression e)
         scope dtb2 = new DtBuilder();
         Expression_toDt(e, dtb2);
         dt_t* dt2 = dtb2.finish();
-        dtb.repeat(dt2, len);
+        assert(len <= uint.max);
+        dtb.repeat(dt2, cast(uint)len);
     }
 }
 


### PR DESCRIPTION
Because of mangling problems on OSX for `unsigned long long` when using a bootstrap dmd, we just use C mangling for now.