### PR TITLE
Automatically convert PROTXXX into a D enum

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -53,9 +53,10 @@ private Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
         {
             BaseClass* b = (*cd.baseclasses)[i];
             Prot access = getAccess(b.sym, smember);
-            switch (access.kind)
+            final switch (access.kind)
             {
             case Protection.none:
+            case Protection.undefined:
                 break;
             case Protection.private_:
                 access_ret = Prot(Protection.none); // private members of base class not accessible
@@ -71,8 +72,6 @@ private Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
                 if (access_ret.isMoreRestrictiveThan(access))
                     access_ret = access;
                 break;
-            default:
-                assert(0);
             }
         }
     }

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -105,7 +105,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     {
         super(id);
         this.loc = loc;
-        protection = Prot(PROTpublic);
+        protection = Prot(Protection.public_);
         sizeok = Sizeok.none; // size not determined yet
     }
 
@@ -120,7 +120,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         sc2.parent = this;
         if (isUnionDeclaration())
             sc2.inunion = 1;
-        sc2.protection = Prot(PROTpublic);
+        sc2.protection = Prot(Protection.public_);
         sc2.explicitProtection = 0;
         sc2.aligndecl = null;
         sc2.userAttribDecl = null;
@@ -660,7 +660,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             // Emulate vthis.dsymbolSemantic()
             vthis.storage_class |= STC.field;
             vthis.parent = this;
-            vthis.protection = Prot(PROTpublic);
+            vthis.protection = Prot(Protection.public_);
             vthis.alignment = t.alignment();
             vthis.semanticRun = PASSsemanticdone;
 
