### PR TITLE
Set CallExp's function declaration immediately for criticalEnter/Exit

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5439,6 +5439,19 @@ extern (C++) final class CallExp : UnaExp
         this.arguments = arguments;
     }
 
+    /***********************************************************
+    * Instatiates a new function call expression
+    * Params:
+    *       loc   = location
+    *       fd    = the declaration of the function to call
+    *       earg1 = the function argument
+    */
+    extern(D) this(const ref Loc loc, FuncDeclaration fd, Expression earg1)
+    {
+        this(loc, new VarExp(loc, fd, false), earg1);
+        this.f = fd;
+    }
+
     static CallExp create(Loc loc, Expression e, Expressions* exps)
     {
         return new CallExp(loc, e, exps);
@@ -5452,6 +5465,18 @@ extern (C++) final class CallExp : UnaExp
     static CallExp create(Loc loc, Expression e, Expression earg1)
     {
         return new CallExp(loc, e, earg1);
+    }
+
+    /***********************************************************
+    * Creates a new function call expression
+    * Params:
+    *       loc   = location
+    *       fd    = the declaration of the function to call
+    *       earg1 = the function argument
+    */
+    static CallExp create(Loc loc, FuncDeclaration fd, Expression earg1)
+    {
+        return new CallExp(loc, fd, earg1);
     }
 
     override Expression syntaxCopy()

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -813,6 +813,7 @@ public:
     static CallExp *create(Loc loc, Expression *e, Expressions *exps);
     static CallExp *create(Loc loc, Expression *e);
     static CallExp *create(Loc loc, Expression *e, Expression *earg1);
+    static CallExp *create(Loc loc, FuncDeclaration *fd, Expression *earg1);
 
     Expression *syntaxCopy();
     bool isLvalue();

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3442,12 +3442,12 @@ else
                 args.push(new Parameter(0, ClassDeclaration.object.type, null, null));
 
                 FuncDeclaration fdenter = FuncDeclaration.genCfunc(args, Type.tvoid, Id.monitorenter);
-                Expression e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), new VarExp(ss.loc, tmp));
+                Expression e = new CallExp(ss.loc, fdenter, new VarExp(ss.loc, tmp));
                 e.type = Type.tvoid; // do not run semantic on e
 
                 cs.push(new ExpStatement(ss.loc, e));
                 FuncDeclaration fdexit = FuncDeclaration.genCfunc(args, Type.tvoid, Id.monitorexit);
-                e = new CallExp(ss.loc, new VarExp(ss.loc, fdexit, false), new VarExp(ss.loc, tmp));
+                e = new CallExp(ss.loc, fdexit, new VarExp(ss.loc, tmp));
                 e.type = Type.tvoid; // do not run semantic on e
                 Statement s = new ExpStatement(ss.loc, e);
                 s = new TryFinallyStatement(ss.loc, ss._body, s);
@@ -3485,14 +3485,14 @@ else
             FuncDeclaration fdenter = FuncDeclaration.genCfunc(args, Type.tvoid, Id.criticalenter, STC.nothrow_);
             Expression e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
             e = e.expressionSemantic(sc);
-            e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), e);
+            e = new CallExp(ss.loc, fdenter, e);
             e.type = Type.tvoid; // do not run semantic on e
             cs.push(new ExpStatement(ss.loc, e));
 
             FuncDeclaration fdexit = FuncDeclaration.genCfunc(args, Type.tvoid, Id.criticalexit, STC.nothrow_);
             e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
             e = e.expressionSemantic(sc);
-            e = new CallExp(ss.loc, new VarExp(ss.loc, fdexit, false), e);
+            e = new CallExp(ss.loc, fdexit, e);
             e.type = Type.tvoid; // do not run semantic on e
             Statement s = new ExpStatement(ss.loc, e);
             s = new TryFinallyStatement(ss.loc, ss._body, s);


### PR DESCRIPTION
This is an alternative to #6840.  Please see the discussion there for context.

Essentially, this is a courtesy PR for LDC to reduce DMD/LDC diff and relieve a minor inconvenience [described here](https://github.com/dlang/dmd/pull/6840#issuecomment-304742970).

This requires @thewilsonator's approval.

