### PR TITLE
Don't require TypeInfo in a minimal runtime if it's not needed

### DIFF
--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -21,6 +21,7 @@ extern (C++):
 import dmd.globals;
 import dmd.dclass;
 import dmd.dmodule;
+import dmd.mtype;
 
 import dmd.root.filename;
 
@@ -123,7 +124,7 @@ void backend_init()
         params.stackstomp,
         params.cpu >= CPU.avx2 ? 2 : params.cpu >= CPU.avx ? 1 : 0,
         params.useModuleInfo && Module.moduleinfo,
-        params.useTypeInfo,
+        params.useTypeInfo && Type.dtypeinfo,
         params.useExceptions && ClassDeclaration.throwable
     );
 

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -120,7 +120,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
             {
                 Scope scx;
                 scx._module = sd.getModule();
-                getTypeInfoType(t, &scx);
+                getTypeInfoType(sd.loc, t, &scx);
                 sd.requestTypeInfo = true;
             }
             else if (!sc.minst)
@@ -130,7 +130,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
             }
             else
             {
-                getTypeInfoType(t, sc);
+                getTypeInfoType(sd.loc, t, sc);
                 sd.requestTypeInfo = true;
 
                 // https://issues.dlang.org/show_bug.cgi?id=15149

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3892,7 +3892,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         buildOpAssign(sd, sc2);
         buildOpEquals(sd, sc2);
 
-        if (global.params.useTypeInfo)  // these functions are used for TypeInfo
+        if (global.params.useTypeInfo && Type.dtypeinfo)  // these functions are used for TypeInfo
         {
             sd.xeq = buildXopEquals(sd, sc2);
             sd.xcmp = buildXopCmp(sd, sc2);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -823,10 +823,10 @@ elem *sarray_toDarray(const ref Loc loc, Type tfrom, Type tto, elem *e)
 /************************************
  */
 
-elem *getTypeInfo(Type t, IRState *irs)
+elem *getTypeInfo(Loc loc, Type t, IRState *irs)
 {
     assert(t.ty != Terror);
-    genTypeInfo(t, null);
+    genTypeInfo(loc, t, null);
     elem *e = el_ptr(toSymbol(t.vtinfo));
     return e;
 }
@@ -865,17 +865,17 @@ StructDeclaration needsDtor(Type t)
  * Set an array pointed to by eptr to evalue:
  *      eptr[0..edim] = evalue;
  * Params:
- *      eptr =    where to write the data to
- *      edim =    number of times to write evalue to eptr[]
- *      tb =      type of evalue
- *      evalue =  value to write
- *      irs =     context
- *      op =      TOK.blit, TOK.assign, or TOK.construct
+ *      exp    = the expression for which this operation is performed
+ *      eptr   = where to write the data to
+ *      edim   = number of times to write evalue to eptr[]
+ *      tb     = type of evalue
+ *      evalue = value to write
+ *      irs    = context
+ *      op     = TOK.blit, TOK.assign, or TOK.construct
  * Returns:
  *      created IR code
  */
-
-private elem *setArray(elem *eptr, elem *edim, Type tb, elem *evalue, IRState *irs, int op)
+private elem *setArray(Expression exp, elem *eptr, elem *edim, Type tb, elem *evalue, IRState *irs, int op)
 {
     assert(op == TOK.blit || op == TOK.assign || op == TOK.construct);
     const sz = cast(uint)tb.size();
@@ -949,7 +949,7 @@ Lagain:
                     r = (op == TOK.construct) ? RTLSYM_ARRAYSETCTOR : RTLSYM_ARRAYSETASSIGN;
                     evalue = el_una(OPaddr, TYnptr, evalue);
                     // This is a hack so we can call postblits on const/immutable objects.
-                    elem *eti = getTypeInfo(tb.unSharedOf().mutableOf(), irs);
+                    elem *eti = getTypeInfo(exp.loc, tb.unSharedOf().mutableOf(), irs);
                     elem *e = el_params(eti, edim, evalue, eptr, null);
                     e = el_bin(OPcall,TYnptr,el_var(getRtlsym(r)),e);
                     return e;
@@ -1323,7 +1323,7 @@ elem *toElem(Expression e, IRState *irs)
             //printf("TypeidExp.toElem() %s\n", e.toChars());
             if (Type t = isType(e.obj))
             {
-                result = getTypeInfo(t, irs);
+                result = getTypeInfo(e.loc, t, irs);
                 result = el_bin(OPadd, result.Ety, result, el_long(TYsize_t, t.vtinfo.offset));
                 return;
             }
@@ -1722,7 +1722,7 @@ elem *toElem(Expression e, IRState *irs)
                 else
                 {
                     // call _d_newitemT(ti)
-                    e = getTypeInfo(ne.newtype, irs);
+                    e = getTypeInfo(ne.loc, ne.newtype, irs);
 
                     int rtl = t.isZeroInit(Loc.initial) ? RTLSYM_NEWITEMT : RTLSYM_NEWITEMIT;
                     ex = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),e);
@@ -1781,7 +1781,7 @@ elem *toElem(Expression e, IRState *irs)
                     e = toElem(arg, irs);
 
                     // call _d_newT(ti, arg)
-                    e = el_param(e, getTypeInfo(ne.type, irs));
+                    e = el_param(e, getTypeInfo(ne.loc, ne.type, irs));
                     int rtl = tda.next.isZeroInit(Loc.initial) ? RTLSYM_NEWARRAYT : RTLSYM_NEWARRAYIT;
                     e = el_bin(OPcall,TYdarray,el_var(getRtlsym(rtl)),e);
                     toTraceGC(irs, e, ne.loc);
@@ -1803,7 +1803,7 @@ elem *toElem(Expression e, IRState *irs)
                     e = el_pair(TYdarray, el_long(TYsize_t, ne.arguments.dim), el_ptr(sdata));
                     if (config.exe == EX_WIN64)
                         e = addressElem(e, Type.tsize_t.arrayOf());
-                    e = el_param(e, getTypeInfo(ne.type, irs));
+                    e = el_param(e, getTypeInfo(ne.loc, ne.type, irs));
                     int rtl = t.isZeroInit(Loc.initial) ? RTLSYM_NEWARRAYMTX : RTLSYM_NEWARRAYMITX;
                     e = el_bin(OPcall,TYdarray,el_var(getRtlsym(rtl)),e);
                     toTraceGC(irs, e, ne.loc);
@@ -1818,7 +1818,7 @@ elem *toElem(Expression e, IRState *irs)
                 elem *ezprefix = ne.argprefix ? toElem(ne.argprefix, irs) : null;
 
                 // call _d_newitemT(ti)
-                e = getTypeInfo(ne.newtype, irs);
+                e = getTypeInfo(ne.loc, ne.newtype, irs);
 
                 int rtl = tp.next.isZeroInit(Loc.initial) ? RTLSYM_NEWITEMT : RTLSYM_NEWITEMIT;
                 e = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),e);
