### PR TITLE
Add and use RESULTS_TEST_DIR + OUTPUT_BASE + EXTRA_FILES in the bash scripts of DMD's testsuite

### DIFF
--- a/test/compilable/crlf.sh
+++ b/test/compilable/crlf.sh
@@ -3,7 +3,6 @@
 # Test CRLF and mixed line ending handling in D lexer.
 
 
-dir=${RESULTS_DIR}/compilable
 fn=${TEST_DIR}/${TEST_NAME}.d
 
 printf '%s\r\n' \

--- a/test/compilable/ddoc9764.sh
+++ b/test/compilable/ddoc9764.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-output_html=${RESULTS_DIR}/${TEST_DIR}/${TEST_NAME}.html
+output_html=${OUTPUT_BASE}.html
 
 rm -f ${output_html}
 
-$DMD -m${MODEL} -D -o- compilable/extra-files/ddoc9764.dd -Df${output_html}
+$DMD -m${MODEL} -D -o- ${EXTRA_FILES}/ddoc9764.dd -Df${output_html}
 
-compilable/extra-files/ddocAny-postscript.sh 9764
+
+${EXTRA_FILES}/ddocAny-postscript.sh 9764

--- a/test/compilable/issue17167.sh
+++ b/test/compilable/issue17167.sh
@@ -4,10 +4,9 @@
 # Test that file paths larger than 248 characters can be used
 # Test CRLF and mixed line ending handling in D lexer.
 
-dir=${RESULTS_DIR}/compilable/
+test_dir=${OUTPUT_BASE}/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
 
-test_dir=${dir}/${TEST_NAME}/uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
-[[ -d $test_dir ]] || mkdir -p "$test_dir"
+mkdir -p "$test_dir"
 bin_base=${test_dir}/${TEST_NAME}
 bin="$bin_base$OBJ"
 src="$bin_base.d"
@@ -17,4 +16,4 @@ echo 'void main() {}' > "${src}"
 # Only compile, not link, since optlink can't handle long file names
 $DMD -m"${MODEL}" "${DFLAGS}" -c -of"${bin}" "${src}"
 
-rm -rf "${dir:?}"/"$TEST_NAME"
+rm -rf "${OUTPUT_BASE}"

--- a/test/compilable/jsonNoOutFile.sh
+++ b/test/compilable/jsonNoOutFile.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-dir=${RESULTS_DIR}/compilable
-$DMD -c -od=${dir} -Xi=compilerInfo compilable/extra-files/emptymain.d
+$DMD -c -od=${RESULTS_TEST_DIR} -Xi=compilerInfo ${EXTRA_FILES}/emptymain.d
 rm -f emptymain.json

--- a/test/compilable/json_nosource.sh
+++ b/test/compilable/json_nosource.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-$DMD -Xi=compilerInfo -Xf=${RESULTS_DIR}/compilable/json_nosource.out
+$DMD -Xi=compilerInfo -Xf=${OUTPUT_BASE}.out
 ./compilable/extra-files/json-postscript.sh json_nosource

--- a/test/compilable/test14894.sh
+++ b/test/compilable/test14894.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
 
-dir=${RESULTS_DIR}/compilable
-src=compilable/extra-files
+$DMD -c -m${MODEL} -of${OUTPUT_BASE}a${OBJ} -I${EXTRA_FILES} ${EXTRA_FILES}/${TEST_NAME}a.d
 
-$DMD -c -m${MODEL} -of${dir}/${TEST_NAME}a${OBJ} -I${src} ${src}/${TEST_NAME}a.d
 
-$DMD -unittest -m${MODEL} -od${dir} -I${src} ${src}/${TEST_NAME}main.d ${dir}/${TEST_NAME}a${OBJ}
+$DMD -unittest -m${MODEL} -od${RESULTS_TEST_DIR} -I${EXTRA_FILES} ${EXTRA_FILES}/${TEST_NAME}main.d ${OUTPUT_BASE}a${OBJ}
 
-rm -f ${dir}/{${TEST_NAME}a${OBJ} ${TEST_NAME}main${EXE} ${TEST_NAME}main${OBJ}}
+rm -f ${OUTPUT_BASE}a${OBJ} ${TEST_NAME}main${EXE} ${TEST_NAME}main${OBJ}}

