### PR TITLE
Convert TXXXX to an enum

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -417,7 +417,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
             return true;
         }
     }
-    else if (e.type.ty == Tclass)
+    else if (e.type.ty == TY.class_)
     {
         // Do access check
         ClassDeclaration cd = (cast(TypeClass)e.type).sym;
@@ -429,7 +429,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
         }
         return checkAccess(cd, loc, sc, d);
     }
-    else if (e.type.ty == Tstruct)
+    else if (e.type.ty == TY.struct_)
     {
         // Do access check
         StructDeclaration cd = (cast(TypeStruct)e.type).sym;

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -181,11 +181,11 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             if (v.storage_class & STC.ref_)
                 return 0;
             auto tv = v.type.baseElemOf();
-            if (tv.ty != Tstruct)
+            if (tv.ty != TY.struct_)
                 return 0;
             if (ad == (cast(TypeStruct)tv).sym)
             {
-                const(char)* psz = (v.type.toBasetype().ty == Tsarray) ? "static array of " : "";
+                const(char)* psz = (v.type.toBasetype().ty == TY.sarray) ? "static array of " : "";
                 ad.error("cannot have field `%s` with %ssame struct type", v.toChars(), psz);
                 ad.type = Type.terror;
                 ad.errors = true;
@@ -224,7 +224,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
         // The previous instance size finalizing had:
-        if (type.ty == Terror)
+        if (type.ty == TY.error)
             return false;   // failed already
         if (sizeok == Sizeok.done)
             return true;    // succeeded
@@ -253,7 +253,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             finalizeSize();
 
         // this aggregate type has:
-        if (type.ty == Terror)
+        if (type.ty == TY.error)
             return false;   // marked as invalid during the finalizing.
         if (sizeok == Sizeok.done)
             return true;    // succeeded to calculate instance size.
@@ -479,16 +479,16 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                      * Get the element of static array type.
                      */
                     Type telem = vx.type;
-                    if (telem.ty == Tsarray)
+                    if (telem.ty == TY.sarray)
                     {
                         /* We cannot use Type::baseElemOf() here.
-                         * If the bottom of the Tsarray is an enum type, baseElemOf()
+                         * If the bottom of the TY.sarray is an enum type, baseElemOf()
                          * will return the base of the enum, and its default initializer
                          * would be different from the enum's.
                          */
-                        while (telem.toBasetype().ty == Tsarray)
+                        while (telem.toBasetype().ty == TY.sarray)
                             telem = (cast(TypeSArray)telem.toBasetype()).next;
-                        if (telem.ty == Tvoid)
+                        if (telem.ty == TY.void_)
                             telem = Type.tuns8.addMod(telem.mod);
                     }
                     if (telem.needsNested() && ctorinit)
@@ -648,7 +648,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         {
             //printf("makeNested %s, enclosing = %s\n", toChars(), enclosing.toChars());
             assert(t);
-            if (t.ty == Tstruct)
+            if (t.ty == TY.struct_)
                 t = Type.tvoidptr; // t should not be a ref type
 
             assert(!vthis);

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -50,7 +50,7 @@ TypeTuple toArgTypes(Type t)
         {
             Type t1 = null;
             Type t2 = null;
-            switch (t.ty)
+            final switch (t.ty)
             {
             case TY.void_:
                 return;
@@ -105,8 +105,28 @@ TypeTuple toArgTypes(Type t)
             case TY.dchar_:
                 t1 = Type.tuns32;
                 break;
-            default:
-                assert(0);
+            case TY.array:
+            case TY.sarray:
+            case TY.aarray:
+            case TY.pointer:
+            case TY.reference:
+            case TY.function_:
+            case TY.ident:
+            case TY.class_:
+            case TY.struct_:
+            case TY.enum_:
+            case TY.delegate_:
+            case TY.none:
+            case TY.error:
+            case TY.instance:
+            case TY.typeof_:
+            case TY.tuple:
+            case TY.slice:
+            case TY.return_:
+            case TY.null_:
+            case TY.vector:
+            case TY.MAX:
+                break;
             }
             if (t1)
             {

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -52,34 +52,34 @@ TypeTuple toArgTypes(Type t)
             Type t2 = null;
             switch (t.ty)
             {
-            case Tvoid:
+            case TY.void_:
                 return;
-            case Tbool:
-            case Tint8:
-            case Tuns8:
-            case Tint16:
-            case Tuns16:
-            case Tint32:
-            case Tuns32:
-            case Tfloat32:
-            case Tint64:
-            case Tuns64:
-            case Tint128:
-            case Tuns128:
-            case Tfloat64:
-            case Tfloat80:
+            case TY.bool_:
+            case TY.int8:
+            case TY.uns8:
+            case TY.int16:
+            case TY.uns16:
+            case TY.int32:
+            case TY.uns32:
+            case TY.float32:
+            case TY.int64:
+            case TY.uns64:
+            case TY.int128:
+            case TY.uns128:
+            case TY.float64:
+            case TY.float80:
                 t1 = t;
                 break;
-            case Timaginary32:
+            case TY.imaginary32:
                 t1 = Type.tfloat32;
                 break;
-            case Timaginary64:
+            case TY.imaginary64:
                 t1 = Type.tfloat64;
                 break;
-            case Timaginary80:
+            case TY.imaginary80:
                 t1 = Type.tfloat80;
                 break;
-            case Tcomplex32:
+            case TY.complex32:
                 if (global.params.is64bit)
                     t1 = Type.tfloat64;
                 else
@@ -88,21 +88,21 @@ TypeTuple toArgTypes(Type t)
                     t2 = Type.tfloat64;
                 }
                 break;
-            case Tcomplex64:
+            case TY.complex64:
                 t1 = Type.tfloat64;
                 t2 = Type.tfloat64;
                 break;
-            case Tcomplex80:
+            case TY.complex80:
                 t1 = Type.tfloat80;
                 t2 = Type.tfloat80;
                 break;
-            case Tchar:
+            case TY.char_:
                 t1 = Type.tuns8;
                 break;
-            case Twchar:
+            case TY.wchar_:
                 t1 = Type.tuns16;
                 break;
-            case Tdchar:
+            case TY.dchar_:
                 t1 = Type.tuns32;
                 break;
             default:
@@ -160,13 +160,13 @@ TypeTuple toArgTypes(Type t)
         {
             switch (t.ty)
             {
-            case Tfloat32:
-            case Timaginary32:
+            case TY.float32:
+            case TY.imaginary32:
                 t = Type.tint32;
                 break;
-            case Tfloat64:
-            case Timaginary64:
-            case Tcomplex32:
+            case TY.float64:
+            case TY.imaginary64:
+            case TY.complex32:
                 t = Type.tint64;
                 break;
             default:
@@ -201,10 +201,10 @@ TypeTuple toArgTypes(Type t)
             const sz1 = t1.size(Loc());
             const sz2 = t2.size(Loc());
             assert(sz1 != SIZE_INVALID && sz2 != SIZE_INVALID);
-            if (t1.ty != t2.ty && (t1.ty == Tfloat80 || t2.ty == Tfloat80))
+            if (t1.ty != t2.ty && (t1.ty == TY.float80 || t2.ty == TY.float80))
                 return null;
             // [float,float] => [cfloat]
-            if (t1.ty == Tfloat32 && t2.ty == Tfloat32 && offset2 == 4)
+            if (t1.ty == TY.float32 && t2.ty == TY.float32 && offset2 == 4)
                 return Type.tfloat64;
             // Merging floating and non-floating types produces the non-floating type
             if (t1.isfloating())
@@ -403,7 +403,7 @@ TypeTuple toArgTypes(Type t)
                     {
                         if (t1.isfloating() && t2.isfloating())
                         {
-                            if ((t1.ty == Tfloat32 || t1.ty == Tfloat64) && (t2.ty == Tfloat32 || t2.ty == Tfloat64))
+                            if ((t1.ty == TY.float32 || t1.ty == TY.float64) && (t2.ty == TY.float32 || t2.ty == TY.float64))
                             {
                             }
                             else
@@ -448,7 +448,7 @@ TypeTuple toArgTypes(Type t)
                 if (tup && tup.arguments.dim == 1)
                 {
                     Type ft1 = (*tup.arguments)[0].type;
-                    if (ft1.ty == Tfloat32 || ft1.ty == Tfloat64)
+                    if (ft1.ty == TY.float32 || ft1.ty == TY.float64)
                         t1 = ft1;
                 }
             }

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -39,12 +39,12 @@ extern (C++) bool isArrayOpValid(Expression e)
     if (e.op == TOKarrayliteral)
     {
         Type t = e.type.toBasetype();
-        while (t.ty == Tarray || t.ty == Tsarray)
+        while (t.ty == TY.array || t.ty == TY.sarray)
             t = t.nextOf().toBasetype();
-        return (t.ty != Tvoid);
+        return (t.ty != TY.void_);
     }
     Type tb = e.type.toBasetype();
-    if (tb.ty == Tarray || tb.ty == Tsarray)
+    if (tb.ty == TY.array || tb.ty == TY.sarray)
     {
         if (isUnaArrayOp(e.op))
         {
@@ -78,7 +78,7 @@ extern (C++) bool isNonAssignmentArrayOp(Expression e)
         return isNonAssignmentArrayOp((cast(SliceExp)e).e1);
 
     Type tb = e.type.toBasetype();
-    if (tb.ty == Tarray || tb.ty == Tsarray)
+    if (tb.ty == TY.array || tb.ty == TY.sarray)
     {
         return (isUnaArrayOp(e.op) || isBinArrayOp(e.op));
     }
@@ -113,9 +113,9 @@ extern (C++) Expression arrayOp(BinExp e, Scope* sc)
 {
     //printf("BinExp.arrayOp() %s\n", toChars());
     Type tb = e.type.toBasetype();
-    assert(tb.ty == Tarray || tb.ty == Tsarray);
+    assert(tb.ty == TY.array || tb.ty == TY.sarray);
     Type tbn = tb.nextOf().toBasetype();
-    if (tbn.ty == Tvoid)
+    if (tbn.ty == TY.void_)
     {
         e.error("cannot perform array operations on `void[]` arrays");
         return new ErrorExp();
@@ -209,7 +209,7 @@ private void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Expressions*
         override void visit(UnaExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty != Tarray && tb.ty != Tsarray) // hoist scalar expressions
+            if (tb.ty != TY.array && tb.ty != TY.sarray) // hoist scalar expressions
             {
                 visit(cast(Expression) e);
             }
@@ -227,7 +227,7 @@ private void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Expressions*
         override void visit(BinExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty != Tarray && tb.ty != Tsarray) // hoist scalar expressions
+            if (tb.ty != TY.array && tb.ty != TY.sarray) // hoist scalar expressions
             {
                 visit(cast(Expression) e);
             }
@@ -318,12 +318,12 @@ extern (C++) bool isArrayOpOperand(Expression e)
     if (e.op == TOKarrayliteral)
     {
         Type t = e.type.toBasetype();
-        while (t.ty == Tarray || t.ty == Tsarray)
+        while (t.ty == TY.array || t.ty == TY.sarray)
             t = t.nextOf().toBasetype();
-        return (t.ty != Tvoid);
+        return (t.ty != TY.void_);
     }
     Type tb = e.type.toBasetype();
-    if (tb.ty == Tarray)
+    if (tb.ty == TY.array)
     {
         return (isUnaArrayOp(e.op) ||
                 isBinArrayOp(e.op) ||

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1730,7 +1730,7 @@ struct ASTBase
                 Parameter p = (*parameters)[i];
                 Type t = p.type.toBasetype();
 
-                if (t.ty == Ttuple)
+                if (t.ty == TY.tuple)
                 {
                     TypeTuple tu = cast(TypeTuple)t;
                     result = _foreach(tu.arguments, dg, &n);
@@ -2478,8 +2478,8 @@ struct ASTBase
         }
     }
 
-    extern (C++) __gshared int Tsize_t = Tuns32;
-    extern (C++) __gshared int Tptrdiff_t = Tint32;
+    extern (C++) __gshared int Tsize_t = TY.uns32;
+    extern (C++) __gshared int Tptrdiff_t = TY.int32;
 
     extern (C++) abstract class Type : RootObject
     {
@@ -2512,7 +2512,7 @@ struct ASTBase
         extern (C++) static __gshared Type twchar;
         extern (C++) static __gshared Type tdchar;
 
-        extern (C++) static __gshared Type[TMAX] basic;
+        extern (C++) static __gshared Type[TY.MAX] basic;
 
         extern (C++) static __gshared Type tshiftcnt;
         extern (C++) static __gshared Type tvoidptr;    // void*
@@ -2547,28 +2547,28 @@ struct ASTBase
         extern (C++) static __gshared ClassDeclaration typeinfoshared;
         extern (C++) static __gshared ClassDeclaration typeinfowild;
         extern (C++) static __gshared StringTable stringtable;
-        extern (C++) static __gshared ubyte[TMAX] sizeTy = ()
+        extern (C++) static __gshared ubyte[TY.MAX] sizeTy = ()
             {
-                ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
-                sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);
-                sizeTy[Tarray] = __traits(classInstanceSize, TypeDArray);
-                sizeTy[Taarray] = __traits(classInstanceSize, TypeAArray);
-                sizeTy[Tpointer] = __traits(classInstanceSize, TypePointer);
-                sizeTy[Treference] = __traits(classInstanceSize, TypeReference);
-                sizeTy[Tfunction] = __traits(classInstanceSize, TypeFunction);
-                sizeTy[Tdelegate] = __traits(classInstanceSize, TypeDelegate);
-                sizeTy[Tident] = __traits(classInstanceSize, TypeIdentifier);
-                sizeTy[Tinstance] = __traits(classInstanceSize, TypeInstance);
-                sizeTy[Ttypeof] = __traits(classInstanceSize, TypeTypeof);
-                sizeTy[Tenum] = __traits(classInstanceSize, TypeEnum);
-                sizeTy[Tstruct] = __traits(classInstanceSize, TypeStruct);
-                sizeTy[Tclass] = __traits(classInstanceSize, TypeClass);
-                sizeTy[Ttuple] = __traits(classInstanceSize, TypeTuple);
-                sizeTy[Tslice] = __traits(classInstanceSize, TypeSlice);
-                sizeTy[Treturn] = __traits(classInstanceSize, TypeReturn);
-                sizeTy[Terror] = __traits(classInstanceSize, TypeError);
-                sizeTy[Tnull] = __traits(classInstanceSize, TypeNull);
-                sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
+                ubyte[TY.MAX] sizeTy = __traits(classInstanceSize, TypeBasic);
+                sizeTy[TY.sarray] = __traits(classInstanceSize, TypeSArray);
+                sizeTy[TY.array] = __traits(classInstanceSize, TypeDArray);
+                sizeTy[TY.aarray] = __traits(classInstanceSize, TypeAArray);
+                sizeTy[TY.pointer] = __traits(classInstanceSize, TypePointer);
+                sizeTy[TY.reference] = __traits(classInstanceSize, TypeReference);
+                sizeTy[TY.function_] = __traits(classInstanceSize, TypeFunction);
+                sizeTy[TY.delegate_] = __traits(classInstanceSize, TypeDelegate);
+                sizeTy[TY.ident] = __traits(classInstanceSize, TypeIdentifier);
+                sizeTy[TY.instance] = __traits(classInstanceSize, TypeInstance);
+                sizeTy[TY.typeof_] = __traits(classInstanceSize, TypeTypeof);
+                sizeTy[TY.enum_] = __traits(classInstanceSize, TypeEnum);
+                sizeTy[TY.struct_] = __traits(classInstanceSize, TypeStruct);
+                sizeTy[TY.class_] = __traits(classInstanceSize, TypeClass);
+                sizeTy[TY.tuple] = __traits(classInstanceSize, TypeTuple);
+                sizeTy[TY.slice] = __traits(classInstanceSize, TypeSlice);
+                sizeTy[TY.return_] = __traits(classInstanceSize, TypeReturn);
+                sizeTy[TY.error] = __traits(classInstanceSize, TypeError);
+                sizeTy[TY.null_] = __traits(classInstanceSize, TypeNull);
+                sizeTy[TY.vector] = __traits(classInstanceSize, TypeVector);
                 return sizeTy;
             }();
 
@@ -2606,72 +2606,72 @@ struct ASTBase
             // Set basic types
             static __gshared TY* basetab =
             [
-                Tvoid,
-                Tint8,
-                Tuns8,
-                Tint16,
-                Tuns16,
-                Tint32,
-                Tuns32,
-                Tint64,
-                Tuns64,
-                Tint128,
-                Tuns128,
-                Tfloat32,
-                Tfloat64,
-                Tfloat80,
-                Timaginary32,
-                Timaginary64,
-                Timaginary80,
-                Tcomplex32,
-                Tcomplex64,
-                Tcomplex80,
-                Tbool,
-                Tchar,
-                Twchar,
-                Tdchar,
-                Terror
+                TY.void_,
+                TY.int8,
+                TY.uns8,
+                TY.int16,
+                TY.uns16,
+                TY.int32,
+                TY.uns32,
+                TY.int64,
+                TY.uns64,
+                TY.int128,
+                TY.uns128,
+                TY.float32,
+                TY.float64,
+                TY.float80,
+                TY.imaginary32,
+                TY.imaginary64,
+                TY.imaginary80,
+                TY.complex32,
+                TY.complex64,
+                TY.complex80,
+                TY.bool_,
+                TY.char_,
+                TY.wchar_,
+                TY.dchar_,
+                TY.error
             ];
 
-            for (size_t i = 0; basetab[i] != Terror; i++)
+            for (size_t i = 0; basetab[i] != TY.error; i++)
             {
                 Type t = new TypeBasic(basetab[i]);
                 t = t.merge();
                 basic[basetab[i]] = t;
             }
-            basic[Terror] = new TypeError();
+            basic[TY.error] = new TypeError();
 
-            tvoid = basic[Tvoid];
-            tint8 = basic[Tint8];
-            tuns8 = basic[Tuns8];
-            tint16 = basic[Tint16];
-            tuns16 = basic[Tuns16];
-            tint32 = basic[Tint32];
-            tuns32 = basic[Tuns32];
-            tint64 = basic[Tint64];
-            tuns64 = basic[Tuns64];
-            tint128 = basic[Tint128];
-            tuns128 = basic[Tuns128];
-            tfloat32 = basic[Tfloat32];
-            tfloat64 = basic[Tfloat64];
-            tfloat80 = basic[Tfloat80];
+            tvoid = basic[TY.void_];
+            tint8 = basic[TY.int8];
+            tuns8 = basic[TY.uns8];
+            tint16 = basic[TY.int16];
+            tuns16 = basic[TY.uns16];
+            tint32 = basic[TY.int32];
+            tuns32 = basic[TY.uns32];
+            tint64 = basic[TY.int64];
+            tuns64 = basic[TY.uns64];
+            tint128 = basic[TY.int128];
+            tuns128 = basic[TY.uns128];
+            tfloat32 = basic[TY.float32];
+            tfloat64 = basic[TY.float64];
+            tfloat80 = basic[TY.float80];
 
-            timaginary32 = basic[Timaginary32];
-            timaginary64 = basic[Timaginary64];
-            timaginary80 = basic[Timaginary80];
+            timaginary32 = basic[TY.imaginary32];
+            timaginary64 = basic[TY.imaginary64];
+            timaginary80 = basic[TY.imaginary80];
 
-            tcomplex32 = basic[Tcomplex32];
-            tcomplex64 = basic[Tcomplex64];
-            tcomplex80 = basic[Tcomplex80];
+            tcomplex32 = basic[TY.complex32];
+            tcomplex64 = basic[TY.complex64];
+            tcomplex80 = basic[TY.complex80];
 
-            tbool = basic[Tbool];
-            tchar = basic[Tchar];
-            twchar = basic[Twchar];
-            tdchar = basic[Tdchar];
+            tbool = basic[TY.bool_];
+            tchar = basic[TY.char_];
+            twchar = basic[TY.wchar_];
+            tdchar = basic[TY.dchar_];
 
             tshiftcnt = tint32;
-            terror = basic[Terror];
-            tnull = basic[Tnull];
+            terror = basic[TY.error];
+            tnull = basic[TY.null_];
             tnull = new TypeNull();
             tnull.deco = tnull.merge().deco;
 
@@ -2683,13 +2683,13 @@ struct ASTBase
 
             if (global.params.isLP64)
             {
-                Tsize_t = Tuns64;
-                Tptrdiff_t = Tint64;
+                Tsize_t = TY.uns64;
+                Tptrdiff_t = TY.int64;
             }
             else
             {
-                Tsize_t = Tuns32;
-                Tptrdiff_t = Tint32;
+                Tsize_t = TY.uns32;
+                Tptrdiff_t = TY.int32;
             }
 
             tsize_t = basic[Tsize_t];
@@ -2699,12 +2699,12 @@ struct ASTBase
 
         final Type pointerTo()
         {
-            if (ty == Terror)
+            if (ty == TY.error)
                 return this;
             if (!pto)
             {
                 Type t = new TypePointer(this);
-                if (ty == Tfunction)
+                if (ty == TY.function_)
                 {
                     t.deco = t.merge().deco;
                     pto = t;
@@ -2717,7 +2717,7 @@ struct ASTBase
 
         final Type arrayOf()
         {
-            if (ty == Terror)
+            if (ty == TY.error)
                 return this;
             if (!arrayof)
             {
@@ -2752,9 +2752,9 @@ struct ASTBase
             t.swcto = null;
             //t.vtinfo = null; these aren't used in parsing
             //t.ctype = null;
-            if (t.ty == Tstruct)
+            if (t.ty == TY.struct_)
                 (cast(TypeStruct)t).att = AliasThisRec.fwdref;
-            if (t.ty == Tclass)
+            if (t.ty == TY.class_)
                 (cast(TypeClass)t).att = AliasThisRec.fwdref;
             return t;
         }
@@ -2834,17 +2834,17 @@ struct ASTBase
         // Truncated
         final Type merge()
         {
-            if (ty == Terror)
+            if (ty == TY.error)
                 return this;
-            if (ty == Ttypeof)
+            if (ty == TY.typeof_)
                 return this;
-            if (ty == Tident)
+            if (ty == TY.ident)
                 return this;
-            if (ty == Tinstance)
+            if (ty == TY.instance)
                 return this;
-            if (ty == Taarray && !(cast(TypeAArray)this).index.merge().deco)
+            if (ty == TY.aarray && !(cast(TypeAArray)this).index.merge().deco)
                 return this;
-            if (ty != Tenum && nextOf() && !nextOf().deco)
+            if (ty != TY.enum_ && nextOf() && !nextOf().deco)
                 return this;
 
             // if (!deco) - code missing
@@ -3055,7 +3055,7 @@ struct ASTBase
         {
             Type mto = null;
             Type tn = nextOf();
-            if (!tn || ty != Tsarray && tn.mod == t.nextOf().mod)
+            if (!tn || ty != TY.sarray && tn.mod == t.nextOf().mod)
             {
                 switch (t.mod)
                 {
@@ -3324,121 +3324,121 @@ struct ASTBase
             uint flags = 0;
             switch (ty)
             {
-            case Tvoid:
+            case TY.void_:
                 d = Token.toChars(TOKvoid);
                 break;
 
-            case Tint8:
+            case TY.int8:
                 d = Token.toChars(TOKint8);
                 flags |= TFlags.integral;
                 break;
 
-            case Tuns8:
+            case TY.uns8:
                 d = Token.toChars(TOKuns8);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Tint16:
+            case TY.int16:
                 d = Token.toChars(TOKint16);
                 flags |= TFlags.integral;
                 break;
 
-            case Tuns16:
+            case TY.uns16:
                 d = Token.toChars(TOKuns16);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Tint32:
+            case TY.int32:
                 d = Token.toChars(TOKint32);
                 flags |= TFlags.integral;
                 break;
 
-            case Tuns32:
+            case TY.uns32:
                 d = Token.toChars(TOKuns32);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Tfloat32:
+            case TY.float32:
                 d = Token.toChars(TOKfloat32);
                 flags |= TFlags.floating | TFlags.real_;
                 break;
 
-            case Tint64:
+            case TY.int64:
                 d = Token.toChars(TOKint64);
                 flags |= TFlags.integral;
                 break;
 
-            case Tuns64:
+            case TY.uns64:
                 d = Token.toChars(TOKuns64);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Tint128:
+            case TY.int128:
                 d = Token.toChars(TOKint128);
                 flags |= TFlags.integral;
                 break;
 
-            case Tuns128:
+            case TY.uns128:
                 d = Token.toChars(TOKuns128);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Tfloat64:
+            case TY.float64:
                 d = Token.toChars(TOKfloat64);
                 flags |= TFlags.floating | TFlags.real_;
                 break;
 
-            case Tfloat80:
+            case TY.float80:
                 d = Token.toChars(TOKfloat80);
                 flags |= TFlags.floating | TFlags.real_;
                 break;
 
-            case Timaginary32:
+            case TY.imaginary32:
                 d = Token.toChars(TOKimaginary32);
                 flags |= TFlags.floating | TFlags.imaginary;
                 break;
 
-            case Timaginary64:
+            case TY.imaginary64:
                 d = Token.toChars(TOKimaginary64);
                 flags |= TFlags.floating | TFlags.imaginary;
                 break;
 
-            case Timaginary80:
+            case TY.imaginary80:
                 d = Token.toChars(TOKimaginary80);
                 flags |= TFlags.floating | TFlags.imaginary;
                 break;
 
-            case Tcomplex32:
+            case TY.complex32:
                 d = Token.toChars(TOKcomplex32);
                 flags |= TFlags.floating | TFlags.complex;
                 break;
 
-            case Tcomplex64:
+            case TY.complex64:
                 d = Token.toChars(TOKcomplex64);
                 flags |= TFlags.floating | TFlags.complex;
                 break;
 
-            case Tcomplex80:
+            case TY.complex80:
                 d = Token.toChars(TOKcomplex80);
                 flags |= TFlags.floating | TFlags.complex;
                 break;
 
-            case Tbool:
+            case TY.bool_:
                 d = "bool";
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Tchar:
+            case TY.char_:
                 d = Token.toChars(TOKchar);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Twchar:
+            case TY.wchar_:
                 d = Token.toChars(TOKwchar);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Tdchar:
+            case TY.dchar_:
                 d = Token.toChars(TOKdchar);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
@@ -3466,7 +3466,7 @@ struct ASTBase
     {
         extern (D) this()
         {
-            super(Terror);
+            super(TY.error);
         }
 
         override Type syntaxCopy()
@@ -3484,7 +3484,7 @@ struct ASTBase
     {
         extern (D) this()
         {
-            super(Tnull);
+            super(TY.null_);
         }
 
         override Type syntaxCopy()
@@ -3505,7 +3505,7 @@ struct ASTBase
 
         extern (D) this(Loc loc, Type baseType)
         {
-            super(Tvector);
+            super(TY.vector);
             this.basetype = basetype;
         }
 
@@ -3526,7 +3526,7 @@ struct ASTBase
 
         extern (D) this(EnumDeclaration sym)
         {
-            super(Tenum);
+            super(TY.enum_);
             this.sym = sym;
         }
 
@@ -3547,13 +3547,13 @@ struct ASTBase
 
         extern (D) this(Parameters* arguments)
         {
-            super(Ttuple);
+            super(TY.tuple);
             this.arguments = arguments;
         }
 
         extern (D) this(Expressions* exps)
         {
-            super(Ttuple);
+            super(TY.tuple);
             auto arguments = new Parameters();
             if (exps)
             {
@@ -3561,7 +3561,7 @@ struct ASTBase
                 for (size_t i = 0; i < exps.dim; i++)
                 {
                     Expression e = (*exps)[i];
-                    if (e.type.ty == Ttuple)
+                    if (e.type.ty == TY.tuple)
                         e.error("cannot form tuple of tuples");
                     auto arg = new Parameter(STC.undefined_, e.type, null, null);
                     (*arguments)[i] = arg;
@@ -3591,7 +3591,7 @@ struct ASTBase
 
         extern (D) this (ClassDeclaration sym)
         {
-            super(Tclass);
+            super(TY.class_);
             this.sym = sym;
         }
 
@@ -3613,7 +3613,7 @@ struct ASTBase
 
         extern (D) this(StructDeclaration sym)
         {
-            super(Tstruct);
+            super(TY.struct_);
             this.sym = sym;
         }
 
@@ -3632,7 +3632,7 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Treference, t);
+            super(TY.reference, t);
             // BUG: what about references to static arrays?
         }
 
@@ -3683,7 +3683,7 @@ struct ASTBase
 
         extern (D) this(Type next, Expression lwr, Expression upr)
         {
-            super(Tslice, next);
+            super(TY.slice, next);
             this.lwr = lwr;
             this.upr = upr;
         }
@@ -3705,8 +3705,8 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Tfunction, t);
-            ty = Tdelegate;
+            super(TY.function_, t);
+            ty = TY.delegate_;
         }
 
         override Type syntaxCopy()
@@ -3732,7 +3732,7 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Tpointer, t);
+            super(TY.pointer, t);
         }
 
         override Type syntaxCopy()
@@ -3774,7 +3774,7 @@ struct ASTBase
 
         extern (D) this(Parameters* parameters, Type treturn, int varargs, LINK linkage, StorageClass stc = 0)
         {
-            super(Tfunction, treturn);
+            super(TY.function_, treturn);
             assert(0 <= varargs && varargs <= 2);
             this.parameters = parameters;
             this.varargs = varargs;
@@ -3847,7 +3847,7 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Tarray, t);
+            super(TY.array, t);
         }
 
         override Type syntaxCopy()
@@ -3876,7 +3876,7 @@ struct ASTBase
 
         extern (D) this(Type t, Type index)
         {
-            super(Taarray, t);
+            super(TY.aarray, t);
             this.index = index;
         }
 
@@ -3918,7 +3918,7 @@ struct ASTBase
 
         final extern (D) this(Type t, Expression dim)
         {
-            super(Tsarray, t);
+            super(TY.sarray, t);
             this.dim = dim;
         }
 
@@ -4044,7 +4044,7 @@ struct ASTBase
 
         extern (D) this(Loc loc, Identifier ident)
         {
-            super(Tident, loc);
+            super(TY.ident, loc);
             this.ident = ident;
         }
 
@@ -4071,7 +4071,7 @@ struct ASTBase
     {
         extern (D) this(Loc loc)
         {
-            super(Treturn, loc);
+            super(TY.return_, loc);
         }
 
         override Type syntaxCopy()
@@ -4094,7 +4094,7 @@ struct ASTBase
 
         extern (D) this(Loc loc, Expression exp)
         {
-            super(Ttypeof, loc);
+            super(TY.typeof_, loc);
             this.exp = exp;
         }
 
@@ -4118,7 +4118,7 @@ struct ASTBase
 
         final extern (D) this(Loc loc, TemplateInstance tempinst)
         {
-            super(Tinstance, loc);
+            super(TY.instance, loc);
             this.tempinst = tempinst;
         }
 
@@ -4220,7 +4220,7 @@ struct ASTBase
             assert(type);
             if (!type.isscalar())
             {
-                if (type.ty != Terror)
+                if (type.ty != TY.error)
                     error("integral constant must be scalar type, not %s", type.toChars());
                 type = Type.terror;
             }
@@ -4240,46 +4240,46 @@ struct ASTBase
              */
             switch (type.toBasetype().ty)
             {
-            case Tbool:
+            case TY.bool_:
                 value = (value != 0);
                 break;
 
-            case Tint8:
+            case TY.int8:
                 value = cast(d_int8)value;
                 break;
 
-            case Tchar:
-            case Tuns8:
+            case TY.char_:
+            case TY.uns8:
                 value = cast(d_uns8)value;
                 break;
 
-            case Tint16:
+            case TY.int16:
                 value = cast(d_int16)value;
                 break;
 
-            case Twchar:
-            case Tuns16:
+            case TY.wchar_:
+            case TY.uns16:
                 value = cast(d_uns16)value;
                 break;
 
-            case Tint32:
+            case TY.int32:
                 value = cast(d_int32)value;
                 break;
 
-            case Tdchar:
-            case Tuns32:
+            case TY.dchar_:
+            case TY.uns32:
                 value = cast(d_uns32)value;
                 break;
 
-            case Tint64:
+            case TY.int64:
                 value = cast(d_int64)value;
                 break;
 
-            case Tuns64:
+            case TY.uns64:
                 value = cast(d_uns64)value;
                 break;
 
-            case Tpointer:
+            case TY.pointer:
                 if (Target.ptrsize == 4)
                     value = cast(d_uns32)value;
                 else if (Target.ptrsize == 8)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -135,106 +135,58 @@ struct ASTBase
     extern (C++) __gshared const(StorageClass) STCStorageClass =
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared | STC.property | STC.safe | STC.trusted | STC.system | STC.disable);
 
-    enum ENUMTY : int
+    enum TY : ubyte
     {
-        Tarray,     // slice array, aka T[]
-        Tsarray,    // static array, aka T[dimension]
-        Taarray,    // associative array, aka T[type]
-        Tpointer,
-        Treference,
-        Tfunction,
-        Tident,
-        Tclass,
-        Tstruct,
-        Tenum,
+        array,     // slice array, aka T[]
+        sarray,    // static array, aka T[dimension]
+        aarray,    // associative array, aka T[type]
+        pointer,
+        reference,
+        function_,
+        ident,
+        class_,
+        struct_,
+        enum_,
 
-        Tdelegate,
-        Tnone,
-        Tvoid,
-        Tint8,
-        Tuns8,
-        Tint16,
-        Tuns16,
-        Tint32,
-        Tuns32,
-        Tint64,
+        delegate_,
+        none,
+        void_,
+        int8,
+        uns8,
+        int16,
+        uns16,
+        int32,
+        uns32,
+        int64,
 
-        Tuns64,
-        Tfloat32,
-        Tfloat64,
-        Tfloat80,
-        Timaginary32,
-        Timaginary64,
-        Timaginary80,
-        Tcomplex32,
-        Tcomplex64,
-        Tcomplex80,
+        uns64,
+        float32,
+        float64,
+        float80,
+        imaginary32,
+        imaginary64,
+        imaginary80,
+        complex32,
+        complex64,
+        complex80,
 
-        Tbool,
-        Tchar,
-        Twchar,
-        Tdchar,
-        Terror,
-        Tinstance,
-        Ttypeof,
-        Ttuple,
-        Tslice,
-        Treturn,
+        bool_,
+        char_,
+        wchar_,
+        dchar_,
+        error,
+        instance,
+        typeof_,
+        tuple,
+        slice,
+        return_,
 
-        Tnull,
-        Tvector,
-        Tint128,
-        Tuns128,
-        TMAX
+        null_,
+        vector,
+        int128,
+        uns128,
+        MAX
     }
-
-    alias Tarray = ENUMTY.Tarray;
-    alias Tsarray = ENUMTY.Tsarray;
-    alias Taarray = ENUMTY.Taarray;
-    alias Tpointer = ENUMTY.Tpointer;
-    alias Treference = ENUMTY.Treference;
-    alias Tfunction = ENUMTY.Tfunction;
-    alias Tident = ENUMTY.Tident;
-    alias Tclass = ENUMTY.Tclass;
-    alias Tstruct = ENUMTY.Tstruct;
-    alias Tenum = ENUMTY.Tenum;
-    alias Tdelegate = ENUMTY.Tdelegate;
-    alias Tnone = ENUMTY.Tnone;
-    alias Tvoid = ENUMTY.Tvoid;
-    alias Tint8 = ENUMTY.Tint8;
-    alias Tuns8 = ENUMTY.Tuns8;
-    alias Tint16 = ENUMTY.Tint16;
-    alias Tuns16 = ENUMTY.Tuns16;
-    alias Tint32 = ENUMTY.Tint32;
-    alias Tuns32 = ENUMTY.Tuns32;
-    alias Tint64 = ENUMTY.Tint64;
-    alias Tuns64 = ENUMTY.Tuns64;
-    alias Tfloat32 = ENUMTY.Tfloat32;
-    alias Tfloat64 = ENUMTY.Tfloat64;
-    alias Tfloat80 = ENUMTY.Tfloat80;
-    alias Timaginary32 = ENUMTY.Timaginary32;
-    alias Timaginary64 = ENUMTY.Timaginary64;
-    alias Timaginary80 = ENUMTY.Timaginary80;
-    alias Tcomplex32 = ENUMTY.Tcomplex32;
-    alias Tcomplex64 = ENUMTY.Tcomplex64;
-    alias Tcomplex80 = ENUMTY.Tcomplex80;
-    alias Tbool = ENUMTY.Tbool;
-    alias Tchar = ENUMTY.Tchar;
-    alias Twchar = ENUMTY.Twchar;
-    alias Tdchar = ENUMTY.Tdchar;
-    alias Terror = ENUMTY.Terror;
-    alias Tinstance = ENUMTY.Tinstance;
-    alias Ttypeof = ENUMTY.Ttypeof;
-    alias Ttuple = ENUMTY.Ttuple;
-    alias Tslice = ENUMTY.Tslice;
-    alias Treturn = ENUMTY.Treturn;
-    alias Tnull = ENUMTY.Tnull;
-    alias Tvector = ENUMTY.Tvector;
-    alias Tint128 = ENUMTY.Tint128;
-    alias Tuns128 = ENUMTY.Tuns128;
-    alias TMAX = ENUMTY.TMAX;
-
-    alias TY = ubyte;
 
     enum TFlags
     {

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3322,7 +3322,7 @@ struct ASTBase
             super(ty);
             const(char)* d;
             uint flags = 0;
-            switch (ty)
+            final switch (ty)
             {
             case TY.void_:
                 d = Token.toChars(TOKvoid);
@@ -3442,8 +3442,27 @@ struct ASTBase
                 d = Token.toChars(TOKdchar);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
-
-            default:
+            case TY.array:
+            case TY.sarray:
+            case TY.aarray:
+            case TY.pointer:
+            case TY.reference:
+            case TY.function_:
+            case TY.ident:
+            case TY.class_:
+            case TY.struct_:
+            case TY.enum_:
+            case TY.delegate_:
+            case TY.none:
+            case TY.error:
+            case TY.instance:
+            case TY.typeof_:
+            case TY.tuple:
+            case TY.slice:
+            case TY.return_:
+            case TY.null_:
+            case TY.vector:
+            case TY.MAX:
                 assert(0);
             }
             this.dstring = d;
@@ -4287,9 +4306,8 @@ struct ASTBase
                 else
                     assert(0);
                 break;
-
             default:
-                break;
+                assert(0);
             }
         }
 

--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -39,12 +39,8 @@ struct ASTCodegen
 
     alias MODFlags                  = dmd.mtype.MODFlags;
     alias Type                      = dmd.mtype.Type;
-    alias Tident                    = dmd.mtype.Tident;
-    alias Tfunction                 = dmd.mtype.Tfunction;
+    alias TY                        = dmd.mtype.TY;
     alias Parameter                 = dmd.mtype.Parameter;
-    alias Taarray                   = dmd.mtype.Taarray;
-    alias Tsarray                   = dmd.mtype.Tsarray;
-    alias Terror                    = dmd.mtype.Terror;
 
     alias STC                       = dmd.declaration.STC;
     alias Dsymbol                   = dmd.dsymbol.Dsymbol;

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -278,7 +278,7 @@ enum
     CENTSIZE       = 16,
     FLOATSIZE      = 4,
     DOUBLESIZE     = 8,
-    TMAXSIZE       = 16,      // largest size a constant can be
+    MAXSIZE       = 16,      // largest size a constant can be
 }
 
 //#define intsize         _tysize[TYint]

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -171,7 +171,7 @@ extern (C++) Expression eval_bswap(Loc loc, FuncDeclaration fd, Expressions* arg
     n = ((n >> 16) & SHORTMASK) | ((n & SHORTMASK) << 16);
     TY ty = arg0.type.toBasetype().ty;
     // If 64 bits, we need to swap high and low uints
-    if (ty == Tint64 || ty == Tuns64)
+    if (ty == TY.int64 || ty == TY.uns64)
         n = ((n >> 32) & INTMASK) | ((n & INTMASK) << 32);
     return new IntegerExp(loc, n, arg0.type);
 }

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -70,9 +70,9 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             Type t = ce.e1.type.toBasetype();
             if (ce.f && ce.f == func)
                 return;
-            if (t.ty == Tfunction && (cast(TypeFunction)t).isnothrow)
+            if (t.ty == TY.function_ && (cast(TypeFunction)t).isnothrow)
                 return;
-            if (t.ty == Tdelegate && (cast(TypeFunction)(cast(TypeDelegate)t).next).isnothrow)
+            if (t.ty == TY.delegate_ && (cast(TypeFunction)(cast(TypeDelegate)t).next).isnothrow)
                 return;
 
             if (mustNotThrow)
@@ -101,7 +101,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=14407
                     Type t = ne.allocator.type.toBasetype();
-                    if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
+                    if (t.ty == TY.function_ && !(cast(TypeFunction)t).isnothrow)
                     {
                         if (mustNotThrow)
                         {
@@ -113,7 +113,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                 }
                 // See if constructor call can throw
                 Type t = ne.member.type.toBasetype();
-                if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
+                if (t.ty == TY.function_ && !(cast(TypeFunction)t).isnothrow)
                 {
                     if (mustNotThrow)
                     {
@@ -132,19 +132,19 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             AggregateDeclaration ad = null;
             switch (tb.ty)
             {
-            case Tclass:
+            case TY.class_:
                 ad = (cast(TypeClass)tb).sym;
                 break;
 
-            case Tpointer:
+            case TY.pointer:
                 tb = (cast(TypePointer)tb).next.toBasetype();
-                if (tb.ty == Tstruct)
+                if (tb.ty == TY.struct_)
                     ad = (cast(TypeStruct)tb).sym;
                 break;
 
-            case Tarray:
+            case TY.array:
                 Type tv = tb.nextOf().baseElemOf();
-                if (tv.ty == Tstruct)
+                if (tv.ty == TY.struct_)
                     ad = (cast(TypeStruct)tv).sym;
                 break;
 
@@ -157,7 +157,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             if (ad.dtor)
             {
                 Type t = ad.dtor.type.toBasetype();
-                if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
+                if (t.ty == TY.function_ && !(cast(TypeFunction)t).isnothrow)
                 {
                     if (mustNotThrow)
                     {
@@ -167,10 +167,10 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                     stop = true;
                 }
             }
-            if (ad.aggDelete && tb.ty != Tarray)
+            if (ad.aggDelete && tb.ty != TY.array)
             {
                 Type t = ad.aggDelete.type;
-                if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
+                if (t.ty == TY.function_ && !(cast(TypeFunction)t).isnothrow)
                 {
                     if (mustNotThrow)
                     {
@@ -190,7 +190,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             /* Element-wise assignment could invoke postblits.
              */
             Type t;
-            if (ae.type.toBasetype().ty == Tsarray)
+            if (ae.type.toBasetype().ty == TY.sarray)
             {
                 if (!ae.e2.isLvalue())
                     return;
@@ -201,10 +201,10 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             else
                 return;
             Type tv = t.baseElemOf();
-            if (tv.ty != Tstruct)
+            if (tv.ty != TY.struct_)
                 return;
             StructDeclaration sd = (cast(TypeStruct)tv).sym;
-            if (!sd.postblit || sd.postblit.type.ty != Tfunction)
+            if (!sd.postblit || sd.postblit.type.ty != TY.function_)
                 return;
             if ((cast(TypeFunction)sd.postblit.type).isnothrow)
             {

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -160,7 +160,7 @@ private bool needOpAssign(StructDeclaration sd)
         if (v.overlapped)               // if field of a union
             continue;                   // user must handle it themselves
         Type tv = v.type.baseElemOf();
-        if (tv.ty == Tstruct)
+        if (tv.ty == TY.struct_)
         {
             TypeStruct ts = cast(TypeStruct)tv;
             if (ts.sym.isUnionDeclaration())
@@ -225,7 +225,7 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
         if (v.overlapped)
             continue;
         Type tv = v.type.baseElemOf();
-        if (tv.ty != Tstruct)
+        if (tv.ty != TY.struct_)
             continue;
         StructDeclaration sdv = (cast(TypeStruct)tv).sym;
         stc = mergeFuncAttrs(stc, hasIdentityOpAssign(sdv, sc));
@@ -358,7 +358,7 @@ extern (C++) bool needOpEquals(StructDeclaration sd)
             continue;
         Type tv = v.type.toBasetype();
         auto tvbase = tv.baseElemOf();
-        if (tvbase.ty == Tstruct)
+        if (tvbase.ty == TY.struct_)
         {
             TypeStruct ts = cast(TypeStruct)tvbase;
             if (ts.sym.isUnionDeclaration())
@@ -375,11 +375,11 @@ extern (C++) bool needOpEquals(StructDeclaration sd)
             //  2. comparison of NANs should be false always.
             goto Lneed;
         }
-        if (tv.ty == Tarray)
+        if (tv.ty == TY.array)
             goto Lneed;
-        if (tv.ty == Taarray)
+        if (tv.ty == TY.aarray)
             goto Lneed;
-        if (tv.ty == Tclass)
+        if (tv.ty == TY.class_)
             goto Lneed;
     }
 Ldontneed:
@@ -678,7 +678,7 @@ private bool needToHash(StructDeclaration sd)
             continue;
         Type tv = v.type.toBasetype();
         auto tvbase = tv.baseElemOf();
-        if (tvbase.ty == Tstruct)
+        if (tvbase.ty == TY.struct_)
         {
             TypeStruct ts = cast(TypeStruct)tvbase;
             if (ts.sym.isUnionDeclaration())
@@ -695,11 +695,11 @@ private bool needToHash(StructDeclaration sd)
              */
             goto Lneed;
         }
-        if (tv.ty == Tarray)
+        if (tv.ty == TY.array)
             goto Lneed;
-        if (tv.ty == Taarray)
+        if (tv.ty == TY.aarray)
             goto Lneed;
-        if (tv.ty == Tclass)
+        if (tv.ty == TY.class_)
             goto Lneed;
     }
 Ldontneed:
@@ -798,7 +798,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         if (v.overlapped)
             continue;
         Type tv = v.type.baseElemOf();
-        if (tv.ty != Tstruct)
+        if (tv.ty != TY.struct_)
             continue;
         auto sdv = (cast(TypeStruct)tv).sym;
         if (!sdv.postblit)
@@ -816,7 +816,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
 
         Expression ex;
         tv = v.type.toBasetype();
-        if (tv.ty == Tstruct)
+        if (tv.ty == TY.struct_)
         {
             // this.v.__xpostblit()
 
@@ -838,7 +838,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             // _ArrayPostblit((cast(S*)this.v.ptr)[0 .. n])
 
             uinteger_t n = 1;
-            while (tv.ty == Tsarray)
+            while (tv.ty == TY.sarray)
             {
                 n *= (cast(TypeSArray)tv).dim.toUInteger();
                 tv = tv.nextOf().toBasetype();
@@ -873,7 +873,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         sdv.dtor.functionSemantic();
 
         tv = v.type.toBasetype();
-        if (tv.ty == Tstruct)
+        if (tv.ty == TY.struct_)
         {
             // this.v.__xdtor()
 
@@ -895,7 +895,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             // _ArrayDtor((cast(S*)this.v.ptr)[0 .. n])
 
             uinteger_t n = 1;
-            while (tv.ty == Tsarray)
+            while (tv.ty == TY.sarray)
             {
                 n *= (cast(TypeSArray)tv).dim.toUInteger();
                 tv = tv.nextOf().toBasetype();
@@ -1016,7 +1016,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
         if (v.overlapped)
             continue;
         auto tv = v.type.baseElemOf();
-        if (tv.ty != Tstruct)
+        if (tv.ty != TY.struct_)
             continue;
         auto sdv = (cast(TypeStruct)tv).sym;
         if (!sdv.dtor)
@@ -1032,7 +1032,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
 
         Expression ex;
         tv = v.type.toBasetype();
-        if (tv.ty == Tstruct)
+        if (tv.ty == TY.struct_)
         {
             // this.v.__xdtor()
 
@@ -1053,7 +1053,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
             // _ArrayDtor((cast(S*)this.v.ptr)[0 .. n])
 
             uinteger_t n = 1;
-            while (tv.ty == Tsarray)
+            while (tv.ty == TY.sarray)
             {
                 n *= (cast(TypeSArray)tv).dim.toUInteger();
                 tv = tv.nextOf().toBasetype();

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -386,20 +386,20 @@ extern (C++) final class StaticForeach : RootObject
             sc = sc.endCTFE();
             aggrfe.aggr = aggrfe.aggr.optimize(WANTvalue);
             auto tab = aggrfe.aggr.type.toBasetype();
-            if (tab.ty != Ttuple)
+            if (tab.ty != TY.tuple)
             {
                 aggrfe.aggr = aggrfe.aggr.ctfeInterpret();
             }
         }
 
-        if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Terror)
+        if (aggrfe && aggrfe.aggr.type.toBasetype().ty == TY.error)
         {
             return;
         }
 
         if (!ready())
         {
-            if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Tarray)
+            if (aggrfe && aggrfe.aggr.type.toBasetype().ty == TY.array)
             {
                 lowerArrayAggregate(sc);
             }
@@ -416,7 +416,7 @@ extern (C++) final class StaticForeach : RootObject
      */
     final extern(D) bool ready()
     {
-        return aggrfe && aggrfe.aggr && aggrfe.aggr.type.toBasetype().ty == Ttuple;
+        return aggrfe && aggrfe.aggr && aggrfe.aggr.type.toBasetype().ty == TY.tuple;
     }
 }
 

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -439,7 +439,7 @@ extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
         if (n2 == -1 && !type.isunsigned())
         {
             // Check for int.min / -1
-            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Tint64)
+            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != TY.int64)
             {
                 e2.error("integer overflow: `int.min / -1`");
                 emplaceExp!(ErrorExp)(&ue);
@@ -504,7 +504,7 @@ extern (C++) UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
         if (n2 == -1 && !type.isunsigned())
         {
             // Check for int.min % -1
-            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Tint64)
+            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != TY.int64)
             {
                 e2.error("integer overflow: `int.min %% -1`");
                 emplaceExp!(ErrorExp)(&ue);
@@ -621,34 +621,34 @@ extern (C++) UnionExp Shr(Loc loc, Type type, Expression e1, Expression e2)
     uint count = cast(uint)dcount;
     switch (e1.type.toBasetype().ty)
     {
-    case Tint8:
+    case TY.int8:
         value = cast(d_int8)value >> count;
         break;
-    case Tuns8:
-    case Tchar:
+    case TY.uns8:
+    case TY.char_:
         value = cast(d_uns8)value >> count;
         break;
-    case Tint16:
+    case TY.int16:
         value = cast(d_int16)value >> count;
         break;
-    case Tuns16:
-    case Twchar:
+    case TY.uns16:
+    case TY.wchar_:
         value = cast(d_uns16)value >> count;
         break;
-    case Tint32:
+    case TY.int32:
         value = cast(d_int32)value >> count;
         break;
-    case Tuns32:
-    case Tdchar:
+    case TY.uns32:
+    case TY.dchar_:
         value = cast(d_uns32)value >> count;
         break;
-    case Tint64:
+    case TY.int64:
         value = cast(d_int64)value >> count;
         break;
-    case Tuns64:
+    case TY.uns64:
         value = cast(d_uns64)value >> count;
         break;
-    case Terror:
+    case TY.error:
         emplaceExp!(ErrorExp)(&ue);
         return ue;
     default:
@@ -667,28 +667,28 @@ extern (C++) UnionExp Ushr(Loc loc, Type type, Expression e1, Expression e2)
     uint count = cast(uint)dcount;
     switch (e1.type.toBasetype().ty)
     {
-    case Tint8:
-    case Tuns8:
-    case Tchar:
+    case TY.int8:
+    case TY.uns8:
+    case TY.char_:
         // Possible only with >>>=. >>> always gets promoted to int.
         value = (value & 0xFF) >> count;
         break;
-    case Tint16:
-    case Tuns16:
-    case Twchar:
+    case TY.int16:
+    case TY.uns16:
+    case TY.wchar_:
         // Possible only with >>>=. >>> always gets promoted to int.
         value = (value & 0xFFFF) >> count;
         break;
-    case Tint32:
-    case Tuns32:
-    case Tdchar:
+    case TY.int32:
+    case TY.uns32:
+    case TY.dchar_:
         value = (value & 0xFFFFFFFF) >> count;
         break;
-    case Tint64:
-    case Tuns64:
+    case TY.int64:
+    case TY.uns64:
         value = cast(d_uns64)value >> count;
         break;
-    case Terror:
+    case TY.error:
         emplaceExp!(ErrorExp)(&ue);
         return ue;
     default:
@@ -907,7 +907,7 @@ extern (C++) UnionExp Equal(TOK op, Loc loc, Type type, Expression e1, Expressio
     {
         cmp = e1.toComplex() == e2.toComplex();
     }
-    else if (e1.type.isintegral() || e1.type.toBasetype().ty == Tpointer)
+    else if (e1.type.isintegral() || e1.type.toBasetype().ty == TY.pointer)
     {
         cmp = (e1.toInteger() == e2.toInteger());
     }
@@ -1055,7 +1055,7 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     // Allow covariant converions of delegates
     // (Perhaps implicit conversion from pure to impure should be a MATCH.constant,
     // then we wouldn't need this extra check.)
-    if (e1.type.toBasetype().ty == Tdelegate && e1.type.implicitConvTo(to) == MATCH.convert)
+    if (e1.type.toBasetype().ty == TY.delegate_ && e1.type.implicitConvTo(to) == MATCH.convert)
     {
         goto L1;
     }
@@ -1063,7 +1063,7 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
      */
     if (e1.op == TOKstring)
     {
-        if (tb.ty == Tarray && typeb.ty == Tarray && tb.nextOf().size() == typeb.nextOf().size())
+        if (tb.ty == TY.array && typeb.ty == TY.array && tb.nextOf().size() == typeb.nextOf().size())
         {
             goto L1;
         }
@@ -1079,7 +1079,7 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     {
         emplaceExp!(CTFEExp)(&ue, TOKcantexp);
     }
-    else if (tb.ty == Tbool)
+    else if (tb.ty == TY.bool_)
     {
         emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() != 0, type);
     }
@@ -1091,31 +1091,31 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
             real_t r = e1.toReal();
             switch (typeb.ty)
             {
-            case Tint8:
+            case TY.int8:
                 result = cast(d_int8)cast(sinteger_t)r;
                 break;
-            case Tchar:
-            case Tuns8:
+            case TY.char_:
+            case TY.uns8:
                 result = cast(d_uns8)cast(dinteger_t)r;
                 break;
-            case Tint16:
+            case TY.int16:
                 result = cast(d_int16)cast(sinteger_t)r;
                 break;
-            case Twchar:
-            case Tuns16:
+            case TY.wchar_:
+            case TY.uns16:
                 result = cast(d_uns16)cast(dinteger_t)r;
                 break;
-            case Tint32:
+            case TY.int32:
                 result = cast(d_int32)r;
                 break;
-            case Tdchar:
-            case Tuns32:
+            case TY.dchar_:
+            case TY.uns32:
                 result = cast(d_uns32)r;
                 break;
-            case Tint64:
+            case TY.int64:
                 result = cast(d_int64)r;
                 break;
-            case Tuns64:
+            case TY.uns64:
                 result = cast(d_uns64)r;
                 break;
             default:
@@ -1147,11 +1147,11 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     {
         emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger(), type);
     }
-    else if (tb.ty == Tvoid)
+    else if (tb.ty == TY.void_)
     {
         emplaceExp!(CTFEExp)(&ue, TOKcantexp);
     }
-    else if (tb.ty == Tstruct && e1.op == TOKint64)
+    else if (tb.ty == TY.struct_ && e1.op == TOKint64)
     {
         // Struct = 0;
         StructDeclaration sd = tb.toDsymbol(null).isStructDeclaration();
@@ -1204,7 +1204,7 @@ extern (C++) UnionExp ArrayLength(Type type, Expression e1)
         size_t dim = ale.keys.dim;
         emplaceExp!(IntegerExp)(&ue, loc, dim, type);
     }
-    else if (e1.type.toBasetype().ty == Tsarray)
+    else if (e1.type.toBasetype().ty == TY.sarray)
     {
         Expression e = (cast(TypeSArray)e1.type.toBasetype()).dim;
         emplaceExp!(UnionExp)(&ue, e);
@@ -1236,7 +1236,7 @@ extern (C++) UnionExp Index(Type type, Expression e1, Expression e2)
             emplaceExp!(IntegerExp)(&ue, loc, es1.charAt(i), type);
         }
     }
-    else if (e1.type.toBasetype().ty == Tsarray && e2.op == TOKint64)
+    else if (e1.type.toBasetype().ty == TY.sarray && e2.op == TOKint64)
     {
         TypeSArray tsa = cast(TypeSArray)e1.type.toBasetype();
         uinteger_t length = tsa.dim.toInteger();
@@ -1260,7 +1260,7 @@ extern (C++) UnionExp Index(Type type, Expression e1, Expression e2)
         else
             emplaceExp!(CTFEExp)(&ue, TOKcantexp);
     }
-    else if (e1.type.toBasetype().ty == Tarray && e2.op == TOKint64)
+    else if (e1.type.toBasetype().ty == TY.array && e2.op == TOKint64)
     {
         uinteger_t i = e2.toInteger();
         if (e1.op == TOKarrayliteral)
@@ -1467,7 +1467,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         t = t2;
     L2:
         Type tn = e.type.toBasetype();
-        if (tn.ty == Tchar || tn.ty == Twchar || tn.ty == Tdchar)
+        if (tn.ty == TY.char_ || tn.ty == TY.wchar_ || tn.ty == TY.dchar_)
         {
             // Create a StringExp
             if (t.nextOf())
@@ -1501,7 +1501,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         if (type == e1.type)
         {
             // Handle null ~= null
-            if (t1.ty == Tarray && t2 == t1.nextOf())
+            if (t1.ty == TY.array && t2 == t1.nextOf())
             {
                 emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, e2);
                 ue.exp().type = type;
@@ -1643,7 +1643,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Tsarray)
+        if (type.toBasetype().ty == TY.sarray)
         {
             e.type = t1.nextOf().sarrayOf(elems.dim);
         }
@@ -1667,7 +1667,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Tsarray)
+        if (type.toBasetype().ty == TY.sarray)
         {
             e.type = t1.nextOf().sarrayOf(elems.dim);
         }
@@ -1685,7 +1685,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Tsarray)
+        if (type.toBasetype().ty == TY.sarray)
         {
             e.type = e2.type.sarrayOf(elems.dim);
         }
@@ -1701,7 +1701,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e2.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Tsarray)
+        if (type.toBasetype().ty == TY.sarray)
         {
             e.type = e1.type.sarrayOf(elems.dim);
         }
@@ -1722,7 +1722,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         t = e2.type;
     L1:
         Type tb = t.toBasetype();
-        if (tb.ty == Tarray && tb.nextOf().equivalent(e.type))
+        if (tb.ty == TY.array && tb.nextOf().equivalent(e.type))
         {
             auto expressions = new Expressions();
             expressions.push(e);

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -346,7 +346,7 @@ private final class CppMangleVisitor : Visitor
     static bool isIdent_char(Identifier ident, RootObject o)
     {
         Type t = isType(o);
-        if (!t || t.ty != Tstruct)
+        if (!t || t.ty != TY.struct_)
             return false;
         Dsymbol s = (cast(TypeStruct)t).toDsymbol(null);
         if (s.ident != ident)
@@ -627,7 +627,7 @@ private final class CppMangleVisitor : Visitor
 
         if (tf.linkage == LINKcpp) //Template args accept extern "C" symbols with special mangling
         {
-            assert(tf.ty == Tfunction);
+            assert(tf.ty == TY.function_);
             mangleFunctionParameters(tf.parameters, tf.varargs);
         }
     }
@@ -651,7 +651,7 @@ private final class CppMangleVisitor : Visitor
             static if (IN_GCC)
             {
                 // Could be a va_list, which we mangle as a pointer.
-                if (t.ty == Tsarray && Type.tvalist.ty == Tsarray)
+                if (t.ty == TY.sarray && Type.tvalist.ty == TY.sarray)
                 {
                     Type tb = t.toBasetype().mutableOf();
                     if (tb == Type.tvalist)
@@ -661,7 +661,7 @@ private final class CppMangleVisitor : Visitor
                     }
                 }
             }
-            if (t.ty == Tsarray)
+            if (t.ty == TY.sarray)
             {
                 // Static arrays in D are passed by value; no counterpart in C++
                 t.error(loc, "Internal Compiler Error: unable to pass static array `%s` to extern(C++) function, use pointer instead",
@@ -732,7 +732,7 @@ public:
      */
     void headOfType(Type t)
     {
-        if (t.ty == Tclass)
+        if (t.ty == TY.class_)
         {
             mangleTypeClass(cast(TypeClass)t, true);
         }
@@ -810,34 +810,34 @@ public:
         char p = 0;
         switch (t.ty)
         {
-            case Tvoid:                 c = 'v';        break;
-            case Tint8:                 c = 'a';        break;
-            case Tuns8:                 c = 'h';        break;
-            case Tint16:                c = 's';        break;
-            case Tuns16:                c = 't';        break;
-            case Tint32:                c = 'i';        break;
-            case Tuns32:                c = 'j';        break;
-            case Tfloat32:              c = 'f';        break;
-            case Tint64:
+            case TY.void_:                 c = 'v';        break;
+            case TY.int8:                 c = 'a';        break;
+            case TY.uns8:                 c = 'h';        break;
+            case TY.int16:                c = 's';        break;
+            case TY.uns16:                c = 't';        break;
+            case TY.int32:                c = 'i';        break;
+            case TY.uns32:                c = 'j';        break;
+            case TY.float32:              c = 'f';        break;
+            case TY.int64:
                 c = Target.c_longsize == 8 ? Target.int64Mangle : 'x';
                 break;
-            case Tuns64:
+            case TY.uns64:
                 c = Target.c_longsize == 8 ? Target.uint64Mangle : 'y';
                 break;
-            case Tint128:                c = 'n';       break;
-            case Tuns128:                c = 'o';       break;
-            case Tfloat64:               c = 'd';       break;
-            case Tfloat80:               c = 'e';       break;
-            case Tbool:                  c = 'b';       break;
-            case Tchar:                  c = 'c';       break;
-            case Twchar:                 c = 't';       break;  // unsigned short (perhaps use 'Ds' ?
-            case Tdchar:                 c = 'w';       break;  // wchar_t (UTF-32) (perhaps use 'Di' ?
-            case Timaginary32:  p = 'G'; c = 'f';       break;  // 'G' means imaginary
-            case Timaginary64:  p = 'G'; c = 'd';       break;
-            case Timaginary80:  p = 'G'; c = 'e';       break;
-            case Tcomplex32:    p = 'C'; c = 'f';       break;  // 'C' means complex
-            case Tcomplex64:    p = 'C'; c = 'd';       break;
-            case Tcomplex80:    p = 'C'; c = 'e';       break;
+            case TY.int128:                c = 'n';       break;
+            case TY.uns128:                c = 'o';       break;
+            case TY.float64:               c = 'd';       break;
+            case TY.float80:               c = 'e';       break;
+            case TY.bool_:                  c = 'b';       break;
+            case TY.char_:                  c = 'c';       break;
+            case TY.wchar_:                 c = 't';       break;  // unsigned short (perhaps use 'Ds' ?
+            case TY.dchar_:                 c = 'w';       break;  // wchar_t (UTF-32) (perhaps use 'Di' ?
+            case TY.imaginary32:  p = 'G'; c = 'f';       break;  // 'G' means imaginary
+            case TY.imaginary64:  p = 'G'; c = 'd';       break;
+            case TY.imaginary80:  p = 'G'; c = 'e';       break;
+            case TY.complex32:    p = 'C'; c = 'f';       break;  // 'C' means complex
+            case TY.complex64:    p = 'C'; c = 'd';       break;
+            case TY.complex80:    p = 'C'; c = 'e';       break;
 
             default:
                 // Handle any target-specific basic types.
@@ -873,7 +873,7 @@ public:
         }
         else
         {
-            assert(t.basetype && t.basetype.ty == Tsarray);
+            assert(t.basetype && t.basetype.ty == TY.sarray);
             assert((cast(TypeSArray)t.basetype).dim);
             version (none)
             {

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -125,7 +125,7 @@ public:
             if (checkTypeSaved(type))
                 return;
         }
-        if ((type.ty == Tbool) && checkTypeSaved(type)) // try to replace long name with number
+        if ((type.ty == TY.bool_) && checkTypeSaved(type)) // try to replace long name with number
         {
             return;
         }
@@ -133,12 +133,12 @@ public:
         {
             switch (type.ty)
             {
-            case Tint64:
-            case Tuns64:
-            case Tint128:
-            case Tuns128:
-            case Tfloat80:
-            case Twchar:
+            case TY.int64:
+            case TY.uns64:
+            case TY.int128:
+            case TY.uns128:
+            case TY.float80:
+            case TY.wchar_:
                 if (checkTypeSaved(type))
                     return;
                 break;
@@ -150,62 +150,62 @@ public:
         mangleModifier(type);
         switch (type.ty)
         {
-        case Tvoid:
+        case TY.void_:
             buf.writeByte('X');
             break;
-        case Tint8:
+        case TY.int8:
             buf.writeByte('C');
             break;
-        case Tuns8:
+        case TY.uns8:
             buf.writeByte('E');
             break;
-        case Tint16:
+        case TY.int16:
             buf.writeByte('F');
             break;
-        case Tuns16:
+        case TY.uns16:
             buf.writeByte('G');
             break;
-        case Tint32:
+        case TY.int32:
             buf.writeByte('H');
             break;
-        case Tuns32:
+        case TY.uns32:
             buf.writeByte('I');
             break;
-        case Tfloat32:
+        case TY.float32:
             buf.writeByte('M');
             break;
-        case Tint64:
+        case TY.int64:
             buf.writestring("_J");
             break;
-        case Tuns64:
+        case TY.uns64:
             buf.writestring("_K");
             break;
-        case Tint128:
+        case TY.int128:
             buf.writestring("_L");
             break;
-        case Tuns128:
+        case TY.uns128:
             buf.writestring("_M");
             break;
-        case Tfloat64:
+        case TY.float64:
             buf.writeByte('N');
             break;
-        case Tbool:
+        case TY.bool_:
             buf.writestring("_N");
             break;
-        case Tchar:
+        case TY.char_:
             buf.writeByte('D');
             break;
-        case Tdchar:
+        case TY.dchar_:
             buf.writeByte('I');
             break;
             // unsigned int
-        case Tfloat80:
+        case TY.float80:
             if (flags & IS_DMC)
                 buf.writestring("_Z"); // DigitalMars long double
             else
                 buf.writestring("_T"); // Intel long double
             break;
-        case Twchar:
+        case TY.wchar_:
             if (flags & IS_DMC)
                 buf.writestring("_Y"); // DigitalMars wchar_t
             else
@@ -242,7 +242,7 @@ public:
             buf.writeByte('P');
         flags |= IS_NOT_TOP_TYPE;
         assert(type.next);
-        if (type.next.ty == Tsarray)
+        if (type.next.ty == TY.sarray)
         {
             mangleArray(cast(TypeSArray)type.next);
         }
@@ -263,7 +263,7 @@ public:
             return;
         }
         assert(type.next);
-        if (type.next.ty == Tfunction)
+        if (type.next.ty == TY.function_)
         {
             const(char)* arg = mangleFunctionType(cast(TypeFunction)type.next); // compute args before checking to save; args should be saved before function type
             // If we've mangled this function early, previous call is meaningless.
@@ -282,7 +282,7 @@ public:
             flags &= ~IGNORE_CONST;
             return;
         }
-        else if (type.next.ty == Tsarray)
+        else if (type.next.ty == TY.sarray)
         {
             if (checkTypeSaved(type))
                 return;
@@ -332,7 +332,7 @@ public:
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
         assert(type.next);
-        if (type.next.ty == Tsarray)
+        if (type.next.ty == TY.sarray)
         {
             mangleArray(cast(TypeSArray)type.next);
         }
@@ -410,29 +410,29 @@ public:
         buf.writeByte('W');
         switch (type.sym.memtype.ty)
         {
-        case Tchar:
-        case Tint8:
+        case TY.char_:
+        case TY.int8:
             buf.writeByte('0');
             break;
-        case Tuns8:
+        case TY.uns8:
             buf.writeByte('1');
             break;
-        case Tint16:
+        case TY.int16:
             buf.writeByte('2');
             break;
-        case Tuns16:
+        case TY.uns16:
             buf.writeByte('3');
             break;
-        case Tint32:
+        case TY.int32:
             buf.writeByte('4');
             break;
-        case Tuns32:
+        case TY.uns32:
             buf.writeByte('5');
             break;
-        case Tint64:
+        case TY.int64:
             buf.writeByte('6');
             break;
-        case Tuns64:
+        case TY.uns64:
             buf.writeByte('7');
             break;
         default:
@@ -616,10 +616,10 @@ private:
         {
             cv_mod = 'A'; // mutable
         }
-        if (t.ty != Tpointer)
+        if (t.ty != TY.pointer)
             t = t.mutableOf();
         t.accept(this);
-        if ((t.ty == Tpointer || t.ty == Treference || t.ty == Tclass) && global.params.is64bit)
+        if ((t.ty == TY.pointer || t.ty == TY.reference || t.ty == TY.class_) && global.params.is64bit)
         {
             buf.writeByte('E');
         }
@@ -933,7 +933,7 @@ private:
         {
             if (flags & IS_NOT_TOP_TYPE)
                 buf.writeByte('B'); // const
-            else if ((flags & IS_DMC) && type.ty != Tpointer)
+            else if ((flags & IS_DMC) && type.ty != TY.pointer)
                 buf.writestring("_O");
         }
         else if (flags & IS_NOT_TOP_TYPE)
@@ -945,7 +945,7 @@ private:
         mangleModifier(type);
         size_t i = 0;
         Type cur = type;
-        while (cur && cur.ty == Tsarray)
+        while (cur && cur.ty == TY.sarray)
         {
             i++;
             cur = cur.nextOf();
@@ -953,7 +953,7 @@ private:
         buf.writeByte('Y');
         mangleNumber(i); // count of dimensions
         cur = type;
-        while (cur && cur.ty == Tsarray) // sizes of dimensions
+        while (cur && cur.ty == TY.sarray) // sizes of dimensions
         {
             TypeSArray sa = cast(TypeSArray)cur;
             mangleNumber(sa.dim ? sa.dim.toInteger() : 0);
@@ -1006,7 +1006,7 @@ private:
             if (type.isref)
                 rettype = rettype.referenceTo();
             flags &= ~IGNORE_CONST;
-            if (rettype.ty == Tstruct || rettype.ty == Tenum)
+            if (rettype.ty == TY.struct_ || rettype.ty == TY.enum_)
             {
                 const id = rettype.toDsymbol(null).ident;
                 if (id != Id.__c_long_double && id != Id.__c_long && id != Id.__c_ulong)
@@ -1042,7 +1042,7 @@ private:
                     td = new TypeDelegate(td);
                     t = merge(t);
                 }
-                if (t.ty == Tsarray)
+                if (t.ty == TY.sarray)
                 {
                     t.error(Loc(), "Internal Compiler Error: unable to pass static array to extern(C++) function.");
                     t.error(Loc(), "Use pointer instead.");

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -366,7 +366,7 @@ extern (C++) UnionExp copyLiteral(Expression e)
             if (!m)
                 m = voidInitLiteral(v.type, v).copy();
 
-            if (v.type.ty == Tarray || v.type.ty == Taarray)
+            if (v.type.ty == TY.array || v.type.ty == TY.aarray)
             {
                 // Don't have to copy array references
             }
@@ -376,7 +376,7 @@ extern (C++) UnionExp copyLiteral(Expression e)
                 m = copyLiteral(m).copy();
 
                 // Block assignment from inside struct literals
-                if (v.type.ty != m.type.ty && v.type.ty == Tsarray)
+                if (v.type.ty != m.type.ty && v.type.ty == TY.sarray)
                 {
                     auto tsa = cast(TypeSArray)v.type;
                     auto len = cast(size_t)tsa.dim.toInteger();
@@ -404,7 +404,7 @@ extern (C++) UnionExp copyLiteral(Expression e)
     if (e.op == TOKslice)
     {
         SliceExp se = cast(SliceExp)e;
-        if (se.type.toBasetype().ty == Tsarray)
+        if (se.type.toBasetype().ty == TY.sarray)
         {
             // same with resolveSlice()
             if (se.e1.op == TOKnull)
@@ -586,7 +586,7 @@ extern (C++) uinteger_t resolveArrayLength(Expression e)
  */
 extern (C++) ArrayLiteralExp createBlockDuplicatedArrayLiteral(Loc loc, Type type, Expression elem, size_t dim)
 {
-    if (type.ty == Tsarray && type.nextOf().ty == Tsarray && elem.type.ty != Tsarray)
+    if (type.ty == TY.sarray && type.nextOf().ty == TY.sarray && elem.type.ty != TY.sarray)
     {
         // If it is a multidimensional array literal, do it recursively
         auto tsa = cast(TypeSArray)type.nextOf();
@@ -596,7 +596,7 @@ extern (C++) ArrayLiteralExp createBlockDuplicatedArrayLiteral(Loc loc, Type typ
 
     // Buzilla 15681
     auto tb = elem.type.toBasetype();
-    const mustCopy = tb.ty == Tstruct || tb.ty == Tsarray;
+    const mustCopy = tb.ty == TY.struct_ || tb.ty == TY.sarray;
 
     auto elements = new Expressions();
     elements.setDim(dim);
@@ -646,7 +646,7 @@ extern (C++) StringExp createBlockDuplicatedStringLiteral(Loc loc, Type type, dc
 extern (C++) bool isAssocArray(Type t)
 {
     t = t.toBasetype();
-    if (t.ty == Taarray)
+    if (t.ty == TY.aarray)
         return true;
     return false;
 }
@@ -655,7 +655,7 @@ extern (C++) bool isAssocArray(Type t)
 extern (C++) TypeAArray toBuiltinAAType(Type t)
 {
     t = t.toBasetype();
-    if (t.ty == Taarray)
+    if (t.ty == TY.aarray)
         return cast(TypeAArray)t;
     assert(0);
 }
@@ -664,7 +664,7 @@ extern (C++) TypeAArray toBuiltinAAType(Type t)
 // Return true if type is TypeInfo_Class
 extern (C++) bool isTypeInfo_Class(Type type)
 {
-    return type.ty == Tclass && (Type.dtypeinfo == (cast(TypeClass)type).sym || Type.dtypeinfo.isBaseOf((cast(TypeClass)type).sym, null));
+    return type.ty == TY.class_ && (Type.dtypeinfo == (cast(TypeClass)type).sym || Type.dtypeinfo.isBaseOf((cast(TypeClass)type).sym, null));
 }
 
 /************** Pointer operations ************************************/
@@ -672,13 +672,13 @@ extern (C++) bool isTypeInfo_Class(Type type)
 extern (C++) bool isPointer(Type t)
 {
     Type tb = t.toBasetype();
-    return tb.ty == Tpointer && tb.nextOf().ty != Tfunction;
+    return tb.ty == TY.pointer && tb.nextOf().ty != TY.function_;
 }
 
 // For CTFE only. Returns true if 'e' is true or a non-null pointer.
 extern (C++) bool isTrueBool(Expression e)
 {
-    return e.isBool(true) || ((e.type.ty == Tpointer || e.type.ty == Tclass) && e.op != TOKnull);
+    return e.isBool(true) || ((e.type.ty == TY.pointer || e.type.ty == TY.class_) && e.op != TOKnull);
 }
 
 /* Is it safe to convert from srcPointee* to destPointee* ?
@@ -688,7 +688,7 @@ extern (C++) bool isTrueBool(Expression e)
 extern (C++) bool isSafePointerCast(Type srcPointee, Type destPointee)
 {
     // It's safe to cast S** to D** if it's OK to cast S* to D*
-    while (srcPointee.ty == Tpointer && destPointee.ty == Tpointer)
+    while (srcPointee.ty == TY.pointer && destPointee.ty == TY.pointer)
     {
         srcPointee = srcPointee.nextOf();
         destPointee = destPointee.nextOf();
@@ -697,18 +697,18 @@ extern (C++) bool isSafePointerCast(Type srcPointee, Type destPointee)
     if (srcPointee.constConv(destPointee))
         return true;
     // It's OK if function pointers differ only in safe/pure/nothrow
-    if (srcPointee.ty == Tfunction && destPointee.ty == Tfunction)
+    if (srcPointee.ty == TY.function_ && destPointee.ty == TY.function_)
         return srcPointee.covariant(destPointee) == 1;
     // it's OK to cast to void*
-    if (destPointee.ty == Tvoid)
+    if (destPointee.ty == TY.void_)
         return true;
     // It's OK to cast from V[K] to void*
-    if (srcPointee.ty == Taarray && destPointee == Type.tvoidptr)
+    if (srcPointee.ty == TY.aarray && destPointee == Type.tvoidptr)
         return true;
     // It's OK if they are the same size (static array of) integers, eg:
     //     int*     --> uint*
     //     int[5][] --> uint[5][]
-    if (srcPointee.ty == Tsarray && destPointee.ty == Tsarray)
+    if (srcPointee.ty == TY.sarray && destPointee.ty == TY.sarray)
     {
         if (srcPointee.size() != destPointee.size())
             return false;
@@ -743,16 +743,16 @@ extern (C++) Expression getAggregateFromPointer(Expression e, dinteger_t* ofs)
     {
         IndexExp ie = cast(IndexExp)e;
         // Note that each AA element is part of its own memory block
-        if ((ie.e1.type.ty == Tarray || ie.e1.type.ty == Tsarray || ie.e1.op == TOKstring || ie.e1.op == TOKarrayliteral) && ie.e2.op == TOKint64)
+        if ((ie.e1.type.ty == TY.array || ie.e1.type.ty == TY.sarray || ie.e1.op == TOKstring || ie.e1.op == TOKarrayliteral) && ie.e2.op == TOKint64)
         {
             *ofs = ie.e2.toInteger();
             return ie.e1;
         }
     }
-    if (e.op == TOKslice && e.type.toBasetype().ty == Tsarray)
+    if (e.op == TOKslice && e.type.toBasetype().ty == TY.sarray)
     {
         SliceExp se = cast(SliceExp)e;
-        if ((se.e1.type.ty == Tarray || se.e1.type.ty == Tsarray || se.e1.op == TOKstring || se.e1.op == TOKarrayliteral) && se.lwr.op == TOKint64)
+        if ((se.e1.type.ty == TY.array || se.e1.type.ty == TY.sarray || se.e1.op == TOKstring || se.e1.op == TOKarrayliteral) && se.lwr.op == TOKint64)
         {
             *ofs = se.lwr.toInteger();
             return se.e1;
@@ -825,7 +825,7 @@ extern (C++) UnionExp pointerDifference(Loc loc, Type type, Expression e1, Expre
 extern (C++) UnionExp pointerArithmetic(Loc loc, TOK op, Type type, Expression eptr, Expression e2)
 {
     UnionExp ue;
-    if (eptr.type.nextOf().ty == Tvoid)
+    if (eptr.type.nextOf().ty == TY.void_)
     {
         error(loc, "cannot perform arithmetic on `void*` pointers at compile time");
     Lcant:
@@ -838,7 +838,7 @@ extern (C++) UnionExp pointerArithmetic(Loc loc, TOK op, Type type, Expression e
     Expression agg1 = getAggregateFromPointer(eptr, &ofs1);
     if (agg1.op == TOKsymoff)
     {
-        if ((cast(SymOffExp)agg1).var.type.ty != Tsarray)
+        if ((cast(SymOffExp)agg1).var.type.ty != TY.sarray)
         {
             error(loc, "cannot perform pointer arithmetic on arrays of unknown length at compile time");
             goto Lcant;
@@ -892,7 +892,7 @@ extern (C++) UnionExp pointerArithmetic(Loc loc, TOK op, Type type, Expression e
         error(loc, "CTFE internal error: pointer arithmetic `%s`", agg1.toChars());
         goto Lcant;
     }
-    if (eptr.type.toBasetype().ty == Tsarray)
+    if (eptr.type.toBasetype().ty == TY.sarray)
     {
         dinteger_t dim = (cast(TypeSArray)eptr.type.toBasetype()).dim.toInteger();
         // Create a CTFE pointer &agg1[indx .. indx+dim]
@@ -1156,7 +1156,7 @@ private int ctfeCmpArrays(Loc loc, Expression e1, Expression e2, uinteger_t len)
  */
 private FuncDeclaration funcptrOf(Expression e)
 {
-    assert(e.type.ty == Tdelegate);
+    assert(e.type.ty == TY.delegate_);
     if (e.op == TOKdelegate)
         return (cast(DelegateExp)e).func;
     if (e.op == TOKfunction)
@@ -1194,7 +1194,7 @@ private int ctfeRawCmp(Loc loc, Expression e1, Expression e2)
     // null == null, regardless of type
     if (e1.op == TOKnull && e2.op == TOKnull)
         return 0;
-    if (e1.type.ty == Tpointer && e2.type.ty == Tpointer)
+    if (e1.type.ty == TY.pointer && e2.type.ty == TY.pointer)
     {
         // Can only be an equality test.
         dinteger_t ofs1, ofs2;
@@ -1207,7 +1207,7 @@ private int ctfeRawCmp(Loc loc, Expression e1, Expression e2)
         }
         return 1;
     }
-    if (e1.type.ty == Tdelegate && e2.type.ty == Tdelegate)
+    if (e1.type.ty == TY.delegate_ && e2.type.ty == TY.delegate_)
     {
         // If .funcptr isn't the same, they are not equal
         if (funcptrOf(e1) != funcptrOf(e2))
@@ -1569,7 +1569,7 @@ extern (C++) Expression ctfeCast(Loc loc, Type type, Type to, Expression e)
         // necessary not to change e's address for pointer comparisons
         r = e;
     }
-    else if (to.toBasetype().ty == Tarray && type.toBasetype().ty == Tarray && to.toBasetype().nextOf().size() == type.toBasetype().nextOf().size())
+    else if (to.toBasetype().ty == TY.array && type.toBasetype().ty == TY.array && to.toBasetype().nextOf().size() == type.toBasetype().nextOf().size())
     {
         // https://issues.dlang.org/show_bug.cgi?id=12495
         // Array reinterpret casts: eg. string to immutable(ubyte)[]
@@ -1640,7 +1640,7 @@ extern (C++) void assignInPlace(Expression dest, Expression src)
             assert(o.op == e.op);
             assignInPlace(o, e);
         }
-        else if (e.type.ty == Tsarray && e.op != TOKvoid && o.type.ty == Tsarray)
+        else if (e.type.ty == TY.sarray && e.op != TOKvoid && o.type.ty == TY.sarray)
         {
             assignInPlace(o, e);
         }
@@ -1737,7 +1737,7 @@ extern (C++) UnionExp changeArrayLiteralLength(Loc loc, TypeArray arrayType, Exp
             for (size_t i = 0; i < copylen; i++)
                 (*elements)[i] = (*ae.elements)[indxlo + i];
         }
-        if (elemType.ty == Tstruct || elemType.ty == Tsarray)
+        if (elemType.ty == TY.struct_ || elemType.ty == TY.sarray)
         {
             /* If it is an aggregate literal representing a value type,
              * we need to create a unique copy for each element
@@ -1768,7 +1768,7 @@ extern (C++) bool isCtfeValueValid(Expression newval)
     }
     if (newval.op == TOKnull)
     {
-        return tb.ty == Tnull || tb.ty == Tpointer || tb.ty == Tarray || tb.ty == Taarray || tb.ty == Tclass || tb.ty == Tdelegate;
+        return tb.ty == TY.null_ || tb.ty == TY.pointer || tb.ty == TY.array || tb.ty == TY.aarray || tb.ty == TY.class_ || tb.ty == TY.delegate_;
     }
     if (newval.op == TOKstring)
         return true; // CTFE would directly use the StringExp in AST.
@@ -1806,7 +1806,7 @@ extern (C++) bool isCtfeValueValid(Expression newval)
     {
         // e1 should be a CTFE reference
         Expression e1 = (cast(AddrExp)newval).e1;
-        return tb.ty == Tpointer && (e1.op == TOKstructliteral && isCtfeValueValid(e1) || e1.op == TOKvar || e1.op == TOKdotvar && isCtfeReferenceValid(e1) || e1.op == TOKindex && isCtfeReferenceValid(e1) || e1.op == TOKslice && e1.type.toBasetype().ty == Tsarray);
+        return tb.ty == TY.pointer && (e1.op == TOKstructliteral && isCtfeValueValid(e1) || e1.op == TOKvar || e1.op == TOKdotvar && isCtfeReferenceValid(e1) || e1.op == TOKindex && isCtfeReferenceValid(e1) || e1.op == TOKslice && e1.type.toBasetype().ty == TY.sarray);
     }
     if (newval.op == TOKslice)
     {
@@ -1814,7 +1814,7 @@ extern (C++) bool isCtfeValueValid(Expression newval)
         SliceExp se = cast(SliceExp)newval;
         assert(se.lwr && se.lwr.op == TOKint64);
         assert(se.upr && se.upr.op == TOKint64);
-        return (tb.ty == Tarray || tb.ty == Tsarray) && (se.e1.op == TOKstring || se.e1.op == TOKarrayliteral);
+        return (tb.ty == TY.array || tb.ty == TY.sarray) && (se.e1.op == TOKstring || se.e1.op == TOKarrayliteral);
     }
     if (newval.op == TOKvoid)
         return true; // uninitialized value
@@ -1944,7 +1944,7 @@ extern (C++) void showCtfeExpr(Expression e, int level = 0)
             if (v)
             {
                 // If it is a void assignment, use the default initializer
-                if ((v.type.ty != z.type.ty) && v.type.ty == Tsarray)
+                if ((v.type.ty != z.type.ty) && v.type.ty == TY.sarray)
                 {
                     for (int j = level; --j;)
                         printf(" ");
@@ -1961,7 +1961,7 @@ extern (C++) void showCtfeExpr(Expression e, int level = 0)
 extern (C++) UnionExp voidInitLiteral(Type t, VarDeclaration var)
 {
     UnionExp ue;
-    if (t.ty == Tsarray)
+    if (t.ty == TY.sarray)
     {
         TypeSArray tsa = cast(TypeSArray)t;
         Expression elem = voidInitLiteral(tsa.next, var).copy();
@@ -1982,7 +1982,7 @@ extern (C++) UnionExp voidInitLiteral(Type t, VarDeclaration var)
         ae.type = tsa;
         ae.ownedByCtfe = OwnedBy.ctfe;
     }
-    else if (t.ty == Tstruct)
+    else if (t.ty == TY.struct_)
     {
         TypeStruct ts = cast(TypeStruct)t;
         auto exps = new Expressions();

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -90,7 +90,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                 return;
             }
 
-            if (t.ty != Terror && e.type.ty != Terror)
+            if (t.ty != TY.error && e.type.ty != TY.error)
             {
                 if (!t.deco)
                 {
@@ -142,7 +142,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
             visit(cast(Expression)e);
 
             Type tb = result.type.toBasetype();
-            if (tb.ty == Tarray)
+            if (tb.ty == TY.array)
                 semanticTypeInfo(sc, (cast(TypeDArray)tb).next);
         }
 
@@ -158,7 +158,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                 ArrayLiteralExp ale = cast(ArrayLiteralExp)e.e1;
                 Type tb = t.toBasetype();
                 Type tx;
-                if (tb.ty == Tsarray)
+                if (tb.ty == TY.sarray)
                     tx = tb.nextOf().sarrayOf(ale.elements ? ale.elements.dim : 0);
                 else
                     tx = tb.nextOf().arrayOf();
@@ -249,11 +249,11 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
         static MATCH implicitMod(Expression e, Type t, MOD mod)
         {
             Type tprime;
-            if (t.ty == Tpointer)
+            if (t.ty == TY.pointer)
                 tprime = t.nextOf().castMod(mod).pointerTo();
-            else if (t.ty == Tarray)
+            else if (t.ty == TY.array)
                 tprime = t.nextOf().castMod(mod).arrayOf();
-            else if (t.ty == Tsarray)
+            else if (t.ty == TY.sarray)
                 tprime = t.nextOf().castMod(mod).sarrayOf(t.size() / t.nextOf().size());
             else
                 tprime = t.castMod(mod);
@@ -272,19 +272,19 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (typeb.ty != Tpointer || tb.ty != Tpointer)
+            if (typeb.ty != TY.pointer || tb.ty != TY.pointer)
                 return MATCH.nomatch;
 
             Type t1b = e.e1.type.toBasetype();
             Type t2b = e.e2.type.toBasetype();
-            if (t1b.ty == Tpointer && t2b.isintegral() && t1b.equivalent(tb))
+            if (t1b.ty == TY.pointer && t2b.isintegral() && t1b.equivalent(tb))
             {
                 // ptr + offset
                 // ptr - offset
                 MATCH m = e.e1.implicitConvTo(t);
                 return (m > MATCH.constant) ? MATCH.constant : m;
             }
-            if (t2b.ty == Tpointer && t1b.isintegral() && t2b.equivalent(tb))
+            if (t2b.ty == TY.pointer && t1b.isintegral() && t2b.equivalent(tb))
             {
                 // offset + ptr
                 MATCH m = e.e2.implicitConvTo(t);
@@ -333,32 +333,32 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             TY toty = t.toBasetype().ty;
             TY oldty = ty;
 
-            if (m == MATCH.nomatch && t.ty == Tenum)
+            if (m == MATCH.nomatch && t.ty == TY.enum_)
                 return;
 
-            if (t.ty == Tvector)
+            if (t.ty == TY.vector)
             {
                 TypeVector tv = cast(TypeVector)t;
                 TypeBasic tb = tv.elementType();
-                if (tb.ty == Tvoid)
+                if (tb.ty == TY.void_)
                     return;
                 toty = tb.ty;
             }
 
             switch (ty)
             {
-            case Tbool:
-            case Tint8:
-            case Tchar:
-            case Tuns8:
-            case Tint16:
-            case Tuns16:
-            case Twchar:
-                ty = Tint32;
+            case TY.bool_:
+            case TY.int8:
+            case TY.char_:
+            case TY.uns8:
+            case TY.int16:
+            case TY.uns16:
+            case TY.wchar_:
+                ty = TY.int32;
                 break;
 
-            case Tdchar:
-                ty = Tuns32;
+            case TY.dchar_:
+                ty = TY.uns32;
                 break;
 
             default:
@@ -369,68 +369,68 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             dinteger_t value = e.toInteger();
             switch (toty)
             {
-            case Tbool:
+            case TY.bool_:
                 if ((value & 1) != value)
                     return;
                 break;
 
-            case Tint8:
-                if (ty == Tuns64 && value & ~0x7FU)
+            case TY.int8:
+                if (ty == TY.uns64 && value & ~0x7FU)
                     return;
                 else if (cast(byte)value != value)
                     return;
                 break;
 
-            case Tchar:
-                if ((oldty == Twchar || oldty == Tdchar) && value > 0x7F)
+            case TY.char_:
+                if ((oldty == TY.wchar_ || oldty == TY.dchar_) && value > 0x7F)
                     return;
-                goto case Tuns8;
-            case Tuns8:
+                goto case TY.uns8;
+            case TY.uns8:
                 //printf("value = %llu %llu\n", (dinteger_t)(unsigned char)value, value);
                 if (cast(ubyte)value != value)
                     return;
                 break;
 
-            case Tint16:
-                if (ty == Tuns64 && value & ~0x7FFFU)
+            case TY.int16:
+                if (ty == TY.uns64 && value & ~0x7FFFU)
                     return;
                 else if (cast(short)value != value)
                     return;
                 break;
 
-            case Twchar:
-                if (oldty == Tdchar && value > 0xD7FF && value < 0xE000)
+            case TY.wchar_:
+                if (oldty == TY.dchar_ && value > 0xD7FF && value < 0xE000)
                     return;
-                goto case Tuns16;
-            case Tuns16:
+                goto case TY.uns16;
+            case TY.uns16:
                 if (cast(ushort)value != value)
                     return;
                 break;
 
-            case Tint32:
-                if (ty == Tuns32)
+            case TY.int32:
+                if (ty == TY.uns32)
                 {
                 }
-                else if (ty == Tuns64 && value & ~0x7FFFFFFFU)
+                else if (ty == TY.uns64 && value & ~0x7FFFFFFFU)
                     return;
                 else if (cast(int)value != value)
                     return;
                 break;
 
-            case Tuns32:
-                if (ty == Tint32)
+            case TY.uns32:
+                if (ty == TY.int32)
                 {
                 }
                 else if (cast(uint)value != value)
                     return;
                 break;
 
-            case Tdchar:
+            case TY.dchar_:
                 if (value > 0x10FFFFU)
                     return;
                 break;
 
-            case Tfloat32:
+            case TY.float32:
                 {
                     float f;
                     if (e.type.isunsigned())
@@ -448,7 +448,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     break;
                 }
 
-            case Tfloat64:
+            case TY.float64:
                 {
                     double f;
                     if (e.type.isunsigned())
@@ -466,7 +466,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     break;
                 }
 
-            case Tfloat80:
+            case TY.float80:
                 {
                     if (e.type.isunsigned())
                     {
@@ -483,10 +483,10 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     break;
                 }
 
-            case Tpointer:
+            case TY.pointer:
                 //printf("type = %s\n", type.toBasetype()->toChars());
                 //printf("t = %s\n", t.toBasetype()->toChars());
-                if (ty == Tpointer && e.type.toBasetype().nextOf().ty == t.toBasetype().nextOf().ty)
+                if (ty == TY.pointer && e.type.toBasetype().nextOf().ty == t.toBasetype().nextOf().ty)
                 {
                     /* Allow things like:
                      *      const char* P = cast(char *)3;
@@ -544,7 +544,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             visit(cast(Expression)e);
             if (result != MATCH.nomatch)
                 return;
-            if (e.type.ty == t.ty && e.type.ty == Tstruct && (cast(TypeStruct)e.type).sym == (cast(TypeStruct)t).sym)
+            if (e.type.ty == t.ty && e.type.ty == TY.struct_ && (cast(TypeStruct)e.type).sym == (cast(TypeStruct)t).sym)
             {
                 result = MATCH.constant;
                 for (size_t i = 0; i < e.elements.dim; i++)
@@ -567,18 +567,18 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 printf("StringExp::implicitConvTo(this=%s, committed=%d, type=%s, t=%s)\n", e.toChars(), e.committed, e.type.toChars(), t.toChars());
             }
-            if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
+            if (!e.committed && t.ty == TY.pointer && t.nextOf().ty == TY.void_)
                 return;
 
-            if (e.type.ty == Tsarray || e.type.ty == Tarray || e.type.ty == Tpointer)
+            if (e.type.ty == TY.sarray || e.type.ty == TY.array || e.type.ty == TY.pointer)
             {
                 TY tyn = e.type.nextOf().ty;
-                if (tyn == Tchar || tyn == Twchar || tyn == Tdchar)
+                if (tyn == TY.char_ || tyn == TY.wchar_ || tyn == TY.dchar_)
                 {
                     switch (t.ty)
                     {
-                    case Tsarray:
-                        if (e.type.ty == Tsarray)
+                    case TY.sarray:
+                        if (e.type.ty == TY.sarray)
                         {
                             TY tynto = t.nextOf().ty;
                             if (tynto == tyn)
@@ -589,7 +589,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                 }
                                 return;
                             }
-                            if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
+                            if (tynto == TY.char_ || tynto == TY.wchar_ || tynto == TY.dchar_)
                             {
                                 if (e.committed && tynto != tyn)
                                     return;
@@ -604,16 +604,16 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                     return;
                                 }
                             }
-                            if (!e.committed && (tynto == Tchar || tynto == Twchar || tynto == Tdchar))
+                            if (!e.committed && (tynto == TY.char_ || tynto == TY.wchar_ || tynto == TY.dchar_))
                             {
                                 result = MATCH.exact;
                                 return;
                             }
                         }
-                        else if (e.type.ty == Tarray)
+                        else if (e.type.ty == TY.array)
                         {
                             TY tynto = t.nextOf().ty;
-                            if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
+                            if (tynto == TY.char_ || tynto == TY.wchar_ || tynto == TY.dchar_)
                             {
                                 if (e.committed && tynto != tyn)
                                     return;
@@ -633,15 +633,15 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                 result = MATCH.exact;
                                 return;
                             }
-                            if (!e.committed && (tynto == Tchar || tynto == Twchar || tynto == Tdchar))
+                            if (!e.committed && (tynto == TY.char_ || tynto == TY.wchar_ || tynto == TY.dchar_))
                             {
                                 result = MATCH.exact;
                                 return;
                             }
                         }
                         goto case; /+ fall through +/
-                    case Tarray:
-                    case Tpointer:
+                    case TY.array:
+                    case TY.pointer:
                         Type tn = t.nextOf();
                         MATCH m = MATCH.exact;
                         if (e.type.nextOf().mod != tn.mod)
@@ -655,17 +655,17 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                         {
                             switch (tn.ty)
                             {
-                            case Tchar:
+                            case TY.char_:
                                 if (e.postfix == 'w' || e.postfix == 'd')
                                     m = MATCH.convert;
                                 result = m;
                                 return;
-                            case Twchar:
+                            case TY.wchar_:
                                 if (e.postfix != 'w')
                                     m = MATCH.convert;
                                 result = m;
                                 return;
-                            case Tdchar:
+                            case TY.dchar_:
                                 if (e.postfix != 'd')
                                     m = MATCH.convert;
                                 result = m;
@@ -694,13 +694,13 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if ((tb.ty == Tarray || tb.ty == Tsarray) &&
-                (typeb.ty == Tarray || typeb.ty == Tsarray))
+            if ((tb.ty == TY.array || tb.ty == TY.sarray) &&
+                (typeb.ty == TY.array || typeb.ty == TY.sarray))
             {
                 result = MATCH.exact;
                 Type typen = typeb.nextOf().toBasetype();
 
-                if (tb.ty == Tsarray)
+                if (tb.ty == TY.sarray)
                 {
                     TypeSArray tsa = cast(TypeSArray)tb;
                     if (e.elements.dim != tsa.dim.toInteger())
@@ -710,7 +710,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 Type telement = tb.nextOf();
                 if (!e.elements.dim)
                 {
-                    if (typen.ty != Tvoid)
+                    if (typen.ty != TY.void_)
                         result = typen.implicitConvTo(telement);
                 }
                 else
@@ -739,13 +739,13 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
 
                 return;
             }
-            else if (tb.ty == Tvector && (typeb.ty == Tarray || typeb.ty == Tsarray))
+            else if (tb.ty == TY.vector && (typeb.ty == TY.array || typeb.ty == TY.sarray))
             {
                 result = MATCH.exact;
                 // Convert array literal to vector type
                 TypeVector tv = cast(TypeVector)tb;
                 TypeSArray tbase = cast(TypeSArray)tv.basetype;
-                assert(tbase.ty == Tsarray);
+                assert(tbase.ty == TY.sarray);
                 const edim = e.elements.dim;
                 const tbasedim = tbase.dim.toInteger();
                 if (edim > tbasedim)
@@ -782,7 +782,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (tb.ty == Taarray && typeb.ty == Taarray)
+            if (tb.ty == TY.aarray && typeb.ty == TY.aarray)
             {
                 result = MATCH.exact;
                 for (size_t i = 0; i < e.keys.dim; i++)
@@ -836,7 +836,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
              */
             Type tx = e.f ? e.f.type : e.e1.type;
             tx = tx.toBasetype();
-            if (tx.ty != Tfunction)
+            if (tx.ty != TY.function_)
                 return;
             TypeFunction tf = cast(TypeFunction)tx;
 
@@ -957,7 +957,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
 
             // Look for pointers to functions where the functions are overloaded.
             if (e.e1.op == TOKoverloadset &&
-                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
+                (tb.ty == TY.pointer || tb.ty == TY.delegate_) && tb.nextOf().ty == TY.function_)
             {
                 OverExp eo = cast(OverExp)e.e1;
                 FuncDeclaration f = null;
@@ -983,8 +983,8 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             }
 
             if (e.e1.op == TOKvar &&
-                typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
-                tb.ty == Tpointer && tb.nextOf().ty == Tfunction)
+                typeb.ty == TY.pointer && typeb.nextOf().ty == TY.function_ &&
+                tb.ty == TY.pointer && tb.nextOf().ty == TY.function_)
             {
                 /* I don't think this can ever happen -
                  * it should have been
@@ -1011,16 +1011,16 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type typeb = e.type.toBasetype();
 
             // Look for pointers to functions where the functions are overloaded.
-            if (typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
-                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
+            if (typeb.ty == TY.pointer && typeb.nextOf().ty == TY.function_ &&
+                (tb.ty == TY.pointer || tb.ty == TY.delegate_) && tb.nextOf().ty == TY.function_)
             {
                 if (FuncDeclaration f = e.var.isFuncDeclaration())
                 {
                     f = f.overloadExactMatch(tb.nextOf());
                     if (f)
                     {
-                        if ((tb.ty == Tdelegate && (f.needThis() || f.isNested())) ||
-                            (tb.ty == Tpointer && !(f.needThis() || f.isNested())))
+                        if ((tb.ty == TY.delegate_ && (f.needThis() || f.isNested())) ||
+                            (tb.ty == TY.pointer && !(f.needThis() || f.isNested())))
                         {
                             result = MATCH.exact;
                         }
@@ -1044,7 +1044,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type typeb = e.type.toBasetype();
 
             // Look for pointers to functions where the functions are overloaded.
-            if (typeb.ty == Tdelegate && tb.ty == Tdelegate)
+            if (typeb.ty == TY.delegate_ && tb.ty == TY.delegate_)
             {
                 if (e.func && e.func.overloadExactMatch(tb.nextOf()))
                     result = MATCH.exact;
@@ -1178,7 +1178,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 if (!fd)
                     continue;
-                if (fd.errors || fd.type.ty != Tfunction)
+                if (fd.errors || fd.type.ty != TY.function_)
                     return; // error
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 if (tf.purity == PURE.impure)
@@ -1255,9 +1255,9 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             /* Consider the .init expression as an argument
              */
             Type ntb = e.newtype.toBasetype();
-            if (ntb.ty == Tarray)
+            if (ntb.ty == TY.array)
                 ntb = ntb.nextOf().toBasetype();
-            if (ntb.ty == Tstruct)
+            if (ntb.ty == TY.struct_)
             {
                 // Don't allow nested structs - uplevel reference may not be convertible
                 StructDeclaration sd = (cast(TypeStruct)ntb).sym;
@@ -1269,7 +1269,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 /* Zeros are implicitly convertible, except for special cases.
                  */
-                if (ntb.ty == Tclass)
+                if (ntb.ty == TY.class_)
                 {
                     /* With new() must look at the class instance initializer.
                      */
@@ -1343,7 +1343,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (tb.ty == Tsarray && typeb.ty == Tarray)
+            if (tb.ty == TY.sarray && typeb.ty == TY.array)
             {
                 typeb = toStaticArrayType(e);
                 if (typeb)
@@ -1356,7 +1356,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
              * same mod bits.
              */
             Type t1b = e.e1.type.toBasetype();
-            if (tb.ty == Tarray && typeb.equivalent(tb))
+            if (tb.ty == TY.array && typeb.equivalent(tb))
             {
                 Type tbn = tb.nextOf();
                 Type tx = null;
@@ -1365,16 +1365,16 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                  * is equivalent with the uniqueness of the referred data. And in here
                  * we can have arbitrary typed reference for that.
                  */
-                if (t1b.ty == Tarray)
+                if (t1b.ty == TY.array)
                     tx = tbn.arrayOf();
-                if (t1b.ty == Tpointer)
+                if (t1b.ty == TY.pointer)
                     tx = tbn.pointerTo();
 
                 /* If e.e1 is static array, at least it should be an rvalue.
                  * If not, e.e1 is a reference, and its uniqueness does not link
                  * to the uniqueness of the referred data.
                  */
-                if (t1b.ty == Tsarray && !e.e1.isLvalue())
+                if (t1b.ty == TY.sarray && !e.e1.isLvalue())
                     tx = tbn.sarrayOf(t1b.size() / tbn.size());
 
                 if (tx)
@@ -1386,7 +1386,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             }
 
             // Enhancement 10724
-            if (tb.ty == Tpointer && e.e1.op == TOKstring)
+            if (tb.ty == TY.pointer && e.e1.op == TOKstring)
                 e.e1.accept(this);
         }
     }
@@ -1413,7 +1413,7 @@ extern (C++) Type toStaticArrayType(SliceExp e)
     else
     {
         Type t1b = e.e1.type.toBasetype();
-        if (t1b.ty == Tsarray)
+        if (t1b.ty == TY.sarray)
             return t1b;
     }
     return null;
@@ -1477,16 +1477,16 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
              */
 
             // Fat Value types
-            const(bool) tob_isFV = (tob.ty == Tstruct || tob.ty == Tsarray);
-            const(bool) t1b_isFV = (t1b.ty == Tstruct || t1b.ty == Tsarray);
+            const(bool) tob_isFV = (tob.ty == TY.struct_ || tob.ty == TY.sarray);
+            const(bool) t1b_isFV = (t1b.ty == TY.struct_ || t1b.ty == TY.sarray);
 
             // Fat Reference types
-            const(bool) tob_isFR = (tob.ty == Tarray || tob.ty == Tdelegate);
-            const(bool) t1b_isFR = (t1b.ty == Tarray || t1b.ty == Tdelegate);
+            const(bool) tob_isFR = (tob.ty == TY.array || tob.ty == TY.delegate_);
+            const(bool) t1b_isFR = (t1b.ty == TY.array || t1b.ty == TY.delegate_);
 
             // Reference types
-            const(bool) tob_isR = (tob_isFR || tob.ty == Tpointer || tob.ty == Taarray || tob.ty == Tclass);
-            const(bool) t1b_isR = (t1b_isFR || t1b.ty == Tpointer || t1b.ty == Taarray || t1b.ty == Tclass);
+            const(bool) tob_isR = (tob_isFR || tob.ty == TY.pointer || tob.ty == TY.aarray || tob.ty == TY.class_);
+            const(bool) t1b_isR = (t1b_isFR || t1b.ty == TY.pointer || t1b.ty == TY.aarray || t1b.ty == TY.class_);
 
             // Arithmetic types (== valueable basic types)
             const(bool) tob_isA = (tob.isintegral() || tob.isfloating());
@@ -1497,7 +1497,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 AggregateDeclaration toad = isAggregate(tob);
                 if (t1ad != toad && t1ad.aliasthis)
                 {
-                    if (t1b.ty == Tclass && tob.ty == Tclass)
+                    if (t1b.ty == TY.class_ && tob.ty == TY.class_)
                     {
                         ClassDeclaration t1cd = t1b.isClassHandle();
                         ClassDeclaration tocd = tob.isClassHandle();
@@ -1514,7 +1514,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     return;
                 }
             }
-            else if (tob.ty == Tvector && t1b.ty != Tvector)
+            else if (tob.ty == TY.vector && t1b.ty != TY.vector)
             {
                 //printf("test1 e = %s, e.type = %s, tob = %s\n", e.toChars(), e.type.toChars(), tob.toChars());
                 TypeVector tv = cast(TypeVector)tob;
@@ -1523,10 +1523,10 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 result = result.expressionSemantic(sc);
                 return;
             }
-            else if (tob.ty != Tvector && t1b.ty == Tvector)
+            else if (tob.ty != TY.vector && t1b.ty == TY.vector)
             {
                 // T[n] <-- __vector(U[m])
-                if (tob.ty == Tsarray)
+                if (tob.ty == TY.sarray)
                 {
                     if (t1b.size(e.loc) == tob.size(e.loc))
                         goto Lok;
@@ -1542,7 +1542,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             // arithmetic values vs. other arithmetic values
             // arithmetic values vs. T*
-            if (tob_isA && (t1b_isA || t1b.ty == Tpointer) || t1b_isA && (tob_isA || tob.ty == Tpointer))
+            if (tob_isA && (t1b_isA || t1b.ty == TY.pointer) || t1b_isA && (tob_isA || tob.ty == TY.pointer))
             {
                 goto Lok;
             }
@@ -1566,9 +1566,9 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
             // Fat values vs. null or references
-            if (tob_isFV && (t1b.ty == Tnull || t1b_isR) || t1b_isFV && (tob.ty == Tnull || tob_isR))
+            if (tob_isFV && (t1b.ty == TY.null_ || t1b_isR) || t1b_isFV && (tob.ty == TY.null_ || tob_isR))
             {
-                if (tob.ty == Tpointer && t1b.ty == Tsarray)
+                if (tob.ty == TY.pointer && t1b.ty == TY.sarray)
                 {
                     // T[n] sa;
                     // cast(U*)sa; // ==> cast(U*)sa.ptr;
@@ -1576,7 +1576,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     result.type = t;
                     return;
                 }
-                if (tob.ty == Tarray && t1b.ty == Tsarray)
+                if (tob.ty == TY.array && t1b.ty == TY.sarray)
                 {
                     // T[n] sa;
                     // cast(U[])sa; // ==> cast(U[])sa[];
@@ -1606,34 +1606,34 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 goto Lok;
 
             // typeof(null) <-- non-null references or values
-            if (tob.ty == Tnull && t1b.ty != Tnull)
+            if (tob.ty == TY.null_ && t1b.ty != TY.null_)
                 goto Lfail; // https://issues.dlang.org/show_bug.cgi?id=14629
             // typeof(null) --> non-null references or arithmetic values
-            if (t1b.ty == Tnull && tob.ty != Tnull)
+            if (t1b.ty == TY.null_ && tob.ty != TY.null_)
                 goto Lok;
 
             // Check size mismatch of references.
-            // Tarray and Tdelegate are (void*).sizeof*2, but others have (void*).sizeof.
+            // TY.array and TY.delegate_ are (void*).sizeof*2, but others have (void*).sizeof.
             if (tob_isFR && t1b_isR || t1b_isFR && tob_isR)
             {
-                if (tob.ty == Tpointer && t1b.ty == Tarray)
+                if (tob.ty == TY.pointer && t1b.ty == TY.array)
                 {
                     // T[] da;
                     // cast(U*)da; // ==> cast(U*)da.ptr;
                     goto Lok;
                 }
-                if (tob.ty == Tpointer && t1b.ty == Tdelegate)
+                if (tob.ty == TY.pointer && t1b.ty == TY.delegate_)
                 {
                     // void delegate() dg;
                     // cast(U*)dg; // ==> cast(U*)dg.ptr;
-                    // Note that it happens even when U is a Tfunction!
+                    // Note that it happens even when U is a TY.function_!
                     e.deprecation("casting from %s to %s is deprecated", e.type.toChars(), t.toChars());
                     goto Lok;
                 }
                 goto Lfail;
             }
 
-            if (t1b.ty == Tvoid && tob.ty != Tvoid)
+            if (t1b.ty == TY.void_ && tob.ty != TY.void_)
             {
             Lfail:
                 e.error("cannot cast expression `%s` of type `%s` to `%s`", e.toChars(), e.type.toChars(), t.toChars());
@@ -1713,7 +1713,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             //printf("StringExp::castTo(t = %s), '%s' committed = %d\n", t.toChars(), e.toChars(), e.committed);
 
-            if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
+            if (!e.committed && t.ty == TY.pointer && t.nextOf().ty == TY.void_)
             {
                 e.error("cannot convert string literal to `void*`");
                 result = new ErrorExp();
@@ -1738,7 +1738,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type typeb = e.type.toBasetype();
 
             //printf("\ttype = %s\n", e.type.toChars());
-            if (tb.ty == Tdelegate && typeb.ty != Tdelegate)
+            if (tb.ty == TY.delegate_ && typeb.ty != TY.delegate_)
             {
                 visit(cast(Expression)e);
                 return;
@@ -1761,7 +1761,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
              *  cast(wchar[2])"abcd"c --> [\u6261, \u6463]
              *  cast(wchar[1])"abcd"c --> [\u6261]
              */
-            if (e.committed && tb.ty == Tsarray && typeb.ty == Tarray)
+            if (e.committed && tb.ty == TY.sarray && typeb.ty == TY.array)
             {
                 se = cast(StringExp)e.copy();
                 d_uns64 szx = tb.nextOf().size();
@@ -1784,7 +1784,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 return;
             }
 
-            if (tb.ty != Tsarray && tb.ty != Tarray && tb.ty != Tpointer)
+            if (tb.ty != TY.sarray && tb.ty != TY.array && tb.ty != TY.pointer)
             {
                 if (!copied)
                 {
@@ -1793,7 +1793,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 }
                 goto Lcast;
             }
-            if (typeb.ty != Tsarray && typeb.ty != Tarray && typeb.ty != Tpointer)
+            if (typeb.ty != TY.sarray && typeb.ty != TY.array && typeb.ty != TY.pointer)
             {
                 if (!copied)
                 {
@@ -1810,7 +1810,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     se = cast(StringExp)e.copy();
                     copied = 1;
                 }
-                if (tb.ty == Tsarray)
+                if (tb.ty == TY.sarray)
                     goto L2; // handle possible change in static array dimension
                 se.type = t;
                 result = se;
@@ -1832,12 +1832,12 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 int ttty = tb.nextOf().toBasetype().ty;
                 switch (X(tfty, ttty))
                 {
-                case X(Tchar, Tchar):
-                case X(Twchar, Twchar):
-                case X(Tdchar, Tdchar):
+                case X(TY.char_, TY.char_):
+                case X(TY.wchar_, TY.wchar_):
+                case X(TY.dchar_, TY.dchar_):
                     break;
 
-                case X(Tchar, Twchar):
+                case X(TY.char_, TY.wchar_):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1851,7 +1851,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.writeUTF16(0);
                     goto L1;
 
-                case X(Tchar, Tdchar):
+                case X(TY.char_, TY.dchar_):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1864,7 +1864,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.write4(0);
                     goto L1;
 
-                case X(Twchar, Tchar):
+                case X(TY.wchar_, TY.char_):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1878,7 +1878,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.writeUTF8(0);
                     goto L1;
 
-                case X(Twchar, Tdchar):
+                case X(TY.wchar_, TY.dchar_):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1891,7 +1891,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.write4(0);
                     goto L1;
 
-                case X(Tdchar, Tchar):
+                case X(TY.dchar_, TY.char_):
                     for (size_t u = 0; u < e.len; u++)
                     {
                         uint c = se.dstring[u];
@@ -1905,7 +1905,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.writeUTF8(0);
                     goto L1;
 
-                case X(Tdchar, Twchar):
+                case X(TY.dchar_, TY.wchar_):
                     for (size_t u = 0; u < e.len; u++)
                     {
                         uint c = se.dstring[u];
@@ -1944,7 +1944,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             assert(copied);
 
             // See if need to truncate or extend the literal
-            if (tb.ty == Tsarray)
+            if (tb.ty == TY.sarray)
             {
                 size_t dim2 = cast(size_t)(cast(TypeSArray)tb).dim.toInteger();
                 //printf("dim from = %d, to = %d\n", (int)se.len, (int)dim2);
@@ -1992,7 +1992,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             // Look for pointers to functions where the functions are overloaded.
             if (e.e1.op == TOKoverloadset &&
-                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
+                (tb.ty == TY.pointer || tb.ty == TY.delegate_) && tb.nextOf().ty == TY.function_)
             {
                 OverExp eo = cast(OverExp)e.e1;
                 FuncDeclaration f = null;
@@ -2026,8 +2026,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
             if (e.e1.op == TOKvar &&
-                typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
-                tb.ty == Tpointer && tb.nextOf().ty == Tfunction)
+                typeb.ty == TY.pointer && typeb.nextOf().ty == TY.function_ &&
+                tb.ty == TY.pointer && tb.nextOf().ty == TY.function_)
             {
                 auto ve = cast(VarExp)e.e1;
                 auto f = ve.var.isFuncDeclaration();
@@ -2105,20 +2105,20 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if ((tb.ty == Tarray || tb.ty == Tsarray) &&
-                (typeb.ty == Tarray || typeb.ty == Tsarray))
+            if ((tb.ty == TY.array || tb.ty == TY.sarray) &&
+                (typeb.ty == TY.array || typeb.ty == TY.sarray))
             {
-                if (tb.nextOf().toBasetype().ty == Tvoid && typeb.nextOf().toBasetype().ty != Tvoid)
+                if (tb.nextOf().toBasetype().ty == TY.void_ && typeb.nextOf().toBasetype().ty != TY.void_)
                 {
                     // Don't do anything to cast non-void[] to void[]
                 }
-                else if (typeb.ty == Tsarray && typeb.nextOf().toBasetype().ty == Tvoid)
+                else if (typeb.ty == TY.sarray && typeb.nextOf().toBasetype().ty == TY.void_)
                 {
                     // Don't do anything for casting void[n] to others
                 }
                 else
                 {
-                    if (tb.ty == Tsarray)
+                    if (tb.ty == TY.sarray)
                     {
                         TypeSArray tsa = cast(TypeSArray)tb;
                         if (e.elements.dim != tsa.dim.toInteger())
@@ -2142,7 +2142,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     return;
                 }
             }
-            else if (tb.ty == Tpointer && typeb.ty == Tsarray)
+            else if (tb.ty == TY.pointer && typeb.ty == TY.sarray)
             {
                 Type tp = typeb.nextOf().pointerTo();
                 if (!tp.equals(ae.type))
@@ -2151,12 +2151,12 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     ae.type = tp;
                 }
             }
-            else if (tb.ty == Tvector && (typeb.ty == Tarray || typeb.ty == Tsarray))
+            else if (tb.ty == TY.vector && (typeb.ty == TY.array || typeb.ty == TY.sarray))
             {
                 // Convert array literal to vector type
                 TypeVector tv = cast(TypeVector)tb;
                 TypeSArray tbase = cast(TypeSArray)tv.basetype;
-                assert(tbase.ty == Tsarray);
+                assert(tbase.ty == TY.sarray);
                 const edim = e.elements.dim;
                 const tbasedim = tbase.dim.toInteger();
                 if (edim > tbasedim)
@@ -2200,8 +2200,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (tb.ty == Taarray && typeb.ty == Taarray &&
-                tb.nextOf().toBasetype().ty != Tvoid)
+            if (tb.ty == TY.aarray && typeb.ty == TY.aarray &&
+                tb.nextOf().toBasetype().ty != TY.void_)
             {
                 AssocArrayLiteralExp ae = cast(AssocArrayLiteralExp)e.copy();
                 ae.keys = e.keys.copy();
@@ -2249,14 +2249,14 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             // Look for pointers to functions where the functions are overloaded.
             if (e.hasOverloads &&
-                typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
-                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
+                typeb.ty == TY.pointer && typeb.nextOf().ty == TY.function_ &&
+                (tb.ty == TY.pointer || tb.ty == TY.delegate_) && tb.nextOf().ty == TY.function_)
             {
                 FuncDeclaration f = e.var.isFuncDeclaration();
                 f = f ? f.overloadExactMatch(tb.nextOf()) : null;
                 if (f)
                 {
-                    if (tb.ty == Tdelegate)
+                    if (tb.ty == TY.delegate_)
                     {
                         if (f.needThis() && hasThis(sc))
                         {
@@ -2326,7 +2326,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
             // Look for delegates to functions where the functions are overloaded.
-            if (typeb.ty == Tdelegate && tb.ty == Tdelegate)
+            if (typeb.ty == TY.delegate_ && tb.ty == TY.delegate_)
             {
                 if (e.func)
                 {
@@ -2405,14 +2405,14 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (e.type.equals(t) || typeb.ty != Tarray ||
-                (tb.ty != Tarray && tb.ty != Tsarray))
+            if (e.type.equals(t) || typeb.ty != TY.array ||
+                (tb.ty != TY.array && tb.ty != TY.sarray))
             {
                 visit(cast(Expression)e);
                 return;
             }
 
-            if (tb.ty == Tarray)
+            if (tb.ty == TY.array)
             {
                 if (typeb.nextOf().equivalent(tb.nextOf()))
                 {
@@ -2427,7 +2427,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 return;
             }
 
-            // Handle the cast from Tarray to Tsarray with CT-known slicing
+            // Handle the cast from TY.array to TY.sarray with CT-known slicing
 
             TypeSArray tsa = cast(TypeSArray)toStaticArrayType(e);
             if (tsa && tsa.size(e.loc) == tb.size(e.loc))
@@ -2436,7 +2436,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                  *  T[a .. b] to const(T)[b-a]
                  *  T[a .. b] to U[dim] if (T.sizeof*(b-a) == U.sizeof*dim)
                  *
-                 * If a SliceExp has Tsarray, it will become lvalue.
+                 * If a SliceExp has TY.sarray, it will become lvalue.
                  * That's handled in SliceExp::isLvalue and toLvalue
                  */
                 result = e.copy();
@@ -2450,11 +2450,11 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                  *  cast(float[2]) [2.0, 1.0, 0.0][0..2];
                  */
                 Type t1b = e.e1.type.toBasetype();
-                if (t1b.ty == Tsarray)
+                if (t1b.ty == TY.sarray)
                     t1b = tb.nextOf().sarrayOf((cast(TypeSArray)t1b).dim.toInteger());
-                else if (t1b.ty == Tarray)
+                else if (t1b.ty == TY.array)
                     t1b = tb.nextOf().arrayOf();
-                else if (t1b.ty == Tpointer)
+                else if (t1b.ty == TY.pointer)
                     t1b = tb.nextOf().pointerTo();
                 else
                     assert(0);
@@ -2510,7 +2510,7 @@ extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
         override void visit(ArrayLiteralExp ale)
         {
             Type tb = t.toBasetype();
-            if (tb.ty == Tarray || tb.ty == Tsarray)
+            if (tb.ty == TY.array || tb.ty == TY.sarray)
             {
                 Type tn = tb.nextOf();
                 if (ale.basis)
@@ -2531,7 +2531,7 @@ extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
         override void visit(AssocArrayLiteralExp aale)
         {
             Type tb = t.toBasetype();
-            if (tb.ty == Taarray)
+            if (tb.ty == TY.aarray)
             {
                 TypeAArray taa = cast(TypeAArray)tb;
                 Type ti = taa.index;
@@ -2561,7 +2561,7 @@ extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
         override void visit(FuncExp fe)
         {
             //printf("FuncExp::inferType('%s'), to=%s\n", fe.type ? fe.type.toChars() : "null", t.toChars());
-            if (t.ty == Tdelegate || t.ty == Tpointer && t.nextOf().ty == Tfunction)
+            if (t.ty == TY.delegate_ || t.ty == TY.pointer && t.nextOf().ty == TY.function_)
             {
                 fe.fd.treq = t;
             }
@@ -2594,7 +2594,7 @@ extern (C++) Expression scaleFactor(BinExp be, Scope* sc)
     Type t2b = be.e2.type.toBasetype();
     Expression eoff;
 
-    if (t1b.ty == Tpointer && t2b.isintegral())
+    if (t1b.ty == TY.pointer && t2b.isintegral())
     {
         // Need to adjust operator by the stride
         // Replace (ptr + int) with (ptr + (int * stride))
@@ -2608,7 +2608,7 @@ extern (C++) Expression scaleFactor(BinExp be, Scope* sc)
         be.e2.type = t;
         be.type = be.e1.type;
     }
-    else if (t2b.ty == Tpointer && t1b.isintegral())
+    else if (t2b.ty == TY.pointer && t1b.isintegral())
     {
         // Need to adjust operator by the stride
         // Replace (int + ptr) with (ptr + (int * stride))
@@ -2655,19 +2655,19 @@ extern (C++) Expression scaleFactor(BinExp be, Scope* sc)
  */
 private bool isVoidArrayLiteral(Expression e, Type other)
 {
-    while (e.op == TOKarrayliteral && e.type.ty == Tarray && ((cast(ArrayLiteralExp)e).elements.dim == 1))
+    while (e.op == TOKarrayliteral && e.type.ty == TY.array && ((cast(ArrayLiteralExp)e).elements.dim == 1))
     {
         auto ale = cast(ArrayLiteralExp)e;
         e = ale.getElement(0);
-        if (other.ty == Tsarray || other.ty == Tarray)
+        if (other.ty == TY.sarray || other.ty == TY.array)
             other = other.nextOf();
         else
             return false;
     }
-    if (other.ty != Tsarray && other.ty != Tarray)
+    if (other.ty != TY.sarray && other.ty != TY.array)
         return false;
     Type t = e.type;
-    return (e.op == TOKarrayliteral && t.ty == Tarray && t.nextOf().ty == Tvoid && (cast(ArrayLiteralExp)e).elements.dim == 0);
+    return (e.op == TOKarrayliteral && t.ty == TY.array && t.nextOf().ty == TY.void_ && (cast(ArrayLiteralExp)e).elements.dim == 0);
 }
 
 /**************************************
@@ -2719,7 +2719,7 @@ extern (C++) bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expres
     assert(t2);
 
     if (t1.mod != t2.mod &&
-        t1.ty == Tenum && t2.ty == Tenum &&
+        t1.ty == TY.enum_ && t2.ty == TY.enum_ &&
         (cast(TypeEnum)t1).sym == (cast(TypeEnum)t2).sym)
     {
         ubyte mod = MODmerge(t1.mod, t2.mod);
@@ -2732,7 +2732,7 @@ Lagain:
     t2b = t2.toBasetype();
 
     TY ty = cast(TY)impcnvResult[t1b.ty][t2b.ty];
-    if (ty != Terror)
+    if (ty != TY.error)
     {
         TY ty1 = cast(TY)impcnvType1[t1b.ty][t2b.ty];
         TY ty2 = cast(TY)impcnvType2[t1b.ty][t2b.ty];
@@ -2767,16 +2767,16 @@ Lagain:
     t1 = t1b;
     t2 = t2b;
 
-    if (t1.ty == Ttuple || t2.ty == Ttuple)
+    if (t1.ty == TY.tuple || t2.ty == TY.tuple)
         goto Lincompatible;
 
     if (t1.equals(t2))
     {
         // merging can not result in new enum type
-        if (t.ty == Tenum)
+        if (t.ty == TY.enum_)
             t = t1b;
     }
-    else if ((t1.ty == Tpointer && t2.ty == Tpointer) || (t1.ty == Tdelegate && t2.ty == Tdelegate))
+    else if ((t1.ty == TY.pointer && t2.ty == TY.pointer) || (t1.ty == TY.delegate_ && t2.ty == TY.delegate_))
     {
         // Bring pointers to compatible type
         Type t1n = t1.nextOf();
@@ -2785,9 +2785,9 @@ Lagain:
         if (t1n.equals(t2n))
         {
         }
-        else if (t1n.ty == Tvoid) // pointers to void are always compatible
+        else if (t1n.ty == TY.void_) // pointers to void are always compatible
             t = t2;
-        else if (t2n.ty == Tvoid)
+        else if (t2n.ty == TY.void_)
         {
         }
         else if (t1.implicitConvTo(t2))
@@ -2798,7 +2798,7 @@ Lagain:
         {
             goto Lt1;
         }
-        else if (t1n.ty == Tfunction && t2n.ty == Tfunction)
+        else if (t1n.ty == TY.function_ && t2n.ty == TY.function_)
         {
             TypeFunction tf1 = cast(TypeFunction)t1n;
             TypeFunction tf2 = cast(TypeFunction)t2n;
@@ -2822,7 +2822,7 @@ Lagain:
                 d.trust = TRUST.trusted;
 
             Type tx = null;
-            if (t1.ty == Tdelegate)
+            if (t1.ty == TY.delegate_)
             {
                 tx = new TypeDelegate(d);
             }
@@ -2850,7 +2850,7 @@ Lagain:
             t = t1;
             goto Lagain;
         }
-        else if (t1n.ty == Tclass && t2n.ty == Tclass)
+        else if (t1n.ty == TY.class_ && t2n.ty == TY.class_)
         {
             ClassDeclaration cd1 = t1n.isClassHandle();
             ClassDeclaration cd2 = t2n.isClassHandle();
@@ -2884,7 +2884,7 @@ Lagain:
             goto Lincompatible;
         }
     }
-    else if ((t1.ty == Tsarray || t1.ty == Tarray) && (e2.op == TOKnull && t2.ty == Tpointer && t2.nextOf().ty == Tvoid || e2.op == TOKarrayliteral && t2.ty == Tsarray && t2.nextOf().ty == Tvoid && (cast(TypeSArray)t2).dim.toInteger() == 0 || isVoidArrayLiteral(e2, t1)))
+    else if ((t1.ty == TY.sarray || t1.ty == TY.array) && (e2.op == TOKnull && t2.ty == TY.pointer && t2.nextOf().ty == TY.void_ || e2.op == TOKarrayliteral && t2.ty == TY.sarray && t2.nextOf().ty == TY.void_ && (cast(TypeSArray)t2).dim.toInteger() == 0 || isVoidArrayLiteral(e2, t1)))
     {
         /*  (T[n] op void*)   => T[]
          *  (T[]  op void*)   => T[]
@@ -2895,7 +2895,7 @@ Lagain:
          */
         goto Lx1;
     }
-    else if ((t2.ty == Tsarray || t2.ty == Tarray) && (e1.op == TOKnull && t1.ty == Tpointer && t1.nextOf().ty == Tvoid || e1.op == TOKarrayliteral && t1.ty == Tsarray && t1.nextOf().ty == Tvoid && (cast(TypeSArray)t1).dim.toInteger() == 0 || isVoidArrayLiteral(e1, t2)))
+    else if ((t2.ty == TY.sarray || t2.ty == TY.array) && (e1.op == TOKnull && t1.ty == TY.pointer && t1.nextOf().ty == TY.void_ || e1.op == TOKarrayliteral && t1.ty == TY.sarray && t1.nextOf().ty == TY.void_ && (cast(TypeSArray)t1).dim.toInteger() == 0 || isVoidArrayLiteral(e1, t2)))
     {
         /*  (void*   op T[n]) => T[]
          *  (void*   op T[])  => T[]
@@ -2906,13 +2906,13 @@ Lagain:
          */
         goto Lx2;
     }
-    else if ((t1.ty == Tsarray || t1.ty == Tarray) && (m = t1.implicitConvTo(t2)) != MATCH.nomatch)
+    else if ((t1.ty == TY.sarray || t1.ty == TY.array) && (m = t1.implicitConvTo(t2)) != MATCH.nomatch)
     {
         // https://issues.dlang.org/show_bug.cgi?id=7285
-        // Tsarray op [x, y, ...] should to be Tsarray
+        // TY.sarray op [x, y, ...] should to be TY.sarray
         // https://issues.dlang.org/show_bug.cgi?id=14737
-        // Tsarray ~ [x, y, ...] should to be Tarray
-        if (t1.ty == Tsarray && e2.op == TOKarrayliteral && op != TOKcat)
+        // TY.sarray ~ [x, y, ...] should to be TY.array
+        if (t1.ty == TY.sarray && e2.op == TOKarrayliteral && op != TOKcat)
             goto Lt1;
         if (m == MATCH.constant && (op == TOKaddass || op == TOKminass || op == TOKmulass || op == TOKdivass || op == TOKmodass || op == TOKpowass || op == TOKandass || op == TOKorass || op == TOKxorass))
         {
@@ -2922,15 +2922,15 @@ Lagain:
         }
         goto Lt2;
     }
-    else if ((t2.ty == Tsarray || t2.ty == Tarray) && t2.implicitConvTo(t1))
+    else if ((t2.ty == TY.sarray || t2.ty == TY.array) && t2.implicitConvTo(t1))
     {
         // https://issues.dlang.org/show_bug.cgi?id=7285
         // https://issues.dlang.org/show_bug.cgi?id=14737
-        if (t2.ty == Tsarray && e1.op == TOKarrayliteral && op != TOKcat)
+        if (t2.ty == TY.sarray && e1.op == TOKarrayliteral && op != TOKcat)
             goto Lt2;
         goto Lt1;
     }
-    else if ((t1.ty == Tsarray || t1.ty == Tarray || t1.ty == Tpointer) && (t2.ty == Tsarray || t2.ty == Tarray || t2.ty == Tpointer) && t1.nextOf().mod != t2.nextOf().mod)
+    else if ((t1.ty == TY.sarray || t1.ty == TY.array || t1.ty == TY.pointer) && (t2.ty == TY.sarray || t2.ty == TY.array || t2.ty == TY.pointer) && t1.nextOf().mod != t2.nextOf().mod)
     {
         /* If one is mutable and the other invariant, then retry
          * with both of them as const
@@ -2947,19 +2947,19 @@ Lagain:
         else
             mod = MODmerge(t1n.mod, t2n.mod);
 
-        if (t1.ty == Tpointer)
+        if (t1.ty == TY.pointer)
             t1 = t1n.castMod(mod).pointerTo();
         else
             t1 = t1n.castMod(mod).arrayOf();
 
-        if (t2.ty == Tpointer)
+        if (t2.ty == TY.pointer)
             t2 = t2n.castMod(mod).pointerTo();
         else
             t2 = t2n.castMod(mod).arrayOf();
         t = t1;
         goto Lagain;
     }
-    else if (t1.ty == Tclass && t2.ty == Tclass)
+    else if (t1.ty == TY.class_ && t2.ty == TY.class_)
     {
         if (t1.mod != t2.mod)
         {
@@ -2979,7 +2979,7 @@ Lagain:
         }
         goto Lcc;
     }
-    else if (t1.ty == Tclass || t2.ty == Tclass)
+    else if (t1.ty == TY.class_ || t2.ty == TY.class_)
     {
     Lcc:
         while (1)
@@ -2990,9 +2990,9 @@ Lagain:
             if (i1 && i2)
             {
                 // We have the case of class vs. void*, so pick class
-                if (t1.ty == Tpointer)
+                if (t1.ty == TY.pointer)
                     i1 = MATCH.nomatch;
-                else if (t2.ty == Tpointer)
+                else if (t2.ty == TY.pointer)
                     i2 = MATCH.nomatch;
             }
 
@@ -3006,7 +3006,7 @@ Lagain:
                 e1 = e1.castTo(sc, t1);
                 goto Lt1;
             }
-            else if (t1.ty == Tclass && t2.ty == Tclass)
+            else if (t1.ty == TY.class_ && t2.ty == TY.class_)
             {
                 TypeClass tc1 = cast(TypeClass)t1;
                 TypeClass tc2 = cast(TypeClass)t2;
@@ -3027,7 +3027,7 @@ Lagain:
                 else
                     goto Lincompatible;
             }
-            else if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.aliasthis)
+            else if (t1.ty == TY.struct_ && (cast(TypeStruct)t1).sym.aliasthis)
             {
                 if (att1 && e1.type == att1)
                     goto Lincompatible;
@@ -3038,7 +3038,7 @@ Lagain:
                 t1 = e1.type;
                 continue;
             }
-            else if (t2.ty == Tstruct && (cast(TypeStruct)t2).sym.aliasthis)
+            else if (t2.ty == TY.struct_ && (cast(TypeStruct)t2).sym.aliasthis)
             {
                 if (att2 && e2.type == att2)
                     goto Lincompatible;
@@ -3053,7 +3053,7 @@ Lagain:
                 goto Lincompatible;
         }
     }
-    else if (t1.ty == Tstruct && t2.ty == Tstruct)
+    else if (t1.ty == TY.struct_ && t2.ty == TY.struct_)
     {
         if (t1.mod != t2.mod)
         {
@@ -3120,9 +3120,9 @@ Lagain:
             goto Lagain;
         }
     }
-    else if (t1.ty == Tstruct || t2.ty == Tstruct)
+    else if (t1.ty == TY.struct_ || t2.ty == TY.struct_)
     {
-        if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.aliasthis)
+        if (t1.ty == TY.struct_ && (cast(TypeStruct)t1).sym.aliasthis)
         {
             if (att1 && e1.type == att1)
                 goto Lincompatible;
@@ -3134,7 +3134,7 @@ Lagain:
             t = t1;
             goto Lagain;
         }
-        if (t2.ty == Tstruct && (cast(TypeStruct)t2).sym.aliasthis)
+        if (t2.ty == TY.struct_ && (cast(TypeStruct)t2).sym.aliasthis)
         {
             if (att2 && e2.type == att2)
                 goto Lincompatible;
@@ -3156,21 +3156,21 @@ Lagain:
     {
         goto Lt1;
     }
-    else if (t1.ty == Tsarray && t2.ty == Tsarray && e2.implicitConvTo(t1.nextOf().arrayOf()))
+    else if (t1.ty == TY.sarray && t2.ty == TY.sarray && e2.implicitConvTo(t1.nextOf().arrayOf()))
     {
     Lx1:
         t = t1.nextOf().arrayOf(); // T[]
         e1 = e1.castTo(sc, t);
         e2 = e2.castTo(sc, t);
     }
-    else if (t1.ty == Tsarray && t2.ty == Tsarray && e1.implicitConvTo(t2.nextOf().arrayOf()))
+    else if (t1.ty == TY.sarray && t2.ty == TY.sarray && e1.implicitConvTo(t2.nextOf().arrayOf()))
     {
     Lx2:
         t = t2.nextOf().arrayOf();
         e1 = e1.castTo(sc, t);
         e2 = e2.castTo(sc, t);
     }
-    else if (t1.ty == Tvector && t2.ty == Tvector)
+    else if (t1.ty == TY.vector && t2.ty == TY.vector)
     {
         // https://issues.dlang.org/show_bug.cgi?id=13841
         // all vector types should have no common types between
@@ -3182,14 +3182,14 @@ Lagain:
 
         goto LmodCompare;
     }
-    else if (t1.ty == Tvector && t2.ty != Tvector && e2.implicitConvTo(t1))
+    else if (t1.ty == TY.vector && t2.ty != TY.vector && e2.implicitConvTo(t1))
     {
         e2 = e2.castTo(sc, t1);
         t2 = t1;
         t = t1;
         goto Lagain;
     }
-    else if (t2.ty == Tvector && t1.ty != Tvector && e1.implicitConvTo(t2))
+    else if (t2.ty == TY.vector && t1.ty != TY.vector && e1.implicitConvTo(t2))
     {
         e1 = e1.castTo(sc, t2);
         t1 = t2;
@@ -3200,7 +3200,7 @@ Lagain:
     {
         if (t1.ty != t2.ty)
         {
-            if (t1.ty == Tvector || t2.ty == Tvector)
+            if (t1.ty == TY.vector || t2.ty == TY.vector)
                 goto Lincompatible;
             e1 = integralPromotions(e1, sc);
             e2 = integralPromotions(e2, sc);
@@ -3221,7 +3221,7 @@ LmodCompare:
         e2 = e2.castTo(sc, t);
         goto Lagain;
     }
-    else if (t1.ty == Tnull && t2.ty == Tnull)
+    else if (t1.ty == TY.null_ && t2.ty == TY.null_)
     {
         ubyte mod = MODmerge(t1.mod, t2.mod);
 
@@ -3230,15 +3230,15 @@ LmodCompare:
         e2 = e2.castTo(sc, t);
         goto Lret;
     }
-    else if (t2.ty == Tnull && (t1.ty == Tpointer || t1.ty == Taarray || t1.ty == Tarray))
+    else if (t2.ty == TY.null_ && (t1.ty == TY.pointer || t1.ty == TY.aarray || t1.ty == TY.array))
     {
         goto Lt1;
     }
-    else if (t1.ty == Tnull && (t2.ty == Tpointer || t2.ty == Taarray || t2.ty == Tarray))
+    else if (t1.ty == TY.null_ && (t2.ty == TY.pointer || t2.ty == TY.aarray || t2.ty == TY.array))
     {
         goto Lt2;
     }
-    else if (t1.ty == Tarray && isBinArrayOp(op) && isArrayOpOperand(e1))
+    else if (t1.ty == TY.array && isBinArrayOp(op) && isArrayOpOperand(e1))
     {
         if (e2.implicitConvTo(t1.nextOf()))
         {
@@ -3253,7 +3253,7 @@ LmodCompare:
             // e1 is left as U[], it will be handled in arrayOp() later.
             t = e2.type.arrayOf();
         }
-        else if (t2.ty == Tarray && isArrayOpOperand(e2))
+        else if (t2.ty == TY.array && isArrayOpOperand(e2))
         {
             if (t1.nextOf().implicitConvTo(t2.nextOf()))
             {
@@ -3273,7 +3273,7 @@ LmodCompare:
         else
             goto Lincompatible;
     }
-    else if (t2.ty == Tarray && isBinArrayOp(op) && isArrayOpOperand(e2))
+    else if (t2.ty == TY.array && isBinArrayOp(op) && isArrayOpOperand(e2))
     {
         if (e1.implicitConvTo(t2.nextOf()))
         {
@@ -3358,11 +3358,11 @@ extern (C++) Expression typeCombine(BinExp be, Scope* sc)
     if (be.op == TOKmin || be.op == TOKadd)
     {
         // struct+struct, and class+class are errors
-        if (t1.ty == Tstruct && t2.ty == Tstruct)
+        if (t1.ty == TY.struct_ && t2.ty == TY.struct_)
             return errorReturn();
-        else if (t1.ty == Tclass && t2.ty == Tclass)
+        else if (t1.ty == TY.class_ && t2.ty == TY.class_)
             return errorReturn();
-        else if (t1.ty == Taarray && t2.ty == Taarray)
+        else if (t1.ty == TY.aarray && t2.ty == TY.aarray)
             return errorReturn();
     }
 
@@ -3386,21 +3386,21 @@ extern (C++) Expression integralPromotions(Expression e, Scope* sc)
     //printf("integralPromotions %s %s\n", e.toChars(), e.type.toChars());
     switch (e.type.toBasetype().ty)
     {
-    case Tvoid:
+    case TY.void_:
         e.error("void has no value");
         return new ErrorExp();
 
-    case Tint8:
-    case Tuns8:
-    case Tint16:
-    case Tuns16:
-    case Tbool:
-    case Tchar:
-    case Twchar:
+    case TY.int8:
+    case TY.uns8:
+    case TY.int16:
+    case TY.uns16:
+    case TY.bool_:
+    case TY.char_:
+    case TY.wchar_:
         e = e.castTo(sc, Type.tint32);
         break;
 
-    case Tdchar:
+    case TY.dchar_:
         e = e.castTo(sc, Type.tuns32);
         break;
 
@@ -3428,14 +3428,14 @@ void fix16997(Scope* sc, UnaExp ue)
     {
         switch (ue.e1.type.toBasetype.ty)
         {
-            case Tint8:
-            case Tuns8:
-            case Tint16:
-            case Tuns16:
-            //case Tbool:       // these operations aren't allowed on bool anyway
-            case Tchar:
-            case Twchar:
-            case Tdchar:
+            case TY.int8:
+            case TY.uns8:
+            case TY.int16:
+            case TY.uns16:
+            //case TY.bool_:       // these operations aren't allowed on bool anyway
+            case TY.char_:
+            case TY.wchar_:
+            case TY.dchar_:
                 ue.deprecation("integral promotion not done for `%s`, use '-transition=intpromote' switch or `%scast(int)(%s)`",
                     ue.toChars(), Token.toChars(ue.op), ue.e1.toChars());
                 break;
@@ -3458,9 +3458,9 @@ extern (C++) bool arrayTypeCompatible(Loc loc, Type t1, Type t2)
     t1 = t1.toBasetype().merge2();
     t2 = t2.toBasetype().merge2();
 
-    if ((t1.ty == Tarray || t1.ty == Tsarray || t1.ty == Tpointer) && (t2.ty == Tarray || t2.ty == Tsarray || t2.ty == Tpointer))
+    if ((t1.ty == TY.array || t1.ty == TY.sarray || t1.ty == TY.pointer) && (t2.ty == TY.array || t2.ty == TY.sarray || t2.ty == TY.pointer))
     {
-        if (t1.nextOf().implicitConvTo(t2.nextOf()) < MATCH.constant && t2.nextOf().implicitConvTo(t1.nextOf()) < MATCH.constant && (t1.nextOf().ty != Tvoid && t2.nextOf().ty != Tvoid))
+        if (t1.nextOf().implicitConvTo(t2.nextOf()) < MATCH.constant && t2.nextOf().implicitConvTo(t1.nextOf()) < MATCH.constant && (t1.nextOf().ty != TY.void_ && t2.nextOf().ty != TY.void_))
         {
             error(loc, "array equality comparison type mismatch, `%s` vs `%s`", t1.toChars(), t2.toChars());
         }
@@ -3480,7 +3480,7 @@ extern (C++) bool arrayTypeCompatibleWithoutCasting(Loc loc, Type t1, Type t2)
     t1 = t1.toBasetype();
     t2 = t2.toBasetype();
 
-    if ((t1.ty == Tarray || t1.ty == Tsarray || t1.ty == Tpointer) && t2.ty == t1.ty)
+    if ((t1.ty == TY.array || t1.ty == TY.sarray || t1.ty == TY.pointer) && t2.ty == t1.ty)
     {
         if (t1.nextOf().implicitConvTo(t2.nextOf()) >= MATCH.constant || t2.nextOf().implicitConvTo(t1.nextOf()) >= MATCH.constant)
             return true;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -63,7 +63,7 @@ extern (C++) bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, 
     {
         VarDeclaration vd = ad.fields[i];
         Type tb = vd.type.baseElemOf();
-        if (tb.ty == Tstruct)
+        if (tb.ty == TY.struct_)
         {
             result |= checkFrameAccess(loc, sc, (cast(TypeStruct)tb).sym);
         }
@@ -842,7 +842,7 @@ extern (C++) final class AliasDeclaration : Declaration
             else
             {
                 Type t = type.typeSemantic(loc, _scope);
-                if (t.ty == Terror)
+                if (t.ty == TY.error)
                     goto Lerr;
                 if (global.errors != olderrors)
                     goto Lerr;
@@ -1159,7 +1159,7 @@ extern (C++) class VarDeclaration : Declaration
             t = Type.tvoidptr;
         }
         Type tv = t.baseElemOf();
-        if (tv.ty == Tstruct)
+        if (tv.ty == TY.struct_)
         {
             auto ts = cast(TypeStruct)tv;
             assert(ts.sym != ad);   // already checked in ad.determineFields()
@@ -1175,7 +1175,7 @@ extern (C++) class VarDeclaration : Declaration
         // pointless error diagnostic "more initializers than fields" on struct literal.
         ad.fields.push(this);
 
-        if (t.ty == Terror)
+        if (t.ty == TY.error)
             return;
 
         const sz = t.size(loc);
@@ -1344,7 +1344,7 @@ extern (C++) class VarDeclaration : Declaration
         Expression e = null;
         // Destructors for structs and arrays of structs
         Type tv = type.baseElemOf();
-        if (tv.ty == Tstruct)
+        if (tv.ty == TY.struct_)
         {
             StructDeclaration sd = (cast(TypeStruct)tv).sym;
             if (!sd.dtor || sd.errors)
@@ -1355,7 +1355,7 @@ extern (C++) class VarDeclaration : Declaration
             if (!sz)
                 return null;
 
-            if (type.toBasetype().ty == Tstruct)
+            if (type.toBasetype().ty == TY.struct_)
             {
                 // v.__xdtor()
                 e = new VarExp(loc, this);

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -58,7 +58,7 @@ extern (C++) Expression toDelegate(Expression e, Type t, Scope* sc)
         return new ErrorExp();
 
     Statement s;
-    if (t.ty == Tvoid)
+    if (t.ty == TY.void_)
         s = new ExpStatement(loc, e);
     else
         s = new ReturnStatement(loc, e);

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -37,56 +37,56 @@ import dmd.tokens;
 import dmd.utf;
 import dmd.visitor;
 
-private immutable char[TMAX] mangleChar =
+private immutable char[TY.MAX] mangleChar =
 [
-    Tchar        : 'a',
-    Tbool        : 'b',
-    Tcomplex80   : 'c',
-    Tfloat64     : 'd',
-    Tfloat80     : 'e',
-    Tfloat32     : 'f',
-    Tint8        : 'g',
-    Tuns8        : 'h',
-    Tint32       : 'i',
-    Timaginary80 : 'j',
-    Tuns32       : 'k',
-    Tint64       : 'l',
-    Tuns64       : 'm',
-    Tnone        : 'n',
-    Tnull        : 'n', // yes, same as TypeNone
-    Timaginary32 : 'o',
-    Timaginary64 : 'p',
-    Tcomplex32   : 'q',
-    Tcomplex64   : 'r',
-    Tint16       : 's',
-    Tuns16       : 't',
-    Twchar       : 'u',
-    Tvoid        : 'v',
-    Tdchar       : 'w',
+    TY.char_        : 'a',
+    TY.bool_        : 'b',
+    TY.complex80   : 'c',
+    TY.float64     : 'd',
+    TY.float80     : 'e',
+    TY.float32     : 'f',
+    TY.int8        : 'g',
+    TY.uns8        : 'h',
+    TY.int32       : 'i',
+    TY.imaginary80 : 'j',
+    TY.uns32       : 'k',
+    TY.int64       : 'l',
+    TY.uns64       : 'm',
+    TY.none        : 'n',
+    TY.null_        : 'n', // yes, same as TypeNone
+    TY.imaginary32 : 'o',
+    TY.imaginary64 : 'p',
+    TY.complex32   : 'q',
+    TY.complex64   : 'r',
+    TY.int16       : 's',
+    TY.uns16       : 't',
+    TY.wchar_       : 'u',
+    TY.void_        : 'v',
+    TY.dchar_       : 'w',
     //              x   // const
     //              y   // immutable
-    Tint128      : 'z', // zi
-    Tuns128      : 'z', // zk
+    TY.int128      : 'z', // zi
+    TY.uns128      : 'z', // zk
 
-    Tarray       : 'A',
-    Ttuple       : 'B',
-    Tclass       : 'C',
-    Tdelegate    : 'D',
-    Tenum        : 'E',
-    Tfunction    : 'F', // D function
-    Tsarray      : 'G',
-    Taarray      : 'H',
-    Tident       : 'I',
+    TY.array       : 'A',
+    TY.tuple       : 'B',
+    TY.class_       : 'C',
+    TY.delegate_    : 'D',
+    TY.enum_        : 'E',
+    TY.function_    : 'F', // D function
+    TY.sarray      : 'G',
+    TY.aarray      : 'H',
+    TY.ident       : 'I',
     //              J   // out
     //              K   // ref
     //              L   // lazy
     //              M   // has this, or scope
     //              N   // Nh:vector Ng:wild
     //              O   // shared
-    Tpointer     : 'P',
+    TY.pointer     : 'P',
     //              Q   // Type/symbol/identifier backward reference
-    Treference   : 'R',
-    Tstruct      : 'S',
+    TY.reference   : 'R',
+    TY.struct_      : 'S',
     //              T   // Ttypedef
     //              U   // C function
     //              V   // Pascal function
@@ -96,12 +96,12 @@ private immutable char[TMAX] mangleChar =
     //              Z   // not variadic, end of parameters
 
     // '@' shouldn't appear anywhere in the deco'd names
-    Tinstance    : '@',
-    Terror       : '@',
-    Ttypeof      : '@',
-    Tslice       : '@',
-    Treturn      : '@',
-    Tvector      : '@',
+    TY.instance    : '@',
+    TY.error       : '@',
+    TY.typeof_      : '@',
+    TY.slice       : '@',
+    TY.return_      : '@',
+    TY.vector      : '@',
 ];
 
 unittest
@@ -125,7 +125,7 @@ private void tyToDecoBuffer(OutBuffer* buf, int ty)
     const c = mangleChar[ty];
     buf.writeByte(c);
     if (c == 'z')
-        buf.writeByte(ty == Tint128 ? 'i' : 'k');
+        buf.writeByte(ty == TY.int128 ? 'i' : 'k');
 }
 
 /*********************************
@@ -505,7 +505,7 @@ public:
         if (fd.needThis() || fd.isNested())
             buf.writeByte('M');
 
-        if (!fd.type || fd.type.ty == Terror)
+        if (!fd.type || fd.type.ty == TY.error)
         {
             // never should have gotten here, but could be the result of
             // failed speculative compilation

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -1170,7 +1170,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
             if (d.type)
             {
                 Type origType = d.originalType ? d.originalType : d.type;
-                if (origType.ty == Tfunction)
+                if (origType.ty == TY.function_)
                 {
                     functionToBufferFull(cast(TypeFunction)origType, buf, d.ident, &hgs, td);
                 }
@@ -1229,7 +1229,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
             }
             else if (Type type = ad.getType()) // type alias
             {
-                if (type.ty == Tclass || type.ty == Tstruct || type.ty == Tenum)
+                if (type.ty == TY.class_ || type.ty == TY.struct_ || type.ty == TY.enum_)
                 {
                     if (Dsymbol s = type.toDsymbol(null)) // elaborate type
                         prettyPrintDsymbol(s, ad.parent);
@@ -1984,7 +1984,7 @@ extern (C++) TypeFunction isTypeFunction(Dsymbol s)
     if (f && f.type)
     {
         Type t = f.originalType ? f.originalType : f.type;
-        if (t.ty == Tfunction)
+        if (t.ty == TY.function_)
             return cast(TypeFunction)t;
     }
     return null;

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -367,7 +367,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             Dsymbol s = (*members)[i];
             s.setFieldOffset(this, &offset, isunion);
         }
-        if (type.ty == Terror)
+        if (type.ty == TY.error)
             return;
 
         // 0 sized struct's are set to 1 byte
@@ -483,14 +483,14 @@ extern (C++) class StructDeclaration : AggregateDeclaration
              * Allow this by doing an explicit cast, which will lengthen the string
              * literal.
              */
-            if (e.op == TOKstring && tb.ty == Tsarray)
+            if (e.op == TOKstring && tb.ty == TY.sarray)
             {
                 StringExp se = cast(StringExp)e;
                 Type typeb = se.type.toBasetype();
                 TY tynto = tb.nextOf().ty;
                 if (!se.committed &&
-                    (typeb.ty == Tarray || typeb.ty == Tsarray) &&
-                    (tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
+                    (typeb.ty == TY.array || typeb.ty == TY.sarray) &&
+                    (tynto == TY.char_ || tynto == TY.wchar_ || tynto == TY.dchar_) &&
                     se.numberOfCodeUnits(tynto) < (cast(TypeSArray)tb).dim.toInteger())
                 {
                     e = se.castTo(sc, t);
@@ -498,7 +498,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
                 }
             }
 
-            while (!e.implicitConvTo(t) && tb.ty == Tsarray)
+            while (!e.implicitConvTo(t) && tb.ty == TY.sarray)
             {
                 /* Static array initialization, as in:
                  *  T[3][5] = e;
@@ -555,7 +555,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
 
             Type tv = v.type.baseElemOf();
-            if (tv.ty == Tstruct)
+            if (tv.ty == TY.struct_)
             {
                 TypeStruct ts = cast(TypeStruct)tv;
                 StructDeclaration sd = ts.sym;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1823,7 +1823,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
             if (ce.op == TOKtype)
             {
                 Type t = (cast(TypeExp)ce).type;
-                if (t.ty == Ttuple)
+                if (t.ty == TY.tuple)
                 {
                     type = cast(TypeTuple)t;
                     goto L1;
@@ -1847,7 +1847,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                     v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, new ExpInitializer(Loc(), e));
                     v.storage_class |= STC.temp | STC.static_ | STC.const_;
                 }
-                else if (ce.type && (t = ce.type.toBasetype()) !is null && (t.ty == Tstruct || t.ty == Tclass))
+                else if (ce.type && (t = ce.type.toBasetype()) !is null && (t.ty == TY.struct_ || t.ty == TY.class_))
                 {
                     // Look for opDollar
                     assert(exp.op == TOKarray || exp.op == TOKslice);
@@ -1900,7 +1900,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                     if (!e.type)
                         exp.error("`%s` has no value", e.toChars());
                     t = e.type.toBasetype();
-                    if (t && t.ty == Tfunction)
+                    if (t && t.ty == TY.function_)
                         e = new CallExp(e.loc, e);
                     v = new VarDeclaration(loc, null, Id.dollar, new ExpInitializer(Loc(), e));
                     v.storage_class |= STC.temp | STC.ctfe | STC.rvalue;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -363,7 +363,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sc2.pop();
         }
         //printf(" semantic type = %s\n", type ? type.toChars() : "null");
-        if (dsym.type.ty == Terror)
+        if (dsym.type.ty == TY.error)
             dsym.errors = true;
 
         dsym.type.checkDeprecated(dsym.loc, sc);
@@ -399,7 +399,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         Type tb = dsym.type.toBasetype();
         Type tbn = tb.baseElemOf();
-        if (tb.ty == Tvoid && !(dsym.storage_class & STC.lazy_))
+        if (tb.ty == TY.void_ && !(dsym.storage_class & STC.lazy_))
         {
             if (inferred)
             {
@@ -410,13 +410,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.type = Type.terror;
             tb = dsym.type;
         }
-        if (tb.ty == Tfunction)
+        if (tb.ty == TY.function_)
         {
             dsym.error("cannot be declared to be a function");
             dsym.type = Type.terror;
             tb = dsym.type;
         }
-        if (tb.ty == Tstruct)
+        if (tb.ty == TY.struct_)
         {
             TypeStruct ts = cast(TypeStruct)tb;
             if (!ts.sym.members)
@@ -427,7 +427,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if ((dsym.storage_class & STC.auto_) && !inferred)
             dsym.error("storage class `auto` has no effect if type is not inferred, did you mean `scope`?");
 
-        if (tb.ty == Ttuple)
+        if (tb.ty == TY.tuple)
         {
             /* Instead, declare variables for each of the tuple elements
              * and add those.
@@ -651,7 +651,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     fprintf(global.stdmsg, "%s: %s.%s is %s field\n", p ? p : "", ad.toPrettyChars(), dsym.toChars(), s);
                 }
                 dsym.storage_class |= STC.field;
-                if (tbn.ty == Tstruct && (cast(TypeStruct)tbn).sym.noDefaultCtor)
+                if (tbn.ty == TY.struct_ && (cast(TypeStruct)tbn).sym.noDefaultCtor)
                 {
                     if (!dsym.isThisDeclaration() && !dsym._init)
                         aad.noDefaultCtor = true;
@@ -722,7 +722,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (!(dsym.storage_class & (STC.ctfe | STC.ref_ | STC.result)) && tbn.ty == Tstruct && (cast(TypeStruct)tbn).sym.noDefaultCtor)
+        if (!(dsym.storage_class & (STC.ctfe | STC.ref_ | STC.result)) && tbn.ty == TY.struct_ && (cast(TypeStruct)tbn).sym.noDefaultCtor)
         {
             if (!dsym._init)
             {
@@ -794,18 +794,18 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // Provide a default initializer
 
             //printf("Providing default initializer for '%s'\n", toChars());
-            if (sz == SIZE_INVALID && dsym.type.ty != Terror)
+            if (sz == SIZE_INVALID && dsym.type.ty != TY.error)
                 dsym.error("size of type `%s` is invalid", dsym.type.toChars());
 
             Type tv = dsym.type;
-            while (tv.ty == Tsarray)    // Don't skip Tenum
+            while (tv.ty == TY.sarray)    // Don't skip TY.enum_
                 tv = tv.nextOf();
             if (tv.needsNested())
             {
                 /* Nested struct requires valid enclosing frame pointer.
                  * In StructLiteralExp::toElem(), it's calculated.
                  */
-                assert(tbn.ty == Tstruct);
+                assert(tbn.ty == TY.struct_);
                 checkFrameAccess(dsym.loc, sc, (cast(TypeStruct)tbn).sym);
 
                 Expression e = tv.defaultInitLiteral(dsym.loc);
@@ -814,7 +814,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 dsym._init = new ExpInitializer(dsym.loc, e);
                 goto Ldtor;
             }
-            if (tv.ty == Tstruct && (cast(TypeStruct)tv).sym.zeroInit == 1)
+            if (tv.ty == TY.struct_ && (cast(TypeStruct)tv).sym.zeroInit == 1)
             {
                 /* If a struct is all zeros, as a special case
                  * set it's initializer to the integer 0.
@@ -828,7 +828,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 dsym._init = new ExpInitializer(dsym.loc, e);
                 goto Ldtor;
             }
-            if (dsym.type.baseElemOf().ty == Tvoid)
+            if (dsym.type.baseElemOf().ty == TY.void_)
             {
                 dsym.error("`%s` does not have a default initializer", dsym.type.toChars());
             }
@@ -862,7 +862,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     {
                         ArrayInitializer ai = dsym._init.isArrayInitializer();
                         Expression e;
-                        if (ai && tb.ty == Taarray)
+                        if (ai && tb.ty == TY.aarray)
                             e = ai.toAssocArrayLiteral();
                         else
                             e = dsym._init.initializerToExpression();
@@ -910,7 +910,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         {
                             // See if initializer is a NewExp that can be allocated on the stack
                             NewExp ne = cast(NewExp)ex;
-                            if (dsym.type.toBasetype().ty == Tclass)
+                            if (dsym.type.toBasetype().ty == TY.class_)
                             {
                                 if (ne.newargs && ne.newargs.dim > 1)
                                 {
@@ -980,7 +980,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                          *  static assert(w.x == 55.0);
                          * because the postblit doesn't get run on the initialization of w.
                          */
-                        if (ti.ty == Tstruct)
+                        if (ti.ty == TY.struct_)
                         {
                             StructDeclaration sd = (cast(TypeStruct)ti).sym;
                             /* Look to see if initializer involves a copy constructor
@@ -1030,7 +1030,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 dsym.type.hasPointers())
             {
                 auto tv = dsym.type.baseElemOf();
-                if (tv.ty == Tstruct &&
+                if (tv.ty == TY.struct_ &&
                     (cast(TypeStruct)tv).sym.dtor.storage_class & STC.scope_)
                 {
                     dsym.storage_class |= STC.scope_;
@@ -1052,7 +1052,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         dsym.semanticRun = PASS.semanticdone;
 
-        if (dsym.type.toBasetype().ty == Terror)
+        if (dsym.type.toBasetype().ty == TY.error)
             dsym.errors = true;
 
         if(sc.scopesym && !sc.scopesym.isAggregateDeclaration())
@@ -1319,7 +1319,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     e = resolveProperties(sc, e);
                     sc = sc.endCTFE();
                     // pragma(msg) is allowed to contain types as well as expressions
-                    if (e.type && e.type.ty == Tvoid)
+                    if (e.type && e.type.ty == TY.void_)
                     {
                         error(pd.loc, "Cannot pass argument `%s` to `pragma msg` because it is `void`", e.toChars());
                         return;
@@ -1723,7 +1723,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             /* Check to see if memtype is forward referenced
              */
-            if (ed.memtype.ty == Tenum)
+            if (ed.memtype.ty == TY.enum_)
             {
                 EnumDeclaration sym = cast(EnumDeclaration)ed.memtype.toDsymbol(sc);
                 if (!sym.memtype || !sym.members || !sym.symtab || sym._scope)
@@ -1738,12 +1738,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     return;
                 }
             }
-            if (ed.memtype.ty == Tvoid)
+            if (ed.memtype.ty == TY.void_)
             {
                 ed.error("base type must not be void");
                 ed.memtype = Type.terror;
             }
-            if (ed.memtype.ty == Terror)
+            if (ed.memtype.ty == TY.error)
             {
                 ed.errors = true;
                 if (ed.members)
@@ -1903,12 +1903,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (first && !em.ed.memtype && !em.ed.isAnonymous())
             {
                 em.ed.memtype = e.type;
-                if (em.ed.memtype.ty == Terror)
+                if (em.ed.memtype.ty == TY.error)
                 {
                     em.ed.errors = true;
                     return errorReturn();
                 }
-                if (em.ed.memtype.ty != Terror)
+                if (em.ed.memtype.ty != TY.error)
                 {
                     /* https://issues.dlang.org/show_bug.cgi?id=11746
                      * All of named enum members should have same type
@@ -2560,10 +2560,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (fld && fld.treq)
         {
             Type treq = fld.treq;
-            assert(treq.nextOf().ty == Tfunction);
-            if (treq.ty == Tdelegate)
+            assert(treq.nextOf().ty == TY.function_);
+            if (treq.ty == TY.delegate_)
                 fld.tok = TOKdelegate;
-            else if (treq.ty == Tpointer && treq.nextOf().ty == Tfunction)
+            else if (treq.ty == TY.pointer && treq.nextOf().ty == TY.function_)
                 fld.tok = TOKfunction;
             else
                 assert(0);
@@ -2577,9 +2577,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!funcdecl.originalType)
             funcdecl.originalType = funcdecl.type.syntaxCopy();
-        if (funcdecl.type.ty != Tfunction)
+        if (funcdecl.type.ty != TY.function_)
         {
-            if (funcdecl.type.ty != Terror)
+            if (funcdecl.type.ty != TY.error)
             {
                 funcdecl.error("`%s` must be a function instead of `%s`", funcdecl.toChars(), funcdecl.type.toChars());
                 funcdecl.type = Type.terror;
@@ -2705,9 +2705,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             funcdecl.type = funcdecl.type.typeSemantic(funcdecl.loc, sc);
             sc = sc.pop();
         }
-        if (funcdecl.type.ty != Tfunction)
+        if (funcdecl.type.ty != TY.function_)
         {
-            if (funcdecl.type.ty != Terror)
+            if (funcdecl.type.ty != TY.error)
             {
                 funcdecl.error("`%s` must be a function instead of `%s`", funcdecl.toChars(), funcdecl.type.toChars());
                 funcdecl.type = Type.terror;
@@ -2787,7 +2787,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (funcdecl.isStaticConstructor() || funcdecl.isStaticDestructor())
             {
-                if (!funcdecl.isStatic() || funcdecl.type.nextOf().ty != Tvoid)
+                if (!funcdecl.isStatic() || funcdecl.type.nextOf().ty != TY.void_)
                     funcdecl.error("static constructors / destructors must be static void");
                 if (f.arguments && f.arguments.dim)
                     funcdecl.error("static constructors / destructors must have empty parameter list");
@@ -3247,7 +3247,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (funcdecl.fbody && funcdecl.isMain() && sc._module.isRoot())
             genCmain(sc);
 
-        assert(funcdecl.type.ty != Terror || funcdecl.errors);
+        assert(funcdecl.type.ty != TY.error || funcdecl.errors);
     }
 
      /// Do the semantic analysis on the external interface to the function.
@@ -3755,7 +3755,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (sd.semanticRun == PASS.init)
             sd.type = sd.type.addSTC(sc.stc | sd.storage_class);
         sd.type = sd.type.typeSemantic(sd.loc, sc);
-        if (sd.type.ty == Tstruct && (cast(TypeStruct)sd.type).sym != sd)
+        if (sd.type.ty == TY.struct_ && (cast(TypeStruct)sd.type).sym != sd)
         {
             auto ti = (cast(TypeStruct)sd.type).sym.isInstantiated();
             if (ti && isError(ti))
@@ -3830,7 +3830,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!sd.determineFields())
         {
-            if (sd.type.ty != Terror)
+            if (sd.type.ty != TY.error)
             {
                 sd.error(sd.loc, "circular or forward reference");
                 sd.errors = true;
@@ -3849,7 +3849,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         foreach (v; sd.fields)
         {
             Type tb = v.type.baseElemOf();
-            if (tb.ty != Tstruct)
+            if (tb.ty != TY.struct_)
                 continue;
             auto sdec = (cast(TypeStruct)tb).sym;
             if (sdec.semanticRun >= PASS.semanticdone)
@@ -3931,13 +3931,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         version (none)
         {
-            if (sd.type.ty == Tstruct && (cast(TypeStruct)sd.type).sym != sd)
+            if (sd.type.ty == TY.struct_ && (cast(TypeStruct)sd.type).sym != sd)
             {
                 printf("this = %p %s\n", sd, sd.toChars());
                 printf("type = %d sym = %p\n", sd.type.ty, (cast(TypeStruct)sd.type).sym);
             }
         }
-        assert(sd.type.ty != Tstruct || (cast(TypeStruct)sd.type).sym == sd);
+        assert(sd.type.ty != TY.struct_ || (cast(TypeStruct)sd.type).sym == sd);
     }
 
     final void interfaceSemantic(ClassDeclaration cd)
@@ -3982,7 +3982,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (cldec.errors)
             cldec.type = Type.terror;
         cldec.type = cldec.type.typeSemantic(cldec.loc, sc);
-        if (cldec.type.ty == Tclass && (cast(TypeClass)cldec.type).sym != cldec)
+        if (cldec.type.ty == TY.class_ && (cast(TypeClass)cldec.type).sym != cldec)
         {
             auto ti = (cast(TypeClass)cldec.type).sym.isInstantiated();
             if (ti && isError(ti))
@@ -4062,7 +4062,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 b.type = resolveBase(b.type.typeSemantic(cldec.loc, sc));
 
                 Type tb = b.type.toBasetype();
-                if (tb.ty == Ttuple)
+                if (tb.ty == TY.tuple)
                 {
                     TypeTuple tup = cast(TypeTuple)tb;
                     cldec.baseclasses.remove(i);
@@ -4091,7 +4091,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 BaseClass* b = (*cldec.baseclasses)[0];
                 Type tb = b.type.toBasetype();
-                TypeClass tc = (tb.ty == Tclass) ? cast(TypeClass)tb : null;
+                TypeClass tc = (tb.ty == TY.class_) ? cast(TypeClass)tb : null;
                 if (!tc)
                 {
                     if (b.type != Type.terror)
@@ -4148,7 +4148,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 BaseClass* b = (*cldec.baseclasses)[i];
                 Type tb = b.type.toBasetype();
-                TypeClass tc = (tb.ty == Tclass) ? cast(TypeClass)tb : null;
+                TypeClass tc = (tb.ty == TY.class_) ? cast(TypeClass)tb : null;
                 if (!tc || !tc.sym.isInterfaceDeclaration())
                 {
                     if (b.type != Type.terror)
@@ -4216,9 +4216,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                 Type t = cldec.object.type;
                 t = t.typeSemantic(cldec.loc, sc).toBasetype();
-                if (t.ty == Terror)
+                if (t.ty == TY.error)
                     badObjectDotD();
-                assert(t.ty == Tclass);
+                assert(t.ty == TY.class_);
                 TypeClass tc = cast(TypeClass)t;
 
                 auto b = new BaseClass(tc);
@@ -4303,7 +4303,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             BaseClass* b = (*cldec.baseclasses)[i];
             Type tb = b.type.toBasetype();
-            assert(tb.ty == Tclass);
+            assert(tb.ty == TY.class_);
             TypeClass tc = cast(TypeClass)tb;
             if (tc.sym.semanticRun < PASS.semanticdone)
             {
@@ -4404,7 +4404,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         foreach (v; cldec.fields)
         {
             Type tb = v.type.baseElemOf();
-            if (tb.ty != Tstruct)
+            if (tb.ty != TY.struct_)
                 continue;
             auto sd = (cast(TypeStruct)tb).sym;
             if (sd.semanticRun >= PASS.semanticdone)
@@ -4506,7 +4506,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (cldec.type.ty == Tclass && (cast(TypeClass)cldec.type).sym != cldec)
+        if (cldec.type.ty == TY.class_ && (cast(TypeClass)cldec.type).sym != cldec)
         {
             // https://issues.dlang.org/show_bug.cgi?id=17492
             ClassDeclaration cd = (cast(TypeClass)cldec.type).sym;
@@ -4576,7 +4576,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (idec.errors)
             idec.type = Type.terror;
         idec.type = idec.type.typeSemantic(idec.loc, sc);
-        if (idec.type.ty == Tclass && (cast(TypeClass)idec.type).sym != idec)
+        if (idec.type.ty == TY.class_ && (cast(TypeClass)idec.type).sym != idec)
         {
             auto ti = (cast(TypeClass)idec.type).sym.isInstantiated();
             if (ti && isError(ti))
@@ -4639,7 +4639,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 b.type = resolveBase(b.type.typeSemantic(idec.loc, sc));
 
                 Type tb = b.type.toBasetype();
-                if (tb.ty == Ttuple)
+                if (tb.ty == TY.tuple)
                 {
                     TypeTuple tup = cast(TypeTuple)tb;
                     idec.baseclasses.remove(i);
@@ -4674,7 +4674,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 BaseClass* b = (*idec.baseclasses)[i];
                 Type tb = b.type.toBasetype();
-                TypeClass tc = (tb.ty == Tclass) ? cast(TypeClass)tb : null;
+                TypeClass tc = (tb.ty == TY.class_) ? cast(TypeClass)tb : null;
                 if (!tc || !tc.sym.isInterfaceDeclaration())
                 {
                     if (b.type != Type.terror)
@@ -4760,7 +4760,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             BaseClass* b = (*idec.baseclasses)[i];
             Type tb = b.type.toBasetype();
-            assert(tb.ty == Tclass);
+            assert(tb.ty == TY.class_);
             TypeClass tc = cast(TypeClass)tb;
             if (tc.sym.semanticRun < PASS.semanticdone)
             {
@@ -4857,13 +4857,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         version (none)
         {
-            if (type.ty == Tclass && (cast(TypeClass)idec.type).sym != idec)
+            if (type.ty == TY.class_ && (cast(TypeClass)idec.type).sym != idec)
             {
                 printf("this = %p %s\n", idec, idec.toChars());
                 printf("type = %d sym = %p\n", idec.type.ty, (cast(TypeClass)idec.type).sym);
             }
         }
-        assert(idec.type.ty != Tclass || (cast(TypeClass)idec.type).sym == idec);
+        assert(idec.type.ty != TY.class_ || (cast(TypeClass)idec.type).sym == idec);
     }
 }
 
@@ -5162,7 +5162,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
              * resolve any "auto ref" storage classes.
              */
             TypeFunction tf = cast(TypeFunction)fd.type;
-            if (tf && tf.ty == Tfunction)
+            if (tf && tf.ty == TY.function_)
                 tf.fargs = fargs;
         }
     }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -106,10 +106,10 @@ extern (C++) bool isError(RootObject o)
 {
     Type t = isType(o);
     if (t)
-        return (t.ty == Terror);
+        return (t.ty == TY.error);
     Expression e = isExpression(o);
     if (e)
-        return (e.op == TOKerror || !e.type || e.type.ty == Terror);
+        return (e.op == TOKerror || !e.type || e.type.ty == TY.error);
     Tuple v = isTuple(o);
     if (v)
         return arrayObjectIsError(&v.objects);
@@ -726,7 +726,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
              * Making parameters is similar to FuncDeclaration.semantic3
              */
             TypeFunction tf = cast(TypeFunction)fd.type;
-            assert(tf.ty == Tfunction);
+            assert(tf.ty == TY.function_);
 
             scx.parent = fd;
 
@@ -908,7 +908,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             FuncDeclaration fd = onemember ? onemember.isFuncDeclaration() : null;
             if (fd)
             {
-                assert(fd.type.ty == Tfunction);
+                assert(fd.type.ty == TY.function_);
                 TypeFunction tf = cast(TypeFunction)fd.type.syntaxCopy();
 
                 fd = new FuncDeclaration(fd.loc, fd.endloc, fd.ident, fd.storage_class, tf);
@@ -926,10 +926,10 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 fd.type = tf.typeSemantic(loc, paramscope);
                 if (global.endGagging(olderrors))
                 {
-                    assert(fd.type.ty != Tfunction);
+                    assert(fd.type.ty != TY.function_);
                     goto Lnomatch;
                 }
-                assert(fd.type.ty == Tfunction);
+                assert(fd.type.ty == TY.function_);
                 fd.originalType = fd.type; // for mangling
             }
 
@@ -1237,7 +1237,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 for (fptupindex = 0; fptupindex < nfparams; fptupindex++)
                 {
                     Parameter fparam = (*fparameters)[fptupindex];
-                    if (fparam.type.ty != Tident)
+                    if (fparam.type.ty != TY.ident)
                         continue;
                     TypeIdentifier tid = cast(TypeIdentifier)fparam.type;
                     if (!tp.ident.equals(tid.ident) || tid.idents.dim)
@@ -1332,7 +1332,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                  */
                 if (fptupindex != IDX_NOTFOUND && parami == fptupindex)
                 {
-                    assert(prmtype.ty == Tident);
+                    assert(prmtype.ty == TY.ident);
                     TypeIdentifier tid = cast(TypeIdentifier)prmtype;
                     if (!declaredTuple)
                     {
@@ -1352,7 +1352,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                             if (!reliesOnTident(p.type, parameters, inferStart))
                             {
                                 Type pt = p.type.syntaxCopy().typeSemantic(fd.loc, paramscope);
-                                rem += pt.ty == Ttuple ? (cast(TypeTuple)pt).arguments.dim : 1;
+                                rem += pt.ty == TY.tuple ? (cast(TypeTuple)pt).arguments.dim : 1;
                             }
                             else
                             {
@@ -1368,10 +1368,10 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                             farg = (*fargs)[argi + i];
 
                             // Check invalid arguments to detect errors early.
-                            if (farg.op == TOKerror || farg.type.ty == Terror)
+                            if (farg.op == TOKerror || farg.type.ty == TY.error)
                                 goto Lnomatch;
 
-                            if (!(fparam.storageClass & STC.lazy_) && farg.type.ty == Tvoid)
+                            if (!(fparam.storageClass & STC.lazy_) && farg.type.ty == TY.void_)
                                 goto Lnomatch;
 
                             Type tt;
@@ -1392,7 +1392,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                             /* Remove top const for dynamic array types and pointer types
                              */
-                            if ((tt.ty == Tarray || tt.ty == Tpointer) && !tt.isMutable() && (!(fparam.storageClass & STC.ref_) || (fparam.storageClass & STC.auto_) && !farg.isLvalue()))
+                            if ((tt.ty == TY.array || tt.ty == TY.pointer) && !tt.isMutable() && (!(fparam.storageClass & STC.ref_) || (fparam.storageClass & STC.auto_) && !farg.isLvalue()))
                             {
                                 tt = tt.mutableOf();
                             }
@@ -1423,7 +1423,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     // should copy prmtype to avoid affecting semantic result
                     prmtype = prmtype.syntaxCopy().typeSemantic(fd.loc, paramscope);
 
-                    if (prmtype.ty == Ttuple)
+                    if (prmtype.ty == TY.tuple)
                     {
                         TypeTuple tt = cast(TypeTuple)prmtype;
                         size_t tt_dim = tt.arguments.dim;
@@ -1476,7 +1476,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         for (size_t i = 0; i < dedtypes.dim; i++)
                         {
                             Type at = isType((*dedtypes)[i]);
-                            if (at && at.ty == Tnone)
+                            if (at && at.ty == TY.none)
                             {
                                 TypeDeduced xt = cast(TypeDeduced)at;
                                 (*dedtypes)[i] = xt.tded; // 'unbox'
@@ -1558,7 +1558,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 }
                 {
                     // Check invalid arguments to detect errors early.
-                    if (farg.op == TOKerror || farg.type.ty == Terror)
+                    if (farg.op == TOKerror || farg.type.ty == TY.error)
                         goto Lnomatch;
 
                     Type att = null;
@@ -1570,7 +1570,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     }
                     Type argtype = farg.type;
 
-                    if (!(fparam.storageClass & STC.lazy_) && argtype.ty == Tvoid && farg.op != TOKfunction)
+                    if (!(fparam.storageClass & STC.lazy_) && argtype.ty == TY.void_ && farg.op != TOKfunction)
                         goto Lnomatch;
 
                     // https://issues.dlang.org/show_bug.cgi?id=12876
@@ -1584,7 +1584,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         /* Allow expressions that have CT-known boundaries and type [] to match with [dim]
                          */
                         Type taai;
-                        if (argtype.ty == Tarray && (prmtype.ty == Tsarray || prmtype.ty == Taarray && (taai = (cast(TypeAArray)prmtype).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+                        if (argtype.ty == TY.array && (prmtype.ty == TY.sarray || prmtype.ty == TY.aarray && (taai = (cast(TypeAArray)prmtype).index).ty == TY.ident && (cast(TypeIdentifier)taai).idents.dim == 0))
                         {
                             if (farg.op == TOKstring)
                             {
@@ -1606,7 +1606,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                         oarg = argtype;
                     }
-                    else if ((fparam.storageClass & STC.out_) == 0 && (argtype.ty == Tarray || argtype.ty == Tpointer) && templateParameterLookup(prmtype, parameters) != IDX_NOTFOUND && (cast(TypeIdentifier)prmtype).idents.dim == 0)
+                    else if ((fparam.storageClass & STC.out_) == 0 && (argtype.ty == TY.array || argtype.ty == TY.pointer) && templateParameterLookup(prmtype, parameters) != IDX_NOTFOUND && (cast(TypeIdentifier)prmtype).idents.dim == 0)
                     {
                         /* The farg passing to the prmtype always make a copy. Therefore,
                          * we can shrink the set of the deduced type arguments for prmtype
@@ -1664,7 +1664,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     {
                         if (!farg.isLvalue())
                         {
-                            if ((farg.op == TOKstring || farg.op == TOKslice) && (prmtype.ty == Tsarray || prmtype.ty == Taarray))
+                            if ((farg.op == TOKstring || farg.op == TOKslice) && (prmtype.ty == TY.sarray || prmtype.ty == TY.aarray))
                             {
                                 // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
                             }
@@ -1679,7 +1679,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         if (!farg.type.isMutable()) // https://issues.dlang.org/show_bug.cgi?id=11916
                             goto Lnomatch;
                     }
-                    if (m == MATCH.nomatch && (fparam.storageClass & STC.lazy_) && prmtype.ty == Tvoid && farg.type.ty != Tvoid)
+                    if (m == MATCH.nomatch && (fparam.storageClass & STC.lazy_) && prmtype.ty == TY.void_ && farg.type.ty != TY.void_)
                         m = MATCH.convert;
                     if (m != MATCH.nomatch)
                     {
@@ -1703,18 +1703,18 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 switch (tb.ty)
                 {
                     // 6764 fix - TypeAArray may be TypeSArray have not yet run semantic().
-                case Tsarray:
-                case Taarray:
+                case TY.sarray:
+                case TY.aarray:
                     {
                         // Perhaps we can do better with this, see TypeFunction.callMatch()
-                        if (tb.ty == Tsarray)
+                        if (tb.ty == TY.sarray)
                         {
                             TypeSArray tsa = cast(TypeSArray)tb;
                             dinteger_t sz = tsa.dim.toInteger();
                             if (sz != nfargs - argi)
                                 goto Lnomatch;
                         }
-                        else if (tb.ty == Taarray)
+                        else if (tb.ty == TY.aarray)
                         {
                             TypeAArray taa = cast(TypeAArray)tb;
                             Expression dim = new IntegerExp(instLoc, nfargs - argi, Type.tsize_t);
@@ -1776,9 +1776,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                                 }
                             }
                         }
-                        goto case Tarray;
+                        goto case TY.array;
                     }
-                case Tarray:
+                case TY.array:
                     {
                         TypeArray ta = cast(TypeArray)tb;
                         Type tret = fparam.isLazyArray();
@@ -1802,7 +1802,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                                     m = arg.implicitConvTo(tret);
                                     if (m == MATCH.nomatch)
                                     {
-                                        if (tret.toBasetype().ty == Tvoid)
+                                        if (tret.toBasetype().ty == TY.void_)
                                             m = MATCH.convert;
                                     }
                                 }
@@ -1820,8 +1820,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         }
                         goto Lmatch;
                     }
-                case Tclass:
-                case Tident:
+                case TY.class_:
+                case TY.ident:
                     goto Lmatch;
 
                 default:
@@ -1840,7 +1840,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             Type at = isType((*dedtypes)[i]);
             if (at)
             {
-                if (at.ty == Tnone)
+                if (at.ty == TY.none)
                 {
                     TypeDeduced xt = cast(TypeDeduced)at;
                     at = xt.tded; // 'unbox'
@@ -2066,7 +2066,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         {
             Type t = ta;
             // consistent with Type.checkDeprecated()
-            while (t.ty != Tenum)
+            while (t.ty != TY.enum_)
             {
                 if (!t.nextOf())
                     break;
@@ -2112,7 +2112,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             fd = new FuncDeclaration(fd.loc, fd.endloc, fd.ident, fd.storage_class, fd.type.syntaxCopy());
         fd.parent = ti;
 
-        assert(fd.type.ty == Tfunction);
+        assert(fd.type.ty == TY.function_);
         TypeFunction tf = cast(TypeFunction)fd.type;
         tf.fargs = fargs;
 
@@ -2171,7 +2171,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         fd.type = fd.type.typeSemantic(fd.loc, scx);
         scx = scx.pop();
 
-        if (fd.type.ty != Tfunction)
+        if (fd.type.ty != TY.function_)
             return null;
 
         fd.originalType = fd.type; // for mangling
@@ -2276,7 +2276,7 @@ extern (C++) final class TypeDeduced : Type
 
     extern (D) this(Type tt, Expression e, Type tparam)
     {
-        super(Tnone);
+        super(TY.none);
         tded = tt;
         argexps.push(e);
         tparams.push(tparam);
@@ -2599,7 +2599,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
             if (!fd)
                 return 0;
 
-            if (fd.type.ty != Tfunction)
+            if (fd.type.ty != TY.function_)
             {
                 m.lastf = fd;   // to propagate "error match"
                 m.count = 1;
@@ -2648,7 +2648,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         //printf("td = %s\n", td.toChars());
         for (size_t ovi = 0; f; f = f.overnext0, ovi++)
         {
-            if (f.type.ty != Tfunction || f.errors)
+            if (f.type.ty != TY.function_ || f.errors)
                 goto Lerror;
 
             /* This is a 'dummy' instance to evaluate constraint properly.
@@ -2702,9 +2702,9 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
             {
                 // Disambiguate by tf.callMatch
                 auto tf1 = cast(TypeFunction)fd.type;
-                assert(tf1.ty == Tfunction);
+                assert(tf1.ty == TY.function_);
                 auto tf2 = cast(TypeFunction)m.lastf.type;
-                assert(tf2.ty == Tfunction);
+                assert(tf2.ty == TY.function_);
                 MATCH c1 = tf1.callMatch(tthis_fd, fargs);
                 MATCH c2 = tf2.callMatch(tthis_best, fargs);
                 //printf("2: c1 = %d, c2 = %d\n", c1, c2);
@@ -2807,9 +2807,9 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         tthis_best = m.lastf.needThis() && !m.lastf.isCtorDeclaration() ? tthis : null;
 
         auto tf = cast(TypeFunction)m.lastf.type;
-        if (tf.ty == Terror)
+        if (tf.ty == TY.error)
             goto Lerror;
-        assert(tf.ty == Tfunction);
+        assert(tf.ty == TY.function_);
         if (!tf.callMatch(tthis_best, fargs))
             goto Lnomatch;
 
@@ -2860,7 +2860,7 @@ private size_t templateIdentifierLookup(Identifier id, TemplateParameters* param
 
 private size_t templateParameterLookup(Type tparam, TemplateParameters* parameters)
 {
-    if (tparam.ty == Tident)
+    if (tparam.ty == TY.ident)
     {
         TypeIdentifier tident = cast(TypeIdentifier)tparam;
         //printf("\ttident = '%s'\n", tident.toChars());
@@ -2946,7 +2946,7 @@ private Type rawTypeMerge(Type t1, Type t2)
         return t1b.castMod(MODmerge(t1b.mod, t2b.mod));
 
     auto ty = cast(TY)impcnvResult[t1b.ty][t2b.ty];
-    if (ty != Terror)
+    if (ty != TY.error)
         return Type.basic[ty];
 
     return null;
@@ -3217,7 +3217,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             if (t == tparam)
                 goto Lexact;
 
-            if (tparam.ty == Tident)
+            if (tparam.ty == TY.ident)
             {
                 // Determine which parameter tparam is
                 size_t i = templateParameterLookup(tparam, parameters);
@@ -3236,10 +3236,10 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     }
 
                     /* BUG: what if tparam is a template instance, that
-                     * has as an argument another Tident?
+                     * has as an argument another TY.ident?
                      */
                     tparam = tparam.typeSemantic(loc, sc);
-                    assert(tparam.ty != Tident);
+                    assert(tparam.ty != TY.ident);
                     result = deduceType(t, sc, tparam, parameters, dedtypes, wm);
                     return;
                 }
@@ -3285,7 +3285,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         if (!tt)
                             goto Lnomatch;
                         Type at = cast(Type)(*dedtypes)[i];
-                        if (at && at.ty == Tnone)
+                        if (at && at.ty == TY.none)
                             at = (cast(TypeDeduced)at).tded;
                         if (!at || tt.equals(at))
                         {
@@ -3323,7 +3323,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     }
 
                     // type vs expressions
-                    if (at.ty == Tnone)
+                    if (at.ty == TY.none)
                     {
                         TypeDeduced xt = cast(TypeDeduced)at;
                         result = xt.matchAll(tt);
@@ -3367,7 +3367,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     }
 
                     // type vs expressions
-                    if (at.ty == Tnone)
+                    if (at.ty == TY.none)
                     {
                         TypeDeduced xt = cast(TypeDeduced)at;
                         result = xt.matchAll(tt);
@@ -3383,12 +3383,12 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     {
                         goto Lexact;
                     }
-                    if (tt.ty == Tclass && at.ty == Tclass)
+                    if (tt.ty == TY.class_ && at.ty == TY.class_)
                     {
                         result = tt.implicitConvTo(at);
                         return;
                     }
-                    if (tt.ty == Tsarray && at.ty == Tarray && tt.nextOf().implicitConvTo(at.nextOf()) >= MATCH.constant)
+                    if (tt.ty == TY.sarray && at.ty == TY.array && tt.nextOf().implicitConvTo(at.nextOf()) >= MATCH.constant)
                     {
                         goto Lexact;
                     }
@@ -3396,7 +3396,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 goto Lnomatch;
             }
 
-            if (tparam.ty == Ttypeof)
+            if (tparam.ty == TY.typeof_)
             {
                 /* Need a loc to go with the semantic routine.
                  */
@@ -3420,7 +3420,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 MATCH m = t.implicitConvTo(tparam);
                 if (m == MATCH.nomatch)
                 {
-                    if (t.ty == Tclass)
+                    if (t.ty == TY.class_)
                     {
                         TypeClass tc = cast(TypeClass)t;
                         if (tc.sym.aliasthis && !(tc.att & AliasThisRec.tracingDT))
@@ -3433,7 +3433,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                             }
                         }
                     }
-                    else if (t.ty == Tstruct)
+                    else if (t.ty == TY.struct_)
                     {
                         TypeStruct ts = cast(TypeStruct)t;
                         if (ts.sym.aliasthis && !(ts.att & AliasThisRec.tracingDT))
@@ -3460,7 +3460,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 }
 
                 Type tpn = tparam.nextOf();
-                if (wm && t.ty == Taarray && tparam.isWild())
+                if (wm && t.ty == TY.aarray && tparam.isWild())
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=12403
                     // In IFTI, stop inout matching on transitive part of AA types.
@@ -3493,7 +3493,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 printf("\ttparam = %d, ", tparam.ty);
                 tparam.print();
             }
-            if (tparam.ty == Tvector)
+            if (tparam.ty == TY.vector)
             {
                 TypeVector tp = cast(TypeVector)tparam;
                 result = deduceType(t.basetype, sc, tp.basetype, parameters, dedtypes, wm);
@@ -3529,7 +3529,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             // Extra check that array dimensions must match
             if (tparam)
             {
-                if (tparam.ty == Tarray)
+                if (tparam.ty == TY.array)
                 {
                     MATCH m = deduceType(t.next, sc, tparam.nextOf(), parameters, dedtypes, wm);
                     result = (m >= MATCH.constant) ? MATCH.convert : MATCH.nomatch;
@@ -3539,7 +3539,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 TemplateParameter tp = null;
                 Expression edim = null;
                 size_t i;
-                if (tparam.ty == Tsarray)
+                if (tparam.ty == TY.sarray)
                 {
                     TypeSArray tsa = cast(TypeSArray)tparam;
                     if (tsa.dim.op == TOKvar && (cast(VarExp)tsa.dim).var.storage_class & STC.templateparameter)
@@ -3552,7 +3552,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     else
                         edim = tsa.dim;
                 }
-                else if (tparam.ty == Taarray)
+                else if (tparam.ty == TY.aarray)
                 {
                     TypeAArray taa = cast(TypeAArray)tparam;
                     i = templateParameterLookup(taa.index, parameters);
@@ -3588,7 +3588,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             }
 
             // Extra check that index type must match
-            if (tparam && tparam.ty == Taarray)
+            if (tparam && tparam.ty == TY.aarray)
             {
                 TypeAArray tp = cast(TypeAArray)tparam;
                 if (!deduceType(t.index, sc, tp.index, parameters, dedtypes))
@@ -3607,7 +3607,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             //printf("\ttparam = %d, ", tparam.ty); tparam.print();
 
             // Extra check that function characteristics must match
-            if (tparam && tparam.ty == Tfunction)
+            if (tparam && tparam.ty == TY.function_)
             {
                 TypeFunction tp = cast(TypeFunction)tparam;
                 if (t.varargs != tp.varargs || t.linkage != tp.linkage)
@@ -3628,7 +3628,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     if (!reliesOnTident(fparam.type, parameters, inferStart))
                     {
                         auto tx = fparam.type.typeSemantic(Loc(), sc);
-                        if (tx.ty == Terror)
+                        if (tx.ty == TY.error)
                         {
                             result = MATCH.nomatch;
                             return;
@@ -3652,7 +3652,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     Parameter fparam = Parameter.getNth(tp.parameters, nfparams - 1);
                     assert(fparam);
                     assert(fparam.type);
-                    if (fparam.type.ty != Tident)
+                    if (fparam.type.ty != TY.ident)
                         goto L1;
                     TypeIdentifier tid = cast(TypeIdentifier)fparam.type;
                     if (tid.idents.dim)
@@ -3740,7 +3740,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         override void visit(TypeIdentifier t)
         {
             // Extra check
-            if (tparam && tparam.ty == Tident)
+            if (tparam && tparam.ty == TY.ident)
             {
                 TypeIdentifier tp = cast(TypeIdentifier)tparam;
                 for (size_t i = 0; i < t.idents.dim; i++)
@@ -3768,7 +3768,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 tparam.print();
             }
             // Extra check
-            if (tparam && tparam.ty == Tinstance && t.tempinst.tempdecl)
+            if (tparam && tparam.ty == TY.instance && t.tempinst.tempdecl)
             {
                 TemplateDeclaration tempdecl = t.tempinst.tempdecl.isTemplateDeclaration();
                 assert(tempdecl);
@@ -3865,7 +3865,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     RootObject o2 = (*tp.tempinst.tiargs)[i];
                     Type t2 = isType(o2);
 
-                    size_t j = (t2 && t2.ty == Tident && i == tp.tempinst.tiargs.dim - 1)
+                    size_t j = (t2 && t2.ty == TY.ident && i == tp.tempinst.tiargs.dim - 1)
                         ? templateParameterLookup(t2, parameters) : IDX_NOTFOUND;
                     if (j != IDX_NOTFOUND && j == parameters.dim - 1 &&
                         (*parameters)[j].isTemplateTupleParameter())
@@ -3973,7 +3973,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                                 goto Lnomatch;
                         }
                     }
-                    else if (e1 && t2 && t2.ty == Tident)
+                    else if (e1 && t2 && t2.ty == TY.ident)
                     {
                         j = templateParameterLookup(t2, parameters);
                     L1:
@@ -3993,7 +3993,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         if (!s1.equals(s2))
                             goto Lnomatch;
                     }
-                    else if (s1 && t2 && t2.ty == Tident)
+                    else if (s1 && t2 && t2.ty == TY.ident)
                     {
                         j = templateParameterLookup(t2, parameters);
                         if (j == IDX_NOTFOUND)
@@ -4035,7 +4035,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
              */
             TemplateInstance ti = t.sym.parent.isTemplateInstance();
 
-            if (tparam && tparam.ty == Tinstance)
+            if (tparam && tparam.ty == TY.instance)
             {
                 if (ti && ti.toAlias() == t.sym)
                 {
@@ -4068,7 +4068,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             }
 
             // Extra check
-            if (tparam && tparam.ty == Tstruct)
+            if (tparam && tparam.ty == TY.struct_)
             {
                 TypeStruct tp = cast(TypeStruct)tparam;
 
@@ -4087,7 +4087,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         override void visit(TypeEnum t)
         {
             // Extra check
-            if (tparam && tparam.ty == Tenum)
+            if (tparam && tparam.ty == TY.enum_)
             {
                 TypeEnum tp = cast(TypeEnum)tparam;
                 if (t.sym == tp.sym)
@@ -4097,7 +4097,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 return;
             }
             Type tb = t.toBasetype();
-            if (tb.ty == tparam.ty || tb.ty == Tsarray && tparam.ty == Taarray)
+            if (tb.ty == tparam.ty || tb.ty == TY.sarray && tparam.ty == TY.aarray)
             {
                 result = deduceType(tb, sc, tparam, parameters, dedtypes, wm);
                 return;
@@ -4169,7 +4169,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
              */
             TemplateInstance ti = t.sym.parent.isTemplateInstance();
 
-            if (tparam && tparam.ty == Tinstance)
+            if (tparam && tparam.ty == TY.instance)
             {
                 if (ti && ti.toAlias() == t.sym)
                 {
@@ -4249,7 +4249,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             }
 
             // Extra check
-            if (tparam && tparam.ty == Tclass)
+            if (tparam && tparam.ty == TY.class_)
             {
                 TypeClass tp = cast(TypeClass)tparam;
 
@@ -4271,7 +4271,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             size_t i = templateParameterLookup(tparam, parameters);
             if (i == IDX_NOTFOUND || (cast(TypeIdentifier)tparam).idents.dim > 0)
             {
-                if (e == emptyArrayElement && tparam.ty == Tarray)
+                if (e == emptyArrayElement && tparam.ty == TY.array)
                 {
                     Type tn = (cast(TypeNext)tparam).next;
                     result = deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
@@ -4321,7 +4321,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             }
 
             TypeDeduced xt = null;
-            if (at.ty == Tnone)
+            if (at.ty == TY.none)
             {
                 xt = cast(TypeDeduced)at;
                 at = xt.tded;
@@ -4413,7 +4413,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 emptyArrayElement = new IdentifierExp(Loc(), Id.p); // dummy
                 emptyArrayElement.type = Type.tvoid;
             }
-            assert(tparam.ty == Tarray);
+            assert(tparam.ty == TY.array);
 
             Type tn = (cast(TypeNext)tparam).next;
             return deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
@@ -4421,7 +4421,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(NullExp e)
         {
-            if (tparam.ty == Tarray && e.type.ty == Tnull)
+            if (tparam.ty == TY.array && e.type.ty == TY.null_)
             {
                 // tparam:T[] <- e:null (void[])
                 result = deduceEmptyArrayElement();
@@ -4433,7 +4433,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         override void visit(StringExp e)
         {
             Type taai;
-            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+            if (e.type.ty == TY.array && (tparam.ty == TY.sarray || tparam.ty == TY.aarray && (taai = (cast(TypeAArray)tparam).index).ty == TY.ident && (cast(TypeIdentifier)taai).idents.dim == 0))
             {
                 // Consider compile-time known boundaries
                 e.type.nextOf().sarrayOf(e.len).accept(this);
@@ -4444,14 +4444,14 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(ArrayLiteralExp e)
         {
-            if ((!e.elements || !e.elements.dim) && e.type.toBasetype().nextOf().ty == Tvoid && tparam.ty == Tarray)
+            if ((!e.elements || !e.elements.dim) && e.type.toBasetype().nextOf().ty == TY.void_ && tparam.ty == TY.array)
             {
                 // tparam:T[] <- e:[] (void[])
                 result = deduceEmptyArrayElement();
                 return;
             }
 
-            if (tparam.ty == Tarray && e.elements && e.elements.dim)
+            if (tparam.ty == TY.array && e.elements && e.elements.dim)
             {
                 Type tn = (cast(TypeDArray)tparam).next;
                 result = MATCH.exact;
@@ -4476,7 +4476,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             }
 
             Type taai;
-            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+            if (e.type.ty == TY.array && (tparam.ty == TY.sarray || tparam.ty == TY.aarray && (taai = (cast(TypeAArray)tparam).index).ty == TY.ident && (cast(TypeIdentifier)taai).idents.dim == 0))
             {
                 // Consider compile-time known boundaries
                 e.type.nextOf().sarrayOf(e.elements.dim).accept(this);
@@ -4487,7 +4487,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(AssocArrayLiteralExp e)
         {
-            if (tparam.ty == Taarray && e.keys && e.keys.dim)
+            if (tparam.ty == TY.aarray && e.keys && e.keys.dim)
             {
                 TypeAArray taa = cast(TypeAArray)tparam;
                 result = MATCH.exact;
@@ -4515,7 +4515,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             if (e.td)
             {
                 Type to = tparam;
-                if (!to.nextOf() || to.nextOf().ty != Tfunction)
+                if (!to.nextOf() || to.nextOf().ty != TY.function_)
                     return;
                 TypeFunction tof = cast(TypeFunction)to.nextOf();
 
@@ -4539,7 +4539,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     for (; u < dim; u++)
                     {
                         Parameter p = Parameter.getNth(tf.parameters, u);
-                        if (p.type.ty == Tident && (cast(TypeIdentifier)p.type).ident == tp.ident)
+                        if (p.type.ty == TY.ident && (cast(TypeIdentifier)p.type).ident == tp.ident)
                         {
                             break;
                         }
@@ -4552,7 +4552,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     if (reliesOnTident(t, parameters, inferStart))
                         return;
                     t = t.typeSemantic(e.loc, sc);
-                    if (t.ty == Terror)
+                    if (t.ty == TY.error)
                         return;
                     tiargs.push(t);
                 }
@@ -4577,11 +4577,11 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
             Type t = e.type;
 
-            if (t.ty == Tdelegate && tparam.ty == Tpointer)
+            if (t.ty == TY.delegate_ && tparam.ty == TY.pointer)
                 return;
 
             // Allow conversion from implicit function pointer to delegate
-            if (e.tok == TOKreserved && t.ty == Tpointer && tparam.ty == Tdelegate)
+            if (e.tok == TOKreserved && t.ty == TY.pointer && tparam.ty == TY.delegate_)
             {
                 TypeFunction tf = cast(TypeFunction)t.nextOf();
                 t = (new TypeDelegate(tf)).merge();
@@ -4593,7 +4593,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         override void visit(SliceExp e)
         {
             Type taai;
-            if (e.type.ty == Tarray && (tparam.ty == Tsarray || tparam.ty == Taarray && (taai = (cast(TypeAArray)tparam).index).ty == Tident && (cast(TypeIdentifier)taai).idents.dim == 0))
+            if (e.type.ty == TY.array && (tparam.ty == TY.sarray || tparam.ty == TY.aarray && (taai = (cast(TypeAArray)tparam).index).ty == TY.ident && (cast(TypeIdentifier)taai).idents.dim == 0))
             {
                 // Consider compile-time known boundaries
                 if (Type tsa = toStaticArrayType(e))
@@ -5587,7 +5587,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
         Type ta = isType(defaultAlias);
         if (ta)
         {
-            if (ta.ty == Tinstance)
+            if (ta.ty == TY.instance)
             {
                 // If the default arg is a template, instantiate for each type
                 da = ta.syntaxCopy();
@@ -5642,7 +5642,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
                         goto Lnomatch;
                 }
             }
-            else if (ta && ta.ty == Tinstance && !specAlias)
+            else if (ta && ta.ty == TY.instance && !specAlias)
             {
                 /* Specialized parameter should be preferred
                  * match to the template type parameter.
@@ -6629,7 +6629,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 }
 
             Ltype:
-                if (ta.ty == Ttuple)
+                if (ta.ty == TY.tuple)
                 {
                     // Expand tuple
                     TypeTuple tt = cast(TypeTuple)ta;
@@ -6650,7 +6650,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     j--;
                     continue;
                 }
-                if (ta.ty == Terror)
+                if (ta.ty == TY.error)
                 {
                     err = true;
                     continue;
@@ -6735,7 +6735,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                      * already semanticed as function pointer, never requires
                      * outer frame. So convert it to global function is valid.
                      */
-                    if (fe.fd.tok == TOKreserved && fe.type.ty == Tpointer)
+                    if (fe.fd.tok == TOKreserved && fe.type.ty == TY.pointer)
                     {
                         // change to non-nested
                         fe.fd.tok = TOKfunction;
@@ -7092,7 +7092,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     return 1;
                 }
                 auto fd = td.onemember.isFuncDeclaration();
-                if (!fd || fd.type.ty != Tfunction)
+                if (!fd || fd.type.ty != TY.function_)
                     return 0;
 
                 foreach (tp; *td.parameters)

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -153,12 +153,12 @@ private elem *callfunc(Loc loc,
     }
 
     t = t.toBasetype();
-    if (t.ty == Tdelegate)
+    if (t.ty == TY.delegate_)
     {
         // A delegate consists of:
         //      { Object *this; Function *funcptr; }
         assert(!fd);
-        assert(t.nextOf().ty == Tfunction);
+        assert(t.nextOf().ty == TY.function_);
         tf = cast(TypeFunction)(t.nextOf());
         ethis = ec;
         ec = el_same(&ethis);
@@ -168,7 +168,7 @@ private elem *callfunc(Loc loc,
     }
     else
     {
-        assert(t.ty == Tfunction);
+        assert(t.ty == TY.function_);
         tf = cast(TypeFunction)(t);
     }
     const ty = fd ? toSymbol(fd).Stype.Tty : ec.Ety;
@@ -276,8 +276,8 @@ private elem *callfunc(Loc loc,
             type *tc;
 
             Type tret2 = tf.next;
-            if (tret2.toBasetype().ty == Tstruct ||
-                tret2.toBasetype().ty == Tsarray)
+            if (tret2.toBasetype().ty == TY.struct_ ||
+                tret2.toBasetype().ty == TY.sarray)
                 tc = Type_toCtype(tret2);
             else
                 tc = type_fake(totym(tret2));
@@ -617,7 +617,7 @@ elem *addressElem(elem *e, Type t, bool alwaysCopy = false)
 
         // Convert to ((tmp=e2),tmp)
         TY ty;
-        if (t && ((ty = t.toBasetype().ty) == Tstruct || ty == Tsarray))
+        if (t && ((ty = t.toBasetype().ty) == TY.struct_ || ty == TY.sarray))
             tx = Type_toCtype(t);
         else if (tybasic(e2.Ety) == TYstruct)
         {
@@ -656,11 +656,11 @@ elem *array_toPtr(Type t, elem *e)
     t = t.toBasetype();
     switch (t.ty)
     {
-        case Tpointer:
+        case TY.pointer:
             break;
 
-        case Tarray:
-        case Tdelegate:
+        case TY.array:
+        case TY.delegate_:
             if (e.Eoper == OPcomma)
             {
                 e.Ety = TYnptr;
@@ -684,7 +684,7 @@ else
             }
             break;
 
-        case Tsarray:
+        case TY.sarray:
             //e = el_una(OPaddr, TYnptr, e);
             e = addressElem(e, t);
             break;
@@ -711,10 +711,10 @@ elem *array_toDarray(Type t, elem *e)
     t = t.toBasetype();
     switch (t.ty)
     {
-        case Tarray:
+        case TY.array:
             break;
 
-        case Tsarray:
+        case TY.sarray:
             e = addressElem(e, t);
             dim = cast(uint)(cast(TypeSArray)t).dim.toInteger();
             e = el_pair(TYdarray, el_long(TYsize_t, dim), e);
@@ -824,7 +824,7 @@ elem *sarray_toDarray(Loc loc, Type tfrom, Type tto, elem *e)
 
 elem *getTypeInfo(Type t, IRState *irs)
 {
-    assert(t.ty != Terror);
+    assert(t.ty != TY.error);
     genTypeInfo(t, null);
     elem *e = el_ptr(toSymbol(t.vtinfo));
     return e;
@@ -836,7 +836,7 @@ elem *getTypeInfo(Type t, IRState *irs)
 StructDeclaration needsPostblit(Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Tstruct)
+    if (t.ty == TY.struct_)
     {
         StructDeclaration sd = (cast(TypeStruct)t).sym;
         if (sd.postblit)
@@ -851,7 +851,7 @@ StructDeclaration needsPostblit(Type t)
 StructDeclaration needsDtor(Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Tstruct)
+    if (t.ty == TY.struct_)
     {
         StructDeclaration sd = (cast(TypeStruct)t).sym;
         if (sd.dtor)
@@ -883,30 +883,30 @@ Lagain:
     int r;
     switch (tb.ty)
     {
-        case Tfloat80:
-        case Timaginary80:
+        case TY.float80:
+        case TY.imaginary80:
             r = RTLSYM_MEMSET80;
             break;
-        case Tcomplex80:
+        case TY.complex80:
             r = RTLSYM_MEMSET160;
             break;
-        case Tcomplex64:
+        case TY.complex64:
             r = RTLSYM_MEMSET128;
             break;
-        case Tfloat32:
-        case Timaginary32:
+        case TY.float32:
+        case TY.imaginary32:
             if (!global.params.is64bit)
                 goto default;          // legacy binary compatibility
             r = RTLSYM_MEMSETFLOAT;
             break;
-        case Tfloat64:
-        case Timaginary64:
+        case TY.float64:
+        case TY.imaginary64:
             if (!global.params.is64bit)
                 goto default;          // legacy binary compatibility
             r = RTLSYM_MEMSETDOUBLE;
             break;
 
-        case Tstruct:
+        case TY.struct_:
         {
             if (!global.params.is64bit)
                 goto default;
@@ -921,7 +921,7 @@ Lagain:
             goto default;
         }
 
-        case Tvector:
+        case TY.vector:
             r = RTLSYM_MEMSETSIMD;
             break;
 
@@ -1251,8 +1251,8 @@ elem *toElem(Expression e, IRState *irs)
 
                 tym_t tym;
                 if (se.var.storage_class & STC.lazy_)
-                    tym = TYdelegate;       // Tdelegate as C type
-                else if (tb.ty == Tfunction)
+                    tym = TYdelegate;       // TY.delegate_ as C type
+                else if (tb.ty == TY.function_)
                     tym = s.Stype.Tty;
                 else
                     tym = totym(se.type);
@@ -1285,7 +1285,7 @@ elem *toElem(Expression e, IRState *irs)
             //printf("FuncExp.toElem() %s\n", fe.toChars());
             FuncLiteralDeclaration fld = fe.fd;
 
-            if (fld.tok == TOKreserved && fe.type.ty == Tpointer)
+            if (fld.tok == TOKreserved && fe.type.ty == TY.pointer)
             {
                 // change to non-nested
                 fld.tok = TOKfunction;
@@ -1329,7 +1329,7 @@ elem *toElem(Expression e, IRState *irs)
             if (Expression ex = isExpression(e.obj))
             {
                 Type t = ex.type.toBasetype();
-                assert(t.ty == Tclass);
+                assert(t.ty == TY.class_);
                 // generate **classptr to get the classinfo
                 result = toElem(ex, irs);
                 result = el_una(OPind,TYnptr,result);
@@ -1361,7 +1361,7 @@ elem *toElem(Expression e, IRState *irs)
             else
                 ethis = el_var(irs.sthis);
 
-            if (te.type.ty == Tstruct)
+            if (te.type.ty == TY.struct_)
             {
                 ethis = el_una(OPind, TYstruct, ethis);
                 ethis.ET = Type_toCtype(te.type);
@@ -1516,12 +1516,12 @@ elem *toElem(Expression e, IRState *irs)
 
             elem *e;
             Type tb = se.type.toBasetype();
-            if (tb.ty == Tarray)
+            if (tb.ty == TY.array)
             {
                 Symbol *si = toStringSymbol(se);
                 e = el_pair(TYdarray, el_long(TYsize_t, se.numberOfCodeUnits()), el_ptr(si));
             }
-            else if (tb.ty == Tsarray)
+            else if (tb.ty == TY.sarray)
             {
                 Symbol *si = toStringSymbol(se);
                 e = el_var(si);
@@ -1529,7 +1529,7 @@ elem *toElem(Expression e, IRState *irs)
                 e.ET = si.Stype;
                 e.ET.Tcount++;
             }
-            else if (tb.ty == Tpointer)
+            else if (tb.ty == TY.pointer)
             {
                 e = el_calloc();
                 e.Eoper = OPstring;
@@ -1558,10 +1558,10 @@ elem *toElem(Expression e, IRState *irs)
                 //printf("\tmember = %s\n", ne.member.toChars());
             elem *e;
             Type ectype;
-            if (t.ty == Tclass)
+            if (t.ty == TY.class_)
             {
                 t = ne.newtype.toBasetype();
-                assert(t.ty == Tclass);
+                assert(t.ty == TY.class_);
                 TypeClass tclass = cast(TypeClass)t;
                 ClassDeclaration cd = tclass.sym;
 
@@ -1691,10 +1691,10 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_combine(e, ezprefix);
                 e = el_combine(e, ez);
             }
-            else if (t.ty == Tpointer && t.nextOf().toBasetype().ty == Tstruct)
+            else if (t.ty == TY.pointer && t.nextOf().toBasetype().ty == TY.struct_)
             {
                 t = ne.newtype.toBasetype();
-                assert(t.ty == Tstruct);
+                assert(t.ty == TY.struct_);
                 TypeStruct tclass = cast(TypeStruct)t;
                 StructDeclaration sd = tclass.sym;
 
@@ -1766,7 +1766,7 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_combine(e, ezprefix);
                 e = el_combine(e, ez);
             }
-            else if (t.ty == Tarray)
+            else if (t.ty == TY.array)
             {
                 TypeDArray tda = cast(TypeDArray)t;
 
@@ -1790,7 +1790,7 @@ elem *toElem(Expression e, IRState *irs)
                     // Multidimensional array allocations
                     for (size_t i = 0; i < ne.arguments.dim; i++)
                     {
-                        assert(t.ty == Tarray);
+                        assert(t.ty == TY.array);
                         t = t.nextOf();
                         assert(t);
                     }
@@ -1811,7 +1811,7 @@ elem *toElem(Expression e, IRState *irs)
                 }
                 e = el_combine(ezprefix, e);
             }
-            else if (t.ty == Tpointer)
+            else if (t.ty == TY.pointer)
             {
                 TypePointer tp = cast(TypePointer)t;
                 elem *ezprefix = ne.argprefix ? toElem(ne.argprefix, irs) : null;
@@ -1861,11 +1861,11 @@ elem *toElem(Expression e, IRState *irs)
             elem *e = toElem(ne.e1, irs);
             Type tb1 = ne.e1.type.toBasetype();
 
-            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
+            assert(tb1.ty != TY.array && tb1.ty != TY.sarray);
 
             switch (tb1.ty)
             {
-                case Tvector:
+                case TY.vector:
                 {
                     // rewrite (-e) as (0-e)
                     elem *ez = el_calloc();
@@ -1895,16 +1895,16 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = ce.e1.type.toBasetype();
             tym_t ty = totym(ce.type);
 
-            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
+            assert(tb1.ty != TY.array && tb1.ty != TY.sarray);
 
             elem *e;
             switch (tb1.ty)
             {
-                case Tbool:
+                case TY.bool_:
                     e = el_bin(OPxor, ty, e1, el_long(ty, 1));
                     break;
 
-                case Tvector:
+                case TY.vector:
                 {
                     // rewrite (~e) as (e^~0)
                     elem *ec = el_calloc();
@@ -1976,7 +1976,7 @@ elem *toElem(Expression e, IRState *irs)
                 FuncDeclaration inv;
 
                 // If e1 is a class object, call the class invariant on it
-                if (global.params.useInvariants && t1.ty == Tclass &&
+                if (global.params.useInvariants && t1.ty == TY.class_ &&
                     !(cast(TypeClass)t1).sym.isInterfaceDeclaration() &&
                     !(cast(TypeClass)t1).sym.isCPPclass())
                 {
@@ -1990,8 +1990,8 @@ elem *toElem(Expression e, IRState *irs)
                     einv = el_bin(OPcall, TYvoid, el_var(getRtlsym(rtl)), el_var(ts));
                 }
                 else if (global.params.useInvariants &&
-                    t1.ty == Tpointer &&
-                    t1.nextOf().ty == Tstruct &&
+                    t1.ty == TY.pointer &&
+                    t1.nextOf().ty == TY.struct_ &&
                     (inv = (cast(TypeStruct)t1.nextOf()).sym.inv) !is null)
                 {
                     // If e1 is a struct object, call the struct invariant on it
@@ -2093,9 +2093,9 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = be.e1.type.toBasetype();
             Type tb2 = be.e2.type.toBasetype();
 
-            assert(!((tb1.ty == Tarray || tb1.ty == Tsarray ||
-                      tb2.ty == Tarray || tb2.ty == Tsarray) &&
-                     tb2.ty != Tvoid &&
+            assert(!((tb1.ty == TY.array || tb1.ty == TY.sarray ||
+                      tb2.ty == TY.array || tb2.ty == TY.sarray) &&
+                     tb2.ty != TY.void_ &&
                      op != OPeq && op != OPandand && op != OPoror));
 
             tym_t tym = totym(be.type);
@@ -2115,9 +2115,9 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = be.e1.type.toBasetype();
             Type tb2 = be.e2.type.toBasetype();
 
-            assert(!((tb1.ty == Tarray || tb1.ty == Tsarray ||
-                      tb2.ty == Tarray || tb2.ty == Tsarray) &&
-                     tb2.ty != Tvoid &&
+            assert(!((tb1.ty == TY.array || tb1.ty == TY.sarray ||
+                      tb2.ty == TY.array || tb2.ty == TY.sarray) &&
+                     tb2.ty != TY.void_ &&
                      op != OPeq && op != OPandand && op != OPoror));
 
             tym_t tym = totym(be.type);
@@ -2213,7 +2213,7 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = ce.e1.type.toBasetype();
             Type tb2 = ce.e2.type.toBasetype();
 
-            Type ta = (tb1.ty == Tarray || tb1.ty == Tsarray) ? tb1 : tb2;
+            Type ta = (tb1.ty == TY.array || tb1.ty == TY.sarray) ? tb1 : tb2;
 
             elem *e;
             if (ce.e1.op == TOKcat)
@@ -2309,14 +2309,14 @@ elem *toElem(Expression e, IRState *irs)
                 eop = cast(OPER)rel_integral(eop);
             }
             elem *e;
-            if (cast(int)eop > 1 && t1.ty == Tclass && t2.ty == Tclass)
+            if (cast(int)eop > 1 && t1.ty == TY.class_ && t2.ty == TY.class_)
             {
                 // Should have already been lowered
                 assert(0);
             }
             else if (cast(int)eop > 1 &&
-                (t1.ty == Tarray || t1.ty == Tsarray) &&
-                (t2.ty == Tarray || t2.ty == Tsarray))
+                (t1.ty == TY.array || t1.ty == TY.sarray) &&
+                (t2.ty == TY.array || t2.ty == TY.sarray))
             {
                 // This codepath was replaced by lowering during semantic
                 // to object.__cmp in druntime.
@@ -2357,12 +2357,12 @@ elem *toElem(Expression e, IRState *irs)
 
             //printf("EqualExp.toElem()\n");
             elem *e;
-            if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0)
+            if (t1.ty == TY.struct_ && (cast(TypeStruct)t1).sym.fields.dim == 0)
             {
                 // we can skip the compare if the structs are empty
                 e = el_long(TYbool, ee.op == TOKequal);
             }
-            else if (t1.ty == Tstruct)
+            else if (t1.ty == TY.struct_)
             {
                 // Do bit compare of struct's
                 elem *es1 = toElem(ee.e1, irs);
@@ -2375,13 +2375,13 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_bin(eop, TYint, e, el_long(TYint, 0));
                 elem_setLoc(e, ee.loc);
             }
-            else if ((t1.ty == Tarray || t1.ty == Tsarray) &&
-                     (t2.ty == Tarray || t2.ty == Tsarray))
+            else if ((t1.ty == TY.array || t1.ty == TY.sarray) &&
+                     (t2.ty == TY.array || t2.ty == TY.sarray))
             {
                 Type telement  = t1.nextOf().toBasetype();
                 Type telement2 = t2.nextOf().toBasetype();
 
-                if ((telement.isintegral() || telement.ty == Tvoid) && telement.ty == telement2.ty)
+                if ((telement.isintegral() || telement.ty == TY.void_) && telement.ty == telement2.ty)
                 {
                     // Optimize comparisons of arrays of basic types
                     // For arrays of integers/characters, and void[],
@@ -2397,7 +2397,7 @@ elem *toElem(Expression e, IRState *irs)
                     elem* esiz1, esiz2; // Data size, to pass to memcmp
                     d_uns64 sz = telement.size(); // Size of one element
 
-                    if (t1.ty == Tarray)
+                    if (t1.ty == TY.array)
                     {
                         elen1 = el_una(global.params.is64bit ? OP128_64 : OP64_32, TYsize_t, el_same(&earr1));
                         esiz1 = el_bin(OPmul, TYsize_t, el_same(&elen1), el_long(TYsize_t, sz));
@@ -2411,7 +2411,7 @@ elem *toElem(Expression e, IRState *irs)
                         eptr1 = el_same(&earr1);
                     }
 
-                    if (t2.ty == Tarray)
+                    if (t2.ty == TY.array)
                     {
                         elen2 = el_una(global.params.is64bit ? OP128_64 : OP64_32, TYsize_t, el_same(&earr2));
                         esiz2 = el_bin(OPmul, TYsize_t, el_same(&elen2), el_long(TYsize_t, sz));
@@ -2425,17 +2425,17 @@ elem *toElem(Expression e, IRState *irs)
                         eptr2 = el_same(&earr2);
                     }
 
-                    elem *esize = t2.ty == Tsarray ? esiz2 : esiz1;
+                    elem *esize = t2.ty == TY.sarray ? esiz2 : esiz1;
 
                     e = el_param(eptr1, eptr2);
                     e = el_bin(OPmemcmp, TYint, e, esize);
                     e = el_bin(eop, TYint, e, el_long(TYint, 0));
 
-                    elem *elen = t2.ty == Tsarray ? elen2 : elen1;
+                    elem *elen = t2.ty == TY.sarray ? elen2 : elen1;
                     elem *esizecheck = el_bin(eop, TYint, el_same(&elen), el_long(TYsize_t, 0));
                     e = el_bin(ee.op == TOKequal ? OPoror : OPandand, TYint, esizecheck, e);
 
-                    if (t1.ty == Tsarray && t2.ty == Tsarray)
+                    if (t1.ty == TY.sarray && t2.ty == TY.sarray)
                         assert(t1.size() == t2.size());
                     else
                     {
@@ -2462,7 +2462,7 @@ elem *toElem(Expression e, IRState *irs)
                     e = el_bin(OPxor, TYint, e, el_long(TYint, 1));
                 elem_setLoc(e,ee.loc);
             }
-            else if (t1.ty == Taarray && t2.ty == Taarray)
+            else if (t1.ty == TY.aarray && t2.ty == TY.aarray)
             {
                 TypeAArray taa = cast(TypeAArray)t1;
                 Symbol *s = aaGetSymbol(taa, "Equal", 0);
@@ -2501,12 +2501,12 @@ elem *toElem(Expression e, IRState *irs)
             //printf("IdentityExp.toElem() %s\n", toChars());
 
             elem *e;
-            if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0)
+            if (t1.ty == TY.struct_ && (cast(TypeStruct)t1).sym.fields.dim == 0)
             {
                 // we can skip the compare if the structs are empty
                 e = el_long(TYbool, ie.op == TOKidentity);
             }
-            else if (t1.ty == Tstruct || t1.isfloating())
+            else if (t1.ty == TY.struct_ || t1.isfloating())
             {
                 // Do bit compare of struct's
                 elem *es1 = toElem(ie.e1, irs);
@@ -2519,8 +2519,8 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_bin(eop, TYint, e, el_long(TYint, 0));
                 elem_setLoc(e, ie.loc);
             }
-            else if ((t1.ty == Tarray || t1.ty == Tsarray) &&
-                     (t2.ty == Tarray || t2.ty == Tsarray))
+            else if ((t1.ty == TY.array || t1.ty == TY.sarray) &&
+                     (t2.ty == TY.array || t2.ty == TY.sarray))
             {
 
                 elem *ea1 = toElem(ie.e1, irs);
@@ -2563,7 +2563,7 @@ elem *toElem(Expression e, IRState *irs)
         override void visit(RemoveExp re)
         {
             Type tb = re.e1.type.toBasetype();
-            assert(tb.ty == Taarray);
+            assert(tb.ty == TY.aarray);
             TypeAArray taa = cast(TypeAArray)tb;
             elem *ea = toElem(re.e1, irs);
             elem *ekey = toElem(re.e2, irs);
@@ -2643,7 +2643,7 @@ elem *toElem(Expression e, IRState *irs)
                     elem *enbytes;
                     elem *einit;
                     // Look for array[]=n
-                    if (ta.ty == Tsarray)
+                    if (ta.ty == TY.sarray)
                     {
                         TypeSArray ts = cast(TypeSArray)ta;
                         n1 = array_toPtr(ta, n1);
@@ -2652,7 +2652,7 @@ elem *toElem(Expression e, IRState *irs)
                         n1 = el_same(&n1x);
                         einit = resolveLengthVar(are.lengthVar, &n1, ta);
                     }
-                    else if (ta.ty == Tarray)
+                    else if (ta.ty == TY.array)
                     {
                         n1 = el_same(&n1x);
                         einit = resolveLengthVar(are.lengthVar, &n1, ta);
@@ -2660,7 +2660,7 @@ elem *toElem(Expression e, IRState *irs)
                         n1 = array_toPtr(ta, n1);
                         enbytes = el_una(global.params.is64bit ? OP128_64 : OP64_32, TYsize_t, enbytes);
                     }
-                    else if (ta.ty == Tpointer)
+                    else if (ta.ty == TY.pointer)
                     {
                         n1 = el_same(&n1x);
                         enbytes = el_long(TYsize_t, -1);   // largest possible index
@@ -2697,7 +2697,7 @@ elem *toElem(Expression e, IRState *irs)
                         printf("enbytes\n");    elem_print(enbytes);
                     }
 
-                    if (irs.arrayBoundsCheck() && eupr && ta.ty != Tpointer)
+                    if (irs.arrayBoundsCheck() && eupr && ta.ty != TY.pointer)
                     {
                         assert(elwr);
                         elem *enbytesx = enbytes;
@@ -2752,7 +2752,7 @@ elem *toElem(Expression e, IRState *irs)
                     }
                     bool destructor = needsDtor(t1.nextOf()) !is null;
 
-                    assert(ae.e2.type.ty != Tpointer);
+                    assert(ae.e2.type.ty != TY.pointer);
 
                     if (!postblit && !destructor && !irs.arrayBoundsCheck())
                     {
@@ -2836,7 +2836,7 @@ elem *toElem(Expression e, IRState *irs)
                         es = el_una(OPaddr, TYnptr, es);
                     es.Ety = TYnptr;
                     e = el_bin(OPeq, TYnptr, es, e);
-                    assert(!(t1b.ty == Tstruct && ae.e2.op == TOKint64));
+                    assert(!(t1b.ty == TY.struct_ && ae.e2.op == TOKint64));
 
                     elem_setLoc(e, ae.loc);
                     result = e;
@@ -2886,7 +2886,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 CallExp ce = cast(CallExp)ae.e2;
                 TypeFunction tf = cast(TypeFunction)ce.e1.type.toBasetype();
-                if (tf.ty == Tfunction && retStyle(tf) == RET.stack)
+                if (tf.ty == TY.function_ && retStyle(tf) == RET.stack)
                 {
                     elem *ehidden = e1;
                     ehidden = el_una(OPaddr, TYnptr, ehidden);
@@ -2920,7 +2920,7 @@ elem *toElem(Expression e, IRState *irs)
             }
 
             //if (ae.op == TOKconstruct) printf("construct\n");
-            if (t1b.ty == Tstruct)
+            if (t1b.ty == TY.struct_)
             {
                 if (ae.e2.op == TOKint64)
                 {
@@ -2979,7 +2979,7 @@ elem *toElem(Expression e, IRState *irs)
                 if (type_size(e.ET) == 0)
                     e.Eoper = OPcomma;
             }
-            else if (t1b.ty == Tsarray)
+            else if (t1b.ty == TY.sarray)
             {
                 if (ae.op == TOKblit && ae.e2.op == TOKint64)
                 {
@@ -3007,7 +3007,7 @@ elem *toElem(Expression e, IRState *irs)
                 /* Implement:
                  *  (sarray = sarray)
                  */
-                assert(ae.e2.type.toBasetype().ty == Tsarray);
+                assert(ae.e2.type.toBasetype().ty == TY.sarray);
 
                 bool postblit = needsPostblit(t1b.nextOf()) !is null;
                 bool destructor = needsDtor(t1b.nextOf()) !is null;
@@ -3149,7 +3149,7 @@ elem *toElem(Expression e, IRState *irs)
             elem *e;
             Type tb1 = ce.e1.type.toBasetype();
             Type tb2 = ce.e2.type.toBasetype();
-            assert(tb1.ty == Tarray);
+            assert(tb1.ty == TY.array);
             Type tb1n = tb1.nextOf().toBasetype();
 
             elem *e1 = toElem(ce.e1, irs);
@@ -3160,13 +3160,13 @@ elem *toElem(Expression e, IRState *irs)
                 case TOKcatdcharass:
                 {
                     // Append dchar to char[] or wchar[]
-                    assert(tb2.ty == Tdchar &&
-                          (tb1n.ty == Tchar || tb1n.ty == Twchar));
+                    assert(tb2.ty == TY.dchar_ &&
+                          (tb1n.ty == TY.char_ || tb1n.ty == TY.wchar_));
 
                     e1 = el_una(OPaddr, TYnptr, e1);
 
                     elem *ep = el_params(e2, e1, null);
-                    int rtl = (tb1.nextOf().ty == Tchar)
+                    int rtl = (tb1.nextOf().ty == TY.char_)
                             ? RTLSYM_ARRAYAPPENDCD
                             : RTLSYM_ARRAYAPPENDWD;
                     e = el_bin(OPcall, TYdarray, el_var(getRtlsym(rtl)), ep);
@@ -3178,7 +3178,7 @@ elem *toElem(Expression e, IRState *irs)
                 case TOKcatass:
                 {
                     // Append array
-                    assert(tb2.ty == Tarray || tb2.ty == Tsarray);
+                    assert(tb2.ty == TY.array || tb2.ty == TY.sarray);
 
                     assert(tb1n.equals(tb2.nextOf().toBasetype()));
 
@@ -3354,7 +3354,7 @@ elem *toElem(Expression e, IRState *irs)
         override void visit(PowAssignExp e)
         {
             Type tb1 = e.e1.type.toBasetype();
-            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
+            assert(tb1.ty != TY.array && tb1.ty != TY.sarray);
 
             e.error("`^^` operator is not supported");
             result = el_long(totym(e.type), 0);  // error recovery
@@ -3392,7 +3392,7 @@ elem *toElem(Expression e, IRState *irs)
         override void visit(PowExp e)
         {
             Type tb1 = e.e1.type.toBasetype();
-            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
+            assert(tb1.ty != TY.array && tb1.ty != TY.sarray);
 
             e.error("`^^` operator is not supported");
             result = el_long(totym(e.type), 0);  // error recovery
@@ -3513,8 +3513,8 @@ elem *toElem(Expression e, IRState *irs)
             // https://issues.dlang.org/show_bug.cgi?id=12900
             Type txb = dve.type.toBasetype();
             Type tyb = v.type.toBasetype();
-            if (txb.ty == Tvector) txb = (cast(TypeVector)txb).basetype;
-            if (tyb.ty == Tvector) tyb = (cast(TypeVector)tyb).basetype;
+            if (txb.ty == TY.vector) txb = (cast(TypeVector)txb).basetype;
+            if (tyb.ty == TY.vector) tyb = (cast(TypeVector)tyb).basetype;
 
             debug if (txb.ty != tyb.ty)
                 printf("[%s] dve = %s, dve.type = %s, v.type = %s\n", dve.loc.toChars(), dve.toChars(), dve.type.toChars(), v.type.toChars());
@@ -3531,7 +3531,7 @@ elem *toElem(Expression e, IRState *irs)
 
             elem *e = toElem(dve.e1, irs);
             Type tb1 = dve.e1.type.toBasetype();
-            if (tb1.ty != Tclass && tb1.ty != Tpointer)
+            if (tb1.ty != TY.class_ && tb1.ty != TY.pointer)
                 e = addressElem(e, tb1);
             e = el_bin(OPadd, TYnptr, e, el_long(TYsize_t, v.offset));
             if (v.storage_class & (STC.out_ | STC.ref_))
@@ -3578,7 +3578,7 @@ elem *toElem(Expression e, IRState *irs)
             else
             {
                 ethis = toElem(de.e1, irs);
-                if (de.e1.type.ty != Tclass && de.e1.type.ty != Tpointer)
+                if (de.e1.type.ty != TY.class_ && de.e1.type.ty != TY.pointer)
                     ethis = addressElem(ethis, de.e1.type);
 
                 if (de.e1.op == TOKsuper || de.e1.op == TOKdottype)
@@ -3648,7 +3648,7 @@ elem *toElem(Expression e, IRState *irs)
             elem *ec;
             FuncDeclaration fd = null;
             bool dctor = false;
-            if (ce.e1.op == TOKdotvar && t1.ty != Tdelegate)
+            if (ce.e1.op == TOKdotvar && t1.ty != TY.delegate_)
             {
                 DotVarExp dve = cast(DotVarExp)ce.e1;
 
@@ -3884,7 +3884,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 IndexExp ae = cast(IndexExp)de.e1;
                 tb = ae.e1.type.toBasetype();
-                assert(tb.ty != Taarray);
+                assert(tb.ty != TY.aarray);
             }
             //e1.type.print();
             elem *e = toElem(de.e1, irs);
@@ -3892,7 +3892,7 @@ elem *toElem(Expression e, IRState *irs)
             int rtl;
             switch (tb.ty)
             {
-                case Tarray:
+                case TY.array:
                 {
                     e = addressElem(e, de.e1.type);
                     rtl = RTLSYM_DELARRAYT;
@@ -3901,7 +3901,7 @@ elem *toElem(Expression e, IRState *irs)
                      */
                     elem *et = null;
                     Type tv = tb.nextOf().baseElemOf();
-                    if (tv.ty == Tstruct)
+                    if (tv.ty == TY.struct_)
                     {
                         // FIXME: ts can be non-mutable, but _d_delarray_t requests TypeInfo_Struct.
                         TypeStruct ts = cast(TypeStruct)tv;
@@ -3915,7 +3915,7 @@ elem *toElem(Expression e, IRState *irs)
                     // call _d_delarray_t(e, et);
                     break;
                 }
-                case Tclass:
+                case TY.class_:
                     if (de.e1.op == TOKvar)
                     {
                         VarExp ve = cast(VarExp)de.e1;
@@ -3934,11 +3934,11 @@ elem *toElem(Expression e, IRState *irs)
                         rtl = RTLSYM_DELINTERFACE;
                     break;
 
-                case Tpointer:
+                case TY.pointer:
                     e = addressElem(e, de.e1.type);
                     rtl = RTLSYM_DELMEMORY;
                     tb = (cast(TypePointer)tb).next.toBasetype();
-                    if (tb.ty == Tstruct)
+                    if (tb.ty == TY.struct_)
                     {
                         TypeStruct ts = cast(TypeStruct)tb;
                         if (ts.sym.dtor)
@@ -3983,33 +3983,33 @@ elem *toElem(Expression e, IRState *irs)
                     const integer = elem.toInteger();
                     switch (elem.type.toBasetype().ty)
                     {
-                        case Tfloat32:
+                        case TY.float32:
                             // Must not call toReal directly, to avoid dmd bug 14203 from breaking dmd
                             e.EV.Vfloat8[i] = complex.re;
                             break;
 
-                        case Tfloat64:
+                        case TY.float64:
                             // Must not call toReal directly, to avoid dmd bug 14203 from breaking dmd
                             e.EV.Vdouble4[i] = complex.re;
                             break;
 
-                        case Tint64:
-                        case Tuns64:
+                        case TY.int64:
+                        case TY.uns64:
                             e.EV.Vullong4[i] = integer;
                             break;
 
-                        case Tint32:
-                        case Tuns32:
+                        case TY.int32:
+                        case TY.uns32:
                             e.EV.Vulong8[i] = cast(uint)integer;
                             break;
 
-                        case Tint16:
-                        case Tuns16:
+                        case TY.int16:
+                        case TY.uns16:
                             e.EV.Vushort16[i] = cast(ushort)integer;
                             break;
 
-                        case Tint8:
-                        case Tuns8:
+                        case TY.int8:
+                        case TY.uns8:
                             e.EV.Vuchar32[i] = cast(ubyte)integer;
                             break;
 
@@ -4060,7 +4060,7 @@ elem *toElem(Expression e, IRState *irs)
             tty = t.ty;
             //printf("fty = %d\n", fty);
 
-            if (tty == Tpointer && fty == Tarray)
+            if (tty == TY.pointer && fty == TY.array)
             {
                 if (e.Eoper == OPvar)
                 {
@@ -4086,7 +4086,7 @@ elem *toElem(Expression e, IRState *irs)
                 goto Lret;
             }
 
-            if (tty == Tpointer && fty == Tsarray)
+            if (tty == TY.pointer && fty == TY.sarray)
             {
                 // e1 . &e1
                 e = el_una(OPaddr, TYnptr, e);
@@ -4094,14 +4094,14 @@ elem *toElem(Expression e, IRState *irs)
             }
 
             // Convert from static array to dynamic array
-            if (tty == Tarray && fty == Tsarray)
+            if (tty == TY.array && fty == TY.sarray)
             {
                 e = sarray_toDarray(ce.loc, tfrom, t, e);
                 goto Lret;
             }
 
             // Convert from dynamic array to dynamic array
-            if (tty == Tarray && fty == Tarray)
+            if (tty == TY.array && fty == TY.array)
             {
                 uint fsize = cast(uint)tfrom.nextOf().size();
                 uint tsize = cast(uint)t.nextOf().size();
@@ -4132,7 +4132,7 @@ elem *toElem(Expression e, IRState *irs)
             }
 
             // Casting between class/interface may require a runtime check
-            if (fty == Tclass && tty == Tclass)
+            if (fty == TY.class_ && tty == TY.class_)
             {
                 ClassDeclaration cdfrom = tfrom.isClassHandle();
                 ClassDeclaration cdto   = t.isClassHandle();
@@ -4212,7 +4212,7 @@ elem *toElem(Expression e, IRState *irs)
                 goto Lret;
             }
 
-            if (fty == Tvector && tty == Tsarray)
+            if (fty == TY.vector && tty == TY.sarray)
             {
                 if (tfrom.size() == t.size())
                     goto Lret;
@@ -4228,18 +4228,18 @@ elem *toElem(Expression e, IRState *irs)
              */
             switch (tty)
             {
-                case Tpointer:
-                    if (fty == Tdelegate)
+                case TY.pointer:
+                    if (fty == TY.delegate_)
                         goto Lpaint;
-                    tty = global.params.is64bit ? Tuns64 : Tuns32;
+                    tty = global.params.is64bit ? TY.uns64 : TY.uns32;
                     break;
 
-                case Tchar:     tty = Tuns8;    break;
-                case Twchar:    tty = Tuns16;   break;
-                case Tdchar:    tty = Tuns32;   break;
-                case Tvoid:     goto Lpaint;
+                case TY.char_:     tty = TY.uns8;    break;
+                case TY.wchar_:    tty = TY.uns16;   break;
+                case TY.dchar_:    tty = TY.uns32;   break;
+                case TY.void_:     goto Lpaint;
 
-                case Tbool:
+                case TY.bool_:
                 {
                     // Construct e?true:false
                     e = el_una(OPbool, ttym, e);
@@ -4252,457 +4252,457 @@ elem *toElem(Expression e, IRState *irs)
 
             switch (fty)
             {
-                case Tnull:
+                case TY.null_:
                 {
                     // typeof(null) is same with void* in binary level.
                     goto Lzero;
                 }
-                case Tpointer:  fty = global.params.is64bit ? Tuns64 : Tuns32;  break;
-                case Tchar:     fty = Tuns8;    break;
-                case Twchar:    fty = Tuns16;   break;
-                case Tdchar:    fty = Tuns32;   break;
+                case TY.pointer:  fty = global.params.is64bit ? TY.uns64 : TY.uns32;  break;
+                case TY.char_:     fty = TY.uns8;    break;
+                case TY.wchar_:    fty = TY.uns16;   break;
+                case TY.dchar_:    fty = TY.uns32;   break;
 
                 default:
                     break;
             }
 
-            static int X(int fty, int tty) { return fty * TMAX + tty; }
+            static int X(int fty, int tty) { return fty * TY.MAX + tty; }
         Lagain:
             switch (X(fty,tty))
             {
                 /* ============================= */
 
-                case X(Tbool,Tint8):
-                case X(Tbool,Tuns8):
+                case X(TY.bool_,TY.int8):
+                case X(TY.bool_,TY.uns8):
                                         goto Lpaint;
-                case X(Tbool,Tint16):
-                case X(Tbool,Tuns16):
-                case X(Tbool,Tint32):
-                case X(Tbool,Tuns32):   eop = OPu8_16;  goto Leop;
-                case X(Tbool,Tint64):
-                case X(Tbool,Tuns64):
-                case X(Tbool,Tfloat32):
-                case X(Tbool,Tfloat64):
-                case X(Tbool,Tfloat80):
-                case X(Tbool,Tcomplex32):
-                case X(Tbool,Tcomplex64):
-                case X(Tbool,Tcomplex80):
+                case X(TY.bool_,TY.int16):
+                case X(TY.bool_,TY.uns16):
+                case X(TY.bool_,TY.int32):
+                case X(TY.bool_,TY.uns32):   eop = OPu8_16;  goto Leop;
+                case X(TY.bool_,TY.int64):
+                case X(TY.bool_,TY.uns64):
+                case X(TY.bool_,TY.float32):
+                case X(TY.bool_,TY.float64):
+                case X(TY.bool_,TY.float80):
+                case X(TY.bool_,TY.complex32):
+                case X(TY.bool_,TY.complex64):
+                case X(TY.bool_,TY.complex80):
                                         e = el_una(OPu8_16, TYuint, e);
-                                        fty = Tuns32;
+                                        fty = TY.uns32;
                                         goto Lagain;
-                case X(Tbool,Timaginary32):
-                case X(Tbool,Timaginary64):
-                case X(Tbool,Timaginary80): goto Lzero;
+                case X(TY.bool_,TY.imaginary32):
+                case X(TY.bool_,TY.imaginary64):
+                case X(TY.bool_,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tint8,Tuns8):    goto Lpaint;
-                case X(Tint8,Tint16):
-                case X(Tint8,Tuns16):
-                case X(Tint8,Tint32):
-                case X(Tint8,Tuns32):   eop = OPs8_16;  goto Leop;
-                case X(Tint8,Tint64):
-                case X(Tint8,Tuns64):
-                case X(Tint8,Tfloat32):
-                case X(Tint8,Tfloat64):
-                case X(Tint8,Tfloat80):
-                case X(Tint8,Tcomplex32):
-                case X(Tint8,Tcomplex64):
-                case X(Tint8,Tcomplex80):
+                case X(TY.int8,TY.uns8):    goto Lpaint;
+                case X(TY.int8,TY.int16):
+                case X(TY.int8,TY.uns16):
+                case X(TY.int8,TY.int32):
+                case X(TY.int8,TY.uns32):   eop = OPs8_16;  goto Leop;
+                case X(TY.int8,TY.int64):
+                case X(TY.int8,TY.uns64):
+                case X(TY.int8,TY.float32):
+                case X(TY.int8,TY.float64):
+                case X(TY.int8,TY.float80):
+                case X(TY.int8,TY.complex32):
+                case X(TY.int8,TY.complex64):
+                case X(TY.int8,TY.complex80):
                                         e = el_una(OPs8_16, TYint, e);
-                                        fty = Tint32;
+                                        fty = TY.int32;
                                         goto Lagain;
-                case X(Tint8,Timaginary32):
-                case X(Tint8,Timaginary64):
-                case X(Tint8,Timaginary80): goto Lzero;
+                case X(TY.int8,TY.imaginary32):
+                case X(TY.int8,TY.imaginary64):
+                case X(TY.int8,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tuns8,Tint8):    goto Lpaint;
-                case X(Tuns8,Tint16):
-                case X(Tuns8,Tuns16):
-                case X(Tuns8,Tint32):
-                case X(Tuns8,Tuns32):   eop = OPu8_16;  goto Leop;
-                case X(Tuns8,Tint64):
-                case X(Tuns8,Tuns64):
-                case X(Tuns8,Tfloat32):
-                case X(Tuns8,Tfloat64):
-                case X(Tuns8,Tfloat80):
-                case X(Tuns8,Tcomplex32):
-                case X(Tuns8,Tcomplex64):
-                case X(Tuns8,Tcomplex80):
+                case X(TY.uns8,TY.int8):    goto Lpaint;
+                case X(TY.uns8,TY.int16):
+                case X(TY.uns8,TY.uns16):
+                case X(TY.uns8,TY.int32):
+                case X(TY.uns8,TY.uns32):   eop = OPu8_16;  goto Leop;
+                case X(TY.uns8,TY.int64):
+                case X(TY.uns8,TY.uns64):
+                case X(TY.uns8,TY.float32):
+                case X(TY.uns8,TY.float64):
+                case X(TY.uns8,TY.float80):
+                case X(TY.uns8,TY.complex32):
+                case X(TY.uns8,TY.complex64):
+                case X(TY.uns8,TY.complex80):
                                         e = el_una(OPu8_16, TYuint, e);
-                                        fty = Tuns32;
+                                        fty = TY.uns32;
                                         goto Lagain;
-                case X(Tuns8,Timaginary32):
-                case X(Tuns8,Timaginary64):
-                case X(Tuns8,Timaginary80): goto Lzero;
+                case X(TY.uns8,TY.imaginary32):
+                case X(TY.uns8,TY.imaginary64):
+                case X(TY.uns8,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tint16,Tint8):
-                case X(Tint16,Tuns8):   eop = OP16_8;   goto Leop;
-                case X(Tint16,Tuns16):  goto Lpaint;
-                case X(Tint16,Tint32):
-                case X(Tint16,Tuns32):  eop = OPs16_32; goto Leop;
-                case X(Tint16,Tint64):
-                case X(Tint16,Tuns64):  e = el_una(OPs16_32, TYint, e);
-                                        fty = Tint32;
+                case X(TY.int16,TY.int8):
+                case X(TY.int16,TY.uns8):   eop = OP16_8;   goto Leop;
+                case X(TY.int16,TY.uns16):  goto Lpaint;
+                case X(TY.int16,TY.int32):
+                case X(TY.int16,TY.uns32):  eop = OPs16_32; goto Leop;
+                case X(TY.int16,TY.int64):
+                case X(TY.int16,TY.uns64):  e = el_una(OPs16_32, TYint, e);
+                                        fty = TY.int32;
                                         goto Lagain;
-                case X(Tint16,Tfloat32):
-                case X(Tint16,Tfloat64):
-                case X(Tint16,Tfloat80):
-                case X(Tint16,Tcomplex32):
-                case X(Tint16,Tcomplex64):
-                case X(Tint16,Tcomplex80):
+                case X(TY.int16,TY.float32):
+                case X(TY.int16,TY.float64):
+                case X(TY.int16,TY.float80):
+                case X(TY.int16,TY.complex32):
+                case X(TY.int16,TY.complex64):
+                case X(TY.int16,TY.complex80):
                                         e = el_una(OPs16_d, TYdouble, e);
-                                        fty = Tfloat64;
+                                        fty = TY.float64;
                                         goto Lagain;
-                case X(Tint16,Timaginary32):
-                case X(Tint16,Timaginary64):
-                case X(Tint16,Timaginary80): goto Lzero;
+                case X(TY.int16,TY.imaginary32):
+                case X(TY.int16,TY.imaginary64):
+                case X(TY.int16,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tuns16,Tint8):
-                case X(Tuns16,Tuns8):   eop = OP16_8;   goto Leop;
-                case X(Tuns16,Tint16):  goto Lpaint;
-                case X(Tuns16,Tint32):
-                case X(Tuns16,Tuns32):  eop = OPu16_32; goto Leop;
-                case X(Tuns16,Tint64):
-                case X(Tuns16,Tuns64):
-                case X(Tuns16,Tfloat64):
-                case X(Tuns16,Tfloat32):
-                case X(Tuns16,Tfloat80):
-                case X(Tuns16,Tcomplex32):
-                case X(Tuns16,Tcomplex64):
-                case X(Tuns16,Tcomplex80):
+                case X(TY.uns16,TY.int8):
+                case X(TY.uns16,TY.uns8):   eop = OP16_8;   goto Leop;
+                case X(TY.uns16,TY.int16):  goto Lpaint;
+                case X(TY.uns16,TY.int32):
+                case X(TY.uns16,TY.uns32):  eop = OPu16_32; goto Leop;
+                case X(TY.uns16,TY.int64):
+                case X(TY.uns16,TY.uns64):
+                case X(TY.uns16,TY.float64):
+                case X(TY.uns16,TY.float32):
+                case X(TY.uns16,TY.float80):
+                case X(TY.uns16,TY.complex32):
+                case X(TY.uns16,TY.complex64):
+                case X(TY.uns16,TY.complex80):
                                         e = el_una(OPu16_32, TYuint, e);
-                                        fty = Tuns32;
+                                        fty = TY.uns32;
                                         goto Lagain;
-                case X(Tuns16,Timaginary32):
-                case X(Tuns16,Timaginary64):
-                case X(Tuns16,Timaginary80): goto Lzero;
+                case X(TY.uns16,TY.imaginary32):
+                case X(TY.uns16,TY.imaginary64):
+                case X(TY.uns16,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tint32,Tint8):
-                case X(Tint32,Tuns8):   e = el_una(OP32_16, TYshort, e);
-                                        fty = Tint16;
+                case X(TY.int32,TY.int8):
+                case X(TY.int32,TY.uns8):   e = el_una(OP32_16, TYshort, e);
+                                        fty = TY.int16;
                                         goto Lagain;
-                case X(Tint32,Tint16):
-                case X(Tint32,Tuns16):  eop = OP32_16;  goto Leop;
-                case X(Tint32,Tuns32):  goto Lpaint;
-                case X(Tint32,Tint64):
-                case X(Tint32,Tuns64):  eop = OPs32_64; goto Leop;
-                case X(Tint32,Tfloat32):
-                case X(Tint32,Tfloat64):
-                case X(Tint32,Tfloat80):
-                case X(Tint32,Tcomplex32):
-                case X(Tint32,Tcomplex64):
-                case X(Tint32,Tcomplex80):
+                case X(TY.int32,TY.int16):
+                case X(TY.int32,TY.uns16):  eop = OP32_16;  goto Leop;
+                case X(TY.int32,TY.uns32):  goto Lpaint;
+                case X(TY.int32,TY.int64):
+                case X(TY.int32,TY.uns64):  eop = OPs32_64; goto Leop;
+                case X(TY.int32,TY.float32):
+                case X(TY.int32,TY.float64):
+                case X(TY.int32,TY.float80):
+                case X(TY.int32,TY.complex32):
+                case X(TY.int32,TY.complex64):
+                case X(TY.int32,TY.complex80):
                                         e = el_una(OPs32_d, TYdouble, e);
-                                        fty = Tfloat64;
+                                        fty = TY.float64;
                                         goto Lagain;
-                case X(Tint32,Timaginary32):
-                case X(Tint32,Timaginary64):
-                case X(Tint32,Timaginary80): goto Lzero;
+                case X(TY.int32,TY.imaginary32):
+                case X(TY.int32,TY.imaginary64):
+                case X(TY.int32,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tuns32,Tint8):
-                case X(Tuns32,Tuns8):   e = el_una(OP32_16, TYshort, e);
-                                        fty = Tuns16;
+                case X(TY.uns32,TY.int8):
+                case X(TY.uns32,TY.uns8):   e = el_una(OP32_16, TYshort, e);
+                                        fty = TY.uns16;
                                         goto Lagain;
-                case X(Tuns32,Tint16):
-                case X(Tuns32,Tuns16):  eop = OP32_16;  goto Leop;
-                case X(Tuns32,Tint32):  goto Lpaint;
-                case X(Tuns32,Tint64):
-                case X(Tuns32,Tuns64):  eop = OPu32_64; goto Leop;
-                case X(Tuns32,Tfloat32):
-                case X(Tuns32,Tfloat64):
-                case X(Tuns32,Tfloat80):
-                case X(Tuns32,Tcomplex32):
-                case X(Tuns32,Tcomplex64):
-                case X(Tuns32,Tcomplex80):
+                case X(TY.uns32,TY.int16):
+                case X(TY.uns32,TY.uns16):  eop = OP32_16;  goto Leop;
+                case X(TY.uns32,TY.int32):  goto Lpaint;
+                case X(TY.uns32,TY.int64):
+                case X(TY.uns32,TY.uns64):  eop = OPu32_64; goto Leop;
+                case X(TY.uns32,TY.float32):
+                case X(TY.uns32,TY.float64):
+                case X(TY.uns32,TY.float80):
+                case X(TY.uns32,TY.complex32):
+                case X(TY.uns32,TY.complex64):
+                case X(TY.uns32,TY.complex80):
                                         e = el_una(OPu32_d, TYdouble, e);
-                                        fty = Tfloat64;
+                                        fty = TY.float64;
                                         goto Lagain;
-                case X(Tuns32,Timaginary32):
-                case X(Tuns32,Timaginary64):
-                case X(Tuns32,Timaginary80): goto Lzero;
+                case X(TY.uns32,TY.imaginary32):
+                case X(TY.uns32,TY.imaginary64):
+                case X(TY.uns32,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tint64,Tint8):
-                case X(Tint64,Tuns8):
-                case X(Tint64,Tint16):
-                case X(Tint64,Tuns16):  e = el_una(OP64_32, TYint, e);
-                                        fty = Tint32;
+                case X(TY.int64,TY.int8):
+                case X(TY.int64,TY.uns8):
+                case X(TY.int64,TY.int16):
+                case X(TY.int64,TY.uns16):  e = el_una(OP64_32, TYint, e);
+                                        fty = TY.int32;
                                         goto Lagain;
-                case X(Tint64,Tint32):
-                case X(Tint64,Tuns32):  eop = OP64_32; goto Leop;
-                case X(Tint64,Tuns64):  goto Lpaint;
-                case X(Tint64,Tfloat32):
-                case X(Tint64,Tfloat64):
-                case X(Tint64,Tfloat80):
-                case X(Tint64,Tcomplex32):
-                case X(Tint64,Tcomplex64):
-                case X(Tint64,Tcomplex80):
+                case X(TY.int64,TY.int32):
+                case X(TY.int64,TY.uns32):  eop = OP64_32; goto Leop;
+                case X(TY.int64,TY.uns64):  goto Lpaint;
+                case X(TY.int64,TY.float32):
+                case X(TY.int64,TY.float64):
+                case X(TY.int64,TY.float80):
+                case X(TY.int64,TY.complex32):
+                case X(TY.int64,TY.complex64):
+                case X(TY.int64,TY.complex80):
                                         e = el_una(OPs64_d, TYdouble, e);
-                                        fty = Tfloat64;
+                                        fty = TY.float64;
                                         goto Lagain;
-                case X(Tint64,Timaginary32):
-                case X(Tint64,Timaginary64):
-                case X(Tint64,Timaginary80): goto Lzero;
+                case X(TY.int64,TY.imaginary32):
+                case X(TY.int64,TY.imaginary64):
+                case X(TY.int64,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tuns64,Tint8):
-                case X(Tuns64,Tuns8):
-                case X(Tuns64,Tint16):
-                case X(Tuns64,Tuns16):  e = el_una(OP64_32, TYint, e);
-                                        fty = Tint32;
+                case X(TY.uns64,TY.int8):
+                case X(TY.uns64,TY.uns8):
+                case X(TY.uns64,TY.int16):
+                case X(TY.uns64,TY.uns16):  e = el_una(OP64_32, TYint, e);
+                                        fty = TY.int32;
                                         goto Lagain;
-                case X(Tuns64,Tint32):
-                case X(Tuns64,Tuns32):  eop = OP64_32;  goto Leop;
-                case X(Tuns64,Tint64):  goto Lpaint;
-                case X(Tuns64,Tfloat32):
-                case X(Tuns64,Tfloat64):
-                case X(Tuns64,Tfloat80):
-                case X(Tuns64,Tcomplex32):
-                case X(Tuns64,Tcomplex64):
-                case X(Tuns64,Tcomplex80):
+                case X(TY.uns64,TY.int32):
+                case X(TY.uns64,TY.uns32):  eop = OP64_32;  goto Leop;
+                case X(TY.uns64,TY.int64):  goto Lpaint;
+                case X(TY.uns64,TY.float32):
+                case X(TY.uns64,TY.float64):
+                case X(TY.uns64,TY.float80):
+                case X(TY.uns64,TY.complex32):
+                case X(TY.uns64,TY.complex64):
+                case X(TY.uns64,TY.complex80):
                                          e = el_una(OPu64_d, TYdouble, e);
-                                         fty = Tfloat64;
+                                         fty = TY.float64;
                                          goto Lagain;
-                case X(Tuns64,Timaginary32):
-                case X(Tuns64,Timaginary64):
-                case X(Tuns64,Timaginary80): goto Lzero;
+                case X(TY.uns64,TY.imaginary32):
+                case X(TY.uns64,TY.imaginary64):
+                case X(TY.uns64,TY.imaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Tfloat32,Tint8):
-                case X(Tfloat32,Tuns8):
-                case X(Tfloat32,Tint16):
-                case X(Tfloat32,Tuns16):
-                case X(Tfloat32,Tint32):
-                case X(Tfloat32,Tuns32):
-                case X(Tfloat32,Tint64):
-                case X(Tfloat32,Tuns64):
-                case X(Tfloat32,Tfloat80): e = el_una(OPf_d, TYdouble, e);
-                                           fty = Tfloat64;
+                case X(TY.float32,TY.int8):
+                case X(TY.float32,TY.uns8):
+                case X(TY.float32,TY.int16):
+                case X(TY.float32,TY.uns16):
+                case X(TY.float32,TY.int32):
+                case X(TY.float32,TY.uns32):
+                case X(TY.float32,TY.int64):
+                case X(TY.float32,TY.uns64):
+                case X(TY.float32,TY.float80): e = el_una(OPf_d, TYdouble, e);
+                                           fty = TY.float64;
                                            goto Lagain;
-                case X(Tfloat32,Tfloat64): eop = OPf_d; goto Leop;
-                case X(Tfloat32,Timaginary32):
-                case X(Tfloat32,Timaginary64):
-                case X(Tfloat32,Timaginary80): goto Lzero;
-                case X(Tfloat32,Tcomplex32):
-                case X(Tfloat32,Tcomplex64):
-                case X(Tfloat32,Tcomplex80):
+                case X(TY.float32,TY.float64): eop = OPf_d; goto Leop;
+                case X(TY.float32,TY.imaginary32):
+                case X(TY.float32,TY.imaginary64):
+                case X(TY.float32,TY.imaginary80): goto Lzero;
+                case X(TY.float32,TY.complex32):
+                case X(TY.float32,TY.complex64):
+                case X(TY.float32,TY.complex80):
                     e = el_bin(OPadd,TYcfloat,el_long(TYifloat,0),e);
-                    fty = Tcomplex32;
+                    fty = TY.complex32;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Tfloat64,Tint8):
-                case X(Tfloat64,Tuns8):    e = el_una(OPd_s16, TYshort, e);
-                                           fty = Tint16;
+                case X(TY.float64,TY.int8):
+                case X(TY.float64,TY.uns8):    e = el_una(OPd_s16, TYshort, e);
+                                           fty = TY.int16;
                                            goto Lagain;
-                case X(Tfloat64,Tint16):   eop = OPd_s16; goto Leop;
-                case X(Tfloat64,Tuns16):   eop = OPd_u16; goto Leop;
-                case X(Tfloat64,Tint32):   eop = OPd_s32; goto Leop;
-                case X(Tfloat64,Tuns32):   eop = OPd_u32; goto Leop;
-                case X(Tfloat64,Tint64):   eop = OPd_s64; goto Leop;
-                case X(Tfloat64,Tuns64):   eop = OPd_u64; goto Leop;
-                case X(Tfloat64,Tfloat32): eop = OPd_f;   goto Leop;
-                case X(Tfloat64,Tfloat80): eop = OPd_ld;  goto Leop;
-                case X(Tfloat64,Timaginary32):
-                case X(Tfloat64,Timaginary64):
-                case X(Tfloat64,Timaginary80):  goto Lzero;
-                case X(Tfloat64,Tcomplex32):
-                case X(Tfloat64,Tcomplex64):
-                case X(Tfloat64,Tcomplex80):
+                case X(TY.float64,TY.int16):   eop = OPd_s16; goto Leop;
+                case X(TY.float64,TY.uns16):   eop = OPd_u16; goto Leop;
+                case X(TY.float64,TY.int32):   eop = OPd_s32; goto Leop;
+                case X(TY.float64,TY.uns32):   eop = OPd_u32; goto Leop;
+                case X(TY.float64,TY.int64):   eop = OPd_s64; goto Leop;
+                case X(TY.float64,TY.uns64):   eop = OPd_u64; goto Leop;
+                case X(TY.float64,TY.float32): eop = OPd_f;   goto Leop;
+                case X(TY.float64,TY.float80): eop = OPd_ld;  goto Leop;
+                case X(TY.float64,TY.imaginary32):
+                case X(TY.float64,TY.imaginary64):
+                case X(TY.float64,TY.imaginary80):  goto Lzero;
+                case X(TY.float64,TY.complex32):
+                case X(TY.float64,TY.complex64):
+                case X(TY.float64,TY.complex80):
                     e = el_bin(OPadd,TYcdouble,el_long(TYidouble,0),e);
-                    fty = Tcomplex64;
+                    fty = TY.complex64;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Tfloat80,Tint8):
-                case X(Tfloat80,Tuns8):
-                case X(Tfloat80,Tint16):
-                case X(Tfloat80,Tuns16):
-                case X(Tfloat80,Tint32):
-                case X(Tfloat80,Tuns32):
-                case X(Tfloat80,Tint64):
-                case X(Tfloat80,Tfloat32): e = el_una(OPld_d, TYdouble, e);
-                                           fty = Tfloat64;
+                case X(TY.float80,TY.int8):
+                case X(TY.float80,TY.uns8):
+                case X(TY.float80,TY.int16):
+                case X(TY.float80,TY.uns16):
+                case X(TY.float80,TY.int32):
+                case X(TY.float80,TY.uns32):
+                case X(TY.float80,TY.int64):
+                case X(TY.float80,TY.float32): e = el_una(OPld_d, TYdouble, e);
+                                           fty = TY.float64;
                                            goto Lagain;
-                case X(Tfloat80,Tuns64):
+                case X(TY.float80,TY.uns64):
                                            eop = OPld_u64; goto Leop;
-                case X(Tfloat80,Tfloat64): eop = OPld_d; goto Leop;
-                case X(Tfloat80,Timaginary32):
-                case X(Tfloat80,Timaginary64):
-                case X(Tfloat80,Timaginary80): goto Lzero;
-                case X(Tfloat80,Tcomplex32):
-                case X(Tfloat80,Tcomplex64):
-                case X(Tfloat80,Tcomplex80):
+                case X(TY.float80,TY.float64): eop = OPld_d; goto Leop;
+                case X(TY.float80,TY.imaginary32):
+                case X(TY.float80,TY.imaginary64):
+                case X(TY.float80,TY.imaginary80): goto Lzero;
+                case X(TY.float80,TY.complex32):
+                case X(TY.float80,TY.complex64):
+                case X(TY.float80,TY.complex80):
                     e = el_bin(OPadd,TYcldouble,e,el_long(TYildouble,0));
-                    fty = Tcomplex80;
+                    fty = TY.complex80;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Timaginary32,Tint8):
-                case X(Timaginary32,Tuns8):
-                case X(Timaginary32,Tint16):
-                case X(Timaginary32,Tuns16):
-                case X(Timaginary32,Tint32):
-                case X(Timaginary32,Tuns32):
-                case X(Timaginary32,Tint64):
-                case X(Timaginary32,Tuns64):
-                case X(Timaginary32,Tfloat32):
-                case X(Timaginary32,Tfloat64):
-                case X(Timaginary32,Tfloat80):  goto Lzero;
-                case X(Timaginary32,Timaginary64): eop = OPf_d; goto Leop;
-                case X(Timaginary32,Timaginary80):
+                case X(TY.imaginary32,TY.int8):
+                case X(TY.imaginary32,TY.uns8):
+                case X(TY.imaginary32,TY.int16):
+                case X(TY.imaginary32,TY.uns16):
+                case X(TY.imaginary32,TY.int32):
+                case X(TY.imaginary32,TY.uns32):
+                case X(TY.imaginary32,TY.int64):
+                case X(TY.imaginary32,TY.uns64):
+                case X(TY.imaginary32,TY.float32):
+                case X(TY.imaginary32,TY.float64):
+                case X(TY.imaginary32,TY.float80):  goto Lzero;
+                case X(TY.imaginary32,TY.imaginary64): eop = OPf_d; goto Leop;
+                case X(TY.imaginary32,TY.imaginary80):
                                            e = el_una(OPf_d, TYidouble, e);
-                                           fty = Timaginary64;
+                                           fty = TY.imaginary64;
                                            goto Lagain;
-                case X(Timaginary32,Tcomplex32):
-                case X(Timaginary32,Tcomplex64):
-                case X(Timaginary32,Tcomplex80):
+                case X(TY.imaginary32,TY.complex32):
+                case X(TY.imaginary32,TY.complex64):
+                case X(TY.imaginary32,TY.complex80):
                     e = el_bin(OPadd,TYcfloat,el_long(TYfloat,0),e);
-                    fty = Tcomplex32;
+                    fty = TY.complex32;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Timaginary64,Tint8):
-                case X(Timaginary64,Tuns8):
-                case X(Timaginary64,Tint16):
-                case X(Timaginary64,Tuns16):
-                case X(Timaginary64,Tint32):
-                case X(Timaginary64,Tuns32):
-                case X(Timaginary64,Tint64):
-                case X(Timaginary64,Tuns64):
-                case X(Timaginary64,Tfloat32):
-                case X(Timaginary64,Tfloat64):
-                case X(Timaginary64,Tfloat80):  goto Lzero;
-                case X(Timaginary64,Timaginary32): eop = OPd_f;   goto Leop;
-                case X(Timaginary64,Timaginary80): eop = OPd_ld;  goto Leop;
-                case X(Timaginary64,Tcomplex32):
-                case X(Timaginary64,Tcomplex64):
-                case X(Timaginary64,Tcomplex80):
+                case X(TY.imaginary64,TY.int8):
+                case X(TY.imaginary64,TY.uns8):
+                case X(TY.imaginary64,TY.int16):
+                case X(TY.imaginary64,TY.uns16):
+                case X(TY.imaginary64,TY.int32):
+                case X(TY.imaginary64,TY.uns32):
+                case X(TY.imaginary64,TY.int64):
+                case X(TY.imaginary64,TY.uns64):
+                case X(TY.imaginary64,TY.float32):
+                case X(TY.imaginary64,TY.float64):
+                case X(TY.imaginary64,TY.float80):  goto Lzero;
+                case X(TY.imaginary64,TY.imaginary32): eop = OPd_f;   goto Leop;
+                case X(TY.imaginary64,TY.imaginary80): eop = OPd_ld;  goto Leop;
+                case X(TY.imaginary64,TY.complex32):
+                case X(TY.imaginary64,TY.complex64):
+                case X(TY.imaginary64,TY.complex80):
                     e = el_bin(OPadd,TYcdouble,el_long(TYdouble,0),e);
-                    fty = Tcomplex64;
+                    fty = TY.complex64;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Timaginary80,Tint8):
-                case X(Timaginary80,Tuns8):
-                case X(Timaginary80,Tint16):
-                case X(Timaginary80,Tuns16):
-                case X(Timaginary80,Tint32):
-                case X(Timaginary80,Tuns32):
-                case X(Timaginary80,Tint64):
-                case X(Timaginary80,Tuns64):
-                case X(Timaginary80,Tfloat32):
-                case X(Timaginary80,Tfloat64):
-                case X(Timaginary80,Tfloat80):  goto Lzero;
-                case X(Timaginary80,Timaginary32): e = el_una(OPld_d, TYidouble, e);
-                                           fty = Timaginary64;
+                case X(TY.imaginary80,TY.int8):
+                case X(TY.imaginary80,TY.uns8):
+                case X(TY.imaginary80,TY.int16):
+                case X(TY.imaginary80,TY.uns16):
+                case X(TY.imaginary80,TY.int32):
+                case X(TY.imaginary80,TY.uns32):
+                case X(TY.imaginary80,TY.int64):
+                case X(TY.imaginary80,TY.uns64):
+                case X(TY.imaginary80,TY.float32):
+                case X(TY.imaginary80,TY.float64):
+                case X(TY.imaginary80,TY.float80):  goto Lzero;
+                case X(TY.imaginary80,TY.imaginary32): e = el_una(OPld_d, TYidouble, e);
+                                           fty = TY.imaginary64;
                                            goto Lagain;
-                case X(Timaginary80,Timaginary64): eop = OPld_d; goto Leop;
-                case X(Timaginary80,Tcomplex32):
-                case X(Timaginary80,Tcomplex64):
-                case X(Timaginary80,Tcomplex80):
+                case X(TY.imaginary80,TY.imaginary64): eop = OPld_d; goto Leop;
+                case X(TY.imaginary80,TY.complex32):
+                case X(TY.imaginary80,TY.complex64):
+                case X(TY.imaginary80,TY.complex80):
                     e = el_bin(OPadd,TYcldouble,el_long(TYldouble,0),e);
-                    fty = Tcomplex80;
+                    fty = TY.complex80;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Tcomplex32,Tint8):
-                case X(Tcomplex32,Tuns8):
-                case X(Tcomplex32,Tint16):
-                case X(Tcomplex32,Tuns16):
-                case X(Tcomplex32,Tint32):
-                case X(Tcomplex32,Tuns32):
-                case X(Tcomplex32,Tint64):
-                case X(Tcomplex32,Tuns64):
-                case X(Tcomplex32,Tfloat32):
-                case X(Tcomplex32,Tfloat64):
-                case X(Tcomplex32,Tfloat80):
+                case X(TY.complex32,TY.int8):
+                case X(TY.complex32,TY.uns8):
+                case X(TY.complex32,TY.int16):
+                case X(TY.complex32,TY.uns16):
+                case X(TY.complex32,TY.int32):
+                case X(TY.complex32,TY.uns32):
+                case X(TY.complex32,TY.int64):
+                case X(TY.complex32,TY.uns64):
+                case X(TY.complex32,TY.float32):
+                case X(TY.complex32,TY.float64):
+                case X(TY.complex32,TY.float80):
                         e = el_una(OPc_r, TYfloat, e);
-                        fty = Tfloat32;
+                        fty = TY.float32;
                         goto Lagain;
-                case X(Tcomplex32,Timaginary32):
-                case X(Tcomplex32,Timaginary64):
-                case X(Tcomplex32,Timaginary80):
+                case X(TY.complex32,TY.imaginary32):
+                case X(TY.complex32,TY.imaginary64):
+                case X(TY.complex32,TY.imaginary80):
                         e = el_una(OPc_i, TYifloat, e);
-                        fty = Timaginary32;
+                        fty = TY.imaginary32;
                         goto Lagain;
-                case X(Tcomplex32,Tcomplex64):
-                case X(Tcomplex32,Tcomplex80):
+                case X(TY.complex32,TY.complex64):
+                case X(TY.complex32,TY.complex80):
                         e = el_una(OPf_d, TYcdouble, e);
-                        fty = Tcomplex64;
+                        fty = TY.complex64;
                         goto Lagain;
 
                 /* ============================= */
 
-                case X(Tcomplex64,Tint8):
-                case X(Tcomplex64,Tuns8):
-                case X(Tcomplex64,Tint16):
-                case X(Tcomplex64,Tuns16):
-                case X(Tcomplex64,Tint32):
-                case X(Tcomplex64,Tuns32):
-                case X(Tcomplex64,Tint64):
-                case X(Tcomplex64,Tuns64):
-                case X(Tcomplex64,Tfloat32):
-                case X(Tcomplex64,Tfloat64):
-                case X(Tcomplex64,Tfloat80):
+                case X(TY.complex64,TY.int8):
+                case X(TY.complex64,TY.uns8):
+                case X(TY.complex64,TY.int16):
+                case X(TY.complex64,TY.uns16):
+                case X(TY.complex64,TY.int32):
+                case X(TY.complex64,TY.uns32):
+                case X(TY.complex64,TY.int64):
+                case X(TY.complex64,TY.uns64):
+                case X(TY.complex64,TY.float32):
+                case X(TY.complex64,TY.float64):
+                case X(TY.complex64,TY.float80):
                         e = el_una(OPc_r, TYdouble, e);
-                        fty = Tfloat64;
+                        fty = TY.float64;
                         goto Lagain;
-                case X(Tcomplex64,Timaginary32):
-                case X(Tcomplex64,Timaginary64):
-                case X(Tcomplex64,Timaginary80):
+                case X(TY.complex64,TY.imaginary32):
+                case X(TY.complex64,TY.imaginary64):
+                case X(TY.complex64,TY.imaginary80):
                         e = el_una(OPc_i, TYidouble, e);
-                        fty = Timaginary64;
+                        fty = TY.imaginary64;
                         goto Lagain;
-                case X(Tcomplex64,Tcomplex32):   eop = OPd_f;   goto Leop;
-                case X(Tcomplex64,Tcomplex80):   eop = OPd_ld;  goto Leop;
+                case X(TY.complex64,TY.complex32):   eop = OPd_f;   goto Leop;
+                case X(TY.complex64,TY.complex80):   eop = OPd_ld;  goto Leop;
 
                 /* ============================= */
 
-                case X(Tcomplex80,Tint8):
-                case X(Tcomplex80,Tuns8):
-                case X(Tcomplex80,Tint16):
-                case X(Tcomplex80,Tuns16):
-                case X(Tcomplex80,Tint32):
-                case X(Tcomplex80,Tuns32):
-                case X(Tcomplex80,Tint64):
-                case X(Tcomplex80,Tuns64):
-                case X(Tcomplex80,Tfloat32):
-                case X(Tcomplex80,Tfloat64):
-                case X(Tcomplex80,Tfloat80):
+                case X(TY.complex80,TY.int8):
+                case X(TY.complex80,TY.uns8):
+                case X(TY.complex80,TY.int16):
+                case X(TY.complex80,TY.uns16):
+                case X(TY.complex80,TY.int32):
+                case X(TY.complex80,TY.uns32):
+                case X(TY.complex80,TY.int64):
+                case X(TY.complex80,TY.uns64):
+                case X(TY.complex80,TY.float32):
+                case X(TY.complex80,TY.float64):
+                case X(TY.complex80,TY.float80):
                         e = el_una(OPc_r, TYldouble, e);
-                        fty = Tfloat80;
+                        fty = TY.float80;
                         goto Lagain;
-                case X(Tcomplex80,Timaginary32):
-                case X(Tcomplex80,Timaginary64):
-                case X(Tcomplex80,Timaginary80):
+                case X(TY.complex80,TY.imaginary32):
+                case X(TY.complex80,TY.imaginary64):
+                case X(TY.complex80,TY.imaginary80):
                         e = el_una(OPc_i, TYildouble, e);
-                        fty = Timaginary80;
+                        fty = TY.imaginary80;
                         goto Lagain;
-                case X(Tcomplex80,Tcomplex32):
-                case X(Tcomplex80,Tcomplex64):
+                case X(TY.complex80,TY.complex32):
+                case X(TY.complex80,TY.complex64):
                         e = el_una(OPld_d, TYcdouble, e);
-                        fty = Tcomplex64;
+                        fty = TY.complex64;
                         goto Lagain;
 
                 /* ============================= */
@@ -4773,7 +4773,7 @@ elem *toElem(Expression e, IRState *irs)
         {
             //printf("SliceExp.toElem() se = %s %s\n", se.type.toChars(), se.toChars());
             Type tb = se.type.toBasetype();
-            assert(tb.ty == Tarray || tb.ty == Tsarray);
+            assert(tb.ty == TY.array || tb.ty == TY.sarray);
             Type t1 = se.e1.type.toBasetype();
             elem *e = toElem(se.e1, irs);
             if (se.lwr)
@@ -4781,7 +4781,7 @@ elem *toElem(Expression e, IRState *irs)
                 uint sz = cast(uint)t1.nextOf().size();
 
                 elem *einit = resolveLengthVar(se.lengthVar, &e, t1);
-                if (t1.ty == Tsarray)
+                if (t1.ty == TY.sarray)
                     e = array_toPtr(se.e1.type, e);
                 if (!einit)
                 {
@@ -4789,8 +4789,8 @@ elem *toElem(Expression e, IRState *irs)
                     e = el_same(&einit);
                 }
                 // e is a temporary, typed:
-                //  TYdarray if t.ty == Tarray
-                //  TYptr if t.ty == Tsarray or Tpointer
+                //  TYdarray if t.ty == TY.array
+                //  TYptr if t.ty == TY.sarray or TY.pointer
 
                 elem *elwr = toElem(se.lwr, irs);
                 elem *eupr = toElem(se.upr, irs);
@@ -4811,12 +4811,12 @@ elem *toElem(Expression e, IRState *irs)
                         eupr2.Ety = TYsize_t;  // make sure unsigned comparison
 
                         elem *elen;
-                        if (t1.ty == Tsarray)
+                        if (t1.ty == TY.sarray)
                         {
                             TypeSArray tsa = cast(TypeSArray)t1;
                             elen = el_long(TYsize_t, tsa.dim.toInteger());
                         }
-                        else if (t1.ty == Tarray)
+                        else if (t1.ty == TY.array)
                         {
                             if (se.lengthVar && !(se.lengthVar.storage_class & STC.const_))
                                 elen = el_var(toSymbol(se.lengthVar));
@@ -4856,7 +4856,7 @@ elem *toElem(Expression e, IRState *irs)
                         elwr = el_combine(elwr, eb);
                     }
                 }
-                if (t1.ty != Tsarray)
+                if (t1.ty != TY.sarray)
                     e = array_toPtr(se.e1.type, e);
 
                 // Create an array reference where:
@@ -4867,14 +4867,14 @@ elem *toElem(Expression e, IRState *irs)
                 elem *eofs = el_bin(OPmul, TYsize_t, elwr2, el_long(TYsize_t, sz));
                 elem *eptr = el_bin(OPadd, TYnptr, e, eofs);
 
-                if (tb.ty == Tarray)
+                if (tb.ty == TY.array)
                 {
                     elem *elen = el_bin(OPmin, TYsize_t, eupr2, el_copytree(elwr2));
                     e = el_pair(TYdarray, elen, eptr);
                 }
                 else
                 {
-                    assert(tb.ty == Tsarray);
+                    assert(tb.ty == TY.sarray);
                     e = el_una(OPind, totym(se.type), eptr);
                     if (tybasic(e.Ety) == TYstruct)
                         e.ET = Type_toCtype(se.type);
@@ -4883,13 +4883,13 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_combine(einit, e);
                 //elem_print(e);
             }
-            else if (t1.ty == Tsarray && tb.ty == Tarray)
+            else if (t1.ty == TY.sarray && tb.ty == TY.array)
             {
                 e = sarray_toDarray(se.loc, t1, null, e);
             }
             else
             {
-                assert(t1.ty == tb.ty);   // Tarray or Tsarray
+                assert(t1.ty == tb.ty);   // TY.array or TY.sarray
 
                 // https://issues.dlang.org/show_bug.cgi?id=14672
                 // If se is in left side operand of element-wise
@@ -4910,7 +4910,7 @@ elem *toElem(Expression e, IRState *irs)
 
             //printf("IndexExp.toElem() %s\n", ie.toChars());
             Type t1 = ie.e1.type.toBasetype();
-            if (t1.ty == Taarray)
+            if (t1.ty == TY.aarray)
             {
                 // set to:
                 //      *aaGetY(aa, aati, valuesize, &key);
@@ -4970,7 +4970,7 @@ elem *toElem(Expression e, IRState *irs)
                 {
                     elem *elength;
 
-                    if (t1.ty == Tsarray)
+                    if (t1.ty == TY.sarray)
                     {
                         TypeSArray tsa = cast(TypeSArray)t1;
                         dinteger_t length = tsa.dim.toInteger();
@@ -4978,7 +4978,7 @@ elem *toElem(Expression e, IRState *irs)
                         elength = el_long(TYsize_t, length);
                         goto L1;
                     }
-                    else if (t1.ty == Tarray)
+                    else if (t1.ty == TY.array)
                     {
                         elength = n1;
                         n1 = el_same(&elength);
@@ -5047,14 +5047,14 @@ elem *toElem(Expression e, IRState *irs)
 
             //printf("ArrayLiteralExp.toElem() %s, type = %s\n", ale.toChars(), ale.type.toChars());
             Type tb = ale.type.toBasetype();
-            if (tb.ty == Tsarray && tb.nextOf().toBasetype().ty == Tvoid)
+            if (tb.ty == TY.sarray && tb.nextOf().toBasetype().ty == TY.void_)
             {
                 // Convert void[n] to ubyte[n]
                 tb = Type.tuns8.sarrayOf((cast(TypeSArray)tb).dim.toUInteger());
             }
 
             elem *e;
-            if (tb.ty == Tsarray && dim)
+            if (tb.ty == TY.sarray && dim)
             {
                 Symbol *stmp = null;
                 e = ExpressionsToStaticArray(ale.loc, ale.elements, &stmp, 0, ale.basis);
@@ -5090,11 +5090,11 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_long(TYsize_t, 0);
             }
 
-            if (tb.ty == Tarray)
+            if (tb.ty == TY.array)
             {
                 e = el_pair(TYdarray, el_long(TYsize_t, dim), e);
             }
-            else if (tb.ty == Tpointer)
+            else if (tb.ty == TY.pointer)
             {
             }
             else
@@ -5294,7 +5294,7 @@ elem *toElem(Expression e, IRState *irs)
                 if (!el)
                     el = basis;
                 if (el.op == TOKarrayliteral &&
-                    el.type.toBasetype().ty == Tsarray)
+                    el.type.toBasetype().ty == TY.sarray)
                 {
                     ArrayLiteralExp ale = cast(ArrayLiteralExp)el;
                     if (ale.elements && ale.elements.dim)
@@ -5369,7 +5369,7 @@ elem *toElem(Expression e, IRState *irs)
                 // call _d_assocarrayliteralTX(TypeInfo_AssociativeArray ti, void[] keys, void[] values)
                 // Prefer this to avoid the varargs fiasco in 64 bit code
 
-                assert(t.ty == Taarray);
+                assert(t.ty == TY.aarray);
                 Type ta = t;
 
                 Symbol *skeys = null;
@@ -5404,7 +5404,7 @@ elem *toElem(Expression e, IRState *irs)
             else
             {
                 elem *e = el_long(TYnptr, 0);      // empty associative array is the null pointer
-                if (t.ty != Taarray)
+                if (t.ty != TY.aarray)
                     e = addressElem(e, Type.tvoidptr);
                 result = e;
                 return;
@@ -5627,7 +5627,7 @@ private elem *toElemStructLit(StructLiteralExp sle, IRState *irs, TOK op, Symbol
 
             Type t1b = v.type.toBasetype();
             Type t2b = el.type.toBasetype();
-            if (t1b.ty == Tsarray)
+            if (t1b.ty == TY.sarray)
             {
                 if (t2b.implicitConvTo(t1b))
                 {

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -93,7 +93,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier par, Ex
         else if (v.storage_class & STC.variadic && p == sc.func)
         {
             Type tb = v.type.toBasetype();
-            if (tb.ty == Tarray || tb.ty == Tsarray)
+            if (tb.ty == TY.array || tb.ty == TY.sarray)
             {
                 unsafeAssign(v, "variadic variable");
             }
@@ -210,7 +210,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
     else if (e1.op == TOKindex)
     {
         auto ie = cast(IndexExp)e1;
-        if (ie.e1.op == TOKvar && ie.e1.type.toBasetype().ty == Tsarray)
+        if (ie.e1.op == TOKvar && ie.e1.type.toBasetype().ty == TY.sarray)
             va = (cast(VarExp)ie.e1).var.isVarDeclaration();
     }
 
@@ -230,7 +230,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
     // Try to infer 'scope' for va if in a function not marked @system
     bool inferScope = false;
-    if (va && sc.func && sc.func.type && sc.func.type.ty == Tfunction)
+    if (va && sc.func && sc.func.type && sc.func.type.ty == TY.function_)
         inferScope = (cast(TypeFunction)sc.func.type).trust != TRUST.system;
 
     bool result = false;
@@ -263,7 +263,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
             if (va &&
                 (va.enclosesLifetimeOf(v) && !(v.storage_class & (STC.parameter | STC.temp)) ||
                  // va is class reference
-                 ae.e1.op == TOKdotvar && va.type.toBasetype().ty == Tclass && (va.enclosesLifetimeOf(v) || !va.isScope) ||
+                 ae.e1.op == TOKdotvar && va.type.toBasetype().ty == TY.class_ && (va.enclosesLifetimeOf(v) || !va.isScope) ||
                  va.storage_class & STC.ref_ && !(v.storage_class & STC.temp)) &&
                 sc.func.setUnsafe())
             {
@@ -292,7 +292,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
         else if (v.storage_class & STC.variadic && p == sc.func)
         {
             Type tb = v.type.toBasetype();
-            if (tb.ty == Tarray || tb.ty == Tsarray)
+            if (tb.ty == TY.array || tb.ty == TY.sarray)
             {
                 if (va && !va.isDataseg() && !va.doNotInferScope)
                 {
@@ -428,7 +428,7 @@ ByRef:
 
         /* Do not allow slicing of a static array returned by a function
          */
-        if (va && ee.op == TOKcall && ee.type.toBasetype().ty == Tsarray && va.type.toBasetype().ty == Tarray &&
+        if (va && ee.op == TOKcall && ee.type.toBasetype().ty == TY.sarray && va.type.toBasetype().ty == TY.array &&
             !(va.storage_class & STC.temp))
         {
             if (!gag)
@@ -614,7 +614,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         else if (v.storage_class & STC.variadic && p == sc.func)
         {
             Type tb = v.type.toBasetype();
-            if (tb.ty == Tarray || tb.ty == Tsarray)
+            if (tb.ty == TY.array || tb.ty == TY.sarray)
             {
                 if (!gag)
                     error(e.loc, "returning `%s` escapes a reference to variadic parameter `%s`", e.toChars(), v.toChars());
@@ -698,7 +698,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                 }
                 // Don't need to be concerned if v's parent does not return a ref
                 FuncDeclaration fd = p.isFuncDeclaration();
-                if (fd && fd.type && fd.type.ty == Tfunction)
+                if (fd && fd.type && fd.type.ty == TY.function_)
                 {
                     TypeFunction tf = cast(TypeFunction)fd.type;
                     if (tf.isref)
@@ -746,7 +746,7 @@ private void inferReturn(FuncDeclaration fd, VarDeclaration v)
         /* v is the 'this' reference, so mark the function
          */
         fd.storage_class |= STC.return_;
-        if (tf.ty == Tfunction)
+        if (tf.ty == TY.function_)
         {
             //printf("'this' too %p %s\n", tf, sc.func.toChars());
             tf.isreturn = true;
@@ -755,7 +755,7 @@ private void inferReturn(FuncDeclaration fd, VarDeclaration v)
     else
     {
         // Perform 'return' inference on parameter
-        if (tf.ty == Tfunction && tf.parameters)
+        if (tf.ty == TY.function_ && tf.parameters)
         {
             const dim = Parameter.dim(tf.parameters);
             foreach (const i; 0 .. dim)
@@ -835,14 +835,14 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(DotVarExp e)
         {
             auto t = e.e1.type.toBasetype();
-            if (t.ty == Tstruct)
+            if (t.ty == TY.struct_)
                 e.e1.accept(this);
         }
 
         override void visit(DelegateExp e)
         {
             Type t = e.e1.type.toBasetype();
-            if (t.ty == Tclass || t.ty == Tpointer)
+            if (t.ty == TY.class_ || t.ty == TY.pointer)
                 escapeByValue(e.e1, er);
             else
                 escapeByRef(e.e1, er);
@@ -863,7 +863,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(ArrayLiteralExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty == Tsarray || tb.ty == Tarray)
+            if (tb.ty == TY.sarray || tb.ty == TY.array)
             {
                 if (e.basis)
                     e.basis.accept(this);
@@ -890,7 +890,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(NewExp e)
         {
             Type tb = e.newtype.toBasetype();
-            if (tb.ty == Tstruct && !e.member && e.arguments)
+            if (tb.ty == TY.struct_ && !e.member && e.arguments)
             {
                 foreach (ex; *e.arguments)
                 {
@@ -903,7 +903,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(CastExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty == Tarray && e.e1.type.toBasetype().ty == Tsarray)
+            if (tb.ty == TY.array && e.e1.type.toBasetype().ty == TY.sarray)
             {
                 escapeByRef(e.e1, er);
             }
@@ -919,7 +919,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
                 Type tb = e.type.toBasetype();
                 if (v)
                 {
-                    if (tb.ty == Tsarray)
+                    if (tb.ty == TY.sarray)
                         return;
                     if (v.storage_class & STC.variadic)
                     {
@@ -929,10 +929,10 @@ private void escapeByValue(Expression e, EscapeByResults* er)
                 }
             }
             Type t1b = e.e1.type.toBasetype();
-            if (t1b.ty == Tsarray)
+            if (t1b.ty == TY.sarray)
             {
                 Type tb = e.type.toBasetype();
-                if (tb.ty != Tsarray)
+                if (tb.ty != TY.sarray)
                     escapeByRef(e.e1, er);
             }
             else
@@ -950,7 +950,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(BinExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty == Tpointer)
+            if (tb.ty == TY.pointer)
             {
                 e.e1.accept(this);
                 e.e2.accept(this);
@@ -987,12 +987,12 @@ private void escapeByValue(Expression e, EscapeByResults* er)
             Type t1 = e.e1.type.toBasetype();
             TypeFunction tf;
             TypeDelegate dg;
-            if (t1.ty == Tdelegate)
+            if (t1.ty == TY.delegate_)
             {
                 dg = cast(TypeDelegate)t1;
                 tf = cast(TypeFunction)(cast(TypeDelegate)t1).next;
             }
-            else if (t1.ty == Tfunction)
+            else if (t1.ty == TY.function_)
                 tf = cast(TypeFunction)t1;
             else
                 return;
@@ -1019,7 +1019,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
                 }
             }
             // If 'this' is returned, check it too
-            if (e.e1.op == TOKdotvar && t1.ty == Tfunction)
+            if (e.e1.op == TOKdotvar && t1.ty == TY.function_)
             {
                 DotVarExp dve = cast(DotVarExp)e.e1;
                 FuncDeclaration fd = dve.var.isFuncDeclaration();
@@ -1131,7 +1131,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
             if (e.e1.op == TOKvar)
             {
                 VarDeclaration v = (cast(VarExp)e.e1).var.isVarDeclaration();
-                if (tb.ty == Tarray || tb.ty == Tsarray)
+                if (tb.ty == TY.array || tb.ty == TY.sarray)
                 {
                     if (v && v.storage_class & STC.variadic)
                     {
@@ -1140,11 +1140,11 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                     }
                 }
             }
-            if (tb.ty == Tsarray)
+            if (tb.ty == TY.sarray)
             {
                 e.e1.accept(this);
             }
-            else if (tb.ty == Tarray)
+            else if (tb.ty == TY.array)
             {
                 escapeByValue(e.e1, er);
             }
@@ -1153,7 +1153,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
         override void visit(DotVarExp e)
         {
             Type t1b = e.e1.type.toBasetype();
-            if (t1b.ty == Tclass)
+            if (t1b.ty == TY.class_)
                 escapeByValue(e.e1, er);
             else
                 e.e1.accept(this);
@@ -1187,9 +1187,9 @@ private void escapeByRef(Expression e, EscapeByResults* er)
              */
             Type t1 = e.e1.type.toBasetype();
             TypeFunction tf;
-            if (t1.ty == Tdelegate)
+            if (t1.ty == TY.delegate_)
                 tf = cast(TypeFunction)(cast(TypeDelegate)t1).next;
-            else if (t1.ty == Tfunction)
+            else if (t1.ty == TY.function_)
                 tf = cast(TypeFunction)t1;
             else
                 return;
@@ -1226,7 +1226,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                     }
                 }
                 // If 'this' is returned by ref, check it too
-                if (e.e1.op == TOKdotvar && t1.ty == Tfunction)
+                if (e.e1.op == TOKdotvar && t1.ty == TY.function_)
                 {
                     DotVarExp dve = cast(DotVarExp)e.e1;
                     if (dve.var.storage_class & STC.return_ || tf.isreturn)
@@ -1238,7 +1238,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                     }
                 }
                 // If it's a delegate, check it too
-                if (e.e1.op == TOKvar && t1.ty == Tdelegate)
+                if (e.e1.op == TOKvar && t1.ty == TY.delegate_)
                 {
                     escapeByValue(e.e1, er);
                 }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -100,8 +100,8 @@ L1:
     /* If e1 is not the 'this' pointer for ad
      */
     if (ad &&
-        !(t.ty == Tpointer && t.nextOf().ty == Tstruct && (cast(TypeStruct)t.nextOf()).sym == ad) &&
-        !(t.ty == Tstruct && (cast(TypeStruct)t).sym == ad))
+        !(t.ty == TY.pointer && t.nextOf().ty == TY.struct_ && (cast(TypeStruct)t.nextOf()).sym == ad) &&
+        !(t.ty == TY.struct_ && (cast(TypeStruct)t).sym == ad))
     {
         ClassDeclaration cd = ad.isClassDeclaration();
         ClassDeclaration tcd = t.isClassHandle();
@@ -236,7 +236,7 @@ Lagain:
                 error(loc, "forward reference to %s `%s`", v.kind(), v.toPrettyChars());
             return new ErrorExp();
         }
-        if (v.type.ty == Terror)
+        if (v.type.ty == TY.error)
             return new ErrorExp();
 
         if ((v.storage_class & STC.manifest) && v._init)
@@ -486,11 +486,11 @@ private bool checkPropertyCall(Expression e, Expression emsg)
                 tf = cast(TypeFunction)ce.f.type;
             }
         }
-        else if (ce.e1.type.ty == Tfunction)
+        else if (ce.e1.type.ty == TY.function_)
             tf = cast(TypeFunction)ce.e1.type;
-        else if (ce.e1.type.ty == Tdelegate)
+        else if (ce.e1.type.ty == TY.delegate_)
             tf = cast(TypeFunction)ce.e1.type.nextOf();
-        else if (ce.e1.type.ty == Tpointer && ce.e1.type.nextOf().ty == Tfunction)
+        else if (ce.e1.type.ty == TY.pointer && ce.e1.type.nextOf().ty == TY.function_)
             tf = cast(TypeFunction)ce.e1.type.nextOf();
         else
             assert(0);
@@ -575,13 +575,13 @@ extern (C++) Expression resolvePropertiesOnly(Scope* sc, Expression e1)
             }
         }
     }
-    else if (e1.op == TOKdotvar && e1.type.ty == Tfunction)
+    else if (e1.op == TOKdotvar && e1.type.ty == TY.function_)
     {
         DotVarExp dve = cast(DotVarExp)e1;
         fd = dve.var.isFuncDeclaration();
         goto Lfd;
     }
-    else if (e1.op == TOKvar && e1.type.ty == Tfunction && (sc.intypeof || !(cast(VarExp)e1).var.needThis()))
+    else if (e1.op == TOKvar && e1.type.ty == TY.function_ && (sc.intypeof || !(cast(VarExp)e1).var.needThis()))
     {
         fd = (cast(VarExp)e1).var.isFuncDeclaration();
     Lfd:
@@ -746,13 +746,13 @@ extern (C++) Expression resolveUFCS(Scope* sc, CallExp ce)
         eleft = die.e1;
 
         Type t = eleft.type.toBasetype();
-        if (t.ty == Tarray || t.ty == Tsarray || t.ty == Tnull || (t.isTypeBasic() && t.ty != Tvoid))
+        if (t.ty == TY.array || t.ty == TY.sarray || t.ty == TY.null_ || (t.isTypeBasic() && t.ty != TY.void_))
         {
             /* Built-in types and arrays have no callable properties, so do shortcut.
              * It is necessary in: e.init()
              */
         }
-        else if (t.ty == Taarray)
+        else if (t.ty == TY.aarray)
         {
             if (ident == Id.remove)
             {
@@ -957,7 +957,7 @@ extern (C++) void expandTuples(Expressions* exps)
             if (arg.op == TOKtype)
             {
                 TypeExp e = cast(TypeExp)arg;
-                if (e.type.toBasetype().ty == Ttuple)
+                if (e.type.toBasetype().ty == TY.tuple)
                 {
                     TypeTuple tt = cast(TypeTuple)e.type.toBasetype();
                     if (!tt.arguments || tt.arguments.dim == 0)
@@ -1139,7 +1139,7 @@ extern (C++) Expression valueNoDtor(Expression e)
 private Expression callCpCtor(Scope* sc, Expression e)
 {
     Type tv = e.type.baseElemOf();
-    if (tv.ty == Tstruct)
+    if (tv.ty == TY.struct_)
     {
         StructDeclaration sd = (cast(TypeStruct)tv).sym;
         if (sd.postblit)
@@ -1852,7 +1852,7 @@ extern (C++) abstract class Expression : RootObject
      */
     bool checkValue()
     {
-        if (type && type.toBasetype().ty == Tvoid)
+        if (type && type.toBasetype().ty == TY.void_)
         {
             error("expression `%s` is `void` and has no value", toChars());
             //print(); assert(0);
@@ -1867,7 +1867,7 @@ extern (C++) abstract class Expression : RootObject
     {
         if (op == TOKerror)
             return true;
-        if (type.toBasetype().ty == Terror)
+        if (type.toBasetype().ty == TY.error)
             return true;
         if (!type.isscalar())
         {
@@ -1881,9 +1881,9 @@ extern (C++) abstract class Expression : RootObject
     {
         if (op == TOKerror)
             return true;
-        if (type.toBasetype().ty == Terror)
+        if (type.toBasetype().ty == TY.error)
             return true;
-        if (type.toBasetype().ty == Tbool)
+        if (type.toBasetype().ty == TY.bool_)
         {
             error("operation not allowed on `bool` `%s`", toChars());
             return true;
@@ -1895,7 +1895,7 @@ extern (C++) abstract class Expression : RootObject
     {
         if (op == TOKerror)
             return true;
-        if (type.toBasetype().ty == Terror)
+        if (type.toBasetype().ty == TY.error)
             return true;
         if (!type.isintegral())
         {
@@ -1909,7 +1909,7 @@ extern (C++) abstract class Expression : RootObject
     {
         if (op == TOKerror)
             return true;
-        if (type.toBasetype().ty == Terror)
+        if (type.toBasetype().ty == TY.error)
             return true;
         if (!type.isintegral() && !type.isfloating())
         {
@@ -2000,13 +2000,13 @@ extern (C++) abstract class Expression : RootObject
             while (outerfunc.toParent2() && outerfunc.isPureBypassingInference() == PURE.impure && outerfunc.toParent2().isFuncDeclaration())
             {
                 outerfunc = outerfunc.toParent2().isFuncDeclaration();
-                if (outerfunc.type.ty == Terror)
+                if (outerfunc.type.ty == TY.error)
                     return true;
             }
             while (calledparent.toParent2() && calledparent.isPureBypassingInference() == PURE.impure && calledparent.toParent2().isFuncDeclaration())
             {
                 calledparent = calledparent.toParent2().isFuncDeclaration();
-                if (calledparent.type.ty == Terror)
+                if (calledparent.type.ty == TY.error)
                     return true;
             }
         }
@@ -2232,7 +2232,7 @@ extern (C++) abstract class Expression : RootObject
     final bool checkPostblit(Scope* sc, Type t)
     {
         t = t.baseElemOf();
-        if (t.ty == Tstruct)
+        if (t.ty == TY.struct_)
         {
             // https://issues.dlang.org/show_bug.cgi?id=11395
             // Require TypeInfo generation for array concatenation
@@ -2259,7 +2259,7 @@ extern (C++) abstract class Expression : RootObject
     {
         if (op == TOKerror)
             return true;
-        if (op == TOKvar && type.ty != Terror)
+        if (op == TOKvar && type.ty != TY.error)
         {
             VarExp ve = cast(VarExp)this;
             if (isNeedThisScope(sc, ve.var))
@@ -2340,7 +2340,7 @@ extern (C++) abstract class Expression : RootObject
         Type att = null;
     Lagain:
         // Structs can be converted to bool using opCast(bool)()
-        if (tb.ty == Tstruct)
+        if (tb.ty == TY.struct_)
         {
             AggregateDeclaration ad = (cast(TypeStruct)tb).sym;
             /* Don't really need to check for opCast first, but by doing so we
@@ -2407,7 +2407,7 @@ extern (C++) abstract class Expression : RootObject
     {
         //printf("Expression::deref()\n");
         // type could be null if forward referencing an 'auto' variable
-        if (type && type.ty == Treference)
+        if (type && type.ty == TY.reference)
         {
             Expression e = new PtrExp(loc, this);
             e.type = (cast(TypeReference)type).next;
@@ -2471,7 +2471,7 @@ extern (C++) final class IntegerExp : Expression
         if (!type.isscalar())
         {
             //printf("%s, loc = %d\n", toChars(), loc.linnum);
-            if (type.ty != Terror)
+            if (type.ty != TY.error)
                 error("integral constant must be scalar type, not `%s`", type.toChars());
             type = Type.terror;
         }
@@ -2516,7 +2516,7 @@ extern (C++) final class IntegerExp : Expression
     {
         normalize(); // necessary until we fix all the paints of 'type'
         Type t = type.toBasetype();
-        if (t.ty == Tuns64)
+        if (t.ty == TY.uns64)
             return real_t(cast(d_uns64)value);
         else
             return real_t(cast(d_int64)value);
@@ -2570,46 +2570,46 @@ extern (C++) final class IntegerExp : Expression
          */
         switch (type.toBasetype().ty)
         {
-        case Tbool:
+        case TY.bool_:
             value = (value != 0);
             break;
 
-        case Tint8:
+        case TY.int8:
             value = cast(d_int8)value;
             break;
 
-        case Tchar:
-        case Tuns8:
+        case TY.char_:
+        case TY.uns8:
             value = cast(d_uns8)value;
             break;
 
-        case Tint16:
+        case TY.int16:
             value = cast(d_int16)value;
             break;
 
-        case Twchar:
-        case Tuns16:
+        case TY.wchar_:
+        case TY.uns16:
             value = cast(d_uns16)value;
             break;
 
-        case Tint32:
+        case TY.int32:
             value = cast(d_int32)value;
             break;
 
-        case Tdchar:
-        case Tuns32:
+        case TY.dchar_:
+        case TY.uns32:
             value = cast(d_uns32)value;
             break;
 
-        case Tint64:
+        case TY.int64:
             value = cast(d_int64)value;
             break;
 
-        case Tuns64:
+        case TY.uns64:
             value = cast(d_uns64)value;
             break;
 
-        case Tpointer:
+        case TY.pointer:
             if (Target.ptrsize == 4)
                 value = cast(d_uns32)value;
             else if (Target.ptrsize == 8)
@@ -2892,12 +2892,12 @@ extern (C++) class ThisExp : Expression
     override final bool isLvalue()
     {
         // Class `this` should be an rvalue; struct `this` should be an lvalue.
-        return type.toBasetype().ty != Tclass;
+        return type.toBasetype().ty != TY.class_;
     }
 
     override final Expression toLvalue(Scope* sc, Expression e)
     {
-        if (type.toBasetype().ty == Tclass)
+        if (type.toBasetype().ty == TY.class_)
         {
             // Class `this` is an rvalue; struct `this` is an lvalue.
             return Expression.toLvalue(sc, e);
@@ -3056,9 +3056,9 @@ extern (C++) final class StringExp : Expression
         switch (tynto)
         {
             case 0:      return len;
-            case Tchar:  encSize = 1; break;
-            case Twchar: encSize = 2; break;
-            case Tdchar: encSize = 4; break;
+            case TY.char_:  encSize = 1; break;
+            case TY.wchar_: encSize = 2; break;
+            case TY.dchar_: encSize = 4; break;
             default:
                 assert(0);
         }
@@ -3121,9 +3121,9 @@ extern (C++) final class StringExp : Expression
         switch (tyto)
         {
             case 0:      encSize = sz; break;
-            case Tchar:  encSize = 1; break;
-            case Twchar: encSize = 2; break;
-            case Tdchar: encSize = 4; break;
+            case TY.char_:  encSize = 1; break;
+            case TY.wchar_: encSize = 2; break;
+            case TY.dchar_: encSize = 4; break;
             default:
                 assert(0);
         }
@@ -3280,13 +3280,13 @@ extern (C++) final class StringExp : Expression
         /* string literal is rvalue in default, but
          * conversion to reference of static array is only allowed.
          */
-        return (type && type.toBasetype().ty == Tsarray);
+        return (type && type.toBasetype().ty == TY.sarray);
     }
 
     override Expression toLvalue(Scope* sc, Expression e)
     {
         //printf("StringExp::toLvalue(%s) type = %s\n", toChars(), type ? type.toChars() : NULL);
-        return (type && type.toBasetype().ty == Tsarray) ? this : Expression.toLvalue(sc, e);
+        return (type && type.toBasetype().ty == TY.sarray) ? this : Expression.toLvalue(sc, e);
     }
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
@@ -3579,12 +3579,12 @@ extern (C++) final class ArrayLiteralExp : Expression
     override StringExp toStringExp()
     {
         TY telem = type.nextOf().toBasetype().ty;
-        if (telem == Tchar || telem == Twchar || telem == Tdchar || (telem == Tvoid && (!elements || elements.dim == 0)))
+        if (telem == TY.char_ || telem == TY.wchar_ || telem == TY.dchar_ || (telem == TY.void_ && (!elements || elements.dim == 0)))
         {
             ubyte sz = 1;
-            if (telem == Twchar)
+            if (telem == TY.wchar_)
                 sz = 2;
-            else if (telem == Tdchar)
+            else if (telem == TY.dchar_)
                 sz = 4;
 
             OutBuffer buf;
@@ -3810,7 +3810,7 @@ extern (C++) final class StructLiteralExp : Expression
                 /* If type is a static array, and e is an initializer for that array,
                  * then the field initializer should be an array literal of e.
                  */
-                if (e.type.castMod(0) != type.castMod(0) && type.ty == Tsarray)
+                if (e.type.castMod(0) != type.castMod(0) && type.ty == TY.sarray)
                 {
                     TypeSArray tsa = cast(TypeSArray)type;
                     size_t length = cast(size_t)tsa.dim.toInteger();
@@ -4398,7 +4398,7 @@ extern (C++) final class FuncExp : Expression
             *presult = null;
 
         TypeFunction tof = null;
-        if (to.ty == Tdelegate)
+        if (to.ty == TY.delegate_)
         {
             if (tok == TOKfunction)
             {
@@ -4408,7 +4408,7 @@ extern (C++) final class FuncExp : Expression
             }
             tof = cast(TypeFunction)to.nextOf();
         }
-        else if (to.ty == Tpointer && to.nextOf().ty == Tfunction)
+        else if (to.ty == TY.pointer && to.nextOf().ty == TY.function_)
         {
             if (tok == TOKdelegate)
             {
@@ -4449,7 +4449,7 @@ extern (C++) final class FuncExp : Expression
                 for (; u < dim; u++)
                 {
                     Parameter p = Parameter.getNth(tf.parameters, u);
-                    if (p.type.ty == Tident && (cast(TypeIdentifier)p.type).ident == tp.ident)
+                    if (p.type.ty == TY.ident && (cast(TypeIdentifier)p.type).ident == tp.ident)
                     {
                         break;
                     }
@@ -4457,7 +4457,7 @@ extern (C++) final class FuncExp : Expression
                 assert(u < dim);
                 Parameter pto = Parameter.getNth(tof.parameters, u);
                 Type t = pto.type;
-                if (t.ty == Terror)
+                if (t.ty == TY.error)
                     goto L1;
                 tiargs.push(t);
             }
@@ -4511,7 +4511,7 @@ extern (C++) final class FuncExp : Expression
             tfx = tfy;
         }
         Type tx;
-        if (tok == TOKdelegate || tok == TOKreserved && (type.ty == Tdelegate || type.ty == Tpointer && to.ty == Tdelegate))
+        if (tok == TOKdelegate || tok == TOKreserved && (type.ty == TY.delegate_ || type.ty == TY.pointer && to.ty == TY.delegate_))
         {
             // Allow conversion from implicit function pointer to delegate
             tx = new TypeDelegate(tfx);
@@ -4519,7 +4519,7 @@ extern (C++) final class FuncExp : Expression
         }
         else
         {
-            assert(tok == TOKfunction || tok == TOKreserved && type.ty == Tpointer);
+            assert(tok == TOKfunction || tok == TOKreserved && type.ty == TY.pointer);
             tx = tfx.pointerTo();
         }
         //printf("\ttx = %s, to = %s\n", tx.toChars(), to.toChars());
@@ -4932,15 +4932,15 @@ extern (C++) abstract class BinExp : Expression
                     {
                         switch (t1.ty)
                         {
-                        case Timaginary32:
+                        case TY.imaginary32:
                             t2 = Type.tfloat32;
                             break;
 
-                        case Timaginary64:
+                        case TY.imaginary64:
                             t2 = Type.tfloat64;
                             break;
 
-                        case Timaginary80:
+                        case TY.imaginary80:
                             t2 = Type.tfloat80;
                             break;
 
@@ -4971,15 +4971,15 @@ extern (C++) abstract class BinExp : Expression
                     Type t3;
                     switch (t1.ty)
                     {
-                    case Timaginary32:
+                    case TY.imaginary32:
                         t3 = Type.tfloat32;
                         break;
 
-                    case Timaginary64:
+                    case TY.imaginary64:
                         t3 = Type.tfloat64;
                         break;
 
-                    case Timaginary80:
+                    case TY.imaginary80:
                         t3 = Type.tfloat80;
                         break;
 
@@ -5039,7 +5039,7 @@ extern (C++) abstract class BinExp : Expression
         if (be.e1.op != TOKindex)
             return be;
         auto ie = cast(IndexExp)be.e1;
-        if (ie.e1.type.toBasetype().ty != Taarray)
+        if (ie.e1.type.toBasetype().ty != TY.aarray)
             return be;
 
         /* Fix evaluation order of setting AA element
@@ -5062,13 +5062,13 @@ extern (C++) abstract class BinExp : Expression
 
             Expression ie1 = ie.e1;
             if (ie1.op != TOKindex ||
-                (cast(IndexExp)ie1).e1.type.toBasetype().ty != Taarray)
+                (cast(IndexExp)ie1).e1.type.toBasetype().ty != TY.aarray)
             {
                 break;
             }
             ie = cast(IndexExp)ie1;
         }
-        assert(ie.e1.type.toBasetype().ty == Taarray);
+        assert(ie.e1.type.toBasetype().ty == TY.aarray);
 
         Expression de;
         ie.e1 = extractSideEffect(sc, "__aatmp", de, ie.e1);
@@ -5454,9 +5454,9 @@ extern (C++) final class CallExp : UnaExp
     override bool isLvalue()
     {
         Type tb = e1.type.toBasetype();
-        if (tb.ty == Tdelegate || tb.ty == Tpointer)
+        if (tb.ty == TY.delegate_ || tb.ty == TY.pointer)
             tb = tb.nextOf();
-        if (tb.ty == Tfunction && (cast(TypeFunction)tb).isref)
+        if (tb.ty == TY.function_ && (cast(TypeFunction)tb).isref)
         {
             if (e1.op == TOKdotvar)
                 if ((cast(DotVarExp)e1).var.isCtorDeclaration())
@@ -5479,7 +5479,7 @@ extern (C++) final class CallExp : UnaExp
          * Use same logic as VarDeclaration::callScopeDtor()
          */
 
-        if (e1.type && e1.type.ty == Tfunction)
+        if (e1.type && e1.type.ty == TY.function_)
         {
             TypeFunction tf = cast(TypeFunction)e1.type;
             if (tf.isref)
@@ -5487,7 +5487,7 @@ extern (C++) final class CallExp : UnaExp
         }
 
         Type tv = type.baseElemOf();
-        if (tv.ty == Tstruct)
+        if (tv.ty == TY.struct_)
         {
             TypeStruct ts = cast(TypeStruct)tv;
             StructDeclaration sd = ts.sym;
@@ -5749,7 +5749,7 @@ extern (C++) final class VectorExp : UnaExp
     extern (D) this(Loc loc, Expression e, Type t)
     {
         super(loc, TOKvector, __traits(classInstanceSize, VectorExp), e);
-        assert(t.ty == Tvector);
+        assert(t.ty == TY.vector);
         to = cast(TypeVector)t;
     }
 
@@ -5809,7 +5809,7 @@ extern (C++) final class SliceExp : UnaExp
     override int checkModifiable(Scope* sc, int flag)
     {
         //printf("SliceExp::checkModifiable %s\n", toChars());
-        if (e1.type.ty == Tsarray || (e1.op == TOKindex && e1.type.ty != Tarray) || e1.op == TOKslice)
+        if (e1.type.ty == TY.sarray || (e1.op == TOKindex && e1.type.ty != TY.array) || e1.op == TOKslice)
         {
             return e1.checkModifiable(sc, flag);
         }
@@ -5821,13 +5821,13 @@ extern (C++) final class SliceExp : UnaExp
         /* slice expression is rvalue in default, but
          * conversion to reference of static array is only allowed.
          */
-        return (type && type.toBasetype().ty == Tsarray);
+        return (type && type.toBasetype().ty == TY.sarray);
     }
 
     override Expression toLvalue(Scope* sc, Expression e)
     {
         //printf("SliceExp::toLvalue(%s) type = %s\n", toChars(), type ? type.toChars() : NULL);
-        return (type && type.toBasetype().ty == Tsarray) ? this : Expression.toLvalue(sc, e);
+        return (type && type.toBasetype().ty == TY.sarray) ? this : Expression.toLvalue(sc, e);
     }
 
     override Expression modifiableLvalue(Scope* sc, Expression e)
@@ -5933,14 +5933,14 @@ extern (C++) final class ArrayExp : UnaExp
 
     override bool isLvalue()
     {
-        if (type && type.toBasetype().ty == Tvoid)
+        if (type && type.toBasetype().ty == TY.void_)
             return false;
         return true;
     }
 
     override Expression toLvalue(Scope* sc, Expression e)
     {
-        if (type && type.toBasetype().ty == Tvoid)
+        if (type && type.toBasetype().ty == TY.void_)
             error("`void`s have no value");
         return this;
     }
@@ -6176,7 +6176,7 @@ extern (C++) final class IndexExp : BinExp
 
     override int checkModifiable(Scope* sc, int flag)
     {
-        if (e1.type.ty == Tsarray || e1.type.ty == Taarray || (e1.op == TOKindex && e1.type.ty != Tarray) || e1.op == TOKslice)
+        if (e1.type.ty == TY.sarray || e1.type.ty == TY.aarray || (e1.op == TOKindex && e1.type.ty != TY.array) || e1.op == TOKslice)
         {
             return e1.checkModifiable(sc, flag);
         }
@@ -6205,10 +6205,10 @@ extern (C++) final class IndexExp : BinExp
 
     Expression markSettingAAElem()
     {
-        if (e1.type.toBasetype().ty == Taarray)
+        if (e1.type.toBasetype().ty == TY.aarray)
         {
             Type t2b = e2.type.toBasetype();
-            if (t2b.ty == Tarray && t2b.nextOf().isMutable())
+            if (t2b.ty == TY.array && t2b.nextOf().isMutable())
             {
                 error("associative arrays can only be assigned values with immutable keys, not `%s`", e2.type.toChars());
                 return new ErrorExp();

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -121,7 +121,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                     if (f.errors)
                         return new ErrorExp();
                     fd = f;
-                    assert(fd.type.ty == Tfunction);
+                    assert(fd.type.ty == TY.function_);
                 }
             }
             if (fd)
@@ -139,7 +139,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                     if (f.errors)
                         return new ErrorExp();
                     fd = f;
-                    assert(fd.type.ty == Tfunction);
+                    assert(fd.type.ty == TY.function_);
                     TypeFunction tf = cast(TypeFunction)fd.type;
                     if (!tf.isref && e2)
                         goto Leproplvalue;
@@ -202,7 +202,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         tthis = null;
         goto Lfd;
     }
-    else if (e1.op == TOKdotvar && e1.type && e1.type.toBasetype().ty == Tfunction)
+    else if (e1.op == TOKdotvar && e1.type && e1.type.toBasetype().ty == TY.function_)
     {
         DotVarExp dve = cast(DotVarExp)e1;
         s = dve.var.isFuncDeclaration();
@@ -210,7 +210,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         tthis = dve.e1.type;
         goto Lfd;
     }
-    else if (e1.op == TOKvar && e1.type && e1.type.toBasetype().ty == Tfunction)
+    else if (e1.op == TOKvar && e1.type && e1.type.toBasetype().ty == TY.function_)
     {
         s = (cast(VarExp)e1).var.isFuncDeclaration();
         tiargs = null;
@@ -232,7 +232,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             {
                 if (fd.errors)
                     return new ErrorExp();
-                assert(fd.type.ty == Tfunction);
+                assert(fd.type.ty == TY.function_);
                 Expression e = new CallExp(loc, e1, e2);
                 return e.expressionSemantic(sc);
             }
@@ -243,7 +243,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             {
                 if (fd.errors)
                     return new ErrorExp();
-                assert(fd.type.ty == Tfunction);
+                assert(fd.type.ty == TY.function_);
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 if (!e2 || tf.isref)
                 {
@@ -257,7 +257,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         if (FuncDeclaration fd = s.isFuncDeclaration())
         {
             // Keep better diagnostic message for invalid property usage of functions
-            assert(fd.type.ty == Tfunction);
+            assert(fd.type.ty == TY.function_);
             Expression e = new CallExp(loc, e1, e2);
             return e.expressionSemantic(sc);
         }
@@ -375,7 +375,7 @@ private bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type* pt)
             t0 = Type.terror;
             continue;
         }
-        if (e.type.ty == Tvoid)
+        if (e.type.ty == TY.void_)
         {
             // void expressions do not concur to the determination of the common
             // type.
@@ -416,7 +416,7 @@ private bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type* pt)
 
     if (!t0)
         t0 = Type.tvoid; // [] is typed as void[]
-    else if (t0.ty != Terror)
+    else if (t0.ty != TY.error)
     {
         for (size_t i = 0; i < exps.dim; i++)
         {
@@ -489,7 +489,7 @@ private bool preFunctionParameters(Loc loc, Scope* sc, Expressions* exps)
 private bool checkDefCtor(Loc loc, Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Tstruct)
+    if (t.ty == TY.struct_)
     {
         StructDeclaration sd = (cast(TypeStruct)t).sym;
         if (sd.noDefaultCtor)
@@ -626,8 +626,8 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 Type tret = p.isLazyArray();
                 switch (tb.ty)
                 {
-                case Tsarray:
-                case Tarray:
+                case TY.sarray:
+                case TY.array:
                     {
                         /* Create a static array variable v of type arg.type:
                          *  T[dim] __arrayArg = [ arguments[i], ..., arguments[nargs-1] ];
@@ -658,17 +658,17 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                         // Convert to a static array literal, or its slice.
                         arg = new ArrayLiteralExp(loc, elements);
                         arg.type = tsa;
-                        if (tb.ty == Tarray)
+                        if (tb.ty == TY.array)
                         {
                             arg = new SliceExp(loc, arg, null, null);
                             arg.type = p.type;
                         }
                         break;
                     }
-                case Tclass:
+                case TY.class_:
                     {
                         /* Set arg to be:
-                         *      new Tclass(arg0, arg1, ..., argn)
+                         *      new TY.class_(arg0, arg1, ..., argn)
                          */
                         auto args = new Expressions();
                         args.setDim(nargs - i);
@@ -694,7 +694,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
             }
 
         L1:
-            if (!(p.storageClass & STC.lazy_ && p.type.ty == Tvoid))
+            if (!(p.storageClass & STC.lazy_ && p.type.ty == TY.void_))
             {
                 bool isRef = (p.storageClass & (STC.ref_ | STC.out_)) != 0;
                 if (ubyte wm = arg.type.deduceWild(p.type, isRef))
@@ -763,7 +763,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
         if (i < nparams)
         {
             Parameter p = Parameter.getNth(tf.parameters, i);
-            if (!(p.storageClass & STC.lazy_ && p.type.ty == Tvoid))
+            if (!(p.storageClass & STC.lazy_ && p.type.ty == TY.void_))
             {
                 Type tprm = p.type;
                 if (p.type.hasWild())
@@ -801,7 +801,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
             else if (p.storageClass & STC.lazy_)
             {
                 // Convert lazy argument to a delegate
-                if (p.type.ty == Tvoid)
+                if (p.type.ty == TY.void_)
                     arg = toDelegate(arg, p.type, sc);
                 else
                     arg = toDelegate(arg, arg.type, sc);
@@ -865,11 +865,11 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 // Promote floats to doubles
                 switch (arg.type.ty)
                 {
-                case Tfloat32:
+                case TY.float32:
                     arg = arg.castTo(sc, Type.tfloat64);
                     break;
 
-                case Timaginary32:
+                case TY.imaginary32:
                     arg = arg.castTo(sc, Type.timaginary64);
                     break;
 
@@ -879,12 +879,12 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 if (tf.varargs == 1)
                 {
                     const(char)* p = tf.linkage == LINKc ? "extern(C)" : "extern(C++)";
-                    if (arg.type.ty == Tarray)
+                    if (arg.type.ty == TY.array)
                     {
                         arg.error("cannot pass dynamic arrays to `%s` vararg functions", p);
                         err = true;
                     }
-                    if (arg.type.ty == Tsarray)
+                    if (arg.type.ty == TY.sarray)
                     {
                         arg.error("cannot pass static arrays to `%s` vararg functions", p);
                         err = true;
@@ -902,7 +902,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
             // Convert static arrays to dynamic arrays
             // BUG: I don't think this is right for D2
             Type tb = arg.type.toBasetype();
-            if (tb.ty == Tsarray)
+            if (tb.ty == TY.sarray)
             {
                 TypeSArray ts = cast(TypeSArray)tb;
                 Type ta = ts.next.arrayOf();
@@ -911,7 +911,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 else
                     arg = arg.castTo(sc, ta);
             }
-            if (tb.ty == Tstruct)
+            if (tb.ty == TY.struct_)
             {
                 //arg = callCpCtor(sc, arg);
             }
@@ -1078,7 +1078,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                  * (or static arrays of them) if appropriate.
                  */
                 Type tv = arg.type.baseElemOf();
-                if (!isRef && tv.ty == Tstruct)
+                if (!isRef && tv.ty == TY.struct_)
                     arg = doCopyOrMove(sc, arg);
             }
 
@@ -1198,7 +1198,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     override void visit(IntegerExp e)
     {
         assert(e.type);
-        if (e.type.ty == Terror)
+        if (e.type.ty == TY.error)
             return setError();
 
         assert(e.type.deco);
@@ -1721,7 +1721,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         /* Disallow array literals of type void being used.
          */
-        if (e.elements.dim > 0 && t0.ty == Tvoid)
+        if (e.elements.dim > 0 && t0.ty == TY.void_)
         {
             e.error("`%s` of type `%s` has no value", e.toChars(), e.type.toChars());
             return setError();
@@ -1824,7 +1824,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(TypeExp exp)
     {
-        if (exp.type.ty == Terror)
+        if (exp.type.ty == TY.error)
             return setError();
 
         //printf("TypeExp::semantic(%s)\n", type.toChars());
@@ -2022,7 +2022,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // T should be analyzed first and edim should go into arguments iff it's
         // not a tuple.
         Expression edim = null;
-        if (!exp.arguments && exp.newtype.ty == Tsarray)
+        if (!exp.arguments && exp.newtype.ty == TY.sarray)
         {
             edim = (cast(TypeSArray)exp.newtype).dim;
             exp.newtype = (cast(TypeNext)exp.newtype).next;
@@ -2050,17 +2050,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             exp.type = exp.newtype.typeSemantic(exp.loc, sc);
         }
-        if (exp.type.ty == Terror)
+        if (exp.type.ty == TY.error)
             return setError();
 
         if (edim)
         {
-            if (exp.type.toBasetype().ty == Ttuple)
+            if (exp.type.toBasetype().ty == TY.tuple)
             {
                 // --> new T[edim]
                 exp.type = new TypeSArray(exp.type, edim);
                 exp.type = exp.type.typeSemantic(exp.loc, sc);
-                if (exp.type.ty == Terror)
+                if (exp.type.ty == TY.error)
                     return setError();
             }
             else
@@ -2087,7 +2087,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        if (exp.thisexp && tb.ty != Tclass)
+        if (exp.thisexp && tb.ty != TY.class_)
         {
             exp.error("`.new` is only for allocating nested classes, not `%s`", tb.toChars());
             return setError();
@@ -2096,7 +2096,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         size_t nargs = exp.arguments ? exp.arguments.dim : 0;
         Expression newprefix = null;
 
-        if (tb.ty == Tclass)
+        if (tb.ty == TY.class_)
         {
             auto cd = (cast(TypeClass)tb).sym;
             cd.size(exp.loc);
@@ -2265,7 +2265,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
-        else if (tb.ty == Tstruct)
+        else if (tb.ty == TY.struct_)
         {
             auto sd = (cast(TypeStruct)tb).sym;
             sd.size(exp.loc);
@@ -2361,7 +2361,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             exp.type = exp.type.pointerTo();
         }
-        else if (tb.ty == Tarray && nargs)
+        else if (tb.ty == TY.array && nargs)
         {
             Type tn = tb.nextOf().baseElemOf();
             Dsymbol s = tn.toDsymbol(sc);
@@ -2373,7 +2373,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             for (size_t i = 0; i < nargs; i++)
             {
-                if (tb.ty != Tarray)
+                if (tb.ty != TY.array)
                 {
                     exp.error("too many arguments for array");
                     return setError();
@@ -2566,7 +2566,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.fd.treq && !exp.fd.type.nextOf())
         {
             TypeFunction tfv = null;
-            if (exp.fd.treq.ty == Tdelegate || (exp.fd.treq.ty == Tpointer && exp.fd.treq.nextOf().ty == Tfunction))
+            if (exp.fd.treq.ty == TY.delegate_ || (exp.fd.treq.ty == TY.pointer && exp.fd.treq.nextOf().ty == TY.function_))
                 tfv = cast(TypeFunction)exp.fd.treq.nextOf();
             if (tfv)
             {
@@ -2603,14 +2603,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (olderrors != global.errors)
         {
-            if (exp.fd.type && exp.fd.type.ty == Tfunction && !exp.fd.type.nextOf())
+            if (exp.fd.type && exp.fd.type.ty == TY.function_ && !exp.fd.type.nextOf())
                 (cast(TypeFunction)exp.fd.type).next = Type.terror;
             e = new ErrorExp();
             goto Ldone;
         }
 
         // Type is a "delegate to" or "pointer to" the function literal
-        if ((exp.fd.isNested() && exp.fd.tok == TOKdelegate) || (exp.tok == TOKreserved && exp.fd.treq && exp.fd.treq.ty == Tdelegate))
+        if ((exp.fd.isNested() && exp.fd.tok == TOKdelegate) || (exp.tok == TOKreserved && exp.fd.treq && exp.fd.treq.ty == TY.delegate_))
         {
             exp.type = new TypeDelegate(exp.fd.type);
             exp.type = exp.type.typeSemantic(exp.loc, sc);
@@ -2631,7 +2631,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 *
                 * So, should keep fd.tok == TOKreserve if fd.treq == NULL.
                 */
-            if (exp.fd.treq && exp.fd.treq.ty == Tpointer)
+            if (exp.fd.treq && exp.fd.treq.ty == TY.pointer)
             {
                 // change to non-nested
                 exp.fd.tok = TOKfunction;
@@ -2683,7 +2683,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     for (size_t u = 0; u < dim; u++)
                     {
                         Parameter p = Parameter.getNth(tfl.parameters, u);
-                        if (p.type.ty == Tident && (cast(TypeIdentifier)p.type).ident == tp.ident)
+                        if (p.type.ty == TY.ident && (cast(TypeIdentifier)p.type).ident == tp.ident)
                         {
                             Expression e = (*arguments)[u];
                             tiargs.push(e.type);
@@ -2933,7 +2933,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.e1 = de.e2;
                 }
             }
-            else if (exp.e1.op == TOKstar && exp.e1.type.ty == Tfunction)
+            else if (exp.e1.op == TOKstar && exp.e1.type.ty == TY.function_)
             {
                 // Rewrite (*fp)(arguments) to fp(arguments)
                 exp.e1 = (cast(PtrExp)exp.e1).e1;
@@ -2953,7 +2953,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // Check for call operator overload
         if (t1)
         {
-            if (t1.ty == Tstruct)
+            if (t1.ty == TY.struct_)
             {
                 auto sd = (cast(TypeStruct)t1).sym;
                 sd.size(exp.loc); // Resolve forward references to construct object
@@ -3028,7 +3028,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 result = e;
                 return;
             }
-            else if (t1.ty == Tclass)
+            else if (t1.ty == TY.class_)
             {
             L1:
                 // Rewrite as e1.call(arguments)
@@ -3045,7 +3045,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // Make sure to use the the enum type itself rather than its
                 // base type
                 // https://issues.dlang.org/show_bug.cgi?id=16346
-                if (exp.e1.type.ty == Tenum)
+                if (exp.e1.type.ty == TY.enum_)
                 {
                     t1 = exp.e1.type;
                 }
@@ -3101,7 +3101,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return f;
         }
 
-        if (exp.e1.op == TOKdotvar && t1.ty == Tfunction || exp.e1.op == TOKdottd)
+        if (exp.e1.op == TOKdotvar && t1.ty == TY.function_ || exp.e1.op == TOKdottd)
         {
             UnaExp ue = cast(UnaExp)exp.e1;
 
@@ -3133,7 +3133,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // Do overload resolution
             exp.f = resolveFuncCall(exp.loc, sc, s, tiargs, ue1 ? ue1.type : null, exp.arguments);
-            if (!exp.f || exp.f.errors || exp.f.type.ty == Terror)
+            if (!exp.f || exp.f.errors || exp.f.type.ty == TY.error)
                 return setError();
 
             if (exp.f.interfaceVirtual)
@@ -3161,7 +3161,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 ethis = ue.e1;
                 tthis = ue.e1.type;
-                if (!(exp.f.type.ty == Tfunction && (cast(TypeFunction)exp.f.type).isscope))
+                if (!(exp.f.type.ty == TY.function_ && (cast(TypeFunction)exp.f.type).isscope))
                 {
                     if (global.params.vsafe && checkParamArgumentEscape(sc, exp.f, Id.This, ethis, false))
                         return setError();
@@ -3233,7 +3233,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             // If we've got a pointer to a function then deference it
             // https://issues.dlang.org/show_bug.cgi?id=16483
-            if (exp.e1.type.ty == Tpointer && exp.e1.type.nextOf().ty == Tfunction)
+            if (exp.e1.type.ty == TY.pointer && exp.e1.type.nextOf().ty == TY.function_)
             {
                 Expression e = new PtrExp(exp.loc, exp.e1);
                 e.type = exp.e1.type.nextOf();
@@ -3346,11 +3346,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("function expected before `()`, not `%s`", exp.e1.toChars());
             return setError();
         }
-        else if (t1.ty == Terror)
+        else if (t1.ty == TY.error)
         {
             return setError();
         }
-        else if (t1.ty != Tfunction)
+        else if (t1.ty != TY.function_)
         {
             TypeFunction tf;
             const(char)* p;
@@ -3364,14 +3364,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tf = cast(TypeFunction)exp.f.type;
                 p = "function literal";
             }
-            else if (t1.ty == Tdelegate)
+            else if (t1.ty == TY.delegate_)
             {
                 TypeDelegate td = cast(TypeDelegate)t1;
-                assert(td.next.ty == Tfunction);
+                assert(td.next.ty == TY.function_);
                 tf = cast(TypeFunction)td.next;
                 p = "delegate";
             }
-            else if (t1.ty == Tpointer && (cast(TypePointer)t1).next.ty == Tfunction)
+            else if (t1.ty == TY.pointer && (cast(TypePointer)t1).next.ty == TY.function_)
             {
                 tf = cast(TypeFunction)(cast(TypePointer)t1).next;
                 p = "function pointer";
@@ -3477,7 +3477,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
             }
 
-            if (t1.ty == Tpointer)
+            if (t1.ty == TY.pointer)
             {
                 Expression e = new PtrExp(exp.loc, exp.e1);
                 e.type = tf;
@@ -3553,7 +3553,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             t1 = exp.f.type;
         }
-        assert(t1.ty == Tfunction);
+        assert(t1.ty == TY.function_);
 
         Expression argprefix;
         if (!exp.arguments)
@@ -3742,7 +3742,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             ta.checkComplexTransition(exp.loc, sc);
 
         Expression e;
-        if (ea && ta.toBasetype().ty == Tclass)
+        if (ea && ta.toBasetype().ty == TY.class_)
         {
             /* Get the dynamic type, which is .classinfo
              */
@@ -3750,7 +3750,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             e = new TypeidExp(ea.loc, ea);
             e.type = Type.typeinfoclass.type;
         }
-        else if (ta.ty == Terror)
+        else if (ta.ty == TY.error)
         {
             e = new ErrorExp();
         }
@@ -3816,7 +3816,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             switch (e.tok2)
             {
             case TOKstruct:
-                if (e.targ.ty != Tstruct)
+                if (e.targ.ty != TY.struct_)
                     goto Lno;
                 if ((cast(TypeStruct)e.targ).sym.isUnionDeclaration())
                     goto Lno;
@@ -3824,7 +3824,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOKunion:
-                if (e.targ.ty != Tstruct)
+                if (e.targ.ty != TY.struct_)
                     goto Lno;
                 if (!(cast(TypeStruct)e.targ).sym.isUnionDeclaration())
                     goto Lno;
@@ -3832,7 +3832,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOKclass:
-                if (e.targ.ty != Tclass)
+                if (e.targ.ty != TY.class_)
                     goto Lno;
                 if ((cast(TypeClass)e.targ).sym.isInterfaceDeclaration())
                     goto Lno;
@@ -3840,7 +3840,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOKinterface:
-                if (e.targ.ty != Tclass)
+                if (e.targ.ty != TY.class_)
                     goto Lno;
                 if (!(cast(TypeClass)e.targ).sym.isInterfaceDeclaration())
                     goto Lno;
@@ -3873,7 +3873,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             case TOKsuper:
                 // If class or interface, get the base class and interfaces
-                if (e.targ.ty != Tclass)
+                if (e.targ.ty != TY.class_)
                     goto Lno;
                 else
                 {
@@ -3892,19 +3892,19 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOKenum:
-                if (e.targ.ty != Tenum)
+                if (e.targ.ty != TY.enum_)
                     goto Lno;
                 if (e.id)
                     tded = (cast(TypeEnum)e.targ).sym.getMemtype(e.loc);
                 else
                     tded = e.targ;
 
-                if (tded.ty == Terror)
+                if (tded.ty == TY.error)
                     return setError();
                 break;
 
             case TOKdelegate:
-                if (e.targ.ty != Tdelegate)
+                if (e.targ.ty != TY.delegate_)
                     goto Lno;
                 tded = (cast(TypeDelegate)e.targ).next; // the underlying function type
                 break;
@@ -3912,13 +3912,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             case TOKfunction:
             case TOKparameters:
                 {
-                    if (e.targ.ty != Tfunction)
+                    if (e.targ.ty != TY.function_)
                         goto Lno;
                     tded = e.targ;
 
                     /* Generate tuple from function parameter types.
                      */
-                    assert(tded.ty == Tfunction);
+                    assert(tded.ty == TY.function_);
                     Parameters* params = (cast(TypeFunction)tded).parameters;
                     size_t dim = Parameter.dim(params);
                     auto args = new Parameters();
@@ -3941,14 +3941,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* Get the 'return type' for the function,
                  * delegate, or pointer to function.
                  */
-                if (e.targ.ty == Tfunction)
+                if (e.targ.ty == TY.function_)
                     tded = (cast(TypeFunction)e.targ).next;
-                else if (e.targ.ty == Tdelegate)
+                else if (e.targ.ty == TY.delegate_)
                 {
                     tded = (cast(TypeDelegate)e.targ).next;
                     tded = (cast(TypeFunction)tded).next;
                 }
-                else if (e.targ.ty == Tpointer && (cast(TypePointer)e.targ).next.ty == Tfunction)
+                else if (e.targ.ty == TY.pointer && (cast(TypePointer)e.targ).next.ty == TY.function_)
                 {
                     tded = (cast(TypePointer)e.targ).next;
                     tded = (cast(TypeFunction)tded).next;
@@ -3970,7 +3970,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOKvector:
-                if (e.targ.ty != Tvector)
+                if (e.targ.ty != TY.vector)
                     goto Lno;
                 tded = (cast(TypeVector)e.targ).basetype;
                 break;
@@ -4121,7 +4121,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e;
             return;
         }
-        if (exp.e1.op == TOKslice || exp.e1.type.ty == Tarray || exp.e1.type.ty == Tsarray)
+        if (exp.e1.op == TOKslice || exp.e1.type.ty == TY.array || exp.e1.type.ty == TY.sarray)
         {
             if (checkNonAssignmentArrayOp(exp.e1))
                 return setError();
@@ -4156,12 +4156,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         int bitwise = (exp.op == TOKandass || exp.op == TOKorass || exp.op == TOKxorass);
         int shift = (exp.op == TOKshlass || exp.op == TOKshrass || exp.op == TOKushrass);
 
-        if (bitwise && exp.type.toBasetype().ty == Tbool)
+        if (bitwise && exp.type.toBasetype().ty == TY.bool_)
             exp.e2 = exp.e2.implicitCastTo(sc, exp.type);
         else if (exp.checkNoBool())
             return setError();
 
-        if ((exp.op == TOKaddass || exp.op == TOKminass) && exp.e1.type.toBasetype().ty == Tpointer && exp.e2.type.toBasetype().isintegral())
+        if ((exp.op == TOKaddass || exp.op == TOKminass) && exp.e1.type.toBasetype().ty == TY.pointer && exp.e2.type.toBasetype().isintegral())
         {
             result = scaleFactor(exp, sc);
             return;
@@ -4180,7 +4180,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (shift)
         {
-            if (exp.e2.type.toBasetype().ty != Tvector)
+            if (exp.e2.type.toBasetype().ty != TY.vector)
                 exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
         }
 
@@ -4520,7 +4520,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             assert(exp.type);
 
-            if (t1.ty == Tpointer)
+            if (t1.ty == TY.pointer)
                 t1 = t1.nextOf();
 
             exp.type = exp.type.addMod(t1.mod);
@@ -4600,7 +4600,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         AggregateDeclaration ad = f.toParent().isAggregateDeclaration();
         if (f.needThis())
             e.e1 = getRightThis(e.loc, sc, ad, e.e1, f);
-        if (f.type.ty == Tfunction)
+        if (f.type.ty == TY.function_)
         {
             TypeFunction tf = cast(TypeFunction)f.type;
             if (!MODmethodConv(e.e1.type.mod, f.type.mod))
@@ -4861,7 +4861,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else if (exp.e1.op == TOKcall)
         {
             CallExp ce = cast(CallExp)exp.e1;
-            if (ce.e1.type.ty == Tfunction)
+            if (ce.e1.type.ty == TY.function_)
             {
                 TypeFunction tf = cast(TypeFunction)ce.e1.type;
                 if (tf.isref && sc.func && !sc.intypeof && sc.func.setUnsafe())
@@ -4880,7 +4880,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              */
             IndexExp ei = cast(IndexExp)exp.e1;
             Type tyi = ei.e1.type.toBasetype();
-            if (tyi.ty == Tsarray && ei.e1.op == TOKvar)
+            if (tyi.ty == TY.sarray && ei.e1.op == TOKvar)
             {
                 VarExp ve = cast(VarExp)ei.e1;
                 VarDeclaration v = ve.var.isVarDeclaration();
@@ -4936,12 +4936,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type tb = exp.e1.type.toBasetype();
         switch (tb.ty)
         {
-        case Tpointer:
+        case TY.pointer:
             exp.type = (cast(TypePointer)tb).next;
             break;
 
-        case Tsarray:
-        case Tarray:
+        case TY.sarray:
+        case TY.array:
             if (isNonAssignmentArrayOp(exp.e1))
                 goto default;
             exp.error("using `*` on an array is no longer supported; use `*(%s).ptr` instead", exp.e1.toChars());
@@ -4949,12 +4949,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e1 = exp.e1.castTo(sc, exp.type.pointerTo());
             break;
 
-        case Terror:
+        case TY.error:
             return setError();
 
         default:
             exp.error("can only `*` a pointer, not a `%s`", exp.e1.type.toChars());
-            goto case Terror;
+            goto case TY.error;
         }
 
         if (exp.checkValue())
@@ -4985,7 +4985,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         fix16997(sc, exp);
         exp.type = exp.e1.type;
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp.e1))
             {
@@ -5055,7 +5055,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         fix16997(sc, exp);
         exp.type = exp.e1.type;
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp.e1))
             {
@@ -5140,7 +5140,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type tb = exp.e1.type.toBasetype();
         switch (tb.ty)
         {
-        case Tclass:
+        case TY.class_:
             {
                 auto cd = (cast(TypeClass)tb).sym;
                 if (cd.isCOMinterface())
@@ -5153,9 +5153,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 ad = cd;
                 break;
             }
-        case Tpointer:
+        case TY.pointer:
             tb = (cast(TypePointer)tb).next.toBasetype();
-            if (tb.ty == Tstruct)
+            if (tb.ty == TY.struct_)
             {
                 ad = (cast(TypeStruct)tb).sym;
                 auto f = ad.aggDelete;
@@ -5204,10 +5204,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             break;
 
-        case Tarray:
+        case TY.array:
             {
                 Type tv = tb.nextOf().baseElemOf();
-                if (tv.ty == Tstruct)
+                if (tv.ty == TY.struct_)
                 {
                     ad = (cast(TypeStruct)tv).sym;
                     if (ad.dtor)
@@ -5229,7 +5229,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 err |= exp.checkSafety(sc, ad.dtor);
                 err |= exp.checkNogc(sc, ad.dtor);
             }
-            if (ad.aggDelete && tb.ty != Tarray)
+            if (ad.aggDelete && tb.ty != TY.array)
             {
                 err |= exp.checkPurity(sc, ad.aggDelete);
                 err |= exp.checkSafety(sc, ad.aggDelete);
@@ -5308,14 +5308,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
         }
 
-        if (exp.to.ty == Ttuple)
+        if (exp.to.ty == TY.tuple)
         {
             exp.error("cannot cast `%s` to tuple type `%s`", exp.e1.toChars(), exp.to.toChars());
             return setError();
         }
 
         // cast(void) is used to mark e1 as unused, so it is safe
-        if (exp.to.ty == Tvoid)
+        if (exp.to.ty == TY.void_)
         {
             exp.type = exp.to;
             result = exp;
@@ -5334,7 +5334,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type t1b = exp.e1.type.toBasetype();
         Type tob = exp.to.toBasetype();
 
-        if (tob.ty == Tstruct && !tob.equals(t1b))
+        if (tob.ty == TY.struct_ && !tob.equals(t1b))
         {
             /* Look to replace:
              *  cast(S)t
@@ -5353,14 +5353,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        if (!t1b.equals(tob) && (t1b.ty == Tarray || t1b.ty == Tsarray))
+        if (!t1b.equals(tob) && (t1b.ty == TY.array || t1b.ty == TY.sarray))
         {
             if (checkNonAssignmentArrayOp(exp.e1))
                 return setError();
         }
 
         // Look for casting to a vector type
-        if (tob.ty == Tvector && t1b.ty != Tvector)
+        if (tob.ty == TY.vector && t1b.ty != TY.vector)
         {
             result = new VectorExp(exp.loc, exp.e1, exp.to);
             return;
@@ -5399,14 +5399,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         exp.e1 = exp.e1.expressionSemantic(sc);
         exp.type = exp.to.typeSemantic(exp.loc, sc);
-        if (exp.e1.op == TOKerror || exp.type.ty == Terror)
+        if (exp.e1.op == TOKerror || exp.type.ty == TY.error)
         {
             result = exp.e1;
             return;
         }
 
         Type tb = exp.type.toBasetype();
-        assert(tb.ty == Tvector);
+        assert(tb.ty == TY.vector);
         TypeVector tv = cast(TypeVector)tb;
         Type te = tv.elementType();
         exp.dim = cast(int)(tv.size(exp.loc) / te.size(exp.loc));
@@ -5430,7 +5430,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 res |= checkElem((cast(ArrayLiteralExp)exp.e1).getElement(i));
             }
         }
-        else if (exp.e1.type.ty == Tvoid)
+        else if (exp.e1.type.ty == TY.void_)
             checkElem(exp.e1);
 
         result = res ? new ErrorExp() : exp;
@@ -5455,7 +5455,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = resolveProperties(sc, exp.e1);
-        if (exp.e1.op == TOKtype && exp.e1.type.ty != Ttuple)
+        if (exp.e1.op == TOKtype && exp.e1.type.ty != TY.tuple)
         {
             if (exp.lwr || exp.upr)
             {
@@ -5473,7 +5473,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // Convert [a,b,c][] to [a,b,c]
                 Type t1b = exp.e1.type.toBasetype();
                 Expression e = exp.e1;
-                if (t1b.ty == Tsarray)
+                if (t1b.ty == TY.sarray)
                 {
                     e = e.copy();
                     e.type = t1b.nextOf().arrayOf();
@@ -5503,13 +5503,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp.e1;
             return;
         }
-        if (exp.e1.type.ty == Terror)
+        if (exp.e1.type.ty == TY.error)
             return setError();
 
         Type t1b = exp.e1.type.toBasetype();
-        if (t1b.ty == Tpointer)
+        if (t1b.ty == TY.pointer)
         {
-            if ((cast(TypePointer)t1b).next.ty == Tfunction)
+            if ((cast(TypePointer)t1b).next.ty == TY.function_)
             {
                 exp.error("cannot slice function pointer `%s`", exp.e1.toChars());
                 return setError();
@@ -5525,10 +5525,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
         }
-        else if (t1b.ty == Tarray)
+        else if (t1b.ty == TY.array)
         {
         }
-        else if (t1b.ty == Tsarray)
+        else if (t1b.ty == TY.sarray)
         {
             if (!exp.arrayop && global.params.vsafe)
             {
@@ -5570,7 +5570,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
-        else if (t1b.ty == Ttuple)
+        else if (t1b.ty == TY.tuple)
         {
             if (!exp.lwr && !exp.upr)
             {
@@ -5583,7 +5583,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
         }
-        else if (t1b.ty == Tvector)
+        else if (t1b.ty == TY.vector)
         {
             // Convert e1 to corresponding static array
             TypeVector tv1 = cast(TypeVector)t1b;
@@ -5593,14 +5593,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            exp.error("`%s` cannot be sliced with `[]`", t1b.ty == Tvoid ? exp.e1.toChars() : t1b.toChars());
+            exp.error("`%s` cannot be sliced with `[]`", t1b.ty == TY.void_ ? exp.e1.toChars() : t1b.toChars());
             return setError();
         }
 
         /* Run semantic on lwr and upr.
          */
         Scope* scx = sc;
-        if (t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Ttuple)
+        if (t1b.ty == TY.sarray || t1b.ty == TY.array || t1b.ty == TY.tuple)
         {
             // Create scope for 'length' variable
             ScopeDsymbol sym = new ArrayScopeSymbol(sc, exp);
@@ -5610,21 +5610,21 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (exp.lwr)
         {
-            if (t1b.ty == Ttuple)
+            if (t1b.ty == TY.tuple)
                 sc = sc.startCTFE();
             exp.lwr = exp.lwr.expressionSemantic(sc);
             exp.lwr = resolveProperties(sc, exp.lwr);
-            if (t1b.ty == Ttuple)
+            if (t1b.ty == TY.tuple)
                 sc = sc.endCTFE();
             exp.lwr = exp.lwr.implicitCastTo(sc, Type.tsize_t);
         }
         if (exp.upr)
         {
-            if (t1b.ty == Ttuple)
+            if (t1b.ty == TY.tuple)
                 sc = sc.startCTFE();
             exp.upr = exp.upr.expressionSemantic(sc);
             exp.upr = resolveProperties(sc, exp.upr);
-            if (t1b.ty == Ttuple)
+            if (t1b.ty == TY.tuple)
                 sc = sc.endCTFE();
             exp.upr = exp.upr.implicitCastTo(sc, Type.tsize_t);
         }
@@ -5633,7 +5633,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.lwr && exp.lwr.type == Type.terror || exp.upr && exp.upr.type == Type.terror)
             return setError();
 
-        if (t1b.ty == Ttuple)
+        if (t1b.ty == TY.tuple)
         {
             exp.lwr = exp.lwr.ctfeInterpret();
             exp.upr = exp.upr.ctfeInterpret();
@@ -5706,7 +5706,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             IntRange lwrRange = getIntRange(exp.lwr);
             IntRange uprRange = getIntRange(exp.upr);
 
-            if (t1b.ty == Tsarray || t1b.ty == Tarray)
+            if (t1b.ty == TY.sarray || t1b.ty == TY.array)
             {
                 Expression el = new ArrayLengthExp(exp.loc, exp.e1);
                 el = el.expressionSemantic(sc);
@@ -5718,7 +5718,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.upperIsInBounds = bounds.contains(uprRange);
                 }
             }
-            else if (t1b.ty == Tpointer)
+            else if (t1b.ty == TY.pointer)
             {
                 exp.upperIsInBounds = true;
             }
@@ -5936,7 +5936,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (!exp.e1.type)
             exp.e1 = exp.e1.expressionSemantic(sc);
         assert(exp.e1.type); // semantic() should already be run on it
-        if (exp.e1.op == TOKtype && exp.e1.type.ty != Ttuple)
+        if (exp.e1.op == TOKtype && exp.e1.type.ty != TY.tuple)
         {
             exp.e2 = exp.e2.expressionSemantic(sc);
             exp.e2 = resolveProperties(sc, exp.e2);
@@ -5954,14 +5954,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp.e1;
             return;
         }
-        if (exp.e1.type.ty == Terror)
+        if (exp.e1.type.ty == TY.error)
             return setError();
 
         // Note that unlike C we do not implement the int[ptr]
 
         Type t1b = exp.e1.type.toBasetype();
 
-        if (t1b.ty == Tvector)
+        if (t1b.ty == TY.vector)
         {
             // Convert e1 to corresponding static array
             TypeVector tv1 = cast(TypeVector)t1b;
@@ -5973,7 +5973,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         /* Run semantic on e2
          */
         Scope* scx = sc;
-        if (t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Ttuple)
+        if (t1b.ty == TY.sarray || t1b.ty == TY.array || t1b.ty == TY.tuple)
         {
             // Create scope for 'length' variable
             ScopeDsymbol sym = new ArrayScopeSymbol(sc, exp);
@@ -5981,11 +5981,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             sym.parent = sc.scopesym;
             sc = sc.push(sym);
         }
-        if (t1b.ty == Ttuple)
+        if (t1b.ty == TY.tuple)
             sc = sc.startCTFE();
         exp.e2 = exp.e2.expressionSemantic(sc);
         exp.e2 = resolveProperties(sc, exp.e2);
-        if (t1b.ty == Ttuple)
+        if (t1b.ty == TY.tuple)
             sc = sc.endCTFE();
         if (exp.e2.op == TOKtuple)
         {
@@ -6003,8 +6003,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         switch (t1b.ty)
         {
-        case Tpointer:
-            if ((cast(TypePointer)t1b).next.ty == Tfunction)
+        case TY.pointer:
+            if ((cast(TypePointer)t1b).next.ty == TY.function_)
             {
                 exp.error("cannot index function pointer `%s`", exp.e1.toChars());
                 return setError();
@@ -6024,14 +6024,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.type = (cast(TypeNext)t1b).next;
             break;
 
-        case Tarray:
+        case TY.array:
             exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
             if (exp.e2.type == Type.terror)
                 return setError();
             exp.type = (cast(TypeNext)t1b).next;
             break;
 
-        case Tsarray:
+        case TY.sarray:
             {
                 exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
                 if (exp.e2.type == Type.terror)
@@ -6039,7 +6039,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.type = t1b.nextOf();
                 break;
             }
-        case Taarray:
+        case TY.aarray:
             {
                 TypeAArray taa = cast(TypeAArray)t1b;
                 /* We can skip the implicit conversion if they differ only by
@@ -6059,7 +6059,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.type = taa.next;
                 break;
             }
-        case Ttuple:
+        case TY.tuple:
             {
                 exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
                 if (exp.e2.type == Type.terror)
@@ -6107,7 +6107,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        if (t1b.ty == Tsarray || t1b.ty == Tarray)
+        if (t1b.ty == TY.sarray || t1b.ty == TY.array)
         {
             Expression el = new ArrayLengthExp(exp.loc, exp.e1);
             el = el.expressionSemantic(sc);
@@ -6172,7 +6172,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.e1 = exp.e1.optimize(WANTvalue);
 
         Type t1 = exp.e1.type.toBasetype();
-        if (t1.ty == Tclass || t1.ty == Tstruct || exp.e1.op == TOKarraylength)
+        if (t1.ty == TY.class_ || t1.ty == TY.struct_ || exp.e1.op == TOKarraylength)
         {
             /* Check for operator overloading,
              * but rewrite in terms of ++e instead of e++
@@ -6218,7 +6218,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e1.checkNoBool())
             return setError();
 
-        if (exp.e1.type.ty == Tpointer)
+        if (exp.e1.type.ty == TY.pointer)
             e = scaleFactor(exp, sc);
         else
             exp.e2 = exp.e2.castTo(sc, exp.e1.type);
@@ -6545,7 +6545,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (!td)
                     goto Lnomatch;
 
-                assert(exp.e1.type.ty == Ttuple);
+                assert(exp.e1.type.ty == TY.tuple);
                 TypeTuple tt = cast(TypeTuple)exp.e1.type;
 
                 Expression e0;
@@ -6622,7 +6622,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // If this is an initialization of a reference,
             // do nothing
         }
-        else if (t1.ty == Tstruct)
+        else if (t1.ty == TY.struct_)
         {
             auto e1x = exp.e1;
             auto e2x = exp.e2;
@@ -6631,7 +6631,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (exp.op == TOKconstruct)
             {
                 Type t2 = e2x.type.toBasetype();
-                if (t2.ty == Tstruct && sd == (cast(TypeStruct)t2).sym)
+                if (t2.ty == TY.struct_ && sd == (cast(TypeStruct)t2).sym)
                 {
                     sd.size(exp.loc);
                     if (sd.sizeok != Sizeok.done)
@@ -6816,7 +6816,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (exp.op == TOKassign)
             {
-                if (e1x.op == TOKindex && (cast(IndexExp)e1x).e1.type.toBasetype().ty == Taarray)
+                if (e1x.op == TOKindex && (cast(IndexExp)e1x).e1.type.toBasetype().ty == TY.aarray)
                 {
                     /*
                      * Rewrite:
@@ -6846,7 +6846,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (e)
                     {
                         Expression ey = null;
-                        if (t2.ty == Tstruct && sd == t2.toDsymbol(sc))
+                        if (t2.ty == TY.struct_ && sd == t2.toDsymbol(sc))
                         {
                             ey = ev;
                         }
@@ -6910,7 +6910,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e1 = e1x;
             exp.e2 = e2x;
         }
-        else if (t1.ty == Tclass)
+        else if (t1.ty == TY.class_)
         {
             // Disallow assignment operator overloads for same type
             if (exp.op == TOKassign && !exp.e2.implicitConvTo(exp.e1.type))
@@ -6923,7 +6923,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
-        else if (t1.ty == Tsarray)
+        else if (t1.ty == TY.sarray)
         {
             // SliceExp cannot have static array type without context inference.
             assert(exp.e1.op != TOKslice);
@@ -6987,7 +6987,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     while (1)
                     {
                         t = t.nextOf().toBasetype();
-                        if (t.ty != Tsarray)
+                        if (t.ty != TY.sarray)
                             break;
                         dim *= (cast(TypeSArray)t).dim.toInteger();
                         e1x.type = t.nextOf().sarrayOf(dim);
@@ -7053,7 +7053,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             SliceExp se = cast(SliceExp)exp.e1;
             while (se.e1.op == TOKslice)
                 se = cast(SliceExp)se.e1;
-            if (se.e1.op == TOKquestion && se.e1.type.toBasetype().ty == Tsarray)
+            if (se.e1.op == TOKquestion && se.e1.type.toBasetype().ty == TY.sarray)
             {
                 se.e1 = se.e1.modifiableLvalue(sc, exp.e1);
                 if (se.e1.op == TOKerror)
@@ -7065,7 +7065,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            if (t1.ty == Tsarray && exp.op == TOKassign)
+            if (t1.ty == TY.sarray && exp.op == TOKassign)
             {
                 Type tn = exp.e1.type.nextOf();
                 if (tn && !tn.baseElemOf().isAssignable())
@@ -7104,11 +7104,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // If it is a array, get the element type. Note that it may be
         // multi-dimensional.
         Type telem = t1;
-        while (telem.ty == Tarray)
+        while (telem.ty == TY.array)
             telem = telem.nextOf();
 
         if (exp.e1.op == TOKslice && t1.nextOf() &&
-            (telem.ty != Tvoid || e2x.op == TOKnull) &&
+            (telem.ty != TY.void_ || e2x.op == TOKnull) &&
             e2x.implicitConvTo(t1.nextOf()))
         {
             // Check for block assignment. If it is of type void[], void[][], etc,
@@ -7119,7 +7119,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
         }
         else if (exp.e1.op == TOKslice &&
-                 (t2.ty == Tarray || t2.ty == Tsarray) &&
+                 (t2.ty == TY.array || t2.ty == TY.sarray) &&
                  t2.nextOf().implicitConvTo(t1.nextOf()))
         {
             // Check element-wise assignment.
@@ -7134,7 +7134,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tsa2 = cast(TypeSArray)t2.nextOf().sarrayOf((cast(ArrayLiteralExp)e2x).elements.dim);
             else if (e2x.op == TOKslice)
                 tsa2 = cast(TypeSArray)toStaticArrayType(cast(SliceExp)e2x);
-            else if (t2.ty == Tsarray)
+            else if (t2.ty == TY.sarray)
                 tsa2 = cast(TypeSArray)t2;
             if (tsa1 && tsa2)
             {
@@ -7209,7 +7209,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 else
                     e2x = e2x.implicitCastTo(sc, exp.e1.type);
             }
-            if (t1n.toBasetype.ty == Tvoid && t2n.toBasetype.ty == Tvoid)
+            if (t1n.toBasetype.ty == TY.void_ && t2n.toBasetype.ty == TY.void_)
             {
                 if (!sc.intypeof && sc.func && sc.func.setUnsafe())
                 {
@@ -7221,7 +7221,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else
         {
             if (0 && global.params.warnings && !global.gag && exp.op == TOKassign &&
-                t1.ty == Tarray && t2.ty == Tsarray &&
+                t1.ty == TY.array && t2.ty == TY.sarray &&
                 e2x.op != TOKslice &&
                 t2.implicitConvTo(t1))
             {
@@ -7247,7 +7247,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         /* Look for array operations
          */
-        if ((t2.ty == Tarray || t2.ty == Tsarray) && isArrayOpValid(exp.e2))
+        if ((t2.ty == TY.array || t2.ty == TY.sarray) && isArrayOpValid(exp.e2))
         {
             // Look for valid array operations
             if (!(exp.memset & MemorySet.blockAssign) &&
@@ -7280,7 +7280,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             VarDeclaration vd = ve.var.isVarDeclaration();
             if (vd && (vd.onstack || vd.mynew))
             {
-                assert(t1.ty == Tclass);
+                assert(t1.ty == TY.class_);
                 exp.error("cannot rebind scope variables");
             }
         }
@@ -7316,7 +7316,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         assert(exp.e1.type && exp.e2.type);
-        if (exp.e1.op == TOKslice || exp.e1.type.ty == Tarray || exp.e1.type.ty == Tsarray)
+        if (exp.e1.op == TOKslice || exp.e1.type.ty == TY.array || exp.e1.type.ty == TY.sarray)
         {
             if (checkNonAssignmentArrayOp(exp.e1))
                 return setError();
@@ -7336,7 +7336,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // Check element types are arithmetic
             Type tb1 = exp.e1.type.nextOf().toBasetype();
             Type tb2 = exp.e2.type.toBasetype();
-            if (tb2.ty == Tarray || tb2.ty == Tsarray)
+            if (tb2.ty == TY.array || tb2.ty == TY.sarray)
                 tb2 = tb2.nextOf().toBasetype();
             if ((tb1.isintegral() || tb1.isfloating()) && (tb2.isintegral() || tb2.isfloating()))
             {
@@ -7400,7 +7400,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e1.op == TOKslice)
         {
             SliceExp se = cast(SliceExp)exp.e1;
-            if (se.e1.type.toBasetype().ty == Tsarray)
+            if (se.e1.type.toBasetype().ty == TY.sarray)
             {
                 exp.error("cannot append to static array `%s`", se.e1.type.toChars());
                 return setError();
@@ -7431,8 +7431,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * TOKcatelemass: appending T to T[]
          * TOKcatdcharass: appending dchar to T[]
          */
-        if ((tb1.ty == Tarray) &&
-            (tb2.ty == Tarray || tb2.ty == Tsarray) &&
+        if ((tb1.ty == TY.array) &&
+            (tb2.ty == TY.array || tb2.ty == TY.sarray) &&
             (exp.e2.implicitConvTo(exp.e1.type) ||
              (tb2.nextOf().implicitConvTo(tb1next) &&
               (tb2.nextOf().size(Loc()) == tb1next.size(Loc())))))
@@ -7444,7 +7444,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             exp.e2 = exp.e2.castTo(sc, exp.e1.type);
         }
-        else if ((tb1.ty == Tarray) && exp.e2.implicitConvTo(tb1next))
+        else if ((tb1.ty == TY.array) && exp.e2.implicitConvTo(tb1next))
         {
             // Append element
             if (exp.e2.checkPostblit(sc, tb2))
@@ -7454,8 +7454,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e2 = exp.e2.castTo(sc, tb1next);
             exp.e2 = doCopyOrMove(sc, exp.e2);
         }
-        else if (tb1.ty == Tarray &&
-                 (tb1next.ty == Tchar || tb1next.ty == Twchar) &&
+        else if (tb1.ty == TY.array &&
+                 (tb1next.ty == TY.char_ || tb1next.ty == TY.wchar_) &&
                  exp.e2.type.ty != tb1next.ty &&
                  exp.e2.implicitConvTo(Type.tdchar))
         {
@@ -7510,24 +7510,24 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type tb2 = exp.e2.type.toBasetype();
 
         bool err = false;
-        if (tb1.ty == Tdelegate || tb1.ty == Tpointer && tb1.nextOf().ty == Tfunction)
+        if (tb1.ty == TY.delegate_ || tb1.ty == TY.pointer && tb1.nextOf().ty == TY.function_)
         {
             err |= exp.e1.checkArithmetic();
         }
-        if (tb2.ty == Tdelegate || tb2.ty == Tpointer && tb2.nextOf().ty == Tfunction)
+        if (tb2.ty == TY.delegate_ || tb2.ty == TY.pointer && tb2.nextOf().ty == TY.function_)
         {
             err |= exp.e2.checkArithmetic();
         }
         if (err)
             return setError();
 
-        if (tb1.ty == Tpointer && exp.e2.type.isintegral() || tb2.ty == Tpointer && exp.e1.type.isintegral())
+        if (tb1.ty == TY.pointer && exp.e2.type.isintegral() || tb2.ty == TY.pointer && exp.e1.type.isintegral())
         {
             result = scaleFactor(exp, sc);
             return;
         }
 
-        if (tb1.ty == Tpointer && tb2.ty == Tpointer)
+        if (tb1.ty == TY.pointer && tb2.ty == TY.pointer)
         {
             result = exp.incompatibleTypes();
             return;
@@ -7540,7 +7540,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -7561,18 +7561,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             switch (exp.type.toBasetype().ty)
             {
-            case Tfloat32:
-            case Timaginary32:
+            case TY.float32:
+            case TY.imaginary32:
                 exp.type = Type.tcomplex32;
                 break;
 
-            case Tfloat64:
-            case Timaginary64:
+            case TY.float64:
+            case TY.imaginary64:
                 exp.type = Type.tcomplex64;
                 break;
 
-            case Tfloat80:
-            case Timaginary80:
+            case TY.float80:
+            case TY.imaginary80:
                 exp.type = Type.tcomplex80;
                 break;
 
@@ -7611,20 +7611,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type t2 = exp.e2.type.toBasetype();
 
         bool err = false;
-        if (t1.ty == Tdelegate || t1.ty == Tpointer && t1.nextOf().ty == Tfunction)
+        if (t1.ty == TY.delegate_ || t1.ty == TY.pointer && t1.nextOf().ty == TY.function_)
         {
             err |= exp.e1.checkArithmetic();
         }
-        if (t2.ty == Tdelegate || t2.ty == Tpointer && t2.nextOf().ty == Tfunction)
+        if (t2.ty == TY.delegate_ || t2.ty == TY.pointer && t2.nextOf().ty == TY.function_)
         {
             err |= exp.e2.checkArithmetic();
         }
         if (err)
             return setError();
 
-        if (t1.ty == Tpointer)
+        if (t1.ty == TY.pointer)
         {
-            if (t2.ty == Tpointer)
+            if (t2.ty == TY.pointer)
             {
                 // https://dlang.org/spec/expression.html#add_expressions
                 // "If both operands are pointers, and the operator is -, the pointers are
@@ -7676,7 +7676,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e;
             return;
         }
-        if (t2.ty == Tpointer)
+        if (t2.ty == TY.pointer)
         {
             exp.type = exp.e2.type;
             exp.error("can't subtract pointer from `%s`", exp.e1.type.toChars());
@@ -7690,7 +7690,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -7712,18 +7712,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             switch (exp.type.ty)
             {
-            case Tfloat32:
-            case Timaginary32:
+            case TY.float32:
+            case TY.imaginary32:
                 exp.type = Type.tcomplex32;
                 break;
 
-            case Tfloat64:
-            case Timaginary64:
+            case TY.float64:
+            case TY.imaginary64:
                 exp.type = Type.tcomplex64;
                 break;
 
-            case Tfloat80:
-            case Timaginary80:
+            case TY.float80:
+            case TY.imaginary80:
                 exp.type = Type.tcomplex80;
                 break;
 
@@ -7801,7 +7801,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         // Check for: array ~ element
-        if ((tb1.ty == Tsarray || tb1.ty == Tarray) && tb2.ty != Tvoid)
+        if ((tb1.ty == TY.sarray || tb1.ty == TY.array) && tb2.ty != TY.void_)
         {
             if (exp.e1.op == TOKarrayliteral)
             {
@@ -7832,7 +7832,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.e2 = exp.e2.implicitCastTo(sc, tb1next);
                 exp.type = tb1next.arrayOf();
             L2elem:
-                if (tb2.ty == Tarray || tb2.ty == Tsarray)
+                if (tb2.ty == TY.array || tb2.ty == TY.sarray)
                 {
                     // Make e2 into [e2]
                     exp.e2 = new ArrayLiteralExp(exp.e2.loc, exp.e2);
@@ -7843,7 +7843,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
         // Check for: element ~ array
-        if ((tb2.ty == Tsarray || tb2.ty == Tarray) && tb1.ty != Tvoid)
+        if ((tb2.ty == TY.sarray || tb2.ty == TY.array) && tb1.ty != TY.void_)
         {
             if (exp.e2.op == TOKarrayliteral)
             {
@@ -7869,7 +7869,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.e1 = exp.e1.implicitCastTo(sc, tb2next);
                 exp.type = tb2next.arrayOf();
             L1elem:
-                if (tb1.ty == Tarray || tb1.ty == Tsarray)
+                if (tb1.ty == TY.array || tb1.ty == TY.sarray)
                 {
                     // Make e1 into [e1]
                     exp.e1 = new ArrayLiteralExp(exp.e1.loc, exp.e1);
@@ -7881,7 +7881,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
     Lpeer:
-        if ((tb1.ty == Tsarray || tb1.ty == Tarray) && (tb2.ty == Tsarray || tb2.ty == Tarray) && (tb1next.mod || tb2next.mod) && (tb1next.mod != tb2next.mod))
+        if ((tb1.ty == TY.sarray || tb1.ty == TY.array) && (tb2.ty == TY.sarray || tb2.ty == TY.array) && (tb1next.mod || tb2next.mod) && (tb1next.mod != tb2next.mod))
         {
             Type t1 = tb1next.mutableOf().constOf().arrayOf();
             Type t2 = tb2next.mutableOf().constOf().arrayOf();
@@ -7903,9 +7903,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = exp.type.toHeadMutable();
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tsarray)
+        if (tb.ty == TY.sarray)
             exp.type = tb.nextOf().arrayOf();
-        if (exp.type.ty == Tarray && tb1next && tb2next && tb1next.mod != tb2next.mod)
+        if (exp.type.ty == TY.array && tb1next && tb2next && tb1next.mod != tb2next.mod)
         {
             exp.type = exp.type.nextOf().toHeadMutable().arrayOf();
         }
@@ -7923,8 +7923,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         Type t1 = exp.e1.type.toBasetype();
         Type t2 = exp.e2.type.toBasetype();
-        if ((t1.ty == Tarray || t1.ty == Tsarray) &&
-            (t2.ty == Tarray || t2.ty == Tsarray))
+        if ((t1.ty == TY.array || t1.ty == TY.sarray) &&
+            (t2.ty == TY.array || t2.ty == TY.sarray))
         {
             // Normalize to ArrayLiteralExp or StringExp as far as possible
             e = exp.optimize(WANTvalue);
@@ -7970,7 +7970,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8003,15 +8003,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     switch (t1.toBasetype().ty)
                     {
-                    case Timaginary32:
+                    case TY.imaginary32:
                         exp.type = Type.tfloat32;
                         break;
 
-                    case Timaginary64:
+                    case TY.imaginary64:
                         exp.type = Type.tfloat64;
                         break;
 
-                    case Timaginary80:
+                    case TY.imaginary80:
                         exp.type = Type.tfloat80;
                         break;
 
@@ -8070,7 +8070,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8112,15 +8112,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     switch (t1.toBasetype().ty)
                     {
-                    case Timaginary32:
+                    case TY.imaginary32:
                         exp.type = Type.tfloat32;
                         break;
 
-                    case Timaginary64:
+                    case TY.imaginary64:
                         exp.type = Type.tfloat64;
                         break;
 
-                    case Timaginary80:
+                    case TY.imaginary80:
                         exp.type = Type.tfloat80;
                         break;
 
@@ -8171,7 +8171,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8230,7 +8230,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8351,7 +8351,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        if (exp.e2.type.toBasetype().ty != Tvector)
+        if (exp.e2.type.toBasetype().ty != TY.vector)
             exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
@@ -8387,7 +8387,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        if (exp.e2.type.toBasetype().ty != Tvector)
+        if (exp.e2.type.toBasetype().ty != TY.vector)
             exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
@@ -8423,7 +8423,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        if (exp.e2.type.toBasetype().ty != Tvector)
+        if (exp.e2.type.toBasetype().ty != TY.vector)
             exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
@@ -8450,7 +8450,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Tbool && exp.e2.type.toBasetype().ty == Tbool)
+        if (exp.e1.type.toBasetype().ty == TY.bool_ && exp.e2.type.toBasetype().ty == TY.bool_)
         {
             exp.type = exp.e1.type;
             result = exp;
@@ -8464,7 +8464,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8505,7 +8505,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Tbool && exp.e2.type.toBasetype().ty == Tbool)
+        if (exp.e1.type.toBasetype().ty == TY.bool_ && exp.e2.type.toBasetype().ty == TY.bool_)
         {
             exp.type = exp.e1.type;
             result = exp;
@@ -8519,7 +8519,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8560,7 +8560,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Tbool && exp.e2.type.toBasetype().ty == Tbool)
+        if (exp.e1.type.toBasetype().ty == TY.bool_ && exp.e2.type.toBasetype().ty == TY.bool_)
         {
             exp.type = exp.e1.type;
             result = exp;
@@ -8574,7 +8574,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Tarray || tb.ty == Tsarray)
+        if (tb.ty == TY.array || tb.ty == TY.sarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8642,7 +8642,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         // Unless the right operand is 'void', the expression is converted to 'bool'.
-        if (e2x.type.ty != Tvoid)
+        if (e2x.type.ty != TY.void_)
             e2x = e2x.toBoolean(sc);
 
         if (e2x.op == TOKtype || e2x.op == TOKscope)
@@ -8662,7 +8662,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         // The result type is 'bool', unless the right operand has type 'void'.
-        if (e2x.type.ty == Tvoid)
+        if (e2x.type.ty == TY.void_)
             exp.type = Type.tvoid;
         else
             exp.type = Type.tbool;
@@ -8694,7 +8694,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         Type t1 = exp.e1.type.toBasetype();
         Type t2 = exp.e2.type.toBasetype();
-        if (t1.ty == Tclass && exp.e2.op == TOKnull || t2.ty == Tclass && exp.e1.op == TOKnull)
+        if (t1.ty == TY.class_ && exp.e2.op == TOKnull || t2.ty == TY.class_ && exp.e1.op == TOKnull)
         {
             exp.error("do not use `null` when comparing class types");
             return setError();
@@ -8734,16 +8734,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression arrayLowering = null;
         t1 = exp.e1.type.toBasetype();
         t2 = exp.e2.type.toBasetype();
-        if ((t1.ty == Tarray || t1.ty == Tsarray || t1.ty == Tpointer) && (t2.ty == Tarray || t2.ty == Tsarray || t2.ty == Tpointer))
+        if ((t1.ty == TY.array || t1.ty == TY.sarray || t1.ty == TY.pointer) && (t2.ty == TY.array || t2.ty == TY.sarray || t2.ty == TY.pointer))
         {
             Type t1next = t1.nextOf();
             Type t2next = t2.nextOf();
-            if (t1next.implicitConvTo(t2next) < MATCH.constant && t2next.implicitConvTo(t1next) < MATCH.constant && (t1next.ty != Tvoid && t2next.ty != Tvoid))
+            if (t1next.implicitConvTo(t2next) < MATCH.constant && t2next.implicitConvTo(t1next) < MATCH.constant && (t1next.ty != TY.void_ && t2next.ty != TY.void_))
             {
                 exp.error("array comparison type mismatch, `%s` vs `%s`", t1next.toChars(), t2next.toChars());
                 return setError();
             }
-            if ((t1.ty == Tarray || t1.ty == Tsarray) && (t2.ty == Tarray || t2.ty == Tsarray))
+            if ((t1.ty == TY.array || t1.ty == TY.sarray) && (t2.ty == TY.array || t2.ty == TY.sarray))
             {
                 // Lower to object.__cmp(e1, e2)
                 Expression al = new IdentifierExp(exp.loc, Id.empty);
@@ -8761,9 +8761,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 arrayLowering = al;
             }
         }
-        else if (t1.ty == Tstruct || t2.ty == Tstruct || (t1.ty == Tclass && t2.ty == Tclass))
+        else if (t1.ty == TY.struct_ || t2.ty == TY.struct_ || (t1.ty == TY.class_ && t2.ty == TY.class_))
         {
-            if (t2.ty == Tstruct)
+            if (t2.ty == TY.struct_)
                 exp.error("need member function `opCmp()` for %s `%s` to compare", t2.toDsymbol(sc).kind(), t2.toChars());
             else
                 exp.error("need member function `opCmp()` for %s `%s` to compare", t1.toDsymbol(sc).kind(), t1.toChars());
@@ -8774,7 +8774,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("compare not defined for complex operands");
             return setError();
         }
-        else if (t1.ty == Taarray || t2.ty == Taarray)
+        else if (t1.ty == TY.aarray || t2.ty == TY.aarray)
         {
             exp.error("`%s` is not defined for associative arrays", Token.toChars(exp.op));
             return setError();
@@ -8832,7 +8832,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             altop = TOKreserved;
             break;
         }
-        if (altop == TOKerror && (t1.ty == Tarray || t1.ty == Tsarray || t2.ty == Tarray || t2.ty == Tsarray))
+        if (altop == TOKerror && (t1.ty == TY.array || t1.ty == TY.sarray || t2.ty == TY.array || t2.ty == TY.sarray))
         {
             exp.error("`%s` is not defined for array comparisons", Token.toChars(exp.op));
             return setError();
@@ -8892,7 +8892,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type t2b = exp.e2.type.toBasetype();
         switch (t2b.ty)
         {
-        case Taarray:
+        case TY.aarray:
             {
                 TypeAArray ta = cast(TypeAArray)t2b;
 
@@ -8910,7 +8910,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
             }
 
-        case Terror:
+        case TY.error:
             return setError();
 
         default:
@@ -8955,7 +8955,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             auto t1 = exp.e1.type;
             auto t2 = exp.e2.type;
-            if (t1.ty == Tenum && t2.ty == Tenum && !t1.equivalent(t2))
+            if (t1.ty == TY.enum_ && t2.ty == TY.enum_ && !t1.equivalent(t2))
                 exp.deprecation("Comparison between different enumeration types `%s` and `%s`; If this behavior is intended consider using `std.conv.asOriginalType`",
                     t1.toChars(), t2.toChars());
         }
@@ -8988,9 +8988,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             Type t1n = t1.nextOf().toBasetype();
             Type t2n = t2.nextOf().toBasetype();
-            if (((t1n.ty == Tchar || t1n.ty == Twchar || t1n.ty == Tdchar) &&
-                 (t2n.ty == Tchar || t2n.ty == Twchar || t2n.ty == Tdchar)) ||
-                (t1n.ty == Tvoid || t2n.ty == Tvoid))
+            if (((t1n.ty == TY.char_ || t1n.ty == TY.wchar_ || t1n.ty == TY.dchar_) &&
+                 (t2n.ty == TY.char_ || t2n.ty == TY.wchar_ || t2n.ty == TY.dchar_)) ||
+                (t1n.ty == TY.void_ || t2n.ty == TY.void_))
             {
                 return false;
             }
@@ -9000,7 +9000,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Type t = t1n;
             while (t.toBasetype().nextOf())
                 t = t.nextOf().toBasetype();
-            if (t.ty != Tstruct)
+            if (t.ty != TY.struct_)
                 return false;
 
             semanticTypeInfo(sc, t);
@@ -9014,7 +9014,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
 
-        if (!(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq(t1, t2)))
+        if (!(t1.ty == TY.array && t2.ty == TY.array && needsDirectEq(t1, t2)))
         {
             if (auto e = typeCombine(exp, sc))
             {
@@ -9031,7 +9031,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = Type.tbool;
 
         // Special handling for array comparisons
-        if (!(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq(t1, t2)))
+        if (!(t1.ty == TY.array && t2.ty == TY.array && needsDirectEq(t1, t2)))
         {
             if (!arrayTypeCompatible(exp.loc, exp.e1.type, exp.e2.type))
             {
@@ -9044,7 +9044,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        if (t1.ty == Tarray && t2.ty == Tarray)
+        if (t1.ty == TY.array && t2.ty == TY.array)
         {
             //printf("Lowering to __equals %s %s\n", e1.toChars(), e2.toChars());
 
@@ -9071,7 +9071,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Taarray)
+        if (exp.e1.type.toBasetype().ty == TY.aarray)
             semanticTypeInfo(sc, exp.e1.type.toBasetype());
 
 
@@ -9133,8 +9133,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e2.op == TOKcall)
             exp.e2 = (cast(CallExp)exp.e2).addDtorHook(sc);
 
-        if (exp.e1.type.toBasetype().ty == Tsarray ||
-            exp.e2.type.toBasetype().ty == Tsarray)
+        if (exp.e1.type.toBasetype().ty == TY.sarray ||
+            exp.e2.type.toBasetype().ty == TY.sarray)
             exp.deprecation("identity comparison of static arrays "
                 ~ "implicitly coerces them to slices, "
                 ~ "which are compared by reference");
@@ -9215,7 +9215,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // the expression to void so that we explicitly discard the expression
         // value if any
         // https://issues.dlang.org/show_bug.cgi?id=16598
-        if (t1.ty == Tvoid || t2.ty == Tvoid)
+        if (t1.ty == TY.void_ || t2.ty == TY.void_)
         {
             exp.type = Type.tvoid;
             exp.e1 = exp.e1.castTo(sc, exp.type);
@@ -9233,9 +9233,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             switch (exp.e1.type.toBasetype().ty)
             {
-            case Tcomplex32:
-            case Tcomplex64:
-            case Tcomplex80:
+            case TY.complex32:
+            case TY.complex64:
+            case TY.complex80:
                 exp.e2 = exp.e2.castTo(sc, exp.e1.type);
                 break;
             default:
@@ -9243,15 +9243,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             switch (exp.e2.type.toBasetype().ty)
             {
-            case Tcomplex32:
-            case Tcomplex64:
-            case Tcomplex80:
+            case TY.complex32:
+            case TY.complex64:
+            case TY.complex80:
                 exp.e1 = exp.e1.castTo(sc, exp.e2.type);
                 break;
             default:
                 break;
             }
-            if (exp.type.toBasetype().ty == Tarray)
+            if (exp.type.toBasetype().ty == TY.array)
             {
                 exp.e1 = exp.e1.castTo(sc, exp.type);
                 exp.e2 = exp.e2.castTo(sc, exp.type);
@@ -9463,7 +9463,7 @@ Expression semanticX(DotIdExp exp, Scope* sc)
         }
     }
 
-    if (exp.e1.op == TOKvar && exp.e1.type.toBasetype().ty == Tsarray && exp.ident == Id.length)
+    if (exp.e1.op == TOKvar && exp.e1.type.toBasetype().ty == TY.sarray && exp.ident == Id.length)
     {
         // bypass checkPurity
         return exp.e1.type.dotExp(sc, exp.e1, exp.ident, exp.noderef ? Type.DotExpFlag.noDeref : 0);
@@ -9622,7 +9622,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                         exp.error("forward reference to %s `%s`", v.kind(), v.toPrettyChars());
                     return new ErrorExp();
                 }
-                if (v.type.ty == Terror)
+                if (v.type.ty == TY.error)
                     return new ErrorExp();
 
                 if ((v.storage_class & STC.manifest) && v._init && !exp.wantsym)
@@ -9776,7 +9776,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             exp.error("undefined identifier `%s` in %s `%s`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars());
         return new ErrorExp();
     }
-    else if (t1b.ty == Tpointer && exp.e1.type.ty != Tenum && exp.ident != Id._init && exp.ident != Id.__sizeof && exp.ident != Id.__xalignof && exp.ident != Id.offsetof && exp.ident != Id._mangleof && exp.ident != Id.stringof)
+    else if (t1b.ty == TY.pointer && exp.e1.type.ty != TY.enum_ && exp.ident != Id._init && exp.ident != Id.__sizeof && exp.ident != Id.__xalignof && exp.ident != Id.offsetof && exp.ident != Id._mangleof && exp.ident != Id.stringof)
     {
         Type t1bn = t1b.nextOf();
         if (flag)
@@ -9791,7 +9791,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
          * as:
          *   (*p).ident
          */
-        if (flag && t1bn.ty == Tvoid)
+        if (flag && t1bn.ty == TY.void_)
             return null;
         e = new PtrExp(exp.loc, exp.e1);
         e = e.expressionSemantic(sc);
@@ -9824,7 +9824,7 @@ Expression semanticY(DotTemplateInstanceExp exp, Scope* sc, int flag)
     {
         exp.e1 = die.e1; // take back
         Type t1b = exp.e1.type.toBasetype();
-        if (t1b.ty == Tarray || t1b.ty == Tsarray || t1b.ty == Taarray || t1b.ty == Tnull || (t1b.isTypeBasic() && t1b.ty != Tvoid))
+        if (t1b.ty == TY.array || t1b.ty == TY.sarray || t1b.ty == TY.aarray || t1b.ty == TY.null_ || (t1b.isTypeBasic() && t1b.ty != TY.void_))
         {
             /* No built-in type has templatized properties, so do shortcut.
              * It is necessary in: 1024.max!"a < b"

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -403,14 +403,14 @@ extern (C++) class FuncDeclaration : Declaration
             thandle = thandle.addStorageClass(storage_class);
             VarDeclaration v = new ThisDeclaration(loc, thandle);
             v.storage_class |= STC.parameter;
-            if (thandle.ty == Tstruct)
+            if (thandle.ty == TY.struct_)
             {
                 v.storage_class |= STC.ref_;
                 // if member function is marked 'inout', then 'this' is 'return ref'
-                if (type.ty == Tfunction && (cast(TypeFunction)type).iswild & 2)
+                if (type.ty == TY.function_ && (cast(TypeFunction)type).iswild & 2)
                     v.storage_class |= STC.return_;
             }
-            if (type.ty == Tfunction)
+            if (type.ty == TY.function_)
             {
                 TypeFunction tf = cast(TypeFunction)type;
                 if (tf.isreturn)
@@ -435,7 +435,7 @@ extern (C++) class FuncDeclaration : Declaration
              */
             VarDeclaration v = new ThisDeclaration(loc, Type.tvoid.pointerTo());
             v.storage_class |= STC.parameter;
-            if (type.ty == Tfunction)
+            if (type.ty == TY.function_)
             {
                 TypeFunction tf = cast(TypeFunction)type;
                 if (tf.isreturn)
@@ -633,7 +633,7 @@ extern (C++) class FuncDeclaration : Declaration
         {
             if (overnext)
                 return overnext.overloadInsert(ad);
-            if (!ad.aliassym && ad.type.ty != Tident && ad.type.ty != Tinstance)
+            if (!ad.aliassym && ad.type.ty != TY.ident && ad.type.ty != TY.instance)
             {
                 //printf("\tad = '%s'\n", ad.type.toChars());
                 return false;
@@ -710,7 +710,7 @@ extern (C++) class FuncDeclaration : Declaration
              * is just a const conversion.
              * This allows things like pure functions to match with an impure function type.
              */
-            if (t.ty == Tfunction)
+            if (t.ty == TY.function_)
             {
                 auto tf = cast(TypeFunction)f.type;
                 if (tf.covariant(t) == 1 &&
@@ -1374,15 +1374,15 @@ extern (C++) class FuncDeclaration : Declaration
         t = t.baseElemOf();
         switch (t.ty)
         {
-            case Tarray:
-            case Tpointer:
+            case TY.array:
+            case TY.pointer:
                 return isTypeIsolatedIndirect(t.nextOf()); // go down one level
 
-            case Taarray:
-            case Tclass:
+            case TY.aarray:
+            case TY.class_:
                 return isTypeIsolatedIndirect(t);
 
-            case Tstruct:
+            case TY.struct_:
                 /* Drill down and check the struct's fields
                  */
                 auto sym = t.toDsymbol(null).isStructDeclaration();
@@ -1449,15 +1449,15 @@ extern (C++) class FuncDeclaration : Declaration
                 tp = tp.baseElemOf();
                 switch (tp.ty)
                 {
-                    case Tarray:
-                    case Tpointer:
+                    case TY.array:
+                    case TY.pointer:
                         return traverseIndirections(tp.nextOf(), t);
 
-                    case Taarray:
-                    case Tclass:
+                    case TY.aarray:
+                    case TY.class_:
                         return traverseIndirections(tp, t);
 
-                    case Tstruct:
+                    case TY.struct_:
                         /* Drill down and check the struct's fields
                          */
                         auto sym = tp.toDsymbol(null).isStructDeclaration();
@@ -2057,7 +2057,7 @@ extern (C++) class FuncDeclaration : Declaration
             fdrequire = fd;
         }
 
-        if (!outId && f.nextOf() && f.nextOf().toBasetype().ty != Tvoid)
+        if (!outId && f.nextOf() && f.nextOf().toBasetype().ty != TY.void_)
             outId = Id.result; // provide a default
 
         if (fensure)
@@ -2239,9 +2239,9 @@ extern (C++) class FuncDeclaration : Declaration
         {
             auto fparam0 = Parameter.getNth(tf.parameters, 0);
             auto t = fparam0.type.toBasetype();
-            if (t.ty != Tarray ||
-                t.nextOf().ty != Tarray ||
-                t.nextOf().nextOf().ty != Tchar ||
+            if (t.ty != TY.array ||
+                t.nextOf().ty != TY.array ||
+                t.nextOf().nextOf().ty != TY.char_ ||
                 fparam0.storageClass & (STC.out_ | STC.ref_ | STC.lazy_))
             {
                 argerr = true;
@@ -2250,7 +2250,7 @@ extern (C++) class FuncDeclaration : Declaration
 
         if (!tf.nextOf())
             error("must return int or void");
-        else if (tf.nextOf().ty != Tint32 && tf.nextOf().ty != Tvoid)
+        else if (tf.nextOf().ty != TY.int32 && tf.nextOf().ty != TY.void_)
             error("must return int or void, not %s", tf.nextOf().toChars());
         else if (tf.varargs || nparams >= 2 || argerr)
             error("parameters must be main() or main(string[] args)");
@@ -2610,7 +2610,7 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                 auto td = s.isTemplateDeclaration();
                 if (fd)
                 {
-                    if (fd.errors || fd.type.ty == Terror)
+                    if (fd.errors || fd.type.ty == TY.error)
                         return 0;
 
                     auto tf = cast(TypeFunction)fd.type;
@@ -2659,11 +2659,11 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
 extern (C++) Type getIndirection(Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Tarray || t.ty == Tpointer)
+    if (t.ty == TY.array || t.ty == TY.pointer)
         return t.nextOf().toBasetype();
-    if (t.ty == Taarray || t.ty == Tclass)
+    if (t.ty == TY.aarray || t.ty == TY.class_)
         return t;
-    if (t.ty == Tstruct)
+    if (t.ty == TY.struct_)
         return t.hasPointers() ? t : null; // TODO
 
     // should consider TypeDelegate?
@@ -2726,7 +2726,7 @@ private bool traverseIndirections(Type ta, Type tb)
                 // if source is the same as target or can be const-converted to target
                 source.constConv(target) != MATCH.nomatch ||
                 // if target is void and source can be const-converted to target
-                (target.ty == Tvoid && MODimplicitConv(source.mod, target.mod));
+                (target.ty == TY.void_ && MODimplicitConv(source.mod, target.mod));
         }
 
         if (mayAliasDirect(reversePass ? tb : ta, reversePass ? ta : tb))
@@ -2740,7 +2740,7 @@ private bool traverseIndirections(Type ta, Type tb)
              return true;
         }
 
-        if (tb.ty == Tclass || tb.ty == Tstruct)
+        if (tb.ty == TY.class_ || tb.ty == TY.struct_)
         {
             for (Ctxt* c = ctxt; c; c = c.prev)
                 if (tb == c.type)
@@ -2760,7 +2760,7 @@ private bool traverseIndirections(Type ta, Type tb)
                     return false;
             }
         }
-        else if (tb.ty == Tarray || tb.ty == Taarray || tb.ty == Tpointer)
+        else if (tb.ty == TY.array || tb.ty == TY.aarray || tb.ty == TY.pointer)
         {
             Type tind = tb.nextOf();
             if (!traverse(ta, tind, ctxt, reversePass))

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -738,11 +738,11 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (fd.semanticRun >= PASS.obj) // if toObjFile() already run
         return;
 
-    if (fd.type && fd.type.ty == Tfunction && (cast(TypeFunction)fd.type).next is null)
+    if (fd.type && fd.type.ty == TY.function_ && (cast(TypeFunction)fd.type).next is null)
         return;
 
     // If errors occurred compiling it, such as https://issues.dlang.org/show_bug.cgi?id=6118
-    if (fd.type && fd.type.ty == Tfunction && (cast(TypeFunction)fd.type).next.ty == Terror)
+    if (fd.type && fd.type.ty == TY.function_ && (cast(TypeFunction)fd.type).next.ty == TY.error)
         return;
 
     if (fd.semantic3Errors)
@@ -990,7 +990,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     //printf("linkage = %d, tyf = x%x\n", linkage, tyf);
     int reverse = tyrevfunc(s.Stype.Tty);
 
-    assert(fd.type.ty == Tfunction);
+    assert(fd.type.ty == TY.function_);
     TypeFunction tf = cast(TypeFunction)fd.type;
     RET retmethod = retStyle(tf);
     if (retmethod == RET.stack)
@@ -1377,78 +1377,78 @@ uint totym(Type tx)
     uint t;
     switch (tx.ty)
     {
-        case Tvoid:     t = TYvoid;     break;
-        case Tint8:     t = TYschar;    break;
-        case Tuns8:     t = TYuchar;    break;
-        case Tint16:    t = TYshort;    break;
-        case Tuns16:    t = TYushort;   break;
-        case Tint32:    t = TYint;      break;
-        case Tuns32:    t = TYuint;     break;
-        case Tint64:    t = TYllong;    break;
-        case Tuns64:    t = TYullong;   break;
-        case Tfloat32:  t = TYfloat;    break;
-        case Tfloat64:  t = TYdouble;   break;
-        case Tfloat80:  t = TYldouble;  break;
-        case Timaginary32: t = TYifloat; break;
-        case Timaginary64: t = TYidouble; break;
-        case Timaginary80: t = TYildouble; break;
-        case Tcomplex32: t = TYcfloat;  break;
-        case Tcomplex64: t = TYcdouble; break;
-        case Tcomplex80: t = TYcldouble; break;
-        case Tbool:     t = TYbool;     break;
-        case Tchar:     t = TYchar;     break;
-        case Twchar:    t = TYwchar_t;  break;
-        case Tdchar:
+        case TY.void_:     t = TYvoid;     break;
+        case TY.int8:     t = TYschar;    break;
+        case TY.uns8:     t = TYuchar;    break;
+        case TY.int16:    t = TYshort;    break;
+        case TY.uns16:    t = TYushort;   break;
+        case TY.int32:    t = TYint;      break;
+        case TY.uns32:    t = TYuint;     break;
+        case TY.int64:    t = TYllong;    break;
+        case TY.uns64:    t = TYullong;   break;
+        case TY.float32:  t = TYfloat;    break;
+        case TY.float64:  t = TYdouble;   break;
+        case TY.float80:  t = TYldouble;  break;
+        case TY.imaginary32: t = TYifloat; break;
+        case TY.imaginary64: t = TYidouble; break;
+        case TY.imaginary80: t = TYildouble; break;
+        case TY.complex32: t = TYcfloat;  break;
+        case TY.complex64: t = TYcdouble; break;
+        case TY.complex80: t = TYcldouble; break;
+        case TY.bool_:     t = TYbool;     break;
+        case TY.char_:     t = TYchar;     break;
+        case TY.wchar_:    t = TYwchar_t;  break;
+        case TY.dchar_:
             t = (global.params.symdebug == 1 || !global.params.isWindows) ? TYdchar : TYulong;
             break;
 
-        case Taarray:   t = TYaarray;   break;
-        case Tclass:
-        case Treference:
-        case Tpointer:  t = TYnptr;     break;
-        case Tdelegate: t = TYdelegate; break;
-        case Tarray:    t = TYdarray;   break;
-        case Tsarray:   t = TYstruct;   break;
+        case TY.aarray:   t = TYaarray;   break;
+        case TY.class_:
+        case TY.reference:
+        case TY.pointer:  t = TYnptr;     break;
+        case TY.delegate_: t = TYdelegate; break;
+        case TY.array:    t = TYdarray;   break;
+        case TY.sarray:   t = TYstruct;   break;
 
-        case Tstruct:
+        case TY.struct_:
             t = TYstruct;
             if (tx.toDsymbol(null).ident == Id.__c_long_double)
                 t = TYdouble;
             break;
 
-        case Tenum:
+        case TY.enum_:
             t = totym(tx.toBasetype());
             break;
 
-        case Tident:
-        case Ttypeof:
+        case TY.ident:
+        case TY.typeof_:
             //printf("ty = %d, '%s'\n", tx.ty, tx.toChars());
             error(Loc(), "forward reference of `%s`", tx.toChars());
             t = TYint;
             break;
 
-        case Tnull:
+        case TY.null_:
             t = TYnptr;
             break;
 
-        case Tvector:
+        case TY.vector:
         {
             TypeVector tv = cast(TypeVector)tx;
             TypeBasic tb = tv.elementType();
             const s32 = tv.alignsize() == 32;   // if 32 byte, 256 bit vector
             switch (tb.ty)
             {
-                case Tvoid:
-                case Tint8:     t = s32 ? TYschar32  : TYschar16;  break;
-                case Tuns8:     t = s32 ? TYuchar32  : TYuchar16;  break;
-                case Tint16:    t = s32 ? TYshort16  : TYshort8;   break;
-                case Tuns16:    t = s32 ? TYushort16 : TYushort8;  break;
-                case Tint32:    t = s32 ? TYlong8    : TYlong4;    break;
-                case Tuns32:    t = s32 ? TYulong8   : TYulong4;   break;
-                case Tint64:    t = s32 ? TYllong4   : TYllong2;   break;
-                case Tuns64:    t = s32 ? TYullong4  : TYullong2;  break;
-                case Tfloat32:  t = s32 ? TYfloat8   : TYfloat4;   break;
-                case Tfloat64:  t = s32 ? TYdouble4  : TYdouble2;  break;
+                case TY.void_:
+                case TY.int8:     t = s32 ? TYschar32  : TYschar16;  break;
+                case TY.uns8:     t = s32 ? TYuchar32  : TYuchar16;  break;
+                case TY.int16:    t = s32 ? TYshort16  : TYshort8;   break;
+                case TY.uns16:    t = s32 ? TYushort16 : TYushort8;  break;
+                case TY.int32:    t = s32 ? TYlong8    : TYlong4;    break;
+                case TY.uns32:    t = s32 ? TYulong8   : TYulong4;   break;
+                case TY.int64:    t = s32 ? TYllong4   : TYllong2;   break;
+                case TY.uns64:    t = s32 ? TYullong4  : TYullong2;  break;
+                case TY.float32:  t = s32 ? TYfloat8   : TYfloat4;   break;
+                case TY.float64:  t = s32 ? TYdouble4  : TYdouble2;  break;
                 default:
                     assert(0);
             }
@@ -1456,7 +1456,7 @@ uint totym(Type tx)
             break;
         }
 
-        case Tfunction:
+        case TY.function_:
         {
             TypeFunction tf = cast(TypeFunction)tx;
             switch (tf.linkage)
@@ -1533,7 +1533,7 @@ uint totym(Type tx)
 
 Symbol *toSymbol(Type t)
 {
-    if (t.ty == Tclass)
+    if (t.ty == TY.class_)
     {
         return toSymbol((cast(TypeClass)t).sym);
     }

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1375,7 +1375,7 @@ bool onlyOneMain(Loc loc)
 uint totym(Type tx)
 {
     uint t;
-    switch (tx.ty)
+    final switch (tx.ty)
     {
         case TY.void_:     t = TYvoid;     break;
         case TY.int8:     t = TYschar;    break;
@@ -1495,7 +1495,15 @@ uint totym(Type tx)
                 t |= mTYnothrow;
             return t;
         }
-        default:
+        case TY.none:
+        case TY.error:
+        case TY.instance:
+        case TY.tuple:
+        case TY.slice:
+        case TY.return_:
+        case TY.int128:
+        case TY.uns128:
+        case TY.MAX:
             //printf("ty = %d, '%s'\n", tx.ty, tx.toChars());
             assert(0);
     }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -719,7 +719,7 @@ public:
      */
     void typeToBuffer(Type t, Identifier ident)
     {
-        if (t.ty == Tfunction)
+        if (t.ty == TY.function_)
         {
             visitFuncIdentWithPrefix(cast(TypeFunction)t, ident, null, true);
             return;
@@ -735,7 +735,7 @@ public:
     void visitWithMask(Type t, ubyte modMask)
     {
         // Tuples and functions don't use the type constructor syntax
-        if (modMask == t.mod || t.ty == Tfunction || t.ty == Ttuple)
+        if (modMask == t.mod || t.ty == TY.function_ || t.ty == TY.tuple)
         {
             t.accept(this);
         }
@@ -830,7 +830,7 @@ public:
     override void visit(TypePointer t)
     {
         //printf("TypePointer::toCBuffer2() next = %d\n", t.next.ty);
-        if (t.next.ty == Tfunction)
+        if (t.next.ty == TY.function_)
             visitFuncIdentWithPostfix(cast(TypeFunction)t.next, "function");
         else
         {
@@ -1597,7 +1597,7 @@ public:
             RootObject oarg = (*ti.tiargs)[0];
             if (Type t = isType(oarg))
             {
-                if (t.equals(Type.tstring) || t.equals(Type.twstring) || t.equals(Type.tdstring) || t.mod == 0 && (t.isTypeBasic() || t.ty == Tident && (cast(TypeIdentifier)t).idents.dim == 0))
+                if (t.equals(Type.tstring) || t.equals(Type.twstring) || t.equals(Type.tdstring) || t.mod == 0 && (t.isTypeBasic() || t.ty == TY.ident && (cast(TypeIdentifier)t).idents.dim == 0))
                 {
                     buf.writestring(t.toChars());
                     return;
@@ -1806,7 +1806,7 @@ public:
                 buf.writeByte(' ');
             d.aliassym.accept(this);
         }
-        else if (d.type.ty == Tfunction)
+        else if (d.type.ty == TY.function_)
         {
             if (stcToBuffer(buf, d.storage_class))
                 buf.writeByte(' ');
@@ -1942,7 +1942,7 @@ public:
 
     override void visit(FuncLiteralDeclaration f)
     {
-        if (f.type.ty == Terror)
+        if (f.type.ty == TY.error)
         {
             buf.writestring("__error");
             return;
@@ -2242,7 +2242,7 @@ public:
         L1:
             switch (t.ty)
             {
-            case Tenum:
+            case TY.enum_:
                 {
                     TypeEnum te = cast(TypeEnum)t;
                     if (hgs.fullDump)
@@ -2264,9 +2264,9 @@ public:
                     t = te.sym.memtype;
                     goto L1;
                 }
-            case Twchar:
+            case TY.wchar_:
                 // BUG: need to cast(wchar)
-            case Tdchar:
+            case TY.dchar_:
                 // BUG: need to cast(dchar)
                 if (cast(uinteger_t)v > 0xFF)
                 {
@@ -2274,7 +2274,7 @@ public:
                     break;
                 }
                 goto case;
-            case Tchar:
+            case TY.char_:
                 {
                     size_t o = buf.offset;
                     if (v == '\'')
@@ -2287,37 +2287,37 @@ public:
                         escapeDdocString(buf, o);
                     break;
                 }
-            case Tint8:
+            case TY.int8:
                 buf.writestring("cast(byte)");
                 goto L2;
-            case Tint16:
+            case TY.int16:
                 buf.writestring("cast(short)");
                 goto L2;
-            case Tint32:
+            case TY.int32:
             L2:
                 buf.printf("%d", cast(int)v);
                 break;
-            case Tuns8:
+            case TY.uns8:
                 buf.writestring("cast(ubyte)");
                 goto L3;
-            case Tuns16:
+            case TY.uns16:
                 buf.writestring("cast(ushort)");
                 goto L3;
-            case Tuns32:
+            case TY.uns32:
             L3:
                 buf.printf("%uu", cast(uint)v);
                 break;
-            case Tint64:
+            case TY.int64:
                 buf.printf("%lldL", v);
                 break;
-            case Tuns64:
+            case TY.uns64:
             L4:
                 buf.printf("%lluLU", v);
                 break;
-            case Tbool:
+            case TY.bool_:
                 buf.writestring(v ? "true" : "false");
                 break;
-            case Tpointer:
+            case TY.pointer:
                 buf.writestring("cast(");
                 buf.writestring(t.toChars());
                 buf.writeByte(')');
@@ -2375,14 +2375,14 @@ public:
             Type t = type.toBasetype();
             switch (t.ty)
             {
-            case Tfloat32:
-            case Timaginary32:
-            case Tcomplex32:
+            case TY.float32:
+            case TY.imaginary32:
+            case TY.complex32:
                 buf.writeByte('F');
                 break;
-            case Tfloat80:
-            case Timaginary80:
-            case Tcomplex80:
+            case TY.float80:
+            case TY.imaginary80:
+            case TY.complex80:
                 buf.writeByte('L');
                 break;
             default:
@@ -3073,7 +3073,7 @@ public:
             if (p.ident)
                 buf.writestring(p.ident.toString());
         }
-        else if (p.type.ty == Tident &&
+        else if (p.type.ty == TY.ident &&
                  (cast(TypeIdentifier)p.type).ident.toString().length > 3 &&
                  strncmp((cast(TypeIdentifier)p.type).ident.toChars(), "__T", 3) == 0)
         {

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -1008,15 +1008,15 @@ version (none)
     {
         switch (popnd.ptype.ty)
         {
-            case Tfloat32:
+            case TY.float32:
                 popnd.s = fconst(popnd.vreal);
                 return(CONSTRUCT_FLAGS(_32, _m, _normal, 0));
 
-            case Tfloat64:
+            case TY.float64:
                 popnd.s = dconst(popnd.vreal);
                 return(CONSTRUCT_FLAGS(0, _m, _normal, _f64));
 
-            case Tfloat80:
+            case TY.float80:
                 popnd.s = ldconst(popnd.vreal);
                 return(CONSTRUCT_FLAGS(0, _m, _normal, _f80));
         }
@@ -1118,12 +1118,12 @@ opflag_t asm_determine_operand_flags(OPND *popnd)
         if (!popnd.ptype)
             return CONSTRUCT_FLAGS(sz, _m, _normal, 0);
         ty = popnd.ptype.ty;
-        if (ty == Tpointer && popnd.ptype.nextOf().ty == Tfunction &&
+        if (ty == TY.pointer && popnd.ptype.nextOf().ty == TY.function_ &&
             !ps.isVarDeclaration())
         {
             return CONSTRUCT_FLAGS(_32, _m, _fn16, 0);
         }
-        else if (ty == Tfunction)
+        else if (ty == TY.function_)
         {
             return CONSTRUCT_FLAGS(_32, _rel, _fn16, 0);
         }
@@ -2224,7 +2224,7 @@ void asm_merge_symbol(ref OPND o1, Dsymbol s)
             goto L2;
         }
         if ((v.isConst() || v.isImmutable() || v.storage_class & STC.manifest) &&
-            !v.type.isfloating() && v.type.ty != Tvector && v._init)
+            !v.type.isfloating() && v.type.ty != TY.vector && v._init)
         {
             ExpInitializer ei = v._init.isExpInitializer();
             if (ei)
@@ -3258,7 +3258,7 @@ uint asm_type_size(Type ptype)
 
     //if (ptype) printf("asm_type_size('%s') = %d\n", ptype.toChars(), (int)ptype.size());
     u = _anysize;
-    if (ptype && ptype.ty != Tfunction /*&& ptype.isscalar()*/)
+    if (ptype && ptype.ty != TY.function_ /*&& ptype.isscalar()*/)
     {
         switch (cast(int)ptype.size())
         {
@@ -4272,7 +4272,7 @@ void asm_primary_exp(out OPND o1)
                 if (o1.ptype && asmstate.tokValue != TOKcomma && asmstate.tokValue != TOKeof)
                 {
                     for (;
-                         o1.ptype.ty == Tsarray;
+                         o1.ptype.ty == TY.sarray;
                          o1.ptype = o1.ptype.nextOf())
                     {
                     }

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -14,17 +14,17 @@ module dmd.impcnvtab;
 
 import dmd.mtype;
 
-immutable ENUMTY[TMAX][TMAX] impcnvResult = impCnvTab.impcnvResultTab;
-immutable ENUMTY[TMAX][TMAX] impcnvType1 = impCnvTab.impcnvType1Tab;
-immutable ENUMTY[TMAX][TMAX] impcnvType2 = impCnvTab.impcnvType2Tab;
+immutable TY[TMAX][TMAX] impcnvResult = impCnvTab.impcnvResultTab;
+immutable TY[TMAX][TMAX] impcnvType1 = impCnvTab.impcnvType1Tab;
+immutable TY[TMAX][TMAX] impcnvType2 = impCnvTab.impcnvType2Tab;
 
 private:
 
 struct ImpCnvTab
 {
-    ENUMTY[TMAX][TMAX] impcnvResultTab;
-    ENUMTY[TMAX][TMAX] impcnvType1Tab;
-    ENUMTY[TMAX][TMAX] impcnvType2Tab;
+    TY[TMAX][TMAX] impcnvResultTab;
+    TY[TMAX][TMAX] impcnvType1Tab;
+    TY[TMAX][TMAX] impcnvType2Tab;
 }
 
 enum ImpCnvTab impCnvTab = generateImpCnvTab();
@@ -44,7 +44,7 @@ ImpCnvTab generateImpCnvTab()
         }
     }
 
-    void X(ENUMTY t1, ENUMTY t2, ENUMTY nt1, ENUMTY nt2, ENUMTY rt)
+    void X(TY t1, TY t2, TY nt1, TY nt2, TY rt)
     {
         impCnvTab.impcnvResultTab[t1][t2] = rt;
         impCnvTab.impcnvType1Tab[t1][t2] = nt1;

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -14,17 +14,17 @@ module dmd.impcnvtab;
 
 import dmd.mtype;
 
-immutable TY[TMAX][TMAX] impcnvResult = impCnvTab.impcnvResultTab;
-immutable TY[TMAX][TMAX] impcnvType1 = impCnvTab.impcnvType1Tab;
-immutable TY[TMAX][TMAX] impcnvType2 = impCnvTab.impcnvType2Tab;
+immutable TY[TY.MAX][TY.MAX] impcnvResult = impCnvTab.impcnvResultTab;
+immutable TY[TY.MAX][TY.MAX] impcnvType1 = impCnvTab.impcnvType1Tab;
+immutable TY[TY.MAX][TY.MAX] impcnvType2 = impCnvTab.impcnvType2Tab;
 
 private:
 
 struct ImpCnvTab
 {
-    TY[TMAX][TMAX] impcnvResultTab;
-    TY[TMAX][TMAX] impcnvType1Tab;
-    TY[TMAX][TMAX] impcnvType2Tab;
+    TY[TY.MAX][TY.MAX] impcnvResultTab;
+    TY[TY.MAX][TY.MAX] impcnvType1Tab;
+    TY[TY.MAX][TY.MAX] impcnvType2Tab;
 }
 
 enum ImpCnvTab impCnvTab = generateImpCnvTab();
@@ -34,13 +34,13 @@ ImpCnvTab generateImpCnvTab()
     ImpCnvTab impCnvTab;
 
     // Set conversion tables
-    foreach (i; 0 .. cast(size_t)TMAX)
+    foreach (i; 0 .. cast(size_t)TY.MAX)
     {
-        foreach (j; 0 .. cast(size_t)TMAX)
+        foreach (j; 0 .. cast(size_t)TY.MAX)
         {
-            impCnvTab.impcnvResultTab[i][j] = Terror;
-            impCnvTab.impcnvType1Tab[i][j] = Terror;
-            impCnvTab.impcnvType2Tab[i][j] = Terror;
+            impCnvTab.impcnvResultTab[i][j] = TY.error;
+            impCnvTab.impcnvType1Tab[i][j] = TY.error;
+            impCnvTab.impcnvType2Tab[i][j] = TY.error;
         }
     }
 
@@ -53,299 +53,299 @@ ImpCnvTab generateImpCnvTab()
 
     /* ======================= */
 
-    X(Tbool,Tbool,   Tbool,Tbool,    Tbool);
-    X(Tbool,Tint8,   Tint32,Tint32,  Tint32);
-    X(Tbool,Tuns8,   Tint32,Tint32,  Tint32);
-    X(Tbool,Tint16,  Tint32,Tint32,  Tint32);
-    X(Tbool,Tuns16,  Tint32,Tint32,  Tint32);
-    X(Tbool,Tint32,  Tint32,Tint32,  Tint32);
-    X(Tbool,Tuns32,  Tuns32,Tuns32,  Tuns32);
-    X(Tbool,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tbool,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tbool,Tint128, Tint128,Tint128, Tint128);
-    X(Tbool,Tuns128, Tuns128,Tuns128, Tuns128);
+    X(TY.bool_,TY.bool_,   TY.bool_,TY.bool_,    TY.bool_);
+    X(TY.bool_,TY.int8,   TY.int32,TY.int32,  TY.int32);
+    X(TY.bool_,TY.uns8,   TY.int32,TY.int32,  TY.int32);
+    X(TY.bool_,TY.int16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.bool_,TY.uns16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.bool_,TY.int32,  TY.int32,TY.int32,  TY.int32);
+    X(TY.bool_,TY.uns32,  TY.uns32,TY.uns32,  TY.uns32);
+    X(TY.bool_,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.bool_,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.bool_,TY.int128, TY.int128,TY.int128, TY.int128);
+    X(TY.bool_,TY.uns128, TY.uns128,TY.uns128, TY.uns128);
 
-    X(Tbool,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tbool,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tbool,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tbool,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tbool,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tbool,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tbool,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tbool,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tbool,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
-
-    /* ======================= */
-
-    X(Tint8,Tint8,   Tint32,Tint32,  Tint32);
-    X(Tint8,Tuns8,   Tint32,Tint32,  Tint32);
-    X(Tint8,Tint16,  Tint32,Tint32,  Tint32);
-    X(Tint8,Tuns16,  Tint32,Tint32,  Tint32);
-    X(Tint8,Tint32,  Tint32,Tint32,  Tint32);
-    X(Tint8,Tuns32,  Tuns32,Tuns32,  Tuns32);
-    X(Tint8,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tint8,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tint8,Tint128, Tint128,Tint128, Tint128);
-    X(Tint8,Tuns128, Tuns128,Tuns128, Tuns128);
-
-    X(Tint8,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tint8,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tint8,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tint8,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tint8,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tint8,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tint8,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tint8,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tint8,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
+    X(TY.bool_,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.bool_,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.bool_,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.bool_,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.bool_,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.bool_,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.bool_,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.bool_,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.bool_,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Tuns8,Tuns8,   Tint32,Tint32,  Tint32);
-    X(Tuns8,Tint16,  Tint32,Tint32,  Tint32);
-    X(Tuns8,Tuns16,  Tint32,Tint32,  Tint32);
-    X(Tuns8,Tint32,  Tint32,Tint32,  Tint32);
-    X(Tuns8,Tuns32,  Tuns32,Tuns32,  Tuns32);
-    X(Tuns8,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tuns8,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tuns8,Tint128,  Tint128,Tint128,  Tint128);
-    X(Tuns8,Tuns128,  Tuns128,Tuns128,  Tuns128);
+    X(TY.int8,TY.int8,   TY.int32,TY.int32,  TY.int32);
+    X(TY.int8,TY.uns8,   TY.int32,TY.int32,  TY.int32);
+    X(TY.int8,TY.int16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.int8,TY.uns16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.int8,TY.int32,  TY.int32,TY.int32,  TY.int32);
+    X(TY.int8,TY.uns32,  TY.uns32,TY.uns32,  TY.uns32);
+    X(TY.int8,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.int8,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.int8,TY.int128, TY.int128,TY.int128, TY.int128);
+    X(TY.int8,TY.uns128, TY.uns128,TY.uns128, TY.uns128);
 
-    X(Tuns8,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tuns8,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tuns8,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tuns8,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tuns8,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tuns8,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tuns8,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tuns8,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tuns8,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
-
-    /* ======================= */
-
-    X(Tint16,Tint16,  Tint32,Tint32,  Tint32);
-    X(Tint16,Tuns16,  Tint32,Tint32,  Tint32);
-    X(Tint16,Tint32,  Tint32,Tint32,  Tint32);
-    X(Tint16,Tuns32,  Tuns32,Tuns32,  Tuns32);
-    X(Tint16,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tint16,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tint16,Tint128,  Tint128,Tint128,  Tint128);
-    X(Tint16,Tuns128,  Tuns128,Tuns128,  Tuns128);
-
-    X(Tint16,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tint16,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tint16,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tint16,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tint16,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tint16,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tint16,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tint16,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tint16,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
+    X(TY.int8,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.int8,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.int8,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.int8,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.int8,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.int8,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.int8,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.int8,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.int8,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Tuns16,Tuns16,  Tint32,Tint32,  Tint32);
-    X(Tuns16,Tint32,  Tint32,Tint32,  Tint32);
-    X(Tuns16,Tuns32,  Tuns32,Tuns32,  Tuns32);
-    X(Tuns16,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tuns16,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tuns16,Tint128, Tint128,Tint128,  Tint128);
-    X(Tuns16,Tuns128, Tuns128,Tuns128,  Tuns128);
+    X(TY.uns8,TY.uns8,   TY.int32,TY.int32,  TY.int32);
+    X(TY.uns8,TY.int16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.uns8,TY.uns16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.uns8,TY.int32,  TY.int32,TY.int32,  TY.int32);
+    X(TY.uns8,TY.uns32,  TY.uns32,TY.uns32,  TY.uns32);
+    X(TY.uns8,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.uns8,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.uns8,TY.int128,  TY.int128,TY.int128,  TY.int128);
+    X(TY.uns8,TY.uns128,  TY.uns128,TY.uns128,  TY.uns128);
 
-    X(Tuns16,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tuns16,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tuns16,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tuns16,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tuns16,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tuns16,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tuns16,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tuns16,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tuns16,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
-
-    /* ======================= */
-
-    X(Tint32,Tint32,  Tint32,Tint32,  Tint32);
-    X(Tint32,Tuns32,  Tuns32,Tuns32,  Tuns32);
-    X(Tint32,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tint32,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tint32,Tint128, Tint128,Tint128,  Tint128);
-    X(Tint32,Tuns128, Tuns128,Tuns128,  Tuns128);
-
-    X(Tint32,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tint32,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tint32,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tint32,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tint32,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tint32,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tint32,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tint32,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tint32,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
+    X(TY.uns8,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.uns8,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.uns8,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.uns8,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.uns8,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.uns8,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.uns8,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.uns8,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.uns8,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Tuns32,Tuns32,  Tuns32,Tuns32,  Tuns32);
-    X(Tuns32,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tuns32,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tuns32,Tint128,  Tint128,Tint128,  Tint128);
-    X(Tuns32,Tuns128,  Tuns128,Tuns128,  Tuns128);
+    X(TY.int16,TY.int16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.int16,TY.uns16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.int16,TY.int32,  TY.int32,TY.int32,  TY.int32);
+    X(TY.int16,TY.uns32,  TY.uns32,TY.uns32,  TY.uns32);
+    X(TY.int16,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.int16,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.int16,TY.int128,  TY.int128,TY.int128,  TY.int128);
+    X(TY.int16,TY.uns128,  TY.uns128,TY.uns128,  TY.uns128);
 
-    X(Tuns32,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tuns32,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tuns32,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tuns32,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tuns32,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tuns32,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tuns32,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tuns32,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tuns32,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
-
-    /* ======================= */
-
-    X(Tint64,Tint64,  Tint64,Tint64,  Tint64);
-    X(Tint64,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tint64,Tint128,  Tint128,Tint128,  Tint128);
-    X(Tint64,Tuns128,  Tuns128,Tuns128,  Tuns128);
-
-    X(Tint64,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tint64,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tint64,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tint64,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tint64,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tint64,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tint64,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tint64,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tint64,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
+    X(TY.int16,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.int16,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.int16,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.int16,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.int16,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.int16,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.int16,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.int16,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.int16,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Tuns64,Tuns64,  Tuns64,Tuns64,  Tuns64);
-    X(Tuns64,Tint128,  Tint128,Tint128,  Tint128);
-    X(Tuns64,Tuns128,  Tuns128,Tuns128,  Tuns128);
+    X(TY.uns16,TY.uns16,  TY.int32,TY.int32,  TY.int32);
+    X(TY.uns16,TY.int32,  TY.int32,TY.int32,  TY.int32);
+    X(TY.uns16,TY.uns32,  TY.uns32,TY.uns32,  TY.uns32);
+    X(TY.uns16,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.uns16,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.uns16,TY.int128, TY.int128,TY.int128,  TY.int128);
+    X(TY.uns16,TY.uns128, TY.uns128,TY.uns128,  TY.uns128);
 
-    X(Tuns64,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tuns64,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tuns64,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tuns64,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tuns64,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tuns64,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tuns64,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tuns64,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tuns64,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
-
-    /* ======================= */
-
-    X(Tint128,Tint128,  Tint128,Tint128,  Tint128);
-    X(Tint128,Tuns128,  Tuns128,Tuns128,  Tuns128);
-
-    X(Tint128,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tint128,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tint128,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tint128,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tint128,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tint128,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tint128,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tint128,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tint128,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
+    X(TY.uns16,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.uns16,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.uns16,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.uns16,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.uns16,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.uns16,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.uns16,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.uns16,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.uns16,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Tuns128,Tuns128,  Tuns128,Tuns128,  Tuns128);
+    X(TY.int32,TY.int32,  TY.int32,TY.int32,  TY.int32);
+    X(TY.int32,TY.uns32,  TY.uns32,TY.uns32,  TY.uns32);
+    X(TY.int32,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.int32,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.int32,TY.int128, TY.int128,TY.int128,  TY.int128);
+    X(TY.int32,TY.uns128, TY.uns128,TY.uns128,  TY.uns128);
 
-    X(Tuns128,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
-    X(Tuns128,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
-    X(Tuns128,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
-    X(Tuns128,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
-    X(Tuns128,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
-    X(Tuns128,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
-    X(Tuns128,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
-    X(Tuns128,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
-    X(Tuns128,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
-
-    /* ======================= */
-
-    X(Tfloat32,Tfloat32,  Tfloat32,Tfloat32, Tfloat32);
-    X(Tfloat32,Tfloat64,  Tfloat64,Tfloat64, Tfloat64);
-    X(Tfloat32,Tfloat80,  Tfloat80,Tfloat80, Tfloat80);
-
-    X(Tfloat32,Timaginary32,  Tfloat32,Timaginary32, Tfloat32);
-    X(Tfloat32,Timaginary64,  Tfloat64,Timaginary64, Tfloat64);
-    X(Tfloat32,Timaginary80,  Tfloat80,Timaginary80, Tfloat80);
-
-    X(Tfloat32,Tcomplex32,  Tfloat32,Tcomplex32, Tcomplex32);
-    X(Tfloat32,Tcomplex64,  Tfloat64,Tcomplex64, Tcomplex64);
-    X(Tfloat32,Tcomplex80,  Tfloat80,Tcomplex80, Tcomplex80);
+    X(TY.int32,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.int32,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.int32,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.int32,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.int32,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.int32,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.int32,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.int32,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.int32,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Tfloat64,Tfloat64,  Tfloat64,Tfloat64, Tfloat64);
-    X(Tfloat64,Tfloat80,  Tfloat80,Tfloat80, Tfloat80);
+    X(TY.uns32,TY.uns32,  TY.uns32,TY.uns32,  TY.uns32);
+    X(TY.uns32,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.uns32,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.uns32,TY.int128,  TY.int128,TY.int128,  TY.int128);
+    X(TY.uns32,TY.uns128,  TY.uns128,TY.uns128,  TY.uns128);
 
-    X(Tfloat64,Timaginary32,  Tfloat64,Timaginary64, Tfloat64);
-    X(Tfloat64,Timaginary64,  Tfloat64,Timaginary64, Tfloat64);
-    X(Tfloat64,Timaginary80,  Tfloat80,Timaginary80, Tfloat80);
-
-    X(Tfloat64,Tcomplex32,  Tfloat64,Tcomplex64, Tcomplex64);
-    X(Tfloat64,Tcomplex64,  Tfloat64,Tcomplex64, Tcomplex64);
-    X(Tfloat64,Tcomplex80,  Tfloat80,Tcomplex80, Tcomplex80);
-
-    /* ======================= */
-
-    X(Tfloat80,Tfloat80,  Tfloat80,Tfloat80, Tfloat80);
-
-    X(Tfloat80,Timaginary32,  Tfloat80,Timaginary80, Tfloat80);
-    X(Tfloat80,Timaginary64,  Tfloat80,Timaginary80, Tfloat80);
-    X(Tfloat80,Timaginary80,  Tfloat80,Timaginary80, Tfloat80);
-
-    X(Tfloat80,Tcomplex32,  Tfloat80,Tcomplex80, Tcomplex80);
-    X(Tfloat80,Tcomplex64,  Tfloat80,Tcomplex80, Tcomplex80);
-    X(Tfloat80,Tcomplex80,  Tfloat80,Tcomplex80, Tcomplex80);
+    X(TY.uns32,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.uns32,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.uns32,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.uns32,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.uns32,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.uns32,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.uns32,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.uns32,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.uns32,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Timaginary32,Timaginary32,  Timaginary32,Timaginary32, Timaginary32);
-    X(Timaginary32,Timaginary64,  Timaginary64,Timaginary64, Timaginary64);
-    X(Timaginary32,Timaginary80,  Timaginary80,Timaginary80, Timaginary80);
+    X(TY.int64,TY.int64,  TY.int64,TY.int64,  TY.int64);
+    X(TY.int64,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.int64,TY.int128,  TY.int128,TY.int128,  TY.int128);
+    X(TY.int64,TY.uns128,  TY.uns128,TY.uns128,  TY.uns128);
 
-    X(Timaginary32,Tcomplex32,  Timaginary32,Tcomplex32, Tcomplex32);
-    X(Timaginary32,Tcomplex64,  Timaginary64,Tcomplex64, Tcomplex64);
-    X(Timaginary32,Tcomplex80,  Timaginary80,Tcomplex80, Tcomplex80);
-
-    /* ======================= */
-
-    X(Timaginary64,Timaginary64,  Timaginary64,Timaginary64, Timaginary64);
-    X(Timaginary64,Timaginary80,  Timaginary80,Timaginary80, Timaginary80);
-
-    X(Timaginary64,Tcomplex32,  Timaginary64,Tcomplex64, Tcomplex64);
-    X(Timaginary64,Tcomplex64,  Timaginary64,Tcomplex64, Tcomplex64);
-    X(Timaginary64,Tcomplex80,  Timaginary80,Tcomplex80, Tcomplex80);
+    X(TY.int64,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.int64,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.int64,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.int64,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.int64,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.int64,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.int64,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.int64,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.int64,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Timaginary80,Timaginary80,  Timaginary80,Timaginary80, Timaginary80);
+    X(TY.uns64,TY.uns64,  TY.uns64,TY.uns64,  TY.uns64);
+    X(TY.uns64,TY.int128,  TY.int128,TY.int128,  TY.int128);
+    X(TY.uns64,TY.uns128,  TY.uns128,TY.uns128,  TY.uns128);
 
-    X(Timaginary80,Tcomplex32,  Timaginary80,Tcomplex80, Tcomplex80);
-    X(Timaginary80,Tcomplex64,  Timaginary80,Tcomplex80, Tcomplex80);
-    X(Timaginary80,Tcomplex80,  Timaginary80,Tcomplex80, Tcomplex80);
-
-    /* ======================= */
-
-    X(Tcomplex32,Tcomplex32,  Tcomplex32,Tcomplex32, Tcomplex32);
-    X(Tcomplex32,Tcomplex64,  Tcomplex64,Tcomplex64, Tcomplex64);
-    X(Tcomplex32,Tcomplex80,  Tcomplex80,Tcomplex80, Tcomplex80);
-
-    /* ======================= */
-
-    X(Tcomplex64,Tcomplex64,  Tcomplex64,Tcomplex64, Tcomplex64);
-    X(Tcomplex64,Tcomplex80,  Tcomplex80,Tcomplex80, Tcomplex80);
+    X(TY.uns64,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.uns64,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.uns64,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.uns64,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.uns64,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.uns64,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.uns64,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.uns64,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.uns64,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
 
     /* ======================= */
 
-    X(Tcomplex80,Tcomplex80,  Tcomplex80,Tcomplex80, Tcomplex80);
+    X(TY.int128,TY.int128,  TY.int128,TY.int128,  TY.int128);
+    X(TY.int128,TY.uns128,  TY.uns128,TY.uns128,  TY.uns128);
 
-    foreach (i; 0 .. cast(size_t)TMAX)
+    X(TY.int128,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.int128,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.int128,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.int128,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.int128,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.int128,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.int128,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.int128,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.int128,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
+
+    /* ======================= */
+
+    X(TY.uns128,TY.uns128,  TY.uns128,TY.uns128,  TY.uns128);
+
+    X(TY.uns128,TY.float32,     TY.float32,TY.float32,     TY.float32);
+    X(TY.uns128,TY.float64,     TY.float64,TY.float64,     TY.float64);
+    X(TY.uns128,TY.float80,     TY.float80,TY.float80,     TY.float80);
+    X(TY.uns128,TY.imaginary32, TY.float32,TY.imaginary32, TY.float32);
+    X(TY.uns128,TY.imaginary64, TY.float64,TY.imaginary64, TY.float64);
+    X(TY.uns128,TY.imaginary80, TY.float80,TY.imaginary80, TY.float80);
+    X(TY.uns128,TY.complex32,   TY.float32,TY.complex32,   TY.complex32);
+    X(TY.uns128,TY.complex64,   TY.float64,TY.complex64,   TY.complex64);
+    X(TY.uns128,TY.complex80,   TY.float80,TY.complex80,   TY.complex80);
+
+    /* ======================= */
+
+    X(TY.float32,TY.float32,  TY.float32,TY.float32, TY.float32);
+    X(TY.float32,TY.float64,  TY.float64,TY.float64, TY.float64);
+    X(TY.float32,TY.float80,  TY.float80,TY.float80, TY.float80);
+
+    X(TY.float32,TY.imaginary32,  TY.float32,TY.imaginary32, TY.float32);
+    X(TY.float32,TY.imaginary64,  TY.float64,TY.imaginary64, TY.float64);
+    X(TY.float32,TY.imaginary80,  TY.float80,TY.imaginary80, TY.float80);
+
+    X(TY.float32,TY.complex32,  TY.float32,TY.complex32, TY.complex32);
+    X(TY.float32,TY.complex64,  TY.float64,TY.complex64, TY.complex64);
+    X(TY.float32,TY.complex80,  TY.float80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.float64,TY.float64,  TY.float64,TY.float64, TY.float64);
+    X(TY.float64,TY.float80,  TY.float80,TY.float80, TY.float80);
+
+    X(TY.float64,TY.imaginary32,  TY.float64,TY.imaginary64, TY.float64);
+    X(TY.float64,TY.imaginary64,  TY.float64,TY.imaginary64, TY.float64);
+    X(TY.float64,TY.imaginary80,  TY.float80,TY.imaginary80, TY.float80);
+
+    X(TY.float64,TY.complex32,  TY.float64,TY.complex64, TY.complex64);
+    X(TY.float64,TY.complex64,  TY.float64,TY.complex64, TY.complex64);
+    X(TY.float64,TY.complex80,  TY.float80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.float80,TY.float80,  TY.float80,TY.float80, TY.float80);
+
+    X(TY.float80,TY.imaginary32,  TY.float80,TY.imaginary80, TY.float80);
+    X(TY.float80,TY.imaginary64,  TY.float80,TY.imaginary80, TY.float80);
+    X(TY.float80,TY.imaginary80,  TY.float80,TY.imaginary80, TY.float80);
+
+    X(TY.float80,TY.complex32,  TY.float80,TY.complex80, TY.complex80);
+    X(TY.float80,TY.complex64,  TY.float80,TY.complex80, TY.complex80);
+    X(TY.float80,TY.complex80,  TY.float80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.imaginary32,TY.imaginary32,  TY.imaginary32,TY.imaginary32, TY.imaginary32);
+    X(TY.imaginary32,TY.imaginary64,  TY.imaginary64,TY.imaginary64, TY.imaginary64);
+    X(TY.imaginary32,TY.imaginary80,  TY.imaginary80,TY.imaginary80, TY.imaginary80);
+
+    X(TY.imaginary32,TY.complex32,  TY.imaginary32,TY.complex32, TY.complex32);
+    X(TY.imaginary32,TY.complex64,  TY.imaginary64,TY.complex64, TY.complex64);
+    X(TY.imaginary32,TY.complex80,  TY.imaginary80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.imaginary64,TY.imaginary64,  TY.imaginary64,TY.imaginary64, TY.imaginary64);
+    X(TY.imaginary64,TY.imaginary80,  TY.imaginary80,TY.imaginary80, TY.imaginary80);
+
+    X(TY.imaginary64,TY.complex32,  TY.imaginary64,TY.complex64, TY.complex64);
+    X(TY.imaginary64,TY.complex64,  TY.imaginary64,TY.complex64, TY.complex64);
+    X(TY.imaginary64,TY.complex80,  TY.imaginary80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.imaginary80,TY.imaginary80,  TY.imaginary80,TY.imaginary80, TY.imaginary80);
+
+    X(TY.imaginary80,TY.complex32,  TY.imaginary80,TY.complex80, TY.complex80);
+    X(TY.imaginary80,TY.complex64,  TY.imaginary80,TY.complex80, TY.complex80);
+    X(TY.imaginary80,TY.complex80,  TY.imaginary80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.complex32,TY.complex32,  TY.complex32,TY.complex32, TY.complex32);
+    X(TY.complex32,TY.complex64,  TY.complex64,TY.complex64, TY.complex64);
+    X(TY.complex32,TY.complex80,  TY.complex80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.complex64,TY.complex64,  TY.complex64,TY.complex64, TY.complex64);
+    X(TY.complex64,TY.complex80,  TY.complex80,TY.complex80, TY.complex80);
+
+    /* ======================= */
+
+    X(TY.complex80,TY.complex80,  TY.complex80,TY.complex80, TY.complex80);
+
+    foreach (i; 0 .. cast(size_t)TY.MAX)
     {
-        foreach (j; 0 .. cast(size_t)TMAX)
+        foreach (j; 0 .. cast(size_t)TY.MAX)
         {
-            if (impCnvTab.impcnvResultTab[i][j] == Terror)
+            if (impCnvTab.impcnvResultTab[i][j] == TY.error)
             {
                 impCnvTab.impcnvResultTab[i][j] = impCnvTab.impcnvResultTab[j][i];
                 impCnvTab.impcnvType1Tab[i][j] = impCnvTab.impcnvType2Tab[j][i];

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -337,7 +337,7 @@ version (all)
             return false;
         }
 
-        if (e.type.ty == Terror)
+        if (e.type.ty == TY.error)
             return false;
         if (e.op == TOKnull)
             return false;
@@ -383,7 +383,7 @@ version (all)
             }
             return true;
         }
-        if (e.type.ty == Tpointer && e.type.nextOf().ty != Tfunction)
+        if (e.type.ty == TY.pointer && e.type.nextOf().ty != TY.function_)
         {
             if (e.op == TOKsymoff) // address of a global is OK
                 return false;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -165,7 +165,7 @@ public:
 
                     Expression e = new CondExp(econd.loc, econd, e1, e2);
                     e.type = e1.type;
-                    if (e.type.ty == Ttuple)
+                    if (e.type.ty == TY.tuple)
                     {
                         e1.type = Type.tvoid;
                         e2.type = Type.tvoid;
@@ -249,7 +249,7 @@ public:
             {
                 result = new CondExp(econd.loc, econd, e1, e2);
                 result.type = e1.type;
-                if (result.type.ty == Ttuple)
+                if (result.type.ty == TY.tuple)
                 {
                     e1.type = Type.tvoid;
                     e2.type = Type.tvoid;
@@ -580,10 +580,10 @@ public:
             visit(cast(UnaExp)e);
 
             Type tb = e.e1.type.toBasetype();
-            if (tb.ty == Tarray)
+            if (tb.ty == TY.array)
             {
                 Type tv = tb.nextOf().baseElemOf();
-                if (tv.ty == Tstruct)
+                if (tv.ty == TY.struct_)
                 {
                     auto ts = cast(TypeStruct)tv;
                     auto sd = ts.sym;
@@ -641,15 +641,15 @@ public:
             visit(cast(BinExp)e);
 
             Type t1 = e.e1.type.toBasetype();
-            if (t1.ty == Tarray || t1.ty == Tsarray)
+            if (t1.ty == TY.array || t1.ty == TY.sarray)
             {
                 Type t = t1.nextOf().toBasetype();
                 while (t.toBasetype().nextOf())
                     t = t.nextOf().toBasetype();
-                if (t.ty == Tstruct)
+                if (t.ty == TY.struct_)
                     semanticTypeInfo(null, t);
             }
-            else if (t1.ty == Taarray)
+            else if (t1.ty == TY.aarray)
             {
                 semanticTypeInfo(null, t1);
             }
@@ -1195,7 +1195,7 @@ public:
             {
                 // delegate literal call
                 auto v = ve.var.isVarDeclaration();
-                if (v && v._init && v.type.ty == Tdelegate && onlyOneAssign(v, parent))
+                if (v && v._init && v.type.ty == TY.delegate_ && onlyOneAssign(v, parent))
                 {
                     //printf("init: %s\n", v._init.toChars());
                     auto ei = v._init.isExpInitializer();
@@ -1229,7 +1229,7 @@ public:
             fd = dve.var.isFuncDeclaration();
             if (fd && fd != parent && canInline(fd, true, false, asStatements))
             {
-                if (dve.e1.op == TOKcall && dve.e1.type.toBasetype().ty == Tstruct)
+                if (dve.e1.op == TOKcall && dve.e1.type.toBasetype().ty == TY.struct_)
                 {
                     /* To create ethis, we'll need to take the address
                      * of dve.e1, but this won't work if dve.e1 is
@@ -1278,7 +1278,7 @@ public:
         if (global.params.verbose && (eresult || sresult))
             fprintf(global.stdmsg, "inlined   %s =>\n          %s\n", fd.toPrettyChars(), parent.toPrettyChars());
 
-        if (eresult && e.type.ty != Tvoid)
+        if (eresult && e.type.ty != TY.void_)
         {
             Expression ex = eresult;
             while (ex.op == TOKcomma)
@@ -1525,7 +1525,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
 
     if (fd.type)
     {
-        assert(fd.type.ty == Tfunction);
+        assert(fd.type.ty == TY.function_);
         TypeFunction tf = cast(TypeFunction)fd.type;
 
         // no variadic parameter lists
@@ -1548,7 +1548,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         static bool hasDtor(Type t)
         {
             auto tv = t.baseElemOf();
-            return tv.ty == Tstruct || tv.ty == Tclass; // for now assume these might have a destructor
+            return tv.ty == TY.struct_ || tv.ty == TY.class_; // for now assume these might have a destructor
         }
 
         /* Don't inline a function that returns non-void, but has
@@ -1560,7 +1560,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
          * 2. don't inline when the return value has a destructor, as it doesn't
          *    get handled properly
          */
-        if (tf.next && tf.next.ty != Tvoid &&
+        if (tf.next && tf.next.ty != TY.void_ &&
             (!(fd.hasReturnExp & 1) ||
              statementsToo && (fd.isArrayOp || hasDtor(tf.next))) &&
             !hdrscan)
@@ -1818,8 +1818,8 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
         }
         else
         {
-            //assert(ethis.type.ty != Tpointer);
-            if (ethis.type.ty == Tpointer)
+            //assert(ethis.type.ty != TY.pointer);
+            if (ethis.type.ty == TY.pointer)
             {
                 Type t = ethis.type.nextOf();
                 ethis = new PtrExp(ethis.loc, ethis);
@@ -1828,7 +1828,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
 
             auto ei = new ExpInitializer(fd.loc, ethis);
             vthis = new VarDeclaration(fd.loc, ethis.type, Id.This, ei);
-            if (ethis.type.ty != Tclass)
+            if (ethis.type.ty != TY.class_)
                 vthis.storage_class = STC.ref_;
             else
                 vthis.storage_class = STC.in_;
@@ -1882,8 +1882,8 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
              * inline scan again because if they are initialized to a symbol,
              * any calls to the fp or dg can be inlined.
              */
-            if (vfrom.type.ty == Tdelegate ||
-                vfrom.type.ty == Tpointer && vfrom.type.nextOf().ty == Tfunction)
+            if (vfrom.type.ty == TY.delegate_ ||
+                vfrom.type.ty == TY.pointer && vfrom.type.nextOf().ty == TY.function_)
             {
                 if (arg.op == TOKvar)
                 {
@@ -1980,7 +1980,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
          * the returned reference is exactly same as vthis, and the 'this' variable
          * already exists at the caller side.
          */
-        if (tf.next.ty == Tstruct && !fd.nrvo_var && !fd.isCtorDeclaration() &&
+        if (tf.next.ty == TY.struct_ && !fd.nrvo_var && !fd.isCtorDeclaration() &&
             !isConstruction(e))
         {
             /* Generate a new variable to hold the result and initialize it with the
@@ -2008,7 +2008,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
         }
 
         // https://issues.dlang.org/show_bug.cgi?id=15210
-        if (tf.next.ty == Tvoid && e && e.type.ty != Tvoid)
+        if (tf.next.ty == TY.void_ && e && e.type.ty != TY.void_)
         {
             e = new CastExp(callLoc, e, Type.tvoid);
             e.type = Type.tvoid;

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -319,7 +319,7 @@ public:
     {
         //printf("VarExp.inlineCost3() %s\n", toChars());
         Type tb = e.type.toBasetype();
-        if (tb.ty == Tstruct)
+        if (tb.ty == TY.struct_)
         {
             StructDeclaration sd = (cast(TypeStruct)tb).sym;
             if (sd.isNested())

--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -327,7 +327,7 @@ struct IntRange
         uinteger_t mask = type.sizemask();
         auto lower = SignExtendedNumber(0);
         auto upper = SignExtendedNumber(mask);
-        if (type.toBasetype().ty == Tdchar)
+        if (type.toBasetype().ty == TY.dchar_)
             upper.value = 0x10FFFFUL;
         else if (!isUnsigned)
         {
@@ -447,7 +447,7 @@ struct IntRange
             return this;
         else if (!type.isunsigned())
             return castSigned(type.sizemask());
-        else if (type.toBasetype().ty == Tdchar)
+        else if (type.toBasetype().ty == TY.dchar_)
             return castDchar();
         else
             return castUnsigned(type.sizemask());
@@ -457,7 +457,7 @@ struct IntRange
     {
         if (!type.isintegral())
             return castUnsigned(UINT64_MAX);
-        else if (type.toBasetype().ty == Tdchar)
+        else if (type.toBasetype().ty == TY.dchar_)
             return castDchar();
         else
             return castUnsigned(type.sizemask());

--- a/src/dmd/irstate.d
+++ b/src/dmd/irstate.d
@@ -243,7 +243,7 @@ struct IRState
                 if (fd)
                 {
                     Type t = fd.type;
-                    if (t.ty == Tfunction && (cast(TypeFunction)t).trust == TRUST.safe)
+                    if (t.ty == TY.function_ && (cast(TypeFunction)t).trust == TRUST.safe)
                         result = true;
                 }
                 break;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -633,7 +633,7 @@ public:
         objectStart();
         jsonProperties(d);
         TypeFunction tf = cast(TypeFunction)d.type;
-        if (tf && tf.ty == Tfunction)
+        if (tf && tf.ty == TY.function_)
             property("parameters", tf.parameters);
         property("endline", "endchar", &d.endloc);
         if (d.foverrides.dim)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -61,8 +61,8 @@ import dmd.visitor;
 enum LOGDOTEXP = 0;         // log ::dotExp()
 enum LOGDEFAULTINIT = 0;    // log ::defaultInit()
 
-extern (C++) __gshared int Tsize_t = Tuns32;
-extern (C++) __gshared int Tptrdiff_t = Tint32;
+extern (C++) __gshared int Tsize_t = TY.uns32;
+extern (C++) __gshared int Tptrdiff_t = TY.int32;
 
 enum SIZE_INVALID = (~cast(d_uns64)0);   // error return from size() functions
 
@@ -274,7 +274,7 @@ Type stripDefaultArgs(Type t)
     if (t is null)
         return t;
 
-    if (t.ty == Tfunction)
+    if (t.ty == TY.function_)
     {
         TypeFunction tf = cast(TypeFunction)t;
         Type tret = stripDefaultArgs(tf.next);
@@ -287,7 +287,7 @@ Type stripDefaultArgs(Type t)
         //printf("strip %s\n   <- %s\n", tf.toChars(), t.toChars());
         t = tf;
     }
-    else if (t.ty == Ttuple)
+    else if (t.ty == TY.tuple)
     {
         TypeTuple tt = cast(TypeTuple)t;
         Parameters* args = stripParams(tt.arguments);
@@ -296,7 +296,7 @@ Type stripDefaultArgs(Type t)
         t = t.copy();
         (cast(TypeTuple)t).arguments = args;
     }
-    else if (t.ty == Tenum)
+    else if (t.ty == TY.enum_)
     {
         // TypeEnum::nextOf() may be != NULL, but it's not necessary here.
         goto Lnot;
@@ -345,7 +345,7 @@ Expression semanticLength(Scope* sc, TupleDeclaration tup, Expression exp)
  */
 Expression semanticLength(Scope* sc, Type t, Expression exp)
 {
-    if (t.ty == Ttuple)
+    if (t.ty == TY.tuple)
     {
         ScopeDsymbol sym = new ArrayScopeSymbol(sc, cast(TypeTuple)t);
         sym.parent = sc.scopesym;
@@ -519,31 +519,31 @@ extern (C++) abstract class Type : RootObject
 
     extern (C++) static __gshared TemplateDeclaration rtinfo;
 
-    extern (C++) static __gshared Type[TMAX] basic;
+    extern (C++) static __gshared Type[TY.MAX] basic;
     extern (C++) static __gshared StringTable stringtable;
 
-    extern (C++) static __gshared ubyte[TMAX] sizeTy = ()
+    extern (C++) static __gshared ubyte[TY.MAX] sizeTy = ()
         {
-            ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
-            sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);
-            sizeTy[Tarray] = __traits(classInstanceSize, TypeDArray);
-            sizeTy[Taarray] = __traits(classInstanceSize, TypeAArray);
-            sizeTy[Tpointer] = __traits(classInstanceSize, TypePointer);
-            sizeTy[Treference] = __traits(classInstanceSize, TypeReference);
-            sizeTy[Tfunction] = __traits(classInstanceSize, TypeFunction);
-            sizeTy[Tdelegate] = __traits(classInstanceSize, TypeDelegate);
-            sizeTy[Tident] = __traits(classInstanceSize, TypeIdentifier);
-            sizeTy[Tinstance] = __traits(classInstanceSize, TypeInstance);
-            sizeTy[Ttypeof] = __traits(classInstanceSize, TypeTypeof);
-            sizeTy[Tenum] = __traits(classInstanceSize, TypeEnum);
-            sizeTy[Tstruct] = __traits(classInstanceSize, TypeStruct);
-            sizeTy[Tclass] = __traits(classInstanceSize, TypeClass);
-            sizeTy[Ttuple] = __traits(classInstanceSize, TypeTuple);
-            sizeTy[Tslice] = __traits(classInstanceSize, TypeSlice);
-            sizeTy[Treturn] = __traits(classInstanceSize, TypeReturn);
-            sizeTy[Terror] = __traits(classInstanceSize, TypeError);
-            sizeTy[Tnull] = __traits(classInstanceSize, TypeNull);
-            sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
+            ubyte[TY.MAX] sizeTy = __traits(classInstanceSize, TypeBasic);
+            sizeTy[TY.sarray] = __traits(classInstanceSize, TypeSArray);
+            sizeTy[TY.array] = __traits(classInstanceSize, TypeDArray);
+            sizeTy[TY.aarray] = __traits(classInstanceSize, TypeAArray);
+            sizeTy[TY.pointer] = __traits(classInstanceSize, TypePointer);
+            sizeTy[TY.reference] = __traits(classInstanceSize, TypeReference);
+            sizeTy[TY.function_] = __traits(classInstanceSize, TypeFunction);
+            sizeTy[TY.delegate_] = __traits(classInstanceSize, TypeDelegate);
+            sizeTy[TY.ident] = __traits(classInstanceSize, TypeIdentifier);
+            sizeTy[TY.instance] = __traits(classInstanceSize, TypeInstance);
+            sizeTy[TY.typeof_] = __traits(classInstanceSize, TypeTypeof);
+            sizeTy[TY.enum_] = __traits(classInstanceSize, TypeEnum);
+            sizeTy[TY.struct_] = __traits(classInstanceSize, TypeStruct);
+            sizeTy[TY.class_] = __traits(classInstanceSize, TypeClass);
+            sizeTy[TY.tuple] = __traits(classInstanceSize, TypeTuple);
+            sizeTy[TY.slice] = __traits(classInstanceSize, TypeSlice);
+            sizeTy[TY.return_] = __traits(classInstanceSize, TypeReturn);
+            sizeTy[TY.error] = __traits(classInstanceSize, TypeError);
+            sizeTy[TY.null_] = __traits(classInstanceSize, TypeNull);
+            sizeTy[TY.vector] = __traits(classInstanceSize, TypeVector);
             return sizeTy;
         }();
 
@@ -633,7 +633,7 @@ extern (C++) abstract class Type : RootObject
         if (equals(t))
             return 1; // covariant
 
-        if (ty != Tfunction || t.ty != Tfunction)
+        if (ty != TY.function_ || t.ty != TY.function_)
             goto Ldistinct;
 
         t1 = cast(TypeFunction)this;
@@ -661,27 +661,27 @@ extern (C++) abstract class Type : RootObject
                     Type tp2 = fparam2.type;
                     if (tp1.ty == tp2.ty)
                     {
-                        if (tp1.ty == Tclass)
+                        if (tp1.ty == TY.class_)
                         {
                             if ((cast(TypeClass)tp1).sym == (cast(TypeClass)tp2).sym && MODimplicitConv(tp2.mod, tp1.mod))
                                 goto Lcov;
                         }
-                        else if (tp1.ty == Tstruct)
+                        else if (tp1.ty == TY.struct_)
                         {
                             if ((cast(TypeStruct)tp1).sym == (cast(TypeStruct)tp2).sym && MODimplicitConv(tp2.mod, tp1.mod))
                                 goto Lcov;
                         }
-                        else if (tp1.ty == Tpointer)
+                        else if (tp1.ty == TY.pointer)
                         {
                             if (tp2.implicitConvTo(tp1))
                                 goto Lcov;
                         }
-                        else if (tp1.ty == Tarray)
+                        else if (tp1.ty == TY.array)
                         {
                             if (tp2.implicitConvTo(tp1))
                                 goto Lcov;
                         }
-                        else if (tp1.ty == Tdelegate)
+                        else if (tp1.ty == TY.delegate_)
                         {
                             if (tp1.implicitConvTo(tp2))
                                 goto Lcov;
@@ -717,7 +717,7 @@ extern (C++) abstract class Type : RootObject
 
             if (t1n.equals(t2n))
                 goto Lcovariant;
-            if (t1n.ty == Tclass && t2n.ty == Tclass)
+            if (t1n.ty == TY.class_ && t2n.ty == TY.class_)
             {
                 /* If same class type, but t2n is const, then it's
                  * covariant. Do this test first because it can work on
@@ -735,14 +735,14 @@ extern (C++) abstract class Type : RootObject
                     return 3; // forward references
                 }
             }
-            if (t1n.ty == Tstruct && t2n.ty == Tstruct)
+            if (t1n.ty == TY.struct_ && t2n.ty == TY.struct_)
             {
                 if ((cast(TypeStruct)t1n).sym == (cast(TypeStruct)t2n).sym && MODimplicitConv(t1n.mod, t2n.mod))
                     goto Lcovariant;
             }
             else if (t1n.ty == t2n.ty && t1n.implicitConvTo(t2n))
                 goto Lcovariant;
-            else if (t1n.ty == Tnull && t1n.implicitConvTo(t2n) && t1n.size() == t2n.size())
+            else if (t1n.ty == TY.null_ && t1n.implicitConvTo(t2n) && t1n.size() == t2n.size())
                 goto Lcovariant;
         }
         goto Lnotcovariant;
@@ -840,7 +840,7 @@ extern (C++) abstract class Type : RootObject
         OutBuffer buf;
         buf.reserve(16);
         HdrGenState hgs;
-        hgs.fullQual = (ty == Tclass && !mod);
+        hgs.fullQual = (ty == TY.class_ && !mod);
 
         .toCBuffer(this, &buf, null, &hgs);
         return buf.extractString();
@@ -865,72 +865,72 @@ extern (C++) abstract class Type : RootObject
         // Set basic types
         static __gshared TY* basetab =
         [
-            Tvoid,
-            Tint8,
-            Tuns8,
-            Tint16,
-            Tuns16,
-            Tint32,
-            Tuns32,
-            Tint64,
-            Tuns64,
-            Tint128,
-            Tuns128,
-            Tfloat32,
-            Tfloat64,
-            Tfloat80,
-            Timaginary32,
-            Timaginary64,
-            Timaginary80,
-            Tcomplex32,
-            Tcomplex64,
-            Tcomplex80,
-            Tbool,
-            Tchar,
-            Twchar,
-            Tdchar,
-            Terror
+            TY.void_,
+            TY.int8,
+            TY.uns8,
+            TY.int16,
+            TY.uns16,
+            TY.int32,
+            TY.uns32,
+            TY.int64,
+            TY.uns64,
+            TY.int128,
+            TY.uns128,
+            TY.float32,
+            TY.float64,
+            TY.float80,
+            TY.imaginary32,
+            TY.imaginary64,
+            TY.imaginary80,
+            TY.complex32,
+            TY.complex64,
+            TY.complex80,
+            TY.bool_,
+            TY.char_,
+            TY.wchar_,
+            TY.dchar_,
+            TY.error
         ];
 
-        for (size_t i = 0; basetab[i] != Terror; i++)
+        for (size_t i = 0; basetab[i] != TY.error; i++)
         {
             Type t = new TypeBasic(basetab[i]);
             t = t.merge();
             basic[basetab[i]] = t;
         }
-        basic[Terror] = new TypeError();
+        basic[TY.error] = new TypeError();
 
-        tvoid = basic[Tvoid];
-        tint8 = basic[Tint8];
-        tuns8 = basic[Tuns8];
-        tint16 = basic[Tint16];
-        tuns16 = basic[Tuns16];
-        tint32 = basic[Tint32];
-        tuns32 = basic[Tuns32];
-        tint64 = basic[Tint64];
-        tuns64 = basic[Tuns64];
-        tint128 = basic[Tint128];
-        tuns128 = basic[Tuns128];
-        tfloat32 = basic[Tfloat32];
-        tfloat64 = basic[Tfloat64];
-        tfloat80 = basic[Tfloat80];
+        tvoid = basic[TY.void_];
+        tint8 = basic[TY.int8];
+        tuns8 = basic[TY.uns8];
+        tint16 = basic[TY.int16];
+        tuns16 = basic[TY.uns16];
+        tint32 = basic[TY.int32];
+        tuns32 = basic[TY.uns32];
+        tint64 = basic[TY.int64];
+        tuns64 = basic[TY.uns64];
+        tint128 = basic[TY.int128];
+        tuns128 = basic[TY.uns128];
+        tfloat32 = basic[TY.float32];
+        tfloat64 = basic[TY.float64];
+        tfloat80 = basic[TY.float80];
 
-        timaginary32 = basic[Timaginary32];
-        timaginary64 = basic[Timaginary64];
-        timaginary80 = basic[Timaginary80];
+        timaginary32 = basic[TY.imaginary32];
+        timaginary64 = basic[TY.imaginary64];
+        timaginary80 = basic[TY.imaginary80];
 
-        tcomplex32 = basic[Tcomplex32];
-        tcomplex64 = basic[Tcomplex64];
-        tcomplex80 = basic[Tcomplex80];
+        tcomplex32 = basic[TY.complex32];
+        tcomplex64 = basic[TY.complex64];
+        tcomplex80 = basic[TY.complex80];
 
-        tbool = basic[Tbool];
-        tchar = basic[Tchar];
-        twchar = basic[Twchar];
-        tdchar = basic[Tdchar];
+        tbool = basic[TY.bool_];
+        tchar = basic[TY.char_];
+        twchar = basic[TY.wchar_];
+        tdchar = basic[TY.dchar_];
 
         tshiftcnt = tint32;
-        terror = basic[Terror];
-        tnull = basic[Tnull];
+        terror = basic[TY.error];
+        tnull = basic[TY.null_];
         tnull = new TypeNull();
         tnull.deco = tnull.merge().deco;
 
@@ -942,13 +942,13 @@ extern (C++) abstract class Type : RootObject
 
         if (global.params.isLP64)
         {
-            Tsize_t = Tuns64;
-            Tptrdiff_t = Tint64;
+            Tsize_t = TY.uns64;
+            Tptrdiff_t = TY.int64;
         }
         else
         {
-            Tsize_t = Tuns32;
-            Tptrdiff_t = Tint32;
+            Tsize_t = TY.uns32;
+            Tptrdiff_t = TY.int32;
         }
 
         tsize_t = basic[Tsize_t];
@@ -977,7 +977,7 @@ extern (C++) abstract class Type : RootObject
         //printf("+trySemantic(%s) %d\n", toChars(), global.errors);
         uint errors = global.startGagging();
         Type t = typeSemantic(this, loc, sc);
-        if (global.endGagging(errors) || t.ty == Terror) // if any errors happened
+        if (global.endGagging(errors) || t.ty == TY.error) // if any errors happened
         {
             t = null;
         }
@@ -1196,9 +1196,9 @@ extern (C++) abstract class Type : RootObject
         t.swcto = null;
         t.vtinfo = null;
         t.ctype = null;
-        if (t.ty == Tstruct)
+        if (t.ty == TY.struct_)
             (cast(TypeStruct)t).att = AliasThisRec.fwdref;
-        if (t.ty == Tclass)
+        if (t.ty == TY.class_)
             (cast(TypeClass)t).att = AliasThisRec.fwdref;
         return t;
     }
@@ -1458,7 +1458,7 @@ extern (C++) abstract class Type : RootObject
         // cache t to this.xto won't break transitivity.
         Type mto = null;
         Type tn = nextOf();
-        if (!tn || ty != Tsarray && tn.mod == t.nextOf().mod)
+        if (!tn || ty != TY.sarray && tn.mod == t.nextOf().mod)
         {
             switch (t.mod)
             {
@@ -1743,7 +1743,7 @@ extern (C++) abstract class Type : RootObject
         }
 
         Type tn = nextOf();
-        if (tn && ty != Tfunction && tn.ty != Tfunction && ty != Tenum)
+        if (tn && ty != TY.function_ && tn.ty != TY.function_ && ty != TY.enum_)
         {
             // Verify transitivity
             switch (mod)
@@ -2017,12 +2017,12 @@ extern (C++) abstract class Type : RootObject
 
     final Type pointerTo()
     {
-        if (ty == Terror)
+        if (ty == TY.error)
             return this;
         if (!pto)
         {
             Type t = new TypePointer(this);
-            if (ty == Tfunction)
+            if (ty == TY.function_)
             {
                 t.deco = t.merge().deco;
                 pto = t;
@@ -2035,7 +2035,7 @@ extern (C++) abstract class Type : RootObject
 
     final Type referenceTo()
     {
-        if (ty == Terror)
+        if (ty == TY.error)
             return this;
         if (!rto)
         {
@@ -2047,7 +2047,7 @@ extern (C++) abstract class Type : RootObject
 
     final Type arrayOf()
     {
-        if (ty == Terror)
+        if (ty == TY.error)
             return this;
         if (!arrayof)
         {
@@ -2131,9 +2131,9 @@ extern (C++) abstract class Type : RootObject
     {
         Type tb = toBasetype();
         AliasThisRec* pflag;
-        if (tb.ty == Tstruct)
+        if (tb.ty == TY.struct_)
             pflag = &(cast(TypeStruct)tb).att;
-        else if (tb.ty == Tclass)
+        else if (tb.ty == TY.class_)
             pflag = &(cast(TypeClass)tb).att;
         else
             return false;
@@ -2319,7 +2319,7 @@ extern (C++) abstract class Type : RootObject
         if (Type tn = nextOf())
         {
             // substitution has no effect on function pointer type.
-            if (ty == Tpointer && tn.ty == Tfunction)
+            if (ty == TY.pointer && tn.ty == TY.function_)
             {
                 t = this;
                 goto L1;
@@ -2330,18 +2330,18 @@ extern (C++) abstract class Type : RootObject
                 t = this;
             else
             {
-                if (ty == Tpointer)
+                if (ty == TY.pointer)
                     t = t.pointerTo();
-                else if (ty == Tarray)
+                else if (ty == TY.array)
                     t = t.arrayOf();
-                else if (ty == Tsarray)
+                else if (ty == TY.sarray)
                     t = new TypeSArray(t, (cast(TypeSArray)this).dim.syntaxCopy());
-                else if (ty == Taarray)
+                else if (ty == TY.aarray)
                 {
                     t = new TypeAArray(t, (cast(TypeAArray)this).index.syntaxCopy());
                     (cast(TypeAArray)t).sc = (cast(TypeAArray)this).sc; // duplicate scope
                 }
-                else if (ty == Tdelegate)
+                else if (ty == TY.delegate_)
                 {
                     t = new TypeDelegate(t);
                 }
@@ -2397,19 +2397,19 @@ extern (C++) abstract class Type : RootObject
     {
         Type t = mutableOf().unSharedOf();
 
-        Type tn = ty == Tenum ? null : nextOf();
-        if (tn && tn.ty != Tfunction)
+        Type tn = ty == TY.enum_ ? null : nextOf();
+        if (tn && tn.ty != TY.function_)
         {
             Type utn = tn.unqualify(m);
             if (utn != tn)
             {
-                if (ty == Tpointer)
+                if (ty == TY.pointer)
                     t = utn.pointerTo();
-                else if (ty == Tarray)
+                else if (ty == TY.array)
                     t = utn.arrayOf();
-                else if (ty == Tsarray)
+                else if (ty == TY.sarray)
                     t = new TypeSArray(utn, (cast(TypeSArray)this).dim);
-                else if (ty == Taarray)
+                else if (ty == TY.aarray)
                 {
                     t = new TypeAArray(utn, (cast(TypeAArray)this).index);
                     (cast(TypeAArray)t).sc = (cast(TypeAArray)this).sc; // duplicate scope
@@ -2469,7 +2469,7 @@ extern (C++) abstract class Type : RootObject
         {
             Type tb = toBasetype();
             e = defaultInitLiteral(loc);
-            if (tb.ty == Tstruct && tb.needsNested())
+            if (tb.ty == TY.struct_ && tb.needsNested())
             {
                 StructLiteralExp se = cast(StructLiteralExp)e;
                 se.useStaticInit = true;
@@ -2503,7 +2503,7 @@ extern (C++) abstract class Type : RootObject
         else
         {
             Dsymbol s = null;
-            if (ty == Tstruct || ty == Tclass || ty == Tenum)
+            if (ty == TY.struct_ || ty == TY.class_ || ty == TY.enum_)
                 s = toDsymbol(null);
             if (s)
                 s = s.search_correct(ident);
@@ -2576,7 +2576,7 @@ extern (C++) abstract class Type : RootObject
             {
                 Type tb = toBasetype();
                 e = defaultInitLiteral(e.loc);
-                if (tb.ty == Tstruct && tb.needsNested())
+                if (tb.ty == TY.struct_ && tb.needsNested())
                 {
                     StructLiteralExp se = cast(StructLiteralExp)e;
                     se.useStaticInit = true;
@@ -2635,7 +2635,7 @@ extern (C++) abstract class Type : RootObject
         }
 
 
-        assert(ty == Tstruct || ty == Tclass);
+        assert(ty == TY.struct_ || ty == TY.class_);
         auto sym = toDsymbol(sc).isAggregateDeclaration();
         assert(sym);
         if (ident != Id.__sizeof &&
@@ -2892,7 +2892,7 @@ extern (C++) abstract class Type : RootObject
     final Type baseElemOf()
     {
         Type t = toBasetype();
-        while (t.ty == Tsarray)
+        while (t.ty == TY.sarray)
             t = (cast(TypeSArray)t).next.toBasetype();
         return t;
     }
@@ -2906,26 +2906,26 @@ extern (C++) abstract class Type : RootObject
         uinteger_t m;
         switch (toBasetype().ty)
         {
-        case Tbool:
+        case TY.bool_:
             m = 1;
             break;
-        case Tchar:
-        case Tint8:
-        case Tuns8:
+        case TY.char_:
+        case TY.int8:
+        case TY.uns8:
             m = 0xFF;
             break;
-        case Twchar:
-        case Tint16:
-        case Tuns16:
+        case TY.wchar_:
+        case TY.int16:
+        case TY.uns16:
             m = 0xFFFFU;
             break;
-        case Tdchar:
-        case Tint32:
-        case Tuns32:
+        case TY.dchar_:
+        case TY.int32:
+        case TY.uns32:
             m = 0xFFFFFFFFU;
             break;
-        case Tint64:
-        case Tuns64:
+        case TY.int64:
+        case TY.uns64:
             m = 0xFFFFFFFFFFFFFFFFUL;
             break;
         default:
@@ -2965,11 +2965,11 @@ extern (C++) abstract class Type : RootObject
             return false;
 
         Type t = baseElemOf();
-        while (t.ty == Tpointer || t.ty == Tarray)
+        while (t.ty == TY.pointer || t.ty == TY.array)
             t = t.nextOf().baseElemOf();
 
         // Basetype is an opaque enum, nothing to check.
-        if (t.ty == Tenum && !(cast(TypeEnum)t).sym.memtype)
+        if (t.ty == TY.enum_ && !(cast(TypeEnum)t).sym.memtype)
             return false;
 
         if (t.isimaginary() || t.iscomplex())
@@ -2977,18 +2977,18 @@ extern (C++) abstract class Type : RootObject
             Type rt;
             switch (t.ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
+            case TY.complex32:
+            case TY.imaginary32:
                 rt = Type.tfloat32;
                 break;
 
-            case Tcomplex64:
-            case Timaginary64:
+            case TY.complex64:
+            case TY.imaginary64:
                 rt = Type.tfloat64;
                 break;
 
-            case Tcomplex80:
-            case Timaginary80:
+            case TY.complex80:
+            case TY.imaginary80:
                 rt = Type.tfloat80;
                 break;
 
@@ -3040,7 +3040,7 @@ extern (C++) abstract class Type : RootObject
 
     final TypeFunction toTypeFunction()
     {
-        if (ty != Tfunction)
+        if (ty != TY.function_)
             assert(0);
         return cast(TypeFunction)this;
     }
@@ -3052,7 +3052,7 @@ extern (C++) final class TypeError : Type
 {
     extern (D) this()
     {
-        super(Terror);
+        super(TY.error);
     }
 
     override Type syntaxCopy()
@@ -3113,9 +3113,9 @@ extern (C++) abstract class TypeNext : Type
 
     override final int hasWild() const
     {
-        if (ty == Tfunction)
+        if (ty == TY.function_)
             return 0;
-        if (ty == Tdelegate)
+        if (ty == TY.delegate_)
             return Type.hasWild();
         return mod & MODFlags.wild || (next && next.hasWild());
     }
@@ -3139,7 +3139,7 @@ extern (C++) abstract class TypeNext : Type
             return cto;
         }
         TypeNext t = cast(TypeNext)Type.makeConst();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             if (next.isShared())
             {
@@ -3169,7 +3169,7 @@ extern (C++) abstract class TypeNext : Type
             return ito;
         }
         TypeNext t = cast(TypeNext)Type.makeImmutable();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             t.next = next.immutableOf();
         }
@@ -3185,7 +3185,7 @@ extern (C++) abstract class TypeNext : Type
             return sto;
         }
         TypeNext t = cast(TypeNext)Type.makeShared();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             if (next.isWild())
             {
@@ -3215,7 +3215,7 @@ extern (C++) abstract class TypeNext : Type
             return scto;
         }
         TypeNext t = cast(TypeNext)Type.makeSharedConst();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             if (next.isWild())
                 t.next = next.sharedWildConstOf();
@@ -3235,7 +3235,7 @@ extern (C++) abstract class TypeNext : Type
             return wto;
         }
         TypeNext t = cast(TypeNext)Type.makeWild();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             if (next.isShared())
             {
@@ -3265,7 +3265,7 @@ extern (C++) abstract class TypeNext : Type
             return wcto;
         }
         TypeNext t = cast(TypeNext)Type.makeWildConst();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             if (next.isShared())
                 t.next = next.sharedWildConstOf();
@@ -3285,7 +3285,7 @@ extern (C++) abstract class TypeNext : Type
             return swto;
         }
         TypeNext t = cast(TypeNext)Type.makeSharedWild();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             if (next.isConst())
                 t.next = next.sharedWildConstOf();
@@ -3305,7 +3305,7 @@ extern (C++) abstract class TypeNext : Type
             return swcto;
         }
         TypeNext t = cast(TypeNext)Type.makeSharedWildConst();
-        if (ty != Tfunction && next.ty != Tfunction && !next.isImmutable())
+        if (ty != TY.function_ && next.ty != TY.function_ && !next.isImmutable())
         {
             t.next = next.sharedWildConstOf();
         }
@@ -3317,7 +3317,7 @@ extern (C++) abstract class TypeNext : Type
     {
         //printf("TypeNext::makeMutable() %p, %s\n", this, toChars());
         TypeNext t = cast(TypeNext)Type.makeMutable();
-        if (ty == Tsarray)
+        if (ty == TY.sarray)
         {
             t.next = next.mutableOf();
         }
@@ -3356,13 +3356,13 @@ extern (C++) abstract class TypeNext : Type
 
     override final ubyte deduceWild(Type t, bool isRef)
     {
-        if (ty == Tfunction)
+        if (ty == TY.function_)
             return 0;
 
         ubyte wm;
 
         Type tn = t.nextOf();
-        if (!isRef && (ty == Tarray || ty == Tpointer) && tn)
+        if (!isRef && (ty == TY.array || ty == TY.pointer) && tn)
         {
             wm = next.deduceWild(tn, true);
             if (!wm)
@@ -3405,121 +3405,121 @@ extern (C++) final class TypeBasic : Type
         uint flags = 0;
         switch (ty)
         {
-        case Tvoid:
+        case TY.void_:
             d = Token.toChars(TOKvoid);
             break;
 
-        case Tint8:
+        case TY.int8:
             d = Token.toChars(TOKint8);
             flags |= TFlags.integral;
             break;
 
-        case Tuns8:
+        case TY.uns8:
             d = Token.toChars(TOKuns8);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Tint16:
+        case TY.int16:
             d = Token.toChars(TOKint16);
             flags |= TFlags.integral;
             break;
 
-        case Tuns16:
+        case TY.uns16:
             d = Token.toChars(TOKuns16);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Tint32:
+        case TY.int32:
             d = Token.toChars(TOKint32);
             flags |= TFlags.integral;
             break;
 
-        case Tuns32:
+        case TY.uns32:
             d = Token.toChars(TOKuns32);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Tfloat32:
+        case TY.float32:
             d = Token.toChars(TOKfloat32);
             flags |= TFlags.floating | TFlags.real_;
             break;
 
-        case Tint64:
+        case TY.int64:
             d = Token.toChars(TOKint64);
             flags |= TFlags.integral;
             break;
 
-        case Tuns64:
+        case TY.uns64:
             d = Token.toChars(TOKuns64);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Tint128:
+        case TY.int128:
             d = Token.toChars(TOKint128);
             flags |= TFlags.integral;
             break;
 
-        case Tuns128:
+        case TY.uns128:
             d = Token.toChars(TOKuns128);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Tfloat64:
+        case TY.float64:
             d = Token.toChars(TOKfloat64);
             flags |= TFlags.floating | TFlags.real_;
             break;
 
-        case Tfloat80:
+        case TY.float80:
             d = Token.toChars(TOKfloat80);
             flags |= TFlags.floating | TFlags.real_;
             break;
 
-        case Timaginary32:
+        case TY.imaginary32:
             d = Token.toChars(TOKimaginary32);
             flags |= TFlags.floating | TFlags.imaginary;
             break;
 
-        case Timaginary64:
+        case TY.imaginary64:
             d = Token.toChars(TOKimaginary64);
             flags |= TFlags.floating | TFlags.imaginary;
             break;
 
-        case Timaginary80:
+        case TY.imaginary80:
             d = Token.toChars(TOKimaginary80);
             flags |= TFlags.floating | TFlags.imaginary;
             break;
 
-        case Tcomplex32:
+        case TY.complex32:
             d = Token.toChars(TOKcomplex32);
             flags |= TFlags.floating | TFlags.complex;
             break;
 
-        case Tcomplex64:
+        case TY.complex64:
             d = Token.toChars(TOKcomplex64);
             flags |= TFlags.floating | TFlags.complex;
             break;
 
-        case Tcomplex80:
+        case TY.complex80:
             d = Token.toChars(TOKcomplex80);
             flags |= TFlags.floating | TFlags.complex;
             break;
 
-        case Tbool:
+        case TY.bool_:
             d = "bool";
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Tchar:
+        case TY.char_:
             d = Token.toChars(TOKchar);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Twchar:
+        case TY.wchar_:
             d = Token.toChars(TOKwchar);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
 
-        case Tdchar:
+        case TY.dchar_:
             d = Token.toChars(TOKdchar);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
@@ -3549,67 +3549,67 @@ extern (C++) final class TypeBasic : Type
         //printf("TypeBasic::size()\n");
         switch (ty)
         {
-        case Tint8:
-        case Tuns8:
+        case TY.int8:
+        case TY.uns8:
             size = 1;
             break;
 
-        case Tint16:
-        case Tuns16:
+        case TY.int16:
+        case TY.uns16:
             size = 2;
             break;
 
-        case Tint32:
-        case Tuns32:
-        case Tfloat32:
-        case Timaginary32:
+        case TY.int32:
+        case TY.uns32:
+        case TY.float32:
+        case TY.imaginary32:
             size = 4;
             break;
 
-        case Tint64:
-        case Tuns64:
-        case Tfloat64:
-        case Timaginary64:
+        case TY.int64:
+        case TY.uns64:
+        case TY.float64:
+        case TY.imaginary64:
             size = 8;
             break;
 
-        case Tfloat80:
-        case Timaginary80:
+        case TY.float80:
+        case TY.imaginary80:
             size = Target.realsize;
             break;
 
-        case Tcomplex32:
+        case TY.complex32:
             size = 8;
             break;
 
-        case Tcomplex64:
-        case Tint128:
-        case Tuns128:
+        case TY.complex64:
+        case TY.int128:
+        case TY.uns128:
             size = 16;
             break;
 
-        case Tcomplex80:
+        case TY.complex80:
             size = Target.realsize * 2;
             break;
 
-        case Tvoid:
+        case TY.void_:
             //size = Type::size();      // error message
             size = 1;
             break;
 
-        case Tbool:
+        case TY.bool_:
             size = 1;
             break;
 
-        case Tchar:
+        case TY.char_:
             size = 1;
             break;
 
-        case Twchar:
+        case TY.wchar_:
             size = 2;
             break;
 
-        case Tdchar:
+        case TY.dchar_:
             size = 4;
             break;
 
@@ -3635,55 +3635,55 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tint8:
+            case TY.int8:
                 ivalue = 0x7F;
                 goto Livalue;
-            case Tuns8:
+            case TY.uns8:
                 ivalue = 0xFF;
                 goto Livalue;
-            case Tint16:
+            case TY.int16:
                 ivalue = 0x7FFFU;
                 goto Livalue;
-            case Tuns16:
+            case TY.uns16:
                 ivalue = 0xFFFFU;
                 goto Livalue;
-            case Tint32:
+            case TY.int32:
                 ivalue = 0x7FFFFFFFU;
                 goto Livalue;
-            case Tuns32:
+            case TY.uns32:
                 ivalue = 0xFFFFFFFFU;
                 goto Livalue;
-            case Tint64:
+            case TY.int64:
                 ivalue = 0x7FFFFFFFFFFFFFFFL;
                 goto Livalue;
-            case Tuns64:
+            case TY.uns64:
                 ivalue = 0xFFFFFFFFFFFFFFFFUL;
                 goto Livalue;
-            case Tbool:
+            case TY.bool_:
                 ivalue = 1;
                 goto Livalue;
-            case Tchar:
+            case TY.char_:
                 ivalue = 0xFF;
                 goto Livalue;
-            case Twchar:
+            case TY.wchar_:
                 ivalue = 0xFFFFU;
                 goto Livalue;
-            case Tdchar:
+            case TY.dchar_:
                 ivalue = 0x10FFFFU;
                 goto Livalue;
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 fvalue = Target.FloatProperties.max;
                 goto Lfvalue;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 fvalue = Target.DoubleProperties.max;
                 goto Lfvalue;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 fvalue = Target.RealProperties.max;
                 goto Lfvalue;
             default:
@@ -3694,40 +3694,40 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tint8:
+            case TY.int8:
                 ivalue = -128;
                 goto Livalue;
-            case Tuns8:
+            case TY.uns8:
                 ivalue = 0;
                 goto Livalue;
-            case Tint16:
+            case TY.int16:
                 ivalue = -32768;
                 goto Livalue;
-            case Tuns16:
+            case TY.uns16:
                 ivalue = 0;
                 goto Livalue;
-            case Tint32:
+            case TY.int32:
                 ivalue = -2147483647 - 1;
                 goto Livalue;
-            case Tuns32:
+            case TY.uns32:
                 ivalue = 0;
                 goto Livalue;
-            case Tint64:
+            case TY.int64:
                 ivalue = (-9223372036854775807L - 1L);
                 goto Livalue;
-            case Tuns64:
+            case TY.uns64:
                 ivalue = 0;
                 goto Livalue;
-            case Tbool:
+            case TY.bool_:
                 ivalue = 0;
                 goto Livalue;
-            case Tchar:
+            case TY.char_:
                 ivalue = 0;
                 goto Livalue;
-            case Twchar:
+            case TY.wchar_:
                 ivalue = 0;
                 goto Livalue;
-            case Tdchar:
+            case TY.dchar_:
                 ivalue = 0;
                 goto Livalue;
             default:
@@ -3739,19 +3739,19 @@ extern (C++) final class TypeBasic : Type
         Lmin_normal:
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 fvalue = Target.FloatProperties.min_normal;
                 goto Lfvalue;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 fvalue = Target.DoubleProperties.min_normal;
                 goto Lfvalue;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 fvalue = Target.RealProperties.min_normal;
                 goto Lfvalue;
             default:
@@ -3762,15 +3762,15 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Tcomplex64:
-            case Tcomplex80:
-            case Timaginary32:
-            case Timaginary64:
-            case Timaginary80:
-            case Tfloat32:
-            case Tfloat64:
-            case Tfloat80:
+            case TY.complex32:
+            case TY.complex64:
+            case TY.complex80:
+            case TY.imaginary32:
+            case TY.imaginary64:
+            case TY.imaginary80:
+            case TY.float32:
+            case TY.float64:
+            case TY.float80:
                 fvalue = Target.RealProperties.nan;
                 goto Lfvalue;
             default:
@@ -3781,15 +3781,15 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Tcomplex64:
-            case Tcomplex80:
-            case Timaginary32:
-            case Timaginary64:
-            case Timaginary80:
-            case Tfloat32:
-            case Tfloat64:
-            case Tfloat80:
+            case TY.complex32:
+            case TY.complex64:
+            case TY.complex80:
+            case TY.imaginary32:
+            case TY.imaginary64:
+            case TY.imaginary80:
+            case TY.float32:
+            case TY.float64:
+            case TY.float80:
                 fvalue = Target.RealProperties.infinity;
                 goto Lfvalue;
             default:
@@ -3800,19 +3800,19 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 ivalue = Target.FloatProperties.dig;
                 goto Lint;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 ivalue = Target.DoubleProperties.dig;
                 goto Lint;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 ivalue = Target.RealProperties.dig;
                 goto Lint;
             default:
@@ -3823,19 +3823,19 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 fvalue = Target.FloatProperties.epsilon;
                 goto Lfvalue;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 fvalue = Target.DoubleProperties.epsilon;
                 goto Lfvalue;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 fvalue = Target.RealProperties.epsilon;
                 goto Lfvalue;
             default:
@@ -3846,19 +3846,19 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 ivalue = Target.FloatProperties.mant_dig;
                 goto Lint;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 ivalue = Target.DoubleProperties.mant_dig;
                 goto Lint;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 ivalue = Target.RealProperties.mant_dig;
                 goto Lint;
             default:
@@ -3869,19 +3869,19 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 ivalue = Target.FloatProperties.max_10_exp;
                 goto Lint;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 ivalue = Target.DoubleProperties.max_10_exp;
                 goto Lint;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 ivalue = Target.RealProperties.max_10_exp;
                 goto Lint;
             default:
@@ -3892,19 +3892,19 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 ivalue = Target.FloatProperties.max_exp;
                 goto Lint;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 ivalue = Target.DoubleProperties.max_exp;
                 goto Lint;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 ivalue = Target.RealProperties.max_exp;
                 goto Lint;
             default:
@@ -3915,19 +3915,19 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 ivalue = Target.FloatProperties.min_10_exp;
                 goto Lint;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 ivalue = Target.DoubleProperties.min_10_exp;
                 goto Lint;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 ivalue = Target.RealProperties.min_10_exp;
                 goto Lint;
             default:
@@ -3938,19 +3938,19 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
-            case Timaginary32:
-            case Tfloat32:
+            case TY.complex32:
+            case TY.imaginary32:
+            case TY.float32:
                 ivalue = Target.FloatProperties.min_exp;
                 goto Lint;
-            case Tcomplex64:
-            case Timaginary64:
-            case Tfloat64:
+            case TY.complex64:
+            case TY.imaginary64:
+            case TY.float64:
                 ivalue = Target.DoubleProperties.min_exp;
                 goto Lint;
-            case Tcomplex80:
-            case Timaginary80:
-            case Tfloat80:
+            case TY.complex80:
+            case TY.imaginary80:
+            case TY.float80:
                 ivalue = Target.RealProperties.min_exp;
                 goto Lint;
             default:
@@ -3992,35 +3992,35 @@ extern (C++) final class TypeBasic : Type
         {
             switch (ty)
             {
-            case Tcomplex32:
+            case TY.complex32:
                 t = tfloat32;
                 goto L1;
 
-            case Tcomplex64:
+            case TY.complex64:
                 t = tfloat64;
                 goto L1;
 
-            case Tcomplex80:
+            case TY.complex80:
                 t = tfloat80;
                 goto L1;
             L1:
                 e = e.castTo(sc, t);
                 break;
 
-            case Tfloat32:
-            case Tfloat64:
-            case Tfloat80:
+            case TY.float32:
+            case TY.float64:
+            case TY.float80:
                 break;
 
-            case Timaginary32:
+            case TY.imaginary32:
                 t = tfloat32;
                 goto L2;
 
-            case Timaginary64:
+            case TY.imaginary64:
                 t = tfloat64;
                 goto L2;
 
-            case Timaginary80:
+            case TY.imaginary80:
                 t = tfloat80;
                 goto L2;
             L2:
@@ -4037,17 +4037,17 @@ extern (C++) final class TypeBasic : Type
             Type t2;
             switch (ty)
             {
-            case Tcomplex32:
+            case TY.complex32:
                 t = timaginary32;
                 t2 = tfloat32;
                 goto L3;
 
-            case Tcomplex64:
+            case TY.complex64:
                 t = timaginary64;
                 t2 = tfloat64;
                 goto L3;
 
-            case Tcomplex80:
+            case TY.complex80:
                 t = timaginary80;
                 t2 = tfloat80;
                 goto L3;
@@ -4056,15 +4056,15 @@ extern (C++) final class TypeBasic : Type
                 e.type = t2;
                 break;
 
-            case Timaginary32:
+            case TY.imaginary32:
                 t = tfloat32;
                 goto L4;
 
-            case Timaginary64:
+            case TY.imaginary64:
                 t = tfloat64;
                 goto L4;
 
-            case Timaginary80:
+            case TY.imaginary80:
                 t = tfloat80;
                 goto L4;
             L4:
@@ -4072,9 +4072,9 @@ extern (C++) final class TypeBasic : Type
                 e.type = t;
                 break;
 
-            case Tfloat32:
-            case Tfloat64:
-            case Tfloat80:
+            case TY.float32:
+            case TY.float64:
+            case TY.float80:
                 e = new RealExp(e.loc, CTFloat.zero, this);
                 break;
 
@@ -4146,13 +4146,13 @@ extern (C++) final class TypeBasic : Type
                 return MATCH.convert;
         }
 
-        if (ty == Tvoid || to.ty == Tvoid)
+        if (ty == TY.void_ || to.ty == TY.void_)
             return MATCH.nomatch;
-        if (to.ty == Tbool)
+        if (to.ty == TY.bool_)
             return MATCH.nomatch;
 
         TypeBasic tob;
-        if (to.ty == Tvector && to.deco)
+        if (to.ty == TY.vector && to.deco)
         {
             TypeVector tv = cast(TypeVector)to;
             tob = tv.elementType();
@@ -4190,7 +4190,7 @@ extern (C++) final class TypeBasic : Type
             if (tob.flags & TFlags.integral)
                 return MATCH.nomatch;
 
-            assert(tob.flags & TFlags.floating || to.ty == Tvector);
+            assert(tob.flags & TFlags.floating || to.ty == TY.vector);
 
             // Disallow implicit conversion from complex to non-complex
             if (flags & TFlags.complex && !(tob.flags & TFlags.complex))
@@ -4217,33 +4217,33 @@ extern (C++) final class TypeBasic : Type
 
         switch (ty)
         {
-        case Tchar:
+        case TY.char_:
             value = 0xFF;
             break;
 
-        case Twchar:
-        case Tdchar:
+        case TY.wchar_:
+        case TY.dchar_:
             value = 0xFFFF;
             break;
 
-        case Timaginary32:
-        case Timaginary64:
-        case Timaginary80:
-        case Tfloat32:
-        case Tfloat64:
-        case Tfloat80:
+        case TY.imaginary32:
+        case TY.imaginary64:
+        case TY.imaginary80:
+        case TY.float32:
+        case TY.float64:
+        case TY.float80:
             return new RealExp(loc, Target.RealProperties.snan, this);
 
-        case Tcomplex32:
-        case Tcomplex64:
-        case Tcomplex80:
+        case TY.complex32:
+        case TY.complex64:
+        case TY.complex80:
             {
                 // Can't use fvalue + I*fvalue (the im part becomes a quiet NaN).
                 const cvalue = complex_t(Target.RealProperties.snan, Target.RealProperties.snan);
                 return new ComplexExp(loc, cvalue, this);
             }
 
-        case Tvoid:
+        case TY.void_:
             error(loc, "`void` does not have a default initializer");
             return new ErrorExp();
 
@@ -4257,18 +4257,18 @@ extern (C++) final class TypeBasic : Type
     {
         switch (ty)
         {
-        case Tchar:
-        case Twchar:
-        case Tdchar:
-        case Timaginary32:
-        case Timaginary64:
-        case Timaginary80:
-        case Tfloat32:
-        case Tfloat64:
-        case Tfloat80:
-        case Tcomplex32:
-        case Tcomplex64:
-        case Tcomplex80:
+        case TY.char_:
+        case TY.wchar_:
+        case TY.dchar_:
+        case TY.imaginary32:
+        case TY.imaginary64:
+        case TY.imaginary80:
+        case TY.float32:
+        case TY.float64:
+        case TY.float80:
+        case TY.complex32:
+        case TY.complex64:
+        case TY.complex80:
             return false; // no
         default:
             return true; // yes
@@ -4299,7 +4299,7 @@ extern (C++) final class TypeVector : Type
 
     extern (D) this(Loc loc, Type basetype)
     {
-        super(Tvector);
+        super(TY.vector);
         this.basetype = basetype;
     }
 
@@ -4407,7 +4407,7 @@ extern (C++) final class TypeVector : Type
     override Expression defaultInit(Loc loc)
     {
         //printf("TypeVector::defaultInit()\n");
-        assert(basetype.ty == Tsarray);
+        assert(basetype.ty == TY.sarray);
         Expression e = basetype.defaultInit(loc);
         auto ve = new VectorExp(loc, e, this);
         ve.type = this;
@@ -4418,7 +4418,7 @@ extern (C++) final class TypeVector : Type
     override Expression defaultInitLiteral(Loc loc)
     {
         //printf("TypeVector::defaultInitLiteral()\n");
-        assert(basetype.ty == Tsarray);
+        assert(basetype.ty == TY.sarray);
         Expression e = basetype.defaultInitLiteral(loc);
         auto ve = new VectorExp(loc, e, this);
         ve.type = this;
@@ -4428,7 +4428,7 @@ extern (C++) final class TypeVector : Type
 
     TypeBasic elementType()
     {
-        assert(basetype.ty == Tsarray);
+        assert(basetype.ty == TY.sarray);
         TypeSArray t = cast(TypeSArray)basetype;
         TypeBasic tb = t.nextOf().isTypeBasic();
         assert(tb);
@@ -4484,7 +4484,7 @@ extern (C++) final class TypeSArray : TypeArray
 
     extern (D) this(Type t, Expression dim)
     {
-        super(Tsarray, t);
+        super(TY.sarray, t);
         //printf("TypeSArray(%s)\n", dim.toChars());
         this.dim = dim;
     }
@@ -4607,7 +4607,7 @@ extern (C++) final class TypeSArray : TypeArray
         }
         else
         {
-            if ((*pt).ty != Terror)
+            if ((*pt).ty != TY.error)
                 next = *pt; // prevent re-running semantic() on 'next'
         Ldefault:
             Type.resolve(loc, sc, pe, pt, ps, intypeid);
@@ -4652,7 +4652,7 @@ extern (C++) final class TypeSArray : TypeArray
     override bool isString()
     {
         TY nty = next.toBasetype().ty;
-        return nty == Tchar || nty == Twchar || nty == Tdchar;
+        return nty == TY.char_ || nty == TY.wchar_ || nty == TY.dchar_;
     }
 
     override bool isZeroInit(Loc loc)
@@ -4667,7 +4667,7 @@ extern (C++) final class TypeSArray : TypeArray
 
     override MATCH constConv(Type to)
     {
-        if (to.ty == Tsarray)
+        if (to.ty == TY.sarray)
         {
             TypeSArray tsa = cast(TypeSArray)to;
             if (!dim.equals(tsa.dim))
@@ -4679,7 +4679,7 @@ extern (C++) final class TypeSArray : TypeArray
     override MATCH implicitConvTo(Type to)
     {
         //printf("TypeSArray::implicitConvTo(to = %s) this = %s\n", to.toChars(), toChars());
-        if (to.ty == Tarray)
+        if (to.ty == TY.array)
         {
             TypeDArray ta = cast(TypeDArray)to;
             if (!MODimplicitConv(next.mod, ta.next.mod))
@@ -4687,7 +4687,7 @@ extern (C++) final class TypeSArray : TypeArray
 
             /* Allow conversion to void[]
              */
-            if (ta.next.ty == Tvoid)
+            if (ta.next.ty == TY.void_)
             {
                 return MATCH.convert;
             }
@@ -4699,7 +4699,7 @@ extern (C++) final class TypeSArray : TypeArray
             }
             return MATCH.nomatch;
         }
-        if (to.ty == Tsarray)
+        if (to.ty == TY.sarray)
         {
             if (this == to)
                 return MATCH.exact;
@@ -4730,7 +4730,7 @@ extern (C++) final class TypeSArray : TypeArray
         {
             printf("TypeSArray::defaultInit() '%s'\n", toChars());
         }
-        if (next.ty == Tvoid)
+        if (next.ty == TY.void_)
             return tuns8.defaultInit(loc);
         else
             return next.defaultInit(loc);
@@ -4744,7 +4744,7 @@ extern (C++) final class TypeSArray : TypeArray
         }
         size_t d = cast(size_t)dim.toInteger();
         Expression elementinit;
-        if (next.ty == Tvoid)
+        if (next.ty == TY.void_)
             elementinit = tuns8.defaultInitLiteral(loc);
         else
             elementinit = next.defaultInitLiteral(loc);
@@ -4766,7 +4766,7 @@ extern (C++) final class TypeSArray : TypeArray
         //if (dim.toInteger() == 0)
         //    return false;
 
-        if (next.ty == Tvoid)
+        if (next.ty == TY.void_)
         {
             // Arrays of void contain arbitrary data, which may include pointers
             return true;
@@ -4801,7 +4801,7 @@ extern (C++) final class TypeDArray : TypeArray
 {
     extern (D) this(Type t)
     {
-        super(Tarray, t);
+        super(TY.array, t);
         //printf("TypeDArray(t = %p)\n", t);
     }
 
@@ -4859,7 +4859,7 @@ extern (C++) final class TypeDArray : TypeArray
         }
         else
         {
-            if ((*pt).ty != Terror)
+            if ((*pt).ty != TY.error)
                 next = *pt; // prevent re-running semantic() on 'next'
         Ldefault:
             Type.resolve(loc, sc, pe, pt, ps, intypeid);
@@ -4912,7 +4912,7 @@ extern (C++) final class TypeDArray : TypeArray
     override bool isString()
     {
         TY nty = next.toBasetype().ty;
-        return nty == Tchar || nty == Twchar || nty == Tdchar;
+        return nty == TY.char_ || nty == TY.wchar_ || nty == TY.dchar_;
     }
 
     override bool isZeroInit(Loc loc) const
@@ -4931,7 +4931,7 @@ extern (C++) final class TypeDArray : TypeArray
         if (equals(to))
             return MATCH.exact;
 
-        if (to.ty == Tarray)
+        if (to.ty == TY.array)
         {
             TypeDArray ta = cast(TypeDArray)to;
 
@@ -4940,7 +4940,7 @@ extern (C++) final class TypeDArray : TypeArray
 
             /* Allow conversion to void[]
              */
-            if (next.ty != Tvoid && ta.next.ty == Tvoid)
+            if (next.ty != TY.void_ && ta.next.ty == TY.void_)
             {
                 return MATCH.convert;
             }
@@ -4986,7 +4986,7 @@ extern (C++) final class TypeAArray : TypeArray
 
     extern (D) this(Type t, Type index)
     {
-        super(Taarray, t);
+        super(TY.aarray, t);
         this.index = index;
     }
 
@@ -5024,7 +5024,7 @@ extern (C++) final class TypeAArray : TypeArray
         //printf("TypeAArray::resolve() %s\n", toChars());
         // Deal with the case where we thought the index was a type, but
         // in reality it was an expression.
-        if (index.ty == Tident || index.ty == Tinstance || index.ty == Tsarray)
+        if (index.ty == TY.ident || index.ty == TY.instance || index.ty == TY.sarray)
         {
             Expression e;
             Type t;
@@ -5104,7 +5104,7 @@ extern (C++) final class TypeAArray : TypeArray
         if (equals(to))
             return MATCH.exact;
 
-        if (to.ty == Taarray)
+        if (to.ty == TY.aarray)
         {
             TypeAArray ta = cast(TypeAArray)to;
 
@@ -5126,7 +5126,7 @@ extern (C++) final class TypeAArray : TypeArray
 
     override MATCH constConv(Type to)
     {
-        if (to.ty == Taarray)
+        if (to.ty == TY.aarray)
         {
             TypeAArray taa = cast(TypeAArray)to;
             MATCH mindex = index.constConv(taa.index);
@@ -5149,7 +5149,7 @@ extern (C++) final class TypePointer : TypeNext
 {
     extern (D) this(Type t)
     {
-        super(Tpointer, t);
+        super(TY.pointer, t);
     }
 
     static TypePointer create(Type t)
@@ -5186,12 +5186,12 @@ extern (C++) final class TypePointer : TypeNext
         if (equals(to))
             return MATCH.exact;
 
-        if (next.ty == Tfunction)
+        if (next.ty == TY.function_)
         {
-            if (to.ty == Tpointer)
+            if (to.ty == TY.pointer)
             {
                 TypePointer tp = cast(TypePointer)to;
-                if (tp.next.ty == Tfunction)
+                if (tp.next.ty == TY.function_)
                 {
                     if (next.equals(tp.next))
                         return MATCH.constant;
@@ -5200,7 +5200,7 @@ extern (C++) final class TypePointer : TypeNext
                     {
                         Type tret = this.next.nextOf();
                         Type toret = tp.next.nextOf();
-                        if (tret.ty == Tclass && toret.ty == Tclass)
+                        if (tret.ty == TY.class_ && toret.ty == TY.class_)
                         {
                             /* https://issues.dlang.org/show_bug.cgi?id=10219
                              * Check covariant interface return with offset tweaking.
@@ -5215,7 +5215,7 @@ extern (C++) final class TypePointer : TypeNext
                         return MATCH.convert;
                     }
                 }
-                else if (tp.next.ty == Tvoid)
+                else if (tp.next.ty == TY.void_)
                 {
                     // Allow conversions to void*
                     return MATCH.convert;
@@ -5223,7 +5223,7 @@ extern (C++) final class TypePointer : TypeNext
             }
             return MATCH.nomatch;
         }
-        else if (to.ty == Tpointer)
+        else if (to.ty == TY.pointer)
         {
             TypePointer tp = cast(TypePointer)to;
             assert(tp.next);
@@ -5233,7 +5233,7 @@ extern (C++) final class TypePointer : TypeNext
 
             /* Alloc conversion to void*
              */
-            if (next.ty != Tvoid && tp.next.ty == Tvoid)
+            if (next.ty != TY.void_ && tp.next.ty == TY.void_)
             {
                 return MATCH.convert;
             }
@@ -5251,7 +5251,7 @@ extern (C++) final class TypePointer : TypeNext
 
     override MATCH constConv(Type to)
     {
-        if (next.ty == Tfunction)
+        if (next.ty == TY.function_)
         {
             if (to.nextOf() && next.equals((cast(TypeNext)to).next))
                 return Type.constConv(to);
@@ -5297,7 +5297,7 @@ extern (C++) final class TypeReference : TypeNext
 {
     extern (D) this(Type t)
     {
-        super(Treference, t);
+        super(TY.reference, t);
         // BUG: what about references to static arrays?
     }
 
@@ -5411,7 +5411,7 @@ extern (C++) final class TypeFunction : TypeNext
 
     extern (D) this(Parameters* parameters, Type treturn, int varargs, LINK linkage, StorageClass stc = 0)
     {
-        super(Tfunction, treturn);
+        super(TY.function_, treturn);
         //if (!treturn) *(char*)0=0;
         //    assert(treturn);
         assert(0 <= varargs && varargs <= 2);
@@ -5507,7 +5507,7 @@ extern (C++) final class TypeFunction : TypeNext
 
             /* Accept immutable(T)[] and immutable(T)* as being strongly pure
              */
-            if (t.ty == Tarray || t.ty == Tpointer)
+            if (t.ty == TY.array || t.ty == TY.pointer)
             {
                 Type tn = t.nextOf().toBasetype();
                 if (tn.mod & MODFlags.immutable_)
@@ -5659,7 +5659,7 @@ extern (C++) final class TypeFunction : TypeNext
                     if (fparam.storageClass & (STC.ref_ | STC.out_))
                     {
                     }
-                    else if (t.ty == Tarray || t.ty == Tpointer)
+                    else if (t.ty == TY.array || t.ty == TY.pointer)
                     {
                         Type tn = t.nextOf().toBasetype();
                         if (!(tn.isMutable() && tn.hasPointers()))
@@ -5854,7 +5854,7 @@ extern (C++) final class TypeFunction : TypeNext
         if (tthis)
         {
             Type t = tthis;
-            if (t.toBasetype().ty == Tpointer)
+            if (t.toBasetype().ty == TY.pointer)
                 t = t.toBasetype().nextOf(); // change struct* to struct
             if (t.mod != mod)
             {
@@ -5903,7 +5903,7 @@ extern (C++) final class TypeFunction : TypeNext
             Type tprm = p.type;
             Type targ = arg.type;
 
-            if (!(p.storageClass & STC.lazy_ && tprm.ty == Tvoid && targ.ty != Tvoid))
+            if (!(p.storageClass & STC.lazy_ && tprm.ty == TY.void_ && targ.ty != TY.void_))
             {
                 bool isRef = (p.storageClass & (STC.ref_ | STC.out_)) != 0;
                 wildmatch |= targ.deduceWild(tprm, isRef);
@@ -5947,7 +5947,7 @@ extern (C++) final class TypeFunction : TypeNext
                 Type targ = arg.type;
                 Type tprm = wildmatch ? p.type.substWildTo(wildmatch) : p.type;
 
-                if (p.storageClass & STC.lazy_ && tprm.ty == Tvoid && targ.ty != Tvoid)
+                if (p.storageClass & STC.lazy_ && tprm.ty == TY.void_ && targ.ty != TY.void_)
                     m = MATCH.convert;
                 else
                 {
@@ -5976,19 +5976,19 @@ extern (C++) final class TypeFunction : TypeNext
                         if (p.storageClass & STC.out_)
                             goto Nomatch;
 
-                        if (arg.op == TOKstring && tp.ty == Tsarray)
+                        if (arg.op == TOKstring && tp.ty == TY.sarray)
                         {
-                            if (ta.ty != Tsarray)
+                            if (ta.ty != TY.sarray)
                             {
                                 Type tn = tp.nextOf().castMod(ta.nextOf().mod);
                                 dinteger_t dim = (cast(StringExp)arg).len;
                                 ta = tn.sarrayOf(dim);
                             }
                         }
-                        else if (arg.op == TOKslice && tp.ty == Tsarray)
+                        else if (arg.op == TOKslice && tp.ty == TY.sarray)
                         {
                             // Allow conversion from T[lwr .. upr] to ref T[upr-lwr]
-                            if (ta.ty != Tsarray)
+                            if (ta.ty != TY.sarray)
                             {
                                 Type tn = ta.nextOf();
                                 dinteger_t dim = (cast(TypeSArray)tp).dim.toUInteger();
@@ -6042,13 +6042,13 @@ extern (C++) final class TypeFunction : TypeNext
 
                     switch (tb.ty)
                     {
-                    case Tsarray:
+                    case TY.sarray:
                         tsa = cast(TypeSArray)tb;
                         sz = tsa.dim.toInteger();
                         if (sz != nargs - u)
                             goto Nomatch;
-                        goto case Tarray;
-                    case Tarray:
+                        goto case TY.array;
+                    case TY.array:
                         {
                             TypeArray ta = cast(TypeArray)tb;
                             for (; u < nargs; u++)
@@ -6064,7 +6064,7 @@ extern (C++) final class TypeFunction : TypeNext
                                 {
                                     if (ta.next.equals(arg.type))
                                         m = MATCH.exact;
-                                    else if (tret.toBasetype().ty == Tvoid)
+                                    else if (tret.toBasetype().ty == TY.void_)
                                         m = MATCH.convert;
                                     else
                                     {
@@ -6083,7 +6083,7 @@ extern (C++) final class TypeFunction : TypeNext
                             }
                             goto Ldone;
                         }
-                    case Tclass:
+                    case TY.class_:
                         // Should see if there's a constructor match?
                         // Or just leave it ambiguous?
                         goto Ldone;
@@ -6110,26 +6110,26 @@ extern (C++) final class TypeFunction : TypeNext
     bool checkRetType(Loc loc)
     {
         Type tb = next.toBasetype();
-        if (tb.ty == Tfunction)
+        if (tb.ty == TY.function_)
         {
             error(loc, "functions cannot return a function");
             next = Type.terror;
         }
-        if (tb.ty == Ttuple)
+        if (tb.ty == TY.tuple)
         {
             error(loc, "functions cannot return a tuple");
             next = Type.terror;
         }
-        if (!isref && (tb.ty == Tstruct || tb.ty == Tsarray))
+        if (!isref && (tb.ty == TY.struct_ || tb.ty == TY.sarray))
         {
             Type tb2 = tb.baseElemOf();
-            if (tb2.ty == Tstruct && !(cast(TypeStruct)tb2).sym.members)
+            if (tb2.ty == TY.struct_ && !(cast(TypeStruct)tb2).sym.members)
             {
                 error(loc, "functions cannot return opaque type `%s` by value", tb.toChars());
                 next = Type.terror;
             }
         }
-        if (tb.ty == Terror)
+        if (tb.ty == TY.error)
             return true;
         return false;
     }
@@ -6154,8 +6154,8 @@ extern (C++) final class TypeDelegate : TypeNext
 
     extern (D) this(Type t)
     {
-        super(Tfunction, t);
-        ty = Tdelegate;
+        super(TY.function_, t);
+        ty = TY.delegate_;
     }
 
     static TypeDelegate create(Type t)
@@ -6224,11 +6224,11 @@ extern (C++) final class TypeDelegate : TypeNext
         version (all)
         {
             // not allowing covariant conversions because it interferes with overriding
-            if (to.ty == Tdelegate && this.nextOf().covariant(to.nextOf()) == 1)
+            if (to.ty == TY.delegate_ && this.nextOf().covariant(to.nextOf()) == 1)
             {
                 Type tret = this.next.nextOf();
                 Type toret = (cast(TypeDelegate)to).next.nextOf();
-                if (tret.ty == Tclass && toret.ty == Tclass)
+                if (tret.ty == TY.class_ && toret.ty == TY.class_)
                 {
                     /* https://issues.dlang.org/show_bug.cgi?id=10219
                      * Check covariant interface return with offset tweaking.
@@ -6613,7 +6613,7 @@ extern (C++) abstract class TypeQualified : Type
                     *pt = Type.terror;
                     return;
                 }
-                if (v.type.ty == Terror)
+                if (v.type.ty == TY.error)
                     *pt = Type.terror;
                 else
                     *pe = new VarExp(loc, v);
@@ -6650,7 +6650,7 @@ extern (C++) abstract class TypeQualified : Type
                 *ps = s;
                 return;
             }
-            if (t.ty == Tinstance && t != this && !t.deco)
+            if (t.ty == TY.instance && t != this && !t.deco)
             {
                 if (!(cast(TypeInstance)t).tempinst.errors)
                     error(loc, "forward reference to `%s`", t.toChars());
@@ -6658,7 +6658,7 @@ extern (C++) abstract class TypeQualified : Type
                 return;
             }
 
-            if (t.ty == Ttuple)
+            if (t.ty == TY.tuple)
                 *pt = t;
             else
                 *pt = t.merge();
@@ -6699,7 +6699,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
 
     extern (D) this(Loc loc, Identifier ident)
     {
-        super(Tident, loc);
+        super(TY.ident, loc);
         this.ident = ident;
     }
 
@@ -6796,7 +6796,7 @@ extern (C++) final class TypeIdentifier : TypeQualified
         Expression e;
         Dsymbol s;
         resolve(loc, sc, &e, &t, &s);
-        if (t && t.ty != Tident)
+        if (t && t.ty != TY.ident)
             s = t.toDsymbol(sc);
         if (e)
             s = getDsymbol(e);
@@ -6819,7 +6819,7 @@ extern (C++) final class TypeInstance : TypeQualified
 
     extern (D) this(Loc loc, TemplateInstance tempinst)
     {
-        super(Tinstance, loc);
+        super(TY.instance, loc);
         this.tempinst = tempinst;
     }
 
@@ -6865,7 +6865,7 @@ extern (C++) final class TypeInstance : TypeQualified
         Dsymbol s;
         //printf("TypeInstance::semantic(%s)\n", toChars());
         resolve(loc, sc, &e, &t, &s);
-        if (t && t.ty != Tinstance)
+        if (t && t.ty != TY.instance)
             s = t.toDsymbol(sc);
         return s;
     }
@@ -6885,7 +6885,7 @@ extern (C++) final class TypeTypeof : TypeQualified
 
     extern (D) this(Loc loc, Expression exp)
     {
-        super(Ttypeof, loc);
+        super(TY.typeof_, loc);
         this.exp = exp;
     }
 
@@ -6988,7 +6988,7 @@ extern (C++) final class TypeTypeof : TypeQualified
             error(loc, "expression `%s` has no type", exp.toChars());
             goto Lerr;
         }
-        if (t.ty == Ttypeof)
+        if (t.ty == TY.typeof_)
         {
             error(loc, "forward reference to `%s`", toChars());
             goto Lerr;
@@ -7032,7 +7032,7 @@ extern (C++) final class TypeReturn : TypeQualified
 {
     extern (D) this(Loc loc)
     {
-        super(Treturn, loc);
+        super(TY.return_, loc);
     }
 
     override const(char)* kind() const
@@ -7130,7 +7130,7 @@ extern (C++) final class TypeStruct : Type
 
     extern (D) this(StructDeclaration sym)
     {
-        super(Tstruct);
+        super(TY.struct_);
         this.sym = sym;
     }
 
@@ -7275,7 +7275,7 @@ extern (C++) final class TypeStruct : Type
                     e.error("forward reference to %s `%s`", v.kind(), v.toPrettyChars());
                 return new ErrorExp();
             }
-            if (v.type.ty == Terror)
+            if (v.type.ty == TY.error)
                 return new ErrorExp();
 
             if ((v.storage_class & STC.manifest) && v._init)
@@ -7696,7 +7696,7 @@ extern (C++) final class TypeEnum : Type
 
     extern (D) this(EnumDeclaration sym)
     {
-        super(Tenum);
+        super(TY.enum_);
         this.sym = sym;
     }
 
@@ -7718,7 +7718,7 @@ extern (C++) final class TypeEnum : Type
     override uint alignsize()
     {
         Type t = sym.getMemtype(Loc());
-        if (t.ty == Terror)
+        if (t.ty == TY.error)
             return 4;
         return t.alignsize();
     }
@@ -7947,7 +7947,7 @@ extern (C++) final class TypeClass : Type
 
     extern (D) this(ClassDeclaration sym)
     {
-        super(Tclass);
+        super(TY.class_);
         this.sym = sym;
     }
 
@@ -8227,7 +8227,7 @@ extern (C++) final class TypeClass : Type
                     e.error("forward reference to %s `%s`", v.kind(), v.toPrettyChars());
                 return new ErrorExp();
             }
-            if (v.type.ty == Terror)
+            if (v.type.ty == TY.error)
                 return new ErrorExp();
 
             if ((v.storage_class & STC.manifest) && v._init)
@@ -8416,7 +8416,7 @@ extern (C++) final class TypeClass : Type
 
     override bool isBaseOf(Type t, int* poffset)
     {
-        if (t && t.ty == Tclass)
+        if (t && t.ty == TY.class_)
         {
             ClassDeclaration cd = (cast(TypeClass)t).sym;
             if (sym.isBaseOf(cd, poffset))
@@ -8552,7 +8552,7 @@ extern (C++) final class TypeTuple : Type
 
     extern (D) this(Parameters* arguments)
     {
-        super(Ttuple);
+        super(TY.tuple);
         //printf("TypeTuple(this = %p)\n", this);
         this.arguments = arguments;
         //printf("TypeTuple() %p, %s\n", this, toChars());
@@ -8575,7 +8575,7 @@ extern (C++) final class TypeTuple : Type
      */
     extern (D) this(Expressions* exps)
     {
-        super(Ttuple);
+        super(TY.tuple);
         auto arguments = new Parameters();
         if (exps)
         {
@@ -8583,7 +8583,7 @@ extern (C++) final class TypeTuple : Type
             for (size_t i = 0; i < exps.dim; i++)
             {
                 Expression e = (*exps)[i];
-                if (e.type.ty == Ttuple)
+                if (e.type.ty == TY.tuple)
                     e.error("cannot form tuple of tuples");
                 auto arg = new Parameter(STC.undefined_, e.type, null, null);
                 (*arguments)[i] = arg;
@@ -8603,20 +8603,20 @@ extern (C++) final class TypeTuple : Type
      */
     extern (D) this()
     {
-        super(Ttuple);
+        super(TY.tuple);
         arguments = new Parameters();
     }
 
     extern (D) this(Type t1)
     {
-        super(Ttuple);
+        super(TY.tuple);
         arguments = new Parameters();
         arguments.push(new Parameter(0, t1, null, null));
     }
 
     extern (D) this(Type t1, Type t2)
     {
-        super(Ttuple);
+        super(TY.tuple);
         arguments = new Parameters();
         arguments.push(new Parameter(0, t1, null, null));
         arguments.push(new Parameter(0, t2, null, null));
@@ -8641,7 +8641,7 @@ extern (C++) final class TypeTuple : Type
         //printf("TypeTuple::equals(%s, %s)\n", toChars(), t.toChars());
         if (this == t)
             return true;
-        if (t.ty == Ttuple)
+        if (t.ty == TY.tuple)
         {
             TypeTuple tt = cast(TypeTuple)t;
             if (arguments.dim == tt.arguments.dim)
@@ -8718,7 +8718,7 @@ extern (C++) final class TypeSlice : TypeNext
 
     extern (D) this(Type next, Expression lwr, Expression upr)
     {
-        super(Tslice, next);
+        super(TY.slice, next);
         //printf("TypeSlice[%s .. %s]\n", lwr.toChars(), upr.toChars());
         this.lwr = lwr;
         this.upr = upr;
@@ -8799,7 +8799,7 @@ extern (C++) final class TypeSlice : TypeNext
         }
         else
         {
-            if ((*pt).ty != Terror)
+            if ((*pt).ty != TY.error)
                 next = *pt; // prevent re-running semantic() on 'next'
         Ldefault:
             Type.resolve(loc, sc, pe, pt, ps, intypeid);
@@ -8819,7 +8819,7 @@ extern (C++) final class TypeNull : Type
     extern (D) this()
     {
         //printf("TypeNull %p\n", this);
-        super(Tnull);
+        super(TY.null_);
     }
 
     override const(char)* kind() const
@@ -8843,10 +8843,10 @@ extern (C++) final class TypeNull : Type
             return m;
 
         // NULL implicitly converts to any pointer type or dynamic array
-        //if (type.ty == Tpointer && type.nextOf().ty == Tvoid)
+        //if (type.ty == TY.pointer && type.nextOf().ty == TY.void_)
         {
             Type tb = to.toBasetype();
-            if (tb.ty == Tnull || tb.ty == Tpointer || tb.ty == Tarray || tb.ty == Taarray || tb.ty == Tclass || tb.ty == Tdelegate)
+            if (tb.ty == TY.null_ || tb.ty == TY.pointer || tb.ty == TY.array || tb.ty == TY.aarray || tb.ty == TY.class_ || tb.ty == TY.delegate_)
                 return MATCH.constant;
         }
 
@@ -8913,10 +8913,10 @@ extern (C++) final class Parameter : RootObject
     Type isLazyArray()
     {
         Type tb = type.toBasetype();
-        if (tb.ty == Tsarray || tb.ty == Tarray)
+        if (tb.ty == TY.sarray || tb.ty == TY.array)
         {
             Type tel = (cast(TypeArray)tb).next.toBasetype();
-            if (tel.ty == Tdelegate)
+            if (tel.ty == TY.delegate_)
             {
                 TypeDelegate td = cast(TypeDelegate)tel;
                 TypeFunction tf = td.next.toTypeFunction();
@@ -9035,7 +9035,7 @@ extern (C++) final class Parameter : RootObject
             Parameter p = (*parameters)[i];
             Type t = p.type.toBasetype();
 
-            if (t.ty == Ttuple)
+            if (t.ty == TY.tuple)
             {
                 TypeTuple tu = cast(TypeTuple)t;
                 result = _foreach(tu.arguments, dg, &n);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -364,106 +364,58 @@ Expression semanticLength(Scope* sc, Type t, Expression exp)
     return exp;
 }
 
-enum ENUMTY : int
+enum TY : ubyte
 {
-    Tarray,     // slice array, aka T[]
-    Tsarray,    // static array, aka T[dimension]
-    Taarray,    // associative array, aka T[type]
-    Tpointer,
-    Treference,
-    Tfunction,
-    Tident,
-    Tclass,
-    Tstruct,
-    Tenum,
+    array,     // slice array, aka T[]
+    sarray,    // static array, aka T[dimension]
+    aarray,    // associative array, aka T[type]
+    pointer,
+    reference,
+    function_,
+    ident,
+    class_,
+    struct_,
+    enum_,
 
-    Tdelegate,
-    Tnone,
-    Tvoid,
-    Tint8,
-    Tuns8,
-    Tint16,
-    Tuns16,
-    Tint32,
-    Tuns32,
-    Tint64,
+    delegate_,
+    none,
+    void_,
+    int8,
+    uns8,
+    int16,
+    uns16,
+    int32,
+    uns32,
+    int64,
 
-    Tuns64,
-    Tfloat32,
-    Tfloat64,
-    Tfloat80,
-    Timaginary32,
-    Timaginary64,
-    Timaginary80,
-    Tcomplex32,
-    Tcomplex64,
-    Tcomplex80,
+    uns64,
+    float32,
+    float64,
+    float80,
+    imaginary32,
+    imaginary64,
+    imaginary80,
+    complex32,
+    complex64,
+    complex80,
 
-    Tbool,
-    Tchar,
-    Twchar,
-    Tdchar,
-    Terror,
-    Tinstance,
-    Ttypeof,
-    Ttuple,
-    Tslice,
-    Treturn,
+    bool_,
+    char_,
+    wchar_,
+    dchar_,
+    error,
+    instance,
+    typeof_,
+    tuple,
+    slice,
+    return_,
 
-    Tnull,
-    Tvector,
-    Tint128,
-    Tuns128,
-    TMAX,
+    null_,
+    vector,
+    int128,
+    uns128,
+    MAX,
 }
-
-alias Tarray = ENUMTY.Tarray;
-alias Tsarray = ENUMTY.Tsarray;
-alias Taarray = ENUMTY.Taarray;
-alias Tpointer = ENUMTY.Tpointer;
-alias Treference = ENUMTY.Treference;
-alias Tfunction = ENUMTY.Tfunction;
-alias Tident = ENUMTY.Tident;
-alias Tclass = ENUMTY.Tclass;
-alias Tstruct = ENUMTY.Tstruct;
-alias Tenum = ENUMTY.Tenum;
-alias Tdelegate = ENUMTY.Tdelegate;
-alias Tnone = ENUMTY.Tnone;
-alias Tvoid = ENUMTY.Tvoid;
-alias Tint8 = ENUMTY.Tint8;
-alias Tuns8 = ENUMTY.Tuns8;
-alias Tint16 = ENUMTY.Tint16;
-alias Tuns16 = ENUMTY.Tuns16;
-alias Tint32 = ENUMTY.Tint32;
-alias Tuns32 = ENUMTY.Tuns32;
-alias Tint64 = ENUMTY.Tint64;
-alias Tuns64 = ENUMTY.Tuns64;
-alias Tfloat32 = ENUMTY.Tfloat32;
-alias Tfloat64 = ENUMTY.Tfloat64;
-alias Tfloat80 = ENUMTY.Tfloat80;
-alias Timaginary32 = ENUMTY.Timaginary32;
-alias Timaginary64 = ENUMTY.Timaginary64;
-alias Timaginary80 = ENUMTY.Timaginary80;
-alias Tcomplex32 = ENUMTY.Tcomplex32;
-alias Tcomplex64 = ENUMTY.Tcomplex64;
-alias Tcomplex80 = ENUMTY.Tcomplex80;
-alias Tbool = ENUMTY.Tbool;
-alias Tchar = ENUMTY.Tchar;
-alias Twchar = ENUMTY.Twchar;
-alias Tdchar = ENUMTY.Tdchar;
-alias Terror = ENUMTY.Terror;
-alias Tinstance = ENUMTY.Tinstance;
-alias Ttypeof = ENUMTY.Ttypeof;
-alias Ttuple = ENUMTY.Ttuple;
-alias Tslice = ENUMTY.Tslice;
-alias Treturn = ENUMTY.Treturn;
-alias Tnull = ENUMTY.Tnull;
-alias Tvector = ENUMTY.Tvector;
-alias Tint128 = ENUMTY.Tint128;
-alias Tuns128 = ENUMTY.Tuns128;
-alias TMAX = ENUMTY.TMAX;
-
-alias TY = ubyte;
 
 enum MODFlags : int
 {

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3403,7 +3403,7 @@ extern (C++) final class TypeBasic : Type
         super(ty);
         const(char)* d;
         uint flags = 0;
-        switch (ty)
+        final switch (ty)
         {
         case TY.void_:
             d = Token.toChars(TOKvoid);
@@ -3523,8 +3523,27 @@ extern (C++) final class TypeBasic : Type
             d = Token.toChars(TOKdchar);
             flags |= TFlags.integral | TFlags.unsigned;
             break;
-
-        default:
+        case TY.array:
+        case TY.sarray:
+        case TY.aarray:
+        case TY.pointer:
+        case TY.reference:
+        case TY.function_:
+        case TY.ident:
+        case TY.class_:
+        case TY.struct_:
+        case TY.enum_:
+        case TY.delegate_:
+        case TY.none:
+        case TY.error:
+        case TY.instance:
+        case TY.typeof_:
+        case TY.tuple:
+        case TY.slice:
+        case TY.return_:
+        case TY.null_:
+        case TY.vector:
+        case TY.MAX:
             assert(0);
         }
         this.dstring = d;
@@ -3547,7 +3566,7 @@ extern (C++) final class TypeBasic : Type
     {
         uint size;
         //printf("TypeBasic::size()\n");
-        switch (ty)
+        final switch (ty)
         {
         case TY.int8:
         case TY.uns8:
@@ -3613,7 +3632,27 @@ extern (C++) final class TypeBasic : Type
             size = 4;
             break;
 
-        default:
+        case TY.array:
+        case TY.sarray:
+        case TY.aarray:
+        case TY.pointer:
+        case TY.reference:
+        case TY.function_:
+        case TY.ident:
+        case TY.class_:
+        case TY.struct_:
+        case TY.enum_:
+        case TY.delegate_:
+        case TY.none:
+        case TY.error:
+        case TY.instance:
+        case TY.typeof_:
+        case TY.tuple:
+        case TY.slice:
+        case TY.return_:
+        case TY.null_:
+        case TY.vector:
+        case TY.MAX:
             assert(0);
         }
         //printf("TypeBasic::size() = %d\n", size);
@@ -3633,7 +3672,7 @@ extern (C++) final class TypeBasic : Type
         //printf("TypeBasic::getProperty('%s')\n", ident.toChars());
         if (ident == Id.max)
         {
-            switch (ty)
+            final switch (ty)
             {
             case TY.int8:
                 ivalue = 0x7F;
@@ -3686,7 +3725,31 @@ extern (C++) final class TypeBasic : Type
             case TY.float80:
                 fvalue = Target.RealProperties.max;
                 goto Lfvalue;
-            default:
+
+            case TY.array:
+            case TY.sarray:
+            case TY.aarray:
+            case TY.pointer:
+            case TY.reference:
+            case TY.function_:
+            case TY.ident:
+            case TY.class_:
+            case TY.struct_:
+            case TY.enum_:
+            case TY.delegate_:
+            case TY.none:
+            case TY.void_:
+            case TY.error:
+            case TY.instance:
+            case TY.typeof_:
+            case TY.tuple:
+            case TY.slice:
+            case TY.return_:
+            case TY.null_:
+            case TY.vector:
+            case TY.int128:
+            case TY.uns128:
+            case TY.MAX:
                 break;
             }
         }

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -68,7 +68,7 @@ public:
 
     override void visit(ArrayLiteralExp e)
     {
-        if (e.type.ty != Tarray || !e.elements || !e.elements.dim)
+        if (e.type.ty != TY.array || !e.elements || !e.elements.dim)
             return;
         if (f.setGC())
         {
@@ -130,13 +130,13 @@ public:
         AggregateDeclaration ad = null;
         switch (tb.ty)
         {
-        case Tclass:
+        case TY.class_:
             ad = (cast(TypeClass)tb).sym;
             break;
 
-        case Tpointer:
+        case TY.pointer:
             tb = (cast(TypePointer)tb).next.toBasetype();
-            if (tb.ty == Tstruct)
+            if (tb.ty == TY.struct_)
                 ad = (cast(TypeStruct)tb).sym;
             break;
 
@@ -159,7 +159,7 @@ public:
     override void visit(IndexExp e)
     {
         Type t1b = e.e1.type.toBasetype();
-        if (t1b.ty == Taarray)
+        if (t1b.ty == TY.aarray)
         {
             if (f.setGC())
             {
@@ -215,7 +215,7 @@ public:
 extern (C++) Expression checkGC(Scope* sc, Expression e)
 {
     FuncDeclaration f = sc.func;
-    if (e && e.op != TOKerror && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) && (f.type.ty == Tfunction && (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc))
+    if (e && e.op != TOKerror && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) && (f.type.ty == TY.function_ && (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc))
     {
         scope NOGCVisitor gcv = new NOGCVisitor(f);
         walkPostorder(e, gcv);

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -309,9 +309,9 @@ static:
         if (hasHiddenArgument)
             return setSymbol!("_objc_msgSend_stret")(TYhfunc);
         // not sure if DMD can handle this
-        else if (returnType.ty == Tcomplex80)
+        else if (returnType.ty == TY.complex80)
             return setSymbol!("_objc_msgSend_fp2ret");
-        else if (returnType.ty == Tfloat80)
+        else if (returnType.ty == TY.float80)
             return setSymbol!("_objc_msgSend_fpret");
         else
             return setSymbol!("_objc_msgSend");

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -370,11 +370,11 @@ private Identifier opId_r(Expression e)
 extern (C++) AggregateDeclaration isAggregate(Type t)
 {
     t = t.toBasetype();
-    if (t.ty == Tclass)
+    if (t.ty == TY.class_)
     {
         return (cast(TypeClass)t).sym;
     }
-    else if (t.ty == Tstruct)
+    else if (t.ty == TY.struct_)
     {
         return (cast(TypeStruct)t).sym;
     }
@@ -643,8 +643,8 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 {
                     // If the non-aggregate expression ae.e1 is indexable or sliceable,
                     // convert it to the corresponding concrete expression.
-                    if (t1b.ty == Tpointer || t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Taarray ||
-                        t1b.ty == Ttuple || t1b.ty == Tvector || ae.e1.op == TOKtype)
+                    if (t1b.ty == TY.pointer || t1b.ty == TY.sarray || t1b.ty == TY.array || t1b.ty == TY.aarray ||
+                        t1b.ty == TY.tuple || t1b.ty == TY.vector || ae.e1.op == TOKtype)
                     {
                         // Convert to SliceExp
                         if (maybeSlice)
@@ -1075,16 +1075,16 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
             /* Check for array equality.
              */
-            if ((t1.ty == Tarray || t1.ty == Tsarray)
-                && (t2.ty == Tarray || t2.ty == Tsarray))
+            if ((t1.ty == TY.array || t1.ty == TY.sarray)
+                && (t2.ty == TY.array || t2.ty == TY.sarray))
             {
                 bool needsDirectEq()
                 {
                     Type t1n = t1.nextOf().toBasetype();
                     Type t2n = t2.nextOf().toBasetype();
-                    if (((t1n.ty == Tchar || t1n.ty == Twchar || t1n.ty == Tdchar) &&
-                         (t2n.ty == Tchar || t2n.ty == Twchar || t2n.ty == Tdchar)) ||
-                        (t1n.ty == Tvoid || t2n.ty == Tvoid))
+                    if (((t1n.ty == TY.char_ || t1n.ty == TY.wchar_ || t1n.ty == TY.dchar_) &&
+                         (t2n.ty == TY.char_ || t2n.ty == TY.wchar_ || t2n.ty == TY.dchar_)) ||
+                        (t1n.ty == TY.void_ || t2n.ty == TY.void_))
                     {
                         return false;
                     }
@@ -1094,14 +1094,14 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     Type t = t1n;
                     while (t.toBasetype().nextOf())
                         t = t.nextOf().toBasetype();
-                    if (t.ty != Tstruct)
+                    if (t.ty != TY.struct_)
                         return false;
 
                     semanticTypeInfo(sc, t);
                     return (cast(TypeStruct)t).sym.hasIdentityEquals;
                 }
 
-                if (needsDirectEq() && !(t1.ty == Tarray && t2.ty == Tarray))
+                if (needsDirectEq() && !(t1.ty == TY.array && t2.ty == TY.array))
                 {
                     /* Rewrite as:
                      *      _ArrayEq(e1, e2)
@@ -1122,8 +1122,8 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
             /* Check for class equality with null literal or typeof(null).
              */
-            if (t1.ty == Tclass && e.e2.op == TOKnull ||
-                t2.ty == Tclass && e.e1.op == TOKnull)
+            if (t1.ty == TY.class_ && e.e2.op == TOKnull ||
+                t2.ty == TY.class_ && e.e1.op == TOKnull)
             {
                 e.error("use `%s` instead of `%s` when comparing with `null`",
                     Token.toChars(e.op == TOKequal ? TOKidentity : TOKnotidentity),
@@ -1131,8 +1131,8 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 result = new ErrorExp();
                 return;
             }
-            if (t1.ty == Tclass && t2.ty == Tnull ||
-                t1.ty == Tnull && t2.ty == Tclass)
+            if (t1.ty == TY.class_ && t2.ty == TY.null_ ||
+                t1.ty == TY.null_ && t2.ty == TY.class_)
             {
                 // Comparing a class with typeof(null) should not call opEquals
                 return;
@@ -1140,7 +1140,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
             /* Check for class equality.
              */
-            if (t1.ty == Tclass && t2.ty == Tclass)
+            if (t1.ty == TY.class_ && t2.ty == TY.class_)
             {
                 ClassDeclaration cd1 = t1.isClassHandle();
                 ClassDeclaration cd2 = t2.isClassHandle();
@@ -1183,12 +1183,12 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                 return;
             }
 
-            if (t1.ty == Tarray && t2.ty == Tarray)
+            if (t1.ty == TY.array && t2.ty == TY.array)
                 return;
 
             /* Check for pointer equality.
              */
-            if (t1.ty == Tpointer || t2.ty == Tpointer)
+            if (t1.ty == TY.pointer || t2.ty == TY.pointer)
             {
                 /* Rewrite:
                  *      ptr1 == ptr2
@@ -1206,7 +1206,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
 
             /* Check for struct equality without opEquals.
              */
-            if (t1.ty == Tstruct && t2.ty == Tstruct)
+            if (t1.ty == TY.struct_ && t2.ty == TY.struct_)
             {
                 auto sd = (cast(TypeStruct)t1).sym;
                 if (sd != (cast(TypeStruct)t2).sym)
@@ -1420,7 +1420,7 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
             if (result)
                 return;
             // Don't attempt 'alias this' if an error occurred
-            if (e.e1.type.ty == Terror || e.e2.type.ty == Terror)
+            if (e.e1.type.ty == TY.error || e.e2.type.ty == TY.error)
             {
                 result = new ErrorExp();
                 return;
@@ -1716,7 +1716,7 @@ extern (C++) Dsymbol search_function(ScopeDsymbol ad, Identifier funcid)
         Dsymbol s2 = s.toAlias();
         //printf("search_function: s2 = '%s'\n", s2.kind());
         FuncDeclaration fd = s2.isFuncDeclaration();
-        if (fd && fd.type.ty == Tfunction)
+        if (fd && fd.type.ty == TY.function_)
             return fd;
         TemplateDeclaration td = s2.isTemplateDeclaration();
         if (td)
@@ -1745,15 +1745,15 @@ extern (C++) bool inferAggregate(ForeachStatement fes, Scope* sc, ref Dsymbol sa
         tab = aggr.type.toBasetype();
         switch (tab.ty)
         {
-        case Tarray:
-        case Tsarray:
-        case Ttuple:
-        case Taarray:
+        case TY.array:
+        case TY.sarray:
+        case TY.tuple:
+        case TY.aarray:
             break;
-        case Tclass:
+        case TY.class_:
             ad = (cast(TypeClass)tab).sym;
             goto Laggr;
-        case Tstruct:
+        case TY.struct_:
             ad = (cast(TypeStruct)tab).sym;
             goto Laggr;
         Laggr:
@@ -1792,13 +1792,13 @@ extern (C++) bool inferAggregate(ForeachStatement fes, Scope* sc, ref Dsymbol sa
                 continue;
             }
             goto Lerr;
-        case Tdelegate:
+        case TY.delegate_:
             if (aggr.op == TOKdelegate)
             {
                 sapply = (cast(DelegateExp)aggr).func;
             }
             break;
-        case Terror:
+        case TY.error:
             break;
         default:
             goto Lerr;
@@ -1833,11 +1833,11 @@ extern (C++) bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbo
         }
         Expression ethis;
         Type tab = fes.aggr.type.toBasetype();
-        if (tab.ty == Tclass || tab.ty == Tstruct)
+        if (tab.ty == TY.class_ || tab.ty == TY.struct_)
             ethis = fes.aggr;
         else
         {
-            assert(tab.ty == Tdelegate && fes.aggr.op == TOKdelegate);
+            assert(tab.ty == TY.delegate_ && fes.aggr.op == TOKdelegate);
             ethis = (cast(DelegateExp)fes.aggr).e1;
         }
         /* Look for like an
@@ -1866,9 +1866,9 @@ extern (C++) bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbo
     Type tab = taggr.toBasetype();
     switch (tab.ty)
     {
-    case Tarray:
-    case Tsarray:
-    case Ttuple:
+    case TY.array:
+    case TY.sarray:
+    case TY.tuple:
         if (fes.parameters.dim == 2)
         {
             if (!p.type)
@@ -1878,13 +1878,13 @@ extern (C++) bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbo
             }
             p = (*fes.parameters)[1];
         }
-        if (!p.type && tab.ty != Ttuple)
+        if (!p.type && tab.ty != TY.tuple)
         {
             p.type = tab.nextOf(); // value type
             p.type = p.type.addStorageClass(p.storageClass);
         }
         break;
-    case Taarray:
+    case TY.aarray:
         {
             TypeAArray taa = cast(TypeAArray)tab;
             if (fes.parameters.dim == 2)
@@ -1905,10 +1905,10 @@ extern (C++) bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbo
             }
             break;
         }
-    case Tclass:
+    case TY.class_:
         ad = (cast(TypeClass)tab).sym;
         goto Laggr;
-    case Tstruct:
+    case TY.struct_:
         ad = (cast(TypeStruct)tab).sym;
         goto Laggr;
     Laggr:
@@ -1942,7 +1942,7 @@ extern (C++) bool inferApplyArgTypes(ForeachStatement fes, Scope* sc, ref Dsymbo
             break;
         }
         break;
-    case Tdelegate:
+    case TY.delegate_:
         {
             if (!inferApplyArgTypesY(cast(TypeFunction)tab.nextOf(), fes.parameters))
                 return false;
@@ -2015,10 +2015,10 @@ private int inferApplyArgTypesY(TypeFunction tf, Parameters* parameters, int fla
     if (Parameter.dim(tf.parameters) != 1)
         goto Lnomatch;
     p = Parameter.getNth(tf.parameters, 0);
-    if (p.type.ty != Tdelegate)
+    if (p.type.ty != TY.delegate_)
         goto Lnomatch;
     tf = cast(TypeFunction)p.type.nextOf();
-    assert(tf.ty == Tfunction);
+    assert(tf.ty == TY.function_);
     /* We now have tf, the type of the delegate. Match it against
      * the parameters, filling in missing parameter types.
      */

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -59,7 +59,7 @@ extern (C++) Expression expandVar(int result, VarDeclaration v)
             return e;
         }
         Type tb = v.type.toBasetype();
-        if (v.storage_class & STC.manifest || v.type.toBasetype().isscalar() || ((result & WANTexpand) && (tb.ty != Tsarray && tb.ty != Tstruct)))
+        if (v.storage_class & STC.manifest || v.type.toBasetype().isscalar() || ((result & WANTexpand) && (tb.ty != TY.sarray && tb.ty != TY.struct_)))
         {
             if (v._init)
             {
@@ -95,7 +95,7 @@ extern (C++) Expression expandVar(int result, VarDeclaration v)
                         // Do not constfold the string literal
                         // if it's typed as a C string, because the value expansion
                         // will drop the pointer identity.
-                        if (!(result & WANTexpand) && ei.type.toBasetype().ty == Tpointer)
+                        if (!(result & WANTexpand) && ei.type.toBasetype().ty == TY.pointer)
                             goto L1;
                     }
                     else
@@ -172,7 +172,7 @@ extern (C++) Expression fromConstInitializer(int result, Expression e1)
             // See bugzilla 4465.
             if (e.op == TOKcomma && (cast(CommaExp)e).e1.op == TOKdeclaration)
                 e = e1;
-            else if (e.type != e1.type && e1.type && e1.type.ty != Tident)
+            else if (e.type != e1.type && e1.type && e1.type.ty != TY.ident)
             {
                 // Type 'paint' operation
                 e = e.copy();
@@ -391,7 +391,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 {
                     sinteger_t index = ae.e2.toInteger();
                     VarExp ve = cast(VarExp)ae.e1;
-                    if (ve.type.ty == Tsarray && !ve.var.isImportedSymbol())
+                    if (ve.type.ty == TY.sarray && !ve.var.isImportedSymbol())
                     {
                         TypeSArray ts = cast(TypeSArray)ve.type;
                         sinteger_t dim = ts.dim.toInteger();
@@ -528,9 +528,9 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             if (e.arguments)
             {
                 Type t1 = e.e1.type.toBasetype();
-                if (t1.ty == Tdelegate)
+                if (t1.ty == TY.delegate_)
                     t1 = t1.nextOf();
-                assert(t1.ty == Tfunction);
+                assert(t1.ty == TY.function_);
                 TypeFunction tf = cast(TypeFunction)t1;
                 for (size_t i = 0; i < e.arguments.dim; i++)
                 {
@@ -554,14 +554,14 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             if (expOptimize(e.e1, result))
                 return;
             e.e1 = fromConstInitializer(result, e.e1);
-            if (e.e1 == e1old && e.e1.op == TOKarrayliteral && e.type.toBasetype().ty == Tpointer && e.e1.type.toBasetype().ty != Tsarray)
+            if (e.e1 == e1old && e.e1.op == TOKarrayliteral && e.type.toBasetype().ty == TY.pointer && e.e1.type.toBasetype().ty != TY.sarray)
             {
                 // Casting this will result in the same expression, and
                 // infinite loop because of Expression::implicitCastTo()
                 return; // no change
             }
             if ((e.e1.op == TOKstring || e.e1.op == TOKarrayliteral) &&
-                (e.type.ty == Tpointer || e.type.ty == Tarray))
+                (e.type.ty == TY.pointer || e.type.ty == TY.array))
             {
                 const esz  = e.type.nextOf().size(e.loc);
                 const e1sz = e.e1.type.toBasetype().nextOf().size(e.e1.loc);
@@ -573,7 +573,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                     // https://issues.dlang.org/show_bug.cgi?id=12937
                     // If target type is void array, trying to paint
                     // e.e1 with that type will cause infinite recursive optimization.
-                    if (e.type.nextOf().ty == Tvoid)
+                    if (e.type.nextOf().ty == TY.void_)
                         return;
                     ret = e.e1.castTo(null, e.type);
                     //printf(" returning1 %s\n", ret.toChars());
@@ -597,12 +597,12 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 ret = e.e1.castTo(null, e.to);
                 return;
             }
-            if (e.e1.op == TOKnull && (e.type.ty == Tpointer || e.type.ty == Tclass || e.type.ty == Tarray))
+            if (e.e1.op == TOKnull && (e.type.ty == TY.pointer || e.type.ty == TY.class_ || e.type.ty == TY.array))
             {
                 //printf(" returning3 %s\n", e.e1.toChars());
                 goto L1;
             }
-            if (e.type.ty == Tclass && e.e1.type.ty == Tclass)
+            if (e.type.ty == TY.class_ && e.e1.type.ty == TY.class_)
             {
                 import dmd.aggregate : Sizeok;
 
@@ -633,7 +633,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             {
                 if (e.e1.op == TOKsymoff)
                 {
-                    if (e.type.toBasetype().ty != Tsarray)
+                    if (e.type.toBasetype().ty != TY.sarray)
                     {
                         const esz = e.type.size(e.loc);
                         const e1sz = e.e1.type.size(e.e1.loc);
@@ -646,7 +646,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                     }
                     return;
                 }
-                if (e.to.toBasetype().ty != Tvoid)
+                if (e.to.toBasetype().ty != TY.void_)
                 {
                     if (e.e1.type.equals(e.type) && e.type.equals(e.to))
                         ret = e.e1;
@@ -931,7 +931,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                         e.e1 = ci;
                 }
             }
-            if (e.e1.op == TOKstring || e.e1.op == TOKarrayliteral || e.e1.op == TOKassocarrayliteral || e.e1.type.toBasetype().ty == Tsarray)
+            if (e.e1.op == TOKstring || e.e1.op == TOKarrayliteral || e.e1.op == TOKassocarrayliteral || e.e1.type.toBasetype().ty == TY.sarray)
             {
                 ret = ArrayLength(e.type, e.e1).copy();
             }
@@ -990,7 +990,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             else
             {
                 Type t = arr.type.toBasetype();
-                if (t.ty == Tsarray)
+                if (t.ty == TY.sarray)
                     len = cast(size_t)(cast(TypeSArray)t).dim.toInteger();
                 else
                     return; // we don't know the length yet
@@ -1071,7 +1071,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 // Replace with (e1, oror)
                 ret = new IntegerExp(e.loc, oror, Type.tbool);
                 ret = Expression.combine(e.e1, ret);
-                if (e.type.toBasetype().ty == Tvoid)
+                if (e.type.toBasetype().ty == TY.void_)
                 {
                     ret = new CastExp(e.loc, ret, Type.tvoid);
                     ret.type = e.type;
@@ -1091,7 +1091,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 }
                 else if (e.e1.isBool(!oror))
                 {
-                    if (e.type.toBasetype().ty == Tvoid)
+                    if (e.type.toBasetype().ty == TY.void_)
                         ret = e.e2;
                     else
                     {

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3555,10 +3555,10 @@ final class Parser(AST) : Lexer
         // See https://issues.dlang.org/show_bug.cgi?id=1215
         // A basic type can look like MyType (typical case), but also:
         //  MyType.T -> A type
-        //  MyType[expr] -> Either a static array of MyType or a type (iif MyType is a Ttuple)
+        //  MyType[expr] -> Either a static array of MyType or a type (iif MyType is a TY.tuple)
         //  MyType[expr].T -> A type.
         //  MyType[expr].T[expr] ->  Either a static array of MyType[expr].T or a type
-        //                           (iif MyType[expr].T is a Ttuple)
+        //                           (iif MyType[expr].T is a TY.tuple)
         while (1)
         {
             switch (token.value)
@@ -3580,14 +3580,14 @@ final class Parser(AST) : Lexer
                         AST.Type t = maybeArray;
                         while (true)
                         {
-                            if (t.ty == AST.Tsarray)
+                            if (t.ty == AST.TY.sarray)
                             {
                                 // The index expression is an Expression.
                                 AST.TypeSArray a = cast(AST.TypeSArray)t;
                                 dimStack.push(a.dim.syntaxCopy());
                                 t = a.next.syntaxCopy();
                             }
-                            else if (t.ty == AST.Taarray)
+                            else if (t.ty == AST.TY.aarray)
                             {
                                 // The index expression is a Type. It will be interpreted as an expression at semantic time.
                                 AST.TypeAArray a = cast(AST.TypeAArray)t;
@@ -4359,7 +4359,7 @@ final class Parser(AST) : Lexer
             else if (t != tfirst)
                 error("multiple declarations must have the same type, not `%s` and `%s`", tfirst.toChars(), t.toChars());
 
-            bool isThis = (t.ty == AST.Tident && (cast(AST.TypeIdentifier)t).ident == Id.This && token.value == TOKassign);
+            bool isThis = (t.ty == AST.TY.ident && (cast(AST.TypeIdentifier)t).ident == Id.This && token.value == TOKassign);
             if (ident)
                 checkCstyleTypeSyntax(loc, t, alt, ident);
             else if (!isThis)
@@ -4431,7 +4431,7 @@ final class Parser(AST) : Lexer
                     break;
                 }
             }
-            else if (t.ty == AST.Tfunction)
+            else if (t.ty == AST.TY.function_)
             {
                 AST.Expression constraint = null;
                 version (none)
@@ -8548,7 +8548,7 @@ final class Parser(AST) : Lexer
         auto t = parseBasicType(true);
         t = parseBasicType2(t);
         t = t.addSTC(stc);
-        if (t.ty == AST.Taarray)
+        if (t.ty == AST.TY.aarray)
         {
             AST.TypeAArray taa = cast(AST.TypeAArray)t;
             AST.Type index = taa.index;
@@ -8560,7 +8560,7 @@ final class Parser(AST) : Lexer
             }
             t = new AST.TypeSArray(taa.next, edim);
         }
-        else if (t.ty == AST.Tsarray)
+        else if (t.ty == AST.TY.sarray)
         {
         }
         else if (token.value == TOKlparen)

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -716,7 +716,7 @@ private extern (C++) class S2irVisitor : Visitor
 
             FuncDeclaration func = irs.getFunc();
             assert(func);
-            assert(func.type.ty == Tfunction);
+            assert(func.type.ty == TY.function_);
             TypeFunction tf = cast(TypeFunction)(func.type);
 
             RET retmethod = retStyle(tf);

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -298,13 +298,13 @@ private extern(C++) final class Semantic2Visitor : Visitor
         {
             // Cannot initialize a thread-local class or pointer to struct variable with a literal
             // that itself is a thread-local reference and would need dynamic initialization also.
-            if ((vd.type.ty == Tclass) && vd.type.isMutable() && !vd.type.isShared())
+            if ((vd.type.ty == TY.class_) && vd.type.isMutable() && !vd.type.isShared())
             {
                 ExpInitializer ei = vd._init.isExpInitializer();
                 if (ei && ei.exp.op == TOKclassreference)
                     vd.error("is a thread-local class and cannot have a static initializer. Use `static this()` to initialize instead.");
             }
-            else if (vd.type.ty == Tpointer && vd.type.nextOf().ty == Tstruct && vd.type.nextOf().isMutable() && !vd.type.nextOf().isShared())
+            else if (vd.type.ty == TY.pointer && vd.type.nextOf().ty == TY.struct_ && vd.type.nextOf().isMutable() && !vd.type.nextOf().isShared())
             {
                 ExpInitializer ei = vd._init.isExpInitializer();
                 if (ei && ei.exp.op == TOKaddress && (cast(AddrExp)ei.exp).e1.op == TOKstructliteral)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -257,10 +257,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
         funcdecl.semanticRun = PASS.semantic3;
         funcdecl.semantic3Errors = false;
 
-        if (!funcdecl.type || funcdecl.type.ty != Tfunction)
+        if (!funcdecl.type || funcdecl.type.ty != TY.function_)
             return;
         TypeFunction f = cast(TypeFunction)funcdecl.type;
-        if (!funcdecl.inferRetType && f.next.ty == Terror)
+        if (!funcdecl.inferRetType && f.next.ty == TY.error)
             return;
 
         if (!funcdecl.fbody && funcdecl.inferRetType && !f.next)
@@ -460,7 +460,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     Parameter fparam = (*f.parameters)[i];
                     if (!fparam.ident)
                         continue; // never used, so ignore
-                    if (fparam.type.ty == Ttuple)
+                    if (fparam.type.ty == TY.tuple)
                     {
                         TypeTuple t = cast(TypeTuple)fparam.type;
                         size_t dim = Parameter.dim(t.arguments);
@@ -569,7 +569,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     fpostinv = null;
                 }
 
-                assert(funcdecl.type == f || (funcdecl.type.ty == Tfunction && f.purity == PURE.impure && (cast(TypeFunction)funcdecl.type).purity >= PURE.fwdref));
+                assert(funcdecl.type == f || (funcdecl.type.ty == TY.function_ && f.purity == PURE.impure && (cast(TypeFunction)funcdecl.type).purity >= PURE.fwdref));
                 f = cast(TypeFunction)funcdecl.type;
 
                 if (funcdecl.inferRetType)
@@ -590,7 +590,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         Expression exp = (*funcdecl.returns)[i].exp;
                         if (exp.op == TOKvar && (cast(VarExp)exp).var == funcdecl.vresult)
                         {
-                            if (f.next.ty == Tvoid && funcdecl.isMain())
+                            if (f.next.ty == TY.void_ && funcdecl.isMain())
                                 exp.type = Type.tint32;
                             else
                                 exp.type = f.next;
@@ -759,7 +759,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 else
                 {
                     const(bool) inlineAsm = (funcdecl.hasReturnExp & 8) != 0;
-                    if ((blockexit & BE.fallthru) && f.next.ty != Tvoid && !inlineAsm)
+                    if ((blockexit & BE.fallthru) && f.next.ty != TY.void_ && !inlineAsm)
                     {
                         Expression e;
                         if (!funcdecl.hasReturnExp)
@@ -784,9 +784,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 if (funcdecl.returns)
                 {
-                    bool implicit0 = (f.next.ty == Tvoid && funcdecl.isMain());
+                    bool implicit0 = (f.next.ty == TY.void_ && funcdecl.isMain());
                     Type tret = implicit0 ? Type.tint32 : f.next;
-                    assert(tret.ty != Tvoid);
+                    assert(tret.ty != TY.void_);
                     if (funcdecl.vresult || funcdecl.returnLabel)
                         funcdecl.buildResultVar(scout ? scout : sc2, tret);
 
@@ -799,7 +799,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         Expression exp = rs.exp;
                         if (exp.op == TOKerror)
                             continue;
-                        if (tret.ty == Terror)
+                        if (tret.ty == TY.error)
                         {
                             // https://issues.dlang.org/show_bug.cgi?id=13702
                             exp = checkGC(sc2, exp);
@@ -901,7 +901,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             {
                 /* fensure is composed of the [out] contracts
                  */
-                if (f.next.ty == Tvoid && funcdecl.outId)
+                if (f.next.ty == TY.void_ && funcdecl.outId)
                     funcdecl.error("void functions have no result");
 
                 sc2 = scout; //push
@@ -909,7 +909,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 // BUG: need to disallow returns and throws
 
-                if (funcdecl.fensure && f.next.ty != Tvoid)
+                if (funcdecl.fensure && f.next.ty != TY.void_)
                     funcdecl.buildResultVar(scout, f.next);
 
                 fens = fens.statementSemantic(sc2);
@@ -987,7 +987,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     funcdecl.returnLabel.statement = ls;
                     a.push(funcdecl.returnLabel.statement);
 
-                    if (f.next.ty != Tvoid && funcdecl.vresult)
+                    if (f.next.ty != TY.void_ && funcdecl.vresult)
                     {
                         // Create: return vresult;
                         Expression e = new VarExp(Loc(), funcdecl.vresult);
@@ -1000,7 +1000,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         a.push(s);
                     }
                 }
-                if (funcdecl.isMain() && f.next.ty == Tvoid)
+                if (funcdecl.isMain() && f.next.ty == TY.void_)
                 {
                     // Add a return 0; statement
                     Statement s = new ReturnStatement(Loc(), new IntegerExp(0));
@@ -1196,7 +1196,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          */
         funcdecl.semanticRun = PASS.semantic3done;
         funcdecl.semantic3Errors = (global.errors != oldErrors) || (funcdecl.fbody && funcdecl.fbody.isErrorStatement());
-        if (funcdecl.type.ty == Terror)
+        if (funcdecl.type.ty == TY.error)
             funcdecl.errors = true;
         //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent.toChars(), toChars(), sc, loc.toChars());
         //fflush(stdout);
@@ -1265,7 +1265,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         // don't do it for unused deprecated types
         // or error ypes
-        if (!ad.getRTInfo && Type.rtinfo && (!ad.isDeprecated() || global.params.useDeprecated) && (ad.type && ad.type.ty != Terror))
+        if (!ad.getRTInfo && Type.rtinfo && (!ad.isDeprecated() || global.params.useDeprecated) && (ad.type && ad.type.ty != TY.error))
         {
             // Evaluate: RTinfo!type
             auto tiargs = new Objects();

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -99,7 +99,7 @@ extern (C++) int callSideEffectLevel(FuncDeclaration f)
      */
     if (f.isCtorDeclaration())
         return 0;
-    assert(f.type.ty == Tfunction);
+    assert(f.type.ty == TY.function_);
     TypeFunction tf = cast(TypeFunction)f.type;
     if (tf.isnothrow)
     {
@@ -116,16 +116,16 @@ extern (C++) int callSideEffectLevel(Type t)
 {
     t = t.toBasetype();
     TypeFunction tf;
-    if (t.ty == Tdelegate)
+    if (t.ty == TY.delegate_)
         tf = cast(TypeFunction)(cast(TypeDelegate)t).next;
     else
     {
-        assert(t.ty == Tfunction);
+        assert(t.ty == TY.function_);
         tf = cast(TypeFunction)t;
     }
     tf.purityLevel();
     PURE purity = tf.purity;
-    if (t.ty == Tdelegate && purity > PURE.weak)
+    if (t.ty == TY.delegate_ && purity > PURE.weak)
     {
         if (tf.isMutable())
             purity = PURE.weak;
@@ -185,9 +185,9 @@ private bool lambdaHasSideEffect(Expression e)
             if (ce.e1.type)
             {
                 Type t = ce.e1.type.toBasetype();
-                if (t.ty == Tdelegate)
+                if (t.ty == TY.delegate_)
                     t = (cast(TypeDelegate)t).next;
-                if (t.ty == Tfunction && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
+                if (t.ty == TY.function_ && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
                 {
                 }
                 else
@@ -201,7 +201,7 @@ private bool lambdaHasSideEffect(Expression e)
             /* if:
              *  cast(classtype)func()  // because it may throw
              */
-            if (ce.to.ty == Tclass && ce.e1.op == TOKcall && ce.e1.type.ty == Tclass)
+            if (ce.to.ty == TY.class_ && ce.e1.op == TOKcall && ce.e1.type.ty == TY.class_)
                 return true;
             break;
         }
@@ -253,7 +253,7 @@ extern (C++) bool discardValue(Expression e)
         if (global.params.warnings && !global.gag)
         {
             CallExp ce = cast(CallExp)e;
-            if (e.type.ty == Tvoid)
+            if (e.type.ty == TY.void_)
             {
                 /* Don't complain about calling void-returning functions with no side-effect,
                  * because purity and nothrow are inferred, and because some of the
@@ -266,9 +266,9 @@ extern (C++) bool discardValue(Expression e)
             else if (ce.e1.type)
             {
                 Type t = ce.e1.type.toBasetype();
-                if (t.ty == Tdelegate)
+                if (t.ty == TY.delegate_)
                     t = (cast(TypeDelegate)t).next;
-                if (t.ty == Tfunction && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
+                if (t.ty == TY.function_ && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
                 {
                     const(char)* s;
                     if (ce.f)

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -154,19 +154,19 @@ struct Target
         assert(type.isTypeBasic());
         switch (type.ty)
         {
-        case Tfloat80:
-        case Timaginary80:
-        case Tcomplex80:
+        case TY.float80:
+        case TY.imaginary80:
+        case TY.complex80:
             return Target.realalignsize;
-        case Tcomplex32:
+        case TY.complex32:
             if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD || global.params.isOpenBSD || global.params.isSolaris)
                 return 4;
             break;
-        case Tint64:
-        case Tuns64:
-        case Tfloat64:
-        case Timaginary64:
-        case Tcomplex64:
+        case TY.int64:
+        case TY.uns64:
+        case TY.float64:
+        case TY.imaginary64:
+        case TY.complex64:
             if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD || global.params.isOpenBSD || global.params.isSolaris)
                 return global.params.is64bit ? 8 : 4;
             break;
@@ -275,17 +275,17 @@ struct Target
             return 1; // not supported
         switch (type.ty)
         {
-        case Tvoid:
-        case Tint8:
-        case Tuns8:
-        case Tint16:
-        case Tuns16:
-        case Tint32:
-        case Tuns32:
-        case Tfloat32:
-        case Tint64:
-        case Tuns64:
-        case Tfloat64:
+        case TY.void_:
+        case TY.int8:
+        case TY.uns8:
+        case TY.int16:
+        case TY.uns16:
+        case TY.int32:
+        case TY.uns32:
+        case TY.float32:
+        case TY.int64:
+        case TY.uns64:
+        case TY.float64:
             break;
         default:
             return 2; // wrong base type
@@ -306,7 +306,7 @@ struct Target
     {
         import dmd.tokens;
 
-        if (type.ty != Tvector)
+        if (type.ty != TY.vector)
             return true; // not a vector op
         auto tvec = cast(TypeVector) type;
 
@@ -388,14 +388,14 @@ struct Target
         // Write the expression into the buffer.
         switch (e.type.ty)
         {
-        case Tint32:
-        case Tuns32:
-        case Tint64:
-        case Tuns64:
+        case TY.int32:
+        case TY.uns32:
+        case TY.int64:
+        case TY.uns64:
             encodeInteger(e, buffer.ptr);
             break;
-        case Tfloat32:
-        case Tfloat64:
+        case TY.float32:
+        case TY.float64:
             encodeReal(e, buffer.ptr);
             break;
         default:
@@ -404,13 +404,13 @@ struct Target
         // Interpret the buffer as a new type.
         switch (type.ty)
         {
-        case Tint32:
-        case Tuns32:
-        case Tint64:
-        case Tuns64:
+        case TY.int32:
+        case TY.uns32:
+        case TY.int64:
+        case TY.uns64:
             return decodeInteger(e.loc, type, buffer.ptr);
-        case Tfloat32:
-        case Tfloat64:
+        case TY.float32:
+        case TY.float64:
             return decodeReal(e.loc, type, buffer.ptr);
         default:
             assert(0);
@@ -525,13 +525,13 @@ private void encodeReal(Expression e, ubyte* buffer)
 {
     switch (e.type.ty)
     {
-    case Tfloat32:
+    case TY.float32:
         {
             float* p = cast(float*)buffer;
             *p = cast(float)e.toReal();
             break;
         }
-    case Tfloat64:
+    case TY.float64:
         {
             double* p = cast(double*)buffer;
             *p = cast(double)e.toReal();
@@ -549,13 +549,13 @@ private Expression decodeReal(Loc loc, Type type, ubyte* buffer)
     real_t value;
     switch (type.ty)
     {
-    case Tfloat32:
+    case TY.float32:
         {
             float* p = cast(float*)buffer;
             value = real_t(*p);
             break;
         }
-    case Tfloat64:
+    case TY.float64:
         {
             double* p = cast(double*)buffer;
             value = real_t(*p);

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -167,7 +167,7 @@ Symbol *toSymbol(Dsymbol s)
                 if (config.exe == EX_WIN64 && vd.isParameter())
                     t = type_fake(TYnptr);
                 else
-                    t = type_fake(TYdelegate);          // Tdelegate as C type
+                    t = type_fake(TYdelegate);          // TY.delegate_ as C type
                 t.Tcount++;
             }
             else if (vd.isParameter())
@@ -282,14 +282,14 @@ Symbol *toSymbol(Dsymbol s)
         override void visit(TypeInfoDeclaration tid)
         {
             //printf("TypeInfoDeclaration.toSymbol(%s), linkage = %d\n", tid.toChars(), tid.linkage);
-            assert(tid.tinfo.ty != Terror);
+            assert(tid.tinfo.ty != TY.error);
             visit(cast(VarDeclaration)tid);
         }
 
         override void visit(TypeInfoClassDeclaration ticd)
         {
             //printf("TypeInfoClassDeclaration.toSymbol(%s), linkage = %d\n", ticd.toChars(), ticd.linkage);
-            assert(ticd.tinfo.ty == Tclass);
+            assert(ticd.tinfo.ty == TY.class_);
             auto tc = cast(TypeClass)ticd.tinfo;
             tc.sym.accept(this);
         }

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -175,7 +175,7 @@ public:
                 // https://issues.dlang.org/show_bug.cgi?id=13792
                 t.ctype = Type_toCtype(Type.tvoid);
             }
-            else if (t.sym.memtype.toBasetype().ty == Tint32)
+            else if (t.sym.memtype.toBasetype().ty == TY.int32)
             {
                 t.ctype = type_enum(t.sym.toPrettyChars(true), Type_toCtype(t.sym.memtype));
             }

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -968,7 +968,7 @@ int cvMember(Dsymbol s, ubyte *p)
         {
             //printf("VarDeclaration.cvMember(p = %p) '%s'\n", p, vd.toChars());
 
-            if (vd.type.toBasetype().ty == Ttuple)
+            if (vd.type.toBasetype().ty == TY.tuple)
                 return;
 
             const id = vd.toChars();

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -690,7 +690,7 @@ elem *resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
         elem *elength;
         Symbol *slength;
 
-        if (t1.ty == Tsarray)
+        if (t1.ty == TY.sarray)
         {
             TypeSArray tsa = cast(TypeSArray)t1;
             dinteger_t length = tsa.dim.toInteger();
@@ -698,7 +698,7 @@ elem *resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
             elength = el_long(TYsize_t, length);
             goto L3;
         }
-        else if (t1.ty == Tarray)
+        else if (t1.ty == TY.array)
         {
             elength = *pe;
             *pe = el_same(&elength);
@@ -973,13 +973,13 @@ RET retStyle(TypeFunction tf)
     if (global.params.isWindows && global.params.is64bit)
     {
         // http://msdn.microsoft.com/en-us/library/7572ztz4.aspx
-        if (tns.ty == Tcomplex32)
+        if (tns.ty == TY.complex32)
             return RET.stack;
         if (tns.isscalar())
             return RET.regs;
 
         tns = tns.baseElemOf();
-        if (tns.ty == Tstruct)
+        if (tns.ty == TY.struct_)
         {
             StructDeclaration sd = (cast(TypeStruct)tns).sym;
             if (sd.ident == Id.__c_long_double)
@@ -996,7 +996,7 @@ RET retStyle(TypeFunction tf)
     else if (global.params.isWindows && global.params.mscoff)
     {
         Type tb = tns.baseElemOf();
-        if (tb.ty == Tstruct)
+        if (tb.ty == TY.struct_)
         {
             StructDeclaration sd = (cast(TypeStruct)tb).sym;
             if (sd.ident == Id.__c_long_double)
@@ -1005,10 +1005,10 @@ RET retStyle(TypeFunction tf)
     }
 
 Lagain:
-    if (tns.ty == Tsarray)
+    if (tns.ty == TY.sarray)
     {
         tns = tns.baseElemOf();
-        if (tns.ty != Tstruct)
+        if (tns.ty != TY.struct_)
         {
 L2:
             if (global.params.isLinux && tf.linkage != LINKd && !global.params.is64bit)
@@ -1035,7 +1035,7 @@ L2:
         }
     }
 
-    if (tns.ty == Tstruct)
+    if (tns.ty == TY.struct_)
     {
         StructDeclaration sd = (cast(TypeStruct)tns).sym;
         if (global.params.isLinux && tf.linkage != LINKd && !global.params.is64bit)
@@ -1058,7 +1058,7 @@ L2:
         if (sd.arg1type && !sd.arg2type)
         {
             tns = sd.arg1type;
-            if (tns.ty != Tstruct)
+            if (tns.ty != TY.struct_)
                 goto L2;
             goto Lagain;
         }
@@ -1091,7 +1091,7 @@ L2:
              tf.linkage == LINKc &&
              tns.iscomplex())
     {
-        if (tns.ty == Tcomplex32)
+        if (tns.ty == TY.complex32)
             return RET.regs;     // in EDX:EAX, not ST1:ST0
         else
             return RET.stack;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -236,7 +236,7 @@ void genModuleInfo(Module m)
 void write_pointers(Type type, Symbol *s, uint offset)
 {
     uint ty = type.toBasetype().ty;
-    if (ty == Tclass)
+    if (ty == TY.class_)
         return objmod.write_pointerRef(s, offset);
 
     write_instance_pointers(type, s, offset);
@@ -316,7 +316,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             //printf("ClassDeclaration.toObjFile('%s')\n", cd.toChars());
 
-            if (cd.type.ty == Terror)
+            if (cd.type.ty == TY.error)
             {
                 cd.error("had semantic errors when compiling");
                 return;
@@ -643,7 +643,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             //printf("InterfaceDeclaration.toObjFile('%s')\n", id.toChars());
 
-            if (id.type.ty == Terror)
+            if (id.type.ty == TY.error)
             {
                 id.error("had semantic errors when compiling");
                 return;
@@ -820,7 +820,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             //printf("StructDeclaration.toObjFile('%s')\n", sd.toChars());
 
-            if (sd.type.ty == Terror)
+            if (sd.type.ty == TY.error)
             {
                 sd.error("had semantic errors when compiling");
                 return;
@@ -887,7 +887,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             //printf("VarDeclaration.toObjFile(%p '%s' type=%s) protection %d\n", vd, vd.toChars(), vd.type.toChars(), vd.protection);
             //printf("\talign = %d\n", vd.alignment);
 
-            if (vd.type.ty == Terror)
+            if (vd.type.ty == TY.error)
             {
                 vd.error("had semantic errors when compiling");
                 return;
@@ -939,7 +939,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             } while (parent);
             s.Sfl = FLdata;
 
-            if (!sz && vd.type.toBasetype().ty != Tsarray)
+            if (!sz && vd.type.toBasetype().ty != TY.sarray)
                 assert(0); // this shouldn't be possible
 
             scope dtb = new DtBuilder();
@@ -989,7 +989,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 return;
             //printf("EnumDeclaration.toObjFile('%s')\n", ed.toChars());
 
-            if (ed.errors || ed.type.ty == Terror)
+            if (ed.errors || ed.type.ty == TY.error)
             {
                 ed.error("had semantic errors when compiling");
                 return;
@@ -1228,7 +1228,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             ExpInitializer ie = vd._init.isExpInitializer();
 
             Type tb = vd.type.toBasetype();
-            if (tb.ty == Tsarray && ie &&
+            if (tb.ty == TY.sarray && ie &&
                 !tb.nextOf().equals(ie.exp.type.toBasetype().nextOf()) &&
                 ie.exp.implicitConvTo(tb.nextOf())
                 )
@@ -1414,7 +1414,7 @@ private void finishVtbl(ClassDeclaration cd)
                 continue;
             // Hiding detected: same name, overlapping specializations
             TypeFunction tf = cast(TypeFunction)fd.type;
-            if (tf.ty == Tfunction)
+            if (tf.ty == TY.function_)
             {
                 cd.error("use of `%s%s` is hidden by `%s`; use `alias %s = %s.%s;` to introduce base class overload set",
                     fd.toPrettyChars(),

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -160,7 +160,7 @@ shared static this()
 extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
 {
     d_uns64 sz;
-    if (t.ty == Tclass && !(cast(TypeClass)t).sym.isInterfaceDeclaration())
+    if (t.ty == TY.class_ && !(cast(TypeClass)t).sym.isInterfaceDeclaration())
         sz = (cast(TypeClass)t).sym.AggregateDeclaration.size(loc);
     else
         sz = t.size(loc);
@@ -216,7 +216,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
 
         override void visit(TypeBasic t)
         {
-            if (t.ty == Tvoid)
+            if (t.ty == TY.void_)
                 setpointer(offset);
         }
 
@@ -257,7 +257,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
 
         override void visit(TypePointer t)
         {
-            if (t.nextOf().ty != Tfunction) // don't mark function pointers
+            if (t.nextOf().ty != TY.function_) // don't mark function pointers
                 setpointer(offset);
         }
 
@@ -333,7 +333,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
             foreach (v; t.sym.fields)
             {
                 offset = structoff + v.offset;
-                if (v.type.ty == Tclass)
+                if (v.type.ty == TY.class_)
                     setpointer(offset);
                 else
                     v.type.accept(this);
@@ -363,7 +363,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
     }
 
     scope PointerBitmapVisitor pbv = new PointerBitmapVisitor(data, sz_size_t);
-    if (t.ty == Tclass)
+    if (t.ty == TY.class_)
         pbv.visitClass(cast(TypeClass)t);
     else
         t.accept(pbv);
@@ -498,7 +498,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     }
     if (e.ident == Id.isAssociativeArray)
     {
-        return isTypeX(t => t.toBasetype().ty == Taarray);
+        return isTypeX(t => t.toBasetype().ty == TY.aarray);
     }
     if (e.ident == Id.isDeprecated)
     {
@@ -515,16 +515,16 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     }
     if (e.ident == Id.isStaticArray)
     {
-        return isTypeX(t => t.toBasetype().ty == Tsarray);
+        return isTypeX(t => t.toBasetype().ty == TY.sarray);
     }
     if (e.ident == Id.isAbstractClass)
     {
-        return isTypeX(t => t.toBasetype().ty == Tclass &&
+        return isTypeX(t => t.toBasetype().ty == TY.class_ &&
                             (cast(TypeClass)t.toBasetype()).sym.isAbstract());
     }
     if (e.ident == Id.isFinalClass)
     {
-        return isTypeX(t => t.toBasetype().ty == Tclass &&
+        return isTypeX(t => t.toBasetype().ty == TY.class_ &&
                             ((cast(TypeClass)t.toBasetype()).sym.storage_class & STC.final_) != 0);
     }
     if (e.ident == Id.isTemplate)
@@ -555,7 +555,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         Type tb = t.baseElemOf();
-        if (auto sd = tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null)
+        if (auto sd = tb.ty == TY.struct_ ? (cast(TypeStruct)tb).sym : null)
         {
             return sd.isPOD() ? True() : False();
         }
@@ -995,11 +995,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         if (t)
         {
-            if (t.ty == Tfunction)
+            if (t.ty == TY.function_)
                 tf = cast(TypeFunction)t;
-            else if (t.ty == Tdelegate)
+            else if (t.ty == TY.delegate_)
                 tf = cast(TypeFunction)t.nextOf();
-            else if (t.ty == Tpointer && t.nextOf().ty == Tfunction)
+            else if (t.ty == TY.pointer && t.nextOf().ty == TY.function_)
                 tf = cast(TypeFunction)t.nextOf();
         }
         if (!tf)
@@ -1036,11 +1036,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         TypeFunction tf = null;
         if (t)
         {
-            if (t.ty == Tfunction)
+            if (t.ty == TY.function_)
                 tf = cast(TypeFunction)t;
-            else if (t.ty == Tdelegate)
+            else if (t.ty == TY.delegate_)
                 tf = cast(TypeFunction)t.nextOf();
-            else if (t.ty == Tpointer && t.nextOf().ty == Tfunction)
+            else if (t.ty == TY.pointer && t.nextOf().ty == TY.function_)
                 tf = cast(TypeFunction)t.nextOf();
         }
         if (tf)
@@ -1088,11 +1088,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         TypeFunction tf = null;
         if (t)
         {
-            if (t.ty == Tfunction)
+            if (t.ty == TY.function_)
                 tf = cast(TypeFunction)t;
-            else if (t.ty == Tdelegate)
+            else if (t.ty == TY.delegate_)
                 tf = cast(TypeFunction)t.nextOf();
-            else if (t.ty == Tpointer && t.nextOf().ty == Tfunction)
+            else if (t.ty == TY.pointer && t.nextOf().ty == TY.function_)
                 tf = cast(TypeFunction)t.nextOf();
         }
         Parameters* fparams;
@@ -1188,11 +1188,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         TypeFunction tf = null;
         if (t)
         {
-            if (t.ty == Tfunction)
+            if (t.ty == TY.function_)
                 tf = cast(TypeFunction)t;
-            else if (t.ty == Tdelegate)
+            else if (t.ty == TY.delegate_)
                 tf = cast(TypeFunction)t.nextOf();
-            else if (t.ty == Tpointer && t.nextOf().ty == Tfunction)
+            else if (t.ty == TY.pointer && t.nextOf().ty == TY.function_)
                 tf = cast(TypeFunction)t.nextOf();
         }
         if (tf)
@@ -1365,7 +1365,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 if (t)
                 {
                     t.typeSemantic(e.loc, sc2);
-                    if (t.ty == Terror)
+                    if (t.ty == TY.error)
                         err = true;
                 }
                 else if (s && s.errors)
@@ -1376,7 +1376,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 ex = ex.expressionSemantic(sc2);
                 ex = resolvePropertiesOnly(sc2, ex);
                 ex = ex.optimize(WANTvalue);
-                if (sc2.func && sc2.func.type.ty == Tfunction)
+                if (sc2.func && sc2.func.type.ty == TY.function_)
                 {
                     const tf = cast(TypeFunction)sc2.func.type;
                     err |= tf.isnothrow && canThrow(ex, sc2.func, false);

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -315,7 +315,7 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting Type\n");
         if (!t)
             return;
-        if (t.ty == AST.Tfunction)
+        if (t.ty == AST.TY.function_)
         {
             visitFunctionType(cast(AST.TypeFunction)t, null);
             return;
@@ -379,7 +379,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.TypePointer t)
     {
         //printf("Visiting TypePointer\n");
-        if (t.next.ty == AST.Tfunction)
+        if (t.next.ty == AST.TY.function_)
         {
             visitFunctionType(cast(AST.TypeFunction)t.next, null);
         }
@@ -777,7 +777,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.FuncLiteralDeclaration f)
     {
         //printf("Visiting FuncLiteralDeclaration\n");
-        if (f.type.ty == AST.Terror)
+        if (f.type.ty == AST.TY.error)
             return;
         AST.TypeFunction tf = cast(AST.TypeFunction)f.type;
         if (!f.inferRetType && tf.next)

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -75,7 +75,7 @@ extern (C++) void genTypeInfo(Type torig, Scope* sc)
 
 extern (C++) Type getTypeInfoType(Type t, Scope* sc)
 {
-    assert(t.ty != Terror);
+    assert(t.ty != TY.error);
     genTypeInfo(t, sc);
     return t.vtinfo.type;
 }
@@ -85,27 +85,27 @@ extern (C++) TypeInfoDeclaration getTypeInfoDeclaration(Type t)
     //printf("Type::getTypeInfoDeclaration() %s\n", t.toChars());
     switch (t.ty)
     {
-    case Tpointer:
+    case TY.pointer:
         return TypeInfoPointerDeclaration.create(t);
-    case Tarray:
+    case TY.array:
         return TypeInfoArrayDeclaration.create(t);
-    case Tsarray:
+    case TY.sarray:
         return TypeInfoStaticArrayDeclaration.create(t);
-    case Taarray:
+    case TY.aarray:
         return TypeInfoAssociativeArrayDeclaration.create(t);
-    case Tstruct:
+    case TY.struct_:
         return TypeInfoStructDeclaration.create(t);
-    case Tvector:
+    case TY.vector:
         return TypeInfoVectorDeclaration.create(t);
-    case Tenum:
+    case TY.enum_:
         return TypeInfoEnumDeclaration.create(t);
-    case Tfunction:
+    case TY.function_:
         return TypeInfoFunctionDeclaration.create(t);
-    case Tdelegate:
+    case TY.delegate_:
         return TypeInfoDelegateDeclaration.create(t);
-    case Ttuple:
+    case TY.tuple:
         return TypeInfoTupleDeclaration.create(t);
-    case Tclass:
+    case TY.class_:
         if ((cast(TypeClass)t).sym.isInterfaceDeclaration())
             return TypeInfoInterfaceDeclaration.create(t);
         else
@@ -235,16 +235,16 @@ extern (C++) bool isSpeculativeType(Type t)
  */
 private bool builtinTypeInfo(Type t)
 {
-    if (t.isTypeBasic() || t.ty == Tclass || t.ty == Tnull)
+    if (t.isTypeBasic() || t.ty == TY.class_ || t.ty == TY.null_)
         return !t.mod;
-    if (t.ty == Tarray)
+    if (t.ty == TY.array)
     {
         Type next = t.nextOf();
         // strings are so common, make them builtin
         return !t.mod &&
                (next.isTypeBasic() !is null && !next.mod ||
-                next.ty == Tchar && next.mod == MODFlags.immutable_ ||
-                next.ty == Tchar && next.mod == MODFlags.const_);
+                next.ty == TY.char_ && next.mod == MODFlags.immutable_ ||
+                next.ty == TY.char_ && next.mod == MODFlags.const_);
     }
     return false;
 }


### PR DESCRIPTION
```bash
replacements=(
"Tarray array"
"Tsarray sarray"
"Taarray aarray"
"Tpointer pointer"
"Treference reference"
"Tfunction function_"
"Tident ident"
"Tclass class_"
"Tstruct struct_"
"Tenum enum_"
"Tdelegate delegate_"
"Tnone none"
"Tvoid void_"
"Tint8 int8"
"Tuns8 uns8"
"Tint16 int16"
"Tuns16 uns16"
"Tint32 int32"
"Tuns32 uns32"
"Tint64 int64"
"Tuns64 uns64"
"Tfloat32 float32"
"Tfloat64 float64"
"Tfloat80 float80"
"Timaginary32 imaginary32"
"Timaginary64 imaginary64"
"Timaginary80 imaginary80"
"Tcomplex32 complex32"
"Tcomplex64 complex64"
"Tcomplex80 complex80"
"Tbool bool_"
"Tchar char_"
"Twchar wchar_"
"Tdchar dchar_"
"Terror error"
"Tinstance instance"
"Ttypeof typeof_"
"Ttuple tuple"
"Tslice slice"
"Treturn return_"
"Tnull null_"
"Tvector vector"
"Tint128 int128"
"Tuns128 uns128"
"TMAX MAX"
)
shopt -s globstar
for r in "${replacements[@]}" ; do
    w=($r)
    sed -E "s/([^a-zA-Z])${w[0]}/TY.${w[1]}/g" -i **/*.d
done
```

~~~- This should be the last PR in this conversion series~~~
~~~- I'm not too happy about the name `ENUMTY`, but it was the existing one. Better ideas?~~~
- I could use `with(ENUMTY)` for all the `switch` loops. This would probably also reduce the size of the diff
- The last commit with a few initial `final switch` shows why `enums` are cool