### PR TITLE
Fix Issue 18365 - allow return storage class to be set in prefix style

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -744,6 +744,10 @@ final class Parser(AST) : Lexer
                 stc = AST.STC.gshared;
                 goto Lstc;
 
+            case TOK.return_:
+                stc = AST.STC.return_;
+                goto Lstc;
+
             //case TOK.manifest:   stc = STC.manifest;     goto Lstc;
 
             case TOK.at:

--- a/test/compilable/test18365.d
+++ b/test/compilable/test18365.d
@@ -1,0 +1,8 @@
+struct FullCaseEntry
+{
+	dchar[3] seq;
+	auto return value()
+	{
+		return seq[0..2];
+	}
+}


### PR DESCRIPTION
As an alternative to https://github.com/dlang/dmd/pull/7836.