--- a/test/compilable/test6461.sh
+++ b/test/compilable/test6461.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 
-dir=${RESULTS_DIR}/compilable
-src=compilable/extra-files/${TEST_NAME}
+src=${EXTRA_FILES}/${TEST_NAME}
 
-$DMD -lib -m${MODEL} -of${dir}/a${LIBEXT} -I${src} ${src}/a.d
-$DMD -lib -m${MODEL} -of${dir}/b${LIBEXT} -I${src} ${src}/b.d
 
-$DMD -m${MODEL} -od${dir} -I${src} ${src}/main.d ${dir}/a${LIBEXT} ${dir}/b${LIBEXT}
+$DMD -lib -m${MODEL} -of${OUTPUT_BASE}a${LIBEXT} -I${src} ${src}/a.d
+$DMD -lib -m${MODEL} -of${OUTPUT_BASE}b${LIBEXT} -I${src} ${src}/b.d
 
-rm -f ${dir}/{a${LIBEXT} b${LIBEXT} main${EXE} main${OBJ}}
+$DMD -m${MODEL} -of${OUTPUT_BASE}_main -I${src} ${src}/main.d ${OUTPUT_BASE}a${LIBEXT} ${OUTPUT_BASE}b${LIBEXT}
+
+rm -f ${OUTPUT_BASE}{a${LIBEXT},b${LIBEXT},_main${EXE},_main${OBJ}}

--- a/test/compilable/test9680.sh
+++ b/test/compilable/test9680.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-dir=${RESULTS_DIR}/compilable
-
 if [ "${OS}" == "win32" -o "${OS}" == "Windows_NT" ]; then
     kinds=( main winmain dllmain )
 else
@@ -11,9 +9,9 @@ fi
 for kind in "${kinds[@]}"
 do
 	file_name=${TEST_NAME}${kind}
-	src_file=compilable/extra-files/${file_name}.d
-	expect_file=compilable/extra-files/${file_name}.out
-	output_file=${dir}/${file_name}.out
+	src_file=${EXTRA_FILES}/${file_name}.d
+	expect_file=${EXTRA_FILES}/${file_name}.out
+	output_file=${RESULTS_TEST_DIR}/${file_name}.out
 
 	rm -f ${output_file}{,.2}
 

--- a/test/compilable/testclidflags.sh
+++ b/test/compilable/testclidflags.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-dir=${RESULTS_DIR}${SEP}compilable
-
 unset DFLAGS
 
 # Force DMD to print the -v menu by passing an invalid object file

--- a/test/runnable/depsprot.sh
+++ b/test/runnable/depsprot.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-name="depsprot"
-dir=${RESULTS_DIR}/runnable
-dmddir=${RESULTS_DIR}${SEP}runnable
-deps_file="${dmddir}${SEP}${name}.deps"
+deps_file="${OUTPUT_BASE}.deps"
 
 # custom error handling
 set +eo pipefail
@@ -18,17 +15,17 @@ die()
     exit 1
 }
 
-$DMD -m${MODEL} -deps=${deps_file} -Irunnable/imports -o- runnable/extra-files/${name}.d
+$DMD -m${MODEL} -deps=${deps_file} -Irunnable/imports -o- ${EXTRA_FILES}/${TEST_NAME}.d
 test $? -ne 0 &&
     die "Error compiling"
 
-grep "^${name}.*${name}_default" ${deps_file} | grep -q private ||
+grep "^${TEST_NAME}.*${TEST_NAME}_default" ${deps_file} | grep -q private ||
     die "Default import protection in dependency file should be 'private'"
 
-grep "^${name}.*${name}_public" ${deps_file} | grep -q public ||
+grep "^${TEST_NAME}.*${TEST_NAME}_public" ${deps_file} | grep -q public ||
     die "Public import protection in dependency file should be 'public'"
 
-grep "^${name}.*${name}_private" ${deps_file} | grep -q private||
+grep "^${TEST_NAME}.*${TEST_NAME}_private" ${deps_file} | grep -q private||
     die "Private import protection in dependency file should be 'private'"
 
 echo "Dependencies file:"

--- a/test/runnable/gdb15729.sh
+++ b/test/runnable/gdb15729.sh
@@ -1,22 +1,18 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
 
