### PR TITLE
Rename <pkg> to <pattern> in dmd usage.

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -193,8 +193,8 @@ struct Usage
         Option("i",
             "same as -i=-std,-core,-etc,-object"
         ),
-        Option("i=[-]<pkg>,...",
-            "include/exclude imported modules whose name matches one of <pkg>"
+        Option("i=[-]<pattern>,[-]<pattern>,...",
+            "include/exclude imported modules whose name matches one of <pattern>"
         ),
         Option("ignore",
             "ignore unsupported pragmas"


### PR DESCRIPTION
I've landed on the term "module pattern" for each item in the list of strings provided for option `-i`.  Given that, the abbreviation `<ptrn>` seems to make more sense than `<pkg>`.