### PR TITLE
Fix Issue 18429 - alias this enum causes segmentation fault

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -245,6 +245,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Declaration d = sx.isDeclaration();
         if (d && !d.isTupleDeclaration())
         {
+            /* https://issues.dlang.org/show_bug.cgi?id=18429
+             *
+             * If the identifier in the AliasThis declaration
+             * is defined later and is a voldemort type, we must
+             * perform semantic on the declaration to deduce the type.
+             */
+            if (!d.type)
+                d.dsymbolSemantic(sc);
+
             Type t = d.type;
             assert(t);
             if (ad.type.implicitConvTo(t) > MATCH.nomatch)

--- a/test/compilable/aliasdecl.d
+++ b/test/compilable/aliasdecl.d
@@ -29,6 +29,13 @@ void main()
     static assert(is(Y4 == void delegate() const));
     static assert(is(Y5.Type == int));
 
+    // Issue 18429
+    struct S
+    {
+        alias a this;
+        enum a = 1;
+    }
+
  /+ struct S
     {
         int value;


### PR DESCRIPTION
If the identifier in the alias this declaration is defined later and is a voldemort type, we must perform semantic on the declaration to deduce the type.