-libname=${dir}${SEP}lib15729${LIBEXT}
-
-$DMD -g -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib15729.d
-$DMD -g -m${MODEL} -I${src} -of${dir}${SEP}gdb15729${EXE} ${src}${SEP}gdb15729.d ${libname}
+$DMD -g -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}${SEP}lib15729.d
+$DMD -g -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}gdb15729.d ${OUTPUT_BASE}${LIBEXT}
 
 if [ $OS == "linux" ]; then
-    cat > ${dir}${SEP}gdb15729.gdb <<-EOF
+    cat > ${OUTPUT_BASE}.gdb <<-EOF
        b lib15729.d:16
        r
        echo RESULT=
        p s.val
 EOF
-    gdb ${dir}${SEP}gdb15729 --batch -x ${dir}${SEP}gdb15729.gdb | grep 'RESULT=.*1234'
+    gdb ${OUTPUT_BASE}${EXE} --batch -x ${OUTPUT_BASE}.gdb | grep 'RESULT=.*1234'
 fi
 
-rm -f ${libname} ${dir}${SEP}{gdb15729${OBJ},gdb15729${EXE},gdb15729.gdb}
+rm -f ${OUTPUT_BASE}{,${OBJ},${EXE},${LIBEXT},.gdb}

--- a/test/runnable/link14198a.sh
+++ b/test/runnable/link14198a.sh
@@ -1,17 +1,14 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+libname=${OUTPUT_BASE}${LIBEXT}
 
-libname=${dir}${SEP}lib14198a${LIBEXT}
 
 # build library
-$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}std14198${SEP}array.d ${src}${SEP}std14198${SEP}conv.d ${src}${SEP}std14198${SEP}format.d ${src}${SEP}std14198${SEP}uni.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}${SEP}std14198${SEP}array.d ${EXTRA_FILES}${SEP}std14198${SEP}conv.d ${EXTRA_FILES}${SEP}std14198${SEP}format.d ${EXTRA_FILES}${SEP}std14198${SEP}uni.d
 
 # Do not link failure with library file, regardless the semantic order.
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198a${EXE}                   ${src}${SEP}test14198.d ${libname}
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198a${EXE} -version=bug14198 ${src}${SEP}test14198.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE}                   ${EXTRA_FILES}${SEP}test14198.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} -version=bug14198 ${EXTRA_FILES}${SEP}test14198.d ${libname}
 
-rm ${libname}
-rm ${dir}/{test14198a${OBJ},test14198a${EXE}}
+rm ${OUTPUT_BASE}{${OBJ},${EXE}} ${libname}

--- a/test/runnable/link14198b.sh
+++ b/test/runnable/link14198b.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/link14198b.sh.out
+out_file=${OUTPUT_BASE}.out
 
-rm -f ${output_file}
-
-libname=${dir}${SEP}lib14198b${LIBEXT}
+rm -f ${out_file}
 
 # Do not link failure even without library file.
 
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198b${EXE}                   ${src}${SEP}test14198.d > ${output_file} 2>&1
-grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${output_file} && exit 1
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE}                   ${EXTRA_FILES}${SEP}test14198.d > ${out_file} 2>&1
+grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${out_file} && exit 1
 
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test14198b${EXE} -version=bug14198 ${src}${SEP}test14198.d > ${output_file} 2>&1
-grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${output_file} && exit 1
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} -version=bug14198 ${EXTRA_FILES}${SEP}test14198.d > ${out_file} 2>&1
+grep -q "_D8std141984conv11__T2toTAyaZ9__T2toTbZ2toFNaNbNiNfbZAya" ${out_file} && exit 1
 
-rm ${dir}/{test14198b${OBJ},test14198b${EXE}}
+rm ${OUTPUT_BASE}{${OBJ},${EXE}}

--- a/test/runnable/link14834.sh
+++ b/test/runnable/link14834.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable
 
-libname=${dir}${SEP}link14834${LIBEXT}
-exename=${dir}${SEP}link14834${EXE}
+libname=${OUTPUT_BASE}${LIBEXT}
+exename=${OUTPUT_BASE}${EXE}
 
-$DMD -m${MODEL} -I${src} -lib           -of${libname} ${src}${SEP}link14834a.d
-$DMD -m${MODEL} -I${src} -inline -debug -of${exename} ${src}${SEP}link14834b.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -lib           -of${libname} ${EXTRA_FILES}${SEP}link14834a.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -inline -debug -of${exename} ${EXTRA_FILES}${SEP}link14834b.d ${libname}
 
