### PR TITLE
Fix Issue 12511 - static overloaded function is not accessible

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -529,7 +529,7 @@ extern (C++) bool symbolIsVisible(Scope *sc, Dsymbol s)
  * but doesn't recurse nor resolve aliases because protection/visibility is an
  * attribute of the alias not the aliasee.
  */
-private Dsymbol mostVisibleOverload(Dsymbol s)
+public Dsymbol mostVisibleOverload(Dsymbol s)
 {
     if (!s.isOverloadable())
         return s;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -8446,6 +8446,15 @@ extern (C++) final class TypeClass : Type
             //printf("e = %s, d = %s\n", e.toChars(), d.toChars());
             if (d.semanticRun == PASS.init)
                 d.dsymbolSemantic(null);
+
+            // If static function, get the most visible overload.
+            // Later on the call is checked for correctness.
+            if (auto fd = d.isFuncDeclaration())
+            {
+                import dmd.access : mostVisibleOverload;
+                d = cast(Declaration)mostVisibleOverload(fd);
+            }
+
             checkAccess(e.loc, sc, e, d);
             auto ve = new VarExp(e.loc, d);
             if (d.isVarDeclaration() && d.needThis())

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -8449,6 +8449,7 @@ extern (C++) final class TypeClass : Type
 
             // If static function, get the most visible overload.
             // Later on the call is checked for correctness.
+            // https://issues.dlang.org/show_bug.cgi?id=12511
             if (auto fd = d.isFuncDeclaration())
             {
                 import dmd.access : mostVisibleOverload;

--- a/test/compilable/imports/a12511.d
+++ b/test/compilable/imports/a12511.d
@@ -1,0 +1,7 @@
+module a12511;
+
+public class A
+{
+    private static void foo() {}
+    public static void foo(int) {}
+}

--- a/test/compilable/test12511.d
+++ b/test/compilable/test12511.d
@@ -1,0 +1,14 @@
+module test12511;
+
+import imports.a12511;
+
+public class B
+{
+    static void bar()
+    {
+        A.foo(0);
+    }
+}
+
+void main()
+{}


### PR DESCRIPTION
Given a class which implements an overload set of static functions, whenever one of them is called the symbol of the first defined function is picked, no matter the privacy attribute. Later on, before checking to which of the actual functions the call is, an access check is performed. If the first defined function is private it doesn't matter if the called function is public; an error message is issued right away.

I solved the issue by making the access check on the most visible overload.