### PR TITLE
Fix Issue 18620 - error cannot be interpreted at compile time is missing context where error occurs

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -200,14 +200,15 @@ extern (C++) final class ThrownExceptionExp : Expression
     }
 }
 
+
 /***********************************************************
  * This type is only used by the interpreter.
  */
-extern (C++) final class CTFEExp : Expression
+extern (C++) class CTFEExp : Expression
 {
-    extern (D) this(TOK tok)
+    extern (D) this(TOK tok, int size = __traits(classInstanceSize, CTFEExp))
     {
-        super(Loc.initial, tok, __traits(classInstanceSize, CTFEExp));
+        super(Loc.initial, tok, size);
         type = Type.tvoid;
     }
 
@@ -244,6 +245,30 @@ extern (C++) final class CTFEExp : Expression
     static bool isGotoExp(const Expression e)
     {
         return e && e.op == TOK.goto_;
+    }
+}
+
+enum CTE : int
+{
+    missingFuncBody,
+}
+
+/* This class is used to pass CTFE errors to
+ * higher levels in the AST so that error
+ * messages can be written on the call site
+ */
+extern (C++) final class CTErrorExp : CTFEExp
+{
+    CTE err;
+    extern (D) this(CTE err)
+    {
+        super(TOK.cantExpression, __traits(classInstanceSize, CTErrorExp));
+        this.err = err;
+    }
+
+    override inout(CTErrorExp) isCTErrorExp() inout
+    {
+        return this;
     }
 }
 

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -200,15 +200,14 @@ extern (C++) final class ThrownExceptionExp : Expression
     }
 }
 
-
 /***********************************************************
  * This type is only used by the interpreter.
  */
-extern (C++) class CTFEExp : Expression
+extern (C++) final class CTFEExp : Expression
 {
-    extern (D) this(TOK tok, int size = __traits(classInstanceSize, CTFEExp))
+    extern (D) this(TOK tok)
     {
-        super(Loc.initial, tok, size);
+        super(Loc.initial, tok, __traits(classInstanceSize, CTFEExp));
         type = Type.tvoid;
     }
 
@@ -236,6 +235,10 @@ extern (C++) class CTFEExp : Expression
     extern (C++) static __gshared CTFEExp breakexp;
     extern (C++) static __gshared CTFEExp continueexp;
     extern (C++) static __gshared CTFEExp gotoexp;
+    /* Used when additional information is needed regarding
+     * a ctfe error.
+     */
+    extern (C++) static __gshared CTFEExp showcontext;
 
     static bool isCantExp(const Expression e)
     {
@@ -248,34 +251,10 @@ extern (C++) class CTFEExp : Expression
     }
 }
 
-enum CTE : int
-{
-    missingFuncBody,
-}
-
-/* This class is used to pass CTFE errors to
- * higher levels in the AST so that error
- * messages can be written on the call site
- */
-extern (C++) final class CTErrorExp : CTFEExp
-{
-    CTE err;
-    extern (D) this(CTE err)
-    {
-        super(TOK.cantExpression, __traits(classInstanceSize, CTErrorExp));
-        this.err = err;
-    }
-
-    override inout(CTErrorExp) isCTErrorExp() inout
-    {
-        return this;
-    }
-}
-
 // True if 'e' is CTFEExp::cantexp, or an exception
 extern (C++) bool exceptionOrCantInterpret(const Expression e)
 {
-    return e && (e.op == TOK.cantExpression || e.op == TOK.thrownException);
+    return e && (e.op == TOK.cantExpression || e.op == TOK.thrownException || e.op == TOK.showCtfeContext);
 }
 
 /************** Aggregate literals (AA/string/array/struct) ******************/

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4997,7 +4997,7 @@ public:
         if (!fd.fbody)
         {
             e.error("`%s` cannot be interpreted at compile time, because it has no available source code", fd.toChars());
-            result = new CTErrorExp(CTE.missingFuncBody);
+            result = CTFEExp.showcontext;
             return;
         }
 

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4997,7 +4997,7 @@ public:
         if (!fd.fbody)
         {
             e.error("`%s` cannot be interpreted at compile time, because it has no available source code", fd.toChars());
-            result = CTFEExp.cantexp;
+            result = new CTErrorExp(CTE.missingFuncBody);
             return;
         }
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -22,7 +22,6 @@ import dmd.astcodegen;
 import dmd.attrib;
 import dmd.blockexit;
 import dmd.clone;
