### PR TITLE
Fix rm: cannot remove ‘test_results/runnable/test13742.exe’: Device or resource busy

### DIFF
--- a/test/runnable/test13742.sh
+++ b/test/runnable/test13742.sh
@@ -19,6 +19,8 @@ $DMD -m${MODEL} -I${src} -cov -of${dir}${SEP}test13742${EXE} ${src}${SEP}test137
 
 ${RESULTS_DIR}/runnable/test13742${EXE} --DRT-covopt=dstpath:${dir}${SEP}
 
-rm ${RESULTS_DIR}/runnable/{runnable-extra-files-{lib13742a,lib13742b,test13742}.lst,test13742{${OBJ},${LIBEXT},${EXE}}}
+# The removal sometimes spuriously fails on the auto-tester with "rm: cannot remove ‘test_results/runnable/test13742.exe’: Device or resource busy"
+# This doesn't verify the test, hence -f and || true are used
+rm -f ${RESULTS_DIR}/runnable/{runnable-extra-files-{lib13742a,lib13742b,test13742}.lst,test13742{${OBJ},${LIBEXT},${EXE}}} || true
 
 echo Success > ${output_file}


### PR DESCRIPTION
Hopefully this prevents this spurious failure from showing up:

```
rm: cannot remove ‘test_results/runnable/test13742.exe’: Device or resource busy
```

https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3028674&isPull=true