### PR TITLE
Add support for Objective-C class/static methods

### DIFF
--- a/changelog/objc_class_methods.dd
+++ b/changelog/objc_class_methods.dd
@@ -1,0 +1,45 @@
+Support for calling Objective-C class (static) methods has been added.
+
+Previously to call an Objective-C class method it was necessary to make explicit
+calls to the Objective-C runtime. The following code is an example of the old
+way to call a class method:
+
+---
+extern (C) Class objc_lookUpClass(in char* name);
+
+extern (Objective-C)
+interface Class
+{
+    NSObject alloc() @selector("alloc");
+}
+
+extern (Objective-C)
+interface NSObject
+{
+    NSObject init() @selector("init");
+}
+
+void main()
+{
+    auto cls = objc_lookUpClass("NSObject");
+    auto o = cls.alloc().init();
+}
+---
+
+The above code can now be replaced with the following:
+
+---
+extern (Objective-C)
+interface NSObject
+{
+    static NSObject alloc() @selector("alloc");
+    NSObject init() @selector("init");
+}
+
+void main()
+{
+    auto o = NSObject.alloc().init();
+}
+---
+
+Note the use of the `static` attribute in the method declaration.

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -289,6 +289,7 @@ public:
 
     Abstract isabstract;                // 0: fwdref, 1: is abstract class, 2: not abstract
     Baseok baseok;                      // set the progress of base classes resolving
+    ObjcClassDeclaration objc;          // Data for a class declaration that is needed for the Objective-C integration
     Symbol *cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 
     static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -27,6 +27,7 @@ import dmd.globals;
 import dmd.id;
 import dmd.identifier;
 import dmd.mtype;
+import dmd.objc;
 import dmd.root.rmem;
 import dmd.target;
 import dmd.visitor;
@@ -243,6 +244,12 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
     /// set the progress of base classes resolving
     Baseok baseok;
+
+    /**
+     * Data for a class declaration that is needed for the Objective-C
+     * integration.
+     */
+    ObjcClassDeclaration objc;
 
     Symbol* cpp_type_info_ptr_sym;      // cached instance of class Id.cpp_type_info_ptr
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4801,6 +4801,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (idec.baseok == Baseok.done)
         {
             idec.baseok = Baseok.semanticdone;
+            objc.setMetaclass(idec);
 
             // initialize vtbl
             if (idec.vtblOffset())

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5423,6 +5423,11 @@ elem *toElem(Expression e, IRState *irs)
             result = toElemStructLit(sle, irs, TOK.construct, sle.sym, true);
         }
 
+        override void visit(ObjcClassReferenceExp e)
+        {
+            result = objc.toElem(e);
+        }
+
         /*****************************************************/
         /*                   CTFE stuff                      */
         /*****************************************************/

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -49,6 +49,7 @@ import dmd.identifier;
 import dmd.inline;
 import dmd.mtype;
 import dmd.nspace;
+import dmd.objc;
 import dmd.opover;
 import dmd.optimize;
 import dmd.root.ctfloat;
