### PR TITLE
sh_do_test: verbose trace + start to remove inferred output_file

### DIFF
--- a/test/compilable/crlf.sh
+++ b/test/compilable/crlf.sh
@@ -2,6 +2,8 @@
 
 # Test CRLF and mixed line ending handling in D lexer.
 
+set -e
+
 dir=${RESULTS_DIR}/compilable
 fn=${TEST_DIR}/${TEST_NAME}.d
 
@@ -45,8 +47,6 @@ printf 'static assert(wstr == "%s");\n' 'foo\nbar\nbaz\n' >> ${fn}
 printf 'enum dstr = q"(\r\nfoo\r\nbar\nbaz\r\n)";\n' >> ${fn}
 printf 'static assert(dstr == "%s");\n' '\nfoo\nbar\nbaz\n' >> ${fn}
 
-$DMD -c -D -Dd${TEST_DIR} -m${MODEL} -of${TEST_DIR}/${TEST_NAME}a${OBJ} ${fn} || exit 1
+$DMD -c -D -Dd${TEST_DIR} -m${MODEL} -of${TEST_DIR}/${TEST_NAME}a${OBJ} ${fn}
 
 rm -f ${TEST_DIR}/${TEST_NAME}a${OBJ} ${TEST_DIR}/${TEST_NAME}.html ${fn}
-
-echo Success

--- a/test/compilable/ddoc9764.sh
+++ b/test/compilable/ddoc9764.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-output_file=${RESULTS_DIR}/${TEST_DIR}/${TEST_NAME}.html
+output_html=${RESULTS_DIR}/${TEST_DIR}/${TEST_NAME}.html
 
-rm -f ${output_file}
+rm -f ${output_html}
 
-$DMD -m${MODEL} -D -o- compilable/extra-files/ddoc9764.dd -Df${output_file}
+$DMD -m${MODEL} -D -o- compilable/extra-files/ddoc9764.dd -Df${output_html}
 
-compilable/extra-files/ddocAny-postscript.sh 9764 && touch ${RESULTS_DIR}/${TEST_NAME}.out
+compilable/extra-files/ddocAny-postscript.sh 9764

--- a/test/compilable/extra-files/ddocAny-postscript.sh
+++ b/test/compilable/extra-files/ddocAny-postscript.sh
@@ -7,4 +7,3 @@ if [ $? -ne 0 ]; then
 fi
 
 rm ${RESULTS_DIR}/compilable/ddoc$1.html{,.2}
-

--- a/test/compilable/issue17167.sh
+++ b/test/compilable/issue17167.sh
@@ -16,8 +16,6 @@ src="$bin_base.d"
 echo 'void main() {}' > "${src}"
 
 # Only compile, not link, since optlink can't handle long file names
-$DMD -m"${MODEL}" "${DFLAGS}" -c -of"${bin}" "${src}" || exit 1
+$DMD -m"${MODEL}" "${DFLAGS}" -c -of"${bin}" "${src}"
 
 rm -rf "${dir:?}"/"$TEST_NAME"
-
-echo Success

--- a/test/compilable/jsonNoOutFile.sh
+++ b/test/compilable/jsonNoOutFile.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 dir=${RESULTS_DIR}/compilable
-output_file=${dir}/jsonNoOutFile.sh.out
-$DMD -c -od=${dir} -Xi=compilerInfo compilable/extra-files/emptymain.d > ${output_file}
-rm -f emptymain.json || true
+$DMD -c -od=${dir} -Xi=compilerInfo compilable/extra-files/emptymain.d
+rm -f emptymain.json

--- a/test/compilable/test14894.sh
+++ b/test/compilable/test14894.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
+set -e
+
 dir=${RESULTS_DIR}/compilable
 src=compilable/extra-files
 
-$DMD -c -m${MODEL} -of${dir}/${TEST_NAME}a${OBJ} -I${src} ${src}/${TEST_NAME}a.d || exit 1
+$DMD -c -m${MODEL} -of${dir}/${TEST_NAME}a${OBJ} -I${src} ${src}/${TEST_NAME}a.d
 
