### PR TITLE
Remove redundant -c from test/compilable

### DIFF
--- a/test/compilable/b6395.d
+++ b/test/compilable/b6395.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 
 // 6395
 

--- a/test/compilable/ddoc9789.d
+++ b/test/compilable/ddoc9789.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -w -o- -c -Dd${RESULTS_DIR}/compilable -o-
+// REQUIRED_ARGS: -D -w -o- -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9789
 
 module ddoc9789;

--- a/test/compilable/ddocunittest.d
+++ b/test/compilable/ddocunittest.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS: -unittest
-// REQUIRED_ARGS: -D -w -o- -c -Dd${RESULTS_DIR}/compilable -o-
+// REQUIRED_ARGS: -D -w -o- -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh unittest
 
 module ddocunittest;

--- a/test/compilable/header18364.d
+++ b/test/compilable/header18364.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -c -o- -Hf${RESULTS_DIR}/compilable/header18364.di
+// REQUIRED_ARGS: -o- -Hf${RESULTS_DIR}/compilable/header18364.di
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh header18364
 module foo.bar.ba;
 @safe pure nothrow @nogc package(foo):

--- a/test/compilable/minimal.d
+++ b/test/compilable/minimal.d
@@ -1,7 +1,7 @@
 // DFLAGS:
 // PERMUTE_ARGS:
 // POST_SCRIPT: compilable/extra-files/minimal/verify_symbols.sh
-// REQUIRED_ARGS: -c -defaultlib= runnable/extra-files/minimal/object.d
+// REQUIRED_ARGS: -defaultlib= runnable/extra-files/minimal/object.d
 
 // This test ensures an empty main with a struct, built with a minimal runtime,
 // does not generate ModuleInfo or exception handling code, and does not

--- a/test/compilable/sw_transition_complex.d
+++ b/test/compilable/sw_transition_complex.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -transition=complex
+// REQUIRED_ARGS: -transition=complex
 
 /*
 TEST_OUTPUT:

--- a/test/compilable/sw_transition_field.d
+++ b/test/compilable/sw_transition_field.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -transition=field
+// REQUIRED_ARGS: -transition=field
 /*
 TEST_OUTPUT:
 ---

--- a/test/compilable/sw_transition_tls.d
+++ b/test/compilable/sw_transition_tls.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -transition=tls
+// REQUIRED_ARGS: -transition=tls
 /*
 TEST_OUTPUT:
 ---

--- a/test/compilable/test17541.d
+++ b/test/compilable/test17541.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: -c compilable/imports/test17541_2.d compilable/imports/test17541_3.d
+/* REQUIRED_ARGS: compilable/imports/test17541_2.d compilable/imports/test17541_3.d
  */
 
 // https://issues.dlang.org/show_bug.cgi?id=17541

--- a/test/compilable/test17752.d
+++ b/test/compilable/test17752.d
@@ -1,5 +1,5 @@
 // https://issues.dlang.org/show_bug.cgi?id=17752
-// REQUIRED_ARGS: -c -de
+// REQUIRED_ARGS: -de
 /*
 TEST_OUTPUT:
 ---

--- a/test/compilable/test6395.d
+++ b/test/compilable/test6395.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -c compilable/b6395 -Icompilable/extra-files
+// REQUIRED_ARGS: compilable/b6395 -Icompilable/extra-files
 
 // 6395
 

--- a/test/compilable/test7190.d
+++ b/test/compilable/test7190.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 
 import example7190.controllers.HomeController;
 import example7190.models.HomeModel;

--- a/test/compilable/test9057.d
+++ b/test/compilable/test9057.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 
 struct Bug9057(T)
 {

--- a/test/compilable/test9399.d
+++ b/test/compilable/test9399.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -c -inline -Icompilable/imports compilable/imports/test9399a
+// REQUIRED_ARGS: -inline -Icompilable/imports compilable/imports/test9399a
 
 import imports.test9399a;
 void fun(int a) {

--- a/test/compilable/test9436.d
+++ b/test/compilable/test9436.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -c compilable/imports/test9436interp.d
+// REQUIRED_ARGS: compilable/imports/test9436interp.d
 
 // this is a dummy module for test 9436.
 

--- a/test/compilable/testDIP37.d
+++ b/test/compilable/testDIP37.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 
 void test1()
 {

--- a/test/compilable/testDIP37_10302.d
+++ b/test/compilable/testDIP37_10302.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 // COMPILED_IMPORTS: extra-files/pkgDIP37_10302/liba.d
 // COMPILED_IMPORTS: extra-files/pkgDIP37_10302/libb.d
 

--- a/test/compilable/testDIP37_10421.d
+++ b/test/compilable/testDIP37_10421.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 // COMPILED_IMPORTS: extra-files/pkgDIP37_10421/algo/package.d
 // COMPILED_IMPORTS: extra-files/pkgDIP37_10421/algo/mod.d
 // COMPILED_IMPORTS: extra-files/pkgDIP37_10421/except.d

--- a/test/compilable/testDIP37a.d
+++ b/test/compilable/testDIP37a.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 // COMPILED_IMPORTS: extra-files/pkgDIP37/datetime/package.d
 // COMPILED_IMPORTS: extra-files/pkgDIP37/datetime/common.d
 


### PR DESCRIPTION
The test script runner already adds `-c` to REQUIRED_ARGS.
No need to specify it again. On the contrary, argument permutation might now try to permutate `-c` with other arguments.