### PR TITLE
Refactor: make checkDisabled and checkDeprecated return bool

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -130,6 +130,7 @@ public:
 
     const char *kind() const;
     d_uns64 size(Loc loc);
+    bool checkDisabled(Loc loc, Scope* sc, bool isAliasedDeclaration = false);
     int checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int flag);
 
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -305,7 +305,7 @@ extern (C++) class Dsymbol : RootObject
         va_end(ap);
     }
 
-    final void checkDeprecated(Loc loc, Scope* sc)
+    final bool checkDeprecated(Loc loc, Scope* sc)
     {
         if (global.params.useDeprecated != 1 && isDeprecated())
         {
@@ -313,16 +313,16 @@ extern (C++) class Dsymbol : RootObject
             for (Dsymbol sp = sc.parent; sp; sp = sp.parent)
             {
                 if (sp.isDeprecated())
-                    return;
+                    return false;
             }
             for (Scope* sc2 = sc; sc2; sc2 = sc2.enclosing)
             {
                 if (sc2.scopesym && sc2.scopesym.isDeprecated())
-                    return;
+                    return false;
 
                 // If inside a StorageClassDeclaration that is deprecated
                 if (sc2.stc & STC.deprecated_)
-                    return;
+                    return false;
             }
             const(char)* message = null;
             for (Dsymbol p = this; p; p = p.parent)
@@ -335,7 +335,11 @@ extern (C++) class Dsymbol : RootObject
                 deprecation(loc, "is deprecated - %s", message);
             else
                 deprecation(loc, "is deprecated");
+
+            return true;
         }
+
+        return false;
     }
 
     /**********************************

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -181,7 +181,7 @@ public:
     void error(const char *format, ...);
     void deprecation(Loc loc, const char *format, ...);
     void deprecation(const char *format, ...);
-    void checkDeprecated(Loc loc, Scope *sc);
+    bool checkDeprecated(Loc loc, Scope *sc);
     Module *getModule();
     Module *getAccessModule();
     Dsymbol *pastMixin();

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1923,15 +1923,19 @@ extern (C++) abstract class Expression : RootObject
         return checkValue();
     }
 
-    final void checkDeprecated(Scope* sc, Dsymbol s)
+    final bool checkDeprecated(Scope* sc, Dsymbol s)
     {
-        s.checkDeprecated(loc, sc);
+        return s.checkDeprecated(loc, sc);
     }
 
-    final void checkDisabled(Scope* sc, Dsymbol s)
+    final bool checkDisabled(Scope* sc, Dsymbol s)
     {
         if (auto d = s.isDeclaration())
-            d.checkDisabled(loc, sc);
+        {
+            return d.checkDisabled(loc, sc);
+        }
+
+        return false;
     }
 
     /*********************************************

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -178,8 +178,8 @@ public:
     bool checkNoBool();
     bool checkIntegral();
     bool checkArithmetic();
-    void checkDeprecated(Scope *sc, Dsymbol *s);
-    void checkDisabled(Scope *sc, Dsymbol *s);
+    bool checkDeprecated(Scope *sc, Dsymbol *s);
+    bool checkDisabled(Scope *sc, Dsymbol *s);
     bool checkPurity(Scope *sc, FuncDeclaration *f);
     bool checkPurity(Scope *sc, VarDeclaration *v);
     bool checkSafety(Scope *sc, FuncDeclaration *f);


### PR DESCRIPTION
This is a followup to #7583 and a proposed prerequisite for #7628.

This also makes the interface consistent with all the other `checkXXX` methods.

It also contains a fix to the C++ interface that I missed in #7583 

cc @ibuclaw C++ interface change
cc @wilzbach 
  