### PR TITLE
Fix Issue 18197 - Correct optimization for OPpair in x87 mode

### DIFF
--- a/src/dmd/backend/cgelem.c
+++ b/src/dmd/backend/cgelem.c
@@ -3579,6 +3579,7 @@ STATIC elem * eleq(elem *e, goal_t goal)
             !el_appears(e2, e1->EV.sp.Vsym) &&
             // Disable this rewrite if we're using x87 and `e1` is a FP-value
             // but `e2` is not, or vice versa
+            // https://issues.dlang.org/show_bug.cgi?id=18197
             (config.fpxmmregs ||
              (tyfloating(e2->E1->Ety) != 0) == (tyfloating(e2->Ety) != 0))
            )

--- a/src/dmd/backend/cgelem.c
+++ b/src/dmd/backend/cgelem.c
@@ -3578,9 +3578,9 @@ STATIC elem * eleq(elem *e, goal_t goal)
             goal == GOALnone &&
             !el_appears(e2, e1->EV.sp.Vsym) &&
             // Disable this rewrite if we're using x87 and `e1` is a FP-value
-            // but `e2` is not
+            // but `e2` is not, or vice versa
             (config.fpxmmregs ||
-             tyfloating(e2->E1->Ety) != 0 == tyfloating(e2->Ety) != 0)
+             (tyfloating(e2->E1->Ety) != 0) == (tyfloating(e2->Ety) != 0))
            )
         {
             // printf("** before:\n"); elem_print(e); printf("\n");

--- a/src/dmd/backend/cgelem.c
+++ b/src/dmd/backend/cgelem.c
@@ -3576,10 +3576,14 @@ STATIC elem * eleq(elem *e, goal_t goal)
             e1->Eoper == OPvar &&
             (e2->Eoper == OPpair || e2->Eoper == OPrpair) &&
             goal == GOALnone &&
-            !el_appears(e2, e1->EV.sp.Vsym)
+            !el_appears(e2, e1->EV.sp.Vsym) &&
+            // Disable this rewrite if we're using x87 and `e1` is a FP-value
+            // but `e2` is not
+            (config.fpxmmregs ||
+             tyfloating(e2->E1->Ety) != 0 == tyfloating(e2->Ety) != 0)
            )
         {
-            //printf("** before:\n"); WReqn(e); printf("\n");
+            // printf("** before:\n"); elem_print(e); printf("\n");
             tym_t ty = (REGSIZE == 8) ? TYllong : TYint;
             if (tyfloating(e1->Ety) && REGSIZE >= 4)
                 ty = (REGSIZE == 8) ? TYdouble : TYfloat;
@@ -3606,7 +3610,7 @@ STATIC elem * eleq(elem *e, goal_t goal)
             }
 
             e2->Eoper = OPcomma;
-            //printf("** after:\n"); WReqn(e2); printf("\n");
+            // printf("** after:\n"); elem_print(e2); printf("\n");
             return optelem(e2,goal);
         }
 

--- a/test/compilable/b18197.d
+++ b/test/compilable/b18197.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -c -m32 -O -inline
+
+struct A
+{
+    double a;
+}
+
+A makeA(double value)
+{
+    return A(value);
+}
+
+double test(double x)
+{
+    ulong p = *cast(ulong *)&x;
+    return makeA(x).a;
+}


### PR DESCRIPTION
Attempting to push a non-fp value into mST0 results in a ICE.

The patch assumes `OPpair` is homogeneous, I hope that invariant holds (and should probably slip an assertion just to be sure).