### PR TITLE
Fix issue 18489 - SROA w/ vector arguments

### DIFF
--- a/src/dmd/backend/gsroa.c
+++ b/src/dmd/backend/gsroa.c
@@ -226,6 +226,12 @@ void sliceStructs()
                 anySlice = true;
                 sia[si].canSlice = true;
                 sia[si].accessSlice = false;
+                // We can't slice whole XMM registers
+                if (tyxmmreg(s->Stype->Tty) &&
+                    s->Spreg >= XMM0 && s->Spreg <= XMM15 && s->Spreg2 == NOREG)
+                {
+                    sia[si].canSlice = false;
+                }
                 break;
 
             case SCstack:

--- a/test/compilable/b18489.d
+++ b/test/compilable/b18489.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -O -m64
+import core.simd;
+
+double dot (double2 a) {
+    return a.ptr[0] * a.ptr[1];
+}
+
+void main () { }


### PR DESCRIPTION
Since we can't easily slice the contents of a XMM register avoid slicing
symbols passed in such registers.