### PR TITLE
Re-fix Issue 12901 in/out contracts on struct constructor must require function body

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1074,7 +1074,7 @@ extern(C++) final class Semantic3Visitor : Visitor
                 }
 
                 // If declaration has no body, don't set sbody to prevent incorrect codegen.
-                if (funcdecl.fbody || funcdecl.fdensure || funcdecl.fdrequire)
+                if (funcdecl.fbody || funcdecl.allowsContractWithoutBody())
                     funcdecl.fbody = sbody;
             }
 

--- a/test/fail_compilation/fail12901.d
+++ b/test/fail_compilation/fail12901.d
@@ -1,0 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12901.d(11): Error: constructor fail12901.S.this in and out contracts can only appear without a body when they are virtual interface functions or abstract
+---
+*/
+
+struct S
+{
+    int a;
+    this(int n)
+    in { a = n; }
+    // no body
+}


### PR DESCRIPTION
Fix as per #7527, but doesn't revert fix in #3664.