### PR TITLE
Automatically convert PUREXXX -> PURE

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -283,18 +283,12 @@ struct ASTBase
 
     enum PURE : int
     {
-        PUREimpure      = 0,    // not pure at all
-        PUREfwdref      = 1,    // it's pure, but not known which level yet
-        PUREweak        = 2,    // no mutable globals are read or written
-        PUREconst       = 3,    // parameters are values or const
-        PUREstrong      = 4,    // parameters are values or immutable
+        impure      = 0,    // not pure at all
+        fwdref      = 1,    // it's pure, but not known which level yet
+        weak        = 2,    // no mutable globals are read or written
+        const_      = 3,    // parameters are values or const
+        strong      = 4,    // parameters are values or immutable
     }
-
-    alias PUREimpure = PURE.PUREimpure;
-    alias PUREfwdref = PURE.PUREfwdref;
-    alias PUREweak = PURE.PUREweak;
-    alias PUREconst = PURE.PUREconst;
-    alias PUREstrong = PURE.PUREstrong;
 
     enum AliasThisRec : int
     {

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3835,7 +3835,7 @@ struct ASTBase
         bool isscope;               // true: 'this' is scope
         LINK linkage;               // calling convention
         TRUST trust;                // level of trust
-        PURE purity = PUREimpure;
+        PURE purity = PURE.impure;
 
         ubyte iswild;
         Expressions* fargs;
@@ -3849,7 +3849,7 @@ struct ASTBase
             this.linkage = linkage;
 
             if (stc & STC.pure_)
-                this.purity = PUREfwdref;
+                this.purity = PURE.fwdref;
             if (stc & STC.nothrow_)
                 this.isnothrow = true;
             if (stc & STC.nogc)

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -50,7 +50,7 @@ extern (C++) StorageClass mergeFuncAttrs(StorageClass s1, FuncDeclaration f)
         s2 |= STC.system;
     else if (tf.trust == TRUSTtrusted)
         s2 |= STC.trusted;
-    if (tf.purity != PUREimpure)
+    if (tf.purity != PURE.impure)
         s2 |= STC.pure_;
     if (tf.isnothrow)
         s2 |= STC.nothrow_;

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -840,7 +840,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 return;
             TypeFunction tf = cast(TypeFunction)tx;
 
-            if (tf.purity == PUREimpure)
+            if (tf.purity == PURE.impure)
                 return;
             if (e.f && e.f.isNested())
                 return;
@@ -1181,7 +1181,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 if (fd.errors || fd.type.ty != Tfunction)
                     return; // error
                 TypeFunction tf = cast(TypeFunction)fd.type;
-                if (tf.purity == PUREimpure)
+                if (tf.purity == PURE.impure)
                     return; // impure
 
                 if (fd == e.member)
@@ -2808,8 +2808,8 @@ Lagain:
             TypeFunction d = cast(TypeFunction)tf1.syntaxCopy();
 
             if (tf1.purity != tf2.purity)
-                d.purity = PUREimpure;
-            assert(d.purity != PUREfwdref);
+                d.purity = PURE.impure;
+            assert(d.purity != PURE.fwdref);
 
             d.isnothrow = (tf1.isnothrow && tf2.isnothrow);
             d.isnogc = (tf1.isnogc && tf2.isnogc);

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2610,7 +2610,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                  *    // See also Expression::checkPurity().
                  *  }
                  */
-                if (tf.purity == PUREimpure && (funcdecl.isNested() || funcdecl.isThis()))
+                if (tf.purity == PURE.impure && (funcdecl.isNested() || funcdecl.isThis()))
                 {
                     FuncDeclaration fd = null;
                     for (Dsymbol p = funcdecl.toParent2(); p; p = p.toParent2())
@@ -2628,9 +2628,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     /* If the parent's purity is inferred, then this function's purity needs
                      * to be inferred first.
                      */
-                    if (fd && fd.isPureBypassingInference() >= PUREweak && !funcdecl.isInstantiated())
+                    if (fd && fd.isPureBypassingInference() >= PURE.weak && !funcdecl.isInstantiated())
                     {
-                        tf.purity = PUREfwdref; // default to pure
+                        tf.purity = PURE.fwdref; // default to pure
                     }
                 }
             }
@@ -2645,7 +2645,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 sc.stc |= STC.nogc;
             if (tf.isproperty)
                 sc.stc |= STC.property;
-            if (tf.purity == PUREfwdref)
+            if (tf.purity == PURE.fwdref)
                 sc.stc |= STC.pure_;
             if (tf.trust != TRUSTdefault)
                 sc.stc &= ~(STC.safe | STC.system | STC.trusted);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1997,13 +1997,13 @@ extern (C++) abstract class Expression : RootObject
              *  }
              */
 
