### PR TITLE
Fix Issue 18578 - First enum value assigned 0 instead of EnumBaseType.init

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2311,7 +2311,22 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (!em.ed.isAnonymous())
                     em.ed.memtype = t;
             }
-            Expression e = new IntegerExp(em.loc, 0, t);
+
+            Expression e;
+
+            if (!t.isZeroInit(em.loc))
+            {
+                deprecation(em.loc,
+                            "Enum `%s` has base type `%s` with non-zero .init; " ~
+                            "initialize the enum member explicitly",
+                            em.ed.toPrettyChars(), t.toPrettyChars());
+                e = new IntegerExp(em.loc, 0, t);
+            }
+            else
+            {
+                e = t.defaultInitLiteral(em.loc);
+            }
+
             e = e.ctfeInterpret();
 
             // save origValue for better json output

--- a/test/fail_compilation/diag7477.d
+++ b/test/fail_compilation/diag7477.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7477.d(13): Error: integral constant must be scalar type, not `Foo`
-fail_compilation/diag7477.d(20): Error: integral constant must be scalar type, not `string`
+fail_compilation/diag7477.d(15): Deprecation: Enum `diag7477.Bar` has base type `Foo` with non-zero .init; initialize the enum member explicitly
+fail_compilation/diag7477.d(15): Error: integral constant must be scalar type, not `Foo`
+fail_compilation/diag7477.d(20): Error: no property `max` for type `string`
+fail_compilation/diag7477.d(23): Error: incompatible types for `(null) + (1)`: `Baz` and `int`
 ---
 */
 


### PR DESCRIPTION
> The value of an EnumMember is given by its AssignExpression. If there is no AssignExpression and it is the first EnumMember, its value is the .init property of the EnumMember's type.

