### PR TITLE
Use -conf= to overwrite the default dmd config

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -119,14 +119,8 @@ coverage()
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL PIC="$PIC"
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL PIC="$PIC"
 
-    # FIXME
-    # Building d_do_test currently uses the host library for linking
-    # Remove me after https://github.com/dlang/dmd/pull/7846 has been merged (-conf=)
-    if [ -f ~/dlang/install.sh ] ; then
-        deactivate
-    else
-        sudo rm -rf /dlang
-    fi
+    # We don't want to end up using the host compiler in the testsuite
+    deactivate
 
     # FIXME
     # Temporarily the failing long file name test has been removed

--- a/test/Makefile
+++ b/test/Makefile
@@ -46,7 +46,7 @@ ifeq ($(findstring win,$(OS)),win)
 
     DRUNTIME_PATH=..\..\druntime
     PHOBOS_PATH=..\..\phobos
-    export DFLAGS=-I$(DRUNTIME_PATH)\import -I$(PHOBOS_PATH)
+    export DFLAGS=-conf= -I$(DRUNTIME_PATH)\import -I$(PHOBOS_PATH)
     export LIB=$(PHOBOS_PATH)
 
     # auto-tester might run the testsuite with a different $(MODEL) than DMD
@@ -94,7 +94,7 @@ else
     PHOBOS_PATH=../../phobos
     # link against shared libraries (defaults to true on supported platforms, can be overridden w/ make SHARED=0)
     SHARED=$(if $(findstring $(OS),linux freebsd),1,)
-    DFLAGS=-I$(DRUNTIME_PATH)/import -I$(PHOBOS_PATH) -L-L$(PHOBOS_PATH)/generated/$(OS)/$(BUILD)/$(MODEL)
+    DFLAGS=-conf= -I$(DRUNTIME_PATH)/import -I$(PHOBOS_PATH) -L-L$(PHOBOS_PATH)/generated/$(OS)/$(BUILD)/$(MODEL)
     ifeq (1,$(SHARED))
         DFLAGS+=-defaultlib=libphobos2.so -L-rpath=$(PHOBOS_PATH)/generated/$(OS)/$(BUILD)/$(MODEL)
     endif

--- a/test/compilable/issue17167.sh
+++ b/test/compilable/issue17167.sh
@@ -14,6 +14,6 @@ src="$bin_base.d"
 echo 'void main() {}' > "${src}"
 
 # Only compile, not link, since optlink can't handle long file names
-$DMD -m"${MODEL}" "${DFLAGS}" -c -of"${bin}" "${src}"
+$DMD -m"${MODEL}" -c -of"${bin}" "${src}"
 
 rm -rf "${OUTPUT_BASE}"


### PR DESCRIPTION
`-conf=` should almost always be used in any of our Makefiles to avoid any issues with user-defined configuration files.

Note: there's currently an permananet failure on some CIs. See also https://github.com/dlang/dmd/pull/7838#issuecomment-363388022