@@ -2212,6 +2212,8 @@ elem *toElem(Expression e, IRState *irs)
             if (global.params.betterC)
             {
                 error(ce.loc, "array concatenation of expression `%s` requires the GC which is not available with -betterC", ce.toChars());
+                result = el_long(TYint, 0);
+                return;
             }
 
             Type tb1 = ce.e1.type.toBasetype();
@@ -2243,7 +2245,7 @@ elem *toElem(Expression e, IRState *irs)
                 elem *ep = el_pair(TYdarray, el_long(TYsize_t, elems.dim), el_ptr(sdata));
                 if (config.exe == EX_WIN64)
                     ep = addressElem(ep, Type.tvoid.arrayOf());
-                ep = el_param(ep, getTypeInfo(ta, irs));
+                ep = el_param(ep, getTypeInfo(ce.loc, ta, irs));
                 e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYCATNTX)), ep);
                 toTraceGC(irs, e, ce.loc);
                 e = el_combine(earr, e);
@@ -2252,7 +2254,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 elem *e1 = eval_Darray(ce.e1);
                 elem *e2 = eval_Darray(ce.e2);
-                elem *ep = el_params(e2, e1, getTypeInfo(ta, irs), null);
+                elem *ep = el_params(e2, e1, getTypeInfo(ce.loc, ta, irs), null);
                 e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYCATT)), ep);
                 toTraceGC(irs, e, ce.loc);
             }
