### PR TITLE
Allow getting type from template declarations.

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2798,6 +2798,10 @@ extern (C++) abstract class Type : RootObject
                 s = getDsymbol(e);
                 break;
 
+            case TOK.dotTemplateDeclaration:
+                s = (cast(DotTemplateExp)e).td;
+                break;
+
             //case TOK.this_:
             //case TOK.super_:
 
@@ -2806,7 +2810,6 @@ extern (C++) abstract class Type : RootObject
             //case TOK.overloadSet:
 
             //case TOK.dotVariable:
-            //case TOK.dotTemplateDeclaration:
             //case TOK.dotTemplateInstance:
             //case TOK.dotType:
             //case TOK.dotIdentifier:

--- a/test/compilable/mixintempl.d
+++ b/test/compilable/mixintempl.d
@@ -1,0 +1,22 @@
+
+struct TypeObj
+{
+    alias This = typeof(this);
+
+    mixin template MixinTempl()
+    {
+        int value;
+    }
+}
+
+ref TypeObj Obj()
+{
+    static TypeObj a;
+    return a;
+}
+
+void func()
+{
+    mixin Obj.This.MixinTempl; // ok
+    mixin Obj.MixinTempl;      // fixed: "MixinTempl!()" is not defined
+}


### PR DESCRIPTION

```D
struct TypeObj
{
    alias This = typeof(this);

    mixin template MixinTempl()
    {
        int value;
    }
}

ref TypeObj Obj()
{
    static TypeObj a;
    return a;
}

void main()
{
    mixin Obj.This.MixinTempl; // ok
    mixin Obj.MixinTempl;      // error: "MixinTempl!()" is not defined
}

```

Couldn't access templates like in the above example, though other symbols such as types are accessible. This allows the second line to be usable.