### PR TITLE
[Trivial] dmd.statementsem: Fix comment

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3503,7 +3503,7 @@ else
         else
         {
             /* Generate our own critical section, then rewrite as:
-             *  shared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsec;
+             *  static shared align(D_CRITICAL_SECTION.alignof) byte[D_CRITICAL_SECTION.sizeof] __critsec;
              *  _d_criticalenter(&__critsec[0]);
              *  try { body } finally { _d_criticalexit(&__critsec[0]); }
              */


### PR DESCRIPTION
Without `static` (implicit for previous `__gshared`), the variable would be allocated on the stack. See https://github.com/dlang/dmd/pull/7918.