### PR TITLE
fix DMDSRC link

### DIFF
--- a/changelog/default_after_variadic.dd
+++ b/changelog/default_after_variadic.dd
@@ -21,4 +21,4 @@ for every invocation:
 string log(string file = __FILE__, int line = __LINE__, T...)(T a);
 ---
 
-For more details, see $(DMDSRC test/runnable/testdefault_after_variadic.d).
+For more details, see $(DMDSRC ../../test/runnable/testdefault_after_variadic.d).

--- a/changelog/default_after_variadic.dd
+++ b/changelog/default_after_variadic.dd
@@ -20,5 +20,3 @@ for every invocation:
 ---
 string log(string file = __FILE__, int line = __LINE__, T...)(T a);
 ---
-
-For more details, see $(DMDSRC ../../test/runnable/testdefault_after_variadic.d).


### PR DESCRIPTION
cc @wilzbach a more robust fix could be to use DMDROOT with:

in dlang.org/dlang.org.ddoc:
s/
DMDSRC=$(HTTPS github.com/dlang/dmd/blob/master/src/dmd/$0, $0)
/
DMDROOT=$(HTTPS github.com/dlang/dmd/blob/master/$0, $0)
DMDSRC=$(DMDROOT src/dmd/$0) #not sure what syntax here ?
/

