### PR TITLE
highlight error messages:  misc. changes

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -687,7 +687,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
                   s.isTemplateDeclaration() ||
                   s.isOverloadSet()))
             {
-                s.error("is not a constructor; identifiers starting with __ are reserved for the implementation");
+                s.error("is not a constructor; identifiers starting with `__` are reserved for the implementation");
                 errors = true;
                 s = null;
             }

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -513,7 +513,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             if (!(s.stc & STC.nothrow_))
             {
                 if (mustNotThrow && !(s.stc & STC.nothrow_))
-                    s.deprecation("asm statement is assumed to throw - mark it with `nothrow` if it does not");
+                    s.deprecation("`asm` statement is assumed to throw - mark it with `nothrow` if it does not");
                 else
                     result |= BE.throw_;
             }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -103,11 +103,11 @@ public:
     {
         if (type.isImmutable() || type.isShared())
         {
-            type.error(Loc(), "Internal Compiler Error: shared or immutable types can not be mapped to C++ (%s)", type.toChars());
+            type.error(Loc(), "Internal Compiler Error: `shared` or `immutable` types can not be mapped to C++ (%s)", type.toChars());
         }
         else
         {
-            type.error(Loc(), "Internal Compiler Error: type %s can not be mapped to C++\n", type.toChars());
+            type.error(Loc(), "Internal Compiler Error: type `%s` can not be mapped to C++\n", type.toChars());
         }
         fatal(); //Fatal, because this error should be handled in frontend
     }
@@ -571,7 +571,7 @@ private:
         // fake mangling for fields to fix https://issues.dlang.org/show_bug.cgi?id=16525
         if (!(d.storage_class & (STC.extern_ | STC.field | STC.gshared)))
         {
-            d.error("Internal Compiler Error: C++ static non- __gshared non-extern variables not supported");
+            d.error("Internal Compiler Error: C++ static non-__gshared non-extern variables not supported");
             fatal();
         }
         buf.writeByte('?');
@@ -716,7 +716,7 @@ private:
                     Expression e = isExpression(o);
                     if (!d && !e)
                     {
-                        sym.error("Internal Compiler Error: %s is unsupported parameter for C++ template", o.toChars());
+                        sym.error("Internal Compiler Error: `%s` is unsupported parameter for C++ template", o.toChars());
                         fatal();
                     }
                     if (d && d.isFuncDeclaration())
@@ -765,7 +765,7 @@ private:
                     }
                     else
                     {
-                        sym.error("Internal Compiler Error: %s is unsupported parameter for C++ template: (%s)", o.toChars());
+                        sym.error("Internal Compiler Error: `%s` is unsupported parameter for C++ template: (%s)", o.toChars());
                         fatal();
                     }
                 }
@@ -1047,7 +1047,7 @@ private:
                 }
                 if (t.ty == Tsarray)
                 {
-                    t.error(Loc(), "Internal Compiler Error: unable to pass static array to extern(C++) function.");
+                    t.error(Loc(), "Internal Compiler Error: unable to pass static array to `extern(C++)` function.");
                     t.error(Loc(), "Use pointer instead.");
                     assert(0);
                 }

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1383,7 +1383,7 @@ public:
                     if (s.isImport() || (ad = s.isAliasDeclaration()) !is null && ad._import !is null)
                     {}
                     else
-                        error(loc, "%s `%s` is private", s.kind(), s.toPrettyChars());
+                        error(loc, "%s `%s` is `private`", s.kind(), s.toPrettyChars());
                 }
                 //printf("\tfound in imports %s.%s\n", toChars(), s.toChars());
                 return s;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1859,7 +1859,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         if (em.semanticRun == PASS.semantic)
         {
-            em.error("circular reference to enum member");
+            em.error("circular reference to `enum` member");
             return errorReturn();
         }
         assert(em.ed);
@@ -2758,12 +2758,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             const(char)* sfunc;
             if (funcdecl.isStatic())
-                sfunc = "`static`";
+                sfunc = "static";
             else if (funcdecl.protection.kind == Prot.Kind.private_ || funcdecl.protection.kind == Prot.Kind.package_)
                 sfunc = protectionToChars(funcdecl.protection.kind);
             else
-                sfunc = "`final`";
-            funcdecl.error("%s functions cannot be `abstract`", sfunc);
+                sfunc = "final";
+            funcdecl.error("`%s` functions cannot be `abstract`", sfunc);
         }
 
         if (funcdecl.isOverride() && !funcdecl.isVirtual())
@@ -2788,7 +2788,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (funcdecl.isStaticConstructor() || funcdecl.isStaticDestructor())
             {
                 if (!funcdecl.isStatic() || funcdecl.type.nextOf().ty != Tvoid)
-                    funcdecl.error("static constructors / destructors must be static void");
+                    funcdecl.error("static constructors / destructors must be `static void`");
                 if (f.arguments && f.arguments.dim)
                     funcdecl.error("static constructors / destructors must have empty parameter list");
                 // BUG: check for invalid storage classes

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -468,7 +468,7 @@ final class Parser(AST) : Lexer
                         {
                             // mixin(string)
                             nextToken();
-                            check(TOK.leftParentheses, "mixin");
+                            check(TOK.leftParentheses, "`mixin`");
                             AST.Expression e = parseAssignExp();
                             check(TOK.rightParentheses);
                             check(TOK.semicolon);
@@ -1514,7 +1514,7 @@ final class Parser(AST) : Lexer
         nextToken();
         if (token.value != TOK.identifier)
         {
-            error("identifier expected following template");
+            error("identifier expected following `template`");
             goto Lerr;
         }
         id = token.ident;
@@ -1552,7 +1552,7 @@ final class Parser(AST) : Lexer
 
         if (!flag && token.value != TOK.leftParentheses)
         {
-            error("parenthesized TemplateParameterList expected following TemplateIdentifier");
+            error("parenthesized template parameter list expected following template identifier");
             goto Lerr;
         }
         nextToken();
@@ -2042,7 +2042,7 @@ final class Parser(AST) : Lexer
                 break;
             }
         default:
-            error("template argument expected following !");
+            error("template argument expected following `!`");
             break;
         }
         return tiargs;
@@ -3210,7 +3210,7 @@ final class Parser(AST) : Lexer
             nextToken();
             if (token.value != TOK.identifier)
             {
-                error("identifier expected following import");
+                error("identifier expected following `import`");
                 break;
             }
 
@@ -3231,7 +3231,7 @@ final class Parser(AST) : Lexer
                 nextToken();
                 if (token.value != TOK.identifier)
                 {
-                    error("identifier expected following package");
+                    error("identifier expected following `package`");
                     break;
                 }
                 id = token.ident;
@@ -3754,7 +3754,7 @@ final class Parser(AST) : Lexer
                     if (stc & (AST.STC.const_ | AST.STC.immutable_ | AST.STC.shared_ | AST.STC.wild | AST.STC.return_))
                     {
                         if (save == TOK.function_)
-                            error("const/immutable/shared/inout/return attributes are only valid for non-static member functions");
+                            error("`const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions");
                         else
                             tf = cast(AST.TypeFunction)tf.addSTC(stc);
                     }
@@ -5399,7 +5399,7 @@ final class Parser(AST) : Lexer
                 else
                 {
                     condition = parseExpression();
-                    check(TOK.semicolon, "for condition");
+                    check(TOK.semicolon, "`for` condition");
                 }
                 if (token.value == TOK.rightParentheses)
                 {
@@ -5659,7 +5659,7 @@ final class Parser(AST) : Lexer
                 if (token.value == TOK.slice)
                 {
                     if (cases.dim > 1)
-                        error("only one case allowed for start of case range");
+                        error("only one `case` allowed for start of case range");
                     nextToken();
                     check(TOK.case_);
                     last = parseAssignExp();
@@ -5724,7 +5724,7 @@ final class Parser(AST) : Lexer
                     exp = null;
                 else
                     exp = parseExpression();
-                check(TOK.semicolon, "return statement");
+                check(TOK.semicolon, "`return` statement");
                 s = new AST.ReturnStatement(loc, exp);
                 break;
             }
@@ -5739,7 +5739,7 @@ final class Parser(AST) : Lexer
                 }
                 else
                     ident = null;
-                check(TOK.semicolon, "break statement");
+                check(TOK.semicolon, "`break` statement");
                 s = new AST.BreakStatement(loc, ident);
                 break;
             }
@@ -5754,7 +5754,7 @@ final class Parser(AST) : Lexer
                 }
                 else
                     ident = null;
-                check(TOK.semicolon, "continue statement");
+                check(TOK.semicolon, "`continue` statement");
                 s = new AST.ContinueStatement(loc, ident);
                 break;
             }
