### PR TITLE
fix Issue 17605 - [REG2.066.0] __traits(compiles, closure) adds link-…

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1550,16 +1550,21 @@ extern (C++) class VarDeclaration : Declaration
         }
 
         // Add this to fdv.closureVars[] if not already there
-        for (size_t i = 0; 1; i++)
+        if (!sc.intypeof && !(sc.flags & SCOPE.compile) &&
+            // https://issues.dlang.org/show_bug.cgi?id=17605
+            (fdv.flags & FUNCFLAG.compileTimeOnly || !(fdthis.flags & FUNCFLAG.compileTimeOnly))
+           )
         {
-            if (i == fdv.closureVars.dim)
+            for (size_t i = 0; 1; i++)
             {
-                if (!sc.intypeof && !(sc.flags & SCOPE.compile))
+                if (i == fdv.closureVars.dim)
+                {
                     fdv.closureVars.push(this);
-                break;
+                    break;
+                }
+                if (fdv.closureVars[i] == this)
+                    break;
             }
-            if (fdv.closureVars[i] == this)
-                break;
         }
 
         //printf("fdthis is %s\n", fdthis.toChars());

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2584,6 +2584,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         //printf("function storage_class = x%llx, sc.stc = x%llx, %x\n", storage_class, sc.stc, Declaration::isFinal());
 
+        if (sc.flags & SCOPE.compile)
+            funcdecl.flags |= FUNCFLAG.compileTimeOnly; // don't emit code for this function
+
         FuncLiteralDeclaration fld = funcdecl.isFuncLiteralDeclaration();
         if (fld && fld.treq)
         {

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -149,6 +149,7 @@ enum FUNCFLAG : uint
     inlineScanned    = 0x20,   /// function has been scanned for inline possibilities
     inferScope       = 0x40,   /// infer 'scope' for parameters
     hasCatches       = 0x80,   /// function has try-catch statements
+    compileTimeOnly  = 0x100,  /// is a compile time only function; no code will be generated for it
 }
 
 /***********************************************************

--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -25,3 +25,14 @@ extern (C) void main()
 {
     test(1);
 }
+
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=17605
+
+extern (C) void test17605()
+{
+    int a;
+    enum bool works = __traits(compiles, { a = 1; });
+    a = 1;
+}
+


### PR DESCRIPTION
…time reference to _d_allocmemory

The offending line was added by https://github.com/dlang/dmd/pull/3625 so we'll try removing the line and see what happens.