### PR TITLE
Move tests from Travis to SemaphoreCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: d
 d:
   - dmd
-  - gdc
   - ldc
 
 script:
+  - DMD_BIN="$DMD"
   - deactivate # deactivate d compiler
+  - export DMD="$DMD_BIN"
   - ./travis.sh
 
 sudo: false
@@ -18,7 +19,6 @@ addons:
 
 env:
   - MODEL=32
-  - MODEL=64
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ DMD
 [![Code coverage](https://img.shields.io/codecov/c/github/dlang/dmd.svg?maxAge=86400)](https://codecov.io/gh/dlang/dmd)
 [![license](https://img.shields.io/github/license/dlang/dmd.svg)](https://github.com/dlang/dmd/blob/master/LICENSE.txt)
 
+[![CircleCI](https://circleci.com/gh/dlang/dmd/tree/master.svg?style=svg)](https://circleci.com/gh/dlang/dmd/tree/master)
+[![Build Status](https://semaphoreci.com/api/v1/cybershadow/dmd/branches/master/badge.svg)](https://semaphoreci.com/cybershadow/dmd)
+
 DMD is the reference compiler for the D programming language.
 
 To report a problem or browse the list of open bugs, please visit the

--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -uexo pipefail
+
+################################################################################
+# Set by the Semaphore job runner
+################################################################################
+
+export MODEL=${MODEL:-64}      # can be {32,64}
+export DMD=${DMD:-dmd}         # can be {dmd,ldc,gdc}
+
+################################################################################
+# Static variables or inferred from Semaphore
+# See also: https://semaphoreci.com/docs/available-environment-variables.html
+################################################################################
+
+export N=4
+export OS_NAME=linux
+export BRANCH=$BRANCH_NAME
+export FULL_BUILD="${PULL_REQUEST_NUMBER+false}"
+
+source ci.sh
+
+################################################################################
+# Always source a DMD instance
+################################################################################
+
+source "$(activate_d "$DMD")"
+
+################################################################################
+# Define commands
+################################################################################
+
+case $1 in
+    setup) setup_repos ;;
+    testsuite) testsuite ;;
+esac

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -uexo pipefail
+
+################################################################################
+# Static variables or inferred from Travis
+# https://docs.travis-ci.com/user/environment-variables/
+################################################################################
+
+export N=2
+export OS_NAME="${TRAVIS_OS_NAME}"
+export MODEL="${MODEL}"
+export BRANCH="${TRAVIS_BRANCH}"
+export FULL_BUILD=false
+
+source ci.sh
+
+################################################################################
+# Commands
+################################################################################
+
+setup_repos
+testsuite


### PR DESCRIPTION
A start to move tests from Travis to Semaphore.
It's amazingly fast:

![image](https://user-images.githubusercontent.com/4370550/34643984-58683fa4-f32e-11e7-9b03-50f36f125706.png)

Notes;
- For now I didn't move the 32-bit runs as they aren't significantly faster on SemaphoreCI and I don't know how much workload can be handled with two workers
- Both CIs use the same script, so that updates will be easier
- (edited) We plan to move away from Travis step-by-step as it got rather unreliable and slow

Semaphore is for now configured as follows:

![image](https://user-images.githubusercontent.com/4370550/34643999-e63de324-f32e-11e7-95bb-997ae58fa1c2.png)

(`if [ -f semaphoreci.sh ...` is done s.t. other PRs don't fail for now)