### PR TITLE
[trivial] Improve error message when aggregate template is used as a type

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1156,7 +1156,12 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         {
             if (s)
             {
-                s.error(loc, "is used as a type");
+                auto td = s.isTemplateDeclaration;
+                if (td && td.onemember && td.onemember.isAggregateDeclaration)
+                    mtype.error(loc, "%s template `%s` is used as a type without instantiation",
+                        s.kind, s.toPrettyChars);
+                else
+                    mtype.error(loc, "%s `%s` is used as a type", s.kind, s.toPrettyChars);
                 //assert(0);
             }
             else

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1158,8 +1158,9 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             {
                 auto td = s.isTemplateDeclaration;
                 if (td && td.onemember && td.onemember.isAggregateDeclaration)
-                    mtype.error(loc, "%s template `%s` is used as a type without instantiation",
-                        s.kind, s.toPrettyChars);
+                    mtype.error(loc, "template %s `%s` is used as a type without instantiation"
+                        ~ "; to instantiate it use `%s!(arguments)`",
+                        s.kind, s.toPrettyChars, s.ident.toChars);
                 else
                     mtype.error(loc, "%s `%s` is used as a type", s.kind, s.toPrettyChars);
                 //assert(0);

--- a/test/fail_compilation/diag6539.d
+++ b/test/fail_compilation/diag6539.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag6539.d(21): Error: overloadset diag6539.Rectangle is used as a type
+fail_compilation/diag6539.d(21): Error: overloadset `diag6539.Rectangle` is used as a type
 ---
 */
 

--- a/test/fail_compilation/notype.d
+++ b/test/fail_compilation/notype.d
@@ -1,0 +1,31 @@
+struct S(int var = 3) {
+    int a;
+}
+S s;
+
+alias A() = int;
+A a;
+
+enum e() = 5;
+e val;
+
+interface I()
+{
+}
+I i;
+
+template t()
+{
+}
+t tv;
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/notype.d(4): Error: struct template `notype.S(int var = 3)` is used as a type without instantiation
+fail_compilation/notype.d(7): Error: template `notype.A()` is used as a type
+fail_compilation/notype.d(10): Error: template `notype.e()` is used as a type
+fail_compilation/notype.d(15): Error: interface template `notype.I()` is used as a type without instantiation
+fail_compilation/notype.d(20): Error: template `notype.t()` is used as a type
+---
+*/

--- a/test/fail_compilation/notype.d
+++ b/test/fail_compilation/notype.d
@@ -22,10 +22,10 @@ t tv;
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/notype.d(4): Error: struct template `notype.S(int var = 3)` is used as a type without instantiation
+fail_compilation/notype.d(4): Error: template struct `notype.S(int var = 3)` is used as a type without instantiation; to instantiate it use `S!(arguments)`
 fail_compilation/notype.d(7): Error: template `notype.A()` is used as a type
 fail_compilation/notype.d(10): Error: template `notype.e()` is used as a type
-fail_compilation/notype.d(15): Error: interface template `notype.I()` is used as a type without instantiation
+fail_compilation/notype.d(15): Error: template interface `notype.I()` is used as a type without instantiation; to instantiate it use `I!(arguments)`
 fail_compilation/notype.d(20): Error: template `notype.t()` is used as a type
 ---
 */


### PR DESCRIPTION
Make it clear with aggregate templates that they are templates and haven't been instantiated.

Note: `s.kind` is e.g. just "struct" for aggregate templates. Non-aggregates say "template".
Note: When `td.onemember` is an alias, we don't know if it resolves to a type or not until the template is instantiated.

http://forum.dlang.org/post/p49c55$m65$1@digitalmars.com