-$DMD -unittest -m${MODEL} -od${dir} -I${src} ${src}/${TEST_NAME}main.d ${dir}/${TEST_NAME}a${OBJ} || exit 1
+$DMD -unittest -m${MODEL} -od${dir} -I${src} ${src}/${TEST_NAME}main.d ${dir}/${TEST_NAME}a${OBJ}
 
 rm -f ${dir}/{${TEST_NAME}a${OBJ} ${TEST_NAME}main${EXE} ${TEST_NAME}main${OBJ}}
-
-echo Success

--- a/test/compilable/test18367.sh
+++ b/test/compilable/test18367.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-set -u -o pipefail
+set -ueo pipefail
 
 # dmd should not segfault on -X with libraries, but no source files
-out=$("$DMD" -conf= -X foo.a 2>&1)
-[ $? -eq 1 ] || exit 1
-echo "$out" | grep -q 'Error: cannot determine JSON filename, specify using `-Xf=<file>` or provide at least one source file'
-[ $? -eq 1 ] || exit 1
+out=$(! "$DMD" -conf= -X foo.a 2>&1)
+echo "$out" | grep 'Error: cannot determine JSON filename, use `-Xf=<file>` or provide a source file'
 
-out=$("$DMD" -conf= -Xi=compilerInfo 2>&1)
-[ $? -eq 1 ] || exit 1
-echo "$out" | grep -q 'Error: cannot determine JSON filename, use `-Xf=<file>` or provide a source file'
+out=$(! "$DMD" -conf= -Xi=compilerInfo 2>&1)
+echo "$out" | grep 'Error: cannot determine JSON filename, use `-Xf=<file>` or provide a source file'

--- a/test/compilable/test6461.sh
+++ b/test/compilable/test6461.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+
 dir=${RESULTS_DIR}/compilable
 src=compilable/extra-files/${TEST_NAME}
 
-$DMD -lib -m${MODEL} -of${dir}/a${LIBEXT} -I${src} ${src}/a.d || exit 1
-$DMD -lib -m${MODEL} -of${dir}/b${LIBEXT} -I${src} ${src}/b.d || exit 1
+$DMD -lib -m${MODEL} -of${dir}/a${LIBEXT} -I${src} ${src}/a.d
+$DMD -lib -m${MODEL} -of${dir}/b${LIBEXT} -I${src} ${src}/b.d
 
-$DMD -m${MODEL} -od${dir} -I${src} ${src}/main.d ${dir}/a${LIBEXT} ${dir}/b${LIBEXT} || exit 1
+$DMD -m${MODEL} -od${dir} -I${src} ${src}/main.d ${dir}/a${LIBEXT} ${dir}/b${LIBEXT}
 
 rm -f ${dir}/{a${LIBEXT} b${LIBEXT} main${EXE} main${OBJ}}
-
-echo Success

--- a/test/compilable/test9680.sh
+++ b/test/compilable/test9680.sh
@@ -26,5 +26,3 @@ do
 
 	rm ${output_file}{,.2}
 done
-
-echo Success

