### PR TITLE
fix issue 18315 - wrong code for `int.min > 0`

### DIFF
--- a/src/dmd/backend/cod4.c
+++ b/src/dmd/backend/cod4.c
@@ -2064,16 +2064,20 @@ void cdcmp(CodeBuilder& cdb,elem *e,regm_t *pretregs)
                     goto oplt;
                 case OPgt:
                     cdb.gen2(0xF7,grex | modregrmx(3,3,reg));         // NEG reg
-#if TARGET_WINDOS
-                    // What does the Windows platform do?
-                    //  lower INT_MIN by 1?   See test exe9.c
-                    // BUG: fix later
+                        /* Flips the sign bit unless the value is 0 or int.min.
+                        Also sets the carry bit when the value is not 0. */
                     code_orflag(cdb.last(), CFpsw);
                     cdb.genc2(0x81,grex | modregrmx(3,3,reg),0);  // SBB reg,0
-#endif
+                        /* Subtracts the carry bit. This turns int.min into 0,
+                        flipping the sign bit.
+                        For other negative and positive values, subtracting 1
+                        doesn't affect the sign bit.
+                        For 0, the carry bit is not set, so this does nothing
+                        and the sign bit is not affected. */
                     goto oplt;
                 case OPlt:
                 oplt:
+                    // Get the sign bit, i.e. 1 if the value is negative.
                     if (!I16)
                         cdb.genc2(0xC1,grex | modregrmx(3,5,reg),sz * 8 - 1); // SHR reg,31
                     else

--- a/src/dmd/backend/cod4.c
+++ b/src/dmd/backend/cod4.c
@@ -2068,8 +2068,8 @@ void cdcmp(CodeBuilder& cdb,elem *e,regm_t *pretregs)
                         Also sets the carry bit when the value is not 0. */
                     code_orflag(cdb.last(), CFpsw);
                     cdb.genc2(0x81,grex | modregrmx(3,3,reg),0);  // SBB reg,0
-                        /* Subtracts the carry bit. This turns int.min into 0,
-                        flipping the sign bit.
+                        /* Subtracts the carry bit. This turns int.min into
+                        int.max, flipping the sign bit.
                         For other negative and positive values, subtracting 1
                         doesn't affect the sign bit.
                         For 0, the carry bit is not set, so this does nothing

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1725,6 +1725,17 @@ void test16997()
 
 ////////////////////////////////////////////////////////////////////////
 
+void test18315() // https://issues.dlang.org/show_bug.cgi?id=18315
+{
+    int i = int.min;
+    bool b = i > 0;
+    assert(!b);
+    b = 0 < i;
+    assert(!b);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 int main()
 {
     testgoto();
@@ -1785,6 +1796,7 @@ int main()
     testeqeqranges();
     testdivcmp();
     test16997();
+    test18315();
     printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
~~Removing the wrong optimization, falling back to cmp instruction.~~

----

I have no idea what I'm doing when it comes to dmd code, and this seems like a place where one can introduce subtle bugs. Please review carefully.