### PR TITLE
Deprecate class allocators and deallocators

### DIFF
--- a/changelog/deprecate_class_allocators.dd
+++ b/changelog/deprecate_class_allocators.dd
@@ -17,7 +17,7 @@ class C
 }
 ---
 
-For more information see https://dlang.org/deprecate.html#Class%20allocators%20and%20deallocators
+See the $(LINK2 $(ROOT_DIR)deprecate.html#Class%20allocators%20and%20deallocators, Deprecated Features) for more information.
 
 Many alternatives for class allocators/deallcators exist. Among them is the generic $(REF make, std,experimental,allocator) and $(REF dispose, std,experimental,allocator) from the allocator package. For other alternatives, see $(LINK2 https://dlang.org/blog/the-gc-series, the recent article about memory allocation on the DBlog) and $(LINK2 https://wiki.dlang.org/Memory_Management, the D Wiki memory management article).
 

--- a/changelog/deprecate_class_allocators.dd
+++ b/changelog/deprecate_class_allocators.dd
@@ -1,0 +1,50 @@
+Class allocators and deallocators have been deprecated
+
+Class allocators and deallocators have been planned for deprecation for years.  Starting with this release the following code will emit deprecation messages.
+
+---
+class C
+{
+    new(size_t size)         // deprecation message
+    {
+        return malloc(size);
+    }
+
+    delete(void* obj)        // deprecation message
+    {
+        free(obj);
+    }
+}
+---
+
+For more information see https://dlang.org/deprecate.html#Class%20allocators%20and%20deallocators
+
+Many alternatives for class allocators/deallcators exist. Among them is the generic $(REF make, std,experimental,allocator) and $(REF dispose, std,experimental,allocator) from the allocator package. For other alternatives, see $(LINK2 https://dlang.org/blog/the-gc-series, the recent article about memory allocation on the DBlog) and $(LINK2 https://wiki.dlang.org/Memory_Management, the D Wiki memory management article).
+
+Users have leveraged allocators in order to disable GC allocation, as illustrated in the following example:
+
+---
+class C
+{
+    @disable new(size_t size);
+}
+
+void main()
+{
+    auto c = new C();  // Error: allocator `new` is not callable because it is annotated with `@disable`
+}
+---
+
+That idiom will remain, but has been enhanced with this release to no longer require the `size_t` argument.  That is, starting with this release, the following syntax is also permitted:
+
+---
+class C
+{
+    @disable new();
+}
+
+void main()
+{
+    auto c = new C();  // Error: allocator `new` is not callable because it is annotated with `@disable`
+}
+---

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3897,6 +3897,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(NewDeclaration nd)
     {
         //printf("NewDeclaration::semantic()\n");
+
+        // `@disable new();` should not be deprecated
+        if (!nd.isDisabled())
+        {
+            // @@@DEPRECATED_2.084@@@
+            // Should be changed to an error in 2.084
+            deprecation(nd.loc, "class allocators have been deprecated, consider moving the allocation strategy outside of the class");
+        }
+
         if (nd.semanticRun >= PASS.semanticdone)
             return;
         if (nd._scope)
@@ -3920,17 +3929,21 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         nd.type = nd.type.typeSemantic(nd.loc, sc);
 
-        // Check that there is at least one argument of type size_t
-        TypeFunction tf = nd.type.toTypeFunction();
-        if (Parameter.dim(tf.parameters) < 1)
+        // allow for `@disable new();` to force users of a type to use an external allocation strategy
+        if (!nd.isDisabled())
         {
-            nd.error("at least one argument of type `size_t` expected");
-        }
-        else
-        {
-            Parameter fparam = Parameter.getNth(tf.parameters, 0);
-            if (!fparam.type.equals(Type.tsize_t))
-                nd.error("first argument must be type `size_t`, not `%s`", fparam.type.toChars());
+            // Check that there is at least one argument of type size_t
+            TypeFunction tf = nd.type.toTypeFunction();
+            if (Parameter.dim(tf.parameters) < 1)
+            {
+                nd.error("at least one argument of type `size_t` expected");
+            }
+            else
+            {
+                Parameter fparam = Parameter.getNth(tf.parameters, 0);
+                if (!fparam.type.equals(Type.tsize_t))
+                    nd.error("first argument must be type `size_t`, not `%s`", fparam.type.toChars());
+            }
         }
 
         funcDeclarationSemantic(nd);
@@ -3939,6 +3952,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     override void visit(DeleteDeclaration deld)
     {
         //printf("DeleteDeclaration::semantic()\n");
+
+        // @@@DEPRECATED_2.084@@@
+        // Should be changed to an error in 2.084
+        deprecation(deld.loc, "class deallocators have been deprecated, consider moving the deallocation strategy outside of the class");
+
         if (deld.semanticRun >= PASS.semanticdone)
             return;
         if (deld._scope)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2601,6 +2601,9 @@ extern (C++) FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymb
         {
             assert(fd);
 
+            if (fd.checkDisabled(loc, sc))
+                return null;
+
             bool hasOverloads = fd.overnext !is null;
             auto tf = fd.type.toTypeFunction();
             if (tthis && !MODimplicitConv(tthis.mod, tf.mod)) // modifier mismatch

--- a/test/compilable/disable_new.d
+++ b/test/compilable/disable_new.d
@@ -1,0 +1,11 @@
+class C
+{
+    // force user of a type to use an external allocation strategy
+    @disable new();
+}
+
+struct S
+{
+    // force user of a type to use an external allocation strategy
+    @disable new();
+}

--- a/test/compilable/vgc1.d
+++ b/test/compilable/vgc1.d
@@ -3,6 +3,14 @@
 
 /***************** NewExp *******************/
 
+/*
+TEST_OUTPUT:
+---
+compilable/vgc1.d(17): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+compilable/vgc1.d(18): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+---
+*/
+
 struct S1 { }
 struct S2 { this(int); }
 struct S3 { this(int) @nogc; }
@@ -12,13 +20,13 @@ struct S5 { @nogc new(size_t); }
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(27): vgc: `new` causes a GC allocation
-compilable/vgc1.d(29): vgc: `new` causes a GC allocation
-compilable/vgc1.d(30): vgc: `new` causes a GC allocation
-compilable/vgc1.d(32): vgc: `new` causes a GC allocation
-compilable/vgc1.d(33): vgc: `new` causes a GC allocation
-compilable/vgc1.d(34): vgc: `new` causes a GC allocation
+compilable/vgc1.d(35): vgc: `new` causes a GC allocation
+compilable/vgc1.d(37): vgc: `new` causes a GC allocation
 compilable/vgc1.d(38): vgc: `new` causes a GC allocation
+compilable/vgc1.d(40): vgc: `new` causes a GC allocation
+compilable/vgc1.d(41): vgc: `new` causes a GC allocation
+compilable/vgc1.d(42): vgc: `new` causes a GC allocation
+compilable/vgc1.d(46): vgc: `new` causes a GC allocation
 ---
 */
 
@@ -41,12 +49,12 @@ void testNew()
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(55): vgc: `new` causes a GC allocation
-compilable/vgc1.d(57): vgc: `new` causes a GC allocation
-compilable/vgc1.d(58): vgc: `new` causes a GC allocation
-compilable/vgc1.d(60): vgc: `new` causes a GC allocation
-compilable/vgc1.d(61): vgc: `new` causes a GC allocation
-compilable/vgc1.d(62): vgc: `new` causes a GC allocation
+compilable/vgc1.d(63): vgc: `new` causes a GC allocation
+compilable/vgc1.d(65): vgc: `new` causes a GC allocation
+compilable/vgc1.d(66): vgc: `new` causes a GC allocation
+compilable/vgc1.d(68): vgc: `new` causes a GC allocation
+compilable/vgc1.d(69): vgc: `new` causes a GC allocation
+compilable/vgc1.d(70): vgc: `new` causes a GC allocation
 ---
 */
 
@@ -74,12 +82,12 @@ void testNewScope()
 /*
 TEST_OUTPUT:
 ---
-compilable/vgc1.d(87): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(87): vgc: `delete` requires the GC
-compilable/vgc1.d(88): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(88): vgc: `delete` requires the GC
-compilable/vgc1.d(89): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-compilable/vgc1.d(89): vgc: `delete` requires the GC
+compilable/vgc1.d(95): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+compilable/vgc1.d(95): vgc: `delete` requires the GC
+compilable/vgc1.d(96): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+compilable/vgc1.d(96): vgc: `delete` requires the GC
+compilable/vgc1.d(97): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+compilable/vgc1.d(97): vgc: `delete` requires the GC
 ---
 */
 void testDelete(int* p, Object o, S1* s)

--- a/test/fail_compilation/disable_new.d
+++ b/test/fail_compilation/disable_new.d
@@ -1,0 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/disable_new.d(23): Error: allocator `disable_new.C.new` is not callable because it is annotated with `@disable`
+fail_compilation/disable_new.d(24): Error: allocator `disable_new.S.new` is not callable because it is annotated with `@disable`
+---
+*/
+
+class C
+{
+    // force user of a type to use an external allocation strategy
+    @disable new();
+}
+
+struct S
+{
+    // force user of a type to use an external allocation strategy
+    @disable new();
+}
+
+void main()
+{
+    auto c = new C();
+    auto s = new S();
+}

--- a/test/fail_compilation/fail14249.d
+++ b/test/fail_compilation/fail14249.d
@@ -2,20 +2,22 @@
 REQUIRED_ARGS: -unittest
 TEST_OUTPUT:
 ---
-fail_compilation/fail14249.d(23): Error: `shared static` constructor can only be member of module/aggregate/template, not function `main`
-fail_compilation/fail14249.d(24): Error: `shared static` destructor can only be member of module/aggregate/template, not function `main`
-fail_compilation/fail14249.d(25): Error: `static` constructor can only be member of module/aggregate/template, not function `main`
-fail_compilation/fail14249.d(26): Error: `static` destructor can only be member of module/aggregate/template, not function `main`
-fail_compilation/fail14249.d(27): Error: `unittest` can only be a member of module/aggregate/template, not function `main`
-fail_compilation/fail14249.d(28): Error: `invariant` can only be a member of aggregate, not function `main`
-fail_compilation/fail14249.d(29): Error: alias this can only be a member of aggregate, not function `main`
-fail_compilation/fail14249.d(30): Error: allocator can only be a member of aggregate, not function `main`
-fail_compilation/fail14249.d(31): Error: deallocator can only be a member of aggregate, not function `main`
-fail_compilation/fail14249.d(32): Error: constructor can only be a member of aggregate, not function `main`
-fail_compilation/fail14249.d(33): Error: destructor can only be a member of aggregate, not function `main`
-fail_compilation/fail14249.d(34): Error: postblit can only be a member of struct, not function `main`
-fail_compilation/fail14249.d(35): Error: anonymous union can only be a part of an aggregate, not function `main`
-fail_compilation/fail14249.d(39): Error: mixin `fail14249.main.Mix!()` error instantiating
+fail_compilation/fail14249.d(25): Error: `shared static` constructor can only be member of module/aggregate/template, not function `main`
+fail_compilation/fail14249.d(26): Error: `shared static` destructor can only be member of module/aggregate/template, not function `main`
+fail_compilation/fail14249.d(27): Error: `static` constructor can only be member of module/aggregate/template, not function `main`
+fail_compilation/fail14249.d(28): Error: `static` destructor can only be member of module/aggregate/template, not function `main`
+fail_compilation/fail14249.d(29): Error: `unittest` can only be a member of module/aggregate/template, not function `main`
+fail_compilation/fail14249.d(30): Error: `invariant` can only be a member of aggregate, not function `main`
+fail_compilation/fail14249.d(31): Error: alias this can only be a member of aggregate, not function `main`
+fail_compilation/fail14249.d(32): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+fail_compilation/fail14249.d(32): Error: allocator can only be a member of aggregate, not function `main`
+fail_compilation/fail14249.d(33): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14249.d(33): Error: deallocator can only be a member of aggregate, not function `main`
+fail_compilation/fail14249.d(34): Error: constructor can only be a member of aggregate, not function `main`
+fail_compilation/fail14249.d(35): Error: destructor can only be a member of aggregate, not function `main`
+fail_compilation/fail14249.d(36): Error: postblit can only be a member of struct, not function `main`
+fail_compilation/fail14249.d(37): Error: anonymous union can only be a part of an aggregate, not function `main`
+fail_compilation/fail14249.d(41): Error: mixin `fail14249.main.Mix!()` error instantiating
 ---
 */
 mixin template Mix()

--- a/test/fail_compilation/fail14407.d
+++ b/test/fail_compilation/fail14407.d
@@ -3,19 +3,21 @@ import imports.a14407;
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14407.d(23): Deprecation: class `imports.a14407.C` is deprecated
-fail_compilation/fail14407.d(23): Deprecation: allocator `imports.a14407.C.new` is deprecated
-fail_compilation/fail14407.d(23): Error: `pure` function `fail14407.testC` cannot call impure allocator `imports.a14407.C.new`
-fail_compilation/fail14407.d(23): Error: `@safe` function `fail14407.testC` cannot call `@system` allocator `imports.a14407.C.new`
-fail_compilation/fail14407.d(23): Error: `@nogc` function `fail14407.testC` cannot call non-@nogc allocator `imports.a14407.C.new`
-fail_compilation/fail14407.d(23): Error: class `imports.a14407.C` member `new` is not accessible
-fail_compilation/fail14407.d(23): Error: `pure` function `fail14407.testC` cannot call impure constructor `imports.a14407.C.this`
-fail_compilation/fail14407.d(23): Error: `@safe` function `fail14407.testC` cannot call `@system` constructor `imports.a14407.C.this`
-fail_compilation/fail14407.d(23): Error: `@nogc` function `fail14407.testC` cannot call non-@nogc constructor `imports.a14407.C.this`
-fail_compilation/fail14407.d(23): Error: class `imports.a14407.C` member `this` is not accessible
-fail_compilation/fail14407.d(23): Error: allocator `imports.a14407.C.new` is not `nothrow`
-fail_compilation/fail14407.d(23): Error: constructor `imports.a14407.C.this` is not `nothrow`
-fail_compilation/fail14407.d(21): Error: `nothrow` function `fail14407.testC` may throw
+fail_compilation/imports/a14407.d(5): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+fail_compilation/imports/a14407.d(14): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+fail_compilation/fail14407.d(25): Deprecation: class `imports.a14407.C` is deprecated
+fail_compilation/fail14407.d(25): Deprecation: allocator `imports.a14407.C.new` is deprecated
+fail_compilation/fail14407.d(25): Error: `pure` function `fail14407.testC` cannot call impure allocator `imports.a14407.C.new`
+fail_compilation/fail14407.d(25): Error: `@safe` function `fail14407.testC` cannot call `@system` allocator `imports.a14407.C.new`
+fail_compilation/fail14407.d(25): Error: `@nogc` function `fail14407.testC` cannot call non-@nogc allocator `imports.a14407.C.new`
+fail_compilation/fail14407.d(25): Error: class `imports.a14407.C` member `new` is not accessible
+fail_compilation/fail14407.d(25): Error: `pure` function `fail14407.testC` cannot call impure constructor `imports.a14407.C.this`
+fail_compilation/fail14407.d(25): Error: `@safe` function `fail14407.testC` cannot call `@system` constructor `imports.a14407.C.this`
+fail_compilation/fail14407.d(25): Error: `@nogc` function `fail14407.testC` cannot call non-@nogc constructor `imports.a14407.C.this`
+fail_compilation/fail14407.d(25): Error: class `imports.a14407.C` member `this` is not accessible
+fail_compilation/fail14407.d(25): Error: allocator `imports.a14407.C.new` is not `nothrow`
+fail_compilation/fail14407.d(25): Error: constructor `imports.a14407.C.this` is not `nothrow`
+fail_compilation/fail14407.d(23): Error: `nothrow` function `fail14407.testC` may throw
 ---
 */
 void testC() pure nothrow @safe @nogc
@@ -26,19 +28,19 @@ void testC() pure nothrow @safe @nogc
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14407.d(46): Deprecation: struct `imports.a14407.S` is deprecated
-fail_compilation/fail14407.d(46): Deprecation: allocator `imports.a14407.S.new` is deprecated
-fail_compilation/fail14407.d(46): Error: `pure` function `fail14407.testS` cannot call impure allocator `imports.a14407.S.new`
-fail_compilation/fail14407.d(46): Error: `@safe` function `fail14407.testS` cannot call `@system` allocator `imports.a14407.S.new`
-fail_compilation/fail14407.d(46): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc allocator `imports.a14407.S.new`
-fail_compilation/fail14407.d(46): Error: struct `imports.a14407.S` member `new` is not accessible
-fail_compilation/fail14407.d(46): Error: `pure` function `fail14407.testS` cannot call impure constructor `imports.a14407.S.this`
-fail_compilation/fail14407.d(46): Error: `@safe` function `fail14407.testS` cannot call `@system` constructor `imports.a14407.S.this`
-fail_compilation/fail14407.d(46): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc constructor `imports.a14407.S.this`
-fail_compilation/fail14407.d(46): Error: struct `imports.a14407.S` member `this` is not accessible
-fail_compilation/fail14407.d(46): Error: allocator `imports.a14407.S.new` is not `nothrow`
-fail_compilation/fail14407.d(46): Error: constructor `imports.a14407.S.this` is not `nothrow`
-fail_compilation/fail14407.d(44): Error: `nothrow` function `fail14407.testS` may throw
+fail_compilation/fail14407.d(48): Deprecation: struct `imports.a14407.S` is deprecated
+fail_compilation/fail14407.d(48): Deprecation: allocator `imports.a14407.S.new` is deprecated
+fail_compilation/fail14407.d(48): Error: `pure` function `fail14407.testS` cannot call impure allocator `imports.a14407.S.new`
+fail_compilation/fail14407.d(48): Error: `@safe` function `fail14407.testS` cannot call `@system` allocator `imports.a14407.S.new`
+fail_compilation/fail14407.d(48): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc allocator `imports.a14407.S.new`
+fail_compilation/fail14407.d(48): Error: struct `imports.a14407.S` member `new` is not accessible
+fail_compilation/fail14407.d(48): Error: `pure` function `fail14407.testS` cannot call impure constructor `imports.a14407.S.this`
+fail_compilation/fail14407.d(48): Error: `@safe` function `fail14407.testS` cannot call `@system` constructor `imports.a14407.S.this`
+fail_compilation/fail14407.d(48): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc constructor `imports.a14407.S.this`
+fail_compilation/fail14407.d(48): Error: struct `imports.a14407.S` member `this` is not accessible
+fail_compilation/fail14407.d(48): Error: allocator `imports.a14407.S.new` is not `nothrow`
+fail_compilation/fail14407.d(48): Error: constructor `imports.a14407.S.this` is not `nothrow`
+fail_compilation/fail14407.d(46): Error: `nothrow` function `fail14407.testS` may throw
 ---
 */
 void testS() pure nothrow @safe @nogc

--- a/test/fail_compilation/fail14486.d
+++ b/test/fail_compilation/fail14486.d
@@ -1,5 +1,23 @@
 // REQUIRED_ARGS: -o-
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14486.d(23): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(24): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(25): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(29): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(30): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(31): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(35): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(36): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(37): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(41): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(42): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(43): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+---
+*/
+
 class  C0a { }
 class  C1a {                  ~this() {} }
 class  C2a {                  ~this() {}  @nogc pure @safe delete(void* p) {} }
@@ -27,22 +45,22 @@ struct S4b {          nothrow ~this() {}           nothrow delete(void* p) {} }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(50): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(50): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
-fail_compilation/fail14486.d(51): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(51): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(51): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(51): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(52): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(52): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(52): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(52): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(53): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(53): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(53): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(53): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(54): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(54): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
+fail_compilation/fail14486.d(68): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(68): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
+fail_compilation/fail14486.d(69): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(69): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(69): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(69): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(70): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(70): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(70): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(70): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(71): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(71): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(71): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(71): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(72): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(72): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
 ---
 */
 void test1a() @nogc pure @safe
@@ -57,15 +75,15 @@ void test1a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(73): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(74): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(75): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(76): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(77): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(74): Error: destructor `fail14486.C1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(75): Error: destructor `fail14486.C2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(76): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(71): Error: `nothrow` function `fail14486.test1b` may throw
+fail_compilation/fail14486.d(91): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(92): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(94): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(95): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(92): Error: destructor `fail14486.C1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(93): Error: destructor `fail14486.C2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(94): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(89): Error: `nothrow` function `fail14486.test1b` may throw
 ---
 */
 void test1b() nothrow
@@ -80,21 +98,21 @@ void test1b() nothrow
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(102): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(102): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
-fail_compilation/fail14486.d(103): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(103): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(103): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(103): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(104): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(104): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(104): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(104): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(105): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(105): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(105): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(105): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(106): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(120): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(120): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
+fail_compilation/fail14486.d(121): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(121): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(121): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(121): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(122): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(122): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(122): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(122): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(123): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(123): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(123): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(123): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(124): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
 ---
 */
 void test2a() @nogc pure @safe
@@ -109,15 +127,15 @@ void test2a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(125): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(126): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(127): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(128): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(129): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(126): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(127): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(128): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(123): Error: `nothrow` function `fail14486.test2b` may throw
+fail_compilation/fail14486.d(143): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(144): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(145): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(146): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(147): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(144): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(145): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(146): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(141): Error: `nothrow` function `fail14486.test2b` may throw
 ---
 */
 void test2b() nothrow
@@ -132,20 +150,20 @@ void test2b() nothrow
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(153): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(153): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(154): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(154): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(154): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(154): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(155): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(155): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(155): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(155): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(156): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(156): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(157): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(157): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(171): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(171): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(172): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(172): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(172): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(172): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(173): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(173): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(173): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(173): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(174): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(174): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(175): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(175): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
 ---
 */
 void test3a() @nogc pure @safe
@@ -160,14 +178,14 @@ void test3a() @nogc pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(175): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(176): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(177): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(178): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(179): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(176): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(177): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(173): Error: `nothrow` function `fail14486.test3b` may throw
+fail_compilation/fail14486.d(193): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(194): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(195): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(196): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(197): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(194): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(195): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(191): Error: `nothrow` function `fail14486.test3b` may throw
 ---
 */
 void test3b() nothrow

--- a/test/fail_compilation/fail7848.d
+++ b/test/fail_compilation/fail7848.d
@@ -3,26 +3,28 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7848.d(35): Error: `pure` function `fail7848.C.__unittest_L33_C30` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(35): Error: `@safe` function `fail7848.C.__unittest_L33_C30` cannot call `@system` function `fail7848.func`
-fail_compilation/fail7848.d(35): Error: `@nogc` function `fail7848.C.__unittest_L33_C30` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(35): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(33): Error: `nothrow` function `fail7848.C.__unittest_L33_C30` may throw
-fail_compilation/fail7848.d(40): Error: `pure` function `fail7848.C.__invariant1` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(40): Error: `@safe` function `fail7848.C.__invariant1` cannot call `@system` function `fail7848.func`
-fail_compilation/fail7848.d(40): Error: `@nogc` function `fail7848.C.__invariant1` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(40): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(38): Error: `nothrow` function `fail7848.C.__invariant1` may throw
-fail_compilation/fail7848.d(45): Error: `pure` allocator `fail7848.C.new` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(45): Error: `@safe` allocator `fail7848.C.new` cannot call `@system` function `fail7848.func`
-fail_compilation/fail7848.d(45): Error: `@nogc` allocator `fail7848.C.new` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(45): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(43): Error: `nothrow` allocator `fail7848.C.new` may throw
-fail_compilation/fail7848.d(51): Error: `pure` deallocator `fail7848.C.delete` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(51): Error: `@safe` deallocator `fail7848.C.delete` cannot call `@system` function `fail7848.func`
-fail_compilation/fail7848.d(51): Error: `@nogc` deallocator `fail7848.C.delete` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(51): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(49): Error: `nothrow` deallocator `fail7848.C.delete` may throw
+fail_compilation/fail7848.d(45): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+fail_compilation/fail7848.d(51): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail7848.d(37): Error: `pure` function `fail7848.C.__unittest_L35_C30` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(37): Error: `@safe` function `fail7848.C.__unittest_L35_C30` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(37): Error: `@nogc` function `fail7848.C.__unittest_L35_C30` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(37): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(35): Error: `nothrow` function `fail7848.C.__unittest_L35_C30` may throw
+fail_compilation/fail7848.d(42): Error: `pure` function `fail7848.C.__invariant1` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(42): Error: `@safe` function `fail7848.C.__invariant1` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(42): Error: `@nogc` function `fail7848.C.__invariant1` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(42): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(40): Error: `nothrow` function `fail7848.C.__invariant1` may throw
+fail_compilation/fail7848.d(47): Error: `pure` allocator `fail7848.C.new` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(47): Error: `@safe` allocator `fail7848.C.new` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(47): Error: `@nogc` allocator `fail7848.C.new` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(47): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(45): Error: `nothrow` allocator `fail7848.C.new` may throw
+fail_compilation/fail7848.d(53): Error: `pure` deallocator `fail7848.C.delete` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(53): Error: `@safe` deallocator `fail7848.C.delete` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(53): Error: `@nogc` deallocator `fail7848.C.delete` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(53): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(51): Error: `nothrow` deallocator `fail7848.C.delete` may throw
 ---
 */
 

--- a/test/fail_compilation/failmemalloc.d
+++ b/test/fail_compilation/failmemalloc.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/failmemalloc.d(13): Error: member allocators not supported by CTFE
+fail_compilation/failmemalloc.d(11): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+fail_compilation/failmemalloc.d(14): Error: member allocators not supported by CTFE
 ---
 */
 

--- a/test/fail_compilation/nogc1.d
+++ b/test/fail_compilation/nogc1.d
@@ -3,6 +3,14 @@
 
 /***************** NewExp *******************/
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/nogc1.d(17): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+fail_compilation/nogc1.d(18): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+---
+*/
+
 struct S1 { }
 struct S2 { this(int); }
 struct S3 { this(int) @nogc; }
@@ -12,14 +20,14 @@ struct S5 { @nogc new(size_t); }
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(27): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(29): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(30): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(32): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(33): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(34): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
-fail_compilation/nogc1.d(35): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc allocator `nogc1.S4.new`
+fail_compilation/nogc1.d(35): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(37): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
 fail_compilation/nogc1.d(38): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(40): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(41): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(42): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
+fail_compilation/nogc1.d(43): Error: `@nogc` function `nogc1.testNew` cannot call non-@nogc allocator `nogc1.S4.new`
+fail_compilation/nogc1.d(46): Error: cannot use `new` in `@nogc` function `nogc1.testNew`
 ---
 */
 @nogc void testNew()
@@ -41,13 +49,13 @@ fail_compilation/nogc1.d(38): Error: cannot use `new` in `@nogc` function `nogc1
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(55): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(57): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(58): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(60): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(61): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
-fail_compilation/nogc1.d(62): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
-fail_compilation/nogc1.d(63): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc allocator `nogc1.S4.new`
+fail_compilation/nogc1.d(63): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(65): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(66): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(68): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(69): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc constructor `nogc1.S2.this`
+fail_compilation/nogc1.d(70): Error: cannot use `new` in `@nogc` function `nogc1.testNewScope`
+fail_compilation/nogc1.d(71): Error: `@nogc` function `nogc1.testNewScope` cannot call non-@nogc allocator `nogc1.S4.new`
 ---
 */
 @nogc void testNewScope()
@@ -72,12 +80,12 @@ fail_compilation/nogc1.d(63): Error: `@nogc` function `nogc1.testNewScope` canno
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nogc1.d(85): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/nogc1.d(85): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(86): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/nogc1.d(86): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
-fail_compilation/nogc1.d(87): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/nogc1.d(87): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(93): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(94): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(94): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
+fail_compilation/nogc1.d(95): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/nogc1.d(95): Error: cannot use `delete` in `@nogc` function `nogc1.testDelete`
 ---
 */
 @nogc void testDelete(int* p, Object o, S1* s)


### PR DESCRIPTION
`delete` was deprecated in 2.079.  Before the `delete` keyword can be removed it will be necessary to also deprecate and remove class allocators and deallocators.  They have been planned for deprecation for years; this PR finally puts the deprecation process in motion.

See https://dlang.org/deprecate.html#Class%20allocators%20and%20deallocators

dlang.org PR:  https://github.com/dlang/dlang.org/pull/2277