### PR TITLE
show -fPIC on all relevant platforms

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -266,7 +266,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("fPIC",
             "generate position independent code",
-            TargetOS.linux
+            TargetOS.all & ~(TargetOS.windows | TargetOS.macOS)
         ),
         Option("g",
             "add symbolic debug info",


### PR DESCRIPTION
- it's always enabled on OSX, so no need to add the flag there