@@ -96,6 +97,18 @@ extern (C++) Expression getRightThis(const ref Loc loc, Scope* sc, AggregateDecl
 L1:
     Type t = e1.type.toBasetype();
     //printf("e1.type = %s, var.type = %s\n", e1.type.toChars(), var.type.toChars());
+
+    if (e1.op == TOK.objcClassReference)
+    {
+        // We already have an Objective-C class reference, just use that as 'this'.
+        return e1;
+    }
+    else if (ad && ad.isClassDeclaration && ad.isClassDeclaration.classKind == ClassKind.objc &&
+             var.isFuncDeclaration && var.isFuncDeclaration.isStatic &&
+             var.isFuncDeclaration.selector)
+    {
+        return new ObjcClassReferenceExp(e1.loc, cast(ClassDeclaration) ad);
+    }
 
     /* If e1 is not the 'this' pointer for ad
      */
@@ -7213,6 +7226,29 @@ extern (C++) final class PrettyFuncInitExp : DefaultInitExp
         e = e.expressionSemantic(sc);
         e = e.castTo(sc, type);
         return e;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/**
+ * Objective-C class reference expression.
+ *
+ * Used to get the metaclass of an Objective-C class, `NSObject.Class`.
+ */
+extern (C++) final class ObjcClassReferenceExp : Expression
+{
+    ClassDeclaration classDeclaration;
+
+    extern (D) this(Loc loc, ClassDeclaration classDeclaration)
+    {
+        super(loc, TOK.objcClassReference,
+            __traits(classInstanceSize, ObjcClassReferenceExp));
+        this.classDeclaration = classDeclaration;
+        type = objc.getRuntimeMetaclass(classDeclaration).getType();
     }
 
     override void accept(Visitor v)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -1382,6 +1382,13 @@ private:
 
 /****************************************************************/
 
+class ObjcClassReferenceExp : public Expression
+{
+    ClassDeclaration* classDeclaration;
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 /* Special values used by the interpreter
  */
 

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1518,7 +1518,7 @@ extern (C++) class FuncDeclaration : Declaration
     override inout(AggregateDeclaration) isThis() inout
     {
         //printf("+FuncDeclaration::isThis() '%s'\n", toChars());
-        auto ad = (storage_class & STC.static_) ? null : isMember2();
+        auto ad = (storage_class & STC.static_) ? objc.isThis(this) : isMember2();
         //printf("-FuncDeclaration::isThis() %p\n", ad);
         return ad;
     }

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -142,6 +142,8 @@ immutable Msgtable[] msgtable =
     { "xopCmp", "__xopCmp" },
     { "xtoHash", "__xtoHash" },
 
+    { "Class" },
+
     { "LINE", "__LINE__" },
     { "FILE", "__FILE__" },
     { "MODULE", "__MODULE__" },

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -8408,7 +8408,15 @@ extern (C++) final class TypeClass : Type
                 e = e.expressionSemantic(sc);
                 return e;
             }
-            if (d.needThis() && sc.intypeof != 1)
+            if (sym.classKind == ClassKind.objc
+                && d.isFuncDeclaration()
+                && d.isFuncDeclaration().isStatic
+                && d.isFuncDeclaration().selector)
+            {
+                auto classRef = new ObjcClassReferenceExp(e.loc, sym);
+                return new DotVarExp(e.loc, classRef, d).expressionSemantic(sc);
+            }
+            else if (d.needThis() && sc.intypeof != 1)
             {
                 /* Rewrite as:
                  *  this.d

--- a/src/dmd/objc.h
+++ b/src/dmd/objc.h
@@ -14,12 +14,14 @@
 #include "root.h"
 #include "stringtable.h"
 
+class AggregateDeclaration;
 class Identifier;
 class FuncDeclaration;
 class ClassDeclaration;
 class InterfaceDeclaration;
 struct Scope;
 class StructDeclaration;
+class Type;
 
 struct ObjcSelector
 {
@@ -41,6 +43,12 @@ struct ObjcSelector
     static ObjcSelector *create(FuncDeclaration *fdecl);
 };
 
+struct ObjcClassDeclaration
+{
+    bool isMeta;
+    ClassDeclaration* metaclass;
+};
+
 class Objc
 {
 public:
@@ -48,9 +56,15 @@ public:
 
     virtual void setObjc(ClassDeclaration* cd) = 0;
     virtual void setObjc(InterfaceDeclaration*) = 0;
+
     virtual void setSelector(FuncDeclaration*, Scope* sc) = 0;
     virtual void validateSelector(FuncDeclaration* fd) = 0;
     virtual void checkLinkage(FuncDeclaration* fd) = 0;
+    virtual AggregateDeclaration* isThis(FuncDeclaration* fd) = 0;
+
+    virtual void setMetaclass(InterfaceDeclaration* id) = 0;
+    virtual void setMetaclass(ClassDeclaration* id) = 0;
+    virtual ClassDeclaration* getRuntimeMetaclass(ClassDeclaration* cd) = 0;
 };
 
 #endif /* DMD_OBJC_H */

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -17,8 +17,10 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.aggregate;
+import dmd.dclass;
 import dmd.declaration;
 import dmd.dmodule;
+import dmd.expression;
 import dmd.func;
 import dmd.globals;
 import dmd.identifier;
@@ -61,6 +63,9 @@ extern(C++) abstract class ObjcGlue
     abstract void setupMethodCall(elem** ec, elem* ehidden, elem* ethis, TypeFunction tf);
     abstract void setupEp(elem* esel, elem** ep, int leftToRight);
     abstract void generateModuleInfo();
+
+    /// Returns: the given expression converted to an `elem` structure
+    abstract elem* toElem(ObjcClassReferenceExp e) const;
 }
 
 private:
@@ -85,6 +90,11 @@ extern(C++) final class Unsupported : ObjcGlue
     override void generateModuleInfo()
     {
         // noop
+    }
+
+    override elem* toElem(ObjcClassReferenceExp e) const
+    {
+        assert(0, "Should never be called when Objective-C is not supported");
     }
 }
 
@@ -127,7 +137,12 @@ extern(C++) final class Supported : ObjcGlue
     override void generateModuleInfo()
     {
         if (Symbols.hasSymbols)
-            Symbols.getModuleInfo();
+            Symbols.getImageInfo();
+    }
+
+    override elem* toElem(ObjcClassReferenceExp e) const
+    {
+        return el_var(Symbols.getClassReference(e.classDeclaration));
     }
 }
 
