### PR TITLE
Fix syntax highlighting anomaly in func.d

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2604,8 +2604,8 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                 }
                 else
                 {
-                    fd.error(loc, "`%s%s` is not callable using argument types `%s`",
-                        parametersTypeToChars(tf.parameters, tf.varargs),
+                    .error(loc, "%s `%s%s%s` is not callable using argument types `%s`",
+                        fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameters, tf.varargs),
                         tf.modToChars(), fargsBuf.peekString());
                 }
             }

--- a/test/fail_compilation/diag13082.d
+++ b/test/fail_compilation/diag13082.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag13082.d(22): Error: constructor diag13082.C.this `(int a)` is not callable using argument types `(string)`
-fail_compilation/diag13082.d(23): Error: constructor diag13082.S.this `(int a)` is not callable using argument types `(string)`
+fail_compilation/diag13082.d(22): Error: constructor `diag13082.C.this(int a)` is not callable using argument types `(string)`
+fail_compilation/diag13082.d(23): Error: constructor `diag13082.S.this(int a)` is not callable using argument types `(string)`
 ---
 */
 

--- a/test/fail_compilation/diag8101.d
+++ b/test/fail_compilation/diag8101.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8101.d(56): Error: function diag8101.f_0 `(int)` is not callable using argument types `()`
+fail_compilation/diag8101.d(56): Error: function `diag8101.f_0(int)` is not callable using argument types `()`
 fail_compilation/diag8101.d(57): Error: none of the overloads of `f_1` are callable using argument types `()`, candidates are:
 fail_compilation/diag8101.d(32):        `diag8101.f_1(int)`
 fail_compilation/diag8101.d(33):        `diag8101.f_1(int, int)`

--- a/test/fail_compilation/diag8101b.d
+++ b/test/fail_compilation/diag8101b.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/diag8101b.d(26): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
 fail_compilation/diag8101b.d(17):        `diag8101b.S.foo(int _param_0)`
 fail_compilation/diag8101b.d(18):        `diag8101b.S.foo(int _param_0, int _param_1)`
-fail_compilation/diag8101b.d(28): Error: function diag8101b.S.bar `(int _param_0)` is not callable using argument types `(double)`
+fail_compilation/diag8101b.d(28): Error: function `diag8101b.S.bar(int _param_0)` is not callable using argument types `(double)`
 fail_compilation/diag8101b.d(31): Error: none of the overloads of `foo` are callable using a const object, candidates are:
 fail_compilation/diag8101b.d(17):        `diag8101b.S.foo(int _param_0)`
 fail_compilation/diag8101b.d(18):        `diag8101b.S.foo(int _param_0, int _param_1)`

--- a/test/fail_compilation/diag9420.d
+++ b/test/fail_compilation/diag9420.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT
 ---
-fail_compilation/diag9420.d(20): Error: function diag9420.S.t3!().tx `()` is not callable using argument types `(int)`
+fail_compilation/diag9420.d(20): Error: function `diag9420.S.t3!().tx()` is not callable using argument types `(int)`
 ---
 */
 

--- a/test/fail_compilation/fail263.d
+++ b/test/fail_compilation/fail263.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail263.d(18): Error: function fail263.f `(byte* p)` is not callable using argument types `(const(byte)*)`
+fail_compilation/fail263.d(18): Error: function `fail263.f(byte* p)` is not callable using argument types `(const(byte)*)`
 ---
 */
 

--- a/test/fail_compilation/fail322.d
+++ b/test/fail_compilation/fail322.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail322.d(10): Error: function fail322.digestToString2 `(ref char[16] digest)` is not callable using argument types `(string)`
+fail_compilation/fail322.d(10): Error: function `fail322.digestToString2(ref char[16] digest)` is not callable using argument types `(string)`
 ---
 */
 

