### PR TITLE
Add changelog for minimal runtime implementation PRs

### DIFF
--- a/changelog/minimal_runtime.dd
+++ b/changelog/minimal_runtime.dd
@@ -1,0 +1,107 @@
+Using D with no/minimal/custom runtime implementation in a pay-as-you-go fashion
+
+$(P DMD has been further decoupled from the runtime so it is now easier and more
+convenient to use D without the runtime in a pay-as-you-go fashion.  This will
+be of interest to users wishing to incrementally or partially port D to new
+platforms, users targeting bare-metal or resource constrained platforms, and
+users wishing to use D as a library from other languages without the runtime.)
+
+$(P Prior to this release, if one attempted to compile a simple D application that
+made no use of any runtime features, the compiler would have emitted a number
+of errors about a missing object.d, a missing `Error` class, missing `TypeInfo`,
+and missing `ModuleInfo`, among others.)
+
+$(P Starting with this release, one can now create a library for use from another
+language, requiring only the `.d` source file that implements that library, and
+an empty `object.d` file)
+
+$(B Example 1)
+---
+module object
+---
+
+---
+module math;
+
+extern(C) int add(int a, int b)
+{
+    return a + b;
+}
+---
+
+$(CONSOLE
+dmd -conf= -lib math.d
+size math.a
+   text    data     bss     dec     hex filename
+      0       0       0       0       0 math.o (ex math.a)
+     20       0       0      20      14 math_1_129.o (ex math.a)
+)
+
+$(P Also, starting with this release, one can now create very small executables
+with a minimal runtime implementation.)
+
+$(B Example 2)
+$(P DMD auto-generates a call to `_d_run_main` which, in turn, calls the user-defined
+`main` function.  DMD automatically generates a call to `g++` which links in the C runtime.)
+---
+module object;
+
+private alias extern(C) int function(char[][] args) MainFunc;
+private extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
+{
+    return mainFunc(null);  // assumes `void main()` for simplicity
+}
+---
+
+---
+module main;
+
+void main() { }
+---
+
+$(CONSOLE
+dmd -conf= -defaultlib= -fPIC main.d object.d -of=main
+size main
+   text    data     bss     dec     hex filename
+   1403     584      16    2003     7d3 main
+)
+
+$(B Example 3)
+$(P Manually generated call to `main`.  No C runtime.)
+---
+module object;
+
+extern(C) void __d_sys_exit(long arg1)
+{
+    asm
+    {
+        mov RAX, 60;
+        mov RDI, arg1;
+        syscall;
+    }
+}
+
+extern void main();
+private extern(C) void _start()
+{
+    main();
+    __d_sys_exit(0);
+}
+---
+
+---
+module main;
+
+void main() { }
+---
+
+$(CONSOLE
+dmd -c -lib main.d object.d -of=main.o
+ld main.o -o main
+size main
+   text    data     bss     dec     hex filename
+     56       0       0      56      38 main
+)
+
+$(P Usage of more advanced D features (e.g. classes, exceptions, etc...) will require
+runtime implementation code, but they can be implemented in a pay-as-you-go fashion.)


### PR DESCRIPTION
Revival of #7829.  For some reason re-opening is disabled.

This makes it known in the changelog that users can now use D without the runtime in a more pay-as-you-go fashion, with a low barrier to entry, and much less friction.  It is the result of the following PRs.

 * #7395 and #7768 for `ModuleInfo`
 * #7786 for `Throwable`
 * #7799 for `TypeInfo`