@@ -135,11 +150,11 @@ struct Segments
 {
     enum Id
     {
-        cString,
         imageInfo,
         methodName,
         moduleInfo,
-        selectorRefs
+        selectorRefs,
+        classRefs,
     }
 
     private
@@ -147,17 +162,24 @@ struct Segments
         __gshared static int[segmentData.length] segments;
 
         __gshared static Segments[__traits(allMembers, Id).length] segmentData = [
-            Segments("__cstring", "__TEXT", S_CSTRING_LITERALS),
-            Segments("__objc_imageinfo", "__DATA", S_REGULAR | S_ATTR_NO_DEAD_STRIP),
-            Segments("__objc_methname", "__TEXT", S_CSTRING_LITERALS),
-            Segments("__objc_classlist", "__DATA", S_REGULAR | S_ATTR_NO_DEAD_STRIP),
-            Segments("__objc_selrefs", "__DATA", S_ATTR_NO_DEAD_STRIP | S_LITERAL_POINTERS)
+            Segments("__objc_imageinfo", "__DATA", S_REGULAR | S_ATTR_NO_DEAD_STRIP, 0),
+            Segments("__objc_methname", "__TEXT", S_CSTRING_LITERALS, 0),
+            Segments("__objc_classlist", "__DATA", S_REGULAR | S_ATTR_NO_DEAD_STRIP, 3),
+            Segments("__objc_selrefs", "__DATA", S_LITERAL_POINTERS | S_ATTR_NO_DEAD_STRIP, 3),
+            Segments("__objc_classrefs", "__DATA", S_REGULAR | S_ATTR_NO_DEAD_STRIP, 3)
         ];
 
-        const(char)* sectionName;
-        const(char)* segmentName;
-        int flags;
-        int alignment = 3;
+        static assert(segmentData.length == __traits(allMembers, Id).length);
+
+        immutable(char*) sectionName;
+        immutable(char*) segmentName;
+        immutable int flags;
+        immutable int alignment;
+
+        this(typeof(this.tupleof) tuple)
+        {
+            this.tupleof = tuple;
+        }
     }
 
     static int opIndex(Id id)
@@ -167,27 +189,27 @@ struct Segments
         if (segmentsPtr[id] != 0)
             return segmentsPtr[id];
 
-        foreach (i, seg ; segmentData)
+        auto seg = segmentData[id];
+
+        version (OSX)
         {
-            version (OSX)
-            {
-                segmentsPtr[i] = MachObj.getsegment(
-                    seg.sectionName,
-                    seg.segmentName,
-                    seg.alignment,
-                    seg.flags
-                );
-            }
-            else
-            {
-                // This should never happen. If the platform is not OSX an error
-                // should have occurred sooner which should have prevented the
-                // code from getting here.
-                assert(0);
-            }
+            segmentsPtr[id] = MachObj.getsegment(
+                seg.sectionName,
+                seg.segmentName,
+                seg.alignment,
+                seg.flags
+            );
+
+            return segmentsPtr[id];
         }
 
-        return segmentsPtr[id];
+        else
+        {
+            // This should never happen. If the platform is not OSX an error
+            // should have occurred sooner which should have prevented the
+            // code from getting here.
+            assert(0);
+        }
     }
 }
 
@@ -206,6 +228,12 @@ static:
 
         Symbol* imageInfo = null;
         Symbol* moduleInfo = null;
+
+        // Cache for `_OBJC_METACLASS_$_`/`_OBJC_CLASS_$_` symbols.
+        StringTable* classNameTable = null;
+
+        // Cache for `L_OBJC_CLASSLIST_REFERENCES_` symbols.
+        StringTable* classReferenceTable = null;
 
         StringTable* methVarNameTable = null;
         StringTable* methVarRefTable = null;
@@ -247,6 +275,44 @@ static:
         }
 
         return false;
