### PR TITLE
[refactor] Replace fprintf(global.stdmsg) with message()

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -523,16 +523,18 @@ extern (C++) final class Module : Package
             return null;
         if (global.params.verbose)
         {
-            fprintf(global.stdmsg, "import    ");
+            OutBuffer buf;
             if (packages)
             {
                 for (size_t i = 0; i < packages.dim; i++)
                 {
                     Identifier pid = (*packages)[i];
-                    fprintf(global.stdmsg, "%s.", pid.toChars());
+                    buf.writestring(pid.toChars());
+                    buf.writeByte('.');
                 }
             }
-            fprintf(global.stdmsg, "%s\t(%s)\n", ident.toChars(), m.srcfile.toChars());
+            buf.printf("%s\t(%s)", ident.toChars(), m.srcfile.toChars());
+            message("import    %s", buf.peekString());
         }
         m = m.parse();
 
@@ -553,12 +555,7 @@ extern (C++) final class Module : Package
         {
             if (!m.isRoot() && onImport)
             {
-                static __gshared bool bodge = false;
-                if(bodge)
-                    fprintf(global.stdmsg, "onImport\n");
                 auto onImportResult = onImport(m);
-                if(bodge)
-                    fprintf(global.stdmsg, "onImport %d\n", onImportResult);
                 if(onImportResult)
                 {
                     m.importedFrom = m;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -648,7 +648,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                     const(char)* p = dsym.loc.toChars();
                     const(char)* s = (dsym.storage_class & STC.immutable_) ? "immutable" : "const";
-                    fprintf(global.stdmsg, "%s: %s.%s is %s field\n", p ? p : "", ad.toPrettyChars(), dsym.toChars(), s);
+                    message("%s: %s.%s is %s field", p ? p : "", ad.toPrettyChars(), dsym.toChars(), s);
                 }
                 dsym.storage_class |= STC.field;
                 if (tbn.ty == Tstruct && (cast(TypeStruct)tbn).sym.noDefaultCtor)
@@ -1368,7 +1368,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 memcpy(name, se.string, se.len);
                 name[se.len] = 0;
                 if (global.params.verbose)
-                    fprintf(global.stdmsg, "library   %s\n", name);
+                    message("library   %s", name);
                 if (global.params.moduleDeps && !global.params.moduleDepsFile)
                 {
                     OutBuffer* ob = global.params.moduleDeps;
@@ -1485,7 +1485,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 /* Print unrecognized pragmas
                  */
-                fprintf(global.stdmsg, "pragma    %s", pd.ident.toChars());
+                OutBuffer buf;
+                buf.writestring(pd.ident.toChars());
                 if (pd.args)
                 {
                     for (size_t i = 0; i < pd.args.dim; i++)
@@ -1497,15 +1498,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         sc = sc.endCTFE();
                         e = e.ctfeInterpret();
                         if (i == 0)
-                            fprintf(global.stdmsg, " (");
+                            buf.writestring(" (");
                         else
-                            fprintf(global.stdmsg, ",");
-                        fprintf(global.stdmsg, "%s", e.toChars());
+                            buf.writeByte(',');
+                        buf.writestring(e.toChars());
                     }
                     if (pd.args.dim)
-                        fprintf(global.stdmsg, ")");
+                        buf.writeByte(')');
                 }
-                fprintf(global.stdmsg, "\n");
+                message("pragma    %s", buf.peekString());
             }
             goto Lnodecl;
         }
@@ -3250,7 +3251,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 printedMain = true;
                 const(char)* name = FileName.searchPath(global.path, mod.srcfile.toChars(), true);
