### PR TITLE
Move addDefaultVersionIdentifiers from mars.d to compiler.d

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -12,7 +12,143 @@
 
 module dmd.compiler;
 
+import core.stdc.stdio;
+import dmd.cond;
+import dmd.globals;
+
 struct Compiler
 {
     const(char)* vendor; // Compiler backend name
+}
+
+/**
+ * Add default `version` identifier for dmd, and set the
+ * target platform in `global`.
+ * https://dlang.org/spec/version.html#predefined-versions
+ *
+ * Needs to be run after all arguments parsing (command line, DFLAGS environment
+ * variable and config file) in order to add final flags (such as `X86_64` or
+ * the `CRuntime` used).
+ */
+void addDefaultVersionIdentifiers()
+{
+    VersionCondition.addPredefinedGlobalIdent("DigitalMars");
+    static if (TARGET_WINDOS)
+    {
+        VersionCondition.addPredefinedGlobalIdent("Windows");
+        global.params.isWindows = true;
+    }
+    else static if (TARGET_LINUX)
+    {
+        VersionCondition.addPredefinedGlobalIdent("Posix");
+        VersionCondition.addPredefinedGlobalIdent("linux");
+        VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        global.params.isLinux = true;
+    }
+    else static if (TARGET_OSX)
+    {
+        VersionCondition.addPredefinedGlobalIdent("Posix");
+        VersionCondition.addPredefinedGlobalIdent("OSX");
+        global.params.isOSX = true;
+        // For legacy compatibility
+        VersionCondition.addPredefinedGlobalIdent("darwin");
+    }
+    else static if (TARGET_FREEBSD)
+    {
+        VersionCondition.addPredefinedGlobalIdent("Posix");
+        VersionCondition.addPredefinedGlobalIdent("FreeBSD");
+        VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        global.params.isFreeBSD = true;
+    }
+    else static if (TARGET_OPENBSD)
+    {
+        VersionCondition.addPredefinedGlobalIdent("Posix");
+        VersionCondition.addPredefinedGlobalIdent("OpenBSD");
+        VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        global.params.isOpenBSD = true;
+    }
+    else static if (TARGET_SOLARIS)
+    {
+        VersionCondition.addPredefinedGlobalIdent("Posix");
+        VersionCondition.addPredefinedGlobalIdent("Solaris");
+        VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        global.params.isSolaris = true;
+    }
+    else
+    {
+        static assert(0, "fix this");
+    }
+    VersionCondition.addPredefinedGlobalIdent("LittleEndian");
+    VersionCondition.addPredefinedGlobalIdent("D_Version2");
+    VersionCondition.addPredefinedGlobalIdent("all");
+
+    if (global.params.cpu >= CPU.sse2)
+    {
+        VersionCondition.addPredefinedGlobalIdent("D_SIMD");
+        if (global.params.cpu >= CPU.avx)
+            VersionCondition.addPredefinedGlobalIdent("D_AVX");
+        if (global.params.cpu >= CPU.avx2)
+            VersionCondition.addPredefinedGlobalIdent("D_AVX2");
+    }
+
+    if (global.params.is64bit)
+    {
+        VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86_64");
+        VersionCondition.addPredefinedGlobalIdent("X86_64");
+        static if (TARGET_WINDOS)
+        {
+            VersionCondition.addPredefinedGlobalIdent("Win64");
+        }
+    }
+    else
+    {
+        VersionCondition.addPredefinedGlobalIdent("D_InlineAsm"); //legacy
+        VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86");
+        VersionCondition.addPredefinedGlobalIdent("X86");
+        static if (TARGET_WINDOS)
+        {
+            VersionCondition.addPredefinedGlobalIdent("Win32");
+        }
+    }
+    static if (TARGET_WINDOS)
+    {
+        if (global.params.mscoff)
+            VersionCondition.addPredefinedGlobalIdent("CRuntime_Microsoft");
+        else
+            VersionCondition.addPredefinedGlobalIdent("CRuntime_DigitalMars");
+    }
+    else static if (TARGET_LINUX)
+    {
+        VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
+    }
+
+    if (global.params.isLP64)
+        VersionCondition.addPredefinedGlobalIdent("D_LP64");
+    if (global.params.doDocComments)
+        VersionCondition.addPredefinedGlobalIdent("D_Ddoc");
+    if (global.params.cov)
+        VersionCondition.addPredefinedGlobalIdent("D_Coverage");
+    if (global.params.pic)
+        VersionCondition.addPredefinedGlobalIdent("D_PIC");
+    if (global.params.useUnitTests)
+        VersionCondition.addPredefinedGlobalIdent("unittest");
+    if (global.params.useAssert == CHECKENABLE.on)
+        VersionCondition.addPredefinedGlobalIdent("assert");
+    if (global.params.useArrayBounds == CHECKENABLE.off)
+        VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
+    if (global.params.betterC)
+        VersionCondition.addPredefinedGlobalIdent("D_BetterC");
+
+    VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
+}
+
+void printPredefinedVersions()
+{
+    if (global.params.verbose && global.params.versionids)
+    {
+        fprintf(global.stdmsg, "predefs  ");
+        foreach (const s; *global.params.versionids)
+            fprintf(global.stdmsg, " %s", s);
+        fprintf(global.stdmsg, "\n");
+    }
 }

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -27,24 +27,11 @@ void initDMD()
     import dmd.expression : Expression;
     import dmd.objc : Objc;
     import dmd.builtin : builtin_init;
