### PR TITLE
Reverse parameter order of xopCmp to match extern(C) ABI

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -510,10 +510,12 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     }
     Loc declLoc = Loc(); // loc is unnecessary so __xopEquals is never called directly
     Loc loc = Loc(); // loc is unnecessary so errors are gagged
+    // Use C linkage: we need to make sure the arguments order (p, q) isn't reversed, in
+    // order to obtain a signature identical to that of method `S.opEquals(ref const S)`.
     auto parameters = new Parameters();
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null));
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.q, null));
-    auto tf = new TypeFunction(parameters, Type.tbool, 0, LINK.d);
+    auto tf = new TypeFunction(parameters, Type.tbool, 0, LINK.c);
     Identifier id = Id.xopEquals;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STC.static_, tf);
     fop.generated = true;
@@ -524,7 +526,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINK.d;
+    sc2.linkage = LINK.c;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();
@@ -535,7 +537,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
 
 /******************************************
  * Build __xopCmp for TypeInfo_Struct
- *      static bool __xopCmp(ref const S p, ref const S q)
+ *      static int __xopCmp(ref const S p, ref const S q)
  *      {
  *          return p.opCmp(q);
  *      }
@@ -630,21 +632,23 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     }
     Loc declLoc = Loc(); // loc is unnecessary so __xopCmp is never called directly
     Loc loc = Loc(); // loc is unnecessary so errors are gagged
+    // Use C linkage: we need to make sure the arguments order (p, q) isn't reversed, in
+    // order to obtain a signature identical to that of method `S.opCmp(ref const S)`.
     auto parameters = new Parameters();
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null));
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.q, null));
-    auto tf = new TypeFunction(parameters, Type.tint32, 0, LINK.d);
+    auto tf = new TypeFunction(parameters, Type.tint32, 0, LINK.c);
     Identifier id = Id.xopCmp;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STC.static_, tf);
     fop.generated = true;
     Expression e1 = new IdentifierExp(loc, Id.p);
     Expression e2 = new IdentifierExp(loc, Id.q);
-    Expression e = new CallExp(loc, new DotIdExp(loc, e2, Id.cmp), e1);
+    Expression e = new CallExp(loc, new DotIdExp(loc, e1, Id.cmp), e2);
     fop.fbody = new ReturnStatement(loc, e);
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINK.d;
+    sc2.linkage = LINK.c;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();

--- a/test/runnable/test5854.d
+++ b/test/runnable/test5854.d
@@ -1,0 +1,53 @@
+struct S1
+{
+    long x1, x2;
+
+    int opCmp(ref const S1 s) const
+    {
+        if (x2 - s.x2 != 0)
+            return x2 < s.x2 ? -1 : 1;
+
+        return x1 < s.x1 ? -1 : x1 == s.x1 ? 0 : 1;
+    }
+}
+
+struct S2
+{
+    long x1, x2;
+
+    int opCmp(in S2 s) const
+    {
+        if (x2 - s.x2 != 0)
+            return x2 < s.x2 ? -1 : 1;
+
+        return x1 < s.x1 ? -1 : x1 == s.x1 ? 0 : 1;
+    }
+}
+
+extern (C) int structcmp(T)(scope T a, scope T b)
+{
+    extern (C) int cmp(scope const void* p1, scope const void* p2, scope void* ti)
+    {
+        return (cast(TypeInfo)ti).compare(p1, p2);
+    }
+    return cmp(&a, &b, cast(void*)typeid(T));
+}
+
+void test5854()
+{
+    alias Tuple(T...) = T;
+
+    foreach (T; Tuple!(S1, S2))
+    {
+        assert(T(1, 3).structcmp(T(4, 4)) == -1);
+        assert(T(1, 3).structcmp(T(4, 3)) == -1);
+        assert(T(4, 3).structcmp(T(4, 3)) ==  0);
+        assert(T(5, 3).structcmp(T(4, 3)) ==  1);
+        assert(T(5, 4).structcmp(T(4, 3)) ==  1);
+    }
+}
+
+void main()
+{
+    test5854();
+}


### PR DESCRIPTION
Required to support dlang/druntime#2025  (and tests will fail until it is pulled also).