### PR TITLE
Cache D installer download on SemaphoreCI

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -22,6 +22,14 @@ export FULL_BUILD="${PULL_REQUEST_NUMBER+false}"
 source ci.sh
 
 ################################################################################
+# Cache the compiler installation on Semaphore
+# See also: https://semaphoreci.com/docs/caching-between-builds.html#additional-dir-caching
+################################################################################
+
+mkdir -p "$SEMAPHORE_CACHE_DIR/dlang"
+ln -s "$SEMAPHORE_CACHE_DIR/dlang" "$HOME/dlang"
+
+################################################################################
 # Always source a DMD instance
 ################################################################################
 


### PR DESCRIPTION
code.dlang.org is often down and there's no mirror for
http://code.dlang.org/download/LATEST yet

See also:
- https://github.com/dlang/dub/issues/1290
- https://github.com/dlang/installer/pull/273
- https://github.com/dlang/installer/pull/291

CC @ibuclaw