### PR TITLE
fix issue 18510 - lld-link.exe fails to open obj file in subpath

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -161,22 +161,12 @@ public int runLINK()
         if (global.params.mscoff)
         {
             OutBuffer cmdbuf;
-            cmdbuf.writestring("/NOLOGO ");
+            cmdbuf.writestring("/NOLOGO");
             for (size_t i = 0; i < global.params.objfiles.dim; i++)
             {
-                if (i)
-                    cmdbuf.writeByte(' ');
+                cmdbuf.writeByte(' ');
                 const(char)* p = global.params.objfiles[i];
-                const(char)* basename = FileName.removeExt(FileName.name(p));
-                const(char)* ext = FileName.ext(p);
-                if (ext && !strchr(basename, '.'))
-                {
-                    // Write name sans extension (but not if a double extension)
-                    writeFilename(&cmdbuf, p, ext - p - 1);
-                }
-                else
-                    writeFilename(&cmdbuf, p);
-                FileName.free(basename);
+                writeFilename(&cmdbuf, p);
             }
             if (global.params.resfile)
             {


### PR DESCRIPTION
LLD doesn't assume .obj automatically for files with `\` in the name, but there is no good reason to strip the extension to begin with