### PR TITLE
Remove myself from DMD posix.mak codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,7 +37,7 @@ src/dmd/root/* @WalterBright
 src/dmd/tk/* @WalterBright
 
 # CI & automation
-posix.mak @CyberShadow @MartinNowak @wilzbach
-src/posix.mak @CyberShadow @MartinNowak @wilzbach
-circle.sh @CyberShadow @MartinNowak @wilzbach
-travis.sh @CyberShadow @MartinNowak @wilzbach
+posix.mak @MartinNowak @wilzbach
+src/posix.mak @MartinNowak @wilzbach
+circle.sh @MartinNowak @wilzbach
+travis.sh @MartinNowak @wilzbach


### PR DESCRIPTION
There's too many changes that are not specifically Makefile-related,
resulting in a pretty bad signal/noise ratio for PRs that I'm
auto-assigned to.