### PR TITLE
[CodeCov] Don't wait for other CIs (attempt III)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,11 @@
 
 codecov:
   notify:
+    # We don't want to wait for the CodeCov report
+    # See https://github.com/codecov/support/issues/312
+    require_ci_to_pass: false
     after_n_builds: 1  # send notifications after the first upload
+
   bot: dlang-bot
   ci:
     # https://docs.codecov.io/docs/detecting-ci-services


### PR DESCRIPTION
I'm now following this advice (https://github.com/codecov/support/issues/312)
and adding `require_ci_to_pass`.