### PR TITLE
fix Issue 18530 - src/rt/tracegc.d(43): Deprecation: The delete keywo…

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5130,6 +5130,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DeleteExp exp)
     {
+        // @@@DEPRECATED_2019-02@@@
+        // 1. Deprecation for 1 year
+        // 2. Error for 1 year
+        // 3. Removal of keyword, "delete" can be used for other identities
+        if (!exp.isRAII)
+            deprecation(exp.loc, "The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.");
+
         if (Expression ex = unaSemantic(exp, sc))
         {
             result = ex;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7758,11 +7758,6 @@ final class Parser(AST) : Lexer
         case TOK.delete_:
             nextToken();
             e = parseUnaryExp();
-            // @@@DEPRECATED_2019-02@@@
-            // 1. Deprecation for 1 year
-            // 2. Error for 1 year
-            // 3. Removal, "delete" can be used for other identities
-            deprecation("The `delete` keyword has been deprecated.  Use `object.destroy()` instead.");
             e = new AST.DeleteExp(loc, e, false);
             break;
 

--- a/test/compilable/vgc1.d
+++ b/test/compilable/vgc1.d
@@ -1,15 +1,6 @@
 // REQUIRED_ARGS: -vgc -o-
 // PERMUTE_ARGS:
 
-/*
-TEST_OUTPUT:
----
-compilable/vgc1.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-compilable/vgc1.d(94): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-compilable/vgc1.d(95): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
----
-*/
-
 /***************** NewExp *******************/
 
 struct S1 { }
@@ -21,13 +12,13 @@ struct S5 { @nogc new(size_t); }
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(36): vgc: `new` causes a GC allocation
+compilable/vgc1.d(27): vgc: `new` causes a GC allocation
+compilable/vgc1.d(29): vgc: `new` causes a GC allocation
+compilable/vgc1.d(30): vgc: `new` causes a GC allocation
+compilable/vgc1.d(32): vgc: `new` causes a GC allocation
+compilable/vgc1.d(33): vgc: `new` causes a GC allocation
+compilable/vgc1.d(34): vgc: `new` causes a GC allocation
 compilable/vgc1.d(38): vgc: `new` causes a GC allocation
-compilable/vgc1.d(39): vgc: `new` causes a GC allocation
-compilable/vgc1.d(41): vgc: `new` causes a GC allocation
-compilable/vgc1.d(42): vgc: `new` causes a GC allocation
-compilable/vgc1.d(43): vgc: `new` causes a GC allocation
-compilable/vgc1.d(47): vgc: `new` causes a GC allocation
 ---
 */
 
@@ -50,12 +41,12 @@ void testNew()
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(64): vgc: `new` causes a GC allocation
-compilable/vgc1.d(66): vgc: `new` causes a GC allocation
-compilable/vgc1.d(67): vgc: `new` causes a GC allocation
-compilable/vgc1.d(69): vgc: `new` causes a GC allocation
-compilable/vgc1.d(70): vgc: `new` causes a GC allocation
-compilable/vgc1.d(71): vgc: `new` causes a GC allocation
+compilable/vgc1.d(55): vgc: `new` causes a GC allocation
+compilable/vgc1.d(57): vgc: `new` causes a GC allocation
+compilable/vgc1.d(58): vgc: `new` causes a GC allocation
+compilable/vgc1.d(60): vgc: `new` causes a GC allocation
+compilable/vgc1.d(61): vgc: `new` causes a GC allocation
+compilable/vgc1.d(62): vgc: `new` causes a GC allocation
 ---
 */
 
@@ -83,9 +74,12 @@ void testNewScope()
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(93): vgc: `delete` requires the GC
-compilable/vgc1.d(94): vgc: `delete` requires the GC
-compilable/vgc1.d(95): vgc: `delete` requires the GC
+compilable/vgc1.d(87): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+compilable/vgc1.d(87): vgc: `delete` requires the GC
+compilable/vgc1.d(88): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+compilable/vgc1.d(88): vgc: `delete` requires the GC
+compilable/vgc1.d(89): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+compilable/vgc1.d(89): vgc: `delete` requires the GC
 ---
 */
 void testDelete(int* p, Object o, S1* s)

--- a/test/fail_compilation/fail14486.d
+++ b/test/fail_compilation/fail14486.d
@@ -1,41 +1,5 @@
 // REQUIRED_ARGS: -o-
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail14486.d(81): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(82): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(83): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(84): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(85): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(99): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(100): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(101): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(102): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(103): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(123): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(124): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(125): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(126): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(127): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(141): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(142): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(143): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(144): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(145): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(164): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(165): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(166): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(167): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(168): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(181): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(182): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(183): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(184): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/fail14486.d(185): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
----
-*/
-
 class  C0a { }
 class  C1a {                  ~this() {} }
 class  C2a {                  ~this() {}  @nogc pure @safe delete(void* p) {} }
@@ -63,17 +27,22 @@ struct S4b {          nothrow ~this() {}           nothrow delete(void* p) {} }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(81): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
-fail_compilation/fail14486.d(82): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(82): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(82): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(83): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(83): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(83): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(84): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(84): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(84): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(85): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
+fail_compilation/fail14486.d(50): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(50): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
+fail_compilation/fail14486.d(51): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(51): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(51): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(51): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(52): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(52): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(52): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(52): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(53): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(53): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(53): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(53): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(54): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(54): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
 ---
 */
 void test1a() @nogc pure @safe
@@ -88,10 +57,15 @@ void test1a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(100): Error: destructor `fail14486.C1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(101): Error: destructor `fail14486.C2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(102): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(97): Error: `nothrow` function `fail14486.test1b` may throw
+fail_compilation/fail14486.d(73): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(74): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(75): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(76): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(77): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(74): Error: destructor `fail14486.C1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(75): Error: destructor `fail14486.C2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(76): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(71): Error: `nothrow` function `fail14486.test1b` may throw
 ---
 */
 void test1b() nothrow
@@ -106,16 +80,21 @@ void test1b() nothrow
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(123): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
-fail_compilation/fail14486.d(124): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(124): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(124): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(125): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(125): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(125): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(126): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(126): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(126): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(102): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(102): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
+fail_compilation/fail14486.d(103): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(103): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(103): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(103): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(104): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(104): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(104): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(104): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(105): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(105): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(105): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(105): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(106): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 ---
 */
 void test2a() @nogc pure @safe
@@ -130,10 +109,15 @@ void test2a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(142): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(143): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(144): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(139): Error: `nothrow` function `fail14486.test2b` may throw
+fail_compilation/fail14486.d(125): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(126): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(127): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(128): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(129): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(126): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(127): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(128): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(123): Error: `nothrow` function `fail14486.test2b` may throw
 ---
 */
 void test2b() nothrow
@@ -148,15 +132,20 @@ void test2b() nothrow
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(164): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(165): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(165): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(165): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(166): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(166): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(166): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(167): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(168): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(153): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(153): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(154): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(154): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(154): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(154): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(155): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(155): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(155): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(155): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(156): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(156): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(157): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(157): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
 ---
 */
 void test3a() @nogc pure @safe
@@ -171,9 +160,14 @@ void test3a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(182): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(183): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(179): Error: `nothrow` function `fail14486.test3b` may throw
+fail_compilation/fail14486.d(175): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(176): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(177): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(178): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(179): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(176): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(177): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(173): Error: `nothrow` function `fail14486.test3b` may throw
 ---
 */
 void test3b() nothrow

--- a/test/fail_compilation/fail2361.d
+++ b/test/fail_compilation/fail2361.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2361.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/fail2361.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail2361.d(14): Error: cannot modify `immutable` expression `c`
 ---
 */

--- a/test/fail_compilation/fail_arrayop2.d
+++ b/test/fail_compilation/fail_arrayop2.d
@@ -1,9 +1,9 @@
 // REQUIRED_ARGS: -o-
 
+
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(281): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
 fail_compilation/fail_arrayop2.d(13): Error: array operation `[1, 2, 3] - [1, 2, 3]` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(16): Error: invalid array operation `"a" - "b"` (possible missing [])
 ---
@@ -198,9 +198,9 @@ void test14895()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_arrayop2.d(246): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(247): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(248): Error: array operation `[1] * 6` without destination memory not allowed
+fail_compilation/fail_arrayop2.d(249): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(253): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(256): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(265): Error: array operation `[1] * 6` without destination memory not allowed
@@ -209,6 +209,7 @@ fail_compilation/fail_arrayop2.d(269): Error: array operation `"abc"[] + '\x01'`
 fail_compilation/fail_arrayop2.d(272): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(275): Error: `([1] * 6)[0..2]` is not an lvalue
 fail_compilation/fail_arrayop2.d(278): Error: can only `*` a pointer, not a `int[]`
+fail_compilation/fail_arrayop2.d(281): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/fail_arrayop2.d(281): Error: `[1] * 6` is not an lvalue
 fail_compilation/fail_arrayop2.d(284): Error: array operation `da[] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(287): Error: array operation `da[] * 6` without destination memory not allowed
@@ -248,7 +249,6 @@ void test15407exp()
                 [1] * 6]; }     // AssocArrayLiteralExp
 
     //TupleExp
-
     // StructLiteralExp.elements <- preFunctionParameters in CallExp
     { auto r = S([1] * 6); }
 

--- a/test/fail_compilation/faildeleteaa.d
+++ b/test/fail_compilation/faildeleteaa.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/faildeleteaa.d(12): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/faildeleteaa.d(12): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/faildeleteaa.d(12): Error: cannot delete type `int`
 ---
 */

--- a/test/fail_compilation/nogc1.d
+++ b/test/fail_compilation/nogc1.d
@@ -1,15 +1,6 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/nogc1.d(91): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/nogc1.d(92): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
-fail_compilation/nogc1.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
----
-*/
-
 /***************** NewExp *******************/
 
 struct S1 { }
@@ -21,14 +12,14 @@ struct S5 { @nogc new(size_t); }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(36): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(27): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(29): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(30): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(32): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(33): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(34): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(35): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc allocator `nogc1.S4.new`
 fail_compilation/nogc1.d(38): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(39): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(41): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(42): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(43): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(44): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc allocator `nogc1.S4.new`
-fail_compilation/nogc1.d(47): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
 ---
 */
 @nogc void testNew()
@@ -50,13 +41,13 @@ fail_compilation/nogc1.d(47): Error: cannot use `new` in `@nogc` function `nogc1
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(64): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(66): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(67): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(69): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(70): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(71): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(72): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc allocator `nogc1.S4.new`
+fail_compilation/nogc1.d(55): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(57): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(58): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(60): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(61): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(62): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(63): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc allocator `nogc1.S4.new`
 ---
 */
 @nogc void testNewScope()
@@ -81,9 +72,12 @@ fail_compilation/nogc1.d(72): Error: `@nogc` function `nogc1.testNewScope` canno
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(91): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(92): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(93): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(85): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(85): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(86): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(86): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(87): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(87): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
 ---
 */
 @nogc void testDelete(int* p, Object o, S1* s)

--- a/test/fail_compilation/test16195.d
+++ b/test/fail_compilation/test16195.d
@@ -1,7 +1,7 @@
 /*
  * TEST_OUTPUT:
 ---
-fail_compilation/test16195.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` instead.
+fail_compilation/test16195.d(14): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 fail_compilation/test16195.d(14): Error: `delete p` is not `@safe` but is used in `@safe` function `test`
 ---
  */


### PR DESCRIPTION
…rd has been deprecated

defer deprecation message into semantic stage so it can still be versioned out.

Please note that the delete declaration is not deprecated, so the message should probably better say "delete expression" instead of "delete keyword".

