### PR TITLE
Fix Issue 17373 -  traits getOverloads + multiple interface inheritan…

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -923,7 +923,33 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                     ex = dve.e1;
             }
 
-            overloadApply(f, (Dsymbol s)
+            bool[string] funcTypeHash;
+
+            /* Compute the function signature and insert it in the
+             * hashtable, if not present. This is needed so that
+             * traits(getOverlods, F3, "visit") does not count `int visit(int)`
+             * twice in the following example:
+             *
+             * =============================================
+             * interface F1 { int visit(int);}
+             * interface F2 { int visit(int); void visit(); }
+             * interface F3 : F2, F1 {}
+             *==============================================
+             */
+            void insertInterfaceInheritedFunction(FuncDeclaration fd, Expression e)
+            {
+                auto funcType = fd.type.toChars();
+                auto len = strlen(funcType);
+                string signature = funcType[0 .. len].idup;
+                //printf("%s - %s\n", fd.toChars, signature);
+                if (signature !in funcTypeHash)
+                {
+                    funcTypeHash[signature] = true;
+                    exps.push(e);
+                }
+            }
+
+            int dg(Dsymbol s)
             {
                 auto fd = s.isFuncDeclaration();
                 if (!fd)
@@ -939,9 +965,32 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 auto e = ex ? new DotVarExp(Loc.initial, ex, fa, false)
                             : new DsymbolExp(Loc.initial, fa, false);
 
-                exps.push(e);
+                // if the parent is an interface declaration
+                // we must check for functions with the same signature
+                // in different inherited interfaces
+                if (sym.isInterfaceDeclaration())
+                    insertInterfaceInheritedFunction(fd, e);
+                else
+                    exps.push(e);
                 return 0;
-            });
+            }
+
+            InterfaceDeclaration ifd = null;
+            if (sym)
+                ifd = sym.isInterfaceDeclaration();
+            // If the symbol passed as a parameter is an
+            // interface that inherits other interfaces
+            if (ifd && ifd.interfaces)
+            {
+                // check the overloads of each inherited interface individually
+                foreach (bc; ifd.interfaces)
+                {
+                    if (auto fd = bc.sym.search(e.loc, f.ident))
+                        overloadApply(fd, &dg);
+                }
+            }
+            else
+                overloadApply(f, &dg);
 
             auto tup = new TupleExp(e.loc, exps);
             return tup.expressionSemantic(scx);

--- a/test/runnable/test17373.d
+++ b/test/runnable/test17373.d
@@ -1,0 +1,20 @@
+interface Foo { void visit (int); }
+interface Bar { void visit(double); }
+interface FooBar : Foo, Bar {}
+static assert(__traits(getOverloads, FooBar, "visit").length == 2);
+
+interface Fbar { void visit(char); void visit(double); }
+interface Triple : Foo, Bar, Fbar {}
+static assert(__traits(getOverloads, Triple, "visit").length == 3);
+
+interface InheritanceMadness : FooBar, Triple {}
+static assert(__traits(getOverloads, Triple, "visit").length == 3);
+
+interface Simple
+{
+    int square(int);
+    real square(real);
+}
+static assert(__traits(getOverloads, Simple, "square").length == 2);
+
+void main() {}


### PR DESCRIPTION
…ce only see one of the interfaces' overloads

Interface inheritance does not create an OverloadSet for overloaded methods in different inherited interfaces. This caused traits(getOverloads) to report incorrect answers. In order to fix this I added a test so that if the symbol passed to traits is a interface declaration, all the inherited interfaces are checked to see if they add a new overload. In order to avoid counting functions with the same signature, but located in different inherited interfaces, I am using a hashtable which stores the function mangled signature.