### PR TITLE
Add a convenience script for running individual tests

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -164,6 +164,12 @@ check_clean_git()
     make -f posix.mak check-clean-git
 }
 
+# sanitycheck for the run_individual_tests script
+check_run_individual()
+{
+	./test/run_individual_tests test/runnable/template2962.d ./test/compilable/test14275.d
+}
+
 codecov()
 {
     # CodeCov gets confused by lst files which it can't matched
@@ -185,6 +191,7 @@ case $1 in
     all)
         coverage;
         check_clean_git;
+        check_run_individual;
         codecov;
     ;;
 esac

--- a/test/run_individual_tests
+++ b/test/run_individual_tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Allows to run a individual tests
+# Allows running tests individually
 # Usage:
 #   ./run_individual_tests <test-file>...
 # Example:

--- a/test/run_individual_tests
+++ b/test/run_individual_tests
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Allows to run a individual tests
+# Usage:
+#   ./run_individual_tests <test-file>...
+# Example:
+#   ./run_individual_tests runnable/template2962.d fail_compilation/fail282.d
+
+# See the Makefile for all available test targets
+
+set -euo pipefail
+
+if [ -z ${1:-} ] ; then
+	cat >&2 << EOF
+./run_individual_tests <test-file>...
+
+Examples:
+
+    ./run_individual_tests runnable/template2962.d
+    ./run_individual_tests runnable/template2962.d fail_compilation/fail282.d
+EOF
+	exit
+fi
+
+# all test files to be run
+files=()
+
+# normalize path to each test file
+for arg in "$@" ; do
+	file="$arg"
+	normalizedDir=$(cd "$(dirname "$file")" && pwd)
+	files+=("test_results/$(basename "$normalizedDir" )/$(basename "$file").out")
+done
+
+# allows the script to be called from anywhere
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+${MAKE:-make} "${files[@]}"


### PR DESCRIPTION
After typing `test_results` and adding `.out` over an over again, I was so annoyed that I finally automated this and though this is worth sharing as others might miss this too.

Usage:

```sh
./run_single runnable/template2962.d fail_compilation/fail282.d
```

Reasons:
- safe time
- auto-completion in CLI works

If we plan to move the documentation to a README.md as proposed [here](https://github.com/dlang/dmd/pull/8038#issuecomment-373524698), this could also be documented though I think it's rather self-explanatory.

This might be a small addition, but it saves a bit of time for me every time and that quickly adds up.