### PR TITLE
fix Issue 18296 - make __coverage a hidden symbol

### DIFF
--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -1185,6 +1185,7 @@ enum
     SFLnodebug      = 0x20000,     // don't generate debug info
     SFLwasstatic    = 0x800000,    // was an uninitialized static
     SFLweak         = 0x1000000,   // resolve to NULL if not found
+    SFLhidden       = 0x2000000,   // not visible outside of DSOs (-fvisibility=hidden)
     SFLartifical    = 0x4000000,   // compiler generated symbol
 
     // CPP
@@ -1207,7 +1208,7 @@ enum
     // OPTIMIZER and CODGEN
     GTregcand       = 0x100,       // if Symbol is a register candidate
     SFLdead         = 0x800,       // this variable is dead
-    GTunregister    = 0x2000000,   // 'unregister' a previous register assignment
+    GTunregister    = 0x8000000,   // 'unregister' a previous register assignment
 
     // OPTIMIZER only
     SFLunambig      = 0x400,       // only accessible by unambiguous reference,

--- a/src/dmd/backend/cc.h
+++ b/src/dmd/backend/cc.h
@@ -1159,6 +1159,7 @@ enum
     SFLnodebug      = 0x20000,     // don't generate debug info
     SFLwasstatic    = 0x800000,    // was an uninitialized static
     SFLweak         = 0x1000000,   // resolve to NULL if not found
+    SFLhidden       = 0x2000000,   // not visible outside of DSOs (-fvisibility=hidden)
     SFLartifical    = 0x4000000,   // compiler generated symbol
 
     // CPP
@@ -1181,7 +1182,7 @@ enum
     // OPTIMIZER and CODGEN
     GTregcand       = 0x100,       // if Symbol is a register candidate
     SFLdead         = 0x800,       // this variable is dead
-    GTunregister    = 0x2000000,   // 'unregister' a previous register assignment
+    GTunregister    = 0x8000000,   // 'unregister' a previous register assignment
 
     // OPTIMIZER only
     SFLunambig      = 0x400,       // only accessible by unambiguous reference,

--- a/src/dmd/backend/elfobj.c
+++ b/src/dmd/backend/elfobj.c
@@ -2406,6 +2406,7 @@ void Obj::pubdef(int seg, Symbol *s, targ_size_t offset)
 void Obj::pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
 {
     int bind;
+    unsigned char visibility = STV_DEFAULT;
     switch (s->Sclass)
     {
         case SCglobal:
@@ -2416,6 +2417,14 @@ void Obj::pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize
         case SCcomdef:
             bind = STB_WEAK;
             break;
+        case SCstatic:
+            if (s->Sflags & SFLhidden)
+            {
+                visibility = STV_HIDDEN;
+                bind = STB_GLOBAL;
+                break;
+            }
+            // fallthrough
         default:
             bind = STB_LOCAL;
             break;
@@ -2433,13 +2442,13 @@ void Obj::pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize
     if (tyfunc(s->ty()))
     {
         s->Sxtrnnum = elf_addsym(namidx, offset, symsize,
-            STT_FUNC, bind, MAP_SEG2SECIDX(seg));
+            STT_FUNC, bind, MAP_SEG2SECIDX(seg), visibility);
     }
     else
     {
         const unsigned typ = (s->ty() & mTYthread) ? STT_TLS : STT_OBJECT;
         s->Sxtrnnum = elf_addsym(namidx, offset, symsize,
-            typ, bind, MAP_SEG2SECIDX(seg));
+            typ, bind, MAP_SEG2SECIDX(seg), visibility);
     }
 }
 

--- a/src/dmd/backend/mscoffobj.c
+++ b/src/dmd/backend/mscoffobj.c
@@ -639,11 +639,15 @@ void build_syment_table(bool bigobj)
         switch (s->Sclass)
         {
             case SCstatic:
+                if (s->Sflags & SFLhidden)
+                    goto Ldefault;
+                // fall-through
             case SClocstat:
                 sym.StorageClass = IMAGE_SYM_CLASS_STATIC;
                 sym.Value = s->Soffset;
                 break;
 
+            Ldefault:
             default:
                 sym.StorageClass = IMAGE_SYM_CLASS_EXTERNAL;
                 if (sym.SectionNumber != IMAGE_SYM_UNDEFINED)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -385,7 +385,8 @@ void genObjFile(Module m, bool multiobj)
         /* Create coverage identifier:
          *  uint[numlines] __coverage;
          */
-        m.cov = toSymbolX(m, "__coverage", SCglobal, type_fake(TYint), "Z");
+        m.cov = toSymbolX(m, "__coverage", SCstatic, type_fake(TYint), "Z");
+        m.cov.Sflags |= SFLhidden;
         m.cov.Stype.Tmangle = mTYman_d;
         m.cov.Sfl = FLdata;
 

--- a/test/runnable/test18296.d
+++ b/test/runnable/test18296.d
@@ -1,0 +1,24 @@
+// REQUIRED_ARGS: -cov
+// PERMUTE_ARGS: -fPIC
+alias AliasSeq(Args...) = Args;
+
+struct Duration
+{
+    this(long hnsecs)
+    {
+        _hnsecs = hnsecs;
+    }
+
+
+    long _hnsecs;
+}
+
+void main()
+{
+    foreach(U; AliasSeq!(Duration, const Duration))
+    {
+        const Duration t = 42;
+        U u = t;
+        assert(t._hnsecs == u._hnsecs);
+    }
+}


### PR DESCRIPTION
- external linkage only for current DSO, but not across DSOs
- avoids GOT indirection on every access
- thus avoids codegen bugs related to those
- uses SCstatic with SFLhidden flag as the access is the same as for
  static symbols, even though linkage is between SCglobal and SCstatic
  In the long-run (and with more usage) a separate SChidden might be cleaner.
- no changes to OMF code as LPUBDEF isn't used