### PR TITLE
Remove codecov/project and codecov/changes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -35,17 +35,11 @@ coverage:
 
   # Learn more at https://docs.codecov.io/docs/commit-status
   status:
-    project:
-      default:
-        informational: true
-        # Informational doesn't work with project yet
-        threshold: 0.1
+    project: off
     patch:
       default:
         informational: true
-    changes:
-      default:
-        informational: true
+    changes: off
 
   # https://docs.codecov.io/docs/fixing-paths
   fixes:


### PR DESCRIPTION
We currently display the following three CodeCov checks:

* codecov/changes - unexpected changes (there are still some bits in the DMD backend that depend on global memory state, but it's typically unrelated to a PR, very hard to fix and we always set it to "green" anyways atm)
* codecov/project - the overall coverage change. Typically this isn't interesting either as it again mostly only due to random coverage changes in the backend. If tests get removed, it makes sense to look at this option, but luckily that doesn't happen frequently and even if it's still just one click away
* codecov/patch - the only coverage option I look at

tl;dr: codecov/changes and codecov/project only show us that the backend
has random coverage. As no one is going to to fix this and we hard-coded
it to be true anyways, it's better to remove it and make the CI overview
box more concise.

See also: https://github.com/dlang/dmd/pull/7617#issuecomment-357557314