### PR TITLE
Fix issue 18232: local vars in union member functions needs initializer.

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -785,7 +785,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         bool isBlit = false;
         d_uns64 sz;
         if (!dsym._init &&
-            !sc.inunion &&
             !(dsym.storage_class & (STC.static_ | STC.gshared | STC.extern_)) &&
             fd &&
             (!(dsym.storage_class & (STC.field | STC.in_ | STC.foreach_ | STC.parameter | STC.result)) ||

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -7987,6 +7987,24 @@ struct S17915(T)
     T owner;
 }
 
+void test18232()
+{
+    static struct Canary
+    {
+        int x = 0x900D_900D;
+    }
+    union U
+    {
+        Canary method()
+        {
+            Canary c;
+            return c;
+        }
+    }
+    U u;
+    assert(u.method() == Canary.init);
+}
+
 /***************************************************/
 
 int main()
@@ -8308,6 +8326,7 @@ int main()
     test16408();
     test17349();
     test17915();
+    test18232();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
The `sc.isunion` condition is too broad, because it also excludes local variables declared inside union member functions. Moreoever, it is not necessary, because the `fd` condition later on already excludes union fields, since they would not be inside a function declaration.