### PR TITLE
Removed comma support for -i (-i=a,b becomes -i=a -i=b)

### DIFF
--- a/changelog/includeimports.dd
+++ b/changelog/includeimports.dd
@@ -1,10 +1,9 @@
-Automatically include imports via -i command line option
+Added the -i command line option to automatically include imports
 
-Added the command line option -i which causes the compiler to treat imported modules as if they were given on the command line.  The option also accepts "module patterns" that include/exclude modules based on their name.  For example, the following will include all modules whose names start with "foo", except for those that start with "foo.bar":
----
-dmd -i=foo,-foo.bar
----
+Added the command line option -i which causes the compiler to treat imported modules as if they were given on the command line.  The option also accepts "module patterns" that include/exclude modules based on their name.  For example, the following will include all modules whose names start with `foo`, except for those that start with `foo.bar`:
+
+$(CONSOLE dmd -i=foo -i=-foo.bar)
+
 The option -i by itself is equivalent to:
----
-dmd -i=-std,-core,-etc,-object
----
+
+$(CONSOLE dmd -i=-std,-core,-etc,-object)

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -311,10 +311,10 @@ dmd -cov -unittest myprog.d
             "look for imports also in directory"
         ),
         Option("i",
-            "same as -i=-std,-core,-etc,-object"
+            "include imported modules except from druntime/phobos (equivalent to -i=-std -i=-core -i=-etc -i=-object)"
         ),
-        Option("i=[-]<pattern>,[-]<pattern>,...",
-            "include/exclude imported modules whose name matches one of <pattern>"
+        Option("i=[-]<pattern>",
+            "include (or exclude if prefixed with '-') imported modules whose names match <pattern>"
         ),
         Option("ignore",
             "ignore unsupported pragmas"

--- a/test/compilable/needsmod.d
+++ b/test/compilable/needsmod.d
@@ -2,7 +2,6 @@
 // ARG_SETS: -i=.
 // ARG_SETS: -i=imports
 // ARG_SETS: -i=imports.foofunc
-// ARG_SETS: -iimports.foofunc
 // PERMUTE_ARGS:
 // LINK:
 import imports.foofunc;

--- a/test/fail_compilation/emptyModulePattern.d
+++ b/test/fail_compilation/emptyModulePattern.d
@@ -1,0 +1,9 @@
+/*
+REQUIRED_ARGS: -i=
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+Error: invalid option '-i=', module patterns cannot be empty
+       run 'dmd -man' to open browser on manual
+---
+*/


### PR DESCRIPTION
@WalterBright has suggested that supporting multiple arguments for a single option using the comma character is "a lot of effort".  He also mentions other command-line options already support multiple arguments because they can be given multiple times.  This PR removes comma support for `-i` so the following
```
-i=foo,-foo.bar,baz
```
must now be specified via:
```
-i=foo i=-foo.bar -i=baz
```