### PR TITLE
Move loadModule and paintAsType from Target to Compiler

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -16,10 +16,13 @@ import dmd.astcodegen;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dsymbolsem;
+import dmd.expression;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
+import dmd.mtype;
 import dmd.parse;
+import dmd.root.ctfloat;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.tokens;
@@ -88,4 +91,132 @@ struct Compiler
         entrypoint = m;
         rootHasMain = sc._module;
     }
+
+    /******************************
+     * Encode the given expression, which is assumed to be an rvalue literal
+     * as another type for use in CTFE.
+     * This corresponds roughly to the idiom *(Type *)&e.
+     */
+    extern (C++) static Expression paintAsType(Expression e, Type type)
+    {
+        // We support up to 512-bit values.
+        ubyte[64] buffer;
+        assert(e.type.size() == type.size());
+        // Write the expression into the buffer.
+        switch (e.type.ty)
+        {
+        case Tint32:
+        case Tuns32:
+        case Tint64:
+        case Tuns64:
+            encodeInteger(e, buffer.ptr);
+            break;
+        case Tfloat32:
+        case Tfloat64:
+            encodeReal(e, buffer.ptr);
+            break;
+        default:
+            assert(0);
+        }
+        // Interpret the buffer as a new type.
+        switch (type.ty)
+        {
+        case Tint32:
+        case Tuns32:
+        case Tint64:
+        case Tuns64:
+            return decodeInteger(e.loc, type, buffer.ptr);
+        case Tfloat32:
+        case Tfloat64:
+            return decodeReal(e.loc, type, buffer.ptr);
+        default:
+            assert(0);
+        }
+    }
+
+    /******************************
+     * For the given module, perform any post parsing analysis.
+     * Certain compiler backends (ie: GDC) have special placeholder
+     * modules whose source are empty, but code gets injected
+     * immediately after loading.
+     */
+    extern (C++) static void loadModule(Module m)
+    {
+    }
+}
+
+/******************************
+ * Private helpers for Compiler::paintAsType.
+ */
+// Write the integer value of 'e' into a unsigned byte buffer.
+private void encodeInteger(Expression e, ubyte* buffer)
+{
+    dinteger_t value = e.toInteger();
+    int size = cast(int)e.type.size();
+    for (int p = 0; p < size; p++)
+    {
+        int offset = p; // Would be (size - 1) - p; on BigEndian
+        buffer[offset] = ((value >> (p * 8)) & 0xFF);
+    }
+}
+
+// Write the bytes encoded in 'buffer' into an integer and returns
+// the value as a new IntegerExp.
+private Expression decodeInteger(const ref Loc loc, Type type, ubyte* buffer)
+{
+    dinteger_t value = 0;
+    int size = cast(int)type.size();
+    for (int p = 0; p < size; p++)
+    {
+        int offset = p; // Would be (size - 1) - p; on BigEndian
+        value |= (cast(dinteger_t)buffer[offset] << (p * 8));
+    }
+    return new IntegerExp(loc, value, type);
+}
+
+// Write the real_t value of 'e' into a unsigned byte buffer.
+private void encodeReal(Expression e, ubyte* buffer)
+{
+    switch (e.type.ty)
+    {
+    case Tfloat32:
+        {
+            float* p = cast(float*)buffer;
+            *p = cast(float)e.toReal();
+            break;
+        }
+    case Tfloat64:
+        {
+            double* p = cast(double*)buffer;
+            *p = cast(double)e.toReal();
+            break;
+        }
+    default:
+        assert(0);
+    }
+}
+
+// Write the bytes encoded in 'buffer' into a real_t and returns
+// the value as a new RealExp.
+private Expression decodeReal(const ref Loc loc, Type type, ubyte* buffer)
+{
+    real_t value;
+    switch (type.ty)
+    {
+    case Tfloat32:
+        {
+            float* p = cast(float*)buffer;
+            value = real_t(*p);
+            break;
+        }
+    case Tfloat64:
+        {
+            double* p = cast(double*)buffer;
+            value = real_t(*p);
+            break;
+        }
+    default:
+        assert(0);
+    }
+    return new RealExp(loc, value, type);
 }

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -13,9 +13,16 @@
 // This file contains a data structure that describes a back-end compiler
 // and implements compiler-specific actions.
 
+class Expression;
+class Module;
+class Type;
 struct Scope;
 
 struct Compiler
 {
+    // CTFE support for cross-compilation.
+    static Expression *paintAsType(Expression *, Type *);
+    // Backend
+    static void loadModule(Module *);
     static void genCmain(Scope *);
 };

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -17,6 +17,7 @@ import core.stdc.string;
 import dmd.arraytypes;
 import dmd.complex;
 import dmd.constfold;
+import dmd.compiler;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dinterpret;
@@ -30,7 +31,6 @@ import dmd.mtype;
 import dmd.root.ctfloat;
 import dmd.root.port;
 import dmd.root.rmem;
-import dmd.target;
 import dmd.tokens;
 import dmd.visitor;
 
@@ -1006,7 +1006,7 @@ Expression paintFloatInt(Expression fromVal, Type to)
     if (exceptionOrCantInterpret(fromVal))
         return fromVal;
     assert(to.size() == 4 || to.size() == 8);
-    return Target.paintAsType(fromVal, to);
+    return Compiler.paintAsType(fromVal, to);
 }
 
 /******** Constant folding, with support for CTFE ***************************/

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -18,6 +18,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.astcodegen;
+import dmd.compiler;
 import dmd.gluelayer;
 import dmd.dimport;
 import dmd.dmacro;