--- a/test/compilable/testclidflags.sh
+++ b/test/compilable/testclidflags.sh
@@ -12,5 +12,3 @@ unset DFLAGS
 ( "$DMD" -conf= -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    (none)"
 ( DFLAGS="-O -D" "$DMD" -conf= -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O -D"
 ( DFLAGS="-O '-Ifoo bar' -c" "$DMD" -conf= -v foo.d 2> /dev/null || true) | grep -q "DFLAGS    -O '-Ifoo bar' -c"
-
-echo Success

--- a/test/runnable/depsprot.sh
+++ b/test/runnable/depsprot.sh
@@ -3,23 +3,19 @@
 name=`basename $0 .sh`
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/${name}.sh.out
 deps_file="${dmddir}${SEP}${name}.deps"
 
 die()
 {
-    cat ${output_file}
     echo "---- deps file ----"
     cat ${deps_file}
     echo
     echo "$@"
-    rm -f ${output_file} ${deps_file}
+    rm -f ${deps_file}
     exit 1
 }
 
-rm -f ${output_file}
-
-$DMD -m${MODEL} -deps=${deps_file} -Irunnable/imports -o- runnable/extra-files/${name}.d >> ${output_file}
+$DMD -m${MODEL} -deps=${deps_file} -Irunnable/imports -o- runnable/extra-files/${name}.d
 test $? -ne 0 &&
     die "Error compiling"
 
@@ -32,9 +28,8 @@ grep "^${name}.*${name}_public" ${deps_file} | grep -q public ||
 grep "^${name}.*${name}_private" ${deps_file} | grep -q private||
     die "Private import protection in dependency file should be 'private'"
 
-echo "Dependencies file:" >> ${output_file}
-cat ${deps_file} >> ${output_file}
-echo >> ${output_file}
+echo "Dependencies file:"
+cat ${deps_file}
+echo
 
 rm ${deps_file}
-

--- a/test/runnable/gdb15729.sh
+++ b/test/runnable/gdb15729.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
+set -e
+
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/gdb15729.sh.out
 
 libname=${dir}${SEP}lib15729${LIBEXT}
 
-$DMD -g -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib15729.d || exit 1
-$DMD -g -m${MODEL} -I${src} -of${dir}${SEP}gdb15729${EXE} ${src}${SEP}gdb15729.d ${libname} || exit 1
+$DMD -g -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib15729.d
+$DMD -g -m${MODEL} -I${src} -of${dir}${SEP}gdb15729${EXE} ${src}${SEP}gdb15729.d ${libname}
 
 if [ $OS == "linux" ]; then
     cat > ${dir}${SEP}gdb15729.gdb <<-EOF
@@ -16,9 +17,7 @@ if [ $OS == "linux" ]; then
        echo RESULT=
        p s.val
 EOF
-    gdb ${dir}${SEP}gdb15729 --batch -x ${dir}${SEP}gdb15729.gdb | grep 'RESULT=.*1234' || exit 1
+    gdb ${dir}${SEP}gdb15729 --batch -x ${dir}${SEP}gdb15729.gdb | grep 'RESULT=.*1234'
 fi
 
 rm -f ${libname} ${dir}${SEP}{gdb15729${OBJ},gdb15729${EXE},gdb15729.gdb}
-
-echo Success >${output_file}

--- a/test/runnable/link14198a.sh
+++ b/test/runnable/link14198a.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 
+set -e
+
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/link14198a.sh.out
 
 libname=${dir}${SEP}lib14198a${LIBEXT}
 
 # build library
-$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}std14198${SEP}array.d ${src}${SEP}std14198${SEP}conv.d ${src}${SEP}std14198${SEP}format.d ${src}${SEP}std14198${SEP}uni.d || exit 1
+$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}std14198${SEP}array.d ${src}${SEP}std14198${SEP}conv.d ${src}${SEP}std14198${SEP}format.d ${src}${SEP}std14198${SEP}uni.d
 
 # Do not link failure with library file, regardless the semantic order.
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198a${EXE}                   ${src}${SEP}test14198.d ${libname} || exit 1
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198a${EXE} -version=bug14198 ${src}${SEP}test14198.d ${libname} || exit 1
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198a${EXE}                   ${src}${SEP}test14198.d ${libname}
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198a${EXE} -version=bug14198 ${src}${SEP}test14198.d ${libname}
 
 rm ${libname}
 rm ${dir}/{test14198a${OBJ},test14198a${EXE}}
-
-echo Success > ${output_file}

