### PR TITLE
Fix Issue 18365 - header file generation doesn't include the return attribute

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -921,6 +921,12 @@ public:
         }
         t.inuse++;
         PrePostAppendStrings pas;
+        extern(C++) int ignoreReturn(void* param, const(char)* name)
+        {
+            if (strcmp(name, "return") != 0)
+                PrePostAppendStrings.fp(param, name);
+            return 0;
+        }
         pas.buf = buf;
         pas.isCtor = (ident == Id.ctor);
         pas.isPostfixStyle = false;
@@ -931,7 +937,7 @@ public:
             MODtoBuffer(buf, t.mod);
             buf.writeByte(' ');
         }
-        t.attributesApply(&pas, &PrePostAppendStrings.fp);
+        t.attributesApply(&pas, &ignoreReturn);
         if (t.linkage > LINK.d && hgs.ddoc != 1 && !hgs.hdrgen)
         {
             linkageToBuffer(buf, t.linkage);
@@ -963,6 +969,11 @@ public:
             buf.writeByte(')');
         }
         parametersToBuffer(t.parameters, t.varargs);
+        if (t.isreturn)
+        {
+            PrePostAppendStrings.fp(&pas, " return");
+            pas.buf.offset -= 1; // remove final whitespace
+        }
         t.inuse--;
     }
 

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -470,7 +470,7 @@ class TestClass
 	{
 		return aa;
 	}
-	ref return retFunc()
+	ref retFunc() return
 	{
 		return aa;
 	}
@@ -509,9 +509,9 @@ struct SafeS
 {
 	@safe 
 	{
-		ref return SafeS foo();
-		return scope SafeS foo2();
-		ref return scope SafeS foo3();
+		ref SafeS foo() return;
+		scope SafeS foo2() return;
+		ref scope SafeS foo3() return;
 		int* p;
 	}
 }

--- a/test/compilable/extra-files/header18365.d
+++ b/test/compilable/extra-files/header18365.d
@@ -1,0 +1,6 @@
+module foo.bar.ba;
+nothrow pure @nogc @safe package(foo) 
+{
+	void foo();
+	nothrow pure @nogc @safe package(foo.bar) void foo2();
+}

--- a/test/compilable/extra-files/header18365.di
+++ b/test/compilable/extra-files/header18365.di
@@ -1,0 +1,11 @@
+struct FullCaseEntry
+{
+	dchar[3] seq;
+	ubyte n;
+	ubyte size;
+	ubyte entry_len;
+	auto const pure nothrow @nogc @property @trusted value() return
+	{
+		return seq[0..entry_len];
+	}
+}

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -587,7 +587,7 @@ class TestClass
 	{
 		return aa;
 	}
-	ref return retFunc()
+	ref retFunc() return
 	{
 		return aa;
 	}
@@ -650,15 +650,15 @@ struct SafeS
 {
 	@safe 
 	{
-		ref return SafeS foo()
+		ref SafeS foo() return
 		{
 			return this;
 		}
-		return scope SafeS foo2()
+		scope SafeS foo2() return
 		{
 			return this;
 		}
-		ref return scope SafeS foo3()
+		ref scope SafeS foo3() return
 		{
 			return this;
 		}

--- a/test/compilable/header18365.d
+++ b/test/compilable/header18365.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -c -o- -Hf${RESULTS_DIR}/compilable/header18365.di
+// POST_SCRIPT: compilable/extra-files/header-postscript.sh
+struct FullCaseEntry
+{
+    dchar[3] seq;
+    ubyte n, size;
+    ubyte entry_len;
+
+    @property auto value() const @trusted pure nothrow @nogc return
+    {
+        return seq[0 .. entry_len];
+    }
+}

--- a/test/fail_compilation/retref2.d
+++ b/test/fail_compilation/retref2.d
@@ -5,7 +5,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/retref2.d(21): Error: function `ref int retref2.D.foo(return ref int)` does not override any function, did you mean to override `ref int retref2.C.foo(ref int)`?
-fail_compilation/retref2.d(22): Error: function `ref return scope int retref2.D.bar()` does not override any function, did you mean to override `ref int retref2.C.bar()`?
+fail_compilation/retref2.d(22): Error: function `ref scope int retref2.D.bar() return` does not override any function, did you mean to override `ref int retref2.C.bar()`?
 ---
 */
 

--- a/test/fail_compilation/test16228.d
+++ b/test/fail_compilation/test16228.d
@@ -1,7 +1,7 @@
 /* REQUIRED_ARGS: -dip25
    TEST_OUTPUT:
 ---
-fail_compilation/test16228.d(22): Error: function type `return int()` has `return` but does not return any indirections
+fail_compilation/test16228.d(22): Error: function type `int() return` has `return` but does not return any indirections
 fail_compilation/test16228.d(23): Error: function `test16228.S.bar` `static` member has no `this` to which `return` can apply
 ---
 */

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -42,7 +42,7 @@ void test3()
         assert(SS.foo4.mangleof == "_D10testscope22SS4foo4MFNcNkKNgPiZi");
 
         // Test scope pretty-printing
-        assert(typeof(SS.foo1).stringof == "ref return ulong(return ref int* delegate() return p)");
+        assert(typeof(SS.foo1).stringof == "ref ulong(return ref int* delegate() return p) return");
         assert(typeof(SS.foo2).stringof == "ref int(return ref int delegate() p)");
         assert(typeof(SS.foo3).stringof == "ref int(return ref inout(int*) p)");
         assert(typeof(SS.foo4).stringof == "ref int(return ref inout(int*) p)");


### PR DESCRIPTION
This is a first approach to the bug that's blocking https://github.com/dlang/phobos/pull/6123.
I'm not a huge fan of working around against the existing code and I will look into accepting `return` as postfix argument too, but maybe someone has a better idea?