### PR TITLE
Improve error message 'for {mutable,non-shared} method is not callable using X'

### DIFF
--- a/test/fail_compilation/diag1730.d
+++ b/test/fail_compilation/diag1730.d
@@ -1,28 +1,41 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag1730.d(38): Error: mutable method `diag1730.S.func` is not callable using a `inout` object
-fail_compilation/diag1730.d(40): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `inout` object
-fail_compilation/diag1730.d(41): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a non-shared `inout` object
-fail_compilation/diag1730.d(42): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared `inout` object
-fail_compilation/diag1730.d(57): Error: `immutable` method `diag1730.S.iFunc` is not callable using a mutable object
-fail_compilation/diag1730.d(58): Error: `shared` method `diag1730.S.sFunc` is not callable using a non-shared object
-fail_compilation/diag1730.d(59): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared mutable object
-fail_compilation/diag1730.d(62): Error: mutable method `diag1730.S.func` is not callable using a `const` object
-fail_compilation/diag1730.d(64): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `const` object
-fail_compilation/diag1730.d(65): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a non-shared `const` object
-fail_compilation/diag1730.d(66): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared `const` object
-fail_compilation/diag1730.d(69): Error: mutable method `diag1730.S.func` is not callable using a `immutable` object
-fail_compilation/diag1730.d(72): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a `immutable` object
-fail_compilation/diag1730.d(76): Error: non-shared method `diag1730.S.func` is not callable using a `shared` object
-fail_compilation/diag1730.d(77): Error: non-shared `const` method `diag1730.S.cFunc` is not callable using a `shared` mutable object
-fail_compilation/diag1730.d(78): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `shared` mutable object
-fail_compilation/diag1730.d(81): Error: non-shared `inout` method `diag1730.S.wFunc` is not callable using a `shared` mutable object
-fail_compilation/diag1730.d(83): Error: non-shared mutable method `diag1730.S.func` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(84): Error: non-shared `const` method `diag1730.S.cFunc` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(85): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(86): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a `shared` `const` object
-fail_compilation/diag1730.d(88): Error: non-shared `inout` method `diag1730.S.wFunc` is not callable using a `shared` `const` object
+fail_compilation/diag1730.d(51): Error: mutable method `diag1730.S.func` is not callable using a `inout` object
+fail_compilation/diag1730.d(51):        Consider adding `const` or `inout` to diag1730.S.func
+fail_compilation/diag1730.d(53): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `inout` object
+fail_compilation/diag1730.d(54): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a non-shared `inout` object
+fail_compilation/diag1730.d(54):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(55): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared `inout` object
+fail_compilation/diag1730.d(70): Error: `immutable` method `diag1730.S.iFunc` is not callable using a mutable object
+fail_compilation/diag1730.d(71): Error: `shared` method `diag1730.S.sFunc` is not callable using a non-shared object
+fail_compilation/diag1730.d(72): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared mutable object
+fail_compilation/diag1730.d(75): Error: mutable method `diag1730.S.func` is not callable using a `const` object
+fail_compilation/diag1730.d(75):        Consider adding `const` or `inout` to diag1730.S.func
+fail_compilation/diag1730.d(77): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `const` object
+fail_compilation/diag1730.d(78): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a non-shared `const` object
+fail_compilation/diag1730.d(78):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(79): Error: `shared` `const` method `diag1730.S.scFunc` is not callable using a non-shared `const` object
+fail_compilation/diag1730.d(82): Error: mutable method `diag1730.S.func` is not callable using a `immutable` object
+fail_compilation/diag1730.d(82):        Consider adding `const` or `inout` to diag1730.S.func
+fail_compilation/diag1730.d(85): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a `immutable` object
+fail_compilation/diag1730.d(85):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(89): Error: non-shared method `diag1730.S.func` is not callable using a `shared` object
+fail_compilation/diag1730.d(89):        Consider adding `shared` to diag1730.S.func
+fail_compilation/diag1730.d(90): Error: non-shared `const` method `diag1730.S.cFunc` is not callable using a `shared` mutable object
+fail_compilation/diag1730.d(90):        Consider adding `shared` to diag1730.S.cFunc
+fail_compilation/diag1730.d(91): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `shared` mutable object
+fail_compilation/diag1730.d(94): Error: non-shared `inout` method `diag1730.S.wFunc` is not callable using a `shared` mutable object
+fail_compilation/diag1730.d(94):        Consider adding `shared` to diag1730.S.wFunc
+fail_compilation/diag1730.d(96): Error: non-shared mutable method `diag1730.S.func` is not callable using a `shared` `const` object
+fail_compilation/diag1730.d(96):        Consider adding `shared` to diag1730.S.func
+fail_compilation/diag1730.d(97): Error: non-shared `const` method `diag1730.S.cFunc` is not callable using a `shared` `const` object
+fail_compilation/diag1730.d(97):        Consider adding `shared` to diag1730.S.cFunc
+fail_compilation/diag1730.d(98): Error: `immutable` method `diag1730.S.iFunc` is not callable using a `shared` `const` object
+fail_compilation/diag1730.d(99): Error: `shared` mutable method `diag1730.S.sFunc` is not callable using a `shared` `const` object
+fail_compilation/diag1730.d(99):        Consider adding `const` or `inout` to diag1730.S.sFunc
+fail_compilation/diag1730.d(101): Error: non-shared `inout` method `diag1730.S.wFunc` is not callable using a `shared` `const` object
+fail_compilation/diag1730.d(101):        Consider adding `shared` to diag1730.S.wFunc
 ---
 */
 struct S

