### PR TITLE
Fix Issue 18367 - dmd should not segfault on -X with libraries, but no source files

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -880,6 +880,12 @@ private int tryMain(size_t argc, const(char)** argv)
             }
             else
             {
+                if (global.params.objfiles.dim == 0)
+                {
+                    error(Loc.initial, "-X requires source files");
+                    fatal();
+                }
+
                 // Generate json file name from first obj name
                 const(char)* n = global.params.objfiles[0];
                 n = FileName.name(n);

--- a/test/compilable/test18367.sh
+++ b/test/compilable/test18367.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -u -o pipefail
+
+name=$(basename "$0" .sh)
+dir=${RESULTS_DIR}/compilable/
+
+# dmd should not segfault on -X with libraries, but no source files
+out=$("$DMD" -conf= -X foo.a 2>&1)
+[ $? -eq 1 ] || exit 1
+echo "$out" | grep -q "Error: -X requires source files"


### PR DESCRIPTION
I wish all segfaults would be that easy.