### PR TITLE
Fix Issue 18325 - Don't display TLS variables when building DMD

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -312,7 +312,6 @@ auto buildDMD()
         command: [
             env["HOST_DMD_RUN"],
             "-of$@",
-            "-vtls",
             "-J"~env["G"],
             "-J../res",
             "-L-lstdc++",

--- a/src/dmd/backend/gloop.c
+++ b/src/dmd/backend/gloop.c
@@ -1268,6 +1268,8 @@ STATIC void markinvar(elem *n,vec_t rd)
  *      e = defnod[] entry that is an assignment to a variable
  */
 
+extern "C"
+{
 void fillInDNunambig(vec_t v, elem *e)
 {
     assert(OTassign(e->Eoper));
@@ -1306,6 +1308,7 @@ void fillInDNunambig(vec_t v, elem *e)
             vec_setbit(i, v);
         }
     }
+}
 }
 
 /********************

--- a/src/dmd/backend/go.h
+++ b/src/dmd/backend/go.h
@@ -98,7 +98,7 @@ void localize();
 int blockinit();
 void compdom();
 void loopopt();
-void fillInDNunambig(vec_t v, elem *e);
+extern "C" { void fillInDNunambig(vec_t v, elem *e); }
 extern "C" { void updaterd(elem *n,vec_t GEN,vec_t KILL); }
 
 /* gother.c */

--- a/src/dmd/backend/goh.d
+++ b/src/dmd/backend/goh.d
@@ -118,7 +118,7 @@ void localize();
 int blockinit();
 void compdom();
 void loopopt();
-void fillInDNunambig(vec_t v, elem *e);
+extern (C) void fillInDNunambig(vec_t v, elem *e);
 extern (C) void updaterd(elem *n,vec_t GEN,vec_t KILL);
 
 /* gother.c */

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -348,7 +348,7 @@ else
     endif
 endif
 
-BACK_OBJS = go.o gflow.o gloop.o var.o el.o \
+BACK_OBJS = go.o gloop.o var.o el.o \
 	os.o nteh.o fp.o cgcs.o \
 	rtlsym.o cgelem.o cgen.o cgreg.o out.o \
 	blockopt.o cg.o type.o dt.o \
@@ -360,7 +360,7 @@ BACK_OBJS = go.o gflow.o gloop.o var.o el.o \
 	ph2.o util2.o tk.o strtold.o md5.o \
 	$(TARGET_OBJS)
 
-BACK_DOBJS = bcomplex.o evalu8.o divcoeff.o dvec.o gsroa.o glocal.o gdag.o gother.o
+BACK_DOBJS = bcomplex.o evalu8.o divcoeff.o dvec.o gsroa.o glocal.o gdag.o gother.o gflow.o
 
 G_OBJS  = $(addprefix $G/, $(BACK_OBJS))
 G_DOBJS = $(addprefix $G/, $(BACK_DOBJS))
@@ -395,7 +395,7 @@ BACK_SRC = \
 	$C/compress.c $C/cgreg.c $C/var.c $C/strtold.c \
 	$C/cgsched.c $C/cod1.c $C/cod2.c $C/cod3.c $C/cod4.c $C/cod5.c \
 	$C/code.c $C/symbol.c $C/debug.c $C/dt.c $C/ee.c $C/el.c \
-	$C/evalu8.d $C/fp.c $C/go.c $C/gflow.c $C/gdag.d \
+	$C/evalu8.d $C/fp.c $C/go.c $C/gflow.d $C/gdag.d \
 	$C/gother.d $C/glocal.d $C/gloop.c $C/gsroa.d $C/newman.c \
 	$C/nteh.c $C/os.c $C/out.c $C/outbuf.c $C/ptrntab.c $C/rtlsym.c \
 	$C/type.c $C/melf.h $C/mach.h $C/mscoff.h $C/bcomplex.h \
