### PR TITLE
Issue 18368 - -X should print all static information on stdout if no files are given

### DIFF
--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -806,3 +806,12 @@ extern (C++) void json_generate(OutBuffer* buf, Modules* modules)
     json.arrayEnd();
     json.removeComma();
 }
+
+extern (C++) void json_info(OutBuffer* buf)
+{
+    scope ToJsonVisitor json = new ToJsonVisitor(buf);
+    json.objectStart();
+    json.property("compilerVendor", global.compiler.vendor);
+    json.objectEnd();
+    json.removeComma();
+}

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -360,8 +360,33 @@ private int tryMain(size_t argc, const(char)** argv)
     }
     if (files.dim == 0)
     {
-        usage();
-        return EXIT_FAILURE;
+        // -X without arguments is the JSON analog of --version
+        if (global.params.doJsonGeneration)
+        {
+            OutBuffer buf;
+            json_info(&buf);
+            buf.writestring("\n");
+            // write to stdout for -X and -Xf=-
+            if (!global.params.jsonfilename || strcmp(global.params.jsonfilename, "-") == 0)
+            {
+                fputs(buf.peekString(), stdout);
+                fflush(stdout);
+            }
+            else
+            {
+                ensurePathToNameExists(Loc.initial, global.params.jsonfilename);
+                auto jsonfile = new File(global.params.jsonfilename);
+                jsonfile.setbuffer(buf.data, buf.offset);
+                jsonfile._ref = 1;
+                writeFile(Loc.initial, jsonfile);
+            }
+            return EXIT_SUCCESS;
+        }
+        else
+        {
+            usage();
+            return EXIT_FAILURE;
+        }
     }
     static if (TARGET.OSX)
     {

--- a/test/compilable/extra-files/testjsonstdout.json
+++ b/test/compilable/extra-files/testjsonstdout.json
@@ -1,0 +1,3 @@
+{
+ "compilerVendor" : "Digital Mars D"
+}

--- a/test/compilable/testjsonstdout.sh
+++ b/test/compilable/testjsonstdout.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+name="$(basename "$0" .sh)"
+dir="${RESULTS_DIR}/compilable/"
+out="$dir/${name}.json.out"
+
+"$DMD" -X > "$out"
+diff "$out" compilable/extra-files/$name.json
+rm "$out"
+
+"$DMD" -Xf=- > "$out"
+diff "$out" compilable/extra-files/$name.json
+rm "$out"
+
+"$DMD" -Xf="$out"
+diff "$out" compilable/extra-files/$name.json
+rm "$out"
+
+echo "OK" > "${dir}/${name}.sh.out"


### PR DESCRIPTION
Based on the discussion in https://github.com/dlang/dmd/pull/7521, https://github.com/dlang/tools/pull/292 and https://github.com/dlang/dmd/pull/7838 the conclusion was the following:

- `-Xq` will allow querying (see https://github.com/dlang/dmd/pull/7838)
- `-X` should support printing to stdout if no files are given to satisfy the probing use case from https://github.com/dlang/dmd/pull/7521

This is a simple version to get approval of the concept.
Moving over the full attributes from https://github.com/dlang/dmd/pull/7521 will be easy and can be done as a follow-up as for now this feature is undocumented.

As you might have noticed, this would also require refactoring the JsonWriter.