### PR TITLE
allow default valued parameters after template variadics

### DIFF
--- a/changelog/default_after_variadic.dd
+++ b/changelog/default_after_variadic.dd
@@ -1,4 +1,4 @@
-Function parameters with default values are now allowed after variadic template parameters, and always take their default values. This allows using special tokens (eg __FILE__) after variadic parameters, which was previously impossible
+Function parameters with default values are now allowed after variadic template parameters, and when IFTI is used, always take their default values. This allows using special tokens (eg __FILE__) after variadic parameters, which was previously impossible. See also test/runnable/testdefault_after_variadic.d
 
 Eg:
 ---

--- a/changelog/default_after_variadic.dd
+++ b/changelog/default_after_variadic.dd
@@ -1,0 +1,17 @@
+Function parameters with default values are now allowed after variadic template parameters, and always take their default values. This allows using special tokens (eg __FILE__) after variadic parameters, which was previously impossible
+
+Eg:
+---
+string log(T...)(T a, string file = __FILE__, int line = __LINE__)
+{
+  return text(file, ":", line, " ", a);
+}
+
+assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
+---
+
+This should be preferred to the previous workaround, which caused template bloat:
+---
+string log(string file = __FILE__, int line = __LINE__, T...)(T a);
+---
+

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1349,7 +1349,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         for (size_t j = parami + 1; j < nfparams; j++)
                         {
                             Parameter p = Parameter.getNth(fparameters, j);
-                            if(p.defaultArg)
+                            if (p.defaultArg)
                             {
                                break;
                             }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1342,13 +1342,17 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         declaredTuple = new Tuple();
                         (*dedargs)[parameters.dim - 1] = declaredTuple;
 
-                        /* Count function parameters following a tuple parameter.
-                         * void foo(U, T...)(int y, T, U, int) {}  // rem == 2 (U, int)
+                        /* Count function parameters with no defaults following a tuple parameter.
+                         * void foo(U, T...)(int y, T, U, double, int bar = 0) {}  // rem == 2 (U, double)
                          */
                         size_t rem = 0;
                         for (size_t j = parami + 1; j < nfparams; j++)
                         {
                             Parameter p = Parameter.getNth(fparameters, j);
+                            if(p.defaultArg)
+                            {
+                               break;
+                            }
                             if (!reliesOnTident(p.type, parameters, inferStart))
                             {
                                 Type pt = p.type.syntaxCopy().typeSemantic(fd.loc, paramscope);

--- a/test/runnable/testdefault_after_variadic.d
+++ b/test/runnable/testdefault_after_variadic.d
@@ -33,7 +33,6 @@ void fun2(U, V, T...)(U gold, V gold2, T a, string file = __FILE__, int line = _
     assert(tuple(file, line) == gold2);
 }
 
-// 
 void fun3(int[] gold, int[] a...)
 {
     assert(gold == a);
@@ -45,16 +44,6 @@ void fun4(T...)(size_t length_gold, int b_gold, T a, int b = 1)
     assert(b == b_gold);
 }
 
-/+
-NOTE: this is disallowed by the parser:
-
-void fun4(int[] gold, int[] a ..., int b = 1)
-{
-    assert(gold==a);
-    assert(b==1);
-}
-+/
-
 // Example in changelog
 string log(T...)(T a, string file = __FILE__, int line = __LINE__)
 {
@@ -64,6 +53,15 @@ string log(T...)(T a, string file = __FILE__, int line = __LINE__)
 void fun_constraint(T...)(T a, string b = "bar") if (T.length == 1)
 {
 }
+
+/+
+NOTE: this is disallowed by the parser:
+void fun5(int[] gold, int[] a ..., int b = 1)
+{
+    assert(gold==a);
+    assert(b==1);
+}
++/
 
 void main()
 {
@@ -76,7 +74,6 @@ void main()
     fun2(tuple(10), tuple(__FILE__, __LINE__), 10);
 
     fun3([1, 2, 3], 1, 2, 3);
-    // fun4([1,2,3], 1,2,3);
 
     fun_constraint(1);
     assert(!__traits(compiles, fun_constraint(1, "baz")));
@@ -96,4 +93,6 @@ void main()
     // with explicit instantiation, and over-ridden `b`
     fun4!int(1, 100, 10, 100);
     fun4!(int, int)(2, 100, 10, 11, 100);
+
+    // fun5([1,2,3], 1,2,3);
 }

--- a/test/runnable/testdefault_after_variadic.d
+++ b/test/runnable/testdefault_after_variadic.d
@@ -45,7 +45,7 @@ string log(T...)(T a, string file = __FILE__, int line = __LINE__)
     return text(file, ":", line, " ", a);
 }
 
-void foo_error(T...)(T a, string b = "bar") if (T.length == 1)
+void fun_constraint(T...)(T a, string b = "bar") if (T.length == 1)
 {
 }
 
@@ -64,6 +64,6 @@ void main()
 
     assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
 
-    // these should not compile, by design
-    assert(!__traits(compiles, foo_error(1, "baz")));
+    fun_constraint(1);
+    assert(!__traits(compiles, fun_constraint(1, "baz")));
 }

--- a/test/runnable/testdefault_after_variadic.d
+++ b/test/runnable/testdefault_after_variadic.d
@@ -45,6 +45,10 @@ string log(T...)(T a, string file = __FILE__, int line = __LINE__)
     return text(file, ":", line, " ", a);
 }
 
+void foo_error(T...)(T a, string b = "bar") if (T.length == 1)
+{
+}
+
 void main()
 {
     fun0(tuple(10), 7, 10, 7);
@@ -59,4 +63,7 @@ void main()
     // fun4([1,2,3], 1,2,3);
 
     assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
+
+    // these should not compile, by design
+    assert(!__traits(compiles, foo_error(1, "baz")));
 }

--- a/test/runnable/testdefault_after_variadic.d
+++ b/test/runnable/testdefault_after_variadic.d
@@ -39,6 +39,12 @@ void fun3(int[] gold, int[] a...)
     assert(gold == a);
 }
 
