### PR TITLE
Don't require object.d for -lib if code does not utilize runtime features

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -634,9 +634,11 @@ extern (C++) final class Module : Package
         {
             if (!strcmp(srcfile.toChars(), "object.d"))
             {
-                .error(loc, "cannot find source code for runtime library file 'object.d'");
-                errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-                errorSupplemental(loc, "config file: %s", FileName.canonicalName(global.inifilename));
+                // object.d is automatically imported.  If object.d doesn't exist, it's not necessarily an error.
+                // For example, the user could be creating a library in D that is intened to be called from
+                // another language and, therefore, does not wish to use features of the D runtime.  We
+                // return `false` here and rely on future semantic processing to catch any errors.
+                return false;
             }
             else
             {

--- a/test/compilable/minimal_lib.d
+++ b/test/compilable/minimal_lib.d
@@ -1,0 +1,11 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -conf= -lib
+
+// This test ensures that a library created in D that does not rely on any
+// runtime features can be compiled without object.d.  The `-conf=` compiler
+// flag ensures the default object.d is not in the import path.
+
+extern(C) int add(int a, int b)
+{
+    return a + b;
+}


### PR DESCRIPTION
This is a followup to the following PRs

 * #7395 and #7768 for `ModuleInfo`
 * #7786 for `Throwable`
 * #7799 for `TypeInfo`

Currently, if one wants to create a library in D, that doesn't utilize any runtime features, and use said library from another language, they will need to create an empty `object.d` file to get a build.  

This PR removes that limitation, so users will only need the .d source files relevant to their library to get a build.
