### PR TITLE
[dmd-cxx] Remove va_argsave and move magic initialization of _argptr to the glue layer

### DIFF
--- a/src/backend/gflow.c
+++ b/src/backend/gflow.c
@@ -1370,7 +1370,9 @@ STATIC void accumlv(vec_t GEN,vec_t KILL,elem *n)
                         t->EV.sp.Voffset == 0 &&
                         tsz == type_size(s->Stype)
                        )
-                    {   assert((unsigned)s->Ssymnum < globsym.top);
+                    {
+                        // printf("%s\n", s->Sident);
+                        assert((unsigned)s->Ssymnum < globsym.top);
                         vec_setbit(s->Ssymnum,KILL);
                     }
                 }

--- a/src/glue.c
+++ b/src/glue.c
@@ -1091,6 +1091,26 @@ void FuncDeclaration_toObjFile(FuncDeclaration *fd, bool multiobj)
         bx.module = fd->getModule();
         irs.blx = &bx;
 
+        // Initialize argptr
+        if (fd->v_argptr)
+        {
+            // Declare va_argsave
+            if (global.params.is64bit &&
+                !global.params.isWindows)
+            {
+                type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, NULL, NULL, false, false, true);
+                // The backend will pick this up by name
+                Symbol *s = symbol_name("__va_argsave", SCauto, t);
+                s->Stype->Tty |= mTYvolatile;
+                symbol_add(s);
+            }
+
+            Symbol *s = toSymbol(fd->v_argptr);
+            symbol_add(s);
+            elem *e = el_una(OPva_start, TYnptr, el_ptr(s));
+            block_appendexp(irs.blx->curblock, e);
+        }
+
         /* Doing this in semantic3() caused all kinds of problems:
          * 1. couldn't reliably get the final mangling of the function name due to fwd refs
          * 2. impact on function inlining


### PR DESCRIPTION
This is the backend patch of a change that was made to the frontend, fixes the segfault mentioned in #7953.

Though really someone should merge the backend in its entirety to the release it should be based on so people aren't scratching their heads why something doesn't work. ;-)