### PR TITLE
Automatically convert SCOPE into a D enum

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -391,7 +391,7 @@ private bool hasPrivateAccess(AggregateDeclaration ad, Dsymbol smember)
  */
 extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
 {
-    if (sc.flags & SCOPEnoaccesscheck)
+    if (sc.flags & SCOPE.noaccesscheck)
         return false;
     static if (LOG)
     {

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -354,7 +354,7 @@ extern (C++) abstract class Declaration : Dsymbol
         {
             for (Scope* scx = sc; scx; scx = scx.enclosing)
             {
-                if (scx.func == parent && (scx.flags & SCOPEcontract))
+                if (scx.func == parent && (scx.flags & SCOPE.contract))
                 {
                     const(char)* s = isParameter() && parent.ident != Id.ensure ? "parameter" : "result";
                     if (!flag)
@@ -369,7 +369,7 @@ extern (C++) abstract class Declaration : Dsymbol
             VarDeclaration vthis = (cast(ThisExp)e1).var;
             for (Scope* scx = sc; scx; scx = scx.enclosing)
             {
-                if (scx.func == vthis.parent && (scx.flags & SCOPEcontract))
+                if (scx.func == vthis.parent && (scx.flags & SCOPE.contract))
                 {
                     if (!flag)
                         error(loc, "cannot modify parameter 'this' in contract");
@@ -1494,7 +1494,7 @@ extern (C++) class VarDeclaration : Declaration
     final bool checkNestedReference(Scope* sc, Loc loc)
     {
         //printf("VarDeclaration::checkNestedReference() %s\n", toChars());
-        if (sc.intypeof == 1 || (sc.flags & SCOPEctfe))
+        if (sc.intypeof == 1 || (sc.flags & SCOPE.ctfe))
             return false;
         if (!parent || parent == sc.parent)
             return false;
@@ -1548,7 +1548,7 @@ extern (C++) class VarDeclaration : Declaration
         {
             if (i == fdv.closureVars.dim)
             {
-                if (!sc.intypeof && !(sc.flags & SCOPEcompile))
+                if (!sc.intypeof && !(sc.flags & SCOPE.compile))
                     fdv.closureVars.push(this);
                 break;
             }

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -189,8 +189,8 @@ struct Scope
             Scope* s = freelist;
             freelist = s.enclosing;
             //printf("freelist %p\n", s);
-            assert(s.flags & SCOPEfree);
-            s.flags &= ~SCOPEfree;
+            assert(s.flags & SCOPE.free);
+            s.flags &= ~SCOPE.free;
             return s;
         }
         return new Scope();
@@ -231,13 +231,13 @@ struct Scope
     {
         Scope* s = copy();
         //printf("Scope::push(this = %p) new = %p\n", this, s);
-        assert(!(flags & SCOPEfree));
+        assert(!(flags & SCOPE.free));
         s.scopesym = null;
         s.enclosing = &this;
         debug
         {
             if (enclosing)
-                assert(!(enclosing.flags & SCOPEfree));
+                assert(!(enclosing.flags & SCOPE.free));
             if (s == enclosing)
             {
                 printf("this = %p, enclosing = %p, enclosing.enclosing = %p\n", s, &this, enclosing);
@@ -247,8 +247,8 @@ struct Scope
         s.slabel = null;
         s.nofree = 0;
         s.fieldinit = saveFieldInit();
-        s.flags = (flags & (SCOPEcontract | SCOPEdebug | SCOPEctfe | SCOPEcompile | SCOPEconstraint |
-                            SCOPEnoaccesscheck | SCOPEignoresymbolvisibility));
+        s.flags = (flags & (SCOPE.contract | SCOPE.debug_ | SCOPE.ctfe | SCOPE.compile | SCOPE.constraint |
+                            SCOPE.noaccesscheck | SCOPE.ignoresymbolvisibility));
         s.lastdc = null;
         assert(&this != s);
         return s;
@@ -284,7 +284,7 @@ struct Scope
         {
             enclosing = freelist;
             freelist = &this;
-            flags |= SCOPEfree;
+            flags |= SCOPE.free;
         }
         return enc;
     }
@@ -306,7 +306,7 @@ struct Scope
     extern (C++) Scope* startCTFE()
     {
         Scope* sc = this.push();
-        sc.flags = this.flags | SCOPEctfe;
+        sc.flags = this.flags | SCOPE.ctfe;
         version (none)
         {
             /* TODO: Currently this is not possible, because we need to
@@ -332,7 +332,7 @@ struct Scope
 
     extern (C++) Scope* endCTFE()
     {
-        assert(flags & SCOPEctfe);
+        assert(flags & SCOPE.ctfe);
         return pop();
     }
 
@@ -522,7 +522,7 @@ struct Scope
             return null;
         }
 
-        if (this.flags & SCOPEignoresymbolvisibility)
+        if (this.flags & SCOPE.ignoresymbolvisibility)
             flags |= IgnoreSymbolVisibility;
 
         Dsymbol sold = void;
@@ -755,7 +755,7 @@ struct Scope
         {
             //printf("\tsc = %p\n", sc);
             sc.nofree = 1;
-            assert(!(flags & SCOPEfree));
+            assert(!(flags & SCOPE.free));
             //assert(sc != sc.enclosing);
             //assert(!sc.enclosing || sc != sc.enclosing.enclosing);
             //if (++i == 10)

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -92,24 +92,27 @@ enum CSXany_ctor        = 0x40;     /// either this() or super() was called
 enum CSXhalt            = 0x80;     /// assert(0)
 
 // Flags that would not be inherited beyond scope nesting
-enum SCOPEctor          = 0x0001;   /// constructor type
-enum SCOPEcondition     = 0x0004;   /// inside static if/assert condition
-enum SCOPEdebug         = 0x0008;   /// inside debug conditional
+enum SCOPE
+{
+    ctor          = 0x0001,   /// constructor type
+    condition     = 0x0004,   /// inside static if/assert condition
+    debug_        = 0x0008,   /// inside debug conditional
 
-// Flags that would be inherited beyond scope nesting
-enum SCOPEnoaccesscheck = 0x0002;   /// don't do access checks
-enum SCOPEconstraint    = 0x0010;   /// inside template constraint
-enum SCOPEinvariant     = 0x0020;   /// inside invariant code
-enum SCOPErequire       = 0x0040;   /// inside in contract code
-enum SCOPEensure        = 0x0060;   /// inside out contract code
-enum SCOPEcontract      = 0x0060;   /// [mask] we're inside contract code
-enum SCOPEctfe          = 0x0080;   /// inside a ctfe-only expression
-enum SCOPEcompile       = 0x0100;   /// inside __traits(compile)
-enum SCOPEignoresymbolvisibility    = 0x0200;   /// ignore symbol visibility
-                                                /// https://issues.dlang.org/show_bug.cgi?id=15907
-enum SCOPEfree          = 0x8000;   /// is on free list
+    // Flags that would be inherited beyond scope nesting
+    noaccesscheck = 0x0002,   /// don't do access checks
+    constraint    = 0x0010,   /// inside template constraint
+    invariant_    = 0x0020,   /// inside invariant code
+    require       = 0x0040,   /// inside in contract code
+    ensure        = 0x0060,   /// inside out contract code
+    contract      = 0x0060,   /// [mask] we're inside contract code
+    ctfe          = 0x0080,   /// inside a ctfe-only expression
+    compile       = 0x0100,   /// inside __traits(compile)
+    ignoresymbolvisibility    = 0x0200,   /// ignore symbol visibility
+                                          /// https://issues.dlang.org/show_bug.cgi?id=15907
+    free          = 0x8000,   /// is on free list
 
-enum SCOPEfullinst      = 0x10000;  /// fully instantiate templates
+    fullinst      = 0x10000,  /// fully instantiate templates
+}
 
 struct Scope
 {

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -193,7 +193,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
             return;
         if (sc.intypeof)
             return;
-        if (sc.flags & (SCOPEctfe | SCOPEcompile))
+        if (sc.flags & (SCOPE.ctfe | SCOPE.compile))
             return;
     }
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2655,7 +2655,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (funcdecl.isCtorDeclaration())
             {
-                sc.flags |= SCOPEctor;
+                sc.flags |= SCOPE.ctor;
                 Type tret = ad.handleType();
                 assert(tret);
                 tret = tret.addStorageClass(funcdecl.storage_class | sc.stc);
@@ -3279,7 +3279,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         sc = sc.push();
         sc.stc &= ~STC.static_; // not a static constructor
-        sc.flags |= SCOPEctor;
+        sc.flags |= SCOPE.ctor;
 
         funcDeclarationSemantic(ctd);
 
@@ -3577,7 +3577,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         sc = sc.push();
         sc.stc &= ~STC.static_; // not a static invariant
         sc.stc |= STC.const_; // invariant() is always const
-        sc.flags = (sc.flags & ~SCOPEcontract) | SCOPEinvariant;
+        sc.flags = (sc.flags & ~SCOPE.contract) | SCOPE.invariant_;
         sc.linkage = LINKd;
 
         funcDeclarationSemantic(invd);
@@ -5244,7 +5244,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     if (global.errors != errorsave)
         goto Laftersemantic;
 
-    if ((sc.func || (sc.flags & SCOPEfullinst)) && !tempinst.tinst)
+    if ((sc.func || (sc.flags & SCOPE.fullinst)) && !tempinst.tinst)
     {
         /* If a template is instantiated inside function, the whole instantiation
          * should be done at that position. But, immediate running semantic3 of

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -770,7 +770,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         assert(ti.inst is null);
         ti.inst = ti; // temporary instantiation to enable genIdent()
-        scx.flags |= SCOPEconstraint;
+        scx.flags |= SCOPE.constraint;
         bool errors;
         bool result = evalStaticCondition(scx, constraint, e, errors);
         ti.inst = null;
@@ -2139,7 +2139,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         {
             // For constructors, emitting return type is necessary for
             // isReturnIsolated() in functionResolve.
-            scx.flags |= SCOPEctor;
+            scx.flags |= SCOPE.ctor;
 
             Dsymbol parent = toParent2();
             Type tret;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -639,7 +639,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
     int flags = 0;
     Dsymbol s;
 
-    if (sc.flags & SCOPEignoresymbolvisibility)
+    if (sc.flags & SCOPE.ignoresymbolvisibility)
         flags |= IgnoreSymbolVisibility;
 
     Dsymbol sold = void;
@@ -1952,7 +1952,7 @@ extern (C++) abstract class Expression : RootObject
             return false;
         if (sc.intypeof == 1)
             return false;
-        if (sc.flags & (SCOPEctfe | SCOPEdebug))
+        if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
             return false;
 
         /* Given:
@@ -2020,7 +2020,7 @@ extern (C++) abstract class Expression : RootObject
         if (!f.isPure() && calledparent != outerfunc)
         {
             FuncDeclaration ff = outerfunc;
-            if (sc.flags & SCOPEcompile ? ff.isPureBypassingInference() >= PUREweak : ff.setImpure())
+            if (sc.flags & SCOPE.compile ? ff.isPureBypassingInference() >= PUREweak : ff.setImpure())
             {
                 error("pure %s '%s' cannot call impure %s '%s'",
                     ff.kind(), ff.toPrettyChars(), f.kind(), f.toPrettyChars());
@@ -2045,7 +2045,7 @@ extern (C++) abstract class Expression : RootObject
             return false;
         if (sc.intypeof == 1)
             return false; // allow violations inside typeof(expression)
-        if (sc.flags & (SCOPEctfe | SCOPEdebug))
+        if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
             return false; // allow violations inside compile-time evaluated expressions and debug conditionals
         if (v.ident == Id.ctfe)
             return false; // magic variable never violates pure and safe
@@ -2084,7 +2084,7 @@ extern (C++) abstract class Expression : RootObject
                 FuncDeclaration ff = s.isFuncDeclaration();
                 if (!ff)
                     break;
-                if (sc.flags & SCOPEcompile ? ff.isPureBypassingInference() >= PUREweak : ff.setImpure())
+                if (sc.flags & SCOPE.compile ? ff.isPureBypassingInference() >= PUREweak : ff.setImpure())
                 {
                     error("pure %s '%s' cannot access mutable static data '%s'",
                         ff.kind(), ff.toPrettyChars(), v.toChars());
@@ -2181,12 +2181,12 @@ extern (C++) abstract class Expression : RootObject
             return false;
         if (sc.intypeof == 1)
             return false;
-        if (sc.flags & SCOPEctfe)
+        if (sc.flags & SCOPE.ctfe)
             return false;
 
         if (!f.isSafe() && !f.isTrusted())
         {
-            if (sc.flags & SCOPEcompile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafe())
+            if (sc.flags & SCOPE.compile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafe())
             {
                 if (loc.linnum == 0) // e.g. implicitly generated dtor
                     loc = sc.func.loc;
@@ -2212,12 +2212,12 @@ extern (C++) abstract class Expression : RootObject
             return false;
         if (sc.intypeof == 1)
             return false;
-        if (sc.flags & SCOPEctfe)
+        if (sc.flags & SCOPE.ctfe)
             return false;
 
         if (!f.isNogc())
         {
-            if (sc.flags & SCOPEcompile ? sc.func.isNogcBypassingInference() : sc.func.setGC())
+            if (sc.flags & SCOPE.compile ? sc.func.isNogcBypassingInference() : sc.func.setGC())
             {
                 if (loc.linnum == 0) // e.g. implicitly generated dtor
                     loc = sc.func.loc;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1335,7 +1335,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (exp.ident == Id.ctfe)
         {
-            if (sc.flags & SCOPEctfe)
+            if (sc.flags & SCOPE.ctfe)
             {
                 exp.error("variable `__ctfe` cannot be read at compile time");
                 return setError();
@@ -2459,7 +2459,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         Expression d = new DeclarationExp(e.loc, e.cd);
         sc = sc.push(); // just create new scope
-        sc.flags &= ~SCOPEctfe; // temporary stop CTFE
+        sc.flags &= ~SCOPE.ctfe; // temporary stop CTFE
         d = d.expressionSemantic(sc);
         sc = sc.pop();
 
@@ -2568,7 +2568,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         uint olderrors;
 
         sc = sc.push(); // just create new scope
-        sc.flags &= ~SCOPEctfe; // temporary stop CTFE
+        sc.flags &= ~SCOPE.ctfe; // temporary stop CTFE
         sc.protection = Prot(PROTpublic); // https://issues.dlang.org/show_bug.cgi?id=12506
 
         /* fd.treq might be incomplete type,
@@ -3483,10 +3483,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (exp.f.checkNestedReference(sc, exp.loc))
                     return setError();
             }
-            else if (sc.func && sc.intypeof != 1 && !(sc.flags & SCOPEctfe))
+            else if (sc.func && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe))
             {
                 bool err = false;
-                if (!tf.purity && !(sc.flags & SCOPEdebug) && sc.func.setImpure())
+                if (!tf.purity && !(sc.flags & SCOPE.debug_) && sc.func.setImpure())
                 {
                     exp.error("pure %s '%s' cannot call impure %s '%s'",
                         sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());
@@ -3829,7 +3829,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
 
         //printf("IsExp::semantic(%s)\n", toChars());
-        if (e.id && !(sc.flags & SCOPEcondition))
+        if (e.id && !(sc.flags & SCOPE.condition))
         {
             e.error("can only declare type aliases within static if conditionals or static asserts");
             return setError();
@@ -3839,7 +3839,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Scope* sc2 = sc.copy(); // keep sc.flags
         sc2.tinst = null;
         sc2.minst = null;
-        sc2.flags |= SCOPEfullinst;
+        sc2.flags |= SCOPE.fullinst;
         Type t = e.targ.trySemantic(e.loc, sc2);
         sc2.pop();
         if (!t)
@@ -8641,7 +8641,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e1x = e1x.toBoolean(sc);
         uint cs1 = sc.callSuper;
 
-        if (sc.flags & SCOPEcondition)
+        if (sc.flags & SCOPE.condition)
         {
             /* If in static if, don't evaluate e2 if we don't have to.
              */
@@ -9608,13 +9608,13 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
          */
         if (ie.sds.isModule() && ie.sds != sc._module)
             flags |= IgnorePrivateImports;
-        if (sc.flags & SCOPEignoresymbolvisibility)
+        if (sc.flags & SCOPE.ignoresymbolvisibility)
             flags |= IgnoreSymbolVisibility;
         Dsymbol s = ie.sds.search(exp.loc, exp.ident, flags);
         /* Check for visibility before resolving aliases because public
          * aliases to private symbols are public.
          */
-        if (s && !(sc.flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc._module, s))
+        if (s && !(sc.flags & SCOPE.ignoresymbolvisibility) && !symbolIsVisible(sc._module, s))
         {
             if (s.isDeclaration())
                 error(exp.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toChars());

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1036,7 +1036,7 @@ extern (C++) class FuncDeclaration : Declaration
 
     Lerr:
         // Don't give error if in template constraint
-        if (!(sc.flags & SCOPEconstraint))
+        if (!(sc.flags & SCOPE.constraint))
         {
             const(char)* xstatic = isStatic() ? "static " : "";
             // better diagnostics for static functions
@@ -1695,7 +1695,7 @@ extern (C++) class FuncDeclaration : Declaration
                 if (!found)
                 {
                     //printf("\tadding sibling %s\n", fdthis.toPrettyChars());
-                    if (!sc.intypeof && !(sc.flags & SCOPEcompile))
+                    if (!sc.intypeof && !(sc.flags & SCOPE.compile))
                         siblingCallers.push(fdthis);
                 }
             }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6560,7 +6560,7 @@ extern (C++) abstract class TypeQualified : Type
                 Type t = s.getType(); // type symbol, type alias, or type tuple?
                 uint errorsave = global.errors;
                 Dsymbol sm = s.searchX(loc, sc, id);
-                if (sm && !(sc.flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc, sm))
+                if (sm && !(sc.flags & SCOPE.ignoresymbolvisibility) && !symbolIsVisible(sc, sm))
                 {
                     .deprecation(loc, "%s is not visible from module %s", sm.toPrettyChars(), sc._module.toChars());
                     // sm = null;
@@ -7281,7 +7281,7 @@ extern (C++) final class TypeStruct : Type
 
             e = new TupleExp(e.loc, e0, exps);
             Scope* sc2 = sc.push();
-            sc2.flags = sc.flags | SCOPEnoaccesscheck;
+            sc2.flags = sc.flags | SCOPE.noaccesscheck;
             e = e.expressionSemantic(sc2);
             sc2.pop();
             return e;
@@ -7289,7 +7289,7 @@ extern (C++) final class TypeStruct : Type
 
         Dsymbol searchSym()
         {
-            int flags = sc.flags & SCOPEignoresymbolvisibility ? IgnoreSymbolVisibility : 0;
+            int flags = sc.flags & SCOPE.ignoresymbolvisibility ? IgnoreSymbolVisibility : 0;
             Dsymbol sold = void;
             if (global.params.bug10378 || global.params.check10378)
             {
@@ -7316,7 +7316,7 @@ extern (C++) final class TypeStruct : Type
         {
             return noMember(sc, e, ident, flag);
         }
-        if (!(sc.flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc, s))
+        if (!(sc.flags & SCOPE.ignoresymbolvisibility) && !symbolIsVisible(sc, s))
         {
             .deprecation(e.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toPrettyChars());
             // return noMember(sc, e, ident, flag);
@@ -8091,7 +8091,7 @@ extern (C++) final class TypeClass : Type
 
             e = new TupleExp(e.loc, e0, exps);
             Scope* sc2 = sc.push();
-            sc2.flags = sc.flags | SCOPEnoaccesscheck;
+            sc2.flags = sc.flags | SCOPE.noaccesscheck;
             e = e.expressionSemantic(sc2);
             sc2.pop();
             return e;
@@ -8099,7 +8099,7 @@ extern (C++) final class TypeClass : Type
 
         Dsymbol searchSym()
         {
-            int flags = sc.flags & SCOPEignoresymbolvisibility ? IgnoreSymbolVisibility : 0;
+            int flags = sc.flags & SCOPE.ignoresymbolvisibility ? IgnoreSymbolVisibility : 0;
             Dsymbol sold = void;
             if (global.params.bug10378 || global.params.check10378)
             {
@@ -8268,7 +8268,7 @@ extern (C++) final class TypeClass : Type
 
             return noMember(sc, e, ident, flag & 1);
         }
-        if (!(sc.flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc, s))
+        if (!(sc.flags & SCOPE.ignoresymbolvisibility) && !symbolIsVisible(sc, s))
         {
             .deprecation(e.loc, "%s is not visible from module %s", s.toPrettyChars(), sc._module.toPrettyChars());
             // return noMember(sc, e, ident, flag);

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -215,7 +215,7 @@ public:
 extern (C++) Expression checkGC(Scope* sc, Expression e)
 {
     FuncDeclaration f = sc.func;
-    if (e && e.op != TOKerror && f && sc.intypeof != 1 && !(sc.flags & SCOPEctfe) && (f.type.ty == Tfunction && (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc))
+    if (e && e.op != TOKerror && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) && (f.type.ty == Tfunction && (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc))
     {
         scope NOGCVisitor gcv = new NOGCVisitor(f);
         walkPostorder(e, gcv);

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -251,7 +251,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             }
         }
 
-        //printf(" sc.incontract = %d\n", (sc.flags & SCOPEcontract));
+        //printf(" sc.incontract = %d\n", (sc.flags & SCOPE.contract));
         if (funcdecl.semanticRun >= PASSsemantic3)
             return;
         funcdecl.semanticRun = PASSsemantic3;
@@ -321,8 +321,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc2.explicitProtection = 0;
             sc2.aligndecl = null;
             if (funcdecl.ident != Id.require && funcdecl.ident != Id.ensure)
-                sc2.flags = sc.flags & ~SCOPEcontract;
-            sc2.flags &= ~SCOPEcompile;
+                sc2.flags = sc.flags & ~SCOPE.contract;
+            sc2.flags &= ~SCOPE.compile;
             sc2.tf = null;
             sc2.os = null;
             sc2.noctor = 0;
@@ -882,7 +882,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 sym.loc = funcdecl.loc;
                 sym.endlinnum = funcdecl.endloc.linnum;
                 sc2 = sc2.push(sym);
-                sc2.flags = (sc2.flags & ~SCOPEcontract) | SCOPErequire;
+                sc2.flags = (sc2.flags & ~SCOPE.contract) | SCOPE.require;
 
                 // BUG: need to error if accessing out parameters
                 // BUG: need to disallow returns and throws
@@ -905,7 +905,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     funcdecl.error("void functions have no result");
 
                 sc2 = scout; //push
-                sc2.flags = (sc2.flags & ~SCOPEcontract) | SCOPEensure;
+                sc2.flags = (sc2.flags & ~SCOPE.contract) | SCOPE.ensure;
 
                 // BUG: need to disallow returns and throws
 
@@ -1183,7 +1183,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         {
             sc = sc.push();
             if (funcdecl.isCtorDeclaration()) // https://issues.dlang.org/show_bug.cgi?id=#15665
-                sc.flags |= SCOPEctor;
+                sc.flags |= SCOPE.ctor;
             sc.stc = 0;
             sc.linkage = funcdecl.linkage; // https://issues.dlang.org/show_bug.cgi?id=8496
             funcdecl.type = f.typeSemantic(funcdecl.loc, sc);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -67,13 +67,13 @@ import dmd.visitor;
  */
 private Identifier fixupLabelName(Scope* sc, Identifier ident)
 {
-    uint flags = (sc.flags & SCOPEcontract);
+    uint flags = (sc.flags & SCOPE.contract);
     const id = ident.toString();
-    if (flags && flags != SCOPEinvariant &&
+    if (flags && flags != SCOPE.invariant_ &&
         !(id.length >= 2 && id[0] == '_' && id[1] == '_'))  // does not start with "__"
     {
         OutBuffer buf;
-        buf.writestring(flags == SCOPErequire ? "__in_" : "__out_");
+        buf.writestring(flags == SCOPE.require ? "__in_" : "__out_");
         buf.writestring(ident.toString());
 
         ident = Identifier.idPool(buf.peekSlice());
@@ -2172,7 +2172,7 @@ else
             if (dc)
             {
                 sc = sc.push();
-                sc.flags |= SCOPEdebug;
+                sc.flags |= SCOPE.debug_;
                 cs.ifbody = cs.ifbody.statementSemantic(sc);
                 sc.pop();
             }
@@ -2937,7 +2937,7 @@ else
         Expression e0 = null;
 
         bool errors = false;
-        if (sc.flags & SCOPEcontract)
+        if (sc.flags & SCOPE.contract)
         {
             rs.error("return statements cannot be in contracts");
             errors = true;
@@ -3833,7 +3833,7 @@ else
         if (ds.statement)
         {
             sc = sc.push();
-            sc.flags |= SCOPEdebug;
+            sc.flags |= SCOPE.debug_;
             ds.statement = ds.statement.statementSemantic(sc);
             sc.pop();
         }

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -77,7 +77,7 @@ bool evalStaticCondition(Scope* sc, Expression exp, Expression e, ref bool error
     uint nerrors = global.errors;
 
     sc = sc.startCTFE();
-    sc.flags |= SCOPEcondition;
+    sc.flags |= SCOPE.condition;
 
     e = e.expressionSemantic(sc);
     e = resolveProperties(sc, e);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -680,7 +680,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return dimError(1);
 
         Scope* sc2 = sc.push();
-        sc2.flags = sc.flags | SCOPEnoaccesscheck;
+        sc2.flags = sc.flags | SCOPE.noaccesscheck;
         bool ok = TemplateInstance.semanticTiargs(e.loc, sc2, e.args, 1);
         sc2.pop();
         if (!ok)
@@ -818,7 +818,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
         // ignore symbol visibility for these traits, should disable access checks as well
         Scope* scx = sc.push();
-        scx.flags |= SCOPEignoresymbolvisibility;
+        scx.flags |= SCOPE.ignoresymbolvisibility;
         scope (exit) scx.pop();
 
         if (e.ident == Id.hasMember)
@@ -1347,7 +1347,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             Scope* sc2 = sc.push();
             sc2.tinst = null;
             sc2.minst = null;
-            sc2.flags = (sc.flags & ~(SCOPEctfe | SCOPEcondition)) | SCOPEcompile | SCOPEfullinst;
+            sc2.flags = (sc.flags & ~(SCOPE.ctfe | SCOPE.condition)) | SCOPE.compile | SCOPE.fullinst;
 
             bool err = false;
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -795,7 +795,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             tf.next = tf.next.typeSemantic(loc, sc);
             sc = sc.pop();
             errors |= tf.checkRetType(loc);
-            if (tf.next.isscope() && !(sc.flags & SCOPEctor))
+            if (tf.next.isscope() && !(sc.flags & SCOPE.ctor))
             {
                 mtype.error(loc, "functions cannot return scope `%s`", tf.next.toChars());
                 errors = true;


### PR DESCRIPTION
```bash
replacements=(
"SCOPEctor ctor"
"SCOPEcondition condition"
"SCOPEdebug debug_"
"SCOPEnoaccesscheck noaccesscheck"
"SCOPEconstraint constraint"
"SCOPEinvariant invariant_"
"SCOPErequire require"
"SCOPEensure ensure"
"SCOPEcontract contract"
"SCOPEctfe ctfe"
"SCOPEcompile compile"
"SCOPEignoresymbolvisibility ignoresymbolvisibility"
"SCOPEfree free"
"SCOPEfullinst fullinst"
)

for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/SCOPE.${w[1]}/g" -i **/*.d
done
```
  