### PR TITLE
Rename potentially conflicting output files + small bash cleanup

### DIFF
--- a/test/compilable/test9680.sh
+++ b/test/compilable/test9680.sh
@@ -11,7 +11,7 @@ do
 	file_name=${TEST_NAME}${kind}
 	src_file=${EXTRA_FILES}/${file_name}.d
 	expect_file=${EXTRA_FILES}/${file_name}.out
-	output_file=${RESULTS_TEST_DIR}/${file_name}.out
+	output_file=${RESULTS_TEST_DIR}/${file_name}.log
 
 	rm -f ${output_file}{,.2}
 

--- a/test/runnable/test13742.sh
+++ b/test/runnable/test13742.sh
@@ -4,11 +4,9 @@
 $DMD -m${MODEL} -I${EXTRA_FILES} -lib -cov -of${OUTPUT_BASE}${LIBEXT} ${EXTRA_FILES}${SEP}lib13742a.d ${EXTRA_FILES}${SEP}lib13742b.d
 $DMD -m${MODEL} -I${EXTRA_FILES} -cov -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test13742.d ${OUTPUT_BASE}${LIBEXT}
 
-covdir=${RESULTS_DIR}${SEP}${TEST_DIR}
-
-${OUTPUT_BASE}${EXE} --DRT-covopt=dstpath:${covdir}
+${OUTPUT_BASE}${EXE} --DRT-covopt=dstpath:${RESULTS_TEST_DIR}
 
 # The removal sometimes spuriously fails on the auto-tester with "rm: cannot remove ‘test_results/runnable/test13742.exe’: Device or resource busy"
 # This doesn't verify the test, hence -f and || true are used
-rm -f ${covdir}/runnable-extra-files-{lib13742a,lib13742b,test13742}.lst || true
+rm -f ${RESULTS_TEST_DIR}/runnable-extra-files-{lib13742a,lib13742b,test13742}.lst || true
 rm -f ${OUTPUT_BASE}{${OBJ},${LIBEXT},${EXE}} || true

--- a/test/runnable/test17619.sh
+++ b/test/runnable/test17619.sh
@@ -5,8 +5,8 @@ if [ ${OS} != "linux" ]; then
     exit 0
 fi
 
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${OBJ} -c ${EXTRA_FILES}${SEP}test17619.d || exit 1
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${OBJ} -c ${EXTRA_FILES}${SEP}test17619.d
 # error out if there is an advance by 0 for a non.zero address
-objdump -Wl ${RESULTS_DIR}/runnable/test17619${OBJ} | grep "advance Address by 0 to 0x[1-9]" && exit 1
+! objdump -Wl ${OUTPUT_BASE}${OBJ} | grep "advance Address by 0 to 0x[1-9]"
 
 rm ${OUTPUT_BASE}${OBJ}

--- a/test/runnable/test18076.sh
+++ b/test/runnable/test18076.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-dir=${RESULTS_DIR}${SEP}runnable
-output_file=${dir}/test18076.sh.out
+output_file=${OUTPUT_BASE}.log
 
 echo 'import std.stdio; void main() { writeln("Success"); }' | \
 	$DMD -m${MODEL} -run - > ${output_file} || exit 1

--- a/test/runnable/test18076.sh
+++ b/test/runnable/test18076.sh
@@ -3,5 +3,7 @@
 output_file=${OUTPUT_BASE}.log
 
 echo 'import std.stdio; void main() { writeln("Success"); }' | \
-	$DMD -m${MODEL} -run - > ${output_file} || exit 1
-grep -q '^Success$' ${output_file} || exit 1
+	$DMD -m${MODEL} -run - > ${output_file}
+grep -q '^Success$' ${output_file}
+
+rm "${output_file}"

--- a/test/tools/sh_do_test.sh
+++ b/test/tools/sh_do_test.sh
@@ -19,11 +19,11 @@ source "$DIR/exported_vars.sh"
 ################################################################################
 
 # Generated variables
-script_name="${TEST_DIR}/${TEST_NAME}.sh"
-output_file="${RESULTS_DIR}/${script_name}.out"
+_script_name="${TEST_DIR}/${TEST_NAME}.sh"
+_output_file="${RESULTS_DIR}/${_script_name}.out"
 
-echo " ... ${script_name}"
-rm -f "${output_file}"
+echo " ... ${_script_name}"
+rm -f "${_output_file}"
 mkdir -p ${RESULTS_TEST_DIR}
 
 function finish {
@@ -34,14 +34,14 @@ function finish {
 
     if [ "$1" -ne 0 ]; then
         echo "=============================="
-        echo "Test ${script_name} failed. The logged output:"
-        cat "${output_file}"
+        echo "Test ${_script_name} failed. The logged output:"
+        cat "${_output_file}"
 
         echo "=============================="
-        echo "Test ${script_name} failed. The xtrace output:"
-        cat "${output_file}.log"
+        echo "Test ${_script_name} failed. The xtrace output:"
+        cat "${_output_file}.log"
 
-        rm -rf "${output_file}"
+        rm -rf "${_output_file}"
         exit $1
     fi
 }
@@ -50,11 +50,11 @@ trap 'finish $?' INT TERM EXIT
 # redirect stdout + stderr to the output file + keep a reference to the std{out,err} streams for later
 exec 40>&1
 exec 41>&2
-exec 1> "${output_file}"
+exec 1> "${_output_file}"
 exec 2>&1
 
 # log all a verbose xtrace to a temporary file which is only displayed when an error occurs
-exec 42> "${output_file}.log"
+exec 42> "${_output_file}.log"
 export BASH_XTRACEFD=42
 
 # fail on errors and undefined variables
@@ -63,4 +63,4 @@ set -euo pipefail
 # activate xtrace logging for the to-be-called shell script
 set -x
 
-source "${script_name}"
+source "${_script_name}"


### PR DESCRIPTION
- Make output_file + script_name "private" (to avoid any accidental dependence on them)
- Rename potentially conflicting output files (it's not a good idea to meddle with the actual output file)
- Small bash cleanup (removed a few `|| exit 1`)