### PR TITLE
fix Issue 12486 - Function returning struct isn't called if `enum` of its result is accessed

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3223,6 +3223,10 @@ private extern(C++) final class DotExpVisitor : Visitor
                 }
                 checkAccess(e.loc, sc, null, v);
                 Expression ve = new VarExp(e.loc, v);
+                if (!isTrivialExp(e))
+                {
+                    ve = new CommaExp(e.loc, e, ve);
+                }
                 ve = ve.expressionSemantic(sc);
                 result = ve;
                 return;

--- a/test/runnable/test12486.d
+++ b/test/runnable/test12486.d
@@ -1,0 +1,18 @@
+module test12486;
+
+struct S { enum a = 1; } // or `const` but not for all types
+
+S f(ref int i)
+{
+    ++i;
+    return S();
+}
+
+void main()
+{
+    int i = 2;
+    assert(f(i).a == 1);
+    // ensure that f(i) was actually called, even though
+    // a is a statically known property of the returned type
+    assert(i == 3);
+}


### PR DESCRIPTION
Fix issue 12486

When accessing an enum member of a struct returned by an expression with side effects, don't discard the expression but evaluate it anyways. (No, this is not safe even if the expression is pure: it might loop infinitely.)