### PR TITLE
Automatically convert MODXXX -> MOD

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -66,7 +66,7 @@ struct ASTBase
         immutable_   = 4,    // type is immutable
         shared_      = 2,    // type is shared
         wild         = 8,    // type is wild
-        wildconst    = (MODwild | MODconst), // type is wild const
+        wildconst    = (MODFlags.wild | MODFlags.const_), // type is wild const
         mutable      = 0x10, // type is mutable (only used in wildcard matching)
     }
 
@@ -2790,7 +2790,7 @@ struct ASTBase
 
         final bool isImmutable() const
         {
-            return (mod & MODimmutable) != 0;
+            return (mod & MODFlags.immutable_) != 0;
         }
 
         final Type nullAttributes()
@@ -2825,7 +2825,7 @@ struct ASTBase
             if (cto)
                 return cto;
             Type t = this.nullAttributes();
-            t.mod = MODconst;
+            t.mod = MODFlags.const_;
             return t;
         }
 
@@ -2834,7 +2834,7 @@ struct ASTBase
             if (wcto)
                 return wcto;
             Type t = this.nullAttributes();
-            t.mod = MODwildconst;
+            t.mod = MODFlags.wildconst;
             return t;
         }
 
@@ -2843,7 +2843,7 @@ struct ASTBase
             if (sto)
                 return sto;
             Type t = this.nullAttributes();
-            t.mod = MODshared;
+            t.mod = MODFlags.shared_;
             return t;
         }
 
@@ -2852,7 +2852,7 @@ struct ASTBase
             if (scto)
                 return scto;
             Type t = this.nullAttributes();
-            t.mod = MODshared | MODconst;
+            t.mod = MODFlags.shared_ | MODFlags.const_;
             return t;
         }
 
@@ -2861,7 +2861,7 @@ struct ASTBase
             if (ito)
                 return ito;
             Type t = this.nullAttributes();
-            t.mod = MODimmutable;
+            t.mod = MODFlags.immutable_;
             return t;
         }
 
@@ -2870,7 +2870,7 @@ struct ASTBase
             if (wto)
                 return wto;
             Type t = this.nullAttributes();
-            t.mod = MODwild;
+            t.mod = MODFlags.wild;
             return t;
         }
 
@@ -2879,7 +2879,7 @@ struct ASTBase
             if (swcto)
                 return swcto;
             Type t = this.nullAttributes();
-            t.mod = MODshared | MODwildconst;
+            t.mod = MODFlags.shared_ | MODFlags.wildconst;
             return t;
         }
 
@@ -2888,7 +2888,7 @@ struct ASTBase
             if (swto)
                 return swto;
             Type t = this.nullAttributes();
-            t.mod = MODshared | MODwild;
+            t.mod = MODFlags.shared_ | MODFlags.wild;
             return t;
         }
 
@@ -2994,11 +2994,11 @@ struct ASTBase
 
         final Type sharedWildConstOf()
         {
-            if (mod == (MODshared | MODwildconst))
+            if (mod == (MODFlags.shared_ | MODFlags.wildconst))
                 return this;
             if (swcto)
             {
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
                 return swcto;
             }
             Type t = makeSharedWildConst();
@@ -3009,11 +3009,11 @@ struct ASTBase
 
         final Type sharedConstOf()
         {
-            if (mod == (MODshared | MODconst))
+            if (mod == (MODFlags.shared_ | MODFlags.const_))
                 return this;
             if (scto)
             {
-                assert(scto.mod == (MODshared | MODconst));
+                assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
                 return scto;
             }
             Type t = makeSharedConst();
@@ -3024,11 +3024,11 @@ struct ASTBase
 
         final Type wildConstOf()
         {
-            if (mod == MODwildconst)
+            if (mod == MODFlags.wildconst)
                 return this;
             if (wcto)
             {
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
                 return wcto;
             }
             Type t = makeWildConst();
@@ -3039,11 +3039,11 @@ struct ASTBase
 
         final Type constOf()
         {
-            if (mod == MODconst)
+            if (mod == MODFlags.const_)
                 return this;
             if (cto)
             {
-                assert(cto.mod == MODconst);
+                assert(cto.mod == MODFlags.const_);
                 return cto;
             }
             Type t = makeConst();
@@ -3054,11 +3054,11 @@ struct ASTBase
 
         final Type sharedWildOf()
         {
-            if (mod == (MODshared | MODwild))
+            if (mod == (MODFlags.shared_ | MODFlags.wild))
                 return this;
             if (swto)
             {
-                assert(swto.mod == (MODshared | MODwild));
+                assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
                 return swto;
             }
             Type t = makeSharedWild();
@@ -3069,11 +3069,11 @@ struct ASTBase
 
         final Type wildOf()
         {
-            if (mod == MODwild)
+            if (mod == MODFlags.wild)
                 return this;
             if (wto)
             {
-                assert(wto.mod == MODwild);
+                assert(wto.mod == MODFlags.wild);
                 return wto;
             }
             Type t = makeWild();
@@ -3084,11 +3084,11 @@ struct ASTBase
 
         final Type sharedOf()
         {
-            if (mod == MODshared)
+            if (mod == MODFlags.shared_)
                 return this;
             if (sto)
             {
-                assert(sto.mod == MODshared);
+                assert(sto.mod == MODFlags.shared_);
                 return sto;
             }
             Type t = makeShared();
@@ -3124,35 +3124,35 @@ struct ASTBase
                     mto = t;
                     break;
 
-                case MODconst:
+                case MODFlags.const_:
                     cto = t;
                     break;
 
-                case MODwild:
+                case MODFlags.wild:
                     wto = t;
                     break;
 
-                case MODwildconst:
+                case MODFlags.wildconst:
                     wcto = t;
                     break;
 
-                case MODshared:
+                case MODFlags.shared_:
                     sto = t;
                     break;
 
-                case MODshared | MODconst:
+                case MODFlags.shared_ | MODFlags.const_:
                     scto = t;
                     break;
 
-                case MODshared | MODwild:
+                case MODFlags.shared_ | MODFlags.wild:
                     swto = t;
                     break;
 
-                case MODshared | MODwildconst:
+                case MODFlags.shared_ | MODFlags.wildconst:
                     swcto = t;
                     break;
 
-                case MODimmutable:
+                case MODFlags.immutable_:
                     ito = t;
                     break;
 
@@ -3172,42 +3172,42 @@ struct ASTBase
             case 0:
                 break;
 
-            case MODconst:
+            case MODFlags.const_:
                 cto = mto;
                 t.cto = this;
                 break;
 
-            case MODwild:
+            case MODFlags.wild:
                 wto = mto;
                 t.wto = this;
                 break;
 
-            case MODwildconst:
+            case MODFlags.wildconst:
                 wcto = mto;
                 t.wcto = this;
                 break;
 
-            case MODshared:
+            case MODFlags.shared_:
                 sto = mto;
                 t.sto = this;
                 break;
 
-            case MODshared | MODconst:
+            case MODFlags.shared_ | MODFlags.const_:
                 scto = mto;
                 t.scto = this;
                 break;
 
-            case MODshared | MODwild:
+            case MODFlags.shared_ | MODFlags.wild:
                 swto = mto;
                 t.swto = this;
                 break;
 
-            case MODshared | MODwildconst:
+            case MODFlags.shared_ | MODFlags.wildconst:
                 swcto = mto;
                 t.swcto = this;
                 break;
 
-            case MODimmutable:
+            case MODFlags.immutable_:
                 t.ito = this;
                 if (t.cto)
                     t.cto.ito = this;
@@ -3240,7 +3240,7 @@ struct ASTBase
                 case 0:
                     break;
 
-                case MODconst:
+                case MODFlags.const_:
                     if (isShared())
                     {
                         if (isWild())
@@ -3257,7 +3257,7 @@ struct ASTBase
                     }
                     break;
 
-                case MODwild:
+                case MODFlags.wild:
                     if (isShared())
                     {
                         if (isConst())
@@ -3274,14 +3274,14 @@ struct ASTBase
                     }
                     break;
 
-                case MODwildconst:
+                case MODFlags.wildconst:
                     if (isShared())
                         t = sharedWildConstOf();
                     else
                         t = wildConstOf();
                     break;
 
-                case MODshared:
+                case MODFlags.shared_:
                     if (isWild())
                     {
                         if (isConst())
@@ -3298,25 +3298,25 @@ struct ASTBase
                     }
                     break;
 
-                case MODshared | MODconst:
+                case MODFlags.shared_ | MODFlags.const_:
                     if (isWild())
                         t = sharedWildConstOf();
                     else
                         t = sharedConstOf();
                     break;
 
-                case MODshared | MODwild:
+                case MODFlags.shared_ | MODFlags.wild:
                     if (isConst())
                         t = sharedWildConstOf();
                     else
                         t = sharedWildOf();
                     break;
 
-                case MODshared | MODwildconst:
+                case MODFlags.shared_ | MODFlags.wildconst:
                     t = sharedWildConstOf();
                     break;
 
-                case MODimmutable:
+                case MODFlags.immutable_:
                     t = immutableOf();
                     break;
 
@@ -3341,17 +3341,17 @@ struct ASTBase
 
         final bool isConst() const
         {
-            return (mod & MODconst) != 0;
+            return (mod & MODFlags.const_) != 0;
         }
 
         final bool isWild() const
         {
-            return (mod & MODwild) != 0;
+            return (mod & MODFlags.wild) != 0;
         }
 
         final bool isShared() const
         {
-            return (mod & MODshared) != 0;
+            return (mod & MODFlags.shared_) != 0;
         }
 
         Type toBasetype()

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -62,20 +62,13 @@ struct ASTBase
 
     enum MODFlags : int
     {
-        MODconst        = 1,    // type is const
-        MODimmutable    = 4,    // type is immutable
-        MODshared       = 2,    // type is shared
-        MODwild         = 8,    // type is wild
-        MODwildconst    = (MODwild | MODconst), // type is wild const
-        MODmutable      = 0x10, // type is mutable (only used in wildcard matching)
+        const_       = 1,    // type is const
+        immutable_   = 4,    // type is immutable
+        shared_      = 2,    // type is shared
+        wild         = 8,    // type is wild
+        wildconst    = (MODwild | MODconst), // type is wild const
+        mutable      = 0x10, // type is mutable (only used in wildcard matching)
     }
-
-    alias MODconst = MODFlags.MODconst;
-    alias MODimmutable = MODFlags.MODimmutable;
-    alias MODshared = MODFlags.MODshared;
-    alias MODwild = MODFlags.MODwild;
-    alias MODwildconst = MODFlags.MODwildconst;
-    alias MODmutable = MODFlags.MODmutable;
 
     alias MOD = ubyte;
 

--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -37,10 +37,7 @@ struct ASTCodegen
     alias typeToExpression          = dmd.typesem.typeToExpression;
     alias UserAttributeDeclaration  = dmd.attrib.UserAttributeDeclaration;
 
-    alias MODconst                  = dmd.mtype.MODconst;
-    alias MODimmutable              = dmd.mtype.MODimmutable;
-    alias MODshared                 = dmd.mtype.MODshared;
-    alias MODwild                   = dmd.mtype.MODwild;
+    alias MODFlags                  = dmd.mtype.MODFlags;
     alias Type                      = dmd.mtype.Type;
     alias Tident                    = dmd.mtype.Tident;
     alias Tfunction                 = dmd.mtype.Tfunction;

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -488,7 +488,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
                 auto parameters = new Parameters();
                 parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, null, null));
                 tfeqptr = new TypeFunction(parameters, Type.tbool, 0, LINKd);
-                tfeqptr.mod = MODconst;
+                tfeqptr.mod = MODFlags.const_;
                 tfeqptr = cast(TypeFunction)tfeqptr.typeSemantic(Loc(), &scx);
             }
             fd = fd.overloadExactMatch(tfeqptr);
@@ -558,7 +558,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
                 auto parameters = new Parameters();
                 parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, null, null));
                 tfcmpptr = new TypeFunction(parameters, Type.tint32, 0, LINKd);
-                tfcmpptr.mod = MODconst;
+                tfcmpptr.mod = MODFlags.const_;
                 tfcmpptr = cast(TypeFunction)tfcmpptr.typeSemantic(Loc(), &scx);
             }
             fd = fd.overloadExactMatch(tfcmpptr);
@@ -722,7 +722,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
         if (!tftohash)
         {
             tftohash = new TypeFunction(null, Type.thash_t, 0, LINKd);
-            tftohash.mod = MODconst;
+            tftohash.mod = MODFlags.const_;
             tftohash = cast(TypeFunction)tftohash.merge();
         }
         if (FuncDeclaration fd = s.isFuncDeclaration())
@@ -1174,7 +1174,7 @@ extern (C++) FuncDeclaration buildInv(AggregateDeclaration ad, Scope* sc)
             {
                 // What should do?
             }
-            StorageClass stcy = (ad.invs[i].storage_class & STC.synchronized_) | (ad.invs[i].type.mod & MODshared ? STC.shared_ : 0);
+            StorageClass stcy = (ad.invs[i].storage_class & STC.synchronized_) | (ad.invs[i].type.mod & MODFlags.shared_ ? STC.shared_ : 0);
             if (i == 0)
                 stcx = stcy;
             else if (stcx ^ stcy)

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -862,7 +862,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
              *    int* mp = foo();            // should be disallowed
              *  }
              */
