### PR TITLE
Use more final switches

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1227,7 +1227,7 @@ public:
     override void visit(LinkDeclaration d)
     {
         const(char)* p;
-        switch (d.linkage)
+        final switch (d.linkage)
         {
         case LINK.d:
             p = "D";
@@ -1247,7 +1247,8 @@ public:
         case LINK.objc:
             p = "Objective-C";
             break;
-        default:
+        case LINK.default_:
+        case LINK.system:
             assert(0);
         }
         buf.writestring("extern (");
@@ -3279,7 +3280,7 @@ extern (C++) void trustToBuffer(OutBuffer* buf, TRUST trust)
 
 extern (C++) const(char)* trustToChars(TRUST trust)
 {
-    switch (trust)
+    final switch (trust)
     {
     case TRUST.default_:
         return null;
@@ -3289,8 +3290,6 @@ extern (C++) const(char)* trustToChars(TRUST trust)
         return "@trusted";
     case TRUST.safe:
         return "@safe";
-    default:
-        assert(0);
     }
 }
 

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -246,7 +246,7 @@ public:
 
     void property(const(char)* name, TRUST trust)
     {
-        switch (trust)
+        final switch (trust)
         {
         case TRUST.default_:
             // Should not be printed
@@ -261,14 +261,12 @@ public:
         case TRUST.safe:
             property(name, "safe");
             break;
-        default:
-            assert(false);
         }
     }
 
     void property(const(char)* name, PURE purity)
     {
-        switch (purity)
+        final switch (purity)
         {
         case PURE.impure:
             // Should not be printed
@@ -286,8 +284,6 @@ public:
         case PURE.fwdref:
             property(name, "fwdref");
             break;
-        default:
-            assert(false);
         }
     }
 


### PR DESCRIPTION
Now that these types are enums, we can make the ignored cases in a `switch` explicit.