### PR TITLE
Upstream GDC patch to mangle va_list as a pointer.

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -657,6 +657,19 @@ private final class CppMangleVisitor : Visitor
                 td = new TypeDelegate(td);
                 t = merge(t);
             }
+            static if (IN_GCC)
+            {
+                // Could be a va_list, which we mangle as a pointer.
+                if (t.ty == Tsarray && Type.tvalist.ty == Tsarray)
+                {
+                    Type tb = t.toBasetype().mutableOf();
+                    if (tb == Type.tvalist)
+                    {
+                        tb = t.nextOf().pointerTo();
+                        t = tb.castMod(t.mod);
+                    }
+                }
+            }
             if (t.ty == Tsarray)
             {
                 // Static arrays in D are passed by value; no counterpart in C++


### PR DESCRIPTION
The default behaviour is to raise an internal compiler error and exit if cppmangle encounters a static array parameter.  This is not compatible with how GDC represents va_lists internally.

In the codegen pass, GDC will saturate a va_list to a pointer if its underlying type is a static array.

Patch taken from #2194 

However... I think that a better way to do this would be to move it to a backend hook, such as `Target.cppTypePassedAs(Type t)`.