### PR TITLE
Automatically convert PKGXXX to PKG

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -462,7 +462,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Package p)
             return false;
     }
     auto name = p.toPrettyChars();
-    if (p.isPkgMod == PKGmodule || p.isModule())
+    if (p.isPkgMod == PKG.module_ || p.isModule())
         deprecation(loc, "%s %s is not accessible here, perhaps add 'static import %s;'", p.kind(), name, name);
     else
         deprecation(loc, "%s %s is not accessible here", p.kind(), name);

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -969,7 +969,7 @@ struct ASTBase
         final extern (D) this(Identifier ident)
         {
             super(ident);
-            this.isPkgMod = PKGunknown;
+            this.isPkgMod = PKG.unknown;
             __gshared uint packageTag;
             this.tag = packageTag++;
         }

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -245,14 +245,10 @@ struct ASTBase
 
     enum PKG : int
     {
-        PKGunknown,     // not yet determined whether it's a package.d or not
-        PKGmodule,      // already determined that's an actual package.d
-        PKGpackage,     // already determined that's an actual package
+        unknown,     // not yet determined whether it's a package.d or not
+        module_,      // already determined that's an actual package.d
+        package_,     // already determined that's an actual package
     }
-
-    alias PKGunknown = PKG.PKGunknown;
-    alias PKGmodule = PKG.PKGmodule;
-    alias PKGpackage = PKG.PKGpackage;
 
     enum StructPOD : int
     {

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -147,15 +147,15 @@ extern (C++) final class Import : Dsymbol
                 }
                 else if (Package p = s.isPackage())
                 {
-                    if (p.isPkgMod == PKGunknown)
+                    if (p.isPkgMod == PKG.unknown)
                     {
                         mod = Module.load(loc, packages, id);
                         if (!mod)
-                            p.isPkgMod = PKGpackage;
+                            p.isPkgMod = PKG.package_;
                         else
                         {
                             // mod is a package.d, or a normal module which conflicts with the package name.
-                            assert(mod.isPackageFile == (p.isPkgMod == PKGmodule));
+                            assert(mod.isPackageFile == (p.isPkgMod == PKG.module_));
                             if (mod.isPackageFile)
                                 mod.tag = p.tag; // reuse the same package tag
                         }

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -153,12 +153,12 @@ extern (C++) class Package : ScopeDsymbol
 {
     PKG isPkgMod;
     uint tag;        // auto incremented tag, used to mask package tree in scopes
-    Module mod;     // !=null if isPkgMod == PKGmodule
+    Module mod;     // !=null if isPkgMod == PKG.module_
 
     final extern (D) this(Identifier ident)
     {
         super(ident);
-        this.isPkgMod = PKGunknown;
+        this.isPkgMod = PKG.unknown;
         __gshared uint packageTag;
         this.tag = packageTag++;
     }
@@ -278,7 +278,7 @@ extern (C++) class Package : ScopeDsymbol
 
     final Module isPackageMod()
     {
-        if (isPkgMod == PKGmodule)
+        if (isPkgMod == PKG.module_)
         {
             return mod;
         }
@@ -988,12 +988,12 @@ extern (C++) final class Module : Package
              *
              * To avoid the conflict:
              * 1. If preceding package name insertion had occurred by Package::resolve,
-             *    later package.d loading will change Package::isPkgMod to PKGmodule and set Package::mod.
+             *    later package.d loading will change Package::isPkgMod to PKG.module_ and set Package::mod.
              * 2. Otherwise, 'package.d' wrapped by 'Package' is inserted to the internal tree in here.
              */
             auto p = new Package(ident);
             p.parent = this.parent;
-            p.isPkgMod = PKGmodule;
+            p.isPkgMod = PKG.module_;
             p.mod = this;
             p.tag = this.tag; // reuse the same package tag
             p.symtab = new DsymbolTable();
@@ -1020,12 +1020,12 @@ extern (C++) final class Module : Package
             }
             else if (Package pkg = prev.isPackage())
             {
-                if (pkg.isPkgMod == PKGunknown && isPackageFile)
+                if (pkg.isPkgMod == PKG.unknown && isPackageFile)
                 {
                     /* If the previous inserted Package is not yet determined as package.d,
                      * link it to the actual module.
                      */
-                    pkg.isPkgMod = PKGmodule;
+                    pkg.isPkgMod = PKG.module_;
                     pkg.mod = this;
                     pkg.tag = this.tag; // reuse the same package tag
                     amodules.push(this); // Add to global array of all modules

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -142,14 +142,10 @@ void semantic3OnDependencies(Module m)
 
 enum PKG : int
 {
-    PKGunknown,     // not yet determined whether it's a package.d or not
-    PKGmodule,      // already determined that's an actual package.d
-    PKGpackage,     // already determined that's an actual package
+    unknown,     // not yet determined whether it's a package.d or not
+    module_,      // already determined that's an actual package.d
+    package_,     // already determined that's an actual package
 }
-
-alias PKGunknown = PKG.PKGunknown;
-alias PKGmodule = PKG.PKGmodule;
-alias PKGpackage = PKG.PKGpackage;
 
 /***********************************************************
  */


### PR DESCRIPTION
```bash
replacements=(
"PKGunknown unknown"
"PKGmodule module_"
"PKGpackage package_"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed "s/${w[0]}/PKG.${w[1]}/g" -i **/*.d
done
```