### PR TITLE
Explore supporting option arguments with commas.

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1949,19 +1949,15 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             }
             else if (arg == "-i")
                 includeImports = true;
-            else if (startsWith(p + 1, "i="))
+            else if (p[1] == 'i' && (p[2] == '=' || p[2] == ','))
             {
                 includeImports = true;
-                if (!p[3])
-                {
-                    error("invalid option '%s', module patterns cannot be empty", p);
-                }
-                else
+                foreach (option; optionRange(p + 2))
                 {
                     // NOTE: we could check that the argument only contains valid "module-pattern" characters.
                     //       Invalid characters doesn't break anything but an error message to the user might
                     //       be nice.
-                    includeModulePatterns.push(p + 3);
+                    includeModulePatterns.push(option.ptr);
                 }
             }
             else if (arg == "-dip25")       // https://dlang.org/dmd.html#switch-dip25
@@ -2021,7 +2017,8 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             {
                 if (!params.imppath)
                     params.imppath = new Strings();
-                params.imppath.push(p + 2 + (p[2] == '='));
+                foreach (imppath; optionRange(p + 2))
+                    params.imppath.push(imppath.ptr);
             }
             else if (p[1] == 'm' && p[2] == 'v' && p[3] == '=') // https://dlang.org/dmd.html#switch-mv
             {
@@ -2038,7 +2035,8 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             {
                 if (!params.fileImppath)
                     params.fileImppath = new Strings();
-                params.fileImppath.push(p + 2 + (p[2] == '='));
+                foreach (fileImppath; optionRange(p + 2))
+                    params.fileImppath.push(fileImppath.ptr);
             }
             else if (startsWith(p + 1, "debug") && p[6] != 'l') // https://dlang.org/dmd.html#switch-debug
             {
@@ -2121,7 +2119,8 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 params.debugy = true;
             else if (p[1] == 'L')                        // https://dlang.org/dmd.html#switch-L
             {
-                params.linkswitches.push(p + 2 + (p[2] == '='));
+                foreach (linkswitch; optionRange(p + 2))
+                    params.linkswitches.push(linkswitch.ptr);
             }
             else if (startsWith(p + 1, "defaultlib="))   // https://dlang.org/dmd.html#switch-defaultlib
             {
@@ -2486,5 +2485,95 @@ private void parseModulePattern(const(char)* modulePattern, MatcherNode* dst, us
                 break;
             }
         }
+    }
+}
+
+auto optionRange(bool mustBeNullTerminated = true)(const(char)* args)
+{
+    return OptionRange!(mustBeNullTerminated)(args);
+}
+// TODO: support array range or pointer range
+struct OptionRange(bool mustBeNullTerminated)
+{
+    char[] current;
+    bool atLast;
+    this(const(char)* args)
+    {
+        if (*args == '\0')
+        {
+            current = null; // no arguments
+        }
+        else if (*args == ',')
+        {
+            args++;
+            auto next = args;
+            for (;; next++)
+            {
+                if (*next == '\0')
+                {
+                    current = cast(char[])args[0 .. next - args];
+                    atLast = true;
+                    return;
+                }
+                if (*next == ',')
+                    break;
+            }
+
+            auto firstComma = next - args;
+
+            static if (mustBeNullTerminated)
+            {
+                // make a copy of args so we can replace commas ',' with '\0'
+                auto argsCopy = strdup(args);
+                argsCopy[firstComma] = '\0';
+                current = argsCopy[0 .. firstComma];
+            }
+            else
+            {
+                current = args[0 .. firstComma];
+            }
+        }
+        else
+        {
+            if (*args == '=')
+            {
+                args++;
+                if (*args == '\0')
+                {
+                    current = null;
+                    return;
+                }
+            }
+            current = cast(char[])args[0 .. strlen(args)];
+            atLast = true;
+        }
+    }
+    @property bool empty() const { return current is null; }
+    @property const(char)[] front() { return current; }
+    void popFront()
+    {
+        if (atLast)
+        {
+            current = null;
+            return;
+        }
+
+        auto next = current.ptr + current.length + 1;
+        auto start = next;
+        for (;; next++)
+        {
+            if (*next == ',')
+            {
+                static if (mustBeNullTerminated)
+                    *next = '\0'; // replace ',' with '\0'
+                break;
+            }
+            if (*next == '\0')
+            {
+                atLast = true;
+                break;
+            }
+        }
+        current = start[0 .. next - start];
     }
 }

--- a/test/compilable/needsmod.d
+++ b/test/compilable/needsmod.d
@@ -1,4 +1,5 @@
 // ARG_SETS: -i
+// ARG_SETS: -i=
 // ARG_SETS: -i=.
 // ARG_SETS: -i=imports
 // ARG_SETS: -i=imports.foofunc

--- a/test/fail_compilation/emptyModulePattern.d
+++ b/test/fail_compilation/emptyModulePattern.d
@@ -1,9 +1,0 @@
-/*
-REQUIRED_ARGS: -i=
-PERMUTE_ARGS:
-TEST_OUTPUT:
----
-Error: invalid option '-i=', module patterns cannot be empty
-       run 'dmd -man' to open browser on manual
----
-*/

--- a/test/fail_compilation/needspkgmod.d
+++ b/test/fail_compilation/needspkgmod.d
@@ -1,4 +1,3 @@
-// ARG_SETS: -i=
 // ARG_SETS: -i=,
 // ARG_SETS: -i=imports.pkgmod313,
 // ARG_SETS: -i=,imports.pkgmod313


### PR DESCRIPTION
An exploration on what it would take to support commas in command-line options that take multiple arguments.

The current proposed syntax is to replace the initial `=` character with a comma `,`, and then seperate additional values with more commas, i.e.
```
dmd -i=foo -i=bar -i=baz
OR
dmd -i,foo,bar,baz
```

By having a separate syntax for "comma mode" and "one value mode", there is no need to support "escaping commas" in the case that the option value has a comma.

All the logic is in the `OptionRange` struct.   It takes an option's argument as a null-terminated string and returns a range of null-terminated strings representing each individual argument.  So the following code:
```D
dosomething(myoption);
```
becomes this:
```D
foreach(option; optionRange(myoption))
    dosomething(option);
```

The `OptionRange` struct takes a modest amount of code. Each option that uses it will require an additional line of code for the `foreach` loop header and possibly an extra level of nesting for the loop body.

Runtime overhead when using normal `-i=` is virtually none.  In the "comma case" `strdup` is called once on the option arguments so that each comma can be replaced by a terminating `'\0'` so that each individual argument will be null-terminated.

> Note that `OptionRange` can be modified to NOT GUARANTEE null-termination, in which case no allocation is necessary, however, I haven't identified any command-line options that could use this right now.

The current implementation has applied this new `optionRange` to `-I`, `-L`, `-J` and `-i` for demonstration, i.e.
```
dmd -I,foo,bar -L,-a,-b,-c -J,somepath,anotherpath -i,foo,bar
```