### PR TITLE
Interpret imports the same regardless of other modules passed on the command line

### DIFF
--- a/changelog/deprecate_compile_seperately_inconsistency.dd
+++ b/changelog/deprecate_compile_seperately_inconsistency.dd
@@ -1,0 +1,21 @@
+Make imports behave the same whether or not both modules were given on the command line
+
+Before, if an import statement matches a filename but does not match its module name, an error is asserted, but only if both modules have been given on the command line. Now it will be an error even if the modules are not both given on the command line, i.e.
+---
+// main.d
+import foo;
+---
+---
+// foo.d
+module bar;
+---
+Before, this module would fail if compiled like this:
+$(CONSOLE dmd -c main.d foo.d)
+
+and pass if compiled like this:
+$(CONSOLE
+dmd -c main.d
+dmd -c foo.d
+)
+
+Now it will fail in both cases.

--- a/test/compilable/badimport.d
+++ b/test/compilable/badimport.d
@@ -1,0 +1,10 @@
+/*
+C1OMPILED_IMPORTS: imports/wrongpkgname.d
+REQUIRED_ARGS: -Ifail_compilation
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+compilable/badimport.d(10): Deprecation: module `wrongpkg.wrongpkgname` from file compilable/imports/wrongpkgname.d must be imported with 'import wrongpkg.wrongpkgname;'
+---
+*/
+import imports.wrongpkgname;

--- a/test/compilable/badimport2.d
+++ b/test/compilable/badimport2.d
@@ -1,0 +1,9 @@
+/*
+REQUIRED_ARGS: -Icompilable/imports
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+compilable/badimport2.d(9): Deprecation: module `wrong_mod_name_bleh` from file compilable/imports/wrong_mod_name.d must be imported with 'import wrong_mod_name_bleh;'
+---
+*/
+import wrong_mod_name;

--- a/test/compilable/imports/a15086.d
+++ b/test/compilable/imports/a15086.d
@@ -1,0 +1,1 @@
+module foo;

--- a/test/compilable/imports/wrong_mod_name.d
+++ b/test/compilable/imports/wrong_mod_name.d
@@ -1,0 +1,1 @@
+module wrong_mod_name_bleh;

--- a/test/compilable/imports/wrongpkgname.d
+++ b/test/compilable/imports/wrongpkgname.d
@@ -1,0 +1,1 @@
+module wrongpkg.wrongpkgname;

--- a/test/compilable/test15086.d
+++ b/test/compilable/test15086.d
@@ -1,0 +1,8 @@
+/*
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+compilable/test15086.d(8): Deprecation: module `foo` from file compilable/imports/a15086.d must be imported with 'import foo;'
+---
+*/
+import imports.a15086;

--- a/test/compilable/test313f.d
+++ b/test/compilable/test313f.d
@@ -1,7 +1,8 @@
 // REQUIRED_ARGS: -de
-import imports.f313;
+// EXTRA_SOURCES: imports/f313.d
+import foo.bar;
 
 void test()
 {
-    imports.f313.bug();
+    foo.bar.bug();
 }

--- a/test/compilable/test314.d
+++ b/test/compilable/test314.d
@@ -1,11 +1,12 @@
 // REQUIRED_ARGS: -de
+// EXTRA_SOURCES: imports/a314.d
 module imports.test314; // package imports
 
-import imports.a314;
+import imports.pkg.a314;
 
 void main()
 {
-    imports.a314.bug("This should work.\n");
+    imports.pkg.a314.bug("This should work.\n");
     renamed.bug("This should work.\n");
     bug("This should work.\n");
 }

--- a/test/compilable/test71.d
+++ b/test/compilable/test71.d
@@ -1,6 +1,7 @@
-import imports.test71;
+// EXTRA_SOURCES: imports/test71.d
+import imports_test71;
 
 void bar()
 {
-    imports.test71.foo();
+    imports_test71.foo();
 }

--- a/test/fail_compilation/dip22b.d
+++ b/test/fail_compilation/dip22b.d
@@ -1,8 +1,9 @@
 /*
 REQUIRED_ARGS: -de
+EXTRA_SOURCES: imports/dip22c.d
 TEST_OUTPUT:
 ---
-fail_compilation/dip22b.d(12): Deprecation: `pkg.dip22c.Foo` is not visible from module `dip22`
+fail_compilation/dip22b.d(13): Deprecation: `pkg.dip22c.Foo` is not visible from module `dip22`
 ---
 */
 module pkg.dip22;

--- a/test/fail_compilation/ice11513a.d
+++ b/test/fail_compilation/ice11513a.d
@@ -1,4 +1,5 @@
 /*
+EXTRA_SOURCES: imports/ice11513x.d
 TEST_OUTPUT:
 ---
 fail_compilation/imports/ice11513x.d(1): Error: package name 'ice11513a' conflicts with usage as a module name in file fail_compilation/ice11513a.d
@@ -7,4 +8,4 @@ fail_compilation/imports/ice11513x.d(1): Error: package name 'ice11513a' conflic
 
 module ice11513a;
 
-import imports.ice11513x;
+import ice11513a.imports;

--- a/test/fail_compilation/imports/dip22b.d
+++ b/test/fail_compilation/imports/dip22b.d
@@ -1,3 +1,3 @@
 module imports.dip22b;
 // this public import only exports symbols that are visible within this module
-public import imports.dip22c;
+public import pkg.dip22c;

--- a/test/fail_compilation/test64.d
+++ b/test/fail_compilation/test64.d
@@ -2,6 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/imports/test64a.d(1): Error: module `imports` from file fail_compilation/imports/test64a.d conflicts with package name imports
+fail_compilation/test64.d(13): Deprecation: module `imports` from file fail_compilation/imports/test64a.d must be imported with 'import imports;'
 ---
 */
 

--- a/test/runnable/link12037.d
+++ b/test/runnable/link12037.d
@@ -1,4 +1,5 @@
-import imports.a12037;
+// EXTRA_SOURCES: imports/a12037.d
+import imports.aXXXXX;
 
 alias CustomFloat!(10, 5) Float16;
 

--- a/test/runnable/uda.d
+++ b/test/runnable/uda.d
@@ -1,4 +1,4 @@
-
+// EXTRA_SOURCES: imports/a9741.d
 import core.stdc.stdio;
 
 template Tuple(T...)
@@ -320,7 +320,7 @@ struct Bug9652
 /************************************************/
 // 9741
 
-import imports.a9741;
+import imports.a9741b;
 
 struct A9741 {}
 


### PR DESCRIPTION
This PR unifies the behavior of imports regardless of what modules were given on the command line (https://issues.dlang.org/show_bug.cgi?id=15086).  Consider the following:

```D
// main.d
import foo;
```
```D
// foo.d
module bar;
```

The above code will fail if compiled together, i.e.
```
dmd -c main.d foo.d
```
```
Error: module `bar` from file foo.d must be imported with 'import bar;'
```

However, if you compile them using 2 invocations, it will succeed:
```
dmd -c main.d
dmd -c foo.d
```

This PR unifies both cases by making them both fail with the same error message.