-${dir}/link14834
+${exename}
 
-rm ${libname} ${exename} ${dir}${SEP}link14834${OBJ}
+rm ${OUTPUT_BASE}{${LIBEXT},${EXE},${OBJ}}

--- a/test/runnable/link846.sh
+++ b/test/runnable/link846.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
-
-libname=${dir}${SEP}link846${LIBEXT}
+libname=${OUTPUT_BASE}${LIBEXT}
 
 # build library with -release
-$DMD -m${MODEL} -I${src} -of${libname} -release -boundscheck=off -lib ${src}${SEP}lib846.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -release -boundscheck=off -lib ${EXTRA_FILES}${SEP}lib846.d
 
 # use lib with -debug
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}link846${EXE} -debug ${src}${SEP}main846.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} -debug ${EXTRA_FILES}${SEP}main846.d ${libname}
 
-rm ${libname}
-rm ${dir}/{link846${OBJ},link846${EXE}}
+rm ${OUTPUT_BASE}{${OBJ},${EXE},${LIBEXT}}

--- a/test/runnable/linkdebug.sh
+++ b/test/runnable/linkdebug.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+libname=${OUTPUT_BASE}${LIBEXT}
 
-libname=${dir}${SEP}libX${LIBEXT}
 
-$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}linkdebug_uni.d ${src}${SEP}linkdebug_range.d ${src}${SEP}linkdebug_primitives.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}${SEP}linkdebug_uni.d ${EXTRA_FILES}${SEP}linkdebug_range.d ${EXTRA_FILES}${SEP}linkdebug_primitives.d
 
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}linkdebug${EXE} -g -debug ${src}${SEP}linkdebug.d ${libname}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} -g -debug ${EXTRA_FILES}${SEP}linkdebug.d ${libname}
 
-rm ${libname}
-rm ${dir}/{linkdebug${OBJ},linkdebug${EXE}}
+rm ${OUTPUT_BASE}{${OBJ},${LIBEXT},${EXE}}

--- a/test/runnable/test10386.sh
+++ b/test/runnable/test10386.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+libname=${OUTPUT_BASE}${LIBEXT}
 
-libname=${dir}${SEP}lib10386${LIBEXT}
 
-$DMD -m${MODEL} -Irunnable -I${src} -of${libname} -c ${src}${SEP}lib10386${SEP}foo${SEP}bar.d ${src}${SEP}lib10386${SEP}foo${SEP}package.d -lib
-$DMD -m${MODEL} -Irunnable -I${src} -of${dir}${SEP}test10386${EXE} ${src}${SEP}test10386.d ${libname}
-
-rm ${dir}/{lib10386${LIBEXT},test10386${OBJ},test10386${EXE}}
+$DMD -m${MODEL} -Irunnable -I${EXTRA_FILES} -of${libname} -c ${EXTRA_FILES}${SEP}lib10386${SEP}foo${SEP}bar.d ${EXTRA_FILES}${SEP}lib10386${SEP}foo${SEP}package.d -lib
+$DMD -m${MODEL} -Irunnable -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test10386.d ${libname}
+rm ${OUTPUT_BASE}{${LIBEXT},${OBJ},${EXE}}

--- a/test/runnable/test10567.sh
+++ b/test/runnable/test10567.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}a${OBJ} -c ${EXTRA_FILES}${SEP}test10567a.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test10567.d ${OUTPUT_BASE}a${OBJ}
 
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test10567a${OBJ} -c ${src}${SEP}test10567a.d
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test10567${EXE} ${src}${SEP}test10567.d ${dir}${SEP}test10567a${OBJ}
-${RESULTS_DIR}/runnable/test10567${EXE}
+${OUTPUT_BASE}${EXE}
 
-rm ${dir}/{test10567a${OBJ},test10567${EXE}}
+rm ${OUTPUT_BASE}{a${OBJ},${EXE}}

--- a/test/runnable/test13666.sh
+++ b/test/runnable/test13666.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+libname=${OUTPUT_BASE}${LIBEXT}
 
-libname=${dir}${SEP}lib13666${LIBEXT}
 
