### PR TITLE
Fix SemaphoreCI badge URL + add AppVeyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ DMD
 [![license](https://img.shields.io/github/license/dlang/dmd.svg)](https://github.com/dlang/dmd/blob/master/LICENSE.txt)
 
 [![CircleCI](https://circleci.com/gh/dlang/dmd/tree/master.svg?style=svg)](https://circleci.com/gh/dlang/dmd/tree/master)
-[![Build Status](https://semaphoreci.com/api/v1/cybershadow/dmd/branches/master/badge.svg)](https://semaphoreci.com/cybershadow/dmd)
+[![SemaphoreCI](https://semaphoreci.com/api/v1/wilzbach/dmd-2/branches/master/badge.svg)](https://semaphoreci.com/wilzbach/dmd-2)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/mv0y9lqyk7jh0x8d?svg=true)](https://ci.appveyor.com/project/greenify/dmd)
 
 DMD is the reference compiler for the D programming language.
 


### PR DESCRIPTION
We switched to this project (https://semaphoreci.com/wilzbach/dmd-2) on SemaphoreCI because it's easy for me to give everyone who is interested access to it.
Also while I was at it, I added a badge for AppVeyor too.

Preview:

![image](https://user-images.githubusercontent.com/4370550/35453964-5733faee-02cc-11e8-92de-536a28e8bf89.png)
