### PR TITLE
Experiment with using only two CircleCi images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/dmd
     docker:
       - image: circleci/node:4.8.2
-    parallelism: 2
+    parallelism: 1
     steps:
       - checkout
       - run:

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -23,10 +23,7 @@ case "${CIRCLE_STAGE}" in
         ;;
     no_pic)
         PIC=0
-        case $CIRCLE_NODE_INDEX in
-            0) MODEL=64 ;;
-            1) MODEL=32 ;;
-        esac
+        MODEL=32
 esac
 
 # clone druntime and phobos


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dmd/pull/7420

In https://github.com/dlang/dmd/pull/7420 we added the `-fPIC` run as a new image
as CodeCov was heavily complaining, this simply tests whether this is still the case.

In other words: this PR removes the no-pie x86_64 CircleCi image as in theory x86_32 + x86_64 in pie should cover almost everything that is covered by the three of them.