-$DMD -m${MODEL} -I${src} -of${libname} -lib ${src}${SEP}lib13666.d
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test13666${EXE} ${src}${SEP}test13666.d ${libname}
-
-rm ${dir}/{lib13666${LIBEXT},test13666${OBJ},test13666${EXE}}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -lib ${EXTRA_FILES}${SEP}lib13666.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test13666.d ${libname}
+rm ${OUTPUT_BASE}{${LIBEXT},${OBJ},${EXE}}

--- a/test/runnable/test13742.sh
+++ b/test/runnable/test13742.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+$DMD -m${MODEL} -I${EXTRA_FILES} -lib -cov -of${OUTPUT_BASE}${LIBEXT} ${EXTRA_FILES}${SEP}lib13742a.d ${EXTRA_FILES}${SEP}lib13742b.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -cov -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test13742.d ${OUTPUT_BASE}${LIBEXT}
 
-$DMD -m${MODEL} -I${src} -lib -cov -of${dir}${SEP}test13742${LIBEXT} ${src}${SEP}lib13742a.d ${src}${SEP}lib13742b.d
-$DMD -m${MODEL} -I${src} -cov -of${dir}${SEP}test13742${EXE} ${src}${SEP}test13742.d ${dir}${SEP}test13742${LIBEXT}
+covdir=${RESULTS_DIR}${SEP}${TEST_DIR}
 
-${RESULTS_DIR}/runnable/test13742${EXE} --DRT-covopt=dstpath:${dir}${SEP}
+${OUTPUT_BASE}${EXE} --DRT-covopt=dstpath:${covdir}
 
 # The removal sometimes spuriously fails on the auto-tester with "rm: cannot remove ‘test_results/runnable/test13742.exe’: Device or resource busy"
 # This doesn't verify the test, hence -f and || true are used
-rm -f ${RESULTS_DIR}/runnable/{runnable-extra-files-{lib13742a,lib13742b,test13742}.lst,test13742{${OBJ},${LIBEXT},${EXE}}} || true
+rm -f ${covdir}/runnable-extra-files-{lib13742a,lib13742b,test13742}.lst || true
+rm -f ${OUTPUT_BASE}{${OBJ},${LIBEXT},${EXE}} || true

--- a/test/runnable/test13774.sh
+++ b/test/runnable/test13774.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+set -e
 
-$DMD -m${MODEL} -I${src} -lib -od${dir} ${src}${SEP}lib13774a.d || exit 1
-$DMD -m${MODEL} -I${src} -lib -od${dir} ${src}${SEP}lib13774b.d ${dir}${SEP}lib13774a${LIBEXT} || exit 1
+$DMD -m${MODEL} -I${EXTRA_FILES} -lib -of${OUTPUT_BASE}a${LIBEXT} ${EXTRA_FILES}${SEP}lib13774a.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -lib -of${OUTPUT_BASE}b${LIBEXT} ${EXTRA_FILES}${SEP}lib13774b.d ${OUTPUT_BASE}a${LIBEXT}
 
-rm ${dir}/{lib13774a${LIBEXT},lib13774b${LIBEXT}}
+rm ${OUTPUT_BASE}{a${LIBEXT},b${LIBEXT}}

--- a/test/runnable/test16096.sh
+++ b/test/runnable/test16096.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 
 
-src=runnable/extra-files
-dir=${RESULTS_DIR}/runnable
-
 if [ "$OS" != 'osx' ] || [ "$MODEL" != '64' ]; then
     exit 0
 fi
 
-$DMD -I${src} -of${dir}${SEP}test16096a.a -lib ${src}/test16096a.d
-$DMD -I${src} -of${dir}${SEP}test16096 ${src}/test16096.d ${dir}/test16096a.a -L-framework -LFoundation
-${RESULTS_DIR}/runnable/test16096
+$DMD -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/test16096a.d
+$DMD -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXT} ${EXTRA_FILES}/test16096.d ${OUTPUT_BASE}${LIBEXT} -L-framework -LFoundation
+${OUTPUT_BASE}${EXE}
 
-rm ${dir}/{test16096a.a,test16096}
+rm ${OUTPUT_BASE}{${LIBEXT},${EXE}}

--- a/test/runnable/test17619.sh
+++ b/test/runnable/test17619.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
-
 if [ ${OS} != "linux" ]; then
     echo "Skipping test17619 on ${OS}."
     exit 0
 fi
 
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}test17619${OBJ} -c ${src}${SEP}test17619.d || exit 1
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${OBJ} -c ${EXTRA_FILES}${SEP}test17619.d || exit 1
 # error out if there is an advance by 0 for a non.zero address
 objdump -Wl ${RESULTS_DIR}/runnable/test17619${OBJ} | grep "advance Address by 0 to 0x[1-9]" && exit 1
 