@@ -2458,7 +2460,7 @@ elem *toElem(Expression e, IRState *irs)
                 elem *ea1 = eval_Darray(ee.e1);
                 elem *ea2 = eval_Darray(ee.e2);
 
-                elem *ep = el_params(getTypeInfo(telement.arrayOf(), irs),
+                elem *ep = el_params(getTypeInfo(ee.loc, telement.arrayOf(), irs),
                         ea2, ea1, null);
                 int rtlfunc = RTLSYM_ARRAYEQ2;
                 e = el_bin(OPcall, TYint, el_var(getRtlsym(rtlfunc)), ep);
@@ -2470,7 +2472,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 TypeAArray taa = cast(TypeAArray)t1;
                 Symbol *s = aaGetSymbol(taa, "Equal", 0);
-                elem *ti = getTypeInfo(taa, irs);
+                elem *ti = getTypeInfo(ee.loc, taa, irs);
                 elem *ea1 = toElem(ee.e1, irs);
                 elem *ea2 = toElem(ee.e2, irs);
                 // aaEqual(ti, e1, e2)
@@ -2553,7 +2555,7 @@ elem *toElem(Expression e, IRState *irs)
             // aaInX(aa, keyti, key);
             key = addressElem(key, ie.e1.type);
             Symbol *s = aaGetSymbol(taa, "InX", 0);
-            elem *keyti = getTypeInfo(taa.index, irs);
+            elem *keyti = getTypeInfo(ie.loc, taa.index, irs);
             elem *ep = el_params(key, keyti, aa, null);
             elem *e = el_bin(OPcall, totym(ie.type), el_var(s), ep);
 
@@ -2574,7 +2576,7 @@ elem *toElem(Expression e, IRState *irs)
 
             ekey = addressElem(ekey, re.e1.type);
             Symbol *s = aaGetSymbol(taa, "DelX", 0);
-            elem *keyti = getTypeInfo(taa.index, irs);
+            elem *keyti = getTypeInfo(re.loc, taa.index, irs);
             elem *ep = el_params(ekey, keyti, ea, null);
             elem *e = el_bin(OPcall, TYnptr, el_var(s), ep);
 
@@ -2611,7 +2613,7 @@ elem *toElem(Expression e, IRState *irs)
                 Type t1 = ale.e1.type.toBasetype();
 
                 // call _d_arraysetlengthT(ti, e2, &ale.e1);
-                elem *p2 = getTypeInfo(t1, irs);
+                elem *p2 = getTypeInfo(ae.loc, t1, irs);
                 elem *ep = el_params(p3, p1, p2, null); // c function
                 int r = t1.nextOf().isZeroInit(Loc.initial) ? RTLSYM_ARRAYSETLENGTHT : RTLSYM_ARRAYSETLENGTHIT;
 
@@ -2728,7 +2730,7 @@ elem *toElem(Expression e, IRState *irs)
                     }
                     else
                         elength = el_copytree(enbytes);
-                    e = setArray(n1, enbytes, tb, evalue, irs, ae.op);
+                    e = setArray(are.e1, n1, enbytes, tb, evalue, irs, ae.op);
                     e = el_pair(TYdarray, elength, e);
                     e = el_combine(einit, e);
                     //elem_print(e);
@@ -2791,7 +2793,7 @@ elem *toElem(Expression e, IRState *irs)
                          *      _d_arrayctor(ti, efrom, eto)
                          */
                         el_free(esize);
