### PR TITLE
Fix Issue 16578 - bogus deprecation - switch skips declaration of variable

### DIFF
--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1610,6 +1610,11 @@ extern (C++) final class SwitchStatement : Statement
                 // All good, the label's scope has no variables
                 return false;
             }
+            else if (vd.storage_class & STC.temp)
+            {
+                // Lifetime ends at end of expression, so no issue with skipping the statement
+                return false;
+            }
             else if (vd.ident == Id.withSym)
             {
                 deprecation("`switch` skips declaration of `with` temporary at %s", vd.loc.toChars());

--- a/test/compilable/test16578a.d
+++ b/test/compilable/test16578a.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -debug
+
+// https://issues.dlang.org/show_bug.cgi?id=16578
+
+string[string] opts;
+
+void main()
+{
+    string arg;
+    switch (arg)
+    {
+        case "-f": opts["fore"] = ""; break;
+        debug { case "-throw": opts["throw"] = ""; break; }
+        default:
+    }
+}

--- a/test/compilable/test16578b.d
+++ b/test/compilable/test16578b.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=16578
+
+void main()
+{
+    string[string] opts;
+    switch (2)
+    {
+    case 0:
+        opts["a"] = "";
+        {
+    case 1:
+            break;
+        }
+    default:
+    }
+}


### PR DESCRIPTION
The fix for this was modeled after the code here:  https://github.com/dlang/dmd/blob/56940531b005903a90ecaf0314e9198812bc69db/src/dmd/statement.d#L2264-L2267

I'm wondering if both the of these should be the same, that is

```D
else if (vd.storage_class & STC.temp || vd.storage_class & STC.exptemp)
{
    // Lifetime ends at end of expression, so no issue with skipping the statement
}
```