### PR TITLE
Remove import of dmd.compiler from dmd.globals.

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -12,7 +12,12 @@
 
 module dmd.compiler;
 
+import dmd.globals;
+
 struct Compiler
 {
-    const(char)* vendor; // Compiler backend name
+    extern(C++) static void _init()
+    {
+        global.vendor = "Digital Mars D";
+    }
 }

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -16,7 +16,7 @@
 
 struct Compiler
 {
-    const char *vendor;     // Compiler backend name
+    static void _init();
 };
 
 #endif /* DMD_COMPILER_H */

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -17,7 +17,6 @@ import core.stdc.stdio;
 import dmd.root.array;
 import dmd.root.filename;
 import dmd.root.outbuffer;
-import dmd.compiler;
 import dmd.identifier;
 
 template xversion(string s)
@@ -240,9 +239,9 @@ struct Global
     Array!(const(char)*)* path;     // Array of char*'s which form the import lookup path
     Array!(const(char)*)* filePath; // Array of char*'s which form the file import lookup path
 
-    const(char)* _version;
+    const(char)* vendor;    // Compiler backend name
+    const(char)* _version;  // Compiler version string
 
-    Compiler compiler;
     Param params;
     uint errors;            // number of errors reported so far
     uint warnings;          // number of warnings reported so far
@@ -353,7 +352,6 @@ struct Global
         copyright = "Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved";
         written = "written by Walter Bright";
         _version = (import("VERSION") ~ '\0').ptr;
-        compiler.vendor = "Digital Mars D";
         stdmsg = stdout;
         main_d = "__main.d";
     }

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -225,9 +225,9 @@ struct Global
     Array<const char *> *path;        // Array of char*'s which form the import lookup path
     Array<const char *> *filePath;    // Array of char*'s which form the file import lookup path
 
-    const char *version;
+    const char *vendor;     // Compiler backend name
+    const char *version;    // Compiler version string
 
-    Compiler compiler;
     Param params;
     unsigned errors;       // number of errors reported so far
     unsigned warnings;     // number of warnings reported so far

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -489,7 +489,7 @@ class Lexer
                         }
                         else if (id == Id.VENDOR)
                         {
-                            t.ustring = global.compiler.vendor;
+                            t.ustring = global.vendor;
                             goto Lstr;
                         }
                         else if (id == Id.TIMESTAMP)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -26,6 +26,7 @@ import dmd.arraytypes;
 import dmd.astcodegen;
 import dmd.gluelayer;
 import dmd.builtin;
+import dmd.compiler;
 import dmd.cond;
 import dmd.console;
 import dmd.dinifile;
@@ -267,6 +268,7 @@ private int tryMain(size_t argc, const(char)** argv)
     Strings files;
     Strings libmodules;
     global._init();
+    Compiler._init();
     debug
     {
         printf("DMD %s DEBUG\n", global._version);

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -25,6 +25,7 @@
 #include "aliasthis.h"
 #include "arraytypes.h"
 #include "attrib.h"
+#include "compiler.h"
 #include "complex_t.h"
 #include "cond.h"
 #include "ctfe.h"
@@ -68,6 +69,7 @@ static void frontend_init()
     global._init();
     global.params.isLinux = true;
 
+    Compiler::_init();
     Type::_init();
     Id::initialize();
     Module::_init();


### PR DESCRIPTION
This is blocking #7534 and #7559, as the D implementation is less encapsulated than C++ version.