### PR TITLE
End deprecation phase for `switch` cases which skip the declaration of a variable

### DIFF
--- a/changelog/switch-skip-declaration.dd
+++ b/changelog/switch-skip-declaration.dd
@@ -1,0 +1,39 @@
+The deprecation for `switch` cases which skip the declaration of a variable has ended
+
+Usage of a variable which is declared in another `switch` case now results in an error.
+
+---
+int i = 2;
+switch (i)
+{
+    case 1:
+    {
+        int j;
+    case 2:
+        j++;
+        j.writeln; // BUG: j is not initialized and e.g. prints -321532879
+        break;
+    }
+    default:
+        break;
+}
+---
+
+If this behavior is wanted, it can explicitly requested by using `void` initialization:
+
+---
+int i = 2;
+switch (i)
+{
+    case 1:
+    {
+        int j = void;
+    case 2:
+        j = 2;
+        j.writeln;
+        break;
+    }
+    default:
+        break;
+}
+---

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1617,13 +1617,13 @@ extern (C++) final class SwitchStatement : Statement
             }
             else if (vd.ident == Id.withSym)
             {
-                deprecation("`switch` skips declaration of `with` temporary at %s", vd.loc.toChars());
+                error("`switch` skips declaration of `with` temporary at %s", vd.loc.toChars());
                 return true;
             }
             else
             {
                 if (!vd._init.isVoidInitializer)
-                    deprecation("`switch` skips declaration of variable `%s` at %s", vd.toPrettyChars(), vd.loc.toChars());
+                error("`switch` skips declaration of variable `%s` at %s", vd.toPrettyChars(), vd.loc.toChars());
 
                 return true;
             }

--- a/test/fail_compilation/skip.d
+++ b/test/fail_compilation/skip.d
@@ -2,8 +2,8 @@
  * REQUIRED_ARGS: -de
  * TEST_OUTPUT:
 ---
-fail_compilation/skip.d(21): Deprecation: `switch` skips declaration of `with` temporary at fail_compilation/skip.d(26)
-fail_compilation/skip.d(43): Deprecation: `switch` skips declaration of variable `skip.test14532.n` at fail_compilation/skip.d(45)
+fail_compilation/skip.d(21): Error: `switch` skips declaration of `with` temporary at fail_compilation/skip.d(26)
+fail_compilation/skip.d(43): Error: `switch` skips declaration of variable `skip.test14532.n` at fail_compilation/skip.d(45)
 ---
  */
 // https://issues.dlang.org/show_bug.cgi?id=10524

--- a/test/fail_compilation/switches.d
+++ b/test/fail_compilation/switches.d
@@ -50,7 +50,7 @@ void test2(int i)
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/switches.d(302): Deprecation: `switch` skips declaration of variable `switches.test3.j` at fail_compilation/switches.d(306)
+fail_compilation/switches.d(302): Error: `switch` skips declaration of variable `switches.test3.j` at fail_compilation/switches.d(306)
 ---
 */
 


### PR DESCRIPTION
This never made it to the deprecation page.

- [x] https://github.com/dlang/dmd/pull/7842