### PR TITLE
Deprecate imaginary and complex types

### DIFF
--- a/changelog/complex-deprecated.dd
+++ b/changelog/complex-deprecated.dd
@@ -1,0 +1,21 @@
+Imaginary and complex types types have been deprecated - use `std.complex`
+
+D supported imaginary and complex versions of all floating point types:
+
+---
+float a = 2;
+ifloat b = 4i;
+cfloat c = a + b;
+assert(c == 2 + 4i);
+---
+
+Corrective action: Use the library types in $(MREF std, complex)
+
+---
+import std.complex, std.conv;
+float a = 2;
+auto b = complex(0f, 4);
+static assert(is(typeof(b) == Complex!float));
+auto c = a + b;
+assert(c.to!string == "2+4i");
+---

--- a/docs/gen_man.d
+++ b/docs/gen_man.d
@@ -127,6 +127,8 @@ void main()
 Language changes listed by \fB-transition=id\fR:`);
     foreach (transition; Usage.transitions)
     {
+        if (transition.deprecated_)
+            continue;
         string additionalOptions;
         if (transition.bugzillaNumber)
             additionalOptions = "," ~ transition.bugzillaNumber;

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -328,8 +328,9 @@ struct Usage
     {
         string bugzillaNumber; /// bugzilla issue number (if existent)
         string name; /// name of the transition
-        string paramName; // internal transition parameter name
-        string helpText; // detailed description of the transition
+        string paramName; /// internal transition parameter name
+        string helpText; /// detailed description of the transition
+        bool deprecated_; /// the flag isn't in use anymore
     }
 
     /// Returns all available transitions
@@ -341,7 +342,7 @@ struct Usage
         Transition(null, "checkimports", "check10378",
             "give deprecation messages about 10378 anomalies"),
         Transition("14488", "complex", "vcomplex",
-            "give deprecation messages about all usages of complex or imaginary types"),
+            "give deprecation messages about all usages of complex or imaginary types", true),
         Transition("16997", "intpromote", "fix16997",
             "fix integral promotions for unary + - ~ operators"),
         Transition(null, "tls", "vtls",
@@ -416,6 +417,8 @@ CPU architectures supported by -mcpu=id:
                 "list information on all language changes")] ~ Usage.transitions;
             foreach (t; allTransitions)
             {
+                if (t.deprecated_)
+                    continue;
                 buf ~= "  =";
                 buf ~= t.name;
                 auto lineLength = 3 + t.name.length;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -87,7 +87,7 @@ struct Param
     bool vtls;              // identify thread local variables
     bool vgc;               // identify gc usage
     bool vfield;            // identify non-mutable field variables
-    bool vcomplex;          // identify complex/imaginary type usage
+    bool vcomplex = true;   // identify complex/imaginary type usage
     ubyte symdebug;         // insert debug symbolic information
     bool symdebugref;       // insert debug information for all referenced types, too
     bool alwaysframe;       // always emit standard stack frame

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1718,7 +1718,15 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                             foreach (t; Usage.transitions)
                             {
                                 if (t.bugzillaNumber !is null)
-                                    buf ~= `case `~t.bugzillaNumber~`: params.`~t.paramName~` = true;break;`;
+                                {
+                                    buf ~= `case `~t.bugzillaNumber~`:`;
+                                    if (t.deprecated_)
+                                        buf ~= `fprintf(global.stdmsg, "-transition=`~t.bugzillaNumber~` has no effect anymore\n");`;
+                                    else
+                                        buf ~= `params.`~t.paramName~` = true;`;
+
+                                    buf ~= "break;";
+                                }
                             }
                             return buf;
                         }
@@ -1738,12 +1746,19 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                             import dmd.cli : Usage;
                             string buf = `case "all":`;
                             foreach (t; Usage.transitions)
-                                buf ~= `params.`~t.paramName~` = true;`;
+                                if (!t.deprecated_)
+                                    buf ~= `params.`~t.paramName~` = true;`;
                             buf ~= "break;";
 
                             foreach (t; Usage.transitions)
                             {
-                                buf ~= `case "`~t.name~`": params.`~t.paramName~` = true;break;`;
+                                buf ~= `case "`~t.name~`":`;
+                                if (t.deprecated_)
+                                    buf ~= `fprintf(global.stdmsg, "-transition=`~t.name~` has no effect anymore\n");`;
+                                else
+                                    buf ~= `params.`~t.paramName~` = true;`;
+
+                                buf ~= "break;";
                             }
                             return buf;
                         }

--- a/test/compilable/sw_transition_complex.d
+++ b/test/compilable/sw_transition_complex.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -transition=complex
+// REQUIRED_ARGS: -c
 
 /*
 TEST_OUTPUT:

--- a/test/fail_compilation/b3841.d
+++ b/test/fail_compilation/b3841.d
@@ -4,21 +4,34 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/b3841.d-mixin-31(31): Warning: `char += float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `int += float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `long += double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `char -= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `int -= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `long -= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `char *= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `int *= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `long *= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `char /= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `int /= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `long /= double` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `char %= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `int %= float` is performing truncating conversion
-fail_compilation/b3841.d-mixin-31(31): Warning: `long %= double` is performing truncating conversion
+fail_compilation/b3841.d(42): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
+fail_compilation/b3841.d-mixin-44(44): Warning: `char += float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `int += float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `long += double` is performing truncating conversion
+fail_compilation/b3841.d(42): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
+fail_compilation/b3841.d-mixin-44(44): Warning: `char -= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `int -= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `long -= double` is performing truncating conversion
+fail_compilation/b3841.d(42): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
+fail_compilation/b3841.d-mixin-44(44): Warning: `char *= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `int *= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `long *= double` is performing truncating conversion
+fail_compilation/b3841.d(42): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
+fail_compilation/b3841.d-mixin-44(44): Warning: `char /= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `int /= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `long /= double` is performing truncating conversion
+fail_compilation/b3841.d(42): Deprecation: use of complex type `cfloat` is deprecated, use `std.complex.Complex!(float)` instead
+fail_compilation/b3841.d-mixin-44(44): Warning: `char %= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `int %= float` is performing truncating conversion
+fail_compilation/b3841.d-mixin-44(44): Warning: `long %= double` is performing truncating conversion
+fail_compilation/b3841.d(42): Deprecation: use of imaginary type `idouble` is deprecated, use `double` instead
+fail_compilation/b3841.d(43): Deprecation: use of imaginary type `ifloat` is deprecated, use `float` instead
+fail_compilation/b3841.d(42): Deprecation: use of imaginary type `ifloat` is deprecated, use `float` instead
+fail_compilation/b3841.d(43): Deprecation: use of imaginary type `idouble` is deprecated, use `double` instead
+fail_compilation/b3841.d(42): Deprecation: use of imaginary type `idouble` is deprecated, use `double` instead
+fail_compilation/b3841.d(43): Deprecation: use of imaginary type `ifloat` is deprecated, use `float` instead
+fail_compilation/b3841.d(42): Deprecation: use of imaginary type `ifloat` is deprecated, use `float` instead
+fail_compilation/b3841.d(43): Deprecation: use of imaginary type `idouble` is deprecated, use `double` instead
 ---
 */
 
