### PR TITLE
Fix issue 18335 - The D_ObjectiveC version identifier is not printed in verbose mode

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -479,6 +479,8 @@ private int tryMain(size_t argc, const(char)** argv)
     Objc._init();
     builtin_init();
 
+    printPredefinedVersions();
+
     if (global.params.verbose)
     {
         fprintf(global.stdmsg, "binary    %s\n", global.params.argv0);
@@ -1348,8 +1350,6 @@ void addDefaultVersionIdentifiers()
         VersionCondition.addPredefinedGlobalIdent("D_BetterC");
 
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
-
-    printPredefinedVersions();
 }
 
 private void printPredefinedVersions()

--- a/test/runnable/test18335.sh
+++ b/test/runnable/test18335.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+output_file="${RESULTS_DIR}/runnable/$(basename $0 .sh)"
+set -ueo pipefail
+
+if [ "${OS}" == "osx" ] && [ "${MODEL}" == "64" ]; then
+    echo "void main(){}" | "${DMD}" -o- -v - | grep predefs | grep -q "D_ObjectiveC"
+fi
+
+echo Success > "${output_file}"


### PR DESCRIPTION
The `D_ObjectiveC` version identifier is set when the `Objc` is initialized. That means that the predefined version identifiers need to be printed after `Objc` has been initialized.