@@ -5789,7 +5789,7 @@ final class Parser(AST) : Lexer
                     }
                     s = new AST.GotoStatement(loc, ident);
                 }
-                check(TOK.semicolon, "goto statement");
+                check(TOK.semicolon, "`goto` statement");
                 break;
             }
         case TOK.synchronized_:
@@ -5890,7 +5890,7 @@ final class Parser(AST) : Lexer
                 AST.Expression exp;
                 nextToken();
                 exp = parseExpression();
-                check(TOK.semicolon, "throw statement");
+                check(TOK.semicolon, "`throw` statement");
                 s = new AST.ThrowStatement(loc, exp);
                 break;
             }
@@ -5907,7 +5907,7 @@ final class Parser(AST) : Lexer
                 nextToken();
                 StorageClass stc = parsePostfix(AST.STC.undefined_, null);
                 if (stc & (AST.STC.const_ | AST.STC.immutable_ | AST.STC.shared_ | AST.STC.wild))
-                    error("const/immutable/shared/inout attributes are not allowed on `asm` blocks");
+                    error("`const`/`immutable`/`shared`/`inout` attributes are not allowed on `asm` blocks");
 
                 check(TOK.leftCurly);
                 Token* toklist = null;
@@ -7491,7 +7491,7 @@ final class Parser(AST) : Lexer
         case TOK.typeid_:
             {
                 nextToken();
-                check(TOK.leftParentheses, "typeid");
+                check(TOK.leftParentheses, "`typeid`");
                 RootObject o;
                 if (isDeclaration(&token, NeedDeclaratorId.no, TOK.reserved, null))
                 {
@@ -7594,7 +7594,7 @@ final class Parser(AST) : Lexer
                 AST.Expression msg = null;
 
                 nextToken();
-                check(TOK.leftParentheses, "assert");
+                check(TOK.leftParentheses, "`assert`");
                 e = parseAssignExp();
                 if (token.value == TOK.comma)
                 {
@@ -7613,7 +7613,7 @@ final class Parser(AST) : Lexer
         case TOK.mixin_:
             {
                 nextToken();
-                check(TOK.leftParentheses, "mixin");
+                check(TOK.leftParentheses, "`mixin`");
                 e = parseAssignExp();
                 check(TOK.rightParentheses);
                 e = new AST.CompileExp(loc, e);
@@ -7622,7 +7622,7 @@ final class Parser(AST) : Lexer
         case TOK.import_:
             {
                 nextToken();
-                check(TOK.leftParentheses, "import");
+                check(TOK.leftParentheses, "`import`");
                 e = parseAssignExp();
                 check(TOK.rightParentheses);
                 e = new AST.ImportExp(loc, e);

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1605,12 +1605,12 @@ extern (C++) final class SwitchStatement : Statement
             }
             else if (vd.ident == Id.withSym)
             {
-                deprecation("'switch' skips declaration of 'with' temporary at %s", vd.loc.toChars());
+                deprecation("`switch` skips declaration of `with` temporary at %s", vd.loc.toChars());
                 return true;
             }
             else
             {
-                deprecation("'switch' skips declaration of variable %s at %s", vd.toPrettyChars(), vd.loc.toChars());
+                deprecation("`switch` skips declaration of variable `%s` at %s", vd.toPrettyChars(), vd.loc.toChars());
                 return true;
             }
 
@@ -2235,16 +2235,16 @@ extern (C++) final class GotoStatement : Statement
             else
             {
                 if (label.statement.os)
-                    error("cannot goto in to `%s` block", Token.toChars(label.statement.os.tok));
+                    error("cannot `goto` in to `%s` block", Token.toChars(label.statement.os.tok));
                 else
-                    error("cannot goto out of `%s` block", Token.toChars(os.tok));
+                    error("cannot `goto` out of `%s` block", Token.toChars(os.tok));
                 return true;
             }
         }
 
         if (label.statement.tf != tf)
         {
-            error("cannot goto in or out of `finally` block");
+            error("cannot `goto` in or out of `finally` block");
             return true;
         }
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -646,7 +646,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         else enum skipCheck = false;
         if (!skipCheck && (dim < 1 || dim > 2))
         {
-            fs.error("only one (value) or two (key,value) arguments for tuple foreach");
+            fs.error("only one (value) or two (key,value) arguments for tuple `foreach`");
             setError();
             return returnEarly();
         }
@@ -731,14 +731,14 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     {
                         if (keyty != Tint64 && keyty != Tuns64)
                         {
-                            fs.error("foreach: key type must be int or uint, long or ulong, not `%s`", p.type.toChars());
+                            fs.error("`foreach`: key type must be `int` or `uint`, `long` or `ulong`, not `%s`", p.type.toChars());
                             setError();
                             return returnEarly();
                         }
                     }
                     else
                     {
-                        fs.error("foreach: key type must be int or uint, not `%s`", p.type.toChars());
+                        fs.error("`foreach`: key type must be `int` or `uint`, not `%s`", p.type.toChars());
                         setError();
                         return returnEarly();
                     }
@@ -799,7 +799,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     }
                     else if (storageClass & STC.alias_)
                     {
-                        fs.error("foreach loop variable cannot be both enum and alias");
+                        fs.error("`foreach` loop variable cannot be both `enum` and `alias`");
                         setError();
                         return false;
                     }
@@ -809,7 +809,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                         var = new AliasDeclaration(loc, ident, ds);
                         if (storageClass & STC.ref_)
                         {
-                            fs.error("symbol `%s` cannot be ref", ds.toChars());
+                            fs.error("symbol `%s` cannot be `ref`", ds.toChars());
                             setError();
                             return false;
                         }
@@ -849,17 +849,17 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                             {
                                 static if (!isStatic)
                                 {
-                                    fs.error("constant value `%s` cannot be ref", ie.toChars());
+                                    fs.error("constant value `%s` cannot be `ref`", ie.toChars());
                                 }
                                 else
                                 {
                                     if (!needExpansion)
                                     {
-                                        fs.error("constant value `%s` cannot be ref", ie.toChars());
+                                        fs.error("constant value `%s` cannot be `ref`", ie.toChars());
                                     }
                                     else
                                     {
-                                        fs.error("constant value `%s` cannot be ref", ident.toChars());
+                                        fs.error("constant value `%s` cannot be `ref`", ident.toChars());
                                     }
                                 }
                                 setError();
@@ -1035,9 +1035,9 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             const(char)* msg = "";
             if (fs.aggr.type && isAggregate(fs.aggr.type))
             {
-                msg = ", define opApply(), range primitives, or use .tupleof";
+                msg = ", define `opApply()`, range primitives, or use `.tupleof`";
             }
-            fs.error("invalid foreach aggregate `%s`%s", oaggr.toChars(), msg);
+            fs.error("invalid `foreach` aggregate `%s`%s", oaggr.toChars(), msg);
             return setError();
         }
 
@@ -1084,7 +1084,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     foreachParamCount, plural, dim);
             }
             else
-                fs.error("cannot uniquely infer foreach argument types");
+                fs.error("cannot uniquely infer `foreach` argument types");
 
             return setError();
         }
@@ -1112,11 +1112,11 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             Parameter p = (*fs.parameters)[i];
             if (p.storageClass & STC.manifest)
             {
-                fs.error("cannot declare enum loop variables for non-unrolled foreach");
+                fs.error("cannot declare `enum` loop variables for non-unrolled foreach");
             }
             if (p.storageClass & STC.alias_)
             {
-                fs.error("cannot declare alias loop variables for non-unrolled foreach");
+                fs.error("cannot declare `alias` loop variables for non-unrolled foreach");
             }
         }
 
@@ -1133,7 +1133,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
 
                 if (dim < 1 || dim > 2)
                 {
-                    fs.error("only one or two arguments for array foreach");
+                    fs.error("only one or two arguments for array `foreach`");
                     goto case Terror;
                 }
 
@@ -1153,7 +1153,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     {
                         if (p.storageClass & STC.ref_)
                         {
-                            fs.error("foreach: value of UTF conversion cannot be ref");
+                            fs.error("`foreach`: value of UTF conversion cannot be `ref`");
                             goto case Terror;
                         }
                         if (dim == 2)
@@ -1161,7 +1161,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                             p = (*fs.parameters)[0];
                             if (p.storageClass & STC.ref_)
                             {
-                                fs.error("foreach: key cannot be ref");
+                                fs.error("`foreach`: key cannot be `ref`");
                                 goto case Terror;
                             }
                         }
@@ -1344,7 +1344,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             }
         case Taarray:
             if (fs.op == TOK.foreach_reverse_)
