### PR TITLE
Fix Issue 18243 - selective import + overload = private visibility

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -512,6 +512,20 @@ extern (C++) bool symbolIsVisible(Dsymbol origin, Dsymbol s)
 extern (C++) bool symbolIsVisible(Scope *sc, Dsymbol s)
 {
     s = mostVisibleOverload(s);
+    return checkSymbolAccess(sc, s);
+}
+
+/**
+ * Check if a symbol is visible from a given scope without taking
+ * into account the most visible overload.
+ *
+ * Params:
+ *  sc = lookup scope
+ *  s = symbol to check for visibility
+ * Returns: true if s is visible by origin
+ */
+extern (C++) bool checkSymbolAccess(Scope *sc, Dsymbol s)
+{
     final switch (s.prot().kind)
     {
     case Prot.Kind.undefined: return true;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2766,7 +2766,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
         if (auto td = s.isTemplateDeclaration())
             return applyTemplate(td);
         return 0;
-    });
+    }, sc);
 
     //printf("td_best = %p, m.lastf = %p\n", td_best, m.lastf);
     if (td_best && ti_best && m.count == 1)

--- a/test/fail_compilation/fail18243.d
+++ b/test/fail_compilation/fail18243.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18243.d(14): Error: none of the overloads of `isNaN` are callable using argument types `!()(float)`
+---
+*/
+
+module fail18243;
+
+import imports.a18243;
+
+void main()
+{
+    bool b = isNaN(float.nan);
+}

--- a/test/fail_compilation/imports/a18243.d
+++ b/test/fail_compilation/imports/a18243.d
@@ -1,0 +1,5 @@
+module a18243;
+
+import std.math : isNaN;
+
+public bool isNaN() { return false; }


### PR DESCRIPTION
I fixed the issue by modifying the overloadApply method. The problem was that when resolving overloads the visibility attribute is not checked at all, so I had to add the scope as an optional parameter so that when an alias declaration is encountered (from imports or plain alias declarations) a check is made to make sure that the called function is indeed visible.