### PR TITLE
[WIP] add extern (C++) struct Darray(T) and Dstring to simplify interop with C++

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -877,6 +877,20 @@ public:
         }
     }
 
+    override void visit(TypeDArray t)
+    {
+        //if (substitute(t))
+            //return;
+
+        // from: template_args
+        buf.writestring("8__dslice");
+        buf.writeByte('I');
+        Type t2 = t.next;
+        assert(t2);
+        headOfType(t2);
+        buf.writeByte('E');
+    }
+
     override void visit(TypeSArray t)
     {
         if (t.isImmutable() || t.isShared())

--- a/src/dmd/interop.d
+++ b/src/dmd/interop.d
@@ -27,3 +27,5 @@ extern (C++) struct Darray(T)
 }
 
 alias Dstring = Darray!char;
+alias Dcstring = Darray!(const(char));
+

--- a/src/dmd/interop.d
+++ b/src/dmd/interop.d
@@ -1,0 +1,29 @@
+/+
+Example usage:
+extern (C++) Dstring funLib(Dstring input)
+{
+    import std.string : toUpper;
+    import std.conv : to;
+    return input.toNative.toUpper.to!Dstring;
+}
++/
+
+extern (C++) struct Darray(T)
+{
+    size_t length;
+    T* ptr;
+
+    extern (D) this(T[] a)
+    {
+        this.length = a.length;
+        this.ptr = a.ptr;
+    }
+
+    extern (D) T[] toNative()
+    {
+        // TODO: could even use a raw cast since ABI is same
+        return ptr[0 .. length];
+    }
+}
+
+alias Dstring = Darray!char;


### PR DESCRIPTION
/cc @klickverbot, @redstar @jacob-carlborg @johanengelen for LDC
/cc @ibuclaw for GDC
If this is deemed useful and has a chance to get merged I can finish this PR.

## WIP support for extern(C++) mangling of D arrays:
```
struct A(T1, T2){}
alias Tarr=A!(int, float)[];

extern(C++) {
void fun2(T)(T a){}
void fun3(Tarr a){}
}

// mangles as __Z4fun38__dsliceI1AIifEE aka fun3(__dslice<A<int, float> >) (correct)
fun3(Tarr.init); 

// mangles as: _Z4fun2I8__dsliceI1AIifEEEv8__dsliceIS1_E aka void fun2<__dslice<A<int, float> > >(__dslice<A>) which is 'not' correct (should show as __dslice<A<int, float> >)
fun2(Tarr.init); 
```

## alternatives considered
* status quo (using char*) => misses length information, adds complications eg extra parameter or `strlen`
* pragma(mangle, ...) is not a viable alternative
it'd be required on every extern(C++) declaration that uses a D array, since https://github.com/dlang/dmd/pull/7458 (pragma(mangle) on alias declarations) was abandonned due to complexity

* std::string, std::vector (https://github.com/dlang/druntime/pull/1316 ) is not viable as these would require copies (not slices)

* https://github.com/dlang/druntime/pull/2123 (Add the core.sentinel module by @marler8997) won't help with D slices in general



## old (needs updating)

eg usage:

```d
// in D
// instead of existing wrappers of the form `extern(C++) char* funLib(char* input)`
extern(C++) Dstring funLib(Dstring input){
  import std.string:toUpper;
  import std.conv:to;
  return input.toNative.toUpper.to!Dstring;
}

// in C++
char a[] = "hello world";
Dstring a2{strlen(a), a};
auto a3=funLib(a2);
```
see full working example [here](https://github.com/timotheecour/dtools/tree/master/tests/d01_dmd_string) showing using such API from C++ with the function defined in D.


originally proposed here: https://github.com/dlang/dmd/pull/7870#discussion_r168283261

motivations:

* https://github.com/dlang/dmd/pull/7870#discussion_r167875454
> Why don't you return string here? Comparing D strings is more efficient (no \0 checking)
You already know the length of the buffer - no need to throw this valuable information away.

Quoting a conversation with Walter here:

> > On 12/5/2017 11:20 AM, Andrei Alexandrescu wrote:
Hi Walter, Seb noticed that the dmd code is going through unpleasant hoops caused by C-style strings. Do you think incrementally switching to D-style strings would improve the compiler? -- Andrei

> Yes, but we have to be mindful of gdc and ldc both relying on the C++ interface to use dmd, and D strings don't work on that interface.
I've already converted a bunch of internal stuff to D strings where the interface to the back end was not involved.