--- a/test/fail_compilation/diag6707.d
+++ b/test/fail_compilation/diag6707.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag6707.d(16): Error: mutable method `diag6707.Foo.value` is not callable using a `const` object
+fail_compilation/diag6707.d(17): Error: mutable method `diag6707.Foo.value` is not callable using a `const` object
+fail_compilation/diag6707.d(17):        Consider adding `const` or `inout` to diag6707.Foo.value
 ---
 */
 

--- a/test/fail_compilation/diag8101b.d
+++ b/test/fail_compilation/diag8101b.d
@@ -1,15 +1,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8101b.d(27): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
-fail_compilation/diag8101b.d(18):        `diag8101b.S.foo(int _param_0)`
-fail_compilation/diag8101b.d(19):        `diag8101b.S.foo(int _param_0, int _param_1)`
-fail_compilation/diag8101b.d(29): Error: function `diag8101b.S.bar(int _param_0)` is not callable using argument types `(double)`
-fail_compilation/diag8101b.d(29):        cannot pass argument `1.00000` of type `double` to parameter `int _param_0`
-fail_compilation/diag8101b.d(32): Error: none of the overloads of `foo` are callable using a `const` object, candidates are:
-fail_compilation/diag8101b.d(18):        `diag8101b.S.foo(int _param_0)`
-fail_compilation/diag8101b.d(19):        `diag8101b.S.foo(int _param_0, int _param_1)`
-fail_compilation/diag8101b.d(34): Error: mutable method `diag8101b.S.bar` is not callable using a `const` object
+fail_compilation/diag8101b.d(28): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
+fail_compilation/diag8101b.d(19):        `diag8101b.S.foo(int _param_0)`
+fail_compilation/diag8101b.d(20):        `diag8101b.S.foo(int _param_0, int _param_1)`
+fail_compilation/diag8101b.d(30): Error: function `diag8101b.S.bar(int _param_0)` is not callable using argument types `(double)`
+fail_compilation/diag8101b.d(30):        cannot pass argument `1.00000` of type `double` to parameter `int _param_0`
+fail_compilation/diag8101b.d(33): Error: none of the overloads of `foo` are callable using a `const` object, candidates are:
+fail_compilation/diag8101b.d(19):        `diag8101b.S.foo(int _param_0)`
+fail_compilation/diag8101b.d(20):        `diag8101b.S.foo(int _param_0, int _param_1)`
+fail_compilation/diag8101b.d(35): Error: mutable method `diag8101b.S.bar` is not callable using a `const` object
+fail_compilation/diag8101b.d(35):        Consider adding `const` or `inout` to diag8101b.S.bar
 ---
 */
 

--- a/test/fail_compilation/fail241.d
+++ b/test/fail_compilation/fail241.d
@@ -1,8 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail241.d(16): Error: mutable method `fail241.Foo.f` is not callable using a `const` object
-fail_compilation/fail241.d(17): Error: mutable method `fail241.Foo.g` is not callable using a `const` object
+fail_compilation/fail241.d(18): Error: mutable method `fail241.Foo.f` is not callable using a `const` object
+fail_compilation/fail241.d(18):        Consider adding `const` or `inout` to fail241.Foo.f
+fail_compilation/fail241.d(19): Error: mutable method `fail241.Foo.g` is not callable using a `const` object
+fail_compilation/fail241.d(19):        Consider adding `const` or `inout` to fail241.Foo.g
 ---
 */
 

--- a/test/fail_compilation/ice9759.d
+++ b/test/fail_compilation/ice9759.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9759.d(24): Error: mutable method `ice9759.Json.opAssign` is not callable using a `const` object
+fail_compilation/ice9759.d(25): Error: mutable method `ice9759.Json.opAssign` is not callable using a `const` object
+fail_compilation/ice9759.d(25):        Consider adding `const` or `inout` to ice9759.Json.opAssign
 ---
 */
 


### PR DESCRIPTION
Mutable method is not callable using const object is a common message (see e.g. https://forum.dlang.org/post/blwbenjxxblercjphozz@forum.dlang.org), so let's be a bit more friendly to newbies and provide helpful advice directly in the error message.