+    }
+
+    /**
+     * Convenience wrapper around `dmd.backend.global.symbol_name`.
+     *
+     * Allows to pass the name of the symbol as a D string.
+     */
+    Symbol* symbolName(const(char)[] name, int sclass, type* t)
+    {
+        return symbol_name(name.ptr, cast(uint) name.length, sclass, t);
+    }
+
+    /**
+     * Gets a global symbol.
+     *
+     * Params:
+     *  name = the name of the symbol
+     *  t = the type of the symbol
+     *
+     * Returns: the symbol
+     */
+    Symbol* getGlobal(const(char)[] name, type* t = type_fake(TYnptr))
+    {
+        return symbolName(name, SCglobal, t);
+    }
+
+    /**
+     * Gets a static symbol.
+     *
+     * Params:
+     *  name = the name of the symbol
+     *  t = the type of the symbol
+     *
+     * Returns: the symbol
+     */
+    Symbol* getStatic(const(char)[] name, type* t = type_fake(TYnptr))
+    {
+        return symbolName(name, SCstatic, t);
     }
 
     Symbol* getCString(const(char)[] str, const(char)* symbolName, Segments.Id segment)
@@ -326,7 +392,7 @@ static:
 
         scope dtb = new DtBuilder();
         dtb.dword(0); // version
-        dtb.dword(0); // flags
+        dtb.dword(64); // flags
 
         imageInfo = symbol_name("L_OBJC_IMAGE_INFO", SCstatic, type_allocn(TYarray, tstypes[TYchar]));
         imageInfo.Sdt = dtb.finish();
@@ -350,6 +416,66 @@ static:
         getImageInfo(); // make sure we also generate image info
 
         return moduleInfo;
+    }
+
+    /*
+     * Returns: the `_OBJC_METACLASS_$_`/`_OBJC_CLASS_$_` symbol for the given
+     *  class declaration.
+     */
+    Symbol* getClassName(const ClassDeclaration classDeclaration)
+    {
+        hasSymbols_ = true;
+
+        auto isMeta = classDeclaration.objc.isMeta;
+        auto prefix = isMeta ? "_OBJC_METACLASS_$_" : "_OBJC_CLASS_$_";
+        auto name = prefix ~ classDeclaration.ident.toString();
+
+        auto stringValue = classNameTable.update(name);
+        auto symbol = cast(Symbol*) stringValue.ptrvalue;
+
+        if (symbol)
+            return symbol;
+
+        symbol = getGlobal(name);
+        stringValue.ptrvalue = symbol;
+
+        return symbol;
+    }
+
+    /*
+     * Returns: the `L_OBJC_CLASSLIST_REFERENCES_$_` symbol for the given class
+     *  declaration.
+     */
+    Symbol* getClassReference(const ClassDeclaration classDeclaration)
+    {
+        hasSymbols_ = true;
+
+        auto name = classDeclaration.ident.toString();
+
+        auto stringValue = classReferenceTable.update(name);
+        auto symbol = cast(Symbol*) stringValue.ptrvalue;
+
+        if (symbol)
+            return symbol;
+
+        scope dtb = new DtBuilder();
+        auto className = getClassName(classDeclaration);
+        dtb.xoff(className, 0, TYnptr);
+
+        auto segment = Segments[Segments.Id.classRefs];
+
+        __gshared size_t classReferenceCount = 0;
+
+        char[42] nameString;
+        auto result = format(nameString, "L_OBJC_CLASSLIST_REFERENCES_$_%lu", classReferenceCount++);
+        symbol = getStatic(result);
+        symbol.Sdt = dtb.finish();
+        symbol.Sseg = segment;
+        outdata(symbol);
+
+        stringValue.ptrvalue = symbol;
+
+        return symbol;
     }
 
     Symbol* getMethVarRef(const(char)[] name)
@@ -384,8 +510,34 @@ static:
         return refSymbol;
     }
 
-    Symbol* getMethVarRef(Identifier ident)
+    Symbol* getMethVarRef(const Identifier ident)
     {
         return getMethVarRef(ident.toString());
     }
+}
+
+private:
+
+/*
+ * Formats the given arguments into the given buffer.
+ *
+ * Convenience wrapper around `snprintf`.
+ *
+ * Params:
+ *  bufLength = length of the buffer
+ *  buffer = the buffer where to store the result
+ *  format = the format string
+ *  args = the arguments to format
+ *
+ * Returns: the formatted result, a slice of the given buffer
+ */
+char[] format(size_t bufLength, Args...)(return ref char[bufLength] buffer,
+    const(char)* format, const Args args)
+{
+    auto length = snprintf(buffer.ptr, buffer.length, format, args);
+
+    assert(length >= 0, "An output error occurred");
+    assert(length < buffer.length, "Output was truncated");
+
+    return buffer[0 .. length];
 }