--- a/test/runnable/link14198b.sh
+++ b/test/runnable/link14198b.sh
@@ -17,5 +17,3 @@ $DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198b${EXE} -version=bug14198 ${src
 grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${output_file} && exit 1
 
 rm ${dir}/{test14198b${OBJ},test14198b${EXE}}
-
-echo Success > ${output_file}

--- a/test/runnable/link14834.sh
+++ b/test/runnable/link14834.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
 
+set -e
+
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}${SEP}link14834.sh.out
-
-rm -f ${output_file}
 
 libname=${dir}${SEP}link14834${LIBEXT}
 exename=${dir}${SEP}link14834${EXE}
 
-$DMD -m${MODEL} -I${src} -lib           -of${libname} ${src}${SEP}link14834a.d            > ${output_file} || exit 1
-$DMD -m${MODEL} -I${src} -inline -debug -of${exename} ${src}${SEP}link14834b.d ${libname} > ${output_file} || exit 1
+$DMD -m${MODEL} -I${src} -lib           -of${libname} ${src}${SEP}link14834a.d
+$DMD -m${MODEL} -I${src} -inline -debug -of${exename} ${src}${SEP}link14834b.d ${libname}
 
-${dir}/link14834 || exit 1
+${dir}/link14834
 
 rm ${libname} ${exename} ${dir}${SEP}link14834${OBJ}
-
-echo Success > ${output_file}

--- a/test/runnable/link846.sh
+++ b/test/runnable/link846.sh
@@ -4,7 +4,6 @@ set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/link846.sh.out
 
 libname=${dir}${SEP}link846${LIBEXT}
 
@@ -16,5 +15,3 @@ $DMD -m${MODEL} -I${src} -of${dir}${SEP}link846${EXE} -debug ${src}${SEP}main846
 
 rm ${libname}
 rm ${dir}/{link846${OBJ},link846${EXE}}
-
-echo Success > ${output_file}

--- a/test/runnable/linkdebug.sh
+++ b/test/runnable/linkdebug.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
+set -e
+
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/linkdebug.sh.out
 
 libname=${dir}${SEP}libX${LIBEXT}
 
-$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}linkdebug_uni.d ${src}${SEP}linkdebug_range.d ${src}${SEP}linkdebug_primitives.d || exit 1
+$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}linkdebug_uni.d ${src}${SEP}linkdebug_range.d ${src}${SEP}linkdebug_primitives.d
 
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}linkdebug${EXE} -g -debug ${src}${SEP}linkdebug.d ${libname} || exit 1
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}linkdebug${EXE} -g -debug ${src}${SEP}linkdebug.d ${libname}
 
 rm ${libname}
 rm ${dir}/{linkdebug${OBJ},linkdebug${EXE}}
-
-echo Success > ${output_file}

--- a/test/runnable/test10386.sh
+++ b/test/runnable/test10386.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test10386.sh.out
 
 libname=${dir}${SEP}lib10386${LIBEXT}
 
-$DMD -m${MODEL} -Irunnable -I${src} -of${libname} -c ${src}${SEP}lib10386${SEP}foo${SEP}bar.d ${src}${SEP}lib10386${SEP}foo${SEP}package.d -lib || exit 1
-$DMD -m${MODEL} -Irunnable -I${src} -of${dir}${SEP}test10386${EXE} ${src}${SEP}test10386.d ${libname} || exit 1
+$DMD -m${MODEL} -Irunnable -I${src} -of${libname} -c ${src}${SEP}lib10386${SEP}foo${SEP}bar.d ${src}${SEP}lib10386${SEP}foo${SEP}package.d -lib
+$DMD -m${MODEL} -Irunnable -I${src} -of${dir}${SEP}test10386${EXE} ${src}${SEP}test10386.d ${libname}
 
 rm ${dir}/{lib10386${LIBEXT},test10386${OBJ},test10386${EXE}}
-
-echo Success >${output_file}