-            if (e.type.immutableOf().implicitConvTo(t) < MATCH.constant && e.type.addMod(MODshared).implicitConvTo(t) < MATCH.constant && e.type.implicitConvTo(t.addMod(MODshared)) < MATCH.constant)
+            if (e.type.immutableOf().implicitConvTo(t) < MATCH.constant && e.type.addMod(MODFlags.shared_).implicitConvTo(t) < MATCH.constant && e.type.implicitConvTo(t.addMod(MODFlags.shared_)) < MATCH.constant)
             {
                 return;
             }
@@ -886,7 +886,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 printf("mod = x%x\n", mod);
             }
-            if (mod & MODwild)
+            if (mod & MODFlags.wild)
                 return; // not sure what to do with this
 
             /* Apply mod bits to each function parameter,
@@ -1155,7 +1155,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 printf("mod = x%x\n", mod);
             }
-            if (mod & MODwild)
+            if (mod & MODFlags.wild)
                 return; // not sure what to do with this
 
             /* Apply mod bits to each argument,
@@ -1186,7 +1186,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
 
                 if (fd == e.member)
                 {
-                    if (e.type.immutableOf().implicitConvTo(t) < MATCH.constant && e.type.addMod(MODshared).implicitConvTo(t) < MATCH.constant && e.type.implicitConvTo(t.addMod(MODshared)) < MATCH.constant)
+                    if (e.type.immutableOf().implicitConvTo(t) < MATCH.constant && e.type.addMod(MODFlags.shared_).implicitConvTo(t) < MATCH.constant && e.type.implicitConvTo(t.addMod(MODFlags.shared_)) < MATCH.constant)
                     {
                         return;
                     }

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -46,7 +46,7 @@ extern (C++) Expression toDelegate(Expression e, Type t, Scope* sc)
     Loc loc = e.loc;
     auto tf = new TypeFunction(null, t, 0, LINKd);
     if (t.hasWild())
-        tf.mod = MODwild;
+        tf.mod = MODFlags.wild;
     auto fld = new FuncLiteralDeclaration(loc, loc, tf, TOKdelegate, null);
     lambdaSetParent(e, fld);
 

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2703,7 +2703,7 @@ public:
             ale.ownedByCtfe = OwnedBy.ctfe;
             result = ale;
         }
-        else if ((cast(TypeNext)e.type).next.mod & (MODconst | MODimmutable))
+        else if ((cast(TypeNext)e.type).next.mod & (MODFlags.const_ | MODFlags.immutable_))
         {
             // If it's immutable, we don't need to dup it
             result = e;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -136,28 +136,28 @@ private void MODtoDecoBuffer(OutBuffer* buf, MOD mod)
     {
     case 0:
         break;
-    case MODconst:
+    case MODFlags.const_:
         buf.writeByte('x');
         break;
-    case MODimmutable:
+    case MODFlags.immutable_:
         buf.writeByte('y');
         break;
-    case MODshared:
+    case MODFlags.shared_:
         buf.writeByte('O');
         break;
-    case MODshared | MODconst:
+    case MODFlags.shared_ | MODFlags.const_:
         buf.writestring("Ox");
         break;
-    case MODwild:
+    case MODFlags.wild:
         buf.writestring("Ng");
         break;
-    case MODwildconst:
+    case MODFlags.wildconst:
         buf.writestring("Ngx");
         break;
-    case MODshared | MODwild:
+    case MODFlags.shared_ | MODFlags.wild:
         buf.writestring("ONg");
         break;
-    case MODshared | MODwildconst:
+    case MODFlags.shared_ | MODFlags.wildconst:
         buf.writestring("ONgx");
         break;
     default:

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1287,15 +1287,15 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                 ubyte mod = fd.type.mod;
                 if (stc & STC.immutable_)
-                    mod = MODimmutable;
+                    mod = MODFlags.immutable_;
                 else
                 {
                     if (stc & (STC.shared_ | STC.synchronized_))
-                        mod |= MODshared;
+                        mod |= MODFlags.shared_;
                     if (stc & STC.const_)
-                        mod |= MODconst;
+                        mod |= MODFlags.const_;
                     if (stc & STC.wild)
-                        mod |= MODwild;
+                        mod |= MODFlags.wild;
                 }
 
                 ubyte thismod = tthis.mod;
@@ -2298,7 +2298,7 @@ extern (C++) final class TypeDeduced : Type
             if (e == emptyArrayElement)
                 continue;
 
-            Type t = tt.addMod(tparams[j].mod).substWildTo(MODconst);
+            Type t = tt.addMod(tparams[j].mod).substWildTo(MODFlags.const_);
 
             MATCH m = e.implicitConvTo(t);
             if (match > m)
@@ -2860,7 +2860,7 @@ private size_t templateParameterLookup(Type tparam, TemplateParameters* paramete
 
 private ubyte deduceWildHelper(Type t, Type* at, Type tparam)
 {
-    if ((tparam.mod & MODwild) == 0)
+    if ((tparam.mod & MODFlags.wild) == 0)
         return 0;
 
     *at = null;
@@ -2872,45 +2872,45 @@ private ubyte deduceWildHelper(Type t, Type* at, Type tparam)
 
     switch (X(tparam.mod, t.mod))
     {
-    case X(MODwild, 0):
-    case X(MODwild, MODconst):
-    case X(MODwild, MODshared):
-    case X(MODwild, MODshared | MODconst):
-    case X(MODwild, MODimmutable):
-    case X(MODwildconst, 0):
-    case X(MODwildconst, MODconst):
-    case X(MODwildconst, MODshared):
-    case X(MODwildconst, MODshared | MODconst):
-    case X(MODwildconst, MODimmutable):
-    case X(MODshared | MODwild, MODshared):
-    case X(MODshared | MODwild, MODshared | MODconst):
-    case X(MODshared | MODwild, MODimmutable):
-    case X(MODshared | MODwildconst, MODshared):
-    case X(MODshared | MODwildconst, MODshared | MODconst):
-    case X(MODshared | MODwildconst, MODimmutable):
+    case X(MODFlags.wild, 0):
+    case X(MODFlags.wild, MODFlags.const_):
+    case X(MODFlags.wild, MODFlags.shared_):
+    case X(MODFlags.wild, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.wild, MODFlags.immutable_):
+    case X(MODFlags.wildconst, 0):
+    case X(MODFlags.wildconst, MODFlags.const_):
+    case X(MODFlags.wildconst, MODFlags.shared_):
+    case X(MODFlags.wildconst, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.wildconst, MODFlags.immutable_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.immutable_):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.immutable_):
         {
-            ubyte wm = (t.mod & ~MODshared);
+            ubyte wm = (t.mod & ~MODFlags.shared_);
             if (wm == 0)
-                wm = MODmutable;
-            ubyte m = (t.mod & (MODconst | MODimmutable)) | (tparam.mod & t.mod & MODshared);
+                wm = MODFlags.mutable;
+            ubyte m = (t.mod & (MODFlags.const_ | MODFlags.immutable_)) | (tparam.mod & t.mod & MODFlags.shared_);
             *at = t.unqualify(m);
             return wm;
         }
-    case X(MODwild, MODwild):
-    case X(MODwild, MODwildconst):
-    case X(MODwild, MODshared | MODwild):
-    case X(MODwild, MODshared | MODwildconst):
-    case X(MODwildconst, MODwild):
-    case X(MODwildconst, MODwildconst):
-    case X(MODwildconst, MODshared | MODwild):
-    case X(MODwildconst, MODshared | MODwildconst):
-    case X(MODshared | MODwild, MODshared | MODwild):
-    case X(MODshared | MODwild, MODshared | MODwildconst):
-    case X(MODshared | MODwildconst, MODshared | MODwild):
-    case X(MODshared | MODwildconst, MODshared | MODwildconst):
+    case X(MODFlags.wild, MODFlags.wild):
+    case X(MODFlags.wild, MODFlags.wildconst):
+    case X(MODFlags.wild, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.wild, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.wildconst, MODFlags.wild):
+    case X(MODFlags.wildconst, MODFlags.wildconst):
+    case X(MODFlags.wildconst, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.wildconst, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.wildconst):
         {
             *at = t.unqualify(tparam.mod & t.mod);
-            return MODwild;
+            return MODFlags.wild;
         }
     default:
         return 0;
@@ -2953,14 +2953,14 @@ private MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
     switch (X(tparam.mod, t.mod))
     {
     case X(0, 0):
-    case X(0, MODconst):
-    case X(0, MODwild):
-    case X(0, MODwildconst):
-    case X(0, MODshared):
-    case X(0, MODshared | MODconst):
-    case X(0, MODshared | MODwild):
-    case X(0, MODshared | MODwildconst):
-    case X(0, MODimmutable):
+    case X(0, MODFlags.const_):
+    case X(0, MODFlags.wild):
+    case X(0, MODFlags.wildconst):
+    case X(0, MODFlags.shared_):
+    case X(0, MODFlags.shared_ | MODFlags.const_):
+    case X(0, MODFlags.shared_ | MODFlags.wild):
+    case X(0, MODFlags.shared_ | MODFlags.wildconst):
+    case X(0, MODFlags.immutable_):
         // foo(U)                       T                       => T
         // foo(U)                       const(T)                => const(T)
         // foo(U)                       inout(T)                => inout(T)
@@ -2974,14 +2974,14 @@ private MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
             *at = t;
             return MATCH.exact;
         }
-    case X(MODconst, MODconst):
-    case X(MODwild, MODwild):
-    case X(MODwildconst, MODwildconst):
-    case X(MODshared, MODshared):
-    case X(MODshared | MODconst, MODshared | MODconst):
-    case X(MODshared | MODwild, MODshared | MODwild):
-    case X(MODshared | MODwildconst, MODshared | MODwildconst):
-    case X(MODimmutable, MODimmutable):
+    case X(MODFlags.const_, MODFlags.const_):
+    case X(MODFlags.wild, MODFlags.wild):
+    case X(MODFlags.wildconst, MODFlags.wildconst):
+    case X(MODFlags.shared_, MODFlags.shared_):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.immutable_, MODFlags.immutable_):
         // foo(const(U))                const(T)                => T
         // foo(inout(U))                inout(T)                => T
         // foo(inout(const(U)))         inout(const(T))         => T
@@ -2994,16 +2994,16 @@ private MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
             *at = t.mutableOf().unSharedOf();
             return MATCH.exact;
         }
-    case X(MODconst, 0):
-    case X(MODconst, MODwild):
-    case X(MODconst, MODwildconst):
-    case X(MODconst, MODshared | MODconst):
-    case X(MODconst, MODshared | MODwild):
-    case X(MODconst, MODshared | MODwildconst):
-    case X(MODconst, MODimmutable):
-    case X(MODwild, MODshared | MODwild):
-    case X(MODwildconst, MODshared | MODwildconst):
-    case X(MODshared | MODconst, MODimmutable):
+    case X(MODFlags.const_, 0):
+    case X(MODFlags.const_, MODFlags.wild):
+    case X(MODFlags.const_, MODFlags.wildconst):
+    case X(MODFlags.const_, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.const_, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.const_, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.const_, MODFlags.immutable_):
+    case X(MODFlags.wild, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.wildconst, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.immutable_):
         // foo(const(U))                T                       => T
         // foo(const(U))                inout(T)                => T
         // foo(const(U))                inout(const(T))         => T
@@ -3018,16 +3018,16 @@ private MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
             *at = t.mutableOf();
             return MATCH.constant;
         }
-    case X(MODconst, MODshared):
+    case X(MODFlags.const_, MODFlags.shared_):
         // foo(const(U))                shared(T)               => shared(T)
         {
             *at = t;
             return MATCH.constant;
         }
-    case X(MODshared, MODshared | MODconst):
-    case X(MODshared, MODshared | MODwild):
-    case X(MODshared, MODshared | MODwildconst):
-    case X(MODshared | MODconst, MODshared):
+    case X(MODFlags.shared_, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.shared_, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.shared_):
         // foo(shared(U))               shared(const(T))        => const(T)
         // foo(shared(U))               shared(inout(T))        => inout(T)
         // foo(shared(U))               shared(inout(const(T))) => inout(const(T))
@@ -3036,10 +3036,10 @@ private MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
             *at = t.unSharedOf();
             return MATCH.constant;
         }
-    case X(MODwildconst, MODimmutable):
-    case X(MODshared | MODconst, MODshared | MODwildconst):
-    case X(MODshared | MODwildconst, MODimmutable):
-    case X(MODshared | MODwildconst, MODshared | MODwild):
+    case X(MODFlags.wildconst, MODFlags.immutable_):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.immutable_):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.wild):
         // foo(inout(const(U)))         immutable(T)            => T
         // foo(shared(const(U)))        shared(inout(const(T))) => T
         // foo(shared(inout(const(U)))) immutable(T)            => T
@@ -3048,56 +3048,56 @@ private MATCH deduceTypeHelper(Type t, Type* at, Type tparam)
             *at = t.unSharedOf().mutableOf();
             return MATCH.constant;
         }
-    case X(MODshared | MODconst, MODshared | MODwild):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.shared_ | MODFlags.wild):
         // foo(shared(const(U)))        shared(inout(T))        => T
         {
             *at = t.unSharedOf().mutableOf();
             return MATCH.constant;
         }
-    case X(MODwild, 0):
-    case X(MODwild, MODconst):
-    case X(MODwild, MODwildconst):
-    case X(MODwild, MODimmutable):
-    case X(MODwild, MODshared):
-    case X(MODwild, MODshared | MODconst):
-    case X(MODwild, MODshared | MODwildconst):
-    case X(MODwildconst, 0):
-    case X(MODwildconst, MODconst):
-    case X(MODwildconst, MODwild):
-    case X(MODwildconst, MODshared):
-    case X(MODwildconst, MODshared | MODconst):
-    case X(MODwildconst, MODshared | MODwild):
-    case X(MODshared, 0):
-    case X(MODshared, MODconst):
-    case X(MODshared, MODwild):
-    case X(MODshared, MODwildconst):
-    case X(MODshared, MODimmutable):
-    case X(MODshared | MODconst, 0):
-    case X(MODshared | MODconst, MODconst):
-    case X(MODshared | MODconst, MODwild):
-    case X(MODshared | MODconst, MODwildconst):
-    case X(MODshared | MODwild, 0):
-    case X(MODshared | MODwild, MODconst):
-    case X(MODshared | MODwild, MODwild):
-    case X(MODshared | MODwild, MODwildconst):
-    case X(MODshared | MODwild, MODimmutable):
-    case X(MODshared | MODwild, MODshared):
-    case X(MODshared | MODwild, MODshared | MODconst):
-    case X(MODshared | MODwild, MODshared | MODwildconst):
-    case X(MODshared | MODwildconst, 0):
-    case X(MODshared | MODwildconst, MODconst):
-    case X(MODshared | MODwildconst, MODwild):
-    case X(MODshared | MODwildconst, MODwildconst):
-    case X(MODshared | MODwildconst, MODshared):
-    case X(MODshared | MODwildconst, MODshared | MODconst):
-    case X(MODimmutable, 0):
-    case X(MODimmutable, MODconst):
-    case X(MODimmutable, MODwild):
-    case X(MODimmutable, MODwildconst):
-    case X(MODimmutable, MODshared):
-    case X(MODimmutable, MODshared | MODconst):
-    case X(MODimmutable, MODshared | MODwild):
-    case X(MODimmutable, MODshared | MODwildconst):
+    case X(MODFlags.wild, 0):
+    case X(MODFlags.wild, MODFlags.const_):
+    case X(MODFlags.wild, MODFlags.wildconst):
+    case X(MODFlags.wild, MODFlags.immutable_):
+    case X(MODFlags.wild, MODFlags.shared_):
+    case X(MODFlags.wild, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.wild, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.wildconst, 0):
+    case X(MODFlags.wildconst, MODFlags.const_):
+    case X(MODFlags.wildconst, MODFlags.wild):
+    case X(MODFlags.wildconst, MODFlags.shared_):
+    case X(MODFlags.wildconst, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.wildconst, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_, 0):
+    case X(MODFlags.shared_, MODFlags.const_):
+    case X(MODFlags.shared_, MODFlags.wild):
+    case X(MODFlags.shared_, MODFlags.wildconst):
+    case X(MODFlags.shared_, MODFlags.immutable_):
+    case X(MODFlags.shared_ | MODFlags.const_, 0):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.const_):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.wild, 0):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.const_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.immutable_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.shared_ | MODFlags.wild, MODFlags.shared_ | MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.wildconst, 0):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.const_):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.wildconst):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.immutable_, 0):
+    case X(MODFlags.immutable_, MODFlags.const_):
+    case X(MODFlags.immutable_, MODFlags.wild):
+    case X(MODFlags.immutable_, MODFlags.wildconst):
+    case X(MODFlags.immutable_, MODFlags.shared_):
+    case X(MODFlags.immutable_, MODFlags.shared_ | MODFlags.const_):
+    case X(MODFlags.immutable_, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.immutable_, MODFlags.shared_ | MODFlags.wildconst):
         // foo(inout(U))                T                       => nomatch
         // foo(inout(U))                const(T)                => nomatch
         // foo(inout(U))                inout(const(T))         => nomatch
@@ -3334,13 +3334,13 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     if (tt.implicitConvTo(at.constOf()))
                     {
                         (*dedtypes)[i] = at.constOf().mutableOf();
-                        *wm |= MODconst;
+                        *wm |= MODFlags.const_;
                         goto Lconst;
                     }
                     if (at.implicitConvTo(tt.constOf()))
                     {
                         (*dedtypes)[i] = tt.constOf().mutableOf();
-                        *wm |= MODconst;
+                        *wm |= MODFlags.const_;
                         goto Lconst;
                     }
                     goto Lnomatch;
@@ -3453,7 +3453,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=12403
                     // In IFTI, stop inout matching on transitive part of AA types.
-                    tpn = tpn.substWildTo(MODmutable);
+                    tpn = tpn.substWildTo(MODFlags.mutable);
                 }
 
                 result = deduceType(t.nextOf(), sc, tpn, parameters, dedtypes, wm);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -562,15 +562,15 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
     {
         Type t = tthis;
         if (t.isImmutable())
-            wildmatch = MODimmutable;
+            wildmatch = MODFlags.immutable_;
         else if (t.isWildConst())
-            wildmatch = MODwildconst;
+            wildmatch = MODFlags.wildconst;
         else if (t.isWild())
-            wildmatch = MODwild;
+            wildmatch = MODFlags.wild;
         else if (t.isConst())
-            wildmatch = MODconst;
+            wildmatch = MODFlags.const_;
         else
-            wildmatch = MODmutable;
+            wildmatch = MODFlags.mutable;
     }
 
     int done = 0;
@@ -710,7 +710,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
         if (done)
             break;
     }
-    if ((wildmatch == MODmutable || wildmatch == MODimmutable) && tf.next.hasWild() && (tf.isref || !tf.next.implicitConvTo(tf.next.immutableOf())))
+    if ((wildmatch == MODFlags.mutable || wildmatch == MODFlags.immutable_) && tf.next.hasWild() && (tf.isref || !tf.next.implicitConvTo(tf.next.immutableOf())))
     {
         if (fd)
         {
@@ -749,7 +749,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
         else if (tf.isWild())
         {
         Linouterr:
-            const(char)* s = wildmatch == MODmutable ? "mutable" : MODtoChars(wildmatch);
+            const(char)* s = wildmatch == MODFlags.mutable ? "mutable" : MODtoChars(wildmatch);
             error(loc, "modify `inout` to `%s` is not allowed inside `inout` function", s);
             return true;
         }
@@ -2905,7 +2905,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     // lazy parameters can be called without violating purity and safety
                     Type tw = ve.var.type;
-                    Type tc = ve.var.type.substWildTo(MODconst);
+                    Type tc = ve.var.type.substWildTo(MODFlags.const_);
                     auto tf = new TypeFunction(null, tc, 0, LINKd, STC.safe | STC.pure_);
                     (tf = cast(TypeFunction)tf.typeSemantic(exp.loc, sc)).next = tw; // hack for bug7757
                     auto t = new TypeDelegate(tf);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1209,10 +1209,10 @@ extern (C++) class FuncDeclaration : Declaration
         if (purity > PURE.weak && needThis())
         {
             // The attribute of the 'this' reference affects purity strength
-            if (type.mod & MODimmutable)
+            if (type.mod & MODFlags.immutable_)
             {
             }
-            else if (type.mod & (MODconst | MODwild) && purity >= PURE.const_)
+            else if (type.mod & (MODFlags.const_ | MODFlags.wild) && purity >= PURE.const_)
                 purity = PURE.const_;
             else
                 purity = PURE.weak;
@@ -2406,22 +2406,22 @@ extern (C++) int overloadApply(Dsymbol fstart, void* param, int function(void*, 
 void MODMatchToBuffer(OutBuffer* buf, ubyte lhsMod, ubyte rhsMod)
 {
     bool bothMutable = ((lhsMod & rhsMod) == 0);
-    bool sharedMismatch = ((lhsMod ^ rhsMod) & MODshared) != 0;
-    bool sharedMismatchOnly = ((lhsMod ^ rhsMod) == MODshared);
+    bool sharedMismatch = ((lhsMod ^ rhsMod) & MODFlags.shared_) != 0;
+    bool sharedMismatchOnly = ((lhsMod ^ rhsMod) == MODFlags.shared_);
 
-    if (lhsMod & MODshared)
+    if (lhsMod & MODFlags.shared_)
         buf.writestring("shared ");
-    else if (sharedMismatch && !(lhsMod & MODimmutable))
+    else if (sharedMismatch && !(lhsMod & MODFlags.immutable_))
         buf.writestring("non-shared ");
 
     if (bothMutable && sharedMismatchOnly)
     {
     }
-    else if (lhsMod & MODimmutable)
+    else if (lhsMod & MODFlags.immutable_)
         buf.writestring("immutable ");
-    else if (lhsMod & MODconst)
+    else if (lhsMod & MODFlags.const_)
         buf.writestring("const ");
-    else if (lhsMod & MODwild)
+    else if (lhsMod & MODFlags.wild)
         buf.writestring("inout ");
     else
         buf.writestring("mutable ");

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1505,20 +1505,20 @@ uint totym(Type tx)
     {
         case 0:
             break;
-        case MODconst:
-        case MODwild:
-        case MODwildconst:
+        case MODFlags.const_:
+        case MODFlags.wild:
+        case MODFlags.wildconst:
             t |= mTYconst;
             break;
-        case MODshared:
+        case MODFlags.shared_:
             t |= mTYshared;
             break;
-        case MODshared | MODconst:
-        case MODshared | MODwild:
-        case MODshared | MODwildconst:
+        case MODFlags.shared_ | MODFlags.const_:
+        case MODFlags.shared_ | MODFlags.wild:
+        case MODFlags.shared_ | MODFlags.wildconst:
             t |= mTYshared | mTYconst;
             break;
-        case MODimmutable:
+        case MODFlags.immutable_:
             t |= mTYimmutable;
             break;
         default:

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -742,27 +742,27 @@ public:
         else
         {
             ubyte m = t.mod & ~(t.mod & modMask);
-            if (m & MODshared)
+            if (m & MODFlags.shared_)
             {
-                MODtoBuffer(buf, MODshared);
+                MODtoBuffer(buf, MODFlags.shared_);
                 buf.writeByte('(');
             }
-            if (m & MODwild)
+            if (m & MODFlags.wild)
             {
-                MODtoBuffer(buf, MODwild);
+                MODtoBuffer(buf, MODFlags.wild);
                 buf.writeByte('(');
             }
-            if (m & (MODconst | MODimmutable))
+            if (m & (MODFlags.const_ | MODFlags.immutable_))
             {
-                MODtoBuffer(buf, m & (MODconst | MODimmutable));
+                MODtoBuffer(buf, m & (MODFlags.const_ | MODFlags.immutable_));
                 buf.writeByte('(');
             }
             t.accept(this);
-            if (m & (MODconst | MODimmutable))
+            if (m & (MODFlags.const_ | MODFlags.immutable_))
                 buf.writeByte(')');
-            if (m & MODwild)
+            if (m & MODFlags.wild)
                 buf.writeByte(')');
-            if (m & MODshared)
+            if (m & MODFlags.shared_)
                 buf.writeByte(')');
         }
     }
@@ -3064,7 +3064,7 @@ public:
         else if (p.storageClass & STC.alias_)
             buf.writestring("alias ");
         StorageClass stc = p.storageClass;
-        if (p.type && p.type.mod & MODshared)
+        if (p.type && p.type.mod & MODFlags.shared_)
             stc &= ~STC.shared_;
         if (stcToBuffer(buf, stc & (STC.const_ | STC.immutable_ | STC.wild | STC.shared_ | STC.scope_ | STC.scopeinferred)))
             buf.writeByte(' ');

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -464,20 +464,13 @@ alias TY = ubyte;
 
 enum MODFlags : int
 {
-    MODconst        = 1,    // type is const
-    MODimmutable    = 4,    // type is immutable
-    MODshared       = 2,    // type is shared
-    MODwild         = 8,    // type is wild
-    MODwildconst    = (MODwild | MODconst), // type is wild const
-    MODmutable      = 0x10, // type is mutable (only used in wildcard matching)
+    const_       = 1,    // type is const
+    immutable_   = 4,    // type is immutable
+    shared_      = 2,    // type is shared
+    wild         = 8,    // type is wild
+    wildconst    = (MODFlags.wild | MODFlags.const_), // type is wild const
+    mutable      = 0x10, // type is mutable (only used in wildcard matching)
 }
-
-alias MODconst = MODFlags.MODconst;
-alias MODimmutable = MODFlags.MODimmutable;
-alias MODshared = MODFlags.MODshared;
-alias MODwild = MODFlags.MODwild;
-alias MODwildconst = MODFlags.MODwildconst;
-alias MODmutable = MODFlags.MODmutable;
 
 alias MOD = ubyte;
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -81,16 +81,16 @@ bool MODimplicitConv(MOD modfrom, MOD modto) pure nothrow @nogc @safe
         return ((m << 4) | n);
     }
 
-    switch (X(modfrom & ~MODshared, modto & ~MODshared))
+    switch (X(modfrom & ~MODFlags.shared_, modto & ~MODFlags.shared_))
     {
-    case X(0, MODconst):
-    case X(MODwild, MODconst):
-    case X(MODwild, MODwildconst):
-    case X(MODwildconst, MODconst):
-        return (modfrom & MODshared) == (modto & MODshared);
+    case X(0, MODFlags.const_):
+    case X(MODFlags.wild, MODFlags.const_):
+    case X(MODFlags.wild, MODFlags.wildconst):
+    case X(MODFlags.wildconst, MODFlags.const_):
+        return (modfrom & MODFlags.shared_) == (modto & MODFlags.shared_);
 
-    case X(MODimmutable, MODconst):
-    case X(MODimmutable, MODwildconst):
+    case X(MODFlags.immutable_, MODFlags.const_):
+    case X(MODFlags.immutable_, MODFlags.wildconst):
         return true;
     default:
         return false;
@@ -114,14 +114,14 @@ MATCH MODmethodConv(MOD modfrom, MOD modto) pure nothrow @nogc @safe
 
     switch (X(modfrom, modto))
     {
-    case X(0, MODwild):
-    case X(MODimmutable, MODwild):
-    case X(MODconst, MODwild):
-    case X(MODwildconst, MODwild):
-    case X(MODshared, MODshared | MODwild):
-    case X(MODshared | MODimmutable, MODshared | MODwild):
-    case X(MODshared | MODconst, MODshared | MODwild):
-    case X(MODshared | MODwildconst, MODshared | MODwild):
+    case X(0, MODFlags.wild):
+    case X(MODFlags.immutable_, MODFlags.wild):
+    case X(MODFlags.const_, MODFlags.wild):
+    case X(MODFlags.wildconst, MODFlags.wild):
+    case X(MODFlags.shared_, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.immutable_, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.const_, MODFlags.shared_ | MODFlags.wild):
+    case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.wild):
         return MATCH.constant;
 
     default:
@@ -139,25 +139,25 @@ MOD MODmerge(MOD mod1, MOD mod2) pure nothrow @nogc @safe
 
     //printf("MODmerge(1 = %x, 2 = %x)\n", mod1, mod2);
     MOD result = 0;
-    if ((mod1 | mod2) & MODshared)
+    if ((mod1 | mod2) & MODFlags.shared_)
     {
         // If either type is shared, the result will be shared
-        result |= MODshared;
-        mod1 &= ~MODshared;
-        mod2 &= ~MODshared;
+        result |= MODFlags.shared_;
+        mod1 &= ~MODFlags.shared_;
+        mod2 &= ~MODFlags.shared_;
     }
-    if (mod1 == 0 || mod1 == MODmutable || mod1 == MODconst || mod2 == 0 || mod2 == MODmutable || mod2 == MODconst)
+    if (mod1 == 0 || mod1 == MODFlags.mutable || mod1 == MODFlags.const_ || mod2 == 0 || mod2 == MODFlags.mutable || mod2 == MODFlags.const_)
     {
         // If either type is mutable or const, the result will be const.
-        result |= MODconst;
+        result |= MODFlags.const_;
     }
     else
     {
-        // MODimmutable vs MODwild
-        // MODimmutable vs MODwildconst
-        //      MODwild vs MODwildconst
-        assert(mod1 & MODwild || mod2 & MODwild);
-        result |= MODwildconst;
+        // MODFlags.immutable_ vs MODFlags.wild
+        // MODFlags.immutable_ vs MODFlags.wildconst
+        //      MODFlags.wild vs MODFlags.wildconst
+        assert(mod1 & MODFlags.wild || mod2 & MODFlags.wild);
+        result |= MODFlags.wildconst;
     }
     return result;
 }
@@ -172,35 +172,35 @@ void MODtoBuffer(OutBuffer* buf, MOD mod) nothrow
     case 0:
         break;
 
-    case MODimmutable:
+    case MODFlags.immutable_:
         buf.writestring(Token.toString(TOKimmutable));
         break;
 
-    case MODshared:
+    case MODFlags.shared_:
         buf.writestring(Token.toString(TOKshared));
         break;
 
-    case MODshared | MODconst:
+    case MODFlags.shared_ | MODFlags.const_:
         buf.writestring(Token.toString(TOKshared));
         buf.writeByte(' ');
         goto case; /+ fall through +/
-    case MODconst:
+    case MODFlags.const_:
         buf.writestring(Token.toString(TOKconst));
         break;
 
-    case MODshared | MODwild:
+    case MODFlags.shared_ | MODFlags.wild:
         buf.writestring(Token.toString(TOKshared));
         buf.writeByte(' ');
         goto case; /+ fall through +/
-    case MODwild:
+    case MODFlags.wild:
         buf.writestring(Token.toString(TOKwild));
         break;
 
-    case MODshared | MODwildconst:
+    case MODFlags.shared_ | MODFlags.wildconst:
         buf.writestring(Token.toString(TOKshared));
         buf.writeByte(' ');
         goto case; /+ fall through +/
-    case MODwildconst:
+    case MODFlags.wildconst:
         buf.writestring(Token.toString(TOKwild));
         buf.writeByte(' ');
         buf.writestring(Token.toString(TOKconst));
@@ -228,13 +228,13 @@ char* MODtoChars(MOD mod) nothrow
 StorageClass ModToStc(uint mod) pure nothrow @nogc @safe
 {
     StorageClass stc = 0;
-    if (mod & MODimmutable)
+    if (mod & MODFlags.immutable_)
         stc |= STC.immutable_;
-    if (mod & MODconst)
+    if (mod & MODFlags.const_)
         stc |= STC.const_;
-    if (mod & MODwild)
+    if (mod & MODFlags.wild)
         stc |= STC.wild;
-    if (mod & MODshared)
+    if (mod & MODFlags.shared_)
         stc |= STC.shared_;
     return stc;
 }
@@ -488,14 +488,14 @@ extern (C++) abstract class Type : RootObject
      * Note that there is no "shared immutable", because that is just immutable
      * Naked == no MOD bits
      */
