### PR TITLE
Allow verbose output to be directed to a file

### DIFF
--- a/changelog/verbose-to-file.dd
+++ b/changelog/verbose-to-file.dd
@@ -1,0 +1,7 @@
+Allow verbose output to be redirected to a file
+
+Enhanced the "-v" option to accept a filename to redirect verbose output to a file, i.e.
+---
+dmd -v=info.txt ...
+---
+This is useful for tools that invoke the compiler and use the verbose output but want do not want to redirect stdout/stderr so that error messages and other information can still get to the user.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -282,8 +282,8 @@ struct Usage
         Option("unittest",
             "compile in unit tests"
         ),
-        Option("v",
-            "verbose"
+        Option("v[=file]",
+            "verbose with option to output to a file (defaults to stdout)"
         ),
         Option("vcolumns",
             "print character (column) numbers in diagnostics"

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -523,16 +523,16 @@ extern (C++) final class Module : Package
             return null;
         if (global.params.verbose)
         {
-            fprintf(global.stdmsg, "import    ");
+            fprintf(global.params.verbose, "import    ");
             if (packages)
             {
                 for (size_t i = 0; i < packages.dim; i++)
                 {
                     Identifier pid = (*packages)[i];
-                    fprintf(global.stdmsg, "%s.", pid.toChars());
+                    fprintf(global.params.verbose, "%s.", pid.toChars());
                 }
             }
-            fprintf(global.stdmsg, "%s\t(%s)\n", ident.toChars(), m.srcfile.toChars());
+            fprintf(global.params.verbose, "%s\t(%s)\n", ident.toChars(), m.srcfile.toChars());
         }
         m = m.parse();
 

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -111,7 +111,7 @@ void backend_init()
         exe,
         false, //params.trace,
         params.nofloat,
-        params.verbose,
+        params.verbose ? true : false,
         params.optimize,
         params.symdebug,
         params.alwaysframe,

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1358,7 +1358,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 memcpy(name, se.string, se.len);
                 name[se.len] = 0;
                 if (global.params.verbose)
-                    fprintf(global.stdmsg, "library   %s\n", name);
+                    fprintf(global.params.verbose, "library   %s\n", name);
                 if (global.params.moduleDeps && !global.params.moduleDepsFile)
                 {
                     OutBuffer* ob = global.params.moduleDeps;
@@ -1475,7 +1475,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 /* Print unrecognized pragmas
                  */
-                fprintf(global.stdmsg, "pragma    %s", pd.ident.toChars());
+                fprintf(global.params.verbose, "pragma    %s", pd.ident.toChars());
                 if (pd.args)
                 {
                     for (size_t i = 0; i < pd.args.dim; i++)
@@ -1487,15 +1487,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         sc = sc.endCTFE();
                         e = e.ctfeInterpret();
                         if (i == 0)
-                            fprintf(global.stdmsg, " (");
+                            fprintf(global.params.verbose, " (");
                         else
-                            fprintf(global.stdmsg, ",");
-                        fprintf(global.stdmsg, "%s", e.toChars());
+                            fprintf(global.params.verbose, ",");
+                        fprintf(global.params.verbose, "%s", e.toChars());
                     }
                     if (pd.args.dim)
-                        fprintf(global.stdmsg, ")");
+                        fprintf(global.params.verbose, ")");
                 }
-                fprintf(global.stdmsg, "\n");
+                fprintf(global.params.verbose, "\n");
             }
             goto Lnodecl;
         }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4276,7 +4276,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (global.params.verbose)