@@ -671,7 +671,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     override final bool isExport()
     {
-        return protection.kind == PROTexport;
+        return protection.kind == Protection.export_;
     }
 
     /*******************************************

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -45,24 +45,16 @@ struct ASTBase
     alias Identifiers           = Array!(Identifier);
     alias Initializers          = Array!(Initializer);
 
-    enum PROTKIND : int
+    enum Protection : int
     {
-        PROTundefined,
-        PROTnone,
-        PROTprivate,
-        PROTpackage,
-        PROTprotected,
-        PROTpublic,
-        PROTexport,
+        undefined,
+        none,
+        private_,
+        package_,
+        protected_,
+        public_,
+        export_,
     }
-
-    alias PROTprivate       = PROTKIND.PROTprivate;
-    alias PROTpackage       = PROTKIND.PROTpackage;
-    alias PROTprotected     = PROTKIND.PROTprotected;
-    alias PROTpublic        = PROTKIND.PROTpublic;
-    alias PROTexport        = PROTKIND.PROTexport;
-    alias PROTundefined     = PROTKIND.PROTundefined;
-    alias PROTnone          = PROTKIND.PROTnone;
 
     enum Sizeok : int
     {

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6196,7 +6196,7 @@ struct ASTBase
 
     extern (C++) static const(char)* protectionToChars(Protection kind)
     {
-        switch (kind)
+        final switch (kind)
         {
         case Protection.undefined:
             return null;
@@ -6212,8 +6212,6 @@ struct ASTBase
             return "public";
         case Protection.export_:
             return "export";
-        default:
-            assert(0);
         }
     }
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -525,7 +525,7 @@ struct ASTBase
         {
             super(id);
             storage_class = STC.undefined_;
-            protection = Prot(PROTundefined);
+            protection = Prot(Protection.undefined);
             linkage = LINKdefault;
         }
 
@@ -574,7 +574,7 @@ struct ASTBase
             this.id = id;
             this.aliasId = aliasId;
             this.isstatic = isstatic;
-            this.protection = Prot(PROTprivate);
+            this.protection = Prot(Protection.private_);
 
             if (aliasId)
             {
@@ -1037,7 +1037,7 @@ struct ASTBase
             this.loc = loc;
             type = new TypeEnum(this);
             this.memtype = memtype;
-            protection = Prot(PROTundefined);
+            protection = Prot(Protection.undefined);
         }
 
         override void accept(Visitor v)
@@ -1056,7 +1056,7 @@ struct ASTBase
         {
             super(id);
             this.loc = loc;
-            protection = Prot(PROTpublic);
+            protection = Prot(Protection.public_);
             sizeok = Sizeok.none;
         }
 
@@ -1092,7 +1092,7 @@ struct ASTBase
             this.literal = literal;
             this.ismixin = ismixin;
             this.isstatic = true;
-            this.protection = Prot(PROTundefined);
+            this.protection = Prot(Protection.undefined);
 
             if (members && ident)
             {
@@ -1340,7 +1340,7 @@ struct ASTBase
         {
             super(decl);
             this.loc = loc;
-            this.protection.kind = PROTpackage;
+            this.protection.kind = Protection.package_;
             this.protection.pkg = null;
             this.pkg_identifiers = pkg_identifiers;
         }
@@ -6161,7 +6161,7 @@ struct ASTBase
 
     struct Prot
     {
-        PROTKIND kind;
+        Protection kind;
         Package pkg;
     }
 
@@ -6194,23 +6194,23 @@ struct ASTBase
 
 
 
-    extern (C++) static const(char)* protectionToChars(PROTKIND kind)
+    extern (C++) static const(char)* protectionToChars(Protection kind)
     {
         switch (kind)
         {
-        case PROTundefined:
+        case Protection.undefined:
             return null;
-        case PROTnone:
+        case Protection.none:
             return "none";
-        case PROTprivate:
+        case Protection.private_:
             return "private";
-        case PROTpackage:
+        case Protection.package_:
             return "package";
-        case PROTprotected:
+        case Protection.protected_:
             return "protected";
-        case PROTpublic:
+        case Protection.public_:
             return "public";
-        case PROTexport:
+        case Protection.export_:
             return "export";
         default:
             assert(0);

--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -52,12 +52,7 @@ struct ASTCodegen
     alias STC                       = dmd.declaration.STC;
     alias Dsymbol                   = dmd.dsymbol.Dsymbol;
     alias Dsymbols                  = dmd.dsymbol.Dsymbols;
-    alias PROTprivate               = dmd.dsymbol.PROTprivate;
-    alias PROTpackage               = dmd.dsymbol.PROTpackage;
-    alias PROTprotected             = dmd.dsymbol.PROTprotected;
-    alias PROTpublic                = dmd.dsymbol.PROTpublic;
-    alias PROTexport                = dmd.dsymbol.PROTexport;
-    alias PROTundefined             = dmd.dsymbol.PROTundefined;
+    alias Protection                = dmd.dsymbol.Protection;
     alias Prot                      = dmd.dsymbol.Prot;
 
     alias stcToBuffer               = dmd.hdrgen.stcToBuffer;

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -537,7 +537,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
     {
         super(decl);
         this.loc = loc;
-        this.protection.kind = PROTpackage;
+        this.protection.kind = Protection.package_;
         this.protection.pkg = null;
         this.pkg_identifiers = pkg_identifiers;
     }
@@ -545,7 +545,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        if (protection.kind == PROTpackage)
+        if (protection.kind == Protection.package_)
             return new ProtDeclaration(this.loc, pkg_identifiers, Dsymbol.arraySyntaxCopy(decl));
         else
             return new ProtDeclaration(this.loc, protection, Dsymbol.arraySyntaxCopy(decl));
@@ -567,7 +567,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
             protection.pkg = tmp ? tmp.isPackage() : null;
             pkg_identifiers = null;
         }
-        if (protection.kind == PROTpackage && protection.pkg && sc._module)
+        if (protection.kind == Protection.package_ && protection.pkg && sc._module)
         {
             Module m = sc._module;
             Package pkg = m.parent ? m.parent.isPackage() : null;
@@ -584,7 +584,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
 
     override const(char)* toPrettyChars(bool)
     {
-        assert(protection.kind > PROTundefined);
+        assert(protection.kind > Protection.undefined);
         OutBuffer buf;
         buf.writeByte('\'');
         protectionToBuffer(&buf, protection);

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -502,10 +502,10 @@ private:
             {
                 switch (d.protection.kind)
                 {
-                case PROTprivate:
+                case Protection.private_:
                     buf.writeByte('E');
                     break;
-                case PROTprotected:
+                case Protection.protected_:
                     buf.writeByte('M');
                     break;
                 default:
@@ -517,10 +517,10 @@ private:
             {
                 switch (d.protection.kind)
                 {
-                case PROTprivate:
+                case Protection.private_:
                     buf.writeByte('A');
                     break;
-                case PROTprotected:
+                case Protection.protected_:
                     buf.writeByte('I');
                     break;
                 default:
@@ -544,10 +544,10 @@ private:
             // <flags> ::= <virtual/protection flag> <calling convention flag>
             switch (d.protection.kind)
             {
-            case PROTprivate:
+            case Protection.private_:
                 buf.writeByte('C');
                 break;
-            case PROTprotected:
+            case Protection.protected_:
                 buf.writeByte('K');
                 break;
             default:
@@ -590,10 +590,10 @@ private:
         {
             switch (d.protection.kind)
             {
-            case PROTprivate:
+            case Protection.private_:
                 buf.writeByte('0');
                 break;
-            case PROTprotected:
+            case Protection.protected_:
                 buf.writeByte('1');
                 break;
             default:

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -564,7 +564,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                             continue;
                         else if (s == this) // happens if s is nested in this and derives from this
                             s = null;
-                        else if (!(flags & IgnoreSymbolVisibility) && !(s.prot().kind == PROTprotected) && !symbolIsVisible(this, s))
+                        else if (!(flags & IgnoreSymbolVisibility) && !(s.prot().kind == Protection.protected_) && !symbolIsVisible(this, s))
                             s = null;
                         else
                             break;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -279,7 +279,7 @@ extern (C++) abstract class Declaration : Dsymbol
     {
         super(id);
         storage_class = STC.undefined_;
-        protection = Prot(PROTundefined);
+        protection = Prot(Protection.undefined);
         linkage = LINKdefault;
     }
 
@@ -1222,12 +1222,12 @@ extern (C++) class VarDeclaration : Declaration
 
     override final bool isExport()
     {
-        return protection.kind == PROTexport;
+        return protection.kind == Protection.export_;
     }
 
     override final bool isImportedSymbol()
     {
-        if (protection.kind == PROTexport && !_init && (storage_class & STC.static_ || parent.isModule()))
+        if (protection.kind == Protection.export_ && !_init && (storage_class & STC.static_ || parent.isModule()))
             return true;
         return false;
     }
@@ -1652,7 +1652,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         super(Loc(), Type.dtypeinfo.type, tinfo.getTypeInfoIdent(), null);
         this.tinfo = tinfo;
         storage_class = STC.static_ | STC.gshared;
-        protection = Prot(PROTpublic);
+        protection = Prot(Protection.public_);
         linkage = LINKc;
         alignment = Target.ptrsize;
     }

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -57,7 +57,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
         this.loc = loc;
         type = new TypeEnum(this);
         this.memtype = memtype;
-        protection = Prot(PROTundefined);
+        protection = Prot(Protection.undefined);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -69,7 +69,7 @@ extern (C++) final class Import : Dsymbol
         this.id = id;
         this.aliasId = aliasId;
         this.isstatic = isstatic;
-        this.protection = PROTprivate; // default to private
+        this.protection = Protection.private_; // default to private
         // Set symbol name (bracketed)
         if (aliasId)
         {

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1119,7 +1119,7 @@ extern (C++) final class Module : Package
         scope (exit)
             insearch = false;
         if (flags & IgnorePrivateImports)
-            protection = Prot(PROTpublic); // only consider public imports
+            protection = Prot(Protection.public_); // only consider public imports
         return super.isPackageAccessible(p, protection);
     }
 

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -809,7 +809,7 @@ private void emitMemberComments(ScopeDsymbol sds, OutBuffer* buf, Scope* sc)
 
 extern (C++) void emitProtection(OutBuffer* buf, Prot prot)
 {
-    if (prot.kind != PROTundefined && prot.kind != PROTpublic)
+    if (prot.kind != Protection.undefined && prot.kind != Protection.public_)
     {
         protectionToBuffer(buf, prot);
         buf.writeByte(' ');
@@ -953,7 +953,7 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                         return;
                     }
                 }
-                if (d.protection.kind == PROTprivate || sc.protection.kind == PROTprivate)
+                if (d.protection.kind == Protection.private_ || sc.protection.kind == Protection.private_)
                     return;
             }
             if (!com)
@@ -974,7 +974,7 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
             }
             else
             {
-                if (ad.prot().kind == PROTprivate || sc.protection.kind == PROTprivate)
+                if (ad.prot().kind == Protection.private_ || sc.protection.kind == Protection.private_)
                     return;
                 if (!ad.comment)
                     return;
@@ -987,7 +987,7 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
         override void visit(TemplateDeclaration td)
         {
             //printf("TemplateDeclaration::emitComment() '%s', kind = %s\n", td.toChars(), td.kind());
-            if (td.prot().kind == PROTprivate || sc.protection.kind == PROTprivate)
+            if (td.prot().kind == Protection.private_ || sc.protection.kind == Protection.private_)
                 return;
             if (!td.comment)
                 return;
@@ -1001,7 +1001,7 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
 
         override void visit(EnumDeclaration ed)
         {
-            if (ed.prot().kind == PROTprivate || sc.protection.kind == PROTprivate)
+            if (ed.prot().kind == Protection.private_ || sc.protection.kind == Protection.private_)
                 return;
             if (ed.isAnonymous() && ed.members)
             {
@@ -1022,7 +1022,7 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
         override void visit(EnumMember em)
         {
             //printf("EnumMember::emitComment(%p '%s'), comment = '%s'\n", em, em.toChars(), em.comment);
-            if (em.prot().kind == PROTprivate || sc.protection.kind == PROTprivate)
+            if (em.prot().kind == Protection.private_ || sc.protection.kind == Protection.private_)
                 return;
             if (!em.comment)
                 return;
@@ -1355,7 +1355,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                     buf.writestring(": ");
                     any = 1;
                 }
-                emitProtection(buf, Prot(PROTpublic));
+                emitProtection(buf, Prot(Protection.public_));
                 if (bc.sym)
                 {
                     buf.printf("$(DDOC_PSUPER_SYMBOL %s)", bc.sym.toPrettyChars());
@@ -1755,7 +1755,7 @@ struct DocComment
                 s = td;
             for (UnitTestDeclaration utd = s.ddocUnittest; utd; utd = utd.ddocUnittest)
             {
-                if (utd.protection.kind == PROTprivate || !utd.comment || !utd.fbody)
+                if (utd.protection.kind == Protection.private_ || !utd.comment || !utd.fbody)
                     continue;
                 // Strip whitespaces to avoid showing empty summary
                 const(char)* c = utd.comment;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -167,7 +167,7 @@ struct Scope
     PINLINE inlining = PINLINEdefault;
 
     /// protection for class members
-    Prot protection = Prot(PROTpublic);
+    Prot protection = Prot(Protection.public_);
     int explicitProtection;         /// set if in an explicit protection attribute
 
     StorageClass stc;               /// storage class
@@ -644,7 +644,7 @@ struct Scope
                 if (scopesym != s.parent)
                 {
                     ++cost; // got to the symbol through an import
-                    if (s.prot().kind == PROTprivate)
+                    if (s.prot().kind == Protection.private_)
                         return null;
                 }
             }

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -66,24 +66,16 @@ struct Ungag
     }
 }
 
-enum PROTKIND : int
+enum Protection : int
 {
-    PROTundefined,
-    PROTnone,           // no access
-    PROTprivate,
-    PROTpackage,
-    PROTprotected,
-    PROTpublic,
-    PROTexport,
+    undefined,
+    none,           // no access
+    private_,
+    package_,
+    protected_,
+    public_,
+    export_,
 }
-
-alias PROTundefined = PROTKIND.PROTundefined;
-alias PROTnone = PROTKIND.PROTnone;
-alias PROTprivate = PROTKIND.PROTprivate;
-alias PROTpackage = PROTKIND.PROTpackage;
-alias PROTprotected = PROTKIND.PROTprotected;
-alias PROTpublic = PROTKIND.PROTpublic;
-alias PROTexport = PROTKIND.PROTexport;
 
 struct Prot
 {

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1873,7 +1873,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         em.semanticRun = PASSsemantic;
 
-        em.protection = em.ed.isAnonymous() ? em.ed.protection : Prot(PROTpublic);
+        em.protection = em.ed.isAnonymous() ? em.ed.protection : Prot(Protection.public_);
         em.linkage = LINKd;
         em.storage_class = STC.manifest;
         em.userAttribDecl = em.ed.isAnonymous() ? em.ed.userAttribDecl : null;
@@ -2351,7 +2351,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             ScopeDsymbol sds = sce.scopesym;
             if (sds)
             {
-                sds.importScope(tm, Prot(PROTpublic));
+                sds.importScope(tm, Prot(Protection.public_));
                 break;
             }
         }
@@ -2758,7 +2758,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             const(char)* sfunc;
             if (funcdecl.isStatic())
                 sfunc = "static";
-            else if (funcdecl.protection.kind == PROTprivate || funcdecl.protection.kind == PROTpackage)
+            else if (funcdecl.protection.kind == Protection.private_ || funcdecl.protection.kind == Protection.package_)
                 sfunc = protectionToChars(funcdecl.protection.kind);
             else
                 sfunc = "non-virtual";
@@ -2767,8 +2767,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (funcdecl.isOverride() && !funcdecl.isVirtual())
         {
-            PROTKIND kind = funcdecl.prot().kind;
-            if ((kind == PROTprivate || kind == PROTpackage) && funcdecl.isMember())
+            Protection kind = funcdecl.prot().kind;
+            if ((kind == Protection.private_ || kind == Protection.package_) && funcdecl.isMember())
                 funcdecl.error("%s method is not virtual and cannot override", protectionToChars(kind));
             else
                 funcdecl.error("cannot override a non-virtual function");
@@ -2890,7 +2890,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         if (f2)
                         {
                             f2 = f2.overloadExactMatch(funcdecl.type);
-                            if (f2 && f2.isFinalFunc() && f2.prot().kind != PROTprivate)
+                            if (f2 && f2.isFinalFunc() && f2.prot().kind != Protection.private_)
                                 funcdecl.error("cannot override final function `%s`", f2.toPrettyChars());
                         }
                     }
@@ -3155,7 +3155,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         if (f2)
                         {
                             f2 = f2.overloadExactMatch(funcdecl.type);
-                            if (f2 && f2.isFinalFunc() && f2.prot().kind != PROTprivate)
+                            if (f2 && f2.isFinalFunc() && f2.prot().kind != Protection.private_)
                                 funcdecl.error("cannot override final function `%s.%s`", b.sym.toChars(), f2.toPrettyChars());
                         }
                     }
@@ -4532,7 +4532,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             foreach (vd; cldec.fields)
             {
                 if (!vd.isThisDeclaration() &&
-                    !vd.prot().isMoreRestrictiveThan(Prot(PROTpublic)))
+                    !vd.prot().isMoreRestrictiveThan(Prot(Protection.public_)))
                 {
                     vd.error("Field members of a synchronized class cannot be `%s`",
                         protectionToChars(vd.prot().kind));
@@ -5112,7 +5112,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     // Declare each template parameter as an alias for the argument type
     Scope* paramscope = _scope.push();
     paramscope.stc = 0;
-    paramscope.protection = Prot(PROTpublic); // https://issues.dlang.org/show_bug.cgi?id=14169
+    paramscope.protection = Prot(Protection.public_); // https://issues.dlang.org/show_bug.cgi?id=14169
                                               // template parameters should be public
     tempinst.declareParameters(paramscope);
     paramscope.pop();

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -552,7 +552,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         this.literal = literal;
         this.ismixin = ismixin;
         this.isstatic = true;
-        this.protection = Prot(PROTundefined);
+        this.protection = Prot(Protection.undefined);
 
         // Compute in advance for Ddoc's use
         // https://issues.dlang.org/show_bug.cgi?id=11153: ident could be NULL if parsing fails.

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2553,7 +2553,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         sc = sc.push(); // just create new scope
         sc.flags &= ~SCOPE.ctfe; // temporary stop CTFE
-        sc.protection = Prot(PROTpublic); // https://issues.dlang.org/show_bug.cgi?id=12506
+        sc.protection = Prot(Protection.public_); // https://issues.dlang.org/show_bug.cgi?id=12506
 
         /* fd.treq might be incomplete type,
             * so should not semantic it.

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1095,14 +1095,14 @@ extern (C++) class FuncDeclaration : Declaration
 
     override final bool isExport()
     {
-        return protection.kind == PROTexport;
+        return protection.kind == Protection.export_;
     }
 
     override final bool isImportedSymbol()
     {
         //printf("isImportedSymbol()\n");
         //printf("protection = %d\n", protection);
-        return (protection.kind == PROTexport) && !fbody;
+        return (protection.kind == Protection.export_) && !fbody;
     }
 
     override final bool isCodeseg()
@@ -1559,10 +1559,10 @@ extern (C++) class FuncDeclaration : Declaration
         version (none)
         {
             printf("FuncDeclaration::isVirtual(%s)\n", toChars());
-            printf("isMember:%p isStatic:%d private:%d ctor:%d !Dlinkage:%d\n", isMember(), isStatic(), protection == PROTprivate, isCtorDeclaration(), linkage != LINKd);
-            printf("result is %d\n", isMember() && !(isStatic() || protection == PROTprivate || protection == PROTpackage) && p.isClassDeclaration() && !(p.isInterfaceDeclaration() && isFinalFunc()));
+            printf("isMember:%p isStatic:%d private:%d ctor:%d !Dlinkage:%d\n", isMember(), isStatic(), protection == Protection.private_, isCtorDeclaration(), linkage != LINKd);
+            printf("result is %d\n", isMember() && !(isStatic() || protection == Protection.private_ || protection == Protection.package_) && p.isClassDeclaration() && !(p.isInterfaceDeclaration() && isFinalFunc()));
         }
-        return isMember() && !(isStatic() || protection.kind == PROTprivate || protection.kind == PROTpackage) && p.isClassDeclaration() && !(p.isInterfaceDeclaration() && isFinalFunc());
+        return isMember() && !(isStatic() || protection.kind == Protection.private_ || protection.kind == Protection.package_) && p.isClassDeclaration() && !(p.isInterfaceDeclaration() && isFinalFunc());
     }
 
     bool isFinalFunc()
@@ -1586,14 +1586,14 @@ extern (C++) class FuncDeclaration : Declaration
     {
         AggregateDeclaration ad = isThis();
         ClassDeclaration cd = ad ? ad.isClassDeclaration() : null;
-        return (ad && !(cd && cd.isCPPclass()) && global.params.useInvariants && (protection.kind == PROTprotected || protection.kind == PROTpublic || protection.kind == PROTexport) && !naked);
+        return (ad && !(cd && cd.isCPPclass()) && global.params.useInvariants && (protection.kind == Protection.protected_ || protection.kind == Protection.public_ || protection.kind == Protection.export_) && !naked);
     }
 
     bool addPostInvariant()
     {
         AggregateDeclaration ad = isThis();
         ClassDeclaration cd = ad ? ad.isClassDeclaration() : null;
-        return (ad && !(cd && cd.isCPPclass()) && ad.inv && global.params.useInvariants && (protection.kind == PROTprotected || protection.kind == PROTpublic || protection.kind == PROTexport) && !naked);
+        return (ad && !(cd && cd.isCPPclass()) && ad.inv && global.params.useInvariants && (protection.kind == Protection.protected_ || protection.kind == Protection.public_ || protection.kind == Protection.export_) && !naked);
     }
 
     override const(char)* kind() const
@@ -2222,7 +2222,7 @@ extern (C++) class FuncDeclaration : Declaration
         {
             tf = new TypeFunction(fparams, treturn, 0, LINKc, stc);
             fd = new FuncDeclaration(Loc(), Loc(), id, STC.static_, tf);
-            fd.protection = Prot(PROTpublic);
+            fd.protection = Prot(Protection.public_);
             fd.linkage = LINKc;
 
             st.insert(fd);

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3335,7 +3335,7 @@ extern (C++) void protectionToBuffer(OutBuffer* buf, Prot prot)
     const(char)* p = protectionToChars(prot.kind);
     if (p)
         buf.writestring(p);
-    if (prot.kind == PROTpackage && prot.pkg)
+    if (prot.kind == Protection.package_ && prot.pkg)
     {
         buf.writeByte('(');
         buf.writestring(prot.pkg.toPrettyChars(true));
@@ -3343,23 +3343,23 @@ extern (C++) void protectionToBuffer(OutBuffer* buf, Prot prot)
     }
 }
 
-extern (C++) const(char)* protectionToChars(PROTKIND kind)
+extern (C++) const(char)* protectionToChars(Protection kind)
 {
     switch (kind)
     {
-    case PROTundefined:
+    case Protection.undefined:
         return null;
-    case PROTnone:
+    case Protection.none:
         return "none";
-    case PROTprivate:
+    case Protection.private_:
         return "private";
-    case PROTpackage:
+    case Protection.package_:
         return "package";
-    case PROTprotected:
+    case Protection.protected_:
         return "protected";
-    case PROTpublic:
+    case Protection.public_:
         return "public";
-    case PROTexport:
+    case Protection.export_:
         return "export";
     default:
         assert(0);

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3345,7 +3345,7 @@ extern (C++) void protectionToBuffer(OutBuffer* buf, Prot prot)
 
 extern (C++) const(char)* protectionToChars(Protection kind)
 {
-    switch (kind)
+    final switch (kind)
     {
     case Protection.undefined:
         return null;
@@ -3361,8 +3361,6 @@ extern (C++) const(char)* protectionToChars(Protection kind)
         return "public";
     case Protection.export_:
         return "export";
-    default:
-        assert(0);
     }
 }
 

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -412,7 +412,7 @@ public:
             property("name", s.toChars());
             property("kind", s.kind());
         }
-        if (s.prot().kind != PROTpublic) // TODO: How about package(names)?
+        if (s.prot().kind != Protection.public_) // TODO: How about package(names)?
             property("protection", protectionToChars(s.prot().kind));
         if (EnumMember em = s.isEnumMember())
         {
@@ -503,7 +503,7 @@ public:
         property("kind", s.kind());
         property("comment", s.comment);
         property("line", "char", &s.loc);
-        if (s.prot().kind != PROTpublic)
+        if (s.prot().kind != Protection.public_)
             property("protection", protectionToChars(s.prot().kind));
         if (s.aliasId)
             property("alias", s.aliasId.toChars());

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -57,7 +57,7 @@ extern (C++) final class Nspace : ScopeDsymbol
                 ScopeDsymbol sds2 = sce.scopesym;
                 if (sds2)
                 {
-                    sds2.importScope(this, Prot(PROTpublic));
+                    sds2.importScope(this, Prot(Protection.public_));
                     break;
                 }
             }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -428,7 +428,7 @@ final class Parser(AST) : Lexer
                 pAttrs = &attrs;
                 pAttrs.comment = token.blockComment;
             }
-            AST.PROTKIND prot;
+            AST.Protection prot;
             StorageClass stc;
             AST.Condition condition;
 
@@ -924,27 +924,27 @@ final class Parser(AST) : Lexer
                 }
 
             case TOKprivate:
-                prot = AST.PROTprivate;
+                prot = AST.Protection.private_;
                 goto Lprot;
 
             case TOKpackage:
-                prot = AST.PROTpackage;
+                prot = AST.Protection.package_;
                 goto Lprot;
 
             case TOKprotected:
-                prot = AST.PROTprotected;
+                prot = AST.Protection.protected_;
                 goto Lprot;
 
             case TOKpublic:
-                prot = AST.PROTpublic;
+                prot = AST.Protection.public_;
                 goto Lprot;
 
             case TOKexport:
-                prot = AST.PROTexport;
+                prot = AST.Protection.export_;
                 goto Lprot;
             Lprot:
                 {
-                    if (pAttrs.protection.kind != AST.PROTundefined)
+                    if (pAttrs.protection.kind != AST.Protection.undefined)
                     {
                         if (pAttrs.protection.kind != prot)
                             error("conflicting protection attribute `%s` and `%s`", AST.protectionToChars(pAttrs.protection.kind), AST.protectionToChars(prot));
@@ -958,7 +958,7 @@ final class Parser(AST) : Lexer
                     // optional qualified package identifier to bind
                     // protection to
                     AST.Identifiers* pkg_prot_idents = null;
-                    if (pAttrs.protection.kind == AST.PROTpackage && token.value == TOKlparen)
+                    if (pAttrs.protection.kind == AST.Protection.package_ && token.value == TOKlparen)
                     {
                         pkg_prot_idents = parseQualifiedIdentifier("protection package");
                         if (pkg_prot_idents)
@@ -974,14 +974,14 @@ final class Parser(AST) : Lexer
 
                     const attrloc = token.loc;
                     a = parseBlock(pLastDecl, pAttrs);
-                    if (pAttrs.protection.kind != AST.PROTundefined)
+                    if (pAttrs.protection.kind != AST.Protection.undefined)
                     {
-                        if (pAttrs.protection.kind == AST.PROTpackage && pkg_prot_idents)
+                        if (pAttrs.protection.kind == AST.Protection.package_ && pkg_prot_idents)
                             s = new AST.ProtDeclaration(attrloc, pkg_prot_idents, a);
                         else
                             s = new AST.ProtDeclaration(attrloc, pAttrs.protection, a);
 
-                        pAttrs.protection = AST.Prot(AST.PROTundefined);
+                        pAttrs.protection = AST.Prot(AST.Protection.undefined);
                     }
                     break;
                 }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -317,7 +317,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc2.fes = funcdecl.fes;
             sc2.linkage = LINKd;
             sc2.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.abstract_ | STC.deprecated_ | STC.override_ | STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property | STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system);
-            sc2.protection = Prot(PROTpublic);
+            sc2.protection = Prot(Protection.public_);
             sc2.explicitProtection = 0;
             sc2.aligndecl = null;
             if (funcdecl.ident != Id.require && funcdecl.ident != Id.ensure)

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -66,20 +66,20 @@ extern (C++):
  * Convert D protection attribute to cv attribute.
  */
 
