### PR TITLE
Remove useless runtime code

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -924,11 +924,7 @@ extern (C++) final class Module : Package
             immutable code_ArrayEq = "bool _ArrayEq(T1, T2)(T1[] a, T2[] b) {\n if (a.length != b.length) return false;\n foreach (size_t i; 0 .. a.length) { if (a[i] != b[i]) return false; }\n return true; }\n";
             immutable code_ArrayPostblit = "void _ArrayPostblit(T)(T[] a) { foreach (ref T e; a) e.__xpostblit(); }\n";
             immutable code_ArrayDtor = "void _ArrayDtor(T)(T[] a) { foreach_reverse (ref T e; a) e.__xdtor(); }\n";
-            immutable code_xopEquals = "bool _xopEquals(in void*, in void*) { throw new Error(\"TypeInfo.equals is not implemented\"); }\n";
-            immutable code_xopCmp = "bool _xopCmp(in void*, in void*) { throw new Error(\"TypeInfo.compare is not implemented\"); }\n";
             Identifier arreq = Id._ArrayEq;
-            Identifier xopeq = Identifier.idPool("_xopEquals");
-            Identifier xopcmp = Identifier.idPool("_xopCmp");
             for (size_t i = 0; i < members.dim; i++)
             {
                 Dsymbol sx = (*members)[i];
@@ -936,10 +932,6 @@ extern (C++) final class Module : Package
                     continue;
                 if (arreq && sx.ident == arreq)
                     arreq = null;
-                if (xopeq && sx.ident == xopeq)
-                    xopeq = null;
-                if (xopcmp && sx.ident == xopcmp)
-                    xopcmp = null;
             }
             if (arreq)
             {
@@ -954,18 +946,6 @@ extern (C++) final class Module : Package
             }
             {
                 scope p = new Parser!ASTCodegen(loc, this, code_ArrayDtor, false);
-                p.nextToken();
-                members.append(p.parseDeclDefs(0));
-            }
-            if (xopeq)
-            {
-                scope p = new Parser!ASTCodegen(loc, this, code_xopEquals, false);
-                p.nextToken();
-                members.append(p.parseDeclDefs(0));
-            }
-            if (xopcmp)
-            {
-                scope p = new Parser!ASTCodegen(loc, this, code_xopCmp, false);
                 p.nextToken();
                 members.append(p.parseDeclDefs(0));
             }


### PR DESCRIPTION
The code being removed in this PR is already in druntime (object.d).  I don't see any reason for it to be in the compiler, and it's interfering with some no-runtime code I'm working on.  

~Let's see what the test suite says.~

Interesting!  Everything passes.  I'm shocked, disappointed, relieved and happy all at the same time.  I'm forced to assume this is just left-over junk.  I wonder how much more of this is hiding in the code.