### PR TITLE
Issue 18594 - Replace lvalue in error messages with 'cannot modify'

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1829,9 +1829,9 @@ extern (C++) abstract class Expression : RootObject
             loc = e.loc;
 
         if (e.op == TOK.type)
-            error("%s `%s` is a type, not an lvalue", e.type.kind(), e.type.toChars());
+            error("`%s` is a `%s` definition and cannot be modified", e.type.toChars(), e.type.kind());
         else
-            error("`%s` is not an lvalue", e.toChars());
+            error("`%s` is not an lvalue and cannot be modified", e.toChars());
 
         return new ErrorExp();
     }
@@ -2614,7 +2614,7 @@ extern (C++) final class IntegerExp : Expression
             e = this;
         else if (!loc.isValid())
             loc = e.loc;
-        e.error("constant `%s` is not an lvalue", e.toChars());
+        e.error("cannot modify constant `%s`", e.toChars());
         return new ErrorExp();
     }
 
@@ -4290,22 +4290,22 @@ extern (C++) final class VarExp : SymbolExp
     {
         if (var.storage_class & STC.manifest)
         {
-            error("manifest constant `%s` is not lvalue", var.toChars());
+            error("manifest constant `%s` cannot be modified", var.toChars());
             return new ErrorExp();
         }
         if (var.storage_class & STC.lazy_)
         {
-            error("lazy variables cannot be lvalues");
+            error("lazy variable `%s` cannot be modified", var.toChars());
             return new ErrorExp();
         }
         if (var.ident == Id.ctfe)
         {
-            error("compiler-generated variable `__ctfe` is not an lvalue");
+            error("cannot modify compiler-generated variable `__ctfe`");
             return new ErrorExp();
         }
         if (var.ident == Id.dollar) // https://issues.dlang.org/show_bug.cgi?id=13574
         {
-            error("`$` is not an lvalue");
+            error("cannot modify operator `$`");
             return new ErrorExp();
         }
         return this;

--- a/test/fail_compilation/checkimports1b.d
+++ b/test/fail_compilation/checkimports1b.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/checkimports1b.d(16): Deprecation: local import search method found struct `imports.diag12598a.lines` instead of variable `checkimports1b.C.lines`
-fail_compilation/checkimports1b.d(16): Error: struct `lines` is a type, not an lvalue
+fail_compilation/checkimports1b.d(16): Error: `lines` is a `struct` definition and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/checkimports1c.d
+++ b/test/fail_compilation/checkimports1c.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/checkimports1c.d(16): Deprecation: local import search method found struct `imports.diag12598a.lines` instead of variable `checkimports1c.C.lines`
-fail_compilation/checkimports1c.d(16): Error: struct `lines` is a type, not an lvalue
+fail_compilation/checkimports1c.d(16): Error: `lines` is a `struct` definition and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/diag10862.d
+++ b/test/fail_compilation/diag10862.d
@@ -1,24 +1,36 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10862.d(28): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(29): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(30): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(31): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(32): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(34): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(35): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(36): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(37): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(39): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 fail_compilation/diag10862.d(40): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 fail_compilation/diag10862.d(41): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 fail_compilation/diag10862.d(42): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(43): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 fail_compilation/diag10862.d(44): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(45): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 fail_compilation/diag10862.d(46): Error: assignment cannot be used as a condition, perhaps `==` was meant?
 fail_compilation/diag10862.d(47): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(49): Error: undefined identifier `semanticError`
+fail_compilation/diag10862.d(48): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(49): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(51): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(52): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(53): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(54): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(56): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(57): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(58): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(59): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(61): Error: undefined identifier `semanticError`
+fail_compilation/diag10862.d(71): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d(74): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d-mixin-77(77): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d-mixin-78(78): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d-mixin-79(79): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d-mixin-80(80): Error: Using the result of a comma expression is not allowed
+fail_compilation/diag10862.d-mixin-80(80): Error: assignment cannot be used as a condition, perhaps `==` was meant?
+fail_compilation/diag10862.d-mixin-83(83): Error: `a + b` is not an lvalue and cannot be modified
+fail_compilation/diag10862.d-mixin-84(84): Error: undefined identifier `c`
+fail_compilation/diag10862.d(86): Error: undefined identifier `semanticError`
+fail_compilation/diag10862.d(93): Error: lazy variable `bar` cannot be modified
+fail_compilation/diag10862.d(95): Error: template instance `diag10862.test3.foo!int` error instantiating
 ---
 */
 void test1()
@@ -49,21 +61,6 @@ void test1()
     semanticError;
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/diag10862.d(74): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d(77): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d-mixin-80(80): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d-mixin-81(81): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d-mixin-82(82): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d-mixin-83(83): Error: Using the result of a comma expression is not allowed
-fail_compilation/diag10862.d-mixin-83(83): Error: assignment cannot be used as a condition, perhaps `==` was meant?
-fail_compilation/diag10862.d-mixin-86(86): Error: `a + b` is not an lvalue
-fail_compilation/diag10862.d-mixin-87(87): Error: undefined identifier `c`
-fail_compilation/diag10862.d(89): Error: undefined identifier `semanticError`
----
-*/
 void test2()
 {
     int a, b;
@@ -87,4 +84,13 @@ void test2()
     if (mixin("a = c")) {}
 
     semanticError;
+}
+
+void test3()
+{
+    void foo(T)(lazy T bar)
+    {
+        bar = 2;
+    }
+    foo(1 + 1);
 }

--- a/test/fail_compilation/diag10926.d
+++ b/test/fail_compilation/diag10926.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10926.d(11): Error: `cast(const(int)[])c` is not an lvalue
+fail_compilation/diag10926.d(11): Error: `cast(const(int)[])c` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/diag12598.d
+++ b/test/fail_compilation/diag12598.d
@@ -2,7 +2,7 @@
 REQUIRED_ARGS: -transition=import
 TEST_OUTPUT:
 ---
-fail_compilation/diag12598.d(14): Error: struct `lines` is a type, not an lvalue
+fail_compilation/diag12598.d(14): Error: `lines` is a `struct` definition and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/diag14102.d
+++ b/test/fail_compilation/diag14102.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag14102.d(14): Error: `-x` is not an lvalue
-fail_compilation/diag14102.d(15): Error: `-(x -= 1)` is not an lvalue
-fail_compilation/diag14102.d(16): Error: `-(x -= 1 -= 1)` is not an lvalue
-fail_compilation/diag14102.d(17): Error: `-(x -= 1 -= 1 -= 1)` is not an lvalue
+fail_compilation/diag14102.d(14): Error: `-x` is not an lvalue and cannot be modified
+fail_compilation/diag14102.d(15): Error: `-(x -= 1)` is not an lvalue and cannot be modified
+fail_compilation/diag14102.d(16): Error: `-(x -= 1 -= 1)` is not an lvalue and cannot be modified
+fail_compilation/diag14102.d(17): Error: `-(x -= 1 -= 1 -= 1)` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/diag4596.d
+++ b/test/fail_compilation/diag4596.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag4596.d(15): Error: `this` is not an lvalue
-fail_compilation/diag4596.d(16): Error: `1 ? this : this` is not an lvalue
-fail_compilation/diag4596.d(18): Error: `super` is not an lvalue
-fail_compilation/diag4596.d(19): Error: `1 ? super : super` is not an lvalue
+fail_compilation/diag4596.d(15): Error: `this` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(16): Error: `1 ? this : this` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(18): Error: `super` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(19): Error: `1 ? super : super` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail10299.d
+++ b/test/fail_compilation/fail10299.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10299.d(11): Error: `foo!string` is not an lvalue
+fail_compilation/fail10299.d(11): Error: `foo!string` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail13116.d
+++ b/test/fail_compilation/fail13116.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13116.d(13): Error: `this` is not an lvalue
+fail_compilation/fail13116.d(14): Error: `this` is not an lvalue and cannot be modified
+fail_compilation/fail13116.d(23): Error: `super` is not an lvalue and cannot be modified
 ---
 */
 struct S
@@ -16,12 +17,6 @@ void main()
 {
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail13116.d(28): Error: `super` is not an lvalue
----
-*/
 class Base { }
 class Derived : Base
 {

--- a/test/fail_compilation/fail13336a.d
+++ b/test/fail_compilation/fail13336a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13336a.d(28): Error: `choose(true)` is not an lvalue
+fail_compilation/fail13336a.d(28): Error: `choose(true)` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail13336b.d
+++ b/test/fail_compilation/fail13336b.d
@@ -7,7 +7,8 @@ double sy;
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13336b.d(16): Error: `cast(double)sx` is not an lvalue
+fail_compilation/fail13336b.d(17): Error: `cast(double)sx` is not an lvalue and cannot be modified
+fail_compilation/fail13336b.d(25): Error: `cast(double)sx` is not an lvalue and cannot be modified
 ---
 */
 ref f1(bool f)
@@ -17,12 +18,6 @@ ref f1(bool f)
     return sy;
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail13336b.d(30): Error: `cast(double)sx` is not an lvalue
----
-*/
 ref f2(bool f)
 {
     if (f)

--- a/test/fail_compilation/fail13574.d
+++ b/test/fail_compilation/fail13574.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13574.d(21): Error: `$` is not an lvalue
-fail_compilation/fail13574.d(27): Error: `$` is not an lvalue
+fail_compilation/fail13574.d(21): Error: cannot modify operator `$`
+fail_compilation/fail13574.d(27): Error: cannot modify operator `$`
 ---
 */
 

--- a/test/fail_compilation/fail17491.d
+++ b/test/fail_compilation/fail17491.d
@@ -1,13 +1,13 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17491.d(24): Error: `(S17491).init` is not an lvalue
-fail_compilation/fail17491.d(25): Error: `S17491(0)` is not an lvalue
-fail_compilation/fail17491.d(27): Error: constant `S17491(0).field` is not an lvalue
-fail_compilation/fail17491.d(28): Error: constant `*&S17491(0).field` is not an lvalue
-fail_compilation/fail17491.d(33): Error: `S17491(0)` is not an lvalue
-fail_compilation/fail17491.d(34): Error: `S17491(0)` is not an lvalue
-fail_compilation/fail17491.d(36): Error: constant `S17491(0).field` is not an lvalue
-fail_compilation/fail17491.d(37): Error: constant `*&S17491(0).field` is not an lvalue
+fail_compilation/fail17491.d(24): Error: `(S17491).init` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(25): Error: `S17491(0)` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(27): Error: cannot modify constant `S17491(0).field`
+fail_compilation/fail17491.d(28): Error: cannot modify constant `*&S17491(0).field`
+fail_compilation/fail17491.d(33): Error: `S17491(0)` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(34): Error: `S17491(0)` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(36): Error: cannot modify constant `S17491(0).field`
+fail_compilation/fail17491.d(37): Error: cannot modify constant `*&S17491(0).field`
 ---
 */
 

--- a/test/fail_compilation/fail351.d
+++ b/test/fail_compilation/fail351.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail351.d(14): Error: `cast(uint)this.num[index]` is not an lvalue
+fail_compilation/fail351.d(14): Error: `cast(uint)this.num[index]` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail6795.d
+++ b/test/fail_compilation/fail6795.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6795.d(12): Error: constant `0` is not an lvalue
-fail_compilation/fail6795.d(13): Error: constant `0` is not an lvalue
+fail_compilation/fail6795.d(12): Error: cannot modify constant `0`
+fail_compilation/fail6795.d(13): Error: cannot modify constant `0`
 ---
 */
 
@@ -16,9 +16,9 @@ void main() {
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail6795.d(31): Error: constant `0` is not an lvalue
-fail_compilation/fail6795.d(32): Error: constant `0` is not an lvalue
-fail_compilation/fail6795.d(33): Error: constant `0` is not an lvalue
+fail_compilation/fail6795.d(31): Error: cannot modify constant `0`
+fail_compilation/fail6795.d(32): Error: cannot modify constant `0`
+fail_compilation/fail6795.d(33): Error: cannot modify constant `0`
 ---
 */
 

--- a/test/fail_compilation/fail9537.d
+++ b/test/fail_compilation/fail9537.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9537.d(26): Error: `foo(tuple(1, 2))` is not an lvalue
+fail_compilation/fail9537.d(26): Error: `foo(tuple(1, 2))` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail9773.d
+++ b/test/fail_compilation/fail9773.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9773.d(7): Error: `""` is not an lvalue
+fail_compilation/fail9773.d(7): Error: `""` is not an lvalue and cannot be modified
 ---
 */
 void f(ref string a = "")

--- a/test/fail_compilation/fail9891.d
+++ b/test/fail_compilation/fail9891.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9891.d(13): Error: `cast(int)i` is not an lvalue
-fail_compilation/fail9891.d(18): Error: `cast(int)i` is not an lvalue
-fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue
+fail_compilation/fail9891.d(13): Error: `cast(int)i` is not an lvalue and cannot be modified
+fail_compilation/fail9891.d(18): Error: `cast(int)i` is not an lvalue and cannot be modified
+fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail_arrayop2.d
+++ b/test/fail_compilation/fail_arrayop2.d
@@ -207,21 +207,21 @@ fail_compilation/fail_arrayop2.d(265): Error: array operation `[1] * 6` without 
 fail_compilation/fail_arrayop2.d(268): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(269): Error: array operation `"abc"[] + '\x01'` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(272): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(275): Error: `([1] * 6)[0..2]` is not an lvalue
+fail_compilation/fail_arrayop2.d(275): Error: `([1] * 6)[0..2]` is not an lvalue and cannot be modified
 fail_compilation/fail_arrayop2.d(278): Error: can only `*` a pointer, not a `int[]`
 fail_compilation/fail_arrayop2.d(281): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail_arrayop2.d(281): Error: `[1] * 6` is not an lvalue
+fail_compilation/fail_arrayop2.d(281): Error: `[1] * 6` is not an lvalue and cannot be modified
 fail_compilation/fail_arrayop2.d(284): Error: array operation `da[] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(287): Error: array operation `da[] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(290): Error: `[1] * 6` is not an lvalue
+fail_compilation/fail_arrayop2.d(290): Error: `[1] * 6` is not an lvalue and cannot be modified
 fail_compilation/fail_arrayop2.d(291): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(294): Error: `[1] * 6` is not an lvalue
-fail_compilation/fail_arrayop2.d(295): Error: `([1] * 6)[]` is not an lvalue
+fail_compilation/fail_arrayop2.d(294): Error: `[1] * 6` is not an lvalue and cannot be modified
+fail_compilation/fail_arrayop2.d(295): Error: `([1] * 6)[]` is not an lvalue and cannot be modified
 fail_compilation/fail_arrayop2.d(298): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(299): Error: array operation `[1] * 6` without destination memory not allowed
 fail_compilation/fail_arrayop2.d(300): Error: array operation `[1] * 6` without destination memory not allowed
-fail_compilation/fail_arrayop2.d(303): Error: `[1] * 6` is not an lvalue
-fail_compilation/fail_arrayop2.d(304): Error: `[1] * 6` is not an lvalue
+fail_compilation/fail_arrayop2.d(303): Error: `[1] * 6` is not an lvalue and cannot be modified
+fail_compilation/fail_arrayop2.d(304): Error: `[1] * 6` is not an lvalue and cannot be modified
 fail_compilation/fail_arrayop2.d(307): Error: `[1] * 6` is not of integral type, it is a `int[]`
 fail_compilation/fail_arrayop2.d(308): Error: `[1] * 6` is not of integral type, it is a `int[]`
 fail_compilation/fail_arrayop2.d(309): Error: `[1] * 6` is not of integral type, it is a `int[]`

--- a/test/fail_compilation/ice10419.d
+++ b/test/fail_compilation/ice10419.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10419.d(12): Error: `arr().length` is not an lvalue
+fail_compilation/ice10419.d(12): Error: `arr().length` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/ice12841.d
+++ b/test/fail_compilation/ice12841.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12841.d(23): Error: `taskPool().amap(Args...)(Args args)` is not an lvalue
-fail_compilation/ice12841.d(24): Error: `amap(Args...)(Args args)` is not an lvalue
+fail_compilation/ice12841.d(23): Error: `taskPool().amap(Args...)(Args args)` is not an lvalue and cannot be modified
+fail_compilation/ice12841.d(24): Error: `amap(Args...)(Args args)` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/ice14929.d
+++ b/test/fail_compilation/ice14929.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14929.d(45): Error: `cast(Node)(*this.current).items[this.index]` is not an lvalue
+fail_compilation/ice14929.d(45): Error: `cast(Node)(*this.current).items[this.index]` is not an lvalue and cannot be modified
 fail_compilation/ice14929.d(88): Error: template instance `ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in"` error instantiating
 fail_compilation/ice14929.d(92):        instantiated from here: `HashmapComponentStorage!int`
 fail_compilation/ice14929.d(92): Error: template instance `ice14929.isComponentStorage!(HashmapComponentStorage!int, int)` error instantiating

--- a/test/fail_compilation/test16381.d
+++ b/test/fail_compilation/test16381.d
@@ -3,7 +3,7 @@ REQUIRED_ARGS: -m64
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/test16381.d(16): Error: `foo()` is not an lvalue
+fail_compilation/test16381.d(16): Error: `foo()` is not an lvalue and cannot be modified
 ---
 */
 


### PR DESCRIPTION
lvalue is a compiler developer term and I have seen quite a few people struggling with this term.