### PR TITLE
Automatically convert LINKXXX to LINK + use final switch

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -485,7 +485,7 @@ struct ASTBase
             super(id);
             storage_class = STC.undefined_;
             protection = Prot(Prot.Kind.undefined);
-            linkage = LINKdefault;
+            linkage = LINK.default_;
         }
 
         override final inout(Declaration) isDeclaration() inout
@@ -6280,19 +6280,19 @@ struct ASTBase
     {
         switch (linkage)
         {
-        case LINKdefault:
+        case LINK.default_:
             return null;
-        case LINKd:
+        case LINK.d:
             return "D";
-        case LINKc:
+        case LINK.c:
             return "C";
-        case LINKcpp:
+        case LINK.cpp:
             return "C++";
-        case LINKwindows:
+        case LINK.windows:
             return "Windows";
-        case LINKpascal:
+        case LINK.pascal:
             return "Pascal";
-        case LINKobjc:
+        case LINK.objc:
             return "Objective-C";
         default:
             assert(0);

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6278,9 +6278,10 @@ struct ASTBase
 
     extern (C++) static const(char)* linkageToChars(LINK linkage)
     {
-        switch (linkage)
+        final switch (linkage)
         {
         case LINK.default_:
+        case LINK.system:
             return null;
         case LINK.d:
             return "D";
@@ -6294,8 +6295,6 @@ struct ASTBase
             return "Pascal";
         case LINK.objc:
             return "Objective-C";
-        default:
-            assert(0);
         }
     }
 

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -439,7 +439,7 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
     {
         super(decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", p, decl);
-        linkage = (p == LINKsystem) ? Target.systemLinkage() : p;
+        linkage = (p == LINK.system) ? Target.systemLinkage() : p;
     }
 
     static LinkDeclaration create(LINK p, Dsymbols* decl)
@@ -491,7 +491,7 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
 
     override Scope* newScope(Scope* sc)
     {
-        return createNewScope(sc, sc.stc, LINKcpp, cppmangle, sc.protection, sc.explicitProtection,
+        return createNewScope(sc, sc.stc, LINK.cpp, cppmangle, sc.protection, sc.explicitProtection,
             sc.aligndecl, sc.inlining);
     }
 

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -74,7 +74,7 @@ enum
     TYifunc             = 0x2E, // interrupt func
     TYptr               = 0x33, // generic pointer type
     TYmfunc             = 0x37, // NT C++ member func
-    TYjfunc             = 0x38, // LINKd D function
+    TYjfunc             = 0x38, // LINK.d D function
     TYhfunc             = 0x39, // C function with hidden parameter
     TYnref              = 0x3A, // near reference
 

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -242,7 +242,7 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
 
     auto fparams = new Parameters();
     fparams.push(new Parameter(STC.nodtor, sd.type, Id.p, null));
-    auto tf = new TypeFunction(fparams, sd.handleType(), 0, LINKd, stc | STC.ref_);
+    auto tf = new TypeFunction(fparams, sd.handleType(), 0, LINK.d, stc | STC.ref_);
     auto fop = new FuncDeclaration(declLoc, Loc(), Id.assign, stc, tf);
     fop.storage_class |= STC.inference;
     fop.generated = true;
@@ -316,7 +316,7 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
     uint errors = global.startGagging(); // Do not report errors, even if the template opAssign fbody makes it.
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINKd;
+    sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     // https://issues.dlang.org/show_bug.cgi?id=15044
@@ -487,7 +487,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
                  */
                 auto parameters = new Parameters();
                 parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, null, null));
-                tfeqptr = new TypeFunction(parameters, Type.tbool, 0, LINKd);
+                tfeqptr = new TypeFunction(parameters, Type.tbool, 0, LINK.d);
                 tfeqptr.mod = MODFlags.const_;
                 tfeqptr = cast(TypeFunction)tfeqptr.typeSemantic(Loc(), &scx);
             }
@@ -513,7 +513,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     auto parameters = new Parameters();
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null));
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.q, null));
-    auto tf = new TypeFunction(parameters, Type.tbool, 0, LINKd);
+    auto tf = new TypeFunction(parameters, Type.tbool, 0, LINK.d);
     Identifier id = Id.xopEquals;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STC.static_, tf);
     fop.generated = true;
@@ -524,7 +524,7 @@ extern (C++) FuncDeclaration buildXopEquals(StructDeclaration sd, Scope* sc)
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINKd;
+    sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();
@@ -557,7 +557,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
                  */
                 auto parameters = new Parameters();
                 parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, null, null));
-                tfcmpptr = new TypeFunction(parameters, Type.tint32, 0, LINKd);
+                tfcmpptr = new TypeFunction(parameters, Type.tint32, 0, LINK.d);
                 tfcmpptr.mod = MODFlags.const_;
                 tfcmpptr = cast(TypeFunction)tfcmpptr.typeSemantic(Loc(), &scx);
             }
@@ -633,7 +633,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     auto parameters = new Parameters();
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null));
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.q, null));
-    auto tf = new TypeFunction(parameters, Type.tint32, 0, LINKd);
+    auto tf = new TypeFunction(parameters, Type.tint32, 0, LINK.d);
     Identifier id = Id.xopCmp;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STC.static_, tf);
     fop.generated = true;
@@ -644,7 +644,7 @@ extern (C++) FuncDeclaration buildXopCmp(StructDeclaration sd, Scope* sc)
     uint errors = global.startGagging(); // Do not report errors
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINKd;
+    sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();
@@ -721,7 +721,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
         static __gshared TypeFunction tftohash;
         if (!tftohash)
         {
-            tftohash = new TypeFunction(null, Type.thash_t, 0, LINKd);
+            tftohash = new TypeFunction(null, Type.thash_t, 0, LINK.d);
             tftohash.mod = MODFlags.const_;
             tftohash = cast(TypeFunction)tftohash.merge();
         }
@@ -740,7 +740,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
     Loc loc = Loc(); // internal code should have no loc to prevent coverage
     auto parameters = new Parameters();
     parameters.push(new Parameter(STC.ref_ | STC.const_, sd.type, Id.p, null));
-    auto tf = new TypeFunction(parameters, Type.thash_t, 0, LINKd, STC.nothrow_ | STC.trusted);
+    auto tf = new TypeFunction(parameters, Type.thash_t, 0, LINK.d, STC.nothrow_ | STC.trusted);
     Identifier id = Id.xtoHash;
     auto fop = new FuncDeclaration(declLoc, Loc(), id, STC.static_, tf);
     fop.generated = true;
@@ -758,7 +758,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
     fop.fbody = new CompileStatement(loc, new StringExp(loc, cast(char*)code));
     Scope* sc2 = sc.push();
     sc2.stc = 0;
