### PR TITLE
Fix CodeCov: use domains to ignore CI providers, allow_coverage_offsets + YAML validation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,12 +8,12 @@ codecov:
     # https://docs.codecov.io/docs/detecting-ci-services
     # Only CircleCi generates coverages files atm.
     # Don't wait for the other CIs
-    - ci/circleci
-    - !CyberShadow/DAutoTest
-    - !auto-tester
-    - !continuous-integration/appveyor/pr
-    - !continuous-integration/jenkins/pr-merge
-    - !continuous-integration/travis-ci/pr
+    - circleci.com
+    - !dtest.dlang.io
+    - !auto-tester.puremagic.com
+    - !appveyor.com
+    - !ci.dlang.io
+    - !travis-ci.org
 
   # At CircleCi, the PR is merged into `master` before the testsuite is run.
   # This allows CodeCov to adjust the resulting coverage diff, s.t. it matches

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,6 +15,13 @@ codecov:
     - !continuous-integration/jenkins/pr-merge
     - !continuous-integration/travis-ci/pr
 
+  # At CircleCi, the PR is merged into `master` before the testsuite is run.
+  # This allows CodeCov to adjust the resulting coverage diff, s.t. it matches
+  # with the GitHub diff.
+  # https://github.com/codecov/support/issues/363
+  # https://docs.codecov.io/v4.3.6/docs/comparing-commits
+  allow_coverage_offsets: true
+
 coverage:
   precision: 3
   round: down
@@ -38,12 +45,5 @@ coverage:
   fixes:
     - "test/.*/::src/"
     - "fail_compilation/::src/"
-
-  # At CircleCi, the PR is merged into `master` before the testsuite is run.
-  # This allows CodeCov to adjust the resulting coverage diff, s.t. it matches
-  # with the GitHub diff.
-  # https://github.com/codecov/support/issues/363
-  # https://docs.codecov.io/v4.3.6/docs/comparing-commits
-  allow_coverage_offsets: true
 
 comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,5 @@
 # Documentation: https://docs.codecov.io/docs/codecov-yaml
+# Validate with: `curl --data-binary @.codecov.yml https://codecov.io/validate`
 
 codecov:
   notify:


### PR DESCRIPTION
Apparently the CodeCov API needs `allow_coverage_offsets` to be based in differently and also prefers domains instead of their CI names to ignore CI providers.

There's the possibility to validate the YAML automatically, but I don't think it changes often to warrant this. The main problem I see is that then our testsuite could fail if CodeCov is down.

```diff
diff --git a/.circleci/config.yml b/.circleci/config.yml
index aacd5c14e..d3b214104 100644
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
       - run:
           command: sudo apt-get update && sudo apt-get install gdb
           name: Install GDB
+      - run:
+          command: wget --content-on-error -qO- --post-file=.codecov.yml https://codecov.io/validate
+          name: Check .codecov.yml for validity
       - run:
           command: ./.circleci/run.sh setup-repos
           name: Clone DMD & DRuntime
```

(I'm sorry about the noise regarding CodeCov, but I hope that we slowly, but steadily improve its configuration).