### PR TITLE
Automatically convert TRUSTXXX -> TRUST

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3859,13 +3859,13 @@ struct ASTBase
             if (stc & STC.scope_)
                 this.isscope = true;
 
-            this.trust = TRUSTdefault;
+            this.trust = TRUST.default_;
             if (stc & STC.safe)
-                this.trust = TRUSTsafe;
+                this.trust = TRUST.safe;
             if (stc & STC.system)
-                this.trust = TRUSTsystem;
+                this.trust = TRUST.system;
             if (stc & STC.trusted)
-                this.trust = TRUSTtrusted;
+                this.trust = TRUST.trusted;
         }
 
         override Type syntaxCopy()

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -270,16 +270,11 @@ struct ASTBase
 
     enum TRUST : int
     {
-        TRUSTdefault    = 0,
-        TRUSTsystem     = 1,    // @system (same as TRUSTdefault)
-        TRUSTtrusted    = 2,    // @trusted
-        TRUSTsafe       = 3,    // @safe
+        default_   = 0,
+        system     = 1,    // @system (same as TRUST.default)
+        trusted    = 2,    // @trusted
+        safe       = 3,    // @safe
     }
-
-    alias TRUSTdefault = TRUST.TRUSTdefault;
-    alias TRUSTsystem = TRUST.TRUSTsystem;
-    alias TRUSTtrusted = TRUST.TRUSTtrusted;
-    alias TRUSTsafe = TRUST.TRUSTsafe;
 
     enum PURE : int
     {

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -44,11 +44,11 @@ extern (C++) StorageClass mergeFuncAttrs(StorageClass s1, FuncDeclaration f)
         return s1;
     StorageClass s2 = (f.storage_class & STC.disable);
     TypeFunction tf = cast(TypeFunction)f.type;
-    if (tf.trust == TRUSTsafe)
+    if (tf.trust == TRUST.safe)
         s2 |= STC.safe;
-    else if (tf.trust == TRUSTsystem)
+    else if (tf.trust == TRUST.system)
         s2 |= STC.system;
-    else if (tf.trust == TRUSTtrusted)
+    else if (tf.trust == TRUST.trusted)
         s2 |= STC.trusted;
     if (tf.purity != PURE.impure)
         s2 |= STC.pure_;

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2816,10 +2816,10 @@ Lagain:
 
             if (tf1.trust == tf2.trust)
                 d.trust = tf1.trust;
-            else if (tf1.trust <= TRUSTsystem || tf2.trust <= TRUSTsystem)
-                d.trust = TRUSTsystem;
+            else if (tf1.trust <= TRUST.system || tf2.trust <= TRUST.system)
+                d.trust = TRUST.system;
             else
-                d.trust = TRUSTtrusted;
+                d.trust = TRUST.trusted;
 
             Type tx = null;
             if (t1.ty == Tdelegate)

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -391,10 +391,10 @@ public:
                 buf.writestring("Nl");
             switch (ta.trust)
             {
-            case TRUSTtrusted:
+            case TRUST.trusted:
                 buf.writestring("Ne");
                 break;
-            case TRUSTsafe:
+            case TRUST.safe:
                 buf.writestring("Nf");
                 break;
             default:

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2646,13 +2646,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 sc.stc |= STC.property;
             if (tf.purity == PURE.fwdref)
                 sc.stc |= STC.pure_;
-            if (tf.trust != TRUSTdefault)
+            if (tf.trust != TRUST.default_)
                 sc.stc &= ~(STC.safe | STC.system | STC.trusted);
-            if (tf.trust == TRUSTsafe)
+            if (tf.trust == TRUST.safe)
                 sc.stc |= STC.safe;
-            if (tf.trust == TRUSTsystem)
+            if (tf.trust == TRUST.system)
                 sc.stc |= STC.system;
-            if (tf.trust == TRUSTtrusted)
+            if (tf.trust == TRUST.trusted)
                 sc.stc |= STC.trusted;
 
             if (funcdecl.isCtorDeclaration())

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -231,7 +231,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
     // Try to infer 'scope' for va if in a function not marked @system
     bool inferScope = false;
     if (va && sc.func && sc.func.type && sc.func.type.ty == Tfunction)
-        inferScope = (cast(TypeFunction)sc.func.type).trust != TRUSTsystem;
+        inferScope = (cast(TypeFunction)sc.func.type).trust != TRUST.system;
 
     bool result = false;
     foreach (VarDeclaration v; er.byvalue)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3467,7 +3467,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());
                     err = true;
                 }
