### PR TITLE
AssertExp: add links to spec

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1953,6 +1953,7 @@ elem *toElem(Expression e, IRState *irs)
 
         override void visit(AssertExp ae)
         {
+            // https://dlang.org/spec/expression.html#assert_expressions
             //printf("AssertExp.toElem() %s\n", toChars());
             elem *e;
             if (global.params.useAssert == CHECKENABLE.on)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5149,6 +5149,7 @@ extern (C++) final class ImportExp : UnaExp
 }
 
 /***********************************************************
+ * https://dlang.org/spec/expression.html#assert_expressions
  */
 extern (C++) final class AssertExp : UnaExp
 {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4315,6 +4315,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(AssertExp exp)
     {
+        // https://dlang.org/spec/expression.html#assert_expressions
         static if (LOGSEMANTIC)
         {
             printf("AssertExp::semantic('%s')\n", exp.toChars());

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7596,6 +7596,7 @@ final class Parser(AST) : Lexer
             }
         case TOKassert:
             {
+                // https://dlang.org/spec/expression.html#assert_expressions
                 AST.Expression msg = null;
 
                 nextToken();


### PR DESCRIPTION
This is a sample of spec URLs I'd like to add to the code. It makes comparing the implementation with the spec very convenient, so that they can be kept in sync.