### PR TITLE
Partial fix for Issue 13761 - Fix code which triggers warnings

### DIFF
--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -1799,7 +1799,7 @@ void cdnot(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         codelem(cdb,e->E1,&retregs,FALSE);
         reg = findreg(retregs);
         getregs(cdb,retregs);
-        cdb.gen2(0xF7 ^ (sz == 1),grex | modregrmx(3,3,reg));   // NEG reg
+        cdb.gen2(sz == 1 ? 0xF6 : 0xF7,grex | modregrmx(3,3,reg));   // NEG reg
         code_orflag(cdb.last(),CFpsw);
         if (!I16 && sz == SHORTSIZE)
             code_orflag(cdb.last(),CFopsize);

--- a/src/dmd/backend/cod3.c
+++ b/src/dmd/backend/cod3.c
@@ -2286,8 +2286,7 @@ bool cse_simple(code *c, elem *e)
 
 void gen_testcse(CodeBuilder& cdb, unsigned sz, targ_uns i)
 {
-    bool byte = sz == 1;
-    cdb.genc(0x81 ^ byte,modregrm(2,7,BPRM),
+    cdb.genc(sz == 1 ? 0x80 : 0x81,modregrm(2,7,BPRM),
                 FLcs,i, FLconst,(targ_uns) 0);
     if ((I64 || I32) && sz == 2)
         cdb.last()->Iflags |= CFopsize;
@@ -3761,7 +3760,7 @@ void prolog_loadparams(CodeBuilder& cdb, tym_t tyf, bool pushalloc, regm_t* name
             }
             else
             {
-                cdb.genc1(0x8B ^ (sz == 1),
+                cdb.genc1(sz == 1 ? 0x8A : 0x8B,
                     modregxrm(2,s->Sreglsw,BPRM),FLconst,Para.size + s->Soffset);
                 code *c = cdb.last();
                 if (!I16 && sz == SHORTSIZE)

--- a/src/dmd/backend/divcoeff.c
+++ b/src/dmd/backend/divcoeff.c
@@ -291,7 +291,7 @@ void test_udiv_coefficients()
 
         //printf("[%d] %d %d %llx %d\n", i, shpre, mhighbit, m, shpost);
         assert(shpre == ps->shpre);
-        assert(mhighbit == ps->highbit);
+        assert(mhighbit == (bool)ps->highbit);
         assert(m == ps->m);
         assert(shpost == ps->shpost);
     }

--- a/src/dmd/backend/mscoff.h
+++ b/src/dmd/backend/mscoff.h
@@ -225,7 +225,6 @@ struct lineno
 #pragma pack(1)
 union auxent
 {
-#pragma pack(1)
     // Function definitions
     struct
     {   unsigned TagIndex;
@@ -238,13 +237,11 @@ union auxent
     // .bf symbols
     struct
     {
-#pragma pack(1)
         unsigned Unused;
         unsigned short Linenumber;
         char filler[6];
         unsigned PointerToNextFunction;
         unsigned short Zeros;
-#pragma pack()
     } x_bf;
 
     // .ef symbols
@@ -279,7 +276,6 @@ union auxent
     } x_section;
 
     char filler[18];
-#pragma pack()
 };
 #pragma pack()
 

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -553,8 +553,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     Expression el = (*e.elements)[i];
                     if (!el)
                         continue;
-                    Type te = el.type;
-                    te = e.sd.fields[i].type.addMod(t.mod);
+                    Type te = e.sd.fields[i].type.addMod(t.mod);
                     MATCH m2 = el.implicitConvTo(te);
                     //printf("\t%s => %s, match = %d\n", el.toChars(), te.toChars(), m2);
                     if (m2 < result)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1161,7 +1161,6 @@ private void getenv_setargv(const(char)* envvalue, Strings* args)
             p = env;
             slash = 0;
             instring = 0;
-            c = 0;
             while (1)
             {
                 c = *env++;

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -144,7 +144,10 @@ nothrow:
                 goto err1;
             }
             if (!_ref)
+            {
                 .free(buffer);
+                buffer = null;
+            }
             _ref = 0; // we own the buffer now
             //printf("\tfile opened\n");
             if (fstat(fd, &buf))


### PR DESCRIPTION
The bits of #4174 that are worth reviving.  Though now that the majority of sources are converted to D, open bugs relating to C++ static analysis tools should be closed, as they either don't apply to D, or cannot be verified.