### PR TITLE
Fix issue 18534 - Correct codegen of some ternary sequences

### DIFF
--- a/src/dmd/backend/cod2.c
+++ b/src/dmd/backend/cod2.c
@@ -2011,8 +2011,7 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
 
         opcode = 0x81;
         switch (sz2)
-        {   case 1:     opcode--;
-                        v1 = (signed char) v1;
+        {   case 1:     v1 = (signed char) v1;
                         v2 = (signed char) v2;
                         break;
             case 2:     v1 = (short) v1;

--- a/test/runnable/b18534.d
+++ b/test/runnable/b18534.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -O
+
+auto blah(char ch) { return ch; }
+auto foo(int i)
+{
+    return blah(i ? 'A' : 'A');
+}
+void main()
+{
+    auto c = foo(0);
+    assert(c == 'A');
+}


### PR DESCRIPTION
Changing the base OPcode from 0x81 to 0x80 also changes how the MOD/RM
field is interpreted: if reg > 3 end up accessing the [8..16] bits of
{eax,ecx,edx,ebx} instead of the [0..8] bits of {esp,ebp,esi,edi} as the
code expects.