### PR TITLE
Add 'man' target to build the MAN pages

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,6 +13,9 @@ include ../src/osmodel.mak
 BUILD=release
 G_BIN=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 
+# Removes inclusion of all dynamic content and timestamps
+export DIFFABLE
+
 ################################################################################
 # Main targets
 ################################################################################

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,23 +1,39 @@
-MAN_PAGE=man/man1/dmd.1
 DMD=dmd
 DMD_ROOT=..
-G=$(DMD_ROOT)/generated
+GENERATED=$(DMD_ROOT)/generated
+G=$(DMD_ROOT)/generated/docs
+DMD_MAN_PAGE=man/man1/dmd.1
+OTHER_MAN_PAGES=$(addprefix man/, \
+	$(addprefix man1/, dumpobj.1 obj2asm.1) \
+	man5/dmd.conf.5 \
+)
+
+include ../src/osmodel.mak
+
+BUILD=release
+G_BIN=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 
 ################################################################################
 # Main targets
 ################################################################################
 
-build: $(MAN_PAGE)
+build: $(addprefix $G/, $(DMD_MAN_PAGE) $(OTHER_MAN_PAGES))
 
 preview:
-	man -l $(MAN_PAGE)
+	man -l $G/$(DMD_MAN_PAGE)
 
 ################################################################################
 # Actual compilation commands
 ################################################################################
 
-$(MAN_PAGE): $G/gen_man
+$G/$(DMD_MAN_PAGE): $(G_BIN)/gen_man
+	@mkdir -p $(dir $@)
 	$< > $@
 
-$G/gen_man: gen_man.d $(DMD_ROOT)/src/dmd/cli.d
+$(G_BIN)/gen_man: gen_man.d $(DMD_ROOT)/src/dmd/cli.d
+	@mkdir -p $(dir $@)
 	$(DMD) -I$(DMD_ROOT)/src -of$@ $^
+
+$G/%: %
+	@mkdir -p $(dir $@)
+	cp $< $@

--- a/docs/gen_man.d
+++ b/docs/gen_man.d
@@ -79,9 +79,14 @@ string bold(string w)
 void main()
 {
     import std.algorithm, std.array, std.conv, std.datetime, std.range, std.stdio, std.uni;
+    import std.process : environment;
     import dmd.cli;
 
     auto now = Clock.currTime;
+    auto diffable = environment.get("DIFFABLE", "0");
+    if (diffable == "1")
+        now = SysTime(DateTime(2018, 01, 01));
+
     writefln(header, now.toISOExtString.take(10));
 
     foreach (option; Usage.options)

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -548,9 +548,20 @@ $G/newdelete.o: $G/%.o: $(ROOT)/%.c $(SRC_MAKE)
 	@echo "  (CC)  ROOT_OBJS  $<"
 	$(CXX) -c -o$@ $(CXXFLAGS) $(ROOT_FLAGS) $(MMD) $<
 
+################################################################################
+# Generate the man pages
+################################################################################
+
+DMD_MAN_PAGE = $(GENERATED)/docs/man1/dmd.1
+
+$(DMD_MAN_PAGE): dmd/cli.d
+	${MAKE} -C ../docs DMD=$(HOST_DMD_PATH) build
+
+man: $(DMD_MAN_PAGE)
+
 ######################################################
 
-install: all
+install: all $(DMD_MAN_PAGE)
 	$(eval bin_dir=$(if $(filter $(OS),osx), bin, bin$(MODEL)))
 	mkdir -p $(INSTALL_DIR)/$(OS)/$(bin_dir)
 	cp $G/dmd $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -25,6 +25,20 @@
 # ENABLE_PROFILE:       Build dmd with a profiling recorder (D)
 # ENABLE_COVERAGE       Build dmd with coverage counting
 # ENABLE_SANITIZERS     Build dmd with sanitizer (e.g. ENABLE_SANITIZERS=address,undefined)
+#
+# Targets
+# -------
+#
+# all					Build dmd
+# unittest              Run all unittest blocks
+# cxx-unittest          Check conformance of the C++ headers
+# build-examples        Build DMD as library examples
+# clean                 Remove all generated files
+# man                   Generate the man pages
+# checkwhitespace       Checks for trailing whitespace and tabs
+# zip                   Packs all sources into a ZIP archive
+# gitzip                Packs all sources into a ZIP archive
+# install               Installs dmd into $(INSTALL_DIR)
 ################################################################################
 
 # get OS and MODEL


### PR DESCRIPTION
We should be a bit careful here to avoid breaking the nightly builds.

- Remove static dmd.1 in favor of the auto-generated one
- Add 'man' target (builds the MAN pages)
- Build MAN pages to generated
- Document Makefile targets

CC other package maintainers: @Vild @jordisayol @WebDrake (who knows more?)
 
See also: https://github.com/dlang/dmd/pull/7507