### PR TITLE
build gen_man with the same model as dmd

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,7 +35,7 @@ $G/$(DMD_MAN_PAGE): $(G_BIN)/gen_man
 
 $(G_BIN)/gen_man: gen_man.d $(DMD_ROOT)/src/dmd/cli.d
 	@mkdir -p $(dir $@)
-	$(DMD) -I$(DMD_ROOT)/src -of$@ $^
+	$(DMD) $(MODEL_FLAG) -I$(DMD_ROOT)/src -of$@ $^
 
 $G/%: %
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
freebsd 11.1 32 is failing due to what looks like crossing 32 and 64 bit builds.