### PR TITLE
Temporarily disable #7577, s.t. a proper deprecation cycle can be started

### DIFF
--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -352,6 +352,10 @@ private extern(C++) final class Semantic2Visitor : Visitor
         fd.semanticRun = PASS.semantic2;
 
         //printf("FuncDeclaration::semantic2 [%s] fd0 = %s %s\n", loc.toChars(), toChars(), type.toChars());
+
+        // https://issues.dlang.org/show_bug.cgi?id=18385
+        // Disable for 2.079, s.t. a deprecation cycle can be started with 2.080
+        if (0)
         if (fd.overnext && !fd.errors)
         {
             OutBuffer buf1;

--- a/test/fail_compilation/fail17492.d
+++ b/test/fail_compilation/fail17492.d
@@ -1,4 +1,8 @@
-/* TEST_OUTPUT:
+/*
+https://issues.dlang.org/show_bug.cgi?id=18385
+Disabled for 2.079, s.t. a deprecation cycle can be started with 2.080
+DISABLED: win32 win64 osx linux freebsd dragonflybsd
+TEST_OUTPUT:
 ---
 fail_compilation/fail17492.d(17): Error: function `fail17492.C.testE()` conflicts with previous declaration at fail_compilation/fail17492.d(10)
 ---

--- a/test/fail_compilation/fail2789.d
+++ b/test/fail_compilation/fail2789.d
@@ -1,4 +1,7 @@
 /*
+DISABLED: win32 win64 osx linux freebsd dragonflybsd
+https://issues.dlang.org/show_bug.cgi?id=18385
+Disabled for 2.079, s.t. a deprecation cycle can be started with 2.080
 TEST_OUTPUT:
 ---
 fail_compilation/fail2789.d(15): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)


### PR DESCRIPTION
Disables https://github.com/dlang/dmd/pull/7577 as it looks like a proper deprecation cycle is needed and 2.079 is right around the corner.