### PR TITLE
[dmd-cxx]: Fix the auto-tester and copy dmd to $(GENERATED)/$(OS)/$(BUILD)/$(MODEL)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ tags
 # OSX
 src/impcnvgen.dSYM/
 src/optabgen.dSYM/
+
+# Generated
+/generated

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -42,6 +42,11 @@ C=backend
 TK=tk
 ROOT=root
 
+GENERATED = ../generated
+BUILD=release
+G = $(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
+$(shell mkdir -p $G)
+
 ifeq (osx,$(OS))
     export MACOSX_DEPLOYMENT_TARGET=10.3
 endif
@@ -328,9 +333,11 @@ backend.a: $(BACK_OBJS)
 ifdef ENABLE_LTO
 dmd: $(DMD_OBJS) $(ROOT_OBJS) $(GLUE_OBJS) $(BACK_OBJS)
 	$(HOST_CC) -o dmd $(MODEL_FLAG) $^ $(LDFLAGS)
+	cp dmd $G/dmd
 else
 dmd: frontend.a root.a glue.a backend.a
 	$(HOST_CC) -o dmd $(MODEL_FLAG) frontend.a root.a glue.a backend.a $(LDFLAGS)
+	cp dmd $G/dmd
 endif
 
 clean:


### PR DESCRIPTION
This should ideally fix the auto-tester build for `dmd-cxx` as Travis is already passing too.

See also: https://github.com/dlang/dmd/pull/7595