### PR TITLE
Refactor: Move @disable check out of checkDeprecated

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -292,6 +292,51 @@ extern (C++) abstract class Declaration : Dsymbol
         return type.size();
     }
 
+    /**
+     * Issue an error if an attempt to call a disabled method is made
+     *
+     * If the declaration is disabled but inside a disabled function,
+     * returns `true` but do not issue an error message.
+     *
+     * Params:
+     *   loc = Location information of the call
+     *   sc  = Scope in which the call occurs
+     *
+     * Returns:
+     *   `true` if this `Declaration` is `@disable`d, `false` otherwise.
+     */
+    final bool checkDisabled(Loc loc, Scope* sc, bool isAliasedDeclaration = false)
+    {
+        if (storage_class & STCdisable)
+        {
+            if (!(sc.func && sc.func.storage_class & STCdisable))
+            {
+                auto p = toParent();
+                if (p && isPostBlitDeclaration())
+                    p.error(loc, "is not copyable because it is annotated with `@disable`");
+                else
+                {
+                    // if the function is @disabled, maybe there
+                    // is an overload in the overload set that isn't
+                    if (isAliasedDeclaration)
+                    {
+                        FuncDeclaration fd = isFuncDeclaration();
+                        if (fd)
+                        {
+                            for (FuncDeclaration ovl = fd; ovl; ovl = cast(FuncDeclaration)ovl.overnext)
+                                if (!(ovl.storage_class & STCdisable))
+                                    return false;
+                        }
+                    }
+                    error(loc, "is not callable because it is annotated with `@disable`");
+                }
+            }
+            return true;
+        }
+
+        return false;
+    }
+
     /*************************************
      * Check to see if declaration can be modified in this context (sc).
      * Issue error if not.

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -306,7 +306,7 @@ extern (C++) class Dsymbol : RootObject
         va_end(ap);
     }
 
-    final void checkDeprecated(Loc loc, Scope* sc, bool isAliasedDeclaration = false)
+    final void checkDeprecated(Loc loc, Scope* sc)
     {
         if (global.params.useDeprecated != 1 && isDeprecated())
         {
@@ -314,15 +314,16 @@ extern (C++) class Dsymbol : RootObject
             for (Dsymbol sp = sc.parent; sp; sp = sp.parent)
             {
                 if (sp.isDeprecated())
-                    goto L1;
+                    return;
             }
             for (Scope* sc2 = sc; sc2; sc2 = sc2.enclosing)
             {
                 if (sc2.scopesym && sc2.scopesym.isDeprecated())
-                    goto L1;
+                    return;
+
                 // If inside a StorageClassDeclaration that is deprecated
                 if (sc2.stc & STCdeprecated)
-                    goto L1;
+                    return;
             }
             const(char)* message = null;
             for (Dsymbol p = this; p; p = p.parent)
@@ -335,32 +336,6 @@ extern (C++) class Dsymbol : RootObject
                 deprecation(loc, "is deprecated - %s", message);
             else
                 deprecation(loc, "is deprecated");
-        }
-    L1:
-        Declaration d = isDeclaration();
-        if (d && d.storage_class & STCdisable)
-        {
-            if (!(sc.func && sc.func.storage_class & STCdisable))
-            {
-                if (d.toParent() && d.isPostBlitDeclaration())
-                    d.toParent().error(loc, "is not copyable because it is annotated with @disable");
-                else
-                {
-                    // if the function is @disabled, maybe there
-                    // is an overload in the overload set that isn't
-                    if (isAliasedDeclaration)
-                    {
-                        FuncDeclaration fd = d.isFuncDeclaration;
-                        if (fd)
-                        {
-                            for (FuncDeclaration ovl = fd; ovl; ovl = cast(FuncDeclaration)ovl.overnext)
-                                if (!(ovl.storage_class & STCdisable))
-                                    return;
-                        }
-                    }
-                    error(loc, "is not callable because it is annotated with @disable");
-                }
-            }
         }
     }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -203,7 +203,11 @@ Lagain:
     else
     {
         if (!s.isFuncDeclaration()) // functions are checked after overloading
+        {
             s.checkDeprecated(loc, sc);
+            if (d)
+                d.checkDisabled(loc, sc);
+        }
 
         // https://issues.dlang.org/show_bug.cgi?id=12023
         // if 's' is a tuple variable, the tuple is returned.
@@ -211,7 +215,11 @@ Lagain:
 
         //printf("s = '%s', s.kind = '%s', s.needThis() = %p\n", s.toChars(), s.kind(), s.needThis());
         if (s != olds && !s.isFuncDeclaration())
+        {
             s.checkDeprecated(loc, sc);
+            if (d)
+                d.checkDisabled(loc, sc);
+        }
     }
 
     if (auto em = s.isEnumMember())
@@ -2229,11 +2237,9 @@ extern (C++) abstract class Expression : RootObject
             StructDeclaration sd = (cast(TypeStruct)t).sym;
             if (sd.postblit)
             {
-                if (sd.postblit.storage_class & STCdisable)
-                {
-                    sd.error(loc, "is not copyable because it is annotated with @disable");
+                if (sd.postblit.checkDisabled(loc, sc))
                     return true;
-                }
+
                 //checkDeprecated(sc, sd.postblit);        // necessary?
                 checkPurity(sc, sd.postblit);
                 checkSafety(sc, sd.postblit);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -1176,7 +1176,11 @@ extern (C++) abstract class Type : RootObject
     {
         Dsymbol s = toDsymbol(sc);
         if (s)
+        {
             s.checkDeprecated(loc, sc);
+            if(auto d = s.isDeclaration())
+                d.checkDisabled(loc, sc);
+        }
     }
 
     final bool isConst() const nothrow pure @nogc @safe
@@ -6514,7 +6518,12 @@ extern (C++) abstract class TypeQualified : Type
             if (d && (d.storage_class & STCtemplateparameter))
                 s = s.toAlias();
             else
-                s.checkDeprecated(loc, sc, true); // check for deprecated or disabled aliases
+            {
+                // check for deprecated or disabled aliases
+                s.checkDeprecated(loc, sc);
+                if (d)
+                    d.checkDisabled(loc, sc, true);
+            }
             s = s.toAlias();
             //printf("\t2: s = '%s' %p, kind = '%s'\n",s.toChars(), s, s.kind());
             for (size_t i = 0; i < idents.dim; i++)
@@ -7307,7 +7316,11 @@ extern (C++) final class TypeStruct : Type
             // return noMember(sc, e, ident, flag);
         }
         if (!s.isFuncDeclaration()) // because of overloading
+        {
             s.checkDeprecated(e.loc, sc);
+            if (auto d = s.isDeclaration())
+                d.checkDisabled(e.loc, sc);
+        }
         s = s.toAlias();
 
         if (auto em = s.isEnumMember())
@@ -8255,7 +8268,11 @@ extern (C++) final class TypeClass : Type
             // return noMember(sc, e, ident, flag);
         }
         if (!s.isFuncDeclaration()) // because of overloading
+        {
             s.checkDeprecated(e.loc, sc);
+            if (auto d = s.isDeclaration())
+                d.checkDisabled(e.loc, sc);
+        }
         s = s.toAlias();
 
         if (auto em = s.isEnumMember())

--- a/test/fail_compilation/disable.d
+++ b/test/fail_compilation/disable.d
@@ -1,15 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/disable.d(50): Error: function disable.DisabledOpAssign.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(53): Error: function disable.DisabledPostblit.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(56): Error: function disable.HasDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(60): Error: generated function disable.Nested!(DisabledOpAssign).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(63): Error: generated function disable.Nested!(DisabledPostblit).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(66): Error: generated function disable.Nested!(HasDtor).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(70): Error: generated function disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(73): Error: generated function disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(76): Error: generated function disable.NestedDtor!(HasDtor).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(50): Error: function disable.DisabledOpAssign.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(53): Error: function disable.DisabledPostblit.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(56): Error: function disable.HasDtor.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(60): Error: generated function disable.Nested!(DisabledOpAssign).Nested.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(63): Error: generated function disable.Nested!(DisabledPostblit).Nested.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(66): Error: generated function disable.Nested!(HasDtor).Nested.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(70): Error: generated function disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(73): Error: generated function disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(76): Error: generated function disable.NestedDtor!(HasDtor).NestedDtor.opAssign is not callable because it is annotated with `@disable`
 ---
  */
 struct DisabledOpAssign {

--- a/test/fail_compilation/fail10968.d
+++ b/test/fail_compilation/fail10968.d
@@ -43,12 +43,12 @@ void bar() pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(66): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(67): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(68): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(71): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(72): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(73): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+fail_compilation/fail10968.d(66): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(67): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(68): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(71): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(72): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(73): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail11355.d
+++ b/test/fail_compilation/fail11355.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11355.d(28): Error: struct fail11355.A is not copyable because it is annotated with @disable
+fail_compilation/fail11355.d(28): Error: struct fail11355.A is not copyable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail15044.d
+++ b/test/fail_compilation/fail15044.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15044.d(30): Error: generated function fail15044.V.opAssign is not callable because it is annotated with @disable
+fail_compilation/fail15044.d(30): Error: generated function fail15044.V.opAssign is not callable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail341.d
+++ b/test/fail_compilation/fail341.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail341.d(26): Error: struct fail341.S is not copyable because it is annotated with @disable
-fail_compilation/fail341.d(27): Error: function fail341.foo is not callable because it is annotated with @disable
+fail_compilation/fail341.d(26): Error: struct fail341.S is not copyable because it is annotated with `@disable`
+fail_compilation/fail341.d(27): Error: function fail341.foo is not callable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail9346.d
+++ b/test/fail_compilation/fail9346.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9346.d(26): Error: struct fail9346.S is not copyable because it is annotated with @disable
-fail_compilation/fail9346.d(27): Error: struct fail9346.S is not copyable because it is annotated with @disable
+fail_compilation/fail9346.d(26): Error: struct fail9346.S is not copyable because it is annotated with `@disable`
+fail_compilation/fail9346.d(27): Error: struct fail9346.S is not copyable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/test17908a.d
+++ b/test/fail_compilation/test17908a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test17908a.d(10): Error: function test17908a.foo is not callable because it is annotated with @disable
+fail_compilation/test17908a.d(10): Error: function test17908a.foo is not callable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/test17908b.d
+++ b/test/fail_compilation/test17908b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test17908b.d(13): Error: function test17908b.foobar is not callable because it is annotated with @disable
+fail_compilation/test17908b.d(13): Error: function test17908b.foobar is not callable because it is annotated with `@disable`
 ---
 */
 void foobar() {}


### PR DESCRIPTION
Revival of #6116 

This separates the check for `@disabled` from the check from `deprecated`, to (hopefully) make the code clearer.

Courtesy of @mathias-lang-sociomantic 