### PR TITLE
Automatically convert RECXXXX -> AliasThisRec

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -298,20 +298,13 @@ struct ASTBase
 
     enum AliasThisRec : int
     {
-        RECno           = 0,    // no alias this recursion
-        RECyes          = 1,    // alias this has recursive dependency
-        RECfwdref       = 2,    // not yet known
-        RECtypeMask     = 3,    // mask to read no/yes/fwdref
-        RECtracing      = 0x4,  // mark in progress of implicitConvTo/deduceWild
-        RECtracingDT    = 0x8,  // mark in progress of deduceType
+        no           = 0,    // no alias this recursion
+        yes          = 1,    // alias this has recursive dependency
+        fwdref       = 2,    // not yet known
+        typeMask     = 3,    // mask to read no/yes/fwdref
+        tracing      = 0x4,  // mark in progress of implicitConvTo/deduceWild
+        tracingDT    = 0x8,  // mark in progress of deduceType
     }
-
-    alias RECno = AliasThisRec.RECno;
-    alias RECyes = AliasThisRec.RECyes;
-    alias RECfwdref = AliasThisRec.RECfwdref;
-    alias RECtypeMask = AliasThisRec.RECtypeMask;
-    alias RECtracing = AliasThisRec.RECtracing;
-    alias RECtracingDT = AliasThisRec.RECtracingDT;
 
     alias Visitor = ParseTimeVisitor!ASTBase;
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2820,9 +2820,9 @@ struct ASTBase
             //t.vtinfo = null; these aren't used in parsing
             //t.ctype = null;
             if (t.ty == Tstruct)
-                (cast(TypeStruct)t).att = RECfwdref;
+                (cast(TypeStruct)t).att = AliasThisRec.fwdref;
             if (t.ty == Tclass)
-                (cast(TypeClass)t).att = RECfwdref;
+                (cast(TypeClass)t).att = AliasThisRec.fwdref;
             return t;
         }
 
@@ -3654,7 +3654,7 @@ struct ASTBase
     extern (C++) final class TypeClass : Type
     {
         ClassDeclaration sym;
-        AliasThisRec att = RECfwdref;
+        AliasThisRec att = AliasThisRec.fwdref;
 
         extern (D) this (ClassDeclaration sym)
         {
@@ -3676,7 +3676,7 @@ struct ASTBase
     extern (C++) final class TypeStruct : Type
     {
         StructDeclaration sym;
-        AliasThisRec att = RECfwdref;
+        AliasThisRec att = AliasThisRec.fwdref;
 
         extern (D) this(StructDeclaration sym)
         {

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -3414,26 +3414,26 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     if (t.ty == Tclass)
                     {
                         TypeClass tc = cast(TypeClass)t;
-                        if (tc.sym.aliasthis && !(tc.att & RECtracingDT))
+                        if (tc.sym.aliasthis && !(tc.att & AliasThisRec.tracingDT))
                         {
                             if (auto ato = t.aliasthisOf())
                             {
-                                tc.att = cast(AliasThisRec)(tc.att | RECtracingDT);
+                                tc.att = cast(AliasThisRec)(tc.att | AliasThisRec.tracingDT);
                                 m = deduceType(ato, sc, tparam, parameters, dedtypes, wm);
-                                tc.att = cast(AliasThisRec)(tc.att & ~RECtracingDT);
+                                tc.att = cast(AliasThisRec)(tc.att & ~AliasThisRec.tracingDT);
                             }
                         }
                     }
                     else if (t.ty == Tstruct)
                     {
                         TypeStruct ts = cast(TypeStruct)t;
-                        if (ts.sym.aliasthis && !(ts.att & RECtracingDT))
+                        if (ts.sym.aliasthis && !(ts.att & AliasThisRec.tracingDT))
                         {
                             if (auto ato = t.aliasthisOf())
                             {
-                                ts.att = cast(AliasThisRec)(ts.att | RECtracingDT);
+                                ts.att = cast(AliasThisRec)(ts.att | AliasThisRec.tracingDT);
                                 m = deduceType(ato, sc, tparam, parameters, dedtypes, wm);
-                                ts.att = cast(AliasThisRec)(ts.att & ~RECtracingDT);
+                                ts.att = cast(AliasThisRec)(ts.att & ~AliasThisRec.tracingDT);
                             }
                         }
                     }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -1249,9 +1249,9 @@ extern (C++) abstract class Type : RootObject
         t.vtinfo = null;
         t.ctype = null;
         if (t.ty == Tstruct)
-            (cast(TypeStruct)t).att = RECfwdref;
+            (cast(TypeStruct)t).att = AliasThisRec.fwdref;
         if (t.ty == Tclass)
-            (cast(TypeClass)t).att = RECfwdref;
+            (cast(TypeClass)t).att = AliasThisRec.fwdref;
         return t;
     }
 
@@ -2190,14 +2190,14 @@ extern (C++) abstract class Type : RootObject
         else
             return false;
 
-        AliasThisRec flag = cast(AliasThisRec)(*pflag & RECtypeMask);
-        if (flag == RECfwdref)
+        AliasThisRec flag = cast(AliasThisRec)(*pflag & AliasThisRec.typeMask);
+        if (flag == AliasThisRec.fwdref)
         {
             Type att = aliasthisOf();
-            flag = att && att.implicitConvTo(this) ? RECyes : RECno;
+            flag = att && att.implicitConvTo(this) ? AliasThisRec.yes : AliasThisRec.no;
         }
-        *pflag = cast(AliasThisRec)(flag | (*pflag & ~RECtypeMask));
-        return flag == RECyes;
+        *pflag = cast(AliasThisRec)(flag | (*pflag & ~AliasThisRec.typeMask));
+        return flag == AliasThisRec.yes;
     }
 
     Type makeConst()
@@ -7192,7 +7192,7 @@ enum AliasThisRec : int
 extern (C++) final class TypeStruct : Type
 {
     StructDeclaration sym;
-    AliasThisRec att = RECfwdref;
+    AliasThisRec att = AliasThisRec.fwdref;
     CPPMANGLE cppmangle = CPPMANGLE.def;
 
     extern (D) this(StructDeclaration sym)
@@ -7699,13 +7699,13 @@ extern (C++) final class TypeStruct : Type
                 }
             }
         }