-            while (outerfunc.toParent2() && outerfunc.isPureBypassingInference() == PUREimpure && outerfunc.toParent2().isFuncDeclaration())
+            while (outerfunc.toParent2() && outerfunc.isPureBypassingInference() == PURE.impure && outerfunc.toParent2().isFuncDeclaration())
             {
                 outerfunc = outerfunc.toParent2().isFuncDeclaration();
                 if (outerfunc.type.ty == Terror)
                     return true;
             }
-            while (calledparent.toParent2() && calledparent.isPureBypassingInference() == PUREimpure && calledparent.toParent2().isFuncDeclaration())
+            while (calledparent.toParent2() && calledparent.isPureBypassingInference() == PURE.impure && calledparent.toParent2().isFuncDeclaration())
             {
                 calledparent = calledparent.toParent2().isFuncDeclaration();
                 if (calledparent.type.ty == Terror)
@@ -2016,7 +2016,7 @@ extern (C++) abstract class Expression : RootObject
         if (!f.isPure() && calledparent != outerfunc)
         {
             FuncDeclaration ff = outerfunc;
-            if (sc.flags & SCOPE.compile ? ff.isPureBypassingInference() >= PUREweak : ff.setImpure())
+            if (sc.flags & SCOPE.compile ? ff.isPureBypassingInference() >= PURE.weak : ff.setImpure())
             {
                 error("pure %s '%s' cannot call impure %s '%s'",
                     ff.kind(), ff.toPrettyChars(), f.kind(), f.toPrettyChars());
@@ -2080,7 +2080,7 @@ extern (C++) abstract class Expression : RootObject
                 FuncDeclaration ff = s.isFuncDeclaration();
                 if (!ff)
                     break;
-                if (sc.flags & SCOPE.compile ? ff.isPureBypassingInference() >= PUREweak : ff.setImpure())
+                if (sc.flags & SCOPE.compile ? ff.isPureBypassingInference() >= PURE.weak : ff.setImpure())
                 {
                     error("pure %s '%s' cannot access mutable static data '%s'",
                         ff.kind(), ff.toPrettyChars(), v.toChars());

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1175,7 +1175,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         //printf("initInferAttributes() for %s (%s)\n", toPrettyChars(), ident.toChars());
         TypeFunction tf = type.toTypeFunction();
-        if (tf.purity == PUREimpure) // purity not specified
+        if (tf.purity == PURE.impure) // purity not specified
             flags |= FUNCFLAG.purityInprocess;
 
         if (tf.trust == TRUSTdefault)
@@ -1201,21 +1201,21 @@ extern (C++) class FuncDeclaration : Declaration
         TypeFunction tf = type.toTypeFunction();
         if (flags & FUNCFLAG.purityInprocess)
             setImpure();
-        if (tf.purity == PUREfwdref)
+        if (tf.purity == PURE.fwdref)
             tf.purityLevel();
         PURE purity = tf.purity;
-        if (purity > PUREweak && isNested())
-            purity = PUREweak;
-        if (purity > PUREweak && needThis())
+        if (purity > PURE.weak && isNested())
+            purity = PURE.weak;
+        if (purity > PURE.weak && needThis())
         {
             // The attribute of the 'this' reference affects purity strength
             if (type.mod & MODimmutable)
             {
             }
-            else if (type.mod & (MODconst | MODwild) && purity >= PUREconst)
-                purity = PUREconst;
+            else if (type.mod & (MODconst | MODwild) && purity >= PURE.const_)
+                purity = PURE.const_;
             else
-                purity = PUREweak;
+                purity = PURE.weak;
         }
         tf.purity = purity;
         // ^ This rely on the current situation that every FuncDeclaration has a
@@ -1226,7 +1226,7 @@ extern (C++) class FuncDeclaration : Declaration
     final PURE isPureBypassingInference()
     {
         if (flags & FUNCFLAG.purityInprocess)
-            return PUREfwdref;
+            return PURE.fwdref;
         else
             return isPure();
     }

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -270,20 +270,20 @@ public:
     {
         switch (purity)
         {
-        case PUREimpure:
+        case PURE.impure:
             // Should not be printed
             //property(name, "impure");
             break;
-        case PUREweak:
+        case PURE.weak:
             property(name, "weak");
             break;
-        case PUREconst:
+        case PURE.const_:
             property(name, "const");
             break;
-        case PUREstrong:
+        case PURE.strong:
             property(name, "strong");
             break;
-        case PUREfwdref:
+        case PURE.fwdref:
             property(name, "fwdref");
             break;
         default:

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5440,18 +5440,12 @@ alias TRUSTformatSystem = TRUSTformat.TRUSTformatSystem;
 
 enum PURE : int
 {
-    PUREimpure      = 0,    // not pure at all
-    PUREfwdref      = 1,    // it's pure, but not known which level yet
-    PUREweak        = 2,    // no mutable globals are read or written
-    PUREconst       = 3,    // parameters are values or const
-    PUREstrong      = 4,    // parameters are values or immutable
+    impure      = 0,    // not pure at all
+    fwdref      = 1,    // it's pure, but not known which level yet
+    weak        = 2,    // no mutable globals are read or written
+    const_      = 3,    // parameters are values or const
+    strong      = 4,    // parameters are values or immutable
 }
-
-alias PUREimpure = PURE.PUREimpure;
-alias PUREfwdref = PURE.PUREfwdref;
-alias PUREweak = PURE.PUREweak;
-alias PUREconst = PURE.PUREconst;
-alias PUREstrong = PURE.PUREstrong;
 
 /***********************************************************
  */

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -567,11 +567,11 @@ enum TRUSTformat
 
 enum PURE
 {
-    PUREimpure = 0,     // not pure at all
-    PUREfwdref = 1,     // it's pure, but not known which level yet
-    PUREweak = 2,       // no mutable globals are read or written
-    PUREconst = 3,      // parameters are values or const
-    PUREstrong = 4,     // parameters are values or immutable
+    impure = 0,     // not pure at all
+    fwdref = 1,     // it's pure, but not known which level yet
+    weak = 2,       // no mutable globals are read or written
+    const_ = 3,      // parameters are values or const
+    strong = 4,     // parameters are values or immutable
 };
 
 class TypeFunction : public TypeNext

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -569,7 +569,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     fpostinv = null;
                 }
 
-                assert(funcdecl.type == f || (funcdecl.type.ty == Tfunction && f.purity == PUREimpure && (cast(TypeFunction)funcdecl.type).purity >= PUREfwdref));
+                assert(funcdecl.type == f || (funcdecl.type.ty == Tfunction && f.purity == PURE.impure && (cast(TypeFunction)funcdecl.type).purity >= PURE.fwdref));
                 f = cast(TypeFunction)funcdecl.type;
 
                 if (funcdecl.inferRetType)
@@ -1115,7 +1115,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             funcdecl.flags &= ~FUNCFLAG.purityInprocess;
             if (funcdecl.type == f)
                 f = cast(TypeFunction)f.copy();
-            f.purity = PUREfwdref;
+            f.purity = PURE.fwdref;
         }
 
         if (funcdecl.flags & FUNCFLAG.safetyInprocess)

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -104,9 +104,9 @@ extern (C++) int callSideEffectLevel(FuncDeclaration f)
     if (tf.isnothrow)
     {
         PURE purity = f.isPure();
-        if (purity == PUREstrong)
+        if (purity == PURE.strong)
             return 2;
-        if (purity == PUREconst)
+        if (purity == PURE.const_)
             return 1;
     }
     return 0;
@@ -125,18 +125,18 @@ extern (C++) int callSideEffectLevel(Type t)
     }
     tf.purityLevel();
     PURE purity = tf.purity;
-    if (t.ty == Tdelegate && purity > PUREweak)
+    if (t.ty == Tdelegate && purity > PURE.weak)
     {
         if (tf.isMutable())
-            purity = PUREweak;
+            purity = PURE.weak;
         else if (!tf.isImmutable())
-            purity = PUREconst;
+            purity = PURE.const_;
     }
     if (tf.isnothrow)
     {
-        if (purity == PUREstrong)
+        if (purity == PURE.strong)
             return 2;
-        if (purity == PUREconst)
+        if (purity == PURE.const_)
             return 1;
     }
     return 0;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3929,7 +3929,7 @@ else
         assert(sc.func);
         // use setImpure/setGC when the deprecation cycle is over
         PURE purity;
-        if (!(cas.stc & STC.pure_) && (purity = sc.func.isPureBypassingInference()) != PUREimpure && purity != PUREfwdref)
+        if (!(cas.stc & STC.pure_) && (purity = sc.func.isPureBypassingInference()) != PURE.impure && purity != PURE.fwdref)
             cas.deprecation("asm statement is assumed to be impure - mark it with 'pure' if it is not");
         if (!(cas.stc & STC.nogc) && sc.func.isNogcBypassingInference())
             cas.deprecation("asm statement is assumed to use the GC - mark it with '@nogc' if it does not");

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1315,7 +1315,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
              * function with the name "toHash".
              * So I'm leaving this here as an experiment for the moment.
              */
-            if (!tf.isnothrow || tf.trust == TRUSTsystem /*|| tf.purity == PUREimpure*/)
+            if (!tf.isnothrow || tf.trust == TRUSTsystem /*|| tf.purity == PURE.impure*/)
                 warning(fd.loc, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf.toChars());
         }
         else

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -736,7 +736,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         }
 
         if (sc.stc & STC.pure_)
-            tf.purity = PUREfwdref;
+            tf.purity = PURE.fwdref;
         if (sc.stc & STC.nothrow_)
             tf.isnothrow = true;
         if (sc.stc & STC.nogc)


### PR DESCRIPTION
```bash
replacements=(
"PUREimpure impure"
"PUREfwdref fwdref"
"PUREweak weak"
"PUREconst const_"
"PUREstrong strong"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/PURE.${w[1]}/g" -i **/*.d
done
```