### PR TITLE
Don't permutate through ARGS on AppVeyor

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -80,5 +80,5 @@ export MODEL="64"
 export MODEL_FLAG="-m64"
 
 cd /c/projects/dmd/test
-../../gnumake/make -j2 all MODEL=$MODEL MODEL_FLAG=$MODEL_FLAG LIB="../../phobos;$LIB"
+../../gnumake/make -j3 all MODEL=$MODEL ARGS="-O -inline -g" MODEL_FLAG=$MODEL_FLAG LIB="../../phobos;$LIB"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ cache:
   - C:\projects\gnumake\make.exe
   - C:\projects\VisualD-v0.45.1-rc2.exe
 
+skip_commits:
+  # Avoid retesting the merged PR on `master` or `stable`
+  message: /^Merge pull request/
+
 artifacts:
   - path: src/dmd.exe
     name: dmd


### PR DESCRIPTION
We don't do this on CircleCi or SemaphoreCI either.
Auto-tester will do this anyways for correctness and AppVeyor is only intended to give us a feedback about MSCOFF builds and building DMD with VisualD.