-    Type cto;       // MODconst                 ? naked version of this type : const version
-    Type ito;       // MODimmutable             ? naked version of this type : immutable version
-    Type sto;       // MODshared                ? naked version of this type : shared mutable version
-    Type scto;      // MODshared | MODconst     ? naked version of this type : shared const version
-    Type wto;       // MODwild                  ? naked version of this type : wild version
-    Type wcto;      // MODwildconst             ? naked version of this type : wild const version
-    Type swto;      // MODshared | MODwild      ? naked version of this type : shared wild version
-    Type swcto;     // MODshared | MODwildconst ? naked version of this type : shared wild const version
+    Type cto;       // MODFlags.const_                 ? naked version of this type : const version
+    Type ito;       // MODFlags.immutable_             ? naked version of this type : immutable version
+    Type sto;       // MODFlags.shared_                ? naked version of this type : shared mutable version
+    Type scto;      // MODFlags.shared_ | MODFlags.const_     ? naked version of this type : shared const version
+    Type wto;       // MODFlags.wild                  ? naked version of this type : wild version
+    Type wcto;      // MODFlags.wildconst             ? naked version of this type : wild const version
+    Type swto;      // MODFlags.shared_ | MODFlags.wild      ? naked version of this type : shared wild version
+    Type swcto;     // MODFlags.shared_ | MODFlags.wildconst ? naked version of this type : shared wild const version
 
     Type pto;       // merged pointer to this type
     Type rto;       // reference to this type