-                fs.warning("cannot use foreach_reverse with an associative array");
+                fs.warning("cannot use `foreach_reverse` with an associative array");
             if (fs.checkForArgTypes())
             {
                 result = fs;
@@ -1354,7 +1354,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             taa = cast(TypeAArray)tab;
             if (dim < 1 || dim > 2)
             {
-                fs.error("only one or two arguments for associative array foreach");
+                fs.error("only one or two arguments for associative array `foreach`");
                 goto case Terror;
             }
             goto Lapply;
@@ -1536,7 +1536,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             }
         case Tdelegate:
             if (fs.op == TOK.foreach_reverse_)
-                fs.deprecation("cannot use foreach_reverse with a delegate");
+                fs.deprecation("cannot use `foreach_reverse` with a delegate");
         Lapply:
             {
                 if (fs.checkForArgTypes())
@@ -1597,7 +1597,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                         {
                             if (!stc)
                             {
-                                fs.error("foreach: cannot make `%s` ref", p.ident.toChars());
+                                fs.error("`foreach`: cannot make `%s` `ref`", p.ident.toChars());
                                 goto case Terror;
                             }
                             goto LcopyArg;
@@ -1670,7 +1670,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                         Type ti = (isRef ? taa.index.addMod(MODFlags.const_) : taa.index);
                         if (isRef ? !ti.constConv(ta) : !ti.implicitConvTo(ta))
                         {
-                            fs.error("foreach: index must be type `%s`, not `%s`",
+                            fs.error("`foreach`: index must be type `%s`, not `%s`",
                                 ti.toChars(), ta.toChars());
                             goto case Terror;
                         }
@@ -1681,7 +1681,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     Type taav = taa.nextOf();
                     if (isRef ? !taav.constConv(ta) : !taav.implicitConvTo(ta))
                     {
-                        fs.error("foreach: value must be type `%s`, not `%s`",
+                        fs.error("`foreach`: value must be type `%s`, not `%s`",
                             taav.toChars(), ta.toChars());
                         goto case Terror;
                     }
@@ -1807,7 +1807,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                         goto case Terror;
                     if (ec.type != Type.tint32)
                     {
-                        fs.error("opApply() function for `%s` must return an int", tab.toChars());
+                        fs.error("`opApply()` function for `%s` must return an `int`", tab.toChars());
                         goto case Terror;
                     }
                 }
@@ -1843,7 +1843,7 @@ else
                         goto case Terror;
                     if (ec.type != Type.tint32)
                     {
-                        fs.error("opApply() function for `%s` must return an int", tab.toChars());
+                        fs.error("`opApply()` function for `%s` must return an `int`", tab.toChars());
                         goto case Terror;
                     }
                 }
@@ -1884,7 +1884,7 @@ else
             break;
 
         default:
-            fs.error("foreach: `%s` is not an aggregate type", fs.aggr.type.toChars());
+            fs.error("`foreach`: `%s` is not an aggregate type", fs.aggr.type.toChars());
             goto case Terror;
         }
         sc2.noctor--;
@@ -2064,7 +2064,7 @@ else
         {
             if (fs.key.type.constConv(fs.prm.type) <= MATCH.nomatch)
             {
-                fs.error("argument type mismatch, `%s` to ref `%s`", fs.key.type.toChars(), fs.prm.type.toChars());
+                fs.error("argument type mismatch, `%s` to `ref %s`", fs.key.type.toChars(), fs.prm.type.toChars());
                 return setError();
             }
         }
@@ -2229,14 +2229,14 @@ else
             {
                 /* Should this be allowed?
                  */
-                ps.error("pragma(lib) not allowed as statement");
+                ps.error("`pragma(lib)` not allowed as statement");
                 return setError();
             }
             else
             {
                 if (!ps.args || ps.args.dim != 1)
                 {
-                    ps.error("string expected for library name");
+                    ps.error("`string` expected for library name");
                     return setError();
                 }
                 else
@@ -2292,7 +2292,7 @@ else
                 inlining = PINLINE.default_;
             else if (!ps.args || ps.args.dim != 1)
             {
-                ps.error("boolean expression expected for pragma(inline)");
+                ps.error("boolean expression expected for `pragma(inline)`");
                 return setError();
             }
             else
@@ -2312,7 +2312,7 @@ else
                     FuncDeclaration fd = sc.func;
                 if (!fd)
                 {
-                    ps.error("pragma(inline) is not inside a function");
+                    ps.error("`pragma(inline)` is not inside a function");
                     return setError();
                 }
                 fd.inlining = inlining;
@@ -2423,7 +2423,7 @@ else
         {
             if (!gcs.exp)
             {
-                gcs.error("no case statement following goto case;");
+                gcs.error("no `case` statement following `goto case;`");
                 sc.pop();
                 return setError();
             }
@@ -2468,7 +2468,7 @@ else
                             if (cs.exp.equals(em.value) || (!cs.exp.type.isString() && !em.value.type.isString() && cs.exp.toInteger() == em.value.toInteger()))
                                 continue Lmembers;
                         }
-                        ss.error("enum member `%s` not represented in final switch", em.toChars());
+                        ss.error("`enum` member `%s` not represented in `final switch`", em.toChars());
                         sc.pop();
                         return setError();
                     }
@@ -2483,7 +2483,7 @@ else
             ss.hasNoDefault = 1;
 
             if (!ss.isFinal && !ss._body.isErrorStatement())
-                ss.error("switch statement without a default; use `final switch` or add `default: assert(0);` or add `default: break;`");
+                ss.error("`switch` statement without a `default`; use `final switch` or add `default: assert(0);` or add `default: break;`");
 
             // Generate runtime error if the default is hit
             auto a = new Statements();
@@ -2643,12 +2643,12 @@ else
                      */
                     if (!v.isConst() && !v.isImmutable())
                     {
-                        cs.deprecation("case variables have to be const or immutable");
+                        cs.deprecation("`case` variables have to be `const` or `immutable`");
                     }
 
                     if (sw.isFinal)
                     {
-                        cs.error("case variables not allowed in final switch statements");
+                        cs.error("`case` variables not allowed in `final switch` statements");
                         errors = true;
                     }
 
@@ -2663,7 +2663,7 @@ else
 
                         if (!scx.search(cs.exp.loc, v.ident, null))
                         {
-                            cs.error("case variable `%s` declared at %s cannot be declared in switch body",
+                            cs.error("`case` variable `%s` declared at %s cannot be declared in `switch` body",
                                 v.toChars(), v.loc.toChars());
                             errors = true;
                         }
@@ -2679,7 +2679,7 @@ else
                 cs.exp = se;
             else if (cs.exp.op != TOK.int64 && cs.exp.op != TOK.error)
             {
-                cs.error("case must be a string or an integral constant, not `%s`", cs.exp.toChars());
+                cs.error("`case` must be a `string` or an integral constant, not `%s`", cs.exp.toChars());
                 errors = true;
             }
 
@@ -2689,7 +2689,7 @@ else
                 //printf("comparing '%s' with '%s'\n", exp.toChars(), cs.exp.toChars());
                 if (cs2.exp.equals(cs.exp))
                 {
-                    cs.error("duplicate `case %s` in switch statement", cs.exp.toChars());
+                    cs.error("duplicate `case %s` in `switch` statement", cs.exp.toChars());
                     errors = true;
                     break;
                 }
@@ -2712,13 +2712,13 @@ else
 
             if (sc.sw.tf != sc.tf)
             {
-                cs.error("switch and case are in different finally blocks");
+                cs.error("`switch` and `case` are in different `finally` blocks");
                 errors = true;
             }
         }
         else
         {
-            cs.error("case not in switch statement");
+            cs.error("`case` not in `switch` statement");
             errors = true;
         }
 
@@ -2740,7 +2740,7 @@ else
         SwitchStatement sw = sc.sw;
         if (sw is null)
         {
-            crs.error("case range not in switch statement");
+            crs.error("case range not in `switch` statement");
             return setError();
         }
 
@@ -2748,7 +2748,7 @@ else
         bool errors = false;
         if (sw.isFinal)
         {
-            crs.error("case ranges not allowed in final switch");
+            crs.error("case ranges not allowed in `final switch`");
             errors = true;
         }
 
@@ -2825,25 +2825,25 @@ else
         {
             if (sc.sw.sdefault)
             {
-                ds.error("switch statement already has a default");
+                ds.error("`switch` statement already has a default");
                 errors = true;
             }
             sc.sw.sdefault = ds;
 
             if (sc.sw.tf != sc.tf)
             {
-                ds.error("switch and default are in different finally blocks");
+                ds.error("`switch` and `default` are in different `finally` blocks");
                 errors = true;
             }
             if (sc.sw.isFinal)
             {
-                ds.error("default statement not allowed in final switch statement");
+                ds.error("`default` statement not allowed in `final switch` statement");
                 errors = true;
             }
         }
         else
         {
-            ds.error("default not in switch statement");
+            ds.error("`default` not in `switch` statement");
             errors = true;
         }
 
@@ -2860,12 +2860,12 @@ else
         gds.sw = sc.sw;
         if (!gds.sw)
         {
-            gds.error("goto default not in switch statement");
+            gds.error("`goto default` not in `switch` statement");
             return setError();
         }
         if (gds.sw.isFinal)
         {
-            gds.error("goto default not allowed in final switch statement");
+            gds.error("`goto default` not allowed in `final switch` statement");
             return setError();
         }
         result = gds;
@@ -2875,7 +2875,7 @@ else
     {
         if (!sc.sw)
         {
-            gcs.error("goto case not in switch statement");
+            gcs.error("`goto case` not in `switch` statement");
             return setError();
         }
 
@@ -2937,17 +2937,17 @@ else
         bool errors = false;
         if (sc.flags & SCOPE.contract)
         {
-            rs.error("return statements cannot be in contracts");
+            rs.error("`return` statements cannot be in contracts");
             errors = true;
         }
         if (sc.os && sc.os.tok != TOK.onScopeFailure)
         {
-            rs.error("return statements cannot be in `%s` bodies", Token.toChars(sc.os.tok));
+            rs.error("`return` statements cannot be in `%s` bodies", Token.toChars(sc.os.tok));
             errors = true;
         }
         if (sc.tf)
         {
-            rs.error("return statements cannot be in `finally` bodies");
+            rs.error("`return` statements cannot be in `finally` bodies");
             errors = true;
         }
 
@@ -3006,7 +3006,7 @@ else
             {
                 if (rs.exp.type.ty != Tvoid)
                 {
-                    rs.error("cannot return non-void from void function");
+                    rs.error("cannot return non-void from `void` function");
                     errors = true;
                     rs.exp = new CastExp(rs.loc, rs.exp, Type.tvoid);
                     rs.exp = rs.exp.expressionSemantic(sc);
@@ -3140,7 +3140,7 @@ else
             if (tbret.ty != Tvoid) // if non-void return
             {
                 if (tbret.ty != Terror)
-                    rs.error("return expression expected");
+                    rs.error("`return` expression expected");
                 errors = true;
             }
             else if (fd.isMain())
@@ -3153,7 +3153,7 @@ else
         // If any branches have called a ctor, but this branch hasn't, it's an error
         if (sc.callSuper & CSX.any_ctor && !(sc.callSuper & (CSX.this_ctor | CSX.super_ctor)))
         {
-            rs.error("return without calling constructor");
+            rs.error("`return` without calling constructor");
             errors = true;
         }
         sc.callSuper |= CSX.return_;
@@ -3168,7 +3168,7 @@ else
                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
                 if (mustInit && !(sc.fieldinit[i] & CSX.this_ctor))
                 {
-                    rs.error("an earlier return statement skips field `%s` initialization", v.toChars());
+                    rs.error("an earlier `return` statement skips field `%s` initialization", v.toChars());
                     errors = true;
                 }
                 sc.fieldinit[i] |= CSX.return_;
@@ -3267,9 +3267,9 @@ else
                 {
                     Statement s = ls.statement;
                     if (!s || !s.hasBreak())
-                        bs.error("label `%s` has no break", bs.ident.toChars());
+                        bs.error("label `%s` has no `break`", bs.ident.toChars());
                     else if (ls.tf != sc.tf)
-                        bs.error("cannot break out of finally block");
+                        bs.error("cannot break out of `finally` block");
                     else
                     {
                         ls.breaks = true;
@@ -3279,14 +3279,14 @@ else
                     return setError();
                 }
             }
-            bs.error("enclosing label `%s` for break not found", bs.ident.toChars());
+            bs.error("enclosing label `%s` for `break` not found", bs.ident.toChars());
             return setError();
         }
         else if (!sc.sbreak)
         {
             if (sc.os && sc.os.tok != TOK.onScopeFailure)
             {
-                bs.error("break is not inside `%s` bodies", Token.toChars(sc.os.tok));
+                bs.error("`break` is not inside `%s` bodies", Token.toChars(sc.os.tok));
             }
             else if (sc.fes)
             {
@@ -3295,7 +3295,7 @@ else
                 return;
             }
             else
-                bs.error("break is not inside a loop or switch");
+                bs.error("`break` is not inside a loop or `switch`");
             return setError();
         }
         else if (sc.sbreak.isForwardingStatement())
@@ -3352,9 +3352,9 @@ else
                 {
                     Statement s = ls.statement;
                     if (!s || !s.hasContinue())
-                        cs.error("label `%s` has no continue", cs.ident.toChars());
+                        cs.error("label `%s` has no `continue`", cs.ident.toChars());
                     else if (ls.tf != sc.tf)
-                        cs.error("cannot continue out of finally block");
+                        cs.error("cannot continue out of `finally` block");
                     else
                     {
                         result = cs;
@@ -3363,14 +3363,14 @@ else
                     return setError();
                 }
             }
-            cs.error("enclosing label `%s` for continue not found", cs.ident.toChars());
+            cs.error("enclosing label `%s` for `continue` not found", cs.ident.toChars());
             return setError();
         }
         else if (!sc.scontinue)
         {
             if (sc.os && sc.os.tok != TOK.onScopeFailure)
             {
-                cs.error("continue is not inside `%s` bodies", Token.toChars(sc.os.tok));
+                cs.error("`continue` is not inside `%s` bodies", Token.toChars(sc.os.tok));
             }
             else if (sc.fes)
             {
@@ -3379,7 +3379,7 @@ else
                 return;
             }
             else
-                cs.error("continue is not inside a loop");
+                cs.error("`continue` is not inside a loop");
             return setError();
         }
         else if (sc.scontinue.isForwardingStatement())
@@ -3407,7 +3407,7 @@ else
             ClassDeclaration cd = ss.exp.type.isClassHandle();
             if (!cd)
             {
-                ss.error("can only synchronize on class objects, not `%s`", ss.exp.type.toChars());
+                ss.error("can only `synchronize` on class objects, not `%s`", ss.exp.type.toChars());
                 return setError();
             }
             else if (cd.isInterfaceDeclaration())
@@ -3532,7 +3532,7 @@ else
             Dsymbol s = (cast(TypeExp)ws.exp).type.toDsymbol(sc);
             if (!s || !s.isScopeDsymbol())
             {
-                ws.error("with type `%s` has no members", ws.exp.toChars());
+                ws.error("`with` type `%s` has no members", ws.exp.toChars());
                 return setError();
             }
             sym = new WithScopeSymbol(ws);
@@ -3596,7 +3596,7 @@ else
             }
             else
             {
-                ws.error("with expressions must be aggregate types or pointers to them, not `%s`", olde.type.toChars());
+                ws.error("`with` expressions must be aggregate types or pointers to them, not `%s`", olde.type.toChars());
                 return setError();
             }
         }
