### PR TITLE
Make Lexer.escapeSequence more reusable and add unittests

### DIFF
--- a/test/fail_compilation/lexer1.d
+++ b/test/fail_compilation/lexer1.d
@@ -16,7 +16,7 @@ fail_compilation/lexer1.d(40): Error: declaration expected, not `65536U`
 fail_compilation/lexer1.d(41): Error: declaration expected, not `"ab\\c\"\u1234a\U00011100a"d`
 fail_compilation/lexer1.d(43): Error: declaration expected, not `module`
 fail_compilation/lexer1.d(45): Error: escape hex sequence has 1 hex digits instead of 2
-fail_compilation/lexer1.d(46): Error: undefined escape hex sequence \G
+fail_compilation/lexer1.d(46): Error: undefined escape hex sequence \xG
 fail_compilation/lexer1.d(47): Error: unnamed character entity &unnamedentity;
 fail_compilation/lexer1.d(48): Error: unterminated named entity &1;
 fail_compilation/lexer1.d(49): Error: unterminated named entity &*;


### PR DESCRIPTION
Moved the logic of the member function `Lexer.escapeSequence` into a static function with the same name.  Allows code to reuse the logic by calling `Lexer.escapeSequence(errorHandler, mystring)` instead of having to create a full lexer to re-use this logic.

I also added unittests for this function that both demonstrate how the function could be used without creating a full lexer.  It tests valid escape sequences as well as invalid ones making sure the correct error message is generated.