### PR TITLE
Have one source of truth for the language transitions

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,7 +22,7 @@ export DIFFABLE
 
 build: $(addprefix $G/, $(DMD_MAN_PAGE) $(OTHER_MAN_PAGES))
 
-preview:
+preview: $(MAN_PAGE)
 	man -l $G/$(DMD_MAN_PAGE)
 
 ################################################################################

--- a/docs/gen_man.d
+++ b/docs/gen_man.d
@@ -76,6 +76,13 @@ string bold(string w)
     return `\fI` ~ w ~ `\fR`;
 }
 
+// capitalize the first letter
+auto capitalize(string w)
+{
+    import std.range, std.uni;
+    return w.take(1).asUpperCase.chain(w.dropOne);
+}
+
 void main()
 {
     import std.algorithm, std.array, std.conv, std.datetime, std.range, std.stdio, std.uni;
@@ -112,8 +119,19 @@ void main()
             }
             writefln(".IP -%s", flag);
             // Capitalize the first letter
-            writeln(help.take(1).asUpperCase.chain(help.dropOne));
+            writeln(help.capitalize);
         }
+    }
+
+    writeln(`.SH TRANSITIONS
+Language changes listed by \fB-transition=id\fR:`);
+    foreach (transition; Usage.transitions)
+    {
+        string additionalOptions;
+        if (transition.bugzillaNumber)
+            additionalOptions = "," ~ transition.bugzillaNumber;
+        writefln(".IP %s%s", transition.name.bold, additionalOptions);
+        writeln(transition.helpText.capitalize);
     }
 
     writefln(footer, now.year);

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -67,14 +67,6 @@ bool isCurrentTargetOS(TargetOS os)
     return (os & targetOS) > 0;
 }
 
-/// Representation of a CLI `Option`
-struct Option
-{
-    string flag; /// The CLI flag without leading `-`, e.g. `color`
-    string helpText; /// A detailed description of the flag
-    TargetOS os = TargetOS.all; /// For which `TargetOS` the flags are applicable
-}
-
 /**
 Contains all available CLI $(LREF Option)s.
 
@@ -82,6 +74,14 @@ See_Also: $(LREF Option)
 */
 struct Usage
 {
+    /// Representation of a CLI `Option`
+    struct Option
+    {
+        string flag; /// The CLI flag without leading `-`, e.g. `color`
+        string helpText; /// A detailed description of the flag
+        TargetOS os = TargetOS.all; /// For which `TargetOS` the flags are applicable
+    }
+
     /// Returns all available CLI options
     static immutable options = [
         Option("allinst",
@@ -316,6 +316,31 @@ struct Usage
             "write JSON file to filename"
         ),
     ];
+
+    /// Representation of a CLI transition
+    struct Transition
+    {
+        string bugzillaNumber; /// bugzilla issue number (if existent)
+        string name; /// name of the transition
+        string paramName; // internal transition parameter name
+        string helpText; // detailed description of the transition
+    }
+
+    /// Returns all available transitions
+    static immutable transitions = [
+        Transition("3449", "field", "vfield",
+            "list all non-mutable fields which occupy an object instance"),
+        Transition("10378", "import", "bug10378",
+            "revert to single phase name lookup"),
+        Transition(null, "checkimports", "check10378",
+            "give deprecation messages about 10378 anomalies"),
+        Transition("14488", "complex", "vcomplex",
+            "give deprecation messages about all usages of complex or imaginary types"),
+        Transition("16997", "intpromote", "fix16997",
+            "fix integral promotions for unary + - ~ operators"),
+        Transition(null, "tls", "vtls",
+            "list all variables going into thread local storage"),
+    ];
 }
 
 /**
@@ -377,14 +402,29 @@ CPU architectures supported by -mcpu=id:
     /// Language changes listed by -transition=id
     static string transitionUsage()
     {
-        return "Language changes listed by -transition=id:
-  =all           list information on all language changes
-  =checkimports  give deprecation messages about 10378 anomalies
-  =complex,14488 give deprecation messages about all usages of complex or imaginary types
-  =field,3449    list all non-mutable fields which occupy an object instance
-  =import,10378  revert to single phase name lookup
-  =intpromote,16997 fix integral promotions for unary + - ~ operators
-  =tls           list all variables going into thread local storage
+        enum maxFlagLength = 20;
+        enum s = () {
+            auto buf = "Language changes listed by -transition=id:
 ";
+            auto allTransitions = [Usage.Transition(null, "all", null,
+                "list information on all language changes")] ~ Usage.transitions;
+            foreach (t; allTransitions)
+            {
+                buf ~= "  =";
+                buf ~= t.name;
+                auto lineLength = 3 + t.name.length;
+                if (t.bugzillaNumber !is null)
+                {
+                    buf ~= "," ~ t.bugzillaNumber;
+                    lineLength += t.bugzillaNumber.length + 1;
+                }
+                foreach (i; 0 .. maxFlagLength - lineLength)
+                    buf ~= " ";
+                buf ~= t.helpText;
+                buf ~= "\n";
+            }
+            return buf;
+        }();
+        return s;
     }
 }

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1696,53 +1696,46 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                         if (num == uint.max)
                             goto Lerror;
 
+                        string generateTransitionsNumbers()
+                        {
+                            import dmd.cli : Usage;
+                            string buf;
+                            foreach (t; Usage.transitions)
+                            {
+                                if (t.bugzillaNumber !is null)
+                                    buf ~= `case `~t.bugzillaNumber~`: params.`~t.paramName~` = true;break;`;
+                            }
+                            return buf;
+                        }
+
                         // Bugzilla issue number
                         switch (num)
                         {
-                        case 3449:
-                            params.vfield = true;
-                            break;
-                        case 10378:
-                            params.bug10378 = true;
-                            break;
-                        case 14488:
-                            params.vcomplex = true;
-                            break;
-                        case 16997:
-                            params.fix16997 = true;
-                            break;
+                        mixin(generateTransitionsNumbers());
                         default:
                             goto Lerror;
                         }
                     }
                     else if (Identifier.isValidIdentifier(p + 12))
                     {
+                        string generateTransitionsText()
+                        {
+                            import dmd.cli : Usage;
+                            string buf = `case "all":`;
+                            foreach (t; Usage.transitions)
+                                buf ~= `params.`~t.paramName~` = true;`;
+                            buf ~= "break;";
+
+                            foreach (t; Usage.transitions)
+                            {
+                                buf ~= `case "`~t.name~`": params.`~t.paramName~` = true;break;`;
+                            }
+                            return buf;
+                        }
                         const ident = p + 12;
                         switch (ident[0 .. strlen(ident)])
                         {
-                        case "all":
-                            params.vtls = true;
-                            params.vfield = true;
-                            params.vcomplex = true;
-                            break;
-                        case "checkimports":
-                            params.check10378 = true;
-                            break;
-                        case "complex":
-                            params.vcomplex = true;
-                            break;
-                        case "field":
-                            params.vfield = true;
-                            break;
-                        case "import":
-                            params.bug10378 = true;
-                            break;
-                        case "intpromote":
-                            params.fix16997 = true;
-                            break;
-                        case "tls":
-                            params.vtls = true;
-                            break;
+                        mixin(generateTransitionsText());
                         default:
                             goto Lerror;
                         }


### PR DESCRIPTION
From `Usage.transitions` the following is generated:

- CLI parsing
- CLI help text
- man pages
- Future: dlang.org documentation