### PR TITLE
[Do not merge] Parser experiment

### DIFF
--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -33,6 +33,70 @@ struct ASTCodegen
     import dmd.typesem;
     import dmd.ctfeexpr;
 
+//    alias initializerToExpression   = dmd.initsem.initializerToExpression;
+    static initializerToExpression(Initializer i, Type t = null)
+    { return dmd.initsem.initializerToExpression(i, t); }
+    alias typeToExpression          = dmd.typesem.typeToExpression;
+    alias UserAttributeDeclaration  = dmd.attrib.UserAttributeDeclaration;
+
+    alias MODconst                  = dmd.mtype.MODconst;
+    alias MODimmutable              = dmd.mtype.MODimmutable;
+    alias MODshared                 = dmd.mtype.MODshared;
+    alias MODwild                   = dmd.mtype.MODwild;
+    alias Type                      = dmd.mtype.Type;
+    alias Tident                    = dmd.mtype.Tident;
+    alias Tfunction                 = dmd.mtype.Tfunction;
+    alias Parameter                 = dmd.mtype.Parameter;
+    alias Taarray                   = dmd.mtype.Taarray;
+    alias Tsarray                   = dmd.mtype.Tsarray;
+    alias Terror                    = dmd.mtype.Terror;
+
+    alias STC                       = dmd.declaration.STC;
+    alias PROTprivate               = dmd.dsymbol.PROTprivate;
+    alias PROTpackage               = dmd.dsymbol.PROTpackage;
+    alias PROTprotected             = dmd.dsymbol.PROTprotected;
+    alias PROTpublic                = dmd.dsymbol.PROTpublic;
+    alias PROTexport                = dmd.dsymbol.PROTexport;
+    alias PROTundefined             = dmd.dsymbol.PROTundefined;
+    alias Prot                      = dmd.dsymbol.Prot;
+
+    alias stcToBuffer               = dmd.hdrgen.stcToBuffer;
+    alias linkageToChars            = dmd.hdrgen.linkageToChars;
+    alias protectionToChars         = dmd.hdrgen.protectionToChars;
+
+    alias isType                    = dmd.dtemplate.isType;
+    alias isExpression              = dmd.dtemplate.isExpression;
+    alias isTuple                   = dmd.dtemplate.isTuple;
+}
+
+struct ASTClassCount
+{
+    import dmd.aggregate;
+    import dmd.aliasthis;
+    import dmd.arraytypes;
+    import dmd.attrib;
+    import dmd.cond;
+    import dmd.dclass;
+    import dmd.declaration;
+    import dmd.denum;
+    import dmd.dimport;
+    import dmd.dmodule;
+    import dmd.dstruct;
+    import dmd.dsymbol;
+    import dmd.dtemplate;
+    import dmd.dversion;
+    import dmd.expression;
+    import dmd.func;
+    import dmd.hdrgen;
+    import dmd.init;
+    import dmd.initsem;
+    import dmd.mtype;
+    import dmd.nspace;
+    import dmd.statement;
+    import dmd.staticassert;
+    import dmd.typesem;
+    import dmd.ctfeexpr;
+
     alias initializerToExpression   = dmd.initsem.initializerToExpression;
     alias typeToExpression          = dmd.typesem.typeToExpression;
     alias UserAttributeDeclaration  = dmd.attrib.UserAttributeDeclaration;
@@ -67,4 +131,18 @@ struct ASTCodegen
     alias isType                    = dmd.dtemplate.isType;
     alias isExpression              = dmd.dtemplate.isExpression;
     alias isTuple                   = dmd.dtemplate.isTuple;
+
+
+    import dmd.globals;
+    import dmd.identifier;
+
+    static int classCount;
+    extern (C++) class ClassDeclaration : dmd.dclass.ClassDeclaration
+    {
+        final extern (D) this(Loc loc, Identifier id, BaseClasses* baseclasses, Dsymbols* members, bool inObject)
+        {
+            ++classCount;
+            super(loc, id, baseclasses, members, inObject);
+        }
+    }
 }

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -112,7 +112,8 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
 {
     alias visit = SemanticTimePermissiveVisitor.visit;
 
-    mixin ParseVisitMethods!ASTCodegen;
+    mixin ParseVisitMethods!ASTCodegen methods;
+    alias visit = methods.visit;
 
     override void visit(ASTCodegen.PeelStatement s)
     {

--- a/test/dub_package/classCount.d
+++ b/test/dub_package/classCount.d
@@ -1,0 +1,158 @@
+#!/usr/bin/env dub
+/+dub.sdl:
+dependency "dmd" path="../.."
++/
+import std.stdio;
+
+// add import paths
+void addImports(T)(T path)
+{
+    import dmd.globals : global;
+    import dmd.arraytypes : Strings;
+
+    stderr.writefln("addImport: %s", path);
+
+    Strings* res = new Strings();
+    foreach (p; path)
+    {
+        import std.string : toStringz;
+        Strings* a = new Strings();
+        a.push(p.toStringz);
+        res.append(a);
+    }
+    global.path = res;
+}
+
+// finds a dmd.conf and parses it for import paths
+auto findImportPaths()
+{
+    import std.file : exists, getcwd;
+    import std.string : fromStringz, toStringz;
+    import std.path : buildPath, buildNormalizedPath, dirName;
+    import std.process : env = environment, execute;
+    import dmd.dinifile : findConfFile;
+    import dmd.errors : fatal;
+    import std.algorithm, std.range, std.regex;
+
+    auto dmdEnv = env.get("DMD", "dmd");
+    auto whichDMD = execute(["which", dmdEnv]);
+    if (whichDMD.status != 0)
+    {
+        stderr.writeln("Can't find DMD.");
+        fatal;
+    }
+
+    immutable dmdFilePath = whichDMD.output;
+    string iniFile;
+
+    if (dmdEnv.canFind("ldmd"))
+    {
+        immutable ldcConfig = "ldc2.conf";
+        immutable binDir = dmdFilePath.dirName;
+        // https://wiki.dlang.org/Using_LDC
+        auto ldcConfigs = [
+            getcwd.buildPath(ldcConfig),
+            binDir.buildPath(ldcConfig),
+            binDir.dirName.buildPath("etc", ldcConfig),
+            "~/.ldc".buildPath(ldcConfig),
+            binDir.buildPath("etc", ldcConfig),
+            binDir.buildPath("etc", "ldc", ldcConfig),
+            "/etc".buildPath(ldcConfig),
+            "/etc/ldc".buildPath(ldcConfig),
+        ].filter!exists;
+        assert(!ldcConfigs.empty, "No ldc2.conf found");
+        iniFile = ldcConfigs.front;
+    }
+    else
+    {
+        auto f = findConfFile(dmdFilePath.toStringz, "dmd.conf");
+        iniFile = f.fromStringz.idup;
+        assert(iniFile.exists, "No dmd.conf found.");
+    }
+
+    return File(iniFile, "r")
+        .byLineCopy
+        .map!(l => l.matchAll(`-I[^ "]+`.regex)
+                    .joiner
+                    .map!(a => a.drop(2)
+                                .replace("%@P%", dmdFilePath.dirName)
+                                .replace("%%ldcbinarypath%%", dmdFilePath.dirName)))
+        .joiner
+        .array
+        .sort
+        .uniq
+        .map!buildNormalizedPath;
+}
+
+// test frontend
+void main()
+{
+    import dmd.astcodegen;
+    import dmd.dmodule : Module;
+    import dmd.globals : global, Loc;
+    import dmd.frontend : initDMD;
+    import dmd.parse : Parser;
+    import dmd.statement : Identifier;
+    import dmd.tokens : TOKeof;
+    import dmd.id : Id;
+
+    initDMD;
+    findImportPaths.addImports;
+
+    auto parse(AST)(Module m, string code)
+    {
+        scope p = new Parser!AST(m, code, false);
+        p.nextToken; // skip the initial token
+        auto members = p.parseModule;
+        assert(!p.errors, "Parsing error occurred.");
+        return members;
+    }
+
+    Identifier id = Identifier.idPool("test-ast");
+    auto m = new Module("test.d", id, 0, 0);
+    m.members = parse!ASTClassCount(m, q{
+        void foo()
+        {
+            foreach (i; 0..10) {}
+        }
+
+        class Foo
+        {
+            class Bar {}
+        }
+    });
+    writeln("class count - ASTClassCount: ", ASTClassCount.classCount);
+
+
+    import dmd.visitor;
+    Identifier id2= Identifier.idPool("test-visitor");
+    auto m2 = new Module("test2.d", id, 0, 0);
+    m2.members = parse!ASTCodegen(m, q{
+        void foo()
+        {
+            foreach (i; 0..10) {}
+        }
+
+        class Foo
+        {
+            class Bar {}
+        }
+    });
+
+    extern (C++) class ClassCountVisitor : SemanticTimeTransitiveVisitor
+    {
+        alias visit = super.visit;
+        int count;
+
+        override void visit(ASTCodegen.ClassDeclaration ad)
+        {
+            ++count;
+            super.visit(ad);
+        }
+    }
+
+    scope p = new ClassCountVisitor();
+    m2.accept(p);
+
+    writeln("class count - visitor: ", p.count);
+}


### PR DESCRIPTION
This is an experiment to see how creating a new AST family would work. The API for dmd as a library is currently reduced to a few (parse time and semantic time) visitors and the semantic methods. This is insufficient and the compiler should be organized to accept families of ASTs since that would enable the user to modify any part of the compiler that he/she finds suitable.

The implementation duplicates the code in ASTCodegen which are all imports and inherits the AST node that needs to be modified (ClassDeclaration) and adds functionality in the method which needs to be modified (in this case, the constructor). The tool simply counts the number of class declarations in the code. Ideally, the AST classes should contain only fields and getter/setter methods and all functionally methods should be moved out of the compiler and be templated with an AST.