@@ -828,7 +828,7 @@ extern (C++) abstract class Type : RootObject
             {
                 //stop attribute inference with const
                 // If adding 'const' will make it covariant
-                if (MODimplicitConv(t2.mod, MODmerge(t1.mod, MODconst)))
+                if (MODimplicitConv(t2.mod, MODmerge(t1.mod, MODFlags.const_)))
                     stc |= STC.const_;
                 else
                     goto Lnotcovariant;
@@ -1076,11 +1076,11 @@ extern (C++) abstract class Type : RootObject
         return buf.extractString();
     }
 
-    /** For each active modifier (MODconst, MODimmutable, etc) call fp with a
+    /** For each active modifier (MODFlags.const_, MODFlags.immutable_, etc) call fp with a
      void* for the work param and a string representation of the attribute. */
     final int modifiersApply(void* param, int function(void*, const(char)*) fp)
     {
-        immutable ubyte[4] modsArr = [MODconst, MODimmutable, MODwild, MODshared];
+        immutable ubyte[4] modsArr = [MODFlags.const_, MODFlags.immutable_, MODFlags.wild, MODFlags.shared_];
 
         foreach (modsarr; modsArr)
         {
@@ -1174,42 +1174,42 @@ extern (C++) abstract class Type : RootObject
 
     final bool isConst() const nothrow pure @nogc @safe
     {
-        return (mod & MODconst) != 0;
+        return (mod & MODFlags.const_) != 0;
     }
 
     final bool isImmutable() const nothrow pure @nogc @safe
     {
-        return (mod & MODimmutable) != 0;
+        return (mod & MODFlags.immutable_) != 0;
     }
 
     final bool isMutable() const nothrow pure @nogc @safe
     {
-        return (mod & (MODconst | MODimmutable | MODwild)) == 0;
+        return (mod & (MODFlags.const_ | MODFlags.immutable_ | MODFlags.wild)) == 0;
     }
 
     final bool isShared() const nothrow pure @nogc @safe
     {
-        return (mod & MODshared) != 0;
+        return (mod & MODFlags.shared_) != 0;
     }
 
     final bool isSharedConst() const nothrow pure @nogc @safe
     {
-        return (mod & (MODshared | MODconst)) == (MODshared | MODconst);
+        return (mod & (MODFlags.shared_ | MODFlags.const_)) == (MODFlags.shared_ | MODFlags.const_);
     }
 
     final bool isWild() const nothrow pure @nogc @safe
     {
-        return (mod & MODwild) != 0;
+        return (mod & MODFlags.wild) != 0;
     }
 
     final bool isWildConst() const nothrow pure @nogc @safe
     {
-        return (mod & MODwildconst) == MODwildconst;
+        return (mod & MODFlags.wildconst) == MODFlags.wildconst;
     }
 
     final bool isSharedWild() const nothrow pure @nogc @safe
     {
-        return (mod & (MODshared | MODwild)) == (MODshared | MODwild);
+        return (mod & (MODFlags.shared_ | MODFlags.wild)) == (MODFlags.shared_ | MODFlags.wild);
     }
 
     final bool isNaked() const nothrow pure @nogc @safe
@@ -1254,11 +1254,11 @@ extern (C++) abstract class Type : RootObject
     final Type constOf()
     {
         //printf("Type::constOf() %p %s\n", this, toChars());
-        if (mod == MODconst)
+        if (mod == MODFlags.const_)
             return this;
         if (cto)
         {
-            assert(cto.mod == MODconst);
+            assert(cto.mod == MODFlags.const_);
             return cto;
         }
         Type t = makeConst();
@@ -1341,11 +1341,11 @@ extern (C++) abstract class Type : RootObject
     final Type sharedOf()
     {
         //printf("Type::sharedOf() %p, %s\n", this, toChars());
-        if (mod == MODshared)
+        if (mod == MODFlags.shared_)
             return this;
         if (sto)
         {
-            assert(sto.mod == MODshared);
+            assert(sto.mod == MODFlags.shared_);
             return sto;
         }
         Type t = makeShared();
@@ -1358,11 +1358,11 @@ extern (C++) abstract class Type : RootObject
     final Type sharedConstOf()
     {
         //printf("Type::sharedConstOf() %p, %s\n", this, toChars());
-        if (mod == (MODshared | MODconst))
+        if (mod == (MODFlags.shared_ | MODFlags.const_))
             return this;
         if (scto)
         {
-            assert(scto.mod == (MODshared | MODconst));
+            assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             return scto;
         }
         Type t = makeSharedConst();
@@ -1411,7 +1411,7 @@ extern (C++) abstract class Type : RootObject
         if (!t)
         {
             t = this.nullAttributes();
-            t.mod = mod & ~MODshared;
+            t.mod = mod & ~MODFlags.shared_;
             t.ctype = ctype;
             t = t.merge();
             t.fixTo(this);
@@ -1428,11 +1428,11 @@ extern (C++) abstract class Type : RootObject
     final Type wildOf()
     {
         //printf("Type::wildOf() %p %s\n", this, toChars());
-        if (mod == MODwild)
+        if (mod == MODFlags.wild)
             return this;
         if (wto)
         {
-            assert(wto.mod == MODwild);
+            assert(wto.mod == MODFlags.wild);
             return wto;
         }
         Type t = makeWild();
@@ -1445,11 +1445,11 @@ extern (C++) abstract class Type : RootObject
     final Type wildConstOf()
     {
         //printf("Type::wildConstOf() %p %s\n", this, toChars());
-        if (mod == MODwildconst)
+        if (mod == MODFlags.wildconst)
             return this;
         if (wcto)
         {
-            assert(wcto.mod == MODwildconst);
+            assert(wcto.mod == MODFlags.wildconst);
             return wcto;
         }
         Type t = makeWildConst();
@@ -1462,11 +1462,11 @@ extern (C++) abstract class Type : RootObject
     final Type sharedWildOf()
     {
         //printf("Type::sharedWildOf() %p, %s\n", this, toChars());
-        if (mod == (MODshared | MODwild))
+        if (mod == (MODFlags.shared_ | MODFlags.wild))
             return this;
         if (swto)
         {
-            assert(swto.mod == (MODshared | MODwild));
+            assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
             return swto;
         }
         Type t = makeSharedWild();
@@ -1479,11 +1479,11 @@ extern (C++) abstract class Type : RootObject
     final Type sharedWildConstOf()
     {
         //printf("Type::sharedWildConstOf() %p, %s\n", this, toChars());
-        if (mod == (MODshared | MODwildconst))
+        if (mod == (MODFlags.shared_ | MODFlags.wildconst))
             return this;
         if (swcto)
         {
-            assert(swcto.mod == (MODshared | MODwildconst));
+            assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             return swcto;
         }
         Type t = makeSharedWildConst();
@@ -1511,35 +1511,35 @@ extern (C++) abstract class Type : RootObject
                 mto = t;
                 break;
 
-            case MODconst:
+            case MODFlags.const_:
                 cto = t;
                 break;
 
-            case MODwild:
+            case MODFlags.wild:
                 wto = t;
                 break;
 
-            case MODwildconst:
+            case MODFlags.wildconst:
                 wcto = t;
                 break;
 
-            case MODshared:
+            case MODFlags.shared_:
                 sto = t;
                 break;
 
-            case MODshared | MODconst:
+            case MODFlags.shared_ | MODFlags.const_:
                 scto = t;
                 break;
 
-            case MODshared | MODwild:
+            case MODFlags.shared_ | MODFlags.wild:
                 swto = t;
                 break;
 
-            case MODshared | MODwildconst:
+            case MODFlags.shared_ | MODFlags.wildconst:
                 swcto = t;
                 break;
 
-            case MODimmutable:
+            case MODFlags.immutable_:
                 ito = t;
                 break;
 
@@ -1559,42 +1559,42 @@ extern (C++) abstract class Type : RootObject
         case 0:
             break;
 
-        case MODconst:
+        case MODFlags.const_:
             cto = mto;
             t.cto = this;
             break;
 
-        case MODwild:
+        case MODFlags.wild:
             wto = mto;
             t.wto = this;
             break;
 
-        case MODwildconst:
+        case MODFlags.wildconst:
             wcto = mto;
             t.wcto = this;
             break;
 
-        case MODshared:
+        case MODFlags.shared_:
             sto = mto;
             t.sto = this;
             break;
 
-        case MODshared | MODconst:
+        case MODFlags.shared_ | MODFlags.const_:
             scto = mto;
             t.scto = this;
             break;
 
-        case MODshared | MODwild:
+        case MODFlags.shared_ | MODFlags.wild:
             swto = mto;
             t.swto = this;
             break;
 
-        case MODshared | MODwildconst:
+        case MODFlags.shared_ | MODFlags.wildconst:
             swcto = mto;
             t.swcto = this;
             break;
 
-        case MODimmutable:
+        case MODFlags.immutable_:
             t.ito = this;
             if (t.cto)
                 t.cto.ito = this;
@@ -1630,157 +1630,157 @@ extern (C++) abstract class Type : RootObject
         {
         case 0:
             if (cto)
-                assert(cto.mod == MODconst);
+                assert(cto.mod == MODFlags.const_);
             if (ito)
-                assert(ito.mod == MODimmutable);
+                assert(ito.mod == MODFlags.immutable_);
             if (sto)
-                assert(sto.mod == MODshared);
+                assert(sto.mod == MODFlags.shared_);
             if (scto)
-                assert(scto.mod == (MODshared | MODconst));
+                assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             if (wto)
-                assert(wto.mod == MODwild);
+                assert(wto.mod == MODFlags.wild);
             if (wcto)
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
             if (swto)
-                assert(swto.mod == (MODshared | MODwild));
+                assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
             if (swcto)
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
-        case MODconst:
+        case MODFlags.const_:
             if (cto)
                 assert(cto.mod == 0);
             if (ito)
-                assert(ito.mod == MODimmutable);
+                assert(ito.mod == MODFlags.immutable_);
             if (sto)
-                assert(sto.mod == MODshared);
+                assert(sto.mod == MODFlags.shared_);
             if (scto)
-                assert(scto.mod == (MODshared | MODconst));
+                assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             if (wto)
-                assert(wto.mod == MODwild);
+                assert(wto.mod == MODFlags.wild);
             if (wcto)
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
             if (swto)
-                assert(swto.mod == (MODshared | MODwild));
+                assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
             if (swcto)
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
-        case MODwild:
+        case MODFlags.wild:
             if (cto)
-                assert(cto.mod == MODconst);
+                assert(cto.mod == MODFlags.const_);
             if (ito)
-                assert(ito.mod == MODimmutable);
+                assert(ito.mod == MODFlags.immutable_);
             if (sto)
-                assert(sto.mod == MODshared);
+                assert(sto.mod == MODFlags.shared_);
             if (scto)
-                assert(scto.mod == (MODshared | MODconst));
+                assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             if (wto)
                 assert(wto.mod == 0);
             if (wcto)
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
             if (swto)
-                assert(swto.mod == (MODshared | MODwild));
+                assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
             if (swcto)
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
-        case MODwildconst:
-            assert(!cto || cto.mod == MODconst);
-            assert(!ito || ito.mod == MODimmutable);
-            assert(!sto || sto.mod == MODshared);
-            assert(!scto || scto.mod == (MODshared | MODconst));
-            assert(!wto || wto.mod == MODwild);
+        case MODFlags.wildconst:
+            assert(!cto || cto.mod == MODFlags.const_);
+            assert(!ito || ito.mod == MODFlags.immutable_);
+            assert(!sto || sto.mod == MODFlags.shared_);
+            assert(!scto || scto.mod == (MODFlags.shared_ | MODFlags.const_));
+            assert(!wto || wto.mod == MODFlags.wild);
             assert(!wcto || wcto.mod == 0);
-            assert(!swto || swto.mod == (MODshared | MODwild));
-            assert(!swcto || swcto.mod == (MODshared | MODwildconst));
+            assert(!swto || swto.mod == (MODFlags.shared_ | MODFlags.wild));
+            assert(!swcto || swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
-        case MODshared:
+        case MODFlags.shared_:
             if (cto)
-                assert(cto.mod == MODconst);
+                assert(cto.mod == MODFlags.const_);
             if (ito)
-                assert(ito.mod == MODimmutable);
+                assert(ito.mod == MODFlags.immutable_);
             if (sto)
                 assert(sto.mod == 0);
             if (scto)
-                assert(scto.mod == (MODshared | MODconst));
+                assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             if (wto)
-                assert(wto.mod == MODwild);
+                assert(wto.mod == MODFlags.wild);
             if (wcto)
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
             if (swto)
-                assert(swto.mod == (MODshared | MODwild));
+                assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
             if (swcto)
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
-        case MODshared | MODconst:
+        case MODFlags.shared_ | MODFlags.const_:
             if (cto)
-                assert(cto.mod == MODconst);
+                assert(cto.mod == MODFlags.const_);
             if (ito)
-                assert(ito.mod == MODimmutable);
+                assert(ito.mod == MODFlags.immutable_);
             if (sto)
-                assert(sto.mod == MODshared);
+                assert(sto.mod == MODFlags.shared_);
             if (scto)
                 assert(scto.mod == 0);
             if (wto)
-                assert(wto.mod == MODwild);
+                assert(wto.mod == MODFlags.wild);
             if (wcto)
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
             if (swto)
-                assert(swto.mod == (MODshared | MODwild));
+                assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
             if (swcto)
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
-        case MODshared | MODwild:
+        case MODFlags.shared_ | MODFlags.wild:
             if (cto)
-                assert(cto.mod == MODconst);
+                assert(cto.mod == MODFlags.const_);
             if (ito)
-                assert(ito.mod == MODimmutable);
+                assert(ito.mod == MODFlags.immutable_);
             if (sto)
-                assert(sto.mod == MODshared);
+                assert(sto.mod == MODFlags.shared_);
             if (scto)
-                assert(scto.mod == (MODshared | MODconst));
+                assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             if (wto)
-                assert(wto.mod == MODwild);
+                assert(wto.mod == MODFlags.wild);
             if (wcto)
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
             if (swto)
                 assert(swto.mod == 0);
             if (swcto)
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
-        case MODshared | MODwildconst:
-            assert(!cto || cto.mod == MODconst);
-            assert(!ito || ito.mod == MODimmutable);
-            assert(!sto || sto.mod == MODshared);
-            assert(!scto || scto.mod == (MODshared | MODconst));
-            assert(!wto || wto.mod == MODwild);
-            assert(!wcto || wcto.mod == MODwildconst);
-            assert(!swto || swto.mod == (MODshared | MODwild));
+        case MODFlags.shared_ | MODFlags.wildconst:
+            assert(!cto || cto.mod == MODFlags.const_);
+            assert(!ito || ito.mod == MODFlags.immutable_);
+            assert(!sto || sto.mod == MODFlags.shared_);
+            assert(!scto || scto.mod == (MODFlags.shared_ | MODFlags.const_));
+            assert(!wto || wto.mod == MODFlags.wild);
+            assert(!wcto || wcto.mod == MODFlags.wildconst);
+            assert(!swto || swto.mod == (MODFlags.shared_ | MODFlags.wild));
             assert(!swcto || swcto.mod == 0);
             break;
 
-        case MODimmutable:
+        case MODFlags.immutable_:
             if (cto)
-                assert(cto.mod == MODconst);
+                assert(cto.mod == MODFlags.const_);
             if (ito)
                 assert(ito.mod == 0);
             if (sto)
-                assert(sto.mod == MODshared);
+                assert(sto.mod == MODFlags.shared_);
             if (scto)
-                assert(scto.mod == (MODshared | MODconst));
+                assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             if (wto)
-                assert(wto.mod == MODwild);
+                assert(wto.mod == MODFlags.wild);
             if (wcto)
-                assert(wcto.mod == MODwildconst);
+                assert(wcto.mod == MODFlags.wildconst);
             if (swto)
-                assert(swto.mod == (MODshared | MODwild));
+                assert(swto.mod == (MODFlags.shared_ | MODFlags.wild));
             if (swcto)
-                assert(swcto.mod == (MODshared | MODwildconst));
+                assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             break;
 
         default:
@@ -1794,15 +1794,15 @@ extern (C++) abstract class Type : RootObject
             switch (mod)
             {
             case 0:
-            case MODconst:
-            case MODwild:
-            case MODwildconst:
-            case MODshared:
-            case MODshared | MODconst:
-            case MODshared | MODwild:
-            case MODshared | MODwildconst:
-            case MODimmutable:
-                assert(tn.mod == MODimmutable || (tn.mod & mod) == mod);
+            case MODFlags.const_:
+            case MODFlags.wild:
+            case MODFlags.wildconst:
+            case MODFlags.shared_:
+            case MODFlags.shared_ | MODFlags.const_:
+            case MODFlags.shared_ | MODFlags.wild:
+            case MODFlags.shared_ | MODFlags.wildconst:
+            case MODFlags.immutable_:
+                assert(tn.mod == MODFlags.immutable_ || (tn.mod & mod) == mod);
                 break;
 
             default:
@@ -1895,35 +1895,35 @@ extern (C++) abstract class Type : RootObject
             t = unSharedOf().mutableOf();
             break;
 
-        case MODconst:
+        case MODFlags.const_:
             t = unSharedOf().constOf();
             break;
 
-        case MODwild:
+        case MODFlags.wild:
             t = unSharedOf().wildOf();
             break;
 
-        case MODwildconst:
+        case MODFlags.wildconst:
             t = unSharedOf().wildConstOf();
             break;
 
-        case MODshared:
+        case MODFlags.shared_:
             t = mutableOf().sharedOf();
             break;
 
-        case MODshared | MODconst:
+        case MODFlags.shared_ | MODFlags.const_:
             t = sharedConstOf();
             break;
 
-        case MODshared | MODwild:
+        case MODFlags.shared_ | MODFlags.wild:
             t = sharedWildOf();
             break;
 
-        case MODshared | MODwildconst:
+        case MODFlags.shared_ | MODFlags.wildconst:
             t = sharedWildConstOf();
             break;
 
-        case MODimmutable:
+        case MODFlags.immutable_:
             t = immutableOf();
             break;
 
@@ -1951,7 +1951,7 @@ extern (C++) abstract class Type : RootObject
             case 0:
                 break;
 
-            case MODconst:
+            case MODFlags.const_:
                 if (isShared())
                 {
                     if (isWild())
@@ -1968,7 +1968,7 @@ extern (C++) abstract class Type : RootObject
                 }
                 break;
 
-            case MODwild:
+            case MODFlags.wild:
                 if (isShared())
                 {
                     if (isConst())
@@ -1985,14 +1985,14 @@ extern (C++) abstract class Type : RootObject
                 }
                 break;
 
-            case MODwildconst:
+            case MODFlags.wildconst:
                 if (isShared())
                     t = sharedWildConstOf();
                 else
                     t = wildConstOf();
                 break;
 
-            case MODshared:
+            case MODFlags.shared_:
                 if (isWild())
                 {
                     if (isConst())
@@ -2009,25 +2009,25 @@ extern (C++) abstract class Type : RootObject
                 }
                 break;
 
-            case MODshared | MODconst:
+            case MODFlags.shared_ | MODFlags.const_:
                 if (isWild())
                     t = sharedWildConstOf();
                 else
                     t = sharedConstOf();
                 break;
 
-            case MODshared | MODwild:
+            case MODFlags.shared_ | MODFlags.wild:
                 if (isConst())
                     t = sharedWildConstOf();
                 else
                     t = sharedWildOf();
                 break;
 
-            case MODshared | MODwildconst:
+            case MODFlags.shared_ | MODFlags.wildconst:
                 t = sharedWildConstOf();
                 break;
 
-            case MODimmutable:
+            case MODFlags.immutable_:
                 t = immutableOf();
                 break;
 
@@ -2047,15 +2047,15 @@ extern (C++) abstract class Type : RootObject
          */
         MOD mod = 0;
         if (stc & STC.immutable_)
-            mod = MODimmutable;
+            mod = MODFlags.immutable_;
         else
         {
             if (stc & (STC.const_ | STC.in_))
-                mod |= MODconst;
+                mod |= MODFlags.const_;
             if (stc & STC.wild)
-                mod |= MODwild;
+                mod |= MODFlags.wild;
             if (stc & STC.shared_)
-                mod |= MODshared;
+                mod |= MODFlags.shared_;
         }
         return addMod(mod);
     }
@@ -2142,7 +2142,7 @@ extern (C++) abstract class Type : RootObject
             auto t = fd.type.nextOf();
             if (!t) // issue 14185
                 return Type.terror;
-            t = t.substWildTo(mod == 0 ? MODmutable : mod);
+            t = t.substWildTo(mod == 0 ? MODFlags.mutable : mod);
             return t;
         }
         if (auto d = s.isDeclaration())
@@ -2164,7 +2164,7 @@ extern (C++) abstract class Type : RootObject
             auto t = fd.type.nextOf();
             if (!t)
                 return Type.terror;
-            t = t.substWildTo(mod == 0 ? MODmutable : mod);
+            t = t.substWildTo(mod == 0 ? MODFlags.mutable : mod);
             return t;
         }
 
@@ -2199,7 +2199,7 @@ extern (C++) abstract class Type : RootObject
         if (cto)
             return cto;
         Type t = this.nullAttributes();
-        t.mod = MODconst;
+        t.mod = MODFlags.const_;
         //printf("-Type::makeConst() %p, %s\n", t, toChars());
         return t;
     }
@@ -2209,7 +2209,7 @@ extern (C++) abstract class Type : RootObject
         if (ito)
             return ito;
         Type t = this.nullAttributes();
-        t.mod = MODimmutable;
+        t.mod = MODFlags.immutable_;
         return t;
     }
 
@@ -2218,7 +2218,7 @@ extern (C++) abstract class Type : RootObject
         if (sto)
             return sto;
         Type t = this.nullAttributes();
-        t.mod = MODshared;
+        t.mod = MODFlags.shared_;
         return t;
     }
 
@@ -2227,7 +2227,7 @@ extern (C++) abstract class Type : RootObject
         if (scto)
             return scto;
         Type t = this.nullAttributes();
-        t.mod = MODshared | MODconst;
+        t.mod = MODFlags.shared_ | MODFlags.const_;
         return t;
     }
 
@@ -2236,7 +2236,7 @@ extern (C++) abstract class Type : RootObject
         if (wto)
             return wto;
         Type t = this.nullAttributes();
-        t.mod = MODwild;
+        t.mod = MODFlags.wild;
         return t;
     }
 
@@ -2245,7 +2245,7 @@ extern (C++) abstract class Type : RootObject
         if (wcto)
             return wcto;
         Type t = this.nullAttributes();
-        t.mod = MODwildconst;
+        t.mod = MODFlags.wildconst;
         return t;
     }
 
@@ -2254,7 +2254,7 @@ extern (C++) abstract class Type : RootObject
         if (swto)
             return swto;
         Type t = this.nullAttributes();
-        t.mod = MODshared | MODwild;
+        t.mod = MODFlags.shared_ | MODFlags.wild;
         return t;
     }
 
@@ -2263,14 +2263,14 @@ extern (C++) abstract class Type : RootObject
         if (swcto)
             return swcto;
         Type t = this.nullAttributes();
-        t.mod = MODshared | MODwildconst;
+        t.mod = MODFlags.shared_ | MODFlags.wildconst;
         return t;
     }
 
     Type makeMutable()
     {
         Type t = this.nullAttributes();
-        t.mod = mod & MODshared;
+        t.mod = mod & MODFlags.shared_;
         return t;
     }
 
@@ -2336,20 +2336,20 @@ extern (C++) abstract class Type : RootObject
         if (t.isWild())
         {
             if (isImmutable())
-                return MODimmutable;
+                return MODFlags.immutable_;
             else if (isWildConst())
             {
                 if (t.isWildConst())
-                    return MODwild;
+                    return MODFlags.wild;
                 else
-                    return MODwildconst;
+                    return MODFlags.wildconst;
             }
             else if (isWild())
-                return MODwild;
+                return MODFlags.wild;
             else if (isConst())
-                return MODconst;
+                return MODFlags.const_;
             else if (isMutable())
-                return MODmutable;
+                return MODFlags.mutable;
             else
                 assert(0);
         }
@@ -2402,22 +2402,22 @@ extern (C++) abstract class Type : RootObject
     L1:
         if (isWild())
         {
-            if (mod == MODimmutable)
+            if (mod == MODFlags.immutable_)
             {
                 t = t.immutableOf();
             }
-            else if (mod == MODwildconst)
+            else if (mod == MODFlags.wildconst)
             {
                 t = t.wildConstOf();
             }
-            else if (mod == MODwild)
+            else if (mod == MODFlags.wild)
             {
                 if (isWildConst())
                     t = t.wildConstOf();
                 else
                     t = t.wildOf();
             }
-            else if (mod == MODconst)
+            else if (mod == MODFlags.const_)
             {
                 t = t.constOf();
             }
@@ -2430,9 +2430,9 @@ extern (C++) abstract class Type : RootObject
             }
         }
         if (isConst())
-            t = t.addMod(MODconst);
+            t = t.addMod(MODFlags.const_);
         if (isShared())
-            t = t.addMod(MODshared);
+            t = t.addMod(MODFlags.shared_);
 
         //printf("-Type::substWildTo t = %s\n", t.toChars());
         return t;
@@ -2898,7 +2898,7 @@ extern (C++) abstract class Type : RootObject
      */
     int hasWild() const
     {
-        return mod & MODwild;
+        return mod & MODFlags.wild;
     }
 
     /***************************************
@@ -3162,7 +3162,7 @@ extern (C++) abstract class TypeNext : Type
             return 0;
         if (ty == Tdelegate)
             return Type.hasWild();
-        return mod & MODwild || (next && next.hasWild());
+        return mod & MODFlags.wild || (next && next.hasWild());
     }
 
     /*******************************
@@ -3180,7 +3180,7 @@ extern (C++) abstract class TypeNext : Type
         //printf("TypeNext::makeConst() %p, %s\n", this, toChars());
         if (cto)
         {
-            assert(cto.mod == MODconst);
+            assert(cto.mod == MODFlags.const_);
             return cto;
         }
         TypeNext t = cast(TypeNext)Type.makeConst();
@@ -3226,7 +3226,7 @@ extern (C++) abstract class TypeNext : Type
         //printf("TypeNext::makeShared() %s\n", toChars());
         if (sto)
         {
-            assert(sto.mod == MODshared);
+            assert(sto.mod == MODFlags.shared_);
             return sto;
         }
         TypeNext t = cast(TypeNext)Type.makeShared();
@@ -3256,7 +3256,7 @@ extern (C++) abstract class TypeNext : Type
         //printf("TypeNext::makeSharedConst() %s\n", toChars());
         if (scto)
         {
-            assert(scto.mod == (MODshared | MODconst));
+            assert(scto.mod == (MODFlags.shared_ | MODFlags.const_));
             return scto;
         }
         TypeNext t = cast(TypeNext)Type.makeSharedConst();
@@ -3276,7 +3276,7 @@ extern (C++) abstract class TypeNext : Type
         //printf("TypeNext::makeWild() %s\n", toChars());
         if (wto)
         {
-            assert(wto.mod == MODwild);
+            assert(wto.mod == MODFlags.wild);
             return wto;
         }
         TypeNext t = cast(TypeNext)Type.makeWild();
@@ -3306,7 +3306,7 @@ extern (C++) abstract class TypeNext : Type
         //printf("TypeNext::makeWildConst() %s\n", toChars());
         if (wcto)
         {
-            assert(wcto.mod == MODwildconst);
+            assert(wcto.mod == MODFlags.wildconst);
             return wcto;
         }
         TypeNext t = cast(TypeNext)Type.makeWildConst();
@@ -3346,7 +3346,7 @@ extern (C++) abstract class TypeNext : Type
         //printf("TypeNext::makeSharedWildConst() %s\n", toChars());
         if (swcto)
         {
-            assert(swcto.mod == (MODshared | MODwildconst));
+            assert(swcto.mod == (MODFlags.shared_ | MODFlags.wildconst));
             return swcto;
         }
         TypeNext t = cast(TypeNext)Type.makeSharedWildConst();
@@ -4185,7 +4185,7 @@ extern (C++) final class TypeBasic : Type
                 return MATCH.exact;
             else if (MODimplicitConv(mod, to.mod))
                 return MATCH.constant;
-            else if (!((mod ^ to.mod) & MODshared)) // for wild matching
+            else if (!((mod ^ to.mod) & MODFlags.shared_)) // for wild matching
                 return MATCH.constant;
             else
                 return MATCH.convert;
@@ -5543,16 +5543,16 @@ extern (C++) final class TypeFunction : TypeNext
         {
             if (isref)
             {
-                if (t.mod & MODimmutable)
+                if (t.mod & MODFlags.immutable_)
                     return PURE.strong;
-                if (t.mod & (MODconst | MODwild))
+                if (t.mod & (MODFlags.const_ | MODFlags.wild))
                     return PURE.const_;
                 return PURE.weak;
             }
 
             t = t.baseElemOf();
 
-            if (!t.hasPointers() || t.mod & MODimmutable)
+            if (!t.hasPointers() || t.mod & MODFlags.immutable_)
                 return PURE.strong;
 
             /* Accept immutable(T)[] and immutable(T)* as being strongly pure
@@ -5560,9 +5560,9 @@ extern (C++) final class TypeFunction : TypeNext
             if (t.ty == Tarray || t.ty == Tpointer)
             {
                 Type tn = t.nextOf().toBasetype();
-                if (tn.mod & MODimmutable)
+                if (tn.mod & MODFlags.immutable_)
                     return PURE.strong;
-                if (tn.mod & (MODconst | MODwild))
+                if (tn.mod & (MODFlags.const_ | MODFlags.wild))
                     return PURE.const_;
             }
 
@@ -5571,7 +5571,7 @@ extern (C++) final class TypeFunction : TypeNext
              * which would maintain strong purity.
              * (Just like for dynamic arrays and pointers above.)
              */
-            if (t.mod & (MODconst | MODwild))
+            if (t.mod & (MODFlags.const_ | MODFlags.wild))
                 return PURE.const_;
 
             /* Should catch delegates and function pointers, and fold in their purity
@@ -5844,18 +5844,18 @@ extern (C++) final class TypeFunction : TypeNext
 
     override Type substWildTo(uint)
     {
-        if (!iswild && !(mod & MODwild))
+        if (!iswild && !(mod & MODFlags.wild))
             return this;
 
         // Substitude inout qualifier of function type to mutable or immutable
         // would break type system. Instead substitude inout to the most weak
         // qualifer - const.
-        uint m = MODconst;
+        uint m = MODFlags.const_;
 
         assert(next);
         Type tret = next.substWildTo(m);
         Parameters* params = parameters;
-        if (mod & MODwild)
+        if (mod & MODFlags.wild)
             params = parameters.copy();
         for (size_t i = 0; i < params.dim; i++)
         {
@@ -5872,7 +5872,7 @@ extern (C++) final class TypeFunction : TypeNext
 
         // Similar to TypeFunction::syntaxCopy;
         auto t = new TypeFunction(params, tret, varargs, linkage);
-        t.mod = ((mod & MODwild) ? (mod & ~MODwild) | MODconst : mod);
+        t.mod = ((mod & MODFlags.wild) ? (mod & ~MODFlags.wild) | MODFlags.const_ : mod);
         t.isnothrow = isnothrow;
         t.isnogc = isnogc;
         t.purity = purity;
@@ -5910,7 +5910,7 @@ extern (C++) final class TypeFunction : TypeNext
             {
                 if (MODimplicitConv(t.mod, mod))
                     match = MATCH.constant;
-                else if ((mod & MODwild) && MODimplicitConv(t.mod, (mod & ~MODwild) | MODconst))
+                else if ((mod & MODFlags.wild) && MODimplicitConv(t.mod, (mod & ~MODFlags.wild) | MODFlags.const_))
                 {
                     match = MATCH.constant;
                 }
@@ -5920,13 +5920,13 @@ extern (C++) final class TypeFunction : TypeNext
             if (isWild())
             {
                 if (t.isWild())
-                    wildmatch |= MODwild;
+                    wildmatch |= MODFlags.wild;
                 else if (t.isConst())
-                    wildmatch |= MODconst;
+                    wildmatch |= MODFlags.const_;
                 else if (t.isImmutable())
-                    wildmatch |= MODimmutable;
+                    wildmatch |= MODFlags.immutable_;
                 else
-                    wildmatch |= MODmutable;
+                    wildmatch |= MODFlags.mutable;
             }
         }
 
@@ -5963,16 +5963,16 @@ extern (C++) final class TypeFunction : TypeNext
         {
             /* Calculate wild matching modifier
              */
-            if (wildmatch & MODconst || wildmatch & (wildmatch - 1))
-                wildmatch = MODconst;
-            else if (wildmatch & MODimmutable)
-                wildmatch = MODimmutable;
-            else if (wildmatch & MODwild)
-                wildmatch = MODwild;
+            if (wildmatch & MODFlags.const_ || wildmatch & (wildmatch - 1))
+                wildmatch = MODFlags.const_;
+            else if (wildmatch & MODFlags.immutable_)
+                wildmatch = MODFlags.immutable_;
+            else if (wildmatch & MODFlags.wild)
+                wildmatch = MODFlags.wild;
             else
             {
-                assert(wildmatch & MODmutable);
-                wildmatch = MODmutable;
+                assert(wildmatch & MODFlags.mutable);
+                wildmatch = MODFlags.mutable;
             }
         }
 

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1894,7 +1894,7 @@ extern (C++) bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbo
                     p.type = taa.index; // key type
                     p.type = p.type.addStorageClass(p.storageClass);
                     if (p.storageClass & STC.ref_) // key must not be mutated via ref
