### PR TITLE
__traits(isSame) for lambda functions which contain function calls

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -671,7 +671,6 @@ class FuncLiteralDeclaration : public FuncDeclaration
 public:
     TOK tok;                       // TOKfunction or TOKdelegate
     Type *treq;                         // target of return type inference
-    const utf8_t *serialization;
 
     // backend
     bool deferToObj;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2952,13 +2952,6 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
     TOK tok;        // TOK.function_ or TOK.delegate_
     Type treq;      // target of return type inference
 
-    /**
-     * The serialization of this. It is used to compare
-     * lambda functions.
-     * != null only if tok == TOK.reserved.
-     */
-    const(char)* serialization;
-
     // backend
     bool deferToObj;
 

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1453,29 +1453,9 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
         if (l1 && l2)
         {
-            const(char)* getSerialization(FuncLiteralDeclaration fld)
-            {
-                import dmd.lambdacomp : SerializeVisitor;
-                auto serVisitor = new SerializeVisitor(sc);
-                fld.accept(serVisitor);
-                if (serVisitor.buf.offset == 0)
-                    return "uncomparable";
-                else
-                    return serVisitor.buf.extractString();
-            }
-
-            if (!l1.serialization)
-                l1.serialization = getSerialization(l1);
-            if (!l2.serialization)
-                l2.serialization = getSerialization(l2);
-
-            //printf("serialization1: %s\n", l1.serialization);
-            //printf("serialization2: %s\n", l2.serialization);
-            if (strcmp(l1.serialization, l2.serialization) == 0 &&
-                strcmp(l1.serialization, "uncomparable") != 0)
-            {
+            import dmd.lambdacomp : isSameFuncLiteral;
+            if (isSameFuncLiteral(l1, l2, sc))
                 return True();
-            }
         }
 
         auto s1 = getDsymbol(o1);

--- a/test/compilable/imports/testlambda1.d
+++ b/test/compilable/imports/testlambda1.d
@@ -1,0 +1,3 @@
+module imports.testlambda1;
+
+int bar() { return 7; }

--- a/test/compilable/imports/testlambda2.d
+++ b/test/compilable/imports/testlambda2.d
@@ -1,0 +1,3 @@
+module imports.testlambda2;
+
+int bar() { return 7; }


### PR DESCRIPTION
This PR adds the capability of comparing lambda functions which contain calls to other functions.

Two functions are considered equal if their serializations is equal. 2 function serializations are equal if : 

-> the mangled names of the functions are equal
-> the serializations of the parameters with which the function is called are equal