+    import dmd.compiler : addDefaultVersionIdentifiers, printPredefinedVersions;
 
     global._init;
-
-    version(linux)
-        global.params.isLinux = 1;
-    else version(OSX)
-        global.params.isOSX = 1;
-    else version(FreeBSD)
-        global.params.isFreeBSD = 1;
-    else version(Windows)
-        global.params.isWindows = 1;
-    else version(Solaris)
-        global.params.isSolaris = 1;
-    else version(OpenBSD)
-        global.params.isOpenBSD = 1;
-    else
-        static assert(0, "OS not supported yet.");
-
+    addDefaultVersionIdentifiers();
+    printPredefinedVersions();
     Type._init();
     Id.initialize();
     Module._init();
@@ -53,4 +40,3 @@ void initDMD()
     Objc._init();
     builtin_init();
 }
-

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -26,6 +26,7 @@ import dmd.arraytypes;
 import dmd.astcodegen;
 import dmd.gluelayer;
 import dmd.builtin;
+import dmd.compiler;
 import dmd.cond;
 import dmd.console;
 import dmd.dinifile;
@@ -1211,143 +1212,6 @@ private void setDefaultLibrary()
         global.params.debuglibname = global.params.defaultlibname;
 }
 
-
-/**
- * Add default `version` identifier for dmd, and set the
- * target platform in `global`.
- * https://dlang.org/spec/version.html#predefined-versions
- *
- * Needs to be run after all arguments parsing (command line, DFLAGS environment
- * variable and config file) in order to add final flags (such as `X86_64` or
- * the `CRuntime` used).
- */
-private void addDefaultVersionIdentifiers()
-{
-    VersionCondition.addPredefinedGlobalIdent("DigitalMars");
-    static if (TARGET.Windows)
-    {
-        VersionCondition.addPredefinedGlobalIdent("Windows");
-        global.params.isWindows = true;
-    }
-    else static if (TARGET.Linux)
-    {
-        VersionCondition.addPredefinedGlobalIdent("Posix");
-        VersionCondition.addPredefinedGlobalIdent("linux");
-        VersionCondition.addPredefinedGlobalIdent("ELFv1");
-        global.params.isLinux = true;
-    }
-    else static if (TARGET.OSX)
-    {
-        VersionCondition.addPredefinedGlobalIdent("Posix");
-        VersionCondition.addPredefinedGlobalIdent("OSX");
-        global.params.isOSX = true;
-        // For legacy compatibility
-        VersionCondition.addPredefinedGlobalIdent("darwin");
-    }
-    else static if (TARGET.FreeBSD)
-    {
-        VersionCondition.addPredefinedGlobalIdent("Posix");
-        VersionCondition.addPredefinedGlobalIdent("FreeBSD");
-        VersionCondition.addPredefinedGlobalIdent("ELFv1");
-        global.params.isFreeBSD = true;
-    }
-    else static if (TARGET.OpenBSD)
-    {
-        VersionCondition.addPredefinedGlobalIdent("Posix");
-        VersionCondition.addPredefinedGlobalIdent("OpenBSD");
-        VersionCondition.addPredefinedGlobalIdent("ELFv1");
-        global.params.isOpenBSD = true;
-    }
-    else static if (TARGET.Solaris)
-    {
-        VersionCondition.addPredefinedGlobalIdent("Posix");
-        VersionCondition.addPredefinedGlobalIdent("Solaris");
-        VersionCondition.addPredefinedGlobalIdent("ELFv1");
-        global.params.isSolaris = true;
-    }
-    else
-    {
-        static assert(0, "fix this");
-    }
-    VersionCondition.addPredefinedGlobalIdent("LittleEndian");
-    VersionCondition.addPredefinedGlobalIdent("D_Version2");
-    VersionCondition.addPredefinedGlobalIdent("all");
-
-    if (global.params.cpu >= CPU.sse2)
-    {
-        VersionCondition.addPredefinedGlobalIdent("D_SIMD");
-        if (global.params.cpu >= CPU.avx)
-            VersionCondition.addPredefinedGlobalIdent("D_AVX");
-        if (global.params.cpu >= CPU.avx2)
-            VersionCondition.addPredefinedGlobalIdent("D_AVX2");
-    }
-
-    if (global.params.is64bit)
-    {
-        VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86_64");
-        VersionCondition.addPredefinedGlobalIdent("X86_64");
-        static if (TARGET.Windows)
-        {
-            VersionCondition.addPredefinedGlobalIdent("Win64");
-        }
-    }
-    else
-    {
-        VersionCondition.addPredefinedGlobalIdent("D_InlineAsm"); //legacy
-        VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86");
-        VersionCondition.addPredefinedGlobalIdent("X86");
-        static if (TARGET.Windows)
-        {
-            VersionCondition.addPredefinedGlobalIdent("Win32");
-        }
-    }
-    static if (TARGET.Windows)
-    {
-        if (global.params.mscoff)
-            VersionCondition.addPredefinedGlobalIdent("CRuntime_Microsoft");
-        else
-            VersionCondition.addPredefinedGlobalIdent("CRuntime_DigitalMars");
-    }
-    else static if (TARGET.Linux)
-    {
-        VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
-    }
-
-    if (global.params.isLP64)
-        VersionCondition.addPredefinedGlobalIdent("D_LP64");
-    if (global.params.doDocComments)
-        VersionCondition.addPredefinedGlobalIdent("D_Ddoc");
-    if (global.params.cov)
-        VersionCondition.addPredefinedGlobalIdent("D_Coverage");
-    if (global.params.pic)
-        VersionCondition.addPredefinedGlobalIdent("D_PIC");
-    if (global.params.useUnitTests)
-        VersionCondition.addPredefinedGlobalIdent("unittest");
-    if (global.params.useAssert == CHECKENABLE.on)
-        VersionCondition.addPredefinedGlobalIdent("assert");
-    if (global.params.useArrayBounds == CHECKENABLE.off)
-        VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
-    if (global.params.betterC)
-        VersionCondition.addPredefinedGlobalIdent("D_BetterC");
-
-    VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
-
-    printPredefinedVersions();
-}
-
-private void printPredefinedVersions()
-{
-    if (global.params.verbose && global.versionids)
-    {
-        fprintf(global.stdmsg, "predefs  ");
-        foreach (const str; *global.versionids)
-            fprintf(global.stdmsg, " %s", str.toChars);
-
-        fprintf(global.stdmsg, "\n");
-    }
-}
-
-
 /****************************************
  * Determine the instruction set to be used.
  * Params:
@@ -2160,6 +2024,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
     }
     return errors;
 }
+<<<<<<< 1018db023831a8c348bb8f9121b08fabb6e32fc2
 
 
 private __gshared bool includeImports = false;
@@ -2436,3 +2301,5 @@ private void parseModulePattern(const(char)* modulePattern, MatcherNode* dst, us
         }
     }
 }
+=======
+>>>>>>> Move addDefaultVersionIdentifiers to frontend.d

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -444,7 +444,7 @@ $G/backend.a: $(G_OBJS) $(SRC_MAKE)
 	$(AR) rcs $@ $(G_OBJS)
 
 $G/lexer.a: $(LEXER_SRCS) $(LEXER_ROOT) $(HOST_DMD_PATH) $(SRC_MAKE)
-	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -lib -of$@ $(MODEL_FLAG) -J$G -L-lstdc++ $(DFLAGS) $(LEXER_SRCS) $(LEXER_ROOT)
+	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -lib -of$@ $(MODEL_FLAG) -J$G -J../res -L-lstdc++ $(DFLAGS) $(LEXER_SRCS) $(LEXER_ROOT)
 
 $G/dmd_frontend: $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
 	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J../res -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^) -version=NoBackend
@@ -466,13 +466,13 @@ unittest: $G/dmd-unittest
 ######## DMD as a library examples
 
 EXAMPLES=$(addprefix $G/examples/, avg impvisitor)
-PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase parsetimevisitor transitivevisitor permissivevisitor strictvisitor))
+PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase compiler parsetimevisitor transitivevisitor permissivevisitor strictvisitor))
 
 $G/parser.a: $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS) $G/dmd $G/dmd.conf $(SRC_MAKE)
-	CC="$(HOST_CXX)" $G/dmd -lib -of$@ $(MODEL_FLAG) -L-lstdc++ -J$G $(DFLAGS) $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS)
+	CC="$(HOST_CXX)" $G/dmd -lib -of$@ $(MODEL_FLAG) -L-lstdc++ -J$G -J../res $(DFLAGS) $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS)
 
 $G/examples/%: $(EX)/%.d $G/parser.a $G/dmd
-	CC="$(HOST_CXX)" $G/dmd -of$@ $(MODEL_FLAG) $(DFLAGS) $G/parser.a $<
+	CC="$(HOST_CXX)" $G/dmd -of$@ $(MODEL_FLAG) -J../res $(DFLAGS) $G/parser.a $<
 
 build-examples: $(EXAMPLES)
 


### PR DESCRIPTION
The frontend interface of the compiler library needs to do some initialization which is done in dmd/mars.d. In order to use initialization methods from mars.d there are 3 options:

1. Duplicate the code in frontend.d
2. Import mars.d and use the method.
3. Put it in another file and make frontend.d and mars.d use it

(1), (2) are obviously bad solutions, so this PR implements (3)