-                        p.type = p.type.addMod(MODconst);
+                        p.type = p.type.addMod(MODFlags.const_);
                 }
                 p = (*fes.parameters)[1];
             }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7791,28 +7791,28 @@ final class Parser(AST) : Lexer
                     case TOKconst:
                         if (peekNext() == TOKlparen)
                             break; // const as type constructor
-                        m |= AST.MODconst; // const as storage class
+                        m |= AST.MODFlags.const_; // const as storage class
                         nextToken();
                         continue;
 
                     case TOKimmutable:
                         if (peekNext() == TOKlparen)
                             break;
-                        m |= AST.MODimmutable;
+                        m |= AST.MODFlags.immutable_;
                         nextToken();
                         continue;
 
                     case TOKshared:
                         if (peekNext() == TOKlparen)
                             break;
-                        m |= AST.MODshared;
+                        m |= AST.MODFlags.shared_;
                         nextToken();
                         continue;
 
                     case TOKwild:
                         if (peekNext() == TOKlparen)
                             break;
-                        m |= AST.MODwild;
+                        m |= AST.MODFlags.wild;
                         nextToken();
                         continue;
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1667,7 +1667,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     Type ta = p.type;
                     if (dim == 2)
                     {
-                        Type ti = (isRef ? taa.index.addMod(MODconst) : taa.index);
+                        Type ti = (isRef ? taa.index.addMod(MODFlags.const_) : taa.index);
                         if (isRef ? !ti.constConv(ta) : !ti.implicitConvTo(ta))
                         {
                             fs.error("foreach: index must be type `%s`, not `%s`",

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -100,20 +100,20 @@ public:
         {
         case 0:
             assert(0);
-        case MODconst:
-        case MODwild:
-        case MODwildconst:
+        case MODFlags.const_:
+        case MODFlags.wild:
+        case MODFlags.wildconst:
             t.ctype.Tty |= mTYconst;
             break;
-        case MODshared:
+        case MODFlags.shared_:
             t.ctype.Tty |= mTYshared;
             break;
-        case MODshared | MODconst:
-        case MODshared | MODwild:
-        case MODshared | MODwildconst:
+        case MODFlags.shared_ | MODFlags.const_:
+        case MODFlags.shared_ | MODFlags.wild:
+        case MODFlags.shared_ | MODFlags.wildconst:
             t.ctype.Tty |= mTYshared | mTYconst;
             break;
-        case MODimmutable:
+        case MODFlags.immutable_:
             t.ctype.Tty |= mTYimmutable;
             break;
         default:

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1136,7 +1136,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         stc = p.storageClass;
 
         // This mirrors hdrgen.visit(Parameter p)
-        if (p.type && p.type.mod & MODshared)
+        if (p.type && p.type.mod & MODFlags.shared_)
             stc &= ~STC.shared_;
 
         auto exps = new Expressions;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -906,7 +906,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                 }
                 else if (fparam.storageClass & STC.out_)
                 {
-                    if (ubyte m = fparam.type.mod & (MODimmutable | MODconst | MODwild))
+                    if (ubyte m = fparam.type.mod & (MODFlags.immutable_ | MODFlags.const_ | MODFlags.wild))
                     {
                         mtype.error(loc, "cannot have %s out parameter of type `%s`", MODtoChars(m), t.toChars());
                         errors = true;

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -243,8 +243,8 @@ private bool builtinTypeInfo(Type t)
         // strings are so common, make them builtin
         return !t.mod &&
                (next.isTypeBasic() !is null && !next.mod ||
-                next.ty == Tchar && next.mod == MODimmutable ||
-                next.ty == Tchar && next.mod == MODconst);
+                next.ty == Tchar && next.mod == MODFlags.immutable_ ||
+                next.ty == Tchar && next.mod == MODFlags.const_);
     }
     return false;
 }


### PR DESCRIPTION
```bash
replacements=(
"MODconst const_"
"MODimmutable immutable_"
"MODshared shared_"
"MODwild wild"
"MODwildconst wildconst"
"MODmutable mutable"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/MODFlags.${w[1]}/g" -i **/*.d
done
```