@@ -47,7 +60,7 @@ void main()
         f!(op, float, long)();
         f!(op, cfloat, long)();
         f!(op, double, float)();
-        
+
         // Should that really be OK ?
         f!(op, short, int)();
         f!(op, float, double)();
@@ -66,7 +79,7 @@ void main()
         // Should that really be OK ?
         f!(op, ifloat, idouble)();
     }
-    
+
     // OK
     f!("^^=", int, int)();
     f!("^^=", long, int)();

--- a/test/fail_compilation/fail101.d
+++ b/test/fail_compilation/fail101.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail101.d(8): Error: cannot implicitly convert expression `1` of type `int` to `creal`
+fail_compilation/fail101.d(9): Deprecation: use of complex type `creal` is deprecated, use `std.complex.Complex!(real)` instead
+fail_compilation/fail101.d(9): Error: cannot implicitly convert expression `1` of type `int` to `creal`
 ---
 */
 

--- a/test/fail_compilation/fail303.d
+++ b/test/fail_compilation/fail303.d
@@ -1,13 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail303.d(19): Error: `double /= cdouble` is undefined. Did you mean `double /= cdouble.re`?
-fail_compilation/fail303.d(20): Error: `ireal *= ireal` is an undefined operation
-fail_compilation/fail303.d(21): Error: `ireal *= creal` is undefined. Did you mean `ireal *= creal.im`?
-fail_compilation/fail303.d(22): Error: `ireal %= creal` is undefined. Did you mean `ireal %= creal.im`?
-fail_compilation/fail303.d(23): Error: `ireal += real` is undefined (result is complex)
-fail_compilation/fail303.d(24): Error: `ireal -= creal` is undefined (result is complex)
-fail_compilation/fail303.d(25): Error: `double -= idouble` is undefined (result is complex)
+fail_compilation/fail303.d(18): Deprecation: use of imaginary type `ireal` is deprecated, use `real` instead
+fail_compilation/fail303.d(20): Error: `double /= cdouble` is undefined. Did you mean `double /= cdouble.re`?
+fail_compilation/fail303.d(21): Error: `ireal *= ireal` is an undefined operation
+fail_compilation/fail303.d(22): Error: `ireal *= creal` is undefined. Did you mean `ireal *= creal.im`?
+fail_compilation/fail303.d(23): Error: `ireal %= creal` is undefined. Did you mean `ireal %= creal.im`?
+fail_compilation/fail303.d(24): Error: `ireal += real` is undefined (result is complex)
+fail_compilation/fail303.d(25): Error: `ireal -= creal` is undefined (result is complex)
+fail_compilation/fail303.d(26): Error: `double -= idouble` is undefined (result is complex)
 ---
 */
 


### PR DESCRIPTION
Turn the complex deprecation on by default.
Follow-up to https://github.com/dlang/dmd/pull/7081

This might need some work, depending on what Jenkins tells us.