### PR TITLE
Remove output_file for auto-updated tests with AUTO_UPDATE=1

### DIFF
--- a/test/d_do_test.d
+++ b/test/d_do_test.d
@@ -815,6 +815,10 @@ int tryMain(string[] args)
                 auto existingText = input_file.readText;
                 auto updatedText = existingText.replace(ce.expected, ce.actual);
                 std.file.write(input_file, updatedText);
+                // remove the output file in test_results as its outdated
+                f.close();
+                output_file.remove();
+                writefln("==> `TEST_OUTPUT` of %s/%s.%s has been updated", input_dir, test_name, test_extension);
                 return Result.return0;
             }
 
@@ -826,7 +830,7 @@ int tryMain(string[] args)
 
             writefln("Test %s/%s.%s failed.  The logged output:", input_dir, test_name, test_extension);
             writeln(output_file.readText);
-            std.file.remove(output_file);
+            output_file.remove();
             return Result.return1;
         }
     }


### PR DESCRIPTION
This improves `AUTO_UPDATE=1` a bit and makes it that two subsequent `AUTO_UPDATE=1` runs update all updatable `TEST_OUTPUT` messages:

```
make run_fail_compilation_tests -j20 AUTO_UPDATE=1
```

Previously, nuking `test_results` would work too, but imho this should work out of the box.
The problem was that Make just uses the timestamp to check whether the file is up-to-date and while we write updated test file and it gets a new timestamp, the output_file is written a few lines later.
There's noneed to keep the file and in fact was an oversight when I added `AUTO_UPDATE` - the other branch of the code below removes the output_file when an error occurred too.

BTW `AUTO_UPDATE=1` also works with `run_individual_tests`:

```
AUTO_UPDATE=1 ./run_individual_tests fail_compilation/diag*.d
```

But I personally just run all `fail_compilation` tests as the ~10s are a small cost compared to figuring out which tests need an update.