### PR TITLE
Add [Environment{arch}] DFLAGS to -v output

### DIFF
--- a/test/compilable/testclidflags.sh
+++ b/test/compilable/testclidflags.sh
@@ -10,8 +10,8 @@ unset DFLAGS
 # Force DMD to print the -v menu by passing an invalid object file
 # It will fail with "no object files to link", but print the log
 # On OSX DMD terminates with a successful exit code, so `|| true` is used.
-( "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    (none)"
-( DFLAGS="-O -D" "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O -D"
-( DFLAGS="-O '-Ifoo bar' -c" "$DMD" -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O '-Ifoo bar' -c"
+( "$DMD" -conf= -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    (none)"
+( DFLAGS="-O -D" "$DMD" -conf= -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O -D"
+( DFLAGS="-O '-Ifoo bar' -c" "$DMD" -conf= -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O '-Ifoo bar' -c"
 
 echo Success >${output_file}


### PR DESCRIPTION
Followup to #7865

#7865 printed DFLAGS from the `dflags` local variable.  The `dflags` local variable was populated from the `[Environment]` section of the config file, but was never populated from the architecture-specific section of the config file (i.e. `[Environment64]`)

This PR defers reading DFLAGS from the `environment` string table until needed in the `-v` output, by which time the architecture-specific section of the config file has already been parsed.