--- a/src/dmd/root/stringtable.d
+++ b/src/dmd/root/stringtable.d
@@ -168,6 +168,11 @@ public:
         return 0;
     }
 
+    StringValue* update(const(char)[] name) nothrow
+    {
+        return update(name.ptr, name.length);
+    }
+
 private:
 nothrow:
     uint allocValue(const(char)* s, size_t length, void* ptrvalue)

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -307,6 +307,8 @@ enum TOK : int
     voidExpression,
     cantExpression,
 
+    objcClassReference,
+
     max_,
 }
 
@@ -710,6 +712,8 @@ extern (C++) struct Token
         TOK.interval: "interval",
         TOK.voidExpression: "voidexp",
         TOK.cantExpression: "cantexp",
+
+        TOK.objcClassReference: "class",
     ];
 
     static assert(() {

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -184,6 +184,8 @@ enum TOK
         TOKvoidexp,
         TOKcantexp,
 
+        TOKobjc_class_reference,
+
         TOKMAX
 };
 

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -65,6 +65,7 @@ public:
     void visit(ASTCodegen.ErrorExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.ComplexExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.StructLiteralExp e) { visit(cast(ASTCodegen.Expression)e); }
+    void visit(ASTCodegen.ObjcClassReferenceExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.SymOffExp e) { visit(cast(ASTCodegen.SymbolExp)e); }
     void visit(ASTCodegen.OverExp e) { visit(cast(ASTCodegen.Expression)e); }
     void visit(ASTCodegen.HaltExp e) { visit(cast(ASTCodegen.Expression)e); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -188,6 +188,7 @@ class TupleExp;
 class ArrayLiteralExp;
 class AssocArrayLiteralExp;
 class StructLiteralExp;
+class ObjcClassReferenceExp;
 class TypeExp;
 class ScopeExp;
 class TemplateExp;
@@ -601,6 +602,7 @@ public:
     virtual void visit(ErrorExp *e) { visit((Expression *)e); }
     virtual void visit(ComplexExp *e) { visit((Expression *)e); }
     virtual void visit(StructLiteralExp *e) { visit((Expression *)e); }
+    virtual void visit(ObjcClassReferenceExp *e) { visit((Expression *)e); }
     virtual void visit(SymOffExp *e) { visit((SymbolExp *)e); }
     virtual void visit(OverExp *e) { visit((Expression *)e); }
     virtual void visit(HaltExp *e) { visit((Expression *)e); }

--- a/test/fail_compilation/objc_non_objc_base.d
+++ b/test/fail_compilation/objc_non_objc_base.d
@@ -1,0 +1,12 @@
+// EXTRA_OBJC_SOURCES
+/*
+TEST_OUTPUT:
+---
+fail_compilation/objc_non_objc_base.d(12): Error: interface `objc_non_objc_base.A` base interface for an Objective-C interface must be `extern (Objective-C)`
+---
+*/
+
+interface Base {}
+
+extern (Objective-C)
+interface A : Base {}

--- a/test/runnable/objc_call_static.d
+++ b/test/runnable/objc_call_static.d
@@ -1,0 +1,22 @@
+// EXTRA_OBJC_SOURCES
+// REQUIRED_ARGS: -L-framework -LFoundation
+
+extern (Objective-C)
+interface NSObject
+{
+    static NSObject alloc() @selector("alloc");
+    static NSObject allocWithZone(void* zone) @selector("allocWithZone:");
+
+    NSObject init() @selector("init");
+}
+
+void main()
+{
+    auto obj1 = NSObject.alloc();
+    auto obj2 = NSObject.allocWithZone(null);
+    auto obj3 = NSObject.alloc().init();
+
+    assert(obj1);
+    assert(obj2);
+    assert(obj3);
+}


### PR DESCRIPTION
A few missing things:

- [x] The header files need to be updated
- [x] Could use some more documentation
- [x] Need to add changelog
- [x] A PR to update the documentation in dlang.org

Documentation of the Objective-C ABI has been started, available in a separate branch: https://github.com/jacob-carlborg/dmd/blob/objc_abi_docs/docs/objective-c_abi.md.

The dlang.org part https://github.com/dlang/dlang.org/pull/2246.