@@ -467,18 +467,18 @@ $G/lexer.a: $(LEXER_SRCS) $(LEXER_ROOT) $(HOST_DMD_PATH) $(SRC_MAKE)
 	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -lib -of$@ $(MODEL_FLAG) -J$G -L-lstdc++ $(DFLAGS) $(LEXER_SRCS) $(LEXER_ROOT)
 
 $G/dmd_frontend: $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
-	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^) -version=NoBackend
+	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^) -version=NoBackend
 
 ifdef ENABLE_LTO
 $G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_GLUE_OBJS) $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $G/dmd.conf
-	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $G/dmd.conf,$^)
+	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $G/dmd.conf,$^)
 else
 $G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/backend.a $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $G/dmd.conf
-	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT) $G/dmd.conf,$^)
+	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT) $G/dmd.conf,$^)
 endif
 
 $G/dmd-unittest: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_GLUE_OBJS) $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
-	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) -g -unittest -main -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -J$G -J$(RES) -L-lstdc++ $(DFLAGS) -g -unittest -main -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
 
 unittest: $G/dmd-unittest
 	$<
@@ -607,7 +607,7 @@ $G/cxxfrontend.o: $G/%.o: tests/%.c $(SRC) $(ROOT_SRC)
 	$(CXX) -c -o$@ $(CXXFLAGS) $(DMD_FLAGS) $(MMD) $<
 
 $G/cxx-unittest: $G/cxxfrontend.o $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_GLUE_OBJS) $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
-	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
+	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -J$G -J$(RES) -L-lstdc++ $(DFLAGS) -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
 
 cxx-unittest: $G/cxx-unittest
 	$<

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -119,7 +119,6 @@
     <ClCompile Include="..\dmd\backend\el.c" />
     <ClCompile Include="..\dmd\backend\elfobj.c" />
     <ClCompile Include="..\dmd\backend\fp.c" />
-    <ClCompile Include="..\dmd\backend\gflow.c" />
     <ClCompile Include="..\dmd\backend\gloop.c" />
     <ClCompile Include="..\dmd\backend\go.c" />
     <ClCompile Include="..\dmd\backend\machobj.c" />

--- a/src/vcbuild/dmd_backend.vcxproj.filters
+++ b/src/vcbuild/dmd_backend.vcxproj.filters
@@ -102,9 +102,6 @@
     <ClCompile Include="..\dmd\backend\fp.c">
       <Filter>dmd\backend</Filter>
     </ClCompile>
-    <ClCompile Include="..\dmd\backend\gflow.c">
-      <Filter>dmd\backend</Filter>
-    </ClCompile>
     <ClCompile Include="..\dmd\backend\gloop.c">
       <Filter>dmd\backend</Filter>
     </ClCompile>

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -233,7 +233,7 @@ BACKSRC= $C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c \
 	$C\compress.c $C\cgreg.c $C\var.c \
 	$C\cgsched.c $C\cod1.c $C\cod2.c $C\cod3.c $C\cod4.c $C\cod5.c \
 	$C\code.c $C\symbol.c $C\debug.c $C\dt.c $C\ee.c $C\el.c \
-	$C\evalu8.d $C\fp.c $C\go.c $C\gflow.c $C\gdag.d \
+	$C\evalu8.d $C\fp.c $C\go.c $C\gflow.d $C\gdag.d \
 	$C\gother.d $C\glocal.d $C\gloop.c $C\gsroa.d $C\newman.c \
 	$C\nteh.c $C\os.c $C\out.c $C\outbuf.c $C\ptrntab.c $C\rtlsym.c \
 	$C\type.c $C\melf.h $C\mach.h $C\mscoff.h $C\bcomplex.h \
@@ -323,25 +323,25 @@ $G\backend.lib: $(GBACKOBJ) $(OBJ_MSVC)
 	$(LIB) -p512 -n -c $@ $(GBACKOBJ) $(OBJ_MSVC)
 
 $G\lexer.lib: $(LEXER_SRCS) $(ROOT_SRCS) $(STRING_IMPORT_FILES) $G
