### PR TITLE
Remove old workaround

### DIFF
--- a/src/dmd/backend/rtlsym.d
+++ b/src/dmd/backend/rtlsym.d
@@ -178,10 +178,6 @@ enum
     RTLSYM_MAX
 }
 
-// Workaround 2.066.x bug by resolving the RTLSYM_MAX value before using it as dimension.
-static if (__VERSION__ <= 2066)
-    private enum computeEnumValue = RTLSYM_MAX;
-
 extern (C++):
 
 extern __gshared Symbol*[RTLSYM_MAX] rtlsym;


### PR DESCRIPTION
Minimal boostrapping compiler is 2.068.2.
So this should pass on all CIs.
Let's see what happens.