### PR TITLE
[stable] Temporary workaround for Issue 16243

### DIFF
--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -255,6 +255,13 @@ extern(C++) void check13956(S13956 arg0, int arg1, int arg2, int arg3, int arg4,
             assert(arg6 == 6);
         // fails on OSX 32-bit
     }
+    else version (FreeBSD)
+    {
+        version (D_LP64)
+            assert(arg6 == 6);
+        // fails on FreeBSD 32-bit
+        // https://issues.dlang.org/show_bug.cgi?id=16243
+    }
     else
         assert(arg6 == 6);
 }


### PR DESCRIPTION
Cherry-pick https://github.com/dlang/dmd/pull/7952 to `stable`, s.t. auto-tester will pass on stable too.
Note this will fail on auto-tester as it requires https://github.com/dlang/phobos/pull/6232 too and requires a manual merge.

See also: https://github.com/braddr/d-tester/issues/70