### PR TITLE
Fix CLang 6.0 build errors

### DIFF
--- a/src/dmd/backend/cod3.c
+++ b/src/dmd/backend/cod3.c
@@ -2704,7 +2704,7 @@ L1:
                         goto L4;
                     genregs(cdb,0x31,reg,reg);
                     goto inc;
-                case -1:
+                case ~(targ_size_t)0:
                     if (I64)
                         goto L4;
                     genregs(cdb,0x31,reg,reg);

--- a/src/dmd/backend/go.c
+++ b/src/dmd/backend/go.c
@@ -65,7 +65,7 @@ void dbg_optprint(char *);
 
 int go_flag(char *cp)
 {   unsigned i;
-    unsigned flag;
+    int flag;
 
     enum GL     // indices of various flags in flagtab[]
     {


### PR DESCRIPTION
(when building under Linux with `HOST_CXX=clang++`)

```
dmd/backend/go.c:123:18: error: case value evaluates to -1, which cannot be narrowed to type 'unsigned int' [-Wc++11-narrowing]
            case -1:                    /* not in flagtab[]     */
                 ^
  (CC)  BACK_OBJS  dmd/backend/dt.c
dmd/backend/go.c:157:18: error: case value evaluates to -1, which cannot be narrowed to type 'unsigned int' [-Wc++11-narrowing]
            case -1:                    /* not in flagtab[]     */
                 ^

dmd/backend/cod3.c:2707:22: error: case value evaluates to -1, which cannot be narrowed to type 'targ_size_t' (aka 'unsigned long') [-Wc++11-narrowing]
                case -1:
                     ^
```

I'm not so familiar with C++.
`flag` is `char`, but looking at the error message it seems that C++
does type widening automatically, so maybe `UINT_MAX` needs to be used
there too?