### PR TITLE
Fix Issue 16492 - support @nogc in debug{} blocks

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2213,7 +2213,7 @@ extern (C++) abstract class Expression : RootObject
 
         if (!f.isNogc())
         {
-            if (sc.flags & SCOPE.compile ? sc.func.isNogcBypassingInference() : sc.func.setGC())
+            if (sc.flags & SCOPE.compile ? sc.func.isNogcBypassingInference() : sc.func.setGC() && !(sc.flags & SCOPE.debug_))
             {
                 if (loc.linnum == 0) // e.g. implicitly generated dtor
                     loc = sc.func.loc;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3465,7 +3465,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());
                     err = true;
                 }
-                if (!tf.isnogc && sc.func.setGC())
+                if (!tf.isnogc && sc.func.setGC() && !(sc.flags & SCOPE.debug_) )
                 {
                     exp.error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), p, exp.e1.toChars());

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -215,7 +215,10 @@ public:
 extern (C++) Expression checkGC(Scope* sc, Expression e)
 {
     FuncDeclaration f = sc.func;
-    if (e && e.op != TOK.error && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) && (f.type.ty == Tfunction && (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc))
+    if (e && e.op != TOK.error && f && sc.intypeof != 1 && !(sc.flags & SCOPE.ctfe) &&
+           (f.type.ty == Tfunction &&
+            (cast(TypeFunction)f.type).isnogc || (f.flags & FUNCFLAG.nogcInprocess) || global.params.vgc) &&
+           !(sc.flags & SCOPE.debug_))
     {
         scope NOGCVisitor gcv = new NOGCVisitor(f);
         walkPostorder(e, gcv);

--- a/test/compilable/test16492.d
+++ b/test/compilable/test16492.d
@@ -1,0 +1,15 @@
+// ARG_SETS: -debug; -o-
+// https://issues.dlang.org/show_bug.cgi?id=16492
+
+void mayCallGC();
+
+void test() @nogc pure
+{
+    debug new int(1);
+    debug
+    {
+        mayCallGC();
+        auto b = [1, 2, 3];
+        b ~= 4;
+    }
+}


### PR DESCRIPTION
`debug` already allows to use non-`pure` within `pure` scopes, imho it only makes sense to do the same for the rest.
If this gets approved, I am happy to do the same for `@safe` and `nothrow`.

Spec PR: https://github.com/dlang/dlang.org/pull/2205