### PR TITLE
fix issue 18352 - [REG 2.078] dmd can't generate 64-bit binaries on Windows

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1046,7 +1046,7 @@ version (Windows)
             if (WindowsSdkDir is null)
             {
                 WindowsSdkDir = GetRegistryString(r"Microsoft\Windows Kits\Installed Roots", "KitsRoot10");
-                if (WindowsSdkDir && !FileName.exists(FileName.combine(WindowsSdkDir, "Lib")))
+                if (WindowsSdkDir && !findLatestSDKDir(FileName.combine(WindowsSdkDir, "Include"), r"um\windows.h"))
                     WindowsSdkDir = null;
             }
             if (WindowsSdkDir is null)


### PR DESCRIPTION
… 10 with VS 2015

checking the KitsRoot10 lib folder is not good enough to detect the SDK, it might just contain the UCRT. Mimick vcvarsall.bat and verify that windows.h exists aswell.