### PR TITLE
fix Issue 5227 - X ^^ FP at compile-time

### DIFF
--- a/changelog/fix5227.dd
+++ b/changelog/fix5227.dd
@@ -1,0 +1,20 @@
+fix Issue 5227 - X ^^ FP at compile-time
+
+The pow operator `^^` can now be used by CTFE.
+
+Adds these std.math functions to those that can be used by CTFE:
+
+round
+floor
+ceil
+trunc
+log
+log2
+log10
+pow
+expm1
+exp2
+fmin
+fmax
+copysign
+fma

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -103,6 +103,116 @@ extern (C++) Expression eval_ldexp(Loc loc, FuncDeclaration fd, Expressions* arg
     return new RealExp(loc, CTFloat.ldexp(arg0.toReal(), cast(int) arg1.toInteger()), arg0.type);
 }
 
+extern (C++) Expression eval_log(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.log(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_log2(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.log2(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_log10(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.log10(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_expm1(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.expm1(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_exp2(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.exp2(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_round(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.round(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_floor(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.floor(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_ceil(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.ceil(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_trunc(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.trunc(arg0.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_copysign(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOK.float64);
+    return new RealExp(loc, CTFloat.copysign(arg0.toReal(), arg1.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_pow(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOK.float64);
+    return new RealExp(loc, CTFloat.pow(arg0.toReal(), arg1.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_fmin(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOK.float64);
+    return new RealExp(loc, CTFloat.fmin(arg0.toReal(), arg1.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_fmax(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOK.float64);
+    return new RealExp(loc, CTFloat.fmax(arg0.toReal(), arg1.toReal()), arg0.type);
+}
+
+extern (C++) Expression eval_fma(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    Expression arg1 = (*arguments)[1];
+    assert(arg1.op == TOK.float64);
+    Expression arg2 = (*arguments)[2];
+    assert(arg2.op == TOK.float64);
+    return new RealExp(loc, CTFloat.fma(arg0.toReal(), arg1.toReal(), arg2.toReal()), arg0.type);
+}
+
 extern (C++) Expression eval_isnan(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
@@ -226,7 +336,7 @@ public extern (C++) void builtin_init()
     add_builtin("_D4core4math4sqrtFNaNbNiNfeZe", &eval_sqrt);
     add_builtin("_D4core4math4fabsFNaNbNiNfeZe", &eval_fabs);
     add_builtin("_D4core4math5expm1FNaNbNiNfeZe", &eval_unimp);
-    add_builtin("_D4core4math4exp21FNaNbNiNfeZe", &eval_unimp);
+    add_builtin("_D4core4math4exp2FNaNbNiNfeZe", &eval_unimp);
     // @trusted @nogc pure nothrow real function(real)
     add_builtin("_D4core4math3sinFNaNbNiNeeZe", &eval_sin);
     add_builtin("_D4core4math3cosFNaNbNiNeeZe", &eval_cos);
@@ -234,7 +344,6 @@ public extern (C++) void builtin_init()
     add_builtin("_D4core4math4sqrtFNaNbNiNeeZe", &eval_sqrt);
     add_builtin("_D4core4math4fabsFNaNbNiNeeZe", &eval_fabs);
     add_builtin("_D4core4math5expm1FNaNbNiNeeZe", &eval_unimp);
-    add_builtin("_D4core4math4exp21FNaNbNiNeeZe", &eval_unimp);
     // @safe @nogc pure nothrow double function(double)
     add_builtin("_D4core4math4sqrtFNaNbNiNfdZd", &eval_sqrt);
     // @safe @nogc pure nothrow float function(float)
@@ -266,15 +375,14 @@ public extern (C++) void builtin_init()
     add_builtin("_D3std4math4sqrtFNaNbNiNfeZe", &eval_sqrt);
     add_builtin("_D3std4math4fabsFNaNbNiNfeZe", &eval_fabs);
     add_builtin("_D3std4math5expm1FNaNbNiNfeZe", &eval_unimp);
-    add_builtin("_D3std4math4exp21FNaNbNiNfeZe", &eval_unimp);
     // @trusted @nogc pure nothrow real function(real)
     add_builtin("_D3std4math3sinFNaNbNiNeeZe", &eval_sin);
     add_builtin("_D3std4math3cosFNaNbNiNeeZe", &eval_cos);
     add_builtin("_D3std4math3tanFNaNbNiNeeZe", &eval_tan);
     add_builtin("_D3std4math4sqrtFNaNbNiNeeZe", &eval_sqrt);
     add_builtin("_D3std4math4fabsFNaNbNiNeeZe", &eval_fabs);
-    add_builtin("_D3std4math5expm1FNaNbNiNeeZe", &eval_unimp);
-    add_builtin("_D3std4math4exp21FNaNbNiNeeZe", &eval_unimp);
+    add_builtin("_D3std4math5expm1FNaNbNiNeeZe", &eval_expm1);
+    add_builtin("_D3std4math4exp2FNaNbNiNeeZe", &eval_exp2);
     // @safe @nogc pure nothrow double function(double)
     add_builtin("_D3std4math4sqrtFNaNbNiNfdZd", &eval_sqrt);
     // @safe @nogc pure nothrow float function(float)
@@ -305,6 +413,39 @@ public extern (C++) void builtin_init()
     add_builtin("_D3std4math5ldexpFNaNbNiNfeiZe", &eval_ldexp);
     add_builtin("_D3std4math5ldexpFNaNbNiNfdiZd", &eval_ldexp);
     add_builtin("_D3std4math5ldexpFNaNbNiNffiZf", &eval_ldexp);
+
+    add_builtin("_D3std4math3logFNaNbNiNfeZe", &eval_log);
+
+    add_builtin("_D3std4math4log2FNaNbNiNfeZe", &eval_log2);
+
+    add_builtin("_D3std4math5log10FNaNbNiNfeZe", &eval_log10);
+
+    add_builtin("_D3std4math5roundFNbNiNeeZe", &eval_round);
+    add_builtin("_D3std4math5roundFNaNbNiNeeZe", &eval_round);
+
+    add_builtin("_D3std4math5floorFNaNbNiNefZf", &eval_floor);
+    add_builtin("_D3std4math5floorFNaNbNiNedZd", &eval_floor);
+    add_builtin("_D3std4math5floorFNaNbNiNeeZe", &eval_floor);
+
+    add_builtin("_D3std4math4ceilFNaNbNiNefZf", &eval_ceil);
+    add_builtin("_D3std4math4ceilFNaNbNiNedZd", &eval_ceil);
+    add_builtin("_D3std4math4ceilFNaNbNiNeeZe", &eval_ceil);
+
+    add_builtin("_D3std4math5truncFNaNbNiNeeZe", &eval_trunc);
+
+    add_builtin("_D3std4math4fminFNaNbNiNfeeZe", &eval_fmin);
+
+    add_builtin("_D3std4math4fmaxFNaNbNiNfeeZe", &eval_fmax);
+
+    add_builtin("_D3std4math__T8copysignTfTfZQoFNaNbNiNeffZf", &eval_copysign);
+    add_builtin("_D3std4math__T8copysignTdTdZQoFNaNbNiNeddZd", &eval_copysign);
+    add_builtin("_D3std4math__T8copysignTeTeZQoFNaNbNiNeeeZe", &eval_copysign);
+
+    add_builtin("_D3std4math__T3powTfTfZQjFNaNbNiNeffZf", &eval_pow);
+    add_builtin("_D3std4math__T3powTdTdZQjFNaNbNiNeddZd", &eval_pow);
+    add_builtin("_D3std4math__T3powTeTeZQjFNaNbNiNeeeZe", &eval_pow);
+
+    add_builtin("_D3std4math3fmaFNaNbNiNfeeeZe", &eval_fma);
 
     // @trusted @nogc pure nothrow bool function(T)
     add_builtin("_D3std4math__T5isNaNTeZQjFNaNbNiNeeZb", &eval_isnan);

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -1,4 +1,4 @@
-/**
+/***
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -42,20 +42,15 @@ private
 extern (C++) struct CTFloat
 {
   nothrow:
-    version(DigitalMars)
-    {
-        static __gshared bool yl2x_supported = true;
-        static __gshared bool yl2xp1_supported = true;
-    }
+    version (GNU)
+        enum yl2x_supported = false;
     else
-    {
-        static __gshared bool yl2x_supported = false;
-        static __gshared bool yl2xp1_supported = false;
-    }
+        enum yl2x_supported = __traits(compiles, core.math.yl2x(1.0L, 2.0L));
+    enum yl2xp1_supported = yl2x_supported;
 
     static void yl2x(const real_t* x, const real_t* y, real_t* res)
     {
-        version(DigitalMars)
+        static if (yl2x_supported)
             *res = core.math.yl2x(*x, *y);
         else
             assert(0);
@@ -63,7 +58,7 @@ extern (C++) struct CTFloat
 
     static void yl2xp1(const real_t* x, const real_t* y, real_t* res)
     {
-        version(DigitalMars)
+        static if (yl2xp1_supported)
             *res = core.math.yl2xp1(*x, *y);
         else
             assert(0);
@@ -87,6 +82,40 @@ extern (C++) struct CTFloat
         static real_t fabs(real_t x) { return core.math.fabs(x); }
         static real_t ldexp(real_t n, int exp) { return core.math.ldexp(n, exp); }
     }
+
+    static if (!is(real_t == real))
+    {
+        static real_t round(real_t x) { return real_t(cast(double)core.stdc.math.roundl(cast(double)x)); }
+        static real_t floor(real_t x) { return real_t(cast(double)core.stdc.math.floor(cast(double)x)); }
+        static real_t ceil(real_t x) { return real_t(cast(double)core.stdc.math.ceil(cast(double)x)); }
+        static real_t trunc(real_t x) { return real_t(cast(double)core.stdc.math.trunc(cast(double)x)); }
+        static real_t log(real_t x) { return real_t(cast(double)core.stdc.math.logl(cast(double)x)); }
+        static real_t log2(real_t x) { return real_t(cast(double)core.stdc.math.log2l(cast(double)x)); }
+        static real_t log10(real_t x) { return real_t(cast(double)core.stdc.math.log10l(cast(double)x)); }
+        static real_t pow(real_t x, real_t y) { return real_t(cast(double)core.stdc.math.powl(cast(double)x, cast(double)y)); }
+        static real_t expm1(real_t x) { return real_t(cast(double)core.stdc.math.expm1l(cast(double)x)); }
+        static real_t exp2(real_t x) { return real_t(cast(double)core.stdc.math.exp2l(cast(double)x)); }
+        static real_t copysign(real_t x, real_t s) { return real_t(cast(double)core.stdc.math.copysignl(cast(double)x, cast(double)s)); }
+    }
+    else
+    {
+        static real_t round(real_t x) { return core.stdc.math.roundl(x); }
+        static real_t floor(real_t x) { return core.stdc.math.floor(x); }
+        static real_t ceil(real_t x) { return core.stdc.math.ceil(x); }
+        static real_t trunc(real_t x) { return core.stdc.math.trunc(x); }
+        static real_t log(real_t x) { return core.stdc.math.logl(x); }
+        static real_t log2(real_t x) { return core.stdc.math.log2l(x); }
+        static real_t log10(real_t x) { return core.stdc.math.log10l(x); }
+        static real_t pow(real_t x, real_t y) { return core.stdc.math.powl(x, y); }
+        static real_t expm1(real_t x) { return core.stdc.math.expm1l(x); }
+        static real_t exp2(real_t x) { return core.stdc.math.exp2l(x); }
+        static real_t copysign(real_t x, real_t s) { return core.stdc.math.copysignl(x, s); }
+    }
+
+    static real_t fmin(real_t x, real_t y) { return x < y ? x : y; }
+    static real_t fmax(real_t x, real_t y) { return x > y ? x : y; }
+
+    static real_t fma(real_t x, real_t y, real_t z) { return (x * y) + z; }
 
     static bool isIdentical(real_t a, real_t b)
     {

--- a/src/dmd/root/ctfloat.h
+++ b/src/dmd/root/ctfloat.h
@@ -31,6 +31,23 @@ struct CTFloat
     static real_t fabs(real_t x);
     static real_t ldexp(real_t n, int exp);
 
+    static real_t round(real_t x);
+    static real_t floor(real_t x);
+    static real_t ceil(real_t x);
+    static real_t trunc(real_t x);
+    static real_t log(real_t x);
+    static real_t log2(real_t x);
+    static real_t log10(real_t x);
+    static real_t pow(real_t x, real_t y);
+    static real_t expm1(real_t x);
+    static real_t exp2(real_t x);
+
+    static real_t fmin(real_t x, real_t y);
+    static real_t fmax(real_t x, real_t y);
+    static real_t copysign(real_t x, real_t s);
+
+    static real_t fma(real_t x, real_t y, real_t z);
+
     static bool isIdentical(real_t a, real_t b);
     static bool isNaN(real_t r);
     static bool isSNaN(real_t r);

--- a/test/compilable/test5227.d
+++ b/test/compilable/test5227.d
@@ -1,0 +1,124 @@
+/*
+REQUIRED_ARGS:
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+log()
+1.70475L
+log2()
+2.45943L
+log10()
+0.740363L
+round()
+6.00000L
+floor()
+5.00000F
+5.00000
+5.00000L
+ceil()
+6.00000F
+6.00000
+6.00000L
+trunc()
+5.00000L
+expm1()
+243.692L
+exp2()
+45.2548L
+fmin()
+-3.2L
+fmax()
+5.2L
+copysign()
+-2.5F
+-2.5
+-2.5L
+pow()
+9.88212F
+9.88212
+9.88212L
+9.88212
+fma()
+-12.84L
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=5227
+
+import std.math;
+
+pragma(msg, "log()");
+enum logf = log(5.5f); //pragma(msg, logf);
+enum logd = log(5.5 ); //pragma(msg, logd);
+enum logr = log(5.5L); pragma(msg, logr);
+
+pragma(msg, "log2()");
+enum log2f = log2(5.5f); //pragma(msg, log2f);
+enum log2d = log2(5.5 ); //pragma(msg, log2d);
+enum log2r = log2(5.5L); pragma(msg, log2r);
+
+pragma(msg, "log10()");
+enum log10f = log10(5.5f); //pragma(msg, log10f);
+enum log10d = log10(5.5 ); //pragma(msg, log10d);
+enum log10r = log10(5.5L); pragma(msg, log10r);
+
+pragma(msg, "round()");
+enum roundf = round(5.5f); //pragma(msg, roundf);
+enum roundd = round(5.5 ); //pragma(msg, roundd);
+enum roundr = round(5.5L); pragma(msg, roundr);
+
+pragma(msg, "floor()");
+enum floorf = floor(5.5f); pragma(msg, floorf);
+enum floord = floor(5.5 ); pragma(msg, floord);
+enum floorr = floor(5.5L); pragma(msg, floorr);
+
+pragma(msg, "ceil()");
+enum ceilf = ceil(5.5f); pragma(msg, ceilf);
+enum ceild = ceil(5.5 ); pragma(msg, ceild);
+enum ceilr = ceil(5.5L); pragma(msg, ceilr);
+
+pragma(msg, "trunc()");
+enum truncf = trunc(5.5f); //pragma(msg, truncf);
+enum truncd = trunc(5.5 ); //pragma(msg, truncd);
+enum truncr = trunc(5.5L); pragma(msg, truncr);
+
+pragma(msg, "expm1()");
+enum expm1f = expm1(5.5f); //pragma(msg, expm1f);
+enum expm1d = expm1(5.5 ); //pragma(msg, expm1d);
+enum expm1r = expm1(5.5L); pragma(msg, expm1r);
+
+pragma(msg, "exp2()");
+enum exp2f = exp2(5.5f); //pragma(msg, exp2f);
+enum exp2d = exp2(5.5 ); //pragma(msg, exp2d);
+enum exp2r = exp2(5.5L); pragma(msg, exp2r);
+
+
+
+pragma(msg, "fmin()");
+enum fminf = fmin(-3.2f, 5.2f); //pragma(msg, fminf);
+enum fmind = fmin(-3.2 , 5.2 ); //pragma(msg, fmind);
+enum fminr = fmin(-3.2L, 5.2L); pragma(msg, fminr);
+
+pragma(msg, "fmax()");
+enum fmaxf = fmax(-3.2f, 5.2f); //pragma(msg, fmaxf);
+enum fmaxd = fmax(-3.2 , 5.2 ); //pragma(msg, fmaxd);
+enum fmaxr = fmax(-3.2L, 5.2L); pragma(msg, fmaxr);
+
+pragma(msg, "copysign()");
+enum csf = copysign(2.5f, -3.0f); pragma(msg, csf); static assert(csf == -2.5);
+enum csd = copysign(2.5 , -3.0 ); pragma(msg, csd); static assert(csd == -2.5);
+enum csr = copysign(2.5L, -3.0L); pragma(msg, csr); static assert(csr == -2.5);
+
+pragma(msg, "pow()");
+enum powf = pow(2.5f, 2.5f); pragma(msg, powf);
+enum powd = pow(2.5 , 2.5 ); pragma(msg, powd);
+enum powr = pow(2.5L, 2.5L); pragma(msg, powr);
+enum powctfe = 2.5 ^^ 2.5; pragma(msg, powctfe);
+
+
+pragma(msg, "fma()");
+enum fmaf = fma(-3.2f, 5.2f, 3.8f); //pragma(msg, fmaf);
+enum fmad = fma(-3.2 , 5.2 , 3.8 ); //pragma(msg, fmad);
+enum fmar = fma(-3.2L, 5.2L, 3.8L); pragma(msg, fmar);
+
+


### PR DESCRIPTION
Adds the CTFE functions:
```
real_t nearbyint(real_t x);
real_t rint(real_t x);
real_t round(real_t x);
real_t floor(real_t x);
real_t ceil(real_t x);
real_t trunc(real_t x);
real_t log(real_t x);
real_t log2(real_t x);
real_t log10(real_t x);
real_t pow(real_t x, real_t y);
real_t expm1(real_t x);
real_t exp2(real_t x);
real_t fmin(real_t x, real_t y);
real_t fmax(real_t x, real_t y);
real_t copysign(real_t x, real_t s);
real_t fma(real_t x, real_t y, real_t z);
```