### PR TITLE
End deprecation phase of read-modify-write on shared variables.

### DIFF
--- a/changelog/rwm-shared-error.dd
+++ b/changelog/rwm-shared-error.dd
@@ -1,0 +1,16 @@
+The deprecation for read-modify-write operations on `shared` variables has ended
+
+Read-modify-write operations are not allowed for `shared` variables:
+
+---
+shared int i;
+i++; // Error: read-modify-write operations are not allowed for shared variables
+---
+
+Use $(REF core, atomic, atomicOp) instead:
+
+---
+import core.atomic : atomicOp;
+shared int i;
+atomicOp!"+="(i, 1);
+---

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2369,11 +2369,9 @@ extern (C++) abstract class Expression : RootObject
             break;
         }
 
-        deprecation("read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!\"%s\"(%s, %s)` instead.", Token.toChars(rmwOp), toChars(), ex ? ex.toChars() : "1");
-        return false;
+        error("read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!\"%s\"(%s, %s)` instead.", Token.toChars(rmwOp), toChars(), ex ? ex.toChars() : "1");
 
-        // note: enable when deprecation becomes an error.
-        // return true;
+         return true;
     }
 
     /***************************************

--- a/test/fail_compilation/diag3672.d
+++ b/test/fail_compilation/diag3672.d
@@ -3,27 +3,27 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3672.d(36): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
-fail_compilation/diag3672.d(37): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
-fail_compilation/diag3672.d(38): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 1)` instead.
-fail_compilation/diag3672.d(39): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 1)` instead.
-fail_compilation/diag3672.d(40): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
-fail_compilation/diag3672.d(41): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 2)` instead.
-fail_compilation/diag3672.d(42): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 3)` instead.
-fail_compilation/diag3672.d(43): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"|="(x, y)` instead.
-fail_compilation/diag3672.d(44): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"*="(x, y)` instead.
-fail_compilation/diag3672.d(45): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"/="(x, y)` instead.
-fail_compilation/diag3672.d(46): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"%="(x, y)` instead.
-fail_compilation/diag3672.d(47): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"&="(x, y)` instead.
-fail_compilation/diag3672.d(48): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"^="(x, y)` instead.
-fail_compilation/diag3672.d(49): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"<<="(x, y)` instead.
-fail_compilation/diag3672.d(50): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!">>="(x, y)` instead.
-fail_compilation/diag3672.d(51): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!">>>="(x, y)` instead.
-fail_compilation/diag3672.d(52): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"^^="(x, y)` instead.
-fail_compilation/diag3672.d(53): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ptr, 1)` instead.
-fail_compilation/diag3672.d(54): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ptr, 1)` instead.
-fail_compilation/diag3672.d(55): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(ptr, 1)` instead.
-fail_compilation/diag3672.d(56): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(ptr, 1)` instead.
+fail_compilation/diag3672.d(36): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
+fail_compilation/diag3672.d(37): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
+fail_compilation/diag3672.d(38): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 1)` instead.
+fail_compilation/diag3672.d(39): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 1)` instead.
+fail_compilation/diag3672.d(40): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 1)` instead.
+fail_compilation/diag3672.d(41): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(x, 2)` instead.
+fail_compilation/diag3672.d(42): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(x, 3)` instead.
+fail_compilation/diag3672.d(43): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"|="(x, y)` instead.
+fail_compilation/diag3672.d(44): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"*="(x, y)` instead.
+fail_compilation/diag3672.d(45): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"/="(x, y)` instead.
+fail_compilation/diag3672.d(46): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"%="(x, y)` instead.
+fail_compilation/diag3672.d(47): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"&="(x, y)` instead.
+fail_compilation/diag3672.d(48): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"^="(x, y)` instead.
+fail_compilation/diag3672.d(49): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"<<="(x, y)` instead.
+fail_compilation/diag3672.d(50): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!">>="(x, y)` instead.
+fail_compilation/diag3672.d(51): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!">>>="(x, y)` instead.
+fail_compilation/diag3672.d(52): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"^^="(x, y)` instead.
+fail_compilation/diag3672.d(53): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ptr, 1)` instead.
+fail_compilation/diag3672.d(54): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ptr, 1)` instead.
+fail_compilation/diag3672.d(55): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(ptr, 1)` instead.
+fail_compilation/diag3672.d(56): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(ptr, 1)` instead.
 ---
 */
 shared int x;

--- a/test/fail_compilation/diag3672a.d
+++ b/test/fail_compilation/diag3672a.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3672a.d(16): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ns.x, 1)` instead.
-fail_compilation/diag3672a.d(18): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(s.sx, 1)` instead.
+fail_compilation/diag3672a.d(16): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(ns.x, 1)` instead.
+fail_compilation/diag3672a.d(18): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(s.sx, 1)` instead.
 ---
 */
 class NS { shared int x; }
@@ -21,8 +21,8 @@ void main()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3672a.d(32): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(s.var, 1)` instead.
-fail_compilation/diag3672a.d(33): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(s.var, 2)` instead.
+fail_compilation/diag3672a.d(32): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(s.var, 1)` instead.
+fail_compilation/diag3672a.d(33): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"-="(s.var, 2)` instead.
 ---
 */
 void test13003()

--- a/test/fail_compilation/fail3672.d
+++ b/test/fail_compilation/fail3672.d
@@ -1,9 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail3672.d(28): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(*p, 1)` instead.
-fail_compilation/fail3672.d(32): Deprecation: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(*sfp, 1)` instead.
-fail_compilation/fail3672.d(32): Error: `*sfp += 1` is not a scalar, it is a `shared(SF)`
+fail_compilation/fail3672.d(27): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(*p, 1)` instead.
+fail_compilation/fail3672.d(31): Error: read-modify-write operations are not allowed for `shared` variables. Use `core.atomic.atomicOp!"+="(*sfp, 1)` instead.
 ---
 */
 


### PR DESCRIPTION
This has been added four years ago - https://github.com/dlang/dmd/commit/7535f3dc86e9e88c4ee609dd98b5305224c3b88a.
There really needs to be a better concept for deprecations.

(This has never been added to the deprecation page.)

Requires

- [x] https://github.com/dlang/druntime/pull/2072 
- [x] https://github.com/vibe-d/vibe.d/pull/2060
- [x] https://github.com/dlang/druntime/pull/2076