### PR TITLE
Fixup C++ headers (based on v2.078.0)

### DIFF
--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -36,7 +36,7 @@ public:
     int inc;
 
     virtual Condition *syntaxCopy() = 0;
-    virtual int include(Scope *sc, ScopeDsymbol *sds) = 0;
+    virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -245,7 +245,6 @@ public:
     virtual d_uns64 size(Loc loc);
     virtual unsigned alignsize();
     Type *trySemantic(Loc loc, Scope *sc);
-    Type *merge();
     Type *merge2();
     void modToBuffer(OutBuffer *buf);
     char *modToChars();

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -335,9 +335,8 @@ public:
     Expression *condition;
     Statement *ifbody;
     Statement *elsebody;
-    Loc endloc;                 // location of closing curly bracket
-
     VarDeclaration *match;      // for MatchExpression results
+    Loc endloc;                 // location of closing curly bracket
 
     Statement *syntaxCopy();
     IfStatement *isIfStatement() { return this; }

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -64,8 +64,8 @@ struct Target
 
     static void _init();
     // Type sizes and support.
-    static unsigned alignsize(Type* type);
-    static unsigned fieldalign(Type* type);
+    static unsigned alignsize(Type *type);
+    static unsigned fieldalign(Type *type);
     static unsigned critsecsize();
     static Type *va_listType();  // get type of va_list
     static int isVectorTypeSupported(int sz, Type *type);

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -297,7 +297,7 @@ class StaticIfCondition;
 
 class Parameter;
 
-class Visitor
+class ParseTimeVisitor
 {
 public:
     virtual void visit(Dsymbol *) { assert(0); }
@@ -557,6 +557,12 @@ public:
     virtual void visit(StructInitializer *i) { visit((Initializer *)i); }
     virtual void visit(ArrayInitializer *i) { visit((Initializer *)i); }
     virtual void visit(VoidInitializer *i) { visit((Initializer *)i); }
+};
+
+class Visitor : public ParseTimeVisitor
+{
+public:
+    using ParseTimeVisitor::visit;
 
     // Miscellaneous
     virtual void visit(ErrorStatement *s) { visit((Statement *)s); }


### PR DESCRIPTION
E.g., reflecting the D `Visitor` class hierarchy with base class `ParseTimeVisitor` also in C++ is crucial for Visual C++.