### PR TITLE
correct namespace mangling for Issue 17772

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -584,7 +584,20 @@ private final class CppMangleVisitor : Visitor
              */
             TemplateInstance ti = d.parent.isTemplateInstance();
             assert(ti);
-            source_name(ti);
+            Dsymbol p = ti.toParent();
+            if (p && !p.isModule() && tf.linkage == LINK.cpp)
+            {
+                buf.writeByte('N');
+                CV_qualifiers(d.type);
+                prefix_name(p);
+                if (d.isDtorDeclaration())
+                    buf.writestring("D1");
+                else
+                    source_name(ti);
+                buf.writeByte('E');
+            }
+            else
+                source_name(ti);
             headOfType(tf.nextOf());  // mangle return type
         }
         else

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -438,3 +438,15 @@ version (linux)
 {
     static assert(test36.mangleof == "_Z6test36PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPiPS12_");
 }
+
+/*****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=17772
+
+extern(C++, SPACE)
+int test37(T)(){ return 0;}
+
+version (Posix) // all non-Windows machines
+{
+    static assert(test37!int.mangleof == "_ZN5SPACE6test37IiEEiv");
+}
+


### PR DESCRIPTION
This fixes the lack of namespace mangling for templates in https://issues.dlang.org/show_bug.cgi?id=17772

Fixing the `T_` mangling is much more problematic, I don't know how to do that yet. This namespace issue is independent, so it is convenient to do it separately.