### PR TITLE
Deprecate import/module name mismatch (ALL CASES)

### DIFF
--- a/changelog/deprecate_bad_module_name.dd
+++ b/changelog/deprecate_bad_module_name.dd
@@ -1,0 +1,48 @@
+Deprecate import module name mismatch
+
+Some instances of module name/import name mismatches were deprecated while others are now considered errors.
+
+Case 1: DEPRECATED: import a module name with a qualified name but the module being imported has no module declaration.
+---
+// main.d
+import foo.bar;
+
+// foo/bar.d
+// this file is empty, it has no module declaration
+---
+The above code will now print:
+
+$(CONSOLE Deprecated: module bar from file foo/bar.d should be imported with 'import bar;' )
+
+Case 2: DEPRECATED: import a module with a qualified name that partially matches the name of the module being imported.
+---
+// main.d
+import foo.bar;
+import foo.baz.buz;
+
+// foo/bar.d
+module bar;
+
+// foo/baz/buz.d
+module baz.buz;
+---
+The above code will now print:
+
+$(CONSOLE Deprecated: module bar from file foo/bar.d should be imported with 'import bar;'
+Deprecated: module baz.buz from file foo/baz/buz.d should be imported with 'import baz.buz;' )
+
+Note that for this rule to apply, the shorter name must completely match the end of the longer name.
+
+Case 3: ERROR: import a module that matches the filename but does not match the module name.
+---
+// main.d
+import foo;
+
+// foo.d
+module bar;
+---
+The above code will now fail and print:
+
+$(CONSOLE Error: module bar from file foo.d must be imported with 'import bar;')
+
+Note that importing a module whose module name does not match its filename is still supported.

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -313,3 +313,22 @@ unittest
     array[2] = 910;
     assert([123, 421, 910, 123, 1, 2, 8, 20, 4, 3] == array.asDArray);
 }
+
+/**
+ * Returns true if every element of $(D left) and $(D right) are equal.
+ * Note that an array of size 0 is considered equivalent to a `null` pointer.
+ * Params:
+ *  left = pointer to array to compare
+ *  right = pointer to array to compare
+ */
+bool opEquals(T)(const(Array!T)* left, const(Array!T)* right)
+{
+    if (left is null || left.dim == 0)
+        return right is null || right.dim == 0;
+    if (right is null || left.dim != right.dim)
+        return false;
+    foreach (i; 0 .. left.dim)
+        if ((*left)[i] != (*right)[i])
+            return false;
+    return true;
+}

