### PR TITLE
Fix indentation of the lambda comparison changelog

### DIFF
--- a/changelog/lambdacomp.dd
+++ b/changelog/lambdacomp.dd
@@ -9,7 +9,6 @@ $(UL
     $(LI the lambda function arguments must not have a template instantiation
     as an explicit argument type. Any other argument types (basic,
     user-defined, template) are supported.)
-
     $(LI the lambda function body must contain a single expression (no return statement)
     which contains only numeric values, manifest constants, enum values and arguments.
     If the expression contains local variables, function calls or return statements,


### PR DESCRIPTION
Fixes this issue:

![image](https://user-images.githubusercontent.com/4370550/35884890-607dd3d6-0b8c-11e8-8535-48043682c201.png)

at https://dlang.org/changelog/pending.html#lambdacomp found by @schveiguy in https://github.com/dlang/phobos/pull/6132.

The changelog tool currently automatically inserts `$(P)` (like Markdown).
It can be argued whether this is a good or bad behavior, but for now, let's fix the changelog.