@@ -3658,7 +3658,7 @@ else
                 const sj = cj.loc.toChars();
                 if (c.type.toBasetype().implicitConvTo(cj.type.toBasetype()))
                 {
-                    tcs.error("catch at %s hides catch at %s", sj, si);
+                    tcs.error("`catch` at %s hides `catch` at %s", sj, si);
                     catchErrors = true;
                 }
             }
@@ -3764,7 +3764,7 @@ else
             }
             if (sc.tf)
             {
-                oss.error("cannot put `%s` statement inside finally block", Token.toChars(oss.tok));
+                oss.error("cannot put `%s` statement inside `finally` block", Token.toChars(oss.tok));
                 return setError();
             }
         }
@@ -3795,7 +3795,7 @@ else
 
         if (!global.params.useExceptions)
         {
-            ts.error("Cannot use throw statements with -betterC");
+            ts.error("Cannot use `throw` statements with -betterC");
             return setError();
         }
 
@@ -3819,7 +3819,7 @@ else
         ClassDeclaration cd = ts.exp.type.toBasetype().isClassHandle();
         if (!cd || ((cd != ClassDeclaration.throwable) && !ClassDeclaration.throwable.isBaseOf(cd, null)))
         {
-            ts.error("can only throw class objects derived from Throwable, not type `%s`", ts.exp.type.toChars());
+            ts.error("can only throw class objects derived from `Throwable`, not type `%s`", ts.exp.type.toChars());
             return setError();
         }
 
@@ -3928,11 +3928,11 @@ else
         // use setImpure/setGC when the deprecation cycle is over
         PURE purity;
         if (!(cas.stc & STC.pure_) && (purity = sc.func.isPureBypassingInference()) != PURE.impure && purity != PURE.fwdref)
-            cas.deprecation("asm statement is assumed to be impure - mark it with 'pure' if it is not");
+            cas.deprecation("`asm` statement is assumed to be impure - mark it with `pure` if it is not");
         if (!(cas.stc & STC.nogc) && sc.func.isNogcBypassingInference())
