### PR TITLE
Improve d_do_test DISABLED to allow true submatches

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -9,6 +9,7 @@ import std.file;
 import std.format;
 import std.process;
 import std.random;
+import std.range : chain;
 import std.regex;
 import std.stdio;
 import std.string;
@@ -637,7 +638,8 @@ int tryMain(string[] args)
         }
     }
 
-    if (testArgs.disabledPlatforms.canFind(envData.os, envData.os ~ envData.model))
+    // allows partial matching, e.g. win for both win32 and win64
+    if (testArgs.disabledPlatforms.any!(a => envData.os.chain(envData.model).canFind(a)))
     {
         testArgs.disabled = true;
         writefln("!!! [DISABLED on %s]", envData.os);


### PR DESCRIPTION
Allows to use `win` for `DISABLED` as it now searches for truw submatches (what was probably intended in the first place).

https://github.com/dlang/dmd/pull/7969#issuecomment-369425112

I'm thinking about supporting `all` too. Anyone is favor or against `all`?