### PR TITLE
Fix the deprecation warning in the DMD DUB package + build with `-de` + CI check

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -103,7 +103,7 @@ test_dub_package() {
             # build with host compiler
             dub --single "$file"
             # build with built compiler (~master)
-            dub --single --compiler="${abs_build_path}" "$file"
+            DFLAGS="-de" dub --single --compiler="${abs_build_path}/dmd" "$file"
         done
         popd
     fi

--- a/dub.sdl
+++ b/dub.sdl
@@ -60,7 +60,6 @@ subPackage {
   versions "GC"
   versions "NoMain"
   sourcePaths "src/dmd"
-  buildRequirements "disallowDeprecations"
   excludedSourceFiles "src/dmd/backend/*"
   excludedSourceFiles "src/dmd/{e2ir,eh,glue,iasm,objc_glue,s2ir,tocsym,toctype,toobj,todt,toir}.d"
 }

--- a/dub.sdl
+++ b/dub.sdl
@@ -60,6 +60,7 @@ subPackage {
   versions "GC"
   versions "NoMain"
   sourcePaths "src/dmd"
+  buildRequirements "disallowDeprecations"
   excludedSourceFiles "src/dmd/backend/*"
   excludedSourceFiles "src/dmd/{e2ir,eh,glue,iasm,objc_glue,s2ir,tocsym,toctype,toobj,todt,toir}.d"
 }

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -223,7 +223,7 @@ Module parseModule(string fileName, string code = null)
     import dmd.astcodegen : ASTCodegen;
     import dmd.globals : Loc;
     import dmd.parse : Parser;
-    import dmd.statement : Identifier;
+    import dmd.identifier : Identifier;
     import dmd.tokens : TOK;
     import std.string : toStringz;
 


### PR DESCRIPTION
`de` is used already for the DMD build, tools, phobos etc. It was simply forgotten for the new DMD DUB package. The idea of building with `-de` is that whenever a new deprecation message gets introduced it should be ensured that all core packages can use the replacement. It's also bad for the image if user see deprecation warnings in a library they use.