### PR TITLE
Fix issue 18461 - Do not remove assignments to ambiguous symbols

### DIFF
--- a/src/dmd/backend/gother.c
+++ b/src/dmd/backend/gother.c
@@ -1488,6 +1488,7 @@ STATIC void accumda(elem *n,vec_t DEAD, vec_t POSS)
                 vec_free(Pr); vec_free(Dr);
                 break;
 
+            case OPrelconst:
             case OPvar:
             {   symbol *v = n->EV.sp.Vsym;
                 targ_size_t voff = n->EV.sp.Voffset;

--- a/test/runnable/b18461.d
+++ b/test/runnable/b18461.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -O -inline -release
+import core.bitop;
+
+void main()
+{
+    size_t test_val = 0b0001_0000;
+
+    if(bt(&test_val, 4) == 0)
+        assert(false);
+} 


### PR DESCRIPTION
If a value is reached through a pointer don't consider it as definitely
dead.

cc @WalterBright 