### PR TITLE
[refactor] Remove unused local variables.

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -328,7 +328,6 @@ extern (C++) UnionExp copyLiteral(Expression e)
     if (e.op == TOKarrayliteral)
     {
         auto ale = cast(ArrayLiteralExp)e;
-        auto basis = ale.basis ? copyLiteral(ale.basis).copy() : null;
         auto elements = copyLiteralArray(ale.elements, ale.basis);
 
         emplaceExp!(ArrayLiteralExp)(&ue, e.loc, elements);

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -1044,7 +1044,7 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
     {
         //printf("%s.InterfaceDeclaration.isBaseOf(cd = '%s')\n", toChars(), cd.toChars());
         assert(!baseClass);
-        foreach (j, b; cd.interfaces)
+        foreach (b; cd.interfaces)
         {
             //printf("\tX base %s\n", b.sym.toChars());
             if (this == b.sym)

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -877,7 +877,6 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                     "documentation comment");
 
                 auto symbol = dc.a[0];
-                auto symbolName = symbol.ident.toString;
 
                 buf.writestring("$(DDOC_MEMBER");
                 buf.writestring("$(DDOC_MEMBER_HEADER");

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2265,7 +2265,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              */
             const(char)* s = "__mixin";
 
-            DsymbolTable symtab;
             if (FuncDeclaration func = sc.parent.isFuncDeclaration())
             {
                 tm.symtab = func.localsymtab;
@@ -2733,7 +2732,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         f = cast(TypeFunction)funcdecl.type;
-        size_t nparams = Parameter.dim(f.parameters);
 
         if ((funcdecl.storage_class & STC.auto_) && !f.isref && !funcdecl.inferRetType)
             funcdecl.error("storage class `auto` has no effect if return type is not inferred");

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -714,8 +714,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         pr.dedargs = dedargs;
         previous = &pr; // add this to threaded list
 
-        uint nerrors = global.errors;
-
         Scope* scx = paramscope.push(ti);
         scx.parent = ti;
         scx.tinst = null;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1720,8 +1720,6 @@ elem *toElem(Expression e, IRState *irs)
                 }
                 else
                 {
-                    d_uns64 elemsize = sd.size(ne.loc);
-
                     // call _d_newitemT(ti)
                     e = getTypeInfo(ne.newtype, irs);
 
@@ -1816,7 +1814,6 @@ elem *toElem(Expression e, IRState *irs)
             else if (t.ty == Tpointer)
             {
                 TypePointer tp = cast(TypePointer)t;
-                Expression di = tp.next.defaultInit();
                 elem *ezprefix = ne.argprefix ? toElem(ne.argprefix, irs) : null;
 
                 // call _d_newitemT(ti)
@@ -2145,7 +2142,6 @@ elem *toElem(Expression e, IRState *irs)
 
                 ev = el_una(OPind, tym, ev);
 
-                CastExp ce = cast(CastExp)e1;
                 for (size_t d = depth; d > 0; d--)
                 {
                     e1 = be.e1;
@@ -2627,7 +2623,6 @@ elem *toElem(Expression e, IRState *irs)
             {
                 SliceExp are = cast(SliceExp)ae.e1;
                 Type t1 = t1b;
-                Type t2 = ae.e2.type.toBasetype();
                 Type ta = are.e1.type.toBasetype();
 
                 // which we do if the 'next' types match
@@ -5280,7 +5275,6 @@ elem *toElem(Expression e, IRState *irs)
             assert(dim);
 
             Type telem = ((*exps)[0] ? (*exps)[0] : basis).type;
-            Type tsarray = telem.sarrayOf(dim);
             targ_size_t szelem = telem.size();
             .type *te = Type_toCtype(telem);   // stmp[] element type
 

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -487,8 +487,6 @@ bool checkThrowEscape(Scope* sc, Expression e, bool gag)
         if (v.isDataseg())
             continue;
 
-        Dsymbol p = v.toParent2();
-
         if (v.isScope() && !v.iscatchvar)       // special case: allow catch var to be rethrown
                                                 // despite being `scope`
         {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -122,7 +122,6 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                         return new ErrorExp();
                     fd = f;
                     assert(fd.type.ty == Tfunction);
-                    TypeFunction tf = cast(TypeFunction)fd.type;
                 }
             }
             if (fd)
@@ -234,7 +233,6 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                 if (fd.errors)
                     return new ErrorExp();
                 assert(fd.type.ty == Tfunction);
-                TypeFunction tf = cast(TypeFunction)fd.type;
                 Expression e = new CallExp(loc, e1, e2);
                 return e.expressionSemantic(sc);
             }
@@ -260,7 +258,6 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         {
             // Keep better diagnostic message for invalid property usage of functions
             assert(fd.type.ty == Tfunction);
-            TypeFunction tf = cast(TypeFunction)fd.type;
             Expression e = new CallExp(loc, e1, e2);
             return e.expressionSemantic(sc);
         }
@@ -9040,9 +9037,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (t1.ty == Tarray && t2.ty == Tarray)
         {
-            Type telement  = t1.nextOf().toBasetype();
-            Type telement2 = t2.nextOf().toBasetype();
-
             //printf("Lowering to __equals %s %s\n", e1.toChars(), e2.toChars());
 
             // For e1 and e2 of struct type, lowers e1 == e2 to object.__equals(e1, e2)

--- a/src/dmd/libelf.d
+++ b/src/dmd/libelf.d
@@ -92,7 +92,6 @@ final class LibElf : Library
             file._ref = 1;
             fromfile = 1;
         }
-        int reason = 0;
         if (buflen < 16)
         {
             static if (LOG)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4509,7 +4509,6 @@ extern (C++) class TypeArray : TypeNext
 
     override Expression dotExp(Scope* sc, Expression e, Identifier ident, int flag)
     {
-        Type n = this.next.toBasetype(); // uncover any typedef's
         static if (LOGDOTEXP)
         {
             printf("TypeArray::dotExp(e = '%s', ident = '%s')\n", e.toChars(), ident.toChars());

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3284,7 +3284,6 @@ final class Parser(AST) : Lexer
                     if (token.value != TOKcomma)
                         break;
                     // recognize import pkg.mod1 : a, b, pkg.mod2;
-                    immutable afterIdent = peekNext2;
                     if (peekNext2 == TOKdot ||      // pkg . mod2
                         peekNext2 == TOKcolon)      // mod2 : c
                         break;  // parse another import
@@ -4964,10 +4963,6 @@ final class Parser(AST) : Lexer
         check(TOKsemicolon);
 
         AST.Expression aggr = parseExpression();
-        static if(isStatic)
-        {
-            bool isRange = false;
-        }
         if (token.value == TOKslice && parameters.dim == 1)
         {
             AST.Parameter p = (*parameters)[0];

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -494,7 +494,6 @@ private extern (C++) class S2irVisitor : Visitor
     override void visit(SwitchStatement s)
 //    { .visit(irs, s); }
     {
-        int string;
         Blockx *blx = irs.blx;
 
         //printf("SwitchStatement.toIR()\n");

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -110,9 +110,9 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
     auto tfromb = tfrom.toBasetype();
     auto ttob = tto.toBasetype();
 
-    if (ttob.ty == Tclass && tfrom.ty == Tclass)
+    if (ttob.ty == Tclass && tfromb.ty == Tclass)
     {
-        ClassDeclaration cdfrom = tfrom.isClassHandle();
+        ClassDeclaration cdfrom = tfromb.isClassHandle();
         ClassDeclaration cdto = ttob.isClassHandle();
 
         int offset;
@@ -122,19 +122,19 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
         if (cdfrom.isCPPinterface() || cdto.isCPPinterface())
             return false;
 
-        if (!MODimplicitConv(tfrom.mod, ttob.mod))
+        if (!MODimplicitConv(tfromb.mod, ttob.mod))
             return false;
         return true;
     }
 
-    if (ttob.ty == Tarray && tfrom.ty == Tsarray) // https://issues.dlang.org/show_bug.cgi?id=12502
-        tfrom = tfrom.nextOf().arrayOf();
+    if (ttob.ty == Tarray && tfromb.ty == Tsarray) // https://issues.dlang.org/show_bug.cgi?id=12502
+        tfromb = tfromb.nextOf().arrayOf();
 
-    if (ttob.ty == Tarray   && tfrom.ty == Tarray ||
-        ttob.ty == Tpointer && tfrom.ty == Tpointer)
+    if (ttob.ty == Tarray   && tfromb.ty == Tarray ||
+        ttob.ty == Tpointer && tfromb.ty == Tpointer)
     {
         Type ttobn = ttob.nextOf().toBasetype();
-        Type tfromn = tfrom.nextOf().toBasetype();
+        Type tfromn = tfromb.nextOf().toBasetype();
 
         /* From void[] to anything mutable is unsafe because:
          *  int*[] api;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -920,7 +920,6 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 auto field = Identifier.idPool(StaticForeach.tupleFieldName.ptr,StaticForeach.tupleFieldName.length);
                 Expression access = new DotIdExp(loc, e, field);
                 access = expressionSemantic(access, sc);
-                auto types = access.type.isTuple();
                 if (!tuple) return returnEarly();
                 //printf("%s\n",tuple.toChars());
                 foreach (l; 0 .. dim)
@@ -2577,7 +2576,6 @@ else
             compileTimeArgs.push(new TypeExp(ss.loc, ss.condition.type.nextOf()));
 
             // The switch labels
-            auto caseLabels = new Expressions();
             foreach (caseString; *csCopy)
             {
                 compileTimeArgs.push(caseString.exp);


### PR DESCRIPTION
Noticed during some patch rebasing, so decided to compile dmd using `gdc -Wunused` and cleaned up what was flagged.

I think I can only see two places where an assignment to a dead var is done _only_ for the side-effect.  If that is the case, then those checks should really be moved elsewhere/handled better.

Let's see what the CI says...