### PR TITLE
Avoid the need of calling initDMD() in library code

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -21,6 +21,11 @@ import std.traits : isNarrowString;
 version (Windows) private enum sep = ";", exe = ".exe";
 version (Posix) private enum sep = ":", exe = "";
 
+shared static this()
+{
+    initDMD();
+}
+
 /*
 Initializes the global variables of the DMD compiler.
 This needs to be done $(I before) calling any function.

--- a/test/dub_package/frontend.d
+++ b/test/dub_package/frontend.d
@@ -10,7 +10,6 @@ void main()
     import dmd.frontend;
     import std.algorithm : each;
 
-    initDMD;
     findImportPaths.each!addImport;
 
     auto m = parseModule("test.d", q{

--- a/test/dub_package/frontend_file.d
+++ b/test/dub_package/frontend_file.d
@@ -12,7 +12,6 @@ void main()
     import std.file : remove, tempDir, fwrite = write;
     import std.path : buildPath;
 
-    initDMD;
     findImportPaths.each!addImport;
 
     auto fileName = tempDir.buildPath("d_frontend_test.d");


### PR DESCRIPTION
Requiring library code to call your initializers was popular in the 90s, it isn't anymore.
Let's go ahead with a good example.
(also DMD as a library is quite similar to Phobos and there isn't any manual interaction needed when calling a function in Phobos)

I initially used `initOnce` as @andralex put a lot of work in avoid module constructor at Phobos (see e.g. https://github.com/dlang/phobos/pull/5421, https://github.com/dlang/phobos/pull/5423, ...), but that was only to ease uses when Phobos is used with `-betterC`, which won't be the case for the DMD DUB package. After all, it's intended for people writing language tools _in D_.

See also: https://github.com/dlang/dmd/pull/7789