### PR TITLE
Automatically convert PASSXXX -> PASS

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -559,7 +559,7 @@ private Dsymbol mostVisibleOverload(Dsymbol s)
         {
             assert(ad.isOverloadable, "Non overloadable Aliasee in overload list");
             // Yet unresolved aliases store overloads in overnext.
-            if (ad.semanticRun < PASSsemanticdone)
+            if (ad.semanticRun < PASS.semanticdone)
                 next = ad.overnext;
             else
             {

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -128,7 +128,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         // semanticRun prevents unnecessary setting of _scope during deferred
         // setScope phases for aggregates which already finished semantic().
         // See https://issues.dlang.org/show_bug.cgi?id=16607
-        if (semanticRun < PASSsemanticdone)
+        if (semanticRun < PASS.semanticdone)
             ScopeDsymbol.setScope(sc);
     }
 
@@ -162,7 +162,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
             auto ad = cast(AggregateDeclaration)param;
 
-            if (v.semanticRun < PASSsemanticdone)
+            if (v.semanticRun < PASS.semanticdone)
                 v.dsymbolSemantic(null);
             // Return in case a recursive determineFields triggered by v.semantic already finished
             if (ad.sizeok != Sizeok.none)
@@ -173,7 +173,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
             if (v.storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared | STC.manifest | STC.ctfe | STC.templateparameter))
                 return 0;
-            if (!v.isField() || v.semanticRun < PASSsemanticdone)
+            if (!v.isField() || v.semanticRun < PASS.semanticdone)
                 return 1;   // unresolvable forward reference
 
             ad.fields.push(v);
@@ -663,7 +663,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             vthis.parent = this;
             vthis.protection = Prot(Prot.Kind.public_);
             vthis.alignment = t.alignment();
-            vthis.semanticRun = PASSsemanticdone;
+            vthis.semanticRun = PASS.semanticdone;
 
             if (sizeok == Sizeok.fwd)
                 fields.push(vthis);
