### PR TITLE
Fix issue 18034 - Bad codegen for OPvecfill

### DIFF
--- a/src/dmd/backend/glocal.c
+++ b/src/dmd/backend/glocal.c
@@ -355,6 +355,11 @@ Loop:
                                   * core.simd intrinsics. The backend type for void16 is Tschar16!
                                   */
                                  (tyvector(em->Ety) != 0) == (tyvector(e->Ety) != 0) && tybasic(e->Ety) == TYschar16) &&
+                                /* Changing the Ety to a OPvecfill node means we're potentially generating
+                                 * wrong code.
+                                 * Ref: https://issues.dlang.org/show_bug.cgi?id=18034
+                                 */
+                                (em->E2->Eoper != OPvecfill || tybasic(e->Ety) == tybasic(em->Ety)) &&
                                 !local_preserveAssignmentTo(em->E1->Ety))
                             {
 #ifdef DEBUG

--- a/test/runnable/b18034.d
+++ b/test/runnable/b18034.d
@@ -1,0 +1,19 @@
+version (D_SIMD)
+{
+import core.simd;
+
+void check(void16 a) {
+    foreach (x; (cast(ushort8)a).array) {
+	assert(x == 1);
+    }
+}
+
+void make(ushort x) {
+    ushort8 v = ushort8(x);
+    check(v);
+}
+
+void main(){	
+    make(1);
+}
+}

--- a/test/runnable/b18034.d
+++ b/test/runnable/b18034.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -O
 version (D_SIMD)
 {
 import core.simd;

--- a/test/runnable/b18034.d
+++ b/test/runnable/b18034.d
@@ -1,24 +1,28 @@
 // REQUIRED_ARGS: -O
 version (D_SIMD)
 {
-import core.simd;
+    import core.simd;
 
-void check(void16 a) {
-    foreach (x; (cast(ushort8)a).array) {
-	assert(x == 1);
+    void check(void16 a) 
+    {
+        foreach (x; (cast(ushort8)a).array) 
+        {
+	        assert(x == 1);
+        }
     }
-}
 
-void make(ushort x) {
-    ushort8 v = ushort8(x);
-    check(v);
-}
+    void make(ushort x) 
+    {
+        ushort8 v = ushort8(x);
+        check(v);
+    }
 
-void main() {	
-    make(1);
-}
+    void main() 
+    {	
+        make(1);
+    }
 }
 else
 {
-void main() { }
+    void main() { }
 }

--- a/test/runnable/b18034.d
+++ b/test/runnable/b18034.d
@@ -13,7 +13,11 @@ void make(ushort x) {
     check(v);
 }
 
-void main(){	
+void main() {	
     make(1);
 }
+}
+else
+{
+void main() { }
 }


### PR DESCRIPTION
Do not replace vector values if that implies a change of Ety, doing so
may end up initializing the vector with the wrong content.

Another idea would be to special-case `OPvecfill` in the `Ety` assignment below to take advantage of the value replacement.