### PR TITLE
Set -euo pipefail by default for all bash scripts

### DIFF
--- a/test/compilable/crlf.sh
+++ b/test/compilable/crlf.sh
@@ -2,7 +2,6 @@
 
 # Test CRLF and mixed line ending handling in D lexer.
 
-set -e
 
 dir=${RESULTS_DIR}/compilable
 fn=${TEST_DIR}/${TEST_NAME}.d

--- a/test/compilable/issue17167.sh
+++ b/test/compilable/issue17167.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
 
 # Test that file paths larger than 248 characters can be used
 # Test CRLF and mixed line ending handling in D lexer.

--- a/test/compilable/jsonNoOutFile.sh
+++ b/test/compilable/jsonNoOutFile.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 dir=${RESULTS_DIR}/compilable
 $DMD -c -od=${dir} -Xi=compilerInfo compilable/extra-files/emptymain.d
 rm -f emptymain.json

--- a/test/compilable/test14894.sh
+++ b/test/compilable/test14894.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 dir=${RESULTS_DIR}/compilable
 src=compilable/extra-files

--- a/test/compilable/test18367.sh
+++ b/test/compilable/test18367.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -ueo pipefail
 
 # dmd should not segfault on -X with libraries, but no source files
 out=$(! "$DMD" -conf= -X foo.a 2>&1)

--- a/test/compilable/test6461.sh
+++ b/test/compilable/test6461.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 dir=${RESULTS_DIR}/compilable
 src=compilable/extra-files/${TEST_NAME}

--- a/test/compilable/testclidflags.sh
+++ b/test/compilable/testclidflags.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 dir=${RESULTS_DIR}${SEP}compilable
 
 unset DFLAGS

--- a/test/runnable/depsprot.sh
+++ b/test/runnable/depsprot.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-name=`basename $0 .sh`
+name="depsprot"
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable
 deps_file="${dmddir}${SEP}${name}.deps"
+
+# custom error handling
+set +eo pipefail
 
 die()
 {

--- a/test/runnable/gdb15729.sh
+++ b/test/runnable/gdb15729.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/link14198a.sh
+++ b/test/runnable/link14198a.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/link14834.sh
+++ b/test/runnable/link14834.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/link846.sh
+++ b/test/runnable/link846.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/linkdebug.sh
+++ b/test/runnable/linkdebug.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test10386.sh
+++ b/test/runnable/test10386.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test10567.sh
+++ b/test/runnable/test10567.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test13666.sh
+++ b/test/runnable/test13666.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test13742.sh
+++ b/test/runnable/test13742.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -ueo pipefail
 
 src=runnable${SEP}extra-files
 dir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test16096.sh
+++ b/test/runnable/test16096.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 src=runnable/extra-files
 dir=${RESULTS_DIR}/runnable

--- a/test/runnable/test18141.sh
+++ b/test/runnable/test18141.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 if [ "${OS}" == "win32" -o "${OS}" == "win64" ]; then
     expected="Windows"

--- a/test/runnable/test18335.sh
+++ b/test/runnable/test18335.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -ueo pipefail
 
 if [ "${OS}" == "osx" ] && [ "${MODEL}" == "64" ]; then
     echo "void main(){}" | "${DMD}" -o- -v - | grep predefs | grep -q "D_ObjectiveC"

--- a/test/runnable/test2.sh
+++ b/test/runnable/test2.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test35.sh
+++ b/test/runnable/test35.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test39.sh
+++ b/test/runnable/test39.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test44.sh
+++ b/test/runnable/test44.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable

--- a/test/runnable/test_shared.sh
+++ b/test/runnable/test_shared.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 
 dir=${RESULTS_DIR}/runnable
 dmddir=${RESULTS_DIR}${SEP}runnable

--- a/test/sh_do_test.sh
+++ b/test/sh_do_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if [ "${RESULTS_DIR}" == "" ]; then
     echo Note: this program is normally called through the Makefile, it
     echo is not meant to be called directly by the user.
@@ -60,6 +62,11 @@ exec 2>&1
 # log all a verbose xtrace to a temporary file which is only displayed when an error occurs
 exec 42> "${output_file}.log"
 export BASH_XTRACEFD=42
+
+# fail on errors and undefined variables
+set -euo pipefail
+
+# activate xtrace logging for the to-be-called shell script
 set -x
 
 source "${script_name}"

--- a/test/sh_do_test.sh
+++ b/test/sh_do_test.sh
@@ -35,8 +35,8 @@ rm -f "${output_file}"
 function finish {
     # reset output stream
     set +x
-    exec 1>&${stdout_copy}
-    exec 2>&${stderr_copy}
+    exec 1>&40
+    exec 2>&41
 
     if [ "$1" -ne 0 ]; then
         echo "=============================="
@@ -54,8 +54,8 @@ function finish {
 trap 'finish $?' INT TERM EXIT
 
 # redirect stdout + stderr to the output file + keep a reference to the std{out,err} streams for later
-exec {stdout_copy}>&1
-exec {stderr_copy}>&2
+exec 40>&1
+exec 41>&2
 exec 1> "${output_file}"
 exec 2>&1
 


### PR DESCRIPTION
- `-e` - abort if a command fails
- `-u` - abort if an undefined variable is accessed
- `-o pipefail` - abort if a command in a pipe fails

These settings are commonly known as "Safe Bash" or "Strict Bash" and imho there's no reason why these shouldn't be the default.

CC @marler8997 @CyberShadow