### PR TITLE
Fix Issue 18295 -  `scope class` check too conservative under -dip1000

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -795,10 +795,13 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             tf.next = tf.next.typeSemantic(loc, sc);
             sc = sc.pop();
             errors |= tf.checkRetType(loc);
-            if (tf.next.isscope() && !(sc.flags & SCOPE.ctor))
+            if (!global.params.vsafe) // https://issues.dlang.org/show_bug.cgi?id=18295
             {
-                mtype.error(loc, "functions cannot return `scope %s`", tf.next.toChars());
-                errors = true;
+                if (tf.next.isscope() && !(sc.flags & SCOPE.ctor))
+                {
+                    mtype.error(loc, "functions cannot return `scope %s`", tf.next.toChars());
+                    errors = true;
+                }
             }
             if (tf.next.hasWild())
                 wildreturn = true;

--- a/test/compilable/test18295.d
+++ b/test/compilable/test18295.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -dip1000
+
+// https://issues.dlang.org/show_bug.cgi?id=18295
+
+// See test/fail_compilation/test18295.d for the non-`-dip1000` version`
+
+scope class C { int i; }    // Notice the use of `scope` here
+
+C increment(scope return C c) @safe  // Prior to the fix for 18295 an error would be emitted here
+{                                    // which is too conservative
+    c.i++;
+    return c;
+}
+
+void main() @safe
+{
+    scope C c = new C();
+    c.increment();
+}


### PR DESCRIPTION
See issue for the details.  This PR also adds coverage for previously uncovered case.

FYI: This is in direct support of https://github.com/dlang/dlang.org/pull/2027