### PR TITLE
fix Issue 18010 - Undefined reference to _d_arraycopy when copying ar…

### DIFF
--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -11,6 +11,21 @@ void test(int ij)
 }
 
 /*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18010
+
+void test1()
+{
+    int[10] a1 = void;
+    int[10] a2 = void;
+    a1[] = a2[];
+}
+
+void test2(int[] a1, int[] a2)
+{
+    a1[] = a2[];
+}
+
+/*******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=17843
 
 struct S


### PR DESCRIPTION
…rays in -betterC

This works by essentially inlining the code that is in _d_arraycopy(). It's faster, too. The downside is you just get a generic array bounds error when making a mistake rather than the detailed one _d_arraycopy() would emit.