### PR TITLE
Document the new -Xi= CLI option as unstable in its changelog

### DIFF
--- a/changelog/json_includes.dd
+++ b/changelog/json_includes.dd
@@ -43,3 +43,5 @@ If JSON is generated without any `-Xi=` options then the old format is used.  Th
 Also note that the compiler can now be invoked with no source files as long as at least one JSON field is provided, i.e.
 
 $(CONSOLE dmd -Xi=compilerInfo)
+
+$(RED This is an experimental command-line flag and will be stabilized in the next release.)


### PR DESCRIPTION
`-Xi=` is still hot and it hasn't been integrated in `rdmd` nor `dub`.
While I doubt that any unexpected problems will occurr, it's good to mark it as "experimental" for this release.

Also note that for the same reason, no documentation for `-Xi=` has been added to `cli.d`.

There have been many precedents for initially undocumented CLI options in DMD - `-vcg-ast` is a recent one which isn't documented as it's still officially experimental.

CC @marler8997