### PR TITLE
Allow using updated CircleCi without rebasing PRs

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -12,7 +12,11 @@ BUILD="debug"
 DMD=dmd
 PIC=1
 
-case $CIRCLE_STAGE in
+case "${CIRCLE_STAGE}" in
+    # Defined by old, existing PRs
+    # Added to avoid needing to rebase them
+    build)
+        ;&
     pic)
         MODEL=64
         PIC=1


### PR DESCRIPTION
The CircleCi setup was updated in https://github.com/dlang/dmd/pull/7420
This leads to `MODEL` being undefined as no `CIRCLECI_STAGE` is defined.
As the `circleci.yml` is only read once in the beginning, PRs would be need to
be rebased for it to take effect.
This change avoids the need to rebase existing PRs.

(this is a bit hard to test - it's based on the error message in https://github.com/dlang/dmd/pull/7769)