### PR TITLE
Revert "Convert TXXXX to Type.Kind"

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -417,7 +417,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
             return true;
         }
     }
-    else if (e.type.ty == Type.Kind.class_)
+    else if (e.type.ty == Tclass)
     {
         // Do access check
         ClassDeclaration cd = (cast(TypeClass)e.type).sym;
@@ -429,7 +429,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
         }
         return checkAccess(cd, loc, sc, d);
     }
-    else if (e.type.ty == Type.Kind.struct_)
+    else if (e.type.ty == Tstruct)
     {
         // Do access check
         StructDeclaration cd = (cast(TypeStruct)e.type).sym;

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -181,11 +181,11 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             if (v.storage_class & STC.ref_)
                 return 0;
             auto tv = v.type.baseElemOf();
-            if (tv.ty != Type.Kind.struct_)
+            if (tv.ty != Tstruct)
                 return 0;
             if (ad == (cast(TypeStruct)tv).sym)
             {
-                const(char)* psz = (v.type.toBasetype().ty == Type.Kind.staticArray) ? "static array of " : "";
+                const(char)* psz = (v.type.toBasetype().ty == Tsarray) ? "static array of " : "";
                 ad.error("cannot have field `%s` with %ssame struct type", v.toChars(), psz);
                 ad.type = Type.terror;
                 ad.errors = true;
@@ -224,7 +224,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
         // The previous instance size finalizing had:
-        if (type.ty == Type.Kind.error)
+        if (type.ty == Terror)
             return false;   // failed already
         if (sizeok == Sizeok.done)
             return true;    // succeeded
@@ -253,7 +253,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             finalizeSize();
 
         // this aggregate type has:
-        if (type.ty == Type.Kind.error)
+        if (type.ty == Terror)
             return false;   // marked as invalid during the finalizing.
         if (sizeok == Sizeok.done)
             return true;    // succeeded to calculate instance size.
@@ -479,16 +479,16 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                      * Get the element of static array type.
                      */
                     Type telem = vx.type;
-                    if (telem.ty == Type.Kind.staticArray)
+                    if (telem.ty == Tsarray)
                     {
                         /* We cannot use Type::baseElemOf() here.
-                         * If the bottom of the Type.Kind.staticArray is an enum type, baseElemOf()
+                         * If the bottom of the Tsarray is an enum type, baseElemOf()
                          * will return the base of the enum, and its default initializer
                          * would be different from the enum's.
                          */
-                        while (telem.toBasetype().ty == Type.Kind.staticArray)
+                        while (telem.toBasetype().ty == Tsarray)
                             telem = (cast(TypeSArray)telem.toBasetype()).next;
-                        if (telem.ty == Type.Kind.void_)
+                        if (telem.ty == Tvoid)
                             telem = Type.tuns8.addMod(telem.mod);
                     }
                     if (telem.needsNested() && ctorinit)
@@ -648,7 +648,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         {
             //printf("makeNested %s, enclosing = %s\n", toChars(), enclosing.toChars());
             assert(t);
-            if (t.ty == Type.Kind.struct_)
+            if (t.ty == Tstruct)
                 t = Type.tvoidptr; // t should not be a ref type
 
             assert(!vthis);

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -52,34 +52,34 @@ TypeTuple toArgTypes(Type t)
             Type t2 = null;
             switch (t.ty)
             {
-            case Type.Kind.void_:
+            case Tvoid:
                 return;
-            case Type.Kind.bool_:
-            case Type.Kind.int8:
-            case Type.Kind.uint8:
-            case Type.Kind.int16:
-            case Type.Kind.uint16:
-            case Type.Kind.int32:
-            case Type.Kind.uint32:
-            case Type.Kind.float32:
-            case Type.Kind.int64:
-            case Type.Kind.uint64:
-            case Type.Kind.int128:
-            case Type.Kind.uint128:
-            case Type.Kind.float64:
-            case Type.Kind.float80:
+            case Tbool:
+            case Tint8:
+            case Tuns8:
+            case Tint16:
+            case Tuns16:
+            case Tint32:
+            case Tuns32:
+            case Tfloat32:
+            case Tint64:
+            case Tuns64:
+            case Tint128:
+            case Tuns128:
+            case Tfloat64:
+            case Tfloat80:
                 t1 = t;
                 break;
-            case Type.Kind.imaginary32:
+            case Timaginary32:
                 t1 = Type.tfloat32;
                 break;
-            case Type.Kind.imaginary64:
+            case Timaginary64:
                 t1 = Type.tfloat64;
                 break;
-            case Type.Kind.imaginary80:
+            case Timaginary80:
                 t1 = Type.tfloat80;
                 break;
-            case Type.Kind.complex32:
+            case Tcomplex32:
                 if (global.params.is64bit)
                     t1 = Type.tfloat64;
                 else
@@ -88,21 +88,21 @@ TypeTuple toArgTypes(Type t)
                     t2 = Type.tfloat64;
                 }
                 break;
-            case Type.Kind.complex64:
+            case Tcomplex64:
                 t1 = Type.tfloat64;
                 t2 = Type.tfloat64;
                 break;
-            case Type.Kind.complex80:
+            case Tcomplex80:
                 t1 = Type.tfloat80;
                 t2 = Type.tfloat80;
                 break;
-            case Type.Kind.char_:
+            case Tchar:
                 t1 = Type.tuns8;
                 break;
-            case Type.Kind.wchar_:
+            case Twchar:
                 t1 = Type.tuns16;
                 break;
-            case Type.Kind.dchar_:
+            case Tdchar:
                 t1 = Type.tuns32;
                 break;
             default:
@@ -160,13 +160,13 @@ TypeTuple toArgTypes(Type t)
         {
             switch (t.ty)
             {
-            case Type.Kind.float32:
-            case Type.Kind.imaginary32:
+            case Tfloat32:
+            case Timaginary32:
                 t = Type.tint32;
                 break;
-            case Type.Kind.float64:
-            case Type.Kind.imaginary64:
-            case Type.Kind.complex32:
+            case Tfloat64:
+            case Timaginary64:
+            case Tcomplex32:
                 t = Type.tint64;
                 break;
             default:
@@ -201,10 +201,10 @@ TypeTuple toArgTypes(Type t)
             const sz1 = t1.size(Loc());
             const sz2 = t2.size(Loc());
             assert(sz1 != SIZE_INVALID && sz2 != SIZE_INVALID);
-            if (t1.ty != t2.ty && (t1.ty == Type.Kind.float80 || t2.ty == Type.Kind.float80))
+            if (t1.ty != t2.ty && (t1.ty == Tfloat80 || t2.ty == Tfloat80))
                 return null;
             // [float,float] => [cfloat]
-            if (t1.ty == Type.Kind.float32 && t2.ty == Type.Kind.float32 && offset2 == 4)
+            if (t1.ty == Tfloat32 && t2.ty == Tfloat32 && offset2 == 4)
                 return Type.tfloat64;
             // Merging floating and non-floating types produces the non-floating type
             if (t1.isfloating())
@@ -403,7 +403,7 @@ TypeTuple toArgTypes(Type t)
                     {
                         if (t1.isfloating() && t2.isfloating())
                         {
-                            if ((t1.ty == Type.Kind.float32 || t1.ty == Type.Kind.float64) && (t2.ty == Type.Kind.float32 || t2.ty == Type.Kind.float64))
+                            if ((t1.ty == Tfloat32 || t1.ty == Tfloat64) && (t2.ty == Tfloat32 || t2.ty == Tfloat64))
                             {
                             }
                             else
@@ -448,7 +448,7 @@ TypeTuple toArgTypes(Type t)
                 if (tup && tup.arguments.dim == 1)
                 {
                     Type ft1 = (*tup.arguments)[0].type;
-                    if (ft1.ty == Type.Kind.float32 || ft1.ty == Type.Kind.float64)
+                    if (ft1.ty == Tfloat32 || ft1.ty == Tfloat64)
                         t1 = ft1;
                 }
             }

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -39,12 +39,12 @@ extern (C++) bool isArrayOpValid(Expression e)
     if (e.op == TOK.arrayLiteral)
     {
         Type t = e.type.toBasetype();
-        while (t.ty == Type.Kind.array || t.ty == Type.Kind.staticArray)
+        while (t.ty == Tarray || t.ty == Tsarray)
             t = t.nextOf().toBasetype();
-        return (t.ty != Type.Kind.void_);
+        return (t.ty != Tvoid);
     }
     Type tb = e.type.toBasetype();
-    if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+    if (tb.ty == Tarray || tb.ty == Tsarray)
     {
         if (isUnaArrayOp(e.op))
         {
@@ -78,7 +78,7 @@ extern (C++) bool isNonAssignmentArrayOp(Expression e)
         return isNonAssignmentArrayOp((cast(SliceExp)e).e1);
 
     Type tb = e.type.toBasetype();
-    if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+    if (tb.ty == Tarray || tb.ty == Tsarray)
     {
         return (isUnaArrayOp(e.op) || isBinArrayOp(e.op));
     }
@@ -113,9 +113,9 @@ extern (C++) Expression arrayOp(BinExp e, Scope* sc)
 {
     //printf("BinExp.arrayOp() %s\n", toChars());
     Type tb = e.type.toBasetype();
-    assert(tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray);
+    assert(tb.ty == Tarray || tb.ty == Tsarray);
     Type tbn = tb.nextOf().toBasetype();
-    if (tbn.ty == Type.Kind.void_)
+    if (tbn.ty == Tvoid)
     {
         e.error("cannot perform array operations on `void[]` arrays");
         return new ErrorExp();
@@ -209,7 +209,7 @@ private void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Expressions*
         override void visit(UnaExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty != Type.Kind.array && tb.ty != Type.Kind.staticArray) // hoist scalar expressions
+            if (tb.ty != Tarray && tb.ty != Tsarray) // hoist scalar expressions
             {
                 visit(cast(Expression) e);
             }
@@ -227,7 +227,7 @@ private void buildArrayOp(Scope* sc, Expression e, Objects* tiargs, Expressions*
         override void visit(BinExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty != Type.Kind.array && tb.ty != Type.Kind.staticArray) // hoist scalar expressions
+            if (tb.ty != Tarray && tb.ty != Tsarray) // hoist scalar expressions
             {
                 visit(cast(Expression) e);
             }
@@ -318,12 +318,12 @@ extern (C++) bool isArrayOpOperand(Expression e)
     if (e.op == TOK.arrayLiteral)
     {
         Type t = e.type.toBasetype();
-        while (t.ty == Type.Kind.array || t.ty == Type.Kind.staticArray)
+        while (t.ty == Tarray || t.ty == Tsarray)
             t = t.nextOf().toBasetype();
-        return (t.ty != Type.Kind.void_);
+        return (t.ty != Tvoid);
     }
     Type tb = e.type.toBasetype();
-    if (tb.ty == Type.Kind.array)
+    if (tb.ty == Tarray)
     {
         return (isUnaArrayOp(e.op) ||
                 isBinArrayOp(e.op) ||

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -135,6 +135,105 @@ struct ASTBase
     extern (C++) __gshared const(StorageClass) STCStorageClass =
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared | STC.property | STC.safe | STC.trusted | STC.system | STC.disable);
 
+    enum ENUMTY : int
+    {
+        Tarray,     // slice array, aka T[]
+        Tsarray,    // static array, aka T[dimension]
+        Taarray,    // associative array, aka T[type]
+        Tpointer,
+        Treference,
+        Tfunction,
+        Tident,
+        Tclass,
+        Tstruct,
+        Tenum,
+
+        Tdelegate,
+        Tnone,
+        Tvoid,
+        Tint8,
+        Tuns8,
+        Tint16,
+        Tuns16,
+        Tint32,
+        Tuns32,
+        Tint64,
+
+        Tuns64,
+        Tfloat32,
+        Tfloat64,
+        Tfloat80,
+        Timaginary32,
+        Timaginary64,
+        Timaginary80,
+        Tcomplex32,
+        Tcomplex64,
+        Tcomplex80,
+
+        Tbool,
+        Tchar,
+        Twchar,
+        Tdchar,
+        Terror,
+        Tinstance,
+        Ttypeof,
+        Ttuple,
+        Tslice,
+        Treturn,
+
+        Tnull,
+        Tvector,
+        Tint128,
+        Tuns128,
+        TMAX
+    }
+
+    alias Tarray = ENUMTY.Tarray;
+    alias Tsarray = ENUMTY.Tsarray;
+    alias Taarray = ENUMTY.Taarray;
+    alias Tpointer = ENUMTY.Tpointer;
+    alias Treference = ENUMTY.Treference;
+    alias Tfunction = ENUMTY.Tfunction;
+    alias Tident = ENUMTY.Tident;
+    alias Tclass = ENUMTY.Tclass;
+    alias Tstruct = ENUMTY.Tstruct;
+    alias Tenum = ENUMTY.Tenum;
+    alias Tdelegate = ENUMTY.Tdelegate;
+    alias Tnone = ENUMTY.Tnone;
+    alias Tvoid = ENUMTY.Tvoid;
+    alias Tint8 = ENUMTY.Tint8;
+    alias Tuns8 = ENUMTY.Tuns8;
+    alias Tint16 = ENUMTY.Tint16;
+    alias Tuns16 = ENUMTY.Tuns16;
+    alias Tint32 = ENUMTY.Tint32;
+    alias Tuns32 = ENUMTY.Tuns32;
+    alias Tint64 = ENUMTY.Tint64;
+    alias Tuns64 = ENUMTY.Tuns64;
+    alias Tfloat32 = ENUMTY.Tfloat32;
+    alias Tfloat64 = ENUMTY.Tfloat64;
+    alias Tfloat80 = ENUMTY.Tfloat80;
+    alias Timaginary32 = ENUMTY.Timaginary32;
+    alias Timaginary64 = ENUMTY.Timaginary64;
+    alias Timaginary80 = ENUMTY.Timaginary80;
+    alias Tcomplex32 = ENUMTY.Tcomplex32;
+    alias Tcomplex64 = ENUMTY.Tcomplex64;
+    alias Tcomplex80 = ENUMTY.Tcomplex80;
+    alias Tbool = ENUMTY.Tbool;
+    alias Tchar = ENUMTY.Tchar;
+    alias Twchar = ENUMTY.Twchar;
+    alias Tdchar = ENUMTY.Tdchar;
+    alias Terror = ENUMTY.Terror;
+    alias Tinstance = ENUMTY.Tinstance;
+    alias Ttypeof = ENUMTY.Ttypeof;
+    alias Ttuple = ENUMTY.Ttuple;
+    alias Tslice = ENUMTY.Tslice;
+    alias Treturn = ENUMTY.Treturn;
+    alias Tnull = ENUMTY.Tnull;
+    alias Tvector = ENUMTY.Tvector;
+    alias Tint128 = ENUMTY.Tint128;
+    alias Tuns128 = ENUMTY.Tuns128;
+    alias TMAX = ENUMTY.TMAX;
+
     alias TY = ubyte;
 
     enum TFlags
@@ -1679,7 +1778,7 @@ struct ASTBase
                 Parameter p = (*parameters)[i];
                 Type t = p.type.toBasetype();
 
-                if (t.ty == Type.Kind.tuple)
+                if (t.ty == Ttuple)
                 {
                     TypeTuple tu = cast(TypeTuple)t;
                     result = _foreach(tu.arguments, dg, &n);
@@ -2427,64 +2526,11 @@ struct ASTBase
         }
     }
 
-    extern (C++) __gshared int Tsize_t = Type.Kind.uint32;
-    extern (C++) __gshared int Tptrdiff_t = Type.Kind.int32;
+    extern (C++) __gshared int Tsize_t = Tuns32;
+    extern (C++) __gshared int Tptrdiff_t = Tint32;
 
     extern (C++) abstract class Type : RootObject
     {
-        enum Kind : int
-        {
-            array,              // slice array, aka T[]
-            staticArray,        // static array, aka T[dimension]
-            associativeArray,   // associative array, aka T[type]
-            pointer,
-            reference,
-            function_,
-            identifier,
-            class_,
-            struct_,
-            enum_,
-
-            delegate_,
-            none,
-            void_,
-            int8,
-            uint8,
-            int16,
-            uint16,
-            int32,
-            uint32,
-            int64,
-
-            uint64,
-            float32,
-            float64,
-            float80,
-            imaginary32,
-            imaginary64,
-            imaginary80,
-            complex32,
-            complex64,
-            complex80,
-
-            bool_,
-            char_,
-            wchar_,
-            dchar_,
-            error,
-            instance,
-            typeof_,
-            tuple,
-            slice,
-            return_,
-
-            null_,
-            vector,
-            int128,
-            uint128,
-            max_,
-        }
-
         TY ty;
         MOD mod;
         char* deco;
@@ -2514,7 +2560,7 @@ struct ASTBase
         extern (C++) static __gshared Type twchar;
         extern (C++) static __gshared Type tdchar;
 
-        extern (C++) static __gshared Type[Type.Kind.max_] basic;
+        extern (C++) static __gshared Type[TMAX] basic;
 
         extern (C++) static __gshared Type tshiftcnt;
         extern (C++) static __gshared Type tvoidptr;    // void*
@@ -2549,28 +2595,28 @@ struct ASTBase
         extern (C++) static __gshared ClassDeclaration typeinfoshared;
         extern (C++) static __gshared ClassDeclaration typeinfowild;
         extern (C++) static __gshared StringTable stringtable;
-        extern (C++) static __gshared ubyte[Type.Kind.max_] sizeTy = ()
+        extern (C++) static __gshared ubyte[TMAX] sizeTy = ()
             {
-                ubyte[Type.Kind.max_] sizeTy = __traits(classInstanceSize, TypeBasic);
-                sizeTy[Type.Kind.staticArray] = __traits(classInstanceSize, TypeSArray);
-                sizeTy[Type.Kind.array] = __traits(classInstanceSize, TypeDArray);
-                sizeTy[Type.Kind.associativeArray] = __traits(classInstanceSize, TypeAArray);
-                sizeTy[Type.Kind.pointer] = __traits(classInstanceSize, TypePointer);
-                sizeTy[Type.Kind.reference] = __traits(classInstanceSize, TypeReference);
-                sizeTy[Type.Kind.function_] = __traits(classInstanceSize, TypeFunction);
-                sizeTy[Type.Kind.delegate_] = __traits(classInstanceSize, TypeDelegate);
-                sizeTy[Type.Kind.identifier] = __traits(classInstanceSize, TypeIdentifier);
-                sizeTy[Type.Kind.instance] = __traits(classInstanceSize, TypeInstance);
-                sizeTy[Type.Kind.typeof_] = __traits(classInstanceSize, TypeTypeof);
-                sizeTy[Type.Kind.enum_] = __traits(classInstanceSize, TypeEnum);
-                sizeTy[Type.Kind.struct_] = __traits(classInstanceSize, TypeStruct);
-                sizeTy[Type.Kind.class_] = __traits(classInstanceSize, TypeClass);
-                sizeTy[Type.Kind.tuple] = __traits(classInstanceSize, TypeTuple);
-                sizeTy[Type.Kind.slice] = __traits(classInstanceSize, TypeSlice);
-                sizeTy[Type.Kind.return_] = __traits(classInstanceSize, TypeReturn);
-                sizeTy[Type.Kind.error] = __traits(classInstanceSize, TypeError);
-                sizeTy[Type.Kind.null_] = __traits(classInstanceSize, TypeNull);
-                sizeTy[Type.Kind.vector] = __traits(classInstanceSize, TypeVector);
+                ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
+                sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);
+                sizeTy[Tarray] = __traits(classInstanceSize, TypeDArray);
+                sizeTy[Taarray] = __traits(classInstanceSize, TypeAArray);
+                sizeTy[Tpointer] = __traits(classInstanceSize, TypePointer);
+                sizeTy[Treference] = __traits(classInstanceSize, TypeReference);
+                sizeTy[Tfunction] = __traits(classInstanceSize, TypeFunction);
+                sizeTy[Tdelegate] = __traits(classInstanceSize, TypeDelegate);
+                sizeTy[Tident] = __traits(classInstanceSize, TypeIdentifier);
+                sizeTy[Tinstance] = __traits(classInstanceSize, TypeInstance);
+                sizeTy[Ttypeof] = __traits(classInstanceSize, TypeTypeof);
+                sizeTy[Tenum] = __traits(classInstanceSize, TypeEnum);
+                sizeTy[Tstruct] = __traits(classInstanceSize, TypeStruct);
+                sizeTy[Tclass] = __traits(classInstanceSize, TypeClass);
+                sizeTy[Ttuple] = __traits(classInstanceSize, TypeTuple);
+                sizeTy[Tslice] = __traits(classInstanceSize, TypeSlice);
+                sizeTy[Treturn] = __traits(classInstanceSize, TypeReturn);
+                sizeTy[Terror] = __traits(classInstanceSize, TypeError);
+                sizeTy[Tnull] = __traits(classInstanceSize, TypeNull);
+                sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
                 return sizeTy;
             }();
 
@@ -2608,72 +2654,72 @@ struct ASTBase
             // Set basic types
             static __gshared TY* basetab =
             [
-                Type.Kind.void_,
-                Type.Kind.int8,
-                Type.Kind.uint8,
-                Type.Kind.int16,
-                Type.Kind.uint16,
-                Type.Kind.int32,
-                Type.Kind.uint32,
-                Type.Kind.int64,
-                Type.Kind.uint64,
-                Type.Kind.int128,
-                Type.Kind.uint128,
-                Type.Kind.float32,
-                Type.Kind.float64,
-                Type.Kind.float80,
-                Type.Kind.imaginary32,
-                Type.Kind.imaginary64,
-                Type.Kind.imaginary80,
-                Type.Kind.complex32,
-                Type.Kind.complex64,
-                Type.Kind.complex80,
-                Type.Kind.bool_,
-                Type.Kind.char_,
-                Type.Kind.wchar_,
-                Type.Kind.dchar_,
-                Type.Kind.error
+                Tvoid,
+                Tint8,
+                Tuns8,
+                Tint16,
+                Tuns16,
+                Tint32,
+                Tuns32,
+                Tint64,
+                Tuns64,
+                Tint128,
+                Tuns128,
+                Tfloat32,
+                Tfloat64,
+                Tfloat80,
+                Timaginary32,
+                Timaginary64,
+                Timaginary80,
+                Tcomplex32,
+                Tcomplex64,
+                Tcomplex80,
+                Tbool,
+                Tchar,
+                Twchar,
+                Tdchar,
+                Terror
             ];
 
-            for (size_t i = 0; basetab[i] != Type.Kind.error; i++)
+            for (size_t i = 0; basetab[i] != Terror; i++)
             {
                 Type t = new TypeBasic(basetab[i]);
                 t = t.merge();
                 basic[basetab[i]] = t;
             }
-            basic[Type.Kind.error] = new TypeError();
+            basic[Terror] = new TypeError();
 
-            tvoid = basic[Type.Kind.void_];
-            tint8 = basic[Type.Kind.int8];
-            tuns8 = basic[Type.Kind.uint8];
-            tint16 = basic[Type.Kind.int16];
-            tuns16 = basic[Type.Kind.uint16];
-            tint32 = basic[Type.Kind.int32];
-            tuns32 = basic[Type.Kind.uint32];
-            tint64 = basic[Type.Kind.int64];
-            tuns64 = basic[Type.Kind.uint64];
-            tint128 = basic[Type.Kind.int128];
-            tuns128 = basic[Type.Kind.uint128];
-            tfloat32 = basic[Type.Kind.float32];
-            tfloat64 = basic[Type.Kind.float64];
-            tfloat80 = basic[Type.Kind.float80];
+            tvoid = basic[Tvoid];
+            tint8 = basic[Tint8];
+            tuns8 = basic[Tuns8];
+            tint16 = basic[Tint16];
+            tuns16 = basic[Tuns16];
+            tint32 = basic[Tint32];
+            tuns32 = basic[Tuns32];
+            tint64 = basic[Tint64];
+            tuns64 = basic[Tuns64];
+            tint128 = basic[Tint128];
+            tuns128 = basic[Tuns128];
+            tfloat32 = basic[Tfloat32];
+            tfloat64 = basic[Tfloat64];
+            tfloat80 = basic[Tfloat80];
 
-            timaginary32 = basic[Type.Kind.imaginary32];
-            timaginary64 = basic[Type.Kind.imaginary64];
-            timaginary80 = basic[Type.Kind.imaginary80];
+            timaginary32 = basic[Timaginary32];
+            timaginary64 = basic[Timaginary64];
+            timaginary80 = basic[Timaginary80];
 
-            tcomplex32 = basic[Type.Kind.complex32];
-            tcomplex64 = basic[Type.Kind.complex64];
-            tcomplex80 = basic[Type.Kind.complex80];
+            tcomplex32 = basic[Tcomplex32];
+            tcomplex64 = basic[Tcomplex64];
+            tcomplex80 = basic[Tcomplex80];
 
-            tbool = basic[Type.Kind.bool_];
-            tchar = basic[Type.Kind.char_];
-            twchar = basic[Type.Kind.wchar_];
-            tdchar = basic[Type.Kind.dchar_];
+            tbool = basic[Tbool];
+            tchar = basic[Tchar];
+            twchar = basic[Twchar];
+            tdchar = basic[Tdchar];
 
             tshiftcnt = tint32;
-            terror = basic[Type.Kind.error];
-            tnull = basic[Type.Kind.null_];
+            terror = basic[Terror];
+            tnull = basic[Tnull];
             tnull = new TypeNull();
             tnull.deco = tnull.merge().deco;
 
@@ -2685,13 +2731,13 @@ struct ASTBase
 
             if (global.params.isLP64)
             {
-                Tsize_t = Type.Kind.uint64;
-                Tptrdiff_t = Type.Kind.int64;
+                Tsize_t = Tuns64;
+                Tptrdiff_t = Tint64;
             }
             else
             {
-                Tsize_t = Type.Kind.uint32;
-                Tptrdiff_t = Type.Kind.int32;
+                Tsize_t = Tuns32;
+                Tptrdiff_t = Tint32;
             }
 
             tsize_t = basic[Tsize_t];
@@ -2701,12 +2747,12 @@ struct ASTBase
 
         final Type pointerTo()
         {
-            if (ty == Type.Kind.error)
+            if (ty == Terror)
                 return this;
             if (!pto)
             {
                 Type t = new TypePointer(this);
-                if (ty == Type.Kind.function_)
+                if (ty == Tfunction)
                 {
                     t.deco = t.merge().deco;
                     pto = t;
@@ -2719,7 +2765,7 @@ struct ASTBase
 
         final Type arrayOf()
         {
-            if (ty == Type.Kind.error)
+            if (ty == Terror)
                 return this;
             if (!arrayof)
             {
@@ -2754,9 +2800,9 @@ struct ASTBase
             t.swcto = null;
             //t.vtinfo = null; these aren't used in parsing
             //t.ctype = null;
-            if (t.ty == Type.Kind.struct_)
+            if (t.ty == Tstruct)
                 (cast(TypeStruct)t).att = AliasThisRec.fwdref;
-            if (t.ty == Type.Kind.class_)
+            if (t.ty == Tclass)
                 (cast(TypeClass)t).att = AliasThisRec.fwdref;
             return t;
         }
@@ -2836,17 +2882,17 @@ struct ASTBase
         // Truncated
         final Type merge()
         {
-            if (ty == Type.Kind.error)
+            if (ty == Terror)
                 return this;
-            if (ty == Type.Kind.typeof_)
+            if (ty == Ttypeof)
                 return this;
-            if (ty == Type.Kind.identifier)
+            if (ty == Tident)
                 return this;
-            if (ty == Type.Kind.instance)
+            if (ty == Tinstance)
                 return this;
-            if (ty == Type.Kind.associativeArray && !(cast(TypeAArray)this).index.merge().deco)
+            if (ty == Taarray && !(cast(TypeAArray)this).index.merge().deco)
                 return this;
-            if (ty != Type.Kind.enum_ && nextOf() && !nextOf().deco)
+            if (ty != Tenum && nextOf() && !nextOf().deco)
                 return this;
 
             // if (!deco) - code missing
@@ -3057,7 +3103,7 @@ struct ASTBase
         {
             Type mto = null;
             Type tn = nextOf();
-            if (!tn || ty != Type.Kind.staticArray && tn.mod == t.nextOf().mod)
+            if (!tn || ty != Tsarray && tn.mod == t.nextOf().mod)
             {
                 switch (t.mod)
                 {
@@ -3326,121 +3372,121 @@ struct ASTBase
             uint flags = 0;
             switch (ty)
             {
-            case Type.Kind.void_:
+            case Tvoid:
                 d = Token.toChars(TOK.void_);
                 break;
 
-            case Type.Kind.int8:
+            case Tint8:
                 d = Token.toChars(TOK.int8);
                 flags |= TFlags.integral;
                 break;
 
-            case Type.Kind.uint8:
+            case Tuns8:
                 d = Token.toChars(TOK.uns8);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.int16:
+            case Tint16:
                 d = Token.toChars(TOK.int16);
                 flags |= TFlags.integral;
                 break;
 
-            case Type.Kind.uint16:
+            case Tuns16:
                 d = Token.toChars(TOK.uns16);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.int32:
+            case Tint32:
                 d = Token.toChars(TOK.int32);
                 flags |= TFlags.integral;
                 break;
 
-            case Type.Kind.uint32:
+            case Tuns32:
                 d = Token.toChars(TOK.uns32);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.float32:
+            case Tfloat32:
                 d = Token.toChars(TOK.float32);
                 flags |= TFlags.floating | TFlags.real_;
                 break;
 
-            case Type.Kind.int64:
+            case Tint64:
                 d = Token.toChars(TOK.int64);
                 flags |= TFlags.integral;
                 break;
 
-            case Type.Kind.uint64:
+            case Tuns64:
                 d = Token.toChars(TOK.uns64);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.int128:
+            case Tint128:
                 d = Token.toChars(TOK.int128);
                 flags |= TFlags.integral;
                 break;
 
-            case Type.Kind.uint128:
+            case Tuns128:
                 d = Token.toChars(TOK.uns128);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.float64:
+            case Tfloat64:
                 d = Token.toChars(TOK.float64);
                 flags |= TFlags.floating | TFlags.real_;
                 break;
 
-            case Type.Kind.float80:
+            case Tfloat80:
                 d = Token.toChars(TOK.float80);
                 flags |= TFlags.floating | TFlags.real_;
                 break;
 
-            case Type.Kind.imaginary32:
+            case Timaginary32:
                 d = Token.toChars(TOK.imaginary32);
                 flags |= TFlags.floating | TFlags.imaginary;
                 break;
 
-            case Type.Kind.imaginary64:
+            case Timaginary64:
                 d = Token.toChars(TOK.imaginary64);
                 flags |= TFlags.floating | TFlags.imaginary;
                 break;
 
-            case Type.Kind.imaginary80:
+            case Timaginary80:
                 d = Token.toChars(TOK.imaginary80);
                 flags |= TFlags.floating | TFlags.imaginary;
                 break;
 
-            case Type.Kind.complex32:
+            case Tcomplex32:
                 d = Token.toChars(TOK.complex32);
                 flags |= TFlags.floating | TFlags.complex;
                 break;
 
-            case Type.Kind.complex64:
+            case Tcomplex64:
                 d = Token.toChars(TOK.complex64);
                 flags |= TFlags.floating | TFlags.complex;
                 break;
 
-            case Type.Kind.complex80:
+            case Tcomplex80:
                 d = Token.toChars(TOK.complex80);
                 flags |= TFlags.floating | TFlags.complex;
                 break;
 
-            case Type.Kind.bool_:
+            case Tbool:
                 d = "bool";
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.char_:
+            case Tchar:
                 d = Token.toChars(TOK.char_);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.wchar_:
+            case Twchar:
                 d = Token.toChars(TOK.wchar_);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
-            case Type.Kind.dchar_:
+            case Tdchar:
                 d = Token.toChars(TOK.dchar_);
                 flags |= TFlags.integral | TFlags.unsigned;
                 break;
@@ -3468,7 +3514,7 @@ struct ASTBase
     {
         extern (D) this()
         {
-            super(Type.Kind.error);
+            super(Terror);
         }
 
         override Type syntaxCopy()
@@ -3486,7 +3532,7 @@ struct ASTBase
     {
         extern (D) this()
         {
-            super(Type.Kind.null_);
+            super(Tnull);
         }
 
         override Type syntaxCopy()
@@ -3507,7 +3553,7 @@ struct ASTBase
 
         extern (D) this(Loc loc, Type baseType)
         {
-            super(Type.Kind.vector);
+            super(Tvector);
             this.basetype = basetype;
         }
 
@@ -3528,7 +3574,7 @@ struct ASTBase
 
         extern (D) this(EnumDeclaration sym)
         {
-            super(Type.Kind.enum_);
+            super(Tenum);
             this.sym = sym;
         }
 
@@ -3549,13 +3595,13 @@ struct ASTBase
 
         extern (D) this(Parameters* arguments)
         {
-            super(Type.Kind.tuple);
+            super(Ttuple);
             this.arguments = arguments;
         }
 
         extern (D) this(Expressions* exps)
         {
-            super(Type.Kind.tuple);
+            super(Ttuple);
             auto arguments = new Parameters();
             if (exps)
             {
@@ -3563,7 +3609,7 @@ struct ASTBase
                 for (size_t i = 0; i < exps.dim; i++)
                 {
                     Expression e = (*exps)[i];
-                    if (e.type.ty == Type.Kind.tuple)
+                    if (e.type.ty == Ttuple)
                         e.error("cannot form tuple of tuples");
                     auto arg = new Parameter(STC.undefined_, e.type, null, null);
                     (*arguments)[i] = arg;
@@ -3593,7 +3639,7 @@ struct ASTBase
 
         extern (D) this (ClassDeclaration sym)
         {
-            super(Type.Kind.class_);
+            super(Tclass);
             this.sym = sym;
         }
 
@@ -3615,7 +3661,7 @@ struct ASTBase
 
         extern (D) this(StructDeclaration sym)
         {
-            super(Type.Kind.struct_);
+            super(Tstruct);
             this.sym = sym;
         }
 
@@ -3634,7 +3680,7 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Type.Kind.reference, t);
+            super(Treference, t);
             // BUG: what about references to static arrays?
         }
 
@@ -3685,7 +3731,7 @@ struct ASTBase
 
         extern (D) this(Type next, Expression lwr, Expression upr)
         {
-            super(Type.Kind.slice, next);
+            super(Tslice, next);
             this.lwr = lwr;
             this.upr = upr;
         }
@@ -3707,8 +3753,8 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Type.Kind.function_, t);
-            ty = Type.Kind.delegate_;
+            super(Tfunction, t);
+            ty = Tdelegate;
         }
 
         override Type syntaxCopy()
@@ -3734,7 +3780,7 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Type.Kind.pointer, t);
+            super(Tpointer, t);
         }
 
         override Type syntaxCopy()
@@ -3776,7 +3822,7 @@ struct ASTBase
 
         extern (D) this(Parameters* parameters, Type treturn, int varargs, LINK linkage, StorageClass stc = 0)
         {
-            super(Type.Kind.function_, treturn);
+            super(Tfunction, treturn);
             assert(0 <= varargs && varargs <= 2);
             this.parameters = parameters;
             this.varargs = varargs;
@@ -3849,7 +3895,7 @@ struct ASTBase
     {
         extern (D) this(Type t)
         {
-            super(Type.Kind.array, t);
+            super(Tarray, t);
         }
 
         override Type syntaxCopy()
@@ -3878,7 +3924,7 @@ struct ASTBase
 
         extern (D) this(Type t, Type index)
         {
-            super(Type.Kind.associativeArray, t);
+            super(Taarray, t);
             this.index = index;
         }
 
@@ -3920,7 +3966,7 @@ struct ASTBase
 
         final extern (D) this(Type t, Expression dim)
         {
-            super(Type.Kind.staticArray, t);
+            super(Tsarray, t);
             this.dim = dim;
         }
 
@@ -4046,7 +4092,7 @@ struct ASTBase
 
         extern (D) this(Loc loc, Identifier ident)
         {
-            super(Type.Kind.identifier, loc);
+            super(Tident, loc);
             this.ident = ident;
         }
 
@@ -4073,7 +4119,7 @@ struct ASTBase
     {
         extern (D) this(Loc loc)
         {
-            super(Type.Kind.return_, loc);
+            super(Treturn, loc);
         }
 
         override Type syntaxCopy()
@@ -4096,7 +4142,7 @@ struct ASTBase
 
         extern (D) this(Loc loc, Expression exp)
         {
-            super(Type.Kind.typeof_, loc);
+            super(Ttypeof, loc);
             this.exp = exp;
         }
 
@@ -4120,7 +4166,7 @@ struct ASTBase
 
         final extern (D) this(Loc loc, TemplateInstance tempinst)
         {
-            super(Type.Kind.instance, loc);
+            super(Tinstance, loc);
             this.tempinst = tempinst;
         }
 
@@ -4222,7 +4268,7 @@ struct ASTBase
             assert(type);
             if (!type.isscalar())
             {
-                if (type.ty != Type.Kind.error)
+                if (type.ty != Terror)
                     error("integral constant must be scalar type, not %s", type.toChars());
                 type = Type.terror;
             }
@@ -4242,46 +4288,46 @@ struct ASTBase
              */
             switch (type.toBasetype().ty)
             {
-            case Type.Kind.bool_:
+            case Tbool:
                 value = (value != 0);
                 break;
 
-            case Type.Kind.int8:
+            case Tint8:
                 value = cast(d_int8)value;
                 break;
 
-            case Type.Kind.char_:
-            case Type.Kind.uint8:
+            case Tchar:
+            case Tuns8:
                 value = cast(d_uns8)value;
                 break;
 
-            case Type.Kind.int16:
+            case Tint16:
                 value = cast(d_int16)value;
                 break;
 
-            case Type.Kind.wchar_:
-            case Type.Kind.uint16:
+            case Twchar:
+            case Tuns16:
                 value = cast(d_uns16)value;
                 break;
 
-            case Type.Kind.int32:
+            case Tint32:
                 value = cast(d_int32)value;
                 break;
 
-            case Type.Kind.dchar_:
-            case Type.Kind.uint32:
+            case Tdchar:
+            case Tuns32:
                 value = cast(d_uns32)value;
                 break;
 
-            case Type.Kind.int64:
+            case Tint64:
                 value = cast(d_int64)value;
                 break;
 
-            case Type.Kind.uint64:
+            case Tuns64:
                 value = cast(d_uns64)value;
                 break;
 
-            case Type.Kind.pointer:
+            case Tpointer:
                 if (Target.ptrsize == 4)
                     value = cast(d_uns32)value;
                 else if (Target.ptrsize == 8)

--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -39,7 +39,12 @@ struct ASTCodegen
 
     alias MODFlags                  = dmd.mtype.MODFlags;
     alias Type                      = dmd.mtype.Type;
+    alias Tident                    = dmd.mtype.Tident;
+    alias Tfunction                 = dmd.mtype.Tfunction;
     alias Parameter                 = dmd.mtype.Parameter;
+    alias Taarray                   = dmd.mtype.Taarray;
+    alias Tsarray                   = dmd.mtype.Tsarray;
+    alias Terror                    = dmd.mtype.Terror;
 
     alias STC                       = dmd.declaration.STC;
     alias Dsymbol                   = dmd.dsymbol.Dsymbol;

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -171,7 +171,7 @@ extern (C++) Expression eval_bswap(Loc loc, FuncDeclaration fd, Expressions* arg
     n = ((n >> 16) & SHORTMASK) | ((n & SHORTMASK) << 16);
     TY ty = arg0.type.toBasetype().ty;
     // If 64 bits, we need to swap high and low uints
-    if (ty == Type.Kind.int64 || ty == Type.Kind.uint64)
+    if (ty == Tint64 || ty == Tuns64)
         n = ((n >> 32) & INTMASK) | ((n & INTMASK) << 32);
     return new IntegerExp(loc, n, arg0.type);
 }

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -70,9 +70,9 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             Type t = ce.e1.type.toBasetype();
             if (ce.f && ce.f == func)
                 return;
-            if (t.ty == Type.Kind.function_ && (cast(TypeFunction)t).isnothrow)
+            if (t.ty == Tfunction && (cast(TypeFunction)t).isnothrow)
                 return;
-            if (t.ty == Type.Kind.delegate_ && (cast(TypeFunction)(cast(TypeDelegate)t).next).isnothrow)
+            if (t.ty == Tdelegate && (cast(TypeFunction)(cast(TypeDelegate)t).next).isnothrow)
                 return;
 
             if (mustNotThrow)
@@ -101,7 +101,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                 {
                     // https://issues.dlang.org/show_bug.cgi?id=14407
                     Type t = ne.allocator.type.toBasetype();
-                    if (t.ty == Type.Kind.function_ && !(cast(TypeFunction)t).isnothrow)
+                    if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
                     {
                         if (mustNotThrow)
                         {
@@ -113,7 +113,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                 }
                 // See if constructor call can throw
                 Type t = ne.member.type.toBasetype();
-                if (t.ty == Type.Kind.function_ && !(cast(TypeFunction)t).isnothrow)
+                if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
                 {
                     if (mustNotThrow)
                     {
@@ -132,19 +132,19 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             AggregateDeclaration ad = null;
             switch (tb.ty)
             {
-            case Type.Kind.class_:
+            case Tclass:
                 ad = (cast(TypeClass)tb).sym;
                 break;
 
-            case Type.Kind.pointer:
+            case Tpointer:
                 tb = (cast(TypePointer)tb).next.toBasetype();
-                if (tb.ty == Type.Kind.struct_)
+                if (tb.ty == Tstruct)
                     ad = (cast(TypeStruct)tb).sym;
                 break;
 
-            case Type.Kind.array:
+            case Tarray:
                 Type tv = tb.nextOf().baseElemOf();
-                if (tv.ty == Type.Kind.struct_)
+                if (tv.ty == Tstruct)
                     ad = (cast(TypeStruct)tv).sym;
                 break;
 
@@ -157,7 +157,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             if (ad.dtor)
             {
                 Type t = ad.dtor.type.toBasetype();
-                if (t.ty == Type.Kind.function_ && !(cast(TypeFunction)t).isnothrow)
+                if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
                 {
                     if (mustNotThrow)
                     {
@@ -167,10 +167,10 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
                     stop = true;
                 }
             }
-            if (ad.aggDelete && tb.ty != Type.Kind.array)
+            if (ad.aggDelete && tb.ty != Tarray)
             {
                 Type t = ad.aggDelete.type;
-                if (t.ty == Type.Kind.function_ && !(cast(TypeFunction)t).isnothrow)
+                if (t.ty == Tfunction && !(cast(TypeFunction)t).isnothrow)
                 {
                     if (mustNotThrow)
                     {
@@ -190,7 +190,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             /* Element-wise assignment could invoke postblits.
              */
             Type t;
-            if (ae.type.toBasetype().ty == Type.Kind.staticArray)
+            if (ae.type.toBasetype().ty == Tsarray)
             {
                 if (!ae.e2.isLvalue())
                     return;
@@ -201,10 +201,10 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
             else
                 return;
             Type tv = t.baseElemOf();
-            if (tv.ty != Type.Kind.struct_)
+            if (tv.ty != Tstruct)
                 return;
             StructDeclaration sd = (cast(TypeStruct)tv).sym;
-            if (!sd.postblit || sd.postblit.type.ty != Type.Kind.function_)
+            if (!sd.postblit || sd.postblit.type.ty != Tfunction)
                 return;
             if ((cast(TypeFunction)sd.postblit.type).isnothrow)
             {

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -160,7 +160,7 @@ private bool needOpAssign(StructDeclaration sd)
         if (v.overlapped)               // if field of a union
             continue;                   // user must handle it themselves
         Type tv = v.type.baseElemOf();
-        if (tv.ty == Type.Kind.struct_)
+        if (tv.ty == Tstruct)
         {
             TypeStruct ts = cast(TypeStruct)tv;
             if (ts.sym.isUnionDeclaration())
@@ -225,7 +225,7 @@ extern (C++) FuncDeclaration buildOpAssign(StructDeclaration sd, Scope* sc)
         if (v.overlapped)
             continue;
         Type tv = v.type.baseElemOf();
-        if (tv.ty != Type.Kind.struct_)
+        if (tv.ty != Tstruct)
             continue;
         StructDeclaration sdv = (cast(TypeStruct)tv).sym;
         stc = mergeFuncAttrs(stc, hasIdentityOpAssign(sdv, sc));
@@ -358,7 +358,7 @@ extern (C++) bool needOpEquals(StructDeclaration sd)
             continue;
         Type tv = v.type.toBasetype();
         auto tvbase = tv.baseElemOf();
-        if (tvbase.ty == Type.Kind.struct_)
+        if (tvbase.ty == Tstruct)
         {
             TypeStruct ts = cast(TypeStruct)tvbase;
             if (ts.sym.isUnionDeclaration())
@@ -375,11 +375,11 @@ extern (C++) bool needOpEquals(StructDeclaration sd)
             //  2. comparison of NANs should be false always.
             goto Lneed;
         }
-        if (tv.ty == Type.Kind.array)
+        if (tv.ty == Tarray)
             goto Lneed;
-        if (tv.ty == Type.Kind.associativeArray)
+        if (tv.ty == Taarray)
             goto Lneed;
-        if (tv.ty == Type.Kind.class_)
+        if (tv.ty == Tclass)
             goto Lneed;
     }
 Ldontneed:
@@ -678,7 +678,7 @@ private bool needToHash(StructDeclaration sd)
             continue;
         Type tv = v.type.toBasetype();
         auto tvbase = tv.baseElemOf();
-        if (tvbase.ty == Type.Kind.struct_)
+        if (tvbase.ty == Tstruct)
         {
             TypeStruct ts = cast(TypeStruct)tvbase;
             if (ts.sym.isUnionDeclaration())
@@ -695,11 +695,11 @@ private bool needToHash(StructDeclaration sd)
              */
             goto Lneed;
         }
-        if (tv.ty == Type.Kind.array)
+        if (tv.ty == Tarray)
             goto Lneed;
-        if (tv.ty == Type.Kind.associativeArray)
+        if (tv.ty == Taarray)
             goto Lneed;
-        if (tv.ty == Type.Kind.class_)
+        if (tv.ty == Tclass)
             goto Lneed;
     }
 Ldontneed:
@@ -798,7 +798,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         if (v.overlapped)
             continue;
         Type tv = v.type.baseElemOf();
-        if (tv.ty != Type.Kind.struct_)
+        if (tv.ty != Tstruct)
             continue;
         auto sdv = (cast(TypeStruct)tv).sym;
         if (!sdv.postblit)
@@ -816,7 +816,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
 
         Expression ex;
         tv = v.type.toBasetype();
-        if (tv.ty == Type.Kind.struct_)
+        if (tv.ty == Tstruct)
         {
             // this.v.__xpostblit()
 
@@ -838,7 +838,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             // _ArrayPostblit((cast(S*)this.v.ptr)[0 .. n])
 
             uinteger_t n = 1;
-            while (tv.ty == Type.Kind.staticArray)
+            while (tv.ty == Tsarray)
             {
                 n *= (cast(TypeSArray)tv).dim.toUInteger();
                 tv = tv.nextOf().toBasetype();
@@ -873,7 +873,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
         sdv.dtor.functionSemantic();
 
         tv = v.type.toBasetype();
-        if (tv.ty == Type.Kind.struct_)
+        if (tv.ty == Tstruct)
         {
             // this.v.__xdtor()
 
@@ -895,7 +895,7 @@ extern (C++) FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             // _ArrayDtor((cast(S*)this.v.ptr)[0 .. n])
 
             uinteger_t n = 1;
-            while (tv.ty == Type.Kind.staticArray)
+            while (tv.ty == Tsarray)
             {
                 n *= (cast(TypeSArray)tv).dim.toUInteger();
                 tv = tv.nextOf().toBasetype();
@@ -1016,7 +1016,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
         if (v.overlapped)
             continue;
         auto tv = v.type.baseElemOf();
-        if (tv.ty != Type.Kind.struct_)
+        if (tv.ty != Tstruct)
             continue;
         auto sdv = (cast(TypeStruct)tv).sym;
         if (!sdv.dtor)
@@ -1032,7 +1032,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
 
         Expression ex;
         tv = v.type.toBasetype();
-        if (tv.ty == Type.Kind.struct_)
+        if (tv.ty == Tstruct)
         {
             // this.v.__xdtor()
 
@@ -1053,7 +1053,7 @@ extern (C++) FuncDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
             // _ArrayDtor((cast(S*)this.v.ptr)[0 .. n])
 
             uinteger_t n = 1;
-            while (tv.ty == Type.Kind.staticArray)
+            while (tv.ty == Tsarray)
             {
                 n *= (cast(TypeSArray)tv).dim.toUInteger();
                 tv = tv.nextOf().toBasetype();

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -386,20 +386,20 @@ extern (C++) final class StaticForeach : RootObject
             sc = sc.endCTFE();
             aggrfe.aggr = aggrfe.aggr.optimize(WANTvalue);
             auto tab = aggrfe.aggr.type.toBasetype();
-            if (tab.ty != Type.Kind.tuple)
+            if (tab.ty != Ttuple)
             {
                 aggrfe.aggr = aggrfe.aggr.ctfeInterpret();
             }
         }
 
-        if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Type.Kind.error)
+        if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Terror)
         {
             return;
         }
 
         if (!ready())
         {
-            if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Type.Kind.array)
+            if (aggrfe && aggrfe.aggr.type.toBasetype().ty == Tarray)
             {
                 lowerArrayAggregate(sc);
             }
@@ -416,7 +416,7 @@ extern (C++) final class StaticForeach : RootObject
      */
     final extern(D) bool ready()
     {
-        return aggrfe && aggrfe.aggr && aggrfe.aggr.type.toBasetype().ty == Type.Kind.tuple;
+        return aggrfe && aggrfe.aggr && aggrfe.aggr.type.toBasetype().ty == Ttuple;
     }
 }
 

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -439,7 +439,7 @@ extern (C++) UnionExp Div(Loc loc, Type type, Expression e1, Expression e2)
         if (n2 == -1 && !type.isunsigned())
         {
             // Check for int.min / -1
-            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Type.Kind.int64)
+            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Tint64)
             {
                 e2.error("integer overflow: `int.min / -1`");
                 emplaceExp!(ErrorExp)(&ue);
@@ -504,7 +504,7 @@ extern (C++) UnionExp Mod(Loc loc, Type type, Expression e1, Expression e2)
         if (n2 == -1 && !type.isunsigned())
         {
             // Check for int.min % -1
-            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Type.Kind.int64)
+            if (n1 == 0xFFFFFFFF80000000UL && type.toBasetype().ty != Tint64)
             {
                 e2.error("integer overflow: `int.min %% -1`");
                 emplaceExp!(ErrorExp)(&ue);
@@ -621,34 +621,34 @@ extern (C++) UnionExp Shr(Loc loc, Type type, Expression e1, Expression e2)
     uint count = cast(uint)dcount;
     switch (e1.type.toBasetype().ty)
     {
-    case Type.Kind.int8:
+    case Tint8:
         value = cast(d_int8)value >> count;
         break;
-    case Type.Kind.uint8:
-    case Type.Kind.char_:
+    case Tuns8:
+    case Tchar:
         value = cast(d_uns8)value >> count;
         break;
-    case Type.Kind.int16:
+    case Tint16:
         value = cast(d_int16)value >> count;
         break;
-    case Type.Kind.uint16:
-    case Type.Kind.wchar_:
+    case Tuns16:
+    case Twchar:
         value = cast(d_uns16)value >> count;
         break;
-    case Type.Kind.int32:
+    case Tint32:
         value = cast(d_int32)value >> count;
         break;
-    case Type.Kind.uint32:
-    case Type.Kind.dchar_:
+    case Tuns32:
+    case Tdchar:
         value = cast(d_uns32)value >> count;
         break;
-    case Type.Kind.int64:
+    case Tint64:
         value = cast(d_int64)value >> count;
         break;
-    case Type.Kind.uint64:
+    case Tuns64:
         value = cast(d_uns64)value >> count;
         break;
-    case Type.Kind.error:
+    case Terror:
         emplaceExp!(ErrorExp)(&ue);
         return ue;
     default:
@@ -667,28 +667,28 @@ extern (C++) UnionExp Ushr(Loc loc, Type type, Expression e1, Expression e2)
     uint count = cast(uint)dcount;
     switch (e1.type.toBasetype().ty)
     {
-    case Type.Kind.int8:
-    case Type.Kind.uint8:
-    case Type.Kind.char_:
+    case Tint8:
+    case Tuns8:
+    case Tchar:
         // Possible only with >>>=. >>> always gets promoted to int.
         value = (value & 0xFF) >> count;
         break;
-    case Type.Kind.int16:
-    case Type.Kind.uint16:
-    case Type.Kind.wchar_:
+    case Tint16:
+    case Tuns16:
+    case Twchar:
         // Possible only with >>>=. >>> always gets promoted to int.
         value = (value & 0xFFFF) >> count;
         break;
-    case Type.Kind.int32:
-    case Type.Kind.uint32:
-    case Type.Kind.dchar_:
+    case Tint32:
+    case Tuns32:
+    case Tdchar:
         value = (value & 0xFFFFFFFF) >> count;
         break;
-    case Type.Kind.int64:
-    case Type.Kind.uint64:
+    case Tint64:
+    case Tuns64:
         value = cast(d_uns64)value >> count;
         break;
-    case Type.Kind.error:
+    case Terror:
         emplaceExp!(ErrorExp)(&ue);
         return ue;
     default:
@@ -907,7 +907,7 @@ extern (C++) UnionExp Equal(TOK op, Loc loc, Type type, Expression e1, Expressio
     {
         cmp = e1.toComplex() == e2.toComplex();
     }
-    else if (e1.type.isintegral() || e1.type.toBasetype().ty == Type.Kind.pointer)
+    else if (e1.type.isintegral() || e1.type.toBasetype().ty == Tpointer)
     {
         cmp = (e1.toInteger() == e2.toInteger());
     }
@@ -1055,7 +1055,7 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     // Allow covariant converions of delegates
     // (Perhaps implicit conversion from pure to impure should be a MATCH.constant,
     // then we wouldn't need this extra check.)
-    if (e1.type.toBasetype().ty == Type.Kind.delegate_ && e1.type.implicitConvTo(to) == MATCH.convert)
+    if (e1.type.toBasetype().ty == Tdelegate && e1.type.implicitConvTo(to) == MATCH.convert)
     {
         goto L1;
     }
@@ -1063,7 +1063,7 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
      */
     if (e1.op == TOK.string_)
     {
-        if (tb.ty == Type.Kind.array && typeb.ty == Type.Kind.array && tb.nextOf().size() == typeb.nextOf().size())
+        if (tb.ty == Tarray && typeb.ty == Tarray && tb.nextOf().size() == typeb.nextOf().size())
         {
             goto L1;
         }
@@ -1079,7 +1079,7 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     {
         emplaceExp!(CTFEExp)(&ue, TOK.cantExpression);
     }
-    else if (tb.ty == Type.Kind.bool_)
+    else if (tb.ty == Tbool)
     {
         emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger() != 0, type);
     }
@@ -1091,31 +1091,31 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
             real_t r = e1.toReal();
             switch (typeb.ty)
             {
-            case Type.Kind.int8:
+            case Tint8:
                 result = cast(d_int8)cast(sinteger_t)r;
                 break;
-            case Type.Kind.char_:
-            case Type.Kind.uint8:
+            case Tchar:
+            case Tuns8:
                 result = cast(d_uns8)cast(dinteger_t)r;
                 break;
-            case Type.Kind.int16:
+            case Tint16:
                 result = cast(d_int16)cast(sinteger_t)r;
                 break;
-            case Type.Kind.wchar_:
-            case Type.Kind.uint16:
+            case Twchar:
+            case Tuns16:
                 result = cast(d_uns16)cast(dinteger_t)r;
                 break;
-            case Type.Kind.int32:
+            case Tint32:
                 result = cast(d_int32)r;
                 break;
-            case Type.Kind.dchar_:
-            case Type.Kind.uint32:
+            case Tdchar:
+            case Tuns32:
                 result = cast(d_uns32)r;
                 break;
-            case Type.Kind.int64:
+            case Tint64:
                 result = cast(d_int64)r;
                 break;
-            case Type.Kind.uint64:
+            case Tuns64:
                 result = cast(d_uns64)r;
                 break;
             default:
@@ -1147,11 +1147,11 @@ extern (C++) UnionExp Cast(Loc loc, Type type, Type to, Expression e1)
     {
         emplaceExp!(IntegerExp)(&ue, loc, e1.toInteger(), type);
     }
-    else if (tb.ty == Type.Kind.void_)
+    else if (tb.ty == Tvoid)
     {
         emplaceExp!(CTFEExp)(&ue, TOK.cantExpression);
     }
-    else if (tb.ty == Type.Kind.struct_ && e1.op == TOK.int64)
+    else if (tb.ty == Tstruct && e1.op == TOK.int64)
     {
         // Struct = 0;
         StructDeclaration sd = tb.toDsymbol(null).isStructDeclaration();
@@ -1204,7 +1204,7 @@ extern (C++) UnionExp ArrayLength(Type type, Expression e1)
         size_t dim = ale.keys.dim;
         emplaceExp!(IntegerExp)(&ue, loc, dim, type);
     }
-    else if (e1.type.toBasetype().ty == Type.Kind.staticArray)
+    else if (e1.type.toBasetype().ty == Tsarray)
     {
         Expression e = (cast(TypeSArray)e1.type.toBasetype()).dim;
         emplaceExp!(UnionExp)(&ue, e);
@@ -1236,7 +1236,7 @@ extern (C++) UnionExp Index(Type type, Expression e1, Expression e2)
             emplaceExp!(IntegerExp)(&ue, loc, es1.charAt(i), type);
         }
     }
-    else if (e1.type.toBasetype().ty == Type.Kind.staticArray && e2.op == TOK.int64)
+    else if (e1.type.toBasetype().ty == Tsarray && e2.op == TOK.int64)
     {
         TypeSArray tsa = cast(TypeSArray)e1.type.toBasetype();
         uinteger_t length = tsa.dim.toInteger();
@@ -1260,7 +1260,7 @@ extern (C++) UnionExp Index(Type type, Expression e1, Expression e2)
         else
             emplaceExp!(CTFEExp)(&ue, TOK.cantExpression);
     }
-    else if (e1.type.toBasetype().ty == Type.Kind.array && e2.op == TOK.int64)
+    else if (e1.type.toBasetype().ty == Tarray && e2.op == TOK.int64)
     {
         uinteger_t i = e2.toInteger();
         if (e1.op == TOK.arrayLiteral)
@@ -1467,7 +1467,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         t = t2;
     L2:
         Type tn = e.type.toBasetype();
-        if (tn.ty == Type.Kind.char_ || tn.ty == Type.Kind.wchar_ || tn.ty == Type.Kind.dchar_)
+        if (tn.ty == Tchar || tn.ty == Twchar || tn.ty == Tdchar)
         {
             // Create a StringExp
             if (t.nextOf())
@@ -1501,7 +1501,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         if (type == e1.type)
         {
             // Handle null ~= null
-            if (t1.ty == Type.Kind.array && t2 == t1.nextOf())
+            if (t1.ty == Tarray && t2 == t1.nextOf())
             {
                 emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, e2);
                 ue.exp().type = type;
@@ -1643,7 +1643,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Type.Kind.staticArray)
+        if (type.toBasetype().ty == Tsarray)
         {
             e.type = t1.nextOf().sarrayOf(elems.dim);
         }
@@ -1667,7 +1667,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Type.Kind.staticArray)
+        if (type.toBasetype().ty == Tsarray)
         {
             e.type = t1.nextOf().sarrayOf(elems.dim);
         }
@@ -1685,7 +1685,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Type.Kind.staticArray)
+        if (type.toBasetype().ty == Tsarray)
         {
             e.type = e2.type.sarrayOf(elems.dim);
         }
@@ -1701,7 +1701,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         emplaceExp!(ArrayLiteralExp)(&ue, e2.loc, elems);
 
         e = ue.exp();
-        if (type.toBasetype().ty == Type.Kind.staticArray)
+        if (type.toBasetype().ty == Tsarray)
         {
             e.type = e1.type.sarrayOf(elems.dim);
         }
@@ -1722,7 +1722,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         t = e2.type;
     L1:
         Type tb = t.toBasetype();
-        if (tb.ty == Type.Kind.array && tb.nextOf().equivalent(e.type))
+        if (tb.ty == Tarray && tb.nextOf().equivalent(e.type))
         {
             auto expressions = new Expressions();
             expressions.push(e);

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -346,7 +346,7 @@ private final class CppMangleVisitor : Visitor
     static bool isIdent_char(Identifier ident, RootObject o)
     {
         Type t = isType(o);
-        if (!t || t.ty != Type.Kind.struct_)
+        if (!t || t.ty != Tstruct)
             return false;
         Dsymbol s = (cast(TypeStruct)t).toDsymbol(null);
         if (s.ident != ident)
@@ -627,7 +627,7 @@ private final class CppMangleVisitor : Visitor
 
         if (tf.linkage == LINK.cpp) //Template args accept extern "C" symbols with special mangling
         {
-            assert(tf.ty == Type.Kind.function_);
+            assert(tf.ty == Tfunction);
             mangleFunctionParameters(tf.parameters, tf.varargs);
         }
     }
@@ -651,7 +651,7 @@ private final class CppMangleVisitor : Visitor
             static if (IN_GCC)
             {
                 // Could be a va_list, which we mangle as a pointer.
-                if (t.ty == Type.Kind.staticArray && Type.tvalist.ty == Type.Kind.staticArray)
+                if (t.ty == Tsarray && Type.tvalist.ty == Tsarray)
                 {
                     Type tb = t.toBasetype().mutableOf();
                     if (tb == Type.tvalist)
@@ -661,7 +661,7 @@ private final class CppMangleVisitor : Visitor
                     }
                 }
             }
-            if (t.ty == Type.Kind.staticArray)
+            if (t.ty == Tsarray)
             {
                 // Static arrays in D are passed by value; no counterpart in C++
                 t.error(loc, "Internal Compiler Error: unable to pass static array `%s` to extern(C++) function, use pointer instead",
@@ -732,7 +732,7 @@ public:
      */
     void headOfType(Type t)
     {
-        if (t.ty == Type.Kind.class_)
+        if (t.ty == Tclass)
         {
             mangleTypeClass(cast(TypeClass)t, true);
         }
@@ -810,34 +810,34 @@ public:
         char p = 0;
         switch (t.ty)
         {
-            case Type.Kind.void_:                 c = 'v';        break;
-            case Type.Kind.int8:                 c = 'a';        break;
-            case Type.Kind.uint8:                 c = 'h';        break;
-            case Type.Kind.int16:                c = 's';        break;
-            case Type.Kind.uint16:                c = 't';        break;
-            case Type.Kind.int32:                c = 'i';        break;
-            case Type.Kind.uint32:                c = 'j';        break;
-            case Type.Kind.float32:              c = 'f';        break;
-            case Type.Kind.int64:
+            case Tvoid:                 c = 'v';        break;
+            case Tint8:                 c = 'a';        break;
+            case Tuns8:                 c = 'h';        break;
+            case Tint16:                c = 's';        break;
+            case Tuns16:                c = 't';        break;
+            case Tint32:                c = 'i';        break;
+            case Tuns32:                c = 'j';        break;
+            case Tfloat32:              c = 'f';        break;
+            case Tint64:
                 c = Target.c_longsize == 8 ? Target.int64Mangle : 'x';
                 break;
-            case Type.Kind.uint64:
+            case Tuns64:
                 c = Target.c_longsize == 8 ? Target.uint64Mangle : 'y';
                 break;
-            case Type.Kind.int128:                c = 'n';       break;
-            case Type.Kind.uint128:                c = 'o';       break;
-            case Type.Kind.float64:               c = 'd';       break;
-            case Type.Kind.float80:               c = 'e';       break;
-            case Type.Kind.bool_:                  c = 'b';       break;
-            case Type.Kind.char_:                  c = 'c';       break;
-            case Type.Kind.wchar_:                 c = 't';       break;  // unsigned short (perhaps use 'Ds' ?
-            case Type.Kind.dchar_:                 c = 'w';       break;  // wchar_t (UTF-32) (perhaps use 'Di' ?
-            case Type.Kind.imaginary32:  p = 'G'; c = 'f';       break;  // 'G' means imaginary
-            case Type.Kind.imaginary64:  p = 'G'; c = 'd';       break;
-            case Type.Kind.imaginary80:  p = 'G'; c = 'e';       break;
-            case Type.Kind.complex32:    p = 'C'; c = 'f';       break;  // 'C' means complex
-            case Type.Kind.complex64:    p = 'C'; c = 'd';       break;
-            case Type.Kind.complex80:    p = 'C'; c = 'e';       break;
+            case Tint128:                c = 'n';       break;
+            case Tuns128:                c = 'o';       break;
+            case Tfloat64:               c = 'd';       break;
+            case Tfloat80:               c = 'e';       break;
+            case Tbool:                  c = 'b';       break;
+            case Tchar:                  c = 'c';       break;
+            case Twchar:                 c = 't';       break;  // unsigned short (perhaps use 'Ds' ?
+            case Tdchar:                 c = 'w';       break;  // wchar_t (UTF-32) (perhaps use 'Di' ?
+            case Timaginary32:  p = 'G'; c = 'f';       break;  // 'G' means imaginary
+            case Timaginary64:  p = 'G'; c = 'd';       break;
+            case Timaginary80:  p = 'G'; c = 'e';       break;
+            case Tcomplex32:    p = 'C'; c = 'f';       break;  // 'C' means complex
+            case Tcomplex64:    p = 'C'; c = 'd';       break;
+            case Tcomplex80:    p = 'C'; c = 'e';       break;
 
             default:
                 // Handle any target-specific basic types.
@@ -873,7 +873,7 @@ public:
         }
         else
         {
-            assert(t.basetype && t.basetype.ty == Type.Kind.staticArray);
+            assert(t.basetype && t.basetype.ty == Tsarray);
             assert((cast(TypeSArray)t.basetype).dim);
             version (none)
             {

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -125,7 +125,7 @@ public:
             if (checkTypeSaved(type))
                 return;
         }
-        if ((type.ty == Type.Kind.bool_) && checkTypeSaved(type)) // try to replace long name with number
+        if ((type.ty == Tbool) && checkTypeSaved(type)) // try to replace long name with number
         {
             return;
         }
@@ -133,12 +133,12 @@ public:
         {
             switch (type.ty)
             {
-            case Type.Kind.int64:
-            case Type.Kind.uint64:
-            case Type.Kind.int128:
-            case Type.Kind.uint128:
-            case Type.Kind.float80:
-            case Type.Kind.wchar_:
+            case Tint64:
+            case Tuns64:
+            case Tint128:
+            case Tuns128:
+            case Tfloat80:
+            case Twchar:
                 if (checkTypeSaved(type))
                     return;
                 break;
@@ -150,62 +150,62 @@ public:
         mangleModifier(type);
         switch (type.ty)
         {
-        case Type.Kind.void_:
+        case Tvoid:
             buf.writeByte('X');
             break;
-        case Type.Kind.int8:
+        case Tint8:
             buf.writeByte('C');
             break;
-        case Type.Kind.uint8:
+        case Tuns8:
             buf.writeByte('E');
             break;
-        case Type.Kind.int16:
+        case Tint16:
             buf.writeByte('F');
             break;
-        case Type.Kind.uint16:
+        case Tuns16:
             buf.writeByte('G');
             break;
-        case Type.Kind.int32:
+        case Tint32:
             buf.writeByte('H');
             break;
-        case Type.Kind.uint32:
+        case Tuns32:
             buf.writeByte('I');
             break;
-        case Type.Kind.float32:
+        case Tfloat32:
             buf.writeByte('M');
             break;
-        case Type.Kind.int64:
+        case Tint64:
             buf.writestring("_J");
             break;
-        case Type.Kind.uint64:
+        case Tuns64:
             buf.writestring("_K");
             break;
-        case Type.Kind.int128:
+        case Tint128:
             buf.writestring("_L");
             break;
-        case Type.Kind.uint128:
+        case Tuns128:
             buf.writestring("_M");
             break;
-        case Type.Kind.float64:
+        case Tfloat64:
             buf.writeByte('N');
             break;
-        case Type.Kind.bool_:
+        case Tbool:
             buf.writestring("_N");
             break;
-        case Type.Kind.char_:
+        case Tchar:
             buf.writeByte('D');
             break;
-        case Type.Kind.dchar_:
+        case Tdchar:
             buf.writeByte('I');
             break;
             // unsigned int
-        case Type.Kind.float80:
+        case Tfloat80:
             if (flags & IS_DMC)
                 buf.writestring("_Z"); // DigitalMars long double
             else
                 buf.writestring("_T"); // Intel long double
             break;
-        case Type.Kind.wchar_:
+        case Twchar:
             if (flags & IS_DMC)
                 buf.writestring("_Y"); // DigitalMars wchar_t
             else
@@ -242,7 +242,7 @@ public:
             buf.writeByte('P');
         flags |= IS_NOT_TOP_TYPE;
         assert(type.next);
-        if (type.next.ty == Type.Kind.staticArray)
+        if (type.next.ty == Tsarray)
         {
             mangleArray(cast(TypeSArray)type.next);
         }
@@ -263,7 +263,7 @@ public:
             return;
         }
         assert(type.next);
-        if (type.next.ty == Type.Kind.function_)
+        if (type.next.ty == Tfunction)
         {
             const(char)* arg = mangleFunctionType(cast(TypeFunction)type.next); // compute args before checking to save; args should be saved before function type
             // If we've mangled this function early, previous call is meaningless.
@@ -282,7 +282,7 @@ public:
             flags &= ~IGNORE_CONST;
             return;
         }
-        else if (type.next.ty == Type.Kind.staticArray)
+        else if (type.next.ty == Tsarray)
         {
             if (checkTypeSaved(type))
                 return;
@@ -332,7 +332,7 @@ public:
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
         assert(type.next);
-        if (type.next.ty == Type.Kind.staticArray)
+        if (type.next.ty == Tsarray)
         {
             mangleArray(cast(TypeSArray)type.next);
         }
@@ -410,29 +410,29 @@ public:
         buf.writeByte('W');
         switch (type.sym.memtype.ty)
         {
-        case Type.Kind.char_:
-        case Type.Kind.int8:
+        case Tchar:
+        case Tint8:
             buf.writeByte('0');
             break;
-        case Type.Kind.uint8:
+        case Tuns8:
             buf.writeByte('1');
             break;
-        case Type.Kind.int16:
+        case Tint16:
             buf.writeByte('2');
             break;
-        case Type.Kind.uint16:
+        case Tuns16:
             buf.writeByte('3');
             break;
-        case Type.Kind.int32:
+        case Tint32:
             buf.writeByte('4');
             break;
-        case Type.Kind.uint32:
+        case Tuns32:
             buf.writeByte('5');
             break;
-        case Type.Kind.int64:
+        case Tint64:
             buf.writeByte('6');
             break;
-        case Type.Kind.uint64:
+        case Tuns64:
             buf.writeByte('7');
             break;
         default:
@@ -616,10 +616,10 @@ private:
         {
             cv_mod = 'A'; // mutable
         }
-        if (t.ty != Type.Kind.pointer)
+        if (t.ty != Tpointer)
             t = t.mutableOf();
         t.accept(this);
-        if ((t.ty == Type.Kind.pointer || t.ty == Type.Kind.reference || t.ty == Type.Kind.class_) && global.params.is64bit)
+        if ((t.ty == Tpointer || t.ty == Treference || t.ty == Tclass) && global.params.is64bit)
         {
             buf.writeByte('E');
         }
@@ -933,7 +933,7 @@ private:
         {
             if (flags & IS_NOT_TOP_TYPE)
                 buf.writeByte('B'); // const
-            else if ((flags & IS_DMC) && type.ty != Type.Kind.pointer)
+            else if ((flags & IS_DMC) && type.ty != Tpointer)
                 buf.writestring("_O");
         }
         else if (flags & IS_NOT_TOP_TYPE)
@@ -945,7 +945,7 @@ private:
         mangleModifier(type);
         size_t i = 0;
         Type cur = type;
-        while (cur && cur.ty == Type.Kind.staticArray)
+        while (cur && cur.ty == Tsarray)
         {
             i++;
             cur = cur.nextOf();
@@ -953,7 +953,7 @@ private:
         buf.writeByte('Y');
         mangleNumber(i); // count of dimensions
         cur = type;
-        while (cur && cur.ty == Type.Kind.staticArray) // sizes of dimensions
+        while (cur && cur.ty == Tsarray) // sizes of dimensions
         {
             TypeSArray sa = cast(TypeSArray)cur;
             mangleNumber(sa.dim ? sa.dim.toInteger() : 0);
@@ -1009,7 +1009,7 @@ private:
             if (type.isref)
                 rettype = rettype.referenceTo();
             flags &= ~IGNORE_CONST;
-            if (rettype.ty == Type.Kind.struct_ || rettype.ty == Type.Kind.enum_)
+            if (rettype.ty == Tstruct || rettype.ty == Tenum)
             {
                 const id = rettype.toDsymbol(null).ident;
                 if (id != Id.__c_long_double && id != Id.__c_long && id != Id.__c_ulong)
@@ -1045,7 +1045,7 @@ private:
                     td = new TypeDelegate(td);
                     t = merge(t);
                 }
-                if (t.ty == Type.Kind.staticArray)
+                if (t.ty == Tsarray)
                 {
                     t.error(Loc(), "Internal Compiler Error: unable to pass static array to extern(C++) function.");
                     t.error(Loc(), "Use pointer instead.");

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -90,7 +90,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                 return;
             }
 
-            if (t.ty != Type.Kind.error && e.type.ty != Type.Kind.error)
+            if (t.ty != Terror && e.type.ty != Terror)
             {
                 if (!t.deco)
                 {
@@ -142,7 +142,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
             visit(cast(Expression)e);
 
             Type tb = result.type.toBasetype();
-            if (tb.ty == Type.Kind.array)
+            if (tb.ty == Tarray)
                 semanticTypeInfo(sc, (cast(TypeDArray)tb).next);
         }
 
@@ -158,7 +158,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
                 ArrayLiteralExp ale = cast(ArrayLiteralExp)e.e1;
                 Type tb = t.toBasetype();
                 Type tx;
-                if (tb.ty == Type.Kind.staticArray)
+                if (tb.ty == Tsarray)
                     tx = tb.nextOf().sarrayOf(ale.elements ? ale.elements.dim : 0);
                 else
                     tx = tb.nextOf().arrayOf();
@@ -249,11 +249,11 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
         static MATCH implicitMod(Expression e, Type t, MOD mod)
         {
             Type tprime;
-            if (t.ty == Type.Kind.pointer)
+            if (t.ty == Tpointer)
                 tprime = t.nextOf().castMod(mod).pointerTo();
-            else if (t.ty == Type.Kind.array)
+            else if (t.ty == Tarray)
                 tprime = t.nextOf().castMod(mod).arrayOf();
-            else if (t.ty == Type.Kind.staticArray)
+            else if (t.ty == Tsarray)
                 tprime = t.nextOf().castMod(mod).sarrayOf(t.size() / t.nextOf().size());
             else
                 tprime = t.castMod(mod);
@@ -272,19 +272,19 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (typeb.ty != Type.Kind.pointer || tb.ty != Type.Kind.pointer)
+            if (typeb.ty != Tpointer || tb.ty != Tpointer)
                 return MATCH.nomatch;
 
             Type t1b = e.e1.type.toBasetype();
             Type t2b = e.e2.type.toBasetype();
-            if (t1b.ty == Type.Kind.pointer && t2b.isintegral() && t1b.equivalent(tb))
+            if (t1b.ty == Tpointer && t2b.isintegral() && t1b.equivalent(tb))
             {
                 // ptr + offset
                 // ptr - offset
                 MATCH m = e.e1.implicitConvTo(t);
                 return (m > MATCH.constant) ? MATCH.constant : m;
             }
-            if (t2b.ty == Type.Kind.pointer && t1b.isintegral() && t2b.equivalent(tb))
+            if (t2b.ty == Tpointer && t1b.isintegral() && t2b.equivalent(tb))
             {
                 // offset + ptr
                 MATCH m = e.e2.implicitConvTo(t);
@@ -333,32 +333,32 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             TY toty = t.toBasetype().ty;
             TY oldty = ty;
 
-            if (m == MATCH.nomatch && t.ty == Type.Kind.enum_)
+            if (m == MATCH.nomatch && t.ty == Tenum)
                 return;
 
-            if (t.ty == Type.Kind.vector)
+            if (t.ty == Tvector)
             {
                 TypeVector tv = cast(TypeVector)t;
                 TypeBasic tb = tv.elementType();
-                if (tb.ty == Type.Kind.void_)
+                if (tb.ty == Tvoid)
                     return;
                 toty = tb.ty;
             }
 
             switch (ty)
             {
-            case Type.Kind.bool_:
-            case Type.Kind.int8:
-            case Type.Kind.char_:
-            case Type.Kind.uint8:
-            case Type.Kind.int16:
-            case Type.Kind.uint16:
-            case Type.Kind.wchar_:
-                ty = Type.Kind.int32;
+            case Tbool:
+            case Tint8:
+            case Tchar:
+            case Tuns8:
+            case Tint16:
+            case Tuns16:
+            case Twchar:
+                ty = Tint32;
                 break;
 
-            case Type.Kind.dchar_:
-                ty = Type.Kind.uint32;
+            case Tdchar:
+                ty = Tuns32;
                 break;
 
             default:
@@ -369,68 +369,68 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             dinteger_t value = e.toInteger();
             switch (toty)
             {
-            case Type.Kind.bool_:
+            case Tbool:
                 if ((value & 1) != value)
                     return;
                 break;
 
-            case Type.Kind.int8:
-                if (ty == Type.Kind.uint64 && value & ~0x7FU)
+            case Tint8:
+                if (ty == Tuns64 && value & ~0x7FU)
                     return;
                 else if (cast(byte)value != value)
                     return;
                 break;
 
-            case Type.Kind.char_:
-                if ((oldty == Type.Kind.wchar_ || oldty == Type.Kind.dchar_) && value > 0x7F)
+            case Tchar:
+                if ((oldty == Twchar || oldty == Tdchar) && value > 0x7F)
                     return;
-                goto case Type.Kind.uint8;
-            case Type.Kind.uint8:
+                goto case Tuns8;
+            case Tuns8:
                 //printf("value = %llu %llu\n", (dinteger_t)(unsigned char)value, value);
                 if (cast(ubyte)value != value)
                     return;
                 break;
 
-            case Type.Kind.int16:
-                if (ty == Type.Kind.uint64 && value & ~0x7FFFU)
+            case Tint16:
+                if (ty == Tuns64 && value & ~0x7FFFU)
                     return;
                 else if (cast(short)value != value)
                     return;
                 break;
 
-            case Type.Kind.wchar_:
-                if (oldty == Type.Kind.dchar_ && value > 0xD7FF && value < 0xE000)
+            case Twchar:
+                if (oldty == Tdchar && value > 0xD7FF && value < 0xE000)
                     return;
-                goto case Type.Kind.uint16;
-            case Type.Kind.uint16:
+                goto case Tuns16;
+            case Tuns16:
                 if (cast(ushort)value != value)
                     return;
                 break;
 
-            case Type.Kind.int32:
-                if (ty == Type.Kind.uint32)
+            case Tint32:
+                if (ty == Tuns32)
                 {
                 }
-                else if (ty == Type.Kind.uint64 && value & ~0x7FFFFFFFU)
+                else if (ty == Tuns64 && value & ~0x7FFFFFFFU)
                     return;
                 else if (cast(int)value != value)
                     return;
                 break;
 
-            case Type.Kind.uint32:
-                if (ty == Type.Kind.int32)
+            case Tuns32:
+                if (ty == Tint32)
                 {
                 }
                 else if (cast(uint)value != value)
                     return;
                 break;
 
-            case Type.Kind.dchar_:
+            case Tdchar:
                 if (value > 0x10FFFFU)
                     return;
                 break;
 
-            case Type.Kind.float32:
+            case Tfloat32:
                 {
                     float f;
                     if (e.type.isunsigned())
@@ -448,7 +448,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     break;
                 }
 
-            case Type.Kind.float64:
+            case Tfloat64:
                 {
                     double f;
                     if (e.type.isunsigned())
@@ -466,7 +466,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     break;
                 }
 
-            case Type.Kind.float80:
+            case Tfloat80:
                 {
                     if (e.type.isunsigned())
                     {
@@ -483,10 +483,10 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                     break;
                 }
 
-            case Type.Kind.pointer:
+            case Tpointer:
                 //printf("type = %s\n", type.toBasetype()->toChars());
                 //printf("t = %s\n", t.toBasetype()->toChars());
-                if (ty == Type.Kind.pointer && e.type.toBasetype().nextOf().ty == t.toBasetype().nextOf().ty)
+                if (ty == Tpointer && e.type.toBasetype().nextOf().ty == t.toBasetype().nextOf().ty)
                 {
                     /* Allow things like:
                      *      const char* P = cast(char *)3;
@@ -544,7 +544,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             visit(cast(Expression)e);
             if (result != MATCH.nomatch)
                 return;
-            if (e.type.ty == t.ty && e.type.ty == Type.Kind.struct_ && (cast(TypeStruct)e.type).sym == (cast(TypeStruct)t).sym)
+            if (e.type.ty == t.ty && e.type.ty == Tstruct && (cast(TypeStruct)e.type).sym == (cast(TypeStruct)t).sym)
             {
                 result = MATCH.constant;
                 for (size_t i = 0; i < e.elements.dim; i++)
@@ -567,18 +567,18 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 printf("StringExp::implicitConvTo(this=%s, committed=%d, type=%s, t=%s)\n", e.toChars(), e.committed, e.type.toChars(), t.toChars());
             }
-            if (!e.committed && t.ty == Type.Kind.pointer && t.nextOf().ty == Type.Kind.void_)
+            if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
                 return;
 
-            if (e.type.ty == Type.Kind.staticArray || e.type.ty == Type.Kind.array || e.type.ty == Type.Kind.pointer)
+            if (e.type.ty == Tsarray || e.type.ty == Tarray || e.type.ty == Tpointer)
             {
                 TY tyn = e.type.nextOf().ty;
-                if (tyn == Type.Kind.char_ || tyn == Type.Kind.wchar_ || tyn == Type.Kind.dchar_)
+                if (tyn == Tchar || tyn == Twchar || tyn == Tdchar)
                 {
                     switch (t.ty)
                     {
-                    case Type.Kind.staticArray:
-                        if (e.type.ty == Type.Kind.staticArray)
+                    case Tsarray:
+                        if (e.type.ty == Tsarray)
                         {
                             TY tynto = t.nextOf().ty;
                             if (tynto == tyn)
@@ -589,7 +589,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                 }
                                 return;
                             }
-                            if (tynto == Type.Kind.char_ || tynto == Type.Kind.wchar_ || tynto == Type.Kind.dchar_)
+                            if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
                             {
                                 if (e.committed && tynto != tyn)
                                     return;
@@ -604,16 +604,16 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                     return;
                                 }
                             }
-                            if (!e.committed && (tynto == Type.Kind.char_ || tynto == Type.Kind.wchar_ || tynto == Type.Kind.dchar_))
+                            if (!e.committed && (tynto == Tchar || tynto == Twchar || tynto == Tdchar))
                             {
                                 result = MATCH.exact;
                                 return;
                             }
                         }
-                        else if (e.type.ty == Type.Kind.array)
+                        else if (e.type.ty == Tarray)
                         {
                             TY tynto = t.nextOf().ty;
-                            if (tynto == Type.Kind.char_ || tynto == Type.Kind.wchar_ || tynto == Type.Kind.dchar_)
+                            if (tynto == Tchar || tynto == Twchar || tynto == Tdchar)
                             {
                                 if (e.committed && tynto != tyn)
                                     return;
@@ -633,15 +633,15 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                                 result = MATCH.exact;
                                 return;
                             }
-                            if (!e.committed && (tynto == Type.Kind.char_ || tynto == Type.Kind.wchar_ || tynto == Type.Kind.dchar_))
+                            if (!e.committed && (tynto == Tchar || tynto == Twchar || tynto == Tdchar))
                             {
                                 result = MATCH.exact;
                                 return;
                             }
                         }
                         goto case; /+ fall through +/
-                    case Type.Kind.array:
-                    case Type.Kind.pointer:
+                    case Tarray:
+                    case Tpointer:
                         Type tn = t.nextOf();
                         MATCH m = MATCH.exact;
                         if (e.type.nextOf().mod != tn.mod)
@@ -655,17 +655,17 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                         {
                             switch (tn.ty)
                             {
-                            case Type.Kind.char_:
+                            case Tchar:
                                 if (e.postfix == 'w' || e.postfix == 'd')
                                     m = MATCH.convert;
                                 result = m;
                                 return;
-                            case Type.Kind.wchar_:
+                            case Twchar:
                                 if (e.postfix != 'w')
                                     m = MATCH.convert;
                                 result = m;
                                 return;
-                            case Type.Kind.dchar_:
+                            case Tdchar:
                                 if (e.postfix != 'd')
                                     m = MATCH.convert;
                                 result = m;
@@ -694,13 +694,13 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if ((tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray) &&
-                (typeb.ty == Type.Kind.array || typeb.ty == Type.Kind.staticArray))
+            if ((tb.ty == Tarray || tb.ty == Tsarray) &&
+                (typeb.ty == Tarray || typeb.ty == Tsarray))
             {
                 result = MATCH.exact;
                 Type typen = typeb.nextOf().toBasetype();
 
-                if (tb.ty == Type.Kind.staticArray)
+                if (tb.ty == Tsarray)
                 {
                     TypeSArray tsa = cast(TypeSArray)tb;
                     if (e.elements.dim != tsa.dim.toInteger())
@@ -710,7 +710,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                 Type telement = tb.nextOf();
                 if (!e.elements.dim)
                 {
-                    if (typen.ty != Type.Kind.void_)
+                    if (typen.ty != Tvoid)
                         result = typen.implicitConvTo(telement);
                 }
                 else
@@ -739,13 +739,13 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
 
                 return;
             }
-            else if (tb.ty == Type.Kind.vector && (typeb.ty == Type.Kind.array || typeb.ty == Type.Kind.staticArray))
+            else if (tb.ty == Tvector && (typeb.ty == Tarray || typeb.ty == Tsarray))
             {
                 result = MATCH.exact;
                 // Convert array literal to vector type
                 TypeVector tv = cast(TypeVector)tb;
                 TypeSArray tbase = cast(TypeSArray)tv.basetype;
-                assert(tbase.ty == Type.Kind.staticArray);
+                assert(tbase.ty == Tsarray);
                 const edim = e.elements.dim;
                 const tbasedim = tbase.dim.toInteger();
                 if (edim > tbasedim)
@@ -782,7 +782,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (tb.ty == Type.Kind.associativeArray && typeb.ty == Type.Kind.associativeArray)
+            if (tb.ty == Taarray && typeb.ty == Taarray)
             {
                 result = MATCH.exact;
                 for (size_t i = 0; i < e.keys.dim; i++)
@@ -836,7 +836,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
              */
             Type tx = e.f ? e.f.type : e.e1.type;
             tx = tx.toBasetype();
-            if (tx.ty != Type.Kind.function_)
+            if (tx.ty != Tfunction)
                 return;
             TypeFunction tf = cast(TypeFunction)tx;
 
@@ -957,7 +957,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
 
             // Look for pointers to functions where the functions are overloaded.
             if (e.e1.op == TOK.overloadSet &&
-                (tb.ty == Type.Kind.pointer || tb.ty == Type.Kind.delegate_) && tb.nextOf().ty == Type.Kind.function_)
+                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
             {
                 OverExp eo = cast(OverExp)e.e1;
                 FuncDeclaration f = null;
@@ -983,8 +983,8 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             }
 
             if (e.e1.op == TOK.variable &&
-                typeb.ty == Type.Kind.pointer && typeb.nextOf().ty == Type.Kind.function_ &&
-                tb.ty == Type.Kind.pointer && tb.nextOf().ty == Type.Kind.function_)
+                typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
+                tb.ty == Tpointer && tb.nextOf().ty == Tfunction)
             {
                 /* I don't think this can ever happen -
                  * it should have been
@@ -1011,16 +1011,16 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type typeb = e.type.toBasetype();
 
             // Look for pointers to functions where the functions are overloaded.
-            if (typeb.ty == Type.Kind.pointer && typeb.nextOf().ty == Type.Kind.function_ &&
-                (tb.ty == Type.Kind.pointer || tb.ty == Type.Kind.delegate_) && tb.nextOf().ty == Type.Kind.function_)
+            if (typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
+                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
             {
                 if (FuncDeclaration f = e.var.isFuncDeclaration())
                 {
                     f = f.overloadExactMatch(tb.nextOf());
                     if (f)
                     {
-                        if ((tb.ty == Type.Kind.delegate_ && (f.needThis() || f.isNested())) ||
-                            (tb.ty == Type.Kind.pointer && !(f.needThis() || f.isNested())))
+                        if ((tb.ty == Tdelegate && (f.needThis() || f.isNested())) ||
+                            (tb.ty == Tpointer && !(f.needThis() || f.isNested())))
                         {
                             result = MATCH.exact;
                         }
@@ -1044,7 +1044,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type typeb = e.type.toBasetype();
 
             // Look for pointers to functions where the functions are overloaded.
-            if (typeb.ty == Type.Kind.delegate_ && tb.ty == Type.Kind.delegate_)
+            if (typeb.ty == Tdelegate && tb.ty == Tdelegate)
             {
                 if (e.func && e.func.overloadExactMatch(tb.nextOf()))
                     result = MATCH.exact;
@@ -1178,7 +1178,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 if (!fd)
                     continue;
-                if (fd.errors || fd.type.ty != Type.Kind.function_)
+                if (fd.errors || fd.type.ty != Tfunction)
                     return; // error
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 if (tf.purity == PURE.impure)
@@ -1255,9 +1255,9 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             /* Consider the .init expression as an argument
              */
             Type ntb = e.newtype.toBasetype();
-            if (ntb.ty == Type.Kind.array)
+            if (ntb.ty == Tarray)
                 ntb = ntb.nextOf().toBasetype();
-            if (ntb.ty == Type.Kind.struct_)
+            if (ntb.ty == Tstruct)
             {
                 // Don't allow nested structs - uplevel reference may not be convertible
                 StructDeclaration sd = (cast(TypeStruct)ntb).sym;
@@ -1269,7 +1269,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             {
                 /* Zeros are implicitly convertible, except for special cases.
                  */
-                if (ntb.ty == Type.Kind.class_)
+                if (ntb.ty == Tclass)
                 {
                     /* With new() must look at the class instance initializer.
                      */
@@ -1343,7 +1343,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (tb.ty == Type.Kind.staticArray && typeb.ty == Type.Kind.array)
+            if (tb.ty == Tsarray && typeb.ty == Tarray)
             {
                 typeb = toStaticArrayType(e);
                 if (typeb)
@@ -1356,7 +1356,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
              * same mod bits.
              */
             Type t1b = e.e1.type.toBasetype();
-            if (tb.ty == Type.Kind.array && typeb.equivalent(tb))
+            if (tb.ty == Tarray && typeb.equivalent(tb))
             {
                 Type tbn = tb.nextOf();
                 Type tx = null;
@@ -1365,16 +1365,16 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
                  * is equivalent with the uniqueness of the referred data. And in here
                  * we can have arbitrary typed reference for that.
                  */
-                if (t1b.ty == Type.Kind.array)
+                if (t1b.ty == Tarray)
                     tx = tbn.arrayOf();
-                if (t1b.ty == Type.Kind.pointer)
+                if (t1b.ty == Tpointer)
                     tx = tbn.pointerTo();
 
                 /* If e.e1 is static array, at least it should be an rvalue.
                  * If not, e.e1 is a reference, and its uniqueness does not link
                  * to the uniqueness of the referred data.
                  */
-                if (t1b.ty == Type.Kind.staticArray && !e.e1.isLvalue())
+                if (t1b.ty == Tsarray && !e.e1.isLvalue())
                     tx = tbn.sarrayOf(t1b.size() / tbn.size());
 
                 if (tx)
@@ -1386,7 +1386,7 @@ extern (C++) MATCH implicitConvTo(Expression e, Type t)
             }
 
             // Enhancement 10724
-            if (tb.ty == Type.Kind.pointer && e.e1.op == TOK.string_)
+            if (tb.ty == Tpointer && e.e1.op == TOK.string_)
                 e.e1.accept(this);
         }
     }
@@ -1413,7 +1413,7 @@ extern (C++) Type toStaticArrayType(SliceExp e)
     else
     {
         Type t1b = e.e1.type.toBasetype();
-        if (t1b.ty == Type.Kind.staticArray)
+        if (t1b.ty == Tsarray)
             return t1b;
     }
     return null;
@@ -1477,16 +1477,16 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
              */
 
             // Fat Value types
-            const(bool) tob_isFV = (tob.ty == Type.Kind.struct_ || tob.ty == Type.Kind.staticArray);
-            const(bool) t1b_isFV = (t1b.ty == Type.Kind.struct_ || t1b.ty == Type.Kind.staticArray);
+            const(bool) tob_isFV = (tob.ty == Tstruct || tob.ty == Tsarray);
+            const(bool) t1b_isFV = (t1b.ty == Tstruct || t1b.ty == Tsarray);
 
             // Fat Reference types
-            const(bool) tob_isFR = (tob.ty == Type.Kind.array || tob.ty == Type.Kind.delegate_);
-            const(bool) t1b_isFR = (t1b.ty == Type.Kind.array || t1b.ty == Type.Kind.delegate_);
+            const(bool) tob_isFR = (tob.ty == Tarray || tob.ty == Tdelegate);
+            const(bool) t1b_isFR = (t1b.ty == Tarray || t1b.ty == Tdelegate);
 
             // Reference types
-            const(bool) tob_isR = (tob_isFR || tob.ty == Type.Kind.pointer || tob.ty == Type.Kind.associativeArray || tob.ty == Type.Kind.class_);
-            const(bool) t1b_isR = (t1b_isFR || t1b.ty == Type.Kind.pointer || t1b.ty == Type.Kind.associativeArray || t1b.ty == Type.Kind.class_);
+            const(bool) tob_isR = (tob_isFR || tob.ty == Tpointer || tob.ty == Taarray || tob.ty == Tclass);
+            const(bool) t1b_isR = (t1b_isFR || t1b.ty == Tpointer || t1b.ty == Taarray || t1b.ty == Tclass);
 
             // Arithmetic types (== valueable basic types)
             const(bool) tob_isA = (tob.isintegral() || tob.isfloating());
@@ -1497,7 +1497,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 AggregateDeclaration toad = isAggregate(tob);
                 if (t1ad != toad && t1ad.aliasthis)
                 {
-                    if (t1b.ty == Type.Kind.class_ && tob.ty == Type.Kind.class_)
+                    if (t1b.ty == Tclass && tob.ty == Tclass)
                     {
                         ClassDeclaration t1cd = t1b.isClassHandle();
                         ClassDeclaration tocd = tob.isClassHandle();
@@ -1514,7 +1514,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     return;
                 }
             }
-            else if (tob.ty == Type.Kind.vector && t1b.ty != Type.Kind.vector)
+            else if (tob.ty == Tvector && t1b.ty != Tvector)
             {
                 //printf("test1 e = %s, e.type = %s, tob = %s\n", e.toChars(), e.type.toChars(), tob.toChars());
                 TypeVector tv = cast(TypeVector)tob;
@@ -1523,10 +1523,10 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 result = result.expressionSemantic(sc);
                 return;
             }
-            else if (tob.ty != Type.Kind.vector && t1b.ty == Type.Kind.vector)
+            else if (tob.ty != Tvector && t1b.ty == Tvector)
             {
                 // T[n] <-- __vector(U[m])
-                if (tob.ty == Type.Kind.staticArray)
+                if (tob.ty == Tsarray)
                 {
                     if (t1b.size(e.loc) == tob.size(e.loc))
                         goto Lok;
@@ -1542,7 +1542,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             // arithmetic values vs. other arithmetic values
             // arithmetic values vs. T*
-            if (tob_isA && (t1b_isA || t1b.ty == Type.Kind.pointer) || t1b_isA && (tob_isA || tob.ty == Type.Kind.pointer))
+            if (tob_isA && (t1b_isA || t1b.ty == Tpointer) || t1b_isA && (tob_isA || tob.ty == Tpointer))
             {
                 goto Lok;
             }
@@ -1566,9 +1566,9 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
             // Fat values vs. null or references
-            if (tob_isFV && (t1b.ty == Type.Kind.null_ || t1b_isR) || t1b_isFV && (tob.ty == Type.Kind.null_ || tob_isR))
+            if (tob_isFV && (t1b.ty == Tnull || t1b_isR) || t1b_isFV && (tob.ty == Tnull || tob_isR))
             {
-                if (tob.ty == Type.Kind.pointer && t1b.ty == Type.Kind.staticArray)
+                if (tob.ty == Tpointer && t1b.ty == Tsarray)
                 {
                     // T[n] sa;
                     // cast(U*)sa; // ==> cast(U*)sa.ptr;
@@ -1576,7 +1576,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     result.type = t;
                     return;
                 }
-                if (tob.ty == Type.Kind.array && t1b.ty == Type.Kind.staticArray)
+                if (tob.ty == Tarray && t1b.ty == Tsarray)
                 {
                     // T[n] sa;
                     // cast(U[])sa; // ==> cast(U[])sa[];
@@ -1606,34 +1606,34 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 goto Lok;
 
             // typeof(null) <-- non-null references or values
-            if (tob.ty == Type.Kind.null_ && t1b.ty != Type.Kind.null_)
+            if (tob.ty == Tnull && t1b.ty != Tnull)
                 goto Lfail; // https://issues.dlang.org/show_bug.cgi?id=14629
             // typeof(null) --> non-null references or arithmetic values
-            if (t1b.ty == Type.Kind.null_ && tob.ty != Type.Kind.null_)
+            if (t1b.ty == Tnull && tob.ty != Tnull)
                 goto Lok;
 
             // Check size mismatch of references.
-            // Type.Kind.array and Type.Kind.delegate_ are (void*).sizeof*2, but others have (void*).sizeof.
+            // Tarray and Tdelegate are (void*).sizeof*2, but others have (void*).sizeof.
             if (tob_isFR && t1b_isR || t1b_isFR && tob_isR)
             {
-                if (tob.ty == Type.Kind.pointer && t1b.ty == Type.Kind.array)
+                if (tob.ty == Tpointer && t1b.ty == Tarray)
                 {
                     // T[] da;
                     // cast(U*)da; // ==> cast(U*)da.ptr;
                     goto Lok;
                 }
-                if (tob.ty == Type.Kind.pointer && t1b.ty == Type.Kind.delegate_)
+                if (tob.ty == Tpointer && t1b.ty == Tdelegate)
                 {
                     // void delegate() dg;
                     // cast(U*)dg; // ==> cast(U*)dg.ptr;
-                    // Note that it happens even when U is a Type.Kind.function_!
+                    // Note that it happens even when U is a Tfunction!
                     e.deprecation("casting from %s to %s is deprecated", e.type.toChars(), t.toChars());
                     goto Lok;
                 }
                 goto Lfail;
             }
 
-            if (t1b.ty == Type.Kind.void_ && tob.ty != Type.Kind.void_)
+            if (t1b.ty == Tvoid && tob.ty != Tvoid)
             {
             Lfail:
                 e.error("cannot cast expression `%s` of type `%s` to `%s`", e.toChars(), e.type.toChars(), t.toChars());
@@ -1713,7 +1713,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             //printf("StringExp::castTo(t = %s), '%s' committed = %d\n", t.toChars(), e.toChars(), e.committed);
 
-            if (!e.committed && t.ty == Type.Kind.pointer && t.nextOf().ty == Type.Kind.void_)
+            if (!e.committed && t.ty == Tpointer && t.nextOf().ty == Tvoid)
             {
                 e.error("cannot convert string literal to `void*`");
                 result = new ErrorExp();
@@ -1738,7 +1738,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type typeb = e.type.toBasetype();
 
             //printf("\ttype = %s\n", e.type.toChars());
-            if (tb.ty == Type.Kind.delegate_ && typeb.ty != Type.Kind.delegate_)
+            if (tb.ty == Tdelegate && typeb.ty != Tdelegate)
             {
                 visit(cast(Expression)e);
                 return;
@@ -1761,7 +1761,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
              *  cast(wchar[2])"abcd"c --> [\u6261, \u6463]
              *  cast(wchar[1])"abcd"c --> [\u6261]
              */
-            if (e.committed && tb.ty == Type.Kind.staticArray && typeb.ty == Type.Kind.array)
+            if (e.committed && tb.ty == Tsarray && typeb.ty == Tarray)
             {
                 se = cast(StringExp)e.copy();
                 d_uns64 szx = tb.nextOf().size();
@@ -1784,7 +1784,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 return;
             }
 
-            if (tb.ty != Type.Kind.staticArray && tb.ty != Type.Kind.array && tb.ty != Type.Kind.pointer)
+            if (tb.ty != Tsarray && tb.ty != Tarray && tb.ty != Tpointer)
             {
                 if (!copied)
                 {
@@ -1793,7 +1793,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 }
                 goto Lcast;
             }
-            if (typeb.ty != Type.Kind.staticArray && typeb.ty != Type.Kind.array && typeb.ty != Type.Kind.pointer)
+            if (typeb.ty != Tsarray && typeb.ty != Tarray && typeb.ty != Tpointer)
             {
                 if (!copied)
                 {
@@ -1810,7 +1810,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     se = cast(StringExp)e.copy();
                     copied = 1;
                 }
-                if (tb.ty == Type.Kind.staticArray)
+                if (tb.ty == Tsarray)
                     goto L2; // handle possible change in static array dimension
                 se.type = t;
                 result = se;
@@ -1832,12 +1832,12 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 int ttty = tb.nextOf().toBasetype().ty;
                 switch (X(tfty, ttty))
                 {
-                case X(Type.Kind.char_, Type.Kind.char_):
-                case X(Type.Kind.wchar_, Type.Kind.wchar_):
-                case X(Type.Kind.dchar_, Type.Kind.dchar_):
+                case X(Tchar, Tchar):
+                case X(Twchar, Twchar):
+                case X(Tdchar, Tdchar):
                     break;
 
-                case X(Type.Kind.char_, Type.Kind.wchar_):
+                case X(Tchar, Twchar):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1851,7 +1851,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.writeUTF16(0);
                     goto L1;
 
-                case X(Type.Kind.char_, Type.Kind.dchar_):
+                case X(Tchar, Tdchar):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1864,7 +1864,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.write4(0);
                     goto L1;
 
-                case X(Type.Kind.wchar_, Type.Kind.char_):
+                case X(Twchar, Tchar):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1878,7 +1878,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.writeUTF8(0);
                     goto L1;
 
-                case X(Type.Kind.wchar_, Type.Kind.dchar_):
+                case X(Twchar, Tdchar):
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
@@ -1891,7 +1891,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.write4(0);
                     goto L1;
 
-                case X(Type.Kind.dchar_, Type.Kind.char_):
+                case X(Tdchar, Tchar):
                     for (size_t u = 0; u < e.len; u++)
                     {
                         uint c = se.dstring[u];
@@ -1905,7 +1905,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     buffer.writeUTF8(0);
                     goto L1;
 
-                case X(Type.Kind.dchar_, Type.Kind.wchar_):
+                case X(Tdchar, Twchar):
                     for (size_t u = 0; u < e.len; u++)
                     {
                         uint c = se.dstring[u];
@@ -1944,7 +1944,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             assert(copied);
 
             // See if need to truncate or extend the literal
-            if (tb.ty == Type.Kind.staticArray)
+            if (tb.ty == Tsarray)
             {
                 size_t dim2 = cast(size_t)(cast(TypeSArray)tb).dim.toInteger();
                 //printf("dim from = %d, to = %d\n", (int)se.len, (int)dim2);
@@ -1992,7 +1992,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             // Look for pointers to functions where the functions are overloaded.
             if (e.e1.op == TOK.overloadSet &&
-                (tb.ty == Type.Kind.pointer || tb.ty == Type.Kind.delegate_) && tb.nextOf().ty == Type.Kind.function_)
+                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
             {
                 OverExp eo = cast(OverExp)e.e1;
                 FuncDeclaration f = null;
@@ -2026,8 +2026,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
             if (e.e1.op == TOK.variable &&
-                typeb.ty == Type.Kind.pointer && typeb.nextOf().ty == Type.Kind.function_ &&
-                tb.ty == Type.Kind.pointer && tb.nextOf().ty == Type.Kind.function_)
+                typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
+                tb.ty == Tpointer && tb.nextOf().ty == Tfunction)
             {
                 auto ve = cast(VarExp)e.e1;
                 auto f = ve.var.isFuncDeclaration();
@@ -2105,20 +2105,20 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if ((tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray) &&
-                (typeb.ty == Type.Kind.array || typeb.ty == Type.Kind.staticArray))
+            if ((tb.ty == Tarray || tb.ty == Tsarray) &&
+                (typeb.ty == Tarray || typeb.ty == Tsarray))
             {
-                if (tb.nextOf().toBasetype().ty == Type.Kind.void_ && typeb.nextOf().toBasetype().ty != Type.Kind.void_)
+                if (tb.nextOf().toBasetype().ty == Tvoid && typeb.nextOf().toBasetype().ty != Tvoid)
                 {
                     // Don't do anything to cast non-void[] to void[]
                 }
-                else if (typeb.ty == Type.Kind.staticArray && typeb.nextOf().toBasetype().ty == Type.Kind.void_)
+                else if (typeb.ty == Tsarray && typeb.nextOf().toBasetype().ty == Tvoid)
                 {
                     // Don't do anything for casting void[n] to others
                 }
                 else
                 {
-                    if (tb.ty == Type.Kind.staticArray)
+                    if (tb.ty == Tsarray)
                     {
                         TypeSArray tsa = cast(TypeSArray)tb;
                         if (e.elements.dim != tsa.dim.toInteger())
@@ -2142,7 +2142,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     return;
                 }
             }
-            else if (tb.ty == Type.Kind.pointer && typeb.ty == Type.Kind.staticArray)
+            else if (tb.ty == Tpointer && typeb.ty == Tsarray)
             {
                 Type tp = typeb.nextOf().pointerTo();
                 if (!tp.equals(ae.type))
@@ -2151,12 +2151,12 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                     ae.type = tp;
                 }
             }
-            else if (tb.ty == Type.Kind.vector && (typeb.ty == Type.Kind.array || typeb.ty == Type.Kind.staticArray))
+            else if (tb.ty == Tvector && (typeb.ty == Tarray || typeb.ty == Tsarray))
             {
                 // Convert array literal to vector type
                 TypeVector tv = cast(TypeVector)tb;
                 TypeSArray tbase = cast(TypeSArray)tv.basetype;
-                assert(tbase.ty == Type.Kind.staticArray);
+                assert(tbase.ty == Tsarray);
                 const edim = e.elements.dim;
                 const tbasedim = tbase.dim.toInteger();
                 if (edim > tbasedim)
@@ -2200,8 +2200,8 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (tb.ty == Type.Kind.associativeArray && typeb.ty == Type.Kind.associativeArray &&
-                tb.nextOf().toBasetype().ty != Type.Kind.void_)
+            if (tb.ty == Taarray && typeb.ty == Taarray &&
+                tb.nextOf().toBasetype().ty != Tvoid)
             {
                 AssocArrayLiteralExp ae = cast(AssocArrayLiteralExp)e.copy();
                 ae.keys = e.keys.copy();
@@ -2249,14 +2249,14 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
 
             // Look for pointers to functions where the functions are overloaded.
             if (e.hasOverloads &&
-                typeb.ty == Type.Kind.pointer && typeb.nextOf().ty == Type.Kind.function_ &&
-                (tb.ty == Type.Kind.pointer || tb.ty == Type.Kind.delegate_) && tb.nextOf().ty == Type.Kind.function_)
+                typeb.ty == Tpointer && typeb.nextOf().ty == Tfunction &&
+                (tb.ty == Tpointer || tb.ty == Tdelegate) && tb.nextOf().ty == Tfunction)
             {
                 FuncDeclaration f = e.var.isFuncDeclaration();
                 f = f ? f.overloadExactMatch(tb.nextOf()) : null;
                 if (f)
                 {
-                    if (tb.ty == Type.Kind.delegate_)
+                    if (tb.ty == Tdelegate)
                     {
                         if (f.needThis() && hasThis(sc))
                         {
@@ -2326,7 +2326,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             }
 
             // Look for delegates to functions where the functions are overloaded.
-            if (typeb.ty == Type.Kind.delegate_ && tb.ty == Type.Kind.delegate_)
+            if (typeb.ty == Tdelegate && tb.ty == Tdelegate)
             {
                 if (e.func)
                 {
@@ -2405,14 +2405,14 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (e.type.equals(t) || typeb.ty != Type.Kind.array ||
-                (tb.ty != Type.Kind.array && tb.ty != Type.Kind.staticArray))
+            if (e.type.equals(t) || typeb.ty != Tarray ||
+                (tb.ty != Tarray && tb.ty != Tsarray))
             {
                 visit(cast(Expression)e);
                 return;
             }
 
-            if (tb.ty == Type.Kind.array)
+            if (tb.ty == Tarray)
             {
                 if (typeb.nextOf().equivalent(tb.nextOf()))
                 {
@@ -2427,7 +2427,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                 return;
             }
 
-            // Handle the cast from Type.Kind.array to Type.Kind.staticArray with CT-known slicing
+            // Handle the cast from Tarray to Tsarray with CT-known slicing
 
             TypeSArray tsa = cast(TypeSArray)toStaticArrayType(e);
             if (tsa && tsa.size(e.loc) == tb.size(e.loc))
@@ -2436,7 +2436,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                  *  T[a .. b] to const(T)[b-a]
                  *  T[a .. b] to U[dim] if (T.sizeof*(b-a) == U.sizeof*dim)
                  *
-                 * If a SliceExp has Type.Kind.staticArray, it will become lvalue.
+                 * If a SliceExp has Tsarray, it will become lvalue.
                  * That's handled in SliceExp::isLvalue and toLvalue
                  */
                 result = e.copy();
@@ -2450,11 +2450,11 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
                  *  cast(float[2]) [2.0, 1.0, 0.0][0..2];
                  */
                 Type t1b = e.e1.type.toBasetype();
-                if (t1b.ty == Type.Kind.staticArray)
+                if (t1b.ty == Tsarray)
                     t1b = tb.nextOf().sarrayOf((cast(TypeSArray)t1b).dim.toInteger());
-                else if (t1b.ty == Type.Kind.array)
+                else if (t1b.ty == Tarray)
                     t1b = tb.nextOf().arrayOf();
-                else if (t1b.ty == Type.Kind.pointer)
+                else if (t1b.ty == Tpointer)
                     t1b = tb.nextOf().pointerTo();
                 else
                     assert(0);
@@ -2510,7 +2510,7 @@ extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
         override void visit(ArrayLiteralExp ale)
         {
             Type tb = t.toBasetype();
-            if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+            if (tb.ty == Tarray || tb.ty == Tsarray)
             {
                 Type tn = tb.nextOf();
                 if (ale.basis)
@@ -2531,7 +2531,7 @@ extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
         override void visit(AssocArrayLiteralExp aale)
         {
             Type tb = t.toBasetype();
-            if (tb.ty == Type.Kind.associativeArray)
+            if (tb.ty == Taarray)
             {
                 TypeAArray taa = cast(TypeAArray)tb;
                 Type ti = taa.index;
@@ -2561,7 +2561,7 @@ extern (C++) Expression inferType(Expression e, Type t, int flag = 0)
         override void visit(FuncExp fe)
         {
             //printf("FuncExp::inferType('%s'), to=%s\n", fe.type ? fe.type.toChars() : "null", t.toChars());
-            if (t.ty == Type.Kind.delegate_ || t.ty == Type.Kind.pointer && t.nextOf().ty == Type.Kind.function_)
+            if (t.ty == Tdelegate || t.ty == Tpointer && t.nextOf().ty == Tfunction)
             {
                 fe.fd.treq = t;
             }
@@ -2594,7 +2594,7 @@ extern (C++) Expression scaleFactor(BinExp be, Scope* sc)
     Type t2b = be.e2.type.toBasetype();
     Expression eoff;
 
-    if (t1b.ty == Type.Kind.pointer && t2b.isintegral())
+    if (t1b.ty == Tpointer && t2b.isintegral())
     {
         // Need to adjust operator by the stride
         // Replace (ptr + int) with (ptr + (int * stride))
@@ -2608,7 +2608,7 @@ extern (C++) Expression scaleFactor(BinExp be, Scope* sc)
         be.e2.type = t;
         be.type = be.e1.type;
     }
-    else if (t2b.ty == Type.Kind.pointer && t1b.isintegral())
+    else if (t2b.ty == Tpointer && t1b.isintegral())
     {
         // Need to adjust operator by the stride
         // Replace (int + ptr) with (ptr + (int * stride))
@@ -2655,19 +2655,19 @@ extern (C++) Expression scaleFactor(BinExp be, Scope* sc)
  */
 private bool isVoidArrayLiteral(Expression e, Type other)
 {
-    while (e.op == TOK.arrayLiteral && e.type.ty == Type.Kind.array && ((cast(ArrayLiteralExp)e).elements.dim == 1))
+    while (e.op == TOK.arrayLiteral && e.type.ty == Tarray && ((cast(ArrayLiteralExp)e).elements.dim == 1))
     {
         auto ale = cast(ArrayLiteralExp)e;
         e = ale.getElement(0);
-        if (other.ty == Type.Kind.staticArray || other.ty == Type.Kind.array)
+        if (other.ty == Tsarray || other.ty == Tarray)
             other = other.nextOf();
         else
             return false;
     }
-    if (other.ty != Type.Kind.staticArray && other.ty != Type.Kind.array)
+    if (other.ty != Tsarray && other.ty != Tarray)
         return false;
     Type t = e.type;
-    return (e.op == TOK.arrayLiteral && t.ty == Type.Kind.array && t.nextOf().ty == Type.Kind.void_ && (cast(ArrayLiteralExp)e).elements.dim == 0);
+    return (e.op == TOK.arrayLiteral && t.ty == Tarray && t.nextOf().ty == Tvoid && (cast(ArrayLiteralExp)e).elements.dim == 0);
 }
 
 /**************************************
@@ -2719,7 +2719,7 @@ extern (C++) bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expres
     assert(t2);
 
     if (t1.mod != t2.mod &&
-        t1.ty == Type.Kind.enum_ && t2.ty == Type.Kind.enum_ &&
+        t1.ty == Tenum && t2.ty == Tenum &&
         (cast(TypeEnum)t1).sym == (cast(TypeEnum)t2).sym)
     {
         ubyte mod = MODmerge(t1.mod, t2.mod);
@@ -2732,7 +2732,7 @@ Lagain:
     t2b = t2.toBasetype();
 
     TY ty = cast(TY)impcnvResult[t1b.ty][t2b.ty];
-    if (ty != Type.Kind.error)
+    if (ty != Terror)
     {
         TY ty1 = cast(TY)impcnvType1[t1b.ty][t2b.ty];
         TY ty2 = cast(TY)impcnvType2[t1b.ty][t2b.ty];
@@ -2767,16 +2767,16 @@ Lagain:
     t1 = t1b;
     t2 = t2b;
 
-    if (t1.ty == Type.Kind.tuple || t2.ty == Type.Kind.tuple)
+    if (t1.ty == Ttuple || t2.ty == Ttuple)
         goto Lincompatible;
 
     if (t1.equals(t2))
     {
         // merging can not result in new enum type
-        if (t.ty == Type.Kind.enum_)
+        if (t.ty == Tenum)
             t = t1b;
     }
-    else if ((t1.ty == Type.Kind.pointer && t2.ty == Type.Kind.pointer) || (t1.ty == Type.Kind.delegate_ && t2.ty == Type.Kind.delegate_))
+    else if ((t1.ty == Tpointer && t2.ty == Tpointer) || (t1.ty == Tdelegate && t2.ty == Tdelegate))
     {
         // Bring pointers to compatible type
         Type t1n = t1.nextOf();
@@ -2785,9 +2785,9 @@ Lagain:
         if (t1n.equals(t2n))
         {
         }
-        else if (t1n.ty == Type.Kind.void_) // pointers to void are always compatible
+        else if (t1n.ty == Tvoid) // pointers to void are always compatible
             t = t2;
-        else if (t2n.ty == Type.Kind.void_)
+        else if (t2n.ty == Tvoid)
         {
         }
         else if (t1.implicitConvTo(t2))
@@ -2798,7 +2798,7 @@ Lagain:
         {
             goto Lt1;
         }
-        else if (t1n.ty == Type.Kind.function_ && t2n.ty == Type.Kind.function_)
+        else if (t1n.ty == Tfunction && t2n.ty == Tfunction)
         {
             TypeFunction tf1 = cast(TypeFunction)t1n;
             TypeFunction tf2 = cast(TypeFunction)t2n;
@@ -2822,7 +2822,7 @@ Lagain:
                 d.trust = TRUST.trusted;
 
             Type tx = null;
-            if (t1.ty == Type.Kind.delegate_)
+            if (t1.ty == Tdelegate)
             {
                 tx = new TypeDelegate(d);
             }
@@ -2850,7 +2850,7 @@ Lagain:
             t = t1;
             goto Lagain;
         }
-        else if (t1n.ty == Type.Kind.class_ && t2n.ty == Type.Kind.class_)
+        else if (t1n.ty == Tclass && t2n.ty == Tclass)
         {
             ClassDeclaration cd1 = t1n.isClassHandle();
             ClassDeclaration cd2 = t2n.isClassHandle();
@@ -2884,7 +2884,7 @@ Lagain:
             goto Lincompatible;
         }
     }
-    else if ((t1.ty == Type.Kind.staticArray || t1.ty == Type.Kind.array) && (e2.op == TOK.null_ && t2.ty == Type.Kind.pointer && t2.nextOf().ty == Type.Kind.void_ || e2.op == TOK.arrayLiteral && t2.ty == Type.Kind.staticArray && t2.nextOf().ty == Type.Kind.void_ && (cast(TypeSArray)t2).dim.toInteger() == 0 || isVoidArrayLiteral(e2, t1)))
+    else if ((t1.ty == Tsarray || t1.ty == Tarray) && (e2.op == TOK.null_ && t2.ty == Tpointer && t2.nextOf().ty == Tvoid || e2.op == TOK.arrayLiteral && t2.ty == Tsarray && t2.nextOf().ty == Tvoid && (cast(TypeSArray)t2).dim.toInteger() == 0 || isVoidArrayLiteral(e2, t1)))
     {
         /*  (T[n] op void*)   => T[]
          *  (T[]  op void*)   => T[]
@@ -2895,7 +2895,7 @@ Lagain:
          */
         goto Lx1;
     }
-    else if ((t2.ty == Type.Kind.staticArray || t2.ty == Type.Kind.array) && (e1.op == TOK.null_ && t1.ty == Type.Kind.pointer && t1.nextOf().ty == Type.Kind.void_ || e1.op == TOK.arrayLiteral && t1.ty == Type.Kind.staticArray && t1.nextOf().ty == Type.Kind.void_ && (cast(TypeSArray)t1).dim.toInteger() == 0 || isVoidArrayLiteral(e1, t2)))
+    else if ((t2.ty == Tsarray || t2.ty == Tarray) && (e1.op == TOK.null_ && t1.ty == Tpointer && t1.nextOf().ty == Tvoid || e1.op == TOK.arrayLiteral && t1.ty == Tsarray && t1.nextOf().ty == Tvoid && (cast(TypeSArray)t1).dim.toInteger() == 0 || isVoidArrayLiteral(e1, t2)))
     {
         /*  (void*   op T[n]) => T[]
          *  (void*   op T[])  => T[]
@@ -2906,13 +2906,13 @@ Lagain:
          */
         goto Lx2;
     }
-    else if ((t1.ty == Type.Kind.staticArray || t1.ty == Type.Kind.array) && (m = t1.implicitConvTo(t2)) != MATCH.nomatch)
+    else if ((t1.ty == Tsarray || t1.ty == Tarray) && (m = t1.implicitConvTo(t2)) != MATCH.nomatch)
     {
         // https://issues.dlang.org/show_bug.cgi?id=7285
-        // Type.Kind.staticArray op [x, y, ...] should to be Type.Kind.staticArray
+        // Tsarray op [x, y, ...] should to be Tsarray
         // https://issues.dlang.org/show_bug.cgi?id=14737
-        // Type.Kind.staticArray ~ [x, y, ...] should to be Type.Kind.array
-        if (t1.ty == Type.Kind.staticArray && e2.op == TOK.arrayLiteral && op != TOK.concatenate)
+        // Tsarray ~ [x, y, ...] should to be Tarray
+        if (t1.ty == Tsarray && e2.op == TOK.arrayLiteral && op != TOK.concatenate)
             goto Lt1;
         if (m == MATCH.constant && (op == TOK.addAssign || op == TOK.minAssign || op == TOK.mulAssign || op == TOK.divAssign || op == TOK.modAssign || op == TOK.powAssign || op == TOK.andAssign || op == TOK.orAssign || op == TOK.xorAssign))
         {
@@ -2922,15 +2922,15 @@ Lagain:
         }
         goto Lt2;
     }
-    else if ((t2.ty == Type.Kind.staticArray || t2.ty == Type.Kind.array) && t2.implicitConvTo(t1))
+    else if ((t2.ty == Tsarray || t2.ty == Tarray) && t2.implicitConvTo(t1))
     {
         // https://issues.dlang.org/show_bug.cgi?id=7285
         // https://issues.dlang.org/show_bug.cgi?id=14737
-        if (t2.ty == Type.Kind.staticArray && e1.op == TOK.arrayLiteral && op != TOK.concatenate)
+        if (t2.ty == Tsarray && e1.op == TOK.arrayLiteral && op != TOK.concatenate)
             goto Lt2;
         goto Lt1;
     }
-    else if ((t1.ty == Type.Kind.staticArray || t1.ty == Type.Kind.array || t1.ty == Type.Kind.pointer) && (t2.ty == Type.Kind.staticArray || t2.ty == Type.Kind.array || t2.ty == Type.Kind.pointer) && t1.nextOf().mod != t2.nextOf().mod)
+    else if ((t1.ty == Tsarray || t1.ty == Tarray || t1.ty == Tpointer) && (t2.ty == Tsarray || t2.ty == Tarray || t2.ty == Tpointer) && t1.nextOf().mod != t2.nextOf().mod)
     {
         /* If one is mutable and the other invariant, then retry
          * with both of them as const
@@ -2947,19 +2947,19 @@ Lagain:
         else
             mod = MODmerge(t1n.mod, t2n.mod);
 
-        if (t1.ty == Type.Kind.pointer)
+        if (t1.ty == Tpointer)
             t1 = t1n.castMod(mod).pointerTo();
         else
             t1 = t1n.castMod(mod).arrayOf();
 
-        if (t2.ty == Type.Kind.pointer)
+        if (t2.ty == Tpointer)
             t2 = t2n.castMod(mod).pointerTo();
         else
             t2 = t2n.castMod(mod).arrayOf();
         t = t1;
         goto Lagain;
     }
-    else if (t1.ty == Type.Kind.class_ && t2.ty == Type.Kind.class_)
+    else if (t1.ty == Tclass && t2.ty == Tclass)
     {
         if (t1.mod != t2.mod)
         {
@@ -2979,7 +2979,7 @@ Lagain:
         }
         goto Lcc;
     }
-    else if (t1.ty == Type.Kind.class_ || t2.ty == Type.Kind.class_)
+    else if (t1.ty == Tclass || t2.ty == Tclass)
     {
     Lcc:
         while (1)
@@ -2990,9 +2990,9 @@ Lagain:
             if (i1 && i2)
             {
                 // We have the case of class vs. void*, so pick class
-                if (t1.ty == Type.Kind.pointer)
+                if (t1.ty == Tpointer)
                     i1 = MATCH.nomatch;
-                else if (t2.ty == Type.Kind.pointer)
+                else if (t2.ty == Tpointer)
                     i2 = MATCH.nomatch;
             }
 
@@ -3006,7 +3006,7 @@ Lagain:
                 e1 = e1.castTo(sc, t1);
                 goto Lt1;
             }
-            else if (t1.ty == Type.Kind.class_ && t2.ty == Type.Kind.class_)
+            else if (t1.ty == Tclass && t2.ty == Tclass)
             {
                 TypeClass tc1 = cast(TypeClass)t1;
                 TypeClass tc2 = cast(TypeClass)t2;
@@ -3027,7 +3027,7 @@ Lagain:
                 else
                     goto Lincompatible;
             }
-            else if (t1.ty == Type.Kind.struct_ && (cast(TypeStruct)t1).sym.aliasthis)
+            else if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.aliasthis)
             {
                 if (att1 && e1.type == att1)
                     goto Lincompatible;
@@ -3038,7 +3038,7 @@ Lagain:
                 t1 = e1.type;
                 continue;
             }
-            else if (t2.ty == Type.Kind.struct_ && (cast(TypeStruct)t2).sym.aliasthis)
+            else if (t2.ty == Tstruct && (cast(TypeStruct)t2).sym.aliasthis)
             {
                 if (att2 && e2.type == att2)
                     goto Lincompatible;
@@ -3053,7 +3053,7 @@ Lagain:
                 goto Lincompatible;
         }
     }
-    else if (t1.ty == Type.Kind.struct_ && t2.ty == Type.Kind.struct_)
+    else if (t1.ty == Tstruct && t2.ty == Tstruct)
     {
         if (t1.mod != t2.mod)
         {
@@ -3120,9 +3120,9 @@ Lagain:
             goto Lagain;
         }
     }
-    else if (t1.ty == Type.Kind.struct_ || t2.ty == Type.Kind.struct_)
+    else if (t1.ty == Tstruct || t2.ty == Tstruct)
     {
-        if (t1.ty == Type.Kind.struct_ && (cast(TypeStruct)t1).sym.aliasthis)
+        if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.aliasthis)
         {
             if (att1 && e1.type == att1)
                 goto Lincompatible;
@@ -3134,7 +3134,7 @@ Lagain:
             t = t1;
             goto Lagain;
         }
-        if (t2.ty == Type.Kind.struct_ && (cast(TypeStruct)t2).sym.aliasthis)
+        if (t2.ty == Tstruct && (cast(TypeStruct)t2).sym.aliasthis)
         {
             if (att2 && e2.type == att2)
                 goto Lincompatible;
@@ -3156,21 +3156,21 @@ Lagain:
     {
         goto Lt1;
     }
-    else if (t1.ty == Type.Kind.staticArray && t2.ty == Type.Kind.staticArray && e2.implicitConvTo(t1.nextOf().arrayOf()))
+    else if (t1.ty == Tsarray && t2.ty == Tsarray && e2.implicitConvTo(t1.nextOf().arrayOf()))
     {
     Lx1:
         t = t1.nextOf().arrayOf(); // T[]
         e1 = e1.castTo(sc, t);
         e2 = e2.castTo(sc, t);
     }
-    else if (t1.ty == Type.Kind.staticArray && t2.ty == Type.Kind.staticArray && e1.implicitConvTo(t2.nextOf().arrayOf()))
+    else if (t1.ty == Tsarray && t2.ty == Tsarray && e1.implicitConvTo(t2.nextOf().arrayOf()))
     {
     Lx2:
         t = t2.nextOf().arrayOf();
         e1 = e1.castTo(sc, t);
         e2 = e2.castTo(sc, t);
     }
-    else if (t1.ty == Type.Kind.vector && t2.ty == Type.Kind.vector)
+    else if (t1.ty == Tvector && t2.ty == Tvector)
     {
         // https://issues.dlang.org/show_bug.cgi?id=13841
         // all vector types should have no common types between
@@ -3182,14 +3182,14 @@ Lagain:
 
         goto LmodCompare;
     }
-    else if (t1.ty == Type.Kind.vector && t2.ty != Type.Kind.vector && e2.implicitConvTo(t1))
+    else if (t1.ty == Tvector && t2.ty != Tvector && e2.implicitConvTo(t1))
     {
         e2 = e2.castTo(sc, t1);
         t2 = t1;
         t = t1;
         goto Lagain;
     }
-    else if (t2.ty == Type.Kind.vector && t1.ty != Type.Kind.vector && e1.implicitConvTo(t2))
+    else if (t2.ty == Tvector && t1.ty != Tvector && e1.implicitConvTo(t2))
     {
         e1 = e1.castTo(sc, t2);
         t1 = t2;
@@ -3200,7 +3200,7 @@ Lagain:
     {
         if (t1.ty != t2.ty)
         {
-            if (t1.ty == Type.Kind.vector || t2.ty == Type.Kind.vector)
+            if (t1.ty == Tvector || t2.ty == Tvector)
                 goto Lincompatible;
             e1 = integralPromotions(e1, sc);
             e2 = integralPromotions(e2, sc);
@@ -3221,7 +3221,7 @@ LmodCompare:
         e2 = e2.castTo(sc, t);
         goto Lagain;
     }
-    else if (t1.ty == Type.Kind.null_ && t2.ty == Type.Kind.null_)
+    else if (t1.ty == Tnull && t2.ty == Tnull)
     {
         ubyte mod = MODmerge(t1.mod, t2.mod);
 
@@ -3230,15 +3230,15 @@ LmodCompare:
         e2 = e2.castTo(sc, t);
         goto Lret;
     }
-    else if (t2.ty == Type.Kind.null_ && (t1.ty == Type.Kind.pointer || t1.ty == Type.Kind.associativeArray || t1.ty == Type.Kind.array))
+    else if (t2.ty == Tnull && (t1.ty == Tpointer || t1.ty == Taarray || t1.ty == Tarray))
     {
         goto Lt1;
     }
-    else if (t1.ty == Type.Kind.null_ && (t2.ty == Type.Kind.pointer || t2.ty == Type.Kind.associativeArray || t2.ty == Type.Kind.array))
+    else if (t1.ty == Tnull && (t2.ty == Tpointer || t2.ty == Taarray || t2.ty == Tarray))
     {
         goto Lt2;
     }
-    else if (t1.ty == Type.Kind.array && isBinArrayOp(op) && isArrayOpOperand(e1))
+    else if (t1.ty == Tarray && isBinArrayOp(op) && isArrayOpOperand(e1))
     {
         if (e2.implicitConvTo(t1.nextOf()))
         {
@@ -3253,7 +3253,7 @@ LmodCompare:
             // e1 is left as U[], it will be handled in arrayOp() later.
             t = e2.type.arrayOf();
         }
-        else if (t2.ty == Type.Kind.array && isArrayOpOperand(e2))
+        else if (t2.ty == Tarray && isArrayOpOperand(e2))
         {
             if (t1.nextOf().implicitConvTo(t2.nextOf()))
             {
@@ -3273,7 +3273,7 @@ LmodCompare:
         else
             goto Lincompatible;
     }
-    else if (t2.ty == Type.Kind.array && isBinArrayOp(op) && isArrayOpOperand(e2))
+    else if (t2.ty == Tarray && isBinArrayOp(op) && isArrayOpOperand(e2))
     {
         if (e1.implicitConvTo(t2.nextOf()))
         {
@@ -3358,11 +3358,11 @@ extern (C++) Expression typeCombine(BinExp be, Scope* sc)
     if (be.op == TOK.min || be.op == TOK.add)
     {
         // struct+struct, and class+class are errors
-        if (t1.ty == Type.Kind.struct_ && t2.ty == Type.Kind.struct_)
+        if (t1.ty == Tstruct && t2.ty == Tstruct)
             return errorReturn();
-        else if (t1.ty == Type.Kind.class_ && t2.ty == Type.Kind.class_)
+        else if (t1.ty == Tclass && t2.ty == Tclass)
             return errorReturn();
-        else if (t1.ty == Type.Kind.associativeArray && t2.ty == Type.Kind.associativeArray)
+        else if (t1.ty == Taarray && t2.ty == Taarray)
             return errorReturn();
     }
 
@@ -3386,21 +3386,21 @@ extern (C++) Expression integralPromotions(Expression e, Scope* sc)
     //printf("integralPromotions %s %s\n", e.toChars(), e.type.toChars());
     switch (e.type.toBasetype().ty)
     {
-    case Type.Kind.void_:
+    case Tvoid:
         e.error("void has no value");
         return new ErrorExp();
 
-    case Type.Kind.int8:
-    case Type.Kind.uint8:
-    case Type.Kind.int16:
-    case Type.Kind.uint16:
-    case Type.Kind.bool_:
-    case Type.Kind.char_:
-    case Type.Kind.wchar_:
+    case Tint8:
+    case Tuns8:
+    case Tint16:
+    case Tuns16:
+    case Tbool:
+    case Tchar:
+    case Twchar:
         e = e.castTo(sc, Type.tint32);
         break;
 
-    case Type.Kind.dchar_:
+    case Tdchar:
         e = e.castTo(sc, Type.tuns32);
         break;
 
@@ -3428,14 +3428,14 @@ void fix16997(Scope* sc, UnaExp ue)
     {
         switch (ue.e1.type.toBasetype.ty)
         {
-            case Type.Kind.int8:
-            case Type.Kind.uint8:
-            case Type.Kind.int16:
-            case Type.Kind.uint16:
-            //case Type.Kind.bool_:       // these operations aren't allowed on bool anyway
-            case Type.Kind.char_:
-            case Type.Kind.wchar_:
-            case Type.Kind.dchar_:
+            case Tint8:
+            case Tuns8:
+            case Tint16:
+            case Tuns16:
+            //case Tbool:       // these operations aren't allowed on bool anyway
+            case Tchar:
+            case Twchar:
+            case Tdchar:
                 ue.deprecation("integral promotion not done for `%s`, use '-transition=intpromote' switch or `%scast(int)(%s)`",
                     ue.toChars(), Token.toChars(ue.op), ue.e1.toChars());
                 break;
@@ -3458,9 +3458,9 @@ extern (C++) bool arrayTypeCompatible(Loc loc, Type t1, Type t2)
     t1 = t1.toBasetype().merge2();
     t2 = t2.toBasetype().merge2();
 
-    if ((t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray || t1.ty == Type.Kind.pointer) && (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray || t2.ty == Type.Kind.pointer))
+    if ((t1.ty == Tarray || t1.ty == Tsarray || t1.ty == Tpointer) && (t2.ty == Tarray || t2.ty == Tsarray || t2.ty == Tpointer))
     {
-        if (t1.nextOf().implicitConvTo(t2.nextOf()) < MATCH.constant && t2.nextOf().implicitConvTo(t1.nextOf()) < MATCH.constant && (t1.nextOf().ty != Type.Kind.void_ && t2.nextOf().ty != Type.Kind.void_))
+        if (t1.nextOf().implicitConvTo(t2.nextOf()) < MATCH.constant && t2.nextOf().implicitConvTo(t1.nextOf()) < MATCH.constant && (t1.nextOf().ty != Tvoid && t2.nextOf().ty != Tvoid))
         {
             error(loc, "array equality comparison type mismatch, `%s` vs `%s`", t1.toChars(), t2.toChars());
         }
@@ -3480,7 +3480,7 @@ extern (C++) bool arrayTypeCompatibleWithoutCasting(Loc loc, Type t1, Type t2)
     t1 = t1.toBasetype();
     t2 = t2.toBasetype();
 
-    if ((t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray || t1.ty == Type.Kind.pointer) && t2.ty == t1.ty)
+    if ((t1.ty == Tarray || t1.ty == Tsarray || t1.ty == Tpointer) && t2.ty == t1.ty)
     {
         if (t1.nextOf().implicitConvTo(t2.nextOf()) >= MATCH.constant || t2.nextOf().implicitConvTo(t1.nextOf()) >= MATCH.constant)
             return true;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -63,7 +63,7 @@ extern (C++) bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, 
     {
         VarDeclaration vd = ad.fields[i];
         Type tb = vd.type.baseElemOf();
-        if (tb.ty == Type.Kind.struct_)
+        if (tb.ty == Tstruct)
         {
             result |= checkFrameAccess(loc, sc, (cast(TypeStruct)tb).sym);
         }
@@ -847,7 +847,7 @@ extern (C++) final class AliasDeclaration : Declaration
             else
             {
                 Type t = type.typeSemantic(loc, _scope);
-                if (t.ty == Type.Kind.error)
+                if (t.ty == Terror)
                     goto Lerr;
                 if (global.errors != olderrors)
                     goto Lerr;
@@ -1164,7 +1164,7 @@ extern (C++) class VarDeclaration : Declaration
             t = Type.tvoidptr;
         }
         Type tv = t.baseElemOf();
-        if (tv.ty == Type.Kind.struct_)
+        if (tv.ty == Tstruct)
         {
             auto ts = cast(TypeStruct)tv;
             assert(ts.sym != ad);   // already checked in ad.determineFields()
@@ -1180,7 +1180,7 @@ extern (C++) class VarDeclaration : Declaration
         // pointless error diagnostic "more initializers than fields" on struct literal.
         ad.fields.push(this);
 
-        if (t.ty == Type.Kind.error)
+        if (t.ty == Terror)
             return;
 
         const sz = t.size(loc);
@@ -1349,7 +1349,7 @@ extern (C++) class VarDeclaration : Declaration
         Expression e = null;
         // Destructors for structs and arrays of structs
         Type tv = type.baseElemOf();
-        if (tv.ty == Type.Kind.struct_)
+        if (tv.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)tv).sym;
             if (!sd.dtor || sd.errors)
@@ -1360,7 +1360,7 @@ extern (C++) class VarDeclaration : Declaration
             if (!sz)
                 return null;
 
-            if (type.toBasetype().ty == Type.Kind.struct_)
+            if (type.toBasetype().ty == Tstruct)
             {
                 // v.__xdtor()
                 e = new VarExp(loc, this);

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -58,7 +58,7 @@ extern (C++) Expression toDelegate(Expression e, Type t, Scope* sc)
         return new ErrorExp();
 
     Statement s;
-    if (t.ty == Type.Kind.void_)
+    if (t.ty == Tvoid)
         s = new ExpStatement(loc, e);
     else
         s = new ReturnStatement(loc, e);

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -622,7 +622,7 @@ private void ctfeCompile(FuncDeclaration fd)
     if (fd.parameters)
     {
         Type tb = fd.type.toBasetype();
-        assert(tb.ty == Type.Kind.function_);
+        assert(tb.ty == Tfunction);
         for (size_t i = 0; i < fd.parameters.dim; i++)
         {
             VarDeclaration v = (*fd.parameters)[i];
@@ -649,8 +649,8 @@ extern (C++) Expression ctfeInterpret(Expression e)
     if (e.op == TOK.error)
         return e;
     assert(e.type); // https://issues.dlang.org/show_bug.cgi?id=14642
-    //assert(e.type.ty != Type.Kind.error);    // FIXME
-    if (e.type.ty == Type.Kind.error)
+    //assert(e.type.ty != Terror);    // FIXME
+    if (e.type.ty == Terror)
         return new ErrorExp();
 
     // This code is outside a function, but still needs to be compiled
@@ -751,7 +751,7 @@ private Expression interpret(FuncDeclaration fd, InterState* istate, Expressions
         ctfeCompile(fd);
 
     Type tb = fd.type.toBasetype();
-    assert(tb.ty == Type.Kind.function_);
+    assert(tb.ty == Tfunction);
     TypeFunction tf = cast(TypeFunction)tb;
     if (tf.varargs && arguments && ((fd.parameters && arguments.dim != fd.parameters.dim) || (!fd.parameters && arguments.dim)))
     {
@@ -810,7 +810,7 @@ private Expression interpret(FuncDeclaration fd, InterState* istate, Expressions
             /* Value parameters
              */
             Type ta = fparam.type.toBasetype();
-            if (ta.ty == Type.Kind.staticArray && earg.op == TOK.address)
+            if (ta.ty == Tsarray && earg.op == TOK.address)
             {
                 /* Static arrays are passed by a simple pointer.
                  * Skip past this to get at the actual arg.
@@ -961,7 +961,7 @@ private Expression interpret(FuncDeclaration fd, InterState* istate, Expressions
         }
     }
     // If fell off the end of a void function, return void
-    if (!e && tf.next.ty == Type.Kind.void_)
+    if (!e && tf.next.ty == Tvoid)
         e = CTFEExp.voidexp;
     if (tf.isref && e.op == TOK.variable && (cast(VarExp)e).var == fd.vthis)
         e = thisarg;
@@ -1264,7 +1264,7 @@ public:
             return;
         }
 
-        assert(istate && istate.fd && istate.fd.type && istate.fd.type.ty == Type.Kind.function_);
+        assert(istate && istate.fd && istate.fd.type && istate.fd.type.ty == Tfunction);
         TypeFunction tf = cast(TypeFunction)istate.fd.type;
 
         /* If the function returns a ref AND it's been called from an assignment,
@@ -1275,7 +1275,7 @@ public:
             result = interpret(s.exp, istate, ctfeNeedLvalue);
             return;
         }
-        if (tf.next && tf.next.ty == Type.Kind.delegate_ && istate.fd.closureVars.dim > 0)
+        if (tf.next && tf.next.ty == Tdelegate && istate.fd.closureVars.dim > 0)
         {
             // To support this, we need to copy all the closure vars
             // into the delegate literal.
@@ -1746,16 +1746,16 @@ public:
         // Little sanity check to make sure it's really a Throwable
         ClassReferenceExp boss = oldest.thrown;
         const next = 4;                         // index of Throwable.next
-        assert((*boss.value.elements)[next].type.ty == Type.Kind.class_); // Throwable.next
+        assert((*boss.value.elements)[next].type.ty == Tclass); // Throwable.next
         ClassReferenceExp collateral = newest.thrown;
         if (isAnErrorException(collateral.originalClass()) && !isAnErrorException(boss.originalClass()))
         {
             /* Find the index of the Error.bypassException field
              */
             auto bypass = next + 1;
-            if ((*collateral.value.elements)[bypass].type.ty == Type.Kind.uint32)
+            if ((*collateral.value.elements)[bypass].type.ty == Tuns32)
                 bypass += 1;  // skip over _refcount field
-            assert((*collateral.value.elements)[bypass].type.ty == Type.Kind.class_);
+            assert((*collateral.value.elements)[bypass].type.ty == Tclass);
 
             // The new exception bypass the existing chain
             (*collateral.value.elements)[bypass] = boss;
@@ -1884,7 +1884,7 @@ public:
         if (exceptionOrCant(e))
             return;
 
-        if (s.wthis.type.ty == Type.Kind.pointer && s.exp.type.ty != Type.Kind.pointer)
+        if (s.wthis.type.ty == Tpointer && s.exp.type.ty != Tpointer)
         {
             e = new AddrExp(s.loc, e);
             e.type = s.wthis.type;
@@ -2053,7 +2053,7 @@ public:
             result = e;
             return;
         }
-        if (e.type.ty != Type.Kind.pointer)
+        if (e.type.ty != Tpointer)
         {
             // Probably impossible
             e.error("cannot interpret `%s` at compile time", e.toChars());
@@ -2070,7 +2070,7 @@ public:
         // Check for taking an address of a shared variable.
         // If the shared variable is an array, the offset might not be zero.
         Type fromType = null;
-        if (e.var.type.ty == Type.Kind.array || e.var.type.ty == Type.Kind.staticArray)
+        if (e.var.type.ty == Tarray || e.var.type.ty == Tsarray)
         {
             fromType = (cast(TypeArray)e.var.type).next;
         }
@@ -2083,14 +2083,14 @@ public:
         Expression val = getVarExp(e.loc, istate, e.var, goal);
         if (exceptionOrCant(val))
             return;
-        if (val.type.ty == Type.Kind.array || val.type.ty == Type.Kind.staticArray)
+        if (val.type.ty == Tarray || val.type.ty == Tsarray)
         {
             // Check for unsupported type painting operations
             Type elemtype = (cast(TypeArray)val.type).next;
             d_uns64 elemsize = elemtype.size();
 
             // It's OK to cast from fixed length to dynamic array, eg &int[3] to int[]*
-            if (val.type.ty == Type.Kind.staticArray && pointee.ty == Type.Kind.array && elemsize == pointee.nextOf().size())
+            if (val.type.ty == Tsarray && pointee.ty == Tarray && elemsize == pointee.nextOf().size())
             {
                 result = new AddrExp(e.loc, val);
                 result.type = e.type;
@@ -2098,7 +2098,7 @@ public:
             }
 
             // It's OK to cast from fixed length to fixed length array, eg &int[n] to int[d]*.
-            if (val.type.ty == Type.Kind.staticArray && pointee.ty == Type.Kind.staticArray && elemsize == pointee.nextOf().size())
+            if (val.type.ty == Tsarray && pointee.ty == Tsarray && elemsize == pointee.nextOf().size())
             {
                 size_t d = cast(size_t)(cast(TypeSArray)pointee).dim.toInteger();
                 Expression elwr = new IntegerExp(e.loc, e.offset / elemsize, Type.tsize_t);
@@ -2249,7 +2249,7 @@ public:
             if (!v.originalType && v.semanticRun < PASS.semanticdone) // semantic() not yet run
             {
                 v.dsymbolSemantic(null);
-                if (v.type.ty == Type.Kind.error)
+                if (v.type.ty == Terror)
                     return CTFEExp.cantexp;
             }
 
@@ -2414,7 +2414,7 @@ public:
         result = getVarExp(e.loc, istate, e.var, goal);
         if (exceptionOrCant(result))
             return;
-        if ((e.var.storage_class & (STC.ref_ | STC.out_)) == 0 && e.type.baseElemOf().ty != Type.Kind.struct_)
+        if ((e.var.storage_class & (STC.ref_ | STC.out_)) == 0 && e.type.baseElemOf().ty != Tstruct)
         {
             /* Ultimately, STC.ref_|STC.out_ check should be enough to see the
              * necessity of type repainting. But currently front-end paints
@@ -2646,7 +2646,7 @@ public:
         }
 
         Type tn = e.type.toBasetype().nextOf().toBasetype();
-        bool wantCopy = (tn.ty == Type.Kind.staticArray || tn.ty == Type.Kind.struct_);
+        bool wantCopy = (tn.ty == Tsarray || tn.ty == Tstruct);
 
         auto basis = interpret(e.basis, istate);
         if (exceptionOrCant(basis))
@@ -2842,7 +2842,7 @@ public:
                 ex = interpret(exp, istate);
                 if (exceptionOrCant(ex))
                     return;
-                if ((v.type.ty != ex.type.ty) && v.type.ty == Type.Kind.staticArray)
+                if ((v.type.ty != ex.type.ty) && v.type.ty == Tsarray)
                 {
                     // Block assignment from inside struct literals
                     auto tsa = cast(TypeSArray)v.type;
@@ -2887,7 +2887,7 @@ public:
             return lenExpr;
         size_t len = cast(size_t)lenExpr.toInteger();
         Type elemType = (cast(TypeArray)newtype).next;
-        if (elemType.ty == Type.Kind.array && argnum < arguments.dim - 1)
+        if (elemType.ty == Tarray && argnum < arguments.dim - 1)
         {
             Expression elem = recursivelyCreateArrayLiteral(loc, elemType, istate, arguments, argnum + 1);
             if (exceptionOrCantInterpret(elem))
@@ -2903,7 +2903,7 @@ public:
             return ae;
         }
         assert(argnum == arguments.dim - 1);
-        if (elemType.ty == Type.Kind.char_ || elemType.ty == Type.Kind.wchar_ || elemType.ty == Type.Kind.dchar_)
+        if (elemType.ty == Tchar || elemType.ty == Twchar || elemType.ty == Tdchar)
         {
             const ch = cast(dchar)elemType.defaultInitLiteral(loc).toInteger();
             const sz = cast(ubyte)elemType.size();
@@ -2933,12 +2933,12 @@ public:
         if (exceptionOrCant(result))
             return;
 
-        if (e.newtype.ty == Type.Kind.array && e.arguments)
+        if (e.newtype.ty == Tarray && e.arguments)
         {
             result = recursivelyCreateArrayLiteral(e.loc, e.newtype, istate, e.arguments, 0);
             return;
         }
-        if (e.newtype.toBasetype().ty == Type.Kind.struct_)
+        if (e.newtype.toBasetype().ty == Tstruct)
         {
             if (e.member)
             {
@@ -2981,7 +2981,7 @@ public:
             result.type = e.type;
             return;
         }
-        if (e.newtype.toBasetype().ty == Type.Kind.class_)
+        if (e.newtype.toBasetype().ty == Tclass)
         {
             ClassDeclaration cd = (cast(TypeClass)e.newtype.toBasetype()).sym;
             size_t totalFieldCount = 0;
@@ -3140,7 +3140,7 @@ public:
         {
             printf("%s BinExp::interpretCommon() %s\n", e.loc.toChars(), e.toChars());
         }
-        if (e.e1.type.ty == Type.Kind.pointer && e.e2.type.ty == Type.Kind.pointer && e.op == TOK.min)
+        if (e.e1.type.ty == Tpointer && e.e2.type.ty == Tpointer && e.op == TOK.min)
         {
             Expression e1 = interpret(e.e1, istate);
             if (exceptionOrCant(e1))
@@ -3151,7 +3151,7 @@ public:
             result = pointerDifference(e.loc, e.type, e1, e2).copy();
             return;
         }
-        if (e.e1.type.ty == Type.Kind.pointer && e.e2.type.isintegral())
+        if (e.e1.type.ty == Tpointer && e.e2.type.isintegral())
         {
             Expression e1 = interpret(e.e1, istate);
             if (exceptionOrCant(e1))
@@ -3162,7 +3162,7 @@ public:
             result = pointerArithmetic(e.loc, e.op, e.type, e1, e2).copy();
             return;
         }
-        if (e.e2.type.ty == Type.Kind.pointer && e.e1.type.isintegral() && e.op == TOK.add)
+        if (e.e2.type.ty == Tpointer && e.e1.type.isintegral() && e.op == TOK.add)
         {
             Expression e1 = interpret(e.e1, istate);
             if (exceptionOrCant(e1))
@@ -3173,7 +3173,7 @@ public:
             result = pointerArithmetic(e.loc, e.op, e.type, e2, e1).copy();
             return;
         }
-        if (e.e1.type.ty == Type.Kind.pointer || e.e2.type.ty == Type.Kind.pointer)
+        if (e.e1.type.ty == Tpointer || e.e2.type.ty == Tpointer)
         {
             e.error("pointer expression `%s` cannot be interpreted at compile time", e.toChars());
             result = CTFEExp.cantexp;
@@ -3228,7 +3228,7 @@ public:
         {
             printf("%s BinExp::interpretCompareCommon() %s\n", e.loc.toChars(), e.toChars());
         }
-        if (e.e1.type.ty == Type.Kind.pointer && e.e2.type.ty == Type.Kind.pointer)
+        if (e.e1.type.ty == Tpointer && e.e2.type.ty == Tpointer)
         {
             Expression e1 = interpret(e.e1, istate);
             if (exceptionOrCant(e1))
@@ -3406,7 +3406,7 @@ public:
             // a[] = e can have const e. So we compare the naked types.
             Type tdst = e1.type.toBasetype();
             Type tsrc = e.e2.type.toBasetype();
-            while (tdst.ty == Type.Kind.staticArray || tdst.ty == Type.Kind.array)
+            while (tdst.ty == Tsarray || tdst.ty == Tarray)
             {
                 tdst = (cast(TypeArray)tdst).next.toBasetype();
                 if (tsrc.equivalent(tdst))
@@ -3457,7 +3457,7 @@ public:
         AssocArrayLiteralExp existingAA = null;
         Expression lastIndex = null;
         Expression oldval = null;
-        if (e1.op == TOK.index && (cast(IndexExp)e1).e1.type.toBasetype().ty == Type.Kind.associativeArray)
+        if (e1.op == TOK.index && (cast(IndexExp)e1).e1.type.toBasetype().ty == Taarray)
         {
             // ---------------------------------------
             //      Deal with AA index assignment
@@ -3471,7 +3471,7 @@ public:
              */
             IndexExp ie = cast(IndexExp)e1;
             int depth = 0; // how many nested AA indices are there?
-            while (ie.e1.op == TOK.index && (cast(IndexExp)ie.e1).e1.type.toBasetype().ty == Type.Kind.associativeArray)
+            while (ie.e1.op == TOK.index && (cast(IndexExp)ie.e1).e1.type.toBasetype().ty == Taarray)
             {
                 assert(ie.modifiable);
                 ie = cast(IndexExp)ie.e1;
@@ -3546,7 +3546,7 @@ public:
                 oldval = copyLiteral(e.e1.type.defaultInitLiteral(e.loc)).copy();
 
                 Expression newaae = oldval;
-                while (e1.op == TOK.index && (cast(IndexExp)e1).e1.type.toBasetype().ty == Type.Kind.associativeArray)
+                while (e1.op == TOK.index && (cast(IndexExp)e1).e1.type.toBasetype().ty == Taarray)
                 {
                     Expression ekey = interpret((cast(IndexExp)e1).e2, istate);
                     if (exceptionOrCant(ekey))
@@ -3617,7 +3617,7 @@ public:
             if (exceptionOrCant(e1))
                 return;
 
-            if (e1.op == TOK.index && (cast(IndexExp)e1).e1.type.toBasetype().ty == Type.Kind.associativeArray)
+            if (e1.op == TOK.index && (cast(IndexExp)e1).e1.type.toBasetype().ty == Taarray)
             {
                 IndexExp ie = cast(IndexExp)e1;
                 assert(ie.e1.op == TOK.assocArrayLiteral);
@@ -3635,7 +3635,7 @@ public:
         if (e.op == TOK.blit && newval.op == TOK.int64)
         {
             Type tbn = e.type.baseElemOf();
-            if (tbn.ty == Type.Kind.struct_)
+            if (tbn.ty == Tstruct)
             {
                 /* Look for special case of struct being initialized with 0.
                  */
@@ -3667,14 +3667,14 @@ public:
                     return;
             }
 
-            if (e.e1.type.ty != Type.Kind.pointer)
+            if (e.e1.type.ty != Tpointer)
             {
                 // ~= can create new values (see bug 6052)
                 if (e.op == TOK.concatenateAssign || e.op == TOK.concatenateElemAssign || e.op == TOK.concatenateDcharAssign)
                 {
                     // We need to dup it and repaint the type. For a dynamic array
                     // we can skip duplication, because it gets copied later anyway.
-                    if (newval.type.ty != Type.Kind.array)
+                    if (newval.type.ty != Tarray)
                     {
                         newval = copyLiteral(newval).copy();
                         newval.type = e.e2.type; // repaint type
@@ -3750,7 +3750,7 @@ public:
             // Note that returnValue is still the new length.
             e1 = (cast(ArrayLengthExp)e1).e1;
             Type t = e1.type.toBasetype();
-            if (t.ty != Type.Kind.array)
+            if (t.ty != Tarray)
             {
                 e.error("`%s` is not yet supported at compile time", e.toChars());
                 result = CTFEExp.cantexp;
@@ -3800,7 +3800,7 @@ public:
             e1.op == TOK.vector ||
             e1.op == TOK.arrayLiteral ||
             e1.op == TOK.string_ ||
-            e1.op == TOK.null_ && e1.type.toBasetype().ty == Type.Kind.array)
+            e1.op == TOK.null_ && e1.type.toBasetype().ty == Tarray)
         {
             // Note that slice assignments don't support things like ++, so
             // we don't need to remember 'returnValue'.
@@ -3905,7 +3905,7 @@ public:
         else if (e1.op == TOK.index)
         {
             IndexExp ie = cast(IndexExp)e1;
-            assert(ie.e1.type.toBasetype().ty != Type.Kind.associativeArray);
+            assert(ie.e1.type.toBasetype().ty != Taarray);
 
             Expression aggregate;
             uinteger_t indexToModify;
@@ -3949,7 +3949,7 @@ public:
         }
 
         Type t1b = e1.type.toBasetype();
-        bool wantCopy = t1b.baseElemOf().ty == Type.Kind.struct_;
+        bool wantCopy = t1b.baseElemOf().ty == Tstruct;
 
         if (newval.op == TOK.structLiteral && oldval)
         {
@@ -4002,7 +4002,7 @@ public:
             if (wantCopy)
                 newval = copyLiteral(newval).copy();
 
-            if (t1b.ty == Type.Kind.staticArray && e.op == TOK.construct && e.e2.isLvalue())
+            if (t1b.ty == Tsarray && e.op == TOK.construct && e.e2.isLvalue())
             {
                 // https://issues.dlang.org/show_bug.cgi?id=9245
                 if (Expression ex = evaluatePostblit(istate, newval))
@@ -4225,7 +4225,7 @@ public:
                 auto aggr2 = se.e1;
                 const srclower = se.lwr.toInteger();
                 const srcupper = se.upr.toInteger();
-                const wantCopy = (newval.type.toBasetype().nextOf().baseElemOf().ty == Type.Kind.struct_);
+                const wantCopy = (newval.type.toBasetype().nextOf().baseElemOf().ty == Tstruct);
 
                 //printf("oldval = %p %s[%d..%u]\nnewval = %p %s[%llu..%llu] wantCopy = %d\n",
                 //    aggregate, aggregate.toChars(), lowerbound, upperbound,
@@ -4355,7 +4355,7 @@ public:
                 extern (C++) Expression assignTo(ArrayLiteralExp ae, size_t lwr, size_t upr)
                 {
                     Expressions* w = ae.elements;
-                    assert(ae.type.ty == Type.Kind.staticArray || ae.type.ty == Type.Kind.array);
+                    assert(ae.type.ty == Tsarray || ae.type.ty == Tarray);
                     bool directblk = (cast(TypeArray)ae.type).next.equivalent(newval.type);
                     for (size_t k = lwr; k < upr; k++)
                     {
@@ -4396,10 +4396,10 @@ public:
             }
 
             Type tn = newval.type.toBasetype();
-            bool wantRef = (tn.ty == Type.Kind.array || isAssocArray(tn) || tn.ty == Type.Kind.class_);
+            bool wantRef = (tn.ty == Tarray || isAssocArray(tn) || tn.ty == Tclass);
             bool cow = newval.op != TOK.structLiteral && newval.op != TOK.arrayLiteral && newval.op != TOK.string_;
             Type tb = tn.baseElemOf();
-            StructDeclaration sd = (tb.ty == Type.Kind.struct_ ? (cast(TypeStruct)tb).sym : null);
+            StructDeclaration sd = (tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null);
 
             RecursiveBlock rb;
             rb.istate = istate;
@@ -4718,7 +4718,7 @@ public:
                 return;
             if (result.op == TOK.voidExpression)
             {
-                assert(e.type.ty == Type.Kind.void_);
+                assert(e.type.ty == Tvoid);
                 result = null;
                 return;
             }
@@ -4904,7 +4904,7 @@ public:
 
             if (pthis.op == TOK.null_)
             {
-                assert(pthis.type.toBasetype().ty == Type.Kind.class_);
+                assert(pthis.type.toBasetype().ty == Tclass);
                 e.error("function call through null class reference `%s`", pthis.toChars());
                 result = CTFEExp.cantexp;
                 return;
@@ -5104,9 +5104,9 @@ public:
 
     static bool resolveIndexing(IndexExp e, InterState* istate, Expression* pagg, uinteger_t* pidx, bool modify)
     {
-        assert(e.e1.type.toBasetype().ty != Type.Kind.associativeArray);
+        assert(e.e1.type.toBasetype().ty != Taarray);
 
-        if (e.e1.type.toBasetype().ty == Type.Kind.pointer)
+        if (e.e1.type.toBasetype().ty == Tpointer)
         {
             // Indexing a pointer. Note that there is no $ in this case.
             Expression e1 = interpret(e.e1, istate);
@@ -5230,7 +5230,7 @@ public:
         {
             printf("%s IndexExp::interpret() %s, goal = %d\n", e.loc.toChars(), e.toChars(), goal);
         }
-        if (e.e1.type.toBasetype().ty == Type.Kind.pointer)
+        if (e.e1.type.toBasetype().ty == Tpointer)
         {
             Expression agg;
             uinteger_t indexToAccess;
@@ -5263,14 +5263,14 @@ public:
             }
         }
 
-        if (e.e1.type.toBasetype().ty == Type.Kind.associativeArray)
+        if (e.e1.type.toBasetype().ty == Taarray)
         {
             Expression e1 = interpret(e.e1, istate);
             if (exceptionOrCant(e1))
                 return;
             if (e1.op == TOK.null_)
             {
-                if (goal == ctfeNeedLvalue && e1.type.ty == Type.Kind.associativeArray && e.modifiable)
+                if (goal == ctfeNeedLvalue && e1.type.ty == Taarray && e.modifiable)
                 {
                     assert(0); // does not reach here?
                 }
@@ -5341,7 +5341,7 @@ public:
         {
             printf("%s SliceExp::interpret() %s\n", e.loc.toChars(), e.toChars());
         }
-        if (e.e1.type.toBasetype().ty == Type.Kind.pointer)
+        if (e.e1.type.toBasetype().ty == Tpointer)
         {
             // Slicing a pointer. Note that there is no $ in this case.
             Expression e1 = interpret(e.e1, istate);
@@ -5602,7 +5602,7 @@ public:
         auto tb = e.e1.type.toBasetype();
         switch (tb.ty)
         {
-        case Type.Kind.class_:
+        case Tclass:
             if (result.op != TOK.classReference)
             {
                 e.error("`delete` on invalid class reference `%s`", result.toChars());
@@ -5627,9 +5627,9 @@ public:
             }
             break;
 
-        case Type.Kind.pointer:
+        case Tpointer:
             tb = (cast(TypePointer)tb).next.toBasetype();
-            if (tb.ty == Type.Kind.struct_)
+            if (tb.ty == Tstruct)
             {
                 if (result.op != TOK.address ||
                     (cast(AddrExp)result).e1.op != TOK.structLiteral)
@@ -5657,9 +5657,9 @@ public:
             }
             break;
 
-        case Type.Kind.array:
+        case Tarray:
             auto tv = tb.nextOf().baseElemOf();
-            if (tv.ty == Type.Kind.struct_)
+            if (tv.ty == Tstruct)
             {
                 if (result.op != TOK.arrayLiteral)
                 {
@@ -5705,12 +5705,12 @@ public:
         if (exceptionOrCant(e1))
             return;
         // If the expression has been cast to void, do nothing.
-        if (e.to.ty == Type.Kind.void_)
+        if (e.to.ty == Tvoid)
         {
             result = CTFEExp.voidexp;
             return;
         }
-        if (e.to.ty == Type.Kind.pointer && e1.op != TOK.null_)
+        if (e.to.ty == Tpointer && e1.op != TOK.null_)
         {
             Type pointee = (cast(TypePointer)e.type).next;
             // Implement special cases of normally-unsafe casts
@@ -5723,7 +5723,7 @@ public:
 
             bool castToSarrayPointer = false;
             bool castBackFromVoid = false;
-            if (e1.type.ty == Type.Kind.array || e1.type.ty == Type.Kind.staticArray || e1.type.ty == Type.Kind.pointer)
+            if (e1.type.ty == Tarray || e1.type.ty == Tsarray || e1.type.ty == Tpointer)
             {
                 // Check for unsupported type painting operations
                 // For slices, we need the type being sliced,
@@ -5739,22 +5739,22 @@ public:
                 // we check this later on.
                 Type ultimatePointee = pointee;
                 Type ultimateSrc = elemtype;
-                while (ultimatePointee.ty == Type.Kind.pointer && ultimateSrc.ty == Type.Kind.pointer)
+                while (ultimatePointee.ty == Tpointer && ultimateSrc.ty == Tpointer)
                 {
                     ultimatePointee = ultimatePointee.nextOf();
                     ultimateSrc = ultimateSrc.nextOf();
                 }
-                if (ultimatePointee.ty == Type.Kind.staticArray && ultimatePointee.nextOf().equivalent(ultimateSrc))
+                if (ultimatePointee.ty == Tsarray && ultimatePointee.nextOf().equivalent(ultimateSrc))
                 {
                     castToSarrayPointer = true;
                 }
-                else if (ultimatePointee.ty != Type.Kind.void_ && ultimateSrc.ty != Type.Kind.void_ && !isSafePointerCast(elemtype, pointee))
+                else if (ultimatePointee.ty != Tvoid && ultimateSrc.ty != Tvoid && !isSafePointerCast(elemtype, pointee))
                 {
                     e.error("reinterpreting cast from `%s*` to `%s*` is not supported in CTFE", elemtype.toChars(), pointee.toChars());
                     result = CTFEExp.cantexp;
                     return;
                 }
-                if (ultimateSrc.ty == Type.Kind.void_)
+                if (ultimateSrc.ty == Tvoid)
                     castBackFromVoid = true;
             }
 
@@ -5824,7 +5824,7 @@ public:
                     result.type = e.type;
                     return;
                 }
-                if (castToSarrayPointer && pointee.toBasetype().ty == Type.Kind.staticArray && (cast(AddrExp)e1).e1.op == TOK.index)
+                if (castToSarrayPointer && pointee.toBasetype().ty == Tsarray && (cast(AddrExp)e1).e1.op == TOK.index)
                 {
                     // &val[idx]
                     dinteger_t dim = (cast(TypeSArray)pointee.toBasetype()).dim.toInteger();
@@ -5867,7 +5867,7 @@ public:
                 return;
             }
         }
-        if (e.to.ty == Type.Kind.staticArray && e.e1.type.ty == Type.Kind.vector)
+        if (e.to.ty == Tsarray && e.e1.type.ty == Tvector)
         {
             // Special handling for: cast(float[4])__vector([w, x, y, z])
             e1 = interpret(e.e1, istate);
@@ -5876,7 +5876,7 @@ public:
             assert(e1.op == TOK.vector);
             e1 = (cast(VectorExp)e1).e1;
         }
-        if (e.to.ty == Type.Kind.array && e1.op == TOK.slice)
+        if (e.to.ty == Tarray && e1.op == TOK.slice)
         {
             // Note that the slice may be void[], so when checking for dangerous
             // casts, we need to use the original type, which is se.e1.
@@ -5894,15 +5894,15 @@ public:
         }
         // Disallow array type painting, except for conversions between built-in
         // types of identical size.
-        if ((e.to.ty == Type.Kind.staticArray || e.to.ty == Type.Kind.array) && (e1.type.ty == Type.Kind.staticArray || e1.type.ty == Type.Kind.array) && !isSafePointerCast(e1.type.nextOf(), e.to.nextOf()))
+        if ((e.to.ty == Tsarray || e.to.ty == Tarray) && (e1.type.ty == Tsarray || e1.type.ty == Tarray) && !isSafePointerCast(e1.type.nextOf(), e.to.nextOf()))
         {
             e.error("array cast from `%s` to `%s` is not supported at compile time", e1.type.toChars(), e.to.toChars());
             result = CTFEExp.cantexp;
             return;
         }
-        if (e.to.ty == Type.Kind.staticArray)
+        if (e.to.ty == Tsarray)
             e1 = resolveSlice(e1);
-        if (e.to.toBasetype().ty == Type.Kind.bool_ && e1.type.ty == Type.Kind.pointer)
+        if (e.to.toBasetype().ty == Tbool && e1.type.ty == Tpointer)
         {
             result = new IntegerExp(e.loc, e1.op != TOK.null_, e.to);
             return;
@@ -6022,7 +6022,7 @@ public:
         // *(&x) ==> x
         result = (cast(AddrExp)result).e1;
 
-        if (result.op == TOK.slice && e.type.toBasetype().ty == Type.Kind.staticArray)
+        if (result.op == TOK.slice && e.type.toBasetype().ty == Tsarray)
         {
             /* aggr[lwr..upr]
              * upr may exceed the upper boundary of aggr, but the check is deferred
@@ -6073,7 +6073,7 @@ public:
 
         if (ex.op == TOK.null_)
         {
-            if (ex.type.toBasetype().ty == Type.Kind.class_)
+            if (ex.type.toBasetype().ty == Tclass)
                 e.error("class `%s` is `null` and cannot be dereferenced", e.e1.toChars());
             else
                 e.error("CTFE internal error: null this `%s`", e.e1.toChars());
@@ -6146,7 +6146,7 @@ public:
             return;
         }
 
-        if (v.type.ty != result.type.ty && v.type.ty == Type.Kind.staticArray)
+        if (v.type.ty != result.type.ty && v.type.ty == Tsarray)
         {
             // Block assignment from inside struct literals
             auto tsa = cast(TypeSArray)v.type;
@@ -6340,7 +6340,7 @@ private Expression scrubArray(Loc loc, Expressions* elems, bool structlit = fals
 
         // A struct .init may contain void members.
         // Static array members are a weird special case (bug 10994).
-        if (structlit && ((m.op == TOK.void_) || (m.op == TOK.arrayLiteral && m.type.ty == Type.Kind.staticArray && isEntirelyVoid((cast(ArrayLiteralExp)m).elements)) || (m.op == TOK.structLiteral && isEntirelyVoid((cast(StructLiteralExp)m).elements))))
+        if (structlit && ((m.op == TOK.void_) || (m.op == TOK.arrayLiteral && m.type.ty == Tsarray && isEntirelyVoid((cast(ArrayLiteralExp)m).elements)) || (m.op == TOK.structLiteral && isEntirelyVoid((cast(StructLiteralExp)m).elements))))
         {
             m = null;
         }
@@ -6445,7 +6445,7 @@ private Expression interpret_keys(InterState* istate, Expression earg, Type retu
         return earg;
     if (earg.op == TOK.null_)
         return new NullExp(earg.loc, returnType);
-    if (earg.op != TOK.assocArrayLiteral && earg.type.toBasetype().ty != Type.Kind.associativeArray)
+    if (earg.op != TOK.assocArrayLiteral && earg.type.toBasetype().ty != Taarray)
         return null;
     assert(earg.op == TOK.assocArrayLiteral);
     AssocArrayLiteralExp aae = cast(AssocArrayLiteralExp)earg;
@@ -6466,7 +6466,7 @@ private Expression interpret_values(InterState* istate, Expression earg, Type re
         return earg;
     if (earg.op == TOK.null_)
         return new NullExp(earg.loc, returnType);
-    if (earg.op != TOK.assocArrayLiteral && earg.type.toBasetype().ty != Type.Kind.associativeArray)
+    if (earg.op != TOK.assocArrayLiteral && earg.type.toBasetype().ty != Taarray)
         return null;
     assert(earg.op == TOK.assocArrayLiteral);
     AssocArrayLiteralExp aae = cast(AssocArrayLiteralExp)earg;
@@ -6488,7 +6488,7 @@ private Expression interpret_dup(InterState* istate, Expression earg)
         return earg;
     if (earg.op == TOK.null_)
         return new NullExp(earg.loc, earg.type);
-    if (earg.op != TOK.assocArrayLiteral && earg.type.toBasetype().ty != Type.Kind.associativeArray)
+    if (earg.op != TOK.assocArrayLiteral && earg.type.toBasetype().ty != Taarray)
         return null;
     assert(earg.op == TOK.assocArrayLiteral);
     AssocArrayLiteralExp aae = cast(AssocArrayLiteralExp)copyLiteral(earg).copy();
@@ -6853,7 +6853,7 @@ private Expression evaluateIfBuiltin(InterState* istate, Loc loc, FuncDeclaratio
     if (!pthis)
     {
         Expression firstarg = nargs > 0 ? (*arguments)[0] : null;
-        if (firstarg && firstarg.type.toBasetype().ty == Type.Kind.associativeArray)
+        if (firstarg && firstarg.type.toBasetype().ty == Taarray)
         {
             TypeAArray firstAAtype = cast(TypeAArray)firstarg.type;
             const id = fd.ident.toChars();
@@ -6924,7 +6924,7 @@ private Expression evaluateIfBuiltin(InterState* istate, Loc loc, FuncDeclaratio
 private Expression evaluatePostblit(InterState* istate, Expression e)
 {
     Type tb = e.type.baseElemOf();
-    if (tb.ty != Type.Kind.struct_)
+    if (tb.ty != Tstruct)
         return null;
     StructDeclaration sd = (cast(TypeStruct)tb).sym;
     if (!sd.postblit)
@@ -6955,7 +6955,7 @@ private Expression evaluatePostblit(InterState* istate, Expression e)
 private Expression evaluateDtor(InterState* istate, Expression e)
 {
     Type tb = e.type.baseElemOf();
-    if (tb.ty != Type.Kind.struct_)
+    if (tb.ty != Tstruct)
         return null;
     StructDeclaration sd = (cast(TypeStruct)tb).sym;
     if (!sd.dtor)

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -37,56 +37,56 @@ import dmd.tokens;
 import dmd.utf;
 import dmd.visitor;
 
-private immutable char[Type.Kind.max_] mangleChar =
+private immutable char[TMAX] mangleChar =
 [
-    Type.Kind.char_        : 'a',
-    Type.Kind.bool_        : 'b',
-    Type.Kind.complex80   : 'c',
-    Type.Kind.float64     : 'd',
-    Type.Kind.float80     : 'e',
-    Type.Kind.float32     : 'f',
-    Type.Kind.int8        : 'g',
-    Type.Kind.uint8        : 'h',
-    Type.Kind.int32       : 'i',
-    Type.Kind.imaginary80 : 'j',
-    Type.Kind.uint32       : 'k',
-    Type.Kind.int64       : 'l',
-    Type.Kind.uint64       : 'm',
-    Type.Kind.none        : 'n',
-    Type.Kind.null_        : 'n', // yes, same as TypeNone
-    Type.Kind.imaginary32 : 'o',
-    Type.Kind.imaginary64 : 'p',
-    Type.Kind.complex32   : 'q',
-    Type.Kind.complex64   : 'r',
-    Type.Kind.int16       : 's',
-    Type.Kind.uint16       : 't',
-    Type.Kind.wchar_       : 'u',
-    Type.Kind.void_        : 'v',
-    Type.Kind.dchar_       : 'w',
+    Tchar        : 'a',
+    Tbool        : 'b',
+    Tcomplex80   : 'c',
+    Tfloat64     : 'd',
+    Tfloat80     : 'e',
+    Tfloat32     : 'f',
+    Tint8        : 'g',
+    Tuns8        : 'h',
+    Tint32       : 'i',
+    Timaginary80 : 'j',
+    Tuns32       : 'k',
+    Tint64       : 'l',
+    Tuns64       : 'm',
+    Tnone        : 'n',
+    Tnull        : 'n', // yes, same as TypeNone
+    Timaginary32 : 'o',
+    Timaginary64 : 'p',
+    Tcomplex32   : 'q',
+    Tcomplex64   : 'r',
+    Tint16       : 's',
+    Tuns16       : 't',
+    Twchar       : 'u',
+    Tvoid        : 'v',
+    Tdchar       : 'w',
     //              x   // const
     //              y   // immutable
-    Type.Kind.int128      : 'z', // zi
-    Type.Kind.uint128      : 'z', // zk
+    Tint128      : 'z', // zi
+    Tuns128      : 'z', // zk
 
-    Type.Kind.array       : 'A',
-    Type.Kind.tuple       : 'B',
-    Type.Kind.class_       : 'C',
-    Type.Kind.delegate_    : 'D',
-    Type.Kind.enum_        : 'E',
-    Type.Kind.function_    : 'F', // D function
-    Type.Kind.staticArray      : 'G',
-    Type.Kind.associativeArray      : 'H',
-    Type.Kind.identifier       : 'I',
+    Tarray       : 'A',
+    Ttuple       : 'B',
+    Tclass       : 'C',
+    Tdelegate    : 'D',
+    Tenum        : 'E',
+    Tfunction    : 'F', // D function
+    Tsarray      : 'G',
+    Taarray      : 'H',
+    Tident       : 'I',
     //              J   // out
     //              K   // ref
     //              L   // lazy
     //              M   // has this, or scope
     //              N   // Nh:vector Ng:wild
     //              O   // shared
-    Type.Kind.pointer     : 'P',
+    Tpointer     : 'P',
     //              Q   // Type/symbol/identifier backward reference
-    Type.Kind.reference   : 'R',
-    Type.Kind.struct_      : 'S',
+    Treference   : 'R',
+    Tstruct      : 'S',
     //              T   // Ttypedef
     //              U   // C function
     //              V   // Pascal function
@@ -96,12 +96,12 @@ private immutable char[Type.Kind.max_] mangleChar =
     //              Z   // not variadic, end of parameters
 
     // '@' shouldn't appear anywhere in the deco'd names
-    Type.Kind.instance    : '@',
-    Type.Kind.error       : '@',
-    Type.Kind.typeof_      : '@',
-    Type.Kind.slice       : '@',
-    Type.Kind.return_      : '@',
-    Type.Kind.vector      : '@',
+    Tinstance    : '@',
+    Terror       : '@',
+    Ttypeof      : '@',
+    Tslice       : '@',
+    Treturn      : '@',
+    Tvector      : '@',
 ];
 
 unittest
@@ -125,7 +125,7 @@ private void tyToDecoBuffer(OutBuffer* buf, int ty)
     const c = mangleChar[ty];
     buf.writeByte(c);
     if (c == 'z')
-        buf.writeByte(ty == Type.Kind.int128 ? 'i' : 'k');
+        buf.writeByte(ty == Tint128 ? 'i' : 'k');
 }
 
 /*********************************
@@ -505,7 +505,7 @@ public:
         if (fd.needThis() || fd.isNested())
             buf.writeByte('M');
 
-        if (!fd.type || fd.type.ty == Type.Kind.error)
+        if (!fd.type || fd.type.ty == Terror)
         {
             // never should have gotten here, but could be the result of
             // failed speculative compilation

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -1170,7 +1170,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
             if (d.type)
             {
                 Type origType = d.originalType ? d.originalType : d.type;
-                if (origType.ty == Type.Kind.function_)
+                if (origType.ty == Tfunction)
                 {
                     functionToBufferFull(cast(TypeFunction)origType, buf, d.ident, &hgs, td);
                 }
@@ -1229,7 +1229,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
             }
             else if (Type type = ad.getType()) // type alias
             {
-                if (type.ty == Type.Kind.class_ || type.ty == Type.Kind.struct_ || type.ty == Type.Kind.enum_)
+                if (type.ty == Tclass || type.ty == Tstruct || type.ty == Tenum)
                 {
                     if (Dsymbol s = type.toDsymbol(null)) // elaborate type
                         prettyPrintDsymbol(s, ad.parent);
@@ -1984,7 +1984,7 @@ extern (C++) TypeFunction isTypeFunction(Dsymbol s)
     if (f && f.type)
     {
         Type t = f.originalType ? f.originalType : f.type;
-        if (t.ty == Type.Kind.function_)
+        if (t.ty == Tfunction)
             return cast(TypeFunction)t;
     }
     return null;

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -367,7 +367,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             Dsymbol s = (*members)[i];
             s.setFieldOffset(this, &offset, isunion);
         }
-        if (type.ty == Type.Kind.error)
+        if (type.ty == Terror)
             return;
 
         // 0 sized struct's are set to 1 byte
@@ -483,14 +483,14 @@ extern (C++) class StructDeclaration : AggregateDeclaration
              * Allow this by doing an explicit cast, which will lengthen the string
              * literal.
              */
-            if (e.op == TOK.string_ && tb.ty == Type.Kind.staticArray)
+            if (e.op == TOK.string_ && tb.ty == Tsarray)
             {
                 StringExp se = cast(StringExp)e;
                 Type typeb = se.type.toBasetype();
                 TY tynto = tb.nextOf().ty;
                 if (!se.committed &&
-                    (typeb.ty == Type.Kind.array || typeb.ty == Type.Kind.staticArray) &&
-                    (tynto == Type.Kind.char_ || tynto == Type.Kind.wchar_ || tynto == Type.Kind.dchar_) &&
+                    (typeb.ty == Tarray || typeb.ty == Tsarray) &&
+                    (tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
                     se.numberOfCodeUnits(tynto) < (cast(TypeSArray)tb).dim.toInteger())
                 {
                     e = se.castTo(sc, t);
@@ -498,7 +498,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
                 }
             }
 
-            while (!e.implicitConvTo(t) && tb.ty == Type.Kind.staticArray)
+            while (!e.implicitConvTo(t) && tb.ty == Tsarray)
             {
                 /* Static array initialization, as in:
                  *  T[3][5] = e;
@@ -555,7 +555,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
 
             Type tv = v.type.baseElemOf();
-            if (tv.ty == Type.Kind.struct_)
+            if (tv.ty == Tstruct)
             {
                 TypeStruct ts = cast(TypeStruct)tv;
                 StructDeclaration sd = ts.sym;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1823,7 +1823,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
             if (ce.op == TOK.type)
             {
                 Type t = (cast(TypeExp)ce).type;
-                if (t.ty == Type.Kind.tuple)
+                if (t.ty == Ttuple)
                 {
                     type = cast(TypeTuple)t;
                     goto L1;
@@ -1847,7 +1847,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                     v = new VarDeclaration(loc, Type.tsize_t, Id.dollar, new ExpInitializer(Loc(), e));
                     v.storage_class |= STC.temp | STC.static_ | STC.const_;
                 }
-                else if (ce.type && (t = ce.type.toBasetype()) !is null && (t.ty == Type.Kind.struct_ || t.ty == Type.Kind.class_))
+                else if (ce.type && (t = ce.type.toBasetype()) !is null && (t.ty == Tstruct || t.ty == Tclass))
                 {
                     // Look for opDollar
                     assert(exp.op == TOK.array || exp.op == TOK.slice);
@@ -1900,7 +1900,7 @@ extern (C++) final class ArrayScopeSymbol : ScopeDsymbol
                     if (!e.type)
                         exp.error("`%s` has no value", e.toChars());
                     t = e.type.toBasetype();
-                    if (t && t.ty == Type.Kind.function_)
+                    if (t && t.ty == Tfunction)
                         e = new CallExp(e.loc, e);
                     v = new VarDeclaration(loc, null, Id.dollar, new ExpInitializer(Loc(), e));
                     v.storage_class |= STC.temp | STC.ctfe | STC.rvalue;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -363,7 +363,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sc2.pop();
         }
         //printf(" semantic type = %s\n", type ? type.toChars() : "null");
-        if (dsym.type.ty == Type.Kind.error)
+        if (dsym.type.ty == Terror)
             dsym.errors = true;
 
         dsym.type.checkDeprecated(dsym.loc, sc);
@@ -399,7 +399,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         Type tb = dsym.type.toBasetype();
         Type tbn = tb.baseElemOf();
-        if (tb.ty == Type.Kind.void_ && !(dsym.storage_class & STC.lazy_))
+        if (tb.ty == Tvoid && !(dsym.storage_class & STC.lazy_))
         {
             if (inferred)
             {
@@ -410,13 +410,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.type = Type.terror;
             tb = dsym.type;
         }
-        if (tb.ty == Type.Kind.function_)
+        if (tb.ty == Tfunction)
         {
             dsym.error("cannot be declared to be a function");
             dsym.type = Type.terror;
             tb = dsym.type;
         }
-        if (tb.ty == Type.Kind.struct_)
+        if (tb.ty == Tstruct)
         {
             TypeStruct ts = cast(TypeStruct)tb;
             if (!ts.sym.members)
@@ -427,7 +427,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if ((dsym.storage_class & STC.auto_) && !inferred)
             dsym.error("storage class `auto` has no effect if type is not inferred, did you mean `scope`?");
 
-        if (tb.ty == Type.Kind.tuple)
+        if (tb.ty == Ttuple)
         {
             /* Instead, declare variables for each of the tuple elements
              * and add those.
@@ -651,7 +651,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     fprintf(global.stdmsg, "%s: %s.%s is %s field\n", p ? p : "", ad.toPrettyChars(), dsym.toChars(), s);
                 }
                 dsym.storage_class |= STC.field;
-                if (tbn.ty == Type.Kind.struct_ && (cast(TypeStruct)tbn).sym.noDefaultCtor)
+                if (tbn.ty == Tstruct && (cast(TypeStruct)tbn).sym.noDefaultCtor)
                 {
                     if (!dsym.isThisDeclaration() && !dsym._init)
                         aad.noDefaultCtor = true;
@@ -722,7 +722,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (!(dsym.storage_class & (STC.ctfe | STC.ref_ | STC.result)) && tbn.ty == Type.Kind.struct_ && (cast(TypeStruct)tbn).sym.noDefaultCtor)
+        if (!(dsym.storage_class & (STC.ctfe | STC.ref_ | STC.result)) && tbn.ty == Tstruct && (cast(TypeStruct)tbn).sym.noDefaultCtor)
         {
             if (!dsym._init)
             {
@@ -794,18 +794,18 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // Provide a default initializer
 
             //printf("Providing default initializer for '%s'\n", toChars());
-            if (sz == SIZE_INVALID && dsym.type.ty != Type.Kind.error)
+            if (sz == SIZE_INVALID && dsym.type.ty != Terror)
                 dsym.error("size of type `%s` is invalid", dsym.type.toChars());
 
             Type tv = dsym.type;
-            while (tv.ty == Type.Kind.staticArray)    // Don't skip Type.Kind.enum_
+            while (tv.ty == Tsarray)    // Don't skip Tenum
                 tv = tv.nextOf();
             if (tv.needsNested())
             {
                 /* Nested struct requires valid enclosing frame pointer.
                  * In StructLiteralExp::toElem(), it's calculated.
                  */
-                assert(tbn.ty == Type.Kind.struct_);
+                assert(tbn.ty == Tstruct);
                 checkFrameAccess(dsym.loc, sc, (cast(TypeStruct)tbn).sym);
 
                 Expression e = tv.defaultInitLiteral(dsym.loc);
@@ -814,7 +814,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 dsym._init = new ExpInitializer(dsym.loc, e);
                 goto Ldtor;
             }
-            if (tv.ty == Type.Kind.struct_ && (cast(TypeStruct)tv).sym.zeroInit == 1)
+            if (tv.ty == Tstruct && (cast(TypeStruct)tv).sym.zeroInit == 1)
             {
                 /* If a struct is all zeros, as a special case
                  * set it's initializer to the integer 0.
@@ -828,7 +828,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 dsym._init = new ExpInitializer(dsym.loc, e);
                 goto Ldtor;
             }
-            if (dsym.type.baseElemOf().ty == Type.Kind.void_)
+            if (dsym.type.baseElemOf().ty == Tvoid)
             {
                 dsym.error("`%s` does not have a default initializer", dsym.type.toChars());
             }
@@ -862,7 +862,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     {
                         ArrayInitializer ai = dsym._init.isArrayInitializer();
                         Expression e;
-                        if (ai && tb.ty == Type.Kind.associativeArray)
+                        if (ai && tb.ty == Taarray)
                             e = ai.toAssocArrayLiteral();
                         else
                             e = dsym._init.initializerToExpression();
@@ -910,7 +910,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         {
                             // See if initializer is a NewExp that can be allocated on the stack
                             NewExp ne = cast(NewExp)ex;
-                            if (dsym.type.toBasetype().ty == Type.Kind.class_)
+                            if (dsym.type.toBasetype().ty == Tclass)
                             {
                                 if (ne.newargs && ne.newargs.dim > 1)
                                 {
@@ -980,7 +980,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                          *  static assert(w.x == 55.0);
                          * because the postblit doesn't get run on the initialization of w.
                          */
-                        if (ti.ty == Type.Kind.struct_)
+                        if (ti.ty == Tstruct)
                         {
                             StructDeclaration sd = (cast(TypeStruct)ti).sym;
                             /* Look to see if initializer involves a copy constructor
@@ -1030,7 +1030,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 dsym.type.hasPointers())
             {
                 auto tv = dsym.type.baseElemOf();
-                if (tv.ty == Type.Kind.struct_ &&
+                if (tv.ty == Tstruct &&
                     (cast(TypeStruct)tv).sym.dtor.storage_class & STC.scope_)
                 {
                     dsym.storage_class |= STC.scope_;
@@ -1052,7 +1052,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         dsym.semanticRun = PASS.semanticdone;
 
-        if (dsym.type.toBasetype().ty == Type.Kind.error)
+        if (dsym.type.toBasetype().ty == Terror)
             dsym.errors = true;
 
         if(sc.scopesym && !sc.scopesym.isAggregateDeclaration())
@@ -1319,7 +1319,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     e = resolveProperties(sc, e);
                     sc = sc.endCTFE();
                     // pragma(msg) is allowed to contain types as well as expressions
-                    if (e.type && e.type.ty == Type.Kind.void_)
+                    if (e.type && e.type.ty == Tvoid)
                     {
                         error(pd.loc, "Cannot pass argument `%s` to `pragma msg` because it is `void`", e.toChars());
                         return;
@@ -1723,7 +1723,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             /* Check to see if memtype is forward referenced
              */
-            if (ed.memtype.ty == Type.Kind.enum_)
+            if (ed.memtype.ty == Tenum)
             {
                 EnumDeclaration sym = cast(EnumDeclaration)ed.memtype.toDsymbol(sc);
                 if (!sym.memtype || !sym.members || !sym.symtab || sym._scope)
@@ -1738,12 +1738,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     return;
                 }
             }
-            if (ed.memtype.ty == Type.Kind.void_)
+            if (ed.memtype.ty == Tvoid)
             {
                 ed.error("base type must not be void");
                 ed.memtype = Type.terror;
             }
-            if (ed.memtype.ty == Type.Kind.error)
+            if (ed.memtype.ty == Terror)
             {
                 ed.errors = true;
                 if (ed.members)
@@ -1903,12 +1903,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (first && !em.ed.memtype && !em.ed.isAnonymous())
             {
                 em.ed.memtype = e.type;
-                if (em.ed.memtype.ty == Type.Kind.error)
+                if (em.ed.memtype.ty == Terror)
                 {
                     em.ed.errors = true;
                     return errorReturn();
                 }
-                if (em.ed.memtype.ty != Type.Kind.error)
+                if (em.ed.memtype.ty != Terror)
                 {
                     /* https://issues.dlang.org/show_bug.cgi?id=11746
                      * All of named enum members should have same type
@@ -2560,10 +2560,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (fld && fld.treq)
         {
             Type treq = fld.treq;
-            assert(treq.nextOf().ty == Type.Kind.function_);
-            if (treq.ty == Type.Kind.delegate_)
+            assert(treq.nextOf().ty == Tfunction);
+            if (treq.ty == Tdelegate)
                 fld.tok = TOK.delegate_;
-            else if (treq.ty == Type.Kind.pointer && treq.nextOf().ty == Type.Kind.function_)
+            else if (treq.ty == Tpointer && treq.nextOf().ty == Tfunction)
                 fld.tok = TOK.function_;
             else
                 assert(0);
@@ -2577,9 +2577,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!funcdecl.originalType)
             funcdecl.originalType = funcdecl.type.syntaxCopy();
-        if (funcdecl.type.ty != Type.Kind.function_)
+        if (funcdecl.type.ty != Tfunction)
         {
-            if (funcdecl.type.ty != Type.Kind.error)
+            if (funcdecl.type.ty != Terror)
             {
                 funcdecl.error("`%s` must be a function instead of `%s`", funcdecl.toChars(), funcdecl.type.toChars());
                 funcdecl.type = Type.terror;
@@ -2705,9 +2705,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             funcdecl.type = funcdecl.type.typeSemantic(funcdecl.loc, sc);
             sc = sc.pop();
         }
-        if (funcdecl.type.ty != Type.Kind.function_)
+        if (funcdecl.type.ty != Tfunction)
         {
-            if (funcdecl.type.ty != Type.Kind.error)
+            if (funcdecl.type.ty != Terror)
             {
                 funcdecl.error("`%s` must be a function instead of `%s`", funcdecl.toChars(), funcdecl.type.toChars());
                 funcdecl.type = Type.terror;
@@ -2787,7 +2787,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             if (funcdecl.isStaticConstructor() || funcdecl.isStaticDestructor())
             {
-                if (!funcdecl.isStatic() || funcdecl.type.nextOf().ty != Type.Kind.void_)
+                if (!funcdecl.isStatic() || funcdecl.type.nextOf().ty != Tvoid)
                     funcdecl.error("static constructors / destructors must be static void");
                 if (f.arguments && f.arguments.dim)
                     funcdecl.error("static constructors / destructors must have empty parameter list");
@@ -3247,7 +3247,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (funcdecl.fbody && funcdecl.isMain() && sc._module.isRoot())
             genCmain(sc);
 
-        assert(funcdecl.type.ty != Type.Kind.error || funcdecl.errors);
+        assert(funcdecl.type.ty != Terror || funcdecl.errors);
     }
 
      /// Do the semantic analysis on the external interface to the function.
@@ -3755,7 +3755,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (sd.semanticRun == PASS.init)
             sd.type = sd.type.addSTC(sc.stc | sd.storage_class);
         sd.type = sd.type.typeSemantic(sd.loc, sc);
-        if (sd.type.ty == Type.Kind.struct_ && (cast(TypeStruct)sd.type).sym != sd)
+        if (sd.type.ty == Tstruct && (cast(TypeStruct)sd.type).sym != sd)
         {
             auto ti = (cast(TypeStruct)sd.type).sym.isInstantiated();
             if (ti && isError(ti))
@@ -3830,7 +3830,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (!sd.determineFields())
         {
-            if (sd.type.ty != Type.Kind.error)
+            if (sd.type.ty != Terror)
             {
                 sd.error(sd.loc, "circular or forward reference");
                 sd.errors = true;
@@ -3849,7 +3849,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         foreach (v; sd.fields)
         {
             Type tb = v.type.baseElemOf();
-            if (tb.ty != Type.Kind.struct_)
+            if (tb.ty != Tstruct)
                 continue;
             auto sdec = (cast(TypeStruct)tb).sym;
             if (sdec.semanticRun >= PASS.semanticdone)
@@ -3931,13 +3931,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         version (none)
         {
-            if (sd.type.ty == Type.Kind.struct_ && (cast(TypeStruct)sd.type).sym != sd)
+            if (sd.type.ty == Tstruct && (cast(TypeStruct)sd.type).sym != sd)
             {
                 printf("this = %p %s\n", sd, sd.toChars());
                 printf("type = %d sym = %p\n", sd.type.ty, (cast(TypeStruct)sd.type).sym);
             }
         }
-        assert(sd.type.ty != Type.Kind.struct_ || (cast(TypeStruct)sd.type).sym == sd);
+        assert(sd.type.ty != Tstruct || (cast(TypeStruct)sd.type).sym == sd);
     }
 
     final void interfaceSemantic(ClassDeclaration cd)
@@ -3982,7 +3982,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (cldec.errors)
             cldec.type = Type.terror;
         cldec.type = cldec.type.typeSemantic(cldec.loc, sc);
-        if (cldec.type.ty == Type.Kind.class_ && (cast(TypeClass)cldec.type).sym != cldec)
+        if (cldec.type.ty == Tclass && (cast(TypeClass)cldec.type).sym != cldec)
         {
             auto ti = (cast(TypeClass)cldec.type).sym.isInstantiated();
             if (ti && isError(ti))
@@ -4062,7 +4062,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 b.type = resolveBase(b.type.typeSemantic(cldec.loc, sc));
 
                 Type tb = b.type.toBasetype();
-                if (tb.ty == Type.Kind.tuple)
+                if (tb.ty == Ttuple)
                 {
                     TypeTuple tup = cast(TypeTuple)tb;
                     cldec.baseclasses.remove(i);
@@ -4091,7 +4091,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 BaseClass* b = (*cldec.baseclasses)[0];
                 Type tb = b.type.toBasetype();
-                TypeClass tc = (tb.ty == Type.Kind.class_) ? cast(TypeClass)tb : null;
+                TypeClass tc = (tb.ty == Tclass) ? cast(TypeClass)tb : null;
                 if (!tc)
                 {
                     if (b.type != Type.terror)
@@ -4148,7 +4148,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 BaseClass* b = (*cldec.baseclasses)[i];
                 Type tb = b.type.toBasetype();
-                TypeClass tc = (tb.ty == Type.Kind.class_) ? cast(TypeClass)tb : null;
+                TypeClass tc = (tb.ty == Tclass) ? cast(TypeClass)tb : null;
                 if (!tc || !tc.sym.isInterfaceDeclaration())
                 {
                     if (b.type != Type.terror)
@@ -4216,9 +4216,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                 Type t = cldec.object.type;
                 t = t.typeSemantic(cldec.loc, sc).toBasetype();
-                if (t.ty == Type.Kind.error)
+                if (t.ty == Terror)
                     badObjectDotD();
-                assert(t.ty == Type.Kind.class_);
+                assert(t.ty == Tclass);
                 TypeClass tc = cast(TypeClass)t;
 
                 auto b = new BaseClass(tc);
@@ -4303,7 +4303,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             BaseClass* b = (*cldec.baseclasses)[i];
             Type tb = b.type.toBasetype();
-            assert(tb.ty == Type.Kind.class_);
+            assert(tb.ty == Tclass);
             TypeClass tc = cast(TypeClass)tb;
             if (tc.sym.semanticRun < PASS.semanticdone)
             {
@@ -4404,7 +4404,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         foreach (v; cldec.fields)
         {
             Type tb = v.type.baseElemOf();
-            if (tb.ty != Type.Kind.struct_)
+            if (tb.ty != Tstruct)
                 continue;
             auto sd = (cast(TypeStruct)tb).sym;
             if (sd.semanticRun >= PASS.semanticdone)
@@ -4506,7 +4506,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (cldec.type.ty == Type.Kind.class_ && (cast(TypeClass)cldec.type).sym != cldec)
+        if (cldec.type.ty == Tclass && (cast(TypeClass)cldec.type).sym != cldec)
         {
             // https://issues.dlang.org/show_bug.cgi?id=17492
             ClassDeclaration cd = (cast(TypeClass)cldec.type).sym;
@@ -4576,7 +4576,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (idec.errors)
             idec.type = Type.terror;
         idec.type = idec.type.typeSemantic(idec.loc, sc);
-        if (idec.type.ty == Type.Kind.class_ && (cast(TypeClass)idec.type).sym != idec)
+        if (idec.type.ty == Tclass && (cast(TypeClass)idec.type).sym != idec)
         {
             auto ti = (cast(TypeClass)idec.type).sym.isInstantiated();
             if (ti && isError(ti))
@@ -4639,7 +4639,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 b.type = resolveBase(b.type.typeSemantic(idec.loc, sc));
 
                 Type tb = b.type.toBasetype();
-                if (tb.ty == Type.Kind.tuple)
+                if (tb.ty == Ttuple)
                 {
                     TypeTuple tup = cast(TypeTuple)tb;
                     idec.baseclasses.remove(i);
@@ -4674,7 +4674,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 BaseClass* b = (*idec.baseclasses)[i];
                 Type tb = b.type.toBasetype();
-                TypeClass tc = (tb.ty == Type.Kind.class_) ? cast(TypeClass)tb : null;
+                TypeClass tc = (tb.ty == Tclass) ? cast(TypeClass)tb : null;
                 if (!tc || !tc.sym.isInterfaceDeclaration())
                 {
                     if (b.type != Type.terror)
@@ -4760,7 +4760,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             BaseClass* b = (*idec.baseclasses)[i];
             Type tb = b.type.toBasetype();
-            assert(tb.ty == Type.Kind.class_);
+            assert(tb.ty == Tclass);
             TypeClass tc = cast(TypeClass)tb;
             if (tc.sym.semanticRun < PASS.semanticdone)
             {
@@ -4857,13 +4857,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         version (none)
         {
-            if (type.ty == Type.Kind.class_ && (cast(TypeClass)idec.type).sym != idec)
+            if (type.ty == Tclass && (cast(TypeClass)idec.type).sym != idec)
             {
                 printf("this = %p %s\n", idec, idec.toChars());
                 printf("type = %d sym = %p\n", idec.type.ty, (cast(TypeClass)idec.type).sym);
             }
         }
-        assert(idec.type.ty != Type.Kind.class_ || (cast(TypeClass)idec.type).sym == idec);
+        assert(idec.type.ty != Tclass || (cast(TypeClass)idec.type).sym == idec);
     }
 }
 
@@ -5162,7 +5162,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
              * resolve any "auto ref" storage classes.
              */
             TypeFunction tf = cast(TypeFunction)fd.type;
-            if (tf && tf.ty == Type.Kind.function_)
+            if (tf && tf.ty == Tfunction)
                 tf.fargs = fargs;
         }
     }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -153,12 +153,12 @@ private elem *callfunc(Loc loc,
     }
 
     t = t.toBasetype();
-    if (t.ty == Type.Kind.delegate_)
+    if (t.ty == Tdelegate)
     {
         // A delegate consists of:
         //      { Object *this; Function *funcptr; }
         assert(!fd);
-        assert(t.nextOf().ty == Type.Kind.function_);
+        assert(t.nextOf().ty == Tfunction);
         tf = cast(TypeFunction)(t.nextOf());
         ethis = ec;
         ec = el_same(&ethis);
@@ -168,7 +168,7 @@ private elem *callfunc(Loc loc,
     }
     else
     {
-        assert(t.ty == Type.Kind.function_);
+        assert(t.ty == Tfunction);
         tf = cast(TypeFunction)(t);
     }
     const ty = fd ? toSymbol(fd).Stype.Tty : ec.Ety;
@@ -276,8 +276,8 @@ private elem *callfunc(Loc loc,
             type *tc;
 
             Type tret2 = tf.next;
-            if (tret2.toBasetype().ty == Type.Kind.struct_ ||
-                tret2.toBasetype().ty == Type.Kind.staticArray)
+            if (tret2.toBasetype().ty == Tstruct ||
+                tret2.toBasetype().ty == Tsarray)
                 tc = Type_toCtype(tret2);
             else
                 tc = type_fake(totym(tret2));
@@ -617,7 +617,7 @@ elem *addressElem(elem *e, Type t, bool alwaysCopy = false)
 
         // Convert to ((tmp=e2),tmp)
         TY ty;
-        if (t && ((ty = t.toBasetype().ty) == Type.Kind.struct_ || ty == Type.Kind.staticArray))
+        if (t && ((ty = t.toBasetype().ty) == Tstruct || ty == Tsarray))
             tx = Type_toCtype(t);
         else if (tybasic(e2.Ety) == TYstruct)
         {
@@ -656,11 +656,11 @@ elem *array_toPtr(Type t, elem *e)
     t = t.toBasetype();
     switch (t.ty)
     {
-        case Type.Kind.pointer:
+        case Tpointer:
             break;
 
-        case Type.Kind.array:
-        case Type.Kind.delegate_:
+        case Tarray:
+        case Tdelegate:
             if (e.Eoper == OPcomma)
             {
                 e.Ety = TYnptr;
@@ -684,7 +684,7 @@ else
             }
             break;
 
-        case Type.Kind.staticArray:
+        case Tsarray:
             //e = el_una(OPaddr, TYnptr, e);
             e = addressElem(e, t);
             break;
@@ -711,10 +711,10 @@ elem *array_toDarray(Type t, elem *e)
     t = t.toBasetype();
     switch (t.ty)
     {
-        case Type.Kind.array:
+        case Tarray:
             break;
 
-        case Type.Kind.staticArray:
+        case Tsarray:
             e = addressElem(e, t);
             dim = cast(uint)(cast(TypeSArray)t).dim.toInteger();
             e = el_pair(TYdarray, el_long(TYsize_t, dim), e);
@@ -824,7 +824,7 @@ elem *sarray_toDarray(Loc loc, Type tfrom, Type tto, elem *e)
 
 elem *getTypeInfo(Type t, IRState *irs)
 {
-    assert(t.ty != Type.Kind.error);
+    assert(t.ty != Terror);
     genTypeInfo(t, null);
     elem *e = el_ptr(toSymbol(t.vtinfo));
     return e;
@@ -836,7 +836,7 @@ elem *getTypeInfo(Type t, IRState *irs)
 StructDeclaration needsPostblit(Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Type.Kind.struct_)
+    if (t.ty == Tstruct)
     {
         StructDeclaration sd = (cast(TypeStruct)t).sym;
         if (sd.postblit)
@@ -851,7 +851,7 @@ StructDeclaration needsPostblit(Type t)
 StructDeclaration needsDtor(Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Type.Kind.struct_)
+    if (t.ty == Tstruct)
     {
         StructDeclaration sd = (cast(TypeStruct)t).sym;
         if (sd.dtor)
@@ -883,30 +883,30 @@ Lagain:
     int r;
     switch (tb.ty)
     {
-        case Type.Kind.float80:
-        case Type.Kind.imaginary80:
+        case Tfloat80:
+        case Timaginary80:
             r = RTLSYM_MEMSET80;
             break;
-        case Type.Kind.complex80:
+        case Tcomplex80:
             r = RTLSYM_MEMSET160;
             break;
-        case Type.Kind.complex64:
+        case Tcomplex64:
             r = RTLSYM_MEMSET128;
             break;
-        case Type.Kind.float32:
-        case Type.Kind.imaginary32:
+        case Tfloat32:
+        case Timaginary32:
             if (!global.params.is64bit)
                 goto default;          // legacy binary compatibility
             r = RTLSYM_MEMSETFLOAT;
             break;
-        case Type.Kind.float64:
-        case Type.Kind.imaginary64:
+        case Tfloat64:
+        case Timaginary64:
             if (!global.params.is64bit)
                 goto default;          // legacy binary compatibility
             r = RTLSYM_MEMSETDOUBLE;
             break;
 
-        case Type.Kind.struct_:
+        case Tstruct:
         {
             if (!global.params.is64bit)
                 goto default;
@@ -921,7 +921,7 @@ Lagain:
             goto default;
         }
 
-        case Type.Kind.vector:
+        case Tvector:
             r = RTLSYM_MEMSETSIMD;
             break;
 
@@ -1251,8 +1251,8 @@ elem *toElem(Expression e, IRState *irs)
 
                 tym_t tym;
                 if (se.var.storage_class & STC.lazy_)
-                    tym = TYdelegate;       // Type.Kind.delegate_ as C type
-                else if (tb.ty == Type.Kind.function_)
+                    tym = TYdelegate;       // Tdelegate as C type
+                else if (tb.ty == Tfunction)
                     tym = s.Stype.Tty;
                 else
                     tym = totym(se.type);
@@ -1285,7 +1285,7 @@ elem *toElem(Expression e, IRState *irs)
             //printf("FuncExp.toElem() %s\n", fe.toChars());
             FuncLiteralDeclaration fld = fe.fd;
 
-            if (fld.tok == TOK.reserved && fe.type.ty == Type.Kind.pointer)
+            if (fld.tok == TOK.reserved && fe.type.ty == Tpointer)
             {
                 // change to non-nested
                 fld.tok = TOK.function_;
@@ -1329,7 +1329,7 @@ elem *toElem(Expression e, IRState *irs)
             if (Expression ex = isExpression(e.obj))
             {
                 Type t = ex.type.toBasetype();
-                assert(t.ty == Type.Kind.class_);
+                assert(t.ty == Tclass);
                 // generate **classptr to get the classinfo
                 result = toElem(ex, irs);
                 result = el_una(OPind,TYnptr,result);
@@ -1361,7 +1361,7 @@ elem *toElem(Expression e, IRState *irs)
             else
                 ethis = el_var(irs.sthis);
 
-            if (te.type.ty == Type.Kind.struct_)
+            if (te.type.ty == Tstruct)
             {
                 ethis = el_una(OPind, TYstruct, ethis);
                 ethis.ET = Type_toCtype(te.type);
@@ -1516,12 +1516,12 @@ elem *toElem(Expression e, IRState *irs)
 
             elem *e;
             Type tb = se.type.toBasetype();
-            if (tb.ty == Type.Kind.array)
+            if (tb.ty == Tarray)
             {
                 Symbol *si = toStringSymbol(se);
                 e = el_pair(TYdarray, el_long(TYsize_t, se.numberOfCodeUnits()), el_ptr(si));
             }
-            else if (tb.ty == Type.Kind.staticArray)
+            else if (tb.ty == Tsarray)
             {
                 Symbol *si = toStringSymbol(se);
                 e = el_var(si);
@@ -1529,7 +1529,7 @@ elem *toElem(Expression e, IRState *irs)
                 e.ET = si.Stype;
                 e.ET.Tcount++;
             }
-            else if (tb.ty == Type.Kind.pointer)
+            else if (tb.ty == Tpointer)
             {
                 e = el_calloc();
                 e.Eoper = OPstring;
@@ -1558,10 +1558,10 @@ elem *toElem(Expression e, IRState *irs)
                 //printf("\tmember = %s\n", ne.member.toChars());
             elem *e;
             Type ectype;
-            if (t.ty == Type.Kind.class_)
+            if (t.ty == Tclass)
             {
                 t = ne.newtype.toBasetype();
-                assert(t.ty == Type.Kind.class_);
+                assert(t.ty == Tclass);
                 TypeClass tclass = cast(TypeClass)t;
                 ClassDeclaration cd = tclass.sym;
 
@@ -1691,10 +1691,10 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_combine(e, ezprefix);
                 e = el_combine(e, ez);
             }
-            else if (t.ty == Type.Kind.pointer && t.nextOf().toBasetype().ty == Type.Kind.struct_)
+            else if (t.ty == Tpointer && t.nextOf().toBasetype().ty == Tstruct)
             {
                 t = ne.newtype.toBasetype();
-                assert(t.ty == Type.Kind.struct_);
+                assert(t.ty == Tstruct);
                 TypeStruct tclass = cast(TypeStruct)t;
                 StructDeclaration sd = tclass.sym;
 
@@ -1766,7 +1766,7 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_combine(e, ezprefix);
                 e = el_combine(e, ez);
             }
-            else if (t.ty == Type.Kind.array)
+            else if (t.ty == Tarray)
             {
                 TypeDArray tda = cast(TypeDArray)t;
 
@@ -1790,7 +1790,7 @@ elem *toElem(Expression e, IRState *irs)
                     // Multidimensional array allocations
                     for (size_t i = 0; i < ne.arguments.dim; i++)
                     {
-                        assert(t.ty == Type.Kind.array);
+                        assert(t.ty == Tarray);
                         t = t.nextOf();
                         assert(t);
                     }
@@ -1811,7 +1811,7 @@ elem *toElem(Expression e, IRState *irs)
                 }
                 e = el_combine(ezprefix, e);
             }
-            else if (t.ty == Type.Kind.pointer)
+            else if (t.ty == Tpointer)
             {
                 TypePointer tp = cast(TypePointer)t;
                 elem *ezprefix = ne.argprefix ? toElem(ne.argprefix, irs) : null;
@@ -1861,11 +1861,11 @@ elem *toElem(Expression e, IRState *irs)
             elem *e = toElem(ne.e1, irs);
             Type tb1 = ne.e1.type.toBasetype();
 
-            assert(tb1.ty != Type.Kind.array && tb1.ty != Type.Kind.staticArray);
+            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
 
             switch (tb1.ty)
             {
-                case Type.Kind.vector:
+                case Tvector:
                 {
                     // rewrite (-e) as (0-e)
                     elem *ez = el_calloc();
@@ -1895,16 +1895,16 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = ce.e1.type.toBasetype();
             tym_t ty = totym(ce.type);
 
-            assert(tb1.ty != Type.Kind.array && tb1.ty != Type.Kind.staticArray);
+            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
 
             elem *e;
             switch (tb1.ty)
             {
-                case Type.Kind.bool_:
+                case Tbool:
                     e = el_bin(OPxor, ty, e1, el_long(ty, 1));
                     break;
 
-                case Type.Kind.vector:
+                case Tvector:
                 {
                     // rewrite (~e) as (e^~0)
                     elem *ec = el_calloc();
@@ -1976,7 +1976,7 @@ elem *toElem(Expression e, IRState *irs)
                 FuncDeclaration inv;
 
                 // If e1 is a class object, call the class invariant on it
-                if (global.params.useInvariants && t1.ty == Type.Kind.class_ &&
+                if (global.params.useInvariants && t1.ty == Tclass &&
                     !(cast(TypeClass)t1).sym.isInterfaceDeclaration() &&
                     !(cast(TypeClass)t1).sym.isCPPclass())
                 {
@@ -1990,8 +1990,8 @@ elem *toElem(Expression e, IRState *irs)
                     einv = el_bin(OPcall, TYvoid, el_var(getRtlsym(rtl)), el_var(ts));
                 }
                 else if (global.params.useInvariants &&
-                    t1.ty == Type.Kind.pointer &&
-                    t1.nextOf().ty == Type.Kind.struct_ &&
+                    t1.ty == Tpointer &&
+                    t1.nextOf().ty == Tstruct &&
                     (inv = (cast(TypeStruct)t1.nextOf()).sym.inv) !is null)
                 {
                     // If e1 is a struct object, call the struct invariant on it
@@ -2093,9 +2093,9 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = be.e1.type.toBasetype();
             Type tb2 = be.e2.type.toBasetype();
 
-            assert(!((tb1.ty == Type.Kind.array || tb1.ty == Type.Kind.staticArray ||
-                      tb2.ty == Type.Kind.array || tb2.ty == Type.Kind.staticArray) &&
-                     tb2.ty != Type.Kind.void_ &&
+            assert(!((tb1.ty == Tarray || tb1.ty == Tsarray ||
+                      tb2.ty == Tarray || tb2.ty == Tsarray) &&
+                     tb2.ty != Tvoid &&
                      op != OPeq && op != OPandand && op != OPoror));
 
             tym_t tym = totym(be.type);
@@ -2115,9 +2115,9 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = be.e1.type.toBasetype();
             Type tb2 = be.e2.type.toBasetype();
 
-            assert(!((tb1.ty == Type.Kind.array || tb1.ty == Type.Kind.staticArray ||
-                      tb2.ty == Type.Kind.array || tb2.ty == Type.Kind.staticArray) &&
-                     tb2.ty != Type.Kind.void_ &&
+            assert(!((tb1.ty == Tarray || tb1.ty == Tsarray ||
+                      tb2.ty == Tarray || tb2.ty == Tsarray) &&
+                     tb2.ty != Tvoid &&
                      op != OPeq && op != OPandand && op != OPoror));
 
             tym_t tym = totym(be.type);
@@ -2213,7 +2213,7 @@ elem *toElem(Expression e, IRState *irs)
             Type tb1 = ce.e1.type.toBasetype();
             Type tb2 = ce.e2.type.toBasetype();
 
-            Type ta = (tb1.ty == Type.Kind.array || tb1.ty == Type.Kind.staticArray) ? tb1 : tb2;
+            Type ta = (tb1.ty == Tarray || tb1.ty == Tsarray) ? tb1 : tb2;
 
             elem *e;
             if (ce.e1.op == TOK.concatenate)
@@ -2309,14 +2309,14 @@ elem *toElem(Expression e, IRState *irs)
                 eop = cast(OPER)rel_integral(eop);
             }
             elem *e;
-            if (cast(int)eop > 1 && t1.ty == Type.Kind.class_ && t2.ty == Type.Kind.class_)
+            if (cast(int)eop > 1 && t1.ty == Tclass && t2.ty == Tclass)
             {
                 // Should have already been lowered
                 assert(0);
             }
             else if (cast(int)eop > 1 &&
-                (t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray) &&
-                (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray))
+                (t1.ty == Tarray || t1.ty == Tsarray) &&
+                (t2.ty == Tarray || t2.ty == Tsarray))
             {
                 // This codepath was replaced by lowering during semantic
                 // to object.__cmp in druntime.
@@ -2357,12 +2357,12 @@ elem *toElem(Expression e, IRState *irs)
 
             //printf("EqualExp.toElem()\n");
             elem *e;
-            if (t1.ty == Type.Kind.struct_ && (cast(TypeStruct)t1).sym.fields.dim == 0)
+            if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0)
             {
                 // we can skip the compare if the structs are empty
                 e = el_long(TYbool, ee.op == TOK.equal);
             }
-            else if (t1.ty == Type.Kind.struct_)
+            else if (t1.ty == Tstruct)
             {
                 // Do bit compare of struct's
                 elem *es1 = toElem(ee.e1, irs);
@@ -2375,13 +2375,13 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_bin(eop, TYint, e, el_long(TYint, 0));
                 elem_setLoc(e, ee.loc);
             }
-            else if ((t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray) &&
-                     (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray))
+            else if ((t1.ty == Tarray || t1.ty == Tsarray) &&
+                     (t2.ty == Tarray || t2.ty == Tsarray))
             {
                 Type telement  = t1.nextOf().toBasetype();
                 Type telement2 = t2.nextOf().toBasetype();
 
-                if ((telement.isintegral() || telement.ty == Type.Kind.void_) && telement.ty == telement2.ty)
+                if ((telement.isintegral() || telement.ty == Tvoid) && telement.ty == telement2.ty)
                 {
                     // Optimize comparisons of arrays of basic types
                     // For arrays of integers/characters, and void[],
@@ -2397,7 +2397,7 @@ elem *toElem(Expression e, IRState *irs)
                     elem* esiz1, esiz2; // Data size, to pass to memcmp
                     d_uns64 sz = telement.size(); // Size of one element
 
-                    if (t1.ty == Type.Kind.array)
+                    if (t1.ty == Tarray)
                     {
                         elen1 = el_una(global.params.is64bit ? OP128_64 : OP64_32, TYsize_t, el_same(&earr1));
                         esiz1 = el_bin(OPmul, TYsize_t, el_same(&elen1), el_long(TYsize_t, sz));
@@ -2411,7 +2411,7 @@ elem *toElem(Expression e, IRState *irs)
                         eptr1 = el_same(&earr1);
                     }
 
-                    if (t2.ty == Type.Kind.array)
+                    if (t2.ty == Tarray)
                     {
                         elen2 = el_una(global.params.is64bit ? OP128_64 : OP64_32, TYsize_t, el_same(&earr2));
                         esiz2 = el_bin(OPmul, TYsize_t, el_same(&elen2), el_long(TYsize_t, sz));
@@ -2425,17 +2425,17 @@ elem *toElem(Expression e, IRState *irs)
                         eptr2 = el_same(&earr2);
                     }
 
-                    elem *esize = t2.ty == Type.Kind.staticArray ? esiz2 : esiz1;
+                    elem *esize = t2.ty == Tsarray ? esiz2 : esiz1;
 
                     e = el_param(eptr1, eptr2);
                     e = el_bin(OPmemcmp, TYint, e, esize);
                     e = el_bin(eop, TYint, e, el_long(TYint, 0));
 
-                    elem *elen = t2.ty == Type.Kind.staticArray ? elen2 : elen1;
+                    elem *elen = t2.ty == Tsarray ? elen2 : elen1;
                     elem *esizecheck = el_bin(eop, TYint, el_same(&elen), el_long(TYsize_t, 0));
                     e = el_bin(ee.op == TOK.equal ? OPoror : OPandand, TYint, esizecheck, e);
 
-                    if (t1.ty == Type.Kind.staticArray && t2.ty == Type.Kind.staticArray)
+                    if (t1.ty == Tsarray && t2.ty == Tsarray)
                         assert(t1.size() == t2.size());
                     else
                     {
@@ -2462,7 +2462,7 @@ elem *toElem(Expression e, IRState *irs)
                     e = el_bin(OPxor, TYint, e, el_long(TYint, 1));
                 elem_setLoc(e,ee.loc);
             }
-            else if (t1.ty == Type.Kind.associativeArray && t2.ty == Type.Kind.associativeArray)
+            else if (t1.ty == Taarray && t2.ty == Taarray)
             {
                 TypeAArray taa = cast(TypeAArray)t1;
                 Symbol *s = aaGetSymbol(taa, "Equal", 0);
@@ -2501,12 +2501,12 @@ elem *toElem(Expression e, IRState *irs)
             //printf("IdentityExp.toElem() %s\n", toChars());
 
             elem *e;
-            if (t1.ty == Type.Kind.struct_ && (cast(TypeStruct)t1).sym.fields.dim == 0)
+            if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0)
             {
                 // we can skip the compare if the structs are empty
                 e = el_long(TYbool, ie.op == TOK.identity);
             }
-            else if (t1.ty == Type.Kind.struct_ || t1.isfloating())
+            else if (t1.ty == Tstruct || t1.isfloating())
             {
                 // Do bit compare of struct's
                 elem *es1 = toElem(ie.e1, irs);
@@ -2519,8 +2519,8 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_bin(eop, TYint, e, el_long(TYint, 0));
                 elem_setLoc(e, ie.loc);
             }
-            else if ((t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray) &&
-                     (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray))
+            else if ((t1.ty == Tarray || t1.ty == Tsarray) &&
+                     (t2.ty == Tarray || t2.ty == Tsarray))
             {
 
                 elem *ea1 = toElem(ie.e1, irs);
@@ -2563,7 +2563,7 @@ elem *toElem(Expression e, IRState *irs)
         override void visit(RemoveExp re)
         {
             Type tb = re.e1.type.toBasetype();
-            assert(tb.ty == Type.Kind.associativeArray);
+            assert(tb.ty == Taarray);
             TypeAArray taa = cast(TypeAArray)tb;
             elem *ea = toElem(re.e1, irs);
             elem *ekey = toElem(re.e2, irs);
@@ -2643,7 +2643,7 @@ elem *toElem(Expression e, IRState *irs)
                     elem *enbytes;
                     elem *einit;
                     // Look for array[]=n
-                    if (ta.ty == Type.Kind.staticArray)
+                    if (ta.ty == Tsarray)
                     {
                         TypeSArray ts = cast(TypeSArray)ta;
                         n1 = array_toPtr(ta, n1);
@@ -2652,7 +2652,7 @@ elem *toElem(Expression e, IRState *irs)
                         n1 = el_same(&n1x);
                         einit = resolveLengthVar(are.lengthVar, &n1, ta);
                     }
-                    else if (ta.ty == Type.Kind.array)
+                    else if (ta.ty == Tarray)
                     {
                         n1 = el_same(&n1x);
                         einit = resolveLengthVar(are.lengthVar, &n1, ta);
@@ -2660,7 +2660,7 @@ elem *toElem(Expression e, IRState *irs)
                         n1 = array_toPtr(ta, n1);
                         enbytes = el_una(global.params.is64bit ? OP128_64 : OP64_32, TYsize_t, enbytes);
                     }
-                    else if (ta.ty == Type.Kind.pointer)
+                    else if (ta.ty == Tpointer)
                     {
                         n1 = el_same(&n1x);
                         enbytes = el_long(TYsize_t, -1);   // largest possible index
@@ -2697,7 +2697,7 @@ elem *toElem(Expression e, IRState *irs)
                         printf("enbytes\n");    elem_print(enbytes);
                     }
 
-                    if (irs.arrayBoundsCheck() && eupr && ta.ty != Type.Kind.pointer)
+                    if (irs.arrayBoundsCheck() && eupr && ta.ty != Tpointer)
                     {
                         assert(elwr);
                         elem *enbytesx = enbytes;
@@ -2752,7 +2752,7 @@ elem *toElem(Expression e, IRState *irs)
                     }
                     bool destructor = needsDtor(t1.nextOf()) !is null;
 
-                    assert(ae.e2.type.ty != Type.Kind.pointer);
+                    assert(ae.e2.type.ty != Tpointer);
 
                     if (!postblit && !destructor && !irs.arrayBoundsCheck())
                     {
@@ -2836,7 +2836,7 @@ elem *toElem(Expression e, IRState *irs)
                         es = el_una(OPaddr, TYnptr, es);
                     es.Ety = TYnptr;
                     e = el_bin(OPeq, TYnptr, es, e);
-                    assert(!(t1b.ty == Type.Kind.struct_ && ae.e2.op == TOK.int64));
+                    assert(!(t1b.ty == Tstruct && ae.e2.op == TOK.int64));
 
                     elem_setLoc(e, ae.loc);
                     result = e;
@@ -2886,7 +2886,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 CallExp ce = cast(CallExp)ae.e2;
                 TypeFunction tf = cast(TypeFunction)ce.e1.type.toBasetype();
-                if (tf.ty == Type.Kind.function_ && retStyle(tf) == RET.stack)
+                if (tf.ty == Tfunction && retStyle(tf) == RET.stack)
                 {
                     elem *ehidden = e1;
                     ehidden = el_una(OPaddr, TYnptr, ehidden);
@@ -2920,7 +2920,7 @@ elem *toElem(Expression e, IRState *irs)
             }
 
             //if (ae.op == TOK.construct) printf("construct\n");
-            if (t1b.ty == Type.Kind.struct_)
+            if (t1b.ty == Tstruct)
             {
                 if (ae.e2.op == TOK.int64)
                 {
@@ -2979,7 +2979,7 @@ elem *toElem(Expression e, IRState *irs)
                 if (type_size(e.ET) == 0)
                     e.Eoper = OPcomma;
             }
-            else if (t1b.ty == Type.Kind.staticArray)
+            else if (t1b.ty == Tsarray)
             {
                 if (ae.op == TOK.blit && ae.e2.op == TOK.int64)
                 {
@@ -3007,7 +3007,7 @@ elem *toElem(Expression e, IRState *irs)
                 /* Implement:
                  *  (sarray = sarray)
                  */
-                assert(ae.e2.type.toBasetype().ty == Type.Kind.staticArray);
+                assert(ae.e2.type.toBasetype().ty == Tsarray);
 
                 bool postblit = needsPostblit(t1b.nextOf()) !is null;
                 bool destructor = needsDtor(t1b.nextOf()) !is null;
@@ -3149,7 +3149,7 @@ elem *toElem(Expression e, IRState *irs)
             elem *e;
             Type tb1 = ce.e1.type.toBasetype();
             Type tb2 = ce.e2.type.toBasetype();
-            assert(tb1.ty == Type.Kind.array);
+            assert(tb1.ty == Tarray);
             Type tb1n = tb1.nextOf().toBasetype();
 
             elem *e1 = toElem(ce.e1, irs);
@@ -3160,13 +3160,13 @@ elem *toElem(Expression e, IRState *irs)
                 case TOK.concatenateDcharAssign:
                 {
                     // Append dchar to char[] or wchar[]
-                    assert(tb2.ty == Type.Kind.dchar_ &&
-                          (tb1n.ty == Type.Kind.char_ || tb1n.ty == Type.Kind.wchar_));
+                    assert(tb2.ty == Tdchar &&
+                          (tb1n.ty == Tchar || tb1n.ty == Twchar));
 
                     e1 = el_una(OPaddr, TYnptr, e1);
 
                     elem *ep = el_params(e2, e1, null);
-                    int rtl = (tb1.nextOf().ty == Type.Kind.char_)
+                    int rtl = (tb1.nextOf().ty == Tchar)
                             ? RTLSYM_ARRAYAPPENDCD
                             : RTLSYM_ARRAYAPPENDWD;
                     e = el_bin(OPcall, TYdarray, el_var(getRtlsym(rtl)), ep);
@@ -3178,7 +3178,7 @@ elem *toElem(Expression e, IRState *irs)
                 case TOK.concatenateAssign:
                 {
                     // Append array
-                    assert(tb2.ty == Type.Kind.array || tb2.ty == Type.Kind.staticArray);
+                    assert(tb2.ty == Tarray || tb2.ty == Tsarray);
 
                     assert(tb1n.equals(tb2.nextOf().toBasetype()));
 
@@ -3354,7 +3354,7 @@ elem *toElem(Expression e, IRState *irs)
         override void visit(PowAssignExp e)
         {
             Type tb1 = e.e1.type.toBasetype();
-            assert(tb1.ty != Type.Kind.array && tb1.ty != Type.Kind.staticArray);
+            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
 
             e.error("`^^` operator is not supported");
             result = el_long(totym(e.type), 0);  // error recovery
@@ -3392,7 +3392,7 @@ elem *toElem(Expression e, IRState *irs)
         override void visit(PowExp e)
         {
             Type tb1 = e.e1.type.toBasetype();
-            assert(tb1.ty != Type.Kind.array && tb1.ty != Type.Kind.staticArray);
+            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
 
             e.error("`^^` operator is not supported");
             result = el_long(totym(e.type), 0);  // error recovery
@@ -3513,8 +3513,8 @@ elem *toElem(Expression e, IRState *irs)
             // https://issues.dlang.org/show_bug.cgi?id=12900
             Type txb = dve.type.toBasetype();
             Type tyb = v.type.toBasetype();
-            if (txb.ty == Type.Kind.vector) txb = (cast(TypeVector)txb).basetype;
-            if (tyb.ty == Type.Kind.vector) tyb = (cast(TypeVector)tyb).basetype;
+            if (txb.ty == Tvector) txb = (cast(TypeVector)txb).basetype;
+            if (tyb.ty == Tvector) tyb = (cast(TypeVector)tyb).basetype;
 
             debug if (txb.ty != tyb.ty)
                 printf("[%s] dve = %s, dve.type = %s, v.type = %s\n", dve.loc.toChars(), dve.toChars(), dve.type.toChars(), v.type.toChars());
@@ -3531,7 +3531,7 @@ elem *toElem(Expression e, IRState *irs)
 
             elem *e = toElem(dve.e1, irs);
             Type tb1 = dve.e1.type.toBasetype();
-            if (tb1.ty != Type.Kind.class_ && tb1.ty != Type.Kind.pointer)
+            if (tb1.ty != Tclass && tb1.ty != Tpointer)
                 e = addressElem(e, tb1);
             e = el_bin(OPadd, TYnptr, e, el_long(TYsize_t, v.offset));
             if (v.storage_class & (STC.out_ | STC.ref_))
@@ -3578,7 +3578,7 @@ elem *toElem(Expression e, IRState *irs)
             else
             {
                 ethis = toElem(de.e1, irs);
-                if (de.e1.type.ty != Type.Kind.class_ && de.e1.type.ty != Type.Kind.pointer)
+                if (de.e1.type.ty != Tclass && de.e1.type.ty != Tpointer)
                     ethis = addressElem(ethis, de.e1.type);
 
                 if (de.e1.op == TOK.super_ || de.e1.op == TOK.dotType)
@@ -3648,7 +3648,7 @@ elem *toElem(Expression e, IRState *irs)
             elem *ec;
             FuncDeclaration fd = null;
             bool dctor = false;
-            if (ce.e1.op == TOK.dotVariable && t1.ty != Type.Kind.delegate_)
+            if (ce.e1.op == TOK.dotVariable && t1.ty != Tdelegate)
             {
                 DotVarExp dve = cast(DotVarExp)ce.e1;
 
@@ -3884,7 +3884,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 IndexExp ae = cast(IndexExp)de.e1;
                 tb = ae.e1.type.toBasetype();
-                assert(tb.ty != Type.Kind.associativeArray);
+                assert(tb.ty != Taarray);
             }
             //e1.type.print();
             elem *e = toElem(de.e1, irs);
@@ -3892,7 +3892,7 @@ elem *toElem(Expression e, IRState *irs)
             int rtl;
             switch (tb.ty)
             {
-                case Type.Kind.array:
+                case Tarray:
                 {
                     e = addressElem(e, de.e1.type);
                     rtl = RTLSYM_DELARRAYT;
@@ -3901,7 +3901,7 @@ elem *toElem(Expression e, IRState *irs)
                      */
                     elem *et = null;
                     Type tv = tb.nextOf().baseElemOf();
-                    if (tv.ty == Type.Kind.struct_)
+                    if (tv.ty == Tstruct)
                     {
                         // FIXME: ts can be non-mutable, but _d_delarray_t requests TypeInfo_Struct.
                         TypeStruct ts = cast(TypeStruct)tv;
@@ -3915,7 +3915,7 @@ elem *toElem(Expression e, IRState *irs)
                     // call _d_delarray_t(e, et);
                     break;
                 }
-                case Type.Kind.class_:
+                case Tclass:
                     if (de.e1.op == TOK.variable)
                     {
                         VarExp ve = cast(VarExp)de.e1;
@@ -3934,11 +3934,11 @@ elem *toElem(Expression e, IRState *irs)
                         rtl = RTLSYM_DELINTERFACE;
                     break;
 
-                case Type.Kind.pointer:
+                case Tpointer:
                     e = addressElem(e, de.e1.type);
                     rtl = RTLSYM_DELMEMORY;
                     tb = (cast(TypePointer)tb).next.toBasetype();
-                    if (tb.ty == Type.Kind.struct_)
+                    if (tb.ty == Tstruct)
                     {
                         TypeStruct ts = cast(TypeStruct)tb;
                         if (ts.sym.dtor)
@@ -3983,33 +3983,33 @@ elem *toElem(Expression e, IRState *irs)
                     const integer = elem.toInteger();
                     switch (elem.type.toBasetype().ty)
                     {
-                        case Type.Kind.float32:
+                        case Tfloat32:
                             // Must not call toReal directly, to avoid dmd bug 14203 from breaking dmd
                             e.EV.Vfloat8[i] = complex.re;
                             break;
 
-                        case Type.Kind.float64:
+                        case Tfloat64:
                             // Must not call toReal directly, to avoid dmd bug 14203 from breaking dmd
                             e.EV.Vdouble4[i] = complex.re;
                             break;
 
-                        case Type.Kind.int64:
-                        case Type.Kind.uint64:
+                        case Tint64:
+                        case Tuns64:
                             e.EV.Vullong4[i] = integer;
                             break;
 
-                        case Type.Kind.int32:
-                        case Type.Kind.uint32:
+                        case Tint32:
+                        case Tuns32:
                             e.EV.Vulong8[i] = cast(uint)integer;
                             break;
 
-                        case Type.Kind.int16:
-                        case Type.Kind.uint16:
+                        case Tint16:
+                        case Tuns16:
                             e.EV.Vushort16[i] = cast(ushort)integer;
                             break;
 
-                        case Type.Kind.int8:
-                        case Type.Kind.uint8:
+                        case Tint8:
+                        case Tuns8:
                             e.EV.Vuchar32[i] = cast(ubyte)integer;
                             break;
 
@@ -4060,7 +4060,7 @@ elem *toElem(Expression e, IRState *irs)
             tty = t.ty;
             //printf("fty = %d\n", fty);
 
-            if (tty == Type.Kind.pointer && fty == Type.Kind.array)
+            if (tty == Tpointer && fty == Tarray)
             {
                 if (e.Eoper == OPvar)
                 {
@@ -4086,7 +4086,7 @@ elem *toElem(Expression e, IRState *irs)
                 goto Lret;
             }
 
-            if (tty == Type.Kind.pointer && fty == Type.Kind.staticArray)
+            if (tty == Tpointer && fty == Tsarray)
             {
                 // e1 . &e1
                 e = el_una(OPaddr, TYnptr, e);
@@ -4094,14 +4094,14 @@ elem *toElem(Expression e, IRState *irs)
             }
 
             // Convert from static array to dynamic array
-            if (tty == Type.Kind.array && fty == Type.Kind.staticArray)
+            if (tty == Tarray && fty == Tsarray)
             {
                 e = sarray_toDarray(ce.loc, tfrom, t, e);
                 goto Lret;
             }
 
             // Convert from dynamic array to dynamic array
-            if (tty == Type.Kind.array && fty == Type.Kind.array)
+            if (tty == Tarray && fty == Tarray)
             {
                 uint fsize = cast(uint)tfrom.nextOf().size();
                 uint tsize = cast(uint)t.nextOf().size();
@@ -4132,7 +4132,7 @@ elem *toElem(Expression e, IRState *irs)
             }
 
             // Casting between class/interface may require a runtime check
-            if (fty == Type.Kind.class_ && tty == Type.Kind.class_)
+            if (fty == Tclass && tty == Tclass)
             {
                 ClassDeclaration cdfrom = tfrom.isClassHandle();
                 ClassDeclaration cdto   = t.isClassHandle();
@@ -4212,7 +4212,7 @@ elem *toElem(Expression e, IRState *irs)
                 goto Lret;
             }
 
-            if (fty == Type.Kind.vector && tty == Type.Kind.staticArray)
+            if (fty == Tvector && tty == Tsarray)
             {
                 if (tfrom.size() == t.size())
                     goto Lret;
@@ -4228,18 +4228,18 @@ elem *toElem(Expression e, IRState *irs)
              */
             switch (tty)
             {
-                case Type.Kind.pointer:
-                    if (fty == Type.Kind.delegate_)
+                case Tpointer:
+                    if (fty == Tdelegate)
                         goto Lpaint;
-                    tty = global.params.is64bit ? Type.Kind.uint64 : Type.Kind.uint32;
+                    tty = global.params.is64bit ? Tuns64 : Tuns32;
                     break;
 
-                case Type.Kind.char_:     tty = Type.Kind.uint8;    break;
-                case Type.Kind.wchar_:    tty = Type.Kind.uint16;   break;
-                case Type.Kind.dchar_:    tty = Type.Kind.uint32;   break;
-                case Type.Kind.void_:     goto Lpaint;
+                case Tchar:     tty = Tuns8;    break;
+                case Twchar:    tty = Tuns16;   break;
+                case Tdchar:    tty = Tuns32;   break;
+                case Tvoid:     goto Lpaint;
 
-                case Type.Kind.bool_:
+                case Tbool:
                 {
                     // Construct e?true:false
                     e = el_una(OPbool, ttym, e);
@@ -4252,457 +4252,457 @@ elem *toElem(Expression e, IRState *irs)
 
             switch (fty)
             {
-                case Type.Kind.null_:
+                case Tnull:
                 {
                     // typeof(null) is same with void* in binary level.
                     goto Lzero;
                 }
-                case Type.Kind.pointer:  fty = global.params.is64bit ? Type.Kind.uint64 : Type.Kind.uint32;  break;
-                case Type.Kind.char_:     fty = Type.Kind.uint8;    break;
-                case Type.Kind.wchar_:    fty = Type.Kind.uint16;   break;
-                case Type.Kind.dchar_:    fty = Type.Kind.uint32;   break;
+                case Tpointer:  fty = global.params.is64bit ? Tuns64 : Tuns32;  break;
+                case Tchar:     fty = Tuns8;    break;
+                case Twchar:    fty = Tuns16;   break;
+                case Tdchar:    fty = Tuns32;   break;
 
                 default:
                     break;
             }
 
-            static int X(int fty, int tty) { return fty * Type.Kind.max_ + tty; }
+            static int X(int fty, int tty) { return fty * TMAX + tty; }
         Lagain:
             switch (X(fty,tty))
             {
                 /* ============================= */
 
-                case X(Type.Kind.bool_,Type.Kind.int8):
-                case X(Type.Kind.bool_,Type.Kind.uint8):
+                case X(Tbool,Tint8):
+                case X(Tbool,Tuns8):
                                         goto Lpaint;
-                case X(Type.Kind.bool_,Type.Kind.int16):
-                case X(Type.Kind.bool_,Type.Kind.uint16):
-                case X(Type.Kind.bool_,Type.Kind.int32):
-                case X(Type.Kind.bool_,Type.Kind.uint32):   eop = OPu8_16;  goto Leop;
-                case X(Type.Kind.bool_,Type.Kind.int64):
-                case X(Type.Kind.bool_,Type.Kind.uint64):
-                case X(Type.Kind.bool_,Type.Kind.float32):
-                case X(Type.Kind.bool_,Type.Kind.float64):
-                case X(Type.Kind.bool_,Type.Kind.float80):
-                case X(Type.Kind.bool_,Type.Kind.complex32):
-                case X(Type.Kind.bool_,Type.Kind.complex64):
-                case X(Type.Kind.bool_,Type.Kind.complex80):
+                case X(Tbool,Tint16):
+                case X(Tbool,Tuns16):
+                case X(Tbool,Tint32):
+                case X(Tbool,Tuns32):   eop = OPu8_16;  goto Leop;
+                case X(Tbool,Tint64):
+                case X(Tbool,Tuns64):
+                case X(Tbool,Tfloat32):
+                case X(Tbool,Tfloat64):
+                case X(Tbool,Tfloat80):
+                case X(Tbool,Tcomplex32):
+                case X(Tbool,Tcomplex64):
+                case X(Tbool,Tcomplex80):
                                         e = el_una(OPu8_16, TYuint, e);
-                                        fty = Type.Kind.uint32;
+                                        fty = Tuns32;
                                         goto Lagain;
-                case X(Type.Kind.bool_,Type.Kind.imaginary32):
-                case X(Type.Kind.bool_,Type.Kind.imaginary64):
-                case X(Type.Kind.bool_,Type.Kind.imaginary80): goto Lzero;
+                case X(Tbool,Timaginary32):
+                case X(Tbool,Timaginary64):
+                case X(Tbool,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.int8,Type.Kind.uint8):    goto Lpaint;
-                case X(Type.Kind.int8,Type.Kind.int16):
-                case X(Type.Kind.int8,Type.Kind.uint16):
-                case X(Type.Kind.int8,Type.Kind.int32):
-                case X(Type.Kind.int8,Type.Kind.uint32):   eop = OPs8_16;  goto Leop;
-                case X(Type.Kind.int8,Type.Kind.int64):
-                case X(Type.Kind.int8,Type.Kind.uint64):
-                case X(Type.Kind.int8,Type.Kind.float32):
-                case X(Type.Kind.int8,Type.Kind.float64):
-                case X(Type.Kind.int8,Type.Kind.float80):
-                case X(Type.Kind.int8,Type.Kind.complex32):
-                case X(Type.Kind.int8,Type.Kind.complex64):
-                case X(Type.Kind.int8,Type.Kind.complex80):
+                case X(Tint8,Tuns8):    goto Lpaint;
+                case X(Tint8,Tint16):
+                case X(Tint8,Tuns16):
+                case X(Tint8,Tint32):
+                case X(Tint8,Tuns32):   eop = OPs8_16;  goto Leop;
+                case X(Tint8,Tint64):
+                case X(Tint8,Tuns64):
+                case X(Tint8,Tfloat32):
+                case X(Tint8,Tfloat64):
+                case X(Tint8,Tfloat80):
+                case X(Tint8,Tcomplex32):
+                case X(Tint8,Tcomplex64):
+                case X(Tint8,Tcomplex80):
                                         e = el_una(OPs8_16, TYint, e);
-                                        fty = Type.Kind.int32;
+                                        fty = Tint32;
                                         goto Lagain;
-                case X(Type.Kind.int8,Type.Kind.imaginary32):
-                case X(Type.Kind.int8,Type.Kind.imaginary64):
-                case X(Type.Kind.int8,Type.Kind.imaginary80): goto Lzero;
+                case X(Tint8,Timaginary32):
+                case X(Tint8,Timaginary64):
+                case X(Tint8,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.uint8,Type.Kind.int8):    goto Lpaint;
-                case X(Type.Kind.uint8,Type.Kind.int16):
-                case X(Type.Kind.uint8,Type.Kind.uint16):
-                case X(Type.Kind.uint8,Type.Kind.int32):
-                case X(Type.Kind.uint8,Type.Kind.uint32):   eop = OPu8_16;  goto Leop;
-                case X(Type.Kind.uint8,Type.Kind.int64):
-                case X(Type.Kind.uint8,Type.Kind.uint64):
-                case X(Type.Kind.uint8,Type.Kind.float32):
-                case X(Type.Kind.uint8,Type.Kind.float64):
-                case X(Type.Kind.uint8,Type.Kind.float80):
-                case X(Type.Kind.uint8,Type.Kind.complex32):
-                case X(Type.Kind.uint8,Type.Kind.complex64):
-                case X(Type.Kind.uint8,Type.Kind.complex80):
+                case X(Tuns8,Tint8):    goto Lpaint;
+                case X(Tuns8,Tint16):
+                case X(Tuns8,Tuns16):
+                case X(Tuns8,Tint32):
+                case X(Tuns8,Tuns32):   eop = OPu8_16;  goto Leop;
+                case X(Tuns8,Tint64):
+                case X(Tuns8,Tuns64):
+                case X(Tuns8,Tfloat32):
+                case X(Tuns8,Tfloat64):
+                case X(Tuns8,Tfloat80):
+                case X(Tuns8,Tcomplex32):
+                case X(Tuns8,Tcomplex64):
+                case X(Tuns8,Tcomplex80):
                                         e = el_una(OPu8_16, TYuint, e);
-                                        fty = Type.Kind.uint32;
+                                        fty = Tuns32;
                                         goto Lagain;
-                case X(Type.Kind.uint8,Type.Kind.imaginary32):
-                case X(Type.Kind.uint8,Type.Kind.imaginary64):
-                case X(Type.Kind.uint8,Type.Kind.imaginary80): goto Lzero;
+                case X(Tuns8,Timaginary32):
+                case X(Tuns8,Timaginary64):
+                case X(Tuns8,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.int16,Type.Kind.int8):
-                case X(Type.Kind.int16,Type.Kind.uint8):   eop = OP16_8;   goto Leop;
-                case X(Type.Kind.int16,Type.Kind.uint16):  goto Lpaint;
-                case X(Type.Kind.int16,Type.Kind.int32):
-                case X(Type.Kind.int16,Type.Kind.uint32):  eop = OPs16_32; goto Leop;
-                case X(Type.Kind.int16,Type.Kind.int64):
-                case X(Type.Kind.int16,Type.Kind.uint64):  e = el_una(OPs16_32, TYint, e);
-                                        fty = Type.Kind.int32;
+                case X(Tint16,Tint8):
+                case X(Tint16,Tuns8):   eop = OP16_8;   goto Leop;
+                case X(Tint16,Tuns16):  goto Lpaint;
+                case X(Tint16,Tint32):
+                case X(Tint16,Tuns32):  eop = OPs16_32; goto Leop;
+                case X(Tint16,Tint64):
+                case X(Tint16,Tuns64):  e = el_una(OPs16_32, TYint, e);
+                                        fty = Tint32;
                                         goto Lagain;
-                case X(Type.Kind.int16,Type.Kind.float32):
-                case X(Type.Kind.int16,Type.Kind.float64):
-                case X(Type.Kind.int16,Type.Kind.float80):
-                case X(Type.Kind.int16,Type.Kind.complex32):
-                case X(Type.Kind.int16,Type.Kind.complex64):
-                case X(Type.Kind.int16,Type.Kind.complex80):
+                case X(Tint16,Tfloat32):
+                case X(Tint16,Tfloat64):
+                case X(Tint16,Tfloat80):
+                case X(Tint16,Tcomplex32):
+                case X(Tint16,Tcomplex64):
+                case X(Tint16,Tcomplex80):
                                         e = el_una(OPs16_d, TYdouble, e);
-                                        fty = Type.Kind.float64;
+                                        fty = Tfloat64;
                                         goto Lagain;
-                case X(Type.Kind.int16,Type.Kind.imaginary32):
-                case X(Type.Kind.int16,Type.Kind.imaginary64):
-                case X(Type.Kind.int16,Type.Kind.imaginary80): goto Lzero;
+                case X(Tint16,Timaginary32):
+                case X(Tint16,Timaginary64):
+                case X(Tint16,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.uint16,Type.Kind.int8):
-                case X(Type.Kind.uint16,Type.Kind.uint8):   eop = OP16_8;   goto Leop;
-                case X(Type.Kind.uint16,Type.Kind.int16):  goto Lpaint;
-                case X(Type.Kind.uint16,Type.Kind.int32):
-                case X(Type.Kind.uint16,Type.Kind.uint32):  eop = OPu16_32; goto Leop;
-                case X(Type.Kind.uint16,Type.Kind.int64):
-                case X(Type.Kind.uint16,Type.Kind.uint64):
-                case X(Type.Kind.uint16,Type.Kind.float64):
-                case X(Type.Kind.uint16,Type.Kind.float32):
-                case X(Type.Kind.uint16,Type.Kind.float80):
-                case X(Type.Kind.uint16,Type.Kind.complex32):
-                case X(Type.Kind.uint16,Type.Kind.complex64):
-                case X(Type.Kind.uint16,Type.Kind.complex80):
+                case X(Tuns16,Tint8):
+                case X(Tuns16,Tuns8):   eop = OP16_8;   goto Leop;
+                case X(Tuns16,Tint16):  goto Lpaint;
+                case X(Tuns16,Tint32):
+                case X(Tuns16,Tuns32):  eop = OPu16_32; goto Leop;
+                case X(Tuns16,Tint64):
+                case X(Tuns16,Tuns64):
+                case X(Tuns16,Tfloat64):
+                case X(Tuns16,Tfloat32):
+                case X(Tuns16,Tfloat80):
+                case X(Tuns16,Tcomplex32):
+                case X(Tuns16,Tcomplex64):
+                case X(Tuns16,Tcomplex80):
                                         e = el_una(OPu16_32, TYuint, e);
-                                        fty = Type.Kind.uint32;
+                                        fty = Tuns32;
                                         goto Lagain;
-                case X(Type.Kind.uint16,Type.Kind.imaginary32):
-                case X(Type.Kind.uint16,Type.Kind.imaginary64):
-                case X(Type.Kind.uint16,Type.Kind.imaginary80): goto Lzero;
+                case X(Tuns16,Timaginary32):
+                case X(Tuns16,Timaginary64):
+                case X(Tuns16,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.int32,Type.Kind.int8):
-                case X(Type.Kind.int32,Type.Kind.uint8):   e = el_una(OP32_16, TYshort, e);
-                                        fty = Type.Kind.int16;
+                case X(Tint32,Tint8):
+                case X(Tint32,Tuns8):   e = el_una(OP32_16, TYshort, e);
+                                        fty = Tint16;
                                         goto Lagain;
-                case X(Type.Kind.int32,Type.Kind.int16):
-                case X(Type.Kind.int32,Type.Kind.uint16):  eop = OP32_16;  goto Leop;
-                case X(Type.Kind.int32,Type.Kind.uint32):  goto Lpaint;
-                case X(Type.Kind.int32,Type.Kind.int64):
-                case X(Type.Kind.int32,Type.Kind.uint64):  eop = OPs32_64; goto Leop;
-                case X(Type.Kind.int32,Type.Kind.float32):
-                case X(Type.Kind.int32,Type.Kind.float64):
-                case X(Type.Kind.int32,Type.Kind.float80):
-                case X(Type.Kind.int32,Type.Kind.complex32):
-                case X(Type.Kind.int32,Type.Kind.complex64):
-                case X(Type.Kind.int32,Type.Kind.complex80):
+                case X(Tint32,Tint16):
+                case X(Tint32,Tuns16):  eop = OP32_16;  goto Leop;
+                case X(Tint32,Tuns32):  goto Lpaint;
+                case X(Tint32,Tint64):
+                case X(Tint32,Tuns64):  eop = OPs32_64; goto Leop;
+                case X(Tint32,Tfloat32):
+                case X(Tint32,Tfloat64):
+                case X(Tint32,Tfloat80):
+                case X(Tint32,Tcomplex32):
+                case X(Tint32,Tcomplex64):
+                case X(Tint32,Tcomplex80):
                                         e = el_una(OPs32_d, TYdouble, e);
-                                        fty = Type.Kind.float64;
+                                        fty = Tfloat64;
                                         goto Lagain;
-                case X(Type.Kind.int32,Type.Kind.imaginary32):
-                case X(Type.Kind.int32,Type.Kind.imaginary64):
-                case X(Type.Kind.int32,Type.Kind.imaginary80): goto Lzero;
+                case X(Tint32,Timaginary32):
+                case X(Tint32,Timaginary64):
+                case X(Tint32,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.uint32,Type.Kind.int8):
-                case X(Type.Kind.uint32,Type.Kind.uint8):   e = el_una(OP32_16, TYshort, e);
-                                        fty = Type.Kind.uint16;
+                case X(Tuns32,Tint8):
+                case X(Tuns32,Tuns8):   e = el_una(OP32_16, TYshort, e);
+                                        fty = Tuns16;
                                         goto Lagain;
-                case X(Type.Kind.uint32,Type.Kind.int16):
-                case X(Type.Kind.uint32,Type.Kind.uint16):  eop = OP32_16;  goto Leop;
-                case X(Type.Kind.uint32,Type.Kind.int32):  goto Lpaint;
-                case X(Type.Kind.uint32,Type.Kind.int64):
-                case X(Type.Kind.uint32,Type.Kind.uint64):  eop = OPu32_64; goto Leop;
-                case X(Type.Kind.uint32,Type.Kind.float32):
-                case X(Type.Kind.uint32,Type.Kind.float64):
-                case X(Type.Kind.uint32,Type.Kind.float80):
-                case X(Type.Kind.uint32,Type.Kind.complex32):
-                case X(Type.Kind.uint32,Type.Kind.complex64):
-                case X(Type.Kind.uint32,Type.Kind.complex80):
+                case X(Tuns32,Tint16):
+                case X(Tuns32,Tuns16):  eop = OP32_16;  goto Leop;
+                case X(Tuns32,Tint32):  goto Lpaint;
+                case X(Tuns32,Tint64):
+                case X(Tuns32,Tuns64):  eop = OPu32_64; goto Leop;
+                case X(Tuns32,Tfloat32):
+                case X(Tuns32,Tfloat64):
+                case X(Tuns32,Tfloat80):
+                case X(Tuns32,Tcomplex32):
+                case X(Tuns32,Tcomplex64):
+                case X(Tuns32,Tcomplex80):
                                         e = el_una(OPu32_d, TYdouble, e);
-                                        fty = Type.Kind.float64;
+                                        fty = Tfloat64;
                                         goto Lagain;
-                case X(Type.Kind.uint32,Type.Kind.imaginary32):
-                case X(Type.Kind.uint32,Type.Kind.imaginary64):
-                case X(Type.Kind.uint32,Type.Kind.imaginary80): goto Lzero;
+                case X(Tuns32,Timaginary32):
+                case X(Tuns32,Timaginary64):
+                case X(Tuns32,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.int64,Type.Kind.int8):
-                case X(Type.Kind.int64,Type.Kind.uint8):
-                case X(Type.Kind.int64,Type.Kind.int16):
-                case X(Type.Kind.int64,Type.Kind.uint16):  e = el_una(OP64_32, TYint, e);
-                                        fty = Type.Kind.int32;
+                case X(Tint64,Tint8):
+                case X(Tint64,Tuns8):
+                case X(Tint64,Tint16):
+                case X(Tint64,Tuns16):  e = el_una(OP64_32, TYint, e);
+                                        fty = Tint32;
                                         goto Lagain;
-                case X(Type.Kind.int64,Type.Kind.int32):
-                case X(Type.Kind.int64,Type.Kind.uint32):  eop = OP64_32; goto Leop;
-                case X(Type.Kind.int64,Type.Kind.uint64):  goto Lpaint;
-                case X(Type.Kind.int64,Type.Kind.float32):
-                case X(Type.Kind.int64,Type.Kind.float64):
-                case X(Type.Kind.int64,Type.Kind.float80):
-                case X(Type.Kind.int64,Type.Kind.complex32):
-                case X(Type.Kind.int64,Type.Kind.complex64):
-                case X(Type.Kind.int64,Type.Kind.complex80):
+                case X(Tint64,Tint32):
+                case X(Tint64,Tuns32):  eop = OP64_32; goto Leop;
+                case X(Tint64,Tuns64):  goto Lpaint;
+                case X(Tint64,Tfloat32):
+                case X(Tint64,Tfloat64):
+                case X(Tint64,Tfloat80):
+                case X(Tint64,Tcomplex32):
+                case X(Tint64,Tcomplex64):
+                case X(Tint64,Tcomplex80):
                                         e = el_una(OPs64_d, TYdouble, e);
-                                        fty = Type.Kind.float64;
+                                        fty = Tfloat64;
                                         goto Lagain;
-                case X(Type.Kind.int64,Type.Kind.imaginary32):
-                case X(Type.Kind.int64,Type.Kind.imaginary64):
-                case X(Type.Kind.int64,Type.Kind.imaginary80): goto Lzero;
+                case X(Tint64,Timaginary32):
+                case X(Tint64,Timaginary64):
+                case X(Tint64,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.uint64,Type.Kind.int8):
-                case X(Type.Kind.uint64,Type.Kind.uint8):
-                case X(Type.Kind.uint64,Type.Kind.int16):
-                case X(Type.Kind.uint64,Type.Kind.uint16):  e = el_una(OP64_32, TYint, e);
-                                        fty = Type.Kind.int32;
+                case X(Tuns64,Tint8):
+                case X(Tuns64,Tuns8):
+                case X(Tuns64,Tint16):
+                case X(Tuns64,Tuns16):  e = el_una(OP64_32, TYint, e);
+                                        fty = Tint32;
                                         goto Lagain;
-                case X(Type.Kind.uint64,Type.Kind.int32):
-                case X(Type.Kind.uint64,Type.Kind.uint32):  eop = OP64_32;  goto Leop;
-                case X(Type.Kind.uint64,Type.Kind.int64):  goto Lpaint;
-                case X(Type.Kind.uint64,Type.Kind.float32):
-                case X(Type.Kind.uint64,Type.Kind.float64):
-                case X(Type.Kind.uint64,Type.Kind.float80):
-                case X(Type.Kind.uint64,Type.Kind.complex32):
-                case X(Type.Kind.uint64,Type.Kind.complex64):
-                case X(Type.Kind.uint64,Type.Kind.complex80):
+                case X(Tuns64,Tint32):
+                case X(Tuns64,Tuns32):  eop = OP64_32;  goto Leop;
+                case X(Tuns64,Tint64):  goto Lpaint;
+                case X(Tuns64,Tfloat32):
+                case X(Tuns64,Tfloat64):
+                case X(Tuns64,Tfloat80):
+                case X(Tuns64,Tcomplex32):
+                case X(Tuns64,Tcomplex64):
+                case X(Tuns64,Tcomplex80):
                                          e = el_una(OPu64_d, TYdouble, e);
-                                         fty = Type.Kind.float64;
+                                         fty = Tfloat64;
                                          goto Lagain;
-                case X(Type.Kind.uint64,Type.Kind.imaginary32):
-                case X(Type.Kind.uint64,Type.Kind.imaginary64):
-                case X(Type.Kind.uint64,Type.Kind.imaginary80): goto Lzero;
+                case X(Tuns64,Timaginary32):
+                case X(Tuns64,Timaginary64):
+                case X(Tuns64,Timaginary80): goto Lzero;
 
                 /* ============================= */
 
-                case X(Type.Kind.float32,Type.Kind.int8):
-                case X(Type.Kind.float32,Type.Kind.uint8):
-                case X(Type.Kind.float32,Type.Kind.int16):
-                case X(Type.Kind.float32,Type.Kind.uint16):
-                case X(Type.Kind.float32,Type.Kind.int32):
-                case X(Type.Kind.float32,Type.Kind.uint32):
-                case X(Type.Kind.float32,Type.Kind.int64):
-                case X(Type.Kind.float32,Type.Kind.uint64):
-                case X(Type.Kind.float32,Type.Kind.float80): e = el_una(OPf_d, TYdouble, e);
-                                           fty = Type.Kind.float64;
+                case X(Tfloat32,Tint8):
+                case X(Tfloat32,Tuns8):
+                case X(Tfloat32,Tint16):
+                case X(Tfloat32,Tuns16):
+                case X(Tfloat32,Tint32):
+                case X(Tfloat32,Tuns32):
+                case X(Tfloat32,Tint64):
+                case X(Tfloat32,Tuns64):
+                case X(Tfloat32,Tfloat80): e = el_una(OPf_d, TYdouble, e);
+                                           fty = Tfloat64;
                                            goto Lagain;
-                case X(Type.Kind.float32,Type.Kind.float64): eop = OPf_d; goto Leop;
-                case X(Type.Kind.float32,Type.Kind.imaginary32):
-                case X(Type.Kind.float32,Type.Kind.imaginary64):
-                case X(Type.Kind.float32,Type.Kind.imaginary80): goto Lzero;
-                case X(Type.Kind.float32,Type.Kind.complex32):
-                case X(Type.Kind.float32,Type.Kind.complex64):
-                case X(Type.Kind.float32,Type.Kind.complex80):
+                case X(Tfloat32,Tfloat64): eop = OPf_d; goto Leop;
+                case X(Tfloat32,Timaginary32):
+                case X(Tfloat32,Timaginary64):
+                case X(Tfloat32,Timaginary80): goto Lzero;
+                case X(Tfloat32,Tcomplex32):
+                case X(Tfloat32,Tcomplex64):
+                case X(Tfloat32,Tcomplex80):
                     e = el_bin(OPadd,TYcfloat,el_long(TYifloat,0),e);
-                    fty = Type.Kind.complex32;
+                    fty = Tcomplex32;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Type.Kind.float64,Type.Kind.int8):
-                case X(Type.Kind.float64,Type.Kind.uint8):    e = el_una(OPd_s16, TYshort, e);
-                                           fty = Type.Kind.int16;
+                case X(Tfloat64,Tint8):
+                case X(Tfloat64,Tuns8):    e = el_una(OPd_s16, TYshort, e);
+                                           fty = Tint16;
                                            goto Lagain;
-                case X(Type.Kind.float64,Type.Kind.int16):   eop = OPd_s16; goto Leop;
-                case X(Type.Kind.float64,Type.Kind.uint16):   eop = OPd_u16; goto Leop;
-                case X(Type.Kind.float64,Type.Kind.int32):   eop = OPd_s32; goto Leop;
-                case X(Type.Kind.float64,Type.Kind.uint32):   eop = OPd_u32; goto Leop;
-                case X(Type.Kind.float64,Type.Kind.int64):   eop = OPd_s64; goto Leop;
-                case X(Type.Kind.float64,Type.Kind.uint64):   eop = OPd_u64; goto Leop;
-                case X(Type.Kind.float64,Type.Kind.float32): eop = OPd_f;   goto Leop;
-                case X(Type.Kind.float64,Type.Kind.float80): eop = OPd_ld;  goto Leop;
-                case X(Type.Kind.float64,Type.Kind.imaginary32):
-                case X(Type.Kind.float64,Type.Kind.imaginary64):
-                case X(Type.Kind.float64,Type.Kind.imaginary80):  goto Lzero;
-                case X(Type.Kind.float64,Type.Kind.complex32):
-                case X(Type.Kind.float64,Type.Kind.complex64):
-                case X(Type.Kind.float64,Type.Kind.complex80):
+                case X(Tfloat64,Tint16):   eop = OPd_s16; goto Leop;
+                case X(Tfloat64,Tuns16):   eop = OPd_u16; goto Leop;
+                case X(Tfloat64,Tint32):   eop = OPd_s32; goto Leop;
+                case X(Tfloat64,Tuns32):   eop = OPd_u32; goto Leop;
+                case X(Tfloat64,Tint64):   eop = OPd_s64; goto Leop;
+                case X(Tfloat64,Tuns64):   eop = OPd_u64; goto Leop;
+                case X(Tfloat64,Tfloat32): eop = OPd_f;   goto Leop;
+                case X(Tfloat64,Tfloat80): eop = OPd_ld;  goto Leop;
+                case X(Tfloat64,Timaginary32):
+                case X(Tfloat64,Timaginary64):
+                case X(Tfloat64,Timaginary80):  goto Lzero;
+                case X(Tfloat64,Tcomplex32):
+                case X(Tfloat64,Tcomplex64):
+                case X(Tfloat64,Tcomplex80):
                     e = el_bin(OPadd,TYcdouble,el_long(TYidouble,0),e);
-                    fty = Type.Kind.complex64;
+                    fty = Tcomplex64;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Type.Kind.float80,Type.Kind.int8):
-                case X(Type.Kind.float80,Type.Kind.uint8):
-                case X(Type.Kind.float80,Type.Kind.int16):
-                case X(Type.Kind.float80,Type.Kind.uint16):
-                case X(Type.Kind.float80,Type.Kind.int32):
-                case X(Type.Kind.float80,Type.Kind.uint32):
-                case X(Type.Kind.float80,Type.Kind.int64):
-                case X(Type.Kind.float80,Type.Kind.float32): e = el_una(OPld_d, TYdouble, e);
-                                           fty = Type.Kind.float64;
+                case X(Tfloat80,Tint8):
+                case X(Tfloat80,Tuns8):
+                case X(Tfloat80,Tint16):
+                case X(Tfloat80,Tuns16):
+                case X(Tfloat80,Tint32):
+                case X(Tfloat80,Tuns32):
+                case X(Tfloat80,Tint64):
+                case X(Tfloat80,Tfloat32): e = el_una(OPld_d, TYdouble, e);
+                                           fty = Tfloat64;
                                            goto Lagain;
-                case X(Type.Kind.float80,Type.Kind.uint64):
+                case X(Tfloat80,Tuns64):
                                            eop = OPld_u64; goto Leop;
-                case X(Type.Kind.float80,Type.Kind.float64): eop = OPld_d; goto Leop;
-                case X(Type.Kind.float80,Type.Kind.imaginary32):
-                case X(Type.Kind.float80,Type.Kind.imaginary64):
-                case X(Type.Kind.float80,Type.Kind.imaginary80): goto Lzero;
-                case X(Type.Kind.float80,Type.Kind.complex32):
-                case X(Type.Kind.float80,Type.Kind.complex64):
-                case X(Type.Kind.float80,Type.Kind.complex80):
+                case X(Tfloat80,Tfloat64): eop = OPld_d; goto Leop;
+                case X(Tfloat80,Timaginary32):
+                case X(Tfloat80,Timaginary64):
+                case X(Tfloat80,Timaginary80): goto Lzero;
+                case X(Tfloat80,Tcomplex32):
+                case X(Tfloat80,Tcomplex64):
+                case X(Tfloat80,Tcomplex80):
                     e = el_bin(OPadd,TYcldouble,e,el_long(TYildouble,0));
-                    fty = Type.Kind.complex80;
+                    fty = Tcomplex80;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Type.Kind.imaginary32,Type.Kind.int8):
-                case X(Type.Kind.imaginary32,Type.Kind.uint8):
-                case X(Type.Kind.imaginary32,Type.Kind.int16):
-                case X(Type.Kind.imaginary32,Type.Kind.uint16):
-                case X(Type.Kind.imaginary32,Type.Kind.int32):
-                case X(Type.Kind.imaginary32,Type.Kind.uint32):
-                case X(Type.Kind.imaginary32,Type.Kind.int64):
-                case X(Type.Kind.imaginary32,Type.Kind.uint64):
-                case X(Type.Kind.imaginary32,Type.Kind.float32):
-                case X(Type.Kind.imaginary32,Type.Kind.float64):
-                case X(Type.Kind.imaginary32,Type.Kind.float80):  goto Lzero;
-                case X(Type.Kind.imaginary32,Type.Kind.imaginary64): eop = OPf_d; goto Leop;
-                case X(Type.Kind.imaginary32,Type.Kind.imaginary80):
+                case X(Timaginary32,Tint8):
+                case X(Timaginary32,Tuns8):
+                case X(Timaginary32,Tint16):
+                case X(Timaginary32,Tuns16):
+                case X(Timaginary32,Tint32):
+                case X(Timaginary32,Tuns32):
+                case X(Timaginary32,Tint64):
+                case X(Timaginary32,Tuns64):
+                case X(Timaginary32,Tfloat32):
+                case X(Timaginary32,Tfloat64):
+                case X(Timaginary32,Tfloat80):  goto Lzero;
+                case X(Timaginary32,Timaginary64): eop = OPf_d; goto Leop;
+                case X(Timaginary32,Timaginary80):
                                            e = el_una(OPf_d, TYidouble, e);
-                                           fty = Type.Kind.imaginary64;
+                                           fty = Timaginary64;
                                            goto Lagain;
-                case X(Type.Kind.imaginary32,Type.Kind.complex32):
-                case X(Type.Kind.imaginary32,Type.Kind.complex64):
-                case X(Type.Kind.imaginary32,Type.Kind.complex80):
+                case X(Timaginary32,Tcomplex32):
+                case X(Timaginary32,Tcomplex64):
+                case X(Timaginary32,Tcomplex80):
                     e = el_bin(OPadd,TYcfloat,el_long(TYfloat,0),e);
-                    fty = Type.Kind.complex32;
+                    fty = Tcomplex32;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Type.Kind.imaginary64,Type.Kind.int8):
-                case X(Type.Kind.imaginary64,Type.Kind.uint8):
-                case X(Type.Kind.imaginary64,Type.Kind.int16):
-                case X(Type.Kind.imaginary64,Type.Kind.uint16):
-                case X(Type.Kind.imaginary64,Type.Kind.int32):
-                case X(Type.Kind.imaginary64,Type.Kind.uint32):
-                case X(Type.Kind.imaginary64,Type.Kind.int64):
-                case X(Type.Kind.imaginary64,Type.Kind.uint64):
-                case X(Type.Kind.imaginary64,Type.Kind.float32):
-                case X(Type.Kind.imaginary64,Type.Kind.float64):
-                case X(Type.Kind.imaginary64,Type.Kind.float80):  goto Lzero;
-                case X(Type.Kind.imaginary64,Type.Kind.imaginary32): eop = OPd_f;   goto Leop;
-                case X(Type.Kind.imaginary64,Type.Kind.imaginary80): eop = OPd_ld;  goto Leop;
-                case X(Type.Kind.imaginary64,Type.Kind.complex32):
-                case X(Type.Kind.imaginary64,Type.Kind.complex64):
-                case X(Type.Kind.imaginary64,Type.Kind.complex80):
+                case X(Timaginary64,Tint8):
+                case X(Timaginary64,Tuns8):
+                case X(Timaginary64,Tint16):
+                case X(Timaginary64,Tuns16):
+                case X(Timaginary64,Tint32):
+                case X(Timaginary64,Tuns32):
+                case X(Timaginary64,Tint64):
+                case X(Timaginary64,Tuns64):
+                case X(Timaginary64,Tfloat32):
+                case X(Timaginary64,Tfloat64):
+                case X(Timaginary64,Tfloat80):  goto Lzero;
+                case X(Timaginary64,Timaginary32): eop = OPd_f;   goto Leop;
+                case X(Timaginary64,Timaginary80): eop = OPd_ld;  goto Leop;
+                case X(Timaginary64,Tcomplex32):
+                case X(Timaginary64,Tcomplex64):
+                case X(Timaginary64,Tcomplex80):
                     e = el_bin(OPadd,TYcdouble,el_long(TYdouble,0),e);
-                    fty = Type.Kind.complex64;
+                    fty = Tcomplex64;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Type.Kind.imaginary80,Type.Kind.int8):
-                case X(Type.Kind.imaginary80,Type.Kind.uint8):
-                case X(Type.Kind.imaginary80,Type.Kind.int16):
-                case X(Type.Kind.imaginary80,Type.Kind.uint16):
-                case X(Type.Kind.imaginary80,Type.Kind.int32):
-                case X(Type.Kind.imaginary80,Type.Kind.uint32):
-                case X(Type.Kind.imaginary80,Type.Kind.int64):
-                case X(Type.Kind.imaginary80,Type.Kind.uint64):
-                case X(Type.Kind.imaginary80,Type.Kind.float32):
-                case X(Type.Kind.imaginary80,Type.Kind.float64):
-                case X(Type.Kind.imaginary80,Type.Kind.float80):  goto Lzero;
-                case X(Type.Kind.imaginary80,Type.Kind.imaginary32): e = el_una(OPld_d, TYidouble, e);
-                                           fty = Type.Kind.imaginary64;
+                case X(Timaginary80,Tint8):
+                case X(Timaginary80,Tuns8):
+                case X(Timaginary80,Tint16):
+                case X(Timaginary80,Tuns16):
+                case X(Timaginary80,Tint32):
+                case X(Timaginary80,Tuns32):
+                case X(Timaginary80,Tint64):
+                case X(Timaginary80,Tuns64):
+                case X(Timaginary80,Tfloat32):
+                case X(Timaginary80,Tfloat64):
+                case X(Timaginary80,Tfloat80):  goto Lzero;
+                case X(Timaginary80,Timaginary32): e = el_una(OPld_d, TYidouble, e);
+                                           fty = Timaginary64;
                                            goto Lagain;
-                case X(Type.Kind.imaginary80,Type.Kind.imaginary64): eop = OPld_d; goto Leop;
-                case X(Type.Kind.imaginary80,Type.Kind.complex32):
-                case X(Type.Kind.imaginary80,Type.Kind.complex64):
-                case X(Type.Kind.imaginary80,Type.Kind.complex80):
+                case X(Timaginary80,Timaginary64): eop = OPld_d; goto Leop;
+                case X(Timaginary80,Tcomplex32):
+                case X(Timaginary80,Tcomplex64):
+                case X(Timaginary80,Tcomplex80):
                     e = el_bin(OPadd,TYcldouble,el_long(TYldouble,0),e);
-                    fty = Type.Kind.complex80;
+                    fty = Tcomplex80;
                     goto Lagain;
 
                 /* ============================= */
 
-                case X(Type.Kind.complex32,Type.Kind.int8):
-                case X(Type.Kind.complex32,Type.Kind.uint8):
-                case X(Type.Kind.complex32,Type.Kind.int16):
-                case X(Type.Kind.complex32,Type.Kind.uint16):
-                case X(Type.Kind.complex32,Type.Kind.int32):
-                case X(Type.Kind.complex32,Type.Kind.uint32):
-                case X(Type.Kind.complex32,Type.Kind.int64):
-                case X(Type.Kind.complex32,Type.Kind.uint64):
-                case X(Type.Kind.complex32,Type.Kind.float32):
-                case X(Type.Kind.complex32,Type.Kind.float64):
-                case X(Type.Kind.complex32,Type.Kind.float80):
+                case X(Tcomplex32,Tint8):
+                case X(Tcomplex32,Tuns8):
+                case X(Tcomplex32,Tint16):
+                case X(Tcomplex32,Tuns16):
+                case X(Tcomplex32,Tint32):
+                case X(Tcomplex32,Tuns32):
+                case X(Tcomplex32,Tint64):
+                case X(Tcomplex32,Tuns64):
+                case X(Tcomplex32,Tfloat32):
+                case X(Tcomplex32,Tfloat64):
+                case X(Tcomplex32,Tfloat80):
                         e = el_una(OPc_r, TYfloat, e);
-                        fty = Type.Kind.float32;
+                        fty = Tfloat32;
                         goto Lagain;
-                case X(Type.Kind.complex32,Type.Kind.imaginary32):
-                case X(Type.Kind.complex32,Type.Kind.imaginary64):
-                case X(Type.Kind.complex32,Type.Kind.imaginary80):
+                case X(Tcomplex32,Timaginary32):
+                case X(Tcomplex32,Timaginary64):
+                case X(Tcomplex32,Timaginary80):
                         e = el_una(OPc_i, TYifloat, e);
-                        fty = Type.Kind.imaginary32;
+                        fty = Timaginary32;
                         goto Lagain;
-                case X(Type.Kind.complex32,Type.Kind.complex64):
-                case X(Type.Kind.complex32,Type.Kind.complex80):
+                case X(Tcomplex32,Tcomplex64):
+                case X(Tcomplex32,Tcomplex80):
                         e = el_una(OPf_d, TYcdouble, e);
-                        fty = Type.Kind.complex64;
+                        fty = Tcomplex64;
                         goto Lagain;
 
                 /* ============================= */
 
-                case X(Type.Kind.complex64,Type.Kind.int8):
-                case X(Type.Kind.complex64,Type.Kind.uint8):
-                case X(Type.Kind.complex64,Type.Kind.int16):
-                case X(Type.Kind.complex64,Type.Kind.uint16):
-                case X(Type.Kind.complex64,Type.Kind.int32):
-                case X(Type.Kind.complex64,Type.Kind.uint32):
-                case X(Type.Kind.complex64,Type.Kind.int64):
-                case X(Type.Kind.complex64,Type.Kind.uint64):
-                case X(Type.Kind.complex64,Type.Kind.float32):
-                case X(Type.Kind.complex64,Type.Kind.float64):
-                case X(Type.Kind.complex64,Type.Kind.float80):
+                case X(Tcomplex64,Tint8):
+                case X(Tcomplex64,Tuns8):
+                case X(Tcomplex64,Tint16):
+                case X(Tcomplex64,Tuns16):
+                case X(Tcomplex64,Tint32):
+                case X(Tcomplex64,Tuns32):
+                case X(Tcomplex64,Tint64):
+                case X(Tcomplex64,Tuns64):
+                case X(Tcomplex64,Tfloat32):
+                case X(Tcomplex64,Tfloat64):
+                case X(Tcomplex64,Tfloat80):
                         e = el_una(OPc_r, TYdouble, e);
-                        fty = Type.Kind.float64;
+                        fty = Tfloat64;
                         goto Lagain;
-                case X(Type.Kind.complex64,Type.Kind.imaginary32):
-                case X(Type.Kind.complex64,Type.Kind.imaginary64):
-                case X(Type.Kind.complex64,Type.Kind.imaginary80):
+                case X(Tcomplex64,Timaginary32):
+                case X(Tcomplex64,Timaginary64):
+                case X(Tcomplex64,Timaginary80):
                         e = el_una(OPc_i, TYidouble, e);
-                        fty = Type.Kind.imaginary64;
+                        fty = Timaginary64;
                         goto Lagain;
-                case X(Type.Kind.complex64,Type.Kind.complex32):   eop = OPd_f;   goto Leop;
-                case X(Type.Kind.complex64,Type.Kind.complex80):   eop = OPd_ld;  goto Leop;
+                case X(Tcomplex64,Tcomplex32):   eop = OPd_f;   goto Leop;
+                case X(Tcomplex64,Tcomplex80):   eop = OPd_ld;  goto Leop;
 
                 /* ============================= */
 
-                case X(Type.Kind.complex80,Type.Kind.int8):
-                case X(Type.Kind.complex80,Type.Kind.uint8):
-                case X(Type.Kind.complex80,Type.Kind.int16):
-                case X(Type.Kind.complex80,Type.Kind.uint16):
-                case X(Type.Kind.complex80,Type.Kind.int32):
-                case X(Type.Kind.complex80,Type.Kind.uint32):
-                case X(Type.Kind.complex80,Type.Kind.int64):
-                case X(Type.Kind.complex80,Type.Kind.uint64):
-                case X(Type.Kind.complex80,Type.Kind.float32):
-                case X(Type.Kind.complex80,Type.Kind.float64):
-                case X(Type.Kind.complex80,Type.Kind.float80):
+                case X(Tcomplex80,Tint8):
+                case X(Tcomplex80,Tuns8):
+                case X(Tcomplex80,Tint16):
+                case X(Tcomplex80,Tuns16):
+                case X(Tcomplex80,Tint32):
+                case X(Tcomplex80,Tuns32):
+                case X(Tcomplex80,Tint64):
+                case X(Tcomplex80,Tuns64):
+                case X(Tcomplex80,Tfloat32):
+                case X(Tcomplex80,Tfloat64):
+                case X(Tcomplex80,Tfloat80):
                         e = el_una(OPc_r, TYldouble, e);
-                        fty = Type.Kind.float80;
+                        fty = Tfloat80;
                         goto Lagain;
-                case X(Type.Kind.complex80,Type.Kind.imaginary32):
-                case X(Type.Kind.complex80,Type.Kind.imaginary64):
-                case X(Type.Kind.complex80,Type.Kind.imaginary80):
+                case X(Tcomplex80,Timaginary32):
+                case X(Tcomplex80,Timaginary64):
+                case X(Tcomplex80,Timaginary80):
                         e = el_una(OPc_i, TYildouble, e);
-                        fty = Type.Kind.imaginary80;
+                        fty = Timaginary80;
                         goto Lagain;
-                case X(Type.Kind.complex80,Type.Kind.complex32):
-                case X(Type.Kind.complex80,Type.Kind.complex64):
+                case X(Tcomplex80,Tcomplex32):
+                case X(Tcomplex80,Tcomplex64):
                         e = el_una(OPld_d, TYcdouble, e);
-                        fty = Type.Kind.complex64;
+                        fty = Tcomplex64;
                         goto Lagain;
 
                 /* ============================= */
@@ -4773,7 +4773,7 @@ elem *toElem(Expression e, IRState *irs)
         {
             //printf("SliceExp.toElem() se = %s %s\n", se.type.toChars(), se.toChars());
             Type tb = se.type.toBasetype();
-            assert(tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray);
+            assert(tb.ty == Tarray || tb.ty == Tsarray);
             Type t1 = se.e1.type.toBasetype();
             elem *e = toElem(se.e1, irs);
             if (se.lwr)
@@ -4781,7 +4781,7 @@ elem *toElem(Expression e, IRState *irs)
                 uint sz = cast(uint)t1.nextOf().size();
 
                 elem *einit = resolveLengthVar(se.lengthVar, &e, t1);
-                if (t1.ty == Type.Kind.staticArray)
+                if (t1.ty == Tsarray)
                     e = array_toPtr(se.e1.type, e);
                 if (!einit)
                 {
@@ -4789,8 +4789,8 @@ elem *toElem(Expression e, IRState *irs)
                     e = el_same(&einit);
                 }
                 // e is a temporary, typed:
-                //  TYdarray if t.ty == Type.Kind.array
-                //  TYptr if t.ty == Type.Kind.staticArray or Type.Kind.pointer
+                //  TYdarray if t.ty == Tarray
+                //  TYptr if t.ty == Tsarray or Tpointer
 
                 elem *elwr = toElem(se.lwr, irs);
                 elem *eupr = toElem(se.upr, irs);
@@ -4811,12 +4811,12 @@ elem *toElem(Expression e, IRState *irs)
                         eupr2.Ety = TYsize_t;  // make sure unsigned comparison
 
                         elem *elen;
-                        if (t1.ty == Type.Kind.staticArray)
+                        if (t1.ty == Tsarray)
                         {
                             TypeSArray tsa = cast(TypeSArray)t1;
                             elen = el_long(TYsize_t, tsa.dim.toInteger());
                         }
-                        else if (t1.ty == Type.Kind.array)
+                        else if (t1.ty == Tarray)
                         {
                             if (se.lengthVar && !(se.lengthVar.storage_class & STC.const_))
                                 elen = el_var(toSymbol(se.lengthVar));
@@ -4856,7 +4856,7 @@ elem *toElem(Expression e, IRState *irs)
                         elwr = el_combine(elwr, eb);
                     }
                 }
-                if (t1.ty != Type.Kind.staticArray)
+                if (t1.ty != Tsarray)
                     e = array_toPtr(se.e1.type, e);
 
                 // Create an array reference where:
@@ -4867,14 +4867,14 @@ elem *toElem(Expression e, IRState *irs)
                 elem *eofs = el_bin(OPmul, TYsize_t, elwr2, el_long(TYsize_t, sz));
                 elem *eptr = el_bin(OPadd, TYnptr, e, eofs);
 
-                if (tb.ty == Type.Kind.array)
+                if (tb.ty == Tarray)
                 {
                     elem *elen = el_bin(OPmin, TYsize_t, eupr2, el_copytree(elwr2));
                     e = el_pair(TYdarray, elen, eptr);
                 }
                 else
                 {
-                    assert(tb.ty == Type.Kind.staticArray);
+                    assert(tb.ty == Tsarray);
                     e = el_una(OPind, totym(se.type), eptr);
                     if (tybasic(e.Ety) == TYstruct)
                         e.ET = Type_toCtype(se.type);
@@ -4883,13 +4883,13 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_combine(einit, e);
                 //elem_print(e);
             }
-            else if (t1.ty == Type.Kind.staticArray && tb.ty == Type.Kind.array)
+            else if (t1.ty == Tsarray && tb.ty == Tarray)
             {
                 e = sarray_toDarray(se.loc, t1, null, e);
             }
             else
             {
-                assert(t1.ty == tb.ty);   // Type.Kind.array or Type.Kind.staticArray
+                assert(t1.ty == tb.ty);   // Tarray or Tsarray
 
                 // https://issues.dlang.org/show_bug.cgi?id=14672
                 // If se is in left side operand of element-wise
@@ -4910,7 +4910,7 @@ elem *toElem(Expression e, IRState *irs)
 
             //printf("IndexExp.toElem() %s\n", ie.toChars());
             Type t1 = ie.e1.type.toBasetype();
-            if (t1.ty == Type.Kind.associativeArray)
+            if (t1.ty == Taarray)
             {
                 // set to:
                 //      *aaGetY(aa, aati, valuesize, &key);
@@ -4970,7 +4970,7 @@ elem *toElem(Expression e, IRState *irs)
                 {
                     elem *elength;
 
-                    if (t1.ty == Type.Kind.staticArray)
+                    if (t1.ty == Tsarray)
                     {
                         TypeSArray tsa = cast(TypeSArray)t1;
                         dinteger_t length = tsa.dim.toInteger();
@@ -4978,7 +4978,7 @@ elem *toElem(Expression e, IRState *irs)
                         elength = el_long(TYsize_t, length);
                         goto L1;
                     }
-                    else if (t1.ty == Type.Kind.array)
+                    else if (t1.ty == Tarray)
                     {
                         elength = n1;
                         n1 = el_same(&elength);
@@ -5047,14 +5047,14 @@ elem *toElem(Expression e, IRState *irs)
 
             //printf("ArrayLiteralExp.toElem() %s, type = %s\n", ale.toChars(), ale.type.toChars());
             Type tb = ale.type.toBasetype();
-            if (tb.ty == Type.Kind.staticArray && tb.nextOf().toBasetype().ty == Type.Kind.void_)
+            if (tb.ty == Tsarray && tb.nextOf().toBasetype().ty == Tvoid)
             {
                 // Convert void[n] to ubyte[n]
                 tb = Type.tuns8.sarrayOf((cast(TypeSArray)tb).dim.toUInteger());
             }
 
             elem *e;
-            if (tb.ty == Type.Kind.staticArray && dim)
+            if (tb.ty == Tsarray && dim)
             {
                 Symbol *stmp = null;
                 e = ExpressionsToStaticArray(ale.loc, ale.elements, &stmp, 0, ale.basis);
@@ -5090,11 +5090,11 @@ elem *toElem(Expression e, IRState *irs)
                 e = el_long(TYsize_t, 0);
             }
 
-            if (tb.ty == Type.Kind.array)
+            if (tb.ty == Tarray)
             {
                 e = el_pair(TYdarray, el_long(TYsize_t, dim), e);
             }
-            else if (tb.ty == Type.Kind.pointer)
+            else if (tb.ty == Tpointer)
             {
             }
             else
@@ -5294,7 +5294,7 @@ elem *toElem(Expression e, IRState *irs)
                 if (!el)
                     el = basis;
                 if (el.op == TOK.arrayLiteral &&
-                    el.type.toBasetype().ty == Type.Kind.staticArray)
+                    el.type.toBasetype().ty == Tsarray)
                 {
                     ArrayLiteralExp ale = cast(ArrayLiteralExp)el;
                     if (ale.elements && ale.elements.dim)
@@ -5369,7 +5369,7 @@ elem *toElem(Expression e, IRState *irs)
                 // call _d_assocarrayliteralTX(TypeInfo_AssociativeArray ti, void[] keys, void[] values)
                 // Prefer this to avoid the varargs fiasco in 64 bit code
 
-                assert(t.ty == Type.Kind.associativeArray);
+                assert(t.ty == Taarray);
                 Type ta = t;
 
                 Symbol *skeys = null;
@@ -5404,7 +5404,7 @@ elem *toElem(Expression e, IRState *irs)
             else
             {
                 elem *e = el_long(TYnptr, 0);      // empty associative array is the null pointer
-                if (t.ty != Type.Kind.associativeArray)
+                if (t.ty != Taarray)
                     e = addressElem(e, Type.tvoidptr);
                 result = e;
                 return;
@@ -5627,7 +5627,7 @@ private elem *toElemStructLit(StructLiteralExp sle, IRState *irs, TOK op, Symbol
 
             Type t1b = v.type.toBasetype();
             Type t2b = el.type.toBasetype();
-            if (t1b.ty == Type.Kind.staticArray)
+            if (t1b.ty == Tsarray)
             {
                 if (t2b.implicitConvTo(t1b))
                 {

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -93,7 +93,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier par, Ex
         else if (v.storage_class & STC.variadic && p == sc.func)
         {
             Type tb = v.type.toBasetype();
-            if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+            if (tb.ty == Tarray || tb.ty == Tsarray)
             {
                 unsafeAssign(v, "variadic variable");
             }
@@ -210,7 +210,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
     else if (e1.op == TOK.index)
     {
         auto ie = cast(IndexExp)e1;
-        if (ie.e1.op == TOK.variable && ie.e1.type.toBasetype().ty == Type.Kind.staticArray)
+        if (ie.e1.op == TOK.variable && ie.e1.type.toBasetype().ty == Tsarray)
             va = (cast(VarExp)ie.e1).var.isVarDeclaration();
     }
 
@@ -230,7 +230,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
     // Try to infer 'scope' for va if in a function not marked @system
     bool inferScope = false;
-    if (va && sc.func && sc.func.type && sc.func.type.ty == Type.Kind.function_)
+    if (va && sc.func && sc.func.type && sc.func.type.ty == Tfunction)
         inferScope = (cast(TypeFunction)sc.func.type).trust != TRUST.system;
 
     bool result = false;
@@ -263,7 +263,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
             if (va &&
                 (va.enclosesLifetimeOf(v) && !(v.storage_class & (STC.parameter | STC.temp)) ||
                  // va is class reference
-                 ae.e1.op == TOK.dotVariable && va.type.toBasetype().ty == Type.Kind.class_ && (va.enclosesLifetimeOf(v) || !va.isScope) ||
+                 ae.e1.op == TOK.dotVariable && va.type.toBasetype().ty == Tclass && (va.enclosesLifetimeOf(v) || !va.isScope) ||
                  va.storage_class & STC.ref_ && !(v.storage_class & STC.temp)) &&
                 sc.func.setUnsafe())
             {
@@ -292,7 +292,7 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
         else if (v.storage_class & STC.variadic && p == sc.func)
         {
             Type tb = v.type.toBasetype();
-            if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+            if (tb.ty == Tarray || tb.ty == Tsarray)
             {
                 if (va && !va.isDataseg() && !va.doNotInferScope)
                 {
@@ -428,7 +428,7 @@ ByRef:
 
         /* Do not allow slicing of a static array returned by a function
          */
-        if (va && ee.op == TOK.call && ee.type.toBasetype().ty == Type.Kind.staticArray && va.type.toBasetype().ty == Type.Kind.array &&
+        if (va && ee.op == TOK.call && ee.type.toBasetype().ty == Tsarray && va.type.toBasetype().ty == Tarray &&
             !(va.storage_class & STC.temp))
         {
             if (!gag)
@@ -614,7 +614,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
         else if (v.storage_class & STC.variadic && p == sc.func)
         {
             Type tb = v.type.toBasetype();
-            if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+            if (tb.ty == Tarray || tb.ty == Tsarray)
             {
                 if (!gag)
                     error(e.loc, "returning `%s` escapes a reference to variadic parameter `%s`", e.toChars(), v.toChars());
@@ -698,7 +698,7 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                 }
                 // Don't need to be concerned if v's parent does not return a ref
                 FuncDeclaration fd = p.isFuncDeclaration();
-                if (fd && fd.type && fd.type.ty == Type.Kind.function_)
+                if (fd && fd.type && fd.type.ty == Tfunction)
                 {
                     TypeFunction tf = cast(TypeFunction)fd.type;
                     if (tf.isref)
@@ -746,7 +746,7 @@ private void inferReturn(FuncDeclaration fd, VarDeclaration v)
         /* v is the 'this' reference, so mark the function
          */
         fd.storage_class |= STC.return_;
-        if (tf.ty == Type.Kind.function_)
+        if (tf.ty == Tfunction)
         {
             //printf("'this' too %p %s\n", tf, sc.func.toChars());
             tf.isreturn = true;
@@ -755,7 +755,7 @@ private void inferReturn(FuncDeclaration fd, VarDeclaration v)
     else
     {
         // Perform 'return' inference on parameter
-        if (tf.ty == Type.Kind.function_ && tf.parameters)
+        if (tf.ty == Tfunction && tf.parameters)
         {
             const dim = Parameter.dim(tf.parameters);
             foreach (const i; 0 .. dim)
@@ -835,14 +835,14 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(DotVarExp e)
         {
             auto t = e.e1.type.toBasetype();
-            if (t.ty == Type.Kind.struct_)
+            if (t.ty == Tstruct)
                 e.e1.accept(this);
         }
 
         override void visit(DelegateExp e)
         {
             Type t = e.e1.type.toBasetype();
-            if (t.ty == Type.Kind.class_ || t.ty == Type.Kind.pointer)
+            if (t.ty == Tclass || t.ty == Tpointer)
                 escapeByValue(e.e1, er);
             else
                 escapeByRef(e.e1, er);
@@ -863,7 +863,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(ArrayLiteralExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty == Type.Kind.staticArray || tb.ty == Type.Kind.array)
+            if (tb.ty == Tsarray || tb.ty == Tarray)
             {
                 if (e.basis)
                     e.basis.accept(this);
@@ -890,7 +890,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(NewExp e)
         {
             Type tb = e.newtype.toBasetype();
-            if (tb.ty == Type.Kind.struct_ && !e.member && e.arguments)
+            if (tb.ty == Tstruct && !e.member && e.arguments)
             {
                 foreach (ex; *e.arguments)
                 {
@@ -903,7 +903,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(CastExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty == Type.Kind.array && e.e1.type.toBasetype().ty == Type.Kind.staticArray)
+            if (tb.ty == Tarray && e.e1.type.toBasetype().ty == Tsarray)
             {
                 escapeByRef(e.e1, er);
             }
@@ -919,7 +919,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
                 Type tb = e.type.toBasetype();
                 if (v)
                 {
-                    if (tb.ty == Type.Kind.staticArray)
+                    if (tb.ty == Tsarray)
                         return;
                     if (v.storage_class & STC.variadic)
                     {
@@ -929,10 +929,10 @@ private void escapeByValue(Expression e, EscapeByResults* er)
                 }
             }
             Type t1b = e.e1.type.toBasetype();
-            if (t1b.ty == Type.Kind.staticArray)
+            if (t1b.ty == Tsarray)
             {
                 Type tb = e.type.toBasetype();
-                if (tb.ty != Type.Kind.staticArray)
+                if (tb.ty != Tsarray)
                     escapeByRef(e.e1, er);
             }
             else
@@ -950,7 +950,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
         override void visit(BinExp e)
         {
             Type tb = e.type.toBasetype();
-            if (tb.ty == Type.Kind.pointer)
+            if (tb.ty == Tpointer)
             {
                 e.e1.accept(this);
                 e.e2.accept(this);
@@ -987,12 +987,12 @@ private void escapeByValue(Expression e, EscapeByResults* er)
             Type t1 = e.e1.type.toBasetype();
             TypeFunction tf;
             TypeDelegate dg;
-            if (t1.ty == Type.Kind.delegate_)
+            if (t1.ty == Tdelegate)
             {
                 dg = cast(TypeDelegate)t1;
                 tf = cast(TypeFunction)(cast(TypeDelegate)t1).next;
             }
-            else if (t1.ty == Type.Kind.function_)
+            else if (t1.ty == Tfunction)
                 tf = cast(TypeFunction)t1;
             else
                 return;
@@ -1019,7 +1019,7 @@ private void escapeByValue(Expression e, EscapeByResults* er)
                 }
             }
             // If 'this' is returned, check it too
-            if (e.e1.op == TOK.dotVariable && t1.ty == Type.Kind.function_)
+            if (e.e1.op == TOK.dotVariable && t1.ty == Tfunction)
             {
                 DotVarExp dve = cast(DotVarExp)e.e1;
                 FuncDeclaration fd = dve.var.isFuncDeclaration();
@@ -1131,7 +1131,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
             if (e.e1.op == TOK.variable)
             {
                 VarDeclaration v = (cast(VarExp)e.e1).var.isVarDeclaration();
-                if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+                if (tb.ty == Tarray || tb.ty == Tsarray)
                 {
                     if (v && v.storage_class & STC.variadic)
                     {
@@ -1140,11 +1140,11 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                     }
                 }
             }
-            if (tb.ty == Type.Kind.staticArray)
+            if (tb.ty == Tsarray)
             {
                 e.e1.accept(this);
             }
-            else if (tb.ty == Type.Kind.array)
+            else if (tb.ty == Tarray)
             {
                 escapeByValue(e.e1, er);
             }
@@ -1153,7 +1153,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
         override void visit(DotVarExp e)
         {
             Type t1b = e.e1.type.toBasetype();
-            if (t1b.ty == Type.Kind.class_)
+            if (t1b.ty == Tclass)
                 escapeByValue(e.e1, er);
             else
                 e.e1.accept(this);
@@ -1187,9 +1187,9 @@ private void escapeByRef(Expression e, EscapeByResults* er)
              */
             Type t1 = e.e1.type.toBasetype();
             TypeFunction tf;
-            if (t1.ty == Type.Kind.delegate_)
+            if (t1.ty == Tdelegate)
                 tf = cast(TypeFunction)(cast(TypeDelegate)t1).next;
-            else if (t1.ty == Type.Kind.function_)
+            else if (t1.ty == Tfunction)
                 tf = cast(TypeFunction)t1;
             else
                 return;
@@ -1226,7 +1226,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                     }
                 }
                 // If 'this' is returned by ref, check it too
-                if (e.e1.op == TOK.dotVariable && t1.ty == Type.Kind.function_)
+                if (e.e1.op == TOK.dotVariable && t1.ty == Tfunction)
                 {
                     DotVarExp dve = cast(DotVarExp)e.e1;
                     if (dve.var.storage_class & STC.return_ || tf.isreturn)
@@ -1238,7 +1238,7 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                     }
                 }
                 // If it's a delegate, check it too
-                if (e.e1.op == TOK.variable && t1.ty == Type.Kind.delegate_)
+                if (e.e1.op == TOK.variable && t1.ty == Tdelegate)
                 {
                     escapeByValue(e.e1, er);
                 }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -121,7 +121,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                     if (f.errors)
                         return new ErrorExp();
                     fd = f;
-                    assert(fd.type.ty == Type.Kind.function_);
+                    assert(fd.type.ty == Tfunction);
                 }
             }
             if (fd)
@@ -139,7 +139,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
                     if (f.errors)
                         return new ErrorExp();
                     fd = f;
-                    assert(fd.type.ty == Type.Kind.function_);
+                    assert(fd.type.ty == Tfunction);
                     TypeFunction tf = cast(TypeFunction)fd.type;
                     if (!tf.isref && e2)
                         goto Leproplvalue;
@@ -202,7 +202,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         tthis = null;
         goto Lfd;
     }
-    else if (e1.op == TOK.dotVariable && e1.type && e1.type.toBasetype().ty == Type.Kind.function_)
+    else if (e1.op == TOK.dotVariable && e1.type && e1.type.toBasetype().ty == Tfunction)
     {
         DotVarExp dve = cast(DotVarExp)e1;
         s = dve.var.isFuncDeclaration();
@@ -210,7 +210,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         tthis = dve.e1.type;
         goto Lfd;
     }
-    else if (e1.op == TOK.variable && e1.type && e1.type.toBasetype().ty == Type.Kind.function_)
+    else if (e1.op == TOK.variable && e1.type && e1.type.toBasetype().ty == Tfunction)
     {
         s = (cast(VarExp)e1).var.isFuncDeclaration();
         tiargs = null;
@@ -232,7 +232,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             {
                 if (fd.errors)
                     return new ErrorExp();
-                assert(fd.type.ty == Type.Kind.function_);
+                assert(fd.type.ty == Tfunction);
                 Expression e = new CallExp(loc, e1, e2);
                 return e.expressionSemantic(sc);
             }
@@ -243,7 +243,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
             {
                 if (fd.errors)
                     return new ErrorExp();
-                assert(fd.type.ty == Type.Kind.function_);
+                assert(fd.type.ty == Tfunction);
                 TypeFunction tf = cast(TypeFunction)fd.type;
                 if (!e2 || tf.isref)
                 {
@@ -257,7 +257,7 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
         if (FuncDeclaration fd = s.isFuncDeclaration())
         {
             // Keep better diagnostic message for invalid property usage of functions
-            assert(fd.type.ty == Type.Kind.function_);
+            assert(fd.type.ty == Tfunction);
             Expression e = new CallExp(loc, e1, e2);
             return e.expressionSemantic(sc);
         }
@@ -375,7 +375,7 @@ private bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type* pt)
             t0 = Type.terror;
             continue;
         }
-        if (e.type.ty == Type.Kind.void_)
+        if (e.type.ty == Tvoid)
         {
             // void expressions do not concur to the determination of the common
             // type.
@@ -416,7 +416,7 @@ private bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type* pt)
 
     if (!t0)
         t0 = Type.tvoid; // [] is typed as void[]
-    else if (t0.ty != Type.Kind.error)
+    else if (t0.ty != Terror)
     {
         for (size_t i = 0; i < exps.dim; i++)
         {
@@ -489,7 +489,7 @@ private bool preFunctionParameters(Loc loc, Scope* sc, Expressions* exps)
 private bool checkDefCtor(Loc loc, Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Type.Kind.struct_)
+    if (t.ty == Tstruct)
     {
         StructDeclaration sd = (cast(TypeStruct)t).sym;
         if (sd.noDefaultCtor)
@@ -626,8 +626,8 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 Type tret = p.isLazyArray();
                 switch (tb.ty)
                 {
-                case Type.Kind.staticArray:
-                case Type.Kind.array:
+                case Tsarray:
+                case Tarray:
                     {
                         /* Create a static array variable v of type arg.type:
                          *  T[dim] __arrayArg = [ arguments[i], ..., arguments[nargs-1] ];
@@ -658,17 +658,17 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                         // Convert to a static array literal, or its slice.
                         arg = new ArrayLiteralExp(loc, elements);
                         arg.type = tsa;
-                        if (tb.ty == Type.Kind.array)
+                        if (tb.ty == Tarray)
                         {
                             arg = new SliceExp(loc, arg, null, null);
                             arg.type = p.type;
                         }
                         break;
                     }
-                case Type.Kind.class_:
+                case Tclass:
                     {
                         /* Set arg to be:
-                         *      new Type.Kind.class_(arg0, arg1, ..., argn)
+                         *      new Tclass(arg0, arg1, ..., argn)
                          */
                         auto args = new Expressions();
                         args.setDim(nargs - i);
@@ -694,7 +694,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
             }
 
         L1:
-            if (!(p.storageClass & STC.lazy_ && p.type.ty == Type.Kind.void_))
+            if (!(p.storageClass & STC.lazy_ && p.type.ty == Tvoid))
             {
                 bool isRef = (p.storageClass & (STC.ref_ | STC.out_)) != 0;
                 if (ubyte wm = arg.type.deduceWild(p.type, isRef))
@@ -763,7 +763,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
         if (i < nparams)
         {
             Parameter p = Parameter.getNth(tf.parameters, i);
-            if (!(p.storageClass & STC.lazy_ && p.type.ty == Type.Kind.void_))
+            if (!(p.storageClass & STC.lazy_ && p.type.ty == Tvoid))
             {
                 Type tprm = p.type;
                 if (p.type.hasWild())
@@ -801,7 +801,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
             else if (p.storageClass & STC.lazy_)
             {
                 // Convert lazy argument to a delegate
-                if (p.type.ty == Type.Kind.void_)
+                if (p.type.ty == Tvoid)
                     arg = toDelegate(arg, p.type, sc);
                 else
                     arg = toDelegate(arg, arg.type, sc);
@@ -865,11 +865,11 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 // Promote floats to doubles
                 switch (arg.type.ty)
                 {
-                case Type.Kind.float32:
+                case Tfloat32:
                     arg = arg.castTo(sc, Type.tfloat64);
                     break;
 
-                case Type.Kind.imaginary32:
+                case Timaginary32:
                     arg = arg.castTo(sc, Type.timaginary64);
                     break;
 
@@ -879,12 +879,12 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 if (tf.varargs == 1)
                 {
                     const(char)* p = tf.linkage == LINK.c ? "extern(C)" : "extern(C++)";
-                    if (arg.type.ty == Type.Kind.array)
+                    if (arg.type.ty == Tarray)
                     {
                         arg.error("cannot pass dynamic arrays to `%s` vararg functions", p);
                         err = true;
                     }
-                    if (arg.type.ty == Type.Kind.staticArray)
+                    if (arg.type.ty == Tsarray)
                     {
                         arg.error("cannot pass static arrays to `%s` vararg functions", p);
                         err = true;
@@ -902,7 +902,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
             // Convert static arrays to dynamic arrays
             // BUG: I don't think this is right for D2
             Type tb = arg.type.toBasetype();
-            if (tb.ty == Type.Kind.staticArray)
+            if (tb.ty == Tsarray)
             {
                 TypeSArray ts = cast(TypeSArray)tb;
                 Type ta = ts.next.arrayOf();
@@ -911,7 +911,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 else
                     arg = arg.castTo(sc, ta);
             }
-            if (tb.ty == Type.Kind.struct_)
+            if (tb.ty == Tstruct)
             {
                 //arg = callCpCtor(sc, arg);
             }
@@ -1078,7 +1078,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                  * (or static arrays of them) if appropriate.
                  */
                 Type tv = arg.type.baseElemOf();
-                if (!isRef && tv.ty == Type.Kind.struct_)
+                if (!isRef && tv.ty == Tstruct)
                     arg = doCopyOrMove(sc, arg);
             }
 
@@ -1198,7 +1198,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     override void visit(IntegerExp e)
     {
         assert(e.type);
-        if (e.type.ty == Type.Kind.error)
+        if (e.type.ty == Terror)
             return setError();
 
         assert(e.type.deco);
@@ -1721,7 +1721,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         /* Disallow array literals of type void being used.
          */
-        if (e.elements.dim > 0 && t0.ty == Type.Kind.void_)
+        if (e.elements.dim > 0 && t0.ty == Tvoid)
         {
             e.error("`%s` of type `%s` has no value", e.toChars(), e.type.toChars());
             return setError();
@@ -1824,7 +1824,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(TypeExp exp)
     {
-        if (exp.type.ty == Type.Kind.error)
+        if (exp.type.ty == Terror)
             return setError();
 
         //printf("TypeExp::semantic(%s)\n", type.toChars());
@@ -2022,7 +2022,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // T should be analyzed first and edim should go into arguments iff it's
         // not a tuple.
         Expression edim = null;
-        if (!exp.arguments && exp.newtype.ty == Type.Kind.staticArray)
+        if (!exp.arguments && exp.newtype.ty == Tsarray)
         {
             edim = (cast(TypeSArray)exp.newtype).dim;
             exp.newtype = (cast(TypeNext)exp.newtype).next;
@@ -2050,17 +2050,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             exp.type = exp.newtype.typeSemantic(exp.loc, sc);
         }
-        if (exp.type.ty == Type.Kind.error)
+        if (exp.type.ty == Terror)
             return setError();
 
         if (edim)
         {
-            if (exp.type.toBasetype().ty == Type.Kind.tuple)
+            if (exp.type.toBasetype().ty == Ttuple)
             {
                 // --> new T[edim]
                 exp.type = new TypeSArray(exp.type, edim);
                 exp.type = exp.type.typeSemantic(exp.loc, sc);
-                if (exp.type.ty == Type.Kind.error)
+                if (exp.type.ty == Terror)
                     return setError();
             }
             else
@@ -2087,7 +2087,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        if (exp.thisexp && tb.ty != Type.Kind.class_)
+        if (exp.thisexp && tb.ty != Tclass)
         {
             exp.error("`.new` is only for allocating nested classes, not `%s`", tb.toChars());
             return setError();
@@ -2096,7 +2096,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         size_t nargs = exp.arguments ? exp.arguments.dim : 0;
         Expression newprefix = null;
 
-        if (tb.ty == Type.Kind.class_)
+        if (tb.ty == Tclass)
         {
             auto cd = (cast(TypeClass)tb).sym;
             cd.size(exp.loc);
@@ -2265,7 +2265,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
-        else if (tb.ty == Type.Kind.struct_)
+        else if (tb.ty == Tstruct)
         {
             auto sd = (cast(TypeStruct)tb).sym;
             sd.size(exp.loc);
@@ -2361,7 +2361,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             exp.type = exp.type.pointerTo();
         }
-        else if (tb.ty == Type.Kind.array && nargs)
+        else if (tb.ty == Tarray && nargs)
         {
             Type tn = tb.nextOf().baseElemOf();
             Dsymbol s = tn.toDsymbol(sc);
@@ -2373,7 +2373,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             for (size_t i = 0; i < nargs; i++)
             {
-                if (tb.ty != Type.Kind.array)
+                if (tb.ty != Tarray)
                 {
                     exp.error("too many arguments for array");
                     return setError();
@@ -2566,7 +2566,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.fd.treq && !exp.fd.type.nextOf())
         {
             TypeFunction tfv = null;
-            if (exp.fd.treq.ty == Type.Kind.delegate_ || (exp.fd.treq.ty == Type.Kind.pointer && exp.fd.treq.nextOf().ty == Type.Kind.function_))
+            if (exp.fd.treq.ty == Tdelegate || (exp.fd.treq.ty == Tpointer && exp.fd.treq.nextOf().ty == Tfunction))
                 tfv = cast(TypeFunction)exp.fd.treq.nextOf();
             if (tfv)
             {
@@ -2603,14 +2603,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (olderrors != global.errors)
         {
-            if (exp.fd.type && exp.fd.type.ty == Type.Kind.function_ && !exp.fd.type.nextOf())
+            if (exp.fd.type && exp.fd.type.ty == Tfunction && !exp.fd.type.nextOf())
                 (cast(TypeFunction)exp.fd.type).next = Type.terror;
             e = new ErrorExp();
             goto Ldone;
         }
 
         // Type is a "delegate to" or "pointer to" the function literal
-        if ((exp.fd.isNested() && exp.fd.tok == TOK.delegate_) || (exp.tok == TOK.reserved && exp.fd.treq && exp.fd.treq.ty == Type.Kind.delegate_))
+        if ((exp.fd.isNested() && exp.fd.tok == TOK.delegate_) || (exp.tok == TOK.reserved && exp.fd.treq && exp.fd.treq.ty == Tdelegate))
         {
             exp.type = new TypeDelegate(exp.fd.type);
             exp.type = exp.type.typeSemantic(exp.loc, sc);
@@ -2631,7 +2631,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 *
                 * So, should keep fd.tok == TOKreserve if fd.treq == NULL.
                 */
-            if (exp.fd.treq && exp.fd.treq.ty == Type.Kind.pointer)
+            if (exp.fd.treq && exp.fd.treq.ty == Tpointer)
             {
                 // change to non-nested
                 exp.fd.tok = TOK.function_;
@@ -2683,7 +2683,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     for (size_t u = 0; u < dim; u++)
                     {
                         Parameter p = Parameter.getNth(tfl.parameters, u);
-                        if (p.type.ty == Type.Kind.identifier && (cast(TypeIdentifier)p.type).ident == tp.ident)
+                        if (p.type.ty == Tident && (cast(TypeIdentifier)p.type).ident == tp.ident)
                         {
                             Expression e = (*arguments)[u];
                             tiargs.push(e.type);
@@ -2933,7 +2933,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.e1 = de.e2;
                 }
             }
-            else if (exp.e1.op == TOK.star && exp.e1.type.ty == Type.Kind.function_)
+            else if (exp.e1.op == TOK.star && exp.e1.type.ty == Tfunction)
             {
                 // Rewrite (*fp)(arguments) to fp(arguments)
                 exp.e1 = (cast(PtrExp)exp.e1).e1;
@@ -2953,7 +2953,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // Check for call operator overload
         if (t1)
         {
-            if (t1.ty == Type.Kind.struct_)
+            if (t1.ty == Tstruct)
             {
                 auto sd = (cast(TypeStruct)t1).sym;
                 sd.size(exp.loc); // Resolve forward references to construct object
@@ -3028,7 +3028,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 result = e;
                 return;
             }
-            else if (t1.ty == Type.Kind.class_)
+            else if (t1.ty == Tclass)
             {
             L1:
                 // Rewrite as e1.call(arguments)
@@ -3045,7 +3045,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // Make sure to use the the enum type itself rather than its
                 // base type
                 // https://issues.dlang.org/show_bug.cgi?id=16346
-                if (exp.e1.type.ty == Type.Kind.enum_)
+                if (exp.e1.type.ty == Tenum)
                 {
                     t1 = exp.e1.type;
                 }
@@ -3101,7 +3101,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return f;
         }
 
-        if (exp.e1.op == TOK.dotVariable && t1.ty == Type.Kind.function_ || exp.e1.op == TOK.dotTemplateDeclaration)
+        if (exp.e1.op == TOK.dotVariable && t1.ty == Tfunction || exp.e1.op == TOK.dotTemplateDeclaration)
         {
             UnaExp ue = cast(UnaExp)exp.e1;
 
@@ -3133,7 +3133,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // Do overload resolution
             exp.f = resolveFuncCall(exp.loc, sc, s, tiargs, ue1 ? ue1.type : null, exp.arguments);
-            if (!exp.f || exp.f.errors || exp.f.type.ty == Type.Kind.error)
+            if (!exp.f || exp.f.errors || exp.f.type.ty == Terror)
                 return setError();
 
             if (exp.f.interfaceVirtual)
@@ -3161,7 +3161,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
                 ethis = ue.e1;
                 tthis = ue.e1.type;
-                if (!(exp.f.type.ty == Type.Kind.function_ && (cast(TypeFunction)exp.f.type).isscope))
+                if (!(exp.f.type.ty == Tfunction && (cast(TypeFunction)exp.f.type).isscope))
                 {
                     if (global.params.vsafe && checkParamArgumentEscape(sc, exp.f, Id.This, ethis, false))
                         return setError();
@@ -3233,7 +3233,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             // If we've got a pointer to a function then deference it
             // https://issues.dlang.org/show_bug.cgi?id=16483
-            if (exp.e1.type.ty == Type.Kind.pointer && exp.e1.type.nextOf().ty == Type.Kind.function_)
+            if (exp.e1.type.ty == Tpointer && exp.e1.type.nextOf().ty == Tfunction)
             {
                 Expression e = new PtrExp(exp.loc, exp.e1);
                 e.type = exp.e1.type.nextOf();
@@ -3346,11 +3346,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("function expected before `()`, not `%s`", exp.e1.toChars());
             return setError();
         }
-        else if (t1.ty == Type.Kind.error)
+        else if (t1.ty == Terror)
         {
             return setError();
         }
-        else if (t1.ty != Type.Kind.function_)
+        else if (t1.ty != Tfunction)
         {
             TypeFunction tf;
             const(char)* p;
@@ -3364,14 +3364,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tf = cast(TypeFunction)exp.f.type;
                 p = "function literal";
             }
-            else if (t1.ty == Type.Kind.delegate_)
+            else if (t1.ty == Tdelegate)
             {
                 TypeDelegate td = cast(TypeDelegate)t1;
-                assert(td.next.ty == Type.Kind.function_);
+                assert(td.next.ty == Tfunction);
                 tf = cast(TypeFunction)td.next;
                 p = "delegate";
             }
-            else if (t1.ty == Type.Kind.pointer && (cast(TypePointer)t1).next.ty == Type.Kind.function_)
+            else if (t1.ty == Tpointer && (cast(TypePointer)t1).next.ty == Tfunction)
             {
                 tf = cast(TypeFunction)(cast(TypePointer)t1).next;
                 p = "function pointer";
@@ -3477,7 +3477,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
             }
 
-            if (t1.ty == Type.Kind.pointer)
+            if (t1.ty == Tpointer)
             {
                 Expression e = new PtrExp(exp.loc, exp.e1);
                 e.type = tf;
@@ -3553,7 +3553,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             t1 = exp.f.type;
         }
-        assert(t1.ty == Type.Kind.function_);
+        assert(t1.ty == Tfunction);
 
         Expression argprefix;
         if (!exp.arguments)
@@ -3742,7 +3742,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             ta.checkComplexTransition(exp.loc, sc);
 
         Expression e;
-        if (ea && ta.toBasetype().ty == Type.Kind.class_)
+        if (ea && ta.toBasetype().ty == Tclass)
         {
             /* Get the dynamic type, which is .classinfo
              */
@@ -3750,7 +3750,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             e = new TypeidExp(ea.loc, ea);
             e.type = Type.typeinfoclass.type;
         }
-        else if (ta.ty == Type.Kind.error)
+        else if (ta.ty == Terror)
         {
             e = new ErrorExp();
         }
@@ -3816,7 +3816,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             switch (e.tok2)
             {
             case TOK.struct_:
-                if (e.targ.ty != Type.Kind.struct_)
+                if (e.targ.ty != Tstruct)
                     goto Lno;
                 if ((cast(TypeStruct)e.targ).sym.isUnionDeclaration())
                     goto Lno;
@@ -3824,7 +3824,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOK.union_:
-                if (e.targ.ty != Type.Kind.struct_)
+                if (e.targ.ty != Tstruct)
                     goto Lno;
                 if (!(cast(TypeStruct)e.targ).sym.isUnionDeclaration())
                     goto Lno;
@@ -3832,7 +3832,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOK.class_:
-                if (e.targ.ty != Type.Kind.class_)
+                if (e.targ.ty != Tclass)
                     goto Lno;
                 if ((cast(TypeClass)e.targ).sym.isInterfaceDeclaration())
                     goto Lno;
@@ -3840,7 +3840,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOK.interface_:
-                if (e.targ.ty != Type.Kind.class_)
+                if (e.targ.ty != Tclass)
                     goto Lno;
                 if (!(cast(TypeClass)e.targ).sym.isInterfaceDeclaration())
                     goto Lno;
@@ -3873,7 +3873,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             case TOK.super_:
                 // If class or interface, get the base class and interfaces
-                if (e.targ.ty != Type.Kind.class_)
+                if (e.targ.ty != Tclass)
                     goto Lno;
                 else
                 {
@@ -3892,19 +3892,19 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOK.enum_:
-                if (e.targ.ty != Type.Kind.enum_)
+                if (e.targ.ty != Tenum)
                     goto Lno;
                 if (e.id)
                     tded = (cast(TypeEnum)e.targ).sym.getMemtype(e.loc);
                 else
                     tded = e.targ;
 
-                if (tded.ty == Type.Kind.error)
+                if (tded.ty == Terror)
                     return setError();
                 break;
 
             case TOK.delegate_:
-                if (e.targ.ty != Type.Kind.delegate_)
+                if (e.targ.ty != Tdelegate)
                     goto Lno;
                 tded = (cast(TypeDelegate)e.targ).next; // the underlying function type
                 break;
@@ -3912,13 +3912,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             case TOK.function_:
             case TOK.parameters:
                 {
-                    if (e.targ.ty != Type.Kind.function_)
+                    if (e.targ.ty != Tfunction)
                         goto Lno;
                     tded = e.targ;
 
                     /* Generate tuple from function parameter types.
                      */
-                    assert(tded.ty == Type.Kind.function_);
+                    assert(tded.ty == Tfunction);
                     Parameters* params = (cast(TypeFunction)tded).parameters;
                     size_t dim = Parameter.dim(params);
                     auto args = new Parameters();
@@ -3941,14 +3941,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* Get the 'return type' for the function,
                  * delegate, or pointer to function.
                  */
-                if (e.targ.ty == Type.Kind.function_)
+                if (e.targ.ty == Tfunction)
                     tded = (cast(TypeFunction)e.targ).next;
-                else if (e.targ.ty == Type.Kind.delegate_)
+                else if (e.targ.ty == Tdelegate)
                 {
                     tded = (cast(TypeDelegate)e.targ).next;
                     tded = (cast(TypeFunction)tded).next;
                 }
-                else if (e.targ.ty == Type.Kind.pointer && (cast(TypePointer)e.targ).next.ty == Type.Kind.function_)
+                else if (e.targ.ty == Tpointer && (cast(TypePointer)e.targ).next.ty == Tfunction)
                 {
                     tded = (cast(TypePointer)e.targ).next;
                     tded = (cast(TypeFunction)tded).next;
@@ -3970,7 +3970,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
 
             case TOK.vector:
-                if (e.targ.ty != Type.Kind.vector)
+                if (e.targ.ty != Tvector)
                     goto Lno;
                 tded = (cast(TypeVector)e.targ).basetype;
                 break;
@@ -4121,7 +4121,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e;
             return;
         }
-        if (exp.e1.op == TOK.slice || exp.e1.type.ty == Type.Kind.array || exp.e1.type.ty == Type.Kind.staticArray)
+        if (exp.e1.op == TOK.slice || exp.e1.type.ty == Tarray || exp.e1.type.ty == Tsarray)
         {
             if (checkNonAssignmentArrayOp(exp.e1))
                 return setError();
@@ -4156,12 +4156,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         int bitwise = (exp.op == TOK.andAssign || exp.op == TOK.orAssign || exp.op == TOK.xorAssign);
         int shift = (exp.op == TOK.leftShiftAssign || exp.op == TOK.rightShiftAssign || exp.op == TOK.unsignedRightShiftAssign);
 
-        if (bitwise && exp.type.toBasetype().ty == Type.Kind.bool_)
+        if (bitwise && exp.type.toBasetype().ty == Tbool)
             exp.e2 = exp.e2.implicitCastTo(sc, exp.type);
         else if (exp.checkNoBool())
             return setError();
 
-        if ((exp.op == TOK.addAssign || exp.op == TOK.minAssign) && exp.e1.type.toBasetype().ty == Type.Kind.pointer && exp.e2.type.toBasetype().isintegral())
+        if ((exp.op == TOK.addAssign || exp.op == TOK.minAssign) && exp.e1.type.toBasetype().ty == Tpointer && exp.e2.type.toBasetype().isintegral())
         {
             result = scaleFactor(exp, sc);
             return;
@@ -4180,7 +4180,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (shift)
         {
-            if (exp.e2.type.toBasetype().ty != Type.Kind.vector)
+            if (exp.e2.type.toBasetype().ty != Tvector)
                 exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
         }
 
@@ -4520,7 +4520,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             assert(exp.type);
 
-            if (t1.ty == Type.Kind.pointer)
+            if (t1.ty == Tpointer)
                 t1 = t1.nextOf();
 
             exp.type = exp.type.addMod(t1.mod);
@@ -4600,7 +4600,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         AggregateDeclaration ad = f.toParent().isAggregateDeclaration();
         if (f.needThis())
             e.e1 = getRightThis(e.loc, sc, ad, e.e1, f);
-        if (f.type.ty == Type.Kind.function_)
+        if (f.type.ty == Tfunction)
         {
             TypeFunction tf = cast(TypeFunction)f.type;
             if (!MODmethodConv(e.e1.type.mod, f.type.mod))
@@ -4861,7 +4861,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else if (exp.e1.op == TOK.call)
         {
             CallExp ce = cast(CallExp)exp.e1;
-            if (ce.e1.type.ty == Type.Kind.function_)
+            if (ce.e1.type.ty == Tfunction)
             {
                 TypeFunction tf = cast(TypeFunction)ce.e1.type;
                 if (tf.isref && sc.func && !sc.intypeof && sc.func.setUnsafe())
@@ -4880,7 +4880,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              */
             IndexExp ei = cast(IndexExp)exp.e1;
             Type tyi = ei.e1.type.toBasetype();
-            if (tyi.ty == Type.Kind.staticArray && ei.e1.op == TOK.variable)
+            if (tyi.ty == Tsarray && ei.e1.op == TOK.variable)
             {
                 VarExp ve = cast(VarExp)ei.e1;
                 VarDeclaration v = ve.var.isVarDeclaration();
@@ -4936,12 +4936,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type tb = exp.e1.type.toBasetype();
         switch (tb.ty)
         {
-        case Type.Kind.pointer:
+        case Tpointer:
             exp.type = (cast(TypePointer)tb).next;
             break;
 
-        case Type.Kind.staticArray:
-        case Type.Kind.array:
+        case Tsarray:
+        case Tarray:
             if (isNonAssignmentArrayOp(exp.e1))
                 goto default;
             exp.error("using `*` on an array is no longer supported; use `*(%s).ptr` instead", exp.e1.toChars());
@@ -4949,12 +4949,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e1 = exp.e1.castTo(sc, exp.type.pointerTo());
             break;
 
-        case Type.Kind.error:
+        case Terror:
             return setError();
 
         default:
             exp.error("can only `*` a pointer, not a `%s`", exp.e1.type.toChars());
-            goto case Type.Kind.error;
+            goto case Terror;
         }
 
         if (exp.checkValue())
@@ -4985,7 +4985,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         fix16997(sc, exp);
         exp.type = exp.e1.type;
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp.e1))
             {
@@ -5055,7 +5055,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         fix16997(sc, exp);
         exp.type = exp.e1.type;
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp.e1))
             {
@@ -5140,7 +5140,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type tb = exp.e1.type.toBasetype();
         switch (tb.ty)
         {
-        case Type.Kind.class_:
+        case Tclass:
             {
                 auto cd = (cast(TypeClass)tb).sym;
                 if (cd.isCOMinterface())
@@ -5153,9 +5153,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 ad = cd;
                 break;
             }
-        case Type.Kind.pointer:
+        case Tpointer:
             tb = (cast(TypePointer)tb).next.toBasetype();
-            if (tb.ty == Type.Kind.struct_)
+            if (tb.ty == Tstruct)
             {
                 ad = (cast(TypeStruct)tb).sym;
                 auto f = ad.aggDelete;
@@ -5204,10 +5204,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             break;
 
-        case Type.Kind.array:
+        case Tarray:
             {
                 Type tv = tb.nextOf().baseElemOf();
-                if (tv.ty == Type.Kind.struct_)
+                if (tv.ty == Tstruct)
                 {
                     ad = (cast(TypeStruct)tv).sym;
                     if (ad.dtor)
@@ -5229,7 +5229,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 err |= exp.checkSafety(sc, ad.dtor);
                 err |= exp.checkNogc(sc, ad.dtor);
             }
-            if (ad.aggDelete && tb.ty != Type.Kind.array)
+            if (ad.aggDelete && tb.ty != Tarray)
             {
                 err |= exp.checkPurity(sc, ad.aggDelete);
                 err |= exp.checkSafety(sc, ad.aggDelete);
@@ -5308,14 +5308,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
         }
 
-        if (exp.to.ty == Type.Kind.tuple)
+        if (exp.to.ty == Ttuple)
         {
             exp.error("cannot cast `%s` to tuple type `%s`", exp.e1.toChars(), exp.to.toChars());
             return setError();
         }
 
         // cast(void) is used to mark e1 as unused, so it is safe
-        if (exp.to.ty == Type.Kind.void_)
+        if (exp.to.ty == Tvoid)
         {
             exp.type = exp.to;
             result = exp;
@@ -5334,7 +5334,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type t1b = exp.e1.type.toBasetype();
         Type tob = exp.to.toBasetype();
 
-        if (tob.ty == Type.Kind.struct_ && !tob.equals(t1b))
+        if (tob.ty == Tstruct && !tob.equals(t1b))
         {
             /* Look to replace:
              *  cast(S)t
@@ -5353,14 +5353,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        if (!t1b.equals(tob) && (t1b.ty == Type.Kind.array || t1b.ty == Type.Kind.staticArray))
+        if (!t1b.equals(tob) && (t1b.ty == Tarray || t1b.ty == Tsarray))
         {
             if (checkNonAssignmentArrayOp(exp.e1))
                 return setError();
         }
 
         // Look for casting to a vector type
-        if (tob.ty == Type.Kind.vector && t1b.ty != Type.Kind.vector)
+        if (tob.ty == Tvector && t1b.ty != Tvector)
         {
             result = new VectorExp(exp.loc, exp.e1, exp.to);
             return;
@@ -5399,14 +5399,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         exp.e1 = exp.e1.expressionSemantic(sc);
         exp.type = exp.to.typeSemantic(exp.loc, sc);
-        if (exp.e1.op == TOK.error || exp.type.ty == Type.Kind.error)
+        if (exp.e1.op == TOK.error || exp.type.ty == Terror)
         {
             result = exp.e1;
             return;
         }
 
         Type tb = exp.type.toBasetype();
-        assert(tb.ty == Type.Kind.vector);
+        assert(tb.ty == Tvector);
         TypeVector tv = cast(TypeVector)tb;
         Type te = tv.elementType();
         exp.dim = cast(int)(tv.size(exp.loc) / te.size(exp.loc));
@@ -5430,7 +5430,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 res |= checkElem((cast(ArrayLiteralExp)exp.e1).getElement(i));
             }
         }
-        else if (exp.e1.type.ty == Type.Kind.void_)
+        else if (exp.e1.type.ty == Tvoid)
             checkElem(exp.e1);
 
         result = res ? new ErrorExp() : exp;
@@ -5455,7 +5455,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = resolveProperties(sc, exp.e1);
-        if (exp.e1.op == TOK.type && exp.e1.type.ty != Type.Kind.tuple)
+        if (exp.e1.op == TOK.type && exp.e1.type.ty != Ttuple)
         {
             if (exp.lwr || exp.upr)
             {
@@ -5473,7 +5473,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // Convert [a,b,c][] to [a,b,c]
                 Type t1b = exp.e1.type.toBasetype();
                 Expression e = exp.e1;
-                if (t1b.ty == Type.Kind.staticArray)
+                if (t1b.ty == Tsarray)
                 {
                     e = e.copy();
                     e.type = t1b.nextOf().arrayOf();
@@ -5503,13 +5503,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp.e1;
             return;
         }
-        if (exp.e1.type.ty == Type.Kind.error)
+        if (exp.e1.type.ty == Terror)
             return setError();
 
         Type t1b = exp.e1.type.toBasetype();
-        if (t1b.ty == Type.Kind.pointer)
+        if (t1b.ty == Tpointer)
         {
-            if ((cast(TypePointer)t1b).next.ty == Type.Kind.function_)
+            if ((cast(TypePointer)t1b).next.ty == Tfunction)
             {
                 exp.error("cannot slice function pointer `%s`", exp.e1.toChars());
                 return setError();
@@ -5525,10 +5525,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
         }
-        else if (t1b.ty == Type.Kind.array)
+        else if (t1b.ty == Tarray)
         {
         }
-        else if (t1b.ty == Type.Kind.staticArray)
+        else if (t1b.ty == Tsarray)
         {
             if (!exp.arrayop && global.params.vsafe)
             {
@@ -5570,7 +5570,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
-        else if (t1b.ty == Type.Kind.tuple)
+        else if (t1b.ty == Ttuple)
         {
             if (!exp.lwr && !exp.upr)
             {
@@ -5583,7 +5583,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
         }
-        else if (t1b.ty == Type.Kind.vector)
+        else if (t1b.ty == Tvector)
         {
             // Convert e1 to corresponding static array
             TypeVector tv1 = cast(TypeVector)t1b;
@@ -5593,14 +5593,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            exp.error("`%s` cannot be sliced with `[]`", t1b.ty == Type.Kind.void_ ? exp.e1.toChars() : t1b.toChars());
+            exp.error("`%s` cannot be sliced with `[]`", t1b.ty == Tvoid ? exp.e1.toChars() : t1b.toChars());
             return setError();
         }
 
         /* Run semantic on lwr and upr.
          */
         Scope* scx = sc;
-        if (t1b.ty == Type.Kind.staticArray || t1b.ty == Type.Kind.array || t1b.ty == Type.Kind.tuple)
+        if (t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Ttuple)
         {
             // Create scope for 'length' variable
             ScopeDsymbol sym = new ArrayScopeSymbol(sc, exp);
@@ -5610,21 +5610,21 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (exp.lwr)
         {
-            if (t1b.ty == Type.Kind.tuple)
+            if (t1b.ty == Ttuple)
                 sc = sc.startCTFE();
             exp.lwr = exp.lwr.expressionSemantic(sc);
             exp.lwr = resolveProperties(sc, exp.lwr);
-            if (t1b.ty == Type.Kind.tuple)
+            if (t1b.ty == Ttuple)
                 sc = sc.endCTFE();
             exp.lwr = exp.lwr.implicitCastTo(sc, Type.tsize_t);
         }
         if (exp.upr)
         {
-            if (t1b.ty == Type.Kind.tuple)
+            if (t1b.ty == Ttuple)
                 sc = sc.startCTFE();
             exp.upr = exp.upr.expressionSemantic(sc);
             exp.upr = resolveProperties(sc, exp.upr);
-            if (t1b.ty == Type.Kind.tuple)
+            if (t1b.ty == Ttuple)
                 sc = sc.endCTFE();
             exp.upr = exp.upr.implicitCastTo(sc, Type.tsize_t);
         }
@@ -5633,7 +5633,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.lwr && exp.lwr.type == Type.terror || exp.upr && exp.upr.type == Type.terror)
             return setError();
 
-        if (t1b.ty == Type.Kind.tuple)
+        if (t1b.ty == Ttuple)
         {
             exp.lwr = exp.lwr.ctfeInterpret();
             exp.upr = exp.upr.ctfeInterpret();
@@ -5706,7 +5706,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             IntRange lwrRange = getIntRange(exp.lwr);
             IntRange uprRange = getIntRange(exp.upr);
 
-            if (t1b.ty == Type.Kind.staticArray || t1b.ty == Type.Kind.array)
+            if (t1b.ty == Tsarray || t1b.ty == Tarray)
             {
                 Expression el = new ArrayLengthExp(exp.loc, exp.e1);
                 el = el.expressionSemantic(sc);
@@ -5718,7 +5718,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     exp.upperIsInBounds = bounds.contains(uprRange);
                 }
             }
-            else if (t1b.ty == Type.Kind.pointer)
+            else if (t1b.ty == Tpointer)
             {
                 exp.upperIsInBounds = true;
             }
@@ -5936,7 +5936,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (!exp.e1.type)
             exp.e1 = exp.e1.expressionSemantic(sc);
         assert(exp.e1.type); // semantic() should already be run on it
-        if (exp.e1.op == TOK.type && exp.e1.type.ty != Type.Kind.tuple)
+        if (exp.e1.op == TOK.type && exp.e1.type.ty != Ttuple)
         {
             exp.e2 = exp.e2.expressionSemantic(sc);
             exp.e2 = resolveProperties(sc, exp.e2);
@@ -5954,14 +5954,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp.e1;
             return;
         }
-        if (exp.e1.type.ty == Type.Kind.error)
+        if (exp.e1.type.ty == Terror)
             return setError();
 
         // Note that unlike C we do not implement the int[ptr]
 
         Type t1b = exp.e1.type.toBasetype();
 
-        if (t1b.ty == Type.Kind.vector)
+        if (t1b.ty == Tvector)
         {
             // Convert e1 to corresponding static array
             TypeVector tv1 = cast(TypeVector)t1b;
@@ -5973,7 +5973,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         /* Run semantic on e2
          */
         Scope* scx = sc;
-        if (t1b.ty == Type.Kind.staticArray || t1b.ty == Type.Kind.array || t1b.ty == Type.Kind.tuple)
+        if (t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Ttuple)
         {
             // Create scope for 'length' variable
             ScopeDsymbol sym = new ArrayScopeSymbol(sc, exp);
@@ -5981,11 +5981,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             sym.parent = sc.scopesym;
             sc = sc.push(sym);
         }
-        if (t1b.ty == Type.Kind.tuple)
+        if (t1b.ty == Ttuple)
             sc = sc.startCTFE();
         exp.e2 = exp.e2.expressionSemantic(sc);
         exp.e2 = resolveProperties(sc, exp.e2);
-        if (t1b.ty == Type.Kind.tuple)
+        if (t1b.ty == Ttuple)
             sc = sc.endCTFE();
         if (exp.e2.op == TOK.tuple)
         {
@@ -6003,8 +6003,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         switch (t1b.ty)
         {
-        case Type.Kind.pointer:
-            if ((cast(TypePointer)t1b).next.ty == Type.Kind.function_)
+        case Tpointer:
+            if ((cast(TypePointer)t1b).next.ty == Tfunction)
             {
                 exp.error("cannot index function pointer `%s`", exp.e1.toChars());
                 return setError();
@@ -6024,14 +6024,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.type = (cast(TypeNext)t1b).next;
             break;
 
-        case Type.Kind.array:
+        case Tarray:
             exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
             if (exp.e2.type == Type.terror)
                 return setError();
             exp.type = (cast(TypeNext)t1b).next;
             break;
 
-        case Type.Kind.staticArray:
+        case Tsarray:
             {
                 exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
                 if (exp.e2.type == Type.terror)
@@ -6039,7 +6039,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.type = t1b.nextOf();
                 break;
             }
-        case Type.Kind.associativeArray:
+        case Taarray:
             {
                 TypeAArray taa = cast(TypeAArray)t1b;
                 /* We can skip the implicit conversion if they differ only by
@@ -6059,7 +6059,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.type = taa.next;
                 break;
             }
-        case Type.Kind.tuple:
+        case Ttuple:
             {
                 exp.e2 = exp.e2.implicitCastTo(sc, Type.tsize_t);
                 if (exp.e2.type == Type.terror)
@@ -6107,7 +6107,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        if (t1b.ty == Type.Kind.staticArray || t1b.ty == Type.Kind.array)
+        if (t1b.ty == Tsarray || t1b.ty == Tarray)
         {
             Expression el = new ArrayLengthExp(exp.loc, exp.e1);
             el = el.expressionSemantic(sc);
@@ -6172,7 +6172,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.e1 = exp.e1.optimize(WANTvalue);
 
         Type t1 = exp.e1.type.toBasetype();
-        if (t1.ty == Type.Kind.class_ || t1.ty == Type.Kind.struct_ || exp.e1.op == TOK.arrayLength)
+        if (t1.ty == Tclass || t1.ty == Tstruct || exp.e1.op == TOK.arrayLength)
         {
             /* Check for operator overloading,
              * but rewrite in terms of ++e instead of e++
@@ -6218,7 +6218,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e1.checkNoBool())
             return setError();
 
-        if (exp.e1.type.ty == Type.Kind.pointer)
+        if (exp.e1.type.ty == Tpointer)
             e = scaleFactor(exp, sc);
         else
             exp.e2 = exp.e2.castTo(sc, exp.e1.type);
@@ -6545,7 +6545,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (!td)
                     goto Lnomatch;
 
-                assert(exp.e1.type.ty == Type.Kind.tuple);
+                assert(exp.e1.type.ty == Ttuple);
                 TypeTuple tt = cast(TypeTuple)exp.e1.type;
 
                 Expression e0;
@@ -6622,7 +6622,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // If this is an initialization of a reference,
             // do nothing
         }
-        else if (t1.ty == Type.Kind.struct_)
+        else if (t1.ty == Tstruct)
         {
             auto e1x = exp.e1;
             auto e2x = exp.e2;
@@ -6631,7 +6631,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (exp.op == TOK.construct)
             {
                 Type t2 = e2x.type.toBasetype();
-                if (t2.ty == Type.Kind.struct_ && sd == (cast(TypeStruct)t2).sym)
+                if (t2.ty == Tstruct && sd == (cast(TypeStruct)t2).sym)
                 {
                     sd.size(exp.loc);
                     if (sd.sizeok != Sizeok.done)
@@ -6816,7 +6816,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else if (exp.op == TOK.assign)
             {
-                if (e1x.op == TOK.index && (cast(IndexExp)e1x).e1.type.toBasetype().ty == Type.Kind.associativeArray)
+                if (e1x.op == TOK.index && (cast(IndexExp)e1x).e1.type.toBasetype().ty == Taarray)
                 {
                     /*
                      * Rewrite:
@@ -6846,7 +6846,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     if (e)
                     {
                         Expression ey = null;
-                        if (t2.ty == Type.Kind.struct_ && sd == t2.toDsymbol(sc))
+                        if (t2.ty == Tstruct && sd == t2.toDsymbol(sc))
                         {
                             ey = ev;
                         }
@@ -6910,7 +6910,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e1 = e1x;
             exp.e2 = e2x;
         }
-        else if (t1.ty == Type.Kind.class_)
+        else if (t1.ty == Tclass)
         {
             // Disallow assignment operator overloads for same type
             if (exp.op == TOK.assign && !exp.e2.implicitConvTo(exp.e1.type))
@@ -6923,7 +6923,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
-        else if (t1.ty == Type.Kind.staticArray)
+        else if (t1.ty == Tsarray)
         {
             // SliceExp cannot have static array type without context inference.
             assert(exp.e1.op != TOK.slice);
@@ -6987,7 +6987,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     while (1)
                     {
                         t = t.nextOf().toBasetype();
-                        if (t.ty != Type.Kind.staticArray)
+                        if (t.ty != Tsarray)
                             break;
                         dim *= (cast(TypeSArray)t).dim.toInteger();
                         e1x.type = t.nextOf().sarrayOf(dim);
@@ -7053,7 +7053,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             SliceExp se = cast(SliceExp)exp.e1;
             while (se.e1.op == TOK.slice)
                 se = cast(SliceExp)se.e1;
-            if (se.e1.op == TOK.question && se.e1.type.toBasetype().ty == Type.Kind.staticArray)
+            if (se.e1.op == TOK.question && se.e1.type.toBasetype().ty == Tsarray)
             {
                 se.e1 = se.e1.modifiableLvalue(sc, exp.e1);
                 if (se.e1.op == TOK.error)
@@ -7065,7 +7065,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            if (t1.ty == Type.Kind.staticArray && exp.op == TOK.assign)
+            if (t1.ty == Tsarray && exp.op == TOK.assign)
             {
                 Type tn = exp.e1.type.nextOf();
                 if (tn && !tn.baseElemOf().isAssignable())
@@ -7104,11 +7104,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // If it is a array, get the element type. Note that it may be
         // multi-dimensional.
         Type telem = t1;
-        while (telem.ty == Type.Kind.array)
+        while (telem.ty == Tarray)
             telem = telem.nextOf();
 
         if (exp.e1.op == TOK.slice && t1.nextOf() &&
-            (telem.ty != Type.Kind.void_ || e2x.op == TOK.null_) &&
+            (telem.ty != Tvoid || e2x.op == TOK.null_) &&
             e2x.implicitConvTo(t1.nextOf()))
         {
             // Check for block assignment. If it is of type void[], void[][], etc,
@@ -7119,7 +7119,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
         }
         else if (exp.e1.op == TOK.slice &&
-                 (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray) &&
+                 (t2.ty == Tarray || t2.ty == Tsarray) &&
                  t2.nextOf().implicitConvTo(t1.nextOf()))
         {
             // Check element-wise assignment.
@@ -7134,7 +7134,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tsa2 = cast(TypeSArray)t2.nextOf().sarrayOf((cast(ArrayLiteralExp)e2x).elements.dim);
             else if (e2x.op == TOK.slice)
                 tsa2 = cast(TypeSArray)toStaticArrayType(cast(SliceExp)e2x);
-            else if (t2.ty == Type.Kind.staticArray)
+            else if (t2.ty == Tsarray)
                 tsa2 = cast(TypeSArray)t2;
             if (tsa1 && tsa2)
             {
@@ -7209,7 +7209,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 else
                     e2x = e2x.implicitCastTo(sc, exp.e1.type);
             }
-            if (t1n.toBasetype.ty == Type.Kind.void_ && t2n.toBasetype.ty == Type.Kind.void_)
+            if (t1n.toBasetype.ty == Tvoid && t2n.toBasetype.ty == Tvoid)
             {
                 if (!sc.intypeof && sc.func && sc.func.setUnsafe())
                 {
@@ -7221,7 +7221,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else
         {
             if (0 && global.params.warnings && !global.gag && exp.op == TOK.assign &&
-                t1.ty == Type.Kind.array && t2.ty == Type.Kind.staticArray &&
+                t1.ty == Tarray && t2.ty == Tsarray &&
                 e2x.op != TOK.slice &&
                 t2.implicitConvTo(t1))
             {
@@ -7247,7 +7247,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         /* Look for array operations
          */
-        if ((t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray) && isArrayOpValid(exp.e2))
+        if ((t2.ty == Tarray || t2.ty == Tsarray) && isArrayOpValid(exp.e2))
         {
             // Look for valid array operations
             if (!(exp.memset & MemorySet.blockAssign) &&
@@ -7280,7 +7280,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             VarDeclaration vd = ve.var.isVarDeclaration();
             if (vd && (vd.onstack || vd.mynew))
             {
-                assert(t1.ty == Type.Kind.class_);
+                assert(t1.ty == Tclass);
                 exp.error("cannot rebind scope variables");
             }
         }
@@ -7316,7 +7316,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         assert(exp.e1.type && exp.e2.type);
-        if (exp.e1.op == TOK.slice || exp.e1.type.ty == Type.Kind.array || exp.e1.type.ty == Type.Kind.staticArray)
+        if (exp.e1.op == TOK.slice || exp.e1.type.ty == Tarray || exp.e1.type.ty == Tsarray)
         {
             if (checkNonAssignmentArrayOp(exp.e1))
                 return setError();
@@ -7336,7 +7336,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // Check element types are arithmetic
             Type tb1 = exp.e1.type.nextOf().toBasetype();
             Type tb2 = exp.e2.type.toBasetype();
-            if (tb2.ty == Type.Kind.array || tb2.ty == Type.Kind.staticArray)
+            if (tb2.ty == Tarray || tb2.ty == Tsarray)
                 tb2 = tb2.nextOf().toBasetype();
             if ((tb1.isintegral() || tb1.isfloating()) && (tb2.isintegral() || tb2.isfloating()))
             {
@@ -7400,7 +7400,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e1.op == TOK.slice)
         {
             SliceExp se = cast(SliceExp)exp.e1;
-            if (se.e1.type.toBasetype().ty == Type.Kind.staticArray)
+            if (se.e1.type.toBasetype().ty == Tsarray)
             {
                 exp.error("cannot append to static array `%s`", se.e1.type.toChars());
                 return setError();
@@ -7431,8 +7431,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * TOK.concatenateElemAssign: appending T to T[]
          * TOK.concatenateDcharAssign: appending dchar to T[]
          */
-        if ((tb1.ty == Type.Kind.array) &&
-            (tb2.ty == Type.Kind.array || tb2.ty == Type.Kind.staticArray) &&
+        if ((tb1.ty == Tarray) &&
+            (tb2.ty == Tarray || tb2.ty == Tsarray) &&
             (exp.e2.implicitConvTo(exp.e1.type) ||
              (tb2.nextOf().implicitConvTo(tb1next) &&
               (tb2.nextOf().size(Loc()) == tb1next.size(Loc())))))
@@ -7444,7 +7444,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             exp.e2 = exp.e2.castTo(sc, exp.e1.type);
         }
-        else if ((tb1.ty == Type.Kind.array) && exp.e2.implicitConvTo(tb1next))
+        else if ((tb1.ty == Tarray) && exp.e2.implicitConvTo(tb1next))
         {
             // Append element
             if (exp.e2.checkPostblit(sc, tb2))
@@ -7454,8 +7454,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.e2 = exp.e2.castTo(sc, tb1next);
             exp.e2 = doCopyOrMove(sc, exp.e2);
         }
-        else if (tb1.ty == Type.Kind.array &&
-                 (tb1next.ty == Type.Kind.char_ || tb1next.ty == Type.Kind.wchar_) &&
+        else if (tb1.ty == Tarray &&
+                 (tb1next.ty == Tchar || tb1next.ty == Twchar) &&
                  exp.e2.type.ty != tb1next.ty &&
                  exp.e2.implicitConvTo(Type.tdchar))
         {
@@ -7510,24 +7510,24 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type tb2 = exp.e2.type.toBasetype();
 
         bool err = false;
-        if (tb1.ty == Type.Kind.delegate_ || tb1.ty == Type.Kind.pointer && tb1.nextOf().ty == Type.Kind.function_)
+        if (tb1.ty == Tdelegate || tb1.ty == Tpointer && tb1.nextOf().ty == Tfunction)
         {
             err |= exp.e1.checkArithmetic();
         }
-        if (tb2.ty == Type.Kind.delegate_ || tb2.ty == Type.Kind.pointer && tb2.nextOf().ty == Type.Kind.function_)
+        if (tb2.ty == Tdelegate || tb2.ty == Tpointer && tb2.nextOf().ty == Tfunction)
         {
             err |= exp.e2.checkArithmetic();
         }
         if (err)
             return setError();
 
-        if (tb1.ty == Type.Kind.pointer && exp.e2.type.isintegral() || tb2.ty == Type.Kind.pointer && exp.e1.type.isintegral())
+        if (tb1.ty == Tpointer && exp.e2.type.isintegral() || tb2.ty == Tpointer && exp.e1.type.isintegral())
         {
             result = scaleFactor(exp, sc);
             return;
         }
 
-        if (tb1.ty == Type.Kind.pointer && tb2.ty == Type.Kind.pointer)
+        if (tb1.ty == Tpointer && tb2.ty == Tpointer)
         {
             result = exp.incompatibleTypes();
             return;
@@ -7540,7 +7540,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -7561,18 +7561,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             switch (exp.type.toBasetype().ty)
             {
-            case Type.Kind.float32:
-            case Type.Kind.imaginary32:
+            case Tfloat32:
+            case Timaginary32:
                 exp.type = Type.tcomplex32;
                 break;
 
-            case Type.Kind.float64:
-            case Type.Kind.imaginary64:
+            case Tfloat64:
+            case Timaginary64:
                 exp.type = Type.tcomplex64;
                 break;
 
-            case Type.Kind.float80:
-            case Type.Kind.imaginary80:
+            case Tfloat80:
+            case Timaginary80:
                 exp.type = Type.tcomplex80;
                 break;
 
@@ -7611,20 +7611,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type t2 = exp.e2.type.toBasetype();
 
         bool err = false;
-        if (t1.ty == Type.Kind.delegate_ || t1.ty == Type.Kind.pointer && t1.nextOf().ty == Type.Kind.function_)
+        if (t1.ty == Tdelegate || t1.ty == Tpointer && t1.nextOf().ty == Tfunction)
         {
             err |= exp.e1.checkArithmetic();
         }
-        if (t2.ty == Type.Kind.delegate_ || t2.ty == Type.Kind.pointer && t2.nextOf().ty == Type.Kind.function_)
+        if (t2.ty == Tdelegate || t2.ty == Tpointer && t2.nextOf().ty == Tfunction)
         {
             err |= exp.e2.checkArithmetic();
         }
         if (err)
             return setError();
 
-        if (t1.ty == Type.Kind.pointer)
+        if (t1.ty == Tpointer)
         {
-            if (t2.ty == Type.Kind.pointer)
+            if (t2.ty == Tpointer)
             {
                 // https://dlang.org/spec/expression.html#add_expressions
                 // "If both operands are pointers, and the operator is -, the pointers are
@@ -7676,7 +7676,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e;
             return;
         }
-        if (t2.ty == Type.Kind.pointer)
+        if (t2.ty == Tpointer)
         {
             exp.type = exp.e2.type;
             exp.error("can't subtract pointer from `%s`", exp.e1.type.toChars());
@@ -7690,7 +7690,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -7712,18 +7712,18 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             switch (exp.type.ty)
             {
-            case Type.Kind.float32:
-            case Type.Kind.imaginary32:
+            case Tfloat32:
+            case Timaginary32:
                 exp.type = Type.tcomplex32;
                 break;
 
-            case Type.Kind.float64:
-            case Type.Kind.imaginary64:
+            case Tfloat64:
+            case Timaginary64:
                 exp.type = Type.tcomplex64;
                 break;
 
-            case Type.Kind.float80:
-            case Type.Kind.imaginary80:
+            case Tfloat80:
+            case Timaginary80:
                 exp.type = Type.tcomplex80;
                 break;
 
@@ -7801,7 +7801,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         // Check for: array ~ element
-        if ((tb1.ty == Type.Kind.staticArray || tb1.ty == Type.Kind.array) && tb2.ty != Type.Kind.void_)
+        if ((tb1.ty == Tsarray || tb1.ty == Tarray) && tb2.ty != Tvoid)
         {
             if (exp.e1.op == TOK.arrayLiteral)
             {
@@ -7832,7 +7832,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.e2 = exp.e2.implicitCastTo(sc, tb1next);
                 exp.type = tb1next.arrayOf();
             L2elem:
-                if (tb2.ty == Type.Kind.array || tb2.ty == Type.Kind.staticArray)
+                if (tb2.ty == Tarray || tb2.ty == Tsarray)
                 {
                     // Make e2 into [e2]
                     exp.e2 = new ArrayLiteralExp(exp.e2.loc, exp.e2);
@@ -7843,7 +7843,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
         // Check for: element ~ array
-        if ((tb2.ty == Type.Kind.staticArray || tb2.ty == Type.Kind.array) && tb1.ty != Type.Kind.void_)
+        if ((tb2.ty == Tsarray || tb2.ty == Tarray) && tb1.ty != Tvoid)
         {
             if (exp.e2.op == TOK.arrayLiteral)
             {
@@ -7869,7 +7869,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.e1 = exp.e1.implicitCastTo(sc, tb2next);
                 exp.type = tb2next.arrayOf();
             L1elem:
-                if (tb1.ty == Type.Kind.array || tb1.ty == Type.Kind.staticArray)
+                if (tb1.ty == Tarray || tb1.ty == Tsarray)
                 {
                     // Make e1 into [e1]
                     exp.e1 = new ArrayLiteralExp(exp.e1.loc, exp.e1);
@@ -7881,7 +7881,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
     Lpeer:
-        if ((tb1.ty == Type.Kind.staticArray || tb1.ty == Type.Kind.array) && (tb2.ty == Type.Kind.staticArray || tb2.ty == Type.Kind.array) && (tb1next.mod || tb2next.mod) && (tb1next.mod != tb2next.mod))
+        if ((tb1.ty == Tsarray || tb1.ty == Tarray) && (tb2.ty == Tsarray || tb2.ty == Tarray) && (tb1next.mod || tb2next.mod) && (tb1next.mod != tb2next.mod))
         {
             Type t1 = tb1next.mutableOf().constOf().arrayOf();
             Type t2 = tb2next.mutableOf().constOf().arrayOf();
@@ -7903,9 +7903,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = exp.type.toHeadMutable();
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tsarray)
             exp.type = tb.nextOf().arrayOf();
-        if (exp.type.ty == Type.Kind.array && tb1next && tb2next && tb1next.mod != tb2next.mod)
+        if (exp.type.ty == Tarray && tb1next && tb2next && tb1next.mod != tb2next.mod)
         {
             exp.type = exp.type.nextOf().toHeadMutable().arrayOf();
         }
@@ -7923,8 +7923,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         Type t1 = exp.e1.type.toBasetype();
         Type t2 = exp.e2.type.toBasetype();
-        if ((t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray) &&
-            (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray))
+        if ((t1.ty == Tarray || t1.ty == Tsarray) &&
+            (t2.ty == Tarray || t2.ty == Tsarray))
         {
             // Normalize to ArrayLiteralExp or StringExp as far as possible
             e = exp.optimize(WANTvalue);
@@ -7970,7 +7970,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8003,15 +8003,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     switch (t1.toBasetype().ty)
                     {
-                    case Type.Kind.imaginary32:
+                    case Timaginary32:
                         exp.type = Type.tfloat32;
                         break;
 
-                    case Type.Kind.imaginary64:
+                    case Timaginary64:
                         exp.type = Type.tfloat64;
                         break;
 
-                    case Type.Kind.imaginary80:
+                    case Timaginary80:
                         exp.type = Type.tfloat80;
                         break;
 
@@ -8070,7 +8070,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8112,15 +8112,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     switch (t1.toBasetype().ty)
                     {
-                    case Type.Kind.imaginary32:
+                    case Timaginary32:
                         exp.type = Type.tfloat32;
                         break;
 
-                    case Type.Kind.imaginary64:
+                    case Timaginary64:
                         exp.type = Type.tfloat64;
                         break;
 
-                    case Type.Kind.imaginary80:
+                    case Timaginary80:
                         exp.type = Type.tfloat80;
                         break;
 
@@ -8171,7 +8171,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8230,7 +8230,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8351,7 +8351,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        if (exp.e2.type.toBasetype().ty != Type.Kind.vector)
+        if (exp.e2.type.toBasetype().ty != Tvector)
             exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
@@ -8387,7 +8387,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        if (exp.e2.type.toBasetype().ty != Type.Kind.vector)
+        if (exp.e2.type.toBasetype().ty != Tvector)
             exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
@@ -8423,7 +8423,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
         exp.e1 = integralPromotions(exp.e1, sc);
-        if (exp.e2.type.toBasetype().ty != Type.Kind.vector)
+        if (exp.e2.type.toBasetype().ty != Tvector)
             exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
 
         exp.type = exp.e1.type;
@@ -8450,7 +8450,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Type.Kind.bool_ && exp.e2.type.toBasetype().ty == Type.Kind.bool_)
+        if (exp.e1.type.toBasetype().ty == Tbool && exp.e2.type.toBasetype().ty == Tbool)
         {
             exp.type = exp.e1.type;
             result = exp;
@@ -8464,7 +8464,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8505,7 +8505,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Type.Kind.bool_ && exp.e2.type.toBasetype().ty == Type.Kind.bool_)
+        if (exp.e1.type.toBasetype().ty == Tbool && exp.e2.type.toBasetype().ty == Tbool)
         {
             exp.type = exp.e1.type;
             result = exp;
@@ -8519,7 +8519,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8560,7 +8560,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Type.Kind.bool_ && exp.e2.type.toBasetype().ty == Type.Kind.bool_)
+        if (exp.e1.type.toBasetype().ty == Tbool && exp.e2.type.toBasetype().ty == Tbool)
         {
             exp.type = exp.e1.type;
             result = exp;
@@ -8574,7 +8574,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         Type tb = exp.type.toBasetype();
-        if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.staticArray)
+        if (tb.ty == Tarray || tb.ty == Tsarray)
         {
             if (!isArrayOpValid(exp))
             {
@@ -8642,7 +8642,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         // Unless the right operand is 'void', the expression is converted to 'bool'.
-        if (e2x.type.ty != Type.Kind.void_)
+        if (e2x.type.ty != Tvoid)
             e2x = e2x.toBoolean(sc);
 
         if (e2x.op == TOK.type || e2x.op == TOK.scope_)
@@ -8662,7 +8662,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         // The result type is 'bool', unless the right operand has type 'void'.
-        if (e2x.type.ty == Type.Kind.void_)
+        if (e2x.type.ty == Tvoid)
             exp.type = Type.tvoid;
         else
             exp.type = Type.tbool;
@@ -8694,7 +8694,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         Type t1 = exp.e1.type.toBasetype();
         Type t2 = exp.e2.type.toBasetype();
-        if (t1.ty == Type.Kind.class_ && exp.e2.op == TOK.null_ || t2.ty == Type.Kind.class_ && exp.e1.op == TOK.null_)
+        if (t1.ty == Tclass && exp.e2.op == TOK.null_ || t2.ty == Tclass && exp.e1.op == TOK.null_)
         {
             exp.error("do not use `null` when comparing class types");
             return setError();
@@ -8734,16 +8734,16 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression arrayLowering = null;
         t1 = exp.e1.type.toBasetype();
         t2 = exp.e2.type.toBasetype();
-        if ((t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray || t1.ty == Type.Kind.pointer) && (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray || t2.ty == Type.Kind.pointer))
+        if ((t1.ty == Tarray || t1.ty == Tsarray || t1.ty == Tpointer) && (t2.ty == Tarray || t2.ty == Tsarray || t2.ty == Tpointer))
         {
             Type t1next = t1.nextOf();
             Type t2next = t2.nextOf();
-            if (t1next.implicitConvTo(t2next) < MATCH.constant && t2next.implicitConvTo(t1next) < MATCH.constant && (t1next.ty != Type.Kind.void_ && t2next.ty != Type.Kind.void_))
+            if (t1next.implicitConvTo(t2next) < MATCH.constant && t2next.implicitConvTo(t1next) < MATCH.constant && (t1next.ty != Tvoid && t2next.ty != Tvoid))
             {
                 exp.error("array comparison type mismatch, `%s` vs `%s`", t1next.toChars(), t2next.toChars());
                 return setError();
             }
-            if ((t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray) && (t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray))
+            if ((t1.ty == Tarray || t1.ty == Tsarray) && (t2.ty == Tarray || t2.ty == Tsarray))
             {
                 // Lower to object.__cmp(e1, e2)
                 Expression al = new IdentifierExp(exp.loc, Id.empty);
@@ -8761,9 +8761,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 arrayLowering = al;
             }
         }
-        else if (t1.ty == Type.Kind.struct_ || t2.ty == Type.Kind.struct_ || (t1.ty == Type.Kind.class_ && t2.ty == Type.Kind.class_))
+        else if (t1.ty == Tstruct || t2.ty == Tstruct || (t1.ty == Tclass && t2.ty == Tclass))
         {
-            if (t2.ty == Type.Kind.struct_)
+            if (t2.ty == Tstruct)
                 exp.error("need member function `opCmp()` for %s `%s` to compare", t2.toDsymbol(sc).kind(), t2.toChars());
             else
                 exp.error("need member function `opCmp()` for %s `%s` to compare", t1.toDsymbol(sc).kind(), t1.toChars());
@@ -8774,7 +8774,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("compare not defined for complex operands");
             return setError();
         }
-        else if (t1.ty == Type.Kind.associativeArray || t2.ty == Type.Kind.associativeArray)
+        else if (t1.ty == Taarray || t2.ty == Taarray)
         {
             exp.error("`%s` is not defined for associative arrays", Token.toChars(exp.op));
             return setError();
@@ -8832,7 +8832,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             altop = TOK.reserved;
             break;
         }
-        if (altop == TOK.error && (t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray || t2.ty == Type.Kind.array || t2.ty == Type.Kind.staticArray))
+        if (altop == TOK.error && (t1.ty == Tarray || t1.ty == Tsarray || t2.ty == Tarray || t2.ty == Tsarray))
         {
             exp.error("`%s` is not defined for array comparisons", Token.toChars(exp.op));
             return setError();
@@ -8892,7 +8892,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Type t2b = exp.e2.type.toBasetype();
         switch (t2b.ty)
         {
-        case Type.Kind.associativeArray:
+        case Taarray:
             {
                 TypeAArray ta = cast(TypeAArray)t2b;
 
@@ -8910,7 +8910,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 break;
             }
 
-        case Type.Kind.error:
+        case Terror:
             return setError();
 
         default:
@@ -8955,7 +8955,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             auto t1 = exp.e1.type;
             auto t2 = exp.e2.type;
-            if (t1.ty == Type.Kind.enum_ && t2.ty == Type.Kind.enum_ && !t1.equivalent(t2))
+            if (t1.ty == Tenum && t2.ty == Tenum && !t1.equivalent(t2))
                 exp.deprecation("Comparison between different enumeration types `%s` and `%s`; If this behavior is intended consider using `std.conv.asOriginalType`",
                     t1.toChars(), t2.toChars());
         }
@@ -8988,9 +8988,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             Type t1n = t1.nextOf().toBasetype();
             Type t2n = t2.nextOf().toBasetype();
-            if (((t1n.ty == Type.Kind.char_ || t1n.ty == Type.Kind.wchar_ || t1n.ty == Type.Kind.dchar_) &&
-                 (t2n.ty == Type.Kind.char_ || t2n.ty == Type.Kind.wchar_ || t2n.ty == Type.Kind.dchar_)) ||
-                (t1n.ty == Type.Kind.void_ || t2n.ty == Type.Kind.void_))
+            if (((t1n.ty == Tchar || t1n.ty == Twchar || t1n.ty == Tdchar) &&
+                 (t2n.ty == Tchar || t2n.ty == Twchar || t2n.ty == Tdchar)) ||
+                (t1n.ty == Tvoid || t2n.ty == Tvoid))
             {
                 return false;
             }
@@ -9000,7 +9000,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Type t = t1n;
             while (t.toBasetype().nextOf())
                 t = t.nextOf().toBasetype();
-            if (t.ty != Type.Kind.struct_)
+            if (t.ty != Tstruct)
                 return false;
 
             semanticTypeInfo(sc, t);
@@ -9014,7 +9014,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
 
-        if (!(t1.ty == Type.Kind.array && t2.ty == Type.Kind.array && needsDirectEq(t1, t2)))
+        if (!(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq(t1, t2)))
         {
             if (auto e = typeCombine(exp, sc))
             {
@@ -9031,7 +9031,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         exp.type = Type.tbool;
 
         // Special handling for array comparisons
-        if (!(t1.ty == Type.Kind.array && t2.ty == Type.Kind.array && needsDirectEq(t1, t2)))
+        if (!(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq(t1, t2)))
         {
             if (!arrayTypeCompatible(exp.loc, exp.e1.type, exp.e2.type))
             {
@@ -9044,7 +9044,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
-        if (t1.ty == Type.Kind.array && t2.ty == Type.Kind.array)
+        if (t1.ty == Tarray && t2.ty == Tarray)
         {
             //printf("Lowering to __equals %s %s\n", e1.toChars(), e2.toChars());
 
@@ -9071,7 +9071,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (exp.e1.type.toBasetype().ty == Type.Kind.associativeArray)
+        if (exp.e1.type.toBasetype().ty == Taarray)
             semanticTypeInfo(sc, exp.e1.type.toBasetype());
 
 
@@ -9133,8 +9133,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.e2.op == TOK.call)
             exp.e2 = (cast(CallExp)exp.e2).addDtorHook(sc);
 
-        if (exp.e1.type.toBasetype().ty == Type.Kind.staticArray ||
-            exp.e2.type.toBasetype().ty == Type.Kind.staticArray)
+        if (exp.e1.type.toBasetype().ty == Tsarray ||
+            exp.e2.type.toBasetype().ty == Tsarray)
             exp.deprecation("identity comparison of static arrays "
                 ~ "implicitly coerces them to slices, "
                 ~ "which are compared by reference");
@@ -9215,7 +9215,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         // the expression to void so that we explicitly discard the expression
         // value if any
         // https://issues.dlang.org/show_bug.cgi?id=16598
-        if (t1.ty == Type.Kind.void_ || t2.ty == Type.Kind.void_)
+        if (t1.ty == Tvoid || t2.ty == Tvoid)
         {
             exp.type = Type.tvoid;
             exp.e1 = exp.e1.castTo(sc, exp.type);
@@ -9233,9 +9233,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             switch (exp.e1.type.toBasetype().ty)
             {
-            case Type.Kind.complex32:
-            case Type.Kind.complex64:
-            case Type.Kind.complex80:
+            case Tcomplex32:
+            case Tcomplex64:
+            case Tcomplex80:
                 exp.e2 = exp.e2.castTo(sc, exp.e1.type);
                 break;
             default:
@@ -9243,15 +9243,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             switch (exp.e2.type.toBasetype().ty)
             {
-            case Type.Kind.complex32:
-            case Type.Kind.complex64:
-            case Type.Kind.complex80:
+            case Tcomplex32:
+            case Tcomplex64:
+            case Tcomplex80:
                 exp.e1 = exp.e1.castTo(sc, exp.e2.type);
                 break;
             default:
                 break;
             }
-            if (exp.type.toBasetype().ty == Type.Kind.array)
+            if (exp.type.toBasetype().ty == Tarray)
             {
                 exp.e1 = exp.e1.castTo(sc, exp.type);
                 exp.e2 = exp.e2.castTo(sc, exp.type);
@@ -9463,7 +9463,7 @@ Expression semanticX(DotIdExp exp, Scope* sc)
         }
     }
 
-    if (exp.e1.op == TOK.variable && exp.e1.type.toBasetype().ty == Type.Kind.staticArray && exp.ident == Id.length)
+    if (exp.e1.op == TOK.variable && exp.e1.type.toBasetype().ty == Tsarray && exp.ident == Id.length)
     {
         // bypass checkPurity
         return exp.e1.type.dotExp(sc, exp.e1, exp.ident, exp.noderef ? Type.DotExpFlag.noDeref : 0);
@@ -9622,7 +9622,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
                         exp.error("forward reference to %s `%s`", v.kind(), v.toPrettyChars());
                     return new ErrorExp();
                 }
-                if (v.type.ty == Type.Kind.error)
+                if (v.type.ty == Terror)
                     return new ErrorExp();
 
                 if ((v.storage_class & STC.manifest) && v._init && !exp.wantsym)
@@ -9776,7 +9776,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             exp.error("undefined identifier `%s` in %s `%s`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars());
         return new ErrorExp();
     }
-    else if (t1b.ty == Type.Kind.pointer && exp.e1.type.ty != Type.Kind.enum_ && exp.ident != Id._init && exp.ident != Id.__sizeof && exp.ident != Id.__xalignof && exp.ident != Id.offsetof && exp.ident != Id._mangleof && exp.ident != Id.stringof)
+    else if (t1b.ty == Tpointer && exp.e1.type.ty != Tenum && exp.ident != Id._init && exp.ident != Id.__sizeof && exp.ident != Id.__xalignof && exp.ident != Id.offsetof && exp.ident != Id._mangleof && exp.ident != Id.stringof)
     {
         Type t1bn = t1b.nextOf();
         if (flag)
@@ -9791,7 +9791,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
          * as:
          *   (*p).ident
          */
-        if (flag && t1bn.ty == Type.Kind.void_)
+        if (flag && t1bn.ty == Tvoid)
             return null;
         e = new PtrExp(exp.loc, exp.e1);
         e = e.expressionSemantic(sc);
@@ -9824,7 +9824,7 @@ Expression semanticY(DotTemplateInstanceExp exp, Scope* sc, int flag)
     {
         exp.e1 = die.e1; // take back
         Type t1b = exp.e1.type.toBasetype();
-        if (t1b.ty == Type.Kind.array || t1b.ty == Type.Kind.staticArray || t1b.ty == Type.Kind.associativeArray || t1b.ty == Type.Kind.null_ || (t1b.isTypeBasic() && t1b.ty != Type.Kind.void_))
+        if (t1b.ty == Tarray || t1b.ty == Tsarray || t1b.ty == Taarray || t1b.ty == Tnull || (t1b.isTypeBasic() && t1b.ty != Tvoid))
         {
             /* No built-in type has templatized properties, so do shortcut.
              * It is necessary in: 1024.max!"a < b"

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -403,14 +403,14 @@ extern (C++) class FuncDeclaration : Declaration
             thandle = thandle.addStorageClass(storage_class);
             VarDeclaration v = new ThisDeclaration(loc, thandle);
             v.storage_class |= STC.parameter;
-            if (thandle.ty == Type.Kind.struct_)
+            if (thandle.ty == Tstruct)
             {
                 v.storage_class |= STC.ref_;
                 // if member function is marked 'inout', then 'this' is 'return ref'
-                if (type.ty == Type.Kind.function_ && (cast(TypeFunction)type).iswild & 2)
+                if (type.ty == Tfunction && (cast(TypeFunction)type).iswild & 2)
                     v.storage_class |= STC.return_;
             }
-            if (type.ty == Type.Kind.function_)
+            if (type.ty == Tfunction)
             {
                 TypeFunction tf = cast(TypeFunction)type;
                 if (tf.isreturn)
@@ -435,7 +435,7 @@ extern (C++) class FuncDeclaration : Declaration
              */
             VarDeclaration v = new ThisDeclaration(loc, Type.tvoid.pointerTo());
             v.storage_class |= STC.parameter;
-            if (type.ty == Type.Kind.function_)
+            if (type.ty == Tfunction)
             {
                 TypeFunction tf = cast(TypeFunction)type;
                 if (tf.isreturn)
@@ -633,7 +633,7 @@ extern (C++) class FuncDeclaration : Declaration
         {
             if (overnext)
                 return overnext.overloadInsert(ad);
-            if (!ad.aliassym && ad.type.ty != Type.Kind.identifier && ad.type.ty != Type.Kind.instance)
+            if (!ad.aliassym && ad.type.ty != Tident && ad.type.ty != Tinstance)
             {
                 //printf("\tad = '%s'\n", ad.type.toChars());
                 return false;
@@ -710,7 +710,7 @@ extern (C++) class FuncDeclaration : Declaration
              * is just a const conversion.
              * This allows things like pure functions to match with an impure function type.
              */
-            if (t.ty == Type.Kind.function_)
+            if (t.ty == Tfunction)
             {
                 auto tf = cast(TypeFunction)f.type;
                 if (tf.covariant(t) == 1 &&
@@ -1374,15 +1374,15 @@ extern (C++) class FuncDeclaration : Declaration
         t = t.baseElemOf();
         switch (t.ty)
         {
-            case Type.Kind.array:
-            case Type.Kind.pointer:
+            case Tarray:
+            case Tpointer:
                 return isTypeIsolatedIndirect(t.nextOf()); // go down one level
 
-            case Type.Kind.associativeArray:
-            case Type.Kind.class_:
+            case Taarray:
+            case Tclass:
                 return isTypeIsolatedIndirect(t);
 
-            case Type.Kind.struct_:
+            case Tstruct:
                 /* Drill down and check the struct's fields
                  */
                 auto sym = t.toDsymbol(null).isStructDeclaration();
@@ -1449,15 +1449,15 @@ extern (C++) class FuncDeclaration : Declaration
                 tp = tp.baseElemOf();
                 switch (tp.ty)
                 {
-                    case Type.Kind.array:
-                    case Type.Kind.pointer:
+                    case Tarray:
+                    case Tpointer:
                         return traverseIndirections(tp.nextOf(), t);
 
-                    case Type.Kind.associativeArray:
-                    case Type.Kind.class_:
+                    case Taarray:
+                    case Tclass:
                         return traverseIndirections(tp, t);
 
-                    case Type.Kind.struct_:
+                    case Tstruct:
                         /* Drill down and check the struct's fields
                          */
                         auto sym = tp.toDsymbol(null).isStructDeclaration();
@@ -2057,7 +2057,7 @@ extern (C++) class FuncDeclaration : Declaration
             fdrequire = fd;
         }
 
-        if (!outId && f.nextOf() && f.nextOf().toBasetype().ty != Type.Kind.void_)
+        if (!outId && f.nextOf() && f.nextOf().toBasetype().ty != Tvoid)
             outId = Id.result; // provide a default
 
         if (fensure)
@@ -2239,9 +2239,9 @@ extern (C++) class FuncDeclaration : Declaration
         {
             auto fparam0 = Parameter.getNth(tf.parameters, 0);
             auto t = fparam0.type.toBasetype();
-            if (t.ty != Type.Kind.array ||
-                t.nextOf().ty != Type.Kind.array ||
-                t.nextOf().nextOf().ty != Type.Kind.char_ ||
+            if (t.ty != Tarray ||
+                t.nextOf().ty != Tarray ||
+                t.nextOf().nextOf().ty != Tchar ||
                 fparam0.storageClass & (STC.out_ | STC.ref_ | STC.lazy_))
             {
                 argerr = true;
@@ -2250,7 +2250,7 @@ extern (C++) class FuncDeclaration : Declaration
 
         if (!tf.nextOf())
             error("must return int or void");
-        else if (tf.nextOf().ty != Type.Kind.int32 && tf.nextOf().ty != Type.Kind.void_)
+        else if (tf.nextOf().ty != Tint32 && tf.nextOf().ty != Tvoid)
             error("must return int or void, not %s", tf.nextOf().toChars());
         else if (tf.varargs || nparams >= 2 || argerr)
             error("parameters must be main() or main(string[] args)");
@@ -2610,7 +2610,7 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
                 auto td = s.isTemplateDeclaration();
                 if (fd)
                 {
-                    if (fd.errors || fd.type.ty == Type.Kind.error)
+                    if (fd.errors || fd.type.ty == Terror)
                         return 0;
 
                     auto tf = cast(TypeFunction)fd.type;
@@ -2659,11 +2659,11 @@ extern (C++) FuncDeclaration resolveFuncCall(Loc loc, Scope* sc, Dsymbol s,
 extern (C++) Type getIndirection(Type t)
 {
     t = t.baseElemOf();
-    if (t.ty == Type.Kind.array || t.ty == Type.Kind.pointer)
+    if (t.ty == Tarray || t.ty == Tpointer)
         return t.nextOf().toBasetype();
-    if (t.ty == Type.Kind.associativeArray || t.ty == Type.Kind.class_)
+    if (t.ty == Taarray || t.ty == Tclass)
         return t;
-    if (t.ty == Type.Kind.struct_)
+    if (t.ty == Tstruct)
         return t.hasPointers() ? t : null; // TODO
 
     // should consider TypeDelegate?
@@ -2726,7 +2726,7 @@ private bool traverseIndirections(Type ta, Type tb)
                 // if source is the same as target or can be const-converted to target
                 source.constConv(target) != MATCH.nomatch ||
                 // if target is void and source can be const-converted to target
-                (target.ty == Type.Kind.void_ && MODimplicitConv(source.mod, target.mod));
+                (target.ty == Tvoid && MODimplicitConv(source.mod, target.mod));
         }
 
         if (mayAliasDirect(reversePass ? tb : ta, reversePass ? ta : tb))
@@ -2740,7 +2740,7 @@ private bool traverseIndirections(Type ta, Type tb)
              return true;
         }
 
-        if (tb.ty == Type.Kind.class_ || tb.ty == Type.Kind.struct_)
+        if (tb.ty == Tclass || tb.ty == Tstruct)
         {
             for (Ctxt* c = ctxt; c; c = c.prev)
                 if (tb == c.type)
@@ -2760,7 +2760,7 @@ private bool traverseIndirections(Type ta, Type tb)
                     return false;
             }
         }
-        else if (tb.ty == Type.Kind.array || tb.ty == Type.Kind.associativeArray || tb.ty == Type.Kind.pointer)
+        else if (tb.ty == Tarray || tb.ty == Taarray || tb.ty == Tpointer)
         {
             Type tind = tb.nextOf();
             if (!traverse(ta, tind, ctxt, reversePass))

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -738,11 +738,11 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     if (fd.semanticRun >= PASS.obj) // if toObjFile() already run
         return;
 
-    if (fd.type && fd.type.ty == Type.Kind.function_ && (cast(TypeFunction)fd.type).next is null)
+    if (fd.type && fd.type.ty == Tfunction && (cast(TypeFunction)fd.type).next is null)
         return;
 
     // If errors occurred compiling it, such as https://issues.dlang.org/show_bug.cgi?id=6118
-    if (fd.type && fd.type.ty == Type.Kind.function_ && (cast(TypeFunction)fd.type).next.ty == Type.Kind.error)
+    if (fd.type && fd.type.ty == Tfunction && (cast(TypeFunction)fd.type).next.ty == Terror)
         return;
 
     if (fd.semantic3Errors)
@@ -990,7 +990,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     //printf("linkage = %d, tyf = x%x\n", linkage, tyf);
     int reverse = tyrevfunc(s.Stype.Tty);
 
-    assert(fd.type.ty == Type.Kind.function_);
+    assert(fd.type.ty == Tfunction);
     TypeFunction tf = cast(TypeFunction)fd.type;
     RET retmethod = retStyle(tf);
     if (retmethod == RET.stack)
@@ -1377,78 +1377,78 @@ uint totym(Type tx)
     uint t;
     switch (tx.ty)
     {
-        case Type.Kind.void_:     t = TYvoid;     break;
-        case Type.Kind.int8:     t = TYschar;    break;
-        case Type.Kind.uint8:     t = TYuchar;    break;
-        case Type.Kind.int16:    t = TYshort;    break;
-        case Type.Kind.uint16:    t = TYushort;   break;
-        case Type.Kind.int32:    t = TYint;      break;
-        case Type.Kind.uint32:    t = TYuint;     break;
-        case Type.Kind.int64:    t = TYllong;    break;
-        case Type.Kind.uint64:    t = TYullong;   break;
-        case Type.Kind.float32:  t = TYfloat;    break;
-        case Type.Kind.float64:  t = TYdouble;   break;
-        case Type.Kind.float80:  t = TYldouble;  break;
-        case Type.Kind.imaginary32: t = TYifloat; break;
-        case Type.Kind.imaginary64: t = TYidouble; break;
-        case Type.Kind.imaginary80: t = TYildouble; break;
-        case Type.Kind.complex32: t = TYcfloat;  break;
-        case Type.Kind.complex64: t = TYcdouble; break;
-        case Type.Kind.complex80: t = TYcldouble; break;
-        case Type.Kind.bool_:     t = TYbool;     break;
-        case Type.Kind.char_:     t = TYchar;     break;
-        case Type.Kind.wchar_:    t = TYwchar_t;  break;
-        case Type.Kind.dchar_:
+        case Tvoid:     t = TYvoid;     break;
+        case Tint8:     t = TYschar;    break;
+        case Tuns8:     t = TYuchar;    break;
+        case Tint16:    t = TYshort;    break;
+        case Tuns16:    t = TYushort;   break;
+        case Tint32:    t = TYint;      break;
+        case Tuns32:    t = TYuint;     break;
+        case Tint64:    t = TYllong;    break;
+        case Tuns64:    t = TYullong;   break;
+        case Tfloat32:  t = TYfloat;    break;
+        case Tfloat64:  t = TYdouble;   break;
+        case Tfloat80:  t = TYldouble;  break;
+        case Timaginary32: t = TYifloat; break;
+        case Timaginary64: t = TYidouble; break;
+        case Timaginary80: t = TYildouble; break;
+        case Tcomplex32: t = TYcfloat;  break;
+        case Tcomplex64: t = TYcdouble; break;
+        case Tcomplex80: t = TYcldouble; break;
+        case Tbool:     t = TYbool;     break;
+        case Tchar:     t = TYchar;     break;
+        case Twchar:    t = TYwchar_t;  break;
+        case Tdchar:
             t = (global.params.symdebug == 1 || !global.params.isWindows) ? TYdchar : TYulong;
             break;
 
-        case Type.Kind.associativeArray:   t = TYaarray;   break;
-        case Type.Kind.class_:
-        case Type.Kind.reference:
-        case Type.Kind.pointer:  t = TYnptr;     break;
-        case Type.Kind.delegate_: t = TYdelegate; break;
-        case Type.Kind.array:    t = TYdarray;   break;
-        case Type.Kind.staticArray:   t = TYstruct;   break;
+        case Taarray:   t = TYaarray;   break;
+        case Tclass:
+        case Treference:
+        case Tpointer:  t = TYnptr;     break;
+        case Tdelegate: t = TYdelegate; break;
+        case Tarray:    t = TYdarray;   break;
+        case Tsarray:   t = TYstruct;   break;
 
-        case Type.Kind.struct_:
+        case Tstruct:
             t = TYstruct;
             if (tx.toDsymbol(null).ident == Id.__c_long_double)
                 t = TYdouble;
             break;
 
-        case Type.Kind.enum_:
+        case Tenum:
             t = totym(tx.toBasetype());
             break;
 
-        case Type.Kind.identifier:
-        case Type.Kind.typeof_:
+        case Tident:
+        case Ttypeof:
             //printf("ty = %d, '%s'\n", tx.ty, tx.toChars());
             error(Loc(), "forward reference of `%s`", tx.toChars());
             t = TYint;
             break;
 
-        case Type.Kind.null_:
+        case Tnull:
             t = TYnptr;
             break;
 
-        case Type.Kind.vector:
+        case Tvector:
         {
             TypeVector tv = cast(TypeVector)tx;
             TypeBasic tb = tv.elementType();
             const s32 = tv.alignsize() == 32;   // if 32 byte, 256 bit vector
             switch (tb.ty)
             {
-                case Type.Kind.void_:
-                case Type.Kind.int8:     t = s32 ? TYschar32  : TYschar16;  break;
-                case Type.Kind.uint8:     t = s32 ? TYuchar32  : TYuchar16;  break;
-                case Type.Kind.int16:    t = s32 ? TYshort16  : TYshort8;   break;
-                case Type.Kind.uint16:    t = s32 ? TYushort16 : TYushort8;  break;
-                case Type.Kind.int32:    t = s32 ? TYlong8    : TYlong4;    break;
-                case Type.Kind.uint32:    t = s32 ? TYulong8   : TYulong4;   break;
-                case Type.Kind.int64:    t = s32 ? TYllong4   : TYllong2;   break;
-                case Type.Kind.uint64:    t = s32 ? TYullong4  : TYullong2;  break;
-                case Type.Kind.float32:  t = s32 ? TYfloat8   : TYfloat4;   break;
-                case Type.Kind.float64:  t = s32 ? TYdouble4  : TYdouble2;  break;
+                case Tvoid:
+                case Tint8:     t = s32 ? TYschar32  : TYschar16;  break;
+                case Tuns8:     t = s32 ? TYuchar32  : TYuchar16;  break;
+                case Tint16:    t = s32 ? TYshort16  : TYshort8;   break;
+                case Tuns16:    t = s32 ? TYushort16 : TYushort8;  break;
+                case Tint32:    t = s32 ? TYlong8    : TYlong4;    break;
+                case Tuns32:    t = s32 ? TYulong8   : TYulong4;   break;
+                case Tint64:    t = s32 ? TYllong4   : TYllong2;   break;
+                case Tuns64:    t = s32 ? TYullong4  : TYullong2;  break;
+                case Tfloat32:  t = s32 ? TYfloat8   : TYfloat4;   break;
+                case Tfloat64:  t = s32 ? TYdouble4  : TYdouble2;  break;
                 default:
                     assert(0);
             }
@@ -1456,7 +1456,7 @@ uint totym(Type tx)
             break;
         }
 
-        case Type.Kind.function_:
+        case Tfunction:
         {
             TypeFunction tf = cast(TypeFunction)tx;
             final switch (tf.linkage)
@@ -1534,7 +1534,7 @@ uint totym(Type tx)
 
 Symbol *toSymbol(Type t)
 {
-    if (t.ty == Type.Kind.class_)
+    if (t.ty == Tclass)
     {
         return toSymbol((cast(TypeClass)t).sym);
     }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -719,7 +719,7 @@ public:
      */
     void typeToBuffer(Type t, Identifier ident)
     {
-        if (t.ty == Type.Kind.function_)
+        if (t.ty == Tfunction)
         {
             visitFuncIdentWithPrefix(cast(TypeFunction)t, ident, null, true);
             return;
@@ -735,7 +735,7 @@ public:
     void visitWithMask(Type t, ubyte modMask)
     {
         // Tuples and functions don't use the type constructor syntax
-        if (modMask == t.mod || t.ty == Type.Kind.function_ || t.ty == Type.Kind.tuple)
+        if (modMask == t.mod || t.ty == Tfunction || t.ty == Ttuple)
         {
             t.accept(this);
         }
@@ -830,7 +830,7 @@ public:
     override void visit(TypePointer t)
     {
         //printf("TypePointer::toCBuffer2() next = %d\n", t.next.ty);
-        if (t.next.ty == Type.Kind.function_)
+        if (t.next.ty == Tfunction)
             visitFuncIdentWithPostfix(cast(TypeFunction)t.next, "function");
         else
         {
@@ -1597,7 +1597,7 @@ public:
             RootObject oarg = (*ti.tiargs)[0];
             if (Type t = isType(oarg))
             {
-                if (t.equals(Type.tstring) || t.equals(Type.twstring) || t.equals(Type.tdstring) || t.mod == 0 && (t.isTypeBasic() || t.ty == Type.Kind.identifier && (cast(TypeIdentifier)t).idents.dim == 0))
+                if (t.equals(Type.tstring) || t.equals(Type.twstring) || t.equals(Type.tdstring) || t.mod == 0 && (t.isTypeBasic() || t.ty == Tident && (cast(TypeIdentifier)t).idents.dim == 0))
                 {
                     buf.writestring(t.toChars());
                     return;
@@ -1806,7 +1806,7 @@ public:
                 buf.writeByte(' ');
             d.aliassym.accept(this);
         }
-        else if (d.type.ty == Type.Kind.function_)
+        else if (d.type.ty == Tfunction)
         {
             if (stcToBuffer(buf, d.storage_class))
                 buf.writeByte(' ');
@@ -1942,7 +1942,7 @@ public:
 
     override void visit(FuncLiteralDeclaration f)
     {
-        if (f.type.ty == Type.Kind.error)
+        if (f.type.ty == Terror)
         {
             buf.writestring("__error");
             return;
@@ -2242,7 +2242,7 @@ public:
         L1:
             switch (t.ty)
             {
-            case Type.Kind.enum_:
+            case Tenum:
                 {
                     TypeEnum te = cast(TypeEnum)t;
                     if (hgs.fullDump)
@@ -2264,9 +2264,9 @@ public:
                     t = te.sym.memtype;
                     goto L1;
                 }
-            case Type.Kind.wchar_:
+            case Twchar:
                 // BUG: need to cast(wchar)
-            case Type.Kind.dchar_:
+            case Tdchar:
                 // BUG: need to cast(dchar)
                 if (cast(uinteger_t)v > 0xFF)
                 {
@@ -2274,7 +2274,7 @@ public:
                     break;
                 }
                 goto case;
-            case Type.Kind.char_:
+            case Tchar:
                 {
                     size_t o = buf.offset;
                     if (v == '\'')
@@ -2287,37 +2287,37 @@ public:
                         escapeDdocString(buf, o);
                     break;
                 }
-            case Type.Kind.int8:
+            case Tint8:
                 buf.writestring("cast(byte)");
                 goto L2;
-            case Type.Kind.int16:
+            case Tint16:
                 buf.writestring("cast(short)");
                 goto L2;
-            case Type.Kind.int32:
+            case Tint32:
             L2:
                 buf.printf("%d", cast(int)v);
                 break;
-            case Type.Kind.uint8:
+            case Tuns8:
                 buf.writestring("cast(ubyte)");
                 goto L3;
-            case Type.Kind.uint16:
+            case Tuns16:
                 buf.writestring("cast(ushort)");
                 goto L3;
-            case Type.Kind.uint32:
+            case Tuns32:
             L3:
                 buf.printf("%uu", cast(uint)v);
                 break;
-            case Type.Kind.int64:
+            case Tint64:
                 buf.printf("%lldL", v);
                 break;
-            case Type.Kind.uint64:
+            case Tuns64:
             L4:
                 buf.printf("%lluLU", v);
                 break;
-            case Type.Kind.bool_:
+            case Tbool:
                 buf.writestring(v ? "true" : "false");
                 break;
-            case Type.Kind.pointer:
+            case Tpointer:
                 buf.writestring("cast(");
                 buf.writestring(t.toChars());
                 buf.writeByte(')');
@@ -2375,14 +2375,14 @@ public:
             Type t = type.toBasetype();
             switch (t.ty)
             {
-            case Type.Kind.float32:
-            case Type.Kind.imaginary32:
-            case Type.Kind.complex32:
+            case Tfloat32:
+            case Timaginary32:
+            case Tcomplex32:
                 buf.writeByte('F');
                 break;
-            case Type.Kind.float80:
-            case Type.Kind.imaginary80:
-            case Type.Kind.complex80:
+            case Tfloat80:
+            case Timaginary80:
+            case Tcomplex80:
                 buf.writeByte('L');
                 break;
             default:
@@ -3073,7 +3073,7 @@ public:
             if (p.ident)
                 buf.writestring(p.ident.toString());
         }
-        else if (p.type.ty == Type.Kind.identifier &&
+        else if (p.type.ty == Tident &&
                  (cast(TypeIdentifier)p.type).ident.toString().length > 3 &&
                  strncmp((cast(TypeIdentifier)p.type).ident.toChars(), "__T", 3) == 0)
         {

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -1008,15 +1008,15 @@ version (none)
     {
         switch (popnd.ptype.ty)
         {
-            case Type.Kind.float32:
+            case Tfloat32:
                 popnd.s = fconst(popnd.vreal);
                 return(CONSTRUCT_FLAGS(_32, _m, _normal, 0));
 
-            case Type.Kind.float64:
+            case Tfloat64:
                 popnd.s = dconst(popnd.vreal);
                 return(CONSTRUCT_FLAGS(0, _m, _normal, _f64));
 
-            case Type.Kind.float80:
+            case Tfloat80:
                 popnd.s = ldconst(popnd.vreal);
                 return(CONSTRUCT_FLAGS(0, _m, _normal, _f80));
         }
@@ -1118,12 +1118,12 @@ opflag_t asm_determine_operand_flags(OPND *popnd)
         if (!popnd.ptype)
             return CONSTRUCT_FLAGS(sz, _m, _normal, 0);
         ty = popnd.ptype.ty;
-        if (ty == Type.Kind.pointer && popnd.ptype.nextOf().ty == Type.Kind.function_ &&
+        if (ty == Tpointer && popnd.ptype.nextOf().ty == Tfunction &&
             !ps.isVarDeclaration())
         {
             return CONSTRUCT_FLAGS(_32, _m, _fn16, 0);
         }
-        else if (ty == Type.Kind.function_)
+        else if (ty == Tfunction)
         {
             return CONSTRUCT_FLAGS(_32, _rel, _fn16, 0);
         }
@@ -2224,7 +2224,7 @@ void asm_merge_symbol(ref OPND o1, Dsymbol s)
             goto L2;
         }
         if ((v.isConst() || v.isImmutable() || v.storage_class & STC.manifest) &&
-            !v.type.isfloating() && v.type.ty != Type.Kind.vector && v._init)
+            !v.type.isfloating() && v.type.ty != Tvector && v._init)
         {
             ExpInitializer ei = v._init.isExpInitializer();
             if (ei)
@@ -3258,7 +3258,7 @@ uint asm_type_size(Type ptype)
 
     //if (ptype) printf("asm_type_size('%s') = %d\n", ptype.toChars(), (int)ptype.size());
     u = _anysize;
-    if (ptype && ptype.ty != Type.Kind.function_ /*&& ptype.isscalar()*/)
+    if (ptype && ptype.ty != Tfunction /*&& ptype.isscalar()*/)
     {
         switch (cast(int)ptype.size())
         {
@@ -4272,7 +4272,7 @@ void asm_primary_exp(out OPND o1)
                 if (o1.ptype && asmstate.tokValue != TOK.comma && asmstate.tokValue != TOK.endOfFile)
                 {
                     for (;
-                         o1.ptype.ty == Type.Kind.staticArray;
+                         o1.ptype.ty == Tsarray;
                          o1.ptype = o1.ptype.nextOf())
                     {
                     }

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -14,17 +14,17 @@ module dmd.impcnvtab;
 
 import dmd.mtype;
 
-immutable Type.Kind[Type.Kind.max_][Type.Kind.max_] impcnvResult = impCnvTab.impcnvResultTab;
-immutable Type.Kind[Type.Kind.max_][Type.Kind.max_] impcnvType1 = impCnvTab.impcnvType1Tab;
-immutable Type.Kind[Type.Kind.max_][Type.Kind.max_] impcnvType2 = impCnvTab.impcnvType2Tab;
+immutable ENUMTY[TMAX][TMAX] impcnvResult = impCnvTab.impcnvResultTab;
+immutable ENUMTY[TMAX][TMAX] impcnvType1 = impCnvTab.impcnvType1Tab;
+immutable ENUMTY[TMAX][TMAX] impcnvType2 = impCnvTab.impcnvType2Tab;
 
 private:
 
 struct ImpCnvTab
 {
-    Type.Kind[Type.Kind.max_][Type.Kind.max_] impcnvResultTab;
-    Type.Kind[Type.Kind.max_][Type.Kind.max_] impcnvType1Tab;
-    Type.Kind[Type.Kind.max_][Type.Kind.max_] impcnvType2Tab;
+    ENUMTY[TMAX][TMAX] impcnvResultTab;
+    ENUMTY[TMAX][TMAX] impcnvType1Tab;
+    ENUMTY[TMAX][TMAX] impcnvType2Tab;
 }
 
 enum ImpCnvTab impCnvTab = generateImpCnvTab();
@@ -34,17 +34,17 @@ ImpCnvTab generateImpCnvTab()
     ImpCnvTab impCnvTab;
 
     // Set conversion tables
-    foreach (i; 0 .. cast(size_t)Type.Kind.max_)
+    foreach (i; 0 .. cast(size_t)TMAX)
     {
-        foreach (j; 0 .. cast(size_t)Type.Kind.max_)
+        foreach (j; 0 .. cast(size_t)TMAX)
         {
-            impCnvTab.impcnvResultTab[i][j] = Type.Kind.error;
-            impCnvTab.impcnvType1Tab[i][j] = Type.Kind.error;
-            impCnvTab.impcnvType2Tab[i][j] = Type.Kind.error;
+            impCnvTab.impcnvResultTab[i][j] = Terror;
+            impCnvTab.impcnvType1Tab[i][j] = Terror;
+            impCnvTab.impcnvType2Tab[i][j] = Terror;
         }
     }
 
-    void X(Type.Kind t1, Type.Kind t2, Type.Kind nt1, Type.Kind nt2, Type.Kind rt)
+    void X(ENUMTY t1, ENUMTY t2, ENUMTY nt1, ENUMTY nt2, ENUMTY rt)
     {
         impCnvTab.impcnvResultTab[t1][t2] = rt;
         impCnvTab.impcnvType1Tab[t1][t2] = nt1;
@@ -53,299 +53,299 @@ ImpCnvTab generateImpCnvTab()
 
     /* ======================= */
 
-    X(Type.Kind.bool_,Type.Kind.bool_,   Type.Kind.bool_,Type.Kind.bool_,    Type.Kind.bool_);
-    X(Type.Kind.bool_,Type.Kind.int8,   Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.bool_,Type.Kind.uint8,   Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.bool_,Type.Kind.int16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.bool_,Type.Kind.uint16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.bool_,Type.Kind.int32,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.bool_,Type.Kind.uint32,  Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32);
-    X(Type.Kind.bool_,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.bool_,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.bool_,Type.Kind.int128, Type.Kind.int128,Type.Kind.int128, Type.Kind.int128);
-    X(Type.Kind.bool_,Type.Kind.uint128, Type.Kind.uint128,Type.Kind.uint128, Type.Kind.uint128);
+    X(Tbool,Tbool,   Tbool,Tbool,    Tbool);
+    X(Tbool,Tint8,   Tint32,Tint32,  Tint32);
+    X(Tbool,Tuns8,   Tint32,Tint32,  Tint32);
+    X(Tbool,Tint16,  Tint32,Tint32,  Tint32);
+    X(Tbool,Tuns16,  Tint32,Tint32,  Tint32);
+    X(Tbool,Tint32,  Tint32,Tint32,  Tint32);
+    X(Tbool,Tuns32,  Tuns32,Tuns32,  Tuns32);
+    X(Tbool,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tbool,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tbool,Tint128, Tint128,Tint128, Tint128);
+    X(Tbool,Tuns128, Tuns128,Tuns128, Tuns128);
 
-    X(Type.Kind.bool_,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.bool_,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.bool_,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.bool_,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.bool_,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.bool_,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.bool_,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.bool_,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.bool_,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.int8,Type.Kind.int8,   Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int8,Type.Kind.uint8,   Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int8,Type.Kind.int16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int8,Type.Kind.uint16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int8,Type.Kind.int32,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int8,Type.Kind.uint32,  Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32);
-    X(Type.Kind.int8,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.int8,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.int8,Type.Kind.int128, Type.Kind.int128,Type.Kind.int128, Type.Kind.int128);
-    X(Type.Kind.int8,Type.Kind.uint128, Type.Kind.uint128,Type.Kind.uint128, Type.Kind.uint128);
-
-    X(Type.Kind.int8,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.int8,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.int8,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.int8,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.int8,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.int8,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.int8,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.int8,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.int8,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
+    X(Tbool,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tbool,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tbool,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tbool,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tbool,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tbool,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tbool,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tbool,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tbool,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.uint8,Type.Kind.uint8,   Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.uint8,Type.Kind.int16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.uint8,Type.Kind.uint16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.uint8,Type.Kind.int32,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.uint8,Type.Kind.uint32,  Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32);
-    X(Type.Kind.uint8,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.uint8,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.uint8,Type.Kind.int128,  Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.uint8,Type.Kind.uint128,  Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
+    X(Tint8,Tint8,   Tint32,Tint32,  Tint32);
+    X(Tint8,Tuns8,   Tint32,Tint32,  Tint32);
+    X(Tint8,Tint16,  Tint32,Tint32,  Tint32);
+    X(Tint8,Tuns16,  Tint32,Tint32,  Tint32);
+    X(Tint8,Tint32,  Tint32,Tint32,  Tint32);
+    X(Tint8,Tuns32,  Tuns32,Tuns32,  Tuns32);
+    X(Tint8,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tint8,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tint8,Tint128, Tint128,Tint128, Tint128);
+    X(Tint8,Tuns128, Tuns128,Tuns128, Tuns128);
 
-    X(Type.Kind.uint8,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.uint8,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.uint8,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.uint8,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.uint8,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.uint8,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.uint8,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.uint8,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.uint8,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.int16,Type.Kind.int16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int16,Type.Kind.uint16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int16,Type.Kind.int32,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int16,Type.Kind.uint32,  Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32);
-    X(Type.Kind.int16,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.int16,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.int16,Type.Kind.int128,  Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.int16,Type.Kind.uint128,  Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
-
-    X(Type.Kind.int16,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.int16,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.int16,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.int16,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.int16,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.int16,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.int16,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.int16,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.int16,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
+    X(Tint8,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tint8,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tint8,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tint8,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tint8,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tint8,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tint8,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tint8,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tint8,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.uint16,Type.Kind.uint16,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.uint16,Type.Kind.int32,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.uint16,Type.Kind.uint32,  Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32);
-    X(Type.Kind.uint16,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.uint16,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.uint16,Type.Kind.int128, Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.uint16,Type.Kind.uint128, Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
+    X(Tuns8,Tuns8,   Tint32,Tint32,  Tint32);
+    X(Tuns8,Tint16,  Tint32,Tint32,  Tint32);
+    X(Tuns8,Tuns16,  Tint32,Tint32,  Tint32);
+    X(Tuns8,Tint32,  Tint32,Tint32,  Tint32);
+    X(Tuns8,Tuns32,  Tuns32,Tuns32,  Tuns32);
+    X(Tuns8,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tuns8,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tuns8,Tint128,  Tint128,Tint128,  Tint128);
+    X(Tuns8,Tuns128,  Tuns128,Tuns128,  Tuns128);
 
-    X(Type.Kind.uint16,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.uint16,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.uint16,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.uint16,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.uint16,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.uint16,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.uint16,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.uint16,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.uint16,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32,Type.Kind.int32,  Type.Kind.int32);
-    X(Type.Kind.int32,Type.Kind.uint32,  Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32);
-    X(Type.Kind.int32,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.int32,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.int32,Type.Kind.int128, Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.int32,Type.Kind.uint128, Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
-
-    X(Type.Kind.int32,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.int32,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.int32,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.int32,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.int32,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.int32,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.int32,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.int32,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.int32,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
+    X(Tuns8,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tuns8,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tuns8,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tuns8,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tuns8,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tuns8,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tuns8,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tuns8,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tuns8,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32,Type.Kind.uint32,  Type.Kind.uint32);
-    X(Type.Kind.uint32,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.uint32,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.uint32,Type.Kind.int128,  Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.uint32,Type.Kind.uint128,  Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
+    X(Tint16,Tint16,  Tint32,Tint32,  Tint32);
+    X(Tint16,Tuns16,  Tint32,Tint32,  Tint32);
+    X(Tint16,Tint32,  Tint32,Tint32,  Tint32);
+    X(Tint16,Tuns32,  Tuns32,Tuns32,  Tuns32);
+    X(Tint16,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tint16,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tint16,Tint128,  Tint128,Tint128,  Tint128);
+    X(Tint16,Tuns128,  Tuns128,Tuns128,  Tuns128);
 
-    X(Type.Kind.uint32,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.uint32,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.uint32,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.uint32,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.uint32,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.uint32,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.uint32,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.uint32,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.uint32,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64,Type.Kind.int64,  Type.Kind.int64);
-    X(Type.Kind.int64,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.int64,Type.Kind.int128,  Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.int64,Type.Kind.uint128,  Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
-
-    X(Type.Kind.int64,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.int64,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.int64,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.int64,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.int64,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.int64,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.int64,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.int64,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.int64,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
+    X(Tint16,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tint16,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tint16,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tint16,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tint16,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tint16,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tint16,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tint16,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tint16,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64,Type.Kind.uint64,  Type.Kind.uint64);
-    X(Type.Kind.uint64,Type.Kind.int128,  Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.uint64,Type.Kind.uint128,  Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
+    X(Tuns16,Tuns16,  Tint32,Tint32,  Tint32);
+    X(Tuns16,Tint32,  Tint32,Tint32,  Tint32);
+    X(Tuns16,Tuns32,  Tuns32,Tuns32,  Tuns32);
+    X(Tuns16,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tuns16,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tuns16,Tint128, Tint128,Tint128,  Tint128);
+    X(Tuns16,Tuns128, Tuns128,Tuns128,  Tuns128);
 
-    X(Type.Kind.uint64,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.uint64,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.uint64,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.uint64,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.uint64,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.uint64,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.uint64,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.uint64,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.uint64,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128,Type.Kind.int128,  Type.Kind.int128);
-    X(Type.Kind.int128,Type.Kind.uint128,  Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
-
-    X(Type.Kind.int128,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.int128,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.int128,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.int128,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.int128,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.int128,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.int128,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.int128,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.int128,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
+    X(Tuns16,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tuns16,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tuns16,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tuns16,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tuns16,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tuns16,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tuns16,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tuns16,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tuns16,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128,Type.Kind.uint128,  Type.Kind.uint128);
+    X(Tint32,Tint32,  Tint32,Tint32,  Tint32);
+    X(Tint32,Tuns32,  Tuns32,Tuns32,  Tuns32);
+    X(Tint32,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tint32,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tint32,Tint128, Tint128,Tint128,  Tint128);
+    X(Tint32,Tuns128, Tuns128,Tuns128,  Tuns128);
 
-    X(Type.Kind.uint128,Type.Kind.float32,     Type.Kind.float32,Type.Kind.float32,     Type.Kind.float32);
-    X(Type.Kind.uint128,Type.Kind.float64,     Type.Kind.float64,Type.Kind.float64,     Type.Kind.float64);
-    X(Type.Kind.uint128,Type.Kind.float80,     Type.Kind.float80,Type.Kind.float80,     Type.Kind.float80);
-    X(Type.Kind.uint128,Type.Kind.imaginary32, Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.uint128,Type.Kind.imaginary64, Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.uint128,Type.Kind.imaginary80, Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.uint128,Type.Kind.complex32,   Type.Kind.float32,Type.Kind.complex32,   Type.Kind.complex32);
-    X(Type.Kind.uint128,Type.Kind.complex64,   Type.Kind.float64,Type.Kind.complex64,   Type.Kind.complex64);
-    X(Type.Kind.uint128,Type.Kind.complex80,   Type.Kind.float80,Type.Kind.complex80,   Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.float32,Type.Kind.float32,  Type.Kind.float32,Type.Kind.float32, Type.Kind.float32);
-    X(Type.Kind.float32,Type.Kind.float64,  Type.Kind.float64,Type.Kind.float64, Type.Kind.float64);
-    X(Type.Kind.float32,Type.Kind.float80,  Type.Kind.float80,Type.Kind.float80, Type.Kind.float80);
-
-    X(Type.Kind.float32,Type.Kind.imaginary32,  Type.Kind.float32,Type.Kind.imaginary32, Type.Kind.float32);
-    X(Type.Kind.float32,Type.Kind.imaginary64,  Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.float32,Type.Kind.imaginary80,  Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-
-    X(Type.Kind.float32,Type.Kind.complex32,  Type.Kind.float32,Type.Kind.complex32, Type.Kind.complex32);
-    X(Type.Kind.float32,Type.Kind.complex64,  Type.Kind.float64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.float32,Type.Kind.complex80,  Type.Kind.float80,Type.Kind.complex80, Type.Kind.complex80);
+    X(Tint32,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tint32,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tint32,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tint32,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tint32,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tint32,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tint32,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tint32,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tint32,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.float64,Type.Kind.float64,  Type.Kind.float64,Type.Kind.float64, Type.Kind.float64);
-    X(Type.Kind.float64,Type.Kind.float80,  Type.Kind.float80,Type.Kind.float80, Type.Kind.float80);
+    X(Tuns32,Tuns32,  Tuns32,Tuns32,  Tuns32);
+    X(Tuns32,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tuns32,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tuns32,Tint128,  Tint128,Tint128,  Tint128);
+    X(Tuns32,Tuns128,  Tuns128,Tuns128,  Tuns128);
 
-    X(Type.Kind.float64,Type.Kind.imaginary32,  Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.float64,Type.Kind.imaginary64,  Type.Kind.float64,Type.Kind.imaginary64, Type.Kind.float64);
-    X(Type.Kind.float64,Type.Kind.imaginary80,  Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-
-    X(Type.Kind.float64,Type.Kind.complex32,  Type.Kind.float64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.float64,Type.Kind.complex64,  Type.Kind.float64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.float64,Type.Kind.complex80,  Type.Kind.float80,Type.Kind.complex80, Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.float80,Type.Kind.float80,  Type.Kind.float80,Type.Kind.float80, Type.Kind.float80);
-
-    X(Type.Kind.float80,Type.Kind.imaginary32,  Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.float80,Type.Kind.imaginary64,  Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-    X(Type.Kind.float80,Type.Kind.imaginary80,  Type.Kind.float80,Type.Kind.imaginary80, Type.Kind.float80);
-
-    X(Type.Kind.float80,Type.Kind.complex32,  Type.Kind.float80,Type.Kind.complex80, Type.Kind.complex80);
-    X(Type.Kind.float80,Type.Kind.complex64,  Type.Kind.float80,Type.Kind.complex80, Type.Kind.complex80);
-    X(Type.Kind.float80,Type.Kind.complex80,  Type.Kind.float80,Type.Kind.complex80, Type.Kind.complex80);
+    X(Tuns32,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tuns32,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tuns32,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tuns32,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tuns32,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tuns32,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tuns32,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tuns32,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tuns32,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.imaginary32,Type.Kind.imaginary32,  Type.Kind.imaginary32,Type.Kind.imaginary32, Type.Kind.imaginary32);
-    X(Type.Kind.imaginary32,Type.Kind.imaginary64,  Type.Kind.imaginary64,Type.Kind.imaginary64, Type.Kind.imaginary64);
-    X(Type.Kind.imaginary32,Type.Kind.imaginary80,  Type.Kind.imaginary80,Type.Kind.imaginary80, Type.Kind.imaginary80);
+    X(Tint64,Tint64,  Tint64,Tint64,  Tint64);
+    X(Tint64,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tint64,Tint128,  Tint128,Tint128,  Tint128);
+    X(Tint64,Tuns128,  Tuns128,Tuns128,  Tuns128);
 
-    X(Type.Kind.imaginary32,Type.Kind.complex32,  Type.Kind.imaginary32,Type.Kind.complex32, Type.Kind.complex32);
-    X(Type.Kind.imaginary32,Type.Kind.complex64,  Type.Kind.imaginary64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.imaginary32,Type.Kind.complex80,  Type.Kind.imaginary80,Type.Kind.complex80, Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.imaginary64,Type.Kind.imaginary64,  Type.Kind.imaginary64,Type.Kind.imaginary64, Type.Kind.imaginary64);
-    X(Type.Kind.imaginary64,Type.Kind.imaginary80,  Type.Kind.imaginary80,Type.Kind.imaginary80, Type.Kind.imaginary80);
-
-    X(Type.Kind.imaginary64,Type.Kind.complex32,  Type.Kind.imaginary64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.imaginary64,Type.Kind.complex64,  Type.Kind.imaginary64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.imaginary64,Type.Kind.complex80,  Type.Kind.imaginary80,Type.Kind.complex80, Type.Kind.complex80);
+    X(Tint64,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tint64,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tint64,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tint64,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tint64,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tint64,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tint64,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tint64,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tint64,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.imaginary80,Type.Kind.imaginary80,  Type.Kind.imaginary80,Type.Kind.imaginary80, Type.Kind.imaginary80);
+    X(Tuns64,Tuns64,  Tuns64,Tuns64,  Tuns64);
+    X(Tuns64,Tint128,  Tint128,Tint128,  Tint128);
+    X(Tuns64,Tuns128,  Tuns128,Tuns128,  Tuns128);
 
-    X(Type.Kind.imaginary80,Type.Kind.complex32,  Type.Kind.imaginary80,Type.Kind.complex80, Type.Kind.complex80);
-    X(Type.Kind.imaginary80,Type.Kind.complex64,  Type.Kind.imaginary80,Type.Kind.complex80, Type.Kind.complex80);
-    X(Type.Kind.imaginary80,Type.Kind.complex80,  Type.Kind.imaginary80,Type.Kind.complex80, Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.complex32,Type.Kind.complex32,  Type.Kind.complex32,Type.Kind.complex32, Type.Kind.complex32);
-    X(Type.Kind.complex32,Type.Kind.complex64,  Type.Kind.complex64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.complex32,Type.Kind.complex80,  Type.Kind.complex80,Type.Kind.complex80, Type.Kind.complex80);
-
-    /* ======================= */
-
-    X(Type.Kind.complex64,Type.Kind.complex64,  Type.Kind.complex64,Type.Kind.complex64, Type.Kind.complex64);
-    X(Type.Kind.complex64,Type.Kind.complex80,  Type.Kind.complex80,Type.Kind.complex80, Type.Kind.complex80);
+    X(Tuns64,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tuns64,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tuns64,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tuns64,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tuns64,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tuns64,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tuns64,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tuns64,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tuns64,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
 
     /* ======================= */
 
-    X(Type.Kind.complex80,Type.Kind.complex80,  Type.Kind.complex80,Type.Kind.complex80, Type.Kind.complex80);
+    X(Tint128,Tint128,  Tint128,Tint128,  Tint128);
+    X(Tint128,Tuns128,  Tuns128,Tuns128,  Tuns128);
 
-    foreach (i; 0 .. cast(size_t)Type.Kind.max_)
+    X(Tint128,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tint128,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tint128,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tint128,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tint128,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tint128,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tint128,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tint128,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tint128,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
+
+    /* ======================= */
+
+    X(Tuns128,Tuns128,  Tuns128,Tuns128,  Tuns128);
+
+    X(Tuns128,Tfloat32,     Tfloat32,Tfloat32,     Tfloat32);
+    X(Tuns128,Tfloat64,     Tfloat64,Tfloat64,     Tfloat64);
+    X(Tuns128,Tfloat80,     Tfloat80,Tfloat80,     Tfloat80);
+    X(Tuns128,Timaginary32, Tfloat32,Timaginary32, Tfloat32);
+    X(Tuns128,Timaginary64, Tfloat64,Timaginary64, Tfloat64);
+    X(Tuns128,Timaginary80, Tfloat80,Timaginary80, Tfloat80);
+    X(Tuns128,Tcomplex32,   Tfloat32,Tcomplex32,   Tcomplex32);
+    X(Tuns128,Tcomplex64,   Tfloat64,Tcomplex64,   Tcomplex64);
+    X(Tuns128,Tcomplex80,   Tfloat80,Tcomplex80,   Tcomplex80);
+
+    /* ======================= */
+
+    X(Tfloat32,Tfloat32,  Tfloat32,Tfloat32, Tfloat32);
+    X(Tfloat32,Tfloat64,  Tfloat64,Tfloat64, Tfloat64);
+    X(Tfloat32,Tfloat80,  Tfloat80,Tfloat80, Tfloat80);
+
+    X(Tfloat32,Timaginary32,  Tfloat32,Timaginary32, Tfloat32);
+    X(Tfloat32,Timaginary64,  Tfloat64,Timaginary64, Tfloat64);
+    X(Tfloat32,Timaginary80,  Tfloat80,Timaginary80, Tfloat80);
+
+    X(Tfloat32,Tcomplex32,  Tfloat32,Tcomplex32, Tcomplex32);
+    X(Tfloat32,Tcomplex64,  Tfloat64,Tcomplex64, Tcomplex64);
+    X(Tfloat32,Tcomplex80,  Tfloat80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Tfloat64,Tfloat64,  Tfloat64,Tfloat64, Tfloat64);
+    X(Tfloat64,Tfloat80,  Tfloat80,Tfloat80, Tfloat80);
+
+    X(Tfloat64,Timaginary32,  Tfloat64,Timaginary64, Tfloat64);
+    X(Tfloat64,Timaginary64,  Tfloat64,Timaginary64, Tfloat64);
+    X(Tfloat64,Timaginary80,  Tfloat80,Timaginary80, Tfloat80);
+
+    X(Tfloat64,Tcomplex32,  Tfloat64,Tcomplex64, Tcomplex64);
+    X(Tfloat64,Tcomplex64,  Tfloat64,Tcomplex64, Tcomplex64);
+    X(Tfloat64,Tcomplex80,  Tfloat80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Tfloat80,Tfloat80,  Tfloat80,Tfloat80, Tfloat80);
+
+    X(Tfloat80,Timaginary32,  Tfloat80,Timaginary80, Tfloat80);
+    X(Tfloat80,Timaginary64,  Tfloat80,Timaginary80, Tfloat80);
+    X(Tfloat80,Timaginary80,  Tfloat80,Timaginary80, Tfloat80);
+
+    X(Tfloat80,Tcomplex32,  Tfloat80,Tcomplex80, Tcomplex80);
+    X(Tfloat80,Tcomplex64,  Tfloat80,Tcomplex80, Tcomplex80);
+    X(Tfloat80,Tcomplex80,  Tfloat80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Timaginary32,Timaginary32,  Timaginary32,Timaginary32, Timaginary32);
+    X(Timaginary32,Timaginary64,  Timaginary64,Timaginary64, Timaginary64);
+    X(Timaginary32,Timaginary80,  Timaginary80,Timaginary80, Timaginary80);
+
+    X(Timaginary32,Tcomplex32,  Timaginary32,Tcomplex32, Tcomplex32);
+    X(Timaginary32,Tcomplex64,  Timaginary64,Tcomplex64, Tcomplex64);
+    X(Timaginary32,Tcomplex80,  Timaginary80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Timaginary64,Timaginary64,  Timaginary64,Timaginary64, Timaginary64);
+    X(Timaginary64,Timaginary80,  Timaginary80,Timaginary80, Timaginary80);
+
+    X(Timaginary64,Tcomplex32,  Timaginary64,Tcomplex64, Tcomplex64);
+    X(Timaginary64,Tcomplex64,  Timaginary64,Tcomplex64, Tcomplex64);
+    X(Timaginary64,Tcomplex80,  Timaginary80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Timaginary80,Timaginary80,  Timaginary80,Timaginary80, Timaginary80);
+
+    X(Timaginary80,Tcomplex32,  Timaginary80,Tcomplex80, Tcomplex80);
+    X(Timaginary80,Tcomplex64,  Timaginary80,Tcomplex80, Tcomplex80);
+    X(Timaginary80,Tcomplex80,  Timaginary80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Tcomplex32,Tcomplex32,  Tcomplex32,Tcomplex32, Tcomplex32);
+    X(Tcomplex32,Tcomplex64,  Tcomplex64,Tcomplex64, Tcomplex64);
+    X(Tcomplex32,Tcomplex80,  Tcomplex80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Tcomplex64,Tcomplex64,  Tcomplex64,Tcomplex64, Tcomplex64);
+    X(Tcomplex64,Tcomplex80,  Tcomplex80,Tcomplex80, Tcomplex80);
+
+    /* ======================= */
+
+    X(Tcomplex80,Tcomplex80,  Tcomplex80,Tcomplex80, Tcomplex80);
+
+    foreach (i; 0 .. cast(size_t)TMAX)
     {
-        foreach (j; 0 .. cast(size_t)Type.Kind.max_)
+        foreach (j; 0 .. cast(size_t)TMAX)
         {
-            if (impCnvTab.impcnvResultTab[i][j] == Type.Kind.error)
+            if (impCnvTab.impcnvResultTab[i][j] == Terror)
             {
                 impCnvTab.impcnvResultTab[i][j] = impCnvTab.impcnvResultTab[j][i];
                 impCnvTab.impcnvType1Tab[i][j] = impCnvTab.impcnvType2Tab[j][i];

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -337,7 +337,7 @@ version (all)
             return false;
         }
 
-        if (e.type.ty == Type.Kind.error)
+        if (e.type.ty == Terror)
             return false;
         if (e.op == TOK.null_)
             return false;
@@ -383,7 +383,7 @@ version (all)
             }
             return true;
         }
-        if (e.type.ty == Type.Kind.pointer && e.type.nextOf().ty != Type.Kind.function_)
+        if (e.type.ty == Tpointer && e.type.nextOf().ty != Tfunction)
         {
             if (e.op == TOK.symbolOffset) // address of a global is OK
                 return false;

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -119,9 +119,9 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
     {
         //printf("StructInitializer::semantic(t = %s) %s\n", t.toChars(), toChars());
         t = t.toBasetype();
-        if (t.ty == Type.Kind.staticArray && t.nextOf().toBasetype().ty == Type.Kind.struct_)
+        if (t.ty == Tsarray && t.nextOf().toBasetype().ty == Tstruct)
             t = t.nextOf().toBasetype();
-        if (t.ty == Type.Kind.struct_)
+        if (t.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)t).sym;
             if (sd.ctor)
@@ -226,9 +226,9 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
             result = ie.initializerSemantic(sc, t, needInterpret);
             return;
         }
-        else if ((t.ty == Type.Kind.delegate_ || t.ty == Type.Kind.pointer && t.nextOf().ty == Type.Kind.function_) && i.value.dim == 0)
+        else if ((t.ty == Tdelegate || t.ty == Tpointer && t.nextOf().ty == Tfunction) && i.value.dim == 0)
         {
-            TOK tok = (t.ty == Type.Kind.delegate_) ? TOK.delegate_ : TOK.function_;
+            TOK tok = (t.ty == Tdelegate) ? TOK.delegate_ : TOK.function_;
             /* Rewrite as empty delegate literal { }
              */
             auto parameters = new Parameters();
@@ -261,18 +261,18 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
         t = t.toBasetype();
         switch (t.ty)
         {
-        case Type.Kind.staticArray:
-        case Type.Kind.array:
+        case Tsarray:
+        case Tarray:
             break;
-        case Type.Kind.vector:
+        case Tvector:
             t = (cast(TypeVector)t).basetype;
             break;
-        case Type.Kind.associativeArray:
-        case Type.Kind.struct_: // consider implicit constructor call
+        case Taarray:
+        case Tstruct: // consider implicit constructor call
             {
                 Expression e;
                 // note: MyStruct foo = [1:2, 3:4] is correct code if MyStruct has a this(int[int])
-                if (t.ty == Type.Kind.associativeArray || i.isAssociativeArray())
+                if (t.ty == Taarray || i.isAssociativeArray())
                     e = i.toAssocArrayLiteral();
                 else
                     e = i.initializerToExpression();
@@ -286,8 +286,8 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
                 result = ei.initializerSemantic(sc, t, needInterpret);
                 return;
             }
-        case Type.Kind.pointer:
-            if (t.nextOf().ty != Type.Kind.function_)
+        case Tpointer:
+            if (t.nextOf().ty != Tfunction)
                 break;
             goto default;
         default:
@@ -352,7 +352,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
             if (length > i.dim)
                 i.dim = length;
         }
-        if (t.ty == Type.Kind.staticArray)
+        if (t.ty == Tsarray)
         {
             uinteger_t edim = (cast(TypeSArray)t).dim.toInteger();
             if (i.dim > edim)
@@ -419,7 +419,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
             result = i; // Failed, suppress duplicate error messages
             return;
         }
-        if (i.exp.type.ty == Type.Kind.tuple && (cast(TypeTuple)i.exp.type).arguments.dim == 0)
+        if (i.exp.type.ty == Ttuple && (cast(TypeTuple)i.exp.type).arguments.dim == 0)
         {
             Type et = i.exp.type;
             i.exp = new TupleExp(i.exp.loc, new Expressions());
@@ -451,14 +451,14 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
          * Allow this by doing an explicit cast, which will lengthen the string
          * literal.
          */
-        if (i.exp.op == TOK.string_ && tb.ty == Type.Kind.staticArray)
+        if (i.exp.op == TOK.string_ && tb.ty == Tsarray)
         {
             StringExp se = cast(StringExp)i.exp;
             Type typeb = se.type.toBasetype();
             TY tynto = tb.nextOf().ty;
             if (!se.committed &&
-                (typeb.ty == Type.Kind.array || typeb.ty == Type.Kind.staticArray) &&
-                (tynto == Type.Kind.char_ || tynto == Type.Kind.wchar_ || tynto == Type.Kind.dchar_) &&
+                (typeb.ty == Tarray || typeb.ty == Tsarray) &&
+                (tynto == Tchar || tynto == Twchar || tynto == Tdchar) &&
                 se.numberOfCodeUnits(tynto) < (cast(TypeSArray)tb).dim.toInteger())
             {
                 i.exp = se.castTo(sc, t);
@@ -466,7 +466,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
             }
         }
         // Look for implicit constructor call
-        if (tb.ty == Type.Kind.struct_ && !(ti.ty == Type.Kind.struct_ && tb.toDsymbol(sc) == ti.toDsymbol(sc)) && !i.exp.implicitConvTo(t))
+        if (tb.ty == Tstruct && !(ti.ty == Tstruct && tb.toDsymbol(sc) == ti.toDsymbol(sc)) && !i.exp.implicitConvTo(t))
         {
             StructDeclaration sd = (cast(TypeStruct)tb).sym;
             if (sd.ctor)
@@ -485,7 +485,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
         }
         // Look for the case of statically initializing an array
         // with a single member.
-        if (tb.ty == Type.Kind.staticArray && !tb.nextOf().equals(ti.toBasetype().nextOf()) && i.exp.implicitConvTo(tb.nextOf()))
+        if (tb.ty == Tsarray && !tb.nextOf().equals(ti.toBasetype().nextOf()) && i.exp.implicitConvTo(tb.nextOf()))
         {
             /* If the variable is not actually used in compile time, array creation is
              * redundant. So delay it until invocation of toExpression() or toDt().
@@ -500,7 +500,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
         {
             // Look for mismatch of compile-time known length to emit
             // better diagnostic message, as same as AssignExp::semantic.
-            if (tb.ty == Type.Kind.staticArray && i.exp.implicitConvTo(tb.nextOf().arrayOf()) > MATCH.nomatch)
+            if (tb.ty == Tsarray && i.exp.implicitConvTo(tb.nextOf().arrayOf()) > MATCH.nomatch)
             {
                 uinteger_t dim1 = (cast(TypeSArray)tb).dim.toInteger();
                 uinteger_t dim2 = dim1;
@@ -757,19 +757,19 @@ private extern(C++) final class InitToExpressionVisitor : Visitor
             t = init.type.toBasetype();
             switch (t.ty)
             {
-            case Type.Kind.vector:
+            case Tvector:
                 t = (cast(TypeVector)t).basetype;
-                goto case Type.Kind.staticArray;
+                goto case Tsarray;
 
-            case Type.Kind.staticArray:
+            case Tsarray:
                 uinteger_t adim = (cast(TypeSArray)t).dim.toInteger();
                 if (adim >= amax)
                     goto Lno;
                 edim = cast(uint)adim;
                 break;
 
-            case Type.Kind.pointer:
-            case Type.Kind.array:
+            case Tpointer:
+            case Tarray:
                 edim = init.dim;
                 break;
 
@@ -838,7 +838,7 @@ private extern(C++) final class InitToExpressionVisitor : Visitor
             if (t)
             {
                 Type tn = t.nextOf().toBasetype();
-                if (tn.ty == Type.Kind.staticArray)
+                if (tn.ty == Tsarray)
                 {
                     const dim = cast(size_t)(cast(TypeSArray)tn).dim.toInteger();
                     Type te = tn.nextOf().toBasetype();
@@ -885,7 +885,7 @@ private extern(C++) final class InitToExpressionVisitor : Visitor
             //printf("ExpInitializer::toExpression(t = %s) exp = %s\n", t.toChars(), exp.toChars());
             Type tb = itype.toBasetype();
             Expression e = (i.exp.op == TOK.construct || i.exp.op == TOK.blit) ? (cast(AssignExp)i.exp).e2 : i.exp;
-            if (tb.ty == Type.Kind.staticArray && e.implicitConvTo(tb.nextOf()))
+            if (tb.ty == Tsarray && e.implicitConvTo(tb.nextOf()))
             {
                 TypeSArray tsa = cast(TypeSArray)tb;
                 size_t d = cast(size_t)tsa.dim.toInteger();

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -165,7 +165,7 @@ public:
 
                     Expression e = new CondExp(econd.loc, econd, e1, e2);
                     e.type = e1.type;
-                    if (e.type.ty == Type.Kind.tuple)
+                    if (e.type.ty == Ttuple)
                     {
                         e1.type = Type.tvoid;
                         e2.type = Type.tvoid;
@@ -249,7 +249,7 @@ public:
             {
                 result = new CondExp(econd.loc, econd, e1, e2);
                 result.type = e1.type;
-                if (result.type.ty == Type.Kind.tuple)
+                if (result.type.ty == Ttuple)
                 {
                     e1.type = Type.tvoid;
                     e2.type = Type.tvoid;
@@ -580,10 +580,10 @@ public:
             visit(cast(UnaExp)e);
 
             Type tb = e.e1.type.toBasetype();
-            if (tb.ty == Type.Kind.array)
+            if (tb.ty == Tarray)
             {
                 Type tv = tb.nextOf().baseElemOf();
-                if (tv.ty == Type.Kind.struct_)
+                if (tv.ty == Tstruct)
                 {
                     auto ts = cast(TypeStruct)tv;
                     auto sd = ts.sym;
@@ -641,15 +641,15 @@ public:
             visit(cast(BinExp)e);
 
             Type t1 = e.e1.type.toBasetype();
-            if (t1.ty == Type.Kind.array || t1.ty == Type.Kind.staticArray)
+            if (t1.ty == Tarray || t1.ty == Tsarray)
             {
                 Type t = t1.nextOf().toBasetype();
                 while (t.toBasetype().nextOf())
                     t = t.nextOf().toBasetype();
-                if (t.ty == Type.Kind.struct_)
+                if (t.ty == Tstruct)
                     semanticTypeInfo(null, t);
             }
-            else if (t1.ty == Type.Kind.associativeArray)
+            else if (t1.ty == Taarray)
             {
                 semanticTypeInfo(null, t1);
             }
@@ -1195,7 +1195,7 @@ public:
             {
                 // delegate literal call
                 auto v = ve.var.isVarDeclaration();
-                if (v && v._init && v.type.ty == Type.Kind.delegate_ && onlyOneAssign(v, parent))
+                if (v && v._init && v.type.ty == Tdelegate && onlyOneAssign(v, parent))
                 {
                     //printf("init: %s\n", v._init.toChars());
                     auto ei = v._init.isExpInitializer();
@@ -1229,7 +1229,7 @@ public:
             fd = dve.var.isFuncDeclaration();
             if (fd && fd != parent && canInline(fd, true, false, asStatements))
             {
-                if (dve.e1.op == TOK.call && dve.e1.type.toBasetype().ty == Type.Kind.struct_)
+                if (dve.e1.op == TOK.call && dve.e1.type.toBasetype().ty == Tstruct)
                 {
                     /* To create ethis, we'll need to take the address
                      * of dve.e1, but this won't work if dve.e1 is
@@ -1278,7 +1278,7 @@ public:
         if (global.params.verbose && (eresult || sresult))
             fprintf(global.stdmsg, "inlined   %s =>\n          %s\n", fd.toPrettyChars(), parent.toPrettyChars());
 
-        if (eresult && e.type.ty != Type.Kind.void_)
+        if (eresult && e.type.ty != Tvoid)
         {
             Expression ex = eresult;
             while (ex.op == TOK.comma)
@@ -1525,7 +1525,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
 
     if (fd.type)
     {
-        assert(fd.type.ty == Type.Kind.function_);
+        assert(fd.type.ty == Tfunction);
         TypeFunction tf = cast(TypeFunction)fd.type;
 
         // no variadic parameter lists
@@ -1548,7 +1548,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
         static bool hasDtor(Type t)
         {
             auto tv = t.baseElemOf();
-            return tv.ty == Type.Kind.struct_ || tv.ty == Type.Kind.class_; // for now assume these might have a destructor
+            return tv.ty == Tstruct || tv.ty == Tclass; // for now assume these might have a destructor
         }
 
         /* Don't inline a function that returns non-void, but has
@@ -1560,7 +1560,7 @@ bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool statementsTo
          * 2. don't inline when the return value has a destructor, as it doesn't
          *    get handled properly
          */
-        if (tf.next && tf.next.ty != Type.Kind.void_ &&
+        if (tf.next && tf.next.ty != Tvoid &&
             (!(fd.hasReturnExp & 1) ||
              statementsToo && (fd.isArrayOp || hasDtor(tf.next))) &&
             !hdrscan)
@@ -1818,8 +1818,8 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
         }
         else
         {
-            //assert(ethis.type.ty != Type.Kind.pointer);
-            if (ethis.type.ty == Type.Kind.pointer)
+            //assert(ethis.type.ty != Tpointer);
+            if (ethis.type.ty == Tpointer)
             {
                 Type t = ethis.type.nextOf();
                 ethis = new PtrExp(ethis.loc, ethis);
@@ -1828,7 +1828,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
 
             auto ei = new ExpInitializer(fd.loc, ethis);
             vthis = new VarDeclaration(fd.loc, ethis.type, Id.This, ei);
-            if (ethis.type.ty != Type.Kind.class_)
+            if (ethis.type.ty != Tclass)
                 vthis.storage_class = STC.ref_;
             else
                 vthis.storage_class = STC.in_;
@@ -1882,8 +1882,8 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
              * inline scan again because if they are initialized to a symbol,
              * any calls to the fp or dg can be inlined.
              */
-            if (vfrom.type.ty == Type.Kind.delegate_ ||
-                vfrom.type.ty == Type.Kind.pointer && vfrom.type.nextOf().ty == Type.Kind.function_)
+            if (vfrom.type.ty == Tdelegate ||
+                vfrom.type.ty == Tpointer && vfrom.type.nextOf().ty == Tfunction)
             {
                 if (arg.op == TOK.variable)
                 {
@@ -1980,7 +1980,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
          * the returned reference is exactly same as vthis, and the 'this' variable
          * already exists at the caller side.
          */
-        if (tf.next.ty == Type.Kind.struct_ && !fd.nrvo_var && !fd.isCtorDeclaration() &&
+        if (tf.next.ty == Tstruct && !fd.nrvo_var && !fd.isCtorDeclaration() &&
             !isConstruction(e))
         {
             /* Generate a new variable to hold the result and initialize it with the
@@ -2008,7 +2008,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
         }
 
         // https://issues.dlang.org/show_bug.cgi?id=15210
-        if (tf.next.ty == Type.Kind.void_ && e && e.type.ty != Type.Kind.void_)
+        if (tf.next.ty == Tvoid && e && e.type.ty != Tvoid)
         {
             e = new CastExp(callLoc, e, Type.tvoid);
             e.type = Type.tvoid;

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -319,7 +319,7 @@ public:
     {
         //printf("VarExp.inlineCost3() %s\n", toChars());
         Type tb = e.type.toBasetype();
-        if (tb.ty == Type.Kind.struct_)
+        if (tb.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)tb).sym;
             if (sd.isNested())

--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -327,7 +327,7 @@ struct IntRange
         uinteger_t mask = type.sizemask();
         auto lower = SignExtendedNumber(0);
         auto upper = SignExtendedNumber(mask);
-        if (type.toBasetype().ty == Type.Kind.dchar_)
+        if (type.toBasetype().ty == Tdchar)
             upper.value = 0x10FFFFUL;
         else if (!isUnsigned)
         {
@@ -447,7 +447,7 @@ struct IntRange
             return this;
         else if (!type.isunsigned())
             return castSigned(type.sizemask());
-        else if (type.toBasetype().ty == Type.Kind.dchar_)
+        else if (type.toBasetype().ty == Tdchar)
             return castDchar();
         else
             return castUnsigned(type.sizemask());
@@ -457,7 +457,7 @@ struct IntRange
     {
         if (!type.isintegral())
             return castUnsigned(UINT64_MAX);
-        else if (type.toBasetype().ty == Type.Kind.dchar_)
+        else if (type.toBasetype().ty == Tdchar)
             return castDchar();
         else
             return castUnsigned(type.sizemask());

--- a/src/dmd/irstate.d
+++ b/src/dmd/irstate.d
@@ -243,7 +243,7 @@ struct IRState
                 if (fd)
                 {
                     Type t = fd.type;
-                    if (t.ty == Type.Kind.function_ && (cast(TypeFunction)t).trust == TRUST.safe)
+                    if (t.ty == Tfunction && (cast(TypeFunction)t).trust == TRUST.safe)
                         result = true;
                 }
                 break;

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -639,7 +639,7 @@ public:
         objectStart();
         jsonProperties(d);
         TypeFunction tf = cast(TypeFunction)d.type;
-        if (tf && tf.ty == Type.Kind.function_)
+        if (tf && tf.ty == Tfunction)
             property("parameters", tf.parameters);
         property("endline", "endchar", &d.endloc);
         if (d.foverrides.dim)

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -68,7 +68,7 @@ public:
 
     override void visit(ArrayLiteralExp e)
     {
-        if (e.type.ty != Type.Kind.array || !e.elements || !e.elements.dim)
+        if (e.type.ty != Tarray || !e.elements || !e.elements.dim)
             return;
         if (f.setGC())
         {
@@ -130,13 +130,13 @@ public:
         AggregateDeclaration ad = null;
         switch (tb.ty)
         {
-        case Type.Kind.class_:
+        case Tclass:
             ad = (cast(TypeClass)tb).sym;
             break;
 
-        case Type.Kind.pointer:
+        case Tpointer:
             tb = (cast(TypePointer)tb).next.toBasetype();
-            if (tb.ty == Type.Kind.struct_)
+            if (tb.ty == Tstruct)
                 ad = (cast(TypeStruct)tb).sym;
             break;
 
@@ -159,7 +159,7 @@ public:
     override void visit(IndexExp e)
     {
         Type t1b = e.e1.type.toBasetype();
-        if (t1b.ty == Type.Kind.associativeArray)
+        if (t1b.ty == Taarray)
         {
             if (f.setGC())
             {
@@ -215,7 +215,7 @@ public:
 extern (C++) Expression checkGC(Scope* sc, Expression e)
 {
     FuncDeclaration f = sc.func;
-    if (e && e.op != TOK.error && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) && (f.type.ty == Type.Kind.function_ && (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc))
+    if (e && e.op != TOK.error && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) && (f.type.ty == Tfunction && (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc))
     {
         scope NOGCVisitor gcv = new NOGCVisitor(f);
         walkPostorder(e, gcv);

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -309,9 +309,9 @@ static:
         if (hasHiddenArgument)
             return setSymbol!("_objc_msgSend_stret")(TYhfunc);
         // not sure if DMD can handle this
-        else if (returnType.ty == Type.Kind.complex80)
+        else if (returnType.ty == Tcomplex80)
             return setSymbol!("_objc_msgSend_fp2ret");
-        else if (returnType.ty == Type.Kind.float80)
+        else if (returnType.ty == Tfloat80)
             return setSymbol!("_objc_msgSend_fpret");
         else
             return setSymbol!("_objc_msgSend");

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -59,7 +59,7 @@ extern (C++) Expression expandVar(int result, VarDeclaration v)
             return e;
         }
         Type tb = v.type.toBasetype();
-        if (v.storage_class & STC.manifest || v.type.toBasetype().isscalar() || ((result & WANTexpand) && (tb.ty != Type.Kind.staticArray && tb.ty != Type.Kind.struct_)))
+        if (v.storage_class & STC.manifest || v.type.toBasetype().isscalar() || ((result & WANTexpand) && (tb.ty != Tsarray && tb.ty != Tstruct)))
         {
             if (v._init)
             {
@@ -95,7 +95,7 @@ extern (C++) Expression expandVar(int result, VarDeclaration v)
                         // Do not constfold the string literal
                         // if it's typed as a C string, because the value expansion
                         // will drop the pointer identity.
-                        if (!(result & WANTexpand) && ei.type.toBasetype().ty == Type.Kind.pointer)
+                        if (!(result & WANTexpand) && ei.type.toBasetype().ty == Tpointer)
                             goto L1;
                     }
                     else
@@ -172,7 +172,7 @@ extern (C++) Expression fromConstInitializer(int result, Expression e1)
             // See bugzilla 4465.
             if (e.op == TOK.comma && (cast(CommaExp)e).e1.op == TOK.declaration)
                 e = e1;
-            else if (e.type != e1.type && e1.type && e1.type.ty != Type.Kind.identifier)
+            else if (e.type != e1.type && e1.type && e1.type.ty != Tident)
             {
                 // Type 'paint' operation
                 e = e.copy();
@@ -391,7 +391,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 {
                     sinteger_t index = ae.e2.toInteger();
                     VarExp ve = cast(VarExp)ae.e1;
-                    if (ve.type.ty == Type.Kind.staticArray && !ve.var.isImportedSymbol())
+                    if (ve.type.ty == Tsarray && !ve.var.isImportedSymbol())
                     {
                         TypeSArray ts = cast(TypeSArray)ve.type;
                         sinteger_t dim = ts.dim.toInteger();
@@ -528,9 +528,9 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             if (e.arguments)
             {
                 Type t1 = e.e1.type.toBasetype();
-                if (t1.ty == Type.Kind.delegate_)
+                if (t1.ty == Tdelegate)
                     t1 = t1.nextOf();
-                assert(t1.ty == Type.Kind.function_);
+                assert(t1.ty == Tfunction);
                 TypeFunction tf = cast(TypeFunction)t1;
                 for (size_t i = 0; i < e.arguments.dim; i++)
                 {
@@ -554,14 +554,14 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             if (expOptimize(e.e1, result))
                 return;
             e.e1 = fromConstInitializer(result, e.e1);
-            if (e.e1 == e1old && e.e1.op == TOK.arrayLiteral && e.type.toBasetype().ty == Type.Kind.pointer && e.e1.type.toBasetype().ty != Type.Kind.staticArray)
+            if (e.e1 == e1old && e.e1.op == TOK.arrayLiteral && e.type.toBasetype().ty == Tpointer && e.e1.type.toBasetype().ty != Tsarray)
             {
                 // Casting this will result in the same expression, and
                 // infinite loop because of Expression::implicitCastTo()
                 return; // no change
             }
             if ((e.e1.op == TOK.string_ || e.e1.op == TOK.arrayLiteral) &&
-                (e.type.ty == Type.Kind.pointer || e.type.ty == Type.Kind.array))
+                (e.type.ty == Tpointer || e.type.ty == Tarray))
             {
                 const esz  = e.type.nextOf().size(e.loc);
                 const e1sz = e.e1.type.toBasetype().nextOf().size(e.e1.loc);
@@ -573,7 +573,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                     // https://issues.dlang.org/show_bug.cgi?id=12937
                     // If target type is void array, trying to paint
                     // e.e1 with that type will cause infinite recursive optimization.
-                    if (e.type.nextOf().ty == Type.Kind.void_)
+                    if (e.type.nextOf().ty == Tvoid)
                         return;
                     ret = e.e1.castTo(null, e.type);
                     //printf(" returning1 %s\n", ret.toChars());
@@ -597,12 +597,12 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 ret = e.e1.castTo(null, e.to);
                 return;
             }
-            if (e.e1.op == TOK.null_ && (e.type.ty == Type.Kind.pointer || e.type.ty == Type.Kind.class_ || e.type.ty == Type.Kind.array))
+            if (e.e1.op == TOK.null_ && (e.type.ty == Tpointer || e.type.ty == Tclass || e.type.ty == Tarray))
             {
                 //printf(" returning3 %s\n", e.e1.toChars());
                 goto L1;
             }
-            if (e.type.ty == Type.Kind.class_ && e.e1.type.ty == Type.Kind.class_)
+            if (e.type.ty == Tclass && e.e1.type.ty == Tclass)
             {
                 import dmd.aggregate : Sizeok;
 
@@ -633,7 +633,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             {
                 if (e.e1.op == TOK.symbolOffset)
                 {
-                    if (e.type.toBasetype().ty != Type.Kind.staticArray)
+                    if (e.type.toBasetype().ty != Tsarray)
                     {
                         const esz = e.type.size(e.loc);
                         const e1sz = e.e1.type.size(e.e1.loc);
@@ -646,7 +646,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                     }
                     return;
                 }
-                if (e.to.toBasetype().ty != Type.Kind.void_)
+                if (e.to.toBasetype().ty != Tvoid)
                 {
                     if (e.e1.type.equals(e.type) && e.type.equals(e.to))
                         ret = e.e1;
@@ -931,7 +931,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                         e.e1 = ci;
                 }
             }
-            if (e.e1.op == TOK.string_ || e.e1.op == TOK.arrayLiteral || e.e1.op == TOK.assocArrayLiteral || e.e1.type.toBasetype().ty == Type.Kind.staticArray)
+            if (e.e1.op == TOK.string_ || e.e1.op == TOK.arrayLiteral || e.e1.op == TOK.assocArrayLiteral || e.e1.type.toBasetype().ty == Tsarray)
             {
                 ret = ArrayLength(e.type, e.e1).copy();
             }
@@ -990,7 +990,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             else
             {
                 Type t = arr.type.toBasetype();
-                if (t.ty == Type.Kind.staticArray)
+                if (t.ty == Tsarray)
                     len = cast(size_t)(cast(TypeSArray)t).dim.toInteger();
                 else
                     return; // we don't know the length yet
@@ -1071,7 +1071,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 // Replace with (e1, oror)
                 ret = new IntegerExp(e.loc, oror, Type.tbool);
                 ret = Expression.combine(e.e1, ret);
-                if (e.type.toBasetype().ty == Type.Kind.void_)
+                if (e.type.toBasetype().ty == Tvoid)
                 {
                     ret = new CastExp(e.loc, ret, Type.tvoid);
                     ret.type = e.type;
@@ -1091,7 +1091,7 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
                 }
                 else if (e.e1.isBool(!oror))
                 {
-                    if (e.type.toBasetype().ty == Type.Kind.void_)
+                    if (e.type.toBasetype().ty == Tvoid)
                         ret = e.e2;
                     else
                     {

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3549,10 +3549,10 @@ final class Parser(AST) : Lexer
         // See https://issues.dlang.org/show_bug.cgi?id=1215
         // A basic type can look like MyType (typical case), but also:
         //  MyType.T -> A type
-        //  MyType[expr] -> Either a static array of MyType or a type (iif MyType is a Type.Kind.tuple)
+        //  MyType[expr] -> Either a static array of MyType or a type (iif MyType is a Ttuple)
         //  MyType[expr].T -> A type.
         //  MyType[expr].T[expr] ->  Either a static array of MyType[expr].T or a type
-        //                           (iif MyType[expr].T is a Type.Kind.tuple)
+        //                           (iif MyType[expr].T is a Ttuple)
         while (1)
         {
             switch (token.value)
@@ -3574,14 +3574,14 @@ final class Parser(AST) : Lexer
                         AST.Type t = maybeArray;
                         while (true)
                         {
-                            if (t.ty == AST.Type.Kind.staticArray)
+                            if (t.ty == AST.Tsarray)
                             {
                                 // The index expression is an Expression.
                                 AST.TypeSArray a = cast(AST.TypeSArray)t;
                                 dimStack.push(a.dim.syntaxCopy());
                                 t = a.next.syntaxCopy();
                             }
-                            else if (t.ty == AST.Type.Kind.associativeArray)
+                            else if (t.ty == AST.Taarray)
                             {
                                 // The index expression is a Type. It will be interpreted as an expression at semantic time.
                                 AST.TypeAArray a = cast(AST.TypeAArray)t;
@@ -4353,7 +4353,7 @@ final class Parser(AST) : Lexer
             else if (t != tfirst)
                 error("multiple declarations must have the same type, not `%s` and `%s`", tfirst.toChars(), t.toChars());
 
-            bool isThis = (t.ty == AST.Type.Kind.identifier && (cast(AST.TypeIdentifier)t).ident == Id.This && token.value == TOK.assign);
+            bool isThis = (t.ty == AST.Tident && (cast(AST.TypeIdentifier)t).ident == Id.This && token.value == TOK.assign);
             if (ident)
                 checkCstyleTypeSyntax(loc, t, alt, ident);
             else if (!isThis)
@@ -4425,7 +4425,7 @@ final class Parser(AST) : Lexer
                     break;
                 }
             }
-            else if (t.ty == AST.Type.Kind.function_)
+            else if (t.ty == AST.Tfunction)
             {
                 AST.Expression constraint = null;
                 version (none)
@@ -8542,7 +8542,7 @@ final class Parser(AST) : Lexer
         auto t = parseBasicType(true);
         t = parseBasicType2(t);
         t = t.addSTC(stc);
-        if (t.ty == AST.Type.Kind.associativeArray)
+        if (t.ty == AST.Taarray)
         {
             AST.TypeAArray taa = cast(AST.TypeAArray)t;
             AST.Type index = taa.index;
@@ -8554,7 +8554,7 @@ final class Parser(AST) : Lexer
             }
             t = new AST.TypeSArray(taa.next, edim);
         }
-        else if (t.ty == AST.Type.Kind.staticArray)
+        else if (t.ty == AST.Tsarray)
         {
         }
         else if (token.value == TOK.leftParentheses)

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -716,7 +716,7 @@ private extern (C++) class S2irVisitor : Visitor
 
             FuncDeclaration func = irs.getFunc();
             assert(func);
-            assert(func.type.ty == Type.Kind.function_);
+            assert(func.type.ty == Tfunction);
             TypeFunction tf = cast(TypeFunction)(func.type);
 
             RET retmethod = retStyle(tf);

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -64,7 +64,7 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
         if (readonly || !e.type.isMutable())
             return false;
 
-        if (v.type.hasPointers() && v.type.toBasetype().ty != Type.Kind.struct_)
+        if (v.type.hasPointers() && v.type.toBasetype().ty != Tstruct)
         {
             if ((ad.type.alignment() < Target.ptrsize ||
                  (v.offset & (Target.ptrsize - 1))) &&
@@ -110,7 +110,7 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
     auto tfromb = tfrom.toBasetype();
     auto ttob = tto.toBasetype();
 
-    if (ttob.ty == Type.Kind.class_ && tfromb.ty == Type.Kind.class_)
+    if (ttob.ty == Tclass && tfromb.ty == Tclass)
     {
         ClassDeclaration cdfrom = tfromb.isClassHandle();
         ClassDeclaration cdto = ttob.isClassHandle();
@@ -127,11 +127,11 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
         return true;
     }
 
-    if (ttob.ty == Type.Kind.array && tfromb.ty == Type.Kind.staticArray) // https://issues.dlang.org/show_bug.cgi?id=12502
+    if (ttob.ty == Tarray && tfromb.ty == Tsarray) // https://issues.dlang.org/show_bug.cgi?id=12502
         tfromb = tfromb.nextOf().arrayOf();
 
-    if (ttob.ty == Type.Kind.array   && tfromb.ty == Type.Kind.array ||
-        ttob.ty == Type.Kind.pointer && tfromb.ty == Type.Kind.pointer)
+    if (ttob.ty == Tarray   && tfromb.ty == Tarray ||
+        ttob.ty == Tpointer && tfromb.ty == Tpointer)
     {
         Type ttobn = ttob.nextOf().toBasetype();
         Type tfromn = tfromb.nextOf().toBasetype();
@@ -143,16 +143,16 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
          *  ai[0] = 7;
          *  *api[0] crash!
          */
-        if (tfromn.ty == Type.Kind.void_ && ttobn.isMutable())
+        if (tfromn.ty == Tvoid && ttobn.isMutable())
         {
-            if (ttob.ty == Type.Kind.array && e.op == TOK.arrayLiteral)
+            if (ttob.ty == Tarray && e.op == TOK.arrayLiteral)
                 return true;
             return false;
         }
 
         // If the struct is opaque we don't know about the struct members then the cast becomes unsafe
-        if (ttobn.ty == Type.Kind.struct_ && !(cast(TypeStruct)ttobn).sym.members ||
-            tfromn.ty == Type.Kind.struct_ && !(cast(TypeStruct)tfromn).sym.members)
+        if (ttobn.ty == Tstruct && !(cast(TypeStruct)ttobn).sym.members ||
+            tfromn.ty == Tstruct && !(cast(TypeStruct)tfromn).sym.members)
             return false;
 
         const frompointers = tfromn.hasPointers();
@@ -165,8 +165,8 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
             return false;
 
         if (!topointers &&
-            ttobn.ty != Type.Kind.function_ && tfromn.ty != Type.Kind.function_ &&
-            (ttob.ty == Type.Kind.array || ttobn.size() <= tfromn.size()) &&
+            ttobn.ty != Tfunction && tfromn.ty != Tfunction &&
+            (ttob.ty == Tarray || ttobn.size() <= tfromn.size()) &&
             MODimplicitConv(tfromn.mod, ttobn.mod))
         {
             return true;

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -298,13 +298,13 @@ private extern(C++) final class Semantic2Visitor : Visitor
         {
             // Cannot initialize a thread-local class or pointer to struct variable with a literal
             // that itself is a thread-local reference and would need dynamic initialization also.
-            if ((vd.type.ty == Type.Kind.class_) && vd.type.isMutable() && !vd.type.isShared())
+            if ((vd.type.ty == Tclass) && vd.type.isMutable() && !vd.type.isShared())
             {
                 ExpInitializer ei = vd._init.isExpInitializer();
                 if (ei && ei.exp.op == TOK.classReference)
                     vd.error("is a thread-local class and cannot have a static initializer. Use `static this()` to initialize instead.");
             }
-            else if (vd.type.ty == Type.Kind.pointer && vd.type.nextOf().ty == Type.Kind.struct_ && vd.type.nextOf().isMutable() && !vd.type.nextOf().isShared())
+            else if (vd.type.ty == Tpointer && vd.type.nextOf().ty == Tstruct && vd.type.nextOf().isMutable() && !vd.type.nextOf().isShared())
             {
                 ExpInitializer ei = vd._init.isExpInitializer();
                 if (ei && ei.exp.op == TOK.address && (cast(AddrExp)ei.exp).e1.op == TOK.structLiteral)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -257,10 +257,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
         funcdecl.semanticRun = PASS.semantic3;
         funcdecl.semantic3Errors = false;
 
-        if (!funcdecl.type || funcdecl.type.ty != Type.Kind.function_)
+        if (!funcdecl.type || funcdecl.type.ty != Tfunction)
             return;
         TypeFunction f = cast(TypeFunction)funcdecl.type;
-        if (!funcdecl.inferRetType && f.next.ty == Type.Kind.error)
+        if (!funcdecl.inferRetType && f.next.ty == Terror)
             return;
 
         if (!funcdecl.fbody && funcdecl.inferRetType && !f.next)
@@ -460,7 +460,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     Parameter fparam = (*f.parameters)[i];
                     if (!fparam.ident)
                         continue; // never used, so ignore
-                    if (fparam.type.ty == Type.Kind.tuple)
+                    if (fparam.type.ty == Ttuple)
                     {
                         TypeTuple t = cast(TypeTuple)fparam.type;
                         size_t dim = Parameter.dim(t.arguments);
@@ -569,7 +569,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     fpostinv = null;
                 }
 
-                assert(funcdecl.type == f || (funcdecl.type.ty == Type.Kind.function_ && f.purity == PURE.impure && (cast(TypeFunction)funcdecl.type).purity >= PURE.fwdref));
+                assert(funcdecl.type == f || (funcdecl.type.ty == Tfunction && f.purity == PURE.impure && (cast(TypeFunction)funcdecl.type).purity >= PURE.fwdref));
                 f = cast(TypeFunction)funcdecl.type;
 
                 if (funcdecl.inferRetType)
@@ -590,7 +590,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         Expression exp = (*funcdecl.returns)[i].exp;
                         if (exp.op == TOK.variable && (cast(VarExp)exp).var == funcdecl.vresult)
                         {
-                            if (f.next.ty == Type.Kind.void_ && funcdecl.isMain())
+                            if (f.next.ty == Tvoid && funcdecl.isMain())
                                 exp.type = Type.tint32;
                             else
                                 exp.type = f.next;
@@ -759,7 +759,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 else
                 {
                     const(bool) inlineAsm = (funcdecl.hasReturnExp & 8) != 0;
-                    if ((blockexit & BE.fallthru) && f.next.ty != Type.Kind.void_ && !inlineAsm)
+                    if ((blockexit & BE.fallthru) && f.next.ty != Tvoid && !inlineAsm)
                     {
                         Expression e;
                         if (!funcdecl.hasReturnExp)
@@ -784,9 +784,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 if (funcdecl.returns)
                 {
-                    bool implicit0 = (f.next.ty == Type.Kind.void_ && funcdecl.isMain());
+                    bool implicit0 = (f.next.ty == Tvoid && funcdecl.isMain());
                     Type tret = implicit0 ? Type.tint32 : f.next;
-                    assert(tret.ty != Type.Kind.void_);
+                    assert(tret.ty != Tvoid);
                     if (funcdecl.vresult || funcdecl.returnLabel)
                         funcdecl.buildResultVar(scout ? scout : sc2, tret);
 
@@ -799,7 +799,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         Expression exp = rs.exp;
                         if (exp.op == TOK.error)
                             continue;
-                        if (tret.ty == Type.Kind.error)
+                        if (tret.ty == Terror)
                         {
                             // https://issues.dlang.org/show_bug.cgi?id=13702
                             exp = checkGC(sc2, exp);
@@ -901,7 +901,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             {
                 /* fensure is composed of the [out] contracts
                  */
-                if (f.next.ty == Type.Kind.void_ && funcdecl.outId)
+                if (f.next.ty == Tvoid && funcdecl.outId)
                     funcdecl.error("void functions have no result");
 
                 sc2 = scout; //push
@@ -909,7 +909,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 // BUG: need to disallow returns and throws
 
-                if (funcdecl.fensure && f.next.ty != Type.Kind.void_)
+                if (funcdecl.fensure && f.next.ty != Tvoid)
                     funcdecl.buildResultVar(scout, f.next);
 
                 fens = fens.statementSemantic(sc2);
@@ -987,7 +987,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     funcdecl.returnLabel.statement = ls;
                     a.push(funcdecl.returnLabel.statement);
 
-                    if (f.next.ty != Type.Kind.void_ && funcdecl.vresult)
+                    if (f.next.ty != Tvoid && funcdecl.vresult)
                     {
                         // Create: return vresult;
                         Expression e = new VarExp(Loc(), funcdecl.vresult);
@@ -1000,7 +1000,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         a.push(s);
                     }
                 }
-                if (funcdecl.isMain() && f.next.ty == Type.Kind.void_)
+                if (funcdecl.isMain() && f.next.ty == Tvoid)
                 {
                     // Add a return 0; statement
                     Statement s = new ReturnStatement(Loc(), new IntegerExp(0));
@@ -1196,7 +1196,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          */
         funcdecl.semanticRun = PASS.semantic3done;
         funcdecl.semantic3Errors = (global.errors != oldErrors) || (funcdecl.fbody && funcdecl.fbody.isErrorStatement());
-        if (funcdecl.type.ty == Type.Kind.error)
+        if (funcdecl.type.ty == Terror)
             funcdecl.errors = true;
         //printf("-FuncDeclaration::semantic3('%s.%s', sc = %p, loc = %s)\n", parent.toChars(), toChars(), sc, loc.toChars());
         //fflush(stdout);
@@ -1265,7 +1265,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         // don't do it for unused deprecated types
         // or error ypes
-        if (!ad.getRTInfo && Type.rtinfo && (!ad.isDeprecated() || global.params.useDeprecated) && (ad.type && ad.type.ty != Type.Kind.error))
+        if (!ad.getRTInfo && Type.rtinfo && (!ad.isDeprecated() || global.params.useDeprecated) && (ad.type && ad.type.ty != Terror))
         {
             // Evaluate: RTinfo!type
             auto tiargs = new Objects();

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -99,7 +99,7 @@ extern (C++) int callSideEffectLevel(FuncDeclaration f)
      */
     if (f.isCtorDeclaration())
         return 0;
-    assert(f.type.ty == Type.Kind.function_);
+    assert(f.type.ty == Tfunction);
     TypeFunction tf = cast(TypeFunction)f.type;
     if (tf.isnothrow)
     {
@@ -116,16 +116,16 @@ extern (C++) int callSideEffectLevel(Type t)
 {
     t = t.toBasetype();
     TypeFunction tf;
-    if (t.ty == Type.Kind.delegate_)
+    if (t.ty == Tdelegate)
         tf = cast(TypeFunction)(cast(TypeDelegate)t).next;
     else
     {
-        assert(t.ty == Type.Kind.function_);
+        assert(t.ty == Tfunction);
         tf = cast(TypeFunction)t;
     }
     tf.purityLevel();
     PURE purity = tf.purity;
-    if (t.ty == Type.Kind.delegate_ && purity > PURE.weak)
+    if (t.ty == Tdelegate && purity > PURE.weak)
     {
         if (tf.isMutable())
             purity = PURE.weak;
@@ -185,9 +185,9 @@ private bool lambdaHasSideEffect(Expression e)
             if (ce.e1.type)
             {
                 Type t = ce.e1.type.toBasetype();
-                if (t.ty == Type.Kind.delegate_)
+                if (t.ty == Tdelegate)
                     t = (cast(TypeDelegate)t).next;
-                if (t.ty == Type.Kind.function_ && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
+                if (t.ty == Tfunction && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
                 {
                 }
                 else
@@ -201,7 +201,7 @@ private bool lambdaHasSideEffect(Expression e)
             /* if:
              *  cast(classtype)func()  // because it may throw
              */
-            if (ce.to.ty == Type.Kind.class_ && ce.e1.op == TOK.call && ce.e1.type.ty == Type.Kind.class_)
+            if (ce.to.ty == Tclass && ce.e1.op == TOK.call && ce.e1.type.ty == Tclass)
                 return true;
             break;
         }
@@ -253,7 +253,7 @@ extern (C++) bool discardValue(Expression e)
         if (global.params.warnings && !global.gag)
         {
             CallExp ce = cast(CallExp)e;
-            if (e.type.ty == Type.Kind.void_)
+            if (e.type.ty == Tvoid)
             {
                 /* Don't complain about calling void-returning functions with no side-effect,
                  * because purity and nothrow are inferred, and because some of the
@@ -266,9 +266,9 @@ extern (C++) bool discardValue(Expression e)
             else if (ce.e1.type)
             {
                 Type t = ce.e1.type.toBasetype();
-                if (t.ty == Type.Kind.delegate_)
+                if (t.ty == Tdelegate)
                     t = (cast(TypeDelegate)t).next;
-                if (t.ty == Type.Kind.function_ && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
+                if (t.ty == Tfunction && (ce.f ? callSideEffectLevel(ce.f) : callSideEffectLevel(ce.e1.type)) > 0)
                 {
                     const(char)* s;
                     if (ce.f)

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -154,19 +154,19 @@ struct Target
         assert(type.isTypeBasic());
         switch (type.ty)
         {
-        case Type.Kind.float80:
-        case Type.Kind.imaginary80:
-        case Type.Kind.complex80:
+        case Tfloat80:
+        case Timaginary80:
+        case Tcomplex80:
             return Target.realalignsize;
-        case Type.Kind.complex32:
+        case Tcomplex32:
             if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD || global.params.isOpenBSD || global.params.isSolaris)
                 return 4;
             break;
-        case Type.Kind.int64:
-        case Type.Kind.uint64:
-        case Type.Kind.float64:
-        case Type.Kind.imaginary64:
-        case Type.Kind.complex64:
+        case Tint64:
+        case Tuns64:
+        case Tfloat64:
+        case Timaginary64:
+        case Tcomplex64:
             if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD || global.params.isOpenBSD || global.params.isSolaris)
                 return global.params.is64bit ? 8 : 4;
             break;
@@ -275,17 +275,17 @@ struct Target
             return 1; // not supported
         switch (type.ty)
         {
-        case Type.Kind.void_:
-        case Type.Kind.int8:
-        case Type.Kind.uint8:
-        case Type.Kind.int16:
-        case Type.Kind.uint16:
-        case Type.Kind.int32:
-        case Type.Kind.uint32:
-        case Type.Kind.float32:
-        case Type.Kind.int64:
-        case Type.Kind.uint64:
-        case Type.Kind.float64:
+        case Tvoid:
+        case Tint8:
+        case Tuns8:
+        case Tint16:
+        case Tuns16:
+        case Tint32:
+        case Tuns32:
+        case Tfloat32:
+        case Tint64:
+        case Tuns64:
+        case Tfloat64:
             break;
         default:
             return 2; // wrong base type
@@ -306,7 +306,7 @@ struct Target
     {
         import dmd.tokens;
 
-        if (type.ty != Type.Kind.vector)
+        if (type.ty != Tvector)
             return true; // not a vector op
         auto tvec = cast(TypeVector) type;
 
@@ -388,14 +388,14 @@ struct Target
         // Write the expression into the buffer.
         switch (e.type.ty)
         {
-        case Type.Kind.int32:
-        case Type.Kind.uint32:
-        case Type.Kind.int64:
-        case Type.Kind.uint64:
+        case Tint32:
+        case Tuns32:
+        case Tint64:
+        case Tuns64:
             encodeInteger(e, buffer.ptr);
             break;
-        case Type.Kind.float32:
-        case Type.Kind.float64:
+        case Tfloat32:
+        case Tfloat64:
             encodeReal(e, buffer.ptr);
             break;
         default:
@@ -404,13 +404,13 @@ struct Target
         // Interpret the buffer as a new type.
         switch (type.ty)
         {
-        case Type.Kind.int32:
-        case Type.Kind.uint32:
-        case Type.Kind.int64:
-        case Type.Kind.uint64:
+        case Tint32:
+        case Tuns32:
+        case Tint64:
+        case Tuns64:
             return decodeInteger(e.loc, type, buffer.ptr);
-        case Type.Kind.float32:
-        case Type.Kind.float64:
+        case Tfloat32:
+        case Tfloat64:
             return decodeReal(e.loc, type, buffer.ptr);
         default:
             assert(0);
@@ -531,13 +531,13 @@ private void encodeReal(Expression e, ubyte* buffer)
 {
     switch (e.type.ty)
     {
-    case Type.Kind.float32:
+    case Tfloat32:
         {
             float* p = cast(float*)buffer;
             *p = cast(float)e.toReal();
             break;
         }
-    case Type.Kind.float64:
+    case Tfloat64:
         {
             double* p = cast(double*)buffer;
             *p = cast(double)e.toReal();
@@ -555,13 +555,13 @@ private Expression decodeReal(Loc loc, Type type, ubyte* buffer)
     real_t value;
     switch (type.ty)
     {
-    case Type.Kind.float32:
+    case Tfloat32:
         {
             float* p = cast(float*)buffer;
             value = real_t(*p);
             break;
         }
-    case Type.Kind.float64:
+    case Tfloat64:
         {
             double* p = cast(double*)buffer;
             value = real_t(*p);

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -167,7 +167,7 @@ Symbol *toSymbol(Dsymbol s)
                 if (config.exe == EX_WIN64 && vd.isParameter())
                     t = type_fake(TYnptr);
                 else
-                    t = type_fake(TYdelegate);          // Type.Kind.delegate_ as C type
+                    t = type_fake(TYdelegate);          // Tdelegate as C type
                 t.Tcount++;
             }
             else if (vd.isParameter())
@@ -283,14 +283,14 @@ Symbol *toSymbol(Dsymbol s)
         override void visit(TypeInfoDeclaration tid)
         {
             //printf("TypeInfoDeclaration.toSymbol(%s), linkage = %d\n", tid.toChars(), tid.linkage);
-            assert(tid.tinfo.ty != Type.Kind.error);
+            assert(tid.tinfo.ty != Terror);
             visit(cast(VarDeclaration)tid);
         }
 
         override void visit(TypeInfoClassDeclaration ticd)
         {
             //printf("TypeInfoClassDeclaration.toSymbol(%s), linkage = %d\n", ticd.toChars(), ticd.linkage);
-            assert(ticd.tinfo.ty == Type.Kind.class_);
+            assert(ticd.tinfo.ty == Tclass);
             auto tc = cast(TypeClass)ticd.tinfo;
             tc.sym.accept(this);
         }

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -175,7 +175,7 @@ public:
                 // https://issues.dlang.org/show_bug.cgi?id=13792
                 t.ctype = Type_toCtype(Type.tvoid);
             }
-            else if (t.sym.memtype.toBasetype().ty == Type.Kind.int32)
+            else if (t.sym.memtype.toBasetype().ty == Tint32)
             {
                 t.ctype = type_enum(t.sym.toPrettyChars(true), Type_toCtype(t.sym.memtype));
             }

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -968,7 +968,7 @@ int cvMember(Dsymbol s, ubyte *p)
         {
             //printf("VarDeclaration.cvMember(p = %p) '%s'\n", p, vd.toChars());
 
-            if (vd.type.toBasetype().ty == Type.Kind.tuple)
+            if (vd.type.toBasetype().ty == Ttuple)
                 return;
 
             const id = vd.toChars();

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -690,7 +690,7 @@ elem *resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
         elem *elength;
         Symbol *slength;
 
-        if (t1.ty == Type.Kind.staticArray)
+        if (t1.ty == Tsarray)
         {
             TypeSArray tsa = cast(TypeSArray)t1;
             dinteger_t length = tsa.dim.toInteger();
@@ -698,7 +698,7 @@ elem *resolveLengthVar(VarDeclaration lengthVar, elem **pe, Type t1)
             elength = el_long(TYsize_t, length);
             goto L3;
         }
-        else if (t1.ty == Type.Kind.array)
+        else if (t1.ty == Tarray)
         {
             elength = *pe;
             *pe = el_same(&elength);
@@ -973,13 +973,13 @@ RET retStyle(TypeFunction tf)
     if (global.params.isWindows && global.params.is64bit)
     {
         // http://msdn.microsoft.com/en-us/library/7572ztz4.aspx
-        if (tns.ty == Type.Kind.complex32)
+        if (tns.ty == Tcomplex32)
             return RET.stack;
         if (tns.isscalar())
             return RET.regs;
 
         tns = tns.baseElemOf();
-        if (tns.ty == Type.Kind.struct_)
+        if (tns.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)tns).sym;
             if (sd.ident == Id.__c_long_double)
@@ -996,7 +996,7 @@ RET retStyle(TypeFunction tf)
     else if (global.params.isWindows && global.params.mscoff)
     {
         Type tb = tns.baseElemOf();
-        if (tb.ty == Type.Kind.struct_)
+        if (tb.ty == Tstruct)
         {
             StructDeclaration sd = (cast(TypeStruct)tb).sym;
             if (sd.ident == Id.__c_long_double)
@@ -1005,10 +1005,10 @@ RET retStyle(TypeFunction tf)
     }
 
 Lagain:
-    if (tns.ty == Type.Kind.staticArray)
+    if (tns.ty == Tsarray)
     {
         tns = tns.baseElemOf();
-        if (tns.ty != Type.Kind.struct_)
+        if (tns.ty != Tstruct)
         {
 L2:
             if (global.params.isLinux && tf.linkage != LINK.d && !global.params.is64bit)
@@ -1035,7 +1035,7 @@ L2:
         }
     }
 
-    if (tns.ty == Type.Kind.struct_)
+    if (tns.ty == Tstruct)
     {
         StructDeclaration sd = (cast(TypeStruct)tns).sym;
         if (global.params.isLinux && tf.linkage != LINK.d && !global.params.is64bit)
@@ -1058,7 +1058,7 @@ L2:
         if (sd.arg1type && !sd.arg2type)
         {
             tns = sd.arg1type;
-            if (tns.ty != Type.Kind.struct_)
+            if (tns.ty != Tstruct)
                 goto L2;
             goto Lagain;
         }
@@ -1091,7 +1091,7 @@ L2:
              tf.linkage == LINK.c &&
              tns.iscomplex())
     {
-        if (tns.ty == Type.Kind.complex32)
+        if (tns.ty == Tcomplex32)
             return RET.regs;     // in EDX:EAX, not ST1:ST0
         else
             return RET.stack;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -236,7 +236,7 @@ void genModuleInfo(Module m)
 void write_pointers(Type type, Symbol *s, uint offset)
 {
     uint ty = type.toBasetype().ty;
-    if (ty == Type.Kind.class_)
+    if (ty == Tclass)
         return objmod.write_pointerRef(s, offset);
 
     write_instance_pointers(type, s, offset);
@@ -316,7 +316,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             //printf("ClassDeclaration.toObjFile('%s')\n", cd.toChars());
 
-            if (cd.type.ty == Type.Kind.error)
+            if (cd.type.ty == Terror)
             {
                 cd.error("had semantic errors when compiling");
                 return;
@@ -643,7 +643,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             //printf("InterfaceDeclaration.toObjFile('%s')\n", id.toChars());
 
-            if (id.type.ty == Type.Kind.error)
+            if (id.type.ty == Terror)
             {
                 id.error("had semantic errors when compiling");
                 return;
@@ -820,7 +820,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
         {
             //printf("StructDeclaration.toObjFile('%s')\n", sd.toChars());
 
-            if (sd.type.ty == Type.Kind.error)
+            if (sd.type.ty == Terror)
             {
                 sd.error("had semantic errors when compiling");
                 return;
@@ -887,7 +887,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             //printf("VarDeclaration.toObjFile(%p '%s' type=%s) protection %d\n", vd, vd.toChars(), vd.type.toChars(), vd.protection);
             //printf("\talign = %d\n", vd.alignment);
 
-            if (vd.type.ty == Type.Kind.error)
+            if (vd.type.ty == Terror)
             {
                 vd.error("had semantic errors when compiling");
                 return;
@@ -939,7 +939,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             } while (parent);
             s.Sfl = FLdata;
 
-            if (!sz && vd.type.toBasetype().ty != Type.Kind.staticArray)
+            if (!sz && vd.type.toBasetype().ty != Tsarray)
                 assert(0); // this shouldn't be possible
 
             scope dtb = new DtBuilder();
@@ -989,7 +989,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 return;
             //printf("EnumDeclaration.toObjFile('%s')\n", ed.toChars());
 
-            if (ed.errors || ed.type.ty == Type.Kind.error)
+            if (ed.errors || ed.type.ty == Terror)
             {
                 ed.error("had semantic errors when compiling");
                 return;
@@ -1228,7 +1228,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             ExpInitializer ie = vd._init.isExpInitializer();
 
             Type tb = vd.type.toBasetype();
-            if (tb.ty == Type.Kind.staticArray && ie &&
+            if (tb.ty == Tsarray && ie &&
                 !tb.nextOf().equals(ie.exp.type.toBasetype().nextOf()) &&
                 ie.exp.implicitConvTo(tb.nextOf())
                 )
@@ -1415,7 +1415,7 @@ private void finishVtbl(ClassDeclaration cd)
                 continue;
             // Hiding detected: same name, overlapping specializations
             TypeFunction tf = cast(TypeFunction)fd.type;
-            if (tf.ty == Type.Kind.function_)
+            if (tf.ty == Tfunction)
             {
                 cd.error("use of `%s%s` is hidden by `%s`; use `alias %s = %s.%s;` to introduce base class overload set",
                     fd.toPrettyChars(),

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -162,7 +162,7 @@ shared static this()
 extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
 {
     d_uns64 sz;
-    if (t.ty == Type.Kind.class_ && !(cast(TypeClass)t).sym.isInterfaceDeclaration())
+    if (t.ty == Tclass && !(cast(TypeClass)t).sym.isInterfaceDeclaration())
         sz = (cast(TypeClass)t).sym.AggregateDeclaration.size(loc);
     else
         sz = t.size(loc);
@@ -218,7 +218,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
 
         override void visit(TypeBasic t)
         {
-            if (t.ty == Type.Kind.void_)
+            if (t.ty == Tvoid)
                 setpointer(offset);
         }
 
@@ -259,7 +259,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
 
         override void visit(TypePointer t)
         {
-            if (t.nextOf().ty != Type.Kind.function_) // don't mark function pointers
+            if (t.nextOf().ty != Tfunction) // don't mark function pointers
                 setpointer(offset);
         }
 
@@ -335,7 +335,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
             foreach (v; t.sym.fields)
             {
                 offset = structoff + v.offset;
-                if (v.type.ty == Type.Kind.class_)
+                if (v.type.ty == Tclass)
                     setpointer(offset);
                 else
                     v.type.accept(this);
@@ -365,7 +365,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
     }
 
     scope PointerBitmapVisitor pbv = new PointerBitmapVisitor(data, sz_size_t);
-    if (t.ty == Type.Kind.class_)
+    if (t.ty == Tclass)
         pbv.visitClass(cast(TypeClass)t);
     else
         t.accept(pbv);
@@ -479,11 +479,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
         if (t)
         {
-            if (t.ty == Type.Kind.function_)
+            if (t.ty == Tfunction)
                 tf = cast(TypeFunction)t;
-            else if (t.ty == Type.Kind.delegate_)
+            else if (t.ty == Tdelegate)
                 tf = cast(TypeFunction)t.nextOf();
-            else if (t.ty == Type.Kind.pointer && t.nextOf().ty == Type.Kind.function_)
+            else if (t.ty == Tpointer && t.nextOf().ty == Tfunction)
                 tf = cast(TypeFunction)t.nextOf();
         }
 
@@ -545,7 +545,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     }
     if (e.ident == Id.isAssociativeArray)
     {
-        return isTypeX(t => t.toBasetype().ty == Type.Kind.associativeArray);
+        return isTypeX(t => t.toBasetype().ty == Taarray);
     }
     if (e.ident == Id.isDeprecated)
     {
@@ -562,16 +562,16 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     }
     if (e.ident == Id.isStaticArray)
     {
-        return isTypeX(t => t.toBasetype().ty == Type.Kind.staticArray);
+        return isTypeX(t => t.toBasetype().ty == Tsarray);
     }
     if (e.ident == Id.isAbstractClass)
     {
-        return isTypeX(t => t.toBasetype().ty == Type.Kind.class_ &&
+        return isTypeX(t => t.toBasetype().ty == Tclass &&
                             (cast(TypeClass)t.toBasetype()).sym.isAbstract());
     }
     if (e.ident == Id.isFinalClass)
     {
-        return isTypeX(t => t.toBasetype().ty == Type.Kind.class_ &&
+        return isTypeX(t => t.toBasetype().ty == Tclass &&
                             ((cast(TypeClass)t.toBasetype()).sym.storage_class & STC.final_) != 0);
     }
     if (e.ident == Id.isTemplate)
@@ -602,7 +602,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         }
 
         Type tb = t.baseElemOf();
-        if (auto sd = tb.ty == Type.Kind.struct_ ? (cast(TypeStruct)tb).sym : null)
+        if (auto sd = tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null)
         {
             return sd.isPOD() ? True() : False();
         }
@@ -1375,7 +1375,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 if (t)
                 {
                     t.typeSemantic(e.loc, sc2);
-                    if (t.ty == Type.Kind.error)
+                    if (t.ty == Terror)
                         err = true;
                 }
                 else if (s && s.errors)
@@ -1386,7 +1386,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 ex = ex.expressionSemantic(sc2);
                 ex = resolvePropertiesOnly(sc2, ex);
                 ex = ex.optimize(WANTvalue);
-                if (sc2.func && sc2.func.type.ty == Type.Kind.function_)
+                if (sc2.func && sc2.func.type.ty == Tfunction)
                 {
                     const tf = cast(TypeFunction)sc2.func.type;
                     err |= tf.isnothrow && canThrow(ex, sc2.func, false);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -477,11 +477,11 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         if (t)
         {
             if (t.ty == Tfunction)
-                tf = cast(TypeFunction)t;
+                return cast(TypeFunction)t;
             else if (t.ty == Tdelegate)
-                tf = cast(TypeFunction)t.nextOf();
+                return cast(TypeFunction)t.nextOf();
             else if (t.ty == Tpointer && t.nextOf().ty == Tfunction)
-                tf = cast(TypeFunction)t.nextOf();
+                return cast(TypeFunction)t.nextOf();
         }
 
         return null;

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -315,7 +315,7 @@ package mixin template ParseVisitMethods(AST)
         //printf("Visiting Type\n");
         if (!t)
             return;
-        if (t.ty == AST.Type.Kind.function_)
+        if (t.ty == AST.Tfunction)
         {
             visitFunctionType(cast(AST.TypeFunction)t, null);
             return;
@@ -379,7 +379,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.TypePointer t)
     {
         //printf("Visiting TypePointer\n");
-        if (t.next.ty == AST.Type.Kind.function_)
+        if (t.next.ty == AST.Tfunction)
         {
             visitFunctionType(cast(AST.TypeFunction)t.next, null);
         }
@@ -777,7 +777,7 @@ package mixin template ParseVisitMethods(AST)
     override void visit(AST.FuncLiteralDeclaration f)
     {
         //printf("Visiting FuncLiteralDeclaration\n");
-        if (f.type.ty == AST.Type.Kind.error)
+        if (f.type.ty == AST.Terror)
             return;
         AST.TypeFunction tf = cast(AST.TypeFunction)f.type;
         if (!f.inferRetType && tf.next)

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -75,7 +75,7 @@ extern (C++) void genTypeInfo(Type torig, Scope* sc)
 
 extern (C++) Type getTypeInfoType(Type t, Scope* sc)
 {
-    assert(t.ty != Type.Kind.error);
+    assert(t.ty != Terror);
     genTypeInfo(t, sc);
     return t.vtinfo.type;
 }
@@ -85,27 +85,27 @@ extern (C++) TypeInfoDeclaration getTypeInfoDeclaration(Type t)
     //printf("Type::getTypeInfoDeclaration() %s\n", t.toChars());
     switch (t.ty)
     {
-    case Type.Kind.pointer:
+    case Tpointer:
         return TypeInfoPointerDeclaration.create(t);
-    case Type.Kind.array:
+    case Tarray:
         return TypeInfoArrayDeclaration.create(t);
-    case Type.Kind.staticArray:
+    case Tsarray:
         return TypeInfoStaticArrayDeclaration.create(t);
-    case Type.Kind.associativeArray:
+    case Taarray:
         return TypeInfoAssociativeArrayDeclaration.create(t);
-    case Type.Kind.struct_:
+    case Tstruct:
         return TypeInfoStructDeclaration.create(t);
-    case Type.Kind.vector:
+    case Tvector:
         return TypeInfoVectorDeclaration.create(t);
-    case Type.Kind.enum_:
+    case Tenum:
         return TypeInfoEnumDeclaration.create(t);
-    case Type.Kind.function_:
+    case Tfunction:
         return TypeInfoFunctionDeclaration.create(t);
-    case Type.Kind.delegate_:
+    case Tdelegate:
         return TypeInfoDelegateDeclaration.create(t);
-    case Type.Kind.tuple:
+    case Ttuple:
         return TypeInfoTupleDeclaration.create(t);
-    case Type.Kind.class_:
+    case Tclass:
         if ((cast(TypeClass)t).sym.isInterfaceDeclaration())
             return TypeInfoInterfaceDeclaration.create(t);
         else
@@ -235,16 +235,16 @@ extern (C++) bool isSpeculativeType(Type t)
  */
 private bool builtinTypeInfo(Type t)
 {
-    if (t.isTypeBasic() || t.ty == Type.Kind.class_ || t.ty == Type.Kind.null_)
+    if (t.isTypeBasic() || t.ty == Tclass || t.ty == Tnull)
         return !t.mod;
-    if (t.ty == Type.Kind.array)
+    if (t.ty == Tarray)
     {
         Type next = t.nextOf();
         // strings are so common, make them builtin
         return !t.mod &&
                (next.isTypeBasic() !is null && !next.mod ||
-                next.ty == Type.Kind.char_ && next.mod == MODFlags.immutable_ ||
-                next.ty == Type.Kind.char_ && next.mod == MODFlags.const_);
+                next.ty == Tchar && next.mod == MODFlags.immutable_ ||
+                next.ty == Tchar && next.mod == MODFlags.const_);
     }
     return false;
 }


### PR DESCRIPTION
Reverts dlang/dmd#7747

This makes things much more verbose. It's harder to read, and all those _ postfixed names are just ugly. It's a good idea gone too far. Please no.