### PR TITLE
[cleanup] Remove dmd.gluelayer import from modules that don't need it

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -40,7 +40,6 @@ import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
 import dmd.globals;
-import dmd.gluelayer;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -41,7 +41,6 @@ import dmd.expression;
 import dmd.expressionsem;
 import dmd.func;
 import dmd.globals;
-import dmd.gluelayer;
 import dmd.id;
 import dmd.identifier;
 import dmd.init;


### PR DESCRIPTION
I imagine there might be other imports in these modules that were copied from `foo` -> `foosem`, but not subsequently checked.  This just removes backend imports from the frontend.