+void fun4(T...)(size_t length_gold, int b_gold, T a, int b = 1)
+{
+    assert(T.length == length_gold);
+    assert(b == b_gold);
+}
+
 /+
 NOTE: this is disallowed by the parser:
 
@@ -77,4 +83,17 @@ void main()
 
     version (with_phobos)
         assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
+
+    // IFTI: `b` is always default-set
+    fun4(0, 1);
+    fun4(1, 1, 10);
+    fun4(2, 1, 10, 11);
+
+    // with explicit instantiation, and default-set `b`
+    fun4!int(1, 1, 10);
+    fun4!(int, int)(2, 1, 10, 11);
+
+    // with explicit instantiation, and over-ridden `b`
+    fun4!int(1, 100, 10, 100);
+    fun4!(int, int)(2, 100, 10, 11, 100);
 }

--- a/test/runnable/testdefault_after_variadic.d
+++ b/test/runnable/testdefault_after_variadic.d
@@ -1,0 +1,62 @@
+/*
+PERMUTE_ARGS:
+*/
+
+import std.typecons : tuple;
+import std.conv : text;
+
+void fun0(U, T...)(U gold, int b_gold, T a, int b)
+{
+    assert(tuple(a) == gold);
+    assert(b == b_gold);
+}
+
+void fun(U, T...)(U gold, T a, int b = 1)
+{
+    assert(tuple(a) == gold);
+    assert(b == 1);
+}
+
+void fun2(U, V, T...)(U gold, V gold2, T a, string file = __FILE__, int line = __LINE__)
+{
+    assert(tuple(a) == gold);
+    assert(tuple(file, line) == gold2);
+}
+
+// 
+void fun3(int[] gold, int[] a...)
+{
+    assert(gold == a);
+}
+
+/+
+NOTE: this is disallowed by the parser:
+
+void fun4(int[] gold, int[] a ..., int b = 1)
+{
+    assert(gold==a);
+    assert(b==1);
+}
++/
+
+// Example in changelog
+string log(T...)(T a, string file = __FILE__, int line = __LINE__)
+{
+    return text(file, ":", line, " ", a);
+}
+
+void main()
+{
+    fun0(tuple(10), 7, 10, 7);
+
+    fun(tuple());
+    fun(tuple(10), 10);
+    fun(tuple(10, 11), 10, 11);
+
+    fun2(tuple(10), tuple(__FILE__, __LINE__), 10);
+
+    fun3([1, 2, 3], 1, 2, 3);
+    // fun4([1,2,3], 1,2,3);
+
+    assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
+}

--- a/test/runnable/testdefault_after_variadic.d
+++ b/test/runnable/testdefault_after_variadic.d
@@ -2,8 +2,18 @@
 PERMUTE_ARGS:
 */
 
-import std.typecons : tuple;
-import std.conv : text;
+version (with_phobos) import std.conv : text;
+
+struct Tuple(T...)
+{
+    T expand;
+    alias expand this;
+}
+
+auto tuple(T...)(T t)
+{
+    return Tuple!T(t);
+}
 
 void fun0(U, T...)(U gold, int b_gold, T a, int b)
 {
@@ -62,8 +72,9 @@ void main()
     fun3([1, 2, 3], 1, 2, 3);
     // fun4([1,2,3], 1,2,3);
 
-    assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
-
     fun_constraint(1);
     assert(!__traits(compiles, fun_constraint(1, "baz")));
+
+    version (with_phobos)
+        assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
 }


### PR DESCRIPTION
Function parameters with default values are now allowed after variadic template parameters, and always take their default values. This allows using special tokens (eg __FILE__) after variadic parameters, which was previously impossible.

Eg:
```d
string log(T...)(T a, string file = __FILE__, int line = __LINE__)
{
  return text(file, ":", line, " ", a);
}

assert(log(10, "abc") == text(__FILE__, ":", __LINE__, " 10abc"));
```

This should be preferred to the previous workaround, which caused template bloat:
```d
string log(string file = __FILE__, int line = __LINE__, T...)(T a);
```