### PR TITLE
Stub out the DUB download for GDC

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -140,7 +140,7 @@ download_install_sh() {
   fi
   for i in {0..4}; do
     for mirror in "${mirrors[@]}" ; do
-        if curl -fsS -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 "$mirror" -O ; then
+        if curl -fsS -A "$CURL_USER_AGENT" --connect-timeout 5 --speed-time 30 --speed-limit 1024 "$mirror" -o "$location" ; then
             break 2
         fi
     done
@@ -149,6 +149,14 @@ download_install_sh() {
 }
 
 activate_d() {
-  download_install_sh "$@"
-  CURL_USER_AGENT="$CURL_USER_AGENT" bash install.sh "$1" --activate
+  local install_sh="install.sh"
+  download_install_sh "$install_sh"
+  # DUB isn't needed for gdc
+  if [ "${DMD:-dmd}" == "gdc" ] ; then
+      touch "$HOME/dlang/dub"
+      # Remove the check of the lastest DUB version
+      # shellcheck disable=2016
+      sed 's/dub="dub-$(fetch $url)"/dub=dub' -i "$install_sh"
+  fi
+  CURL_USER_AGENT="$CURL_USER_AGENT" bash "$install_sh" "$1" --activate
 }


### PR DESCRIPTION
The install script downloads `dub` by default if it isn't shipped by the
binary release. That's the case for old DMD releases + GDC.
So as mentioned in https://github.com/dlang/dmd/pull/7685, the gdc builds often fail with:

```
++ CURL_USER_AGENT='DMD-CI curl 7.35.0 (x86_64-pc-linux-gnu) libcurl/7.35.0 OpenSSL/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3'
++ bash install.sh gdc --activate
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
curl: (28) Operation too slow. Less than 1024 bytes/sec transferred the last 30 seconds
Failed to download 'http://code.dlang.org/download/LATEST'
```

However, `dub` is only used for the DMD as library tests and they don't work with
`gdc` at the moment.

In summary: we try to fetch `dub` from rather unstable `code.dlang.org`
server and break the build due to download failures, but we don't even
need `dub`.

See also: https://github.com/dlang/dmd/pull/7691