### PR TITLE
Experiment with setting after_n_builds to 3 to see CodeCov status updates again

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ codecov:
     # We don't want to wait for the CodeCov report
     # See https://github.com/codecov/support/issues/312
     require_ci_to_pass: false
-    after_n_builds: 1  # send notifications after the first upload
+    after_n_builds: 3  # send notifications after all CircleCi builds
     wait_for_ci: false
 
   bot: dlang-bot


### PR DESCRIPTION
For some yet to be determined reason CodeCov doesn't show up in the status update.
However, the reports are still properly processed and the [browser extension](https://github.com/codecov/browser-extension) still works nicely.