@@ -702,7 +702,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                 extern (C++) static int fp(Dsymbol s, void* ctxt)
                 {
                     auto f = s.isCtorDeclaration();
-                    if (f && f.semanticRun == PASSinit)
+                    if (f && f.semanticRun == PASS.init)
                         f.dsymbolSemantic(null);
                     return 0;
                 }

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -493,10 +493,10 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         {
             /* cd.baseClass might not be set if cd is forward referenced.
              */
-            if (!cd.baseClass && cd.semanticRun < PASSsemanticdone && !cd.isInterfaceDeclaration())
+            if (!cd.baseClass && cd.semanticRun < PASS.semanticdone && !cd.isInterfaceDeclaration())
             {
                 cd.dsymbolSemantic(null);
-                if (!cd.baseClass && cd.semanticRun < PASSsemanticdone)
+                if (!cd.baseClass && cd.semanticRun < PASS.semanticdone)
                     cd.error("base class is forward referenced by `%s`", toChars());
             }
 
@@ -915,9 +915,9 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         this.dsymbolSemantic(null);
 
         /* The next line should work, but does not because when ClassDeclaration.dsymbolSemantic()
-         * is called recursively it can set PASSsemanticdone without finishing it.
+         * is called recursively it can set PASS.semanticdone without finishing it.
          */
-        //if (semanticRun < PASSsemanticdone)
+        //if (semanticRun < PASS.semanticdone)
         {
             /* Could not complete semantic(). Try running semantic() on
              * each of the virtual functions,

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -725,7 +725,7 @@ extern (C++) final class AliasDeclaration : Declaration
          *  simple Overload class (an array) and then later have that resolve
          *  all collisions.
          */
-        if (semanticRun >= PASSsemanticdone)
+        if (semanticRun >= PASS.semanticdone)
         {
             /* Semantic analysis is already finished, and the aliased entity
              * is not overloadable.
@@ -863,7 +863,7 @@ extern (C++) final class AliasDeclaration : Declaration
             return aliassym;
         }
 
-        if (semanticRun >= PASSsemanticdone)
+        if (semanticRun >= PASS.semanticdone)
         {
             // semantic is already done.
 
@@ -909,7 +909,7 @@ extern (C++) final class AliasDeclaration : Declaration
     override bool isOverloadable()
     {
         // assume overloadable until alias is resolved
-        return semanticRun < PASSsemanticdone ||
+        return semanticRun < PASS.semanticdone ||
             aliassym && aliassym.isOverloadable();
     }
 

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -105,7 +105,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
 
     override void setScope(Scope* sc)
     {
-        if (semanticRun > PASSinit)
+        if (semanticRun > PASS.init)
             return;
         ScopeDsymbol.setScope(sc);
     }
@@ -193,7 +193,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             dsymbolSemantic(this, _scope);
         if (errors)
             return errorReturn();
-        if (semanticRun == PASSinit || !members)
+        if (semanticRun == PASS.init || !members)
         {
             error("is forward referenced looking for `.%s`", id.toChars());
             return errorReturn();
@@ -259,7 +259,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             dsymbolSemantic(this, _scope);
         if (errors)
             goto Lerrors;
-        if (semanticRun == PASSinit || !members)
+        if (semanticRun == PASS.init || !members)
         {
             error(loc, "forward reference of `%s.init`", toChars());
             goto Lerrors;

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -616,7 +616,7 @@ private void ctfeCompile(FuncDeclaration fd)
     }
     assert(!fd.ctfeCode);
     assert(!fd.semantic3Errors);
-    assert(fd.semanticRun == PASSsemantic3done);
+    assert(fd.semanticRun == PASS.semantic3done);
 
     fd.ctfeCode = new CompiledCtfeFunction(fd);
     if (fd.parameters)
@@ -736,14 +736,14 @@ private Expression interpret(FuncDeclaration fd, InterState* istate, Expressions
     {
         printf("\n********\n%s FuncDeclaration::interpret(istate = %p) %s\n", fd.loc.toChars(), istate, fd.toChars());
     }
-    if (fd.semanticRun == PASSsemantic3)
+    if (fd.semanticRun == PASS.semantic3)
     {
         fd.error("circular dependency. Functions cannot be interpreted while being compiled");
         return CTFEExp.cantexp;
     }
     if (!fd.functionSemantic3())
         return CTFEExp.cantexp;
-    if (fd.semanticRun < PASSsemantic3done)
+    if (fd.semanticRun < PASS.semantic3done)
         return CTFEExp.cantexp;
 
     // CTFE-compile the function
@@ -2246,7 +2246,7 @@ public:
             if (v.ident == Id.ctfe)
                 return new IntegerExp(loc, 1, Type.tbool);
 
-            if (!v.originalType && v.semanticRun < PASSsemanticdone) // semantic() not yet run
+            if (!v.originalType && v.semanticRun < PASS.semanticdone) // semantic() not yet run
             {
                 v.dsymbolSemantic(null);
                 if (v.type.ty == Terror)
@@ -4925,7 +4925,7 @@ public:
             }
         }
 
-        if (fd && fd.semanticRun >= PASSsemantic3done && fd.semantic3Errors)
+        if (fd && fd.semanticRun >= PASS.semantic3done && fd.semantic3Errors)
         {
             e.error("CTFE failed because of previous errors in `%s`", fd.toChars());
             result = CTFEExp.cantexp;

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -131,7 +131,7 @@ void semantic3OnDependencies(Module m)
     if (!m)
         return;
 
-    if (m.semanticRun > PASSsemantic3)
+    if (m.semanticRun > PASS.semantic3)
         return;
 
     m.semantic3(null);

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -150,7 +150,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
 
             // If the struct is in a non-root module, run semantic3 to get
             // correct symbols for the member function.
-            if (sd.semanticRun >= PASSsemantic3)
+            if (sd.semanticRun >= PASS.semantic3)
             {
                 // semantic3 is already done
             }
@@ -282,7 +282,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     {
         if (xeq &&
             xeq._scope &&
-            xeq.semanticRun < PASSsemantic3done)
+            xeq.semanticRun < PASS.semantic3done)
         {
             uint errors = global.startGagging();
             xeq.semantic3(xeq._scope);
@@ -292,7 +292,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
 
         if (xcmp &&
             xcmp._scope &&
-            xcmp.semanticRun < PASSsemantic3done)
+            xcmp.semanticRun < PASS.semantic3done)
         {
             uint errors = global.startGagging();
             xcmp.semantic3(xcmp._scope);
@@ -303,28 +303,28 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         FuncDeclaration ftostr = search_toString(this);
         if (ftostr &&
             ftostr._scope &&
-            ftostr.semanticRun < PASSsemantic3done)
+            ftostr.semanticRun < PASS.semantic3done)
         {
             ftostr.semantic3(ftostr._scope);
         }
 
         if (xhash &&
             xhash._scope &&
-            xhash.semanticRun < PASSsemantic3done)
+            xhash.semanticRun < PASS.semantic3done)
         {
             xhash.semantic3(xhash._scope);
         }
 
         if (postblit &&
             postblit._scope &&
-            postblit.semanticRun < PASSsemantic3done)
+            postblit.semanticRun < PASS.semantic3done)
         {
             postblit.semantic3(postblit._scope);
         }
 
         if (dtor &&
             dtor._scope &&
-            dtor.semanticRun < PASSsemantic3done)
+            dtor.semanticRun < PASS.semantic3done)
         {
             dtor.semantic3(dtor._scope);
         }

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -197,14 +197,14 @@ extern (C++) class Dsymbol : RootObject
     final extern (D) this()
     {
         //printf("Dsymbol::Dsymbol(%p)\n", this);
-        this.semanticRun = PASSinit;
+        this.semanticRun = PASS.init;
     }
 
     final extern (D) this(Identifier ident)
     {
         //printf("Dsymbol::Dsymbol(%p, ident)\n", this);
         this.ident = ident;
-        this.semanticRun = PASSinit;
+        this.semanticRun = PASS.init;
     }
 
     static Dsymbol create(Identifier ident)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -142,28 +142,17 @@ struct Prot
 
 enum PASS : int
 {
-    PASSinit,           // initial state
-    PASSsemantic,       // semantic() started
-    PASSsemanticdone,   // semantic() done
-    PASSsemantic2,      // semantic2() started
-    PASSsemantic2done,  // semantic2() done
-    PASSsemantic3,      // semantic3() started
-    PASSsemantic3done,  // semantic3() done
-    PASSinline,         // inline started
-    PASSinlinedone,     // inline done
-    PASSobj,            // toObjFile() run
+    init,           // initial state
+    semantic,       // semantic() started
+    semanticdone,   // semantic() done
+    semantic2,      // semantic2() started
+    semantic2done,  // semantic2() done
+    semantic3,      // semantic3() started
+    semantic3done,  // semantic3() done
+    inline,         // inline started
+    inlinedone,     // inline done
+    obj,            // toObjFile() run
 }
-
-alias PASSinit = PASS.PASSinit;
-alias PASSsemantic = PASS.PASSsemantic;
-alias PASSsemanticdone = PASS.PASSsemanticdone;
-alias PASSsemantic2 = PASS.PASSsemantic2;
-alias PASSsemantic2done = PASS.PASSsemantic2done;
-alias PASSsemantic3 = PASS.PASSsemantic3;
-alias PASSsemantic3done = PASS.PASSsemantic3done;
-alias PASSinline = PASS.PASSinline;
-alias PASSinlinedone = PASS.PASSinlinedone;
-alias PASSobj = PASS.PASSobj;
 
 // Search options
 enum : int

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -195,7 +195,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(AliasThis dsym)
     {
-        if (dsym.semanticRun != PASSinit)
+        if (dsym.semanticRun != PASS.init)
             return;
 
         if (dsym._scope)
@@ -207,7 +207,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc)
             return;
 
-        dsym.semanticRun = PASSsemantic;
+        dsym.semanticRun = PASS.semantic;
 
         Dsymbol p = sc.parent.pastMixin();
         AggregateDeclaration ad = p.isAggregateDeclaration();
@@ -254,14 +254,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         ad.aliasthis = s;
-        dsym.semanticRun = PASSsemanticdone;
+        dsym.semanticRun = PASS.semanticdone;
     }
 
     override void visit(AliasDeclaration dsym)
     {
-        if (dsym.semanticRun >= PASSsemanticdone)
+        if (dsym.semanticRun >= PASS.semanticdone)
             return;
-        assert(dsym.semanticRun <= PASSsemantic);
+        assert(dsym.semanticRun <= PASS.semantic);
 
         dsym.storage_class |= sc.stc & STC.deprecated_;
         dsym.protection = sc.protection;
@@ -284,11 +284,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("linkage = %d\n", sc.linkage);
             //if (strcmp(toChars(), "mul") == 0) assert(0);
         }
-        //if (semanticRun > PASSinit)
+        //if (semanticRun > PASS.init)
         //    return;
         //semanticRun = PSSsemantic;
 
-        if (dsym.semanticRun >= PASSsemanticdone)
+        if (dsym.semanticRun >= PASS.semanticdone)
             return;
 
         Scope* scx = null;
@@ -302,7 +302,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc)
             return;
 
-        dsym.semanticRun = PASSsemantic;
+        dsym.semanticRun = PASS.semantic;
 
         /* Pick up storage classes from context, but except synchronized,
          * override, abstract, and final.
@@ -581,7 +581,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             v2.parent = dsym.parent;
             v2.isexp = true;
             dsym.aliassym = v2;
-            dsym.semanticRun = PASSsemanticdone;
+            dsym.semanticRun = PASS.semanticdone;
             return;
         }
 
@@ -1050,7 +1050,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        dsym.semanticRun = PASSsemanticdone;
+        dsym.semanticRun = PASS.semanticdone;
 
         if (dsym.type.toBasetype().ty == Terror)
             dsym.errors = true;
@@ -1071,7 +1071,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(Import imp)
     {
         //printf("Import::semantic('%s') %s\n", toPrettyChars(), id.toChars());
-        if (imp.semanticRun > PASSinit)
+        if (imp.semanticRun > PASS.init)
             return;
 
         if (imp._scope)
@@ -1082,7 +1082,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc)
             return;
 
-        imp.semanticRun = PASSsemantic;
+        imp.semanticRun = PASS.semantic;
 
         // Load if not already done so
         if (!imp.mod)
@@ -1167,7 +1167,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sc = sc.pop();
         }
 
-        imp.semanticRun = PASSsemanticdone;
+        imp.semanticRun = PASS.semanticdone;
 
         // object self-imports itself, so skip that
         // https://issues.dlang.org/show_bug.cgi?id=7547
@@ -1248,9 +1248,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     void attribSemantic(AttribDeclaration ad)
     {
-        if (ad.semanticRun != PASSinit)
+        if (ad.semanticRun != PASS.init)
             return;
-        ad.semanticRun = PASSsemantic;
+        ad.semanticRun = PASS.semantic;
         Dsymbols* d = ad.include(sc);
         //printf("\tAttribDeclaration::semantic '%s', d = %p\n",toChars(), d);
         if (d)
@@ -1267,7 +1267,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (sc2 != sc)
                 sc2.pop();
         }
-        ad.semanticRun = PASSsemanticdone;
+        ad.semanticRun = PASS.semanticdone;
     }
 
     override void visit(AttribDeclaration atd)
@@ -1603,35 +1603,35 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(StaticAssert sa)
     {
-        if (sa.semanticRun < PASSsemanticdone)
-            sa.semanticRun = PASSsemanticdone;
+        if (sa.semanticRun < PASS.semanticdone)
+            sa.semanticRun = PASS.semanticdone;
     }
 
     override void visit(DebugSymbol ds)
     {
         //printf("DebugSymbol::semantic() %s\n", toChars());
-        if (ds.semanticRun < PASSsemanticdone)
-            ds.semanticRun = PASSsemanticdone;
+        if (ds.semanticRun < PASS.semanticdone)
+            ds.semanticRun = PASS.semanticdone;
     }
 
     override void visit(VersionSymbol vs)
     {
-        if (vs.semanticRun < PASSsemanticdone)
-            vs.semanticRun = PASSsemanticdone;
+        if (vs.semanticRun < PASS.semanticdone)
+            vs.semanticRun = PASS.semanticdone;
     }
 
     override void visit(Package pkg)
     {
-        if (pkg.semanticRun < PASSsemanticdone)
-            pkg.semanticRun = PASSsemanticdone;
+        if (pkg.semanticRun < PASS.semanticdone)
+            pkg.semanticRun = PASS.semanticdone;
     }
 
     override void visit(Module m)
     {
-        if (m.semanticRun != PASSinit)
+        if (m.semanticRun != PASS.init)
             return;
         //printf("+Module::semantic(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
-        m.semanticRun = PASSsemantic;
+        m.semanticRun = PASS.semantic;
         // Note that modules get their own scope, from scratch.
         // This is so regardless of where in the syntax a module
         // gets imported, it is unaffected by context.
@@ -1658,7 +1658,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sc = sc.pop();
             sc.pop(); // 2 pops because Scope::createGlobal() created 2
         }
-        m.semanticRun = PASSsemanticdone;
+        m.semanticRun = PASS.semanticdone;
         //printf("-Module::semantic(this = %p, '%s'): parent = %p\n", this, toChars(), parent);
     }
 
@@ -1666,14 +1666,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     {
         //printf("EnumDeclaration::semantic(sd = %p, '%s') %s\n", sc.scopesym, sc.scopesym.toChars(), toChars());
         //printf("EnumDeclaration::semantic() %p %s\n", this, toChars());
-        if (ed.semanticRun >= PASSsemanticdone)
+        if (ed.semanticRun >= PASS.semanticdone)
             return; // semantic() already completed
-        if (ed.semanticRun == PASSsemantic)
+        if (ed.semanticRun == PASS.semantic)
         {
             assert(ed.memtype);
             error(ed.loc, "circular reference to enum base type `%s`", ed.memtype.toChars());
             ed.errors = true;
-            ed.semanticRun = PASSsemanticdone;
+            ed.semanticRun = PASS.semanticdone;
             return;
         }
         uint dprogress_save = Module.dprogress;
@@ -1697,11 +1697,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             ed.isdeprecated = true;
         ed.userAttribDecl = sc.userAttribDecl;
 
-        ed.semanticRun = PASSsemantic;
+        ed.semanticRun = PASS.semantic;
 
         if (!ed.members && !ed.memtype) // enum ident;
         {
-            ed.semanticRun = PASSsemanticdone;
+            ed.semanticRun = PASS.semanticdone;
             return;
         }
 
@@ -1734,7 +1734,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     ed._scope._module.addDeferredSemantic(ed);
                     Module.dprogress = dprogress_save;
                     //printf("\tdeferring %s\n", toChars());
-                    ed.semanticRun = PASSinit;
+                    ed.semanticRun = PASS.init;
                     return;
                 }
             }
@@ -1754,12 +1754,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         s.errors = true; // poison all the members
                     }
                 }
-                ed.semanticRun = PASSsemanticdone;
+                ed.semanticRun = PASS.semanticdone;
                 return;
             }
         }
 
-        ed.semanticRun = PASSsemanticdone;
+        ed.semanticRun = PASS.semanticdone;
 
         if (!ed.members) // enum ident : memtype;
             return;
@@ -1852,12 +1852,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         void errorReturn()
         {
             em.errors = true;
-            em.semanticRun = PASSsemanticdone;
+            em.semanticRun = PASS.semanticdone;
         }
 
-        if (em.errors || em.semanticRun >= PASSsemanticdone)
+        if (em.errors || em.semanticRun >= PASS.semanticdone)
             return;
-        if (em.semanticRun == PASSsemantic)
+        if (em.semanticRun == PASS.semantic)
         {
             em.error("circular reference to enum member");
             return errorReturn();
@@ -1866,7 +1866,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         em.ed.dsymbolSemantic(sc);
         if (em.ed.errors)
             return errorReturn();
-        if (em.errors || em.semanticRun >= PASSsemanticdone)
+        if (em.errors || em.semanticRun >= PASS.semanticdone)
             return;
 
         if (em._scope)
@@ -1874,7 +1874,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc)
             return;
 
-        em.semanticRun = PASSsemantic;
+        em.semanticRun = PASS.semantic;
 
         em.protection = em.ed.isAnonymous() ? em.ed.protection : Prot(Prot.Kind.public_);
         em.linkage = LINKd;
@@ -1918,7 +1918,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     for (size_t i = 0; i < em.ed.members.dim; i++)
                     {
                         EnumMember enm = (*em.ed.members)[i].isEnumMember();
-                        if (!enm || enm == em || enm.semanticRun < PASSsemanticdone || enm.origType)
+                        if (!enm || enm == em || enm.semanticRun < PASS.semanticdone || enm.origType)
                             continue;
 
                         //printf("[%d] em = %s, em.semanticRun = %d\n", i, toChars(), em.semanticRun);
@@ -2005,7 +2005,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
             }
             assert(emprev);
-            if (emprev.semanticRun < PASSsemanticdone) // if forward reference
+            if (emprev.semanticRun < PASS.semanticdone) // if forward reference
                 emprev.dsymbolSemantic(emprev._scope); // resolve it
             if (emprev.errors)
                 return errorReturn();
@@ -2065,7 +2065,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             em.type = em.value.type;
 
         assert(em.origValue);
-        em.semanticRun = PASSsemanticdone;
+        em.semanticRun = PASS.semanticdone;
     }
 
     override void visit(TemplateDeclaration tempdecl)
@@ -2076,7 +2076,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("sc.stc = %llx\n", sc.stc);
             printf("sc.module = %s\n", sc._module.toChars());
         }
-        if (tempdecl.semanticRun != PASSinit)
+        if (tempdecl.semanticRun != PASS.init)
             return; // semantic() already run
 
         if (tempdecl._scope)
@@ -2103,7 +2103,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             tempdecl._scope.setNoFree();
         }
 
-        tempdecl.semanticRun = PASSsemantic;
+        tempdecl.semanticRun = PASS.semantic;
 
         tempdecl.parent = sc.parent;
         tempdecl.protection = sc.protection;
@@ -2200,7 +2200,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          *  o no virtual functions or non-static data members of classes
          */
 
-        tempdecl.semanticRun = PASSsemanticdone;
+        tempdecl.semanticRun = PASS.semanticdone;
     }
 
     override void visit(TemplateInstance ti)
@@ -2215,18 +2215,18 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("+TemplateMixin.dsymbolSemantic('%s', this=%p)\n",tm.toChars(), tm);
             fflush(stdout);
         }
-        if (tm.semanticRun != PASSinit)
+        if (tm.semanticRun != PASS.init)
         {
             // When a class/struct contains mixin members, and is done over
             // because of forward references, never reach here so semanticRun
-            // has been reset to PASSinit.
+            // has been reset to PASS.init.
             static if (LOG)
             {
                 printf("\tsemantic done\n");
             }
             return;
         }
-        tm.semanticRun = PASSsemantic;
+        tm.semanticRun = PASS.semantic;
         static if (LOG)
         {
             printf("\tdo semantic\n");
@@ -2245,7 +2245,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          */
         if (!tm.findTempDecl(sc) || !tm.semanticTiargs(sc) || !tm.findBestMatch(sc, null))
         {
-            if (tm.semanticRun == PASSinit) // forward reference had occurred
+            if (tm.semanticRun == PASS.init) // forward reference had occurred
             {
                 //printf("forward reference - deferring\n");
                 tm._scope = scx ? scx : sc.copy();
@@ -2452,7 +2452,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(Nspace ns)
     {
-        if (ns.semanticRun != PASSinit)
+        if (ns.semanticRun != PASS.init)
             return;
         static if (LOG)
         {
@@ -2466,7 +2466,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc)
             return;
 
-        ns.semanticRun = PASSsemantic;
+        ns.semanticRun = PASS.semantic;
         ns.parent = sc.parent;
         if (ns.members)
         {
@@ -2488,7 +2488,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
             sc.pop();
         }
-        ns.semanticRun = PASSsemanticdone;
+        ns.semanticRun = PASS.semanticdone;
         static if (LOG)
         {
             printf("-Nspace::semantic('%s')\n", ns.toChars());
@@ -2510,7 +2510,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             printf("type: %p, %s\n", funcdecl.type, funcdecl.type.toChars());
         }
 
-        if (funcdecl.semanticRun != PASSinit && funcdecl.isFuncLiteralDeclaration())
+        if (funcdecl.semanticRun != PASS.init && funcdecl.isFuncLiteralDeclaration())
         {
             /* Member functions that have return types that are
              * forward references can have semantic() run more than
@@ -2520,10 +2520,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
 
-        if (funcdecl.semanticRun >= PASSsemanticdone)
+        if (funcdecl.semanticRun >= PASS.semanticdone)
             return;
-        assert(funcdecl.semanticRun <= PASSsemantic);
-        funcdecl.semanticRun = PASSsemantic;
+        assert(funcdecl.semanticRun <= PASS.semantic);
+        funcdecl.semanticRun = PASS.semantic;
 
         if (funcdecl._scope)
         {
@@ -3222,7 +3222,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             funcdecl.initInferAttributes();
 
         Module.dprogress++;
-        funcdecl.semanticRun = PASSsemanticdone;
+        funcdecl.semanticRun = PASS.semanticdone;
 
         /* Save scope for possible later use (if we need the
          * function internals)
@@ -3259,7 +3259,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(CtorDeclaration ctd)
     {
         //printf("CtorDeclaration::semantic() %s\n", toChars());
-        if (ctd.semanticRun >= PASSsemanticdone)
+        if (ctd.semanticRun >= PASS.semanticdone)
             return;
         if (ctd._scope)
         {
@@ -3340,7 +3340,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         //printf("PostBlitDeclaration::semantic() %s\n", toChars());
         //printf("ident: %s, %s, %p, %p\n", ident.toChars(), Id::dtor.toChars(), ident, Id::dtor);
         //printf("stc = x%llx\n", sc.stc);
-        if (pbd.semanticRun >= PASSsemanticdone)
+        if (pbd.semanticRun >= PASS.semanticdone)
             return;
         if (pbd._scope)
         {
@@ -3358,7 +3358,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             pbd.errors = true;
             return;
         }
-        if (pbd.ident == Id.postblit && pbd.semanticRun < PASSsemantic)
+        if (pbd.ident == Id.postblit && pbd.semanticRun < PASS.semantic)
             ad.postblits.push(pbd);
         if (!pbd.type)
             pbd.type = new TypeFunction(null, Type.tvoid, false, LINKd, pbd.storage_class);
@@ -3376,7 +3376,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     {
         //printf("DtorDeclaration::semantic() %s\n", toChars());
         //printf("ident: %s, %s, %p, %p\n", ident.toChars(), Id::dtor.toChars(), ident, Id::dtor);
-        if (dd.semanticRun >= PASSsemanticdone)
+        if (dd.semanticRun >= PASS.semanticdone)
             return;
         if (dd._scope)
         {
@@ -3394,7 +3394,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dd.errors = true;
             return;
         }
-        if (dd.ident == Id.dtor && dd.semanticRun < PASSsemantic)
+        if (dd.ident == Id.dtor && dd.semanticRun < PASS.semantic)
             ad.dtors.push(dd);
         if (!dd.type)
             dd.type = new TypeFunction(null, Type.tvoid, false, LINKd, dd.storage_class);
@@ -3412,7 +3412,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(StaticCtorDeclaration scd)
     {
         //printf("StaticCtorDeclaration::semantic()\n");
-        if (scd.semanticRun >= PASSsemanticdone)
+        if (scd.semanticRun >= PASS.semanticdone)
             return;
         if (scd._scope)
         {
@@ -3437,7 +3437,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          * it could get called multiple times by the module constructors
          * for different modules. Thus, protect it with a gate.
          */
-        if (scd.isInstantiated() && scd.semanticRun < PASSsemantic)
+        if (scd.isInstantiated() && scd.semanticRun < PASS.semantic)
         {
             /* Add this prefix to the function:
              *      static int gate;
@@ -3479,7 +3479,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(StaticDtorDeclaration sdd)
     {
-        if (sdd.semanticRun >= PASSsemanticdone)
+        if (sdd.semanticRun >= PASS.semanticdone)
             return;
         if (sdd._scope)
         {
@@ -3504,7 +3504,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          * it could get called multiple times by the module constructors
          * for different modules. Thus, protect it with a gate.
          */
-        if (sdd.isInstantiated() && sdd.semanticRun < PASSsemantic)
+        if (sdd.isInstantiated() && sdd.semanticRun < PASS.semantic)
         {
             /* Add this prefix to the function:
              *      static int gate;
@@ -3549,7 +3549,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(InvariantDeclaration invd)
     {
-        if (invd.semanticRun >= PASSsemanticdone)
+        if (invd.semanticRun >= PASS.semanticdone)
             return;
         if (invd._scope)
         {
@@ -3568,7 +3568,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
         if (invd.ident != Id.classInvariant &&
-             invd.semanticRun < PASSsemantic &&
+             invd.semanticRun < PASS.semantic &&
              !ad.isUnionDeclaration()           // users are on their own with union fields
            )
             ad.invs.push(invd);
@@ -3594,7 +3594,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // https://issues.dlang.org/show_bug.cgi?id=16995
         utd.setIdentifier();
 
-        if (utd.semanticRun >= PASSsemanticdone)
+        if (utd.semanticRun >= PASS.semanticdone)
             return;
         if (utd._scope)
         {
@@ -3644,7 +3644,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(NewDeclaration nd)
     {
         //printf("NewDeclaration::semantic()\n");
-        if (nd.semanticRun >= PASSsemanticdone)
+        if (nd.semanticRun >= PASS.semanticdone)
             return;
         if (nd._scope)
         {
@@ -3686,7 +3686,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(DeleteDeclaration deld)
     {
         //printf("DeleteDeclaration::semantic()\n");
-        if (deld.semanticRun >= PASSsemanticdone)
+        if (deld.semanticRun >= PASS.semanticdone)
             return;
         if (deld._scope)
         {
@@ -3730,7 +3730,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         //static int count; if (++count == 20) assert(0);
 
-        if (sd.semanticRun >= PASSsemanticdone)
+        if (sd.semanticRun >= PASS.semanticdone)
             return;
         int errors = global.errors;
 
@@ -3752,7 +3752,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (sd.errors)
             sd.type = Type.terror;
-        if (sd.semanticRun == PASSinit)
+        if (sd.semanticRun == PASS.init)
             sd.type = sd.type.addSTC(sc.stc | sd.storage_class);
         sd.type = sd.type.typeSemantic(sd.loc, sc);
         if (sd.type.ty == Tstruct && (cast(TypeStruct)sd.type).sym != sd)
@@ -3765,7 +3765,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // Ungag errors when not speculative
         Ungag ungag = sd.ungagSpeculative();
 
-        if (sd.semanticRun == PASSinit)
+        if (sd.semanticRun == PASS.init)
         {
             sd.protection = sc.protection;
 
@@ -3782,11 +3782,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         else if (sd.symtab && !scx)
             return;
 
-        sd.semanticRun = PASSsemantic;
+        sd.semanticRun = PASS.semantic;
 
         if (!sd.members) // if opaque declaration
         {
-            sd.semanticRun = PASSsemanticdone;
+            sd.semanticRun = PASS.semanticdone;
             return;
         }
         if (!sd.symtab)
@@ -3838,7 +3838,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
 
             sc2.pop();
-            sd.semanticRun = PASSsemanticdone;
+            sd.semanticRun = PASS.semanticdone;
             return;
         }
         /* Following special member functions creation needs semantic analysis
@@ -3852,7 +3852,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (tb.ty != Tstruct)
                 continue;
             auto sdec = (cast(TypeStruct)tb).sym;
-            if (sdec.semanticRun >= PASSsemanticdone)
+            if (sdec.semanticRun >= PASS.semanticdone)
                 continue;
 
             sc2.pop();
@@ -3888,7 +3888,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         sd.inv = buildInv(sd, sc2);
 
         Module.dprogress++;
-        sd.semanticRun = PASSsemanticdone;
+        sd.semanticRun = PASS.semanticdone;
         //printf("-StructDeclaration::semantic(this=%p, '%s')\n", this, toChars());
 
         sc2.pop();
@@ -3959,7 +3959,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         //{ static int n;  if (++n == 20) *(char*)0=0; }
 
-        if (cldec.semanticRun >= PASSsemanticdone)
+        if (cldec.semanticRun >= PASS.semanticdone)
             return;
         int errors = global.errors;
 
@@ -3992,7 +3992,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // Ungag errors when not speculative
         Ungag ungag = cldec.ungagSpeculative();
 
-        if (cldec.semanticRun == PASSinit)
+        if (cldec.semanticRun == PASS.init)
         {
             cldec.protection = sc.protection;
 
@@ -4015,10 +4015,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         else if (cldec.symtab && !scx)
         {
-            cldec.semanticRun = PASSsemanticdone;
+            cldec.semanticRun = PASS.semanticdone;
             return;
         }
-        cldec.semanticRun = PASSsemantic;
+        cldec.semanticRun = PASS.semantic;
 
         if (cldec.baseok < Baseok.done)
         {
@@ -4081,7 +4081,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (cldec.baseok >= Baseok.done)
             {
                 //printf("%s already semantic analyzed, semanticRun = %d\n", toChars(), semanticRun);
-                if (cldec.semanticRun >= PASSsemanticdone)
+                if (cldec.semanticRun >= PASS.semanticdone)
                     return;
                 goto Lancestorsdone;
             }
@@ -4264,7 +4264,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!cldec.members) // if opaque declaration
         {
-            cldec.semanticRun = PASSsemanticdone;
+            cldec.semanticRun = PASS.semanticdone;
             return;
         }
         if (!cldec.symtab)
@@ -4305,7 +4305,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             Type tb = b.type.toBasetype();
             assert(tb.ty == Tclass);
             TypeClass tc = cast(TypeClass)tb;
-            if (tc.sym.semanticRun < PASSsemanticdone)
+            if (tc.sym.semanticRun < PASS.semanticdone)
             {
                 // Forward referencee of one or more bases, try again later
                 cldec._scope = scx ? scx : sc.copy();
@@ -4407,7 +4407,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (tb.ty != Tstruct)
                 continue;
             auto sd = (cast(TypeStruct)tb).sym;
-            if (sd.semanticRun >= PASSsemanticdone)
+            if (sd.semanticRun >= PASS.semanticdone)
                 continue;
 
             sc2.pop();
@@ -4486,7 +4486,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         cldec.inv = buildInv(cldec, sc2);
 
         Module.dprogress++;
-        cldec.semanticRun = PASSsemanticdone;
+        cldec.semanticRun = PASS.semanticdone;
         //printf("-ClassDeclaration.dsymbolSemantic(%s), type = %p\n", toChars(), type);
         //members.print();
 
@@ -4552,7 +4552,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(InterfaceDeclaration idec)
     {
         //printf("InterfaceDeclaration.dsymbolSemantic(%s), type = %p\n", toChars(), type);
-        if (idec.semanticRun >= PASSsemanticdone)
+        if (idec.semanticRun >= PASS.semanticdone)
             return;
         int errors = global.errors;
 
@@ -4586,7 +4586,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // Ungag errors when not speculative
         Ungag ungag = idec.ungagSpeculative();
 
-        if (idec.semanticRun == PASSinit)
+        if (idec.semanticRun == PASS.init)
         {
             idec.protection = sc.protection;
 
@@ -4600,11 +4600,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (idec.sizeok == Sizeok.done || !scx)
             {
-                idec.semanticRun = PASSsemanticdone;
+                idec.semanticRun = PASS.semanticdone;
                 return;
             }
         }
-        idec.semanticRun = PASSsemantic;
+        idec.semanticRun = PASS.semantic;
 
         if (idec.baseok < Baseok.done)
         {
@@ -4658,7 +4658,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (idec.baseok >= Baseok.done)
             {
                 //printf("%s already semantic analyzed, semanticRun = %d\n", toChars(), semanticRun);
-                if (idec.semanticRun >= PASSsemanticdone)
+                if (idec.semanticRun >= PASS.semanticdone)
                     return;
                 goto Lancestorsdone;
             }
@@ -4750,7 +4750,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!idec.members) // if opaque declaration
         {
-            idec.semanticRun = PASSsemanticdone;
+            idec.semanticRun = PASS.semanticdone;
             return;
         }
         if (!idec.symtab)
@@ -4762,7 +4762,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             Type tb = b.type.toBasetype();
             assert(tb.ty == Tclass);
             TypeClass tc = cast(TypeClass)tb;
-            if (tc.sym.semanticRun < PASSsemanticdone)
+            if (tc.sym.semanticRun < PASS.semanticdone)
             {
                 // Forward referencee of one or more bases, try again later
                 idec._scope = scx ? scx : sc.copy();
@@ -4843,7 +4843,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         Module.dprogress++;
-        idec.semanticRun = PASSsemanticdone;
+        idec.semanticRun = PASS.semanticdone;
         //printf("-InterfaceDeclaration.dsymbolSemantic(%s), type = %p\n", toChars(), type);
         //members.print();
 
@@ -4895,7 +4895,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
         }
         return;
     }
-    if (tempinst.semanticRun != PASSinit)
+    if (tempinst.semanticRun != PASS.init)
     {
         static if (LOG)
         {
@@ -4906,7 +4906,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
             global.gag = 0;
         tempinst.error(tempinst.loc, "recursive template expansion");
         if (tempinst.gagged)
-            tempinst.semanticRun = PASSinit;
+            tempinst.semanticRun = PASS.init;
         else
             tempinst.inst = tempinst;
         tempinst.errors = true;
@@ -4928,7 +4928,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
 
     tempinst.gagged = (global.gag > 0);
 
-    tempinst.semanticRun = PASSsemantic;
+    tempinst.semanticRun = PASS.semantic;
 
     static if (LOG)
     {
@@ -4945,7 +4945,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
         {
             // https://issues.dlang.org/show_bug.cgi?id=13220
             // Roll back status for later semantic re-running
-            tempinst.semanticRun = PASSinit;
+            tempinst.semanticRun = PASS.init;
         }
         else
             tempinst.inst = tempinst;
@@ -5093,7 +5093,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
 
     // Create our own scope for the template parameters
     Scope* _scope = tempdecl._scope;
-    if (tempdecl.semanticRun == PASSinit)
+    if (tempdecl.semanticRun == PASS.init)
     {
         tempinst.error("template instantiation `%s` forward references template declaration `%s`", tempinst.toChars(), tempdecl.toChars());
         return;
@@ -5181,7 +5181,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
 
     tempinst.tryExpandMembers(sc2);
 
-    tempinst.semanticRun = PASSsemanticdone;
+    tempinst.semanticRun = PASS.semanticdone;
 
     /* ConditionalDeclaration may introduce eponymous declaration,
      * so we should find it once again after semantic.
@@ -5383,7 +5383,7 @@ Laftersemantic:
                 target_symbol_list.remove(target_symbol_list_idx);
                 tempinst.memberOf = null;                    // no longer a member
             }
-            tempinst.semanticRun = PASSinit;
+            tempinst.semanticRun = PASS.init;
             tempinst.inst = null;
             tempinst.symtab = null;
         }
@@ -5422,7 +5422,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
         auto td = ds.aliassym.isTemplateDeclaration();
         if (fd || td && td.literal)
         {
-            if (fd && fd.semanticRun >= PASSsemanticdone)
+            if (fd && fd.semanticRun >= PASS.semanticdone)
                 return;
 
             Expression e = new FuncExp(ds.loc, ds.aliassym);
@@ -5537,7 +5537,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
         ds.aliassym = null;
     }
     ds.inuse = 0;
-    ds.semanticRun = PASSsemanticdone;
+    ds.semanticRun = PASS.semanticdone;
 
     if (auto sx = ds.overnext)
     {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2367,12 +2367,12 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         if (tiargs && tiargs.dim > 0)
             return 0;
 
-        if (fd.semanticRun < PASSsemanticdone)
+        if (fd.semanticRun < PASS.semanticdone)
         {
             Ungag ungag = fd.ungagSpeculative();
             fd.dsymbolSemantic(null);
         }
-        if (fd.semanticRun == PASSinit)
+        if (fd.semanticRun == PASS.init)
         {
             .error(loc, "forward reference to template `%s`", fd.toChars());
             return 1;
@@ -2504,13 +2504,13 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         if (!sc)
             sc = td._scope; // workaround for Type.aliasthisOf
 
-        if (td.semanticRun == PASSinit && td._scope)
+        if (td.semanticRun == PASS.init && td._scope)
         {
             // Try to fix forward reference. Ungag errors while doing so.
             Ungag ungag = td.ungagSpeculative();
             td.dsymbolSemantic(td._scope);
         }
-        if (td.semanticRun == PASSinit)
+        if (td.semanticRun == PASS.init)
         {
             .error(loc, "forward reference to template `%s`", td.toChars());
         Lerror:
@@ -2529,7 +2529,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
             auto ti = new TemplateInstance(loc, td, tiargs);
             Objects dedtypes;
             dedtypes.setDim(td.parameters.dim);
-            assert(td.semanticRun != PASSinit);
+            assert(td.semanticRun != PASS.init);
             MATCH mta = td.matchWithInstance(sc, ti, &dedtypes, fargs, 0);
             //printf("matchWithInstance = %d\n", mta);
             if (mta <= MATCH.nomatch || mta < ta_last)   // no match or less match
@@ -6447,7 +6447,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 if (!td)
                     return 0;
 
-                if (td.semanticRun == PASSinit)
+                if (td.semanticRun == PASS.init)
                 {
                     if (td._scope)
                     {
@@ -6455,7 +6455,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                         Ungag ungag = td.ungagSpeculative();
                         td.dsymbolSemantic(td._scope);
                     }
-                    if (td.semanticRun == PASSinit)
+                    if (td.semanticRun == PASS.init)
                     {
                         error("`%s` forward references template declaration `%s`",
                             toChars(), td.toChars());
@@ -6785,7 +6785,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 (*tiargs)[j] = sa;
 
                 TemplateDeclaration td = sa.isTemplateDeclaration();
-                if (td && td.semanticRun == PASSinit && td.literal)
+                if (td && td.semanticRun == PASS.init && td.literal)
                 {
                     td.dsymbolSemantic(sc);
                 }
@@ -6897,7 +6897,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
                 dedtypes.setDim(td.parameters.dim);
                 dedtypes.zero();
-                assert(td.semanticRun != PASSinit);
+                assert(td.semanticRun != PASS.init);
 
                 MATCH m = td.matchWithInstance(sc, this, &dedtypes, fargs, 0);
                 //printf("matchWithInstance = %d\n", m);
@@ -7035,7 +7035,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     final bool needsTypeInference(Scope* sc, int flag = 0)
     {
         //printf("TemplateInstance.needsTypeInference() %s\n", toChars());
-        if (semanticRun != PASSinit)
+        if (semanticRun != PASS.init)
             return false;
 
         uint olderrs = global.errors;
@@ -7111,7 +7111,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                      */
                     dedtypes.setDim(td.parameters.dim);
                     dedtypes.zero();
-                    if (td.semanticRun == PASSinit)
+                    if (td.semanticRun == PASS.init)
                     {
                         if (td._scope)
                         {
@@ -7119,7 +7119,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                             Ungag ungag = td.ungagSpeculative();
                             td.dsymbolSemantic(td._scope);
                         }
-                        if (td.semanticRun == PASSinit)
+                        if (td.semanticRun == PASS.init)
                         {
                             error("`%s` forward references template declaration `%s`", toChars(), td.toChars());
                             return 1;
@@ -7144,7 +7144,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             if (!global.gag)
             {
                 errorSupplemental(loc, "while looking for match for `%s`", toChars());
-                semanticRun = PASSsemanticdone;
+                semanticRun = PASS.semanticdone;
                 inst = this;
             }
             errors = true;
@@ -7342,9 +7342,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         Dsymbols* a = mi.members;
         a.push(this);
         memberOf = mi;
-        if (mi.semanticRun >= PASSsemantic2done && mi.isRoot())
+        if (mi.semanticRun >= PASS.semantic2done && mi.isRoot())
             Module.addDeferredSemantic2(this);
-        if (mi.semanticRun >= PASSsemantic3done && mi.isRoot())
+        if (mi.semanticRun >= PASS.semantic3done && mi.isRoot())
             Module.addDeferredSemantic3(this);
         return a;
     }
@@ -7727,13 +7727,13 @@ extern (C++) final class TemplateMixin : TemplateInstance
                 if (!td)
                     return 0;
 
-                if (td.semanticRun == PASSinit)
+                if (td.semanticRun == PASS.init)
                 {
                     if (td._scope)
                         td.dsymbolSemantic(td._scope);
                     else
                     {
-                        semanticRun = PASSinit;
+                        semanticRun = PASS.init;
                         return 1;
                     }
                 }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3525,7 +3525,7 @@ elem *toElem(Expression e, IRState *irs)
             if (global.params.useInline && v.offset == 0)
             {
                 FuncDeclaration fd = v.parent.isFuncDeclaration();
-                if (fd && fd.semanticRun < PASSobj)
+                if (fd && fd.semanticRun < PASS.obj)
                     setClosureVarOffset(fd);
             }
 
@@ -3550,7 +3550,7 @@ elem *toElem(Expression e, IRState *irs)
             int directcall = 0;
             //printf("DelegateExp.toElem() '%s'\n", de.toChars());
 
-            if (de.func.semanticRun == PASSsemantic3done)
+            if (de.func.semanticRun == PASS.semantic3done)
             {
                 // Bug 7745 - only include the function if it belongs to this module
                 // ie, it is a member of this module, or is a template instance

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -480,7 +480,7 @@ private bool checkPropertyCall(Expression e, Expression emsg)
             tf = cast(TypeFunction)ce.f.type;
             /* If a forward reference to ce.f, try to resolve it
              */
-            if (!tf.deco && ce.f.semanticRun < PASSsemanticdone)
+            if (!tf.deco && ce.f.semanticRun < PASS.semanticdone)
             {
                 ce.f.dsymbolSemantic(null);
                 tf = cast(TypeFunction)ce.f.type;
@@ -3972,7 +3972,7 @@ extern (C++) final class ScopeExp : Expression
             //assert(ti.needsTypeInference(sc));
             if (ti.tempdecl &&
                 ti.semantictiargsdone &&
-                ti.semanticRun == PASSinit)
+                ti.semanticRun == PASS.init)
             {
                 error("partial %s `%s` has no type", sds.kind(), toChars());
                 return true;
@@ -4384,7 +4384,7 @@ extern (C++) final class FuncExp : Expression
     {
         if (td)
             return new FuncExp(loc, td.syntaxCopy(null));
-        else if (fd.semanticRun == PASSinit)
+        else if (fd.semanticRun == PASS.init)
             return new FuncExp(loc, fd.syntaxCopy(null));
         else // https://issues.dlang.org/show_bug.cgi?id=13481
              // Prevent multiple semantic analysis of lambda body.

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1341,7 +1341,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // Create the magic __ctfe bool variable
             auto vd = new VarDeclaration(exp.loc, Type.tbool, Id.ctfe, null);
             vd.storage_class |= STC.temp;
-            vd.semanticRun = PASSsemanticdone;
+            vd.semanticRun = PASS.semanticdone;
             Expression e = new VarExp(exp.loc, vd);
             e = e.expressionSemantic(sc);
             result = e;
@@ -3880,7 +3880,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     ClassDeclaration cd = (cast(TypeClass)e.targ).sym;
                     auto args = new Parameters();
                     args.reserve(cd.baseclasses.dim);
-                    if (cd.semanticRun < PASSsemanticdone)
+                    if (cd.semanticRun < PASS.semanticdone)
                         cd.dsymbolSemantic(null);
                     for (size_t i = 0; i < cd.baseclasses.dim; i++)
                     {

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -343,7 +343,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     final bool functionSemantic3()
     {
-        if (semanticRun < PASSsemantic3 && _scope)
+        if (semanticRun < PASS.semantic3 && _scope)
         {
             /* Forward reference - we need to run semantic3 on this function.
              * If errors are gagged, and it's not part of a template instance,
@@ -382,7 +382,7 @@ extern (C++) class FuncDeclaration : Declaration
          */
         if (!type.deco)
         {
-            bool inSemantic3 = (inferRetType && semanticRun >= PASSsemantic3);
+            bool inSemantic3 = (inferRetType && semanticRun >= PASS.semantic3);
             .error(loc, "forward reference to %s'%s'",
                 (inSemantic3 ? "inferred return type of function " : "").ptr,
                 toChars());
@@ -1119,7 +1119,7 @@ extern (C++) class FuncDeclaration : Declaration
     {
         if (storage_class & STC.abstract_)
             return true;
-        if (semanticRun >= PASSsemanticdone)
+        if (semanticRun >= PASS.semanticdone)
             return false;
 
         if (_scope)
@@ -1309,7 +1309,7 @@ extern (C++) class FuncDeclaration : Declaration
     final bool setGC()
     {
         //printf("setGC() %s\n", toChars());
-        if (flags & FUNCFLAG.nogcInprocess && semanticRun < PASSsemantic3 && _scope)
+        if (flags & FUNCFLAG.nogcInprocess && semanticRun < PASS.semantic3 && _scope)
         {
             this.semantic2(_scope);
             this.semantic3(_scope);
@@ -1911,7 +1911,7 @@ extern (C++) class FuncDeclaration : Declaration
             vresult.parent = this;
         }
 
-        if (sc && vresult.semanticRun == PASSinit)
+        if (sc && vresult.semanticRun == PASS.init)
         {
             TypeFunction tf = type.toTypeFunction();
             if (tf.isref)
@@ -1970,7 +1970,7 @@ extern (C++) class FuncDeclaration : Declaration
              * be completed before code generation occurs.
              * https://issues.dlang.org/show_bug.cgi?id=3602
              */
-            if (fdv.frequire && fdv.semanticRun != PASSsemantic3done)
+            if (fdv.frequire && fdv.semanticRun != PASS.semantic3done)
             {
                 assert(fdv._scope);
                 Scope* sc = fdv._scope.push();
@@ -2115,7 +2115,7 @@ extern (C++) class FuncDeclaration : Declaration
              * https://issues.dlang.org/show_bug.cgi?id=3602 and
              * https://issues.dlang.org/show_bug.cgi?id=5230
              */
-            if (needsFensure(fdv) && fdv.semanticRun != PASSsemantic3done)
+            if (needsFensure(fdv) && fdv.semanticRun != PASS.semantic3done)
             {
                 assert(fdv._scope);
                 Scope* sc = fdv._scope.push();
@@ -2996,7 +2996,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
             }
         }
 
-        if (semanticRun < PASSsemantic3done)
+        if (semanticRun < PASS.semantic3done)
             return;
 
         if (fes)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -708,7 +708,7 @@ UnitTestDeclaration needsDeferredNested(FuncDeclaration fd)
         if (!fdp)
             break;
         if (UnitTestDeclaration udp = fdp.isUnitTestDeclaration())
-            return udp.semanticRun < PASSobj ? udp : null;
+            return udp.semanticRun < PASS.obj ? udp : null;
         fd = fdp;
     }
     return null;
@@ -735,7 +735,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         }
     }
 
-    if (fd.semanticRun >= PASSobj) // if toObjFile() already run
+    if (fd.semanticRun >= PASS.obj) // if toObjFile() already run
         return;
 
     if (fd.type && fd.type.ty == Tfunction && (cast(TypeFunction)fd.type).next is null)
@@ -764,7 +764,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         return;
     }
 
-    if (fd.semanticRun == PASSsemanticdone)
+    if (fd.semanticRun == PASS.semanticdone)
     {
         /* What happened is this function failed semantic3() with errors,
          * but the errors were gagged.
@@ -773,7 +773,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         fd.error("errors compiling the function");
         return;
     }
-    assert(fd.semanticRun == PASSsemantic3done);
+    assert(fd.semanticRun == PASS.semantic3done);
     assert(fd.ident != Id.empty);
 
     for (FuncDeclaration fd2 = fd; fd2; )
@@ -804,7 +804,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     }
 
     // start code generation
-    fd.semanticRun = PASSobj;
+    fd.semanticRun = PASS.obj;
 
     if (global.params.verbose)
         fprintf(global.stdmsg, "function  %s\n", fd.toPrettyChars());
@@ -859,7 +859,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         {
             FuncDeclaration fdc = (*fd.inlinedNestedCallees)[i];
             FuncDeclaration fp = fdc.toParent2().isFuncDeclaration();
-            if (fp && fp.semanticRun < PASSobj)
+            if (fp && fp.semanticRun < PASS.obj)
             {
                 toObjFile(fp, multiobj);
             }
@@ -876,7 +876,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
          * in order to calculate correct frame pointer offset.
          */
         FuncDeclaration fdp = fd.toParent2().isFuncDeclaration();
-        if (fdp && fdp.semanticRun < PASSobj)
+        if (fdp && fdp.semanticRun < PASS.obj)
         {
             toObjFile(fdp, multiobj);
         }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1959,7 +1959,7 @@ public:
         parametersToBuffer(tf.parameters, tf.varargs);
         CompoundStatement cs = f.fbody.isCompoundStatement();
         Statement s1;
-        if (f.semanticRun >= PASSsemantic3done && cs)
+        if (f.semanticRun >= PASS.semantic3done && cs)
         {
             s1 = (*cs.statements)[cs.statements.dim - 1];
         }

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -654,7 +654,7 @@ private extern(C++) final class InferTypeVisitor : Visitor
         {
             ScopeExp se = cast(ScopeExp)init.exp;
             TemplateInstance ti = se.sds.isTemplateInstance();
-            if (ti && ti.semanticRun == PASSsemantic && !ti.aliasdecl)
+            if (ti && ti.semanticRun == PASS.semantic && !ti.aliasdecl)
                 se.error("cannot infer type from %s `%s`, possible circular dependency", se.sds.kind(), se.toChars());
             else
                 se.error("cannot infer type from %s `%s`", se.sds.kind(), se.toChars());

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1483,7 +1483,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         return false;
     }
 
-    if (fd.semanticRun < PASSsemantic3 && !hdrscan)
+    if (fd.semanticRun < PASS.semantic3 && !hdrscan)
     {
         if (!fd.fbody)
             return false;
@@ -1492,7 +1492,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         Module.runDeferredSemantic3();
         if (global.errors)
             return false;
-        assert(fd.semanticRun >= PASSsemantic3done);
+        assert(fd.semanticRun >= PASS.semantic3done);
     }
 
     final switch (statementsToo ? fd.inlineStatusStmt : fd.inlineStatusExp)
@@ -1694,9 +1694,9 @@ Lno:
  */
 public void inlineScanModule(Module m)
 {
-    if (m.semanticRun != PASSsemantic3done)
+    if (m.semanticRun != PASS.semantic3done)
         return;
-    m.semanticRun = PASSinline;
+    m.semanticRun = PASS.inline;
 
     // Note that modules get their own scope, from scratch.
     // This is so regardless of where in the syntax a module
@@ -1712,7 +1712,7 @@ public void inlineScanModule(Module m)
         scope InlineScanVisitor v = new InlineScanVisitor();
         s.accept(v);
     }
-    m.semanticRun = PASSinlinedone;
+    m.semanticRun = PASS.inlinedone;
 }
 
 /***********************************************************

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -773,7 +773,7 @@ extern (C++) abstract class Type : RootObject
 
                 // If t1n is forward referenced:
                 ClassDeclaration cd = (cast(TypeClass)t1n).sym;
-                if (cd.semanticRun < PASSsemanticdone && !cd.isBaseInfoComplete())
+                if (cd.semanticRun < PASS.semanticdone && !cd.isBaseInfoComplete())
                     cd.dsymbolSemantic(null);
                 if (!cd.isBaseInfoComplete())
                 {
@@ -7425,7 +7425,7 @@ extern (C++) final class TypeStruct : Type
                     return e;
                 }
             }
-            if (d.semanticRun == PASSinit)
+            if (d.semanticRun == PASS.init)
                 d.dsymbolSemantic(null);
             checkAccess(e.loc, sc, e, d);
             auto ve = new VarExp(e.loc, d);
@@ -7783,7 +7783,7 @@ extern (C++) final class TypeEnum : Type
         if (ident == Id._mangleof)
             return getProperty(e.loc, ident, flag & 1);
 
-        if (sym.semanticRun < PASSsemanticdone)
+        if (sym.semanticRun < PASS.semanticdone)
             sym.dsymbolSemantic(null);
         if (!sym.members)
         {
@@ -8199,7 +8199,7 @@ extern (C++) final class TypeClass : Type
 
             if (ident == Id.outer && sym.vthis)
             {
-                if (sym.vthis.semanticRun == PASSinit)
+                if (sym.vthis.semanticRun == PASS.init)
                     sym.vthis.dsymbolSemantic(null);
 
                 if (auto cdp = sym.toParent2().isClassDeclaration())
@@ -8429,7 +8429,7 @@ extern (C++) final class TypeClass : Type
                 }
             }
             //printf("e = %s, d = %s\n", e.toChars(), d.toChars());
-            if (d.semanticRun == PASSinit)
+            if (d.semanticRun == PASS.init)
                 d.dsymbolSemantic(null);
             checkAccess(e.loc, sc, e, d);
             auto ve = new VarExp(e.loc, d);
@@ -8481,9 +8481,9 @@ extern (C++) final class TypeClass : Type
         if (cdto)
         {
             //printf("TypeClass::implicitConvTo(to = '%s') %s, isbase = %d %d\n", to.toChars(), toChars(), cdto.isBaseInfoComplete(), sym.isBaseInfoComplete());
-            if (cdto.semanticRun < PASSsemanticdone && !cdto.isBaseInfoComplete())
+            if (cdto.semanticRun < PASS.semanticdone && !cdto.isBaseInfoComplete())
                 cdto.dsymbolSemantic(null);
-            if (sym.semanticRun < PASSsemanticdone && !sym.isBaseInfoComplete())
+            if (sym.semanticRun < PASS.semanticdone && !sym.isBaseInfoComplete())
                 sym.dsymbolSemantic(null);
             if (cdto.isBaseOf(sym, null) && MODimplicitConv(mod, to.mod))
             {

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -50,7 +50,7 @@ extern (C++) Expression expandVar(int result, VarDeclaration v)
     Expression e = null;
     if (!v)
         return e;
-    if (!v.originalType && v.semanticRun < PASSsemanticdone) // semantic() not yet run
+    if (!v.originalType && v.semanticRun < PASS.semanticdone) // semantic() not yet run
         v.dsymbolSemantic(null);
     if (v.isConst() || v.isImmutable() || v.storage_class & STC.manifest)
     {

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -138,9 +138,9 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
     override void visit(TemplateInstance tempinst)
     {
-        if (tempinst.semanticRun >= PASSsemantic2)
+        if (tempinst.semanticRun >= PASS.semantic2)
             return;
-        tempinst.semanticRun = PASSsemantic2;
+        tempinst.semanticRun = PASS.semantic2;
         static if (LOG)
         {
             printf("+TemplateInstance.semantic2('%s')\n", tempinst.toChars());
@@ -200,9 +200,9 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
     override void visit(TemplateMixin tmix)
     {
-        if (tmix.semanticRun >= PASSsemantic2)
+        if (tmix.semanticRun >= PASS.semantic2)
             return;
-        tmix.semanticRun = PASSsemantic2;
+        tmix.semanticRun = PASS.semantic2;
         static if (LOG)
         {
             printf("+TemplateMixin.semantic2('%s')\n", tmix.toChars());
@@ -232,7 +232,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
     override void visit(VarDeclaration vd)
     {
-        if (vd.semanticRun < PASSsemanticdone && vd.inuse)
+        if (vd.semanticRun < PASS.semanticdone && vd.inuse)
             return;
 
         //printf("VarDeclaration::semantic2('%s')\n", toChars());
@@ -311,15 +311,15 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     vd.error("is a thread-local pointer to struct and cannot have a static initializer. Use `static this()` to initialize instead.");
             }
         }
-        vd.semanticRun = PASSsemantic2done;
+        vd.semanticRun = PASS.semantic2done;
     }
 
     override void visit(Module mod)
     {
         //printf("Module::semantic2('%s'): parent = %p\n", toChars(), parent);
-        if (mod.semanticRun != PASSsemanticdone) // semantic() not completed yet - could be recursive call
+        if (mod.semanticRun != PASS.semanticdone) // semantic() not completed yet - could be recursive call
             return;
-        mod.semanticRun = PASSsemantic2;
+        mod.semanticRun = PASS.semantic2;
         // Note that modules get their own scope, from scratch.
         // This is so regardless of where in the syntax a module
         // gets imported, it is unaffected by context.
@@ -337,17 +337,17 @@ private extern(C++) final class Semantic2Visitor : Visitor
         }
         sc = sc.pop();
         sc.pop();
-        mod.semanticRun = PASSsemantic2done;
+        mod.semanticRun = PASS.semantic2done;
         //printf("-Module::semantic2('%s'): parent = %p\n", toChars(), parent);
     }
 
     override void visit(FuncDeclaration fd)
     {
-        if (fd.semanticRun >= PASSsemantic2done)
+        if (fd.semanticRun >= PASS.semantic2done)
             return;
-        assert(fd.semanticRun <= PASSsemantic2);
+        assert(fd.semanticRun <= PASS.semantic2);
 
-        fd.semanticRun = PASSsemantic2;
+        fd.semanticRun = PASS.semantic2;
 
         objc.setSelector(fd, sc);
         objc.validateSelector(fd);
@@ -374,9 +374,9 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
     override void visit(Nspace ns)
     {
-        if (ns.semanticRun >= PASSsemantic2)
+        if (ns.semanticRun >= PASS.semantic2)
             return;
-        ns.semanticRun = PASSsemantic2;
+        ns.semanticRun = PASS.semantic2;
         static if (LOG)
         {
             printf("+Nspace::semantic2('%s')\n", ns.toChars());

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -102,9 +102,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
             printf("TemplateInstance.semantic3('%s'), semanticRun = %d\n", tempinst.toChars(), tempinst.semanticRun);
         }
         //if (toChars()[0] == 'D') *(char*)0=0;
-        if (tempinst.semanticRun >= PASSsemantic3)
+        if (tempinst.semanticRun >= PASS.semantic3)
             return;
-        tempinst.semanticRun = PASSsemantic3;
+        tempinst.semanticRun = PASS.semantic3;
         if (!tempinst.errors && tempinst.members)
         {
             TemplateDeclaration tempdecl = tempinst.tempdecl.isTemplateDeclaration();
@@ -156,9 +156,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
     override void visit(TemplateMixin tmix)
     {
-        if (tmix.semanticRun >= PASSsemantic3)
+        if (tmix.semanticRun >= PASS.semantic3)
             return;
-        tmix.semanticRun = PASSsemantic3;
+        tmix.semanticRun = PASS.semantic3;
         static if (LOG)
         {
             printf("TemplateMixin.semantic3('%s')\n", tmix.toChars());
@@ -180,9 +180,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
     override void visit(Module mod)
     {
         //printf("Module::semantic3('%s'): parent = %p\n", toChars(), parent);
-        if (mod.semanticRun != PASSsemantic2done)
+        if (mod.semanticRun != PASS.semantic2done)
             return;
-        mod.semanticRun = PASSsemantic3;
+        mod.semanticRun = PASS.semantic3;
         // Note that modules get their own scope, from scratch.
         // This is so regardless of where in the syntax a module
         // gets imported, it is unaffected by context.
@@ -203,7 +203,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         }
         sc = sc.pop();
         sc.pop();
-        mod.semanticRun = PASSsemantic3done;
+        mod.semanticRun = PASS.semantic3done;
     }
 
     override void visit(FuncDeclaration funcdecl)
@@ -252,9 +252,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
         }
 
         //printf(" sc.incontract = %d\n", (sc.flags & SCOPE.contract));
-        if (funcdecl.semanticRun >= PASSsemantic3)
+        if (funcdecl.semanticRun >= PASS.semantic3)
             return;
-        funcdecl.semanticRun = PASSsemantic3;
+        funcdecl.semanticRun = PASS.semantic3;
         funcdecl.semantic3Errors = false;
 
         if (!funcdecl.type || funcdecl.type.ty != Tfunction)
@@ -1194,7 +1194,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          * done by TemplateInstance::semantic.
          * Otherwise, error gagging should be temporarily ungagged by functionSemantic3.
          */
-        funcdecl.semanticRun = PASSsemantic3done;
+        funcdecl.semanticRun = PASS.semantic3done;
         funcdecl.semantic3Errors = (global.errors != oldErrors) || (funcdecl.fbody && funcdecl.fbody.isErrorStatement());
         if (funcdecl.type.ty == Terror)
             funcdecl.errors = true;
@@ -1204,9 +1204,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
     override void visit(Nspace ns)
     {
-        if (ns.semanticRun >= PASSsemantic3)
+        if (ns.semanticRun >= PASS.semantic3)
             return;
-        ns.semanticRun = PASSsemantic3;
+        ns.semanticRun = PASS.semantic3;
         static if (LOG)
         {
             printf("Nspace::semantic3('%s')\n", ns.toChars());
@@ -1290,6 +1290,6 @@ private extern(C++) final class Semantic3Visitor : Visitor
         }
         if (sd)
             sd.semanticTypeInfoMembers();
-        ad.semanticRun = PASSsemantic3done;
+        ad.semanticRun = PASS.semantic3done;
     }
 }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -818,7 +818,7 @@ private void membersToDt(AggregateDeclaration ad, DtBuilder dtb,
                 if (init.isVoidInitializer())
                     continue;
 
-                assert(vd.semanticRun >= PASSsemantic2done);
+                assert(vd.semanticRun >= PASS.semantic2done);
 
                 ExpInitializer ei = init.isExpInitializer();
                 Type tb = vd.type.toBasetype();

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -336,7 +336,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             else if (global.params.symdebug)
                 toDebug(cd);
 
-            assert(cd.semanticRun >= PASSsemantic3done);     // semantic() should have been run to completion
+            assert(cd.semanticRun >= PASS.semantic3done);     // semantic() should have been run to completion
 
             enum_SC scclass = SCcomdat;
 
@@ -985,7 +985,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
         override void visit(EnumDeclaration ed)
         {
-            if (ed.semanticRun >= PASSobj)  // already written
+            if (ed.semanticRun >= PASS.obj)  // already written
                 return;
             //printf("EnumDeclaration.toObjFile('%s')\n", ed.toChars());
 
@@ -1025,7 +1025,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 ed.sinit.Sdt = dtb.finish();
                 outdata(ed.sinit);
             }
-            ed.semanticRun = PASSobj;
+            ed.semanticRun = PASS.obj;
         }
 
         override void visit(TypeInfoDeclaration tid)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -699,7 +699,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 e.error("argument `%s` has no protection", o.toChars());
             return new ErrorExp();
         }
-        if (s.semanticRun == PASSinit)
+        if (s.semanticRun == PASS.init)
             s.dsymbolSemantic(null);
 
         auto protName = protectionToChars(s.prot().kind); // TODO: How about package(names)
@@ -1302,7 +1302,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         auto cd = sds.isClassDeclaration();
         if (cd && e.ident == Id.allMembers)
         {
-            if (cd.semanticRun < PASSsemanticdone)
+            if (cd.semanticRun < PASS.semanticdone)
                 cd.dsymbolSemantic(null); // https://issues.dlang.org/show_bug.cgi?id=13668
                                    // Try to resolve forward reference
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -524,12 +524,12 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             /* AA's need typeid(index).equals() and getHash(). Issue error if not correctly set up.
              */
             StructDeclaration sd = (cast(TypeStruct)tbase).sym;
-            if (sd.semanticRun < PASSsemanticdone)
+            if (sd.semanticRun < PASS.semanticdone)
                 sd.dsymbolSemantic(null);
 
             // duplicate a part of StructDeclaration::semanticTypeInfoMembers
             //printf("AA = %s, key: xeq = %p, xerreq = %p xhash = %p\n", toChars(), sd.xeq, sd.xerreq, sd.xhash);
-            if (sd.xeq && sd.xeq._scope && sd.xeq.semanticRun < PASSsemantic3done)
+            if (sd.xeq && sd.xeq._scope && sd.xeq.semanticRun < PASS.semantic3done)
             {
                 uint errors = global.startGagging();
                 sd.xeq.semantic3(sd.xeq._scope);
@@ -588,7 +588,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         else if (tbase.ty == Tclass && !(cast(TypeClass)tbase).sym.isInterfaceDeclaration())
         {
             ClassDeclaration cd = (cast(TypeClass)tbase).sym;
-            if (cd.semanticRun < PASSsemanticdone)
+            if (cd.semanticRun < PASS.semanticdone)
                 cd.dsymbolSemantic(null);
 
             if (!ClassDeclaration.object)


### PR DESCRIPTION
```bash
replacements=(
"PASSinit init"
"PASSsemantic semantic"
"PASSsemanticdone semanticdone"
"PASSsemantic2 semantic2"
"PASSsemantic2done semantic2done"
"PASSsemantic3 semantic3"
"PASSsemantic3done semantic3done"
"PASSinline inline"
"PASSinlinedone inlinedone"
"PASSobj obj"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/PASS.${w[1]}/g" -i **/*.d
done
```