### PR TITLE
Fix Issue 17752 - Switch skips over declaration issued for explicitly uninitialized variables

### DIFF
--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1605,7 +1605,9 @@ extern (C++) final class SwitchStatement : Statement
             }
             else
             {
-                deprecation("'switch' skips declaration of variable %s at %s", vd.toPrettyChars(), vd.loc.toChars());
+                if (!vd._init.isVoidInitializer)
+                    deprecation("'switch' skips declaration of variable %s at %s", vd.toPrettyChars(), vd.loc.toChars());
+
                 return true;
             }
 

--- a/test/compilable/test17752.d
+++ b/test/compilable/test17752.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=17752
+// REQUIRED_ARGS: -c -de
+/*
+TEST_OUTPUT:
+---
+---
+*/
+void main (string[] args)
+{
+    switch (args.length)
+    {
+        // initialization not done on purpose is allowed
+        int x = void;
+    default:
+        break;
+    }
+}


### PR DESCRIPTION
Required for https://github.com/dlang/dmd/pull/7817