### PR TITLE
Add dmd.frontend to the documentation build

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -615,7 +615,8 @@ DOC_OUTPUT_DIR=$(DOCDIR)
 ifneq ($(DOCSRC),)
 
 # list all files for which documentation should be generated, use sort to remove duplicates
-SRC_DOCUMENTABLES = $(sort $(ROOT_SRCS) $(DMD_SRCS) $(LEXER_SRCS) $(LEXER_ROOT) $(PARSER_SRCS))
+SRC_DOCUMENTABLES = $(sort $(ROOT_SRCS) $(DMD_SRCS) $(LEXER_SRCS) $(LEXER_ROOT) $(PARSER_SRCS) \
+                           $D/frontend.d)
 
 D2HTML=$(foreach p,$1,$(if $(subst package.d,,$(notdir $p)),$(subst /,_,$(subst .d,.html,$p)),$(subst /,_,$(subst /package.d,.html,$p))))
 HTMLS=$(addprefix $(DOC_OUTPUT_DIR)/, \


### PR DESCRIPTION
As `dmd.frontend` isn't part of the default sources, it needs to be added manually.
This depends on https://github.com/dlang/dmd/pull/7783 as `dlang.org` builds the documentation with `-de`.

-- edit:

FYI: ddox doesn't have this problem as it doesn't need the Makefiles -> https://dlang.org/library-prerelease/dmd/frontend.html