### PR TITLE
Reset asmstate using value assignment.

### DIFF
--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -4378,7 +4378,9 @@ extern (C++) public Statement asmSemantic(AsmStatement s, Scope *sc)
     if (!s.tokens)
         return null;
 
-    memset(&asmstate, 0, asmstate.sizeof);
+    asmstate.ucItype = 0;
+    asmstate.bReturnax = false;
+    asmstate.lbracketNestCount = 0;
 
     asmstate.statement = s;
     asmstate.sc = sc;


### PR DESCRIPTION
Later on, `bInit` is used as a gate for initializing some other fields.

https://github.com/dlang/dmd/blob/bd2465510a172414cc626f7d7ebc3d0db8aece3f/src/dmd/iasm.d#L4401-L4407

By using `memset, `bInit` is always false, and new memory is always allocated on function entry.

Looks like a logic bug, and one that costs us 80KB of more memory building druntime and 300KB building phobos.

Looks like `bReturnax` is a dead field also, but I'm not willing to touch that.