### PR TITLE
Fix Issue 18218 - __traits(isDeprecated, creal) should return true

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -502,6 +502,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     }
     if (e.ident == Id.isDeprecated)
     {
+        if (global.params.vcomplex)
+        {
+            if (isTypeX(t => t.iscomplex() || t.isimaginary()))
+                return True();
+        }
         return isDsymX(t => t.isDeprecated());
     }
     if (e.ident == Id.isFuture)

--- a/test/compilable/sw_transition_complex.d
+++ b/test/compilable/sw_transition_complex.d
@@ -154,3 +154,11 @@ deprecated struct Foo
     ifloat a = 2i;
     cfloat b = 2f + 2i;
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=18218
+static assert(__traits(isDeprecated, cfloat));
+static assert(__traits(isDeprecated, cdouble));
+static assert(__traits(isDeprecated, creal));
+static assert(__traits(isDeprecated, ifloat));
+static assert(__traits(isDeprecated, idouble));
+static assert(__traits(isDeprecated, ireal));


### PR DESCRIPTION
This is needed to be able to build Phobos with `-transition=complex`