### PR TITLE
test18367: use proper library extension for Windows

### DIFF
--- a/test/compilable/test18367.sh
+++ b/test/compilable/test18367.sh
@@ -2,7 +2,7 @@
 
 
 # dmd should not segfault on -X with libraries, but no source files
-out=$(! "$DMD" -conf= -X foo.a 2>&1)
+out=$(! "$DMD" -conf= -X foo${LIBEXT} 2>&1)
 echo "$out" | grep 'Error: cannot determine JSON filename, use `-Xf=<file>` or provide a source file'
 
 out=$(! "$DMD" -conf= -Xi=compilerInfo 2>&1)


### PR DESCRIPTION
Please also note that the failing test doesn't stop the auto-tester from reporting success! Not sure when this has been introduced.