### PR TITLE
Move common BASH test logic to wrapper

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -216,15 +216,13 @@ $(RESULTS_DIR)/runnable/%.d.out: runnable/%.d $(RESULTS_DIR)/.created test_tools
 	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d
 
 $(RESULTS_DIR)/runnable/%.sh.out: runnable/%.sh $(RESULTS_DIR)/.created test_tools $(DMD)
-	$(QUIET) echo " ... $(<D)/$*.sh"
-	$(QUIET) ./$(<D)/$*.sh
+	$(QUIET) ./sh_do_test.sh $(<D) $*
 
 $(RESULTS_DIR)/compilable/%.d.out: compilable/%.d $(RESULTS_DIR)/.created test_tools $(DMD)
 	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d
 
 $(RESULTS_DIR)/compilable/%.sh.out: compilable/%.sh $(RESULTS_DIR)/.created test_tools $(DMD)
-	$(QUIET) echo " ... $(<D)/$*.sh"
-	$(QUIET) ./$(<D)/$*.sh
+	$(QUIET) ./sh_do_test.sh $(<D) $*
 
 $(RESULTS_DIR)/fail_compilation/%.d.out: fail_compilation/%.d $(RESULTS_DIR)/.created test_tools $(DMD)
 	$(QUIET) $(RESULTS_DIR)/d_do_test $(<D) $* d

--- a/test/compilable/crlf.sh
+++ b/test/compilable/crlf.sh
@@ -2,9 +2,8 @@
 
 # Test CRLF and mixed line ending handling in D lexer.
 
-name=`basename $0 .sh`
 dir=${RESULTS_DIR}/compilable
-fn=${dir}/${name}.d
+fn=${TEST_DIR}/${TEST_NAME}.d
 
 printf '%s\r\n' \
        '#!/usr/bin/env dmd -run' \
@@ -46,8 +45,8 @@ printf 'static assert(wstr == "%s");\n' 'foo\nbar\nbaz\n' >> ${fn}
 printf 'enum dstr = q"(\r\nfoo\r\nbar\nbaz\r\n)";\n' >> ${fn}
 printf 'static assert(dstr == "%s");\n' '\nfoo\nbar\nbaz\n' >> ${fn}
 
-$DMD -c -D -Dd${dir} -m${MODEL} -of${dir}/${name}a${OBJ} ${fn} || exit 1
+$DMD -c -D -Dd${TEST_DIR} -m${MODEL} -of${TEST_DIR}/${TEST_NAME}a${OBJ} ${fn} || exit 1
 
-rm -f ${dir}/${name}a${OBJ} ${dir}/${name}.html ${fn}
+rm -f ${TEST_DIR}/${TEST_NAME}a${OBJ} ${TEST_DIR}/${TEST_NAME}.html ${fn}
 
-echo Success >${dir}/`basename $0`.out
+echo Success

--- a/test/compilable/ddoc9764.sh
+++ b/test/compilable/ddoc9764.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
-name=`basename $0 .sh`
-dir=${RESULTS_DIR}/compilable
-output_file=${dir}/${name}.html
+output_file=${RESULTS_DIR}/${TEST_DIR}/${TEST_NAME}.html
 
 rm -f ${output_file}
 
 $DMD -m${MODEL} -D -o- compilable/extra-files/ddoc9764.dd -Df${output_file}
 
-compilable/extra-files/ddocAny-postscript.sh 9764 && touch ${dir}/`basename $0`.out
+compilable/extra-files/ddocAny-postscript.sh 9764 && touch ${TEST_DIR}/${TEST_NAME}.out

--- a/test/compilable/issue17167.sh
+++ b/test/compilable/issue17167.sh
@@ -5,12 +5,11 @@ set -euo pipefail
 # Test that file paths larger than 248 characters can be used
 # Test CRLF and mixed line ending handling in D lexer.
 
-name=$(basename "$0" .sh)
 dir=${RESULTS_DIR}/compilable/
 
-test_dir=${dir}/${name}/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+test_dir=${dir}/${TEST_NAME}/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
 [[ -d $test_dir ]] || mkdir -p "$test_dir"
-bin_base=${test_dir}/${name}
+bin_base=${test_dir}/${TEST_NAME}
 bin="$bin_base$OBJ"
 src="$bin_base.d"
 
@@ -19,6 +18,6 @@ echo 'void main() {}' > "${src}"
 # Only compile, not link, since optlink can't handle long file names
 $DMD -m"${MODEL}" "${DFLAGS}" -c -of"${bin}" "${src}" || exit 1
 
-rm -rf "${dir:?}"/"$name"
+rm -rf "${dir:?}"/"$TEST_NAME"
 
-echo Success >"${dir}"/"$(basename $0)".out
+echo Success

--- a/test/compilable/jsonNoOutFile.sh
+++ b/test/compilable/jsonNoOutFile.sh
@@ -4,4 +4,3 @@ dir=${RESULTS_DIR}/compilable
 output_file=${dir}/jsonNoOutFile.sh.out
 $DMD -c -od=${dir} -Xi=compilerInfo compilable/extra-files/emptymain.d > ${output_file}
 rm -f emptymain.json || true
-

--- a/test/compilable/test14894.sh
+++ b/test/compilable/test14894.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
-name=`basename $0 .sh`
 dir=${RESULTS_DIR}/compilable
 src=compilable/extra-files
 