-    sc2.linkage = LINKd;
+    sc2.linkage = LINK.d;
     fop.dsymbolSemantic(sc2);
     fop.semantic2(sc2);
     sc2.pop();

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -169,7 +169,7 @@ extern (C++) final class StaticForeach : RootObject
      */
     private extern(D) Expression wrapAndCall(Loc loc, Statement s)
     {
-        auto tf = new TypeFunction(new Parameters(), null, 0, LINK.def, 0);
+        auto tf = new TypeFunction(new Parameters(), null, 0, LINK.default_, 0);
         auto fd = new FuncLiteralDeclaration(loc, loc, tf, TOKreserved, null);
         fd.fbody = s;
         auto fe = new FuncExp(loc, fd);

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -49,7 +49,7 @@ const(char)* toCppMangleItanium(Dsymbol s)
 {
     //printf("toCppMangleItanium(%s)\n", s.toChars());
     OutBuffer buf;
-    Target.prefixName(&buf, LINKcpp);
+    Target.prefixName(&buf, LINK.cpp);
     scope CppMangleVisitor v = new CppMangleVisitor(&buf, s.loc);
     v.mangleOf(s);
     return buf.extractString();
@@ -223,7 +223,7 @@ private final class CppMangleVisitor : Visitor
                 {
                     bool is_nested = d.toParent() &&
                         !d.toParent().isModule() &&
-                        (cast(TypeFunction)d.isFuncDeclaration().type).linkage == LINKcpp;
+                        (cast(TypeFunction)d.isFuncDeclaration().type).linkage == LINK.cpp;
                     if (is_nested)
                         buf.writeByte('X');
                     buf.writeByte('L');
@@ -591,7 +591,7 @@ private final class CppMangleVisitor : Visitor
         else
         {
             Dsymbol p = d.toParent();
-            if (p && !p.isModule() && tf.linkage == LINKcpp)
+            if (p && !p.isModule() && tf.linkage == LINK.cpp)
             {
                 /* <nested-name> ::= N [<CV-qualifiers>] <prefix> <unqualified-name> E
                  *               ::= N [<CV-qualifiers>] <template-prefix> <template-args> E
@@ -625,7 +625,7 @@ private final class CppMangleVisitor : Visitor
             }
         }
 
-        if (tf.linkage == LINKcpp) //Template args accept extern "C" symbols with special mangling
+        if (tf.linkage == LINK.cpp) //Template args accept extern "C" symbols with special mangling
         {
             assert(tf.ty == Tfunction);
             mangleFunctionParameters(tf.parameters, tf.varargs);
@@ -644,7 +644,7 @@ private final class CppMangleVisitor : Visitor
             else if (fparam.storageClass & STC.lazy_)
             {
                 // Mangle as delegate
-                Type td = new TypeFunction(null, t, 0, LINKd);
+                Type td = new TypeFunction(null, t, 0, LINK.d);
                 td = new TypeDelegate(td);
                 t = merge(t);
             }
@@ -950,7 +950,7 @@ public:
         if (substitute(t))
             return;
         buf.writeByte('F');
-        if (t.linkage == LINKc)
+        if (t.linkage == LINK.c)
             buf.writeByte('Y');
         Type tn = t.next;
         if (t.isref)

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -973,7 +973,7 @@ private:
         }
         else
         {
-            switch (type.linkage)
+            final switch (type.linkage)
             {
             case LINK.c:
                 tmp.buf.writeByte('A');
@@ -990,7 +990,10 @@ private:
             case LINK.pascal:
                 tmp.buf.writeByte('C');
                 break;
-            default:
+            case LINK.d:
+            case LINK.default_:
+            case LINK.system:
+            case LINK.objc:
                 tmp.visit(cast(Type)type);
                 break;
             }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -975,19 +975,19 @@ private:
         {
             switch (type.linkage)
             {
-            case LINKc:
+            case LINK.c:
                 tmp.buf.writeByte('A');
                 break;
-            case LINKcpp:
+            case LINK.cpp:
                 if (needthis && type.varargs != 1)
                     tmp.buf.writeByte('E'); // thiscall
                 else
                     tmp.buf.writeByte('A'); // cdecl
                 break;
-            case LINKwindows:
+            case LINK.windows:
                 tmp.buf.writeByte('G'); // stdcall
                 break;
-            case LINKpascal:
+            case LINK.pascal:
                 tmp.buf.writeByte('C');
                 break;
             default:
@@ -1038,7 +1038,7 @@ private:
                 else if (p.storageClass & STC.lazy_)
                 {
                     // Mangle as delegate
-                    Type td = new TypeFunction(null, t, 0, LINKd);
+                    Type td = new TypeFunction(null, t, 0, LINK.d);
                     td = new TypeDelegate(td);
                     t = merge(t);
                 }

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -894,7 +894,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
              */
 
             size_t nparams = Parameter.dim(tf.parameters);
-            size_t j = (tf.linkage == LINKd && tf.varargs == 1); // if TypeInfoArray was prepended
+            size_t j = (tf.linkage == LINK.d && tf.varargs == 1); // if TypeInfoArray was prepended
             if (e.e1.op == TOKdotvar)
             {
                 /* Treat 'this' as just another function argument
@@ -1197,7 +1197,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 Expressions* args = (fd == e.allocator) ? e.newargs : e.arguments;
 
                 size_t nparams = Parameter.dim(tf.parameters);
-                size_t j = (tf.linkage == LINKd && tf.varargs == 1); // if TypeInfoArray was prepended
+                size_t j = (tf.linkage == LINK.d && tf.varargs == 1); // if TypeInfoArray was prepended
                 for (size_t i = j; i < e.arguments.dim; ++i)
                 {
                     Expression earg = (*args)[i];

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -1022,11 +1022,11 @@ extern (C++) final class InterfaceDeclaration : ClassDeclaration
     {
         auto sc2 = super.newScope(sc);
         if (com)
-            sc2.linkage = LINKwindows;
+            sc2.linkage = LINK.windows;
         else if (classKind == ClassKind.cpp)
-            sc2.linkage = LINKcpp;
+            sc2.linkage = LINK.cpp;
         else if (classKind == ClassKind.objc)
-            sc2.linkage = LINKobjc;
+            sc2.linkage = LINK.objc;
         return sc2;
     }
 

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -280,7 +280,7 @@ extern (C++) abstract class Declaration : Dsymbol
         super(id);
         storage_class = STC.undefined_;
         protection = Prot(Prot.Kind.undefined);
-        linkage = LINKdefault;
+        linkage = LINK.default_;
     }
 
     override const(char)* kind() const
@@ -1653,7 +1653,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         this.tinfo = tinfo;
         storage_class = STC.static_ | STC.gshared;
         protection = Prot(Prot.Kind.public_);
-        linkage = LINKc;
+        linkage = LINK.c;
         alignment = Target.ptrsize;
     }
 

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -44,7 +44,7 @@ extern (C++) Expression toDelegate(Expression e, Type t, Scope* sc)
 {
     //printf("Expression::toDelegate(t = %s) %s\n", t.toChars(), e.toChars());
     Loc loc = e.loc;
-    auto tf = new TypeFunction(null, t, 0, LINKd);
+    auto tf = new TypeFunction(null, t, 0, LINK.d);
     if (t.hasWild())
         tf.mod = MODFlags.wild;
     auto fld = new FuncLiteralDeclaration(loc, loc, tf, TOKdelegate, null);

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -353,22 +353,22 @@ public:
         ubyte mc;
         switch (t.linkage)
         {
-        case LINKd:
+        case LINK.d:
             mc = 'F';
             break;
-        case LINKc:
+        case LINK.c:
             mc = 'U';
             break;
-        case LINKwindows:
+        case LINK.windows:
             mc = 'W';
             break;
-        case LINKpascal:
+        case LINK.pascal:
             mc = 'V';
             break;
-        case LINKcpp:
+        case LINK.cpp:
             mc = 'R';
             break;
-        case LINKobjc:
+        case LINK.objc:
             mc = 'Y';
             break;
         default:
@@ -543,20 +543,20 @@ public:
 
     static const(char)* externallyMangledIdentifier(Declaration d)
     {
-        if (!d.parent || d.parent.isModule() || d.linkage == LINKcpp) // if at global scope
+        if (!d.parent || d.parent.isModule() || d.linkage == LINK.cpp) // if at global scope
         {
             switch (d.linkage)
             {
-                case LINKd:
+                case LINK.d:
                     break;
-                case LINKc:
-                case LINKwindows:
-                case LINKpascal:
-                case LINKobjc:
+                case LINK.c:
+                case LINK.windows:
+                case LINK.pascal:
+                case LINK.objc:
                     return d.ident.toChars();
-                case LINKcpp:
+                case LINK.cpp:
                     return Target.toCppMangle(d);
-                case LINKdefault:
+                case LINK.default_:
                     d.error("forward declaration");
                     return d.ident.toChars();
                 default:

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -351,8 +351,10 @@ public:
         if (modMask != t.mod)
             MODtoDecoBuffer(buf, t.mod);
         ubyte mc;
-        switch (t.linkage)
+        final switch (t.linkage)
         {
+        case LINK.default_:
+        case LINK.system:
         case LINK.d:
             mc = 'F';
             break;
@@ -371,8 +373,6 @@ public:
         case LINK.objc:
             mc = 'Y';
             break;
-        default:
-            assert(0);
         }
         buf.writeByte(mc);
         if (ta.purity || ta.isnothrow || ta.isnogc || ta.isproperty || ta.isref || ta.trust || ta.isreturn || ta.isscope)
@@ -545,7 +545,7 @@ public:
     {
         if (!d.parent || d.parent.isModule() || d.linkage == LINK.cpp) // if at global scope
         {
-            switch (d.linkage)
+            final switch (d.linkage)
             {
                 case LINK.d:
                     break;
@@ -557,11 +557,9 @@ public:
                 case LINK.cpp:
                     return Target.toCppMangle(d);
                 case LINK.default_:
+                case LINK.system:
                     d.error("forward declaration");
                     return d.ident.toChars();
-                default:
-                    fprintf(stderr, "'%s', linkage = %d\n", d.toChars(), d.linkage);
-                    assert(0);
             }
         }
         return null;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -158,7 +158,7 @@ struct Scope
     AlignDeclaration aligndecl;
 
     /// linkage for external functions
-    LINK linkage = LINKd;
+    LINK linkage = LINK.d;
 
     /// mangle type
     CPPMANGLE cppmangle = CPPMANGLE.def;

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -53,7 +53,7 @@ extern (C++) FuncDeclaration search_toString(StructDeclaration sd)
         static __gshared TypeFunction tftostring;
         if (!tftostring)
         {
-            tftostring = new TypeFunction(null, Type.tstring, 0, LINKd);
+            tftostring = new TypeFunction(null, Type.tstring, 0, LINK.d);
             tftostring = tftostring.merge().toTypeFunction();
         }
         fd = fd.overloadExactMatch(tftostring);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1530,7 +1530,7 @@ public:
                 Parameters* p = new Parameter(STC.in_, Type.tchar.constOf().arrayOf(), null, null);
                 parameters.push(p);
                 Type tret = null;
-                tfgetmembers = new TypeFunction(parameters, tret, 0, LINKd);
+                tfgetmembers = new TypeFunction(parameters, tret, 0, LINK.d);
                 tfgetmembers = cast(TypeFunction)tfgetmembers.dsymbolSemantic(Loc(), &sc);
             }
             if (fdx)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1065,7 +1065,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(TypeInfoDeclaration dsym)
     {
-        assert(dsym.linkage == LINKc);
+        assert(dsym.linkage == LINK.c);
     }
 
     override void visit(Import imp)
@@ -1877,7 +1877,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         em.semanticRun = PASS.semantic;
 
         em.protection = em.ed.isAnonymous() ? em.ed.protection : Prot(Prot.Kind.public_);
-        em.linkage = LINKd;
+        em.linkage = LINK.d;
         em.storage_class = STC.manifest;
         em.userAttribDecl = em.ed.isAnonymous() ? em.ed.userAttribDecl : null;
 
@@ -2472,7 +2472,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             assert(sc);
             sc = sc.push(ns);
-            sc.linkage = LINKcpp; // note that namespaces imply C++ linkage
+            sc.linkage = LINK.cpp; // note that namespaces imply C++ linkage
             sc.parent = ns;
             foreach (s; *ns.members)
             {
@@ -3361,11 +3361,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (pbd.ident == Id.postblit && pbd.semanticRun < PASS.semantic)
             ad.postblits.push(pbd);
         if (!pbd.type)
-            pbd.type = new TypeFunction(null, Type.tvoid, false, LINKd, pbd.storage_class);
+            pbd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, pbd.storage_class);
 
         sc = sc.push();
         sc.stc &= ~STC.static_; // not static
-        sc.linkage = LINKd;
+        sc.linkage = LINK.d;
 
         funcDeclarationSemantic(pbd);
 
@@ -3397,12 +3397,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dd.ident == Id.dtor && dd.semanticRun < PASS.semantic)
             ad.dtors.push(dd);
         if (!dd.type)
-            dd.type = new TypeFunction(null, Type.tvoid, false, LINKd, dd.storage_class);
+            dd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, dd.storage_class);
 
         sc = sc.push();
         sc.stc &= ~STC.static_; // not a static destructor
-        if (sc.linkage != LINKcpp)
-            sc.linkage = LINKd;
+        if (sc.linkage != LINK.cpp)
+            sc.linkage = LINK.d;
 
         funcDeclarationSemantic(dd);
 
@@ -3431,7 +3431,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
         if (!scd.type)
-            scd.type = new TypeFunction(null, Type.tvoid, false, LINKd, scd.storage_class);
+            scd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, scd.storage_class);
 
         /* If the static ctor appears within a template instantiation,
          * it could get called multiple times by the module constructors
@@ -3498,7 +3498,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
         if (!sdd.type)
-            sdd.type = new TypeFunction(null, Type.tvoid, false, LINKd, sdd.storage_class);
+            sdd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, sdd.storage_class);
 
         /* If the static ctor appears within a template instantiation,
          * it could get called multiple times by the module constructors
@@ -3573,13 +3573,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
            )
             ad.invs.push(invd);
         if (!invd.type)
-            invd.type = new TypeFunction(null, Type.tvoid, false, LINKd, invd.storage_class);
+            invd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, invd.storage_class);
 
         sc = sc.push();
         sc.stc &= ~STC.static_; // not a static invariant
         sc.stc |= STC.const_; // invariant() is always const
         sc.flags = (sc.flags & ~SCOPE.contract) | SCOPE.invariant_;
-        sc.linkage = LINKd;
+        sc.linkage = LINK.d;
 
         funcDeclarationSemantic(invd);
 
@@ -3617,9 +3617,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (global.params.useUnitTests)
         {
             if (!utd.type)
-                utd.type = new TypeFunction(null, Type.tvoid, false, LINKd, utd.storage_class);
+                utd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, utd.storage_class);
             Scope* sc2 = sc.push();
-            sc2.linkage = LINKd;
+            sc2.linkage = LINK.d;
             funcDeclarationSemantic(utd);
             sc2.pop();
         }
@@ -3663,7 +3663,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
         Type tret = Type.tvoid.pointerTo();
         if (!nd.type)
-            nd.type = new TypeFunction(nd.parameters, tret, nd.varargs, LINKd, nd.storage_class);
+            nd.type = new TypeFunction(nd.parameters, tret, nd.varargs, LINK.d, nd.storage_class);
 
         nd.type = nd.type.typeSemantic(nd.loc, sc);
 
@@ -3704,7 +3704,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
         if (!deld.type)
-            deld.type = new TypeFunction(deld.parameters, Type.tvoid, 0, LINKd, deld.storage_class);
+            deld.type = new TypeFunction(deld.parameters, Type.tvoid, 0, LINK.d, deld.storage_class);
 
         deld.type = deld.type.typeSemantic(deld.loc, sc);
 
@@ -4008,9 +4008,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             cldec.userAttribDecl = sc.userAttribDecl;
 
-            if (sc.linkage == LINKcpp)
+            if (sc.linkage == LINK.cpp)
                 cldec.classKind = ClassKind.cpp;
-            if (sc.linkage == LINKobjc)
+            if (sc.linkage == LINK.objc)
                 objc.setObjc(cldec);
         }
         else if (cldec.symtab && !scx)
@@ -4451,7 +4451,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 //printf("Creating default this(){} for class %s\n", toChars());
                 auto btf = fd.type.toTypeFunction();
-                auto tf = new TypeFunction(null, null, 0, LINKd, fd.storage_class);
+                auto tf = new TypeFunction(null, null, 0, LINK.d, fd.storage_class);
                 tf.mod       = btf.mod;
                 tf.purity    = btf.purity;
                 tf.isnothrow = btf.isnothrow;
@@ -4663,10 +4663,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 goto Lancestorsdone;
             }
 
-            if (!idec.baseclasses.dim && sc.linkage == LINKcpp)
+            if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
 
-            if (sc.linkage == LINKobjc)
+            if (sc.linkage == LINK.objc)
                 objc.setObjc(idec);
 
             // Check for errors, handle forward references

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -194,7 +194,7 @@ private elem *callfunc(Loc loc,
         assert(elems);
 
         // j=1 if _arguments[] is first argument
-        int j = (tf.linkage == LINKd && tf.varargs == 1);
+        int j = (tf.linkage == LINK.d && tf.varargs == 1);
 
         foreach (const i; 0 .. n)
         {
@@ -288,7 +288,7 @@ private elem *callfunc(Loc loc,
         if ((global.params.isLinux ||
              global.params.isOSX ||
              global.params.isFreeBSD ||
-             global.params.isSolaris) && tf.linkage != LINKd)
+             global.params.isSolaris) && tf.linkage != LINK.d)
         {
                 // ehidden goes last on Linux/OSX C++
         }
@@ -3743,7 +3743,7 @@ elem *toElem(Expression e, IRState *irs)
                     // multiple times within the same function, eg in a loop
                     // see issue 3822
                     if (fd && fd.ident == Id.__alloca &&
-                        !fd.fbody && fd.linkage == LINKc &&
+                        !fd.fbody && fd.linkage == LINK.c &&
                         arguments && arguments.dim == 1)
                     {   Expression arg = (*arguments)[0];
                         arg = arg.optimize(WANTvalue);

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1002,7 +1002,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
                 /* j=1 if _arguments[] is first argument,
                  * skip it because it is not passed by ref
                  */
-                int j = (tf.linkage == LINKd && tf.varargs == 1);
+                int j = (tf.linkage == LINK.d && tf.varargs == 1);
                 for (size_t i = j; i < e.arguments.dim; ++i)
                 {
                     Expression arg = (*e.arguments)[i];
@@ -1200,7 +1200,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                     /* j=1 if _arguments[] is first argument,
                      * skip it because it is not passed by ref
                      */
-                    int j = (tf.linkage == LINKd && tf.varargs == 1);
+                    int j = (tf.linkage == LINK.d && tf.varargs == 1);
                     for (size_t i = j; i < e.arguments.dim; ++i)
                     {
                         Expression arg = (*e.arguments)[i];

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -857,7 +857,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
         {
             // These will be the trailing ... arguments
             // If not D linkage, do promotions
-            if (tf.linkage != LINKd)
+            if (tf.linkage != LINK.d)
             {
                 // Promote bytes, words, etc., to ints
                 arg = integralPromotions(arg, sc);
@@ -878,7 +878,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 }
                 if (tf.varargs == 1)
                 {
-                    const(char)* p = tf.linkage == LINKc ? "extern(C)" : "extern(C++)";
+                    const(char)* p = tf.linkage == LINK.c ? "extern(C)" : "extern(C++)";
                     if (arg.type.ty == Tarray)
                     {
                         arg.error("cannot pass dynamic arrays to `%s` vararg functions", p);
@@ -1088,7 +1088,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
     //if (eprefix) printf("eprefix: %s\n", eprefix.toChars());
 
     // If D linkage and variadic, add _arguments[] as first argument
-    if (tf.linkage == LINKd && tf.varargs == 1)
+    if (tf.linkage == LINK.d && tf.varargs == 1)
     {
         assert(arguments.dim >= nparams);
 
@@ -2906,7 +2906,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // lazy parameters can be called without violating purity and safety
                     Type tw = ve.var.type;
                     Type tc = ve.var.type.substWildTo(MODFlags.const_);
-                    auto tf = new TypeFunction(null, tc, 0, LINKd, STC.safe | STC.pure_);
+                    auto tf = new TypeFunction(null, tc, 0, LINK.d, STC.safe | STC.pure_);
                     (tf = cast(TypeFunction)tf.typeSemantic(exp.loc, sc)).next = tw; // hack for bug7757
                     auto t = new TypeDelegate(tf);
                     ve.type = t.typeSemantic(exp.loc, sc);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1056,12 +1056,12 @@ extern (C++) class FuncDeclaration : Declaration
 
     final bool isMain()
     {
-        return ident == Id.main && linkage != LINKc && !isMember() && !isNested();
+        return ident == Id.main && linkage != LINK.c && !isMember() && !isNested();
     }
 
     final bool isCMain()
     {
-        return ident == Id.main && linkage == LINKc && !isMember() && !isNested();
+        return ident == Id.main && linkage == LINK.c && !isMember() && !isNested();
     }
 
     final bool isWinMain()
@@ -1069,24 +1069,24 @@ extern (C++) class FuncDeclaration : Declaration
         //printf("FuncDeclaration::isWinMain() %s\n", toChars());
         version (none)
         {
-            bool x = ident == Id.WinMain && linkage != LINKc && !isMember();
+            bool x = ident == Id.WinMain && linkage != LINK.c && !isMember();
             printf("%s\n", x ? "yes" : "no");
             return x;
         }
         else
         {
-            return ident == Id.WinMain && linkage != LINKc && !isMember();
+            return ident == Id.WinMain && linkage != LINK.c && !isMember();
         }
     }
 
     final bool isDllMain()
     {
-        return ident == Id.DllMain && linkage != LINKc && !isMember();
+        return ident == Id.DllMain && linkage != LINK.c && !isMember();
     }
 
     final bool isRtInit()
     {
-        return ident == Id.rt_init && linkage == LINKc && !isMember() && !isNested();
+        return ident == Id.rt_init && linkage == LINK.c && !isMember() && !isNested();
     }
 
     override final bool isExport()
@@ -1502,7 +1502,7 @@ extern (C++) class FuncDeclaration : Declaration
         auto f = toAliasFunc();
         //printf("\ttoParent2() = '%s'\n", f.toParent2().toChars());
         return ((f.storage_class & STC.static_) == 0) &&
-                (f.linkage == LINKd) &&
+                (f.linkage == LINK.d) &&
                 (f.toParent2().isFuncDeclaration() !is null);
     }
 
@@ -1555,7 +1555,7 @@ extern (C++) class FuncDeclaration : Declaration
         version (none)
         {
             printf("FuncDeclaration::isVirtual(%s)\n", toChars());
-            printf("isMember:%p isStatic:%d private:%d ctor:%d !Dlinkage:%d\n", isMember(), isStatic(), protection == Prot.Kind.private_, isCtorDeclaration(), linkage != LINKd);
+            printf("isMember:%p isStatic:%d private:%d ctor:%d !Dlinkage:%d\n", isMember(), isStatic(), protection == Prot.Kind.private_, isCtorDeclaration(), linkage != LINK.d);
             printf("result is %d\n", isMember() && !(isStatic() || protection == Prot.Kind.private_ || protection == Prot.Kind.package_) && p.isClassDeclaration() && !(p.isInterfaceDeclaration() && isFinalFunc()));
         }
         return isMember() && !(isStatic() || protection.kind == Prot.Kind.private_ || protection.kind == Prot.Kind.package_) && p.isClassDeclaration() && !(p.isInterfaceDeclaration() && isFinalFunc());
@@ -2043,7 +2043,7 @@ extern (C++) class FuncDeclaration : Declaration
              *   __require();
              */
             Loc loc = frequire.loc;
-            auto tf = new TypeFunction(null, Type.tvoid, 0, LINKd);
+            auto tf = new TypeFunction(null, Type.tvoid, 0, LINK.d);
             tf.isnothrow = f.isnothrow;
             tf.isnogc = f.isnogc;
             tf.purity = f.purity;
@@ -2075,7 +2075,7 @@ extern (C++) class FuncDeclaration : Declaration
                 p = new Parameter(STC.ref_ | STC.const_, f.nextOf(), outId, null);
                 fparams.push(p);
             }
-            auto tf = new TypeFunction(fparams, Type.tvoid, 0, LINKd);
+            auto tf = new TypeFunction(fparams, Type.tvoid, 0, LINK.d);
             tf.isnothrow = f.isnothrow;
             tf.isnogc = f.isnogc;
             tf.purity = f.purity;
@@ -2216,10 +2216,10 @@ extern (C++) class FuncDeclaration : Declaration
         }
         else
         {
-            tf = new TypeFunction(fparams, treturn, 0, LINKc, stc);
+            tf = new TypeFunction(fparams, treturn, 0, LINK.c, stc);
             fd = new FuncDeclaration(Loc(), Loc(), id, STC.static_, tf);
             fd.protection = Prot(Prot.Kind.public_);
-            fd.linkage = LINKc;
+            fd.linkage = LINK.c;
 
             st.insert(fd);
         }

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -414,7 +414,7 @@ nothrow:
 
 enum LINK : int
 {
-    def,        // default
+    default_,
     d,
     c,
     cpp,
@@ -424,7 +424,7 @@ enum LINK : int
     system,
 }
 
-alias LINKdefault = LINK.def;
+alias LINKdefault = LINK.default_;
 alias LINKd = LINK.d;
 alias LINKc = LINK.c;
 alias LINKcpp = LINK.cpp;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -424,15 +424,6 @@ enum LINK : int
     system,
 }
 
-alias LINKdefault = LINK.default_;
-alias LINKd = LINK.d;
-alias LINKc = LINK.c;
-alias LINKcpp = LINK.cpp;
-alias LINKwindows = LINK.windows;
-alias LINKpascal = LINK.pascal;
-alias LINKobjc = LINK.objc;
-alias LINKsystem = LINK.system;
-
 enum CPPMANGLE : int
 {
     def,

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1096,7 +1096,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     }
 
     if ((global.params.isLinux || global.params.isOSX || global.params.isFreeBSD || global.params.isSolaris) &&
-         fd.linkage != LINKd && shidden && sthis)
+         fd.linkage != LINK.d && shidden && sthis)
     {
         /* swap shidden and sthis
          */
@@ -1461,19 +1461,19 @@ uint totym(Type tx)
             TypeFunction tf = cast(TypeFunction)tx;
             switch (tf.linkage)
             {
-                case LINKwindows:
+                case LINK.windows:
                     if (global.params.is64bit)
                         goto Lc;
                     t = (tf.varargs == 1) ? TYnfunc : TYnsfunc;
                     break;
 
-                case LINKpascal:
+                case LINK.pascal:
                     t = (tf.varargs == 1) ? TYnfunc : TYnpfunc;
                     break;
 
-                case LINKc:
-                case LINKcpp:
-                case LINKobjc:
+                case LINK.c:
+                case LINK.cpp:
+                case LINK.objc:
                 Lc:
                     t = TYnfunc;
                     if (global.params.isWindows)
@@ -1483,7 +1483,7 @@ uint totym(Type tx)
                         t = TYhfunc;
                     break;
 
-                case LINKd:
+                case LINK.d:
                     t = (tf.varargs == 1) ? TYnfunc : TYjfunc;
                     break;
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1459,7 +1459,7 @@ uint totym(Type tx)
         case Tfunction:
         {
             TypeFunction tf = cast(TypeFunction)tx;
-            switch (tf.linkage)
+            final switch (tf.linkage)
             {
                 case LINK.windows:
                     if (global.params.is64bit)
@@ -1487,7 +1487,8 @@ uint totym(Type tx)
                     t = (tf.varargs == 1) ? TYnfunc : TYjfunc;
                     break;
 
-                default:
+                case LINK.default_:
+                case LINK.system:
                     printf("linkage = %d\n", tf.linkage);
                     assert(0);
             }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3307,7 +3307,7 @@ private void linkageToBuffer(OutBuffer* buf, LINK linkage)
 
 extern (C++) const(char)* linkageToChars(LINK linkage)
 {
-    switch (linkage)
+    final switch (linkage)
     {
     case LINK.default_:
         return null;
@@ -3325,8 +3325,6 @@ extern (C++) const(char)* linkageToChars(LINK linkage)
         return "Objective-C";
     case LINK.system:
         return "System";
-    default:
-        assert(0);
     }
 }
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -885,7 +885,7 @@ public:
         pas.buf = buf;
         pas.isCtor = false;
         pas.isPostfixStyle = true;
-        if (t.linkage > LINKd && hgs.ddoc != 1 && !hgs.hdrgen)
+        if (t.linkage > LINK.d && hgs.ddoc != 1 && !hgs.hdrgen)
         {
             linkageToBuffer(buf, t.linkage);
             buf.writeByte(' ');
@@ -932,7 +932,7 @@ public:
             buf.writeByte(' ');
         }
         t.attributesApply(&pas, &PrePostAppendStrings.fp);
-        if (t.linkage > LINKd && hgs.ddoc != 1 && !hgs.hdrgen)
+        if (t.linkage > LINK.d && hgs.ddoc != 1 && !hgs.hdrgen)
         {
             linkageToBuffer(buf, t.linkage);
             buf.writeByte(' ');
@@ -1229,22 +1229,22 @@ public:
         const(char)* p;
         switch (d.linkage)
         {
-        case LINKd:
+        case LINK.d:
             p = "D";
             break;
-        case LINKc:
+        case LINK.c:
             p = "C";
             break;
-        case LINKcpp:
+        case LINK.cpp:
             p = "C++";
             break;
-        case LINKwindows:
+        case LINK.windows:
             p = "Windows";
             break;
-        case LINKpascal:
+        case LINK.pascal:
             p = "Pascal";
             break;
-        case LINKobjc:
+        case LINK.objc:
             p = "Objective-C";
             break;
         default:
@@ -3309,21 +3309,21 @@ extern (C++) const(char)* linkageToChars(LINK linkage)
 {
     switch (linkage)
     {
-    case LINKdefault:
+    case LINK.default_:
         return null;
-    case LINKd:
+    case LINK.d:
         return "D";
-    case LINKc:
+    case LINK.c:
         return "C";
-    case LINKcpp:
+    case LINK.cpp:
         return "C++";
-    case LINKwindows:
+    case LINK.windows:
         return "Windows";
-    case LINKpascal:
+    case LINK.pascal:
         return "Pascal";
-    case LINKobjc:
+    case LINK.objc:
         return "Objective-C";
-    case LINKsystem:
+    case LINK.system:
         return "System";
     default:
         assert(0);

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -232,7 +232,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
             /* Rewrite as empty delegate literal { }
              */
             auto parameters = new Parameters();
-            Type tf = new TypeFunction(parameters, null, 0, LINKd);
+            Type tf = new TypeFunction(parameters, null, 0, LINK.d);
             auto fd = new FuncLiteralDeclaration(i.loc, Loc(), tf, tok, null);
             fd.fbody = new CompoundStatement(i.loc, new Statements());
             fd.endloc = i.loc;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1769,7 +1769,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             auto tmp = Identifier.generateId("__retvar");
             vret = new VarDeclaration(fd.loc, eret.type, tmp, ei);
             vret.storage_class |= STC.temp | STC.ref_;
-            vret.linkage = LINKd;
+            vret.linkage = LINK.d;
             vret.parent = parent;
 
             ei.exp = new ConstructExp(fd.loc, vret, eret);
@@ -1832,7 +1832,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
                 vthis.storage_class = STC.ref_;
             else
                 vthis.storage_class = STC.in_;
-            vthis.linkage = LINKd;
+            vthis.linkage = LINK.d;
             vthis.parent = parent;
 
             ei.exp = new ConstructExp(fd.loc, vthis, ethis);

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -446,7 +446,7 @@ public:
         // can't handle that at present.
         if (e.e1.op == TOKdotvar && (cast(DotVarExp)e.e1).e1.op == TOKsuper)
             cost = COST_MAX;
-        else if (e.f && e.f.ident == Id.__alloca && e.f.linkage == LINKc && !allowAlloca)
+        else if (e.f && e.f.ident == Id.__alloca && e.f.linkage == LINK.c && !allowAlloca)
             cost = COST_MAX; // inlining alloca may cause stack overflows
         else
             cost++;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -295,24 +295,24 @@ public:
     {
         switch (linkage)
         {
-        case LINKdefault:
+        case LINK.default_:
             // Should not be printed
             //property(name, "default");
             break;
-        case LINKd:
+        case LINK.d:
             // Should not be printed
             //property(name, "d");
             break;
-        case LINKc:
+        case LINK.c:
             property(name, "c");
             break;
-        case LINKcpp:
+        case LINK.cpp:
             property(name, "cpp");
             break;
-        case LINKwindows:
+        case LINK.windows:
             property(name, "windows");
             break;
-        case LINKpascal:
+        case LINK.pascal:
             property(name, "pascal");
             break;
         default:

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -293,7 +293,7 @@ public:
 
     void property(const(char)* name, LINK linkage)
     {
-        switch (linkage)
+        final switch (linkage)
         {
         case LINK.default_:
             // Should not be printed
@@ -302,6 +302,10 @@ public:
         case LINK.d:
             // Should not be printed
             //property(name, "d");
+            break;
+        case LINK.system:
+            // Should not be printed
+            //property(name, "system");
             break;
         case LINK.c:
             property(name, "c");
@@ -315,8 +319,9 @@ public:
         case LINK.pascal:
             property(name, "pascal");
             break;
-        default:
-            assert(false);
+        case LINK.objc:
+            property(name, "objc");
+            break;
         }
     }
 

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -434,6 +434,7 @@ public:
             return;
         jsonProperties(cast(Dsymbol)d);
         propertyStorageClass("storageClass", d.storage_class);
+        property("linkage", d.linkage);
         property("type", "deco", d.type);
         // Emit originalType if it differs from type
         if (d.type != d.originalType && d.originalType)

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -63,7 +63,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             }
             assert(sc);
             sc = sc.push(this);
-            sc.linkage = LINKcpp; // namespaces default to C++ linkage
+            sc.linkage = LINK.cpp; // namespaces default to C++ linkage
             sc.parent = this;
             foreach (s; *members)
             {
@@ -81,7 +81,7 @@ extern (C++) final class Nspace : ScopeDsymbol
         {
             assert(sc);
             sc = sc.push(this);
-            sc.linkage = LINKcpp; // namespaces default to C++ linkage
+            sc.linkage = LINK.cpp; // namespaces default to C++ linkage
             sc.parent = this;
             foreach (s; *members)
             {

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -253,7 +253,7 @@ extern(C++) private final class Supported : Objc
 
     override void checkLinkage(FuncDeclaration fd)
     {
-        if (fd.linkage != LINKobjc && fd.selector)
+        if (fd.linkage != LINK.objc && fd.selector)
             fd.error("must have Objective-C linkage to attach a selector");
     }
 

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -267,7 +267,7 @@ final class Parser(AST) : Lexer
         }
 
         mod = _module;
-        linkage = LINKd;
+        linkage = LINK.d;
         //nextToken();              // start up the scanner
     }
 
@@ -277,7 +277,7 @@ final class Parser(AST) : Lexer
 
         //printf("Parser::Parser()\n");
         mod = _module;
-        linkage = LINKd;
+        linkage = LINK.d;
         //nextToken();              // start up the scanner
     }
 
@@ -875,7 +875,7 @@ final class Parser(AST) : Lexer
                     AST.Identifiers* idents = null;
                     CPPMANGLE cppmangle;
                     const link = parseLinkage(&idents, cppmangle);
-                    if (pAttrs.link != LINKdefault)
+                    if (pAttrs.link != LINK.default_)
                     {
                         if (pAttrs.link != link)
                         {
@@ -896,7 +896,7 @@ final class Parser(AST) : Lexer
                     a = parseBlock(pLastDecl, pAttrs);
                     if (idents)
                     {
-                        assert(link == LINKcpp);
+                        assert(link == LINK.cpp);
                         assert(idents.dim);
                         for (size_t i = idents.dim; i;)
                         {
@@ -908,17 +908,17 @@ final class Parser(AST) : Lexer
                             }
                             s = new AST.Nspace(linkLoc, id, a);
                         }
-                        pAttrs.link = LINKdefault;
+                        pAttrs.link = LINK.default_;
                     }
                     else if (cppmangle != CPPMANGLE.def)
                     {
-                        assert(link == LINKcpp);
+                        assert(link == LINK.cpp);
                         s = new AST.CPPMangleDeclaration(cppmangle, a);
                     }
-                    else if (pAttrs.link != LINKdefault)
+                    else if (pAttrs.link != LINK.default_)
                     {
                         s = new AST.LinkDeclaration(pAttrs.link, a);
-                        pAttrs.link = LINKdefault;
+                        pAttrs.link = LINK.default_;
                     }
                     break;
                 }
@@ -2133,7 +2133,7 @@ final class Parser(AST) : Lexer
     {
         AST.Identifiers* idents = null;
         cppmangle = CPPMANGLE.def;
-        LINK link = LINKdefault;
+        LINK link = LINK.default_;
         nextToken();
         assert(token.value == TOKlparen);
         nextToken();
@@ -2142,17 +2142,17 @@ final class Parser(AST) : Lexer
             Identifier id = token.ident;
             nextToken();
             if (id == Id.Windows)
-                link = LINKwindows;
+                link = LINK.windows;
             else if (id == Id.Pascal)
-                link = LINKpascal;
+                link = LINK.pascal;
             else if (id == Id.D)
-                link = LINKd;
+                link = LINK.d;
             else if (id == Id.C)
             {
-                link = LINKc;
+                link = LINK.c;
                 if (token.value == TOKplusplus)
                 {
-                    link = LINKcpp;
+                    link = LINK.cpp;
                     nextToken();
                     if (token.value == TOKcomma) // , namespaces or class or struct
                     {
@@ -2196,7 +2196,7 @@ final class Parser(AST) : Lexer
                     nextToken();
                     if (token.ident == Id.C)
                     {
-                        link = LINKobjc;
+                        link = LINK.objc;
                         nextToken();
                     }
                     else
@@ -2207,18 +2207,18 @@ final class Parser(AST) : Lexer
             }
             else if (id == Id.System)
             {
-                link = LINKsystem;
+                link = LINK.system;
             }
             else
             {
             LinvalidLinkage:
                 error("valid linkage identifiers are `D`, `C`, `C++`, `Objective-C`, `Pascal`, `Windows`, `System`");
-                link = LINKd;
+                link = LINK.d;
             }
         }
         else
         {
-            link = LINKd; // default
+            link = LINK.d; // default
         }
         check(TOKrparen);
         *pidents = idents;
@@ -4672,7 +4672,7 @@ final class Parser(AST) : Lexer
 
         // The following is irrelevant, as it is overridden by sc.linkage in
         // TypeFunction::semantic
-        linkage = LINKd; // nested functions have D linkage
+        linkage = LINK.d; // nested functions have D linkage
     L1:
         switch (token.value)
         {

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -385,7 +385,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         {
             assert(sc);
             sc = sc.push(ns);
-            sc.linkage = LINKcpp;
+            sc.linkage = LINK.cpp;
             foreach (s; *ns.members)
             {
                 static if (LOG)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -315,7 +315,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc2.scontinue = null;
             sc2.sw = null;
             sc2.fes = funcdecl.fes;
-            sc2.linkage = LINKd;
+            sc2.linkage = LINK.d;
             sc2.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.abstract_ | STC.deprecated_ | STC.override_ | STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property | STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system);
             sc2.protection = Prot(Prot.Kind.public_);
             sc2.explicitProtection = 0;
@@ -374,7 +374,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             // Declare hidden variable _arguments[] and _argptr
             if (f.varargs == 1)
             {
-                if (f.linkage == LINKd)
+                if (f.linkage == LINK.d)
                 {
                     // Declare _arguments[]
                     funcdecl.v_arguments = new VarDeclaration(Loc(), Type.typeinfotypelist.type, Id._arguments_typeinfo, null);
@@ -391,7 +391,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     sc2.insert(_arguments);
                     _arguments.parent = funcdecl;
                 }
-                if (f.linkage == LINKd || (f.parameters && Parameter.dim(f.parameters)))
+                if (f.linkage == LINK.d || (f.parameters && Parameter.dim(f.parameters)))
                 {
                     // Declare _argptr
                     Type t = Type.tvalist;
@@ -1214,7 +1214,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         if (ns.members)
         {
             sc = sc.push(ns);
-            sc.linkage = LINKcpp;
+            sc.linkage = LINK.cpp;
             foreach (s; *ns.members)
             {
                 s.semantic3(sc);

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1627,7 +1627,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 // https://issues.dlang.org/show_bug.cgi?id=13840
                 // Throwable nested function inside nothrow function is acceptable.
                 StorageClass stc = mergeFuncAttrs(STC.safe | STC.pure_ | STC.nogc, fs.func);
-                tfld = new TypeFunction(params, Type.tint32, 0, LINKd, stc);
+                tfld = new TypeFunction(params, Type.tint32, 0, LINK.d, stc);
                 fs.cases = new Statements();
                 fs.gotos = new ScopeStatements();
                 auto fld = new FuncLiteralDeclaration(loc, Loc(), tfld, TOKdelegate, fs);
@@ -1707,7 +1707,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                         dgparams.push(new Parameter(0, Type.tvoidptr, null, null));
                         if (dim == 2)
                             dgparams.push(new Parameter(0, Type.tvoidptr, null, null));
-                        fldeTy[i] = new TypeDelegate(new TypeFunction(dgparams, Type.tint32, 0, LINKd));
+                        fldeTy[i] = new TypeDelegate(new TypeFunction(dgparams, Type.tint32, 0, LINK.d));
                         params.push(new Parameter(0, fldeTy[i], null, null));
                         fdapply[i] = FuncDeclaration.genCfunc(params, Type.tint32, name[i]);
                     }
@@ -1775,7 +1775,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     dgparams.push(new Parameter(0, Type.tvoidptr, null, null));
                     if (dim == 2)
                         dgparams.push(new Parameter(0, Type.tvoidptr, null, null));
-                    dgty = new TypeDelegate(new TypeFunction(dgparams, Type.tint32, 0, LINKd));
+                    dgty = new TypeDelegate(new TypeFunction(dgparams, Type.tint32, 0, LINK.d));
                     params.push(new Parameter(0, dgty, null, null));
                     fdapply = FuncDeclaration.genCfunc(params, Type.tint32, fdname.ptr);
 

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -433,13 +433,19 @@ struct Target
      */
     extern (C++) static void prefixName(OutBuffer* buf, LINK linkage)
     {
-        switch (linkage)
+        final switch (linkage)
         {
         case LINK.cpp:
             if (global.params.isOSX)
                 buf.prependbyte('_');
             break;
-        default:
+        case LINK.default_:
+        case LINK.d:
+        case LINK.c:
+        case LINK.windows:
+        case LINK.pascal:
+        case LINK.objc:
+        case LINK.system:
             break;
         }
     }

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -435,7 +435,7 @@ struct Target
     {
         switch (linkage)
         {
-        case LINKcpp:
+        case LINK.cpp:
             if (global.params.isOSX)
                 buf.prependbyte('_');
             break;
@@ -478,7 +478,7 @@ struct Target
      */
     extern (C++) static LINK systemLinkage()
     {
-        return global.params.isWindows ? LINKwindows : LINKc;
+        return global.params.isWindows ? LINK.windows : LINK.c;
     }
 
     /**

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -245,23 +245,23 @@ Symbol *toSymbol(Dsymbol s)
             mangle_t m = 0;
             switch (vd.linkage)
             {
-                case LINKwindows:
+                case LINK.windows:
                     m = global.params.is64bit ? mTYman_c : mTYman_std;
                     break;
 
-                case LINKpascal:
+                case LINK.pascal:
                     m = mTYman_pas;
                     break;
 
-                case LINKobjc:
-                case LINKc:
+                case LINK.objc:
+                case LINK.c:
                     m = mTYman_c;
                     break;
 
-                case LINKd:
+                case LINK.d:
                     m = mTYman_d;
                     break;
-                case LINKcpp:
+                case LINK.cpp:
                     s.Sflags |= SFLpublic;
                     m = mTYman_d;
                     break;
@@ -343,24 +343,24 @@ Symbol *toSymbol(Dsymbol s)
             {
                 switch (fd.linkage)
                 {
-                    case LINKwindows:
+                    case LINK.windows:
                         t.Tmangle = global.params.is64bit ? mTYman_c : mTYman_std;
                         break;
 
-                    case LINKpascal:
+                    case LINK.pascal:
                         t.Tty = TYnpfunc;
                         t.Tmangle = mTYman_pas;
                         break;
 
-                    case LINKc:
-                    case LINKobjc:
+                    case LINK.c:
+                    case LINK.objc:
                         t.Tmangle = mTYman_c;
                         break;
 
-                    case LINKd:
+                    case LINK.d:
                         t.Tmangle = mTYman_d;
                         break;
-                    case LINKcpp:
+                    case LINK.cpp:
                         s.Sflags |= SFLpublic;
                         if (fd.isThis() && !global.params.is64bit && global.params.isWindows)
                         {

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -243,7 +243,7 @@ Symbol *toSymbol(Dsymbol s)
             }
 
             mangle_t m = 0;
-            switch (vd.linkage)
+            final switch (vd.linkage)
             {
                 case LINK.windows:
                     m = global.params.is64bit ? mTYman_c : mTYman_std;
@@ -265,7 +265,8 @@ Symbol *toSymbol(Dsymbol s)
                     s.Sflags |= SFLpublic;
                     m = mTYman_d;
                     break;
-                default:
+                case LINK.default_:
+                case LINK.system:
                     printf("linkage = %d, vd = %s %s @ [%s]\n",
                         vd.linkage, vd.kind(), vd.toChars(), vd.loc.toChars());
                     assert(0);
@@ -341,7 +342,7 @@ Symbol *toSymbol(Dsymbol s)
             }
             else
             {
-                switch (fd.linkage)
+                final switch (fd.linkage)
                 {
                     case LINK.windows:
                         t.Tmangle = global.params.is64bit ? mTYman_c : mTYman_std;
@@ -375,7 +376,8 @@ Symbol *toSymbol(Dsymbol s)
                         }
                         t.Tmangle = mTYman_d;
                         break;
-                    default:
+                    case LINK.default_:
+                    case LINK.system:
                         printf("linkage = %d\n", fd.linkage);
                         assert(0);
                 }

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1011,7 +1011,7 @@ Lagain:
         if (tns.ty != Tstruct)
         {
 L2:
-            if (global.params.isLinux && tf.linkage != LINKd && !global.params.is64bit)
+            if (global.params.isLinux && tf.linkage != LINK.d && !global.params.is64bit)
             {
                                                 // 32 bit C/C++ structs always on stack
             }
@@ -1038,7 +1038,7 @@ L2:
     if (tns.ty == Tstruct)
     {
         StructDeclaration sd = (cast(TypeStruct)tns).sym;
-        if (global.params.isLinux && tf.linkage != LINKd && !global.params.is64bit)
+        if (global.params.isLinux && tf.linkage != LINK.d && !global.params.is64bit)
         {
             if (sd.ident == Id.__c_long || sd.ident == Id.__c_ulong)
                 return RET.regs;
@@ -1046,7 +1046,7 @@ L2:
             //printf("  2 RET.stack\n");
             return RET.stack;            // 32 bit C/C++ structs always on stack
         }
-        if (global.params.isWindows && tf.linkage == LINKcpp && !global.params.is64bit &&
+        if (global.params.isWindows && tf.linkage == LINK.cpp && !global.params.is64bit &&
                  sd.isPOD() && sd.ctor)
         {
             // win32 returns otherwise POD structs with ctors via memory
@@ -1088,7 +1088,7 @@ L2:
         return RET.stack;
     }
     else if ((global.params.isLinux || global.params.isOSX || global.params.isFreeBSD || global.params.isSolaris) &&
-             tf.linkage == LINKc &&
+             tf.linkage == LINK.c &&
              tns.iscomplex())
     {
         if (tns.ty == Tcomplex32)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1139,7 +1139,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     else if (auto f = s.isFuncDeclaration())
                     {
                         objmod.setModuleCtorDtor(s.csym, isCtor);
-                        if (f.linkage != LINKc)
+                        if (f.linkage != LINK.c)
                             f.error("must be extern(C) for pragma %s", isCtor ? "crt_constructor".ptr : "crt_destructor".ptr);
                         return 1;
                     }
@@ -1324,7 +1324,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             Symbol *tlvInit = symbol_name(tlvInitName, SCstatic, t);
             tlvInit.Sdt = null;
             tlvInit.Salignment = type_alignsize(s.Stype);
-            if (vd.linkage == LINKcpp)
+            if (vd.linkage == LINK.cpp)
                 tlvInit.Sflags |= SFLpublic;
 
             return tlvInit;
@@ -1343,20 +1343,20 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             switch (vd.linkage)
             {
-                case LINKwindows:
+                case LINK.windows:
                     return global.params.is64bit ? mTYman_c : mTYman_std;
 
-                case LINKpascal:
+                case LINK.pascal:
                     return mTYman_pas;
 
-                case LINKobjc:
-                case LINKc:
+                case LINK.objc:
+                case LINK.c:
                     return mTYman_c;
 
-                case LINKd:
+                case LINK.d:
                     return mTYman_d;
 
-                case LINKcpp:
+                case LINK.cpp:
                     return mTYman_d;
 
                 default:

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1341,7 +1341,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
          */
         static mangle_t mangle(const VarDeclaration vd)
         {
-            switch (vd.linkage)
+            final switch (vd.linkage)
             {
                 case LINK.windows:
                     return global.params.is64bit ? mTYman_c : mTYman_std;
@@ -1359,7 +1359,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 case LINK.cpp:
                     return mTYman_d;
 
-                default:
+                case LINK.default_:
+                case LINK.system:
                     printf("linkage = %d\n", vd.linkage);
                     assert(0);
             }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1082,7 +1082,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             errors = true;
         }
 
-        if (tf.varargs == 1 && tf.linkage != LINKd && Parameter.dim(tf.parameters) == 0)
+        if (tf.varargs == 1 && tf.linkage != LINK.d && Parameter.dim(tf.parameters) == 0)
         {
             mtype.error(loc, "variadic functions with non-D linkage must have at least one parameter");
             errors = true;

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -807,6 +807,123 @@
       "offset" : 0
      }
     ]
+   },
+   {
+    "name" : "vlinkageDefault",
+    "kind" : "variable",
+    "line" : 180,
+    "char" : 12,
+    "storageClass" : [
+     "extern"
+    ],
+    "deco" : "i"
+   },
+   {
+    "name" : "vlinkageD",
+    "kind" : "variable",
+    "line" : 181,
+    "char" : 15,
+    "deco" : "i"
+   },
+   {
+    "name" : "vlinakgeC",
+    "kind" : "variable",
+    "line" : 182,
+    "char" : 15,
+    "linkage" : "c",
+    "deco" : "i"
+   },
+   {
+    "name" : "vlinkageCpp",
+    "kind" : "variable",
+    "line" : 183,
+    "char" : 27,
+    "storageClass" : [
+     "__gshared"
+    ],
+    "linkage" : "cpp",
+    "deco" : "i"
+   },
+   {
+    "name" : "vlinkageWindows",
+    "kind" : "variable",
+    "line" : 184,
+    "char" : 21,
+    "linkage" : "windows",
+    "deco" : "i"
+   },
+   {
+    "name" : "vlinkagePascal",
+    "kind" : "variable",
+    "line" : 185,
+    "char" : 20,
+    "linkage" : "pascal",
+    "deco" : "i"
+   },
+   {
+    "name" : "vlinkageObjc",
+    "kind" : "variable",
+    "line" : 186,
+    "char" : 25,
+    "linkage" : "objc",
+    "deco" : "i"
+   },
+   {
+    "name" : "flinkageDefault",
+    "kind" : "function",
+    "line" : 188,
+    "char" : 12,
+    "storageClass" : [
+     "extern"
+    ],
+    "deco" : "FZi"
+   },
+   {
+    "name" : "flinkageD",
+    "kind" : "function",
+    "line" : 189,
+    "char" : 15,
+    "deco" : "FZi"
+   },
+   {
+    "name" : "linakgeC",
+    "kind" : "function",
+    "line" : 190,
+    "char" : 15,
+    "linkage" : "c",
+    "deco" : "UZi"
+   },
+   {
+    "name" : "flinkageCpp",
+    "kind" : "function",
+    "line" : 191,
+    "char" : 17,
+    "linkage" : "cpp",
+    "deco" : "RZi"
+   },
+   {
+    "name" : "flinkageWindows",
+    "kind" : "function",
+    "line" : 192,
+    "char" : 21,
+    "linkage" : "windows",
+    "deco" : "WZi"
+   },
+   {
+    "name" : "flinkagePascal",
+    "kind" : "function",
+    "line" : 193,
+    "char" : 20,
+    "linkage" : "pascal",
+    "deco" : "VZi"
+   },
+   {
+    "name" : "flinkageObjc",
+    "kind" : "function",
+    "line" : 194,
+    "char" : 25,
+    "linkage" : "objc",
+    "deco" : "YZi"
    }
   ]
  }

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -176,3 +176,19 @@ struct SafeS
 
 	int* p;
 }
+
+extern int vlinkageDefault;
+extern(D) int vlinkageD;
+extern(C) int vlinakgeC;
+extern(C++) __gshared int vlinkageCpp;
+extern(Windows) int vlinkageWindows;
+extern(Pascal) int vlinkagePascal;
+extern(Objective-C) int vlinkageObjc;
+
+extern int flinkageDefault();
+extern(D) int flinkageD();
+extern(C) int linakgeC();
+extern(C++) int flinkageCpp();
+extern(Windows) int flinkageWindows();
+extern(Pascal) int flinkagePascal();
+extern(Objective-C) int flinkageObjc();


### PR DESCRIPTION
```bash
replacements=(
"LINKdefault default_"
"LINKd d"
"LINKc c"
"LINKcpp cpp"
"LINKwindows windows"
"LINKpascal pascal"
"LINKobjc objc"
"LINKsystem system"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/LINK.${w[1]}/g" -i **/*.d
done
```