### PR TITLE
windows: fix sh failures not triggering test suite failure

### DIFF
--- a/test/sh_do_test.sh
+++ b/test/sh_do_test.sh
@@ -52,7 +52,7 @@ function finish {
         cat "${output_file}.log"
 
         rm -rf "${output_file}"
-        exit $?
+        exit $1
     fi
 }
 trap 'finish $?' INT TERM EXIT


### PR DESCRIPTION
do not return the result of `rm` but the test