### PR TITLE
Use sinteger_t and uinteger_t for Token.int64value and uns64value

### DIFF
--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -3361,16 +3361,16 @@ code *asm_db_parse(OP *pop)
         switch (asmstate.tokValue)
         {
             case TOKint32v:
-                dt.ul = cast(d_int32)asmstate.tok.int64value;
+                dt.ul = cast(d_int32)asmstate.tok.intvalue;
                 goto L1;
             case TOKuns32v:
-                dt.ul = cast(d_uns32)asmstate.tok.uns64value;
+                dt.ul = cast(d_uns32)asmstate.tok.unsvalue;
                 goto L1;
             case TOKint64v:
-                dt.ul = asmstate.tok.int64value;
+                dt.ul = asmstate.tok.intvalue;
                 goto L1;
             case TOKuns64v:
-                dt.ul = asmstate.tok.uns64value;
+                dt.ul = asmstate.tok.unsvalue;
                 goto L1;
             L1:
                 switch (op)
@@ -3542,11 +3542,11 @@ int asm_getnum()
     switch (asmstate.tokValue)
     {
         case TOKint32v:
-            v = cast(d_int32)asmstate.tok.int64value;
+            v = cast(d_int32)asmstate.tok.intvalue;
             break;
 
         case TOKuns32v:
-            v = cast(d_uns32)asmstate.tok.uns64value;
+            v = cast(d_uns32)asmstate.tok.unsvalue;
             break;
 
         case TOKidentifier:
@@ -4178,7 +4178,7 @@ void asm_primary_exp(out OPND o1)
                     asm_token();
                     if (asmstate.tokValue == TOKint32v)
                     {
-                        uint n = cast(uint)asmstate.tok.uns64value;
+                        uint n = cast(uint)asmstate.tok.unsvalue;
                         if (n > 7)
                             asmerr("bad operand");
                         else
@@ -4287,18 +4287,18 @@ void asm_primary_exp(out OPND o1)
             break;
 
         case TOKint32v:
-            o1.disp = cast(d_int32)asmstate.tok.int64value;
+            o1.disp = cast(d_int32)asmstate.tok.intvalue;
             asm_token();
             break;
 
         case TOKuns32v:
-            o1.disp = cast(d_uns32)asmstate.tok.uns64value;
+            o1.disp = cast(d_uns32)asmstate.tok.unsvalue;
             asm_token();
             break;
 
         case TOKint64v:
         case TOKuns64v:
-            o1.disp = asmstate.tok.int64value;
+            o1.disp = asmstate.tok.intvalue;
             asm_token();
             break;
 

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -340,7 +340,7 @@ class Lexer
                 if (!isZeroSecond(p[1]))        // if numeric literal does not continue
                 {
                     ++p;
-                    t.uns64value = 0;
+                    t.unsvalue = 0;
                     t.value = TOKint32v;
                     return;
                 }
@@ -349,7 +349,7 @@ class Lexer
             case '1': .. case '9':
                 if (!isDigitSecond(p[1]))       // if numeric literal does not continue
                 {
-                    t.uns64value = *p - '0';
+                    t.unsvalue = *p - '0';
                     ++p;
                     t.value = TOKint32v;
                     return;
@@ -361,7 +361,7 @@ class Lexer
             case '\'':
                 if (issinglechar(p[1]) && p[2] == '\'')
                 {
-                    t.uns64value = p[1];        // simple one character literal
+                    t.unsvalue = p[1];        // simple one character literal
                     t.value = TOKcharv;
                     p += 3;
                 }
@@ -536,7 +536,7 @@ class Lexer
                                     break;
                             }
                             t.value = TOKint64v;
-                            t.uns64value = major * 1000 + minor;
+                            t.unsvalue = major * 1000 + minor;
                         }
                         else if (id == Id.EOFX)
                         {
@@ -1697,16 +1697,16 @@ class Lexer
             switch (*p)
             {
             case 'u':
-                t.uns64value = escapeSequence();
+                t.unsvalue = escapeSequence();
                 tk = TOKwcharv;
                 break;
             case 'U':
             case '&':
-                t.uns64value = escapeSequence();
+                t.unsvalue = escapeSequence();
                 tk = TOKdcharv;
                 break;
             default:
-                t.uns64value = escapeSequence();
+                t.unsvalue = escapeSequence();
                 break;
             }
             break;
@@ -1723,7 +1723,7 @@ class Lexer
             goto case;
         case '\'':
             error("unterminated character constant");
-            t.uns64value = '?';
+            t.unsvalue = '?';
             return tk;
         default:
             if (c & 0x80)
@@ -1738,13 +1738,13 @@ class Lexer
                 else
                     tk = TOKdcharv;
             }
-            t.uns64value = c;
+            t.unsvalue = c;
             break;
         }
         if (*p != '\'')
         {
             error("unterminated character constant");
-            t.uns64value = '?';
+            t.unsvalue = '?';
             return tk;
         }
         p++;
@@ -2059,7 +2059,7 @@ class Lexer
             }
             assert(0);
         }
-        t.uns64value = n;
+        t.unsvalue = n;
         return result;
     }
 
@@ -2276,9 +2276,9 @@ class Lexer
         scan(&tok);
         if (tok.value == TOKint32v || tok.value == TOKint64v)
         {
-            const lin = cast(int)(tok.uns64value - 1);
-            if (lin != tok.uns64value - 1)
-                error("line number `%lld` out of range", cast(ulong)tok.uns64value);
+            const lin = cast(int)(tok.unsvalue - 1);
+            if (lin != tok.unsvalue - 1)
+                error("line number `%lld` out of range", cast(ulong)tok.unsvalue);
             else
                 linnum = lin;
         }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1063,7 +1063,7 @@ final class Parser(AST) : Lexer
                     if (token.value == TOKidentifier)
                         s = new AST.DebugSymbol(token.loc, token.ident);
                     else if (token.value == TOKint32v || token.value == TOKint64v)
