### PR TITLE
Fix issue 14761 - Call destructors on CondExp branches

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -9287,6 +9287,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             printf("e2 : %s\n", exp.e2.type.toChars());
         }
 
+        exp.e1 = exp.e1.addDtorHook(sc);
+        exp.e2 = exp.e2.addDtorHook(sc);
+
         /* https://issues.dlang.org/show_bug.cgi?id=14696
          * If either e1 or e2 contain temporaries which need dtor,
          * make them conditional.

--- a/test/runnable/b17461.d
+++ b/test/runnable/b17461.d
@@ -1,0 +1,31 @@
+// PERMUTE_ARGS:
+
+void t()
+{
+    auto a = A(B().p ? B() : B());
+}
+
+struct A
+{
+    int p;
+}
+
+struct B
+{
+    int p = 42;
+    alias p this;
+
+    ~this()
+    {
+        import std.conv: text;
+        assert(p == 42, text(p)); /* fails; prints "1234567890" */
+    }
+}
+
+void main()
+{
+    stomp();
+    t();
+}
+
+void stomp() { int[5] stomper = 1234567890; }


### PR DESCRIPTION
We must generate the destructors before `hookDtors` is called otherwise we end up calling `__dtor` twice on the same leaf.

I'm waiting for the CI results.