### PR TITLE
Peel off outer ForwardingStatement after running semantic

### DIFF
--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -188,18 +188,6 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             result = blockExit(s.statement, func, mustNotThrow);
         }
 
-        override void visit(ForwardingStatement s)
-        {
-            if (s.statement)
-            {
-                s.statement.accept(this);
-            }
-            else
-            {
-                result = BE.fallthru;
-            }
-        }
-
         override void visit(WhileStatement s)
         {
             assert(global.errors);

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1052,54 +1052,6 @@ extern (C++) final class ForwardingStatement : Statement
         return new ForwardingStatement(loc, statement.syntaxCopy());
     }
 
-    override Statement getRelatedLabeled()
-    {
-        if (!statement)
-        {
-            return null;
-        }
-        return statement.getRelatedLabeled();
-    }
-
-    override bool hasBreak()
-    {
-        if (!statement)
-        {
-            return false;
-        }
-        return statement.hasBreak();
-    }
-
-    override bool hasContinue()
-    {
-        if (!statement)
-        {
-            return false;
-        }
-        return statement.hasContinue();
-    }
-
-    override Statement scopeCode(Scope* sc, Statement* sentry, Statement* sexception, Statement* sfinally)
-    {
-        if (!statement)
-        {
-            return this;
-        }
-        sc = sc.push(sym);
-        statement = statement.scopeCode(sc, sentry, sexception, sfinally);
-        sc = sc.pop();
-        return statement ? this : null;
-    }
-
-    override inout(Statement) last() inout nothrow pure
-    {
-        if (!statement)
-        {
-            return null;
-        }
-        return statement.last();
-    }
-
     /***********************
      * ForwardingStatements are distributed over the flattened
      * sequence of statements. This prevents flattening to be

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -229,11 +229,6 @@ class ForwardingStatement : public Statement
     Statement *statement;
 
     Statement *syntaxCopy();
-    Statement *getRelatedLabeled();
-    bool hasBreak();
-    bool hasContinue();
-    Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexception, Statement **sfinally);
-    Statement *last();
     Statements *flatten(Scope *sc);
     ForwardingStatement *isForwardingStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -434,7 +434,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         result = ss;
     }
 
-    override void visit(ForwardingStatement ss){
+    override void visit(ForwardingStatement ss)
+    {
         assert(ss.sym);
         for (Scope* csc = sc; !ss.sym.forward; csc = csc.enclosing)
         {
@@ -446,7 +447,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         sc.scontinue = ss;
         ss.statement = ss.statement.statementSemantic(sc);
         sc = sc.pop();
-        result = ss.statement ? ss : null;
+        result = ss.statement;
     }
 
     override void visit(WhileStatement ws)

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -35,11 +35,7 @@ public:
     void visit(ASTCodegen.SwitchErrorStatement s) { visit(cast(ASTCodegen.Statement)s); }
     void visit(ASTCodegen.DebugStatement s) { visit(cast(ASTCodegen.Statement)s); }
     void visit(ASTCodegen.DtorExpStatement s) { visit(cast(ASTCodegen.ExpStatement)s); }
-    void visit(ASTCodegen.ForwardingStatement s)
-    {
-        if(s.statement)
-            s.statement.accept(this);
-    }
+    void visit(ASTCodegen.ForwardingStatement s) { visit(cast(ASTCodegen.Statement)s); }
     void visit(ASTCodegen.OverloadSet s) { visit(cast(ASTCodegen.Dsymbol)s); }
     void visit(ASTCodegen.LabelDsymbol s) { visit(cast(ASTCodegen.Dsymbol)s); }
     void visit(ASTCodegen.WithScopeSymbol s) { visit(cast(ASTCodegen.ScopeDsymbol)s); }


### PR DESCRIPTION
FYI - @tgehr 

As it has no use outside of semantic analysis.