### PR TITLE
Revert "Experiment with using only two CircleCi images"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/dmd
     docker:
       - image: circleci/node:4.8.2
-    parallelism: 1
+    parallelism: 2
     steps:
       - checkout
       - run:

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -23,7 +23,10 @@ case "${CIRCLE_STAGE}" in
         ;;
     no_pic)
         PIC=0
-        MODEL=32
+        case $CIRCLE_NODE_INDEX in
+            0) MODEL=64 ;;
+            1) MODEL=32 ;;
+        esac
 esac
 
 # clone druntime and phobos


### PR DESCRIPTION
Reverts dlang/dmd#7818 - unfortunately I hit the bed before seeing the result here:

![image](https://user-images.githubusercontent.com/4370550/35613450-64ab90f8-066c-11e8-8bfb-67542c06892d.png)

https://codecov.io/gh/dlang/dmd/compare/7fa030612d7dcb84645cc389714b0268363327eb...2a2444f2d3f2e73e7bf2ed25187566d43e2442e8

![image](https://user-images.githubusercontent.com/4370550/35613747-35e24cc0-066d-11e8-8aa5-b23824e3defe.png)


So it doesn't look good. I should have marked this more as experimental and WIP. Sorry.

(We recently https://github.com/dlang/dmd/pull/7711 disabled the display of the overall project coverage change as it (1) the backend has too much global state (i.e. random coverage state) too be informative and (2) it's not relevant to reviewers typically when they look at the diff. The important bit is that the diff is covered and the overall coverage changes are only in a few exceptions (like this one) interesting to look at, but then can be easily accessed by simply clicking on the CodeCov "Details" link in the CI status overview.)