-	$(HOST_DC) -of$@ -vtls -lib -J$G $(DFLAGS) $(LEXER_SRCS) $(ROOT_SRCS)
+	$(HOST_DC) -of$@ -lib -J$G $(DFLAGS) $(LEXER_SRCS) $(ROOT_SRCS)
 
 $G\parser.lib: $(PARSER_SRCS) $G\lexer.lib $G
-	$(HOST_DC) -of$@ -vtls -lib $(DFLAGS) $(PARSER_SRCS) $G\lexer.lib
+	$(HOST_DC) -of$@ -lib $(DFLAGS) $(PARSER_SRCS) $G\lexer.lib
 
 parser_test: $G\parser.lib examples\test_parser.d
-	$(HOST_DC) -of$@ -vtls $(DFLAGS) $G\parser.lib examples\test_parser.d examples\impvisitor.d
+	$(HOST_DC) -of$@ $(DFLAGS) $G\parser.lib examples\test_parser.d examples\impvisitor.d
 
 example_avg: $G\libparser.lib examples\avg.d
-	$(HOST_DC) -of$@ -vtls $(DFLAGS) $G\libparser.lib examples\avg.d
+	$(HOST_DC) -of$@ $(DFLAGS) $G\libparser.lib examples\avg.d
 
 DMDFRONTENDEXE = $G\dmd_frontend.exe
 
 $(DMDFRONTENDEXE): $(FRONT_SRCS) $D\gluelayer.d $(ROOT_SRCS) $G\newdelete.obj $G\lexer.lib $(STRING_IMPORT_FILES)
-	$(HOST_DC) $(DSRC) -of$@ -vtls -J$G -J../res -L/STACK:8388608 $(DFLAGS) $(LFLAGS) $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) newdelete.obj -version=NoBackend
+	$(HOST_DC) $(DSRC) -of$@ -J$G -J../res -L/STACK:8388608 $(DFLAGS) $(LFLAGS) $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) newdelete.obj -version=NoBackend
 	copy $(DMDFRONTENDEXE) .
 
 $(TARGETEXE): $(DMD_SRCS) $(ROOT_SRCS) $G\newdelete.obj $(LIBS) $(STRING_IMPORT_FILES)
-	$(HOST_DC) $(DSRC) -of$@ -vtls -J$G -J../res -L/STACK:8388608 $(DFLAGS) $(LFLAGS) $(DMD_SRCS) $(ROOT_SRCS) $G\newdelete.obj $(LIBS)
+	$(HOST_DC) $(DSRC) -of$@ -J$G -J../res -L/STACK:8388608 $(DFLAGS) $(LFLAGS) $(DMD_SRCS) $(ROOT_SRCS) $G\newdelete.obj $(LIBS)
 	copy $(TARGETEXE) .
 
 ############################ Maintenance Targets #############################
@@ -544,8 +544,8 @@ $G/fp.obj : $C\fp.c
 $G/go.obj : $C\go.c
 	$(CC) -c -o$@ $(MFLAGS) $C\go
 
-$G/gflow.obj : $C\gflow.c
-	$(CC) -c -o$@ $(MFLAGS) $C\gflow
+$G/gflow.obj : $C\gflow.d
+	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\gflow
 
 $G/gdag.obj : $C\gdag.d
 	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\gdag


### PR DESCRIPTION
The first `-vtls` flag was added in https://github.com/dlang/dmd/commit/7a087dcb4d51586868a0e08f4d8e8e269d4b41cb, but no one seems to know anymore why it was added.

AFAICT was `-vtls` is a legacy flag from the [long gone migration to shared](https://dlang.org/articles/migrate-to-shared.html).

Alternative PR: https://github.com/dlang/druntime/pull/2138