### PR TITLE
Ternary codegen fixes/optimization

### DIFF
--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -2011,8 +2011,7 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 
         opcode = 0x81;
         switch (sz2)
-        {   case 1:     opcode--;
-                        v1 = (signed char) v1;
+        {   case 1:     v1 = (signed char) v1;
                         v2 = (signed char) v2;
                         break;
             case 2:     v1 = (short) v1;

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -2054,6 +2054,20 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
             cgstate.stackclean--;
             return;
 	}
+        else if (v1 == v2)
+        {
+            unsigned reg = findreg(retregs);
+
+            movregconst(cdb, reg, v1, 0);
+
+            freenode(e21);
+            freenode(e22);
+            freenode(e2);
+
+            fixresult(cdb,e,retregs,pretregs);
+            cgstate.stackclean--;
+            return;
+        }
         else
         {
             codelem(cdb,e1,&retregs,FALSE);

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -2022,7 +2022,7 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
                         break;
         }
 
-	if (I64 && v1 != (targ_ullong)(targ_ulong)v1)
+        if (I64 && v1 != (targ_ullong)(targ_ulong)v1)
         {
             // only zero-extension from 32-bits is available for 'or'
         }
@@ -2030,21 +2030,21 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         {
             // only sign-extension from 32-bits is available for 'and'
         }
-	else if (I64 && sz2 > 1)
-	{
+        else if (I64 && sz2 > 1)
+        {
             unsigned reg = findreg(retregs);
-	    unsigned reg_alt;
-	    unsigned reg_flags = mPSW;
+            unsigned reg_alt;
+            unsigned reg_flags = mPSW;
 
-	    // generate the test only to update the flags
+            // generate the test only to update the flags
             codelem(cdb, e1, &reg_flags, FALSE);
 
-	    // load both the constants in some registers
-	    regwithvalue(cdb, ALLREGS, v2, &reg_alt, 0);
-	    movregconst(cdb, reg, v1, 0);
+            // load both the constants in some registers
+            regwithvalue(cdb, ALLREGS, v2, &reg_alt, 0);
+            movregconst(cdb, reg, v1, 0);
 
-	    // generate a CMOV{eq,ne}
-	    cdb.gen2(0x0f44 + (jop == JNC), grex | modregxrmx(3, reg, reg_alt));
+            // generate a CMOV{eq,ne}
+            cdb.gen2(0x0f44 + (jop == JNC), grex | modregxrmx(3, reg, reg_alt));
 
             freenode(e21);
             freenode(e22);
@@ -2053,7 +2053,7 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
             fixresult(cdb,e,retregs,pretregs);
             cgstate.stackclean--;
             return;
-	}
+        }
         else if (v1 == v2)
         {
             unsigned reg = findreg(retregs);

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -2022,7 +2022,7 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
                         break;
         }
 
-        if (I64 && v1 != (targ_ullong)(targ_ulong)v1)
+	if (I64 && v1 != (targ_ullong)(targ_ulong)v1)
         {
             // only zero-extension from 32-bits is available for 'or'
         }
@@ -2030,6 +2030,30 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         {
             // only sign-extension from 32-bits is available for 'and'
         }
+	else if (I64 && sz2 > 1)
+	{
+            unsigned reg = findreg(retregs);
+	    unsigned reg_alt;
+	    unsigned reg_flags = mPSW;
+
+	    // generate the test only to update the flags
+            codelem(cdb, e1, &reg_flags, FALSE);
+
+	    // load both the constants in some registers
+	    regwithvalue(cdb, ALLREGS, v2, &reg_alt, 0);
+	    movregconst(cdb, reg, v1, 0);
+
+	    // generate a CMOV{eq,ne}
+	    cdb.gen2(0x0f44 + (jop == JNC), grex | modregxrmx(3, reg, reg_alt));
+
+            freenode(e21);
+            freenode(e22);
+            freenode(e2);
+
+            fixresult(cdb,e,retregs,pretregs);
+            cgstate.stackclean--;
+            return;
+	}
         else
         {
             codelem(cdb,e1,&retregs,FALSE);

--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -2030,6 +2030,20 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
         {
             // only sign-extension from 32-bits is available for 'and'
         }
+        else if (v1 == v2)
+        {
+            unsigned reg = findreg(retregs);
+
+            movregconst(cdb, reg, v1, 0);
+
+            freenode(e21);
+            freenode(e22);
+            freenode(e2);
+
+            fixresult(cdb,e,retregs,pretregs);
+            cgstate.stackclean--;
+            return;
+        }
         else if (I64 && sz2 > 1)
         {
             unsigned reg = findreg(retregs);
@@ -2045,20 +2059,6 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 
             // generate a CMOV{eq,ne}
             cdb.gen2(0x0f44 + (jop == JNC), grex | modregxrmx(3, reg, reg_alt));
-
-            freenode(e21);
-            freenode(e22);
-            freenode(e2);
-
-            fixresult(cdb,e,retregs,pretregs);
-            cgstate.stackclean--;
-            return;
-        }
-        else if (v1 == v2)
-        {
-            unsigned reg = findreg(retregs);
-
-            movregconst(cdb, reg, v1, 0);
 
             freenode(e21);
             freenode(e22);

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1210,6 +1210,13 @@ extern (C++) Expression Expression_optimize(Expression e, int result, bool keepL
             {
                 expOptimize(e.e1, result, keepLvalue);
                 expOptimize(e.e2, result, keepLvalue);
+
+                // If both the branches are equal and the comparison has no side
+                // effects then simplify the expression
+                if (e.e1.equals(e.e2) && !hasSideEffect(e.econd))
+                {
+                    ret = e.e1;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes 18534 and adds some niceties.
Adding more optimizations to the dmd backend feels like putting lipstick on a pig but those were low-hanging fruits.