-$DMD -c -m${MODEL} -of${dir}/${name}a${OBJ} -I${src} ${src}/${name}a.d || exit 1
+$DMD -c -m${MODEL} -of${dir}/${TEST_NAME}a${OBJ} -I${src} ${src}/${TEST_NAME}a.d || exit 1
 
-$DMD -unittest -m${MODEL} -od${dir} -I${src} ${src}/${name}main.d ${dir}/${name}a${OBJ} || exit 1
+$DMD -unittest -m${MODEL} -od${dir} -I${src} ${src}/${TEST_NAME}main.d ${dir}/${TEST_NAME}a${OBJ} || exit 1
 
-rm -f ${dir}/{${name}a${OBJ} ${name}main${EXE} ${name}main${OBJ}}
+rm -f ${dir}/{${TEST_NAME}a${OBJ} ${TEST_NAME}main${EXE} ${TEST_NAME}main${OBJ}}
 
-echo Success >${dir}/`basename $0`.out
+echo Success

--- a/test/compilable/test18367.sh
+++ b/test/compilable/test18367.sh
@@ -2,9 +2,6 @@
 
 set -u -o pipefail
 
-name=$(basename "$0" .sh)
-dir=${RESULTS_DIR}/compilable/
-
 # dmd should not segfault on -X with libraries, but no source files
 out=$("$DMD" -conf= -X foo.a 2>&1)
 [ $? -eq 1 ] || exit 1

--- a/test/compilable/test6461.sh
+++ b/test/compilable/test6461.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-name=`basename $0 .sh`
 dir=${RESULTS_DIR}/compilable
-src=compilable/extra-files/${name}
+src=compilable/extra-files/${TEST_NAME}
 
 if [ "${OS}" == "win32" -o "${OS}" == "win64" ]; then
     LIBEXT=.lib
@@ -17,5 +16,4 @@ $DMD -m${MODEL} -od${dir} -I${src} ${src}/main.d ${dir}/a${LIBEXT} ${dir}/b${LIB
 
 rm -f ${dir}/{a${LIBEXT} b${LIBEXT} main${EXE} main${OBJ}}
 
-echo Success >${dir}/`basename $0`.out
-
+echo Success

--- a/test/compilable/test9680.sh
+++ b/test/compilable/test9680.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-name=`basename $0 .sh`
 dir=${RESULTS_DIR}/compilable
 
 if [ "${OS}" == "win32" -o "${OS}" == "Windows_NT" ]; then
@@ -11,7 +10,7 @@ fi
 
 for kind in "${kinds[@]}"
 do
-	file_name=${name}${kind}
+	file_name=${TEST_NAME}${kind}
 	src_file=compilable/extra-files/${file_name}.d
 	expect_file=compilable/extra-files/${file_name}.out
 	output_file=${dir}/${file_name}.out
@@ -28,4 +27,4 @@ do
 	rm ${output_file}{,.2}
 done
 
-echo Success >${dir}/`basename $0`.out
+echo Success

--- a/test/compilable/testclidflags.sh
+++ b/test/compilable/testclidflags.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 dir=${RESULTS_DIR}${SEP}compilable
-output_file=${dir}/testclidflags.sh.out
 
 unset DFLAGS
 
@@ -14,4 +13,4 @@ unset DFLAGS
 ( DFLAGS="-O -D" "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O -D"
 ( DFLAGS="-O '-Ifoo bar' -c" "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O '-Ifoo bar' -c"
 
-echo Success >${output_file}
+echo Success

--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -792,10 +792,11 @@ int tryMain(string[] args)
 
             f.writeln();
             f.writeln("==============================");
-            f.writeln("Test failed: ", e.msg);
+            f.writef("Test %s/%s.%s failed: ", input_dir, test_name, test_extension);
+            f.writeln(e.msg);
             f.close();
 
-            writeln("Test failed.  The logged output:");
+            writefln("Test %s/%s.%s failed.  The logged output:", input_dir, test_name, test_extension);
             writeln(cast(string)std.file.read(output_file));
             std.file.remove(output_file);
             return Result.return1;

--- a/test/sh_do_test.sh
+++ b/test/sh_do_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if [ "${RESULTS_DIR}" == "" ]; then
+    echo Note: this program is normally called through the Makefile, it
+    echo is not meant to be called directly by the user.
+    exit 1
+fi
+
+# TEST_DIR should be one of compilable, fail_compilation or runnable
+export TEST_DIR=$1
+export TEST_NAME=$2
+script_name=${TEST_DIR}/${TEST_NAME}.sh
+
+echo " ... ${script_name}"
+
+output_file=${RESULTS_DIR}/${script_name}.out
+rm -f ${output_file}
+
+./${script_name} > ${output_file}  2>&1
+if [ $? -ne 0 ]; then
+    # duplicate d_do_test output
+    echo >> ${output_file}
+    echo ============================== >> ${output_file}
+    echo Test ${script_name} failed >> ${output_file}
+
+    echo Test ${script_name} failed. The logged output:
+    cat ${output_file}
+    exit 1
+fi


### PR DESCRIPTION
This PR creates a wrapper to hold common logic/settings for all BASH tests.  Currently, this wrapper will pipe `stdout`/`stderr` to the test output file, and when a failure occurs, will dump the output file with a message saying the test failed (just like `d_do_test` does with `.d` tests).

It also exports common variables to the test script, currently
* `${TEST_DIR}` (i.e. compilable/runnable)
* `${TEST_NAME}` being the base name of the test.

TODO:

Maybe `set -euo pipefail` and/or `set -x` in wrapper?