### PR TITLE
Fix Issue 18647 - Use of delete should be allowed without a deprecation in a deprecated scope

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5130,12 +5130,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DeleteExp exp)
     {
-        // @@@DEPRECATED_2019-02@@@
-        // 1. Deprecation for 1 year
-        // 2. Error for 1 year
-        // 3. Removal of keyword, "delete" can be used for other identities
-        if (!exp.isRAII)
-            deprecation(exp.loc, "The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.");
+        if (!sc.isDeprecated)
+        {
+            // @@@DEPRECATED_2019-02@@@
+            // 1. Deprecation for 1 year
+            // 2. Error for 1 year
+            // 3. Removal of keyword, "delete" can be used for other identities
+            if (!exp.isRAII)
+                deprecation(exp.loc, "The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.");
+        }
 
         if (Expression ex = unaSemantic(exp, sc))
         {

--- a/test/compilable/test17906.d
+++ b/test/compilable/test17906.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -de
+// https://issues.dlang.org/show_bug.cgi?id=18647
 deprecated void main ()
 {
     Object o = new Object;

--- a/test/compilable/test17906.d
+++ b/test/compilable/test17906.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -de
+deprecated void main ()
+{
+    Object o = new Object;
+    delete o;
+}


### PR DESCRIPTION
Targetting stable as this is rather relevant to the `delete` deprecation that was part of 2.079