-            fprintf(global.stdmsg, "file      %.*s\t(%s)\n", cast(int)se.len, se.string, name);
+            fprintf(global.params.verbose, "file      %.*s\t(%s)\n", cast(int)se.len, se.string, name);
         if (global.params.moduleDeps !is null)
         {
             OutBuffer* ob = global.params.moduleDeps;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -81,7 +81,7 @@ struct Param
     bool oneobj;            // write one object file instead of multiple ones
     bool trace;             // insert profiling hooks
     bool tracegc;           // instrument calls to 'new'
-    bool verbose;           // verbose compile
+    FILE* verbose;          // verbose compile
     bool vcg_ast;           // write-out codegen-ast
     bool showColumns;       // print character (column) numbers in diagnostics
     bool vtls;              // identify thread local variables

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -70,7 +70,7 @@ struct Param
     bool oneobj;        // write one object file instead of multiple ones
     bool trace;         // insert profiling hooks
     bool tracegc;       // instrument calls to 'new'
-    bool verbose;       // verbose compile
+    FILE* verbose;      // verbose compile
     bool vcg_ast;       // write-out codegen-ast
     bool showColumns;   // print character (column) numbers in diagnostics
     bool vtls;          // identify thread local variables

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -323,8 +323,8 @@ void genObjFile(Module m, bool multiobj)
 
     if (m.ident == Id.entrypoint)
     {
-        bool v = global.params.verbose;
-        global.params.verbose = false;
+        auto v = global.params.verbose;
+        global.params.verbose = null;
 
         for (size_t i = 0; i < m.members.dim; i++)
         {
@@ -807,7 +807,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     fd.semanticRun = PASS.obj;
 
     if (global.params.verbose)
-        fprintf(global.stdmsg, "function  %s\n", fd.toPrettyChars());
+        fprintf(global.params.verbose, "function  %s\n", fd.toPrettyChars());
 
     Symbol *s = toSymbol(fd);
     func_t *f = s.Sfunc;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1276,7 +1276,7 @@ public:
             return;
 
         if (global.params.verbose && (eresult || sresult))
-            fprintf(global.stdmsg, "inlined   %s =>\n          %s\n", fd.toPrettyChars(), parent.toPrettyChars());
+            fprintf(global.params.verbose, "inlined   %s =>\n          %s\n", fd.toPrettyChars(), parent.toPrettyChars());
 
         if (eresult && e.type.ty != Type.Kind.void_)
         {
@@ -1706,7 +1706,7 @@ public void inlineScanModule(Module m)
     {
         Dsymbol s = (*m.members)[i];
         //if (global.params.verbose)
-        //    fprintf(global.stdmsg, "inline scan symbol %s\n", s.toChars());
+        //    fprintf(global.params.verbose, "inline scan symbol %s\n", s.toChars());
         scope InlineScanVisitor v = new InlineScanVisitor();
         s.accept(v);
     }

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -803,7 +803,7 @@ extern (C++) void json_generate(OutBuffer* buf, Modules* modules)
     {
         Module m = (*modules)[i];
         if (global.params.verbose)
-            fprintf(global.stdmsg, "json gen %s\n", m.toChars());
+            fprintf(global.params.verbose, "json gen %s\n", m.toChars());
         m.accept(json);
     }
     json.arrayEnd();

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -103,7 +103,7 @@ class Library
     final void write()
     {
         if (global.params.verbose)
-            fprintf(global.stdmsg, "library   %s\n", loc.filename);
+            fprintf(global.params.verbose, "library   %s\n", loc.filename);
 
         OutBuffer libbuf;
         WriteLibToBuffer(&libbuf);

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -671,8 +671,8 @@ public int runLINK()
         {
             // Print it
             for (size_t i = 0; i < argv.dim; i++)
-                fprintf(global.stdmsg, "%s ", argv[i]);
-            fprintf(global.stdmsg, "\n");
+                fprintf(global.params.verbose, "%s ", argv[i]);
+            fprintf(global.params.verbose, "\n");
         }
         argv.push(null);
         // set up pipes
@@ -745,7 +745,7 @@ version (Windows)
         int status;
         size_t len;
         if (global.params.verbose)
-            fprintf(global.stdmsg, "%s %s\n", cmd, args);
+            fprintf(global.params.verbose, "%s %s\n", cmd, args);
         if (!global.params.mscoff)
         {
             if ((len = strlen(args)) > 255)
@@ -808,7 +808,7 @@ version (Windows)
             }
         }
         //if (global.params.verbose)
-        //    fprintf(global.stdmsg, "\n");
+        //    fprintf(global.params.verbose, "\n");
         if (status)
         {
             if (status == -1)
@@ -853,10 +853,10 @@ public int runProgram()
     //printf("runProgram()\n");
     if (global.params.verbose)
     {
-        fprintf(global.stdmsg, "%s", global.params.exefile);
+        fprintf(global.params.verbose, "%s", global.params.exefile);
         for (size_t i = 0; i < global.params.runargs.dim; ++i)
-            fprintf(global.stdmsg, " %s", global.params.runargs[i]);
-        fprintf(global.stdmsg, "\n");
+            fprintf(global.params.verbose, " %s", global.params.runargs[i]);
+        fprintf(global.params.verbose, "\n");
     }
     // Build argv[]
     Strings argv;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2247,7 +2247,7 @@ else
 
                     if (global.params.verbose)
                     {
-                        fprintf(global.stdmsg, "library   %.*s\n", cast(int)se.len, se.string);
+                        fprintf(global.params.verbose, "library   %.*s\n", cast(int)se.len, se.string);
                     }
                 }
             }


### PR DESCRIPTION
Provide an option to direct verbose output to a file.  This can be used to allow tools to invoke the compiler and capture the verbose output without having to redirect stdout/stderr.  This is a potential solution to the rdmd "single invocation problem" and can also be used by other tools to gain information from the compiler without having to redirect stdout/stderr so that error messages and other information still gets back to the user.

EDIT: had originally pushed this to allow rdmd to support single invocation, but now I have another tool that can use it.