### PR TITLE
fix issue 18354 - [Reg 2.078] Building fails with VC 2015 Build Tools

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -960,21 +960,23 @@ version (Windows)
         const(char)* linkOptions(bool x64)
         {
             OutBuffer cmdbuf;
-            if (auto p = getVCDir(VCDir.Lib, x64))
+            if (auto vclibdir = getVCDir(VCDir.Lib, x64))
             {
                 cmdbuf.writestring(" /LIBPATH:\"");
-                cmdbuf.writestring(p);
+                cmdbuf.writestring(vclibdir);
                 cmdbuf.writeByte('\"');
-            }
-            if (VisualStudioVersion && strcmp(VisualStudioVersion, "14") >= 0)
-            {
-                if (auto p = getUCRTLibPath(x64))
+
+                if (FileName.exists(FileName.combine(vclibdir, "legacy_stdio_definitions.lib")))
                 {
-                    cmdbuf.writestring(" /LIBPATH:\"");
-                    cmdbuf.writestring(p);
-                    cmdbuf.writeByte('\"');
+                    // VS2015 or later use UCRT
+                    cmdbuf.writestring(" legacy_stdio_definitions.lib");
+                    if (auto p = getUCRTLibPath(x64))
+                    {
+                        cmdbuf.writestring(" /LIBPATH:\"");
+                        cmdbuf.writestring(p);
+                        cmdbuf.writeByte('\"');
+                    }
                 }
-                cmdbuf.writestring(" legacy_stdio_definitions.lib");
             }
             const(char)* windowssdkdir = getenv("WindowsSdkDir");
             if (auto p = getSDKLibPath(x64))


### PR DESCRIPTION
replace VS version check with check for existence of legacy_stdio_definitions.lib

cherry-picked from https://github.com/dlang/dmd/pull/7500