-                        elem *eti = getTypeInfo(t1.nextOf().toBasetype(), irs);
+                        elem *eti = getTypeInfo(ae.e1.loc, t1.nextOf().toBasetype(), irs);
                         if (config.exe == EX_WIN64)
                         {
                             eto   = addressElem(eto,   Type.tvoid.arrayOf());
@@ -3084,7 +3086,7 @@ elem *toElem(Expression e, IRState *irs)
                     /* Generate:
                      *      _d_arrayctor(ti, e2, e1)
                      */
-                    elem *eti = getTypeInfo(t1b.nextOf().toBasetype(), irs);
+                    elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
                     if (config.exe == EX_WIN64)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
@@ -3106,7 +3108,7 @@ elem *toElem(Expression e, IRState *irs)
                      * or:
                      *      _d_arrayassign_r(ti, e2, e1, etmp)
                      */
-                    elem *eti = getTypeInfo(t1b.nextOf().toBasetype(), irs);
+                    elem *eti = getTypeInfo(ae.e1.loc, t1b.nextOf().toBasetype(), irs);
                     if (config.exe == EX_WIN64)
                     {
                         e1 = addressElem(e1, Type.tvoid.arrayOf());
@@ -3191,7 +3193,7 @@ elem *toElem(Expression e, IRState *irs)
                         e2 = addressElem(e2, tb2, true);
                     else
                         e2 = useOPstrpar(e2);
-                    elem *ep = el_params(e2, e1, getTypeInfo(ce.e1.type, irs), null);
+                    elem *ep = el_params(e2, e1, getTypeInfo(ce.e1.loc, ce.e1.type, irs), null);
                     e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYAPPENDT)), ep);
                     toTraceGC(irs, e, ce.loc);
                     break;
@@ -3228,7 +3230,7 @@ elem *toElem(Expression e, IRState *irs)
 
                     // Extend array with _d_arrayappendcTX(TypeInfo ti, e1, 1)
                     e1 = el_una(OPaddr, TYnptr, e1);
-                    elem *ep = el_param(e1, getTypeInfo(ce.e1.type, irs));
+                    elem *ep = el_param(e1, getTypeInfo(ce.e1.loc, ce.e1.type, irs));
                     ep = el_param(el_long(TYsize_t, 1), ep);
                     e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYAPPENDCTX)), ep);
                     toTraceGC(irs, e, ce.loc);
@@ -3911,7 +3913,7 @@ elem *toElem(Expression e, IRState *irs)
                         TypeStruct ts = cast(TypeStruct)tv;
                         StructDeclaration sd = ts.sym;
                         if (sd.dtor)
-                            et = getTypeInfo(tb.nextOf(), irs);
+                            et = getTypeInfo(de.e1.loc, tb.nextOf(), irs);
                     }
                     if (!et)                            // if no destructors needed
                         et = el_long(TYnptr, 0);        // pass null for TypeInfo
@@ -3948,7 +3950,7 @@ elem *toElem(Expression e, IRState *irs)
                         if (ts.sym.dtor)
                         {
                             rtl = RTLSYM_DELSTRUCT;
-                            elem *et = getTypeInfo(tb, irs);
+                            elem *et = getTypeInfo(de.e1.loc, tb, irs);
                             e = el_params(et, e, null);
                         }
                     }
@@ -4941,12 +4943,12 @@ elem *toElem(Expression e, IRState *irs)
                 {
                     n1 = el_una(OPaddr, TYnptr, n1);
                     s = aaGetSymbol(taa, "GetY", 1);
-                    ti = getTypeInfo(taa.unSharedOf().mutableOf(), irs);
+                    ti = getTypeInfo(ie.e1.loc, taa.unSharedOf().mutableOf(), irs);
                 }
                 else
                 {
                     s = aaGetSymbol(taa, "GetRvalueX", 1);
-                    ti = getTypeInfo(taa.index, irs);
+                    ti = getTypeInfo(ie.e1.loc, taa.index, irs);
                 }
                 //printf("taa.index = %s\n", taa.index.toChars());
                 //printf("ti:\n"); elem_print(ti);
@@ -5074,7 +5076,7 @@ elem *toElem(Expression e, IRState *irs)
                 // call _d_arrayliteralTX(ti, dim)
                 e = el_bin(OPcall, TYnptr,
                     el_var(getRtlsym(RTLSYM_ARRAYLITERALTX)),
-                    el_param(el_long(TYsize_t, dim), getTypeInfo(ale.type, irs)));
+                    el_param(el_long(TYsize_t, dim), getTypeInfo(ale.loc, ale.type, irs)));
                 toTraceGC(irs, e, ale.loc);
 
                 Symbol *stmp = symbol_genauto(Type_toCtype(Type.tvoid.pointerTo()));
@@ -5353,7 +5355,7 @@ elem *toElem(Expression e, IRState *irs)
                 else
                 {
                     elem *edim = el_long(TYsize_t, j - i);
-                    eeq = setArray(ev, edim, telem, ep, null, TOK.blit);
+                    eeq = setArray(el, ev, edim, telem, ep, null, TOK.blit);
                 }
                 e = el_combine(e, eeq);
                 i = j;
