### PR TITLE
Fix Issue 17663 - header generation (-H) is broken with public override of private default

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -590,6 +590,11 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         return buf.extractString();
     }
 
+    override final inout(ProtDeclaration) isProtDeclaration() inout
+    {
+        return this;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -115,6 +115,7 @@ public:
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
     const char *toPrettyChars(bool unused);
+    ProtDeclaration *isProtDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1212,6 +1212,11 @@ extern (C++) class Dsymbol : RootObject
         return null;
     }
 
+    inout(ProtDeclaration) isProtDeclaration() inout
+    {
+        return null;
+    }
+
     inout(OverloadSet) isOverloadSet() inout
     {
         return null;

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -52,6 +52,7 @@ class UnitTestDeclaration;
 class NewDeclaration;
 class VarDeclaration;
 class AttribDeclaration;
+class ProtDeclaration;
 class Package;
 class Module;
 class Import;
@@ -279,6 +280,7 @@ public:
     virtual DeleteDeclaration *isDeleteDeclaration() { return NULL; }
     virtual SymbolDeclaration *isSymbolDeclaration() { return NULL; }
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
+    virtual ProtDeclaration *isProtDeclaration() { return NULL; }
     virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1281,7 +1281,11 @@ public:
     {
         protectionToBuffer(buf, d.protection);
         buf.writeByte(' ');
-        visit(cast(AttribDeclaration)d);
+        AttribDeclaration ad = cast(AttribDeclaration)d;
+        if (ad.decl.dim == 1 && (*ad.decl)[0].isProtDeclaration)
+            visit(cast(AttribDeclaration)(*ad.decl)[0]);
+        else
+            visit(cast(AttribDeclaration)d);
     }
 
     override void visit(AlignDeclaration d)

--- a/test/compilable/extra-files/header2.d
+++ b/test/compilable/extra-files/header2.d
@@ -170,3 +170,7 @@ class LeClass
     }
 }
 const levar = new class LeClass, LeInterface {};
+
+// 17663
+private:
+public struct Export {}

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -131,3 +131,6 @@ const levar = new class LeClass, LeInterface
 {
 }
 ;
+private struct Export
+{
+}

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -233,3 +233,6 @@ const levar = new class LeClass, LeInterface
 {
 }
 ;
+private struct Export
+{
+}


### PR DESCRIPTION
Whenever there's a block preceded by a visibility attribute and the block contains a single declaration : 

```d
private:
public struct Export {}
```

the generated header is going to be `private public struct Export {} `. This happens because
the header generation does not check for consecutive ProtDeclaration AST nodes.

For blocks that contain more than 1 declaration, the generated header is fine because it is treated
as a block:

```d
private:
public struct Export {}
private struct Import {}
```
Will result in the generated header file:

```d
private
{
    public struct Export {}
    private struct Import {}
}
```

I fixed the issue by adding a check that ensures that if there are 2 ProtDeclaration AST nodes consecutively, the second one is skipped.