-rm ${dir}/test17619${OBJ}
+rm ${OUTPUT_BASE}${OBJ}

--- a/test/runnable/test18141.sh
+++ b/test/runnable/test18141.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 if [ "${OS}" == "win32" -o "${OS}" == "win64" ]; then
     expected="Windows"
 else

--- a/test/runnable/test2.sh
+++ b/test/runnable/test2.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 
-dir=${RESULTS_DIR}/runnable
-dmddir=${RESULTS_DIR}${SEP}runnable
+output_file=${OUTPUT_BASE}.log
+
+
+set -x
 
 a[0]=''
 a[1]='-debug'
@@ -12,11 +14,16 @@ a[3]='-debug=2 -debug=bar'
 for x in "${a[@]}"; do
     echo "executing with args: $x"
 
-    $DMD -m${MODEL} $x -unittest -od${dmddir} -of${dmddir}${SEP}test2${EXE} runnable/extra-files/test2.d
+    $DMD -m${MODEL} $x -unittest -of${OUTPUT_BASE}${EXE} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/test2.d >> ${output_file}
+    if [ $? -ne 0 ]; then
+        cat ${output_file}
+        rm -f ${output_file}
+        exit 1
+    fi
 
-    ${dir}/test2
+    ${OUTPUT_BASE}${EXE} >> ${output_file}
 
-    rm ${dir}/{test2${OBJ},test2${EXE}}
+    rm ${OUTPUT_BASE}{${OBJ},${EXE}}
 
     echo
 done

--- a/test/runnable/test35.sh
+++ b/test/runnable/test35.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 
 
-dir=${RESULTS_DIR}/runnable
-dmddir=${RESULTS_DIR}${SEP}runnable
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test35.d
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -c ${EXTRA_FILES}/test35.d
 
-$DMD -m${MODEL} -od${dmddir} -c -release runnable/imports/test35a.d
+$DMD -m${MODEL} -od${RESULTS_TEST_DIR} -c -release ${TEST_DIR}/imports/test35a.d
 
-$DMD -m${MODEL} -of${dmddir}${SEP}test35${EXE} ${dir}/test35${OBJ} ${dir}/test35a${OBJ}
+$DMD -m${MODEL} -of${OUTPUT_BASE}${EXE} ${OUTPUT_BASE}${OBJ} ${OUTPUT_BASE}a${OBJ}
 
-${dir}/test35
+${OUTPUT_BASE}${EXE}
 
-rm ${dir}/{test35${OBJ},test35a${OBJ},test35${EXE}}
+rm ${OUTPUT_BASE}{${OBJ},a${OBJ},${EXE}}

--- a/test/runnable/test39.sh
+++ b/test/runnable/test39.sh
@@ -1,21 +1,20 @@
 #!/usr/bin/env bash
 
 
-dir=${RESULTS_DIR}/runnable
-dmddir=${RESULTS_DIR}${SEP}runnable
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/extra-files/test39.d
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -c ${EXTRA_FILES}/test39.d
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -c runnable/imports/test39a.d
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -c ${TEST_DIR}/imports/test39a.d
+libname=${OUTPUT_BASE}a${LIBEXT}
 
 if [ ${OS} == "win32" -o ${OS} == "win64" ]; then
-    $DMD -m${MODEL} -lib -of${dmddir}${SEP}test39a.lib ${dmddir}${SEP}test39a.obj  2>&1
+    $DMD -m${MODEL} -lib -of${libname} ${OUTPUT_BASE}a${OBJ}
 else
-    ar -r ${dir}/test39a.a ${dir}/test39a.o  2>&1
+    ar -r ${libname} ${OUTPUT_BASE}a${OBJ}
 fi
 
-$DMD -m${MODEL} -of${dmddir}${SEP}test39${EXE} ${dir}/test39${OBJ} ${dir}/test39a${LIBEXT}
+$DMD -m${MODEL} -of${OUTPUT_BASE}${EXE} ${OUTPUT_BASE}${OBJ} ${libname}
 
-${dir}/test39
+${OUTPUT_BASE}${EXE}
 
