### PR TITLE
Add ability to override DFLAGS env variable in test suite

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -36,6 +36,10 @@
 #                        once by explicitly passing the modules to the compiler.
 #                        default: (none)
 #
+#   DFLAGS:              Overrides the DFLAGS environment variable if specified in the test.
+#                        No values are permitted; an error will be emitted if the value is not
+#                        empty.
+#
 #   EXTRA_SOURCES:       list of extra files to build and link along with the test
 #                        default: (none)
 #

--- a/test/compilable/minimal.d
+++ b/test/compilable/minimal.d
@@ -1,3 +1,4 @@
+// DFLAGS:
 // PERMUTE_ARGS:
 // POST_SCRIPT: compilable/extra-files/minimal/verify_symbols.sh
 // REQUIRED_ARGS: -c -defaultlib= runnable/extra-files/minimal/object.d

--- a/test/fail_compilation/no_object.d
+++ b/test/fail_compilation/no_object.d
@@ -1,0 +1,15 @@
+/*
+DFLAGS:
+REQUIRED_ARGS:
+TEST_OUTPUT:
+---
+Error: cannot find source code for runtime library file 'object.d'
+       dmd might not be correctly installed. Run 'dmd -man' for installation instructions.
+       config file: (null)
+import path[0] = fail_compilation
+---
+*/
+
+// Due to the empty D FLAGS test variable specified above, only the current
+// directory is in the import path.  Therefore, compilation fails because the compiler
+// cannot locate object.d

--- a/test/runnable/minimal.d
+++ b/test/runnable/minimal.d
@@ -1,3 +1,4 @@
+// DFLAGS:
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -defaultlib= runnable/extra-files/minimal/object.d
 


### PR DESCRIPTION
The test suite makefile adds the import directories for druntime and phobos to the `DFLAGS` environment variable:
https://github.com/dlang/dmd/blob/c55c9be607f6939c6212759c054880b7074bff6d/test/Makefile#L173-L177
This makes it impossible to write tests for no- or minimal-runtime programming, due to the implicit import of object.d.  See #7825 for evidence.

This PR adds a `DFLAGS:` test variable that clears the `DFLAGS` environment variable enabling us to write no- or minimal-runtime tests among other potential possibilities.