--- a/test/runnable/test10567.sh
+++ b/test/runnable/test10567.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
+set -e
+
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test10567.sh.out
 
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test10567a${OBJ} -c ${src}${SEP}test10567a.d || exit 1
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test10567${EXE} ${src}${SEP}test10567.d ${dir}${SEP}test10567a${OBJ} || exit 1
-${RESULTS_DIR}/runnable/test10567${EXE} || exit 1
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}test10567a${OBJ} -c ${src}${SEP}test10567a.d
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}test10567${EXE} ${src}${SEP}test10567.d ${dir}${SEP}test10567a${OBJ}
+${RESULTS_DIR}/runnable/test10567${EXE}
 
 rm ${dir}/{test10567a${OBJ},test10567${EXE}}
-
-echo Success >${output_file}

--- a/test/runnable/test13666.sh
+++ b/test/runnable/test13666.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test13666.sh.out
 
 libname=${dir}${SEP}lib13666${LIBEXT}
 
-$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib13666.d || exit 1
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test13666${EXE} ${src}${SEP}test13666.d ${libname} || exit 1
+$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib13666.d
+$DMD -m${MODEL} -I${src} -of${dir}${SEP}test13666${EXE} ${src}${SEP}test13666.d ${libname}
 
 rm ${dir}/{lib13666${LIBEXT},test13666${OBJ},test13666${EXE}}
-
-echo Success >${output_file}

--- a/test/runnable/test13742.sh
+++ b/test/runnable/test13742.sh
@@ -4,7 +4,6 @@ set -ueo pipefail
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test13742.sh.out
 
 $DMD -m${MODEL} -I${src} -lib -cov -of${dir}${SEP}test13742${LIBEXT} ${src}${SEP}lib13742a.d ${src}${SEP}lib13742b.d
 $DMD -m${MODEL} -I${src} -cov -of${dir}${SEP}test13742${EXE} ${src}${SEP}test13742.d ${dir}${SEP}test13742${LIBEXT}
@@ -14,5 +13,3 @@ ${RESULTS_DIR}/runnable/test13742${EXE} --DRT-covopt=dstpath:${dir}${SEP}
 # The removal sometimes spuriously fails on the auto-tester with "rm: cannot remove ‘test_results/runnable/test13742.exe’: Device or resource busy"
 # This doesn't verify the test, hence -f and || true are used
 rm -f ${RESULTS_DIR}/runnable/{runnable-extra-files-{lib13742a,lib13742b,test13742}.lst,test13742{${OBJ},${LIBEXT},${EXE}}} || true
-
-echo Success > ${output_file}

--- a/test/runnable/test13774.sh
+++ b/test/runnable/test13774.sh
@@ -2,11 +2,8 @@
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test13774.sh.out
 
 $DMD -m${MODEL} -I${src} -lib -od${dir} ${src}${SEP}lib13774a.d || exit 1
 $DMD -m${MODEL} -I${src} -lib -od${dir} ${src}${SEP}lib13774b.d ${dir}${SEP}lib13774a${LIBEXT} || exit 1
 
 rm ${dir}/{lib13774a${LIBEXT},lib13774b${LIBEXT}}
-
-echo Success >${output_file}

--- a/test/runnable/test16096.sh
+++ b/test/runnable/test16096.sh
@@ -4,23 +4,13 @@ set -e
 
 src=runnable/extra-files
 dir=${RESULTS_DIR}/runnable
-output_file=${dir}/test16096.sh.out
 
 if [ "$OS" != 'osx' ] || [ "$MODEL" != '64' ]; then
     exit 0
 fi
 
-function teardown {
-    if [ "$?" -ne 0 ] && [ -r "$output_file" ]; then
-        cat "${output_file}" 1>&2
-    fi
-    rm -f "${output_file}"
-}
-
-trap teardown EXIT
-
-$DMD -I${src} -of${dir}${SEP}test16096a.a -lib ${src}/test16096a.d >> "${output_file}" 2>&1
-$DMD -I${src} -of${dir}${SEP}test16096 ${src}/test16096.d ${dir}/test16096a.a -L-framework -LFoundation >> "${output_file}" 2>&1
-${RESULTS_DIR}/runnable/test16096 >> "${output_file}" 2>&1
+$DMD -I${src} -of${dir}${SEP}test16096a.a -lib ${src}/test16096a.d
+$DMD -I${src} -of${dir}${SEP}test16096 ${src}/test16096.d ${dir}/test16096a.a -L-framework -LFoundation
+${RESULTS_DIR}/runnable/test16096
 
 rm ${dir}/{test16096a.a,test16096}