-rm ${dir}/{test39${OBJ},test39a${OBJ},test39a${LIBEXT},test39${EXE}}
+rm ${OUTPUT_BASE}{${OBJ},a${OBJ},${EXE}} ${libname}

--- a/test/runnable/test44.sh
+++ b/test/runnable/test44.sh
@@ -2,14 +2,13 @@
 
 
 dir=${RESULTS_DIR}/runnable
-dmddir=${RESULTS_DIR}${SEP}runnable
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_1${EXE} runnable/extra-files/test44.d runnable/imports/test44a.d
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -of${OUTPUT_BASE}_1${EXE} ${EXTRA_FILES}/test44.d ${TEST_DIR}/imports/test44a.d
 
-${dir}/test44_1
+${OUTPUT_BASE}_1
 
-$DMD -m${MODEL} -Irunnable -od${dmddir} -of${dmddir}${SEP}test44_2${EXE} runnable/imports/test44a.d runnable/extra-files/test44.d
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -of${OUTPUT_BASE}_2${EXE} ${TEST_DIR}/imports/test44a.d ${EXTRA_FILES}/test44.d
 
-${dir}/test44_2
+${OUTPUT_BASE}_2
 
-rm ${dir}/{test44_1${OBJ},test44_1${EXE},test44_2${OBJ},test44_2${EXE}}
+rm ${OUTPUT_BASE}{_1${OBJ},_1${EXE},_2${OBJ},_2${EXE}}

--- a/test/runnable/test9287.sh
+++ b/test/runnable/test9287.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+set -e
 
 echo 'import std.stdio; void main() { writeln("Success"); }' | \
-	$DMD -m${MODEL} -of${dir}${SEP}test9287a${EXE} - || exit 1
+	$DMD -m${MODEL} -of${OUTPUT_BASE}${EXE} -
 
-${RESULTS_DIR}/runnable/test9287a${EXE}
+${OUTPUT_BASE}${EXE}
 
-rm -f ${dir}/test9287a{${OBJ},${EXE}}
+rm -f ${OUTPUT_BASE}{${OBJ},${EXE}}

--- a/test/runnable/test9377.sh
+++ b/test/runnable/test9377.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
-src=runnable${SEP}extra-files
-dir=${RESULTS_DIR}${SEP}runnable
+libname=${OUTPUT_BASE}${LIBEXT}
 
-libname=${dir}${SEP}lib9377${LIBEXT}
-
-$DMD -m${MODEL} -I${src} -of${libname} -c ${src}${SEP}mul9377a.d ${src}${SEP}mul9377b.d -lib || exit 1
-$DMD -m${MODEL} -I${src} -of${dir}${SEP}mul9377${EXE} ${src}${SEP}multi9377.d ${libname} || exit 1
-
-rm ${dir}/{lib9377${LIBEXT},mul9377${OBJ},mul9377${EXE}}
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${libname} -c ${EXTRA_FILES}${SEP}mul9377a.d ${EXTRA_FILES}${SEP}mul9377b.d -lib || exit 1
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}multi9377.d ${libname} || exit 1
+rm ${OUTPUT_BASE}{${LIBEXT},${OBJ},${EXE}}

--- a/test/runnable/test_shared.sh
+++ b/test/runnable/test_shared.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 
 
-dir=${RESULTS_DIR}/runnable
-dmddir=${RESULTS_DIR}${SEP}runnable
 
 if [ ${OS} != "linux" ]; then
     echo "Skipping shared library test on ${OS}."
     exit 0
 fi
 
-$DMD -m${MODEL} -of${dmddir}${SEP}test_shared${EXE} -defaultlib=libphobos2.so runnable/extra-files/test_shared.d
+$DMD -m${MODEL} -of${OUTPUT_BASE}${EXE} -defaultlib=libphobos2.so ${EXTRA_FILES}${SEP}test_shared.d
 
-LD_LIBRARY_PATH=../../phobos/generated/${OS}/release/${MODEL} ${dmddir}${SEP}test_shared${EXE}
+LD_LIBRARY_PATH=../../phobos/generated/${OS}/release/${MODEL} ${OUTPUT_BASE}${EXE}

--- a/test/runnable/test_switches.sh
+++ b/test/runnable/test_switches.sh
@@ -13,19 +13,18 @@
 # -of=<objname>
 # -Xf=<filename>
 
