### PR TITLE
Optional ModuleInfo (Part 2):  Backend Optimizations

### DIFF
--- a/src/dmd/backend/backconfig.c
+++ b/src/dmd/backend/backconfig.c
@@ -51,7 +51,9 @@ void out_config_init(
         bool alwaysframe,       // always create standard function frame
         bool stackstomp,        // add stack stomping code
         unsigned char avx,      // use AVX instruction set (0, 1, 2)
-        bool betterC            // implement "Better C"
+        bool useModuleInfo,     // implement ModuleInfo
+        bool useTypeInfo,       // implement TypeInfo
+        bool useExceptions      // implement exception handling
         )
 {
 #if MARS
@@ -74,7 +76,7 @@ void out_config_init(
     {   config.exe = EX_WIN64;
         config.fpxmmregs = TRUE;
         config.avx = avx;
-        config.ehmethod = betterC ? EH_NONE : EH_DM;
+        config.ehmethod = useExceptions ? EH_DM : EH_NONE;
 
         // Not sure we really need these two lines, try removing them later
         config.flags |= CFGnoebp;
@@ -85,7 +87,7 @@ void out_config_init(
     else
     {
         config.exe = EX_WIN32;
-        config.ehmethod = betterC ? EH_NONE : EH_WIN32;
+        config.ehmethod = useExceptions ? EH_WIN32 : EH_NONE;
         config.objfmt = mscoff ? OBJ_MSCOFF : OBJ_OMF;
     }
 
@@ -96,14 +98,14 @@ void out_config_init(
 #if TARGET_LINUX
     if (model == 64)
     {   config.exe = EX_LINUX64;
-        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
+        config.ehmethod = useExceptions ? EH_DWARF : EH_NONE;
         config.fpxmmregs = TRUE;
         config.avx = avx;
     }
     else
     {
         config.exe = EX_LINUX;
-        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
+        config.ehmethod = useExceptions ? EH_DWARF : EH_NONE;
         if (!exe)
             config.flags |= CFGromable; // put switch tables in code segment
     }
@@ -121,12 +123,12 @@ void out_config_init(
     if (model == 64)
     {   config.exe = EX_OSX64;
         config.fpxmmregs = TRUE;
-        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
+        config.ehmethod = useExceptions ? EH_DWARF : EH_NONE;
     }
     else
     {
         config.exe = EX_OSX;
-        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
+        config.ehmethod = useExceptions ? EH_DWARF : EH_NONE;
     }
     config.flags |= CFGnoebp;
     if (!exe)
@@ -140,14 +142,14 @@ void out_config_init(
 #if TARGET_FREEBSD
     if (model == 64)
     {   config.exe = EX_FREEBSD64;
-        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
+        config.ehmethod = useExceptions ? EH_DWARF : EH_NONE;
         config.fpxmmregs = TRUE;
         config.avx = avx;
     }
     else
     {
         config.exe = EX_FREEBSD;
-        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
+        config.ehmethod = useExceptions ? EH_DWARF : EH_NONE;
         if (!exe)
             config.flags |= CFGromable; // put switch tables in code segment
     }
@@ -176,12 +178,12 @@ void out_config_init(
     if (!exe)
         config.flags3 |= CFG3pic;
     config.objfmt = OBJ_ELF;
-    config.ehmethod = betterC ? EH_NONE : EH_DM;
+    config.ehmethod = useExceptions ? EH_DM : EH_NONE;
 #endif
 #if TARGET_DRAGONFLYBSD
     if (model == 64)
     {   config.exe = EX_DRAGONFLYBSD64;
-        config.ehmethod = betterC ? EH_NONE : EH_DWARF;
+        config.ehmethod = useExceptions ? EH_DWARF : EH_NONE;
         config.fpxmmregs = TRUE;
         config.avx = avx;
     }
@@ -214,7 +216,7 @@ void out_config_init(
     if (!exe)
         config.flags3 |= CFG3pic;
     config.objfmt = OBJ_ELF;
-    config.ehmethod = betterC ? EH_NONE : EH_DM;
+    config.ehmethod = useExceptions ? EH_DM : EH_NONE;
 #endif
     config.flags2 |= CFG2nodeflib;      // no default library
     config.flags3 |= CFG3eseqds;
@@ -272,7 +274,9 @@ void out_config_init(
     if (stackstomp)
         config.flags2 |= CFG2stomp;
 
-    config.betterC = betterC;
+    config.useModuleInfo = useModuleInfo;
+    config.useTypeInfo = useTypeInfo;
+    config.useExceptions = useExceptions;
 
     ph_init();
     block_init();

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -696,7 +696,9 @@ struct Config
                                 // to near
     linkage_t linkage;          // default function call linkage
     EHmethod ehmethod;          // exception handling method
-    bool betterC;               // implement "Better C"
+    bool useModuleInfo;         // implement ModuleInfo
+    bool useTypeInfo;           // implement TypeInfo
+    bool useExceptions;         // implement exception handling
 
     static uint sizeCheck();
     unittest { assert(sizeCheck() == Config.sizeof); }

--- a/src/dmd/backend/cdef.h
+++ b/src/dmd/backend/cdef.h
@@ -956,7 +956,9 @@ struct Config
                                 // to near
     linkage_t linkage;          // default function call linkage
     EHmethod ehmethod;          // exception handling method
-    bool betterC;               // implement "Better C"
+    bool useModuleInfo;         // implement ModuleInfo
+    bool useTypeInfo;           // implement TypeInfo
+    bool useExceptions;         // implement exception handling
 
     static unsigned sizeCheck();
 };

--- a/src/dmd/backend/dwarf.c
+++ b/src/dmd/backend/dwarf.c
@@ -104,7 +104,7 @@ bool doUnwindEhFrame()
      */
     assert(!(usednteh & ~(EHtry | EHcleanup)));
     return (usednteh & (EHtry | EHcleanup)) ||
-           (config.exe & (EX_FREEBSD | EX_FREEBSD64 | EX_DRAGONFLYBSD64)) && !config.betterC;
+           (config.exe & (EX_FREEBSD | EX_FREEBSD64 | EX_DRAGONFLYBSD64)) && config.useExceptions;
 }
 
 #if ELFOBJ

--- a/src/dmd/backend/elfobj.c
+++ b/src/dmd/backend/elfobj.c
@@ -1166,7 +1166,7 @@ void Obj::term(const char *objfilename)
     }
 
 #if MARS
-    if (!config.betterC)
+    if (config.useModuleInfo)
         obj_rtinit();
 #endif
 
@@ -3362,7 +3362,6 @@ void Obj::moduleinfo(Symbol *scc)
     SegData[seg]->SDoffset +=
         reftoident(seg, SegData[seg]->SDoffset, scc, 0, CFflags);
 }
-
 
 /***************************************
  * Create startup/shutdown code to register an executable/shared

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -19,6 +19,7 @@ import core.stdc.stddef;
 extern (C++):
 
 import dmd.globals;
+import dmd.dmodule;
 
 import dmd.root.filename;
 
@@ -58,7 +59,9 @@ void out_config_init(
         bool alwaysframe,       // always create standard function frame
         bool stackstomp,        // add stack stomping code
         ubyte avx,              // use AVX instruction set (0, 1, 2)
-        bool betterC            // implement "Better C"
+        bool useModuleInfo,     // implement ModuleInfo
+        bool useTypeInfo,       // implement TypeInfo
+        bool useExceptions      // implement exception handling
         );
 
 void out_config_debug(
@@ -118,7 +121,9 @@ void backend_init()
         params.alwaysframe,
         params.stackstomp,
         params.cpu >= CPU.avx2 ? 2 : params.cpu >= CPU.avx ? 1 : 0,
-        params.betterC
+        params.useModuleInfo && Module.moduleinfo,
+        params.useTypeInfo,
+        params.useExceptions
     );
 
     debug

--- a/test/runnable/extra-files/no_object_ModuleInfo/verify_symbols.sh
+++ b/test/runnable/extra-files/no_object_ModuleInfo/verify_symbols.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ! nm "$1" | grep -q ModuleInfo ; then
+if ! nm "$1" | grep -q 'ModuleInfo\|_d_dso_registry\__start_minfo\|__stop_minfo' ; then
     exit 0
 fi
 


### PR DESCRIPTION
This pull request is a follow up to #7395 and the rationale for this change is basically the same.

If `ModuleInfo` isn't declared in the runtime, there's no reason for the compiler (1) emit an error and (2) generate object code for it.  PR #7395 took care of (1) and this PR takes care of (2).  That is, prior to this PR, if `ModuleInfo` was not declared in the runtime, the backend still generated `__start_minfo`, `__stop_minfo`, and friends.

To make this work, the `betterC` backend config flag is split into its 3 component parts.  That way the `useExceptions` flag can be used to turn on/off EH code generation, and the `useModuleInfo` flag can be used to turn on/off module info code generation independently.  The `useModuleInfo` config flag is set with `params.useModuleInfo && Module.moduleinfo`.  `-betteC` functionality still works the same, but now there's a little more fine tuning that can be done by what is declared or not declared in the runtime.

Benefits
 - Resulting binaries are smaller
 - Fewer useless stubs are required to generate a minimal runtime
 - No more linker errors for the aforementioned stubs

This will be of interest to users wishing to incrementally or partially port D to new platforms, users hoping to target resource constrained platforms, and users wishing to use D as a library from other languages without druntime.

If this PR is merged, I should be able to do one more followup that can get an empty `main` program down to 56 bytes with or without the `-betterC` flag.