--- a/test/runnable/test17619.sh
+++ b/test/runnable/test17619.sh
@@ -2,18 +2,14 @@
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test17619.sh.out
 
 if [ ${OS} != "linux" ]; then
     echo "Skipping test17619 on ${OS}."
-    touch ${output_file}
     exit 0
-fi 
+fi
 
 $DMD -m${MODEL} -I${src} -of${dir}${SEP}test17619${OBJ} -c ${src}${SEP}test17619.d || exit 1
 # error out if there is an advance by 0 for a non.zero address
 objdump -Wl ${RESULTS_DIR}/runnable/test17619${OBJ} | grep "advance Address by 0 to 0x[1-9]" && exit 1
 
 rm ${dir}/test17619${OBJ}
-
-echo Success >${output_file}

--- a/test/runnable/test18141.sh
+++ b/test/runnable/test18141.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test18141.sh.out
-
 set -e
 
 if [ "${OS}" == "win32" -o "${OS}" == "win64" ]; then
@@ -11,4 +8,4 @@ else
     expected="Posix"
 fi
 
-echo "void main(){}" | "${DMD}" -v -o- - | grep "predefs" | grep "${expected}" > "${output_file}"
+echo "void main(){}" | "${DMD}" -v -o- - | grep "predefs" | grep "${expected}"

--- a/test/runnable/test18335.sh
+++ b/test/runnable/test18335.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 
-output_file="${RESULTS_DIR}/runnable/$(basename $0 .sh)"
 set -ueo pipefail
 
 if [ "${OS}" == "osx" ] && [ "${MODEL}" == "64" ]; then
     echo "void main(){}" | "${DMD}" -o- -v - | grep predefs | grep -q "D_ObjectiveC"
 fi
-
-echo Success > "${output_file}"

--- a/test/runnable/test2.sh
+++ b/test/runnable/test2.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
+set -e
+
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test2.sh.out
-
-rm -f ${output_file}
 
 a[0]=''
 a[1]='-debug'
@@ -12,23 +11,13 @@ a[2]='-debug=1'
 a[3]='-debug=2 -debug=bar'
 
 for x in "${a[@]}"; do
-    echo "executing with args: $x" >> ${output_file}
+    echo "executing with args: $x"
 
-    $DMD -m${MODEL} $x -unittest -od${dmddir} -of${dmddir}${SEP}test2${EXE} runnable/extra-files/test2.d >> ${output_file}
-    if [ $? -ne 0 ]; then
-        cat ${output_file}
-        rm -f ${output_file}
-        exit 1
-    fi
+    $DMD -m${MODEL} $x -unittest -od${dmddir} -of${dmddir}${SEP}test2${EXE} runnable/extra-files/test2.d
 
-    ${dir}/test2 >> ${output_file}
-    if [ $? -ne 0 ]; then
-        cat ${output_file}
-        rm -f ${output_file}
-        exit 1
-    fi
+    ${dir}/test2
 
     rm ${dir}/{test2${OBJ},test2${EXE}}
 
-    echo >> ${output_file}
+    echo
 done

--- a/test/runnable/test35.sh
+++ b/test/runnable/test35.sh
@@ -1,38 +1,16 @@
 #!/usr/bin/env bash
 
+set -e
+
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test35.sh.out
 
-rm -f ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test35.d
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test35.d >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+$DMD -m${MODEL} -od${dmddir} -c -release runnable/imports/test35a.d
 
-$DMD -m${MODEL} -od${dmddir} -c -release runnable/imports/test35a.d >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+$DMD -m${MODEL} -of${dmddir}${SEP}test35${EXE} ${dir}/test35${OBJ} ${dir}/test35a${OBJ}
 
