### PR TITLE
Fix SemaphoreCI badge URL + warnings article URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ DMD
 ===
 
 [![GitHub tag](https://img.shields.io/github/tag/dlang/dmd.svg?maxAge=86400)](https://github.com/dlang/dmd/releases)
-[![Build Status](https://travis-ci.org/dlang/dmd.svg?branch=master)](https://travis-ci.org/dlang/dmd)
 [![Code coverage](https://img.shields.io/codecov/c/github/dlang/dmd.svg?maxAge=86400)](https://codecov.io/gh/dlang/dmd)
 [![license](https://img.shields.io/github/license/dlang/dmd.svg)](https://github.com/dlang/dmd/blob/master/LICENSE.txt)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DMD
 [![license](https://img.shields.io/github/license/dlang/dmd.svg)](https://github.com/dlang/dmd/blob/master/LICENSE.txt)
 
 [![CircleCI](https://circleci.com/gh/dlang/dmd/tree/master.svg?style=svg)](https://circleci.com/gh/dlang/dmd/tree/master)
-[![SemaphoreCI](https://semaphoreci.com/api/v1/wilzbach/dmd-2/branches/master/badge.svg)](https://semaphoreci.com/wilzbach/dmd-2)
+[![SemaphoreCI](https://semaphoreci.com/api/v1/dlang/dmd-2/branches/master/badge.svg)](https://semaphoreci.com/wilzbach/dmd-2)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/mv0y9lqyk7jh0x8d?svg=true)](https://ci.appveyor.com/project/greenify/dmd)
 
 DMD is the reference compiler for the D programming language.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -550,11 +550,11 @@ dmd -cov -unittest myprog.d
         ),
         Option("w",
             "warnings as errors (compilation will halt)",
-            `Enable $(LINK2 $(ROOT_DIR)/warnings.html, warnings)`
+            `Enable $(LINK2 $(ROOT_DIR)articles/warnings.html, warnings)`
         ),
         Option("wi",
             "warnings as messages (compilation will continue)",
-            `Enable $(LINK2 warnings.html, informational warnings (i.e. compilation
+            `Enable $(LINK2 $(ROOT_DIR)articles/warnings.html, informational warnings (i.e. compilation
             still proceeds normally))`,
         ),
         Option("X",


### PR DESCRIPTION
I recently changed the SemaphoreCI project to the `dlang` organization, because we got two additional boxes for free from the awesome people at Semaphore (at the moment we even have eight for one month).
The `warnings` article URL is not broken (we have redirects), but it doesn't hurt to update it. One jump less for the user.