### PR TITLE
Removed set -x in test 13742.sh

### DIFF
--- a/test/runnable/test13742.sh
+++ b/test/runnable/test13742.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -x # debug windows issues
 set -ueo pipefail
 
 src=runnable${SEP}extra-files


### PR DESCRIPTION
I think @MartinNowak may have accidentally left in a `set -x` in the test13742.sh BASH script (https://github.com/dlang/dmd/pull/7719/commits/69e7bd18892df18f682906916bf8c8ad87fb30e5).  This PR removes it.