### PR TITLE
Use "" (empty argument) to indicate no file after -run

### DIFF
--- a/test/compilable/diag13110a.sh
+++ b/test/compilable/diag13110a.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+name=`basename $0 .sh`
+dir=${RESULTS_DIR}/compilable
+output_file=${dir}/${name}.d
+
+out=$(${DMD} -m${MODEL} -run compilable/extra-files/hello.d)
+echo ${out} | grep -q hello
+
+out=$(${DMD} -m${MODEL} compilable/extra-files/hello.d -run "")
+echo ${out} | grep -q hello

--- a/test/compilable/diag13110b.sh
+++ b/test/compilable/diag13110b.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+name=`basename $0 .sh`
+dir=${RESULTS_DIR}/compilable
+output_file=${dir}/${name}.sh.out
+
+out=$(${DMD} -m${MODEL} -run compilable/extra-files/echoargs.d a b c)
+echo ${out} | grep -q "a b c"
+
+out=$(${DMD} -m${MODEL} compilable/extra-files/echoargs.d -run "" a b c)
+echo ${out} | grep -q "a b c"

--- a/test/compilable/extra-files/echoargs.d
+++ b/test/compilable/extra-files/echoargs.d
@@ -1,0 +1,12 @@
+import core.stdc.stdio;
+int main(string[] args)
+{
+    string prefix = "";
+    foreach(arg; args[1 .. $])
+    {
+        printf("%s%.*s", prefix.ptr, arg.length, arg.ptr);
+        prefix = " ";
+    }
+    printf("\n");
+    return 0;
+}

--- a/test/compilable/extra-files/hello.d
+++ b/test/compilable/extra-files/hello.d
@@ -1,0 +1,6 @@
+import core.stdc.stdio;
+int main()
+{
+    printf("hello\n");
+    return 0;
+}

--- a/test/fail_compilation/diag6743.d
+++ b/test/fail_compilation/diag6743.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -run test.exe
 TEST_OUTPUT:
 ---
-Error: -run must be followed by a source file, not 'test.exe'
+Error: -run must be followed by a source file, '-' or '', not 'test.exe'
        run 'dmd -man' to open browser on manual
 ---
 */


### PR DESCRIPTION
Fix issue 18477

Currently, `-run` must appear at the end of the command line and be followed by a single source file and then the arguments to pass to the compiled program, i.e.
```BASH
dmd <files/options>... -run <file> <arg>...
# EXAMPLE
dmd foo.d bar.d -run baz.d <arg>...
```

This interface makes it difficult for tools to take a list of source files and pass them to dmd with the `-run` option, i.e.
```BASH
FILES=foo.d bar.d baz.d
dmd ???<insert-bash-vodo>???
```

For myself and others, this interface is confusing.  Having to put exactly one source file after `-run` followed by the compiled program arguments is unintuitive.  It requires that one of the files be "split up" from the rest and moved behind the `-run` argument.  I'm not sure why it was designed this way, my best guess is that it is supposed to indicate which source file has the `main` function, but DMD already knows this which violates the DRY principle, and furthermore, DMD doesn't enforce this requirement.

It's too late to change this interface and break tools that use it this way, however, I propose we support `--` as a special argument after `-run` to indicate "no file".
```BASH
dmd foo.d bar.d baz.d -run -- <arg1> <arg2> ...
```

This allows all source files to be given before `-run` while maintaining compatibility with the original interface.  It's also unambiguous.  Note that supporting a special argument to mean "no file" would be required even if we wanted to make the file argument completely optional (i.e. `dmd foo.d -run arg1 arg2...`).  For example, if we just made the file optional, then we would need to define a mechanism to determine when the first argument after `-run` is a file meant for the compiler.  Assume that "mechanism" is when the argument has a `.d` extension.  But then when we want to pass an argument with a `.d` extension as the first argument to the compiled program, we will need to come up with a mechanism to negate the original "mechanism", which is why we would still need to define a special argument to indicate "no file".  So in any case, if we want to support this and be backwards compatible, we must support a special argument that means "no file".

So just note that this change improves some use cases for `-run` without superseding future improvements, such as making the file after `-run` optional or creating a new command-line option that does not take a file but only arguments to the command-line program.  In other words, it is the minimum change set needed to make `-run` more usable without breaking compatibility.