### PR TITLE
Group scattered AST visitors into a `visitors` package

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -44,7 +44,7 @@ subPackage {
     "src/dmd/astbase.d" \
     "src/dmd/parse.d" \
     "src/dmd/visitor/package.d" \
-    "src/dmd/visitor/parsetime.d" \
+    "src/dmd/visitor/parse_time.d" \
     "src/dmd/visitor/permissive.d" \
     "src/dmd/visitor/strict.d" \
     "src/dmd/visitor/transitive.d"

--- a/dub.sdl
+++ b/dub.sdl
@@ -43,9 +43,11 @@ subPackage {
   sourceFiles \
     "src/dmd/astbase.d" \
     "src/dmd/parse.d" \
-    "src/dmd/transitivevisitor.d" \
-    "src/dmd/permissivevisitor.d" \
-    "src/dmd/strictvisitor.d"
+    "src/dmd/visitor/package.d" \
+    "src/dmd/visitor/parsetime.d" \
+    "src/dmd/visitor/permissive.d" \
+    "src/dmd/visitor/strict.d" \
+    "src/dmd/visitor/transitive.d"
 
   dependency "dmd:lexer" version="*"
 }

--- a/dub.sdl
+++ b/dub.sdl
@@ -43,9 +43,10 @@ subPackage {
   sourceFiles \
     "src/dmd/astbase.d" \
     "src/dmd/parse.d" \
-    "src/dmd/visitor/package.d" \
     "src/dmd/visitor/parse_time.d" \
     "src/dmd/visitor/permissive.d" \
+    "src/dmd/visitor/semantic.d" \
+    "src/dmd/visitor/stoppable.d" \
     "src/dmd/visitor/strict.d" \
     "src/dmd/visitor/transitive.d"
 

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -737,7 +737,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -33,7 +33,7 @@ import dmd.mtype;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum Sizeok : int
 {

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -146,7 +146,7 @@ public:
     Symbol *sinit;
 
     AggregateDeclaration *isAggregateDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 struct StructFlags
@@ -195,7 +195,7 @@ public:
     bool isPOD();
 
     StructDeclaration *isStructDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class UnionDeclaration : public StructDeclaration
@@ -205,7 +205,7 @@ public:
     const char *kind() const;
 
     UnionDeclaration *isUnionDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 struct BaseClass
@@ -321,7 +321,7 @@ public:
     Symbol *vtblsym;
 
     ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class InterfaceDeclaration : public ClassDeclaration
@@ -337,7 +337,7 @@ public:
     bool isCOMinterface() const;
 
     InterfaceDeclaration *isInterfaceDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_AGGREGATE_H */

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -55,7 +55,7 @@ extern (C++) final class AliasThis : Dsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -23,7 +23,7 @@ import dmd.identifier;
 import dmd.mtype;
 import dmd.opover;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************************************
  * alias ident this;

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -29,7 +29,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;
     AliasThis *isAliasThis() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif

--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -15,7 +15,7 @@ module dmd.apply;
 import dmd.arraytypes;
 import dmd.dtemplate;
 import dmd.expression;
-import dmd.visitor;
+import dmd.visitor.stoppable;
 
 /**************************************
  * An Expression tree walker that will visit each Expression e in the tree,

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -35,9 +35,9 @@ import dmd.visitor.semantic;
  */
 TypeTuple toArgTypes(Type t)
 {
-    extern (C++) final class ToArgTypes : Visitor
+    extern (C++) final class ToArgTypes : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         TypeTuple result;
 

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -18,7 +18,7 @@ import core.checkedint;
 import dmd.declaration;
 import dmd.globals;
 import dmd.mtype;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /****************************************************
  * This breaks a type down into 'simpler' types that can be passed to a function

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -175,9 +175,9 @@ extern (C++) Expression arrayOp(BinAssignExp e, Scope* sc)
  */
 private void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Expressions* args)
 {
-    extern (C++) final class BuildArrayOpVisitor : Visitor
+    extern (C++) final class BuildArrayOpVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
         Scope* sc;
         Objects* tiargs;
         Expressions* args;

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -27,7 +27,7 @@ import dmd.mtype;
 import dmd.root.outbuffer;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /**********************************************
  * Check that there are no uses of arrays without [].

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -5,7 +5,7 @@ module dmd.astbase;
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astbase.d
  */
 
-import dmd.parsetimevisitor;
+import dmd.parsetime;
 
 /** The ASTBase  family defines a family of AST nodes appropriate for parsing with
   * no semantic information. It defines all the AST nodes that the parser needs

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -287,7 +287,7 @@ struct ASTBase
         tracingDT    = 0x8,  // mark in progress of deduceType
     }
 
-    alias Visitor = ParseTimeVisitor!ASTBase;
+    alias SemanticVisitor = ParseTimeVisitor!ASTBase;
 
     extern (C++) class Dsymbol : RootObject
     {
@@ -449,7 +449,7 @@ struct ASTBase
             return DYNCAST.dsymbol;
         }
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -466,7 +466,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -492,7 +492,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -507,7 +507,7 @@ struct ASTBase
             super(id);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -561,7 +561,7 @@ struct ASTBase
             aliases.push(_alias);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -581,7 +581,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -616,7 +616,7 @@ struct ASTBase
             this.loc = loc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -637,7 +637,7 @@ struct ASTBase
             this.loc = loc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -668,7 +668,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -718,7 +718,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -749,7 +749,7 @@ struct ASTBase
             return true;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -766,7 +766,7 @@ struct ASTBase
             this.objects = objects;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -789,7 +789,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -802,7 +802,7 @@ struct ASTBase
             super(loc, endloc, id, stc, null);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -815,7 +815,7 @@ struct ASTBase
             super(loc, endloc, Id.ctor, stc, type);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -832,7 +832,7 @@ struct ASTBase
             super(loc, endloc, id, stc, null);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -846,7 +846,7 @@ struct ASTBase
             this.fbody = fbody;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -864,7 +864,7 @@ struct ASTBase
             this.codedoc = codedoc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -882,7 +882,7 @@ struct ASTBase
             this.varargs = varargs;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -898,7 +898,7 @@ struct ASTBase
             this.parameters = fparams;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -915,7 +915,7 @@ struct ASTBase
             super(loc, endloc, Identifier.generateId(name), STC.static_ | stc, null);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -932,7 +932,7 @@ struct ASTBase
             super(loc, endloc, Identifier.generateId(name), STC.static_ | stc, null);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -945,7 +945,7 @@ struct ASTBase
             super(loc, endloc, "_sharedStaticCtor", stc);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -958,7 +958,7 @@ struct ASTBase
             super(loc, endloc, "_sharedStaticDtor", stc);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -977,7 +977,7 @@ struct ASTBase
             this.tag = packageTag++;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -998,7 +998,7 @@ struct ASTBase
             protection = Prot(Prot.Kind.undefined);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1023,7 +1023,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1073,7 +1073,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1147,7 +1147,7 @@ struct ASTBase
             return ti;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1162,7 +1162,7 @@ struct ASTBase
             this.members = members;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1179,7 +1179,7 @@ struct ASTBase
             this.exp = exp;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1211,7 +1211,7 @@ struct ASTBase
             return udas;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1227,7 +1227,7 @@ struct ASTBase
             linkage = p;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1244,7 +1244,7 @@ struct ASTBase
             this.isunion = isunion;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1261,7 +1261,7 @@ struct ASTBase
             this.ealign = ealign;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1277,7 +1277,7 @@ struct ASTBase
             cppmangle = p;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1303,7 +1303,7 @@ struct ASTBase
             this.pkg_identifiers = pkg_identifiers;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1321,7 +1321,7 @@ struct ASTBase
             this.args = args;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1337,7 +1337,7 @@ struct ASTBase
             this.stc = stc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1355,7 +1355,7 @@ struct ASTBase
             this.elsedecl = elsedecl;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1371,7 +1371,7 @@ struct ASTBase
             this.msg = msg;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1384,7 +1384,7 @@ struct ASTBase
             super(condition, decl, elsedecl);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1400,7 +1400,7 @@ struct ASTBase
             this.sfe = sfe;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1420,7 +1420,7 @@ struct ASTBase
             this.origType = origType;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1441,7 +1441,7 @@ struct ASTBase
             srcfile = new File(srcfilename);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1465,7 +1465,7 @@ struct ASTBase
             }
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1478,7 +1478,7 @@ struct ASTBase
             super(loc, id, false);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1677,7 +1677,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1690,7 +1690,7 @@ struct ASTBase
             super(loc, id, baseclasses, null, false);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1709,7 +1709,7 @@ struct ASTBase
             this.tqual = tqual;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1799,7 +1799,7 @@ struct ASTBase
             return new Parameter(storageClass, type ? type.syntaxCopy() : null, ident, defaultArg ? defaultArg.syntaxCopy() : null);
         }
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1843,7 +1843,7 @@ struct ASTBase
             return null;
         }
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1859,7 +1859,7 @@ struct ASTBase
             this.imports = imports;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1877,7 +1877,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1898,7 +1898,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1916,7 +1916,7 @@ struct ASTBase
             this.statement = statement;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1932,7 +1932,7 @@ struct ASTBase
             this.sa = sa;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1948,7 +1948,7 @@ struct ASTBase
             this.exp = exp;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1968,7 +1968,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -1992,7 +1992,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2012,7 +2012,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2039,7 +2039,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2063,7 +2063,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2088,7 +2088,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2106,7 +2106,7 @@ struct ASTBase
             this.statement = statement;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2126,7 +2126,7 @@ struct ASTBase
             this.elsebody = elsebody;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2142,7 +2142,7 @@ struct ASTBase
             this.sfe = sfe;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2162,7 +2162,7 @@ struct ASTBase
             this._body = _body;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2182,7 +2182,7 @@ struct ASTBase
             this.isFinal = isFinal;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2202,7 +2202,7 @@ struct ASTBase
             this.statement = s;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2220,7 +2220,7 @@ struct ASTBase
             this.statement = s;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2236,7 +2236,7 @@ struct ASTBase
             this.statement = s;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2252,7 +2252,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2268,7 +2268,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2281,7 +2281,7 @@ struct ASTBase
             super(loc);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2297,7 +2297,7 @@ struct ASTBase
             this.exp = exp;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2313,7 +2313,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2331,7 +2331,7 @@ struct ASTBase
             this._body = _body;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2351,7 +2351,7 @@ struct ASTBase
             this.endloc = endloc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2369,7 +2369,7 @@ struct ASTBase
             this.catches = catches;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2387,7 +2387,7 @@ struct ASTBase
             this.finalbody = finalbody;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2403,7 +2403,7 @@ struct ASTBase
             this.exp = exp;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2419,7 +2419,7 @@ struct ASTBase
             this.tokens = tokens;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2445,7 +2445,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2474,7 +2474,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2487,7 +2487,7 @@ struct ASTBase
             super(loc, statements);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -2503,7 +2503,7 @@ struct ASTBase
             this.stc = stc;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3351,7 +3351,7 @@ struct ASTBase
             return null;
         }
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3503,7 +3503,7 @@ struct ASTBase
             return (flags & (TFlags.integral | TFlags.floating)) != 0;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3521,7 +3521,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3540,7 +3540,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3561,7 +3561,7 @@ struct ASTBase
             return new TypeVector(basetype.syntaxCopy());
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3582,7 +3582,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3625,7 +3625,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3647,7 +3647,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3669,7 +3669,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3696,7 +3696,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3717,7 +3717,7 @@ struct ASTBase
             return next;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3742,7 +3742,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3769,7 +3769,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3795,7 +3795,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3871,7 +3871,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3884,7 +3884,7 @@ struct ASTBase
             super(ty, next);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3910,7 +3910,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3953,7 +3953,7 @@ struct ASTBase
             return null;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -3986,7 +3986,7 @@ struct ASTBase
             return e;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4079,7 +4079,7 @@ struct ASTBase
             return e;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4108,7 +4108,7 @@ struct ASTBase
             return toExpressionHelper(new IdentifierExp(loc, ident));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4129,7 +4129,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4153,7 +4153,7 @@ struct ASTBase
             return t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4182,7 +4182,7 @@ struct ASTBase
             return toExpressionHelper(new ScopeExp(loc, tempinst));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4235,7 +4235,7 @@ struct ASTBase
             return DYNCAST.expression;
         }
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4251,7 +4251,7 @@ struct ASTBase
             this.declaration = declaration;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4340,7 +4340,7 @@ struct ASTBase
             }
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4362,7 +4362,7 @@ struct ASTBase
             this.arguments = arguments;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4388,7 +4388,7 @@ struct ASTBase
             this.parameters = parameters;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4405,7 +4405,7 @@ struct ASTBase
             this.type = type;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4419,7 +4419,7 @@ struct ASTBase
             this.type = type;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4435,7 +4435,7 @@ struct ASTBase
             this.obj = o;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4453,7 +4453,7 @@ struct ASTBase
             this.args = args;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4496,7 +4496,7 @@ struct ASTBase
             this.sz = 1;                    // work around LDC bug #1286
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4518,7 +4518,7 @@ struct ASTBase
             this.arguments = arguments;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4537,7 +4537,7 @@ struct ASTBase
             this.values = values;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4568,7 +4568,7 @@ struct ASTBase
             this.elements = elements;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4595,7 +4595,7 @@ struct ASTBase
             assert(fd.fbody);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4613,7 +4613,7 @@ struct ASTBase
             this.upr = upr;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4627,7 +4627,7 @@ struct ASTBase
             this.type = type;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4644,7 +4644,7 @@ struct ASTBase
             assert(!sds.isTemplateDeclaration());
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4660,7 +4660,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4676,7 +4676,7 @@ struct ASTBase
             this.e1 = e1;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4692,7 +4692,7 @@ struct ASTBase
             this.subop = subop;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4710,7 +4710,7 @@ struct ASTBase
             this.e2 = e2;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4728,7 +4728,7 @@ struct ASTBase
             this.hasOverloads = hasOverloads;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4747,7 +4747,7 @@ struct ASTBase
             this.fd = fd;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4766,7 +4766,7 @@ struct ASTBase
             this.hasOverloads = hasOverloads;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4783,7 +4783,7 @@ struct ASTBase
             this.type = var.type;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4882,7 +4882,7 @@ struct ASTBase
             return sa;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4895,7 +4895,7 @@ struct ASTBase
             super(loc, Id.dollar);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4908,7 +4908,7 @@ struct ASTBase
             super(loc, TOK.this_, __traits(classInstanceSize, ThisExp));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4922,7 +4922,7 @@ struct ASTBase
             op = TOK.super_;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4935,7 +4935,7 @@ struct ASTBase
             super(loc, TOK.address, __traits(classInstanceSize, AddrExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4948,7 +4948,7 @@ struct ASTBase
             super(loc, op, __traits(classInstanceSize, PreExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4966,7 +4966,7 @@ struct ASTBase
             type = t;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4979,7 +4979,7 @@ struct ASTBase
             super(loc, TOK.negate, __traits(classInstanceSize, NegExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -4992,7 +4992,7 @@ struct ASTBase
             super(loc, TOK.uadd, __traits(classInstanceSize, UAddExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5005,7 +5005,7 @@ struct ASTBase
             super(loc, TOK.not, __traits(classInstanceSize, NotExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5018,7 +5018,7 @@ struct ASTBase
             super(loc, TOK.tilde, __traits(classInstanceSize, ComExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5034,7 +5034,7 @@ struct ASTBase
             this.isRAII = isRAII;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5056,7 +5056,7 @@ struct ASTBase
             this.mod = mod;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5099,7 +5099,7 @@ struct ASTBase
             this.arguments = arguments;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5115,7 +5115,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5131,7 +5131,7 @@ struct ASTBase
             this.msg = msg;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5144,7 +5144,7 @@ struct ASTBase
             super(loc, TOK.mixin_, __traits(classInstanceSize, CompileExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5157,7 +5157,7 @@ struct ASTBase
             super(loc, TOK.import_, __traits(classInstanceSize, ImportExp), e);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5178,7 +5178,7 @@ struct ASTBase
             this.ti = ti;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5202,7 +5202,7 @@ struct ASTBase
             arguments = args;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5215,7 +5215,7 @@ struct ASTBase
             super(loc, TOK.functionString, __traits(classInstanceSize, FuncInitExp));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5228,7 +5228,7 @@ struct ASTBase
             super(loc, TOK.prettyFunction, __traits(classInstanceSize, PrettyFuncInitExp));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5241,7 +5241,7 @@ struct ASTBase
             super(loc, tok, __traits(classInstanceSize, FileInitExp));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5254,7 +5254,7 @@ struct ASTBase
             super(loc, TOK.line, __traits(classInstanceSize, LineInitExp));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5267,7 +5267,7 @@ struct ASTBase
             super(loc, TOK.moduleString, __traits(classInstanceSize, ModuleInitExp));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5284,7 +5284,7 @@ struct ASTBase
             allowCommaExp = isGenerated = generated;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5297,7 +5297,7 @@ struct ASTBase
             super(loc, op, __traits(classInstanceSize, PostExp), e, new IntegerExp(loc, 1, Type.tint32));
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5310,7 +5310,7 @@ struct ASTBase
             super(loc, TOK.pow, __traits(classInstanceSize, PowExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5323,7 +5323,7 @@ struct ASTBase
             super(loc, TOK.mul, __traits(classInstanceSize, MulExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5336,7 +5336,7 @@ struct ASTBase
             super(loc, TOK.div, __traits(classInstanceSize, DivExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5349,7 +5349,7 @@ struct ASTBase
             super(loc, TOK.mod, __traits(classInstanceSize, ModExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5362,7 +5362,7 @@ struct ASTBase
             super(loc, TOK.add, __traits(classInstanceSize, AddExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5375,7 +5375,7 @@ struct ASTBase
             super(loc, TOK.min, __traits(classInstanceSize, MinExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5388,7 +5388,7 @@ struct ASTBase
             super(loc, TOK.concatenate, __traits(classInstanceSize, CatExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5401,7 +5401,7 @@ struct ASTBase
             super(loc, TOK.leftShift, __traits(classInstanceSize, ShlExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5414,7 +5414,7 @@ struct ASTBase
             super(loc, TOK.rightShift, __traits(classInstanceSize, ShrExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5427,7 +5427,7 @@ struct ASTBase
             super(loc, TOK.unsignedRightShift, __traits(classInstanceSize, UshrExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5441,7 +5441,7 @@ struct ASTBase
             assert(op == TOK.equal || op == TOK.notEqual);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5454,7 +5454,7 @@ struct ASTBase
             super(loc, TOK.in_, __traits(classInstanceSize, InExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5467,7 +5467,7 @@ struct ASTBase
             super(loc, op, __traits(classInstanceSize, IdentityExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5480,7 +5480,7 @@ struct ASTBase
             super(loc, op, __traits(classInstanceSize, CmpExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5493,7 +5493,7 @@ struct ASTBase
             super(loc, TOK.and, __traits(classInstanceSize, AndExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5506,7 +5506,7 @@ struct ASTBase
             super(loc, TOK.xor, __traits(classInstanceSize, XorExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5519,7 +5519,7 @@ struct ASTBase
             super(loc, TOK.or, __traits(classInstanceSize, OrExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5532,7 +5532,7 @@ struct ASTBase
             super(loc, op, __traits(classInstanceSize, LogicalExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5548,7 +5548,7 @@ struct ASTBase
             this.econd = econd;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5561,7 +5561,7 @@ struct ASTBase
             super(loc, TOK.assign, __traits(classInstanceSize, AssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5574,7 +5574,7 @@ struct ASTBase
             super(loc, op, size, e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5587,7 +5587,7 @@ struct ASTBase
             super(loc, TOK.addAssign, __traits(classInstanceSize, AddAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5600,7 +5600,7 @@ struct ASTBase
             super(loc, TOK.minAssign, __traits(classInstanceSize, MinAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5613,7 +5613,7 @@ struct ASTBase
             super(loc, TOK.mulAssign, __traits(classInstanceSize, MulAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5626,7 +5626,7 @@ struct ASTBase
             super(loc, TOK.divAssign, __traits(classInstanceSize, DivAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5639,7 +5639,7 @@ struct ASTBase
             super(loc, TOK.modAssign, __traits(classInstanceSize, ModAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5652,7 +5652,7 @@ struct ASTBase
             super(loc, TOK.powAssign, __traits(classInstanceSize, PowAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5665,7 +5665,7 @@ struct ASTBase
             super(loc, TOK.andAssign, __traits(classInstanceSize, AndAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5678,7 +5678,7 @@ struct ASTBase
             super(loc, TOK.orAssign, __traits(classInstanceSize, OrAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5691,7 +5691,7 @@ struct ASTBase
             super(loc, TOK.xorAssign, __traits(classInstanceSize, XorAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5704,7 +5704,7 @@ struct ASTBase
             super(loc, TOK.leftShiftAssign, __traits(classInstanceSize, ShlAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5717,7 +5717,7 @@ struct ASTBase
             super(loc, TOK.rightShiftAssign, __traits(classInstanceSize, ShrAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5730,7 +5730,7 @@ struct ASTBase
             super(loc, TOK.unsignedRightShiftAssign, __traits(classInstanceSize, UshrAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5743,7 +5743,7 @@ struct ASTBase
             super(loc, TOK.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5762,7 +5762,7 @@ struct ASTBase
 
         abstract TemplateParameter syntaxCopy(){ return null;}
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5783,7 +5783,7 @@ struct ASTBase
             this.defaultAlias = defaultAlias;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5802,7 +5802,7 @@ struct ASTBase
             this.defaultType = defaultType;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5816,7 +5816,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5838,7 +5838,7 @@ struct ASTBase
             this.defaultValue = defaultValue;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5851,7 +5851,7 @@ struct ASTBase
             super(loc, ident, specType, defaultType);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5866,7 +5866,7 @@ struct ASTBase
             this.loc = loc;
         }
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5902,7 +5902,7 @@ struct ASTBase
             this.exp = exp;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5921,7 +5921,7 @@ struct ASTBase
             this.ident = ident;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5934,7 +5934,7 @@ struct ASTBase
             super(mod, level, ident);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5947,7 +5947,7 @@ struct ASTBase
             super(mod, level, ident);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5973,7 +5973,7 @@ struct ASTBase
             return null;
         }
 
-        void accept(Visitor v)
+        void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -5994,7 +5994,7 @@ struct ASTBase
             return this;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -6016,7 +6016,7 @@ struct ASTBase
             this.value.push(value);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -6042,7 +6042,7 @@ struct ASTBase
             type = null;
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }
@@ -6055,7 +6055,7 @@ struct ASTBase
             super(loc);
         }
 
-        override void accept(Visitor v)
+        override void accept(SemanticVisitor v)
         {
             v.visit(this);
         }

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -5,7 +5,7 @@ module dmd.astbase;
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astbase.d
  */
 
-import dmd.parsetime;
+import dmd.visitor.parse_time;
 
 /** The ASTBase  family defines a family of AST nodes appropriate for parsing with
   * no semantic information. It defines all the AST nodes that the parser needs

--- a/src/dmd/asttypename.d
+++ b/src/dmd/asttypename.d
@@ -74,7 +74,7 @@ mixin
     string astTypeNameFunctions;
     string visitOverloads;
 
-    foreach (ov; __traits(getOverloads, Visitor, "visit"))
+    foreach (ov; __traits(getOverloads, SemanticVisitor, "visit"))
     {
         static if (is(typeof(ov) P == function))
         {
@@ -100,9 +100,9 @@ string astTypeName(` ~ P[0].stringof ~ ` node)
     }
 
     return astTypeNameFunctions ~ `
-private extern(C++) final class AstTypeNameVisitor : Visitor
+private extern(C++) final class AstTypeNameVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public :
     string typeName;
 ` ~ visitOverloads ~ "}";

--- a/src/dmd/asttypename.d
+++ b/src/dmd/asttypename.d
@@ -39,7 +39,7 @@ import dmd.root.rootobject;
 import dmd.statement;
 import dmd.staticassert;
 import dmd.nspace;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /// Returns: the typename of the dynamic ast-node-type
 /// (this is a development tool, do not use in actual code)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -30,7 +30,7 @@ import dmd.mtype;
 import dmd.root.outbuffer;
 import dmd.target;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************************************
  */

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -266,7 +266,7 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -371,7 +371,7 @@ extern (C++) class StorageClassDeclaration : AttribDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -423,7 +423,7 @@ extern (C++) final class DeprecatedDeclaration : StorageClassDeclaration
         return AttribDeclaration.setScope(sc);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -464,7 +464,7 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
         return "extern ()";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -500,7 +500,7 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
         return "extern ()";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -600,7 +600,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -634,7 +634,7 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
         return createNewScope(sc, sc.stc, sc.linkage, sc.cppmangle, sc.protection, sc.explicitProtection, this, sc.inlining);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -756,7 +756,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -822,7 +822,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
         return "pragma";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -917,7 +917,7 @@ extern (C++) class ConditionalDeclaration : AttribDeclaration
         }
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1016,7 +1016,7 @@ extern (C++) final class StaticIfDeclaration : ConditionalDeclaration
         return "static if";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1138,7 +1138,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         return "static foreach";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1245,7 +1245,7 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
         return "mixin";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1332,7 +1332,7 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
         return "UserAttribute";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -51,7 +51,7 @@ public:
     void addLocalClass(ClassDeclarations *);
     AttribDeclaration *isAttribDeclaration() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StorageClassDeclaration : public AttribDeclaration
@@ -65,7 +65,7 @@ public:
     void addMember(Scope *sc, ScopeDsymbol *sds);
     StorageClassDeclaration *isStorageClassDeclaration() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DeprecatedDeclaration : public StorageClassDeclaration
@@ -78,7 +78,7 @@ public:
     Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
     const char *getMessage();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class LinkDeclaration : public AttribDeclaration
@@ -90,7 +90,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *toChars();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CPPMangleDeclaration : public AttribDeclaration
@@ -101,7 +101,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *toChars();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ProtDeclaration : public AttribDeclaration
@@ -116,7 +116,7 @@ public:
     const char *kind() const;
     const char *toPrettyChars(bool unused);
     ProtDeclaration *isProtDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AlignDeclaration : public AttribDeclaration
@@ -128,7 +128,7 @@ public:
     AlignDeclaration(Loc loc, Expression *ealign, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AnonDeclaration : public AttribDeclaration
@@ -145,7 +145,7 @@ public:
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;
     AnonDeclaration *isAnonDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PragmaDeclaration : public AttribDeclaration
@@ -156,7 +156,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ConditionalDeclaration : public AttribDeclaration
@@ -170,7 +170,7 @@ public:
     Dsymbols *include(Scope *sc);
     void addComment(const utf8_t *comment);
     void setScope(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticIfDeclaration : public ConditionalDeclaration
@@ -185,7 +185,7 @@ public:
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticForeachDeclaration : public ConditionalDeclaration
@@ -204,7 +204,7 @@ public:
     void setScope(Scope *sc);
     void importAll(Scope *sc);
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ForwardingAttribDeclaration : AttribDeclaration
@@ -231,7 +231,7 @@ public:
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**
@@ -249,7 +249,7 @@ public:
     static Expressions *concat(Expressions *udas1, Expressions *udas2);
     Expressions *getAttributes();
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_ATTRIB_H */

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -26,7 +26,7 @@ import dmd.identifier;
 import dmd.mtype;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /**
  * BE stands for BlockExit.

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -62,9 +62,9 @@ enum BE : int
  */
 int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
 {
-    extern (C++) final class BlockExit : Visitor
+    extern (C++) final class BlockExit : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         FuncDeclaration func;
         bool mustNotThrow;

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -27,7 +27,7 @@ import dmd.init;
 import dmd.mtype;
 import dmd.root.rootobject;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.stoppable;
 
 /********************************************
  * Returns true if the expression may throw exceptions.

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -63,7 +63,7 @@ extern (C++) abstract class Condition : RootObject
         return null;
     }
 
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -441,7 +441,7 @@ extern (C++) class DVCondition : Condition
         return this; // don't need to copy
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -535,7 +535,7 @@ extern (C++) final class DebugCondition : DVCondition
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -800,7 +800,7 @@ extern (C++) final class VersionCondition : DVCondition
         return (inc == 1);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -876,7 +876,7 @@ extern (C++) final class StaticIfCondition : Condition
         return (inc == 1);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -27,7 +27,7 @@ import dmd.root.outbuffer;
 import dmd.root.rootobject;
 import dmd.tokens;
 import dmd.utils;
-import dmd.visitor;
+import dmd.visitor.semantic;
 import dmd.id;
 import dmd.statement;
 import dmd.declaration;

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -38,7 +38,7 @@ public:
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticForeach
@@ -62,7 +62,7 @@ public:
     Module *mod;
 
     Condition *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DebugCondition : public DVCondition
@@ -73,7 +73,7 @@ public:
 
     int include(Scope *sc);
     DebugCondition *isDebugCondition() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class VersionCondition : public DVCondition
@@ -84,7 +84,7 @@ public:
     static void addPredefinedGlobalIdent(const char *ident);
 
     int include(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticIfCondition : public Condition
@@ -95,7 +95,7 @@ public:
 
     Condition *syntaxCopy();
     int include(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -12,7 +12,7 @@
 #define DMD_DEBCOND_H
 
 #include "globals.h"
-#include "visitor.h"
+#include "visitors.h"
 
 class Expression;
 class Identifier;

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -64,9 +64,9 @@ const(char)* cppTypeInfoMangleItanium(Dsymbol s)
     return buf.extractString();
 }
 
-private final class CppMangleVisitor : Visitor
+private final class CppMangleVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
     Objects components;         // array of components available for substitution
     OutBuffer* buf;             // append the mangling to buf[]
     Loc loc;                    // location for use in error messages

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -41,7 +41,7 @@ import dmd.root.rootobject;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 extern (C++):
 

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -49,12 +49,12 @@ const(char)* cppTypeInfoMangleMSVC(Dsymbol s)
     assert(0);
 }
 
-private final class VisualCPPMangler : Visitor
+private final class VisualCPPMangler : SemanticVisitor
 {
     enum VC_SAVED_TYPE_CNT = 10u;
     enum VC_SAVED_IDENT_CNT = 10u;
 
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
     const(char)*[VC_SAVED_IDENT_CNT] saved_idents;
     Type[VC_SAVED_TYPE_CNT] saved_types;
 

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -29,7 +29,7 @@ import dmd.root.rootobject;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /* Do mangling for C++ linkage for Digital Mars C++ and Microsoft Visual C++
  */

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -47,7 +47,7 @@ public:
     /// Return index of the field, or -1 if not found
     /// Same as getFieldIndex, but checks for a direct match with the VarDeclaration
     int findFieldIndexByName(VarDeclaration *v);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // The various functions are used only to detect compiler CTFE bugs
@@ -66,7 +66,7 @@ public:
     VarDeclaration *var;
 
     const char *toChars();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Create an appropriate void initializer
@@ -82,7 +82,7 @@ public:
     const char *toChars();
     /// Generate an error message when this exception is not caught
     void generateUncaughtError();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /****************************************************************/

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -32,7 +32,7 @@ import dmd.root.port;
 import dmd.root.rmem;
 import dmd.target;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************************************
  * Global status of the CTFE engine. Mostly used for performance diagnostics

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -113,7 +113,7 @@ extern (C++) final class ClassReferenceExp : Expression
         return -1;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -138,7 +138,7 @@ extern (C++) final class VoidInitExp : Expression
         return "void";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -190,7 +190,7 @@ extern (C++) final class ThrownExceptionExp : Expression
             errorSupplemental(loc, "thrown from here");
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -49,9 +49,9 @@ enum LOG = false;
  */
 extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
 {
-    extern (C++) final class ImplicitCastTo : Visitor
+    extern (C++) final class ImplicitCastTo : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Type t;
         Scope* sc;
@@ -178,9 +178,9 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
  */
 extern (C++) MATCH implicitConvTo(Expression e, Type t)
 {
-    extern (C++) final class ImplicitConvTo : Visitor
+    extern (C++) final class ImplicitConvTo : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Type t;
         MATCH result;
@@ -1400,9 +1400,9 @@ extern (C++) Type toStaticArrayType(SliceExp e)
  */
 extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 {
-    extern (C++) final class CastTo : Visitor
+    extern (C++) final class CastTo : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Type t;
         Scope* sc;
@@ -2463,9 +2463,9 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
  */
 extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
 {
-    extern (C++) final class InferType : Visitor
+    extern (C++) final class InferType : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Type t;
         int flag;
@@ -3470,9 +3470,9 @@ extern (C++) bool arrayTypeCompatibleWithoutCasting(Type t1, Type t2)
  */
 extern (C++) IntRange getIntRange(Expression e)
 {
-    extern (C++) final class IntRangeVisitor : Visitor
+    extern (C++) final class IntRangeVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
     public:
         IntRange range;

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -39,7 +39,7 @@ import dmd.root.rmem;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.utf;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum LOG = false;
 

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -29,7 +29,7 @@ import dmd.identifier;
 import dmd.mtype;
 import dmd.root.rmem;
 import dmd.target;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum Abstract : int
 {

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -989,7 +989,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1132,7 +1132,7 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -36,7 +36,7 @@ import dmd.root.rootobject;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /************************************
  * Check to see the aggregate type is nested and its context pointer is

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -530,7 +530,7 @@ extern (C++) abstract class Declaration : Dsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -661,7 +661,7 @@ extern (C++) final class TupleDeclaration : Declaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -923,7 +923,7 @@ extern (C++) final class AliasDeclaration : Declaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1038,7 +1038,7 @@ extern (C++) final class OverDeclaration : Declaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1606,7 +1606,7 @@ extern (C++) class VarDeclaration : Declaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1646,7 +1646,7 @@ extern (C++) final class SymbolDeclaration : Declaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1693,7 +1693,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1718,7 +1718,7 @@ extern (C++) final class TypeInfoStructDeclaration : TypeInfoDeclaration
         return new TypeInfoStructDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1743,7 +1743,7 @@ extern (C++) final class TypeInfoClassDeclaration : TypeInfoDeclaration
         return new TypeInfoClassDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1768,7 +1768,7 @@ extern (C++) final class TypeInfoInterfaceDeclaration : TypeInfoDeclaration
         return new TypeInfoInterfaceDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1793,7 +1793,7 @@ extern (C++) final class TypeInfoPointerDeclaration : TypeInfoDeclaration
         return new TypeInfoPointerDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1818,7 +1818,7 @@ extern (C++) final class TypeInfoArrayDeclaration : TypeInfoDeclaration
         return new TypeInfoArrayDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1843,7 +1843,7 @@ extern (C++) final class TypeInfoStaticArrayDeclaration : TypeInfoDeclaration
         return new TypeInfoStaticArrayDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1868,7 +1868,7 @@ extern (C++) final class TypeInfoAssociativeArrayDeclaration : TypeInfoDeclarati
         return new TypeInfoAssociativeArrayDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1893,7 +1893,7 @@ extern (C++) final class TypeInfoEnumDeclaration : TypeInfoDeclaration
         return new TypeInfoEnumDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1918,7 +1918,7 @@ extern (C++) final class TypeInfoFunctionDeclaration : TypeInfoDeclaration
         return new TypeInfoFunctionDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1943,7 +1943,7 @@ extern (C++) final class TypeInfoDelegateDeclaration : TypeInfoDeclaration
         return new TypeInfoDelegateDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1968,7 +1968,7 @@ extern (C++) final class TypeInfoTupleDeclaration : TypeInfoDeclaration
         return new TypeInfoTupleDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1993,7 +1993,7 @@ extern (C++) final class TypeInfoConstDeclaration : TypeInfoDeclaration
         return new TypeInfoConstDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2018,7 +2018,7 @@ extern (C++) final class TypeInfoInvariantDeclaration : TypeInfoDeclaration
         return new TypeInfoInvariantDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2043,7 +2043,7 @@ extern (C++) final class TypeInfoSharedDeclaration : TypeInfoDeclaration
         return new TypeInfoSharedDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2068,7 +2068,7 @@ extern (C++) final class TypeInfoWildDeclaration : TypeInfoDeclaration
         return new TypeInfoWildDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2093,7 +2093,7 @@ extern (C++) final class TypeInfoVectorDeclaration : TypeInfoDeclaration
         return new TypeInfoVectorDeclaration(tinfo);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2120,7 +2120,7 @@ extern (C++) final class ThisDeclaration : VarDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -164,7 +164,7 @@ public:
     Prot prot();
 
     Declaration *isDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**************************************************************/
@@ -184,7 +184,7 @@ public:
     bool needThis();
 
     TupleDeclaration *isTupleDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**************************************************************/
@@ -206,7 +206,7 @@ public:
     bool isOverloadable();
 
     AliasDeclaration *isAliasDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**************************************************************/
@@ -227,7 +227,7 @@ public:
     bool isOverloadable();
 
     OverDeclaration *isOverDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**************************************************************/
@@ -283,7 +283,7 @@ public:
     Dsymbol *toAlias();
     // Eliminate need for dynamic_cast
     VarDeclaration *isVarDeclaration() { return (VarDeclaration *)this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**************************************************************/
@@ -297,7 +297,7 @@ public:
 
     // Eliminate need for dynamic_cast
     SymbolDeclaration *isSymbolDeclaration() { return (SymbolDeclaration *)this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoDeclaration : public VarDeclaration
@@ -310,7 +310,7 @@ public:
     const char *toChars();
 
     TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoStructDeclaration : public TypeInfoDeclaration
@@ -318,7 +318,7 @@ class TypeInfoStructDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoStructDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoClassDeclaration : public TypeInfoDeclaration
@@ -326,7 +326,7 @@ class TypeInfoClassDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoClassDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoInterfaceDeclaration : public TypeInfoDeclaration
@@ -334,7 +334,7 @@ class TypeInfoInterfaceDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoInterfaceDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoPointerDeclaration : public TypeInfoDeclaration
@@ -342,7 +342,7 @@ class TypeInfoPointerDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoPointerDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoArrayDeclaration : public TypeInfoDeclaration
@@ -350,7 +350,7 @@ class TypeInfoArrayDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoArrayDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoStaticArrayDeclaration : public TypeInfoDeclaration
@@ -358,7 +358,7 @@ class TypeInfoStaticArrayDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoStaticArrayDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoAssociativeArrayDeclaration : public TypeInfoDeclaration
@@ -366,7 +366,7 @@ class TypeInfoAssociativeArrayDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoAssociativeArrayDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoEnumDeclaration : public TypeInfoDeclaration
@@ -374,7 +374,7 @@ class TypeInfoEnumDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoEnumDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoFunctionDeclaration : public TypeInfoDeclaration
@@ -382,7 +382,7 @@ class TypeInfoFunctionDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoFunctionDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoDelegateDeclaration : public TypeInfoDeclaration
@@ -390,7 +390,7 @@ class TypeInfoDelegateDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoDelegateDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoTupleDeclaration : public TypeInfoDeclaration
@@ -398,7 +398,7 @@ class TypeInfoTupleDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoTupleDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoConstDeclaration : public TypeInfoDeclaration
@@ -406,7 +406,7 @@ class TypeInfoConstDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoConstDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoInvariantDeclaration : public TypeInfoDeclaration
@@ -414,7 +414,7 @@ class TypeInfoInvariantDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoInvariantDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoSharedDeclaration : public TypeInfoDeclaration
@@ -422,7 +422,7 @@ class TypeInfoSharedDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoSharedDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoWildDeclaration : public TypeInfoDeclaration
@@ -430,7 +430,7 @@ class TypeInfoWildDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoWildDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeInfoVectorDeclaration : public TypeInfoDeclaration
@@ -438,7 +438,7 @@ class TypeInfoVectorDeclaration : public TypeInfoDeclaration
 public:
     static TypeInfoVectorDeclaration *create(Type *tinfo);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**************************************************************/
@@ -448,7 +448,7 @@ class ThisDeclaration : public VarDeclaration
 public:
     Dsymbol *syntaxCopy(Dsymbol *);
     ThisDeclaration *isThisDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 enum ILS
@@ -644,7 +644,7 @@ public:
     FuncDeclaration *isFuncDeclaration() { return this; }
 
     virtual FuncDeclaration *toAliasFunc() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 FuncDeclaration *resolveFuncCall(Loc loc, Scope *sc, Dsymbol *s,
@@ -663,7 +663,7 @@ public:
     const char *kind() const;
 
     FuncDeclaration *toAliasFunc();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class FuncLiteralDeclaration : public FuncDeclaration
@@ -688,7 +688,7 @@ public:
     FuncLiteralDeclaration *isFuncLiteralDeclaration() { return this; }
     const char *kind() const;
     const char *toPrettyChars(bool QualifyTypes = false);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CtorDeclaration : public FuncDeclaration
@@ -702,7 +702,7 @@ public:
     bool addPostInvariant();
 
     CtorDeclaration *isCtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PostBlitDeclaration : public FuncDeclaration
@@ -715,7 +715,7 @@ public:
     bool overloadInsert(Dsymbol *s);
 
     PostBlitDeclaration *isPostBlitDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DtorDeclaration : public FuncDeclaration
@@ -730,7 +730,7 @@ public:
     bool overloadInsert(Dsymbol *s);
 
     DtorDeclaration *isDtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticCtorDeclaration : public FuncDeclaration
@@ -744,7 +744,7 @@ public:
     bool hasStaticCtorOrDtor();
 
     StaticCtorDeclaration *isStaticCtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SharedStaticCtorDeclaration : public StaticCtorDeclaration
@@ -753,7 +753,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
 
     SharedStaticCtorDeclaration *isSharedStaticCtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticDtorDeclaration : public FuncDeclaration
@@ -769,7 +769,7 @@ public:
     bool addPostInvariant();
 
     StaticDtorDeclaration *isStaticDtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SharedStaticDtorDeclaration : public StaticDtorDeclaration
@@ -778,7 +778,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
 
     SharedStaticDtorDeclaration *isSharedStaticDtorDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class InvariantDeclaration : public FuncDeclaration
@@ -790,7 +790,7 @@ public:
     bool addPostInvariant();
 
     InvariantDeclaration *isInvariantDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class UnitTestDeclaration : public FuncDeclaration
@@ -808,7 +808,7 @@ public:
     bool addPostInvariant();
 
     UnitTestDeclaration *isUnitTestDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class NewDeclaration : public FuncDeclaration
@@ -824,7 +824,7 @@ public:
     bool addPostInvariant();
 
     NewDeclaration *isNewDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 
@@ -841,7 +841,7 @@ public:
     bool addPostInvariant();
 
     DeleteDeclaration *isDeleteDeclaration() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_DECLARATION_H */

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -25,7 +25,7 @@ import dmd.initsem;
 import dmd.mtype;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.stoppable;
 
 
 /*********************************

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -319,7 +319,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
 
     Symbol* sinit;
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -377,7 +377,7 @@ extern (C++) final class EnumMember : VarDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -26,7 +26,7 @@ import dmd.init;
 import dmd.mtype;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************************************
  */

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -23,7 +23,7 @@ import dmd.expression;
 import dmd.globals;
 import dmd.identifier;
 import dmd.mtype;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************************************
  */

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -304,7 +304,7 @@ extern (C++) final class Import : Dsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -984,9 +984,9 @@ private Expression interpret(FuncDeclaration fd, InterState* istate, Expressions
     return e;
 }
 
-private extern (C++) final class Interpreter : Visitor
+private extern (C++) final class Interpreter : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     InterState* istate;
     CtfeGoal goal;

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -41,7 +41,9 @@ import dmd.root.rootobject;
 import dmd.statement;
 import dmd.tokens;
 import dmd.utf;
-import dmd.visitor;
+import dmd.visitor.stoppable;
+import dmd.visitor.transitive;
+import dmd.visitor.semantic;
 
 enum CtfeGoal : int
 {

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -166,9 +166,9 @@ private void MODtoDecoBuffer(OutBuffer* buf, MOD mod)
     }
 }
 
-private extern (C++) final class Mangler : Visitor
+private extern (C++) final class Mangler : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     static assert(Key.sizeof == size_t.sizeof);
     AA* types;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -35,7 +35,7 @@ import dmd.root.aav;
 import dmd.target;
 import dmd.tokens;
 import dmd.utf;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 private immutable char[TMAX] mangleChar =
 [

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -38,7 +38,7 @@ import dmd.root.port;
 import dmd.semantic2;
 import dmd.semantic3;
 import dmd.target;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 version(Windows) {
     extern (C) char* getcwd(char* buffer, size_t maxlen);

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -265,7 +265,7 @@ extern (C++) class Package : ScopeDsymbol
         return ScopeDsymbol.search(loc, ident, flags);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1317,7 +1317,7 @@ extern (C++) final class Module : Package
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -818,9 +818,9 @@ extern (C++) void emitProtection(OutBuffer* buf, Prot prot)
 
 private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
 {
-    extern (C++) final class EmitComment : Visitor
+    extern (C++) final class EmitComment : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         OutBuffer* buf;
         Scope* sc;
@@ -1093,9 +1093,9 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
 
 private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
 {
-    extern (C++) final class ToDocBuffer : Visitor
+    extern (C++) final class ToDocBuffer : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         OutBuffer* buf;
         Scope* sc;

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -47,7 +47,7 @@ import dmd.root.rmem;
 import dmd.tokens;
 import dmd.utf;
 import dmd.utils;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 struct Escape
 {

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -34,7 +34,7 @@ import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.typinf;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***************************************
  * Search sd for a member function of the form:

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -69,9 +69,9 @@ extern (C++) FuncDeclaration search_toString(StructDeclaration sd)
  */
 extern (C++) void semanticTypeInfo(Scope* sc, Type t)
 {
-    extern (C++) final class FullTypeInfoVisitor : Visitor
+    extern (C++) final class FullTypeInfoVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Scope* sc;
 
@@ -575,7 +575,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -608,7 +608,7 @@ extern (C++) final class UnionDeclaration : StructDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1224,7 +1224,7 @@ extern (C++) class Dsymbol : RootObject
 
     /************
      */
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1687,7 +1687,7 @@ public:
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1744,7 +1744,7 @@ extern (C++) final class WithScopeSymbol : ScopeDsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1956,7 +1956,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1994,7 +1994,7 @@ extern (C++) final class OverloadSet : Dsymbol
         return "overloadset";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -49,7 +49,7 @@ import dmd.root.rootobject;
 import dmd.root.speller;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 struct Ungag
 {

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -283,7 +283,7 @@ public:
     virtual ProtDeclaration *isProtDeclaration() { return NULL; }
     virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Dsymbol that generates a scope
@@ -320,7 +320,7 @@ public:
     static Dsymbol *getNth(Dsymbols *members, size_t nth, size_t *pn = NULL);
 
     ScopeDsymbol *isScopeDsymbol() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // With statement scope
@@ -333,7 +333,7 @@ public:
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
 
     WithScopeSymbol *isWithScopeSymbol() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Array Index/Slice scope
@@ -349,7 +349,7 @@ public:
     Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
 
     ArrayScopeSymbol *isArrayScopeSymbol() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Overload Sets
@@ -362,7 +362,7 @@ public:
     void push(Dsymbol *s);
     OverloadSet *isOverloadSet() { return this; }
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Forwarding ScopeDsymbol

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -20,7 +20,7 @@
 
 #include "mars.h"
 #include "arraytypes.h"
-#include "visitor.h"
+#include "visitors.h"
 
 class Identifier;
 struct Scope;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -174,9 +174,9 @@ package bool allowsContractWithoutBody(FuncDeclaration funcdecl)
     return true;
 }
 
-private extern(C++) final class DsymbolSemanticVisitor : Visitor
+private extern(C++) final class DsymbolSemanticVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Scope* sc;
     this(Scope* sc)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -68,7 +68,7 @@ import dmd.statement;
 import dmd.target;
 import dmd.templateparamsem;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum LOG = false;
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2266,7 +2266,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3203,9 +3203,9 @@ __gshared Expression emptyArrayElement = null;
  */
 MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm = null, size_t inferStart = 0)
 {
-    extern (C++) final class DeduceType : Visitor
+    extern (C++) final class DeduceType : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Scope* sc;
         Type tparam;
@@ -4657,9 +4657,9 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
  */
 bool reliesOnTident(Type t, TemplateParameters* tparams = null, size_t iStart = 0)
 {
-    extern (C++) final class ReliesOnTident : Visitor
+    extern (C++) final class ReliesOnTident : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         TemplateParameters* tparams;
         size_t iStart;
@@ -5125,7 +5125,7 @@ extern (C++) class TemplateParameter
      */
     abstract void* dummyArg();
 
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5293,7 +5293,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
         return cast(void*)t;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5320,7 +5320,7 @@ extern (C++) final class TemplateThisParameter : TemplateTypeParameter
         return new TemplateThisParameter(loc, ident, specType ? specType.syntaxCopy() : null, defaultType ? defaultType.syntaxCopy() : null);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5549,7 +5549,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
         return cast(void*)e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5767,7 +5767,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
         return cast(void*)s;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5901,7 +5901,7 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
         return null;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7503,7 +7503,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7801,7 +7801,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -46,7 +46,7 @@ import dmd.semantic2;
 import dmd.semantic3;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 import dmd.templateparamsem;
 

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -106,7 +106,7 @@ extern (C++) final class DebugSymbol : Dsymbol
         return "debug";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -196,7 +196,7 @@ extern (C++) final class VersionSymbol : Dsymbol
         return "version";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -21,7 +21,7 @@ import dmd.dsymbolsem;
 import dmd.globals;
 import dmd.identifier;
 import dmd.root.outbuffer;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************************************
  * DebugSymbol's happen for statements like:

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -56,7 +56,7 @@ import dmd.toir;
 import dmd.tokens;
 import dmd.toobj;
 import dmd.typinf;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1040,7 +1040,7 @@ void clearStringTab()
 
 elem *toElem(Expression e, IRState *irs)
 {
-    extern (C++) class ToElemVisitor : Visitor
+    extern (C++) class ToElemVisitor : SemanticVisitor
     {
         IRState *irs;
         elem *result;
@@ -1051,7 +1051,7 @@ elem *toElem(Expression e, IRState *irs)
             result = null;
         }
 
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
         /***************************************
          */

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -64,7 +64,7 @@ public:
     EnumDeclaration *isEnumDeclaration() { return this; }
 
     Symbol *sinit;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 
@@ -91,7 +91,7 @@ public:
     Expression *getVarExp(Loc loc, Scope *sc);
 
     EnumMember *isEnumMember() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_ENUM_H */

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -792,9 +792,9 @@ private void inferReturn(FuncDeclaration fd, VarDeclaration v)
 private void escapeByValue(Expression e, EscapeByResults* er)
 {
     //printf("[%s] escapeByValue, e: %s\n", e.loc.toChars(), e.toChars());
-    extern (C++) final class EscapeVisitor : Visitor
+    extern (C++) final class EscapeVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         EscapeByResults* er;
 
@@ -1076,9 +1076,9 @@ private void escapeByValue(Expression e, EscapeByResults* er)
 private void escapeByRef(Expression e, EscapeByResults* er)
 {
     //printf("[%s] escapeByRef, e: %s\n", e.loc.toChars(), e.toChars());
-    extern (C++) final class EscapeRefVisitor : Visitor
+    extern (C++) final class EscapeRefVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         EscapeByResults* er;
 

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -27,7 +27,7 @@ import dmd.init;
 import dmd.mtype;
 import dmd.root.rootobject;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 import dmd.arraytypes;
 
 /****************************************

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2452,7 +2452,7 @@ extern (C++) abstract class Expression : RootObject
         return true;
     }
 
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2549,7 +2549,7 @@ extern (C++) final class IntegerExp : Expression
         return new ErrorExp();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2642,7 +2642,7 @@ extern (C++) final class ErrorExp : Expression
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2714,7 +2714,7 @@ extern (C++) final class RealExp : Expression
         return result ? cast(bool)value : !cast(bool)value;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2787,7 +2787,7 @@ extern (C++) final class ComplexExp : Expression
             return !value;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2820,7 +2820,7 @@ extern (C++) class IdentifierExp : Expression
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2835,7 +2835,7 @@ extern (C++) final class DollarExp : IdentifierExp
         super(loc, Id.dollar);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2866,7 +2866,7 @@ extern (C++) final class DsymbolExp : Expression
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2906,7 +2906,7 @@ extern (C++) class ThisExp : Expression
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2923,7 +2923,7 @@ extern (C++) final class SuperExp : ThisExp
         op = TOK.super_;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2971,7 +2971,7 @@ extern (C++) final class NullExp : Expression
         return null;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3337,7 +3337,7 @@ extern (C++) final class StringExp : Expression
         return this.string[0 .. len];
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3437,7 +3437,7 @@ extern (C++) final class TupleExp : Expression
         return false;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3630,7 +3630,7 @@ extern (C++) final class ArrayLiteralExp : Expression
         return null;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3694,7 +3694,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
         return result ? (dim != 0) : (dim == 0);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3894,7 +3894,7 @@ extern (C++) final class StructLiteralExp : Expression
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3929,7 +3929,7 @@ extern (C++) final class TypeExp : Expression
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3988,7 +3988,7 @@ extern (C++) final class ScopeExp : Expression
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4036,7 +4036,7 @@ extern (C++) final class TemplateExp : Expression
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4081,7 +4081,7 @@ extern (C++) final class NewExp : Expression
             arraySyntaxCopy(arguments));
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4111,7 +4111,7 @@ extern (C++) final class NewAnonClassExp : Expression
         return new NewAnonClassExp(loc, thisexp ? thisexp.syntaxCopy() : null, arraySyntaxCopy(newargs), cast(ClassDeclaration)cd.syntaxCopy(null), arraySyntaxCopy(arguments));
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4132,7 +4132,7 @@ extern (C++) class SymbolExp : Expression
         this.hasOverloads = hasOverloads;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4164,7 +4164,7 @@ extern (C++) final class SymOffExp : SymbolExp
         return result ? true : false;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4259,7 +4259,7 @@ extern (C++) final class VarExp : SymbolExp
         return Expression.modifiableLvalue(sc, e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4290,7 +4290,7 @@ extern (C++) final class OverExp : Expression
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4577,7 +4577,7 @@ extern (C++) final class FuncExp : Expression
         return false;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4614,7 +4614,7 @@ extern (C++) final class DeclarationExp : Expression
         return false;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4638,7 +4638,7 @@ extern (C++) final class TypeidExp : Expression
         return new TypeidExp(loc, objectSyntaxCopy(obj));
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4664,7 +4664,7 @@ extern (C++) final class TraitsExp : Expression
         return new TraitsExp(loc, ident, TemplateInstance.arraySyntaxCopy(args));
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4679,7 +4679,7 @@ extern (C++) final class HaltExp : Expression
         super(loc, TOK.halt, __traits(classInstanceSize, HaltExp));
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4723,7 +4723,7 @@ extern (C++) final class IsExp : Expression
         return new IsExp(loc, targ.syntaxCopy(), id, tok, tspec ? tspec.syntaxCopy() : null, tok2, p);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4790,7 +4790,7 @@ extern (C++) class UnaExp : Expression
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5081,7 +5081,7 @@ extern (C++) abstract class BinExp : Expression
         return Expression.combine(e0, be);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5113,7 +5113,7 @@ extern (C++) class BinAssignExp : BinExp
         return toLvalue(sc, this);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5128,7 +5128,7 @@ extern (C++) final class CompileExp : UnaExp
         super(loc, TOK.mixin_, __traits(classInstanceSize, CompileExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5143,7 +5143,7 @@ extern (C++) final class ImportExp : UnaExp
         super(loc, TOK.import_, __traits(classInstanceSize, ImportExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5167,7 +5167,7 @@ extern (C++) final class AssertExp : UnaExp
         return new AssertExp(loc, e1.syntaxCopy(), msg ? msg.syntaxCopy() : null);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5192,7 +5192,7 @@ extern (C++) final class DotIdExp : UnaExp
         return new DotIdExp(loc, e, ident);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5211,7 +5211,7 @@ extern (C++) final class DotTemplateExp : UnaExp
         this.td = td;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5273,7 +5273,7 @@ extern (C++) final class DotVarExp : UnaExp
         return Expression.modifiableLvalue(sc, e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5347,7 +5347,7 @@ extern (C++) final class DotTemplateInstanceExp : UnaExp
         return ti.updateTempDecl(sc, s);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5367,7 +5367,7 @@ extern (C++) final class DelegateExp : UnaExp
         this.hasOverloads = hasOverloads;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5385,7 +5385,7 @@ extern (C++) final class DotTypeExp : UnaExp
         this.sym = s;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5508,7 +5508,7 @@ extern (C++) final class CallExp : UnaExp
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5563,7 +5563,7 @@ extern (C++) final class AddrExp : UnaExp
         super(loc, TOK.address, __traits(classInstanceSize, AddrExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5617,7 +5617,7 @@ extern (C++) final class PtrExp : UnaExp
         return Expression.modifiableLvalue(sc, e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5632,7 +5632,7 @@ extern (C++) final class NegExp : UnaExp
         super(loc, TOK.negate, __traits(classInstanceSize, NegExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5647,7 +5647,7 @@ extern (C++) final class UAddExp : UnaExp
         super(loc, TOK.uadd, __traits(classInstanceSize, UAddExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5662,7 +5662,7 @@ extern (C++) final class ComExp : UnaExp
         super(loc, TOK.tilde, __traits(classInstanceSize, ComExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5677,7 +5677,7 @@ extern (C++) final class NotExp : UnaExp
         super(loc, TOK.not, __traits(classInstanceSize, NotExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5701,7 +5701,7 @@ extern (C++) final class DeleteExp : UnaExp
         return new ErrorExp();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5734,7 +5734,7 @@ extern (C++) final class CastExp : UnaExp
         return to ? new CastExp(loc, e1.syntaxCopy(), to.syntaxCopy()) : new CastExp(loc, e1.syntaxCopy(), mod);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5764,7 +5764,7 @@ extern (C++) final class VectorExp : UnaExp
         return new VectorExp(loc, e1.syntaxCopy(), to.syntaxCopy());
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5842,7 +5842,7 @@ extern (C++) final class SliceExp : UnaExp
         return e1.isBool(result);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5893,7 +5893,7 @@ extern (C++) final class ArrayLengthExp : UnaExp
         return e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5946,7 +5946,7 @@ extern (C++) final class ArrayExp : UnaExp
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5961,7 +5961,7 @@ extern (C++) final class DotExp : BinExp
         super(loc, TOK.dot, __traits(classInstanceSize, DotExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6031,7 +6031,7 @@ extern (C++) final class CommaExp : BinExp
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6077,7 +6077,7 @@ extern (C++) final class IntervalExp : Expression
         return new IntervalExp(loc, lwr.syntaxCopy(), upr.syntaxCopy());
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6111,7 +6111,7 @@ extern (C++) final class DelegatePtrExp : UnaExp
         return Expression.modifiableLvalue(sc, e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6147,7 +6147,7 @@ extern (C++) final class DelegateFuncptrExp : UnaExp
         return Expression.modifiableLvalue(sc, e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6227,7 +6227,7 @@ extern (C++) final class IndexExp : BinExp
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6243,7 +6243,7 @@ extern (C++) final class PostExp : BinExp
         super(loc, op, __traits(classInstanceSize, PostExp), e, new IntegerExp(loc, 1, Type.tint32));
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6259,7 +6259,7 @@ extern (C++) final class PreExp : UnaExp
         super(loc, op, __traits(classInstanceSize, PreExp), e);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6319,7 +6319,7 @@ extern (C++) class AssignExp : BinExp
         return new ErrorExp();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6349,7 +6349,7 @@ extern (C++) final class ConstructExp : AssignExp
             memset |= MemorySet.referenceInit;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6379,7 +6379,7 @@ extern (C++) final class BlitExp : AssignExp
             memset |= MemorySet.referenceInit;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6394,7 +6394,7 @@ extern (C++) final class AddAssignExp : BinAssignExp
         super(loc, TOK.addAssign, __traits(classInstanceSize, AddAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6409,7 +6409,7 @@ extern (C++) final class MinAssignExp : BinAssignExp
         super(loc, TOK.minAssign, __traits(classInstanceSize, MinAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6424,7 +6424,7 @@ extern (C++) final class MulAssignExp : BinAssignExp
         super(loc, TOK.mulAssign, __traits(classInstanceSize, MulAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6439,7 +6439,7 @@ extern (C++) final class DivAssignExp : BinAssignExp
         super(loc, TOK.divAssign, __traits(classInstanceSize, DivAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6454,7 +6454,7 @@ extern (C++) final class ModAssignExp : BinAssignExp
         super(loc, TOK.modAssign, __traits(classInstanceSize, ModAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6469,7 +6469,7 @@ extern (C++) final class AndAssignExp : BinAssignExp
         super(loc, TOK.andAssign, __traits(classInstanceSize, AndAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6484,7 +6484,7 @@ extern (C++) final class OrAssignExp : BinAssignExp
         super(loc, TOK.orAssign, __traits(classInstanceSize, OrAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6499,7 +6499,7 @@ extern (C++) final class XorAssignExp : BinAssignExp
         super(loc, TOK.xorAssign, __traits(classInstanceSize, XorAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6514,7 +6514,7 @@ extern (C++) final class PowAssignExp : BinAssignExp
         super(loc, TOK.powAssign, __traits(classInstanceSize, PowAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6529,7 +6529,7 @@ extern (C++) final class ShlAssignExp : BinAssignExp
         super(loc, TOK.leftShiftAssign, __traits(classInstanceSize, ShlAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6544,7 +6544,7 @@ extern (C++) final class ShrAssignExp : BinAssignExp
         super(loc, TOK.rightShiftAssign, __traits(classInstanceSize, ShrAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6559,7 +6559,7 @@ extern (C++) final class UshrAssignExp : BinAssignExp
         super(loc, TOK.unsignedRightShiftAssign, __traits(classInstanceSize, UshrAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6582,7 +6582,7 @@ extern (C++) final class CatAssignExp : BinAssignExp
         super(loc, TOK.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6598,7 +6598,7 @@ extern (C++) final class AddExp : BinExp
         super(loc, TOK.add, __traits(classInstanceSize, AddExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6613,7 +6613,7 @@ extern (C++) final class MinExp : BinExp
         super(loc, TOK.min, __traits(classInstanceSize, MinExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6629,7 +6629,7 @@ extern (C++) final class CatExp : BinExp
         super(loc, TOK.concatenate, __traits(classInstanceSize, CatExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6645,7 +6645,7 @@ extern (C++) final class MulExp : BinExp
         super(loc, TOK.mul, __traits(classInstanceSize, MulExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6661,7 +6661,7 @@ extern (C++) final class DivExp : BinExp
         super(loc, TOK.div, __traits(classInstanceSize, DivExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6677,7 +6677,7 @@ extern (C++) final class ModExp : BinExp
         super(loc, TOK.mod, __traits(classInstanceSize, ModExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6693,7 +6693,7 @@ extern (C++) final class PowExp : BinExp
         super(loc, TOK.pow, __traits(classInstanceSize, PowExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6708,7 +6708,7 @@ extern (C++) final class ShlExp : BinExp
         super(loc, TOK.leftShift, __traits(classInstanceSize, ShlExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6723,7 +6723,7 @@ extern (C++) final class ShrExp : BinExp
         super(loc, TOK.rightShift, __traits(classInstanceSize, ShrExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6738,7 +6738,7 @@ extern (C++) final class UshrExp : BinExp
         super(loc, TOK.unsignedRightShift, __traits(classInstanceSize, UshrExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6753,7 +6753,7 @@ extern (C++) final class AndExp : BinExp
         super(loc, TOK.and, __traits(classInstanceSize, AndExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6768,7 +6768,7 @@ extern (C++) final class OrExp : BinExp
         super(loc, TOK.or, __traits(classInstanceSize, OrExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6783,7 +6783,7 @@ extern (C++) final class XorExp : BinExp
         super(loc, TOK.xor, __traits(classInstanceSize, XorExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6809,7 +6809,7 @@ extern (C++) final class LogicalExp : BinExp
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6829,7 +6829,7 @@ extern (C++) final class CmpExp : BinExp
         super(loc, op, __traits(classInstanceSize, CmpExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6844,7 +6844,7 @@ extern (C++) final class InExp : BinExp
         super(loc, TOK.in_, __traits(classInstanceSize, InExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6861,7 +6861,7 @@ extern (C++) final class RemoveExp : BinExp
         type = Type.tbool;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6882,7 +6882,7 @@ extern (C++) final class EqualExp : BinExp
         assert(op == TOK.equal || op == TOK.notEqual);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6902,7 +6902,7 @@ extern (C++) final class IdentityExp : BinExp
         super(loc, op, __traits(classInstanceSize, IdentityExp), e1, e2);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7038,7 +7038,7 @@ extern (C++) final class CondExp : BinExp
         //printf("-%s\n", toChars());
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7056,7 +7056,7 @@ extern (C++) class DefaultInitExp : Expression
         this.subop = subop;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7086,7 +7086,7 @@ extern (C++) final class FileInitExp : DefaultInitExp
         return e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7108,7 +7108,7 @@ extern (C++) final class LineInitExp : DefaultInitExp
         return e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7136,7 +7136,7 @@ extern (C++) final class ModuleInitExp : DefaultInitExp
         return e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7166,7 +7166,7 @@ extern (C++) final class FuncInitExp : DefaultInitExp
         return e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7208,7 +7208,7 @@ extern (C++) final class PrettyFuncInitExp : DefaultInitExp
         return e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -62,7 +62,8 @@ import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.utf;
-import dmd.visitor;
+import dmd.visitor.stoppable;
+import dmd.visitor.semantic;
 
 enum LOGSEMANTIC = false;
 void emplaceExp(T : Expression, Args...)(void* p, Args args)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -15,7 +15,7 @@
 #include "identifier.h"
 #include "arraytypes.h"
 #include "intrange.h"
-#include "visitor.h"
+#include "visitors.h"
 #include "tokens.h"
 
 #include "rmem.h"

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -217,7 +217,7 @@ public:
         return true;
     }
 
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class IntegerExp : public Expression
@@ -233,7 +233,7 @@ public:
     complex_t toComplex();
     bool isBool(bool result);
     Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
     dinteger_t getInteger() { return value; }
     void setInteger(dinteger_t value);
     void normalize();
@@ -243,7 +243,7 @@ class ErrorExp : public Expression
 {
 public:
     Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 
     static ErrorExp *errorexp; // handy shared value
 };
@@ -261,7 +261,7 @@ public:
     real_t toImaginary();
     complex_t toComplex();
     bool isBool(bool result);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ComplexExp : public Expression
@@ -277,7 +277,7 @@ public:
     real_t toImaginary();
     complex_t toComplex();
     bool isBool(bool result);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class IdentifierExp : public Expression
@@ -288,13 +288,13 @@ public:
     static IdentifierExp *create(Loc loc, Identifier *ident);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DollarExp : public IdentifierExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DsymbolExp : public Expression
@@ -305,7 +305,7 @@ public:
 
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ThisExp : public Expression
@@ -317,14 +317,14 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SuperExp : public ThisExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class NullExp : public Expression
@@ -335,7 +335,7 @@ public:
     bool equals(RootObject *o);
     bool isBool(bool result);
     StringExp *toStringExp();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StringExp : public Expression
@@ -359,7 +359,7 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     unsigned charAt(uinteger_t i) const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;
     char *toPtr();
@@ -383,7 +383,7 @@ public:
     Expression *syntaxCopy();
     bool equals(RootObject *o);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ArrayLiteralExp : public Expression
@@ -401,7 +401,7 @@ public:
     bool isBool(bool result);
     StringExp *toStringExp();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AssocArrayLiteralExp : public Expression
@@ -415,7 +415,7 @@ public:
     Expression *syntaxCopy();
     bool isBool(bool result);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // scrubReturnValue is running
@@ -465,7 +465,7 @@ public:
     int getFieldIndex(Type *type, unsigned offset);
     Expression *addDtorHook(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DotIdExp;
@@ -477,7 +477,7 @@ public:
     Expression *syntaxCopy();
     bool checkType();
     bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ScopeExp : public Expression
@@ -488,7 +488,7 @@ public:
     Expression *syntaxCopy();
     bool checkType();
     bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TemplateExp : public Expression
@@ -501,7 +501,7 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     bool checkType();
     bool checkValue();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class NewExp : public Expression
@@ -524,7 +524,7 @@ public:
     static NewExp *create(Loc loc, Expression *thisexp, Expressions *newargs, Type *newtype, Expressions *arguments);
     Expression *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class NewAnonClassExp : public Expression
@@ -538,7 +538,7 @@ public:
     Expressions *arguments;     // Array of Expression's to call class constructor
 
     Expression *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SymbolExp : public Expression
@@ -547,7 +547,7 @@ public:
     Declaration *var;
     bool hasOverloads;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Offset from symbol
@@ -559,7 +559,7 @@ public:
 
     bool isBool(bool result);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Variable
@@ -575,7 +575,7 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Overload Set
@@ -587,7 +587,7 @@ public:
 
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Function/Delegate literal
@@ -607,7 +607,7 @@ public:
     bool checkType();
     bool checkValue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Declaration of a symbol
@@ -624,7 +624,7 @@ public:
 
     bool hasCode();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeidExp : public Expression
@@ -633,7 +633,7 @@ public:
     RootObject *obj;
 
     Expression *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TraitsExp : public Expression
@@ -643,14 +643,14 @@ public:
     Objects *args;
 
     Expression *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class HaltExp : public Expression
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class IsExp : public Expression
@@ -667,7 +667,7 @@ public:
     TemplateParameters *parameters;
 
     Expression *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /****************************************************************/
@@ -682,7 +682,7 @@ public:
     Expression *incompatibleTypes();
     Expression *resolveLoc(Loc loc, Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 typedef UnionExp (*fp_t)(Loc loc, Type *, Expression *, Expression *);
@@ -705,7 +705,7 @@ public:
 
     Expression *reorderSettingAAElem(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class BinAssignExp : public BinExp
@@ -715,7 +715,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *ex);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /****************************************************************/
@@ -723,13 +723,13 @@ public:
 class CompileExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ImportExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AssertExp : public UnaExp
@@ -739,7 +739,7 @@ public:
 
     Expression *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DotIdExp : public UnaExp
@@ -750,7 +750,7 @@ public:
     bool wantsym;       // do not replace Symbol with its initializer during semantic()
 
     static DotIdExp *create(Loc loc, Expression *e, Identifier *ident);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DotTemplateExp : public UnaExp
@@ -758,7 +758,7 @@ class DotTemplateExp : public UnaExp
 public:
     TemplateDeclaration *td;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DotVarExp : public UnaExp
@@ -772,7 +772,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DotTemplateInstanceExp : public UnaExp
@@ -782,7 +782,7 @@ public:
 
     Expression *syntaxCopy();
     bool findTempDecl(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DelegateExp : public UnaExp
@@ -792,7 +792,7 @@ public:
     bool hasOverloads;
 
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DotTypeExp : public UnaExp
@@ -800,7 +800,7 @@ class DotTypeExp : public UnaExp
 public:
     Dsymbol *sym;               // symbol that represents a type
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CallExp : public UnaExp
@@ -819,14 +819,14 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *addDtorHook(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AddrExp : public UnaExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PtrExp : public UnaExp
@@ -837,34 +837,34 @@ public:
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class NegExp : public UnaExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class UAddExp : public UnaExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ComExp : public UnaExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class NotExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DeleteExp : public UnaExp
@@ -872,7 +872,7 @@ class DeleteExp : public UnaExp
 public:
     bool isRAII;
     Expression *toBoolean(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CastExp : public UnaExp
@@ -884,7 +884,7 @@ public:
 
     Expression *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class VectorExp : public UnaExp
@@ -895,7 +895,7 @@ public:
 
     static VectorExp *create(Loc loc, Expression *e, Type *t);
     Expression *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SliceExp : public UnaExp
@@ -915,7 +915,7 @@ public:
     Expression *modifiableLvalue(Scope *sc, Expression *e);
     bool isBool(bool result);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ArrayLengthExp : public UnaExp
@@ -923,7 +923,7 @@ class ArrayLengthExp : public UnaExp
 public:
 
     static Expression *rewriteOpAssign(BinExp *exp);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class IntervalExp : public Expression
@@ -933,7 +933,7 @@ public:
     Expression *upr;
 
     Expression *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DelegatePtrExp : public UnaExp
@@ -942,7 +942,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DelegateFuncptrExp : public UnaExp
@@ -951,7 +951,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // e1[a0,a1,a2,a3,...]
@@ -967,7 +967,7 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /****************************************************************/
@@ -975,7 +975,7 @@ public:
 class DotExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CommaExp : public BinExp
@@ -990,7 +990,7 @@ public:
     bool isBool(bool result);
     Expression *toBoolean(Scope *sc);
     Expression *addDtorHook(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class IndexExp : public BinExp
@@ -1008,7 +1008,7 @@ public:
 
     Expression *markSettingAAElem();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* For both i++ and i--
@@ -1016,7 +1016,7 @@ public:
 class PostExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* For both ++i and --i
@@ -1024,7 +1024,7 @@ public:
 class PreExp : public UnaExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 enum MemorySet
@@ -1042,215 +1042,215 @@ public:
     Expression *toLvalue(Scope *sc, Expression *ex);
     Expression *toBoolean(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ConstructExp : public AssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class BlitExp : public AssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AddAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class MinAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class MulAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DivAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ModAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AndAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class OrAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class XorAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PowAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ShlAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ShrAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class UshrAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CatAssignExp : public BinAssignExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AddExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class MinExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CatExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class MulExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DivExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ModExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PowExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ShlExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ShrExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class UshrExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class AndExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class OrExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class XorExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class LogicalExp : public BinExp
 {
 public:
     Expression *toBoolean(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CmpExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class InExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class RemoveExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // == and !=
@@ -1259,7 +1259,7 @@ class EqualExp : public BinExp
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // is and !is
@@ -1267,7 +1267,7 @@ public:
 class IdentityExp : public BinExp
 {
 public:
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /****************************************************************/
@@ -1285,7 +1285,7 @@ public:
     Expression *toBoolean(Scope *sc);
     void hookDtors(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /****************************************************************/
@@ -1295,42 +1295,42 @@ class DefaultInitExp : public Expression
 public:
     TOK subop;             // which of the derived classes this is
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class FileInitExp : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(Loc loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class LineInitExp : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(Loc loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ModuleInitExp : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(Loc loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class FuncInitExp : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(Loc loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PrettyFuncInitExp : public DefaultInitExp
 {
 public:
     Expression *resolveLoc(Loc loc, Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /****************************************************************/

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1161,9 +1161,9 @@ private Module loadStdMath()
     return impStdMath.mod;
 }
 
-private extern (C++) final class ExpressionSemanticVisitor : Visitor
+private extern (C++) final class ExpressionSemanticVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Scope* sc;
     Expression result;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -68,7 +68,7 @@ import dmd.typesem;
 import dmd.typinf;
 import dmd.utf;
 import dmd.utils;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum LOGSEMANTIC = false;
 

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2272,7 +2272,7 @@ extern (C++) class FuncDeclaration : Declaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2939,7 +2939,7 @@ extern (C++) final class FuncAliasDeclaration : FuncDeclaration
         return funcalias.toAliasFunc();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3080,7 +3080,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         return Dsymbol.toPrettyChars(QualifyTypes);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3133,7 +3133,7 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3180,7 +3180,7 @@ extern (C++) final class PostBlitDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3243,7 +3243,7 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3300,7 +3300,7 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3327,7 +3327,7 @@ extern (C++) final class SharedStaticCtorDeclaration : StaticCtorDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3386,7 +3386,7 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3413,7 +3413,7 @@ extern (C++) final class SharedStaticDtorDeclaration : StaticDtorDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3456,7 +3456,7 @@ extern (C++) final class InvariantDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3521,7 +3521,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3573,7 +3573,7 @@ extern (C++) final class NewDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3628,7 +3628,7 @@ extern (C++) final class DeleteDeclaration : FuncDeclaration
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -46,7 +46,7 @@ import dmd.statement_rewrite_walker;
 import dmd.statement;
 import dmd.statementsem;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /// Inline Status
 enum ILS : int

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -81,9 +81,9 @@ extern (C++) void genhdrfile(Module m)
     writeFile(m.loc, m.hdrfile);
 }
 
-extern (C++) final class PrettyPrintVisitor : Visitor
+extern (C++) final class PrettyPrintVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     OutBuffer* buf;
     HdrGenState* hgs;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -49,7 +49,7 @@ import dmd.staticassert;
 import dmd.target;
 import dmd.tokens;
 import dmd.utils;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 struct HdrGenState
 {

--- a/src/dmd/import.h
+++ b/src/dmd/import.h
@@ -58,7 +58,7 @@ public:
     bool overloadInsert(Dsymbol *s);
 
     Import *isImport() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_IMPORT_H */

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -100,7 +100,7 @@ extern (C++) class Initializer : RootObject
         return null;
     }
 
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -127,7 +127,7 @@ extern (C++) final class VoidInitializer : Initializer
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -152,7 +152,7 @@ extern (C++) final class ErrorInitializer : Initializer
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -196,7 +196,7 @@ extern (C++) final class StructInitializer : Initializer
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -288,7 +288,7 @@ extern (C++) final class ArrayInitializer : Initializer
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -317,7 +317,7 @@ extern (C++) final class ExpInitializer : Initializer
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -30,7 +30,7 @@ import dmd.mtype;
 import dmd.root.outbuffer;
 import dmd.root.rootobject;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum NeedInterpret : int
 {

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -15,7 +15,7 @@
 
 #include "mars.h"
 #include "arraytypes.h"
-#include "visitor.h"
+#include "visitors.h"
 
 class Identifier;
 class Expression;

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -45,7 +45,7 @@ public:
     virtual StructInitializer  *isStructInitializer()  { return NULL; }
     virtual ArrayInitializer   *isArrayInitializer()  { return NULL; }
     virtual ExpInitializer     *isExpInitializer()  { return NULL; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class VoidInitializer : public Initializer
@@ -56,7 +56,7 @@ public:
     Initializer *syntaxCopy();
 
     virtual VoidInitializer *isVoidInitializer() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ErrorInitializer : public Initializer
@@ -65,7 +65,7 @@ public:
     Initializer *syntaxCopy();
 
     virtual ErrorInitializer *isErrorInitializer() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StructInitializer : public Initializer
@@ -78,7 +78,7 @@ public:
     void addInit(Identifier *field, Initializer *value);
 
     StructInitializer *isStructInitializer() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ArrayInitializer : public Initializer
@@ -96,7 +96,7 @@ public:
     Expression *toAssocArrayLiteral();
 
     ArrayInitializer *isArrayInitializer() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ExpInitializer : public Initializer
@@ -108,7 +108,7 @@ public:
     Initializer *syntaxCopy();
 
     ExpInitializer *isExpInitializer() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -34,7 +34,7 @@ import dmd.init;
 import dmd.mtype;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************
  * Translate init to an `Expression` in order to infer the type.

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -88,9 +88,9 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
 /* ****************************** Implementation ************************ */
 
 
-private extern(C++) final class InitializerSemanticVisitor : Visitor
+private extern(C++) final class InitializerSemanticVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Initializer result;
     Scope* sc;
@@ -538,9 +538,9 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
     }
 }
 
-private extern(C++) final class InferTypeVisitor : Visitor
+private extern(C++) final class InferTypeVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Initializer result;
     Scope* sc;
@@ -702,9 +702,9 @@ private extern(C++) final class InferTypeVisitor : Visitor
     }
 }
 
-private extern(C++) final class InitToExpressionVisitor : Visitor
+private extern(C++) final class InitToExpressionVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Expression result;
     Type itype;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -82,10 +82,10 @@ final class InlineDoState
  *  - Copying the trees of the function to be inlined
  *  - Renaming the variables
  */
-private extern (C++) final class DoInlineAs(Result) : Visitor
+private extern (C++) final class DoInlineAs(Result) : SemanticVisitor
 if (is(Result == Statement) || is(Result == Expression))
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     InlineDoState ids;
     Result result;
@@ -803,9 +803,9 @@ Result doInlineAs(Result)(Expression e, InlineDoState ids)
  * Walk the trees, looking for functions to inline.
  * Inline any that can be.
  */
-private extern (C++) final class InlineScanVisitor : Visitor
+private extern (C++) final class InlineScanVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     FuncDeclaration parent;     // function being scanned
     // As the visit method cannot return a value, these variables

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -37,7 +37,7 @@ import dmd.mtype;
 import dmd.opover;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 import dmd.inlinecost;
 
 private:

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -34,7 +34,8 @@ import dmd.mtype;
 import dmd.opover;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.stoppable;
+import dmd.visitor.semantic;
 
 enum COST_MAX = 250;
 

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -97,9 +97,9 @@ private:
  * Walk trees to determine if inlining can be done, and if so,
  * if it is too complex to be worth inlining or not.
  */
-extern (C++) final class InlineCostVisitor : Visitor
+extern (C++) final class InlineCostVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     int nested;
     bool hasthis;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -33,7 +33,7 @@ import dmd.id;
 import dmd.identifier;
 import dmd.mtype;
 import dmd.root.outbuffer;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 version(Windows) {
     extern (C) char* getcwd(char* buffer, size_t maxlen);

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -41,9 +41,9 @@ version(Windows) {
     import core.sys.posix.unistd : getcwd;
 }
 
-private extern (C++) final class ToJsonVisitor : Visitor
+private extern (C++) final class ToJsonVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     OutBuffer* buf;
     int indentLevel;

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -33,7 +33,7 @@ import dmd.root.stringtable;
 import dmd.dscope;
 import dmd.statement;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.transitive;
 
 enum LOG = false;
 

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -48,7 +48,7 @@ public:
     bool isAncestorPackageOf(const Package * const pkg) const;
 
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 
     Module *isPackageMod();
 };
@@ -165,7 +165,7 @@ public:
     Symbol *sfilename;          // symbol for filename
 
     Module *isModule() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -56,7 +56,7 @@ import dmd.sideeffect;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum LOGDOTEXP = 0;         // log ::dotExp()
 enum LOGDEFAULTINIT = 0;    // log ::defaultInit()

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3004,7 +3004,7 @@ extern (C++) abstract class Type : RootObject
         return null;
     }
 
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3057,7 +3057,7 @@ extern (C++) final class TypeError : Type
         return new ErrorExp();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -3356,7 +3356,7 @@ extern (C++) abstract class TypeNext : Type
         next = next.addMod(mod);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4252,7 +4252,7 @@ extern (C++) final class TypeBasic : Type
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4411,7 +4411,7 @@ extern (C++) final class TypeVector : Type
         return basetype.isZeroInit(loc);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4440,7 +4440,7 @@ extern (C++) class TypeArray : TypeNext
         return e;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4759,7 +4759,7 @@ extern (C++) final class TypeSArray : TypeArray
         return next.needsNested();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -4941,7 +4941,7 @@ extern (C++) final class TypeDArray : TypeArray
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5108,7 +5108,7 @@ extern (C++) final class TypeAArray : TypeArray
         return Type.constConv(to);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5256,7 +5256,7 @@ extern (C++) final class TypePointer : TypeNext
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -5319,7 +5319,7 @@ extern (C++) final class TypeReference : TypeNext
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6145,7 +6145,7 @@ extern (C++) final class TypeFunction : TypeNext
         return new ErrorExp();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6304,7 +6304,7 @@ extern (C++) final class TypeDelegate : TypeNext
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6698,7 +6698,7 @@ extern (C++) abstract class TypeQualified : Type
         }
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6820,7 +6820,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
         return s;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -6886,7 +6886,7 @@ extern (C++) final class TypeInstance : TypeQualified
         return s;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7036,7 +7036,7 @@ extern (C++) final class TypeTypeof : TypeQualified
             return TypeQualified.size(loc);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7119,7 +7119,7 @@ extern (C++) final class TypeReturn : TypeQualified
         return;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7699,7 +7699,7 @@ extern (C++) final class TypeStruct : Type
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -7948,7 +7948,7 @@ extern (C++) final class TypeEnum : Type
         return sym.getMemtype(Loc.initial).nextOf();
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -8565,7 +8565,7 @@ extern (C++) final class TypeClass : Type
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -8729,7 +8729,7 @@ extern (C++) final class TypeTuple : Type
         return new TupleExp(loc, exps);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -8833,7 +8833,7 @@ extern (C++) final class TypeSlice : TypeNext
         }
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -8895,7 +8895,7 @@ extern (C++) final class TypeNull : Type
         return new NullExp(Loc.initial, Type.tnull);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -8962,7 +8962,7 @@ extern (C++) final class Parameter : RootObject
         return DYNCAST.parameter;
     }
 
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -343,7 +343,7 @@ public:
 
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeError : public Type
@@ -356,7 +356,7 @@ public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     Expression *defaultInitLiteral(Loc loc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeNext : public Type
@@ -379,7 +379,7 @@ public:
     MATCH constConv(Type *to);
     unsigned char deduceWild(Type *t, bool isRef);
     void transitive();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeBasic : public Type
@@ -407,7 +407,7 @@ public:
 
     // For eliminating dynamic_cast
     TypeBasic *isTypeBasic();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeVector : public Type
@@ -433,14 +433,14 @@ public:
     TypeBasic *elementType();
     bool isZeroInit(Loc loc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeArray : public TypeNext
 {
 public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Static array, one with a fixed dimension
@@ -466,7 +466,7 @@ public:
     bool needsDestruction();
     bool needsNested();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Dynamic array, no dimension
@@ -486,7 +486,7 @@ public:
     Expression *defaultInit(Loc loc);
     bool hasPointers() /*const*/;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeAArray : public TypeArray
@@ -509,7 +509,7 @@ public:
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypePointer : public TypeNext
@@ -526,7 +526,7 @@ public:
     bool isZeroInit(Loc loc) /*const*/;
     bool hasPointers() /*const*/;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeReference : public TypeNext
@@ -538,7 +538,7 @@ public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
     bool isZeroInit(Loc loc) /*const*/;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 enum RET
@@ -615,7 +615,7 @@ public:
     bool checkRetType(Loc loc);
 
     Expression *defaultInit(Loc loc) /*const*/;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeDelegate : public TypeNext
@@ -636,7 +636,7 @@ public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool hasPointers() /*const*/;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeQualified : public Type
@@ -658,7 +658,7 @@ public:
     void resolveHelper(Loc loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
         Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeIdentifier : public TypeQualified
@@ -671,7 +671,7 @@ public:
     Type *syntaxCopy();
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Dsymbol *toDsymbol(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* Similar to TypeIdentifier, but with a TemplateInstance as the root
@@ -685,7 +685,7 @@ public:
     Type *syntaxCopy();
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Dsymbol *toDsymbol(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeTypeof : public TypeQualified
@@ -699,7 +699,7 @@ public:
     Dsymbol *toDsymbol(Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     d_uns64 size(Loc loc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeReturn : public TypeQualified
@@ -709,7 +709,7 @@ public:
     Type *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // Whether alias this dependency is recursive or not.
@@ -753,7 +753,7 @@ public:
     unsigned char deduceWild(Type *t, bool isRef);
     Type *toHeadMutable();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeEnum : public Type
@@ -789,7 +789,7 @@ public:
     bool hasVoidInitPointers();
     Type *nextOf();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeClass : public Type
@@ -816,7 +816,7 @@ public:
     bool isBoolean() /*const*/;
     bool hasPointers() /*const*/;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeTuple : public Type
@@ -830,7 +830,7 @@ public:
     bool equals(RootObject *o);
     Expression *getProperty(Loc loc, Identifier *ident, int flag);
     Expression *defaultInit(Loc loc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeSlice : public TypeNext
@@ -842,7 +842,7 @@ public:
     const char *kind();
     Type *syntaxCopy();
     void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TypeNull : public Type
@@ -856,7 +856,7 @@ public:
 
     d_uns64 size(Loc loc) /*const*/;
     Expression *defaultInit(Loc loc) /*const*/;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /**************************************************************/
@@ -877,7 +877,7 @@ public:
     Type *isLazyArray();
     // kludge for template.isType()
     int dyncast() const { return DYNCAST_PARAMETER; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 
     static Parameters *arraySyntaxCopy(Parameters *parameters);
     static size_t dim(Parameters *parameters);

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -21,7 +21,7 @@
 
 #include "arraytypes.h"
 #include "expression.h"
-#include "visitor.h"
+#include "visitors.h"
 
 struct Scope;
 class Identifier;

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -22,7 +22,7 @@ import dmd.globals;
 import dmd.init;
 import dmd.mtype;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.stoppable;
 
 /**************************************
  * Look for GC-allocations

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -19,7 +19,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.globals;
 import dmd.identifier;
-import dmd.visitor;
+import dmd.visitor.semantic;
 import core.stdc.stdio;
 
 private enum LOG = false;

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -169,7 +169,7 @@ extern (C++) final class Nspace : ScopeDsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -33,7 +33,7 @@ class Nspace : public ScopeDsymbol
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;
     Nspace *isNspace() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_NSPACE_H */

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -68,9 +68,9 @@ extern (C++) bool isCommutative(TOK op)
  */
 private Identifier opId(Expression e)
 {
-    extern (C++) final class OpIdVisitor : Visitor
+    extern (C++) final class OpIdVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Identifier id;
 
@@ -276,9 +276,9 @@ private Identifier opId(Expression e)
  */
 private Identifier opId_r(Expression e)
 {
-    extern (C++) final class OpIdRVisitor : Visitor
+    extern (C++) final class OpIdRVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Identifier id;
 
@@ -447,9 +447,9 @@ extern (C++) Objects* opToArg(Scope* sc, TOK op)
  */
 extern (C++) Expression op_overload(Expression e, Scope* sc)
 {
-    extern (C++) final class OpOverload : Visitor
+    extern (C++) final class OpOverload : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Scope* sc;
         Expression result;

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -33,7 +33,7 @@ import dmd.mtype;
 import dmd.statement;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************
  * Determine if operands of binary op can be reversed

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -264,9 +264,9 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Type type)
  */
 extern (C++) Expression Expression_optimize(Expression e, int result, bool keepLvalue)
 {
-    extern (C++) final class OptimizeVisitor : Visitor
+    extern (C++) final class OptimizeVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
         Expression ret;
         private const int result;

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -28,7 +28,7 @@ import dmd.mtype;
 import dmd.root.ctfloat;
 import dmd.sideeffect;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /*************************************
  * If variable has a const initializer,

--- a/src/dmd/printast.d
+++ b/src/dmd/printast.d
@@ -32,9 +32,9 @@ void printAST(Expression e, int indent = 0)
 
 private:
 
-extern (C++) final class PrintASTVisitor : Visitor
+extern (C++) final class PrintASTVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     int indent;
 

--- a/src/dmd/printast.d
+++ b/src/dmd/printast.d
@@ -16,7 +16,7 @@ import core.stdc.stdio;
 
 import dmd.expression;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /********************
  * Print AST data structure in a nice format.

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -46,7 +46,7 @@ import dmd.toctype;
 import dmd.tocsym;
 import dmd.toir;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 import dmd.tk.dlist;
 

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -164,7 +164,7 @@ private void incUsage(IRState *irs, const ref Loc loc)
 }
 
 
-private extern (C++) class S2irVisitor : Visitor
+private extern (C++) class S2irVisitor : SemanticVisitor
 {
     IRState *irs;
 
@@ -173,7 +173,7 @@ private extern (C++) class S2irVisitor : Visitor
         this.irs = irs;
     }
 
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     /****************************************
      * This should be overridden by each statement class.

--- a/src/dmd/sapply.d
+++ b/src/dmd/sapply.d
@@ -13,7 +13,7 @@
 module dmd.sapply;
 
 import dmd.statement;
-import dmd.visitor;
+import dmd.visitor.stoppable;
 
 /**************************************
  * A Statement tree walker that will visit each Statement s in the tree,

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -81,9 +81,9 @@ extern(C++) void semantic2(Dsymbol dsym, Scope* sc)
     dsym.accept(v);
 }
 
-private extern(C++) final class Semantic2Visitor : Visitor
+private extern(C++) final class Semantic2Visitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
     Scope* sc;
     this(Scope* sc)
     {

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -67,7 +67,7 @@ import dmd.statement;
 import dmd.target;
 import dmd.templateparamsem;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum LOG = false;
 

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -83,9 +83,9 @@ extern(C++) void semantic3(Dsymbol dsym, Scope* sc)
     dsym.accept(v);
 }
 
-private extern(C++) final class Semantic3Visitor : Visitor
+private extern(C++) final class Semantic3Visitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Scope* sc;
     this(Scope* sc)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -69,7 +69,7 @@ import dmd.statement;
 import dmd.target;
 import dmd.templateparamsem;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 enum LOG = false;
 

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -23,7 +23,7 @@ import dmd.identifier;
 import dmd.init;
 import dmd.mtype;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.stoppable;
 
 /**************************************************
  * Front-end expression rewriting should create temporary variables for

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -404,11 +404,11 @@ extern (C++) abstract class Statement : RootObject
     }
 
     /**************************
-     * Support Visitor Pattern
+     * Support SemanticVisitor Pattern
      * Params:
      *  v = visitor;
      */
-    void accept(Visitor v)
+    void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -436,7 +436,7 @@ extern (C++) final class ErrorStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -454,7 +454,7 @@ extern (C++) final class PeelStatement : Statement
         this.s = s;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -465,9 +465,9 @@ extern (C++) final class PeelStatement : Statement
  */
 extern (C++) Statement toStatement(Dsymbol s)
 {
-    extern (C++) final class ToStmt : Visitor
+    extern (C++) final class ToStmt : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         Statement result;
 
@@ -711,7 +711,7 @@ extern (C++) class ExpStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -735,7 +735,7 @@ extern (C++) final class DtorExpStatement : ExpStatement
         return new DtorExpStatement(loc, exp ? exp.syntaxCopy() : null, var);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -803,7 +803,7 @@ extern (C++) final class CompileStatement : Statement
         return compileIt(sc);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -903,7 +903,7 @@ extern (C++) class CompoundStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -930,7 +930,7 @@ extern (C++) final class CompoundDeclarationStatement : CompoundStatement
         return new CompoundDeclarationStatement(loc, a);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -971,7 +971,7 @@ extern (C++) final class UnrolledLoopStatement : Statement
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1018,7 +1018,7 @@ extern (C++) class ScopeStatement : Statement
         return statement ? statement.hasContinue() : false;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1097,7 +1097,7 @@ extern (C++) final class ForwardingStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1138,7 +1138,7 @@ extern (C++) final class WhileStatement : Statement
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1178,7 +1178,7 @@ extern (C++) final class DoStatement : Statement
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1242,7 +1242,7 @@ extern (C++) final class ForStatement : Statement
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1310,7 +1310,7 @@ extern (C++) final class ForeachStatement : Statement
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1355,7 +1355,7 @@ extern (C++) final class ForeachRangeStatement : Statement
         return true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1397,7 +1397,7 @@ extern (C++) final class IfStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1445,7 +1445,7 @@ extern (C++) final class ConditionalStatement : Statement
         return a;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1500,7 +1500,7 @@ extern (C++) final class StaticForeachStatement : Statement
         }
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1527,7 +1527,7 @@ extern (C++) final class PragmaStatement : Statement
         return new PragmaStatement(loc, ident, Expression.arraySyntaxCopy(args), _body ? _body.syntaxCopy() : null);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1550,7 +1550,7 @@ extern (C++) final class StaticAssertStatement : Statement
         return new StaticAssertStatement(cast(StaticAssert)sa.syntaxCopy(null));
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1638,7 +1638,7 @@ extern (C++) final class SwitchStatement : Statement
         return !error;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1677,7 +1677,7 @@ extern (C++) final class CaseStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1704,7 +1704,7 @@ extern (C++) final class CaseRangeStatement : Statement
         return new CaseRangeStatement(loc, first.syntaxCopy(), last.syntaxCopy(), statement.syntaxCopy());
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1733,7 +1733,7 @@ extern (C++) final class DefaultStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1760,7 +1760,7 @@ extern (C++) final class GotoDefaultStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1789,7 +1789,7 @@ extern (C++) final class GotoCaseStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1812,7 +1812,7 @@ extern (C++) final class SwitchErrorStatement : Statement
         this.exp = exp;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1841,7 +1841,7 @@ extern (C++) final class ReturnStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1869,7 +1869,7 @@ extern (C++) final class BreakStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1892,7 +1892,7 @@ extern (C++) final class ContinueStatement : Statement
         return new ContinueStatement(loc, ident);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1927,7 +1927,7 @@ extern (C++) final class SynchronizedStatement : Statement
         return false; //true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1955,7 +1955,7 @@ extern (C++) final class WithStatement : Statement
         return new WithStatement(loc, exp.syntaxCopy(), _body ? _body.syntaxCopy() : null, endloc);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -1991,7 +1991,7 @@ extern (C++) final class TryCatchStatement : Statement
         return false;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2063,7 +2063,7 @@ extern (C++) final class TryFinallyStatement : Statement
         return false; //true;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2135,7 +2135,7 @@ extern (C++) final class OnScopeStatement : Statement
         return null;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2163,7 +2163,7 @@ extern (C++) final class ThrowStatement : Statement
         return s;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2199,7 +2199,7 @@ extern (C++) final class DebugStatement : Statement
         return a;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2285,7 +2285,7 @@ extern (C++) final class GotoStatement : Statement
         return false;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2355,7 +2355,7 @@ extern (C++) final class LabelStatement : Statement
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2383,7 +2383,7 @@ extern (C++) final class LabelDsymbol : Dsymbol
         return this;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2411,7 +2411,7 @@ extern (C++) final class AsmStatement : Statement
         return new AsmStatement(loc, tokens);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2446,7 +2446,7 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
         return null;
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }
@@ -2475,7 +2475,7 @@ extern (C++) final class ImportStatement : Statement
         return new ImportStatement(loc, m);
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -46,7 +46,8 @@ import dmd.sapply;
 import dmd.sideeffect;
 import dmd.staticassert;
 import dmd.tokens;
-import dmd.visitor;
+import dmd.visitor.stoppable;
+import dmd.visitor.semantic;
 
 /**
  * Returns:
@@ -405,7 +406,7 @@ extern (C++) abstract class Statement : RootObject
     /**************************
      * Support Visitor Pattern
      * Params:
-     *  v = visitor
+     *  v = visitor;
      */
     void accept(Visitor v)
     {

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -109,7 +109,7 @@ public:
     virtual BreakStatement *isBreakStatement() { return NULL; }
     virtual DtorExpStatement *isDtorExpStatement() { return NULL; }
     virtual ForwardingStatement *isForwardingStatement() { return NULL; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /** Any Statement that fails semantic() or has a component that is an ErrorExp or
@@ -121,7 +121,7 @@ public:
     Statement *syntaxCopy();
 
     ErrorStatement *isErrorStatement() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PeelStatement : public Statement
@@ -129,7 +129,7 @@ class PeelStatement : public Statement
 public:
     Statement *s;
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ExpStatement : public Statement
@@ -143,7 +143,7 @@ public:
     Statements *flatten(Scope *sc);
 
     ExpStatement *isExpStatement() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DtorExpStatement : public ExpStatement
@@ -155,7 +155,7 @@ public:
     VarDeclaration *var;
 
     Statement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 
     DtorExpStatement *isDtorExpStatement() { return this; }
 };
@@ -167,7 +167,7 @@ public:
 
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CompoundStatement : public Statement
@@ -182,14 +182,14 @@ public:
     Statement *last();
 
     CompoundStatement *isCompoundStatement() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CompoundDeclarationStatement : public CompoundStatement
 {
 public:
     Statement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* The purpose of this is so that continue will go to the next
@@ -204,7 +204,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ScopeStatement : public Statement
@@ -219,7 +219,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ForwardingStatement : public Statement
@@ -230,7 +230,7 @@ class ForwardingStatement : public Statement
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
     ForwardingStatement *isForwardingStatement() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class WhileStatement : public Statement
@@ -244,7 +244,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DoStatement : public Statement
@@ -258,7 +258,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ForStatement : public Statement
@@ -281,7 +281,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ForeachStatement : public Statement
@@ -306,7 +306,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ForeachRangeStatement : public Statement
@@ -325,7 +325,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class IfStatement : public Statement
@@ -341,7 +341,7 @@ public:
     Statement *syntaxCopy();
     IfStatement *isIfStatement() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ConditionalStatement : public Statement
@@ -354,7 +354,7 @@ public:
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticForeachStatement : public Statement
@@ -365,7 +365,7 @@ public:
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class PragmaStatement : public Statement
@@ -377,7 +377,7 @@ public:
 
     Statement *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class StaticAssertStatement : public Statement
@@ -387,7 +387,7 @@ public:
 
     Statement *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SwitchStatement : public Statement
@@ -409,7 +409,7 @@ public:
     bool hasBreak();
     bool checkLabel();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class CaseStatement : public Statement
@@ -425,7 +425,7 @@ public:
     int compare(RootObject *obj);
     CaseStatement *isCaseStatement() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 
@@ -437,7 +437,7 @@ public:
     Statement *statement;
 
     Statement *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 
@@ -450,7 +450,7 @@ public:
     Statement *syntaxCopy();
     DefaultStatement *isDefaultStatement() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class GotoDefaultStatement : public Statement
@@ -461,7 +461,7 @@ public:
     Statement *syntaxCopy();
     GotoDefaultStatement *isGotoDefaultStatement() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class GotoCaseStatement : public Statement
@@ -473,14 +473,14 @@ public:
     Statement *syntaxCopy();
     GotoCaseStatement *isGotoCaseStatement() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SwitchErrorStatement : public Statement
 {
 public:
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ReturnStatement : public Statement
@@ -492,7 +492,7 @@ public:
     Statement *syntaxCopy();
 
     ReturnStatement *isReturnStatement() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class BreakStatement : public Statement
@@ -503,7 +503,7 @@ public:
     Statement *syntaxCopy();
 
     BreakStatement *isBreakStatement() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ContinueStatement : public Statement
@@ -513,7 +513,7 @@ public:
 
     Statement *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class SynchronizedStatement : public Statement
@@ -526,7 +526,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class WithStatement : public Statement
@@ -539,7 +539,7 @@ public:
 
     Statement *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TryCatchStatement : public Statement
@@ -551,7 +551,7 @@ public:
     Statement *syntaxCopy();
     bool hasBreak();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class Catch : public RootObject
@@ -584,7 +584,7 @@ public:
     bool hasBreak();
     bool hasContinue();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class OnScopeStatement : public Statement
@@ -596,7 +596,7 @@ public:
     Statement *syntaxCopy();
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ThrowStatement : public Statement
@@ -609,7 +609,7 @@ public:
 
     Statement *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class DebugStatement : public Statement
@@ -619,7 +619,7 @@ public:
 
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class GotoStatement : public Statement
@@ -634,7 +634,7 @@ public:
     Statement *syntaxCopy();
     bool checkLabel();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class LabelStatement : public Statement
@@ -655,7 +655,7 @@ public:
 
     LabelStatement *isLabelStatement() { return this; }
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class LabelDsymbol : public Dsymbol
@@ -665,7 +665,7 @@ public:
 
     static LabelDsymbol *create(Identifier *ident);
     LabelDsymbol *isLabel();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 Statement* asmSemantic(AsmStatement *s, Scope *sc);
@@ -682,7 +682,7 @@ public:
 
     Statement *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 // a complete asm {} block
@@ -694,7 +694,7 @@ public:
     CompoundAsmStatement *syntaxCopy();
     Statements *flatten(Scope *sc);
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class ImportStatement : public Statement
@@ -704,7 +704,7 @@ public:
 
     Statement *syntaxCopy();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_STATEMENT_H */

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -19,7 +19,7 @@
 
 #include "arraytypes.h"
 #include "dsymbol.h"
-#include "visitor.h"
+#include "visitors.h"
 #include "tokens.h"
 
 struct OutBuffer;

--- a/src/dmd/statement_rewrite_walker.d
+++ b/src/dmd/statement_rewrite_walker.d
@@ -15,7 +15,7 @@ module dmd.statement_rewrite_walker;
 import core.stdc.stdio;
 
 import dmd.statement;
-import dmd.visitor;
+import dmd.visitor.permissive;
 
 
 /** A visitor to walk entire statements and provides ability to replace any sub-statements.

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -53,7 +53,7 @@ import dmd.statement;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /*****************************************
  * CTFE requires FuncDeclaration::labtab for the interpretation.

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -127,9 +127,9 @@ extern(C++) Statement statementSemantic(Statement s, Scope* sc)
     return v.result;
 }
 
-private extern (C++) final class StatementSemanticVisitor : Visitor
+private extern (C++) final class StatementSemanticVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Statement result;
     Scope* sc;

--- a/src/dmd/staticassert.d
+++ b/src/dmd/staticassert.d
@@ -19,7 +19,7 @@ import dmd.globals;
 import dmd.id;
 import dmd.identifier;
 import dmd.mtype;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /***********************************************************
  */

--- a/src/dmd/staticassert.d
+++ b/src/dmd/staticassert.d
@@ -59,7 +59,7 @@ extern (C++) final class StaticAssert : Dsymbol
         return "static assert";
     }
 
-    override void accept(Visitor v)
+    override void accept(SemanticVisitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/staticassert.h
+++ b/src/dmd/staticassert.h
@@ -29,7 +29,7 @@ public:
     void addMember(Scope *sc, ScopeDsymbol *sds);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -108,7 +108,7 @@ public:
     TemplateTupleParameter *isVariadic();
     bool isOverloadable();
 
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* For type-parameter:
@@ -159,7 +159,7 @@ public:
     /* Create dummy argument based on parameter.
      */
     virtual void *dummyArg() = 0;
-    virtual void accept(Visitor *v) { v->visit(this); }
+    virtual void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* Syntax:
@@ -182,7 +182,7 @@ public:
     bool hasDefaultArg();
     MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* Syntax:
@@ -193,7 +193,7 @@ class TemplateThisParameter : public TemplateTypeParameter
 public:
     TemplateThisParameter *isTemplateThisParameter();
     TemplateParameter *syntaxCopy();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* Syntax:
@@ -215,7 +215,7 @@ public:
     bool hasDefaultArg();
     MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* Syntax:
@@ -239,7 +239,7 @@ public:
     bool hasDefaultArg();
     MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* Syntax:
@@ -258,7 +258,7 @@ public:
     MATCH matchArg(Loc loc, Scope *sc, Objects *tiargs, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     MATCH matchArg(Scope *sc, RootObject *oarg, size_t i, TemplateParameters *parameters, Objects *dedtypes, Declaration **psparam);
     void *dummyArg();
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 /* Given:
@@ -333,7 +333,7 @@ public:
     void trySemantic3(Scope *sc2);
 
     TemplateInstance *isTemplateInstance() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class TemplateMixin : public TemplateInstance
@@ -352,7 +352,7 @@ public:
     bool findTempDecl(Scope *sc);
 
     TemplateMixin *isTemplateMixin() { return this; }
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 Expression *isExpression(RootObject *o);

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -24,7 +24,7 @@ import dmd.expressionsem;
 import dmd.root.rootobject;
 import dmd.mtype;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /************************************************
  * Performs semantic on TemplateParameter AST nodes.

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -44,9 +44,9 @@ extern(C++) bool tpsemantic(TemplateParameter tp, Scope* sc, TemplateParameters*
 }
 
 
-private extern (C++) final class TemplateParameterSemanticVisitor : Visitor
+private extern (C++) final class TemplateParameterSemanticVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Scope* sc;
     TemplateParameters* parameters;

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -43,7 +43,7 @@ import dmd.toctype;
 import dmd.todt;
 import dmd.tokens;
 import dmd.typinf;
-import dmd.visitor;
+import dmd.visitor.semantic;
 import dmd.irstate;
 import dmd.dmangle;
 

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -110,9 +110,9 @@ __gshared Symbol *scc;
 
 Symbol *toSymbol(Dsymbol s)
 {
-    extern (C++) static final class ToSymbol : Visitor
+    extern (C++) static final class ToSymbol : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
         Symbol *result;
 

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -25,7 +25,7 @@ import dmd.glue;
 import dmd.id;
 import dmd.mtype;
 import dmd.tocvdebug;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 private extern (C++) final class ToCtypeVisitor : Visitor
 {

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -27,9 +27,9 @@ import dmd.mtype;
 import dmd.tocvdebug;
 import dmd.visitor.semantic;
 
-private extern (C++) final class ToCtypeVisitor : Visitor
+private extern (C++) final class ToCtypeVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     extern (D) this()
     {

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -38,7 +38,7 @@ import dmd.id;
 import dmd.mtype;
 import dmd.target;
 import dmd.toctype;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -774,7 +774,7 @@ void toDebug(ClassDeclaration cd)
 
 int cvMember(Dsymbol s, ubyte *p)
 {
-    extern (C++) class CVMember : Visitor
+    extern (C++) class CVMember : SemanticVisitor
     {
         ubyte *p;
         int result;
@@ -785,7 +785,7 @@ int cvMember(Dsymbol s, ubyte *p)
             result = 0;
         }
 
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
         override void visit(Dsymbol s)
         {

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -63,7 +63,7 @@ alias Dts = Array!(dt_t*);
 
 extern (C++) void Initializer_toDt(Initializer init, DtBuilder dtb)
 {
-    extern (C++) class InitToDt : Visitor
+    extern (C++) class InitToDt : SemanticVisitor
     {
         DtBuilder dtb;
 
@@ -72,7 +72,7 @@ extern (C++) void Initializer_toDt(Initializer init, DtBuilder dtb)
             this.dtb = dtb;
         }
 
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
         override void visit(Initializer)
         {
@@ -223,7 +223,7 @@ extern (C++) void Initializer_toDt(Initializer init, DtBuilder dtb)
 
 extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
 {
-    extern (C++) class ExpToDt : Visitor
+    extern (C++) class ExpToDt : SemanticVisitor
     {
         DtBuilder dtb;
 
@@ -232,7 +232,7 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
             this.dtb = dtb;
         }
 
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
         override void visit(Expression e)
         {
@@ -846,7 +846,7 @@ private void membersToDt(AggregateDeclaration ad, DtBuilder dtb,
 
 extern (C++) void Type_toDt(Type t, DtBuilder dtb)
 {
-    extern (C++) class TypeToDt : Visitor
+    extern (C++) class TypeToDt : SemanticVisitor
     {
     public:
         DtBuilder dtb;
@@ -856,7 +856,7 @@ extern (C++) void Type_toDt(Type t, DtBuilder dtb)
             this.dtb = dtb;
         }
 
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
 
         override void visit(Type t)
         {
@@ -953,7 +953,7 @@ extern (C++) void ClassReferenceExp_toInstanceDt(ClassReferenceExp ce, DtBuilder
 
 /****************************************************
  */
-private extern (C++) class TypeInfoDtVisitor : Visitor
+private extern (C++) class TypeInfoDtVisitor : SemanticVisitor
 {
     DtBuilder dtb;
 
@@ -980,7 +980,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         this.dtb = dtb;
     }
 
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     override void visit(TypeInfoDeclaration d)
     {

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -41,7 +41,7 @@ import dmd.tocsym;
 import dmd.toobj;
 import dmd.typesem;
 import dmd.typinf;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 import dmd.backend.cc;
 import dmd.backend.dt;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -55,7 +55,7 @@ import dmd.todt;
 import dmd.tokens;
 import dmd.traits;
 import dmd.typinf;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -281,9 +281,9 @@ void write_instance_pointers(Type type, Symbol *s, uint offset)
 void toObjFile(Dsymbol ds, bool multiobj)
 {
     //printf("toObjFile(%s)\n", ds.toChars());
-    extern (C++) final class ToObjFile : Visitor
+    extern (C++) final class ToObjFile : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         bool multiobj;
 

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -39,7 +39,7 @@ import dmd.root.speller;
 import dmd.root.stringtable;
 import dmd.tokens;
 import dmd.typesem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 import dmd.root.rootobject;
 
 enum LOGSEMANTIC = false;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -183,9 +183,9 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
     data.setDim(cast(size_t)cntdata);
     data.zero();
 
-    extern (C++) final class PointerBitmapVisitor : Visitor
+    extern (C++) final class PointerBitmapVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         extern (D) this(Array!(d_uns64)* _data, d_uns64 _sz_size_t)
         {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -35,7 +35,7 @@ import dmd.id;
 import dmd.identifier;
 import dmd.init;
 import dmd.initsem;
-import dmd.visitor;
+import dmd.visitor.semantic;
 import dmd.mtype;
 import dmd.opover;
 import dmd.root.rmem;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -140,9 +140,9 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
     return  v.result;
 }
 
-private extern (C++) final class TypeToExpressionVisitor : Visitor
+private extern (C++) final class TypeToExpressionVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     Expression result;
     Type itype;
@@ -246,9 +246,9 @@ extern (C++) Expression typeToExpressionHelper(TypeQualified t, Expression e, si
     return e;
 }
 
-private extern (C++) final class TypeSemanticVisitor : Visitor
+private extern (C++) final class TypeSemanticVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
     Loc loc;
     Scope* sc;
     Type result;

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -139,9 +139,9 @@ extern (C++) TypeInfoDeclaration getTypeInfoDeclaration(Type t)
 
 extern (C++) bool isSpeculativeType(Type t)
 {
-    extern (C++) final class SpeculativeTypeVisitor : Visitor
+    extern (C++) final class SpeculativeTypeVisitor : SemanticVisitor
     {
-        alias visit = Visitor.visit;
+        alias visit = SemanticVisitor.visit;
     public:
         bool result;
 

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -21,7 +21,7 @@ import dmd.errors;
 import dmd.globals;
 import dmd.gluelayer;
 import dmd.mtype;
-import dmd.visitor;
+import dmd.visitor.semantic;
 
 /****************************************************
  * Generates the `TypeInfo` object associated with `torig` if it

--- a/src/dmd/version.h
+++ b/src/dmd/version.h
@@ -27,7 +27,7 @@ public:
     const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 class VersionSymbol : public Dsymbol
@@ -40,7 +40,7 @@ public:
     const char *toChars();
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
-    void accept(Visitor *v) { v->visit(this); }
+    void accept(SemanticVisitor *v) { v->visit(this); }
 };
 
 #endif /* DMD_VERSION_H */

--- a/src/dmd/visitor/package.d
+++ b/src/dmd/visitor/package.d
@@ -13,7 +13,7 @@
 module dmd.visitor;
 
 import dmd.astcodegen;
-import dmd.visitor.parsetime;
+import dmd.visitor.parse_time;
 import dmd.tokens;
 import dmd.visitor.transitive;
 import dmd.expression;

--- a/src/dmd/visitor/package.d
+++ b/src/dmd/visitor/package.d
@@ -5,17 +5,17 @@
  * Copyright:   Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/visitor.d, _visitor.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/visitor/package.d, _package.d)
  * Documentation:  https://dlang.org/phobos/dmd_visitor.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor.d
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/package.d
  */
 
 module dmd.visitor;
 
 import dmd.astcodegen;
-import dmd.parsetimevisitor;
+import dmd.visitor.parsetime;
 import dmd.tokens;
-import dmd.transitivevisitor;
+import dmd.visitor.transitive;
 import dmd.expression;
 import dmd.root.rootobject;
 

--- a/src/dmd/visitor/parse_time.d
+++ b/src/dmd/visitor/parse_time.d
@@ -1,9 +1,9 @@
 /**
- * Documentation:  https://dlang.org/phobos/dmd_visitor_parsetime.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/parsetime.d
+ * Documentation:  https://dlang.org/phobos/dmd_visitor_parse_time.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/parse_time.d
  */
 
-module dmd.visitor.parsetime;
+module dmd.visitor.parse_time;
 
 /** Basic and dumm visitor which implements a visit method for each AST node
   * implemented in AST. This visitor is the parent of strict, transitive

--- a/src/dmd/visitor/parsetime.d
+++ b/src/dmd/visitor/parsetime.d
@@ -1,13 +1,13 @@
 /**
- * Documentation:  https://dlang.org/phobos/dmd_parsetimevisitor.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/parsetimevisitor.d
+ * Documentation:  https://dlang.org/phobos/dmd_visitor_parsetime.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/parsetime.d
  */
 
-module dmd.parsetimevisitor;
+module dmd.visitor.parsetime;
 
 /** Basic and dumm visitor which implements a visit method for each AST node
   * implemented in AST. This visitor is the parent of strict, transitive
-  * and permissive visitors.
+  * and permissive visitor.
   */
 extern (C++) class ParseTimeVisitor(AST)
 {

--- a/src/dmd/visitor/permissive.d
+++ b/src/dmd/visitor/permissive.d
@@ -5,7 +5,7 @@
 
 module dmd.visitor.permissive;
 
-import dmd.visitor.parsetime;
+import dmd.visitor.parse_time;
 
 /** PermissiveVisitor overrides all the visit methods in  the parent class
   * that assert(0) in order to facilitate the traversal of subsets of the AST.

--- a/src/dmd/visitor/permissive.d
+++ b/src/dmd/visitor/permissive.d
@@ -31,9 +31,9 @@ extern(C++) class PermissiveVisitor(AST): ParseTimeVisitor!AST
  * The PermissiveVisitor overrides the root AST nodes with
  * empty visiting methods.
  */
-extern (C++) class SemanticTimePermissiveVisitor : Visitor
+extern (C++) class SemanticTimePermissiveVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 
     override void visit(ASTCodegen.Dsymbol){}
     override void visit(ASTCodegen.Parameter){}

--- a/src/dmd/visitor/permissive.d
+++ b/src/dmd/visitor/permissive.d
@@ -1,11 +1,11 @@
 /**
- * Documentation:  https://dlang.org/phobos/dmd_permissivevisitor.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/permissivevisitor.d
+ * Documentation:  https://dlang.org/phobos/dmd_visitor_permissive.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/permissive.d
  */
 
-module dmd.permissivevisitor;
+module dmd.visitor.permissive;
 
-import dmd.parsetimevisitor;
+import dmd.visitor.parsetime;
 
 /** PermissiveVisitor overrides all the visit methods in  the parent class
   * that assert(0) in order to facilitate the traversal of subsets of the AST.

--- a/src/dmd/visitor/permissive.d
+++ b/src/dmd/visitor/permissive.d
@@ -5,7 +5,9 @@
 
 module dmd.visitor.permissive;
 
+import dmd.astcodegen;
 import dmd.visitor.parse_time;
+import dmd.visitor.semantic;
 
 /** PermissiveVisitor overrides all the visit methods in  the parent class
   * that assert(0) in order to facilitate the traversal of subsets of the AST.
@@ -24,3 +26,22 @@ extern(C++) class PermissiveVisitor(AST): ParseTimeVisitor!AST
     override void visit(AST.Condition){}
     override void visit(AST.Initializer){}
 }
+
+/**
+ * The PermissiveVisitor overrides the root AST nodes with
+ * empty visiting methods.
+ */
+extern (C++) class SemanticTimePermissiveVisitor : Visitor
+{
+    alias visit = Visitor.visit;
+
+    override void visit(ASTCodegen.Dsymbol){}
+    override void visit(ASTCodegen.Parameter){}
+    override void visit(ASTCodegen.Statement){}
+    override void visit(ASTCodegen.Type){}
+    override void visit(ASTCodegen.Expression){}
+    override void visit(ASTCodegen.TemplateParameter){}
+    override void visit(ASTCodegen.Condition){}
+    override void visit(ASTCodegen.Initializer){}
+}
+

--- a/src/dmd/visitor/semantic.d
+++ b/src/dmd/visitor/semantic.d
@@ -16,12 +16,12 @@ import dmd.astcodegen;
 import dmd.visitor.parse_time;
 
 /**
- * Classic Visitor class which implements visit methods for all the AST
+ * Classic SemanticVisitor class which implements visit methods for all the AST
  * nodes present in the compiler. The visit methods for AST nodes
  * created at parse time are inherited while the visiting methods
  * for AST nodes created at semantic time are implemented.
  */
-extern (C++) class Visitor : ParseTimeVisitor!ASTCodegen
+extern (C++) class SemanticVisitor : ParseTimeVisitor!ASTCodegen
 {
     alias visit = ParseTimeVisitor!ASTCodegen.visit;
 public:

--- a/src/dmd/visitor/stoppable.d
+++ b/src/dmd/visitor/stoppable.d
@@ -6,9 +6,9 @@ module dmd.visitor.stoppable;
 
 import dmd.visitor.semantic;
 
-extern (C++) class StoppableVisitor : Visitor
+extern (C++) class StoppableVisitor : SemanticVisitor
 {
-    alias visit = Visitor.visit;
+    alias visit = SemanticVisitor.visit;
 public:
     bool stop;
 

--- a/src/dmd/visitor/stoppable.d
+++ b/src/dmd/visitor/stoppable.d
@@ -1,0 +1,18 @@
+/**
+ * Documentation:  https://dlang.org/phobos/dmd_visitor_stoppable.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/stoppable.d
+ */
+module dmd.visitor.stoppable;
+
+import dmd.visitor.semantic;
+
+extern (C++) class StoppableVisitor : Visitor
+{
+    alias visit = Visitor.visit;
+public:
+    bool stop;
+
+    final extern (D) this()
+    {
+    }
+}

--- a/src/dmd/visitor/strict.d
+++ b/src/dmd/visitor/strict.d
@@ -5,7 +5,7 @@
 
 module dmd.visitor.strict;
 
-import dmd.visitor.parsetime;
+import dmd.visitor.parse_time;
 
 /** The StrictVisitor asserts 0 an all visiting functions in order to
   * make sure that all the nodes are visited.

--- a/src/dmd/visitor/strict.d
+++ b/src/dmd/visitor/strict.d
@@ -1,11 +1,11 @@
 /**
- * Documentation:  https://dlang.org/phobos/dmd_strictvisitor.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/strictvisitor.d
+ * Documentation:  https://dlang.org/phobos/dmd_visitor_strict.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/strict.d
  */
 
-module dmd.strictvisitor;
+module dmd.visitor.strict;
 
-import dmd.parsetimevisitor;
+import dmd.visitor.parsetime;
 
 /** The StrictVisitor asserts 0 an all visiting functions in order to
   * make sure that all the nodes are visited.

--- a/src/dmd/visitor/transitive.d
+++ b/src/dmd/visitor/transitive.d
@@ -14,7 +14,7 @@ import dmd.visitor.semantic;
 
 import core.stdc.stdio;
 
-/** Visitor that implements the AST traversal logic. The nodes just accept their children.
+/** SemanticVisitor that implements the AST traversal logic. The nodes just accept their children.
   */
 extern(C++) class ParseTimeTransitiveVisitor(AST) : PermissiveVisitor!AST
 {

--- a/src/dmd/visitor/transitive.d
+++ b/src/dmd/visitor/transitive.d
@@ -1,11 +1,11 @@
 /**
- * Documentation:  https://dlang.org/phobos/dmd_transitivevisitor.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/transitivevisitor.d
+ * Documentation:  https://dlang.org/phobos/dmd_visitor_transitive.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/visitor/transitive.d
  */
 
-module dmd.transitivevisitor;
+module dmd.visitor.transitive;
 
-import dmd.permissivevisitor;
+import dmd.visitor.permissive;
 import dmd.tokens;
 import dmd.root.rootobject;
 

--- a/src/dmd/visitors.h
+++ b/src/dmd/visitors.h
@@ -4,7 +4,7 @@
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt
- * https://github.com/dlang/dmd/blob/master/src/visitor.h
+ * https://github.com/dlang/dmd/blob/master/src/visitors.h
  */
 
 #ifndef DMD_VISITOR_H

--- a/src/dmd/visitors.h
+++ b/src/dmd/visitors.h
@@ -559,7 +559,7 @@ public:
     virtual void visit(VoidInitializer *i) { visit((Initializer *)i); }
 };
 
-class Visitor : public ParseTimeVisitor
+class SemanticVisitor : public ParseTimeVisitor
 {
 public:
     using ParseTimeVisitor::visit;
@@ -623,7 +623,7 @@ public:
     virtual void visit(ThrownExceptionExp *e) { visit((Expression *)e); }
 };
 
-class StoppableVisitor : public Visitor
+class StoppableVisitor : public SemanticVisitor
 {
 public:
     bool stop;

--- a/src/examples/avg.d
+++ b/src/examples/avg.d
@@ -11,7 +11,7 @@ module examples.avg;
 
 import dmd.astbase;
 import dmd.parse;
-import dmd.transitivevisitor;
+import dmd.visitor.transitive;
 
 import dmd.globals;
 import dmd.id;

--- a/src/examples/impvisitor.d
+++ b/src/examples/impvisitor.d
@@ -3,8 +3,8 @@
 dependency "dmd" path="../.."
 +/
 
-import dmd.permissivevisitor;
-import dmd.transitivevisitor;
+import dmd.visitor.permissive;
+import dmd.visitor.transitive;
 
 import dmd.tokens;
 import dmd.root.outbuffer;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -300,7 +300,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	sideeffect statement staticassert target typesem traits \
 	typinf utils scanelf scanmach statement_rewrite_walker statementsem staticcond safe blockexit printast \
 	semantic2 semantic3 \
-	$(addprefix visitor/, package parsetime permissive transitive)))
+	$(addprefix visitor/, package parse_time permissive transitive)))
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors globals id identifier lexer tokens utf))
 
@@ -467,7 +467,7 @@ unittest: $G/dmd-unittest
 ######## DMD as a library examples
 
 EXAMPLES=$(addprefix $G/examples/, avg impvisitor)
-PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase $(addprefix visitor/, parsetime transitive permissive strict)))
+PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase $(addprefix visitor/, parse_time transitive permissive strict)))
 
 $G/parser.a: $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS) $G/dmd $G/dmd.conf $(SRC_MAKE)
 	CC="$(HOST_CXX)" $G/dmd -lib -of$@ $(MODEL_FLAG) -L-lstdc++ -J$G $(DFLAGS) $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS)

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -296,10 +296,11 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\
 	hdrgen id impcnvtab imphint init initsem inline inlinecost intrange	\
-	json lambdacomp lib libelf libmach link mars mtype nogc nspace objc opover optimize parse permissivevisitor sapply templateparamsem	\
-	sideeffect statement staticassert target typesem traits transitivevisitor parsetimevisitor visitor	\
+	json lambdacomp lib libelf libmach link mars mtype nogc nspace objc opover optimize parse sapply templateparamsem	\
+	sideeffect statement staticassert target typesem traits \
 	typinf utils scanelf scanmach statement_rewrite_walker statementsem staticcond safe blockexit printast \
-	semantic2 semantic3))
+	semantic2 semantic3 \
+	$(addprefix visitor/, package parsetime permissive transitive)))
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors globals id identifier lexer tokens utf))
 
@@ -466,7 +467,7 @@ unittest: $G/dmd-unittest
 ######## DMD as a library examples
 
 EXAMPLES=$(addprefix $G/examples/, avg impvisitor)
-PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase parsetimevisitor transitivevisitor permissivevisitor strictvisitor))
+PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase $(addprefix visitor/, parsetime transitive permissive strict)))
 
 $G/parser.a: $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS) $G/dmd $G/dmd.conf $(SRC_MAKE)
 	CC="$(HOST_CXX)" $G/dmd -lib -of$@ $(MODEL_FLAG) -L-lstdc++ -J$G $(DFLAGS) $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS)

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -300,7 +300,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	sideeffect statement staticassert target typesem traits \
 	typinf utils scanelf scanmach statement_rewrite_walker statementsem staticcond safe blockexit printast \
 	semantic2 semantic3 \
-	$(addprefix visitor/, package parse_time permissive transitive)))
+	$(addprefix visitor/, parse_time permissive semantic stoppable transitive)))
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors globals id identifier lexer tokens utf))
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -403,7 +403,7 @@ SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
 	id.h import.h init.h intrange.h json.h \
 	mars.h module.h mtype.h nspace.h objc.h                         \
 	scope.h statement.h staticassert.h target.h template.h tokens.h	\
-	version.h visitor.h libomf.d scanomf.d libmscoff.d scanmscoff.d)         \
+	version.h visitors.h libomf.d scanomf.d libmscoff.d scanmscoff.d)         \
 	$(DMD_SRCS)
 
 ROOT_SRC = $(addprefix $(ROOT)/, array.h ctfloat.h file.h filename.h \

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -54,7 +54,7 @@
 #include "template.h"
 #include "tokens.h"
 #include "version.h"
-#include "visitor.h"
+#include "visitors.h"
 
 /**********************************/
 

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -90,7 +90,7 @@ static void frontend_term()
 
 /**********************************/
 
-class TestVisitor : public Visitor
+class TestVisitor : public SemanticVisitor
 {
   public:
     bool expr;

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -213,7 +213,7 @@ SRCS = $D/aggregate.h $D/aliasthis.h $D/arraytypes.h	\
 	$D/id.h $D/import.h $D/init.h $D/intrange.h $D/json.h	\
 	$D/mars.h $D/module.h $D/mtype.h $D/nspace.h $D/objc.h                         \
 	$D/scope.h $D/statement.h $D/staticassert.h $D/target.h $D/template.h $D/tokens.h	\
-	$D/version.h $D/visitor.h $D/objc.d $(DMD_SRCS)
+	$D/version.h $D/visitors.h $D/objc.d $(DMD_SRCS)
 
 # Glue layer
 GLUESRC= \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -157,9 +157,9 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/expression.d $D/expressionsem.d $D/func.d $D/hdrgen.d $D/id.d $D/imphint.d	\
 	$D/impcnvtab.d $D/init.d $D/initsem.d $D/inline.d $D/inlinecost.d $D/intrange.d $D/json.d $D/lib.d $D/link.d	\
 	$D/mars.d $D/mtype.d $D/nogc.d $D/nspace.d $D/objc.d $D/opover.d $D/optimize.d $D/parse.d	\
-	$D/sapply.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d	\
-	$D/safe.d $D/blockexit.d $D/visitor/permissive.d $D/visitor/transitive.d $D/visitor/parse_time.d $D/printast.d $D/typesem.d \
-	$D/traits.d $D/utils.d $D/visitor/package.d $D/libomf.d $D/scanomf.d $D/templateparamsem.d $D/typinf.d \
+	$D/sapply.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d $D/safe.d $D/blockexit.d \
+	$D/visitor/parse_time.d $D/visitor/permissive.d $D/visitor/semantic.d $D/visitor/stoppable.d $D/visitor/transitive.d \
+	$D/printast.d $D/typesem.d $D/traits.d $D/utils.d$D/libomf.d $D/scanomf.d $D/templateparamsem.d $D/typinf.d \
 	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d \
 	$D/semantic2.d $D/semantic3.d
 
@@ -170,7 +170,7 @@ LEXER_ROOT=$(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d $(ROOT)/filename.d \
 	$(ROOT)/outbuffer.d $(ROOT)/port.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
 	$(ROOT)/stringtable.d $(ROOT)/hash.d
 
-PARSER_SRCS=$D/astbase.d $D/visitor/parse_time.d $D/parse.d $D/visitor/transitive.d $D/visitor/permissive.d $D/visitor/strict.d
+PARSER_SRCS=$D/astbase.d $D/visitor/parse_time.d $D/parse.d $D/visitor/stoppable.d $D/visitor/transitive.d $D/visitor/permissive.d $D/visitor/strict.d
 
 GLUE_SRCS=$D/irstate.d $D/toctype.d $D/glue.d $D/gluelayer.d $D/todt.d $D/tocsym.d $D/toir.d $D/dmsc.d \
 	$D/tocvdebug.d $D/s2ir.d $D/toobj.d $D/e2ir.d $D/objc_glue.d $D/eh.d $D/iasm.d

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -158,8 +158,8 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/impcnvtab.d $D/init.d $D/initsem.d $D/inline.d $D/inlinecost.d $D/intrange.d $D/json.d $D/lib.d $D/link.d	\
 	$D/mars.d $D/mtype.d $D/nogc.d $D/nspace.d $D/objc.d $D/opover.d $D/optimize.d $D/parse.d	\
 	$D/sapply.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d	\
-	$D/safe.d $D/blockexit.d $D/permissivevisitor.d $D/transitivevisitor.d $D/parsetimevisitor.d $D/printast.d $D/typesem.d \
-	$D/traits.d $D/utils.d $D/visitor.d $D/libomf.d $D/scanomf.d $D/templateparamsem.d $D/typinf.d \
+	$D/safe.d $D/blockexit.d $D/visitor/permissive.d $D/visitor/transitive.d $D/visitor/parsetime.d $D/printast.d $D/typesem.d \
+	$D/traits.d $D/utils.d $D/visitor/package.d $D/libomf.d $D/scanomf.d $D/templateparamsem.d $D/typinf.d \
 	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d \
 	$D/semantic2.d $D/semantic3.d
 
@@ -170,7 +170,7 @@ LEXER_ROOT=$(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d $(ROOT)/filename.d \
 	$(ROOT)/outbuffer.d $(ROOT)/port.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
 	$(ROOT)/stringtable.d $(ROOT)/hash.d
 
-PARSER_SRCS=$D/astbase.d $D/parsetimevisitor.d $D/parse.d $D/transitivevisitor.d $D/permissivevisitor.d $D/strictvisitor.d
+PARSER_SRCS=$D/astbase.d $D/visitor/parsetime.d $D/parse.d $D/visitor/transitive.d $D/visitor/permissive.d $D/visitor/strict.d
 
 GLUE_SRCS=$D/irstate.d $D/toctype.d $D/glue.d $D/gluelayer.d $D/todt.d $D/tocsym.d $D/toir.d $D/dmsc.d \
 	$D/tocvdebug.d $D/s2ir.d $D/toobj.d $D/e2ir.d $D/objc_glue.d $D/eh.d $D/iasm.d

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -158,7 +158,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/impcnvtab.d $D/init.d $D/initsem.d $D/inline.d $D/inlinecost.d $D/intrange.d $D/json.d $D/lib.d $D/link.d	\
 	$D/mars.d $D/mtype.d $D/nogc.d $D/nspace.d $D/objc.d $D/opover.d $D/optimize.d $D/parse.d	\
 	$D/sapply.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d	\
-	$D/safe.d $D/blockexit.d $D/visitor/permissive.d $D/visitor/transitive.d $D/visitor/parsetime.d $D/printast.d $D/typesem.d \
+	$D/safe.d $D/blockexit.d $D/visitor/permissive.d $D/visitor/transitive.d $D/visitor/parse_time.d $D/printast.d $D/typesem.d \
 	$D/traits.d $D/utils.d $D/visitor/package.d $D/libomf.d $D/scanomf.d $D/templateparamsem.d $D/typinf.d \
 	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d \
 	$D/semantic2.d $D/semantic3.d
@@ -170,7 +170,7 @@ LEXER_ROOT=$(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d $(ROOT)/filename.d \
 	$(ROOT)/outbuffer.d $(ROOT)/port.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
 	$(ROOT)/stringtable.d $(ROOT)/hash.d
 
-PARSER_SRCS=$D/astbase.d $D/visitor/parsetime.d $D/parse.d $D/visitor/transitive.d $D/visitor/permissive.d $D/visitor/strict.d
+PARSER_SRCS=$D/astbase.d $D/visitor/parse_time.d $D/parse.d $D/visitor/transitive.d $D/visitor/permissive.d $D/visitor/strict.d
 
 GLUE_SRCS=$D/irstate.d $D/toctype.d $D/glue.d $D/gluelayer.d $D/todt.d $D/tocsym.d $D/toir.d $D/dmsc.d \
 	$D/tocvdebug.d $D/s2ir.d $D/toobj.d $D/e2ir.d $D/objc_glue.d $D/eh.d $D/iasm.d


### PR DESCRIPTION
I started off by moving the four visitors (`parsetime`, `permissive`, `strict`, `transitive`)
to their own package.
Then `visitor.d` and `visitors` looked a bit strange, so I moved `visitor.d` to `visitors/package.d`

As there is also `astXXXX`, `dmd.ast.visitors` would work too.

CC @RazvanN7