### PR TITLE
-color=on should overwrite the default detection

### DIFF
--- a/changelog/color-auto.dd
+++ b/changelog/color-auto.dd
@@ -1,0 +1,21 @@
+`-color` and `-color=on` will now always output colorized console output
+
+Before this release `-color` wouldn't output colorized console output if
+the terminal detection failed.
+With this release, a new option `auto` is introduced for `-color=<value>`
+which will continue to be the default:
+
+$(UL
+    $(LI `auto`: enable colorized output if a tty is detected (default))
+    $(LI `on`: always use colored output.)
+    $(LI `off`: never use colored output.)
+)
+
+Hence, it is now possible to use `-color` (a shortcut for `-color=on`) to
+force DMD to emit colorized console output.
+For example, this will now use colorized console output:
+
+$(CONSOLE
+> echo $(DOLLAR)(echo "test" | dmd -color - 2>&1)
+__stdin.d(2): $(RED Error): no identifier for declarator $(B test)
+)

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -172,11 +172,12 @@ struct Usage
         Option("color",
             "turn colored console output on"
         ),
-        Option("color=[on|off]",
+        Option("color=[auto|on|off]",
             "force colored console output on or off",
             `Show colored console output. The default depends on terminal capabilities.
             $(UL
-                $(LI $(B on): always use colored output. Same as $(B -color))
+                $(LI $(B auto): use colored output if a tty is detected)
+                $(LI $(B on): always use colored output.)
                 $(LI $(B off): never use colored output.)
             )`
         ),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -134,7 +134,7 @@ struct Param
     // 2: informational warnings (no errors)
     byte warnings;
     bool pic;               // generate position-independent-code for shared libs
-    bool color = true;      // use ANSI colors in console output
+    bool color;             // use ANSI colors in console output
     bool cov;               // generate code coverage data
     ubyte covPercent;       // 0..100 code coverage percentage required
     bool nofloat;           // code should not pull in floating point support
@@ -360,6 +360,11 @@ struct Global
         }
         _version = (import("VERSION") ~ '\0').ptr;
         compiler.vendor = "Digital Mars D";
+
+        // -color=auto is the default value
+        import dmd.console : Console;
+        if (Console.detectTerminal())
+            params.color = true;
     }
 
     /**

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1573,19 +1573,22 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 params.link = false;
             else if (startsWith(p + 1, "color")) // https://dlang.org/dmd.html#switch-color
             {
-                params.color = true;
                 // Parse:
                 //      -color
                 //      -color=on|off
                 if (p[6] == '=')
                 {
-                    if (strcmp(p + 7, "off") == 0)
+                    if (strcmp(p + 7, "on") == 0)
+                        params.color = true;
+                    else if (strcmp(p + 7, "off") == 0)
                         params.color = false;
-                    else if (strcmp(p + 7, "on") != 0)
+                    else if (strcmp(p + 7, "auto") != 0)
                         goto Lerror;
                 }
                 else if (p[6])
                     goto Lerror;
+                else
+                    params.color = true;
             }
             else if (startsWith(p + 1, "conf=")) // https://dlang.org/dmd.html#switch-conf
             {

--- a/test/compilable/testcolor.sh
+++ b/test/compilable/testcolor.sh
@@ -1,0 +1,43 @@
+compare()
+{
+    local actual expected
+    actual="$1"
+    expected="$2"
+    if [ "$actual" != "$expected" ] ; then
+        echo "Expected: $expected"
+        echo "Actual:   $actual"
+        echo "$expected" | hexdump -C
+        echo "$actual" | hexdump -C
+        exit 1
+    fi
+}
+
+filterAnsi()
+{
+    cat | sed "s/$(printf "\x1b")\(\[[0-9;]*m\)/[\1/g" | sed "s/\[\[/[/g" | sed "s/m\[m/m/g" | tr -d "\n" | tr -d "\r"
+}
+
+check()
+{
+    local actual expected
+    # try to emulate the `strings` command
+    # sed on some OSes doesn't support direct hex byte in its input string
+    actual=$(echo "$2" | ("$DMD" -c -o- "$1" - 2>&1 || true) | filterAnsi)
+    compare "$actual" "$3"
+}
+
+expectedWithoutColor='__stdin.d(2): Error: no identifier for declarator `test`'
+expectedWithColor="[1m__stdin.d(2): [1;31mError: [mno identifier for declarator [0;36m[1mtest[0;36m"
+
+check -c "test" "$expectedWithoutColor"
+check -color=auto "test" "$expectedWithoutColor"
+check -color=on "test" "$expectedWithColor"
+
+# Faking a TTY only works on Linux
+#if [ "$OS" == "linux" ] ; then
+    export SHELL="bash"
+    script -q --return -c "echo test | $DMD -c -o- -"
+    script -q --return -c "$DMD -c -o- foo.d"
+    actual="$(! script -q --return -c "echo test | $DMD -c -o- -" /dev/null | filterAnsi)"
+    compare "$actual" "$expectedWithColor"
+#fi


### PR DESCRIPTION
Imho if I as a user tell DMD that it should do colorized output, I expect it to obey my command.
This would avoid the faketty hack in https://github.com/dlang/dmd/pull/7822 and run.dlang.io (https://github.com/dlang-tour/core-exec/blob/master/entrypoint.sh)