### PR TITLE
fix Issue 12004 and Issue 13174: Disallow shared destructors and always call the unshared one.

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3410,7 +3410,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, dd.storage_class);
 
         sc = sc.push();
-        sc.stc &= ~STC.static_; // not a static destructor
+        sc.stc &= ~(STC.static_|STC.shared_); // not a static destructor
         if (sc.linkage != LINK.cpp)
             sc.linkage = LINK.d;
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2397,24 +2397,33 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         /* For constructors, qualifier check will be opposite direction.
          * Qualified constructor always makes qualified object, then will be checked
          * that it is implicitly convertible to tthis.
+         *
+         * For destructors, the shared qualifier is stripped from the object.
          */
         Type tthis_fd = fd.needThis() ? tthis : null;
         bool isCtorCall = tthis_fd && fd.isCtorDeclaration();
-        if (isCtorCall)
+        if (tthis_fd)
         {
-            //printf("%s tf.mod = x%x tthis_fd.mod = x%x %d\n", tf.toChars(),
-            //        tf.mod, tthis_fd.mod, fd.isReturnIsolated());
-            if (MODimplicitConv(tf.mod, tthis_fd.mod) ||
-                tf.isWild() && tf.isShared() == tthis_fd.isShared() ||
-                fd.isReturnIsolated())
+            if (isCtorCall)
             {
-                /* && tf.isShared() == tthis_fd.isShared()*/
-                // Uniquely constructed object can ignore shared qualifier.
-                // TODO: Is this appropriate?
-                tthis_fd = null;
+                //printf("%s tf.mod = x%x tthis_fd.mod = x%x %d\n", tf.toChars(),
+                //        tf.mod, tthis_fd.mod, fd.isReturnIsolated());
+                if (MODimplicitConv(tf.mod, tthis_fd.mod) ||
+                    tf.isWild() && tf.isShared() == tthis_fd.isShared() ||
+                    fd.isReturnIsolated())
+                {
+                    /* && tf.isShared() == tthis_fd.isShared()*/
+                    // Uniquely constructed object can ignore shared qualifier.
+                    // TODO: Is this appropriate?
+                    tthis_fd = null;
+                }
+                else
+                    return 0;   // MATCH.nomatch
             }
-            else
-                return 0;   // MATCH.nomatch
+            else if (fd.isDtorDeclaration() && tthis_fd.isShared())
+            {
+                tthis_fd = tthis_fd.unSharedOf();
+            }
         }
         MATCH mfa = tf.callMatch(tthis_fd, fargs);
         //printf("test1: mfa = %d\n", mfa);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2456,6 +2456,8 @@ final class Parser(AST) : Lexer
                 error(loc, "use `static ~this()` to declare a static destructor");
             else if (ss == (AST.STC.shared_ | AST.STC.static_))
                 error(loc, "use `shared static ~this()` to declare a shared static destructor");
+            else if (ss == AST.STC.shared_)
+                error(loc, "destructor cannot be shared");
         }
 
         auto f = new AST.DtorDeclaration(loc, Loc(), stc, Id.dtor);

--- a/test/compilable/testshareddtor.d
+++ b/test/compilable/testshareddtor.d
@@ -1,0 +1,35 @@
+// PERMUTE_ARGS:
+
+/***************************************************/
+// Tests calling unshared dtors from shared objects.
+// See issues:
+// https://issues.dlang.org/show_bug.cgi?id=12004
+// https://issues.dlang.org/show_bug.cgi?id=13174
+
+struct B12004
+{
+    ~this() {}
+}
+
+struct C12004
+{
+    shared B12004 b;
+}
+
+class D12004
+{
+    ~this() {}
+}
+
+class E12004
+{
+    shared D12004 d;
+
+    this(shared D12004 d) { this.d = d; }
+}
+
+void test12004()
+{
+    C12004(shared(B12004)());
+    new E12004(new shared(D12004)());
+}

--- a/test/compilable/testshareddtor.d
+++ b/test/compilable/testshareddtor.d
@@ -33,3 +33,47 @@ void test12004()
     C12004(shared(B12004)());
     new E12004(new shared(D12004)());
 }
+
+/***************************************************/
+// Struct member destructor can not be called from shared struct instance
+// See https://issues.dlang.org/show_bug.cgi?id=8295.
+
+struct A8295a
+{
+    char[] buf;
+
+    this(size_t size)
+    {
+        buf = new char[size];
+    }
+
+    ~this()
+    {
+        buf = null;
+    }
+}
+
+struct B8295a
+{
+    A8295a f;
+}
+
+shared B8295a test8295a;
+
+/***************************************************/
+
+struct A8295b
+{
+    int a;
+}
+
+struct B8295b
+{
+    A8295b f;
+
+    ~this()
+    {
+    }
+}
+
+shared B8295b test8295b;

--- a/test/fail_compilation/fail12004.d
+++ b/test/fail_compilation/fail12004.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12004.d(9): Error: destructor cannot be shared
+---
+*/
+
+struct S {
+    ~this() shared {}
+}


### PR DESCRIPTION
Rebase of  #4072 on ddmd.