### PR TITLE
Turn .ptr deprecation into an error

### DIFF
--- a/changelog/ptr-safe-end-of-deprecation.dd
+++ b/changelog/ptr-safe-end-of-deprecation.dd
@@ -1,0 +1,26 @@
+`.ptr` on arrays can no longer be used in `@safe` code
+
+The deprecation period for using `.ptr` on arrays in `@safe` ended.
+The following now triggers an error instead of a deprecation:
+
+---
+@safe ubyte* oops(ubyte[] arr) {
+    return arr.ptr;
+}
+---
+
+Use `&arr[0]` instead:
+
+---
+@safe ubyte oops(ubyte[] arr) {
+    return &arr[0];
+}
+---
+
+Note that this only applies to SafeD - in `@system` code `.ptr` may still be used:
+
+---
+@system ubyte* oops(ubyte[] arr) {
+    return arr.ptr;
+}
+---

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4688,9 +4688,8 @@ extern (C++) final class TypeSArray : TypeArray
             }
             else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
             {
-                // MAINTENANCE: turn into error in 2.073
-                e.deprecation("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
-                // return new ErrorExp();
+                e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
+                return new ErrorExp();
             }
             e = e.castTo(sc, e.type.nextOf().pointerTo());
         }
@@ -4950,9 +4949,8 @@ extern (C++) final class TypeDArray : TypeArray
         {
             if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
             {
-                // MAINTENANCE: turn into error in 2.073
-                e.deprecation("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
-                // return new ErrorExp();
+                e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
+                    return new ErrorExp();
             }
             e = e.castTo(sc, next.pointerTo());
             return e;

--- a/test/fail_compilation/test11176.d
+++ b/test/fail_compilation/test11176.d
@@ -1,8 +1,8 @@
 /*
-REQUIRED_ARGS: -de
+TEST_OUTPUT:
 ---
-fail_compilation/test11176.d(12): Deprecation: b.ptr cannot be used in @safe code, use &b[0] instead
-fail_compilation/test11176.d(16): Deprecation: b.ptr cannot be used in @safe code, use &b[0] instead
+fail_compilation/test11176.d(12): Error: `b.ptr` cannot be used in `@safe` code, use `&b[0]` instead
+fail_compilation/test11176.d(16): Error: `b.ptr` cannot be used in `@safe` code, use `&b[0]` instead
 ---
 */
 


### PR DESCRIPTION
This was scheduled to happen in 2.073 - we really need a file or wiki to list
these things, s.t. they aren't forgotten.

I'm abusing auto-tester for testing as due to `-fPIC` I still
can't run the testsuite locally.