### PR TITLE
Fix Issue 18604 - in parameter storage class should be deprecated

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2775,6 +2775,7 @@ final class Parser(AST) : Lexer
                     goto L2;
 
                 case TOK.in_:
+                    deprecation("`in` is equivalent to `const`");
                     stc = AST.STC.in_;
                     goto L2;
 


### PR DESCRIPTION
`in` currently just means `const` even though it was supposed to mean `scope const`. This makes it redundant and confusing and should be deprecated. Maybe after it has been deprecated and been an error for one version, it can be re-introduced with the proper meaning, but for now it should definitely trigger a deprecation warning.

https://github.com/dlang/druntime/pull/2139#issuecomment-372455730
https://dlang.org/spec/function.html#parameters

----

This change is rather trivial, but requires `s/in /const /` (or better `s/in /scope const/`) for druntime and Phobos.
As most of the work here is updating druntime, Phobos and the testsuite, I would only do so if there's a consensus that we can't fix `in`.