### PR TITLE
[refactor] Replace 'goto Ldefault' with 'goto default'

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -899,20 +899,20 @@ Lagain:
         case Tfloat32:
         case Timaginary32:
             if (!global.params.is64bit)
-                goto Ldefault;          // legacy binary compatibility
+                goto default;          // legacy binary compatibility
             r = RTLSYM_MEMSETFLOAT;
             break;
         case Tfloat64:
         case Timaginary64:
             if (!global.params.is64bit)
-                goto Ldefault;          // legacy binary compatibility
+                goto default;          // legacy binary compatibility
             r = RTLSYM_MEMSETDOUBLE;
             break;
 
         case Tstruct:
         {
             if (!global.params.is64bit)
-                goto Ldefault;
+                goto default;
 
             TypeStruct tc = cast(TypeStruct)tb;
             StructDeclaration sd = tc.sym;
@@ -921,7 +921,7 @@ Lagain:
                 tb = sd.arg1type;
                 goto Lagain;
             }
-            goto Ldefault;
+            goto default;
         }
 
         case Tvector:
@@ -929,7 +929,6 @@ Lagain:
             break;
 
         default:
-        Ldefault:
             switch (sz)
             {
                 case 1:      r = RTLSYM_MEMSET8;    break;

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -3504,11 +3504,10 @@ code *asm_db_parse(OP *pop)
                     }
                     goto L3;
                 }
-                goto Ldefault;
+                goto default;
             }
 
             default:
-            Ldefault:
                 asmerr("constant initializer expected");          // constant initializer
                 break;
         }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2759,25 +2759,25 @@ final class Parser(AST) : Lexer
 
                 case TOKconst:
                     if (peek(&token).value == TOKlparen)
-                        goto Ldefault;
+                        goto default;
                     stc = AST.STCconst;
                     goto L2;
 
                 case TOKimmutable:
                     if (peek(&token).value == TOKlparen)
-                        goto Ldefault;
+                        goto default;
                     stc = AST.STCimmutable;
                     goto L2;
 
                 case TOKshared:
                     if (peek(&token).value == TOKlparen)
-                        goto Ldefault;
+                        goto default;
                     stc = AST.STCshared;
                     goto L2;
 
                 case TOKwild:
                     if (peek(&token).value == TOKlparen)
-                        goto Ldefault;
+                        goto default;
                     stc = AST.STCwild;
                     goto L2;
 
@@ -2854,7 +2854,6 @@ final class Parser(AST) : Lexer
                         goto L3;
                     }
                 default:
-                Ldefault:
                     {
                         stc = storageClass & (AST.STCin | AST.STCout | AST.STCref | AST.STClazy);
                         // if stc is not a power of 2
@@ -5946,17 +5945,17 @@ final class Parser(AST) : Lexer
                                 continue;
                             }
                         }
-                        goto Ldefault;
+                        goto default;
 
                     case TOKlcurly:
                         ++nestlevel;
-                        goto Ldefault;
+                        goto default;
 
                     case TOKrcurly:
                         if (nestlevel > 0)
                         {
                             --nestlevel;
-                            goto Ldefault;
+                            goto default;
                         }
                         if (toklist || label)
                         {
@@ -5991,7 +5990,6 @@ final class Parser(AST) : Lexer
                         goto Lerror;
 
                     default:
-                    Ldefault:
                         *ptoklist = Token.alloc();
                         memcpy(*ptoklist, &token, Token.sizeof);
                         ptoklist = &(*ptoklist).next;


### PR DESCRIPTION
Some artefact of the old C++ code.