### PR TITLE
Remove deprecated -dylib CLI flag

### DIFF
--- a/changelog/deprecation-dylib.dd
+++ b/changelog/deprecation-dylib.dd
@@ -1,0 +1,9 @@
+The deprecation period of the `-dylib` flag on OSX has ended. Use `-shared`
+
+The deprecation period of the `-dylib` flag on OSX has ended.
+
+$(CONSOLE dmd -dylib awesome_d_library.d)
+
+Use the `-shared` flag to generate a shared library:
+
+$(CONSOLE dmd -shared awesome_d_library.d)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1545,19 +1545,6 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             }
             else if (arg == "-shared")
                 params.dll = true;
-            else if (arg == "-dylib")
-            {
-                static if (TARGET.OSX)
-                {
-                    Loc loc;
-                    deprecation(loc, "use -shared instead of -dylib");
-                    params.dll = true;
-                }
-                else
-                {
-                    goto Lerror;
-                }
-            }
             else if (arg == "-fPIC")
             {
                 static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)


### PR DESCRIPTION
They aren't documented either.

Requires:
- [ ] https://github.com/dlang/dub/pull/1361
- [x] https://github.com/dlang-community/D-YAML/pull/87