### PR TITLE
issue 18515: Fix it so that neither g++ nor CC is required.

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -569,7 +569,7 @@ int tryMain(string[] args)
         {
             case "win32": envData.ccompiler = "dmc"; break;
             case "win64": envData.ccompiler = `\"Program Files (x86)"\"Microsoft Visual Studio 10.0"\VC\bin\amd64\cl.exe`; break;
-            default:      envData.ccompiler = "g++"; break;
+            default:      envData.ccompiler = "c++"; break;
         }
     }
     bool msc = envData.ccompiler.toLower.endsWith("cl.exe");


### PR DESCRIPTION
It was previously fixed so that cc is used if CC isn't set when
compiling dmd, but the test suite still had g++ hardcoded, so if the
system was set up with clang and not gcc, the dmd test suite barfed
midway through. This fixes it so that it uses c++ if CC isn't set
instead of using g++.

I don't know if this will fix the problem that Brad is having with the 32-bit FreeBSD auto-tester that's forcing him to set CC, but it does fix it so that my 64-bit FreeBSD system can run the dmd test suite without g++.