### PR TITLE
Refactor: Move @disable check out of checkDeprecated

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1931,8 +1931,7 @@ extern (C++) abstract class Expression : RootObject
 
     final void checkDisabled(Scope* sc, Dsymbol s)
     {
-        auto d = s.isDeclaration();
-        if (d)
+        if (auto d = s.isDeclaration())
             d.checkDisabled(loc, sc);
     }
 

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -179,6 +179,7 @@ public:
     bool checkIntegral();
     bool checkArithmetic();
     void checkDeprecated(Scope *sc, Dsymbol *s);
+    void checkDisabled(Scope *sc, Dsymbol *s);
     bool checkPurity(Scope *sc, FuncDeclaration *f);
     bool checkPurity(Scope *sc, VarDeclaration *v);
     bool checkSafety(Scope *sc, FuncDeclaration *f);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2221,6 +2221,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 exp.checkDeprecated(sc, f);
+                exp.checkDisabled(sc, f);
                 exp.checkPurity(sc, f);
                 exp.checkSafety(sc, f);
                 exp.checkNogc(sc, f);
@@ -2250,6 +2251,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 exp.checkDeprecated(sc, f);
+                exp.checkDisabled(sc, f);
                 exp.checkPurity(sc, f);
                 exp.checkSafety(sc, f);
                 exp.checkNogc(sc, f);
@@ -2301,6 +2303,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 exp.checkDeprecated(sc, f);
+                exp.checkDisabled(sc, f);
                 exp.checkPurity(sc, f);
                 exp.checkSafety(sc, f);
                 exp.checkNogc(sc, f);
@@ -2330,6 +2333,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
 
                 exp.checkDeprecated(sc, f);
+                exp.checkDisabled(sc, f);
                 exp.checkPurity(sc, f);
                 exp.checkSafety(sc, f);
                 exp.checkNogc(sc, f);
@@ -3187,6 +3191,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             exp.checkDeprecated(sc, exp.f);
+            exp.checkDisabled(sc, exp.f);
             exp.checkPurity(sc, exp.f);
             exp.checkSafety(sc, exp.f);
             exp.checkNogc(sc, exp.f);
@@ -3290,6 +3295,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
 
             exp.checkDeprecated(sc, exp.f);
+            exp.checkDisabled(sc, exp.f);
             exp.checkPurity(sc, exp.f);
             exp.checkSafety(sc, exp.f);
             exp.checkNogc(sc, exp.f);
@@ -3330,6 +3336,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
 
             exp.checkDeprecated(sc, exp.f);
+            exp.checkDisabled(sc, exp.f);
             exp.checkPurity(sc, exp.f);
             exp.checkSafety(sc, exp.f);
             exp.checkNogc(sc, exp.f);
@@ -3557,6 +3564,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             exp.checkDeprecated(sc, exp.f);
+            exp.checkDisabled(sc, exp.f);
             exp.checkPurity(sc, exp.f);
             exp.checkSafety(sc, exp.f);
             exp.checkNogc(sc, exp.f);
@@ -9617,6 +9625,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             s = s.toAlias();
 
             exp.checkDeprecated(sc, s);
+            exp.checkDisabled(sc, s);
 
             EnumMember em = s.isEnumMember();
             if (em)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -1173,8 +1173,7 @@ extern (C++) abstract class Type : RootObject
      */
     void checkDeprecated(Loc loc, Scope* sc)
     {
-        Dsymbol s = toDsymbol(sc);
-        if (s)
+        if (Dsymbol s = toDsymbol(sc))
         {
             s.checkDeprecated(loc, sc);
         }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -1175,7 +1175,9 @@ extern (C++) abstract class Type : RootObject
     {
         Dsymbol s = toDsymbol(sc);
         if (s)
+        {
             s.checkDeprecated(loc, sc);
+        }
     }
 
     final bool isConst() const nothrow pure @nogc @safe
@@ -6513,7 +6515,12 @@ extern (C++) abstract class TypeQualified : Type
             if (d && (d.storage_class & STCtemplateparameter))
                 s = s.toAlias();
             else
-                s.checkDeprecated(loc, sc, true); // check for deprecated or disabled aliases
+            {
+                // check for deprecated or disabled aliases
+                s.checkDeprecated(loc, sc);
+                if (d)
+                    d.checkDisabled(loc, sc, true);
+            }
             s = s.toAlias();
             //printf("\t2: s = '%s' %p, kind = '%s'\n",s.toChars(), s, s.kind());
             for (size_t i = 0; i < idents.dim; i++)
@@ -7306,7 +7313,11 @@ extern (C++) final class TypeStruct : Type
             // return noMember(sc, e, ident, flag);
         }
         if (!s.isFuncDeclaration()) // because of overloading
