### PR TITLE
Update runnable/test4.d for AArch64 and PPC64.

### DIFF
--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -254,6 +254,26 @@ else version(ARM)
     assert(TRECT6.BottomRight.offsetof == 16);
     assert(TRECT6.foo2.offsetof == 24);
 }
+else version (AArch64)
+{
+    assert(TRECT6.Left.offsetof == 8);
+    assert(TRECT6.Top.offsetof == 12);
+    assert(TRECT6.Right.offsetof == 16);
+    assert(TRECT6.Bottom.offsetof == 20);
+    assert(TRECT6.TopLeft.offsetof == 8);
+    assert(TRECT6.BottomRight.offsetof == 16);
+    assert(TRECT6.foo2.offsetof == 24);
+}
+else version (PPC64)
+{
+    assert(TRECT6.Left.offsetof == 8);
+    assert(TRECT6.Top.offsetof == 12);
+    assert(TRECT6.Right.offsetof == 16);
+    assert(TRECT6.Bottom.offsetof == 20);
+    assert(TRECT6.TopLeft.offsetof == 8);
+    assert(TRECT6.BottomRight.offsetof == 16);
+    assert(TRECT6.foo2.offsetof == 24);
+}
 else
 {
     assert(TRECT6.Left.offsetof == 4);


### PR DESCRIPTION
Both architectures have alignment similar to x86_64.