### PR TITLE
Automatically convert TARGET_XXXX to a TARGET enum

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -27,12 +27,15 @@ template xversion(string s)
 
 enum IN_GCC     = xversion!`IN_GCC`;
 
-enum TARGET_LINUX   = xversion!`linux`;
-enum TARGET_OSX     = xversion!`OSX`;
-enum TARGET_FREEBSD = xversion!`FreeBSD`;
-enum TARGET_OPENBSD = xversion!`OpenBSD`;
-enum TARGET_SOLARIS = xversion!`Solaris`;
-enum TARGET_WINDOS  = xversion!`Windows`;
+enum TARGET : bool
+{
+    Linux   = xversion!`linux`,
+    OSX     = xversion!`OSX`,
+    FreeBSD = xversion!`FreeBSD`,
+    OpenBSD = xversion!`OpenBSD`,
+    Solaris = xversion!`Solaris`,
+    Windows = xversion!`Windows`,
+}
 
 enum CHECKENABLE : ubyte
 {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -293,11 +293,11 @@ struct Global
 
     extern (C++) void _init()
     {
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             obj_ext = "obj";
         }
-        else static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
         {
             obj_ext = "o";
         }
@@ -305,11 +305,11 @@ struct Global
         {
             static assert(0, "fix this");
         }
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             lib_ext = "lib";
         }
-        else static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
         {
             lib_ext = "a";
         }
@@ -317,15 +317,15 @@ struct Global
         {
             static assert(0, "fix this");
         }
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             dll_ext = "dll";
         }
-        else static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
         {
             dll_ext = "so";
         }
-        else static if (TARGET_OSX)
+        else static if (TARGET.OSX)
         {
             dll_ext = "dylib";
         }
@@ -333,11 +333,11 @@ struct Global
         {
             static assert(0, "fix this");
         }
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             run_noext = false;
         }
