### PR TITLE
Implement DIP1006 - more selective control over run-time checks

### DIFF
--- a/changelog/dip1006.dd
+++ b/changelog/dip1006.dd
@@ -1,4 +1,4 @@
-allow to disable only specific run-time checks
+Allow to disable only specific run-time checks
 
-The $(LINK2 $(TT -release), https://dlang.org/dmd-linux.html#switch-release) switch now accepts optional arguments to only disable some run-time checks, e.g. $(TT -release=in,out,invariant) disables in-/out-contracts and invariants, but still leaves assertions enabled.
+The $(LINK2 $(TT -release), https://dlang.org/dmd.html#switch-release) switch now accepts optional arguments to only disable some run-time checks, e.g. $(TT -release=in,out,invariant) disables in-/out-contracts and invariants, but still leaves assertions enabled.
 Also see $(LINK2 DIP1006, https://github.com/dlang/DIPs/blob/master/DIPs/DIP1006.md).

--- a/changelog/dip1006.dd
+++ b/changelog/dip1006.dd
@@ -1,0 +1,4 @@
+allow to disable only specific run-time checks
+
+The $(LINK2 $(TT -release), https://dlang.org/dmd-linux.html#switch-release) switch now accepts optional arguments to only disable some run-time checks, e.g. $(TT -release=in,out,invariant) disables in-/out-contracts and invariants, but still leaves assertions enabled.
+Also see $(LINK2 DIP1006, https://github.com/dlang/DIPs/blob/master/DIPs/DIP1006.md).

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -509,12 +509,15 @@ dmd -cov -unittest myprog.d
                 to the file $(TT profilegc.log) upon program termination.)
             )`,
         ),
-        Option("release",
-            "compile release version",
-            `Compile release version, which means not emitting run-time
-            checks for contracts and asserts. Array bounds checking is not
-            done for system and trusted functions, and assertion failures
-            are undefined behaviour.`
+        Option("release[=<assert,in,out,invariant>]",
+            "disable run-time checks",
+            `Disable in-/out-contracts, invariants, and assertions.
+            It is possible to disable only some run-time checks by specifying them
+            as comma separated arguments (e.g. $(TT -release=assert,invariant)).
+            By default $(TT $(SWLINK -release)) will disable all run-time checks.
+            Any $(TT $(SWLINK -release)) switch furthermore sets the default of
+            $(SWLINK -boundscheck) to safeonly.
+            $(P Note that $(SWLINK -unittest) (re-)enables assertions in unittests and function bodies.)`
         ),
         Option("run <srcfile>",
             "compile, link, and run the program srcfile",

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -127,7 +127,7 @@ struct Param
     bool useUnitTests;          // generate unittest code
     bool useInline = false;     // inline expand functions
     bool useDIP25;          // implement http://wiki.dlang.org/DIP25
-    bool release;           // build release version
+    bool optimizeLinking;   // use optimized linker settings
     bool preservePaths;     // true means don't strip path from source file
     // 0: disable warnings
     // 1: warnings as errors

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -224,8 +224,8 @@ public int runLINK()
             {
                 cmdbuf.writeByte(' ');
                 cmdbuf.writestring("/DEBUG");
-                // in release mode we need to reactivate /OPT:REF after /DEBUG
-                if (global.params.release)
+                // in release mode we reactivate /OPT:REF after /DEBUG to still minimize binary size
+                if (global.params.linkRelease)
                     cmdbuf.writestring(" /OPT:REF");
             }
             if (global.params.dll)

--- a/test/runnable/test_dip1006.d
+++ b/test/runnable/test_dip1006.d
@@ -1,0 +1,38 @@
+// REQUIRED_ARGS: -release=in,out,invariant
+// PERMUTE_ARGS:
+class C
+{
+    int foo(int a)
+    in { assert(a != 0); } // skipped
+    out(res) { assert(res != 0); } // skipped
+    body
+    {
+        return a;
+    }
+
+    invariant // skipped
+    {
+        assert(false);
+    }
+
+    void bar(int a)
+    {
+        assert(a != 0); // triggered
+    }
+}
+
+void main()
+{
+    import core.exception : AssertError;
+
+    auto c = new C;
+    c.foo(0);
+
+    bool catched;
+    try
+        c.bar(0);
+    catch (AssertError e)
+        catched = true;
+    if (!catched)
+        assert(0);
+}

--- a/test/runnable/test_dip1006b.d
+++ b/test/runnable/test_dip1006b.d
@@ -1,0 +1,32 @@
+// REQUIRED_ARGS: -release=in,invariant
+// PERMUTE_ARGS:
+class C
+{
+    int foo(int a)
+    in { assert(a != 0); } // skipped
+    out(res) { assert(res != 0, "out"); } // triggered
+    body
+    {
+        return a;
+    }
+
+    invariant // skipped
+    {
+        assert(false);
+    }
+}
+
+void main()
+{
+    import core.exception : AssertError;
+
+    auto c = new C;
+    bool catched;
+    try
+        c.foo(0);
+    catch (AssertError e)
+        catched = e.msg == "out";
+
+    if (!catched)
+        assert(0);
+}


### PR DESCRIPTION
- allow to disable only some run-time checks e.g. with -release=in,out,invariant
- cli was proposed in DIP1006 review discussion
  https://forum.dlang.org/post/rsafosvkhxddkxptaziy@forum.dlang.org
  but hasn't yet been added to https://github.com/dlang/DIPs/blob/master/DIPs/DIP1006.md