-            cas.deprecation("asm statement is assumed to use the GC - mark it with '@nogc' if it does not");
+            cas.deprecation("`asm` statement is assumed to use the GC - mark it with `@nogc` if it does not");
         if (!(cas.stc & (STC.trusted | STC.safe)) && sc.func.setUnsafe())
-            cas.error("asm statement is assumed to be @system - mark it with '@trusted' if it is not");
+            cas.error("`asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not");
 
         result = cas;
     }
@@ -3975,7 +3975,7 @@ void catchSemantic(Catch c, Scope* sc)
     if (sc.os && sc.os.tok != TOK.onScopeFailure)
     {
         // If enclosing is scope(success) or scope(exit), this will be placed in finally block.
-        error(c.loc, "cannot put catch statement inside `%s`", Token.toChars(sc.os.tok));
+        error(c.loc, "cannot put `catch` statement inside `%s`", Token.toChars(sc.os.tok));
         c.errors = true;
     }
     if (sc.tf)
@@ -3986,7 +3986,7 @@ void catchSemantic(Catch c, Scope* sc)
          * To fix, have the compiler automatically convert the finally
          * body into a nested function.
          */
-        error(c.loc, "cannot put catch statement inside finally block");
+        error(c.loc, "cannot put `catch` statement inside `finally` block");
         c.errors = true;
     }
 
@@ -3996,8 +3996,8 @@ void catchSemantic(Catch c, Scope* sc)
 
     if (!c.type)
     {
-        deprecation(c.loc, "catch statement without an exception " ~
-            "specification is deprecated; use catch(Throwable) for old behavior");
+        deprecation(c.loc, "`catch` statement without an exception " ~
+            "specification is deprecated; use `catch(Throwable)` for old behavior");
 
         // reference .object.Throwable
         c.type = getThrowable();
@@ -4023,20 +4023,20 @@ void catchSemantic(Catch c, Scope* sc)
             }
             if (sc.func && !sc.intypeof && !c.internalCatch && sc.func.setUnsafe())
             {
-                error(c.loc, "cannot catch C++ class objects in @safe code");
+                error(c.loc, "cannot catch C++ class objects in `@safe` code");
                 c.errors = true;
             }
         }
         else if (cd != ClassDeclaration.throwable && !ClassDeclaration.throwable.isBaseOf(cd, null))
         {
-            error(c.loc, "can only catch class objects derived from Throwable, not `%s`", c.type.toChars());
+            error(c.loc, "can only catch class objects derived from `Throwable`, not `%s`", c.type.toChars());
             c.errors = true;
         }
         else if (sc.func && !sc.intypeof && !c.internalCatch &&
                  cd != ClassDeclaration.exception && !ClassDeclaration.exception.isBaseOf(cd, null) &&
                  sc.func.setUnsafe())
         {
-            error(c.loc, "can only catch class objects derived from Exception in @safe code, not `%s`", c.type.toChars());
+            error(c.loc, "can only catch class objects derived from `Exception` in `@safe` code, not `%s`", c.type.toChars());
             c.errors = true;
         }
         else if (global.params.ehnogc)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1140,7 +1140,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                     {
                         objmod.setModuleCtorDtor(s.csym, isCtor);
                         if (f.linkage != LINK.c)
-                            f.error("must be extern(C) for pragma %s", isCtor ? "crt_constructor".ptr : "crt_destructor".ptr);
+                            f.error("must be `extern(C)` for `pragma(%s)`", isCtor ? "crt_constructor".ptr : "crt_destructor".ptr);
                         return 1;
                     }
                     else

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -908,7 +908,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                 {
                     if (ubyte m = fparam.type.mod & (MODFlags.immutable_ | MODFlags.const_ | MODFlags.wild))
                     {
-                        mtype.error(loc, "cannot have %s out parameter of type `%s`", MODtoChars(m), t.toChars());
+                        mtype.error(loc, "cannot have `%s out` parameter of type `%s`", MODtoChars(m), t.toChars());
                         errors = true;
                     }
                     else
@@ -918,7 +918,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                             tv = tv.nextOf().toBasetype();
                         if (tv.ty == Tstruct && (cast(TypeStruct)tv).sym.noDefaultCtor)
                         {
-                            mtype.error(loc, "cannot have out parameter of type `%s` because the default construction is disabled", fparam.type.toChars());
+                            mtype.error(loc, "cannot have `out` parameter of type `%s` because the default construction is disabled", fparam.type.toChars());
                             errors = true;
                         }
                     }

--- a/test/compilable/deprecate12979a.d
+++ b/test/compilable/deprecate12979a.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/deprecate12979a.d(13): Deprecation: asm statement is assumed to throw - mark it with `nothrow` if it does not
+compilable/deprecate12979a.d(13): Deprecation: `asm` statement is assumed to throw - mark it with `nothrow` if it does not
 ---
 */
 

--- a/test/compilable/test12558.d
+++ b/test/compilable/test12558.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/test12558.d(16): Deprecation: catch statement without an exception specification is deprecated; use catch(Throwable) for old behavior
-compilable/test12558.d(21): Deprecation: catch statement without an exception specification is deprecated; use catch(Throwable) for old behavior
+compilable/test12558.d(16): Deprecation: `catch` statement without an exception specification is deprecated; use `catch(Throwable)` for old behavior
+compilable/test12558.d(21): Deprecation: `catch` statement without an exception specification is deprecated; use `catch(Throwable)` for old behavior
 ---
 */
 

--- a/test/fail_compilation/betterc.d
+++ b/test/fail_compilation/betterc.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -betterC
  * TEST_OUTPUT:
 ---
-fail_compilation/betterc.d(11): Error: Cannot use throw statements with -betterC
+fail_compilation/betterc.d(11): Error: Cannot use `throw` statements with -betterC
 fail_compilation/betterc.d(16): Error: Cannot use try-catch statements with -betterC
 ---
 */

--- a/test/fail_compilation/cppeh1.d
+++ b/test/fail_compilation/cppeh1.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/cppeh1.d(26): Error: cannot catch C++ class objects in @safe code
+fail_compilation/cppeh1.d(26): Error: cannot catch C++ class objects in `@safe` code
 ---
 */
 

--- a/test/fail_compilation/deprecate12979a.d
+++ b/test/fail_compilation/deprecate12979a.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979a.d(14): Deprecation: asm statement is assumed to throw - mark it with `nothrow` if it does not
+fail_compilation/deprecate12979a.d(14): Deprecation: `asm` statement is assumed to throw - mark it with `nothrow` if it does not
 ---
 */
 

--- a/test/fail_compilation/deprecate12979b.d
+++ b/test/fail_compilation/deprecate12979b.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979b.d(13): Deprecation: asm statement is assumed to be impure - mark it with 'pure' if it is not
+fail_compilation/deprecate12979b.d(13): Deprecation: `asm` statement is assumed to be impure - mark it with `pure` if it is not
 ---
 */
 

--- a/test/fail_compilation/deprecate12979c.d
+++ b/test/fail_compilation/deprecate12979c.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979c.d(13): Deprecation: asm statement is assumed to use the GC - mark it with '@nogc' if it does not
+fail_compilation/deprecate12979c.d(13): Deprecation: `asm` statement is assumed to use the GC - mark it with `@nogc` if it does not
 ---
 */
 