-                if (tf.trust <= TRUSTsystem && sc.func.setUnsafe())
+                if (tf.trust <= TRUST.system && sc.func.setUnsafe())
                 {
                     exp.error("`@safe` %s `%s` cannot call `@system` %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1178,7 +1178,7 @@ extern (C++) class FuncDeclaration : Declaration
         if (tf.purity == PURE.impure) // purity not specified
             flags |= FUNCFLAG.purityInprocess;
 
-        if (tf.trust == TRUSTdefault)
+        if (tf.trust == TRUST.default_)
             flags |= FUNCFLAG.safetyInprocess;
 
         if (!tf.isnothrow)
@@ -1253,7 +1253,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         if (flags & FUNCFLAG.safetyInprocess)
             setUnsafe();
-        return type.toTypeFunction().trust == TRUSTsafe;
+        return type.toTypeFunction().trust == TRUST.safe;
     }
 
     final bool isSafeBypassingInference()
@@ -1265,7 +1265,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         if (flags & FUNCFLAG.safetyInprocess)
             setUnsafe();
-        return type.toTypeFunction().trust == TRUSTtrusted;
+        return type.toTypeFunction().trust == TRUST.trusted;
     }
 
     /**************************************
@@ -1278,7 +1278,7 @@ extern (C++) class FuncDeclaration : Declaration
         if (flags & FUNCFLAG.safetyInprocess)
         {
             flags &= ~FUNCFLAG.safetyInprocess;
-            type.toTypeFunction().trust = TRUSTsystem;
+            type.toTypeFunction().trust = TRUST.system;
             if (fes)
                 fes.func.setUnsafe();
         }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3281,13 +3281,13 @@ extern (C++) const(char)* trustToChars(TRUST trust)
 {
     switch (trust)
     {
-    case TRUSTdefault:
+    case TRUST.default_:
         return null;
-    case TRUSTsystem:
+    case TRUST.system:
         return "@system";
-    case TRUSTtrusted:
+    case TRUST.trusted:
         return "@trusted";
-    case TRUSTsafe:
+    case TRUST.safe:
         return "@safe";
     default:
         assert(0);

--- a/src/dmd/irstate.d
+++ b/src/dmd/irstate.d
@@ -243,7 +243,7 @@ struct IRState
                 if (fd)
                 {
                     Type t = fd.type;
-                    if (t.ty == Tfunction && (cast(TypeFunction)t).trust == TRUSTsafe)
+                    if (t.ty == Tfunction && (cast(TypeFunction)t).trust == TRUST.safe)
                         result = true;
                 }
                 break;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -248,17 +248,17 @@ public:
     {
         switch (trust)
         {
-        case TRUSTdefault:
+        case TRUST.default_:
             // Should not be printed
             //property(name, "default");
             break;
-        case TRUSTsystem:
+        case TRUST.system:
             property(name, "system");
             break;
-        case TRUSTtrusted:
+        case TRUST.trusted:
             property(name, "trusted");
             break;
-        case TRUSTsafe:
+        case TRUST.safe:
             property(name, "safe");
             break;
         default:

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -859,7 +859,7 @@ extern (C++) abstract class Type : RootObject
 
         /* Can convert safe/trusted to system
          */
-        if (t1.trust <= TRUSTsystem && t2.trust >= TRUSTtrusted)
+        if (t1.trust <= TRUST.system && t2.trust >= TRUST.trusted)
         {
             // Should we infer trusted or safe? Go with safe.
             stc |= STC.safe;
@@ -5422,8 +5422,8 @@ enum TRUST : int
 
 enum TRUSTformat : int
 {
-    TRUSTformatDefault,     // do not emit @system when trust == TRUSTdefault
-    TRUSTformatSystem,      // emit @system when trust == TRUSTdefault
+    TRUSTformatDefault,     // do not emit @system when trust == TRUST.default_
+    TRUSTformatSystem,      // emit @system when trust == TRUST.default_
 }
 
 alias TRUSTformatDefault = TRUSTformat.TRUSTformatDefault;
@@ -5489,13 +5489,13 @@ extern (C++) final class TypeFunction : TypeNext
         if (stc & STC.scopeinferred)
             this.isscopeinferred = true;
 
-        this.trust = TRUSTdefault;
+        this.trust = TRUST.default_;
         if (stc & STC.safe)
-            this.trust = TRUSTsafe;
+            this.trust = TRUST.safe;
         if (stc & STC.system)
-            this.trust = TRUSTsystem;
+            this.trust = TRUST.system;
         if (stc & STC.trusted)
-            this.trust = TRUSTtrusted;
+            this.trust = TRUST.trusted;
     }
 
     static TypeFunction create(Parameters* parameters, Type treturn, int varargs, LINK linkage, StorageClass stc = 0)