-$DMD -m${MODEL} -of${dmddir}${SEP}test35${EXE} ${dir}/test35${OBJ} ${dir}/test35a${OBJ} >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
-
-${dir}/test35 >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+${dir}/test35
 
 rm ${dir}/{test35${OBJ},test35a${OBJ},test35${EXE}}
-

--- a/test/runnable/test39.sh
+++ b/test/runnable/test39.sh
@@ -1,49 +1,22 @@
 #!/usr/bin/env bash
 
+set -e
+
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test39.sh.out
 
-rm -f ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test39.d
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test39.d >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
-
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/imports/test39a.d >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/imports/test39a.d
 
 if [ ${OS} == "win32" -o ${OS} == "win64" ]; then
-    $DMD -m${MODEL} -lib -of${dmddir}${SEP}test39a.lib ${dmddir}${SEP}test39a.obj >> ${output_file} 2>&1
+    $DMD -m${MODEL} -lib -of${dmddir}${SEP}test39a.lib ${dmddir}${SEP}test39a.obj  2>&1
 else
-    ar -r ${dir}/test39a.a ${dir}/test39a.o >> ${output_file} 2>&1
-fi
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
+    ar -r ${dir}/test39a.a ${dir}/test39a.o  2>&1
 fi
 
-$DMD -m${MODEL} -of${dmddir}${SEP}test39${EXE} ${dir}/test39${OBJ} ${dir}/test39a${LIBEXT} >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+$DMD -m${MODEL} -of${dmddir}${SEP}test39${EXE} ${dir}/test39${OBJ} ${dir}/test39a${LIBEXT}
 
-${dir}/test39 >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+${dir}/test39
 
 rm ${dir}/{test39${OBJ},test39a${OBJ},test39a${LIBEXT},test39${EXE}}
-

--- a/test/runnable/test44.sh
+++ b/test/runnable/test44.sh
@@ -1,38 +1,16 @@
 #!/usr/bin/env bash
 
+set -e
+
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test44.sh.out
 
-rm -f ${output_file}
+$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_1${EXE} runnable/extra-files/test44.d runnable/imports/test44a.d
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_1${EXE} runnable/extra-files/test44.d runnable/imports/test44a.d >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+${dir}/test44_1
 
-${dir}/test44_1 >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_2${EXE} runnable/imports/test44a.d runnable/extra-files/test44.d
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_2${EXE} runnable/imports/test44a.d runnable/extra-files/test44.d >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
-
-${dir}/test44_2 >> ${output_file}
-if [ $? -ne 0 ]; then
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-fi
+${dir}/test44_2
 
 rm ${dir}/{test44_1${OBJ},test44_1${EXE},test44_2${OBJ},test44_2${EXE}}
-

--- a/test/runnable/test9287.sh
+++ b/test/runnable/test9287.sh
@@ -2,11 +2,10 @@
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test9287.sh.out
 
 echo 'import std.stdio; void main() { writeln("Success"); }' | \
 	$DMD -m${MODEL} -of${dir}${SEP}test9287a${EXE} - || exit 1
 
-${RESULTS_DIR}/runnable/test9287a${EXE} > ${output_file}
+${RESULTS_DIR}/runnable/test9287a${EXE}
 
-\rm -f ${dir}/test9287a{${OBJ},${EXE}}
+rm -f ${dir}/test9287a{${OBJ},${EXE}}

--- a/test/runnable/test9377.sh
+++ b/test/runnable/test9377.sh
@@ -2,7 +2,6 @@
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test9377.sh.out
 
 libname=${dir}${SEP}lib9377${LIBEXT}
 
@@ -10,5 +9,3 @@ $DMD -m${MODEL} -I${src} -of${libname} -c ${src}${SEP}mul9377a.d ${src}${SEP}mul
 $DMD -m${MODEL} -I${src} -of${dir}${SEP}mul9377${EXE} ${src}${SEP}multi9377.d ${libname} || exit 1
 
 rm ${dir}/{lib9377${LIBEXT},mul9377${OBJ},mul9377${EXE}}
