### PR TITLE
fix Issue 18057 - [ICE] Segmentation fault (stack overflow) in Expression::ctfeInterpret()

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -459,7 +459,13 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 else if (vx._init)
                 {
                     assert(!vx._init.isVoidInitializer());
-                    e = vx.getConstInitializer(false);
+                    if (vx.inuse)   // https://issues.dlang.org/show_bug.cgi?id=18057
+                    {
+                        vx.error(loc, "recursive initialization of field");
+                        errors = true;
+                    }
+                    else
+                        e = vx.getConstInitializer(false);
                 }
                 else
                 {

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -7731,3 +7731,14 @@ bool foo17407()
 
 static assert(!foo17407);
 
+/**************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18057
+// Recursive field initializer causes segfault.
+
+struct RBNode(T)
+{
+    RBNode!T *copy = new RBNode!T;
+}
+
+static assert(!__traits(compiles, { alias bug18057 = RBNode!int; }));
+

--- a/test/fail_compilation/fail18057.d
+++ b/test/fail_compilation/fail18057.d
@@ -1,0 +1,16 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/fail18057.d(16): Error: template instance RBNode!int `RBNode` is not a template declaration, it is a struct
+fail_compilation/fail18057.d(13): Error: variable fail18057.RBNode.copy recursive initialization of field
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=18057
+// Recursive field initializer causes segfault.
+struct RBNode
+{
+    RBNode *copy = new RBNode;
+}
+
+alias bug18057 = RBNode!int;


### PR DESCRIPTION
Inside `AggregateDeclaration::fill` looks to be the better place to have this error rather than `VarDeclaration::getConstInitializer`.  In the latter location you'd get the same error printed twice.