### PR TITLE
fix issue 18233 - building with -m64 doesn't work with sc.ini from zip

### DIFF
--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -17,124 +17,12 @@ LINKCMD=%@P%\link.exe
 
 
 [Environment64]
-LIB="%@P%\..\lib64"
-
+LIB=%@P%\..\lib64
 ; needed to avoid COMDAT folding (bugzilla 10664)
 DFLAGS=%DFLAGS% -L/OPT:NOICF
-
-; default to 32-bit linker (can generate 64-bit code) that has a common path
-; for VS2008, VS2010, VS2012, and VS2013. This will be overridden below if the
-; installer detects VS.
-LINKCMD=%VCINSTALLDIR%\bin\link.exe
-
-
-; -----------------------------------------------------------------------------
-; This enclosed section is specially crafted to be activated by the Windows
-; installer when it detects the actual paths to VC and SDK installations so
-; modify this in the default sc.ini within the dmd git repo with care.
-;
-; End users: You can fill in the path to VC and Windows SDK and uncomment out
-; the appropriate LINKCMD to manually enable support yourself.
-;
-; Users using Visual Studio 2010 Express with SDK 7.0A: The installer cannot
-; determine the path to the 64-bit compiler included with SDK 7.0A. It's
-; recommended to install the Windows SDK 7.1A. Alternatively you can set
-; LINKCMD as the path to link.exe SDK 7.0A installs. It would typically be:
-;   C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\link.exe
-
-
-; Windows installer replaces the following lines with the actual paths
-;VCINSTALLDIR=
-;WindowsSdkDir=
-;UniversalCRTSdkDir=
-;UCRTVersion=
-
-; Windows installer uncomments the version detected
-;VC2017 LINKCMD=%VCINSTALLDIR%\bin\HostX86\x86\link.exe
-;VC2015 LINKCMD=%VCINSTALLDIR%\bin\x86_amd64\link.exe
-;VC2013 LINKCMD=%VCINSTALLDIR%\bin\x86_amd64\link.exe
-;VC2012 LINKCMD=%VCINSTALLDIR%\bin\x86_amd64\link.exe
-;VC2010 LINKCMD=%VCINSTALLDIR%\bin\amd64\link.exe
-;VC2008 LINKCMD=%VCINSTALLDIR%\bin\amd64\link.exe
-
-; needed with /DEBUG to find mspdb*.dll (only for VS2012 or later)
-;VC2017 PATH=%PATH%;%VCINSTALLDIR%\bin\HostX86\x86
-;VC2015 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\bin
-;VC2013 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\..\Common7\IDE;%VCINSTALLDIR%\bin
-;VC2012 PATH=%PATH%;%VCINSTALLDIR%\bin\x86_amd64;%VCINSTALLDIR%\..\Common7\IDE
-
-; ----------------------------------------------------------------------------
-
-
-; Add the library subdirectories of all VC and Windows SDK versions so things
-; just work for users using dmd from the VS 64-bit Command Prompt
-
-; C Runtime libraries
-LIB=%LIB%;"%VCINSTALLDIR%\lib\amd64"
-;VC2017 LIB=%LIB%;"%VCINSTALLDIR%\lib\x64"
-
-; Platform/UCRT libraries (Windows SDK 10.0)
-LIB=%LIB%;"%UniversalCRTSdkDir%\Lib\%UCRTVersion%\um\x64"
-LIB=%LIB%;"%UniversalCRTSdkDir%\Lib\%UCRTVersion%\ucrt\x64"
-
-; Platform libraries (Windows SDK 8.1)
-LIB=%LIB%;"%WindowsSdkDir%\Lib\winv6.3\um\x64"
-
-; Platform libraries (Windows SDK 8)
-LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um\x64"
-
-; Platform libraries (Windows SDK 7 and 6)
-LIB=%LIB%;"%WindowsSdkDir%\Lib\x64"
-
-; DirectX (newer versions are included in the Platform SDK but this
-; will allow us to support older versions)
-LIB=%LIB%;"%DXSDK_DIR%\Lib\x64"
-
 
 ; -----------------------------------------------------------------------------
 [Environment32mscoff]
-LIB="%@P%\..\lib32mscoff"
-
-; settings very much copied from Environment64, see comments there
+LIB=%@P%\..\lib32mscoff
 ; needed to avoid COMDAT folding (bugzilla 10664)
 DFLAGS=%DFLAGS% -L/OPT:NOICF
-
-; Windows installer replaces the following lines with the actual paths
-;VCINSTALLDIR=
-;WindowsSdkDir=
-;UniversalCRTSdkDir=
-;UCRTVersion=
-
-LINKCMD=%VCINSTALLDIR%\bin\link.exe
-
-; needed with /DEBUG to find mspdb*.dll (only for VS2012 or VS2013)
-;VC2017 LINKCMD=%VCINSTALLDIR%\bin\HostX86\x86\link.exe
-;VC2015 PATH=%PATH%;%VCINSTALLDIR%\bin
-;VC2013 PATH=%PATH%;%VCINSTALLDIR%\..\Common7\IDE;%VCINSTALLDIR%\bin
-;VC2012 PATH=%PATH%;%VCINSTALLDIR%\..\Common7\IDE
-
-; ----------------------------------------------------------------------------
-; Add the library subdirectories of all VC and Windows SDK versions so things
-; just work for users using dmd from the VS Command Prompt
-
-; C Runtime libraries
-LIB=%LIB%;"%VCINSTALLDIR%\lib"
-;VC2017 LIB=%LIB%;"%VCINSTALLDIR%\lib\x86"
-
-; Platform/UCRT libraries (Windows SDK 10.0)
-LIB=%LIB%;"%UniversalCRTSdkDir%\Lib\%UCRTVersion%\um\x86"
-LIB=%LIB%;"%UniversalCRTSdkDir%\Lib\%UCRTVersion%\ucrt\x86"
-
-; Platform libraries (Windows SDK 8.1)
-LIB=%LIB%;"%WindowsSdkDir%\Lib\winv6.3\um\x86"
-
-; Platform libraries (Windows SDK 8)
-LIB=%LIB%;"%WindowsSdkDir%\Lib\win8\um\x86"
-
-; Platform libraries (Windows SDK 7 and 6)
-LIB=%LIB%;"%WindowsSdkDir%\Lib"
-
-; DirectX (newer versions are included in the Platform SDK but this
-; will allow us to support older versions)
-LIB=%LIB%;"%DXSDK_DIR%\Lib\x86"
-


### PR DESCRIPTION
… distribution and VS2017

These entries are auto-detected and should be removed.

It's especially LINKCMD that doesn't work with VS2017.