--- a/test/fail_compilation/deprecate12979d.d
+++ b/test/fail_compilation/deprecate12979d.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate12979d.d(12): Error: asm statement is assumed to be @system - mark it with '@trusted' if it is not
+fail_compilation/deprecate12979d.d(12): Error: `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
 ---
 */
 

--- a/test/fail_compilation/deprecate1553.d
+++ b/test/fail_compilation/deprecate1553.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/deprecate1553.d(19): Deprecation: cannot use foreach_reverse with a delegate
+fail_compilation/deprecate1553.d(19): Deprecation: cannot use `foreach_reverse` with a delegate
 ---
 */
 

--- a/test/fail_compilation/diag10405.d
+++ b/test/fail_compilation/diag10405.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10405.d(10): Error: cannot return non-void from void function
+fail_compilation/diag10405.d(10): Error: cannot return non-void from `void` function
 ---
 */
 

--- a/test/fail_compilation/diag4528.d
+++ b/test/fail_compilation/diag4528.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag4528.d(14): Error: function diag4528.Foo.pva private functions cannot be `abstract`
-fail_compilation/diag4528.d(15): Error: function diag4528.Foo.pka package functions cannot be `abstract`
+fail_compilation/diag4528.d(14): Error: function diag4528.Foo.pva `private` functions cannot be `abstract`
+fail_compilation/diag4528.d(15): Error: function diag4528.Foo.pka `package` functions cannot be `abstract`
 fail_compilation/diag4528.d(16): Error: function diag4528.Foo.pvsa `static` functions cannot be `abstract`
 fail_compilation/diag4528.d(17): Error: function diag4528.Foo.pksa `static` functions cannot be `abstract`
 fail_compilation/diag4528.d(18): Error: function diag4528.Foo.pbsa `static` functions cannot be `abstract`

--- a/test/fail_compilation/diag9312.d
+++ b/test/fail_compilation/diag9312.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9312.d(10): Error: with expressions must be aggregate types or pointers to them, not `int`
+fail_compilation/diag9312.d(10): Error: `with` expressions must be aggregate types or pointers to them, not `int`
 ---
 */
 

--- a/test/fail_compilation/diag9358.d
+++ b/test/fail_compilation/diag9358.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag9358.d(12): Error: `x` must be of integral or string type, it is a `double`
-fail_compilation/diag9358.d(14): Error: case must be a string or an integral constant, not `1.1`
-fail_compilation/diag9358.d(15): Error: case must be a string or an integral constant, not `2.1`
+fail_compilation/diag9358.d(14): Error: `case` must be a `string` or an integral constant, not `1.1`
+fail_compilation/diag9358.d(15): Error: `case` must be a `string` or an integral constant, not `2.1`
 ---
 */
 void main()

--- a/test/fail_compilation/dip22d.d
+++ b/test/fail_compilation/dip22d.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -transition=import
 TEST_OUTPUT:
 ---
 fail_compilation/dip22d.d(12): Error: `imports.dip22d.Foo` at fail_compilation/imports/dip22d.d(3) conflicts with `imports.dip22e.Foo` at fail_compilation/imports/dip22e.d(3)
-fail_compilation/dip22d.d(12): Error: module dip22d struct `imports.dip22d.Foo` is private
+fail_compilation/dip22d.d(12): Error: module dip22d struct `imports.dip22d.Foo` is `private`
 ---
 */
 import imports.dip22d;

--- a/test/fail_compilation/fail10115.d
+++ b/test/fail_compilation/fail10115.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10115.d(35): Error: cannot have out parameter of type `S` because the default construction is disabled
-fail_compilation/fail10115.d(35): Error: cannot have out parameter of type `E` because the default construction is disabled
-fail_compilation/fail10115.d(35): Error: cannot have out parameter of type `U` because the default construction is disabled
+fail_compilation/fail10115.d(35): Error: cannot have `out` parameter of type `S` because the default construction is disabled
+fail_compilation/fail10115.d(35): Error: cannot have `out` parameter of type `E` because the default construction is disabled
+fail_compilation/fail10115.d(35): Error: cannot have `out` parameter of type `U` because the default construction is disabled
 fail_compilation/fail10115.d(40): Error: struct fail10115.S default construction is disabled
 fail_compilation/fail10115.d(41): Error: struct fail10115.S default construction is disabled
 fail_compilation/fail10115.d(42): Error: union fail10115.U default construction is disabled

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10528.d(23): Error: module fail10528 variable `a10528.a` is private
+fail_compilation/fail10528.d(23): Error: module fail10528 variable `a10528.a` is `private`
 fail_compilation/fail10528.d(23): Deprecation: a10528.a is not visible from module fail10528
 fail_compilation/fail10528.d(24): Error: `a10528.a` is not visible from module `fail10528`
-fail_compilation/fail10528.d(26): Error: module fail10528 enum member `a10528.b` is private
+fail_compilation/fail10528.d(26): Error: module fail10528 enum member `a10528.b` is `private`
 fail_compilation/fail10528.d(26): Deprecation: a10528.b is not visible from module fail10528
 fail_compilation/fail10528.d(27): Error: `a10528.b` is not visible from module `fail10528`
 fail_compilation/fail10528.d(29): Deprecation: `a10528.S.c` is not visible from module `fail10528`

--- a/test/fail_compilation/fail10630.d
+++ b/test/fail_compilation/fail10630.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10630.d(12): Error: cannot have out parameter of type `S` because the default construction is disabled
+fail_compilation/fail10630.d(12): Error: cannot have `out` parameter of type `S` because the default construction is disabled
 ---
 */
 

--- a/test/fail_compilation/fail10947.d
+++ b/test/fail_compilation/fail10947.d
@@ -1,15 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10947.d(21): Error: cannot have immutable out parameter of type `immutable(S)`
-fail_compilation/fail10947.d(22): Error: cannot have immutable out parameter of type `immutable(S)`
-fail_compilation/fail10947.d(23): Error: cannot have immutable out parameter of type `immutable(S)`
-fail_compilation/fail10947.d(25): Error: cannot have const out parameter of type `const(S)`
-fail_compilation/fail10947.d(26): Error: cannot have const out parameter of type `const(S)`
-fail_compilation/fail10947.d(27): Error: cannot have const out parameter of type `const(S)`
-fail_compilation/fail10947.d(29): Error: cannot have inout out parameter of type `inout(S)`
-fail_compilation/fail10947.d(30): Error: cannot have inout out parameter of type `inout(S)`
-fail_compilation/fail10947.d(31): Error: cannot have inout out parameter of type `inout(S)`
+fail_compilation/fail10947.d(21): Error: cannot have `immutable out` parameter of type `immutable(S)`
+fail_compilation/fail10947.d(22): Error: cannot have `immutable out` parameter of type `immutable(S)`
+fail_compilation/fail10947.d(23): Error: cannot have `immutable out` parameter of type `immutable(S)`
+fail_compilation/fail10947.d(25): Error: cannot have `const out` parameter of type `const(S)`
+fail_compilation/fail10947.d(26): Error: cannot have `const out` parameter of type `const(S)`
+fail_compilation/fail10947.d(27): Error: cannot have `const out` parameter of type `const(S)`
+fail_compilation/fail10947.d(29): Error: cannot have `inout out` parameter of type `inout(S)`
+fail_compilation/fail10947.d(30): Error: cannot have `inout out` parameter of type `inout(S)`
+fail_compilation/fail10947.d(31): Error: cannot have `inout out` parameter of type `inout(S)`
 ---
 */
 

--- a/test/fail_compilation/fail11562.d
+++ b/test/fail_compilation/fail11562.d
@@ -3,10 +3,10 @@ REQUIRED_ARGS: -o-
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/fail11562.d(16): Error: cannot goto in or out of `finally` block
-fail_compilation/fail11562.d(37): Error: cannot goto in or out of `finally` block
-fail_compilation/fail11562.d(49): Error: cannot goto in or out of `finally` block
-fail_compilation/fail11562.d(64): Error: cannot goto in or out of `finally` block
+fail_compilation/fail11562.d(16): Error: cannot `goto` in or out of `finally` block
+fail_compilation/fail11562.d(37): Error: cannot `goto` in or out of `finally` block
+fail_compilation/fail11562.d(49): Error: cannot `goto` in or out of `finally` block
+fail_compilation/fail11562.d(64): Error: cannot `goto` in or out of `finally` block
 ---
 */
 

--- a/test/fail_compilation/fail118.d
+++ b/test/fail_compilation/fail118.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail118.d(26): Error: invalid foreach aggregate `Iter`, define opApply(), range primitives, or use .tupleof
-fail_compilation/fail118.d(27): Error: invalid foreach aggregate `Iter`, define opApply(), range primitives, or use .tupleof
+fail_compilation/fail118.d(26): Error: invalid `foreach` aggregate `Iter`, define `opApply()`, range primitives, or use `.tupleof`
+fail_compilation/fail118.d(27): Error: invalid `foreach` aggregate `Iter`, define `opApply()`, range primitives, or use `.tupleof`
 ---
 */
 

--- a/test/fail_compilation/fail13756.d
+++ b/test/fail_compilation/fail13756.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13756.d(11): Error: foreach: index must be type `const(int)`, not `int`
+fail_compilation/fail13756.d(11): Error: `foreach`: index must be type `const(int)`, not `int`
 ---
 */
 

--- a/test/fail_compilation/fail15535.d
+++ b/test/fail_compilation/fail15535.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15535.d(17): Error: goto default not allowed in final switch statement
+fail_compilation/fail15535.d(17): Error: `goto default` not allowed in `final switch` statement
 ---
 */
 

--- a/test/fail_compilation/fail169.d
+++ b/test/fail_compilation/fail169.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail169.d(8): Error: cannot have const out parameter of type `const(int)`
+fail_compilation/fail169.d(8): Error: cannot have `const out` parameter of type `const(int)`
 ---
 */
 

--- a/test/fail_compilation/fail187.d
+++ b/test/fail_compilation/fail187.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail187.d(16): Error: catch at fail_compilation/fail187.d(20) hides catch at fail_compilation/fail187.d(24)
+fail_compilation/fail187.d(16): Error: `catch` at fail_compilation/fail187.d(20) hides `catch` at fail_compilation/fail187.d(24)
 ---
 */
 

--- a/test/fail_compilation/fail208.d
+++ b/test/fail_compilation/fail208.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail208.d(18): Error: return expression expected
+fail_compilation/fail208.d(18): Error: `return` expression expected
 fail_compilation/fail208.d(21):        called from here: `MakeA()`
 ---
 */

--- a/test/fail_compilation/fail23.d
+++ b/test/fail_compilation/fail23.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail23.d(14): Error: break is not inside a loop or switch
+fail_compilation/fail23.d(14): Error: `break` is not inside a loop or `switch`
 ---
 */
 

--- a/test/fail_compilation/fail2456.d
+++ b/test/fail_compilation/fail2456.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2456.d(14): Error: cannot put `scope(success)` statement inside finally block
+fail_compilation/fail2456.d(14): Error: cannot put `scope(success)` statement inside `finally` block
 ---
 */
 void test_success()
@@ -18,7 +18,7 @@ void test_success()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2456.d(31): Error: cannot put `scope(failure)` statement inside finally block
+fail_compilation/fail2456.d(31): Error: cannot put `scope(failure)` statement inside `finally` block
 ---
 */
 void test_failure()
@@ -84,8 +84,8 @@ void test2456a()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2456.d(96): Error: cannot put catch statement inside `scope(success)`
-fail_compilation/fail2456.d(108): Error: cannot put catch statement inside `scope(exit)`
+fail_compilation/fail2456.d(96): Error: cannot put `catch` statement inside `scope(success)`
+fail_compilation/fail2456.d(108): Error: cannot put `catch` statement inside `scope(exit)`
 ---
 */
 void test2456b()

--- a/test/fail_compilation/fail249.d
+++ b/test/fail_compilation/fail249.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail249.d(16): Error: invalid foreach aggregate `bar()`
+fail_compilation/fail249.d(16): Error: invalid `foreach` aggregate `bar()`
 ---
 */
 

--- a/test/fail_compilation/fail261.d
+++ b/test/fail_compilation/fail261.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail261.d(18): Error: invalid foreach aggregate `range`, define opApply(), range primitives, or use .tupleof
+fail_compilation/fail261.d(18): Error: invalid `foreach` aggregate `range`, define `opApply()`, range primitives, or use `.tupleof`
 ---
 */
 

--- a/test/fail_compilation/fail288.d
+++ b/test/fail_compilation/fail288.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail288.d(14): Error: case ranges not allowed in final switch
+fail_compilation/fail288.d(14): Error: case ranges not allowed in `final switch`
 ---
 */
 

--- a/test/fail_compilation/fail305.d
+++ b/test/fail_compilation/fail305.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail305.d(10): Error: cannot return non-void from void function
+fail_compilation/fail305.d(10): Error: cannot return non-void from `void` function
 ---
 */
 

--- a/test/fail_compilation/fail3144.d
+++ b/test/fail_compilation/fail3144.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3144.d(12): Error: break is not inside a loop or switch
-fail_compilation/fail3144.d(15): Error: break is not inside a loop or switch
+fail_compilation/fail3144.d(12): Error: `break` is not inside a loop or `switch`
+fail_compilation/fail3144.d(15): Error: `break` is not inside a loop or `switch`
 ---
 */
 

--- a/test/fail_compilation/fail315.d
+++ b/test/fail_compilation/fail315.d
@@ -5,7 +5,7 @@ fail_compilation/fail315.d-mixin-16(16): Error: found `;` when expecting `,`
 fail_compilation/fail315.d-mixin-16(16): Error: expression expected, not `}`
 fail_compilation/fail315.d-mixin-16(16): Error: found `EOF` when expecting `,`
 fail_compilation/fail315.d-mixin-16(16): Error: found `EOF` when expecting `]`
-fail_compilation/fail315.d-mixin-16(16): Error: found `EOF` when expecting `;` following return statement
+fail_compilation/fail315.d-mixin-16(16): Error: found `EOF` when expecting `;` following `return` statement
 fail_compilation/fail315.d-mixin-16(16): Error: found `EOF` when expecting `}` following compound statement
 fail_compilation/fail315.d(21): Error: template instance fail315.foo!() error instantiating
 ---

--- a/test/fail_compilation/fail327.d
+++ b/test/fail_compilation/fail327.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail327.d(10): Error: asm statement is assumed to be @system - mark it with '@trusted' if it is not
+fail_compilation/fail327.d(10): Error: `asm` statement is assumed to be `@system` - mark it with `@trusted` if it is not
 ---
 */
 

--- a/test/fail_compilation/fail34.d
+++ b/test/fail_compilation/fail34.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail34.d(31): Error: duplicate `case "123"` in switch statement
+fail_compilation/fail34.d(31): Error: duplicate `case "123"` in `switch` statement
 ---
 */
 

--- a/test/fail_compilation/fail41.d
+++ b/test/fail_compilation/fail41.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail41.d(17): Error: cannot return non-void from void function
+fail_compilation/fail41.d(17): Error: cannot return non-void from `void` function
 ---
 */
 

--- a/test/fail_compilation/fail4448.d
+++ b/test/fail_compilation/fail4448.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4448.d(19): Error: label `L1` has no break
+fail_compilation/fail4448.d(19): Error: label `L1` has no `break`
 fail_compilation/fail4448.d(26):        called from here: `bug4448()`
 fail_compilation/fail4448.d(26):        while evaluating: `static assert(bug4448() == 3)`
 ---

--- a/test/fail_compilation/fail6107.d
+++ b/test/fail_compilation/fail6107.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6107.d(10): Error: variable fail6107.Foo.__ctor is not a constructor; identifiers starting with __ are reserved for the implementation
-fail_compilation/fail6107.d(14): Error: variable fail6107.Bar.__ctor is not a constructor; identifiers starting with __ are reserved for the implementation
+fail_compilation/fail6107.d(10): Error: variable fail6107.Foo.__ctor is not a constructor; identifiers starting with `__` are reserved for the implementation
+fail_compilation/fail6107.d(14): Error: variable fail6107.Bar.__ctor is not a constructor; identifiers starting with `__` are reserved for the implementation
 ---
 */
 struct Foo

--- a/test/fail_compilation/fail6889.d
+++ b/test/fail_compilation/fail6889.d
@@ -1,13 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6889.d(16): Error: cannot goto out of `scope(success)` block
-fail_compilation/fail6889.d(17): Error: cannot goto in to `scope(success)` block
-fail_compilation/fail6889.d(19): Error: return statements cannot be in `scope(success)` bodies
-fail_compilation/fail6889.d(23): Error: continue is not inside `scope(success)` bodies
-fail_compilation/fail6889.d(24): Error: break is not inside `scope(success)` bodies
-fail_compilation/fail6889.d(29): Error: continue is not inside `scope(success)` bodies
-fail_compilation/fail6889.d(30): Error: break is not inside `scope(success)` bodies
+fail_compilation/fail6889.d(16): Error: cannot `goto` out of `scope(success)` block
+fail_compilation/fail6889.d(17): Error: cannot `goto` in to `scope(success)` block
+fail_compilation/fail6889.d(19): Error: `return` statements cannot be in `scope(success)` bodies
+fail_compilation/fail6889.d(23): Error: `continue` is not inside `scope(success)` bodies
+fail_compilation/fail6889.d(24): Error: `break` is not inside `scope(success)` bodies
+fail_compilation/fail6889.d(29): Error: `continue` is not inside `scope(success)` bodies
+fail_compilation/fail6889.d(30): Error: `break` is not inside `scope(success)` bodies
 ---
 */
 void test_success()
@@ -46,7 +46,7 @@ L1:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6889.d(56): Error: cannot goto in to `scope(failure)` block
+fail_compilation/fail6889.d(56): Error: cannot `goto` in to `scope(failure)` block
 ---
 */
 void test_failure()
@@ -85,13 +85,13 @@ L1:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6889.d(100): Error: cannot goto out of `scope(exit)` block
-fail_compilation/fail6889.d(101): Error: cannot goto in to `scope(exit)` block
-fail_compilation/fail6889.d(103): Error: return statements cannot be in `scope(exit)` bodies
-fail_compilation/fail6889.d(107): Error: continue is not inside `scope(exit)` bodies
-fail_compilation/fail6889.d(108): Error: break is not inside `scope(exit)` bodies
-fail_compilation/fail6889.d(113): Error: continue is not inside `scope(exit)` bodies
-fail_compilation/fail6889.d(114): Error: break is not inside `scope(exit)` bodies
+fail_compilation/fail6889.d(100): Error: cannot `goto` out of `scope(exit)` block
+fail_compilation/fail6889.d(101): Error: cannot `goto` in to `scope(exit)` block
+fail_compilation/fail6889.d(103): Error: `return` statements cannot be in `scope(exit)` bodies
+fail_compilation/fail6889.d(107): Error: `continue` is not inside `scope(exit)` bodies
+fail_compilation/fail6889.d(108): Error: `break` is not inside `scope(exit)` bodies
+fail_compilation/fail6889.d(113): Error: `continue` is not inside `scope(exit)` bodies
+fail_compilation/fail6889.d(114): Error: `break` is not inside `scope(exit)` bodies
 ---
 */
 void test_exit()

--- a/test/fail_compilation/fail73.d
+++ b/test/fail_compilation/fail73.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail73.d(20): Error: case not in switch statement
+fail_compilation/fail73.d(20): Error: `case` not in `switch` statement
 ---
 */
 

--- a/test/fail_compilation/fail92.d
+++ b/test/fail_compilation/fail92.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail92.d(15): Error: invalid foreach aggregate `t`
+fail_compilation/fail92.d(15): Error: invalid `foreach` aggregate `t`
 fail_compilation/fail92.d(23): Error: template instance fail92.crash!(typeof(null)) error instantiating
 ---
 */

--- a/test/fail_compilation/fail9368.d
+++ b/test/fail_compilation/fail9368.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9368.d(20): Error: enum member `b` not represented in final switch
+fail_compilation/fail9368.d(20): Error: `enum` member `b` not represented in `final switch`
 ---
 */
 
@@ -26,7 +26,7 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9368.d(41): Error: enum member `B` not represented in final switch
+fail_compilation/fail9368.d(41): Error: `enum` member `B` not represented in `final switch`
 ---
 */
 

--- a/test/fail_compilation/fail9892.d
+++ b/test/fail_compilation/fail9892.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9892.d(11): Error: enum member fail9892.a circular reference to enum member
+fail_compilation/fail9892.d(11): Error: enum member fail9892.a circular reference to `enum` member
 ---
 */
 

--- a/test/fail_compilation/ice10341.d
+++ b/test/fail_compilation/ice10341.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10341.d(10): Error: case range not in switch statement
+fail_compilation/ice10341.d(10): Error: case range not in `switch` statement
 ---
 */
 

--- a/test/fail_compilation/ice10651.d
+++ b/test/fail_compilation/ice10651.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10651.d(11): Error: can only throw class objects derived from Throwable, not type `int*`
+fail_compilation/ice10651.d(11): Error: can only throw class objects derived from `Throwable`, not type `int*`
 ---
 */
 

--- a/test/fail_compilation/ice17831.d
+++ b/test/fail_compilation/ice17831.d
@@ -2,11 +2,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice17831.d(19): Error: case variable `i` declared at fail_compilation/ice17831.d(17) cannot be declared in switch body
-fail_compilation/ice17831.d(33): Error: case variable `i` declared at fail_compilation/ice17831.d(31) cannot be declared in switch body
-fail_compilation/ice17831.d(48): Error: case variable `i` declared at fail_compilation/ice17831.d(45) cannot be declared in switch body
-fail_compilation/ice17831.d(61): Error: case variable `i` declared at fail_compilation/ice17831.d(60) cannot be declared in switch body
-fail_compilation/ice17831.d(73): Error: case variable `i` declared at fail_compilation/ice17831.d(72) cannot be declared in switch body
+fail_compilation/ice17831.d(19): Error: `case` variable `i` declared at fail_compilation/ice17831.d(17) cannot be declared in `switch` body
+fail_compilation/ice17831.d(33): Error: `case` variable `i` declared at fail_compilation/ice17831.d(31) cannot be declared in `switch` body
+fail_compilation/ice17831.d(48): Error: `case` variable `i` declared at fail_compilation/ice17831.d(45) cannot be declared in `switch` body
+fail_compilation/ice17831.d(61): Error: `case` variable `i` declared at fail_compilation/ice17831.d(60) cannot be declared in `switch` body
+fail_compilation/ice17831.d(73): Error: `case` variable `i` declared at fail_compilation/ice17831.d(72) cannot be declared in `switch` body
 ---
  */
 

--- a/test/fail_compilation/pragmas.d
+++ b/test/fail_compilation/pragmas.d
@@ -8,8 +8,8 @@ PERMUTE_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/pragmas.d(103): Error: boolean expression expected for pragma(inline)
-fail_compilation/pragmas.d(108): Error: boolean expression expected for pragma(inline)
+fail_compilation/pragmas.d(103): Error: boolean expression expected for `pragma(inline)`
+fail_compilation/pragmas.d(108): Error: boolean expression expected for `pragma(inline)`
 fail_compilation/pragmas.d(113): Error: pragma(inline, true or false) expected, not `"string"`
 fail_compilation/pragmas.d(118): Error: unrecognized `pragma(unrecognized)`
 ---

--- a/test/fail_compilation/skip.d
+++ b/test/fail_compilation/skip.d
@@ -2,8 +2,8 @@
  * REQUIRED_ARGS: -de
  * TEST_OUTPUT:
 ---
-fail_compilation/skip.d(21): Deprecation: 'switch' skips declaration of 'with' temporary at fail_compilation/skip.d(26)
-fail_compilation/skip.d(43): Deprecation: 'switch' skips declaration of variable skip.test14532.n at fail_compilation/skip.d(45)
+fail_compilation/skip.d(21): Deprecation: `switch` skips declaration of `with` temporary at fail_compilation/skip.d(26)
+fail_compilation/skip.d(43): Deprecation: `switch` skips declaration of variable `skip.test14532.n` at fail_compilation/skip.d(45)
 ---
  */
 // https://issues.dlang.org/show_bug.cgi?id=10524

--- a/test/fail_compilation/switches.d
+++ b/test/fail_compilation/switches.d
@@ -29,7 +29,7 @@ void test1(int i)
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/switches.d(205): Error: no case statement following goto case;
+fail_compilation/switches.d(205): Error: no `case` statement following `goto case;`
 ---
 */
 
@@ -50,7 +50,7 @@ void test2(int i)
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/switches.d(302): Deprecation: 'switch' skips declaration of variable switches.test3.j at fail_compilation/switches.d(306)
+fail_compilation/switches.d(302): Deprecation: `switch` skips declaration of variable `switches.test3.j` at fail_compilation/switches.d(306)
 ---
 */
 

--- a/test/fail_compilation/test12979.d
+++ b/test/fail_compilation/test12979.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12979.d(13): Error: const/immutable/shared/inout attributes are not allowed on `asm` blocks
+fail_compilation/test12979.d(13): Error: `const`/`immutable`/`shared`/`inout` attributes are not allowed on `asm` blocks
 ---
 */
 

--- a/test/fail_compilation/test16523.d
+++ b/test/fail_compilation/test16523.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test16523.d(13): Deprecation: case variables have to be const or immutable
+fail_compilation/test16523.d(13): Deprecation: `case` variables have to be `const` or `immutable`
 ---
 */
 

--- a/test/fail_compilation/test17868b.d
+++ b/test/fail_compilation/test17868b.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ----
-fail_compilation/test17868b.d(10): Error: function test17868b.foo must be extern(C) for pragma crt_constructor
-fail_compilation/test17868b.d(14): Error: function test17868b.bar must be extern(C) for pragma crt_constructor
+fail_compilation/test17868b.d(10): Error: function test17868b.foo must be `extern(C)` for `pragma(crt_constructor)`
+fail_compilation/test17868b.d(14): Error: function test17868b.bar must be `extern(C)` for `pragma(crt_constructor)`
 fail_compilation/test17868b.d(9): Error: pragma crt_constructor can only apply to a single declaration
 ----
  */

--- a/test/fail_compilation/test4838.d
+++ b/test/fail_compilation/test4838.d
@@ -1,12 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test4838.d(13): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
-fail_compilation/test4838.d(14): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
-fail_compilation/test4838.d(15): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
-fail_compilation/test4838.d(16): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
-fail_compilation/test4838.d(17): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
-fail_compilation/test4838.d(18): Error: const/immutable/shared/inout/return attributes are only valid for non-static member functions
+fail_compilation/test4838.d(13): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(14): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(15): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(16): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(17): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
+fail_compilation/test4838.d(18): Error: `const`/`immutable`/`shared`/`inout`/`return` attributes are only valid for non-static member functions
 ---
 */
 

--- a/test/fail_compilation/warn13679.d
+++ b/test/fail_compilation/warn13679.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn13679.d(14): Warning: cannot use foreach_reverse with an associative array
+fail_compilation/warn13679.d(14): Warning: cannot use `foreach_reverse` with an associative array
 ---
 */
 


### PR DESCRIPTION
Should be only a few subjective ones remaining after this.

I'll have at least one more PR after this to address the `.error` member functions that automatically prepend the output of `.toChars()` to the error message.