### PR TITLE
refactor inferForeachAggregate

### DIFF
--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -746,6 +746,7 @@ extern (C++) final class DtorExpStatement : ExpStatement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#mixin-statement
  */
 extern (C++) final class CompileStatement : Statement
 {
@@ -1248,13 +1249,14 @@ extern (C++) final class ForStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#foreach-statement
  */
 extern (C++) final class ForeachStatement : Statement
 {
     TOK op;                     // TOK.foreach_ or TOK.foreach_reverse_
-    Parameters* parameters;     // array of Parameter*'s
-    Expression aggr;
-    Statement _body;
+    Parameters* parameters;     // array of Parameters, one for each ForeachType
+    Expression aggr;            // ForeachAggregate
+    Statement _body;            // NoScopeNonEmptyStatement
     Loc endloc;                 // location of closing curly bracket
 
     VarDeclaration key;
@@ -1282,21 +1284,6 @@ extern (C++) final class ForeachStatement : Statement
             aggr.syntaxCopy(),
             _body ? _body.syntaxCopy() : null,
             endloc);
-    }
-
-    bool checkForArgTypes()
-    {
-        bool result = false;
-        foreach (p; *parameters)
-        {
-            if (!p.type)
-            {
-                error("cannot infer type for `%s`", p.ident.toChars());
-                p.type = Type.terror;
-                result = true;
-            }
-        }
-        return result;
     }
 
     override bool hasBreak()


### PR DESCRIPTION
Rewrite `inferAggregate()` as `inferForeachAggregate()` as an attempt to make the foreach semantic analysis easier to understand.