### PR TITLE
Don't overwrite the codecov/project status to green

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -42,7 +42,7 @@ coverage:
         threshold: 0.1
     patch:
       default:
-        informational: true
+        informational: false
     changes:
       default:
         informational: true


### PR DESCRIPTION
Now that we CodeCov properly find the base commit, it will only error if the patch reduces the coverage of a file, which shouldn't happen too often.

Follow-up to https://github.com/dlang/dmd/pull/7711