### PR TITLE
fix test suite when building with -m32mscoff

### DIFF
--- a/test/runnable/testpdb.d
+++ b/test/runnable/testpdb.d
@@ -2,6 +2,7 @@
 // PERMUTE_ARGS:
 
 import core.time;
+import core.demangle;
 
 void main(string[] args)
 {
@@ -73,7 +74,7 @@ void testSymbolHasChildren(IDiaSymbol sym, string name)
 
 void testLineNumbers(IDiaSession session, IDiaSymbol globals)
 {
-    IDiaSymbol funcsym = searchSymbol(globals, test15432.mangleof);
+    IDiaSymbol funcsym = searchSymbol(globals, cPrefix ~ test15432.mangleof);
     assert(funcsym, "symbol test15432 not found");
     ubyte[] funcRange;
     Line[] lines = findSymbolLineNumbers(session, funcsym, &funcRange);


### PR DESCRIPTION
Adapt to changes in https://github.com/dlang/dmd/pull/7620. I suspect more code breakage will appear as `GetProcAddress(fun.mangleof)` no longer works.