### PR TITLE
Fix Issue 18468 - cannot use `synchronized {}` in @safe code

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3460,14 +3460,15 @@ else
         else
         {
             /* Generate our own critical section, then rewrite as:
-             *  __gshared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsec;
-             *  _d_criticalenter(__critsec.ptr);
-             *  try { body } finally { _d_criticalexit(__critsec.ptr); }
+             *  shared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsec;
+             *  _d_criticalenter(&__critsec[0]);
+             *  try { body } finally { _d_criticalexit(&__critsec[0]); }
              */
             auto id = Identifier.generateId("__critsec");
             auto t = Type.tint8.sarrayOf(Target.ptrsize + Target.critsecsize());
             auto tmp = new VarDeclaration(ss.loc, t, id, null);
-            tmp.storage_class |= STC.temp | STC.gshared | STC.static_;
+            tmp.storage_class |= STC.temp | STC.shared_ | STC.static_;
+            Expression tmpExp = new VarExp(ss.loc, tmp);
 
             auto cs = new Statements();
             cs.push(new ExpStatement(ss.loc, tmp));
@@ -3483,14 +3484,15 @@ else
             args.push(new Parameter(0, t.pointerTo(), null, null));
 
             FuncDeclaration fdenter = FuncDeclaration.genCfunc(args, Type.tvoid, Id.criticalenter, STC.nothrow_);
-            Expression e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
+            Expression int0 = new IntegerExp(ss.loc, dinteger_t(0), Type.tint8);
+            Expression e = new AddrExp(ss.loc, new IndexExp(ss.loc, tmpExp, int0));
             e = e.expressionSemantic(sc);
             e = new CallExp(ss.loc, new VarExp(ss.loc, fdenter, false), e);
             e.type = Type.tvoid; // do not run semantic on e
             cs.push(new ExpStatement(ss.loc, e));
 
             FuncDeclaration fdexit = FuncDeclaration.genCfunc(args, Type.tvoid, Id.criticalexit, STC.nothrow_);
-            e = new DotIdExp(ss.loc, new VarExp(ss.loc, tmp), Id.ptr);
+            e = new AddrExp(ss.loc, new IndexExp(ss.loc, tmpExp, int0));
             e = e.expressionSemantic(sc);
             e = new CallExp(ss.loc, new VarExp(ss.loc, fdexit, false), e);
             e.type = Type.tvoid; // do not run semantic on e

--- a/test/compilable/test18468.d
+++ b/test/compilable/test18468.d
@@ -1,0 +1,5 @@
+// https://issues.dlang.org/show_bug.cgi?id=18468
+@safe void main()
+{
+    synchronized {}
+}


### PR DESCRIPTION
DRuntime already uses `shared` internally: https://github.com/dlang/druntime/blob/master/src/rt/critical_.d#L32