### PR TITLE
Run individual tests with all available cores by default

### DIFF
--- a/test/run_individual_tests
+++ b/test/run_individual_tests
@@ -9,6 +9,9 @@
 
 set -euo pipefail
 
+# if PROCS is not set, auto-detect or fallback to 4
+PROCS="${PROCS:-$(nproc 2> /dev/null || sysctl -n hw.physicalcpu 2> /dev/null || echo 4)}"
+
 if [ -z ${1:-} ] ; then
 	cat >&2 << EOF
 ./run_individual_tests <test-file>...
@@ -34,4 +37,5 @@ done
 # allows the script to be called from anywhere
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
-${MAKE:-make} "${files[@]}"
+echo ${PROCS}
+${MAKE:-make} "${files[@]}" -j${PROCS}


### PR DESCRIPTION
I just realized that we can use this wrapper to conveniently run all shell scripts, e.g.

```bash
./run_individual_tests compilable/*.sh
./run_individual_tests **/*.sh # requires globbing support by your shell
```

For this and imho in general, it's a sane default to use all available cores.
It can be opted-out with `PROCS=1` (though I doubt that this is a frequent need).