### PR TITLE
refactor: add foreachBodyToFunction()

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1870,7 +1870,6 @@ else
      *  Function literal created, as an expression
      *  null if error.
      */
-
     static FuncExp foreachBodyToFunction(Scope* sc, ForeachStatement fs, TypeFunction tfld)
     {
         auto params = new Parameters();


### PR DESCRIPTION
Pulling it out into a separate function makes it easier to understand. Reducing the scope of various variables is a plus, too.