### PR TITLE
Fixup C++ headers

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -122,7 +122,7 @@ public:
     bool determineFields();
     bool determineSize(Loc loc);
     virtual void finalizeSize() = 0;
-    d_uns64 size(Loc loc);
+    d_uns64 size(const Loc &loc);
     bool checkOverlappedFields();
     bool fill(Loc loc, Expressions *elements, bool ctorinit);
     static void alignmember(structalign_t salign, unsigned size, unsigned *poffset);
@@ -191,7 +191,7 @@ public:
     Dsymbol *search(Loc, Identifier *ident, int flags = SearchLocalsOnly);
     const char *kind() const;
     void finalizeSize();
-    bool fit(Loc loc, Scope *sc, Expressions *elements, Type *stype);
+    bool fit(const Loc &loc, Scope *sc, Expressions *elements, Type *stype);
     bool isPOD();
 
     StructDeclaration *isStructDeclaration() { return this; }

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -125,7 +125,7 @@ public:
     Expression *ealign;
     structalign_t salign;
 
-    AlignDeclaration(Loc loc, Expression *ealign, Dsymbols *decl);
+    AlignDeclaration(const Loc &loc, Expression *ealign, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -138,11 +138,11 @@ Expression *resolveSlice(Expression *e);
 uinteger_t resolveArrayLength(Expression *e);
 
 /// Create an array literal consisting of 'elem' duplicated 'dim' times.
-ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Loc loc, Type *type,
+ArrayLiteralExp *createBlockDuplicatedArrayLiteral(const Loc &loc, Type *type,
         Expression *elem, size_t dim);
 
 /// Create a string literal consisting of 'value' duplicated 'dim' times.
-StringExp *createBlockDuplicatedStringLiteral(Loc loc, Type *type,
+StringExp *createBlockDuplicatedStringLiteral(const Loc &loc, Type *type,
         unsigned value, size_t dim, unsigned char sz);
 
 
@@ -155,13 +155,13 @@ StringExp *createBlockDuplicatedStringLiteral(Loc loc, Type *type,
 void assignInPlace(Expression *dest, Expression *src);
 
 /// Given an AA literal aae,  set arr[index] = newval and return the new array.
-Expression *assignAssocArrayElement(Loc loc, AssocArrayLiteralExp *aae,
+Expression *assignAssocArrayElement(const Loc &loc, AssocArrayLiteralExp *aae,
     Expression *index, Expression *newval);
 
 /// Given array literal oldval of type ArrayLiteralExp or StringExp, of length
 /// oldlen, change its length to newlen. If the newlen is longer than oldlen,
 /// all new elements will be set to the default initializer for the element type.
-UnionExp changeArrayLiteralLength(Loc loc, TypeArray *arrayType,
+UnionExp changeArrayLiteralLength(const Loc &loc, TypeArray *arrayType,
     Expression *oldval,  size_t oldlen, size_t newlen);
 
 
@@ -185,7 +185,7 @@ Expression *getAggregateFromPointer(Expression *e, dinteger_t *ofs);
 bool pointToSameMemoryBlock(Expression *agg1, Expression *agg2);
 
 // return e1 - e2 as an integer, or error if not possible
-UnionExp pointerDifference(Loc loc, Type *type, Expression *e1, Expression *e2);
+UnionExp pointerDifference(const Loc &loc, Type *type, Expression *e1, Expression *e2);
 
 /// Return 1 if true, 0 if false
 /// -1 if comparison is illegal because they point to non-comparable memory blocks
@@ -193,7 +193,7 @@ int comparePointers(TOK op, Expression *agg1, dinteger_t ofs1, Expression *agg2,
 
 // Return eptr op e2, where eptr is a pointer, e2 is an integer,
 // and op is TOKadd or TOKmin
-UnionExp pointerArithmetic(Loc loc, TOK op, Type *type,
+UnionExp pointerArithmetic(const Loc &loc, TOK op, Type *type,
     Expression *eptr, Expression *e2);
 
 // True if conversion from type 'from' to 'to' involves a reinterpret_cast
@@ -213,7 +213,7 @@ TypeAArray *toBuiltinAAType(Type *t);
  *  Return ae[e2] if present, or NULL if not found.
  *  Return TOKcantexp on error.
  */
-Expression *findKeyInAA(Loc loc, AssocArrayLiteralExp *ae, Expression *e2);
+Expression *findKeyInAA(const Loc &loc, AssocArrayLiteralExp *ae, Expression *e2);
 
 /// True if type is TypeInfo_Class
 bool isTypeInfo_Class(Type *type);
@@ -228,10 +228,10 @@ bool isTypeInfo_Class(Type *type);
 bool isCtfeComparable(Expression *e);
 
 /// Evaluate ==, !=.  Resolves slices before comparing. Returns 0 or 1
-int ctfeEqual(Loc loc, TOK op, Expression *e1, Expression *e2);
+int ctfeEqual(const Loc &loc, TOK op, Expression *e1, Expression *e2);
 
 /// Evaluate is, !is.  Resolves slices before comparing. Returns 0 or 1
-int ctfeIdentity(Loc loc, TOK op, Expression *e1, Expression *e2);
+int ctfeIdentity(const Loc &loc, TOK op, Expression *e1, Expression *e2);
 
 /// Returns rawCmp OP 0; where OP is ==, !=, <, >=, etc. Result is 0 or 1
 int specificCmp(TOK op, int rawCmp);
@@ -246,17 +246,17 @@ int intSignedCmp(TOK op, sinteger_t n1, sinteger_t n2);
 int realCmp(TOK op, real_t r1, real_t r2);
 
 /// Evaluate >,<=, etc. Resolves slices before comparing. Returns 0 or 1
-int ctfeCmp(Loc loc, TOK op, Expression *e1, Expression *e2);
+int ctfeCmp(const Loc &loc, TOK op, Expression *e1, Expression *e2);
 
 /// Returns e1 ~ e2. Resolves slices before concatenation.
-UnionExp ctfeCat(Loc loc, Type *type, Expression *e1, Expression *e2);
+UnionExp ctfeCat(const Loc &loc, Type *type, Expression *e1, Expression *e2);
 
 /// Same as for constfold.Index, except that it only works for static arrays,
 /// dynamic arrays, and strings.
-Expression *ctfeIndex(Loc loc, Type *type, Expression *e1, uinteger_t indx);
+Expression *ctfeIndex(const Loc &loc, Type *type, Expression *e1, uinteger_t indx);
 
 /// Cast 'e' of type 'type' to type 'to'.
-Expression *ctfeCast(Loc loc, Type *type, Type *to, Expression *e);
+Expression *ctfeCast(const Loc &loc, Type *type, Type *to, Expression *e);
 
 
 #endif /* DMD_CTFE_H */

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -475,7 +475,7 @@ extern (C++) abstract class Declaration : Dsymbol
         return (storage_class & STC.parameter) != 0;
     }
 
-    override final bool isDeprecated() const pure nothrow @nogc @safe
+    override final bool isDeprecated() pure nothrow @nogc @safe
     {
         return (storage_class & STC.deprecated_) != 0;
     }

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -129,7 +129,7 @@ public:
     const char *mangleOverride;      // overridden symbol with pragma(mangle, "...")
 
     const char *kind() const;
-    d_uns64 size(Loc loc);
+    d_uns64 size(const Loc &loc);
     bool checkDisabled(Loc loc, Scope* sc, bool isAliasedDeclaration = false);
     int checkModify(Loc loc, Scope *sc, Expression *e1, int flag);
 
@@ -150,7 +150,7 @@ public:
     bool isScope() const        { return (storage_class & STCscope) != 0; }
     bool isSynchronized() const { return (storage_class & STCsynchronized) != 0; }
     bool isParameter() const    { return (storage_class & STCparameter) != 0; }
-    bool isDeprecated() const   { return (storage_class & STCdeprecated) != 0; }
+    bool isDeprecated()         { return (storage_class & STCdeprecated) != 0; }
     bool isOverride() const     { return (storage_class & STCoverride) != 0; }
     bool isResult() const       { return (storage_class & STCresult) != 0; }
     bool isField() const        { return (storage_class & STCfield) != 0; }
@@ -572,11 +572,11 @@ public:
 
     unsigned flags;                     // FUNCFLAGxxxxx
 
-    static FuncDeclaration *create(Loc loc, Loc endloc, Identifier *id, StorageClass storage_class, Type *type);
+    static FuncDeclaration *create(const Loc &loc, const Loc &endloc, Identifier *id, StorageClass storage_class, Type *type);
     Dsymbol *syntaxCopy(Dsymbol *);
     bool functionSemantic();
     bool functionSemantic3();
-    bool checkForwardRef(Loc loc);
+    bool checkForwardRef(const Loc &loc);
     // called from semantic3
     VarDeclaration *declareThis(Scope *sc, AggregateDeclaration *ad);
     bool equals(RootObject *o);
@@ -586,12 +586,12 @@ public:
     BaseClass *overrideInterface();
     bool overloadInsert(Dsymbol *s);
     FuncDeclaration *overloadExactMatch(Type *t);
-    FuncDeclaration *overloadModMatch(Loc loc, Type *tthis, bool &hasOverloads);
+    FuncDeclaration *overloadModMatch(const Loc &loc, Type *tthis, bool &hasOverloads);
     TemplateDeclaration *findTemplateDeclRoot();
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g);
     LabelDsymbol *searchLabel(Identifier *ident);
-    int getLevel(Loc loc, Scope *sc, FuncDeclaration *fd); // lexical nesting level difference
+    int getLevel(const Loc &loc, Scope *sc, FuncDeclaration *fd); // lexical nesting level difference
     const char *toPrettyChars(bool QualifyTypes = false);
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
     bool isMain() const;
@@ -615,7 +615,7 @@ public:
     bool isNogcBypassingInference();
     bool setGC();
 
-    void printGCUsage(Loc loc, const char *warn);
+    void printGCUsage(const Loc &loc, const char *warn);
     bool isolateReturn();
     bool parametersIntersect(Type *t);
     virtual bool isNested();
@@ -623,7 +623,7 @@ public:
     bool needThis();
     bool isVirtualMethod();
     virtual bool isVirtual() const;
-    virtual bool isFinalFunc() const;
+    bool isFinalFunc() const;
     virtual bool addPreInvariant();
     virtual bool addPostInvariant();
     const char *kind() const;
@@ -647,7 +647,7 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-FuncDeclaration *resolveFuncCall(Loc loc, Scope *sc, Dsymbol *s,
+FuncDeclaration *resolveFuncCall(const Loc &loc, Scope *sc, Dsymbol *s,
         Objects *tiargs,
         Type *tthis,
         Expressions *arguments,

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -179,9 +179,9 @@ public:
     virtual bool isAnonymous();
     void error(Loc loc, const char *format, ...);
     void error(const char *format, ...);
-    void deprecation(Loc loc, const char *format, ...);
+    void deprecation(const Loc &loc, const char *format, ...);
     void deprecation(const char *format, ...);
-    bool checkDeprecated(Loc loc, Scope *sc);
+    bool checkDeprecated(const Loc &loc, Scope *sc);
     Module *getModule();
     Module *getAccessModule();
     Dsymbol *pastMixin();
@@ -205,11 +205,11 @@ public:
     virtual void addMember(Scope *sc, ScopeDsymbol *sds);
     virtual void setScope(Scope *sc);
     virtual void importAll(Scope *sc);
-    virtual Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
+    virtual Dsymbol *search(const Loc &loc, Identifier *ident, int flags = IgnoreNone);
     Dsymbol *search_correct(Identifier *id);
-    Dsymbol *searchX(Loc loc, Scope *sc, RootObject *id);
+    Dsymbol *searchX(const Loc &loc, Scope *sc, RootObject *id);
     virtual bool overloadInsert(Dsymbol *s);
-    virtual d_uns64 size(Loc loc);
+    virtual d_uns64 size(const Loc &loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member
     virtual bool isExport();                    // is Dsymbol exported?
@@ -303,13 +303,13 @@ private:
 
 public:
     Dsymbol *syntaxCopy(Dsymbol *s);
-    Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
     OverloadSet *mergeOverloadSet(Identifier *ident, OverloadSet *os, Dsymbol *s);
     virtual void importScope(Dsymbol *s, Prot protection);
     void addAccessiblePackage(Package *p, Prot protection);
     virtual bool isPackageAccessible(Package *p, Prot protection, int flags = 0);
     bool isforwardRef();
-    static void multiplyDefined(Loc loc, Dsymbol *s1, Dsymbol *s2);
+    static void multiplyDefined(const Loc &loc, Dsymbol *s1, Dsymbol *s2);
     const char *kind() const;
     FuncDeclaration *findGetMembers();
     virtual Dsymbol *symtabInsert(Dsymbol *s);
@@ -330,7 +330,7 @@ class WithScopeSymbol : public ScopeDsymbol
 public:
     WithStatement *withstate;
 
-    Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
 
     WithScopeSymbol *isWithScopeSymbol() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -346,7 +346,7 @@ public:
     TupleDeclaration *td;       // for tuples of objects
     Scope *sc;
 
-    Dsymbol *search(Loc loc, Identifier *ident, int flags = IgnoreNone);
+    Dsymbol *search(const Loc &loc, Identifier *ident, int flags = IgnoreNone);
 
     ArrayScopeSymbol *isArrayScopeSymbol() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -57,9 +57,9 @@ public:
     Dsymbol *search(Loc, Identifier *ident, int flags = SearchLocalsOnly);
     bool isDeprecated();                // is Dsymbol deprecated?
     Prot prot();
-    Expression *getMaxMinValue(Loc loc, Identifier *id);
-    Expression *getDefaultValue(Loc loc);
-    Type *getMemtype(Loc loc);
+    Expression *getMaxMinValue(const Loc &loc, Identifier *id);
+    Expression *getDefaultValue(const Loc &loc);
+    Type *getMemtype(const Loc &loc);
 
     EnumDeclaration *isEnumDeclaration() { return this; }
 
@@ -88,7 +88,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     const char *kind() const;
-    Expression *getVarExp(Loc loc, Scope *sc);
+    Expression *getVarExp(const Loc &loc, Scope *sc);
 
     EnumMember *isEnumMember() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -58,7 +58,7 @@ Expression *resolveProperties(Scope *sc, Expression *e);
 Expression *resolvePropertiesOnly(Scope *sc, Expression *e1);
 bool checkAccess(Loc loc, Scope *sc, Expression *e, Declaration *d);
 bool checkAccess(Loc loc, Scope *sc, Package *p);
-Expression *build_overload(Loc loc, Scope *sc, Expression *ethis, Expression *earg, Dsymbol *d);
+Expression *build_overload(const Loc &loc, Scope *sc, Expression *ethis, Expression *earg, Dsymbol *d);
 Dsymbol *search_function(ScopeDsymbol *ad, Identifier *funcid);
 void expandTuples(Expressions *exps);
 TupleDeclaration *isAliasThisTuple(Expression *e);
@@ -171,7 +171,7 @@ public:
     {
         return ::castTo(this, sc, t);
     }
-    virtual Expression *resolveLoc(Loc loc, Scope *sc);
+    virtual Expression *resolveLoc(const Loc &loc, Scope *sc);
     virtual bool checkType();
     virtual bool checkValue();
     bool checkScalar();
@@ -469,7 +469,7 @@ public:
 };
 
 class DotIdExp;
-DotIdExp *typeDotIdExp(Loc loc, Type *type, Identifier *ident);
+DotIdExp *typeDotIdExp(const Loc &loc, Type *type, Identifier *ident);
 
 class TypeExp : public Expression
 {
@@ -680,13 +680,13 @@ public:
 
     Expression *syntaxCopy();
     Expression *incompatibleTypes();
-    Expression *resolveLoc(Loc loc, Scope *sc);
+    Expression *resolveLoc(const Loc &loc, Scope *sc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
 
-typedef UnionExp (*fp_t)(Loc loc, Type *, Expression *, Expression *);
-typedef int (*fp2_t)(Loc loc, TOK, Expression *, Expression *);
+typedef UnionExp (*fp_t)(const Loc &loc, Type *, Expression *, Expression *);
+typedef int (*fp2_t)(const Loc &loc, TOK, Expression *, Expression *);
 
 class BinExp : public Expression
 {
@@ -1301,35 +1301,35 @@ public:
 class FileInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(Loc loc, Scope *sc);
+    Expression *resolveLoc(const Loc &loc, Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class LineInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(Loc loc, Scope *sc);
+    Expression *resolveLoc(const Loc &loc, Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class ModuleInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(Loc loc, Scope *sc);
+    Expression *resolveLoc(const Loc &loc, Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class FuncInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(Loc loc, Scope *sc);
+    Expression *resolveLoc(const Loc &loc, Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class PrettyFuncInitExp : public DefaultInitExp
 {
 public:
-    Expression *resolveLoc(Loc loc, Scope *sc);
+    Expression *resolveLoc(const Loc &loc, Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1395,24 +1395,24 @@ UnionExp Cast(Loc loc, Type *type, Type *to, Expression *e1);
 UnionExp ArrayLength(Type *type, Expression *e1);
 UnionExp Ptr(Type *type, Expression *e1);
 
-UnionExp Add(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Min(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Mul(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Div(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Mod(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Pow(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Shl(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Shr(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Ushr(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp And(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Or(Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Xor(Loc loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Add(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Min(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Mul(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Div(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Mod(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Pow(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Shl(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Shr(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Ushr(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp And(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Or(const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Xor(const Loc &loc, Type *type, Expression *e1, Expression *e2);
 UnionExp Index(Type *type, Expression *e1, Expression *e2);
 UnionExp Cat(Type *type, Expression *e1, Expression *e2);
 
-UnionExp Equal(TOK op, Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Cmp(TOK op, Loc loc, Type *type, Expression *e1, Expression *e2);
-UnionExp Identity(TOK op, Loc loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Equal(TOK op, const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Cmp(TOK op, const Loc &loc, Type *type, Expression *e1, Expression *e2);
+UnionExp Identity(TOK op, const Loc &loc, Type *type, Expression *e1, Expression *e2);
 
 UnionExp Slice(Type *type, Expression *e1, Expression *lwr, Expression *upr);
 

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -242,9 +242,9 @@ public:
     static void _init();
 
     d_uns64 size();
-    virtual d_uns64 size(Loc loc);
+    virtual d_uns64 size(const Loc &loc);
     virtual unsigned alignsize();
-    Type *trySemantic(Loc loc, Scope *sc);
+    Type *trySemantic(const Loc &loc, Scope *sc);
     Type *merge2();
     void modToBuffer(OutBuffer *buf);
     char *modToChars();
@@ -264,7 +264,7 @@ public:
     virtual bool isString();
     virtual bool isAssignable();
     virtual bool isBoolean();
-    virtual void checkDeprecated(Loc loc, Scope *sc);
+    virtual void checkDeprecated(const Loc &loc, Scope *sc);
     bool isConst() const       { return (mod & MODconst) != 0; }
     bool isImmutable() const   { return (mod & MODimmutable) != 0; }
     bool isMutable() const     { return (mod & (MODconst | MODimmutable | MODwild)) == 0; }
@@ -318,15 +318,15 @@ public:
 
     virtual Type *toHeadMutable();
     virtual ClassDeclaration *isClassHandle();
-    virtual Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    virtual Expression *getProperty(const Loc &loc, Identifier *ident, int flag);
     virtual Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     virtual structalign_t alignment();
     Expression *noMember(Scope *sc, Expression *e, Identifier *ident, int flag);
-    virtual Expression *defaultInit(Loc loc = Loc());
-    virtual Expression *defaultInitLiteral(Loc loc);
-    virtual bool isZeroInit(Loc loc = Loc());                // if initializer is 0
+    virtual Expression *defaultInit(const Loc &loc = Loc());
+    virtual Expression *defaultInitLiteral(const Loc &loc);
+    virtual bool isZeroInit(const Loc &loc = Loc());                // if initializer is 0
     Identifier *getTypeInfoIdent();
-    virtual void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    virtual void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void resolveExp(Expression *e, Type **pt, Expression **pe, Dsymbol **ps);
     virtual int hasWild() const;
     virtual bool hasPointers();
@@ -336,10 +336,10 @@ public:
     uinteger_t sizemask();
     virtual bool needsDestruction();
     virtual bool needsNested();
-    bool checkComplexTransition(Loc loc, Scope *sc);
+    bool checkComplexTransition(const Loc &loc, Scope *sc);
 
-    static void error(Loc loc, const char *format, ...);
-    static void warning(Loc loc, const char *format, ...);
+    static void error(const Loc &loc, const char *format, ...);
+    static void warning(const Loc &loc, const char *format, ...);
 
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();
@@ -351,11 +351,11 @@ class TypeError : public Type
 public:
     Type *syntaxCopy();
 
-    d_uns64 size(Loc loc);
-    Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    d_uns64 size(const Loc &loc);
+    Expression *getProperty(const Loc &loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    Expression *defaultInit(Loc loc);
-    Expression *defaultInitLiteral(Loc loc);
+    Expression *defaultInit(const Loc &loc);
+    Expression *defaultInitLiteral(const Loc &loc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -364,7 +364,7 @@ class TypeNext : public Type
 public:
     Type *next;
 
-    void checkDeprecated(Loc loc, Scope *sc);
+    void checkDeprecated(const Loc &loc, Scope *sc);
     int hasWild() const;
     Type *nextOf();
     Type *makeConst();
@@ -390,9 +390,9 @@ public:
 
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc) /*const*/;
+    d_uns64 size(const Loc &loc) /*const*/;
     unsigned alignsize();
-    Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    Expression *getProperty(const Loc &loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool isintegral();
     bool isfloating() /*const*/;
@@ -402,8 +402,8 @@ public:
     bool isscalar() /*const*/;
     bool isunsigned() /*const*/;
     MATCH implicitConvTo(Type *to);
-    Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc) /*const*/;
 
     // For eliminating dynamic_cast
     TypeBasic *isTypeBasic();
@@ -418,9 +418,9 @@ public:
     static TypeVector *create(Type *basetype);
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc);
+    d_uns64 size(const Loc &loc);
     unsigned alignsize();
-    Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    Expression *getProperty(const Loc &loc, Identifier *ident, int flag);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool isintegral();
     bool isfloating();
@@ -428,10 +428,10 @@ public:
     bool isunsigned();
     bool isBoolean() /*const*/;
     MATCH implicitConvTo(Type *to);
-    Expression *defaultInit(Loc loc);
-    Expression *defaultInitLiteral(Loc loc);
+    Expression *defaultInit(const Loc &loc);
+    Expression *defaultInitLiteral(const Loc &loc);
     TypeBasic *elementType();
-    bool isZeroInit(Loc loc);
+    bool isZeroInit(const Loc &loc);
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -451,17 +451,17 @@ public:
 
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc);
+    d_uns64 size(const Loc &loc);
     unsigned alignsize();
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool isString();
-    bool isZeroInit(Loc loc);
+    bool isZeroInit(const Loc &loc);
     structalign_t alignment();
     MATCH constConv(Type *to);
     MATCH implicitConvTo(Type *to);
-    Expression *defaultInit(Loc loc);
-    Expression *defaultInitLiteral(Loc loc);
+    Expression *defaultInit(const Loc &loc);
+    Expression *defaultInitLiteral(const Loc &loc);
     bool hasPointers();
     bool needsDestruction();
     bool needsNested();
@@ -475,15 +475,15 @@ class TypeDArray : public TypeArray
 public:
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc) /*const*/;
+    d_uns64 size(const Loc &loc) /*const*/;
     unsigned alignsize() /*const*/;
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool isString();
-    bool isZeroInit(Loc loc) /*const*/;
+    bool isZeroInit(const Loc &loc) /*const*/;
     bool isBoolean() /*const*/;
     MATCH implicitConvTo(Type *to);
-    Expression *defaultInit(Loc loc);
+    Expression *defaultInit(const Loc &loc);
     bool hasPointers() /*const*/;
 
     void accept(Visitor *v) { v->visit(this); }
@@ -499,11 +499,11 @@ public:
     static TypeAArray *create(Type *t, Type *index);
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc);
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    d_uns64 size(const Loc &loc);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc) /*const*/;
     bool isBoolean() /*const*/;
     bool hasPointers() /*const*/;
     MATCH implicitConvTo(Type *to);
@@ -518,12 +518,12 @@ public:
     static TypePointer *create(Type *t);
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc) /*const*/;
+    d_uns64 size(const Loc &loc) /*const*/;
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
     bool isscalar() /*const*/;
-    Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc) /*const*/;
     bool hasPointers() /*const*/;
 
     void accept(Visitor *v) { v->visit(this); }
@@ -534,10 +534,10 @@ class TypeReference : public TypeNext
 public:
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc) /*const*/;
+    d_uns64 size(const Loc &loc) /*const*/;
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -612,9 +612,9 @@ public:
 
     Type *substWildTo(unsigned mod);
     MATCH callMatch(Type *tthis, Expressions *toargs, int flag = 0);
-    bool checkRetType(Loc loc);
+    bool checkRetType(const Loc &loc);
 
-    Expression *defaultInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -627,11 +627,11 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Type *addStorageClass(StorageClass stc);
-    d_uns64 size(Loc loc) /*const*/;
+    d_uns64 size(const Loc &loc) /*const*/;
     unsigned alignsize() /*const*/;
     MATCH implicitConvTo(Type *to);
-    Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc) /*const*/;
     bool isBoolean() /*const*/;
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool hasPointers() /*const*/;
@@ -651,11 +651,11 @@ public:
     void addIdent(Identifier *ident);
     void addInst(TemplateInstance *inst);
     void addIndex(RootObject *expr);
-    d_uns64 size(Loc loc);
+    d_uns64 size(const Loc &loc);
 
-    void resolveTupleIndex(Loc loc, Scope *sc, Dsymbol *s,
+    void resolveTupleIndex(const Loc &loc, Scope *sc, Dsymbol *s,
         Expression **pe, Type **pt, Dsymbol **ps, RootObject *oindex);
-    void resolveHelper(Loc loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
+    void resolveHelper(const Loc &loc, Scope *sc, Dsymbol *s, Dsymbol *scopesym,
         Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
 
     void accept(Visitor *v) { v->visit(this); }
@@ -669,7 +669,7 @@ public:
 
     const char *kind();
     Type *syntaxCopy();
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -683,7 +683,7 @@ public:
 
     const char *kind();
     Type *syntaxCopy();
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     Dsymbol *toDsymbol(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -697,8 +697,8 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
-    d_uns64 size(Loc loc);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    d_uns64 size(const Loc &loc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -708,7 +708,7 @@ public:
     const char *kind();
     Type *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -733,15 +733,15 @@ public:
 
     static TypeStruct *create(StructDeclaration *sym);
     const char *kind();
-    d_uns64 size(Loc loc);
+    d_uns64 size(const Loc &loc);
     unsigned alignsize();
     Type *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     structalign_t alignment();
-    Expression *defaultInit(Loc loc);
-    Expression *defaultInitLiteral(Loc loc);
-    bool isZeroInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc);
+    Expression *defaultInitLiteral(const Loc &loc);
+    bool isZeroInit(const Loc &loc) /*const*/;
     bool isAssignable();
     bool isBoolean() /*const*/;
     bool needsDestruction() /*const*/;
@@ -763,11 +763,11 @@ public:
 
     const char *kind();
     Type *syntaxCopy();
-    d_uns64 size(Loc loc);
+    d_uns64 size(const Loc &loc);
     unsigned alignsize();
     Dsymbol *toDsymbol(Scope *sc);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
-    Expression *getProperty(Loc loc, Identifier *ident, int flag);
+    Expression *getProperty(const Loc &loc, Identifier *ident, int flag);
     bool isintegral();
     bool isfloating();
     bool isreal();
@@ -783,8 +783,8 @@ public:
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
     Type *toBasetype();
-    Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc);
+    Expression *defaultInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc);
     bool hasPointers();
     bool hasVoidInitPointers();
     Type *nextOf();
@@ -800,7 +800,7 @@ public:
     CPPMANGLE cppmangle;
 
     const char *kind();
-    d_uns64 size(Loc loc) /*const*/;
+    d_uns64 size(const Loc &loc) /*const*/;
     Type *syntaxCopy();
     Dsymbol *toDsymbol(Scope *sc);
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
@@ -810,8 +810,8 @@ public:
     MATCH constConv(Type *to);
     unsigned char deduceWild(Type *t, bool isRef);
     Type *toHeadMutable();
-    Expression *defaultInit(Loc loc);
-    bool isZeroInit(Loc loc) /*const*/;
+    Expression *defaultInit(const Loc &loc);
+    bool isZeroInit(const Loc &loc) /*const*/;
     bool isscope() /*const*/;
     bool isBoolean() /*const*/;
     bool hasPointers() /*const*/;
@@ -828,8 +828,8 @@ public:
     const char *kind();
     Type *syntaxCopy();
     bool equals(RootObject *o);
-    Expression *getProperty(Loc loc, Identifier *ident, int flag);
-    Expression *defaultInit(Loc loc);
+    Expression *getProperty(const Loc &loc, Identifier *ident, int flag);
+    Expression *defaultInit(const Loc &loc);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -841,7 +841,7 @@ public:
 
     const char *kind();
     Type *syntaxCopy();
-    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    void resolve(const Loc &loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -854,8 +854,8 @@ public:
     MATCH implicitConvTo(Type *to);
     bool isBoolean() /*const*/;
 
-    d_uns64 size(Loc loc) /*const*/;
-    Expression *defaultInit(Loc loc) /*const*/;
+    d_uns64 size(const Loc &loc) /*const*/;
+    Expression *defaultInit(const Loc &loc) /*const*/;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -320,7 +320,7 @@ public:
     // Internal
     bool findTempDecl(Scope *sc, WithScopeSymbol **pwithsym);
     bool updateTempDecl(Scope *sc, Dsymbol *s);
-    static bool semanticTiargs(Loc loc, Scope *sc, Objects *tiargs, int flags);
+    static bool semanticTiargs(const Loc &loc, Scope *sc, Objects *tiargs, int flags);
     bool semanticTiargs(Scope *sc);
     bool findBestMatch(Scope *sc, Expressions *fargs);
     bool needsTypeInference(Scope *sc, int flag = 0);


### PR DESCRIPTION
Based on 2.079.0-beta.1. Many `Loc -> const Loc &` transitions were missing; I may have missed some, as not all `Loc` by-value params transitioned to const refs, so I had to check manually.