@@ -5390,7 +5392,7 @@ elem *toElem(Expression e, IRState *irs)
                     ek = addressElem(ek, Type.tvoid.arrayOf());
                 }
                 elem *e = el_params(ev, ek,
-                                    getTypeInfo(ta, irs),
+                                    getTypeInfo(aale.loc, ta, irs),
                                     null);
 
                 // call _d_assocarrayliteralTX(ti, keys, values)
@@ -5642,7 +5644,7 @@ private elem *toElemStructLit(StructLiteralExp sle, IRState *irs, TOK op, Symbol
                 else
                 {
                     elem *edim = el_long(TYsize_t, t1b.size() / t2b.size());
-                    e1 = setArray(e1, edim, t2b, ep, irs, op == TOK.construct ? TOK.blit : op);
+                    e1 = setArray(el, e1, edim, t2b, ep, irs, op == TOK.construct ? TOK.blit : op);
                 }
             }
             else

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3765,7 +3765,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             // Handle this in the glue layer
             e = new TypeidExp(exp.loc, ta);
-            e.type = getTypeInfoType(ta, sc);
+            e.type = getTypeInfoType(exp.loc, ta, sc);
 
             semanticTypeInfo(sc, ta);
 

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -586,7 +586,7 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
         {
             if (Type t = isType(e.obj))
             {
-                genTypeInfo(t, null);
+                genTypeInfo(e.loc, t, null);
                 Symbol *s = toSymbol(t.vtinfo);
                 dtb.xoff(s, 0);
                 return;
@@ -1000,7 +1000,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         dtb.size(0);                                     // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(tm, null);
+        genTypeInfo(d.loc, tm, null);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1013,7 +1013,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         dtb.size(0);                                         // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(tm, null);
+        genTypeInfo(d.loc, tm, null);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1026,7 +1026,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         dtb.size(0);                                     // monitor
         Type tm = d.tinfo.unSharedOf();
         tm = tm.merge();
-        genTypeInfo(tm, null);
+        genTypeInfo(d.loc, tm, null);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1039,7 +1039,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         dtb.size(0);                                 // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
-        genTypeInfo(tm, null);
+        genTypeInfo(d.loc, tm, null);
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
@@ -1065,7 +1065,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         // TypeInfo for enum members
         if (sd.memtype)
         {
-            genTypeInfo(sd.memtype, null);
+            genTypeInfo(d.loc, sd.memtype, null);
             dtb.xoff(toSymbol(sd.memtype.vtinfo), 0);
         }
         else
@@ -1106,7 +1106,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypePointer tc = cast(TypePointer)d.tinfo;
 
-        genTypeInfo(tc.next, null);
+        genTypeInfo(d.loc, tc.next, null);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for type being pointed to
     }
 
@@ -1122,7 +1122,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypeDArray tc = cast(TypeDArray)d.tinfo;
 
-        genTypeInfo(tc.next, null);
+        genTypeInfo(d.loc, tc.next, null);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for array of type
     }
 
@@ -1138,7 +1138,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypeSArray tc = cast(TypeSArray)d.tinfo;
 
-        genTypeInfo(tc.next, null);
+        genTypeInfo(d.loc, tc.next, null);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0);   // TypeInfo for array of type
 
         dtb.size(tc.dim.toInteger());          // length
@@ -1156,7 +1156,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypeVector tc = cast(TypeVector)d.tinfo;
 
-        genTypeInfo(tc.basetype, null);
+        genTypeInfo(d.loc, tc.basetype, null);
         dtb.xoff(toSymbol(tc.basetype.vtinfo), 0); // TypeInfo for equivalent static array
     }
 
@@ -1172,10 +1172,10 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypeAArray tc = cast(TypeAArray)d.tinfo;
 
-        genTypeInfo(tc.next, null);
+        genTypeInfo(d.loc, tc.next, null);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0);   // TypeInfo for array of type
 
-        genTypeInfo(tc.index, null);
+        genTypeInfo(d.loc, tc.index, null);
         dtb.xoff(toSymbol(tc.index.vtinfo), 0);  // TypeInfo for array of type
     }
 
