### PR TITLE
[Trivial] Revise the fix for issue #18093

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -616,7 +616,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     final BaseClass* overrideInterface()
     {
-        if (ClassDeclaration cd = parent.isClassDeclaration())
+        if (ClassDeclaration cd = toParent2().isClassDeclaration())
         {
             foreach (b; cd.interfaces)
             {


### PR DESCRIPTION
Make sure to skip over template mixin parents etc., all the way up to the containing class, instead of returning null if the immediate parent isn't a class.