### PR TITLE
Add override for message that accepts a location.

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -654,9 +654,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 if (global.params.vfield && dsym.storage_class & (STC.const_ | STC.immutable_) && dsym._init && !dsym._init.isVoidInitializer())
                 {
-                    const(char)* p = dsym.loc.toChars();
                     const(char)* s = (dsym.storage_class & STC.immutable_) ? "immutable" : "const";
-                    message("%s: %s.%s is %s field", p ? p : "", ad.toPrettyChars(), dsym.toChars(), s);
+                    message(dsym.loc, "`%s.%s` is `%s` field", ad.toPrettyChars(), dsym.toChars(), s);
                 }
                 dsym.storage_class |= STC.field;
                 if (tbn.ty == Tstruct && (cast(TypeStruct)tbn).sym.noDefaultCtor)

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -166,6 +166,21 @@ extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format
  * Print a verbose message.
  * Doesn't prefix or highlight messages.
  * Params:
+ *      loc    = location of message
+ *      format = printf-style format specification
+ *      ...    = printf-style variadic arguments
+ */
+extern (C++) void message(const ref Loc loc, const(char)* format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vmessage(loc, format, ap);
+    va_end(ap);
+}
+
+/**
+ * Same as above, but doesn't take a location argument.
+ * Params:
  *      format = printf-style format specification
  *      ...    = printf-style variadic arguments
  */
@@ -173,7 +188,7 @@ extern (C++) void message(const(char)* format, ...)
 {
     va_list ap;
     va_start(ap, format);
-    vmessage(format, ap);
+    vmessage(Loc.initial, format, ap);
     va_end(ap);
 }
 
@@ -327,11 +342,18 @@ extern (C++) void vdeprecation(const ref Loc loc, const(char)* format, va_list a
 /**
  * Same as $(D message), but takes a va_list parameter.
  * Params:
- *      format = printf-style format specification
- *      ap     = printf-style variadic arguments
+ *      loc       = location of message
+ *      format    = printf-style format specification
+ *      ap        = printf-style variadic arguments
  */
-extern (C++) void vmessage(const(char)* format, va_list ap)
+extern (C++) void vmessage(const ref Loc loc, const(char)* format, va_list ap)
 {
+    const p = loc.toChars();
+    if (*p)
+    {
+        fprintf(stdout, "%s: ", p);
+        mem.xfree(cast(void*)p);
+    }
     OutBuffer tmp;
     tmp.vprintf(format, ap);
     fputs(tmp.peekString(), stdout);

--- a/src/dmd/errors.h
+++ b/src/dmd/errors.h
@@ -40,7 +40,8 @@ D_ATTRIBUTE_FORMAT(2, 0) void vwarningSupplemental(const Loc& loc, const char *f
 D_ATTRIBUTE_FORMAT(2, 0) void vdeprecation(const Loc& loc, const char *format, va_list ap, const char *p1 = NULL, const char *p2 = NULL);
 D_ATTRIBUTE_FORMAT(2, 0) void vdeprecationSupplemental(const Loc& loc, const char *format, va_list ap);
 D_ATTRIBUTE_FORMAT(1, 2) void message(const char *format, ...);
-D_ATTRIBUTE_FORMAT(1, 0) void vmessage(const char *format, va_list);
+D_ATTRIBUTE_FORMAT(2, 3) void message(const Loc& loc, const char *format, ...);
+D_ATTRIBUTE_FORMAT(2, 0) void vmessage(const Loc& loc, const char *format, va_list);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define D_ATTRIBUTE_NORETURN __attribute__((noreturn))

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1336,7 +1336,7 @@ extern (C++) class FuncDeclaration : Declaration
         Module m = getModule();
         if (m && m.isRoot() && !inUnittest())
         {
-            message("%s: vgc: %s", loc.toChars(), warn);
+            message(loc, "vgc: %s", warn);
         }
     }
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1833,7 +1833,7 @@ version (none)
 {
                     if (global.params.vsafe)
                     {
-                        message("%s: To enforce `@safe`, the compiler allocates a closure unless `opApply()` uses `scope`", loc.toChars());
+                        message(loc, "To enforce `@safe`, the compiler allocates a closure unless `opApply()` uses `scope`");
                     }
                     fld.tookAddressOf = 1;
 }

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -205,10 +205,7 @@ Symbol *toSymbol(Dsymbol s)
 
                     if (global.params.vtls)
                     {
-                        const(char)* p = vd.loc.toChars();
-                        message("%s: %s is thread local", p ? p : "", vd.toChars());
-                        if (p)
-                            mem.xfree(cast(void*)p);
+                        message(vd.loc, "`%s` is thread local", vd.toChars());
                     }
                 }
                 s.Sclass = SCextern;

--- a/test/compilable/sw_transition_field.d
+++ b/test/compilable/sw_transition_field.d
@@ -3,10 +3,10 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/sw_transition_field.d(15): sw_transition_field.S1.ix is immutable field
-compilable/sw_transition_field.d(16): sw_transition_field.S1.cx is const field
-compilable/sw_transition_field.d(21): sw_transition_field.S2!(immutable(int)).S2.f is immutable field
-compilable/sw_transition_field.d(21): sw_transition_field.S2!(const(int)).S2.f is const field
+compilable/sw_transition_field.d(15): `sw_transition_field.S1.ix` is `immutable` field
+compilable/sw_transition_field.d(16): `sw_transition_field.S1.cx` is `const` field
+compilable/sw_transition_field.d(21): `sw_transition_field.S2!(immutable(int)).S2.f` is `immutable` field
+compilable/sw_transition_field.d(21): `sw_transition_field.S2!(const(int)).S2.f` is `const` field
 ---
 */
 

--- a/test/compilable/sw_transition_tls.d
+++ b/test/compilable/sw_transition_tls.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/sw_transition_tls.d(11): x is thread local
-compilable/sw_transition_tls.d(15): y is thread local
+compilable/sw_transition_tls.d(11): `x` is thread local
+compilable/sw_transition_tls.d(15): `y` is thread local
 ---
 */
 


### PR DESCRIPTION
And added backticks to the messages so they _could_ be syntax highlighted, but it's probably better to add in a prefix to visually separate the **bold** location and highlighted names before doing that.