### PR TITLE
fix Issue 18484 - [dip1000] Subtype allows reference to escape with i…

### DIFF
--- a/test/fail_compilation/test18484.d
+++ b/test/fail_compilation/test18484.d
@@ -1,0 +1,26 @@
+/* REQUIRED_ARGS: -dip1000
+TEST_OUTPUT:
+---
+fail_compilation/test18484.d(19): Error: returning `x.bar()` escapes a reference to local variable `x`
+fail_compilation/test18484.d(24): Error: escaping reference to stack allocated value returned by `S(0)`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=18484
+
+struct S
+{
+    int* bar() return;
+    int i;
+}
+
+int* test1()
+{
+    auto x = S(); return x.bar();  // error
+}
+
+int* test2()
+{
+    return S().bar();  // error
+}
+


### PR DESCRIPTION
…mplicit casting