### PR TITLE
[trivial] Remove unnecessary nop's from testcase.

### DIFF
--- a/test/fail_compilation/fail12635.d
+++ b/test/fail_compilation/fail12635.d
@@ -1,21 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12635.d(19): Error: Cannot generate a segment prefix for a branching instruction
+fail_compilation/fail12635.d(13): Error: Cannot generate a segment prefix for a branching instruction
 ---
 */
 
 void foo()
 {
-    enum NOP = 0x9090_9090_9090_9090;
-
     asm
     {
     L1:
-        dq NOP,NOP,NOP,NOP;    //  32
-        dq NOP,NOP,NOP,NOP;    //  64
-        dq NOP,NOP,NOP,NOP;    //  96
-        dq NOP,NOP,NOP,NOP;    // 128
         jmp DS:L1;
     }
 }


### PR DESCRIPTION
LDC does not support data definition directives in inline assembly (https://github.com/ldc-developers/ldc/pull/2550), making this test fail.
Removing the NOP's does no harm here and focusses the testcase on what it is meant to test.
https://github.com/dlang/dmd/pull/3483#issuecomment-362105971