-                        s = new AST.DebugSymbol(token.loc, cast(uint)token.uns64value);
+                        s = new AST.DebugSymbol(token.loc, cast(uint)token.unsvalue);
                     else
                     {
                         error("identifier or integer expected, not `%s`", token.toChars());
@@ -1087,7 +1087,7 @@ final class Parser(AST) : Lexer
                     if (token.value == TOKidentifier)
                         s = new AST.VersionSymbol(token.loc, token.ident);
                     else if (token.value == TOKint32v || token.value == TOKint64v)
-                        s = new AST.VersionSymbol(token.loc, cast(uint)token.uns64value);
+                        s = new AST.VersionSymbol(token.loc, cast(uint)token.unsvalue);
                     else
                     {
                         error("identifier or integer expected, not `%s`", token.toChars());
@@ -2275,7 +2275,7 @@ final class Parser(AST) : Lexer
             if (token.value == TOKidentifier)
                 id = token.ident;
             else if (token.value == TOKint32v || token.value == TOKint64v)
-                level = cast(uint)token.uns64value;
+                level = cast(uint)token.unsvalue;
             else
                 error("identifier or integer expected inside debug(...), not `%s`", token.toChars());
             nextToken();
@@ -2303,7 +2303,7 @@ final class Parser(AST) : Lexer
             if (token.value == TOKidentifier)
                 id = token.ident;
             else if (token.value == TOKint32v || token.value == TOKint64v)
-                level = cast(uint)token.uns64value;
+                level = cast(uint)token.unsvalue;
             else if (token.value == TOKunittest)
                 id = Identifier.idPool(Token.toString(TOKunittest));
             else if (token.value == TOKassert)
@@ -7216,22 +7216,22 @@ final class Parser(AST) : Lexer
             break;
 
         case TOKint32v:
-            e = new AST.IntegerExp(loc, cast(d_int32)token.int64value, AST.Type.tint32);
+            e = new AST.IntegerExp(loc, cast(d_int32)token.intvalue, AST.Type.tint32);
             nextToken();
             break;
 
         case TOKuns32v:
-            e = new AST.IntegerExp(loc, cast(d_uns32)token.uns64value, AST.Type.tuns32);
+            e = new AST.IntegerExp(loc, cast(d_uns32)token.unsvalue, AST.Type.tuns32);
             nextToken();
             break;
 
         case TOKint64v:
-            e = new AST.IntegerExp(loc, token.int64value, AST.Type.tint64);
+            e = new AST.IntegerExp(loc, token.intvalue, AST.Type.tint64);
             nextToken();
             break;
 
         case TOKuns64v:
-            e = new AST.IntegerExp(loc, token.uns64value, AST.Type.tuns64);
+            e = new AST.IntegerExp(loc, token.unsvalue, AST.Type.tuns64);
             nextToken();
             break;
 
@@ -7323,17 +7323,17 @@ final class Parser(AST) : Lexer
             break;
 
         case TOKcharv:
-            e = new AST.IntegerExp(loc, cast(d_uns8)token.uns64value, AST.Type.tchar);
+            e = new AST.IntegerExp(loc, cast(d_uns8)token.unsvalue, AST.Type.tchar);
             nextToken();
             break;
 
         case TOKwcharv:
-            e = new AST.IntegerExp(loc, cast(d_uns16)token.uns64value, AST.Type.twchar);
+            e = new AST.IntegerExp(loc, cast(d_uns16)token.unsvalue, AST.Type.twchar);
             nextToken();
             break;
 
         case TOKdcharv:
-            e = new AST.IntegerExp(loc, cast(d_uns32)token.uns64value, AST.Type.tdchar);
+            e = new AST.IntegerExp(loc, cast(d_uns32)token.unsvalue, AST.Type.tdchar);
             nextToken();
             break;
 

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -571,8 +571,8 @@ extern (C++) struct Token
     union
     {
         // Integers
-        d_int64 int64value;
-        d_uns64 uns64value;
+        sinteger_t intvalue;
+        uinteger_t unsvalue;
         // Floats
         real_t floatvalue;
 
@@ -937,19 +937,19 @@ extern (C++) struct Token
         switch (value)
         {
         case TOKint32v:
-            sprintf(&buffer[0], "%d", cast(d_int32)int64value);
+            sprintf(&buffer[0], "%d", cast(d_int32)intvalue);
             break;
         case TOKuns32v:
         case TOKcharv:
         case TOKwcharv:
         case TOKdcharv:
-            sprintf(&buffer[0], "%uU", cast(d_uns32)uns64value);
+            sprintf(&buffer[0], "%uU", cast(d_uns32)unsvalue);
             break;
         case TOKint64v:
-            sprintf(&buffer[0], "%lldL", cast(long)int64value);
+            sprintf(&buffer[0], "%lldL", cast(long)intvalue);
             break;
         case TOKuns64v:
-            sprintf(&buffer[0], "%lluUL", cast(ulong)uns64value);
+            sprintf(&buffer[0], "%lluUL", cast(ulong)unsvalue);
             break;
         case TOKfloat32v:
             CTFloat.sprint(&buffer[0], 'g', floatvalue);

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -200,8 +200,8 @@ struct Token
     union
     {
         // Integers
-        d_int64 int64value;
-        d_uns64 uns64value;
+        sinteger_t intvalue;
+        uinteger_t unsvalue;
 
         // Floats
         real_t floatvalue;


### PR DESCRIPTION
Remove the encoded size from the field name.

One part of #6743, and there are plenty more to come as I cherry-pick parts that have nothing to do with adding a synthetic integer type itself.