### PR TITLE
[WIP] simpler fix for issue 18322 ___FILE_FULL_PATH___

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1823,7 +1823,7 @@ extern (C++) abstract class Expression : RootObject
     }
 
     /****************************************
-     * Resolve __FILE__, __LINE__, __MODULE__, __FUNCTION__, __PRETTY_FUNCTION__ to loc.
+     * Resolve __FILE__, __FILE_FULL_PATH__, __LINE__, __MODULE__, __FUNCTION__, __PRETTY_FUNCTION__ to loc.
      */
     Expression resolveLoc(const ref Loc loc, Scope* sc)
     {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -7081,9 +7081,13 @@ extern (C++) final class FileInitExp : DefaultInitExp
     override Expression resolveLoc(const ref Loc loc, Scope* sc)
     {
         //printf("FileInitExp::resolve() %s\n", toChars());
-        const(char)* s = loc.isValid() ? loc.filename : sc._module.ident.toChars();
-        if (subop == TOK.fileFullPath)
-            s = FileName.combine(sc._module.srcfilePath, s);
+        auto mod = sc.callsc ? sc.callsc._module : sc._module;
+        // CHECKME: mod.ident.toChars() or sc._module.ident.toChars()?
+        const(char)* s = loc.isValid() ? loc.filename : mod.ident.toChars();
+        if (subop == TOK.fileFullPath){
+          s = mod.srcfile.toChars();
+          s = FileName.toAbsolute(s);
+        }
         Expression e = new StringExp(loc, cast(char*)s);
         e = e.expressionSemantic(sc);
         e = e.castTo(sc, type);

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -30,6 +30,8 @@ version (Windows) extern (C) int stricmp(const char*, const char*) pure;
 version (Windows) extern (Windows) DWORD GetFullPathNameW(LPCWSTR, DWORD, LPWSTR, LPWSTR*) @nogc;
 version (Windows) extern (Windows) void SetLastError(DWORD) @nogc;
 version (Posix) extern (C) char* canonicalize_file_name(const char*);
+version (Posix) import core.sys.posix.unistd : getcwd;
+version (Windows) extern (C) char* getcwd(char* buffer, size_t maxlen);
 }
 
 alias Strings = Array!(const(char)*);
@@ -97,6 +99,21 @@ nothrow:
             assert(0);
         }
     }
+
+    /**
+    Return the given name as an absolute path
+
+    Params:
+        name = path
+        base = the absolute base to prefix name with if it is relative
+
+    Returns: name as an absolute path relative to base
+    */
+    static const(char)* toAbsolute(const(char)* name, const(char)* base = getcwd(null, 0))
+    {
+        return absolute(name) ? name : combine(base, name);
+    }
+
 
     /********************************
      * Determine file name extension as slice of input.

--- a/test/compilable/line.d
+++ b/test/compilable/line.d
@@ -19,12 +19,12 @@ static assert(__FILE_FULL_PATH__[$-__FILE__.length..$] == __FILE__);
 
 static assert(__LINE__ == 101);
 static assert(__FILE__ == "newfile.d");
-static assert(__FILE_FULL_PATH__ == "newfile.d");
+static assert(__FILE_FULL_PATH__[$ - 9 .. $] == "newfile.d");
 
 # line 200
 
 static assert(__LINE__ == 201);
 static assert(__FILE__ == "newfile.d");
-static assert(__FILE_FULL_PATH__ == "newfile.d");
+static assert(__FILE_FULL_PATH__[$ - 9 .. $] == "newfile.d");
 
 

--- a/test/runnable/imports/test18322import.d
+++ b/test/runnable/imports/test18322import.d
@@ -1,0 +1,16 @@
+module test18322import;
+void fun(string templateFileFullPath = __FILE_FULL_PATH__,
+    string templateFile = __FILE__)(string expectedFilename, string fileFullPath = __FILE_FULL_PATH__)
+{
+    // make sure it is an absolute path
+    version(Windows)
+        assert(fileFullPath[1..3] == ":\\");
+    else
+        assert(fileFullPath[0] == '/');
+
+    assert(templateFileFullPath == fileFullPath);
+    import std.stdio;
+    writeln("expectedFilename:", expectedFilename, " 2:", fileFullPath[$ - expectedFilename.length .. $], " templateFileFullPath:", templateFileFullPath, " templateFile:", templateFile, " fileFullPath:", fileFullPath);
+    assert(fileFullPath[$ - expectedFilename.length .. $] == expectedFilename);
+    assert(fileFullPath[$ - templateFile.length .. $] == templateFile);
+}

--- a/test/runnable/test18322.d
+++ b/test/runnable/test18322.d
@@ -1,0 +1,21 @@
+/*
+REQUIRED_ARGS: -Irunnable/imports
+COMPILED_IMPORTS: imports/test18322import.d
+PERMUTE_ARGS:
+*/
+import test18322import;
+void main(){
+    version(Windows)
+        auto sep = "\\";
+    else
+        auto sep = "/";
+
+    auto filename = "runnable" ~ sep ~ "test18322.d";
+
+    fun(filename);
+    mixin(`fun(filename ~ "-mixin-16");`);
+
+    #line 100 "poundlinefile.d"
+    fun("poundlinefile.d");
+    mixin(`fun("poundlinefile.d-mixin-101");`);
+}


### PR DESCRIPTION
fix for https://issues.dlang.org/show_bug.cgi?id=18322
`void fun(string file=__FILE_FULL_PATH__)() returns relative path (pointing to nowhere)`

compared to https://github.com/dlang/dmd/pull/7798:
* the main difference is the use of sc.callsc in resolveLoc
* minimal change

- [ ] TODO: target stable instead of master
- [ ] TODO: resolve CHECKME in resolveLoc

NOTE: currently fails with mixin test test/runnable/test18322.d