### PR TITLE
Appveyor: add building via VS projects

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -62,6 +62,7 @@ for proj in druntime phobos; do
     fi
 done
 
+# build via makefile
 cd /c/projects/dmd/src
 make -f win64.mak reldmd DMD=../src/dmd
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,11 @@ environment:
       D_COMPILER:          dmd
       D_VERSION:           2.077.1
       C_COMPILER:          MSVC
+      VISUALD_VER:         v0.45.1-rc2
 
 cache:
-  - gnumake/make.exe
+  - C:\projects\gnumake\make.exe
+  - C:\projects\VisualD-v0.45.1-rc2.exe
 
 artifacts:
   - path: src/dmd.exe
@@ -23,7 +25,32 @@ init:
 build_script:
   - cd c:/projects/
   - call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+
+  # Download & install Visual D (needs admin rights?)
+  - set VISUALD_INSTALLER=VisualD-%VISUALD_VER%.exe
+  - set VISUALD_URL=https://github.com/dlang/visuald/releases/download/%VISUALD_VER%/%VISUALD_INSTALLER%
+  - ps: |
+        If (-not (Test-Path $Env:VISUALD_INSTALLER)) {
+            Start-FileDownload $Env:VISUALD_URL -FileName $Env:VISUALD_INSTALLER
+        }
+  - .\%VISUALD_INSTALLER% /S
+  # configure DMD path
+  - reg add "HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\ToolsOptionsPages\Projects\Visual D Settings" /v DMDInstallDir /t REG_SZ /d c:\projects\dmd2 /reg:32 /f
+  # disable link dependencies monitoring, fails on AppVeyor server
+  - reg add "HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\ToolsOptionsPages\Projects\Visual D Settings" /v optlinkDeps /t REG_DWORD /d 0 /reg:32 /f
+
   - bash --version
   - sh --login /c/projects/dmd/appveyor.sh
+
+  # build via VS projects (needs dmd downloaded in appveyor.sh)
+  - cd c:\projects\dmd\src
+  # upgrade used compiler version to VS2015
+  - sed -i s/v120/v140/ vcbuild\dmd_backend.vcxproj
+  - devenv /Build "Release|Win32" /Project dmd vcbuild\dmd.sln
+
+  # sanity check: build druntime unittests
+  - cd c:\projects\druntime
+  - set PATH=c:\projects\dmd2\windows\bin;%PATH%
+  - make -f win64.mak MODEL=32mscoff DMD=..\dmd\generated\Windows\Release\Win32\dmd.exe VCDIR="%VCINSTALLDIR%." SDKDIR=unused unittest32mscoff
 
 test_script: true


### PR DESCRIPTION
This also fixes caching of gnumake, see https://ci.appveyor.com/project/greenify/dmd/build/1.0.411#L3133