### PR TITLE
Fix no_Throwable test so it doesn't import druntime's object.d

### DIFF
--- a/test/fail_compilation/no_Throwable.d
+++ b/test/fail_compilation/no_Throwable.d
@@ -1,8 +1,10 @@
-/* REQUIRED_ARGS: -c -I=fail_compilation/extra-files/no_Throwable/
+/* 
+DFLAGS:
+REQUIRED_ARGS: -c -I=fail_compilation/extra-files/no_Throwable/
 TEST_OUTPUT:
 ---
-fail_compilation/no_Throwable.d(11): Error: Cannot use `throw` statements because `object.Throwable` was not declared
-fail_compilation/no_Throwable.d(16): Error: Cannot use try-catch statements because `object.Throwable` was not declared
+fail_compilation/no_Throwable.d(13): Error: Cannot use `throw` statements because `object.Throwable` was not declared
+fail_compilation/no_Throwable.d(18): Error: Cannot use try-catch statements because `object.Throwable` was not declared
 ---
 */
 


### PR DESCRIPTION
Now that #7845 is merged, we can properly create tests that don't automatically import druntime.

The `no_Throwable` test, added in #7786, also should clear DFLAGS to prevent druntime's object.d from being imported.  This PR doesn't change the behavior of the test, as DMD, by chance, imported the correct object.d anyway, but this PR does make the desired behavior more explicit to avoid the potential for a false positive.