@@ -37,7 +38,6 @@ import dmd.root.outbuffer;
 import dmd.root.port;
 import dmd.semantic2;
 import dmd.semantic3;
-import dmd.target;
 import dmd.utils;
 import dmd.visitor;
 
@@ -527,7 +527,7 @@ extern (C++) final class Module : Package
             assert(m.isRoot());
         }
 
-        Target.loadModule(m);
+        Compiler.loadModule(m);
         return m;
     }
 

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -18,7 +18,6 @@ import dmd.cppmangle;
 import dmd.cppmanglewin;
 import dmd.dclass;
 import dmd.declaration;
-import dmd.dmodule;
 import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.expression;
@@ -434,65 +433,6 @@ struct Target
     }
 
     /**
-     * Encode the given expression, which is assumed to be an rvalue literal
-     * as another type for use in CTFE.
-     * This corresponds roughly to the idiom `*cast(T*)&e`.
-     * Params:
-     *      e    = literal constant expression
-     *      type = target type of the result
-     * Returns:
-     *      resulting `Expression` re-evaluated as `type`
-     */
-    extern (C++) static Expression paintAsType(Expression e, Type type)
-    {
-        // We support up to 512-bit values.
-        ubyte[64] buffer;
-        assert(e.type.size() == type.size());
-        // Write the expression into the buffer.
-        switch (e.type.ty)
-        {
-        case Tint32:
-        case Tuns32:
-        case Tint64:
-        case Tuns64:
-            encodeInteger(e, buffer.ptr);
-            break;
-        case Tfloat32:
-        case Tfloat64:
-            encodeReal(e, buffer.ptr);
-            break;
-        default:
-            assert(0);
-        }
-        // Interpret the buffer as a new type.
-        switch (type.ty)
-        {
-        case Tint32:
-        case Tuns32:
-        case Tint64:
-        case Tuns64:
-            return decodeInteger(e.loc, type, buffer.ptr);
-        case Tfloat32:
-        case Tfloat64:
-            return decodeReal(e.loc, type, buffer.ptr);
-        default:
-            assert(0);
-        }
-    }
-
-    /**
-     * Perform any post parsing analysis on the given module.
-     * Certain compiler backends (ie: GDC) have special placeholder
-     * modules whose source are empty, but code gets injected
-     * immediately after loading.
-     * Params:
-     *      m = module to inspect
-     */
-    extern (C++) static void loadModule(Module m)
-    {
-    }
-
-    /**
      * Mangle the given symbol for C++ ABI.
      * Params:
      *      s = declaration with C++ linkage
@@ -795,80 +735,4 @@ struct Target
                 return null;
         }
     }
-}
-
-/******************************
- * Private helpers for Target::paintAsType.
- */
-// Write the integer value of 'e' into a unsigned byte buffer.
-private void encodeInteger(Expression e, ubyte* buffer)
-{
-    dinteger_t value = e.toInteger();
-    int size = cast(int)e.type.size();
-    for (int p = 0; p < size; p++)
-    {
-        int offset = p; // Would be (size - 1) - p; on BigEndian
-        buffer[offset] = ((value >> (p * 8)) & 0xFF);
-    }
-}
-
-// Write the bytes encoded in 'buffer' into an integer and returns
-// the value as a new IntegerExp.
-private Expression decodeInteger(const ref Loc loc, Type type, ubyte* buffer)
-{
-    dinteger_t value = 0;
-    int size = cast(int)type.size();
-    for (int p = 0; p < size; p++)
-    {
-        int offset = p; // Would be (size - 1) - p; on BigEndian
-        value |= (cast(dinteger_t)buffer[offset] << (p * 8));
-    }
-    return new IntegerExp(loc, value, type);
-}
-
-// Write the real_t value of 'e' into a unsigned byte buffer.
-private void encodeReal(Expression e, ubyte* buffer)
-{
-    switch (e.type.ty)
-    {
-    case Tfloat32:
-        {
-            float* p = cast(float*)buffer;
-            *p = cast(float)e.toReal();
-            break;
-        }
-    case Tfloat64:
-        {
-            double* p = cast(double*)buffer;
-            *p = cast(double)e.toReal();
-            break;
-        }
-    default:
-        assert(0);
-    }
-}
-
-// Write the bytes encoded in 'buffer' into a real_t and returns
-// the value as a new RealExp.
-private Expression decodeReal(const ref Loc loc, Type type, ubyte* buffer)
-{
-    real_t value;
-    switch (type.ty)
-    {
-    case Tfloat32:
-        {
-            float* p = cast(float*)buffer;
-            value = real_t(*p);
-            break;
-        }
-    case Tfloat64:
-        {
-            double* p = cast(double*)buffer;
-            value = real_t(*p);
-            break;
-        }
-    default:
-        assert(0);
-    }
-    return new RealExp(loc, value, type);
 }

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -23,7 +23,6 @@ class Parameter;
 class Type;
 class TypeTuple;
 class TypeFunction;
-class Module;
 
 struct Target
 {
@@ -74,10 +73,7 @@ struct Target
     static Type *va_listType();  // get type of va_list
     static int isVectorTypeSupported(int sz, Type *type);
     static bool isVectorOpSupported(Type *type, TOK op, Type *t2 = NULL);
-    // CTFE support for cross-compilation.
-    static Expression *paintAsType(Expression *e, Type *type);
     // ABI and backend.
-    static void loadModule(Module *m);
     static const char *toCppMangle(Dsymbol *s);
     static const char *cppTypeInfoMangle(ClassDeclaration *cd);
     static const char *cppTypeMangle(Type *t);


### PR DESCRIPTION
These are a couple of funny little functions that are compiler-specific, but are not directly related to the target platform.