-out_dir=${RESULTS_DIR}/runnable/test_switches
-src_file=${out_dir}/src.d
+src_file=${OUTPUT_BASE}/src.d
 
 clean()
 {
-    rm -rf ${out_dir} || true
+    rm -rf ${OUTPUT_BASE}
 }
 
 prepare()
 {
     clean;
-    mkdir ${out_dir}
-    echo "module mymod;" > ${out_dir}/mymod.d
+    mkdir -p ${OUTPUT_BASE}
+    echo "module mymod;" > ${OUTPUT_BASE}/mymod.d
     echo "module src; import mymod;" > ${src_file}
 }
 
@@ -42,11 +41,11 @@ checkFile()
 
 checkFiles()
 {
-    checkFile ${out_dir}/json.json
-    checkFile ${out_dir}/mymod.d
-    checkFile ${out_dir}/src.d
-    checkFile ${out_dir}/src.di
-    checkFile ${out_dir}/src.html
+    checkFile ${OUTPUT_BASE}/json.json
+    checkFile ${OUTPUT_BASE}/mymod.d
+    checkFile ${OUTPUT_BASE}/src.d
+    checkFile ${OUTPUT_BASE}/src.di
+    checkFile ${OUTPUT_BASE}/src.html
 }
 
 # @BUG@: -Df doesn't take -Dd into account when it's set
@@ -56,11 +55,11 @@ checkFiles()
 # as there's no common linker switch which all linkers support
 
 prepare;
-$DMD -c -of=mymod.o -od=${out_dir} -D -Df=${out_dir}/src.html -Hf=${out_dir}/src.di -I=${out_dir} -L=-v -Xf=${out_dir}/json.json ${src_file}
+$DMD -c -of=mymod.o -od=${OUTPUT_BASE} -D -Df=${OUTPUT_BASE}/src.html -Hf=${OUTPUT_BASE}/src.di -I=${OUTPUT_BASE} -L=-v -Xf=${OUTPUT_BASE}/json.json ${src_file}
 checkFiles;
 
 prepare;
-$DMD -c -of=mymod.o -od=${out_dir} -D -Dd=${out_dir} -Hd=${out_dir} -I=${out_dir} -L=-v -Xf=${out_dir}/json.json ${src_file}
+$DMD -c -of=mymod.o -od=${OUTPUT_BASE} -D -Dd=${OUTPUT_BASE} -Hd=${OUTPUT_BASE} -I=${OUTPUT_BASE} -L=-v -Xf=${OUTPUT_BASE}/json.json ${src_file}
 checkFiles;
 
 clean;

--- a/test/sh_do_test.sh
+++ b/test/sh_do_test.sh
@@ -14,6 +14,9 @@ fi
 
 export TEST_DIR=$1 # TEST_DIR should be one of compilable, fail_compilation or runnable
 export TEST_NAME=$2 # name of the test, e.g. test12345
+export RESULTS_TEST_DIR=${RESULTS_DIR}/${TEST_DIR} # reference to the resulting test_dir folder, e.g .test_results/runnable
+export OUTPUT_BASE=${RESULTS_TEST_DIR}/${TEST_NAME} # reference to the resulting files without a suffix, e.g. test_results/runnable/test123
+export EXTRA_FILES=${TEST_DIR}/extra-files # reference to the extra files directory
 
 if [ "$OS" == "win32" ] || [ "$OS" == "win64" ]; then
     export LIBEXT=.lib
@@ -31,6 +34,7 @@ output_file="${RESULTS_DIR}/${script_name}.out"
 
 echo " ... ${script_name}"
 rm -f "${output_file}"
+mkdir -p ${RESULTS_TEST_DIR}
 
 function finish {
     # reset output stream


### PR DESCRIPTION
Turns out we can save quite a lot when we move the redundant definitions in the bash files to the new wrapper.
This also opens the opportunity to run the shell script in a temporary directory [1] or do other things as now most scripts don't have any hard-coded information anymore.

I'm not fixed about the names `EXTRA_FILES` could also be named `SRC` for example.

[1] this would mean e.g. that no manual cleaning of the generated files is necessary anymore, but it's just one potential opportunity. The big motivation of this PR is to remove the redundant declarations and thus let the test scripts focus on what's important: testing and not startup/cleanup code.

CC @marler8997 @timotheecour @CyberShadow 