### PR TITLE
outbuf: check for overflow errors

### DIFF
--- a/src/dmd/backend/machobj.c
+++ b/src/dmd/backend/machobj.c
@@ -609,7 +609,9 @@ void patch(seg_data *pseg, targ_size_t offset, int seg, targ_size_t value)
     //printf("patch(offset = x%04x, seg = %d, value = x%llx)\n", (unsigned)offset, seg, value);
     if (I64)
     {
-        int32_t *p = (int32_t *)(fobjbuf->buf + SecHdrTab64[pseg->SDshtidx].offset + offset);
+        targ_size_t off = SecHdrTab64[pseg->SDshtidx].offset + offset;
+        assert(fobjbuf->buf + off + 4 <= fobjbuf->pend);
+        int32_t *p = (int32_t *)(fobjbuf->buf + off);
 #if 0
         printf("\taddr1 = x%llx\n\taddr2 = x%llx\n\t*p = x%llx\n\tdelta = x%llx\n",
             SecHdrTab64[pseg->SDshtidx].addr,

--- a/src/dmd/backend/outbuf.h
+++ b/src/dmd/backend/outbuf.h
@@ -14,6 +14,9 @@
 #include        <string.h>
 
 #include <stddef.h>     // for size_t
+#ifndef DEBUG
+#include <assert.h>
+#endif
 
 #if __APPLE__ && __i386__
     /* size_t is 'unsigned long', which makes it mangle differently
@@ -65,6 +68,14 @@ struct Outbuffer
     // Write an array to the buffer, no reserve check
     void writen(const void *b, d_size_t len)
     {
+        if (p < buf ||
+            p > pend ||
+            p == NULL ||
+            (int)len < 0 ||
+            p + len > pend)
+        {
+            *(volatile char*)0=0;
+        }
         memcpy(p,b,len);
         p += len;
     }


### PR DESCRIPTION
This is an attempt to track down the dmd crash in OSX 32. Don't pull it.