### PR TITLE
fix Issue 14907 - DMD crash when using template name as a default value of template's typed argument

### DIFF
--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -79,6 +79,7 @@ public:
     bool ismixin;               // template declaration is only to be used as a mixin
     bool isstatic;              // this is static template declaration
     Prot protection;
+    int inuse;                  // for recursive expansion detection
 
     TemplatePrevious *previous;         // threaded list of previous instantiation attempts on stack
 

--- a/test/fail_compilation/ice14907.d
+++ b/test/fail_compilation/ice14907.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice14907.d(14): Error: struct ice14907.S(int v = S) recursive template expansion
+fail_compilation/ice14907.d(19):        while looking for match for `S!()`
+fail_compilation/ice14907.d(15): Error: template ice14907.f(int v = f)() recursive template expansion
+fail_compilation/ice14907.d(20):        while looking for match for `f!()`
+fail_compilation/ice14907.d(15): Error: template ice14907.f(int v = f)() recursive template expansion
+fail_compilation/ice14907.d(21): Error: template `ice14907.f` cannot deduce function from argument types `!()()`, candidates are:
+fail_compilation/ice14907.d(15):        `ice14907.f(int v = f)()`
+---
+*/
+
+struct S(int v = S) {}
+void f(int v = f)() {}
+
+void main()
+{
+    S!() s;     // OK <- ICE
+    f!()();     // OK <- ICE
+    f();        // OK <- ICE
+}


### PR DESCRIPTION
Add TemplateDeclaration::inuse, and use it to detect recursive template expansion during the template parameter matching.

Revival of #4882.