### PR TITLE
Fix Issue 17899: Allow delegate initialisation at module scope

### DIFF
--- a/changelog/fix17899.dd
+++ b/changelog/fix17899.dd
@@ -1,0 +1,8 @@
+Fix issue 17899 - Allow delegates to be initialised at compile time
+
+delegates may now be initialised at module scope. This changes the effect of the fix for 13259 (turning the ICE that resulted into an error) making the follow legal:
+---
+void delegate() bar = (){};
+---
+
+The function pointer is set to the function of the delegate, the context pointer is set to null.

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -543,11 +543,6 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
                 e.fd.vthis = null;
             }
             Symbol *s = toSymbol(e.fd);
-            if (e.fd.isNested())
-            {
-                e.error("non-constant nested delegate literal expression `%s`", e.toChars());
-                return;
-            }
             toObjFile(e.fd, false);
             dtb.xoff(s, 0);
         }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -544,7 +544,7 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
             }
             Symbol *s = toSymbol(e.fd);
             toObjFile(e.fd, false);
-            if (e.fd.tok == TOKdelegate)
+            if (e.fd.tok == TOK.delegate_)
                 dtb.size(0);
             dtb.xoff(s, 0);
         }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -544,6 +544,8 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
             }
             Symbol *s = toSymbol(e.fd);
             toObjFile(e.fd, false);
+            if (e.fd.tok == TOKdelegate)
+                dtb.size(0);
             dtb.xoff(s, 0);
         }
 

--- a/test/fail_compilation/ice13259.d
+++ b/test/fail_compilation/ice13259.d
@@ -1,8 +1,0 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice13259.d(8): Error: non-constant nested delegate literal expression `__dgliteral3`
----
-*/
-
-auto dg = delegate {};

--- a/test/runnable/test17899.d
+++ b/test/runnable/test17899.d
@@ -1,5 +1,8 @@
 module test17899;
 
+// Test that the ICE in 13259 does not ICE but produces correct code
+auto dg = delegate {}; 
+
 int setme = 0;
 void delegate() bar1 = (){ setme = 1;};
 
@@ -7,6 +10,7 @@ __gshared void delegate() bar2 = (){ setme = 2;};
 
 void main()
 {
+    dg();
     assert(setme == 0);
     bar1();
     assert(setme == 1);

--- a/test/runnable/test17899.d
+++ b/test/runnable/test17899.d
@@ -1,0 +1,15 @@
+module test17899;
+
+int setme = 0;
+void delegate() bar1 = (){ setme = 1;};
+
+__gshared void delegate() bar2 = (){ setme = 2;};
+
+void main()
+{
+    assert(setme == 0);
+    bar1();
+    assert(setme == 1);
+    bar2();
+    assert(setme == 2);
+}


### PR DESCRIPTION
~~Delegates are being codegenned with `.ptr` and `.funcptr` swapped, but otherwise working as intended~~ Fixed, all green.