### PR TITLE
[refactor] Remove dead parameters from many functions

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3550,7 +3550,7 @@ struct ASTBase
     {
         Type basetype;
 
-        extern (D) this(Loc loc, Type baseType)
+        extern (D) this(Type baseType)
         {
             super(Tvector);
             this.basetype = basetype;
@@ -3558,7 +3558,7 @@ struct ASTBase
 
         override Type syntaxCopy()
         {
-            return new TypeVector(Loc.initial, basetype.syntaxCopy());
+            return new TypeVector(basetype.syntaxCopy());
         }
 
         override void accept(Visitor v)

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -189,7 +189,7 @@ UnionExp pointerDifference(Loc loc, Type *type, Expression *e1, Expression *e2);
 
 /// Return 1 if true, 0 if false
 /// -1 if comparison is illegal because they point to non-comparable memory blocks
-int comparePointers(Loc loc, TOK op, Type *type, Expression *agg1, dinteger_t ofs1, Expression *agg2, dinteger_t ofs2);
+int comparePointers(TOK op, Expression *agg1, dinteger_t ofs1, Expression *agg2, dinteger_t ofs2);
 
 // Return eptr op e2, where eptr is a pointer, e2 is an integer,
 // and op is TOKadd or TOKmin

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -154,9 +154,6 @@ StringExp *createBlockDuplicatedStringLiteral(Loc loc, Type *type,
  */
 void assignInPlace(Expression *dest, Expression *src);
 
-/// Create a new struct literal, which is the same as se except that se.field[offset] = elem
-Expression * modifyStructField(Type *type, StructLiteralExp *se, size_t offset, Expression *newval);
-
 /// Given an AA literal aae,  set arr[index] = newval and return the new array.
 Expression *assignAssocArrayElement(Loc loc, AssocArrayLiteralExp *aae,
     Expression *index, Expression *newval);

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -913,7 +913,7 @@ extern (C++) UnionExp pointerArithmetic(const ref Loc loc, TOK op, Type type, Ex
 
 // Return 1 if true, 0 if false
 // -1 if comparison is illegal because they point to non-comparable memory blocks
-extern (C++) int comparePointers(const ref Loc loc, TOK op, Type type, Expression agg1, dinteger_t ofs1, Expression agg2, dinteger_t ofs2)
+extern (C++) int comparePointers(TOK op, Expression agg1, dinteger_t ofs1, Expression agg2, dinteger_t ofs2)
 {
     if (pointToSameMemoryBlock(agg1, agg2))
     {

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -126,7 +126,7 @@ extern (C++) final class VoidInitExp : Expression
 {
     VarDeclaration var;
 
-    extern (D) this(VarDeclaration var, Type type)
+    extern (D) this(VarDeclaration var)
     {
         super(var.loc, TOK.void_, __traits(classInstanceSize, VoidInitExp));
         this.var = var;
@@ -1997,6 +1997,6 @@ extern (C++) UnionExp voidInitLiteral(Type t, VarDeclaration var)
         se.ownedByCtfe = OwnedBy.ctfe;
     }
     else
-        emplaceExp!(VoidInitExp)(&ue, var, t);
+        emplaceExp!(VoidInitExp)(&ue, var);
     return ue;
 }

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3450,7 +3450,7 @@ extern (C++) bool arrayTypeCompatible(Loc loc, Type t1, Type t2)
  * This is to enable comparing things like an immutable
  * array with a mutable one.
  */
-extern (C++) bool arrayTypeCompatibleWithoutCasting(Loc loc, Type t1, Type t2)
+extern (C++) bool arrayTypeCompatibleWithoutCasting(Type t1, Type t2)
 {
     t1 = t1.toBasetype();
     t2 = t2.toBasetype();

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -344,7 +344,7 @@ extern (C++) abstract class Declaration : Dsymbol
      * Check to see if declaration can be modified in this context (sc).
      * Issue error if not.
      */
-    final int checkModify(Loc loc, Scope* sc, Type t, Expression e1, int flag)
+    final int checkModify(Loc loc, Scope* sc, Expression e1, int flag)
     {
         VarDeclaration v = isVarDeclaration();
         if (v && v.canassign)

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -131,7 +131,7 @@ public:
     const char *kind() const;
     d_uns64 size(Loc loc);
     bool checkDisabled(Loc loc, Scope* sc, bool isAliasedDeclaration = false);
-    int checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int flag);
+    int checkModify(Loc loc, Scope *sc, Expression *e1, int flag);
 
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
 

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -3241,7 +3241,7 @@ public:
             Expression agg1 = getAggregateFromPointer(e1, &ofs1);
             Expression agg2 = getAggregateFromPointer(e2, &ofs2);
             //printf("agg1 = %p %s, agg2 = %p %s\n", agg1, agg1.toChars(), agg2, agg2.toChars());
-            int cmp = comparePointers(e.loc, e.op, e.type, agg1, ofs1, agg2, ofs2);
+            int cmp = comparePointers(e.op, agg1, ofs1, agg2, ofs2);
             if (cmp == -1)
             {
                 char dir = (e.op == TOK.greaterThan || e.op == TOK.greaterOrEqual) ? '<' : '>';
@@ -4681,7 +4681,7 @@ public:
         TOK cmpop = ex.op;
         if (nott)
             cmpop = reverseRelation(cmpop);
-        int cmp = comparePointers(e.loc, cmpop, e.e1.type, agg1, ofs1, agg2, ofs2);
+        int cmp = comparePointers(cmpop, agg1, ofs1, agg2, ofs2);
         // We already know this is a valid comparison.
         assert(cmp >= 0);
         if (e.op == TOK.andAnd && cmp == 1 || e.op == TOK.orOr && cmp == 0)

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -388,7 +388,7 @@ extern (C++) void gendocfile(Module m)
     }
     DocComment.parseMacros(&m.escapetable, &m.macrotable, mbuf.peekSlice().ptr, mbuf.peekSlice().length);
     Scope* sc = Scope.createGlobal(m); // create root scope
-    DocComment* dc = DocComment.parse(sc, m, m.comment);
+    DocComment* dc = DocComment.parse(m, m.comment);
     dc.pmacrotable = &m.macrotable;
     dc.pescapetable = &m.escapetable;
     sc.lastdc = dc;
@@ -921,7 +921,7 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
             }
             if (s)
             {
-                DocComment* dc = DocComment.parse(sc, s, com);
+                DocComment* dc = DocComment.parse(s, com);
                 dc.pmacrotable = &sc._module.macrotable;
                 sc.lastdc = dc;
             }
@@ -1407,7 +1407,7 @@ struct DocComment
     Escape** pescapetable;
     Dsymbols a;
 
-    extern (C++) static DocComment* parse(Scope* sc, Dsymbol s, const(char)* comment)
+    extern (C++) static DocComment* parse(Dsymbol s, const(char)* comment)
     {
         //printf("parse(%s): '%s'\n", s.toChars(), comment);
         auto dc = new DocComment();

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -36,7 +36,7 @@ import dmd.tokens;
 
 //version=LOGSEARCH;
 
-extern (C++) bool mergeFieldInit(Loc loc, ref uint fieldInit, uint fi, bool mustInit)
+private bool mergeFieldInit(ref uint fieldInit, uint fi, bool mustInit)
 {
     if (fi != fieldInit)
     {
@@ -422,7 +422,7 @@ struct Scope
             {
                 VarDeclaration v = ad.fields[i];
                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                if (!.mergeFieldInit(loc, fieldinit[i], fies[i], mustInit))
+                if (!.mergeFieldInit(fieldinit[i], fies[i], mustInit))
                 {
                     .error(loc, "one path skips field `%s`", ad.fields[i].toChars());
                 }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4209,7 +4209,7 @@ extern (C++) final class VarExp : SymbolExp
     {
         //printf("VarExp::checkModifiable %s", toChars());
         assert(type);
-        return var.checkModify(loc, sc, type, null, flag);
+        return var.checkModify(loc, sc, null, flag);
     }
 
     bool checkReadModifyWrite();
@@ -5249,7 +5249,7 @@ extern (C++) final class DotVarExp : UnaExp
             return 2;
 
         if (e1.op == TOK.this_)
-            return var.checkModify(loc, sc, type, e1, flag);
+            return var.checkModify(loc, sc, e1, flag);
 
         //printf("\te1 = %s\n", e1.toChars());
         return e1.checkModifiable(sc, flag);
@@ -5598,7 +5598,7 @@ extern (C++) final class PtrExp : UnaExp
         if (e1.op == TOK.symbolOffset)
         {
             SymOffExp se = cast(SymOffExp)e1;
-            return se.var.checkModify(loc, sc, type, null, flag);
+            return se.var.checkModify(loc, sc, null, flag);
         }
         else if (e1.op == TOK.address)
         {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -466,7 +466,7 @@ extern (C++) bool isNeedThisScope(Scope* sc, Declaration d)
  * Bugs:
  * This doesn't appear to do anything.
  */
-private bool checkPropertyCall(Expression e, Expression emsg)
+private bool checkPropertyCall(Expression e)
 {
     while (e.op == TOK.comma)
         e = (cast(CommaExp)e).e2;
@@ -884,7 +884,7 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
             e = e.trySemantic(sc);
             if (!e)
             {
-                checkPropertyCall(ex, e1);
+                checkPropertyCall(ex);
                 ex = new AssignExp(loc, ex, e2);
                 return ex.expressionSemantic(sc);
             }
@@ -894,7 +894,7 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
             // strict setter prints errors if fails
             e = e.expressionSemantic(sc);
         }
-        checkPropertyCall(e, e1);
+        checkPropertyCall(e);
         return e;
     }
     else
@@ -906,7 +906,7 @@ extern (C++) Expression resolveUFCSProperties(Scope* sc, Expression e1, Expressi
         (*arguments)[0] = eleft;
         e = new CallExp(loc, e, arguments);
         e = e.expressionSemantic(sc);
-        checkPropertyCall(e, e1);
+        checkPropertyCall(e);
         return e.expressionSemantic(sc);
     }
 }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6069,7 +6069,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  * https://issues.dlang.org/show_bug.cgi?id=2684
                  * see also bug https://issues.dlang.org/show_bug.cgi?id=2954 b
                  */
-                if (!arrayTypeCompatibleWithoutCasting(exp.e2.loc, exp.e2.type, taa.index))
+                if (!arrayTypeCompatibleWithoutCasting(exp.e2.type, taa.index))
                 {
                     exp.e2 = exp.e2.implicitCastTo(sc, taa.index); // type checking
                     if (exp.e2.type == Type.terror)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -452,7 +452,7 @@ private bool arrayExpressionToCommonType(Scope* sc, Expressions* exps, Type* pt)
  * Returns:
  *      true    a semantic error occurred
  */
-private bool preFunctionParameters(Loc loc, Scope* sc, Expressions* exps)
+private bool preFunctionParameters(Scope* sc, Expressions* exps)
 {
     bool err = false;
     if (exps)
@@ -2077,12 +2077,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         //printf("tb: %s, deco = %s\n", tb.toChars(), tb.deco);
 
         if (arrayExpressionSemantic(exp.newargs, sc) ||
-            preFunctionParameters(exp.loc, sc, exp.newargs))
+            preFunctionParameters(sc, exp.newargs))
         {
             return setError();
         }
         if (arrayExpressionSemantic(exp.arguments, sc) ||
-            preFunctionParameters(exp.loc, sc, exp.arguments))
+            preFunctionParameters(sc, exp.arguments))
         {
             return setError();
         }
@@ -2748,7 +2748,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         if (exp.e1.op == TOK.function_)
         {
-            if (arrayExpressionSemantic(exp.arguments, sc) || preFunctionParameters(exp.loc, sc, exp.arguments))
+            if (arrayExpressionSemantic(exp.arguments, sc) || preFunctionParameters(sc, exp.arguments))
                 return setError();
 
             // Run e1 semantic even if arguments have any errors
@@ -2947,7 +2947,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp.e1;
             return;
         }
-        if (arrayExpressionSemantic(exp.arguments, sc) || preFunctionParameters(exp.loc, sc, exp.arguments))
+        if (arrayExpressionSemantic(exp.arguments, sc) || preFunctionParameters(sc, exp.arguments))
             return setError();
 
         // Check for call operator overload

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -721,7 +721,7 @@ public:
     {
         if (t.ty == Tfunction)
         {
-            visitFuncIdentWithPrefix(cast(TypeFunction)t, ident, null, true);
+            visitFuncIdentWithPrefix(cast(TypeFunction)t, ident, null);
             return;
         }
         visitWithMask(t, 0);
@@ -912,7 +912,7 @@ public:
         t.inuse--;
     }
 
-    void visitFuncIdentWithPrefix(TypeFunction t, Identifier ident, TemplateDeclaration td, bool isPostfixStyle)
+    void visitFuncIdentWithPrefix(TypeFunction t, Identifier ident, TemplateDeclaration td)
     {
         if (t.inuse)
         {
@@ -3370,7 +3370,7 @@ extern (C++) void functionToBufferFull(TypeFunction tf, OutBuffer* buf, Identifi
 {
     //printf("TypeFunction::toCBuffer() this = %p\n", this);
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
-    v.visitFuncIdentWithPrefix(tf, ident, td, true);
+    v.visitFuncIdentWithPrefix(tf, ident, td);
 }
 
 // ident is inserted before the argument list and will be "function" or "delegate" for a type

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -399,7 +399,7 @@ class Lexer
                 else
                     goto case_ident;
             case '"':
-                t.value = escapeStringConstant(t, 0);
+                t.value = escapeStringConstant(t);
                 return;
             case 'a':
             case 'b':
@@ -1620,7 +1620,7 @@ class Lexer
 
     /**************************************
      */
-    final TOK escapeStringConstant(Token* t, int wide)
+    final TOK escapeStringConstant(Token* t)
     {
         const start = loc();
         p++;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4339,15 +4339,15 @@ extern (C++) final class TypeVector : Type
 {
     Type basetype;
 
-    extern (D) this(const ref Loc loc, Type basetype)
+    extern (D) this(Type basetype)
     {
         super(Tvector);
         this.basetype = basetype;
     }
 
-    static TypeVector create(const ref Loc loc, Type basetype)
+    static TypeVector create(Type basetype)
     {
-        return new TypeVector(loc, basetype);
+        return new TypeVector(basetype);
     }
 
     override const(char)* kind() const
@@ -4357,7 +4357,7 @@ extern (C++) final class TypeVector : Type
 
     override Type syntaxCopy()
     {
-        return new TypeVector(Loc.initial, basetype.syntaxCopy());
+        return new TypeVector(basetype.syntaxCopy());
     }
 
     override d_uns64 size(const ref Loc loc)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -9051,24 +9051,6 @@ extern (C++) final class Parameter : RootObject
         return params;
     }
 
-    /****************************************
-     * Determine if parameter list is really a template parameter list
-     * (i.e. it has auto or alias parameters)
-     */
-    extern (D) static int isTPL(Parameters* parameters)
-    {
-        //printf("Parameter::isTPL()\n");
-
-        int isTPLDg(size_t n, Parameter p)
-        {
-            if (p.storageClass & (STC.alias_ | STC.auto_ | STC.static_))
-                return 1;
-            return 0;
-        }
-
-        return _foreach(parameters, &isTPLDg);
-    }
-
     /***************************************
      * Determine number of arguments, folding in tuples.
      */

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -888,6 +888,6 @@ public:
 };
 
 bool arrayTypeCompatible(Loc loc, Type *t1, Type *t2);
-bool arrayTypeCompatibleWithoutCasting(Loc loc, Type *t1, Type *t2);
+bool arrayTypeCompatibleWithoutCasting(Type *t1, Type *t2);
 
 #endif /* DMD_MTYPE_H */

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -415,7 +415,7 @@ class TypeVector : public Type
 public:
     Type *basetype;
 
-    static TypeVector *create(Loc loc, Type *basetype);
+    static TypeVector *create(Type *basetype);
     const char *kind();
     Type *syntaxCopy();
     d_uns64 size(Loc loc);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4428,16 +4428,6 @@ final class Parser(AST) : Lexer
             else if (t.ty == AST.Tfunction)
             {
                 AST.Expression constraint = null;
-                version (none)
-                {
-                    TypeFunction tf = cast(TypeFunction)t;
-                    if (Parameter.isTPL(tf.parameters))
-                    {
-                        if (!tpl)
-                            tpl = new TemplateParameters();
-                    }
-                }
-
                 //printf("%s funcdecl t = %s, storage_class = x%lx\n", loc.toChars(), t.toChars(), storage_class);
                 auto f = new AST.FuncDeclaration(loc, Loc.initial, ident, storage_class | (disable ? AST.STC.disable : 0), t);
                 if (pAttrs)

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2109,12 +2109,11 @@ final class Parser(AST) : Lexer
      */
     AST.Type parseVector()
     {
-        const loc = token.loc;
         nextToken();
         check(TOK.leftParentheses);
         AST.Type tb = parseType();
         check(TOK.rightParentheses);
-        return new AST.TypeVector(loc, tb);
+        return new AST.TypeVector(tb);
     }
 
     /***********************************


### PR DESCRIPTION
When doing a sweep of the C++ codebase, these were picked up and found in master also.