### PR TITLE
Remove extra field in module.h

### DIFF
--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -77,7 +77,6 @@ public:
     const char *arg;    // original argument name
     ModuleDeclaration *md; // if !NULL, the contents of the ModuleDeclaration declaration
     File *srcfile;      // input source file
-    const char* srcfilePath; // the path prefix to the srcfile if it applies
     File *objfile;      // output .obj file
     File *hdrfile;      // 'header' file
     File *docfile;      // output documentation file


### PR DESCRIPTION
Bug introduced by (https://github.com/dlang/dmd/pull/7798).  The `srcfilePath` field was removed from the `Module` class in `dmodule.d` but not `module.h`.

This discrepancy was not caught with the test suite, however, one of my other PRs exposed this bug so here's the fix.