### PR TITLE
Try running the testsuite with -j8 on SemaphoreCI

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -14,7 +14,7 @@ export DMD=${DMD:-dmd}         # can be {dmd,ldc,gdc}
 # See also: https://semaphoreci.com/docs/available-environment-variables.html
 ################################################################################
 
-export N=4
+export N=8
 export OS_NAME=linux
 export BRANCH=$BRANCH_NAME
 export FULL_BUILD="${PULL_REQUEST_NUMBER+false}"


### PR DESCRIPTION
Just an experiment to see whether this improves things.
Currently it takes about 8 mins for this loop to run:

- build
- test
  - test_dmd
  - test_druntime
  - test_dub_package
  - test_phobos
- rebuild
- rebuild 1
- test_dmd