@@ -1191,7 +1191,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypeFunction tc = cast(TypeFunction)d.tinfo;
 
-        genTypeInfo(tc.next, null);
+        genTypeInfo(d.loc, tc.next, null);
         dtb.xoff(toSymbol(tc.next.vtinfo), 0); // TypeInfo for function return value
 
         const(char)* name = d.tinfo.deco;
@@ -1216,7 +1216,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
 
         TypeDelegate tc = cast(TypeDelegate)d.tinfo;
 
-        genTypeInfo(tc.next.nextOf(), null);
+        genTypeInfo(d.loc, tc.next.nextOf(), null);
         dtb.xoff(toSymbol(tc.next.nextOf().vtinfo), 0); // TypeInfo for delegate return value
 
         const(char)* name = d.tinfo.deco;
@@ -1375,7 +1375,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
                 // m_argi
                 if (t)
                 {
-                    genTypeInfo(t, null);
+                    genTypeInfo(d.loc, t, null);
                     dtb.xoff(toSymbol(t.vtinfo), 0);
                 }
                 else
@@ -1444,7 +1444,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         {
             Parameter arg = (*tu.arguments)[i];
 
-            genTypeInfo(arg.type, null);
+            genTypeInfo(d.loc, arg.type, null);
             Symbol* s = toSymbol(arg.type.vtinfo);
             dtbargs.xoff(s, 0);
         }

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -373,7 +373,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            genTypeInfo(cd.type, null);
+            genTypeInfo(cd.loc, cd.type, null);
             //toObjFile(cd.type.vtinfo, multiobj);
 
             //////////////////////////////////////////////
@@ -672,7 +672,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            genTypeInfo(id.type, null);
+            genTypeInfo(id.loc, id.type, null);
             id.type.vtinfo.accept(this);
 
             //////////////////////////////////////////////
@@ -841,8 +841,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 else if (global.params.symdebug)
                     toDebug(sd);
 
-                if (global.params.useTypeInfo)
-                    genTypeInfo(sd.type, null);
+                if (global.params.useTypeInfo && Type.dtypeinfo)
+                    genTypeInfo(sd.loc, sd.type, null);
 
                 // Generate static initializer
                 toInitializer(sd);
@@ -1004,7 +1004,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 toDebug(ed);
 
             if (global.params.useTypeInfo)
-                genTypeInfo(ed.type, null);
+                genTypeInfo(ed.loc, ed.type, null);
 
             TypeEnum tc = cast(TypeEnum)ed.type;
             if (!tc.sym.members || ed.type.isZeroInit(Loc.initial))

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -24,14 +24,26 @@ import dmd.mtype;
 import dmd.visitor;
 
 /****************************************************
- * Get the exact TypeInfo.
+ * Generates the `TypeInfo` object associated with `torig` if it
+ * hasn't already been generated
+ * Params:
+ *      loc   = the location for reporting line numbers in errors
+ *      torig = the type to generate the `TypeInfo` object for
+ *      sc    = the scope
  */
-extern (C++) void genTypeInfo(Type torig, Scope* sc)
+extern (C++) void genTypeInfo(Loc loc, Type torig, Scope* sc)
 {
     //printf("Type::genTypeInfo() %p, %s\n", this, toChars());
+
+    if (!global.params.useTypeInfo)
+    {
+        torig.error(loc, "`TypeInfo` cannot be used with -betterC");
+        fatal();
+    }
+
     if (!Type.dtypeinfo)
     {
-        torig.error(Loc.initial, "TypeInfo not found. object.d may be incorrectly installed or corrupt, compile with -v switch");
+        torig.error(loc, "`object.TypeInfo` could not be found, but is implicitly used");
         fatal();
     }
 
@@ -73,10 +85,19 @@ extern (C++) void genTypeInfo(Type torig, Scope* sc)
     assert(torig.vtinfo);
 }
 
