### PR TITLE
[Semaphore] Install DUB from GitHub for GDC builds

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -140,7 +140,7 @@ download_install_sh() {
   fi
   for i in {0..4}; do
     for mirror in "${mirrors[@]}" ; do
-        if curl -fsS -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 "$mirror" -O ; then
+        if curl -fsS -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 "$mirror" -o "$location" ; then
             break 2
         fi
     done
@@ -148,7 +148,28 @@ download_install_sh() {
   done
 }
 
+install_dub() {
+  local url="https://github.com/dlang/dub/releases/download/v${DUB_VERSION}/dub-${DUB_VERSION}-${OS_NAME}-x86_64.tar.gz"
+  local root_dir="$HOME/dlang"
+  local dub="$root_dir/dub"
+  local location="${dub}.tgz"
+  if [ -f "${dub}" ] ; then
+      return
+  fi
+  for i in {0..4}; do
+    if curl -fsSL -A "$CURL_USER_AGENT" --connect-timeout 10 --speed-time 30 --speed-limit 1024 "$url" -o "$location" ; then
+        break
+    fi
+    sleep $((1 << i))
+  done
+  tar -C "$root_dir" -zxf "$location"
+}
+
 activate_d() {
   download_install_sh "$@"
+  if [ "${DMD:-dmd}" == "gdc" ] ; then
+    export DUB_VERSION="1.6.0"
+    install_dub
+  fi
   CURL_USER_AGENT="$CURL_USER_AGENT" bash install.sh "$1" --activate
 }


### PR DESCRIPTION
As mentioned in https://github.com/dlang/dmd/pull/7685, the gdc builds often fail with:

```
++ CURL_USER_AGENT='DMD-CI curl 7.35.0 (x86_64-pc-linux-gnu) libcurl/7.35.0 OpenSSL/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3'
++ bash install.sh gdc --activate
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
Failed to download 'http://code.dlang.org/download/LATEST'
```

Since dlang/installer#218, we don't download dub automatically, but use the bundled version if it's provided (DMD + LDC ship with a bundled dub binary).
I recently copied all DUB binaries from code.dlang.org to GitHub, so we can simply fetch it from there.

See also: https://github.com/dlang/dub/issues/1290

CC @ibuclaw