### PR TITLE
Bump OSX deployment target to 10.9

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -82,7 +82,7 @@ G = $(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 $(shell mkdir -p $G)
 
 ifeq (osx,$(OS))
-    export MACOSX_DEPLOYMENT_TARGET=10.7
+    export MACOSX_DEPLOYMENT_TARGET=10.9
 endif
 
 HOST_CXX=c++


### PR DESCRIPTION
This warning is getting annoying in the logs:

```
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
```

Let's see what breaks.