### PR TITLE
Use dmd.target as entrypoint for toArgTypes, remove imports of dmd.argtypes

### DIFF
--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -28,7 +28,7 @@ import dmd.visitor;
  *      tuple of types, each element can be passed in a register.
  *      A tuple of zero length means the type cannot be passed/returned in registers.
  */
-extern (C++) TypeTuple toArgTypes(Type t)
+TypeTuple toArgTypes(Type t)
 {
     extern (C++) final class ToArgTypes : Visitor
     {

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -13,7 +13,6 @@
 module dmd.dstruct;
 
 import dmd.aggregate;
-import dmd.argtypes;
 import dmd.arraytypes;
 import dmd.declaration;
 import dmd.dmodule;
@@ -31,6 +30,7 @@ import dmd.identifier;
 import dmd.mtype;
 import dmd.opover;
 import dmd.semantic3;
+import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.typinf;
@@ -420,7 +420,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
         }
 
-        auto tt = toArgTypes(type);
+        auto tt = Target.toArgTypes(type);
         size_t dim = tt.arguments.dim;
         if (dim >= 1)
         {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -19,7 +19,6 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.apply;
-import dmd.argtypes;
 import dmd.arrayop;
 import dmd.arraytypes;
 import dmd.gluelayer;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -18,7 +18,6 @@ import core.stdc.string;
 import dmd.access;
 import dmd.aggregate;
 import dmd.aliasthis;
-import dmd.argtypes;
 import dmd.arrayop;
 import dmd.arraytypes;
 import dmd.attrib;
@@ -3991,7 +3990,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  * The results of this are highly platform dependent, and intended
                  * primarly for use in implementing va_arg().
                  */
-                tded = toArgTypes(e.targ);
+                tded = Target.toArgTypes(e.targ);
                 if (!tded)
                     goto Lno;
                 // not valid for a parameter

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -12,6 +12,7 @@
 
 module dmd.target;
 
+import dmd.argtypes;
 import dmd.cppmangle;
 import dmd.cppmanglewin;
 import dmd.dclass;
@@ -478,6 +479,15 @@ struct Target
     extern (C++) static LINK systemLinkage()
     {
         return global.params.isWindows ? LINKwindows : LINKc;
+    }
+
+    /**
+     * Return a tuple describing how argument type is put to a function.
+     * Value is an empty tuple if type is always passed on the stack.
+     */
+    extern (C++) static TypeTuple toArgTypes(Type t)
+    {
+        return .toArgTypes(t);
     }
 }
 

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -21,6 +21,7 @@ class ClassDeclaration;
 class Dsymbol;
 class Expression;
 class Type;
+class TypeTuple;
 class Module;
 struct OutBuffer;
 
@@ -78,6 +79,7 @@ struct Target
     static const char *cppTypeInfoMangle(ClassDeclaration *cd);
     static const char *cppTypeMangle(Type *t);
     static LINK systemLinkage();
+    static TypeTuple *toArgTypes(Type *t);
 };
 
 #endif


### PR DESCRIPTION
`dmd.argtypes` implements a functionality that is different on every target platform.  So don't pull this module into the frontend.