### PR TITLE
Deprecate hexstring literals

### DIFF
--- a/changelog/hexstrings.dd
+++ b/changelog/hexstrings.dd
@@ -1,0 +1,4 @@
+HexString literals are deprecated.
+
+$(LINK2 http://dlang.org/spec/lex.html#HexString, HexString literals) are deprecated.
+Use $(LINK2 https://dlang.org/phobos/std_conv.html#hexString, `std.conv.hexString`) instead.

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -381,6 +381,7 @@ class Lexer
                     goto case_ident;
                 p++;
                 t.value = hexStringConstant(t);
+                deprecation("Built-in hex string literals are deprecated, use `std.conv.hexString` instead.");
                 return;
             case 'q':
                 if (p[1] == '"')

--- a/test/compilable/crlf.sh
+++ b/test/compilable/crlf.sh
@@ -46,9 +46,6 @@ printf 'static assert(wstr == "%s");\n' 'foo\nbar\nbaz\n' >> ${fn}
 printf 'enum dstr = q"(\r\nfoo\r\nbar\nbaz\r\n)";\n' >> ${fn}
 printf 'static assert(dstr == "%s");\n' '\nfoo\nbar\nbaz\n' >> ${fn}
 
-printf 'enum xstr = x"61 62\n63\r\n64";\n' >> ${fn}
-printf 'static assert(xstr == "abcd");\n' >> ${fn}
-
 $DMD -c -D -Dd${dir} -m${MODEL} -of${dir}/${name}a${OBJ} ${fn} || exit 1
 
 rm -f ${dir}/${name}a${OBJ} ${dir}/${name}.html ${fn}

--- a/test/fail_compilation/dephexstrings.d
+++ b/test/fail_compilation/dephexstrings.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/dephexstrings.d(8): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+---
+*/
+enum xstr = x"60";

--- a/test/fail_compilation/fail136.d
+++ b/test/fail_compilation/fail136.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail136.d(10): Error: `"\xef\xbb\xbf"` has no effect
+fail_compilation/fail136.d(11): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+fail_compilation/fail136.d(11): Error: `"\xef\xbb\xbf"` has no effect
 ---
 */
 

--- a/test/fail_compilation/lexer1.d
+++ b/test/fail_compilation/lexer1.d
@@ -1,6 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/lexer1.d(30): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
 fail_compilation/lexer1.d(30): Error: declaration expected, not `x"01 02 03"w`
 fail_compilation/lexer1.d(31): Error: declaration expected, not `2147483649U`
 fail_compilation/lexer1.d(32): Error: declaration expected, not `0.1`
@@ -26,7 +27,6 @@ fail_compilation/lexer1.d(52): Error: escape octal sequence \400 is larger than 
 */
 
 // https://dlang.dawg.eu/coverage/src/lexer.c.gcov.html
-
 x"01 02 03"w;
 0x80000001;
 0.1;

--- a/test/fail_compilation/lexer2.d
+++ b/test/fail_compilation/lexer2.d
@@ -1,11 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/lexer2.d(14): Error: odd number (3) of hex characters in hex string
-fail_compilation/lexer2.d(15): Error: non-hex character 'G' in hex string
-fail_compilation/lexer2.d(16): Error: heredoc rest of line should be blank
-fail_compilation/lexer2.d(18): Error: unterminated delimited string constant starting at fail_compilation/lexer2.d(18)
-fail_compilation/lexer2.d(20): Error: semicolon expected following auto declaration, not `EOF`
+fail_compilation/lexer2.d(16): Error: odd number (3) of hex characters in hex string
+fail_compilation/lexer2.d(16): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+fail_compilation/lexer2.d(17): Error: non-hex character 'G' in hex string
+fail_compilation/lexer2.d(17): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+fail_compilation/lexer2.d(18): Error: heredoc rest of line should be blank
+fail_compilation/lexer2.d(20): Error: unterminated delimited string constant starting at fail_compilation/lexer2.d(20)
+fail_compilation/lexer2.d(22): Error: semicolon expected following auto declaration, not `EOF`
 ---
 */
 


### PR DESCRIPTION
Revival of https://github.com/dlang/dmd/pull/6925

Requires:
- [x] https://github.com/dlang/phobos/pull/6058

Dlang.org PR: https://github.com/dlang/dlang.org/pull/2118