--- a/test/fail_compilation/fail332.d
+++ b/test/fail_compilation/fail332.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail332.d(14): Error: function fail332.foo `(int _param_0, ...)` is not callable using argument types `()`
+fail_compilation/fail332.d(14): Error: function `fail332.foo(int _param_0, ...)` is not callable using argument types `()`
 ---
 */
 

--- a/test/fail_compilation/fail53.d
+++ b/test/fail_compilation/fail53.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail53.d(25): Error: function object.Object.opEquals `(Object o)` is not callable using argument types `(int)`
+fail_compilation/fail53.d(25): Error: function `object.Object.opEquals(Object o)` is not callable using argument types `(int)`
 ---
 */
 

--- a/test/fail_compilation/fail55.d
+++ b/test/fail_compilation/fail55.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail55.d(22): Error: function object.Object.opCmp `(Object o)` is not callable using argument types `(int)`
+fail_compilation/fail55.d(22): Error: function `object.Object.opCmp(Object o)` is not callable using argument types `(int)`
 ---
 */
 

--- a/test/fail_compilation/ice10922.d
+++ b/test/fail_compilation/ice10922.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(9): Error: function ice10922.__lambda4 `(const(uint) n)` is not callable using argument types `()`
+fail_compilation/ice10922.d(9): Error: function `ice10922.__lambda4(const(uint) n)` is not callable using argument types `()`
 ---
 */
 

--- a/test/fail_compilation/ice12501.d
+++ b/test/fail_compilation/ice12501.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12501.d(29): Error: function ice12501.foo `(int value)` is not callable using argument types `(int, int)`
-fail_compilation/ice12501.d(29): Error: function ice12501.foo `(int value)` is not callable using argument types `(int, int)`
+fail_compilation/ice12501.d(29): Error: function `ice12501.foo(int value)` is not callable using argument types `(int, int)`
+fail_compilation/ice12501.d(29): Error: function `ice12501.foo(int value)` is not callable using argument types `(int, int)`
 fail_compilation/ice12501.d(43): Error: template instance ice12501.reduce!(foo, foo).reduce!(Tuple!(int, int), int[]) error instantiating
 ---
 */

--- a/test/fail_compilation/ice14923.d
+++ b/test/fail_compilation/ice14923.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14923.d(21): Error: function ice14923.parse `(C a)` is not callable using argument types `(A)`
+fail_compilation/ice14923.d(21): Error: function `ice14923.parse(C a)` is not callable using argument types `(A)`
 fail_compilation/ice14923.d(21):        instantiated from here: bar!((b) => parse(b))
 ---
 */

--- a/test/fail_compilation/ice8255.d
+++ b/test/fail_compilation/ice8255.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice8255.d(10): Error: function ice8255.F!(G).F.f `(ref G _param_0)` is not callable using argument types `(G)`
+fail_compilation/ice8255.d(10): Error: function `ice8255.F!(G).F.f(ref G _param_0)` is not callable using argument types `(G)`
 fail_compilation/ice8255.d(10):        while evaluating pragma(msg, F().f(G()))
 ---
 */

--- a/test/fail_compilation/ice9540.d
+++ b/test/fail_compilation/ice9540.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9540.d(34): Error: function ice9540.A.test.AddFront!(this, f).AddFront.dg `(int _param_0)` is not callable using argument types `()`
+fail_compilation/ice9540.d(34): Error: function `ice9540.A.test.AddFront!(this, f).AddFront.dg(int _param_0)` is not callable using argument types `()`
 fail_compilation/ice9540.d(25): Error: template instance ice9540.A.test.AddFront!(this, f) error instantiating
 ---
 */


### PR DESCRIPTION
_Before_
function the.function.name`(int a, float b)` is not callable using...

_After_
function `the.function.name(int a, float b)` is not callable using...

It is hoped that this will aid in the review of some of the other diagnostic messaging PRs that tend to get sidetracked due to these anomalies.

This anomaly was introduced in #7550

cc @ntrel @WalterBright 