-        else static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
         {
             // Allow 'script' D source files to have no extension.
             run_noext = true;

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -23,16 +23,16 @@ import dmd.root.outbuffer;
 import dmd.root.file;
 import dmd.root.filename;
 
-static if (TARGET_WINDOS)
+static if (TARGET.Windows)
 {
     import dmd.libomf;
     import dmd.libmscoff;
 }
-else static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
 {
     import dmd.libelf;
 }
-else static if (TARGET_OSX)
+else static if (TARGET.OSX)
 {
     import dmd.libmach;
 }
@@ -47,15 +47,15 @@ class Library
 {
     static Library factory()
     {
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             return (global.params.mscoff || global.params.is64bit) ? LibMSCoff_factory() : LibOMF_factory();
         }
-        else static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
         {
             return LibElf_factory();
         }
-        else static if (TARGET_OSX)
+        else static if (TARGET.OSX)
         {
             return LibMach_factory();
         }

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -203,7 +203,7 @@ private int tryMain(size_t argc, const(char)** argv)
     global.params.argv0 = arguments[0];
 
     // Temporary: Use 32 bits as the default on Windows, for config parsing
-    static if (TARGET_WINDOS)
+    static if (TARGET.Windows)
         global.params.is64bit = false;
 
     global.inifilename = parse_conf_arg(&arguments);
@@ -356,16 +356,16 @@ private int tryMain(size_t argc, const(char)** argv)
         usage();
         return EXIT_FAILURE;
     }
-    static if (TARGET_OSX)
+    static if (TARGET.OSX)
     {
         global.params.pic = 1;
     }
-    static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+    static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
     {
         if (global.params.lib && global.params.dll)
             error(Loc(), "cannot mix -lib and -shared");
     }
-    static if (TARGET_WINDOS)
+    static if (TARGET.Windows)
     {
         if (!global.params.mscrtlib)
             global.params.mscrtlib = "libcmt";
@@ -539,7 +539,7 @@ private int tryMain(size_t argc, const(char)** argv)
                 libmodules.push(files[i]);
                 continue;
             }
-            static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+            static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
             {
                 if (FileName.equals(ext, global.dll_ext))
                 {
@@ -564,7 +564,7 @@ private int tryMain(size_t argc, const(char)** argv)
                 global.params.mapfile = files[i];
                 continue;
             }
-            static if (TARGET_WINDOS)
+            static if (TARGET.Windows)
             {
                 if (FileName.equals(ext, "res"))
                 {
@@ -1185,7 +1185,7 @@ private void setDefaultLibrary()
 {
     if (global.params.defaultlibname is null)
     {
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             if (global.params.is64bit)
                 global.params.defaultlibname = "phobos64";
@@ -1194,11 +1194,11 @@ private void setDefaultLibrary()
             else
                 global.params.defaultlibname = "phobos";
         }
-        else static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
         {
             global.params.defaultlibname = "libphobos2.a";
         }
-        else static if (TARGET_OSX)
+        else static if (TARGET.OSX)
         {
             global.params.defaultlibname = "phobos2";
         }
@@ -1224,19 +1224,19 @@ private void setDefaultLibrary()
 private void addDefaultVersionIdentifiers()
 {
     VersionCondition.addPredefinedGlobalIdent("DigitalMars");
-    static if (TARGET_WINDOS)
+    static if (TARGET.Windows)
     {
         VersionCondition.addPredefinedGlobalIdent("Windows");
         global.params.isWindows = true;
     }
-    else static if (TARGET_LINUX)
+    else static if (TARGET.Linux)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("linux");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         global.params.isLinux = true;
     }
-    else static if (TARGET_OSX)
+    else static if (TARGET.OSX)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OSX");
@@ -1244,21 +1244,21 @@ private void addDefaultVersionIdentifiers()
         // For legacy compatibility
         VersionCondition.addPredefinedGlobalIdent("darwin");
     }
-    else static if (TARGET_FREEBSD)
+    else static if (TARGET.FreeBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("FreeBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         global.params.isFreeBSD = true;
     }
-    else static if (TARGET_OPENBSD)
+    else static if (TARGET.OpenBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OpenBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         global.params.isOpenBSD = true;
     }
-    else static if (TARGET_SOLARIS)
+    else static if (TARGET.Solaris)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("Solaris");
@@ -1286,7 +1286,7 @@ private void addDefaultVersionIdentifiers()
     {
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86_64");
         VersionCondition.addPredefinedGlobalIdent("X86_64");
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             VersionCondition.addPredefinedGlobalIdent("Win64");
         }
@@ -1296,19 +1296,19 @@ private void addDefaultVersionIdentifiers()
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm"); //legacy
         VersionCondition.addPredefinedGlobalIdent("D_InlineAsm_X86");
         VersionCondition.addPredefinedGlobalIdent("X86");
-        static if (TARGET_WINDOS)
+        static if (TARGET.Windows)
         {
             VersionCondition.addPredefinedGlobalIdent("Win32");
         }
     }
-    static if (TARGET_WINDOS)
+    static if (TARGET.Windows)
     {
         if (global.params.mscoff)
             VersionCondition.addPredefinedGlobalIdent("CRuntime_Microsoft");
         else
             VersionCondition.addPredefinedGlobalIdent("CRuntime_DigitalMars");
     }
-    else static if (TARGET_LINUX)
+    else static if (TARGET.Linux)
     {
         VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
     }
@@ -1364,7 +1364,7 @@ private CPU setTargetCPU(CPU cpu)
         baseline = CPU.sse2;
     else
     {
-        static if (TARGET_OSX)
+        static if (TARGET.OSX)
         {
             baseline = CPU.sse2;
         }
@@ -1528,7 +1528,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 params.dll = true;
             else if (arg == "-dylib")
             {
-                static if (TARGET_OSX)
+                static if (TARGET.OSX)
                 {
                     Loc loc;
                     deprecation(loc, "use -shared instead of -dylib");
@@ -1541,7 +1541,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             }
             else if (arg == "-fPIC")
             {
-                static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+                static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
                 {
                     params.pic = 1;
                 }
@@ -1585,14 +1585,14 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             else if (arg == "-m64") // https://dlang.org/dmd.html#switch-m64
             {
                 params.is64bit = true;
-                static if (TARGET_WINDOS)
+                static if (TARGET.Windows)
                 {
                     params.mscoff = true;
                 }
             }
             else if (arg == "-m32mscoff") // https://dlang.org/dmd.html#switch-m32mscoff
             {
-                static if (TARGET_WINDOS)
+                static if (TARGET.Windows)
                 {
                     params.is64bit = 0;
                     params.mscoff = true;
@@ -1604,7 +1604,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             }
             else if (strncmp(p + 1, "mscrtlib=", 9) == 0)
             {
-                static if (TARGET_WINDOS)
+                static if (TARGET.Windows)
                 {
                     params.mscrtlib = p + 10;
                 }
@@ -2141,7 +2141,7 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
         }
         else
         {
-            static if (TARGET_WINDOS)
+            static if (TARGET.Windows)
             {
                 const(char)* ext = FileName.ext(p);
                 if (ext && FileName.compare(ext, "exe") == 0)

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -446,9 +446,9 @@ struct Target
 
     extern (C++) static const(char)* toCppMangle(Dsymbol s)
     {
-        static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
             return toCppMangleItanium(s);
-        else static if (TARGET_WINDOS)
+        else static if (TARGET.Windows)
             return toCppMangleMSVC(s);
         else
             static assert(0, "fix this");
@@ -456,9 +456,9 @@ struct Target
 
     extern (C++) static const(char)* cppTypeInfoMangle(ClassDeclaration cd)
     {
-        static if (TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS)
+        static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris)
             return cppTypeInfoMangleItanium(cd);
-        else static if (TARGET_WINDOS)
+        else static if (TARGET.Windows)
             return cppTypeInfoMangleMSVC(cd);
         else
             static assert(0, "fix this");


### PR DESCRIPTION
```bash
replacements=(
"TARGET_LINUX linux"
"TARGET_OSX OSX"
"TARGET_FREEBSD FreeBSD"
"TARGET_OPENBSD OpenBSD"
"TARGET_SOLARIS Solaris"
"TARGET_WINDOS Windows"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/TARGET.${w[1]}/g" -i **/*.d
done
```