### PR TITLE
Fix Issue 17970 - shared struct destructor doesn't compile anymore

### DIFF
--- a/test/compilable/test17970.d
+++ b/test/compilable/test17970.d
@@ -1,0 +1,28 @@
+shared struct Shared
+{
+    static Shared make()
+    {
+        return Shared();
+    }
+
+    ~this()
+    {
+    }
+}
+
+shared struct Foo
+{
+    ~this()
+    {
+    }
+}
+
+struct Inner { ~this() {} }
+struct Outer { shared(Inner) inner; }
+
+void main()
+{
+    Foo x = Foo();
+    auto s = Shared.make();
+    Outer _;
+}


### PR DESCRIPTION
The problem here is that if a struct is declared as shared the dtor is automatically considered to be shared, but when the struct is instantiated the instance is no longer considered to be shared when the function call matching is done. The fix makes it so that if a struct declaration is shared, when the destructor is called, the instantiated struct is also considered shared.