### PR TITLE
fix Issue 17784 - [scope][DIP1000] Confusing error message for escapi…

### DIFF
--- a/test/fail_compilation/fail17842.d
+++ b/test/fail_compilation/fail17842.d
@@ -2,7 +2,7 @@
  * TEST_OUTPUT:
 ---
 fail_compilation/fail17842.d(14): Error: scope variable `p` assigned to non-scope `*q`
-fail_compilation/fail17842.d(23): Error: scope variable `obj` may not be returned
+fail_compilation/fail17842.d(23): Error: scope variable `obj` may not be copied into allocated memory
 ---
  */
 

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -297,7 +297,7 @@ struct T17388
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(1306): Error: returning `& i` escapes a reference to local variable `i`
+fail_compilation/retscope2.d(1306): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
 ---
 */
 

--- a/test/fail_compilation/retscope3.d
+++ b/test/fail_compilation/retscope3.d
@@ -6,8 +6,8 @@ PERMUTE_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope3.d(2008): Error: returning `& i` escapes a reference to local variable `i`
-fail_compilation/retscope3.d(2017): Error: returning `S2000(& i)` escapes a reference to local variable `i`
+fail_compilation/retscope3.d(2008): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/retscope3.d(2017): Error: copying `S2000(& i)` into allocated memory escapes a reference to local variable `i`
 ---
 */
 
@@ -90,3 +90,42 @@ void test3000() @safe
     }
 }
 
+/**********************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/retscope3.d(4003): Error: copying `u[]` into allocated memory escapes a reference to variadic parameter `u`
+fail_compilation/retscope3.d(4016): Error: storing reference to outer local variable `i` into allocated memory causes it to escape
+fail_compilation/retscope3.d(4025): Error: storing reference to stack allocated value returned by `makeSA()` into allocated memory causes it to escape
+---
+*/
+
+#line 4000
+
+void bar4000(int[1] u...) @safe
+{
+    int[][] n = [u[]];
+}
+
+void bar4001() @safe
+{
+    static int i;
+    int*[] n = [&i];
+}
+
+ref int bar4002(return ref int i) @safe
+{
+    void nested()
+    {
+        int*[] n = [&i];
+    }
+    return i;
+}
+
+int[3] makeSA() @safe;
+
+void bar4003() @safe
+{
+    int[][] a = [makeSA()[]];
+}

--- a/test/fail_compilation/retscope6.d
+++ b/test/fail_compilation/retscope6.d
@@ -6,7 +6,7 @@ PERMUTE_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope6.d(6007): Error: returning `& i` escapes a reference to local variable `i`
+fail_compilation/retscope6.d(6007): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
 ---
 */
 

--- a/test/fail_compilation/test18282.d
+++ b/test/fail_compilation/test18282.d
@@ -2,12 +2,12 @@
    TEST_OUTPUT:
 ---
 fail_compilation/test18282.d(25): Error: scope variable `aa` may not be returned
-fail_compilation/test18282.d(34): Error: returning `& i` escapes a reference to local variable `i`
-fail_compilation/test18282.d(35): Error: returning `& i` escapes a reference to local variable `i`
+fail_compilation/test18282.d(34): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/test18282.d(35): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
 fail_compilation/test18282.d(36): Error: scope variable `staa` may not be returned
-fail_compilation/test18282.d(44): Error: returning `S2000(& i)` escapes a reference to local variable `i`
-fail_compilation/test18282.d(53): Error: returning `& i` escapes a reference to local variable `i`
-fail_compilation/test18282.d(53): Error: returning `& c` escapes a reference to local variable `c`
+fail_compilation/test18282.d(44): Error: copying `S2000(& i)` into allocated memory escapes a reference to local variable `i`
+fail_compilation/test18282.d(53): Error: copying `& i` into allocated memory escapes a reference to local variable `i`
+fail_compilation/test18282.d(53): Error: copying `& c` into allocated memory escapes a reference to local variable `c`
 ---
  */
 
@@ -57,10 +57,10 @@ void bar2()
 /******************************
 TEST_OUTPUT:
 ---
-fail_compilation/test18282.d(1007): Error: returning `& foo` escapes a reference to local variable `foo`
-fail_compilation/test18282.d(1008): Error: returning `& foo` escapes a reference to local variable `foo`
-fail_compilation/test18282.d(1009): Error: returning `& foo` escapes a reference to local variable `foo`
-fail_compilation/test18282.d(1016): Error: returning `&this` escapes a reference to parameter `this`, perhaps annotate with `return`
+fail_compilation/test18282.d(1007): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
+fail_compilation/test18282.d(1008): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
+fail_compilation/test18282.d(1009): Error: copying `& foo` into allocated memory escapes a reference to local variable `foo`
+fail_compilation/test18282.d(1016): Error: copying `&this` into allocated memory escapes a reference to parameter variable `this`
 ---
 */
 


### PR DESCRIPTION
…ng local via new-expression

This splits off `checkNewEscape()` from `checkReturnEscapeImpl()` which enables customizing the error messages and removes confusing logic trying to deal with both Return and New.