### PR TITLE
Update SemaphoreCI badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DMD
 [![license](https://img.shields.io/github/license/dlang/dmd.svg)](https://github.com/dlang/dmd/blob/master/LICENSE.txt)
 
 [![CircleCI](https://circleci.com/gh/dlang/dmd/tree/master.svg?style=svg)](https://circleci.com/gh/dlang/dmd/tree/master)
-[![SemaphoreCI](https://semaphoreci.com/api/v1/dlang/dmd-2/branches/master/badge.svg)](https://semaphoreci.com/wilzbach/dmd-2)
+[![SemaphoreCI](https://semaphoreci.com/api/v1/dlang/dmd-2/branches/master/badge.svg)](https://semaphoreci.com/dlang/dmd-2)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/mv0y9lqyk7jh0x8d?svg=true)](https://ci.appveyor.com/project/greenify/dmd)
 
 DMD is the reference compiler for the D programming language.


### PR DESCRIPTION
Correct URL is https://semaphoreci.com/dlang/dmd-2

The failures are due to spurious download failures, which are hopefully addressed by https://github.com/dlang/installer/pull/304