### PR TITLE
Use supportedFeatures object for feature detection

### DIFF
--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -905,7 +905,12 @@ public:
         }
         arrayEnd();
 
-        propertyBool("supportsIncludeImports", true);
+        propertyStart("supportedFeatures");
+        {
+            objectStart();
+            scope(exit) objectEnd();
+            propertyBool("includeImports", true);
+        }
         objectEnd();
     }
 

--- a/test/compilable/extra-files/json2.out
+++ b/test/compilable/extra-files/json2.out
@@ -33,7 +33,9 @@
             "VALUES_REMOVED_FOR_TEST"
         ],
         "size_t": 0,
-        "supportsIncludeImports": true,
+        "supportedFeatures": {
+            "includeImports": true
+        },
         "vendor": "VALUE_REMOVED_FOR_TEST",
         "version": "VALUE_REMOVED_FOR_TEST"
     },

--- a/test/compilable/extra-files/jsonCompilerInfo.out
+++ b/test/compilable/extra-files/jsonCompilerInfo.out
@@ -12,7 +12,9 @@
             "VALUES_REMOVED_FOR_TEST"
         ],
         "size_t": 0,
-        "supportsIncludeImports": true,
+        "supportedFeatures": {
+            "includeImports": true
+        },
         "vendor": "VALUE_REMOVED_FOR_TEST",
         "version": "VALUE_REMOVED_FOR_TEST"
     }

--- a/test/compilable/extra-files/jsonNoOutFile.out
+++ b/test/compilable/extra-files/jsonNoOutFile.out
@@ -1,7 +1,9 @@
 {
     "compilerInfo": {
         "binary": "VALUE_REMOVED_FOR_TEST",
-        "supportsIncludeImports": true,
+        "supportedFeatures": {
+            "includeImports": true
+        },
         "version": "VALUE_REMOVED_FOR_TEST"
     }
 }

--- a/test/compilable/extra-files/json_nosource.out
+++ b/test/compilable/extra-files/json_nosource.out
@@ -12,7 +12,9 @@
             "VALUES_REMOVED_FOR_TEST"
         ],
         "size_t": 0,
-        "supportsIncludeImports": true,
+        "supportedFeatures": {
+            "includeImports": true
+        },
         "vendor": "VALUE_REMOVED_FOR_TEST",
         "version": "VALUE_REMOVED_FOR_TEST"
     }


### PR DESCRIPTION
The new JSON output for `-Xi=compilerInfo` was added in https://github.com/dlang/dmd/pull/7838 and is still not documented and thus we can use the opportunity to make breaking changes.

Imho, it's a better idea to group all features in one object as there might be more coming up in the future.

CC @marler8997 @timotheecour