-        else if (sym.aliasthis && !(att & RECtracing))
+        else if (sym.aliasthis && !(att & AliasThisRec.tracing))
         {
             if (auto ato = aliasthisOf())
             {
-                att = cast(AliasThisRec)(att | RECtracing);
+                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
                 m = ato.implicitConvTo(to);
-                att = cast(AliasThisRec)(att & ~RECtracing);
+                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
             }
             else
                 m = MATCH.nomatch; // no match
@@ -7731,13 +7731,13 @@ extern (C++) final class TypeStruct : Type
 
         ubyte wm = 0;
 
-        if (t.hasWild() && sym.aliasthis && !(att & RECtracing))
+        if (t.hasWild() && sym.aliasthis && !(att & AliasThisRec.tracing))
         {
             if (auto ato = aliasthisOf())
             {
-                att = cast(AliasThisRec)(att | RECtracing);
+                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
                 wm = ato.deduceWild(t, isRef);
-                att = cast(AliasThisRec)(att & ~RECtracing);
+                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
             }
         }
 
@@ -8009,7 +8009,7 @@ extern (C++) final class TypeEnum : Type
 extern (C++) final class TypeClass : Type
 {
     ClassDeclaration sym;
-    AliasThisRec att = RECfwdref;
+    AliasThisRec att = AliasThisRec.fwdref;
     CPPMANGLE cppmangle = CPPMANGLE.def;
 
     extern (D) this(ClassDeclaration sym)
@@ -8515,13 +8515,13 @@ extern (C++) final class TypeClass : Type
         }
 
         m = MATCH.nomatch;
-        if (sym.aliasthis && !(att & RECtracing))
+        if (sym.aliasthis && !(att & AliasThisRec.tracing))
         {
             if (auto ato = aliasthisOf())
             {
-                att = cast(AliasThisRec)(att | RECtracing);
+                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
                 m = ato.implicitConvTo(to);
-                att = cast(AliasThisRec)(att & ~RECtracing);
+                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
             }
         }
 
@@ -8558,13 +8558,13 @@ extern (C++) final class TypeClass : Type
 
         ubyte wm = 0;
 
-        if (t.hasWild() && sym.aliasthis && !(att & RECtracing))
+        if (t.hasWild() && sym.aliasthis && !(att & AliasThisRec.tracing))
         {
             if (auto ato = aliasthisOf())
             {
-                att = cast(AliasThisRec)(att | RECtracing);
+                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
                 wm = ato.deduceWild(t, isRef);
-                att = cast(AliasThisRec)(att & ~RECtracing);
+                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
             }
         }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -7179,20 +7179,13 @@ extern (C++) final class TypeReturn : TypeQualified
 // Whether alias this dependency is recursive or not.
 enum AliasThisRec : int
 {
-    RECno           = 0,    // no alias this recursion
-    RECyes          = 1,    // alias this has recursive dependency
-    RECfwdref       = 2,    // not yet known
-    RECtypeMask     = 3,    // mask to read no/yes/fwdref
-    RECtracing      = 0x4,  // mark in progress of implicitConvTo/deduceWild
-    RECtracingDT    = 0x8,  // mark in progress of deduceType
+    no           = 0,    // no alias this recursion
+    yes          = 1,    // alias this has recursive dependency
+    fwdref       = 2,    // not yet known
+    typeMask     = 3,    // mask to read no/yes/fwdref
+    tracing      = 0x4,  // mark in progress of implicitConvTo/deduceWild
+    tracingDT    = 0x8,  // mark in progress of deduceType
 }
-
-alias RECno = AliasThisRec.RECno;
-alias RECyes = AliasThisRec.RECyes;
-alias RECfwdref = AliasThisRec.RECfwdref;
-alias RECtypeMask = AliasThisRec.RECtypeMask;
-alias RECtracing = AliasThisRec.RECtracing;
-alias RECtracingDT = AliasThisRec.RECtracingDT;
 
 /***********************************************************
  */


### PR DESCRIPTION
```
replacements=(
"RECno no"
"RECyes yes"
"RECfwdref fwdref"
"RECtypeMask typeMask"
"RECtracing tracing"
"RECtracingDT tracingDT"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/AliasThisRec.${w[1]}/g" -i **/*.d
done
```