### PR TITLE
Fix issue 18242 - Warn if object.Exception is missing

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4123,7 +4123,7 @@ void catchSemantic(Catch c, Scope* sc)
             error(c.loc, "can only catch class objects derived from `Throwable`, not `%s`", c.type.toChars());
             c.errors = true;
         }
-        else if (sc.func && !sc.intypeof && !c.internalCatch &&
+        else if (sc.func && !sc.intypeof && !c.internalCatch && ClassDeclaration.exception &&
                  cd != ClassDeclaration.exception && !ClassDeclaration.exception.isBaseOf(cd, null) &&
                  sc.func.setUnsafe())
         {

--- a/test/compilable/b18242.d
+++ b/test/compilable/b18242.d
@@ -6,7 +6,7 @@ class Object { }
 
 class TypeInfo { }
 class TypeInfo_Class : TypeInfo { 
-    version(D_LP64) { ubyte[136] _x; } else { ubyte[68] _x };
+    version(D_LP64) { ubyte[136] _x; } else { ubyte[68] _x; }
 }
 
 class Throwable { }

--- a/test/compilable/b18242.d
+++ b/test/compilable/b18242.d
@@ -1,0 +1,15 @@
+// REQUIRED_ARGS: -c
+// PERMUTE_ARGS:
+module object;
+
+class Object { }
+
+class TypeInfo { }
+class TypeInfo_Class : TypeInfo { ubyte[136] _x; }
+
+class Throwable { }
+
+int _d_run_main() {
+    try { } catch(Throwable e) { return 1; }
+    return 0;
+}

--- a/test/compilable/b18242.d
+++ b/test/compilable/b18242.d
@@ -5,13 +5,15 @@ module object;
 class Object { }
 
 class TypeInfo { }
-class TypeInfo_Class : TypeInfo { 
+class TypeInfo_Class : TypeInfo 
+{ 
     version(D_LP64) { ubyte[136] _x; } else { ubyte[68] _x; }
 }
 
 class Throwable { }
 
-int _d_run_main() {
+int _d_run_main() 
+{
     try { } catch(Throwable e) { return 1; }
     return 0;
 }

--- a/test/compilable/b18242.d
+++ b/test/compilable/b18242.d
@@ -5,7 +5,9 @@ module object;
 class Object { }
 
 class TypeInfo { }
-class TypeInfo_Class : TypeInfo { ubyte[136] _x; }
+class TypeInfo_Class : TypeInfo { 
+    version(D_LP64) { ubyte[136] _x; } else { ubyte[68] _x };
+}
 
 class Throwable { }
 


### PR DESCRIPTION
Let's not segfault if no `Exception` class is defined.