-extern (C++) Type getTypeInfoType(Type t, Scope* sc)
+/****************************************************
+ * Gets the type of the `TypeInfo` object associated with `t`
+ * Params:
+ *      loc = the location for reporting line nunbers in errors
+ *      t   = the type to get the type of the `TypeInfo` object for
+ *      sc  = the scope
+ * Returns:
+ *      The type of the `TypeInfo` object associated with `t`
+ */
+extern (C++) Type getTypeInfoType(Loc loc, Type t, Scope* sc)
 {
     assert(t.ty != Terror);
-    genTypeInfo(t, sc);
+    genTypeInfo(loc, t, sc);
     return t.vtinfo.type;
 }
 

--- a/test/compilable/extra-files/minimal/verify_symbols.sh
+++ b/test/compilable/extra-files/minimal/verify_symbols.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# ensure no ModuleInfo-related code was generated
-if ! nm "$1" | grep -q 'ModuleInfo\|_d_dso_registry\__start_minfo\|__stop_minfo' ; then
+# ensure no ModuleInfo or TypeInfo related code was generated
+if ! nm "$1" | grep -q 'ModuleInfo\|_d_dso_registry\__start_minfo\|__stop_minfo\|TypeInfo' ; then
     # ensure no exception handling code was generated
     if ! objdump -h "$1" | grep -q ".eh_frame" ; then
         exit 0

--- a/test/compilable/minimal.d
+++ b/test/compilable/minimal.d
@@ -2,7 +2,10 @@
 // POST_SCRIPT: compilable/extra-files/minimal/verify_symbols.sh
 // REQUIRED_ARGS: -c -defaultlib= runnable/extra-files/minimal/object.d
 
-// This test ensures an empty main built with a minimal runtime does not generate
-// ModuleInfo and exception handling code
+// This test ensures an empty main with a struct, built with a minimal runtime,
+// does not generate ModuleInfo or exception handling code, and does not
+// require TypeInfo
+
+struct S { }
 
 void main() { }

--- a/test/fail_compilation/betterc.d
+++ b/test/fail_compilation/betterc.d
@@ -1,8 +1,9 @@
 /* REQUIRED_ARGS: -betterC
  * TEST_OUTPUT:
 ---
-fail_compilation/betterc.d(11): Error: Cannot use `throw` statements with -betterC
-fail_compilation/betterc.d(16): Error: Cannot use try-catch statements with -betterC
+fail_compilation/betterc.d(12): Error: Cannot use `throw` statements with -betterC
+fail_compilation/betterc.d(17): Error: Cannot use try-catch statements with -betterC
+fail_compilation/betterc.d(29): Error: `TypeInfo` cannot be used with -betterC
 ---
 */
 
@@ -20,4 +21,10 @@ void test2()
     catch (Exception e)
     {
     }
+}
+
+void test3()
+{
+    int i;
+    auto ti = typeid(i);
 }

--- a/test/fail_compilation/extra-files/no_TypeInfo/object.d
+++ b/test/fail_compilation/extra-files/no_TypeInfo/object.d
@@ -1,0 +1,1 @@
+module object;

--- a/test/fail_compilation/no_TypeInfo.d
+++ b/test/fail_compilation/no_TypeInfo.d
@@ -1,0 +1,15 @@
+/* 
+DFLAGS:
+REQUIRED_ARGS: -c -I=fail_compilation/extra-files/no_TypeInfo/
+TEST_OUTPUT:
+---
+fail_compilation/no_TypeInfo.d(13): Error: `object.TypeInfo` could not be found, but is implicitly used
+---
+*/
+
+void test()
+{
+    int i;
+    auto ti = typeid(i);
+}
+


### PR DESCRIPTION
This is a followup to the following PRs

 * #7395 and #7768 for `ModuleInfo`
 * #7786 for `Throwable`

It is to `TypeInfo` what the above PRs were for `ModuleInfo` and `Throwable`

With this PR, it is now possible to have the same functionality as -betterC (without the -betterC compiler switch) by simply adding the following minimal runtime for executables...

```D
module object;

private alias extern(C) int function(char[][] args) MainFunc;
private extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
{
    return mainFunc(null);  // assuming `void main()`
}
```

... or the following minimal runtime for libraries:

```D
module object;
```

For libraries it would be nice to not require an empty object.d file, but I'm leaving that for another potential PR.      UPDATE: See  #7825

Again, this will be of interest to users wishing to incrementally or partially port D to new platforms, users hoping to target resource constrained platforms, and users wishing to use D as a library from other languages without druntime.