### PR TITLE
Improve GDC workaround against a failing DUB registry

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -153,10 +153,10 @@ activate_d() {
   download_install_sh "$install_sh"
   # DUB isn't needed for gdc
   if [ "${DMD:-dmd}" == "gdc" ] ; then
-      touch "$HOME/dlang/dub"
+      mkdir -p $HOME/dlang/dub
       # Remove the check of the lastest DUB version
       # shellcheck disable=2016
-      sed 's/dub="dub-$(fetch $url)"/dub=dub' -i "$install_sh"
+      sed 's/dub="dub-$(fetch $url)"/dub=dub/' -i "$install_sh"
   fi
   CURL_USER_AGENT="$CURL_USER_AGENT" bash "$install_sh" "$1" --activate
 }


### PR DESCRIPTION
See also: https://github.com/dlang/dmd/pull/7692
I see the following in the logs:

```
++ '[' gdc == gdc ']'
++ touch /home/runner/dlang/dub
touch: cannot touch ‘/home/runner/dlang/dub’: No such file or directory
++ sed 's/dub="dub-$(fetch $url)"/dub=dub' -i install.sh
sed: -e expression #1, char 33: unterminated `s' command
++ CURL_USER_AGENT='DMD-CI curl 7.35.0 (x86_64-pc-linux-gnu) libcurl/7.35.0 OpenSSL/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3'
++ bash install.sh gdc --activate
curl: (22) The requested URL returned error: 502 Bad Gateway
```

https://semaphoreci.com/wilzbach/dmd-2/branches/master/builds/29