+        {
             s.checkDeprecated(e.loc, sc);
+            if (auto d = s.isDeclaration())
+                d.checkDisabled(e.loc, sc);
+        }
         s = s.toAlias();
 
         if (auto em = s.isEnumMember())
@@ -8254,7 +8265,11 @@ extern (C++) final class TypeClass : Type
             // return noMember(sc, e, ident, flag);
         }
         if (!s.isFuncDeclaration()) // because of overloading
+        {
             s.checkDeprecated(e.loc, sc);
+            if (auto d = s.isDeclaration())
+                d.checkDisabled(e.loc, sc);
+        }
         s = s.toAlias();
 
         if (auto em = s.isEnumMember())

--- a/test/fail_compilation/disable.d
+++ b/test/fail_compilation/disable.d
@@ -1,15 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/disable.d(50): Error: function disable.DisabledOpAssign.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(53): Error: function disable.DisabledPostblit.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(56): Error: function disable.HasDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(60): Error: generated function disable.Nested!(DisabledOpAssign).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(63): Error: generated function disable.Nested!(DisabledPostblit).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(66): Error: generated function disable.Nested!(HasDtor).Nested.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(70): Error: generated function disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(73): Error: generated function disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign is not callable because it is annotated with @disable
-fail_compilation/disable.d(76): Error: generated function disable.NestedDtor!(HasDtor).NestedDtor.opAssign is not callable because it is annotated with @disable
+fail_compilation/disable.d(50): Error: function disable.DisabledOpAssign.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(53): Error: function disable.DisabledPostblit.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(56): Error: function disable.HasDtor.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(60): Error: generated function disable.Nested!(DisabledOpAssign).Nested.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(63): Error: generated function disable.Nested!(DisabledPostblit).Nested.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(66): Error: generated function disable.Nested!(HasDtor).Nested.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(70): Error: generated function disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(73): Error: generated function disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign is not callable because it is annotated with `@disable`
+fail_compilation/disable.d(76): Error: generated function disable.NestedDtor!(HasDtor).NestedDtor.opAssign is not callable because it is annotated with `@disable`
 ---
  */
 struct DisabledOpAssign {

--- a/test/fail_compilation/fail10968.d
+++ b/test/fail_compilation/fail10968.d
@@ -43,12 +43,12 @@ void bar() pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(66): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(67): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(68): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(71): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(72): Error: struct fail10968.SD is not copyable because it is annotated with @disable
-fail_compilation/fail10968.d(73): Error: struct fail10968.SD is not copyable because it is annotated with @disable
+fail_compilation/fail10968.d(66): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(67): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(68): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(71): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(72): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(73): Error: struct fail10968.SD is not copyable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail11355.d
+++ b/test/fail_compilation/fail11355.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11355.d(28): Error: struct fail11355.A is not copyable because it is annotated with @disable
+fail_compilation/fail11355.d(28): Error: struct fail11355.A is not copyable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail15044.d
+++ b/test/fail_compilation/fail15044.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15044.d(30): Error: generated function fail15044.V.opAssign is not callable because it is annotated with @disable
+fail_compilation/fail15044.d(30): Error: generated function fail15044.V.opAssign is not callable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail341.d
+++ b/test/fail_compilation/fail341.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail341.d(26): Error: struct fail341.S is not copyable because it is annotated with @disable
-fail_compilation/fail341.d(27): Error: function fail341.foo is not callable because it is annotated with @disable
+fail_compilation/fail341.d(26): Error: struct fail341.S is not copyable because it is annotated with `@disable`
+fail_compilation/fail341.d(27): Error: function fail341.foo is not callable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail9346.d
+++ b/test/fail_compilation/fail9346.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9346.d(26): Error: struct fail9346.S is not copyable because it is annotated with @disable
-fail_compilation/fail9346.d(27): Error: struct fail9346.S is not copyable because it is annotated with @disable
+fail_compilation/fail9346.d(26): Error: struct fail9346.S is not copyable because it is annotated with `@disable`
+fail_compilation/fail9346.d(27): Error: struct fail9346.S is not copyable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/test17908a.d
+++ b/test/fail_compilation/test17908a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test17908a.d(10): Error: function test17908a.foo is not callable because it is annotated with @disable
+fail_compilation/test17908a.d(10): Error: function test17908a.foo is not callable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/test17908b.d
+++ b/test/fail_compilation/test17908b.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test17908b.d(13): Error: function test17908b.foobar is not callable because it is annotated with @disable
+fail_compilation/test17908b.d(13): Error: function test17908b.foobar is not callable because it is annotated with `@disable`
 ---
 */
 void foobar() {}


### PR DESCRIPTION
Revival of #6116 

This separates the check for `@disabled` from the check for `deprecated` to (hopefully) make the code clearer.

Courtesy of @mathias-lang-sociomantic 

@ibuclaw  C++ interface change