### PR TITLE
Set length variable for slice and index expressions during semantic

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5706,6 +5706,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.type.equals(t1b))
             exp.type = exp.e1.type;
 
+        // We might know $ now
+        setLengthVarIfKnown(exp.lengthVar, t1b);
+
         if (exp.lwr && exp.upr)
         {
             exp.lwr = exp.lwr.optimize(WANTvalue);
@@ -5735,7 +5738,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             exp.lowerIsLessThanUpper = (lwrRange.imax <= uprRange.imin);
 
-            //printf("upperIsInBounds = %d lowerIsLessThanUpper = %d\n", upperIsInBounds, lowerIsLessThanUpper);
+            //printf("upperIsInBounds = %d lowerIsLessThanUpper = %d\n", exp.upperIsInBounds, exp.lowerIsLessThanUpper);
         }
 
         result = exp;
@@ -6114,6 +6117,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("`%s` must be an array or pointer type, not `%s`", exp.e1.toChars(), exp.e1.type.toChars());
             return setError();
         }
+
+        // We might know $ now
+        setLengthVarIfKnown(exp.lengthVar, t1b);
 
         if (t1b.ty == Tsarray || t1b.ty == Tarray)
         {

--- a/test/runnable/testbounds.d
+++ b/test/runnable/testbounds.d
@@ -185,34 +185,53 @@ void test13976()
 {
     int[] da = new int[](10);
     int[10] sa;
-    size_t l = 0;               // upperInRange
-    size_t u = 9;               // | lowerLessThan
-                                // | |  check code
-    { auto s = da[l .. u];   }  // 0 0  (u <= 10 && l <= u  )
-    { auto s = da[1 .. u];   }  // 0 0  (u <= 10 && l <= u  )
-    { auto s = da[l .. 10];  }  // 0 0  (u <= 10 && l <= u  )
-    { auto s = da[1 .. u%5]; }  // 0 0  (u <= 10 && l <= u%5)
+    enum size_t two = 2;
+    enum size_t five = 5;
+    size_t lb = 0;                    // upperInRange
+    size_t ub = 9;                    // | lowerLessThan
+                                      // | |  check code
+    { auto s = da[lb .. ub];        } // 0 0  (ub   <= $  && lb <= ub  )
+    { auto s = da[1 .. ub];         } // 0 0  (ub   <= $  && 1  <= ub  )
+    { auto s = da[lb .. 10];        } // 0 0  (10   <= $  && lb <= 10  )
+    { auto s = da[1 .. ub%5];       } // 0 0  (ub%5 <= $  && 1  <= ub%5)
 
-    { auto s = da[l .. u];   }  // 0 0  (u   <= 10 && l <= u)
-    { auto s = da[0 .. u];   }  // 0 1  (u   <= 10          )
-    { auto s = da[l .. 10];  }  // 0 0  (u   <= 10 && l <= u)
-    { auto s = da[0 .. u%5]; }  // 0 1  (u%5 <= 10          )
+    { auto s = da[lb .. ub];        } // 0 0  (ub   <= $  && lb <= ub  )
+    { auto s = da[0 .. ub];         } // 0 1  (ub   <= $               )
+    { auto s = da[lb .. 10];        } // 0 0  (10   <= $  && lb <= 10  )
+    { auto s = da[0 .. ub%5];       } // 0 1  (ub%5 <= $               )
 
-    { auto s = sa[l .. u];   }  // 0 0  (u <= 10 && l <= u  )
-    { auto s = sa[1 .. u];   }  // 0 0  (u <= 10 && l <= u  )
-    { auto s = sa[l .. 10];  }  // 1 0  (           l <= u  )
-    { auto s = sa[1 .. u%5]; }  // 1 0  (           l <= u%5)
+    { auto s = da[0 .. 0];          } // 0 1  (0    <= $               )
+    { auto s = da[0 .. $];          } // 0 1  ($    <= $               )
+    { auto s = da[1 .. $];          } // 0 0  ($    <= $  && 1   <= $  )
+    { auto s = da[$ .. $];          } // 0 0  ($    <= $  && $   <= $  )
+    { auto s = da[0 .. $/two];      } // 0 1  ($/2  <= $               )
+    { auto s = da[$/two .. $];      } // 0 0  ($    <= $  && $/2 <= $  )
+    { auto s = da[$/five .. $/two]; } // 0 0  ($/2  <= $  && $/5 <= $/2)
 
-    { auto s = sa[l .. u];   }  // 0 0  (u <= 10 && l <= u )
-    { auto s = sa[0 .. u];   }  // 0 1  (u <= 10           )
-    { auto s = sa[l .. 10];  }  // 1 0  (           l <= 10)
-    { auto s = sa[0 .. u%5]; }  // 1 1  NULL
+    { auto s = sa[lb .. ub];        } // 0 0  (ub   <= 10 && lb <= ub  )
+    { auto s = sa[1 .. ub];         } // 0 0  (ub   <= 10 && 1  <= ub  )
+    { auto s = sa[lb .. 10];        } // 1 0  (              lb <= 10  )
+    { auto s = sa[1 .. ub%5];       } // 1 0  (              1  <= ub%5)
+
+    { auto s = sa[lb .. ub];        } // 0 0  (ub   <= 10 && lb <= ub  )
+    { auto s = sa[0 .. ub];         } // 0 1  (ub   <= 10              )
+    { auto s = sa[lb .. 10];        } // 1 0  (              lb <= 10  )
+    { auto s = sa[0 .. ub%5];       } // 1 1  NULL
+
+    { auto s = sa[0 .. 0];          } // 1 1  NULL
+    { auto s = sa[0 .. $];          } // 1 1  NULL
+    { auto s = sa[1 .. $];          } // 1 1  NULL
+    { auto s = sa[$ .. $];          } // 1 1  NULL
+    { auto s = sa[0 .. $/two];      } // 1 1  NULL
+    { auto s = sa[$/two .. $];      } // 1 1  NULL
+    { auto s = sa[$/five .. $/two]; } // 1 1  NULL
 
     int* p = new int[](10).ptr;
-    { auto s = p[0 .. u];    }  // 1 1  NULL
-    { auto s = p[l .. u];    }  // 1 0  (l <= u)
-    { auto s = p[0 .. u%5];  }  // 1 1  NULL
-    { auto s = p[1 .. u%5];  }  // 1 0  (l <= u%5)
+    { auto s = p[0 .. ub];          } // 1 1  NULL
+    { auto s = p[lb .. ub];         } // 1 0  (lb <= ub  )
+    { auto s = p[0 .. ub%5];        } // 1 1  NULL
+    { auto s = p[1 .. ub%5];        } // 1 0  (1  <= ub%5)
+    { auto s = p[0 .. 0];           } // 1 1  NULL
 }
 
 /******************************************/


### PR DESCRIPTION
Optimization opportunity noticed in #7677.

For static arrays, slice and indexes using values known at compile time should now never generate array bounds checks at codegen.

Before:
```
int[10] sa;
enum n = 2;                  // upperInRange
enum m = 5;                  // | lowerLessThan
                             // | |  check code
{ auto s = sa[0 .. 0];     } // 1 1  NULL
{ auto s = sa[0 .. $];     } // 0 1  ($ <= 10           )
{ auto s = sa[1 .. $];     } // 0 0  ($ <= 10 && 1 <= $ )
{ auto s = sa[$ .. $];     } // 0 0  ($ <= 10 && $ <= $ )
{ auto s = sa[0 .. $/n];   } // 0 1  ($/n <= 10         )
{ auto s = sa[$/n .. $];   } // 0 0  ($ <= 10 && 5 <= $ )
{ auto s = sa[$/m .. $/n]; } // 0 0  ($/n <= 10 && $/n <= $/m)
```
After
```
int[10] sa;
enum n = 2;                  // upperInRange
enum m = 5;                  // | lowerLessThan
                             // | |  check code
{ auto s = sa[0 .. 0];     } // 1 1  NULL
{ auto s = sa[0 .. $];     } // 1 1  NULL
{ auto s = sa[1 .. $];     } // 1 1  NULL
{ auto s = sa[$ .. $];     } // 1 1  NULL
{ auto s = sa[0 .. $/n];   } // 1 1  NULL
{ auto s = sa[$/n .. $];   } // 1 1  NULL
{ auto s = sa[$/m .. $/n]; } // 1 1  NULL
```

For reviewing the test changes (mostly just whitespace alignment with the rest of the function).
https://github.com/dlang/dmd/pull/7682/files?w=1