### PR TITLE
[Trivial] Fix super.visit issue in SemanticTimeTransitiveVisitor

### DIFF
--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -112,7 +112,8 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
 {
     alias visit = SemanticTimePermissiveVisitor.visit;
 
-    mixin ParseVisitMethods!ASTCodegen;
+    mixin ParseVisitMethods!ASTCodegen __methods;
+    alias visit = __methods.visit;
 
     override void visit(ASTCodegen.PeelStatement s)
     {


### PR DESCRIPTION
The methods which are mixed in aren't included in the overload set of the scope. This needs to be done manually. In my opinion, the compiler should do this automatically, but this PR only fixes the current issue so that calls to super.visit will be resolved correctly.