--- a/test/compilable/extra-files/test14894a.d
+++ b/test/compilable/extra-files/test14894a.d
@@ -1,4 +1,4 @@
-module imports.test14894a;
+module test14894a;
 
 mixin template Protocol()
 {

--- a/test/compilable/imports/a313templatemixin1.d
+++ b/test/compilable/imports/a313templatemixin1.d
@@ -1,3 +1,4 @@
+module imports.a313templatemixin1;
 void bug()
 {
 }

--- a/test/compilable/imports/a313templatemixin2.d
+++ b/test/compilable/imports/a313templatemixin2.d
@@ -1,3 +1,4 @@
+module imports.a313templatemixin2;
 void bug()
 {
 }

--- a/test/compilable/imports/checkimports3a.d
+++ b/test/compilable/imports/checkimports3a.d
@@ -1,1 +1,2 @@
+module imports.checkimports3a;
 void foo() {}

--- a/test/compilable/imports/checkimports3b.d
+++ b/test/compilable/imports/checkimports3b.d
@@ -1,1 +1,2 @@
+module imports.checkimports3b;
 private void foo(int) {}

--- a/test/compilable/imports/checkimports3c.d
+++ b/test/compilable/imports/checkimports3c.d
@@ -1,1 +1,2 @@
+module imports.checkimports3c;
 void foo(string) {}

--- a/test/compilable/imports/fwdref12201a.d
+++ b/test/compilable/imports/fwdref12201a.d
@@ -1,1 +1,2 @@
+module imports.fwdref12201a;
 alias int FILE;

--- a/test/compilable/imports/fwdref2_test17548.d
+++ b/test/compilable/imports/fwdref2_test17548.d
@@ -1,9 +1,9 @@
-module fwdref2_test17548;
+module imports.fwdref2_test17548;
 
 import test17548;
 
 struct S2 {
     void bar(int arg = .test17548.cnst) {}
     S1 s;
-    import fwdref2_test17548;
+    import imports.fwdref2_test17548;
 }

--- a/test/compilable/imports/fwdref9514.d
+++ b/test/compilable/imports/fwdref9514.d
@@ -1,3 +1,4 @@
+module imports.fwdref9514;
 bool find9514(alias pred, R)(R range)
 {
     return true;

--- a/test/compilable/imports/g313public.d
+++ b/test/compilable/imports/g313public.d
@@ -1,3 +1,4 @@
+module imports.g313public;
 void bug()
 {
 }

--- a/test/compilable/imports/g313staticif.d
+++ b/test/compilable/imports/g313staticif.d
@@ -1,3 +1,4 @@
+module imports.g313staticif;
 void bug()
 {
 }

--- a/test/compilable/imports/g313stringmixin.d
+++ b/test/compilable/imports/g313stringmixin.d
@@ -1,3 +1,4 @@
+module imports.g313stringmixin;
 void bug()
 {
 }

--- a/test/compilable/imports/g313templatemixin.d
+++ b/test/compilable/imports/g313templatemixin.d
@@ -1,3 +1,4 @@
+module imports.g313templatemixin;
 void bug()
 {
 }

--- a/test/compilable/imports/imp16085.d
+++ b/test/compilable/imports/imp16085.d
@@ -1,3 +1,4 @@
+module imports.imp16085;
 struct Pass
 {
 }

--- a/test/compilable/imports/imp16085b.d
+++ b/test/compilable/imports/imp16085b.d
@@ -1,4 +1,5 @@
-import imp16085 : S;
+module imports.imp16085b;
+import imports.imp16085 : S;
 
 struct Fail
 {

--- a/test/compilable/imports/protectionimp.d
+++ b/test/compilable/imports/protectionimp.d
@@ -1,3 +1,4 @@
+module imports.protectionimp;
 private
 {
     void privF() {}

--- a/test/compilable/imports/test11563core_bitop.d
+++ b/test/compilable/imports/test11563core_bitop.d
@@ -1,1 +1,1 @@
-module test11563core_bitop;
+module imports.test11563core_bitop;

--- a/test/compilable/imports/test15857a.d
+++ b/test/compilable/imports/test15857a.d
@@ -1,2 +1,3 @@
+module imports.test15857a;
 public import imports.test15857b;
 public import imports.test15857c;

--- a/test/compilable/imports/test15857b.d
+++ b/test/compilable/imports/test15857b.d
@@ -1,1 +1,2 @@
+module imports.test15857b;
 void bar15857(int) {}

--- a/test/compilable/imports/test15857c.d
+++ b/test/compilable/imports/test15857c.d
@@ -1,1 +1,2 @@
+module imports.test15857c;
 void bar15857(string) {}

--- a/test/compilable/imports/test71.d
+++ b/test/compilable/imports/test71.d
@@ -1,4 +1,4 @@
-module imports_test71;
+module imports.test71;
 import imports = object;
 
 void foo()

--- a/test/compilable/test15925.d
+++ b/test/compilable/test15925.d
@@ -1,8 +1,9 @@
-/* REQUIRED_ARGS: -transition=import -transition=checkimports
+/* REQUIRED_ARGS: -transition=import -transition=checkimports -Icompilable/imports
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-compilable/test15925.d(17): Deprecation: local import search method found variable `imp15925.X` instead of nothing
+compilable/test15925.d(12): Deprecation: module `imp15925` from file compilable/imports/imp15925.d should be imported with 'import imp15925;'
+compilable/test15925.d(18): Deprecation: local import search method found variable `imp15925.X` instead of nothing
 ---
 */
 

--- a/test/compilable/test313f.d
+++ b/test/compilable/test313f.d
@@ -1,7 +1,8 @@
 // REQUIRED_ARGS: -de
-import imports.f313;
+// EXTRA_SOURCES: imports/f313.d
+import foo.bar;
 
 void test()
 {
-    imports.f313.bug();
+    foo.bar.bug();
 }

--- a/test/compilable/test314.d
+++ b/test/compilable/test314.d
@@ -1,11 +1,12 @@
 // REQUIRED_ARGS: -de
+// EXTRA_SOURCES: imports/a314.d
 module imports.test314; // package imports
 
-import imports.a314;
+import imports.pkg.a314;
 
 void main()
 {
-    imports.a314.bug("This should work.\n");
+    imports.pkg.a314.bug("This should work.\n");
     renamed.bug("This should work.\n");
     bug("This should work.\n");
 }

--- a/test/fail_compilation/badimport.d
+++ b/test/fail_compilation/badimport.d
@@ -1,0 +1,10 @@
+/*
+EXTRA_SOURCES: imports/nomodname.d
+REQUIRED_ARGS: -Ifail_compilation -de
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/badimport.d(10): Error: module `nomodname` from file fail_compilation/imports/nomodname.d must be imported with 'import nomodname;'
+---
+*/
+import imports.nomodname;

--- a/test/fail_compilation/badimport2.d
+++ b/test/fail_compilation/badimport2.d
@@ -1,0 +1,10 @@
+/*
+EXTRA_SOURCES: imports/incompletemodname.d
+REQUIRED_ARGS: -Ifail_compilation -de
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/badimport2.d(10): Error: module `incompletemodname` from file fail_compilation/imports/incompletemodname.d must be imported with 'import incompletemodname;'
+---
+*/
+import imports.incompletemodname;

--- a/test/fail_compilation/badimport3.d
+++ b/test/fail_compilation/badimport3.d
@@ -1,0 +1,10 @@
+/*
+COMPILED_IMPORTS: imports/incompletemodname.d
+REQUIRED_ARGS: -Ifail_compilation
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/badimport3.d(10): Error: module `wrongpkg.wrongpkgname` from file fail_compilation/imports/wrongpkgname.d must be imported with 'import wrongpkg.wrongpkgname;'
+---
+*/
+import imports.wrongpkgname;

--- a/test/fail_compilation/badimport4.d
+++ b/test/fail_compilation/badimport4.d
@@ -1,0 +1,10 @@
+/*
+EXRTRA_SOURCES: imports/wrong_mod_name.d
+REQUIRED_ARGS: -Ifail_compilation/imports
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/badimport4.d(10): Error: module `wrong_mod_name_bleh` from file fail_compilation/imports/wrong_mod_name.d must be imported with 'import wrong_mod_name_bleh;'
+---
+*/
+import wrong_mod_name;

--- a/test/fail_compilation/dip22b.d
+++ b/test/fail_compilation/dip22b.d
@@ -1,8 +1,9 @@
 /*
+EXTRA_SOURCES: imports/dip22c.d
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/dip22b.d(12): Deprecation: `pkg.dip22c.Foo` is not visible from module `dip22`
+fail_compilation/dip22b.d(13): Deprecation: `pkg.dip22c.Foo` is not visible from module `dip22`
 ---
 */
 module pkg.dip22;

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -1,18 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10528.d(23): Error: module `fail10528` variable `a10528.a` is `private`
-fail_compilation/fail10528.d(23): Deprecation: `a10528.a` is not visible from module `fail10528`
-fail_compilation/fail10528.d(24): Error: `a10528.a` is not visible from module `fail10528`
-fail_compilation/fail10528.d(26): Error: module `fail10528` enum member `a10528.b` is `private`
-fail_compilation/fail10528.d(26): Deprecation: `a10528.b` is not visible from module `fail10528`
-fail_compilation/fail10528.d(27): Error: `a10528.b` is not visible from module `fail10528`
-fail_compilation/fail10528.d(29): Deprecation: `a10528.S.c` is not visible from module `fail10528`
-fail_compilation/fail10528.d(29): Error: variable `a10528.S.c` is not accessible from module `fail10528`
-fail_compilation/fail10528.d(30): Error: variable `a10528.S.c` is not accessible from module `fail10528`
-fail_compilation/fail10528.d(32): Deprecation: `a10528.C.d` is not visible from module `fail10528`
-fail_compilation/fail10528.d(32): Error: variable `a10528.C.d` is not accessible from module `fail10528`
-fail_compilation/fail10528.d(33): Error: variable `a10528.C.d` is not accessible from module `fail10528`
+fail_compilation/fail10528.d(23): Error: module `fail10528` variable `imports.a10528.a` is `private`
+fail_compilation/fail10528.d(23): Deprecation: `imports.a10528.a` is not visible from module `fail10528`
+fail_compilation/fail10528.d(24): Error: `imports.a10528.a` is not visible from module `fail10528`
+fail_compilation/fail10528.d(26): Error: module `fail10528` enum member `imports.a10528.b` is `private`
+fail_compilation/fail10528.d(26): Deprecation: `imports.a10528.b` is not visible from module `fail10528`
+fail_compilation/fail10528.d(27): Error: `imports.a10528.b` is not visible from module `fail10528`
+fail_compilation/fail10528.d(29): Deprecation: `imports.a10528.S.c` is not visible from module `fail10528`
+fail_compilation/fail10528.d(29): Error: variable `imports.a10528.S.c` is not accessible from module `fail10528`
+fail_compilation/fail10528.d(30): Error: variable `imports.a10528.S.c` is not accessible from module `fail10528`
+fail_compilation/fail10528.d(32): Deprecation: `imports.a10528.C.d` is not visible from module `fail10528`
+fail_compilation/fail10528.d(32): Error: variable `imports.a10528.C.d` is not accessible from module `fail10528`
+fail_compilation/fail10528.d(33): Error: variable `imports.a10528.C.d` is not accessible from module `fail10528`
 ---
 */
 

--- a/test/fail_compilation/fail17625.d
+++ b/test/fail_compilation/fail17625.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail17625.d(16): Deprecation: `b17625.boo` is not visible from module `fail17625`
-fail_compilation/fail17625.d(16): Error: function `b17625.boo` is not accessible from module `fail17625`
+fail_compilation/fail17625.d(16): Deprecation: `imports.b17625.boo` is not visible from module `fail17625`
+fail_compilation/fail17625.d(16): Error: function `imports.b17625.boo` is not accessible from module `fail17625`
 ---
 */
 

--- a/test/fail_compilation/fail320.d
+++ b/test/fail_compilation/fail320.d
@@ -1,7 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail320.d(10): Error: no overload matches for `foo`
+fail_compilation/fail320.d(10): Deprecation: module `fail320a` from file fail_compilation/imports/fail320a.d should be imported with 'import fail320a;'
+fail_compilation/fail320.d(11): Deprecation: module `fail320b` from file fail_compilation/imports/fail320b.d should be imported with 'import fail320b;'
+fail_compilation/fail320.d(12): Error: no overload matches for `foo`
 ---
 */
 

--- a/test/fail_compilation/ice10727a.d
+++ b/test/fail_compilation/ice10727a.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/imports/foo10727a.d(34): Error: undefined identifier `Frop`
+fail_compilation/imports/foo10727a.d(36): Error: undefined identifier `Frop`
 ---
 */
 

--- a/test/fail_compilation/ice10727b.d
+++ b/test/fail_compilation/ice10727b.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/imports/foo10727b.d(25): Error: undefined identifier `Frop`
+fail_compilation/imports/foo10727b.d(27): Error: undefined identifier `Frop`
 ---
 */
 

--- a/test/fail_compilation/ice11513a.d
+++ b/test/fail_compilation/ice11513a.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_SOURCES: imports/ice11513x.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/ice11513x.d(1): Error: package name 'ice11513a' conflicts with usage as a module name in file fail_compilation/ice11513a.d
@@ -7,4 +8,4 @@ fail_compilation/imports/ice11513x.d(1): Error: package name 'ice11513a' conflic
 
 module ice11513a;
 
-import imports.ice11513x;
+import ice11513a.imports;

--- a/test/fail_compilation/ice11513b.d
+++ b/test/fail_compilation/ice11513b.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_SOURCES: imports/ice11513y.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/ice11513y.d(1): Error: package name 'ice11513b' conflicts with usage as a module name in file fail_compilation/ice11513b.d
@@ -7,4 +8,4 @@ fail_compilation/imports/ice11513y.d(1): Error: package name 'ice11513b' conflic
 
 module ice11513b;
 
-import imports.ice11513y;
+import ice11513b.imports.ice11513y;

--- a/test/fail_compilation/ice11919.d
+++ b/test/fail_compilation/ice11919.d
@@ -2,8 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice11919.d(17): Error: cannot interpret `foo` at compile time
-fail_compilation/imports/a11919.d(4): Error: template instance `a11919.doBar!(Foo).doBar.zoo!(t)` error instantiating
-fail_compilation/imports/a11919.d(11):        instantiated from here: `doBar!(Foo)`
+fail_compilation/imports/a11919.d(5): Error: template instance `imports.a11919.doBar!(Foo).doBar.zoo!(t)` error instantiating
+fail_compilation/imports/a11919.d(12):        instantiated from here: `doBar!(Foo)`
 fail_compilation/ice11919.d(25):        instantiated from here: `doBar!(Bar)`
 ---
 */

--- a/test/fail_compilation/ice9865.d
+++ b/test/fail_compilation/ice9865.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9865.d(8): Error: alias `ice9865.Baz` recursive alias declaration
+fail_compilation/ice9865.d(9): Deprecation: module `ice9865b` from file fail_compilation/imports/ice9865b.d should be imported with 'import ice9865b;'
+fail_compilation/ice9865.d(9): Error: alias `ice9865.Baz` recursive alias declaration
 ---
 */
 

--- a/test/fail_compilation/imports/a10528.d
+++ b/test/fail_compilation/imports/a10528.d
@@ -1,3 +1,4 @@
+module imports.a10528;
 private enum string a = "asdfgh";
 private enum { b = "asdfgh" }
 

--- a/test/fail_compilation/imports/a11919.d
+++ b/test/fail_compilation/imports/a11919.d
@@ -1,3 +1,4 @@
+module imports.a11919;
 void doBar(T)(T t)
 {
     static if (t.tupleof.length)

--- a/test/fail_compilation/imports/a17625.d
+++ b/test/fail_compilation/imports/a17625.d
@@ -1,3 +1,3 @@
-module a17625;
+module imports.a17625;
 
 private int boo() { return 69; }

--- a/test/fail_compilation/imports/a17630.d
+++ b/test/fail_compilation/imports/a17630.d
@@ -1,3 +1,3 @@
-module a17630;
+module imports.a17630;
 
 import b17630;

--- a/test/fail_compilation/imports/a18219.d
+++ b/test/fail_compilation/imports/a18219.d
@@ -1,4 +1,4 @@
-module a18219;
+module imports.a18219;
 
 struct AST
 {

--- a/test/fail_compilation/imports/a18243.d
+++ b/test/fail_compilation/imports/a18243.d
@@ -1,4 +1,4 @@
-module a18243;
+module imports.a18243;
 
 import std.math : isNaN;
 

--- a/test/fail_compilation/imports/b17625.d
+++ b/test/fail_compilation/imports/b17625.d
@@ -1,3 +1,3 @@
-module b17625;
+module imports.b17625;
 
 private int boo() { return 45; }

--- a/test/fail_compilation/imports/dip22b.d
+++ b/test/fail_compilation/imports/dip22b.d
@@ -1,3 +1,3 @@
 module imports.dip22b;
 // this public import only exports symbols that are visible within this module
-public import imports.dip22c;
+public import pkg.dip22c;

--- a/test/fail_compilation/imports/foo10727a.d
+++ b/test/fail_compilation/imports/foo10727a.d
@@ -1,3 +1,5 @@
+module imports.foo10727a;
+
 struct CirBuff(T)
 {
     import imports.stdtraits10727 : isArray;

--- a/test/fail_compilation/imports/foo10727b.d
+++ b/test/fail_compilation/imports/foo10727b.d
@@ -1,3 +1,5 @@
+module imports.foo10727b;
+
 struct CirBuff(T)
 {
     import imports.stdtraits10727 : isArray;

--- a/test/fail_compilation/imports/incompletemodname.d
+++ b/test/fail_compilation/imports/incompletemodname.d
@@ -1,0 +1,3 @@
+// The point of this module is that it should be called imports.incompletemodname
+// but it omits the "imports" in it's name.
+module incompletemodname;

--- a/test/fail_compilation/imports/nomodname.d
+++ b/test/fail_compilation/imports/nomodname.d
@@ -1,0 +1,1 @@
+// intentionally no module declaration

--- a/test/fail_compilation/imports/stdtraits10727.d
+++ b/test/fail_compilation/imports/stdtraits10727.d
@@ -1,3 +1,5 @@
+module imports.stdtraits10727;
+
 template StaticArrayTypeOf(T)
 {
     inout(U[n]) idx(U, size_t n)( inout(U[n]) );

--- a/test/fail_compilation/imports/test13152a.d
+++ b/test/fail_compilation/imports/test13152a.d
@@ -1,3 +1,4 @@
+module imports.test13152a;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152b.d
+++ b/test/fail_compilation/imports/test13152b.d
@@ -1,3 +1,4 @@
+module imports.test13152b;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152c.d
+++ b/test/fail_compilation/imports/test13152c.d
@@ -1,3 +1,4 @@
+module imports.test13152c;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152d.d
+++ b/test/fail_compilation/imports/test13152d.d
@@ -1,3 +1,4 @@
+module imports.test13152d;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152e.d
+++ b/test/fail_compilation/imports/test13152e.d
@@ -1,3 +1,4 @@
+module imports.test13152e;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152f.d
+++ b/test/fail_compilation/imports/test13152f.d
@@ -1,3 +1,4 @@
+module imports.test13152f;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152g.d
+++ b/test/fail_compilation/imports/test13152g.d
@@ -1,3 +1,4 @@
+module imports.test13152g;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152h.d
+++ b/test/fail_compilation/imports/test13152h.d
@@ -1,3 +1,4 @@
+module imports.test13152h;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152i.d
+++ b/test/fail_compilation/imports/test13152i.d
@@ -1,3 +1,4 @@
+module imports.test13152i;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152j.d
+++ b/test/fail_compilation/imports/test13152j.d
@@ -1,3 +1,4 @@
+module imports.test13152j;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152k.d
+++ b/test/fail_compilation/imports/test13152k.d
@@ -1,3 +1,4 @@
+module imports.test13152k;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152l.d
+++ b/test/fail_compilation/imports/test13152l.d
@@ -1,3 +1,4 @@
+module imports.test13152l;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152m.d
+++ b/test/fail_compilation/imports/test13152m.d
@@ -1,3 +1,4 @@
+module imports.test13152m;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152n.d
+++ b/test/fail_compilation/imports/test13152n.d
@@ -1,3 +1,4 @@
+module imports.test13152n;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152o.d
+++ b/test/fail_compilation/imports/test13152o.d
@@ -1,3 +1,4 @@
+module imports.test13152o;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152p.d
+++ b/test/fail_compilation/imports/test13152p.d
@@ -1,3 +1,4 @@
+module imports.test13152p;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152q.d
+++ b/test/fail_compilation/imports/test13152q.d
@@ -1,3 +1,4 @@
+module imports.test13152q;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152r.d
+++ b/test/fail_compilation/imports/test13152r.d
@@ -1,3 +1,4 @@
+module imports.test13152r;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152s.d
+++ b/test/fail_compilation/imports/test13152s.d
@@ -1,3 +1,4 @@
+module imports.test13152s;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152t.d
+++ b/test/fail_compilation/imports/test13152t.d
@@ -1,3 +1,4 @@
+module imports.test13152t;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152u.d
+++ b/test/fail_compilation/imports/test13152u.d
@@ -1,3 +1,4 @@
+module imports.test13152u;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152v.d
+++ b/test/fail_compilation/imports/test13152v.d
@@ -1,3 +1,4 @@
+module imports.test13152v;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152w.d
+++ b/test/fail_compilation/imports/test13152w.d
@@ -1,3 +1,4 @@
+module imports.test13152w;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152x.d
+++ b/test/fail_compilation/imports/test13152x.d
@@ -1,3 +1,4 @@
+module imports.test13152x;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152y.d
+++ b/test/fail_compilation/imports/test13152y.d
@@ -1,3 +1,4 @@
+module imports.test13152y;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test13152z.d
+++ b/test/fail_compilation/imports/test13152z.d
@@ -1,3 +1,4 @@
+module imports.test13152z;
 public import imports.test13152a;
 public import imports.test13152b;
 public import imports.test13152c;

--- a/test/fail_compilation/imports/test64b.d
+++ b/test/fail_compilation/imports/test64b.d
@@ -1,0 +1,4 @@
+module imports.test64b;
+
+const char[] file2 = "File2";
+

--- a/test/fail_compilation/imports/wrong_mod_name.d
+++ b/test/fail_compilation/imports/wrong_mod_name.d
@@ -1,0 +1,1 @@
+module wrong_mod_name_bleh;

--- a/test/fail_compilation/imports/wrongpkgname.d
+++ b/test/fail_compilation/imports/wrongpkgname.d
@@ -1,0 +1,1 @@
+module wrongpkg.wrongpkgname;

--- a/test/fail_compilation/test64.d
+++ b/test/fail_compilation/test64.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_SOURCES: imports/test64b.d imports/test64a.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/test64a.d(1): Error: module `imports` from file fail_compilation/imports/test64a.d conflicts with package name imports
@@ -9,7 +10,7 @@ fail_compilation/imports/test64a.d(1): Error: module `imports` from file fail_co
 
 //import std.stdio;
 
-import imports.test64a;
+import imports;
 
 int main(string[] args)
 {

--- a/test/runnable/extra-files/lib846.d
+++ b/test/runnable/extra-files/lib846.d
@@ -1,4 +1,4 @@
-module link846a;
+module lib846;
 
 template ElemTypeOf(T)
 {

--- a/test/runnable/imports/a12037.d
+++ b/test/runnable/imports/a12037.d
@@ -1,4 +1,4 @@
-module imports.aXXXXX;
+module imports.a12037;
 
 auto min(A, B)(A a, B b) { return a < b ? a : b; }
 alias TypeTuple(T...) = T;

--- a/test/runnable/imports/a9741.d
+++ b/test/runnable/imports/a9741.d
@@ -1,4 +1,4 @@
-module imports.a9741b;
+module imports.a9741;
 
 template ShowAttributes(alias X)
 {

--- a/test/runnable/imports/bar10378.d
+++ b/test/runnable/imports/bar10378.d
@@ -1,4 +1,4 @@
 
-module bar;
+module imports.bar10378;
 
 void writeln() { }

--- a/test/runnable/imports/link13043a.d
+++ b/test/runnable/imports/link13043a.d
@@ -1,4 +1,4 @@
-module imports.lin13043a;
+module imports.link13043a;
 
 struct QualifiedNameTests
 {

--- a/test/runnable/imports/std15017variant.d
+++ b/test/runnable/imports/std15017variant.d
@@ -1,4 +1,4 @@
-module imports.std15017;
+module imports.std15017variant;
 
 struct VariantN(size_t maxDataSize)
 {


### PR DESCRIPTION
This PR modifies dmd to verify that the name of a module always matches the name that was used to import it.  Depending on the situation, if the names do not match then this PR will either provide a deprecation message or assert an error.

1. _DEPRECATED_: import a module with a qualified name but the module being imported has no module declaration
```D
// main.d
import foo.bar;
// foo/bar.d
// note the missing module declaration
```
```
 Deprecated: module 'bar' from file foo/bar.d should be imported with 'import bar;'
```

2. _DEPRECATED_: import a module with a qualified name that partially matches the name of the module being imported

```D
// main.d
import foo.bar;
import foo.baz.buz;
// foo/bar.d
module bar;
// foo/baz/buz.d
module baz.buz;
```
```
 Deprecated: module 'bar' from file foo/bar.d should be imported with 'import bar;'
 Deprecated: module 'baz.buz' from file foo/baz/buz.d should be imported with 'import baz.buz;'
```
> NOTE: for this rule to apply, the ends of the imported name and the module name itself must match.

3. _ERROR_: importing a module that matches the filename but does not match the module name
```D
// main.d
import foo;
// foo.d
module bar;
```
```
 Error: module 'bar' from file foo.d must be imported with 'import bar;'
```

4. NOT APPLICABLE/STILL WORKS:  import a module with the correct module name but does not match the filename
```D
// main.d
import bar;
// foo.d
module bar;
```

NOTE: this also addresses a bug found by @timotheecour 

https://github.com/dlang/dmd/pull/7777#discussion_r163939438

NOTE: The DMD test suite itself was using some of this functionality in a fair amount of tests, i.e.
* `test/runnable/imports/link7745b.d`
* `test/fail_compilation/imports/a11919.d`