### PR TITLE
Fix Issue 18430 - isSame is wrong for non global lambdas

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1460,7 +1460,6 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             {
                 return True();
             }
-            return False();
         }
 
         auto s1 = getDsymbol(o1);

--- a/test/compilable/test18430.d
+++ b/test/compilable/test18430.d
@@ -1,0 +1,11 @@
+template Alias(alias a)
+{
+    alias Alias = a;
+}
+
+void main()
+{
+    auto scale = 4;
+    alias edentity = a => a * scale;
+    static assert(__traits(isSame, Alias!edentity, edentity)); // fails in dmd-nightly
+}


### PR DESCRIPTION
The code in the bug report:

```d
template Alias(alias a)
{
    alias Alias = a;
}

auto foo()
{
    auto scale = 4;
    alias edentity = a => a * scale;
    static assert(__traits(isSame, Alias!edentity, edentity)); // fails in dmd-nightly
}
```

__traits(isSame) compares either 2 dsymbols or 2 lambda functions. Since an alias to a lambda function is considered to be both (a dsymbol and a lambda function), __traits(isSame) will first check that the lambda functions are indeed identical and the result will be false, since lambdas which have template instantiations as arguments are considered to be incomparable. On the other hand, if treated as dsymbols, the result will be true.

The fix is pretty simple: if 2 lambda functions are not equal `__traits` will not return false, but check if the parameters are equal dsymbols.