### PR TITLE
Add Musl flag -libcmusl.

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -114,6 +114,7 @@ struct Param
     bool isOpenBSD;         // generate code for OpenBSD
     bool isDragonFlyBSD;    // generate code for DragonFlyBSD
     bool isSolaris;         // generate code for Solaris
+    bool isLibcMusl;        // Use the Musl C Runtime
     bool hasObjectiveC;     // target supports Objective-C
     bool mscoff = false;    // for Win32: write MsCoff object files instead of OMF
     // 0: don't allow use of deprecated features

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1383,7 +1383,15 @@ void addDefaultVersionIdentifiers()
     }
     else static if (TARGET.Linux)
     {
-        VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
+        version (CRuntime_Musl)
+            VersionCondition.addPredefinedGlobalIdent("CRuntime_Musl");
+        else
+        {
+            if (global.params.isLibcMusl)
+                VersionCondition.addPredefinedGlobalIdent("CRuntime_Musl");
+            else
+                VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
+        }
     }
 
     if (global.params.isLP64)
@@ -1675,6 +1683,17 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 else
                 {
                     error("-mscrtlib");
+                }
+            }
+            else if (arg == "-libcmusl")
+            {
+                static if (TARGET.Linux)
+                {
+                    params.isLibcMusl = true;
+                }
+                else
+                {
+                    error("-libcmusl is only supported on linux");
                 }
             }
             else if (startsWith(p + 1, "profile")) // https://dlang.org/dmd.html#switch-profile


### PR DESCRIPTION
Dmd 2.079 and ldc 1.8 shipped with [@yshui's Musl port](https://github.com/dlang/druntime/pulls?q=is%3Apr+author%3Ayshui+is%3Aclosed), which is useful for running D apps in Alpine linux containers for microservices, though only ldc 1.8 has a flag to enable it, ldc-developers/ldc#2373.  Dmd 2.079 has to be manually modified to invoke `CRuntime_Musl`, hence this pull to finally enable it.

All ~but one~ of the stdlib unit tests pass with Musl, ~an assert related to `core.stdc.time.tzdata` not having a time zone set by default with Musl, dlang/phobos#6193~ (fixed in dlang/phobos#6548).  Also, a few of the additional tests in druntime trip some asserts related to shared libraries, dlang/druntime#2071, and a couple tests fail in the dmd testsuite, ldc-developers/ldc#2604.

This pull was tested both on a linux/x64/glibc distro with a Musl package installed, [Arch linux](https://www.archlinux.org/packages/community/x86_64/musl/), followed by running those same cross-compiled tests on Alpine, and dmd building natively on the latest Alpine linux/x64 3.7.0, by bootstrapping with the native Alpine build of ldc 1.8. I also used ldc's cross-compilation tool `ldc-build-runtime` and the Musl package to cross-compile the tests with the 1.8 release, no problem.  I was only unable to cross-compile a D compiler itself for Alpine, because Arch's Musl package doesn't support C++.

The runtime flag in this pull is merely a placeholder till we decide how we want to deal with cross-compiling from a non-Musl distro. I see three possibilities:

1. Take out the runtime flag and make them manually change it, ie the status quo before this pull.
2. A runtime flag specific to Musl, ie this pull.
3. A runtime flag that lets the user choose from several libc's, which might be particularly useful since @rracariu is finishing up his uClibc port.

I implemented the second option here, but don't care what's done.  I will amend this pull, including updating `dmd.cli`, once the dmd devs decide on an approach.