### PR TITLE
Print DFLAGS on -v to ease debugging

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -486,6 +486,31 @@ private int tryMain(size_t argc, const(char)** argv)
         message("binary    %s", global.params.argv0);
         message("version   %s", global._version);
         message("config    %s", global.inifilename ? global.inifilename : "(none)");
+        // Print DFLAGS environment variable
+        {
+            OutBuffer buf;
+            foreach (flag; dflags.asDArray)
+            {
+                bool needsQuoting;
+                for (auto flagp = flag; flagp; flagp++)
+                {
+                    auto c = flagp[0];
+                    if (!(isalnum(c) || c == '_'))
+                    {
+                        needsQuoting = true;
+                        break;
+                    }
+                }
+
+                if (flag.strchr(' '))
+                    buf.printf("'%s' ", flag);
+                else
+                    buf.printf("%s ", flag);
+            }
+
+            auto res = buf.peekSlice() ? buf.peekSlice()[0 .. $ - 1] : "(none)";
+            message("DFLAGS    %.*s", res.length, res.ptr);
+        }
     }
     //printf("%d source files\n",files.dim);
 

--- a/test/compilable/testclidflags.sh
+++ b/test/compilable/testclidflags.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir=${RESULTS_DIR}${SEP}compilable
+output_file=${dir}/testclidflags.sh.out
+
+unset DFLAGS
+
+# Force DMD to print the -v menu by passing an invalid object file
+# It will fail with "no object files to link", but print the log
+# On OSX DMD terminates with a successful exit code, so `|| true` is used.
+( "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    (none)"
+( DFLAGS="-O -D" "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O -D"
+( DFLAGS="-O '-Ifoo bar' -c" "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O '-Ifoo bar' -c"
+
+echo Success >${output_file}


### PR DESCRIPTION
Motivation: it can be tricky to figure out what dflags DMD has read. This helps debugging at almost no cost (and `-v` is only used for debugging anyhow).

See also: https://github.com/dlang/dmd/pull/7845