### PR TITLE
Improve documentation for the in-test DISABLED parameter

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -74,9 +74,12 @@
 #                        note: the make variable REQUIRED_ARGS is also added to the $(DMD)
 #                              command line (see below)
 #
-#   DISABLED:            text describing why the test is disabled (if empty, the test is
-#                        considered to be enabled).
+#   DISABLED:            selectively disable the test on specific platforms (if empty, the test is
+#                        considered to be enabled on all platform).
 #                        default: (none, enabled)
+#                        Valid platforms: win linux osx freebsd dragonflybsd netbsd
+#                        Optionally a MODEL suffix can used for further filtering, e.g.
+#                        win32 win64 linux32 linux64 osx32 osx64 freebsd32 freebsd64
 
 ifeq (Windows_NT,$(OS))
     ifeq ($(findstring WOW64, $(shell uname)),WOW64)

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -126,7 +126,8 @@ bool findTestParameter(const ref EnvData envData, string file, string token, ref
     //writeln("arg: '", result, "'");
 
     string result2;
-    if (findTestParameter(envData, file[tokenStart+lineEnd..$], token, result2, multiLineDelimiter)) {
+    if (findTestParameter(envData, file[tokenStart+lineEnd..$], token, result2, multiLineDelimiter))
+    {
         if(result2.length > 0)
             result ~= multiLineDelimiter ~ result2;
     }


### PR DESCRIPTION
The current documentation was inacurate. It's doing the following:

```d
if (testArgs.disabledPlatforms.canFind(envData.os, envData.os ~ envData.model))
{
	testArgs.disabled = true;
	writefln("!!! [DISABLED on %s]", envData.os);
}
```