### PR TITLE
mars.d: replace many strcmp()s with D string comparisons

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1560,17 +1560,18 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
     for (size_t i = 1; i < arguments.dim; i++)
     {
         const(char)* p = arguments[i];
+        const(char)[] arg = p[0 .. strlen(p)];
         if (*p == '-')
         {
-            if (strcmp(p + 1, "allinst") == 0) // https://dlang.org/dmd.html#switch-allinst
+            if (arg == "-allinst")               // https://dlang.org/dmd.html#switch-allinst
                 params.allInst = true;
-            else if (strcmp(p + 1, "de") == 0) // https://dlang.org/dmd.html#switch-de
+            else if (arg == "-de")               // https://dlang.org/dmd.html#switch-de
                 params.useDeprecated = 0;
-            else if (strcmp(p + 1, "d") == 0)  // https://dlang.org/dmd.html#switch-d
+            else if (arg == "-d")                // https://dlang.org/dmd.html#switch-d
                 params.useDeprecated = 1;
-            else if (strcmp(p + 1, "dw") == 0) // https://dlang.org/dmd.html#switch-dw
+            else if (arg == "-dw")               // https://dlang.org/dmd.html#switch-dw
                 params.useDeprecated = 2;
-            else if (strcmp(p + 1, "c") == 0)  // https://dlang.org/dmd.html#switch-c
+            else if (arg == "-c")                // https://dlang.org/dmd.html#switch-c
                 params.link = false;
             else if (startsWith(p + 1, "color")) // https://dlang.org/dmd.html#switch-color
             {
@@ -1613,9 +1614,9 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else if (p[4])
                     goto Lerror;
             }
-            else if (strcmp(p + 1, "shared") == 0)
+            else if (arg == "-shared")
                 params.dll = true;
-            else if (strcmp(p + 1, "dylib") == 0)
+            else if (arg == "-dylib")
             {
                 static if (TARGET_OSX)
                 {
@@ -1628,7 +1629,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (strcmp(p + 1, "fPIC") == 0)
+            else if (arg == "-fPIC")
             {
                 static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
                 {
@@ -1639,39 +1640,39 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (strcmp(p + 1, "map") == 0) // https://dlang.org/dmd.html#switch-map
+            else if (arg == "-map") // https://dlang.org/dmd.html#switch-map
                 params.map = true;
-            else if (strcmp(p + 1, "multiobj") == 0)
+            else if (arg == "-multiobj")
                 params.multiobj = true;
-            else if (strcmp(p + 1, "g") == 0) // https://dlang.org/dmd.html#switch-g
+            else if (arg == "-g") // https://dlang.org/dmd.html#switch-g
                 params.symdebug = 1;
-            else if (strcmp(p + 1, "gc") == 0)  // https://dlang.org/dmd.html#switch-gc
+            else if (arg == "-gc")  // https://dlang.org/dmd.html#switch-gc
             {
                 Loc loc;
                 deprecation(loc, "use -g instead of -gc");
                 params.symdebug = 2;
             }
-            else if (strcmp(p + 1, "gf") == 0)
+            else if (arg == "-gf")
             {
                 if (!params.symdebug)
                     params.symdebug = 1;
                 params.symdebugref = true;
             }
-            else if (strcmp(p + 1, "gs") == 0)  // https://dlang.org/dmd.html#switch-gs
+            else if (arg == "-gs")  // https://dlang.org/dmd.html#switch-gs
                 params.alwaysframe = true;
-            else if (strcmp(p + 1, "gx") == 0)  // https://dlang.org/dmd.html#switch-gx
+            else if (arg == "-gx")  // https://dlang.org/dmd.html#switch-gx
                 params.stackstomp = true;
-            else if (strcmp(p + 1, "gt") == 0)
+            else if (arg == "-gt")
             {
                 error("use -profile instead of -gt");
                 params.trace = true;
             }
-            else if (strcmp(p + 1, "m32") == 0) // https://dlang.org/dmd.html#switch-m32
+            else if (arg == "-m32") // https://dlang.org/dmd.html#switch-m32
             {
                 params.is64bit = false;
                 params.mscoff = false;
             }
-            else if (strcmp(p + 1, "m64") == 0) // https://dlang.org/dmd.html#switch-m64
+            else if (arg == "-m64") // https://dlang.org/dmd.html#switch-m64
             {
                 params.is64bit = true;
                 static if (TARGET_WINDOS)
@@ -1679,7 +1680,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     params.mscoff = true;
                 }
             }
-            else if (strcmp(p + 1, "m32mscoff") == 0) // https://dlang.org/dmd.html#switch-m32mscoff
+            else if (arg == "-m32mscoff") // https://dlang.org/dmd.html#switch-m32mscoff
             {
                 static if (TARGET_WINDOS)
                 {
@@ -1719,15 +1720,15 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     params.trace = true;
             }
-            else if (strcmp(p + 1, "v") == 0) // https://dlang.org/dmd.html#switch-v
+            else if (arg == "-v") // https://dlang.org/dmd.html#switch-v
                 params.verbose = true;
-            else if (strcmp(p + 1, "vcg-ast") == 0)
+            else if (arg == "-vcg-ast")
                 params.vcg_ast = true;
-            else if (strcmp(p + 1, "vtls") == 0) // https://dlang.org/dmd.html#switch-vtls
+            else if (arg == "-vtls") // https://dlang.org/dmd.html#switch-vtls
                 params.vtls = true;
-            else if (strcmp(p + 1, "vcolumns") == 0) // https://dlang.org/dmd.html#switch-vcolumns
+            else if (arg == "-vcolumns") // https://dlang.org/dmd.html#switch-vcolumns
                 params.showColumns = true;
-            else if (strcmp(p + 1, "vgc") == 0) // https://dlang.org/dmd.html#switch-vgc
+            else if (arg == "-vgc") // https://dlang.org/dmd.html#switch-vgc
                 params.vgc = true;
             else if (startsWith(p + 1, "verrors")) // https://dlang.org/dmd.html#switch-verrors
             {
@@ -1857,11 +1858,11 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (strcmp(p + 1, "w") == 0)   // https://dlang.org/dmd.html#switch-w
+            else if (arg == "-w")   // https://dlang.org/dmd.html#switch-w
                 params.warnings = 1;
-            else if (strcmp(p + 1, "wi") == 0)  // https://dlang.org/dmd.html#switch-wi
+            else if (arg == "-wi")  // https://dlang.org/dmd.html#switch-wi
                 params.warnings = 2;
-            else if (strcmp(p + 1, "O") == 0)   // https://dlang.org/dmd.html#switch-O
+            else if (arg == "-O")   // https://dlang.org/dmd.html#switch-O
                 params.optimize = true;
             else if (p[1] == 'o')
             {
@@ -1961,39 +1962,39 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     goto Lerror;
                 }
             }
-            else if (strcmp(p + 1, "ignore") == 0)      // https://dlang.org/dmd.html#switch-ignore
+            else if (arg == "-ignore")      // https://dlang.org/dmd.html#switch-ignore
                 params.ignoreUnsupportedPragmas = true;
-            else if (strcmp(p + 1, "property") == 0)
+            else if (arg == "-property")
                 params.enforcePropertySyntax = true;
-            else if (strcmp(p + 1, "inline") == 0) // https://dlang.org/dmd.html#switch-inline
+            else if (arg == "-inline")      // https://dlang.org/dmd.html#switch-inline
             {
                 params.useInline = true;
                 params.hdrStripPlainFunctions = false;
             }
-            else if (strcmp(p + 1, "dip25") == 0)       // https://dlang.org/dmd.html#switch-dip25
+            else if (arg == "-dip25")       // https://dlang.org/dmd.html#switch-dip25
                 params.useDIP25 = true;
-            else if (strcmp(p + 1, "dip1000") == 0)
+            else if (arg == "-dip1000")
             {
                 params.useDIP25 = true;
                 params.vsafe = true;
             }
-            else if (strcmp(p + 1, "dip1008") == 0)
+            else if (arg == "-dip1008")
             {
                 params.ehnogc = true;
             }
-            else if (strcmp(p + 1, "lib") == 0) // https://dlang.org/dmd.html#switch-lib
+            else if (arg == "-lib")         // https://dlang.org/dmd.html#switch-lib
                 params.lib = true;
-            else if (strcmp(p + 1, "nofloat") == 0)
+            else if (arg == "-nofloat")
                 params.nofloat = true;
-            else if (strcmp(p + 1, "quiet") == 0)
+            else if (arg == "-quiet")
             {
                 // Ignore
             }
-            else if (strcmp(p + 1, "release") == 0) // https://dlang.org/dmd.html#switch-release
+            else if (arg == "-release")     // https://dlang.org/dmd.html#switch-release
                 params.release = true;
-            else if (strcmp(p + 1, "betterC") == 0) // https://dlang.org/dmd.html#switch-betterC
+            else if (arg == "-betterC")     // https://dlang.org/dmd.html#switch-betterC
                 params.betterC = true;
-            else if (strcmp(p + 1, "noboundscheck") == 0) // https://dlang.org/dmd.html#switch-noboundscheck
+            else if (arg == "-noboundscheck") // https://dlang.org/dmd.html#switch-noboundscheck
             {
                 params.useArrayBounds = CHECKENABLE.off;
             }
@@ -2021,9 +2022,9 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (strcmp(p + 1, "unittest") == 0)
+            else if (arg == "-unittest")
                 params.useUnitTests = true;
-            else if (p[1] == 'I') // https://dlang.org/dmd.html#switch-I
+            else if (p[1] == 'I')              // https://dlang.org/dmd.html#switch-I
             {
                 if (!params.imppath)
                     params.imppath = new Strings();
@@ -2040,7 +2041,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (p[1] == 'J') // https://dlang.org/dmd.html#switch-J
+            else if (p[1] == 'J')             // https://dlang.org/dmd.html#switch-J
             {
                 if (!params.fileImppath)
                     params.fileImppath = new Strings();
@@ -2102,33 +2103,34 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                     goto Lerror;
             }
-            else if (strcmp(p + 1, "-b") == 0)
+            else if (arg == "--b")
                 params.debugb = true;
-            else if (strcmp(p + 1, "-c") == 0)
+            else if (arg == "--c")
                 params.debugc = true;
-            else if (strcmp(p + 1, "-f") == 0)
+            else if (arg == "--f")
                 params.debugf = true;
-            else if (strcmp(p + 1, "-help") == 0 || strcmp(p + 1, "h") == 0)
+            else if (arg == "--help" ||
+                     arg == "-h")
             {
                 params.usage = true;
                 return false;
             }
-            else if (strcmp(p + 1, "-r") == 0)
+            else if (arg == "--r")
                 params.debugr = true;
-            else if (strcmp(p + 1, "-version") == 0)
+            else if (arg == "--version")
             {
                 params.logo = true;
                 return false;
             }
-            else if (strcmp(p + 1, "-x") == 0)
+            else if (arg == "--x")
                 params.debugx = true;
-            else if (strcmp(p + 1, "-y") == 0)
+            else if (arg == "--y")
                 params.debugy = true;
-            else if (p[1] == 'L')       // https://dlang.org/dmd.html#switch-L
+            else if (p[1] == 'L')                        // https://dlang.org/dmd.html#switch-L
             {
                 params.linkswitches.push(p + 2 + (p[2] == '='));
             }
-            else if (startsWith(p + 1, "defaultlib=")) // https://dlang.org/dmd.html#switch-defaultlib
+            else if (startsWith(p + 1, "defaultlib="))   // https://dlang.org/dmd.html#switch-defaultlib
             {
                 params.defaultlibname = p + 1 + 11;
             }
@@ -2136,7 +2138,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             {
                 params.debuglibname = p + 1 + 9;
             }
-            else if (startsWith(p + 1, "deps")) // https://dlang.org/dmd.html#switch-deps
+            else if (startsWith(p + 1, "deps"))          // https://dlang.org/dmd.html#switch-deps
             {
                 if (params.moduleDeps)
                 {
@@ -2156,7 +2158,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 }
                 params.moduleDeps = new OutBuffer();
             }
-            else if (strcmp(p + 1, "main") == 0)        // https://dlang.org/dmd.html#switch-main
+            else if (arg == "-main")             // https://dlang.org/dmd.html#switch-main
             {
                 params.addMain = true;
             }
@@ -2165,7 +2167,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 params.manual = true;
                 return false;
             }
-            else if (strcmp(p + 1, "run") == 0)         // https://dlang.org/dmd.html#switch-run
+            else if (arg == "-run")              // https://dlang.org/dmd.html#switch-run
             {
                 params.run = true;
                 size_t length = argc - i - 1;
@@ -2216,7 +2218,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                     params.objname = p;
                     continue;
                 }
-                if (strcmp(p, `/?`) == 0)
+                if (arg == "/?")
                 {
                     params.usage = true;
                     return false;


### PR DESCRIPTION
D string comparisons are simpler to read and safer than `strcmp()`. Eventually a string switch statement should be used for this.