### PR TITLE
[CodeCov] Remove fixing paths

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -47,9 +47,4 @@ coverage:
       default:
         informational: true
 
-  # https://docs.codecov.io/docs/fixing-paths
-  fixes:
-    - "test/.*/::src/"
-    - "fail_compilation/::src/"
-
 comment: false


### PR DESCRIPTION
It seems that Codecov [now does check for the YAML of a PR](https://github.com/dlang/dmd/pull/7711#issuecomment-357589675).
Hence, we can give removing `fixes` a try - it looks like it's not needed anymore.