### PR TITLE
Fix issue 15206 - SROA doesn't play well with double slices

### DIFF
--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -113,6 +113,11 @@ private void sliceStructs_Gather(SymInfo *sia, elem *e)
                             {
                                 sia[si].canSlice = false;
                             }
+                            // Disable SROA on OSX32 (because XMM registers?)
+                            else if (!(config.exe & EX_OSX))
+                            {
+                                sliceStructs_Gather(sia, e.EV.E1);
+                            }
                         }
                         return;
                     }

--- a/test/compilable/b15206.d
+++ b/test/compilable/b15206.d
@@ -1,0 +1,19 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -O
+
+void main()
+{
+}
+
+struct Line
+{
+    double slope;
+    double intercept;
+}
+
+Line nLineProjection(double[] historicData)
+{
+    Line projLine;
+    projLine.intercept = historicData[$-1] + projLine.slope;
+    return projLine;
+}


### PR DESCRIPTION
The double-access pattern in the example makes the SROA pass generate a first slice as `TYdouble` and another one as `TYnptr`, the latter should be `TYdouble` as well.

I'm not sure this is the right fix so let's see what Jerkins thinks of it.
CC @WalterBright