-import dmd.ctfeexpr;
 import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
@@ -561,10 +560,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     {
         version (none)
         {
-            printf("VarDeclaration::semantic('%s', parent = '%s')\n", dsym.toChars(), sc.parent ? sc.parent.toChars() : null);
-            printf(" type = %s\n", dsym.type ? dsym.type.toChars() : "null");
+            printf("VarDeclaration::semantic('%s', parent = '%s') sem = %d\n", toChars(), sc.parent ? sc.parent.toChars() : null, sem);
+            printf(" type = %s\n", type ? type.toChars() : "null");
             printf(" stc = x%x\n", sc.stc);
-            printf(" storage_class = x%llx\n", dsym.storage_class);
+            printf(" storage_class = x%llx\n", storage_class);
             printf("linkage = %d\n", sc.linkage);
             //if (strcmp(toChars(), "mul") == 0) assert(0);
         }
@@ -1140,7 +1139,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 // possibilities.
                 if (fd && !(dsym.storage_class & (STC.manifest | STC.static_ | STC.tls | STC.gshared | STC.extern_)) && !dsym._init.isVoidInitializer())
                 {
-                    //printf("fd = '%s', var = '%s'\n", fd.toChars(), dsym.toChars());
+                    //printf("fd = '%s', var = '%s'\n", fd.toChars(), toChars());
                     if (!ei)
                     {
                         ArrayInitializer ai = dsym._init.isArrayInitializer();
@@ -1216,22 +1215,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 }
                 else
                 {
-                    import dmd.hdrgen : toCBuffer, HdrGenState;
-                    OutBuffer buff;
-                    HdrGenState hgs;
-                    toCBuffer(dsym, &buff, &hgs);
-                    if (buff.offset != 0)
-                        buff.setsize(buff.offset-1);
-
                     // https://issues.dlang.org/show_bug.cgi?id=14166
                     // Don't run CTFE for the temporary variables inside typeof
                     dsym._init = dsym._init.initializerSemantic(sc, dsym.type, sc.intypeof == 1 ? INITnointerpret : INITinterpret);
                     const init_err = dsym._init.isExpInitializer();
-                    if (init_err)
+                    if (init_err && init_err.exp.op == TOK.showCtfeContext)
                     {
-                        const errExp = init_err.exp.isCTErrorExp;
-                        if (errExp && errExp.err == CTE.missingFuncBody)
-                            errorSupplemental(dsym.loc, "compile time context created here: `%s`", buff.extractString());
+                         errorSupplemental(dsym.loc, "compile time context created here");
                     }
                 }
             }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1655,6 +1655,7 @@ extern (C++) abstract class Expression : RootObject
         CTFEExp.breakexp = new CTFEExp(TOK.break_);
         CTFEExp.continueexp = new CTFEExp(TOK.continue_);
         CTFEExp.gotoexp = new CTFEExp(TOK.goto_);
+        CTFEExp.showcontext = new CTFEExp(TOK.showCtfeContext);
     }
 
     /*********************************
@@ -2544,11 +2545,6 @@ extern (C++) abstract class Expression : RootObject
     bool isBool(bool result)
     {
         return false;
-    }
-
-    inout(CTErrorExp) isCTErrorExp() inout
-    {
-        return null;
     }
 
     final Expression op_overload(Scope* sc)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2546,6 +2546,11 @@ extern (C++) abstract class Expression : RootObject
         return false;
     }
 
+    inout(CTErrorExp) isCTErrorExp() inout
+    {
+        return null;
+    }
+
     final Expression op_overload(Scope* sc)
     {
         return .op_overload(this, sc);

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -394,7 +394,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
 
     override void visit(ExpInitializer i)
     {
-        //printf("ExpInitializer::semantic(%s), type = %s\n", exp.toChars(), t.toChars());
+        //printf("ExpInitializer::semantic(%s), type = %s\n", i.exp.toChars(), t.toChars());
         if (needInterpret)
             sc = sc.startCTFE();
         i.exp = i.exp.expressionSemantic(sc);
@@ -546,7 +546,7 @@ private extern(C++) final class InitializerSemanticVisitor : Visitor
             i.exp = i.exp.ctfeInterpret();
         else
             i.exp = i.exp.optimize(WANTvalue);
-        //printf("-ExpInitializer::semantic(): "); exp.print();
+        //printf("-ExpInitializer::semantic(): "); i.exp.print();
         result = i;
     }
 }
@@ -895,7 +895,7 @@ private extern(C++) final class InitToExpressionVisitor : Visitor
     {
         if (itype)
         {
-            //printf("ExpInitializer::toExpression(t = %s) exp = %s\n", t.toChars(), exp.toChars());
+            //printf("ExpInitializer::toExpression(t = %s) exp = %s\n", itype.toChars(), i.exp.toChars());
             Type tb = itype.toBasetype();
             Expression e = (i.exp.op == TOK.construct || i.exp.op == TOK.blit) ? (cast(AssignExp)i.exp).e2 : i.exp;
             if (tb.ty == Tsarray && e.implicitConvTo(tb.nextOf()))

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -283,6 +283,7 @@ enum TOK : int
     interval = 231,
     voidExpression,
     cantExpression,
+    showCtfeContext,
 
     objcClassReference,
 
@@ -693,6 +694,7 @@ extern (C++) struct Token
         TOK.interval: "interval",
         TOK.voidExpression: "voidexp",
         TOK.cantExpression: "cantexp",
+        TOK.showCtfeContext : "showCtfeContext",
 
         TOK.objcClassReference: "class",
     ];

--- a/test/fail_compilation/fail18620.d
+++ b/test/fail_compilation/fail18620.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail18620.d(14): Error: `strlen` cannot be interpreted at compile time, because it has no available source code
-fail_compilation/fail18620.d(19):        compile time context created here: `static A a = new A("a");`
+fail_compilation/fail18620.d(19):        compile time context created here
 fail_compilation/fail18620.d(14): Error: `strlen` cannot be interpreted at compile time, because it has no available source code
-fail_compilation/fail18620.d(20):        compile time context created here: `__gshared A b = new A("b");`
+fail_compilation/fail18620.d(20):        compile time context created here
 ---
 */
 class A{

--- a/test/fail_compilation/fail18620.d
+++ b/test/fail_compilation/fail18620.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18620.d(14): Error: `strlen` cannot be interpreted at compile time, because it has no available source code
+fail_compilation/fail18620.d(19):        compile time context created here: `static A a = new A("a");`
+fail_compilation/fail18620.d(14): Error: `strlen` cannot be interpreted at compile time, because it has no available source code
+fail_compilation/fail18620.d(20):        compile time context created here: `__gshared A b = new A("b");`
+---
+*/
+class A{
+    this(const(char)* s)
+    {
+        import core.stdc.string;
+        auto a=strlen(s);
+    }
+}
+
+void main(){
+    static a = new A("a");
+    __gshared b = new A("b");
+}


### PR DESCRIPTION
…ing context where error occurs.

The fix currently produces redundant output for some cases, but that is because I have not found a simple, direct way to pas information from the ctfe interpreting visitor to the starting declaration. Suggestions welcome. cc @UplinkCoder 

Ideally, I would send a token from the interpret visitor all the way to the the point in the code after interpret has been run on the Initializer, but that cannot be done by simply sending ErrorExp  