-
-echo Success >${output_file}

--- a/test/runnable/test_shared.sh
+++ b/test/runnable/test_shared.sh
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
 
+set -e
+
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test_shared.sh.out
-
-rm -f ${output_file}
 
 if [ ${OS} != "linux" ]; then
     echo "Skipping shared library test on ${OS}."
-    touch ${output_file}
     exit 0
 fi
 
-die()
-{
-    cat ${output_file}
-    rm -f ${output_file}
-    exit 1
-}
-
-$DMD -m${MODEL} -of${dmddir}${SEP}test_shared${EXE} -defaultlib=libphobos2.so runnable/extra-files/test_shared.d >> ${output_file}
-if [ $? -ne 0 ]; then die; fi
+$DMD -m${MODEL} -of${dmddir}${SEP}test_shared${EXE} -defaultlib=libphobos2.so runnable/extra-files/test_shared.d
 
 LD_LIBRARY_PATH=../../phobos/generated/${OS}/release/${MODEL} ${dmddir}${SEP}test_shared${EXE}
-if [ $? -ne 0 ]; then die; fi

--- a/test/sh_do_test.sh
+++ b/test/sh_do_test.sh
@@ -13,7 +13,7 @@ fi
 export TEST_DIR=$1 # TEST_DIR should be one of compilable, fail_compilation or runnable
 export TEST_NAME=$2 # name of the test, e.g. test12345
 
-if [ $OS == "win32" -o  $OS == "win64" ]; then
+if [ "$OS" == "win32" ] || [ "$OS" == "win64" ]; then
     export LIBEXT=.lib
     export OBJ=.obj
 else
@@ -24,20 +24,42 @@ fi
 ################################################################################
 
 # Generated variables
-script_name=${TEST_DIR}/${TEST_NAME}.sh
-output_file=${RESULTS_DIR}/${script_name}.out
+script_name="${TEST_DIR}/${TEST_NAME}.sh"
+output_file="${RESULTS_DIR}/${script_name}.out"
 
 echo " ... ${script_name}"
-rm -f ${output_file}
+rm -f "${output_file}"
 
-./${script_name} > ${output_file}  2>&1
-if [ $? -ne 0 ]; then
-    # duplicate d_do_test output
-    echo >> ${output_file}
-    echo ============================== >> ${output_file}
-    echo Test ${script_name} failed >> ${output_file}
+function finish {
+    # reset output stream
+    set +x
+    exec 1>&${stdout_copy}
+    exec 2>&${stderr_copy}
 
-    echo Test ${script_name} failed. The logged output:
-    cat ${output_file}
-    exit 1
-fi
+    if [ "$1" -ne 0 ]; then
+        echo "=============================="
+        echo "Test ${script_name} failed. The logged output:"
+        cat "${output_file}"
+
+        echo "=============================="
+        echo "Test ${script_name} failed. The xtrace output:"
+        cat "${output_file}.log"
+
+        rm -rf "${output_file}"
+        exit $?
+    fi
+}
+trap 'finish $?' INT TERM EXIT
+
+# redirect stdout + stderr to the output file + keep a reference to the std{out,err} streams for later
+exec {stdout_copy}>&1
+exec {stderr_copy}>&2
+exec 1> "${output_file}"
+exec 2>&1
+
+# log all a verbose xtrace to a temporary file which is only displayed when an error occurs
+exec 42> "${output_file}.log"
+export BASH_XTRACEFD=42
+set -x
+
+source "${script_name}"


### PR DESCRIPTION
Now that a dedicated Bash wrapper exists, a lot of boilerplate code can be removed from the bash scripts.

This is a start which saves an verbose trace of the bash log in `.log` and all stdout and stddev in `output_file`. A trap will print both output when an error occurs.

There's a lot more that can be done, see https://github.com/dlang/dmd/pull/7928 for ideas.

CC @marler8997 @CyberShadow