-uint PROTtoATTR(PROTKIND prot)
+uint PROTtoATTR(Protection prot)
 {
     uint attribute;
 
     switch (prot)
     {
-        case PROTprivate:       attribute = 1;  break;
-        case PROTpackage:       attribute = 2;  break;
-        case PROTprotected:     attribute = 2;  break;
-        case PROTpublic:        attribute = 3;  break;
-        case PROTexport:        attribute = 3;  break;
+        case Protection.private_:       attribute = 1;  break;
+        case Protection.package_:       attribute = 2;  break;
+        case Protection.protected_:     attribute = 2;  break;
+        case Protection.public_:        attribute = 3;  break;
+        case Protection.export_:        attribute = 3;  break;
 
-        case PROTundefined:
-        case PROTnone:
+        case Protection.undefined:
+        case Protection.none:
         default:
             //printf("prot = %d\n", prot);
             assert(0);
@@ -691,7 +691,7 @@ void toDebug(ClassDeclaration cd)
             {
                 BaseClass *bc = (*cd.baseclasses)[i];
                 idx_t typidx2 = cv4_typidx(Type_toCtype(bc.sym.type).Tnext);
-                uint attribute = PROTtoATTR(PROTpublic);
+                uint attribute = PROTtoATTR(Protection.public_);
 
                 uint elementlen;
                 final switch (config.fulltypes)

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -70,7 +70,7 @@ uint PROTtoATTR(Protection prot)
 {
     uint attribute;
 
-    switch (prot)
+    final switch (prot)
     {
         case Protection.private_:       attribute = 1;  break;
         case Protection.package_:       attribute = 2;  break;
@@ -80,7 +80,6 @@ uint PROTtoATTR(Protection prot)
 
         case Protection.undefined:
         case Protection.none:
-        default:
             //printf("prot = %d\n", prot);
             assert(0);
     }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -816,7 +816,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
              */
             Scope* argsc = sc.push();
             argsc.stc = 0; // don't inherit storage class
-            argsc.protection = Prot(PROTpublic);
+            argsc.protection = Prot(Protection.public_);
             argsc.func = null;
 
             size_t dim = Parameter.dim(tf.parameters);

--- a/src/replace.sh
+++ b/src/replace.sh
@@ -1,0 +1,15 @@
+replacements=(
+"PROTundefined undefined"
+"PROTnone none"
+"PROTprivate private_"
+"PROTpackage package_"
+"PROTprotected protected_"
+"PROTpublic public_"
+"PROTexport export_"
+)
+
+for r in "${replacements[@]}" ; do
+    w=($r)
+    sed "s/${w[0]}/Protection.${w[1]}/g" -i **/*.d
+done
+sed "s/PROTKIND/Protection/g" -i **/*.d


### PR DESCRIPTION
I wasn't sure if it should be named `PROTKIND` or just `PROT` -
there were some incosistencies.

```shell
replacements=(
"PROTundefined undefined"
"PROTnone none"
"PROTprivate private_"
"PROTpackage package_"
"PROTprotected protected_"
"PROTpublic public_"
"PROTexport export_"
)

for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/Protection.${w[1]}/g" -i **/*.d
done
sed "s/PROTKIND/Protection/g" -i **/*.d
```
  