@@ -5752,7 +5752,7 @@ extern (C++) final class TypeFunction : TypeNext
             (stc & STC.nothrow_ && !t.isnothrow) ||
             (stc & STC.nogc && !t.isnogc) ||
             (stc & STC.scope_ && !t.isscope) ||
-            (stc & STC.safe && t.trust < TRUSTtrusted))
+            (stc & STC.safe && t.trust < TRUST.trusted))
         {
             // Klunky to change these
             auto tf = new TypeFunction(t.parameters, t.next, t.varargs, t.linkage, 0);
@@ -5776,7 +5776,7 @@ extern (C++) final class TypeFunction : TypeNext
             if (stc & STC.nogc)
                 tf.isnogc = true;
             if (stc & STC.safe)
-                tf.trust = TRUSTsafe;
+                tf.trust = TRUST.safe;
             if (stc & STC.scope_)
             {
                 tf.isscope = true;
@@ -5832,11 +5832,11 @@ extern (C++) final class TypeFunction : TypeNext
 
         TRUST trustAttrib = trust;
 
-        if (trustAttrib == TRUSTdefault)
+        if (trustAttrib == TRUST.default_)
         {
-            // Print out "@system" when trust equals TRUSTdefault (if desired).
+            // Print out "@system" when trust equals TRUST.default_ (if desired).
             if (trustFormat == TRUSTformatSystem)
-                trustAttrib = TRUSTsystem;
+                trustAttrib = TRUST.system;
             else
                 return res; // avoid calling with an empty string
         }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5414,16 +5414,11 @@ enum RET : int
 
 enum TRUST : int
 {
-    TRUSTdefault    = 0,
-    TRUSTsystem     = 1,    // @system (same as TRUSTdefault)
-    TRUSTtrusted    = 2,    // @trusted
-    TRUSTsafe       = 3,    // @safe
+    default_   = 0,
+    system     = 1,    // @system (same as TRUST.default)
+    trusted    = 2,    // @trusted
+    safe       = 3,    // @safe
 }
-
-alias TRUSTdefault = TRUST.TRUSTdefault;
-alias TRUSTsystem = TRUST.TRUSTsystem;
-alias TRUSTtrusted = TRUST.TRUSTtrusted;
-alias TRUSTsafe = TRUST.TRUSTsafe;
 
 enum TRUSTformat : int
 {

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1123,7 +1123,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             funcdecl.flags &= ~FUNCFLAG.safetyInprocess;
             if (funcdecl.type == f)
                 f = cast(TypeFunction)f.copy();
-            f.trust = TRUSTsafe;
+            f.trust = TRUST.safe;
         }
 
         if (funcdecl.flags & FUNCFLAG.nogcInprocess)

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1315,7 +1315,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
              * function with the name "toHash".
              * So I'm leaving this here as an experiment for the moment.
              */
-            if (!tf.isnothrow || tf.trust == TRUSTsystem /*|| tf.purity == PURE.impure*/)
+            if (!tf.isnothrow || tf.trust == TRUST.system /*|| tf.purity == PURE.impure*/)
                 warning(fd.loc, "toHash() must be declared as extern (D) size_t toHash() const nothrow @safe, not %s", tf.toChars());
         }
         else

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -753,14 +753,14 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 //        if (tf.isreturn && !tf.isref)
 //            tf.isscope = true;                                  // return by itself means 'return scope'
 
-        if (tf.trust == TRUSTdefault)
+        if (tf.trust == TRUST.default_)
         {
             if (sc.stc & STC.safe)
-                tf.trust = TRUSTsafe;
+                tf.trust = TRUST.safe;
             else if (sc.stc & STC.system)
-                tf.trust = TRUSTsystem;
+                tf.trust = TRUST.system;
             else if (sc.stc & STC.trusted)
-                tf.trust = TRUSTtrusted;
+                tf.trust = TRUST.trusted;
         }
 
         if (sc.stc & STC.property)
@@ -774,14 +774,14 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
              * If the parent's @safe-ty is inferred, then this function's @safe-ty needs
              * to be inferred first.
              */
-            if (tf.trust == TRUSTdefault)
+            if (tf.trust == TRUST.default_)
                 for (Dsymbol p = sc.func; p; p = p.toParent2())
                 {
                     FuncDeclaration fd = p.isFuncDeclaration();
                     if (fd)
                     {
                         if (fd.isSafeBypassingInference())
-                            tf.trust = TRUSTsafe; // default to @safe
+                            tf.trust = TRUST.safe; // default to @safe
                         break;
                     }
                 }


### PR DESCRIPTION
```bash
replacements=(
"TRUSTdefault default_"
"TRUSTsystem system"
"TRUSTtrusted trusted"
"TRUSTsafe safe"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/TRUST.${w[1]}/g" -i **/*.d
done
```