### PR TITLE
Automatically convert CSX into a D enum

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -113,7 +113,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                 assert(i < dim);
                 uint fi = sc.fieldinit[i];
 
-                if (fi & CSXthis_ctor)
+                if (fi & CSX.this_ctor)
                 {
                     if (var.type.isMutable() && e1.type.isMutable())
                         result = false;
@@ -123,7 +123,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                         .error(loc, "%s field `%s` initialized multiple times", modStr, var.toChars());
                     }
                 }
-                else if (sc.noctor || (fi & CSXlabel))
+                else if (sc.noctor || (fi & CSX.label))
                 {
                     if (!mustInit && var.type.isMutable() && e1.type.isMutable())
                         result = false;
@@ -134,7 +134,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                     }
                 }
 
-                sc.fieldinit[i] |= CSXthis_ctor;
+                sc.fieldinit[i] |= CSX.this_ctor;
                 if (var.overlapped) // https://issues.dlang.org/show_bug.cgi?id=15258
                 {
                     foreach (j, v; ad.fields)
@@ -142,7 +142,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                         if (v is var || !var.isOverlappedWith(v))
                             continue;
                         v.ctorinit = true;
-                        sc.fieldinit[j] = CSXthis_ctor;
+                        sc.fieldinit[j] = CSX.this_ctor;
                     }
                 }
             }

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -41,40 +41,40 @@ extern (C++) bool mergeFieldInit(Loc loc, ref uint fieldInit, uint fi, bool must
     if (fi != fieldInit)
     {
         // Have any branches returned?
-        bool aRet = (fi & CSXreturn) != 0;
-        bool bRet = (fieldInit & CSXreturn) != 0;
+        bool aRet = (fi & CSX.return_) != 0;
+        bool bRet = (fieldInit & CSX.return_) != 0;
         // Have any branches halted?
-        bool aHalt = (fi & CSXhalt) != 0;
-        bool bHalt = (fieldInit & CSXhalt) != 0;
+        bool aHalt = (fi & CSX.halt) != 0;
+        bool bHalt = (fieldInit & CSX.halt) != 0;
         bool ok;
         if (aHalt && bHalt)
         {
             ok = true;
-            fieldInit = CSXhalt;
+            fieldInit = CSX.halt;
         }
         else if (!aHalt && aRet)
         {
-            ok = !mustInit || (fi & CSXthis_ctor);
+            ok = !mustInit || (fi & CSX.this_ctor);
             fieldInit = fieldInit;
         }
         else if (!bHalt && bRet)
         {
-            ok = !mustInit || (fieldInit & CSXthis_ctor);
+            ok = !mustInit || (fieldInit & CSX.this_ctor);
             fieldInit = fi;
         }
         else if (aHalt)
         {
-            ok = !mustInit || (fieldInit & CSXthis_ctor);
+            ok = !mustInit || (fieldInit & CSX.this_ctor);
             fieldInit = fieldInit;
         }
         else if (bHalt)
         {
-            ok = !mustInit || (fi & CSXthis_ctor);
+            ok = !mustInit || (fi & CSX.this_ctor);
             fieldInit = fi;
         }
         else
         {
-            ok = !mustInit || !((fieldInit ^ fi) & CSXthis_ctor);
+            ok = !mustInit || !((fieldInit ^ fi) & CSX.this_ctor);
             fieldInit |= fi;
         }
         return ok;
@@ -345,21 +345,21 @@ struct Scope
         if (cs != callSuper)
         {
             // Have ALL branches called a constructor?
-            int aAll = (cs & (CSXthis_ctor | CSXsuper_ctor)) != 0;
-            int bAll = (callSuper & (CSXthis_ctor | CSXsuper_ctor)) != 0;
+            int aAll = (cs & (CSX.this_ctor | CSX.super_ctor)) != 0;
+            int bAll = (callSuper & (CSX.this_ctor | CSX.super_ctor)) != 0;
             // Have ANY branches called a constructor?
-            bool aAny = (cs & CSXany_ctor) != 0;
-            bool bAny = (callSuper & CSXany_ctor) != 0;
+            bool aAny = (cs & CSX.any_ctor) != 0;
+            bool bAny = (callSuper & CSX.any_ctor) != 0;
             // Have any branches returned?
-            bool aRet = (cs & CSXreturn) != 0;
-            bool bRet = (callSuper & CSXreturn) != 0;
+            bool aRet = (cs & CSX.return_) != 0;
+            bool bRet = (callSuper & CSX.return_) != 0;
             // Have any branches halted?
-            bool aHalt = (cs & CSXhalt) != 0;
-            bool bHalt = (callSuper & CSXhalt) != 0;
+            bool aHalt = (cs & CSX.halt) != 0;
+            bool bHalt = (callSuper & CSX.halt) != 0;
             bool ok = true;
             if (aHalt && bHalt)
             {
-                callSuper = CSXhalt;
+                callSuper = CSX.halt;
             }
             else if ((!aHalt && aRet && !aAny && bAny) || (!bHalt && bRet && !bAny && aAny))
             {
@@ -372,11 +372,11 @@ struct Scope
                 // If one branch has called a ctor and then exited, anything the
                 // other branch has done is OK (except returning without a
                 // ctor call, but we already checked that).
-                callSuper |= cs & (CSXany_ctor | CSXlabel);
+                callSuper |= cs & (CSX.any_ctor | CSX.label);
             }
             else if (bHalt || bRet && bAll)
             {
-                callSuper = cs | (callSuper & (CSXany_ctor | CSXlabel));
+                callSuper = cs | (callSuper & (CSX.any_ctor | CSX.label));
             }
             else
             {
@@ -385,8 +385,8 @@ struct Scope
                 // If one returned without a ctor, we must remember that
                 // (Don't bother if we've already found an error)
                 if (ok && aRet && !aAny)
-                    callSuper |= CSXreturn;
-                callSuper |= cs & (CSXany_ctor | CSXlabel);
+                    callSuper |= CSX.return_;
+                callSuper |= cs & (CSX.any_ctor | CSX.label);
             }
             if (!ok)
                 error(loc, "one path skips constructor");

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -82,14 +82,17 @@ extern (C++) bool mergeFieldInit(Loc loc, ref uint fieldInit, uint fi, bool must
     return true;
 }
 
-enum CSXthis_ctor       = 0x01;     /// called this()
-enum CSXsuper_ctor      = 0x02;     /// called super()
-enum CSXthis            = 0x04;     /// referenced this
-enum CSXsuper           = 0x08;     /// referenced super
-enum CSXlabel           = 0x10;     /// seen a label
-enum CSXreturn          = 0x20;     /// seen a return statement
-enum CSXany_ctor        = 0x40;     /// either this() or super() was called
-enum CSXhalt            = 0x80;     /// assert(0)
+enum CSX
+{
+    this_ctor       = 0x01,     /// called this()
+    super_ctor      = 0x02,     /// called super()
+    this_           = 0x04,     /// referenced this
+    super_          = 0x08,     /// referenced super
+    label           = 0x10,     /// seen a label
+    return_         = 0x20,     /// seen a return statement
+    any_ctor        = 0x40,     /// either this() or super() was called
+    halt            = 0x80,     /// assert(0)
+}
 
 // Flags that would not be inherited beyond scope nesting
 enum SCOPEctor          = 0x0001;   /// constructor type

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1454,7 +1454,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         if (!sc.intypeof)
-            sc.callSuper |= CSXthis;
+            sc.callSuper |= CSX.this_;
         result = e;
         return;
 
@@ -1538,7 +1538,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         if (!sc.intypeof)
-            sc.callSuper |= CSXsuper;
+            sc.callSuper |= CSX.super_;
         result = e;
         return;
 
@@ -3280,15 +3280,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
 
-            if (!sc.intypeof && !(sc.callSuper & CSXhalt))
+            if (!sc.intypeof && !(sc.callSuper & CSX.halt))
             {
-                if (sc.noctor || sc.callSuper & CSXlabel)
+                if (sc.noctor || sc.callSuper & CSX.label)
                     exp.error("constructor calls not allowed in loops or after labels");
-                if (sc.callSuper & (CSXsuper_ctor | CSXthis_ctor))
+                if (sc.callSuper & (CSX.super_ctor | CSX.this_ctor))
                     exp.error("multiple constructor calls");
-                if ((sc.callSuper & CSXreturn) && !(sc.callSuper & CSXany_ctor))
+                if ((sc.callSuper & CSX.return_) && !(sc.callSuper & CSX.any_ctor))
                     exp.error("an earlier return statement skips constructor");
-                sc.callSuper |= CSXany_ctor | CSXsuper_ctor;
+                sc.callSuper |= CSX.any_ctor | CSX.super_ctor;
             }
 
             tthis = cd.type.addMod(sc.func.type.mod);
@@ -3321,15 +3321,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
 
-            if (!sc.intypeof && !(sc.callSuper & CSXhalt))
+            if (!sc.intypeof && !(sc.callSuper & CSX.halt))
             {
-                if (sc.noctor || sc.callSuper & CSXlabel)
+                if (sc.noctor || sc.callSuper & CSX.label)
                     exp.error("constructor calls not allowed in loops or after labels");
-                if (sc.callSuper & (CSXsuper_ctor | CSXthis_ctor))
+                if (sc.callSuper & (CSX.super_ctor | CSX.this_ctor))
                     exp.error("multiple constructor calls");
-                if ((sc.callSuper & CSXreturn) && !(sc.callSuper & CSXany_ctor))
+                if ((sc.callSuper & CSX.return_) && !(sc.callSuper & CSX.any_ctor))
                     exp.error("an earlier return statement skips constructor");
-                sc.callSuper |= CSXany_ctor | CSXthis_ctor;
+                sc.callSuper |= CSX.any_ctor | CSX.this_ctor;
             }
 
             tthis = ad.type.addMod(sc.func.type.mod);
@@ -4386,11 +4386,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             FuncDeclaration fd = sc.parent.isFuncDeclaration();
             if (fd)
                 fd.hasReturnExp |= 4;
-            sc.callSuper |= CSXhalt;
+            sc.callSuper |= CSX.halt;
             if (sc.fieldinit)
             {
                 for (size_t i = 0; i < sc.fieldinit_dim; i++)
-                    sc.fieldinit[i] |= CSXhalt;
+                    sc.fieldinit[i] |= CSX.halt;
             }
 
             if (global.params.useAssert == CHECKENABLE.off)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -631,7 +631,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     ClassDeclaration cd = ad2.isClassDeclaration();
 
                     // Verify that all the ctorinit fields got initialized
-                    if (!(sc2.callSuper & CSXthis_ctor))
+                    if (!(sc2.callSuper & CSX.this_ctor))
                     {
                         foreach (i, v; ad2.fields)
                         {
@@ -655,7 +655,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             else
                             {
                                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                                if (mustInit && !(sc2.fieldinit[i] & CSXthis_ctor))
+                                if (mustInit && !(sc2.fieldinit[i] & CSX.this_ctor))
                                 {
                                     funcdecl.error("field `%s` must be initialized but skipped", v.toChars());
                                 }
@@ -664,7 +664,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                     sc2.freeFieldinit();
 
-                    if (cd && !(sc2.callSuper & CSXany_ctor) && cd.baseClass && cd.baseClass.ctor)
+                    if (cd && !(sc2.callSuper & CSX.any_ctor) && cd.baseClass && cd.baseClass.ctor)
                     {
                         sc2.callSuper = 0;
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3153,12 +3153,12 @@ else
         }
 
         // If any branches have called a ctor, but this branch hasn't, it's an error
-        if (sc.callSuper & CSXany_ctor && !(sc.callSuper & (CSXthis_ctor | CSXsuper_ctor)))
+        if (sc.callSuper & CSX.any_ctor && !(sc.callSuper & (CSX.this_ctor | CSX.super_ctor)))
         {
             rs.error("return without calling constructor");
             errors = true;
         }
-        sc.callSuper |= CSXreturn;
+        sc.callSuper |= CSX.return_;
         if (sc.fieldinit)
         {
             auto ad = fd.isMember2();
@@ -3168,12 +3168,12 @@ else
             {
                 VarDeclaration v = ad.fields[i];
                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                if (mustInit && !(sc.fieldinit[i] & CSXthis_ctor))
+                if (mustInit && !(sc.fieldinit[i] & CSX.this_ctor))
                 {
                     rs.error("an earlier return statement skips field `%s` initialization", v.toChars());
                     errors = true;
                 }
-                sc.fieldinit[i] |= CSXreturn;
+                sc.fieldinit[i] |= CSX.return_;
             }
         }
 
@@ -3899,12 +3899,12 @@ else
 
         sc = sc.push();
         sc.scopesym = sc.enclosing.scopesym;
-        sc.callSuper |= CSXlabel;
+        sc.callSuper |= CSX.label;
         if (sc.fieldinit)
         {
             size_t dim = sc.fieldinit_dim;
             foreach (i; 0 .. dim)
-                sc.fieldinit[i] |= CSXlabel;
+                sc.fieldinit[i] |= CSX.label;
         }
         sc.slabel = ls;
         if (ls.statement)


### PR DESCRIPTION
```bash
replacements=(
"CSXthis_ctor this_ctor"
"CSXsuper_ctor super_ctor"
"CSXthis this_"
"CSXsuper super_"
"CSXlabel label"
"CSXreturn return_"
"CSXany_ctor any_ctor"
"CSXhalt halt"
)

for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/CSX.${w[1]}/g" -i **/*.d
done
```

This looks like one of the last ugly C enum in the frontend except for `PROT`
and the `T` types.