-                fprintf(global.stdmsg, "entry     %-10s\t%s\n", type, name);
+                message("entry     %-10s\t%s", type, name);
             }
         }
 

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -163,6 +163,21 @@ extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format
 }
 
 /**
+ * Print a verbose message.
+ * Doesn't prefix or highlight messages.
+ * Params:
+ *      format = printf-style format specification
+ *      ...    = printf-style variadic arguments
+ */
+extern (C++) void message(const(char)* format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vmessage(format, ap);
+    va_end(ap);
+}
+
+/**
  * Just print to stderr, doesn't care about gagging.
  * (format,ap) text within backticks gets syntax highlighted.
  * Params:
@@ -307,6 +322,21 @@ extern (C++) void vdeprecation(const ref Loc loc, const(char)* format, va_list a
         verror(loc, format, ap, p1, p2, header);
     else if (global.params.useDeprecated == 2 && !global.gag)
         verrorPrint(loc, Classification.deprecation, header, format, ap, p1, p2);
+}
+
+/**
+ * Same as $(D message), but takes a va_list parameter.
+ * Params:
+ *      format = printf-style format specification
+ *      ap     = printf-style variadic arguments
+ */
+extern (C++) void vmessage(const(char)* format, va_list ap)
+{
+    OutBuffer tmp;
+    tmp.vprintf(format, ap);
+    fputs(tmp.peekString(), stdout);
+    fputc('\n', stdout);
+    fflush(stdout);     // ensure it gets written out in case of compiler aborts
 }
 
 /**

--- a/src/dmd/errors.h
+++ b/src/dmd/errors.h
@@ -39,6 +39,8 @@ D_ATTRIBUTE_FORMAT(2, 0) void vwarning(const Loc& loc, const char *format, va_li
 D_ATTRIBUTE_FORMAT(2, 0) void vwarningSupplemental(const Loc& loc, const char *format, va_list ap);
 D_ATTRIBUTE_FORMAT(2, 0) void vdeprecation(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 D_ATTRIBUTE_FORMAT(2, 0) void vdeprecationSupplemental(const Loc& loc, const char *format, va_list ap);
+D_ATTRIBUTE_FORMAT(1, 2) void message(const char *format, ...);
+D_ATTRIBUTE_FORMAT(1, 0) void vmessage(const char *format, va_list);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define D_ATTRIBUTE_NORETURN __attribute__((noreturn))

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4283,7 +4283,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         if (global.params.verbose)
-            fprintf(global.stdmsg, "file      %.*s\t(%s)\n", cast(int)se.len, se.string, name);
+            message("file      %.*s\t(%s)", cast(int)se.len, se.string, name);
         if (global.params.moduleDeps !is null)
         {
             OutBuffer* ob = global.params.moduleDeps;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1335,7 +1335,7 @@ extern (C++) class FuncDeclaration : Declaration
         Module m = getModule();
         if (m && m.isRoot() && !inUnittest())
         {
-            fprintf(global.stdmsg, "%s: vgc: %s\n", loc.toChars(), warn);
+            message("%s: vgc: %s", loc.toChars(), warn);
         }
     }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -13,7 +13,6 @@
 module dmd.globals;
 
 import core.stdc.stdint;
-import core.stdc.stdio;
 import dmd.root.array;
 import dmd.root.filename;
 import dmd.root.outbuffer;
@@ -251,7 +250,6 @@ struct Global
     Param params;
     uint errors;            // number of errors reported so far
     uint warnings;          // number of warnings reported so far
-    FILE* stdmsg;           // where to send verbose messages
     uint gag;               // !=0 means gag reporting of errors & warnings
     uint gaggedErrors;      // number of errors reported while gagged
 
@@ -350,7 +348,6 @@ struct Global
         }
         _version = (import("VERSION") ~ '\0').ptr;
         compiler.vendor = "Digital Mars D";
-        stdmsg = stdout;
     }
 }
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -232,7 +232,6 @@ struct Global
     Param params;
     unsigned errors;       // number of errors reported so far
     unsigned warnings;     // number of warnings reported so far
-    FILE *stdmsg;          // where to send verbose messages
     unsigned gag;          // !=0 means gag reporting of errors & warnings
     unsigned gaggedErrors; // number of errors reported while gagged
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -807,7 +807,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     fd.semanticRun = PASS.obj;
 
     if (global.params.verbose)
-        fprintf(global.stdmsg, "function  %s\n", fd.toPrettyChars());
+        message("function  %s", fd.toPrettyChars());
 
     Symbol *s = toSymbol(fd);
     func_t *f = s.Sfunc;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -26,6 +26,7 @@ import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.expression;
+import dmd.errors;
 import dmd.func;
 import dmd.globals;
 import dmd.id;
@@ -1276,7 +1277,7 @@ public:
             return;
 
         if (global.params.verbose && (eresult || sresult))
-            fprintf(global.stdmsg, "inlined   %s =>\n          %s\n", fd.toPrettyChars(), parent.toPrettyChars());
+            message("inlined   %s =>\n          %s", fd.toPrettyChars(), parent.toPrettyChars());
 
         if (eresult && e.type.ty != Tvoid)
         {
@@ -1706,7 +1707,7 @@ public void inlineScanModule(Module m)
     {
         Dsymbol s = (*m.members)[i];
         //if (global.params.verbose)
-        //    fprintf(global.stdmsg, "inline scan symbol %s\n", s.toChars());
+        //    message("inline scan symbol %s", s.toChars());
         scope InlineScanVisitor v = new InlineScanVisitor();
         s.accept(v);
     }

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -24,6 +24,7 @@ import dmd.dimport;
 import dmd.dmodule;
 import dmd.dsymbol;
 import dmd.dtemplate;
+import dmd.errors;
 import dmd.expression;
 import dmd.func;
 import dmd.globals;
@@ -799,7 +800,7 @@ extern (C++) void json_generate(OutBuffer* buf, Modules* modules)
     {
         Module m = (*modules)[i];
         if (global.params.verbose)
-            fprintf(global.stdmsg, "json gen %s\n", m.toChars());
+            message("json gen %s", m.toChars());
         m.accept(json);
     }
     json.arrayEnd();

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -103,7 +103,7 @@ class Library
     final void write()
     {
         if (global.params.verbose)
-            fprintf(global.stdmsg, "library   %s\n", loc.filename);
+            message("library   %s", loc.filename);
 
         OutBuffer libbuf;
         WriteLibToBuffer(&libbuf);

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -670,9 +670,13 @@ public int runLINK()
         if (global.params.verbose)
         {
             // Print it
+            OutBuffer buf;
             for (size_t i = 0; i < argv.dim; i++)
-                fprintf(global.stdmsg, "%s ", argv[i]);
-            fprintf(global.stdmsg, "\n");
+            {
+                buf.writestring(argv[i]);
+                buf.writeByte(' ');
+            }
+            message(buf.peekString());
         }
         argv.push(null);
         // set up pipes
@@ -745,7 +749,7 @@ version (Windows)
         int status;
         size_t len;
         if (global.params.verbose)
-            fprintf(global.stdmsg, "%s %s\n", cmd, args);
+            message("%s %s", cmd, args);
         if (!global.params.mscoff)
         {
             if ((len = strlen(args)) > 255)
@@ -807,8 +811,6 @@ version (Windows)
                 status = spawnlp(0, cmd, cmd, args, null);
             }
         }
-        //if (global.params.verbose)
-        //    fprintf(global.stdmsg, "\n");
         if (status)
         {
             if (status == -1)
@@ -853,10 +855,14 @@ public int runProgram()
     //printf("runProgram()\n");
     if (global.params.verbose)
     {
-        fprintf(global.stdmsg, "%s", global.params.exefile);
+        OutBuffer buf;
+        buf.writestring(global.params.exefile);
         for (size_t i = 0; i < global.params.runargs.dim; ++i)
-            fprintf(global.stdmsg, " %s", global.params.runargs[i]);
-        fprintf(global.stdmsg, "\n");
+        {
+            buf.writeByte(' ');
+            buf.writestring(global.params.runargs[i]);
+        }
+        message(buf.peekString());
     }
     // Build argv[]
     Strings argv;

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -483,9 +483,9 @@ private int tryMain(size_t argc, const(char)** argv)
 
     if (global.params.verbose)
     {
-        fprintf(global.stdmsg, "binary    %s\n", global.params.argv0);
-        fprintf(global.stdmsg, "version   %s\n", global._version);
-        fprintf(global.stdmsg, "config    %s\n", global.inifilename ? global.inifilename : "(none)");
+        message("binary    %s", global.params.argv0);
+        message("version   %s", global._version);
+        message("config    %s", global.inifilename ? global.inifilename : "(none)");
     }
     //printf("%d source files\n",files.dim);
 
@@ -677,7 +677,7 @@ private int tryMain(size_t argc, const(char)** argv)
     {
         Module m = modules[modi];
         if (global.params.verbose)
-            fprintf(global.stdmsg, "parse     %s\n", m.toChars());
+            message("parse     %s", m.toChars());
         if (!Module.rootModule)
             Module.rootModule = m;
         m.importedFrom = m; // m.isRoot() == true
@@ -734,7 +734,7 @@ private int tryMain(size_t argc, const(char)** argv)
         foreach (m; modules)
         {
             if (global.params.verbose)
-                fprintf(global.stdmsg, "import    %s\n", m.toChars());
+                message("import    %s", m.toChars());
             genhdrfile(m);
         }
     }
@@ -745,7 +745,7 @@ private int tryMain(size_t argc, const(char)** argv)
     foreach (m; modules)
     {
         if (global.params.verbose)
-            fprintf(global.stdmsg, "importall %s\n", m.toChars());
+            message("importall %s", m.toChars());
         m.importAll(null);
     }
     if (global.errors)
@@ -757,7 +757,7 @@ private int tryMain(size_t argc, const(char)** argv)
     foreach (m; modules)
     {
         if (global.params.verbose)
-            fprintf(global.stdmsg, "semantic  %s\n", m.toChars());
+            message("semantic  %s", m.toChars());
         m.dsymbolSemantic(null);
     }
     //if (global.errors)
@@ -778,7 +778,7 @@ private int tryMain(size_t argc, const(char)** argv)
     foreach (m; modules)
     {
         if (global.params.verbose)
-            fprintf(global.stdmsg, "semantic2 %s\n", m.toChars());
+            message("semantic2 %s", m.toChars());
         m.semantic2(null);
     }
     Module.runDeferredSemantic2();
@@ -789,7 +789,7 @@ private int tryMain(size_t argc, const(char)** argv)
     foreach (m; modules)
     {
         if (global.params.verbose)
-            fprintf(global.stdmsg, "semantic3 %s\n", m.toChars());
+            message("semantic3 %s", m.toChars());
         m.semantic3(null);
     }
     if (includeImports)
@@ -801,7 +801,7 @@ private int tryMain(size_t argc, const(char)** argv)
             auto m = compiledImports[i];
             assert(m.isRoot);
             if (global.params.verbose)
-                fprintf(global.stdmsg, "semantic3 %s\n", m.toChars());
+                message("semantic3 %s", m.toChars());
             m.semantic3(null);
             modules.push(m);
         }
@@ -816,7 +816,7 @@ private int tryMain(size_t argc, const(char)** argv)
         foreach (m; modules)
         {
             if (global.params.verbose)
-                fprintf(global.stdmsg, "inline scan %s\n", m.toChars());
+                message("inline scan %s", m.toChars());
             inlineScanModule(m);
         }
     }
@@ -935,7 +935,7 @@ private int tryMain(size_t argc, const(char)** argv)
         foreach (m; modules)
         {
             if (global.params.verbose)
-                fprintf(global.stdmsg, "code      %s\n", m.toChars());
+                message("code      %s", m.toChars());
             genObjFile(m, false);
             if (entrypoint && m == rootHasMain)
                 genObjFile(entrypoint, false);
@@ -950,7 +950,7 @@ private int tryMain(size_t argc, const(char)** argv)
         foreach (m; modules)
         {
             if (global.params.verbose)
-                fprintf(global.stdmsg, "code      %s\n", m.toChars());
+                message("code      %s", m.toChars());
             obj_start(cast(char*)m.srcfile.toChars());
             genObjFile(m, global.params.multiobj);
             if (entrypoint && m == rootHasMain)
@@ -1356,11 +1356,13 @@ private void printPredefinedVersions()
 {
     if (global.params.verbose && global.versionids)
     {
-        fprintf(global.stdmsg, "predefs  ");
+        OutBuffer buf;
         foreach (const str; *global.versionids)
-            fprintf(global.stdmsg, " %s", str.toChars);
-
-        fprintf(global.stdmsg, "\n");
+        {
+            buf.writeByte(' ');
+            buf.writestring(str.toChars());
+        }
+        message("predefs  %s", buf.peekString());
     }
 }
 
@@ -2196,7 +2198,7 @@ private extern(C++) bool marsOnImport(Module m)
             (m.md && m.md.packages) ? m.md.packages : &empty, m.ident, m.isPackageFile)))
         {
             if (global.params.verbose)
-                fprintf(global.stdmsg, "compileimport (%s)\n", m.srcfile.toChars);
+                message("compileimport (%s)", m.srcfile.toChars);
             compiledImports.push(m);
             return true; // this import will be compiled
         }
@@ -2341,7 +2343,7 @@ private void createMatchNodes()
             // changes the default behavior from inclusion to exclusion.
             if (includeByDefault && !matchNodes[entryIndex].isExclude)
             {
-                //fprintf(global.stdmsg, "Matcher: found 'include pattern', switching default behavior to exclusion\n");
+                //printf("Matcher: found 'include pattern', switching default behavior to exclusion\n");
                 includeByDefault = false;
             }
         }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1817,12 +1817,7 @@ version (none)
 {
                     if (global.params.vsafe)
                     {
-                        fprintf(
-                            global.stdmsg,
-                            "%s: To enforce `@safe`, the compiler allocates a closure unless `opApply()` uses `scope`\n",
-                            loc.toChars()
-                        );
-                        fflush(global.stdmsg);
+                        message("%s: To enforce `@safe`, the compiler allocates a closure unless `opApply()` uses `scope`", loc.toChars());
                     }
                     fld.tookAddressOf = 1;
 }
@@ -2247,7 +2242,7 @@ else
 
                     if (global.params.verbose)
                     {
-                        fprintf(global.stdmsg, "library   %.*s\n", cast(int)se.len, se.string);
+                        message("library   %.*s", cast(int)se.len, se.string);
                     }
                 }
             }

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -206,7 +206,7 @@ Symbol *toSymbol(Dsymbol s)
                     if (global.params.vtls)
                     {
                         const(char)* p = vd.loc.toChars();
-                        fprintf(global.stdmsg, "%s: %s is thread local\n", p ? p : "", vd.toChars());
+                        message("%s: %s is thread local", p ? p : "", vd.toChars());
                         if (p)
                             mem.xfree(cast(void*)p);
                     }


### PR DESCRIPTION
Although I have a funny deja vu feeling here that I've tried to do this before in a former PR.

Removes the `stdmsg` field from `Global` as where you want to send verbose messages is encapsulated in `vmessage()`.

The name of the actual functions are up for debate if you have a better name.

Alternatives could be `verbose()` or `verbatim()`.