### PR TITLE
fix Issue 15374 - Move genCmain into Compiler struct.

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -12,10 +12,80 @@
 
 module dmd.compiler;
 
+import dmd.astcodegen;
+import dmd.dmodule;
+import dmd.dscope;
+import dmd.dsymbolsem;
+import dmd.globals;
+import dmd.id;
+import dmd.identifier;
+import dmd.parse;
+import dmd.semantic2;
+import dmd.semantic3;
+import dmd.tokens;
+
+/// DMD-generated module `__entrypoint` where the C main resides
+package __gshared Module entrypoint = null;
+/// Module in which the D main is
+package __gshared Module rootHasMain = null;
+
 /**
  * A data structure that describes a back-end compiler and implements
  * compiler-specific actions.
  */
 struct Compiler
 {
+    /**
+     * Generate C main() in response to seeing D main().
+     *
+     * This function will generate a module called `__entrypoint`,
+     * and set the globals `entrypoint` and `rootHasMain`.
+     *
+     * This used to be in druntime, but contained a reference to _Dmain
+     * which didn't work when druntime was made into a dll and was linked
+     * to a program, such as a C++ program, that didn't have a _Dmain.
+     *
+     * Params:
+     *   sc = Scope which triggered the generation of the C main,
+     *        used to get the module where the D main is.
+     */
+    extern (C++) static void genCmain(Scope* sc)
+    {
+        if (entrypoint)
+            return;
+        /* The D code to be generated is provided as D source code in the form of a string.
+         * Note that Solaris, for unknown reasons, requires both a main() and an _main()
+         */
+        immutable cmaincode =
+        q{
+            extern(C)
+            {
+                int _d_run_main(int argc, char **argv, void* mainFunc);
+                int _Dmain(char[][] args);
+                int main(int argc, char **argv)
+                {
+                    return _d_run_main(argc, argv, &_Dmain);
+                }
+                version (Solaris) int _main(int argc, char** argv) { return main(argc, argv); }
+            }
+        };
+        Identifier id = Id.entrypoint;
+        auto m = new Module("__entrypoint.d", id, 0, 0);
+        scope p = new Parser!ASTCodegen(m, cmaincode, false);
+        p.scanloc = Loc.initial;
+        p.nextToken();
+        m.members = p.parseModule();
+        assert(p.token.value == TOK.endOfFile);
+        assert(!p.errors); // shouldn't have failed to parse it
+        bool v = global.params.verbose;
+        global.params.verbose = false;
+        m.importedFrom = m;
+        m.importAll(null);
+        m.dsymbolSemantic(null);
+        m.semantic2(null);
+        m.semantic3(null);
+        global.params.verbose = v;
+        entrypoint = m;
+        rootHasMain = sc._module;
+    }
 }

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -13,6 +13,9 @@
 // This file contains a data structure that describes a back-end compiler
 // and implements compiler-specific actions.
 
+struct Scope;
+
 struct Compiler
 {
+    static void genCmain(Scope *);
 };

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -22,6 +22,7 @@ import dmd.astcodegen;
 import dmd.attrib;
 import dmd.blockexit;
 import dmd.clone;
+import dmd.compiler;
 import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
@@ -46,7 +47,6 @@ import dmd.identifier;
 import dmd.init;
 import dmd.initsem;
 import dmd.hdrgen;
-import dmd.mars;
 import dmd.mtype;
 import dmd.nogc;
 import dmd.nspace;
@@ -3609,7 +3609,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         if (funcdecl.fbody && funcdecl.isMain() && sc._module.isRoot())
-            genCmain(sc);
+            Compiler.genCmain(sc);
 
         assert(funcdecl.type.ty != Terror || funcdecl.errors);
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -224,9 +224,9 @@ struct Global
     Array<const char *> *path;        // Array of char*'s which form the import lookup path
     Array<const char *> *filePath;    // Array of char*'s which form the file import lookup path
 
-    const char *version;
+    const char *version;     // Compiler version string
+    const char *vendor;      // Compiler backend name
 
-    Compiler compiler;
     Param params;
     unsigned errors;         // number of errors reported so far
     unsigned warnings;       // number of warnings reported so far

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -23,16 +23,15 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 import dmd.arraytypes;
-import dmd.astcodegen;
 import dmd.gluelayer;
 import dmd.builtin;
 import dmd.cond;
 import dmd.console;
+import dmd.compiler;
 import dmd.dinifile;
 import dmd.dinterpret;
 import dmd.dmodule;
 import dmd.doc;
-import dmd.dscope;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.errors;
@@ -47,7 +46,6 @@ import dmd.lib;
 import dmd.link;
 import dmd.mtype;
 import dmd.objc;
-import dmd.parse;
 import dmd.root.array;
 import dmd.root.file;
 import dmd.root.filename;
@@ -59,7 +57,6 @@ import dmd.root.stringtable;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.target;
-import dmd.tokens;
 import dmd.utils;
 
 /**
@@ -113,67 +110,6 @@ Where:
   @<cmdfile>       read arguments from cmdfile
 %.*s", FileName.canonicalName(global.inifilename), help.length, &help[0]);
 }
-
-/// DMD-generated module `__entrypoint` where the C main resides
-private __gshared Module entrypoint = null;
-/// Module in which the D main is
-private __gshared Module rootHasMain = null;
-
-
-/**
- * Generate C main() in response to seeing D main().
- *
- * This function will generate a module called `__entrypoint`,
- * and set the globals `entrypoint` and `rootHasMain`.
- *
- * This used to be in druntime, but contained a reference to _Dmain
- * which didn't work when druntime was made into a dll and was linked
- * to a program, such as a C++ program, that didn't have a _Dmain.
- *
- * Params:
- *   sc = Scope which triggered the generation of the C main,
- *        used to get the module where the D main is.
- */
-void genCmain(Scope* sc)
-{
-    if (entrypoint)
-        return;
-    /* The D code to be generated is provided as D source code in the form of a string.
-     * Note that Solaris, for unknown reasons, requires both a main() and an _main()
-     */
-    immutable cmaincode =
-    q{
-        extern(C)
-        {
-            int _d_run_main(int argc, char **argv, void* mainFunc);
-            int _Dmain(char[][] args);
-            int main(int argc, char **argv)
-            {
-                return _d_run_main(argc, argv, &_Dmain);
-            }
-            version (Solaris) int _main(int argc, char** argv) { return main(argc, argv); }
-        }
-    };
-    Identifier id = Id.entrypoint;
-    auto m = new Module("__entrypoint.d", id, 0, 0);
-    scope p = new Parser!ASTCodegen(m, cmaincode, false);
-    p.scanloc = Loc.initial;
-    p.nextToken();
-    m.members = p.parseModule();
-    assert(p.token.value == TOK.endOfFile);
-    assert(!p.errors); // shouldn't have failed to parse it
-    bool v = global.params.verbose;
-    global.params.verbose = false;
-    m.importedFrom = m;
-    m.importAll(null);
-    m.dsymbolSemantic(null);
-    m.semantic2(null);
-    m.semantic3(null);
-    global.params.verbose = v;
-    entrypoint = m;
-    rootHasMain = sc._module;
-}
-
 
 /**
  * DMD's real entry point

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -70,6 +70,7 @@ static void frontend_init()
 
     global._init();
     global.params.isLinux = true;
+    global.vendor = "Front-End Tester";
 
     Type::_init();
     Id::initialize();


### PR DESCRIPTION
Probably a good time to think about what to do with `entrypoint` and `rootHasMain`.  Keep as top-level vars? Or move into `Global`.