### PR TITLE
Allow passing additional DFLAGS to the DMD build

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -221,9 +221,11 @@ ifeq ($(CXX_KIND), clang++)
 CXXFLAGS += \
     -xc++
 endif
-DFLAGS := -version=MARS $(PIC)
+
+DFLAGS=
+override DFLAGS += -version=MARS $(PIC)
 # Enable D warnings
-DFLAGS += -w -de
+override DFLAGS += -w -de
 
 ifneq (,$(DEBUG))
 ENABLE_DEBUG := 1
@@ -235,11 +237,11 @@ endif
 # Append different flags for debugging, profiling and release.
 ifdef ENABLE_DEBUG
 CXXFLAGS += -g -g3 -DDEBUG=1 -DUNITTEST
-DFLAGS += -g -debug
+override DFLAGS += -g -debug
 endif
 ifdef ENABLE_RELEASE
 CXXFLAGS += -O2
-DFLAGS += -O -release -inline
+override DFLAGS += -O -release -inline
 endif
 ifdef ENABLE_PROFILING
 CXXFLAGS  += -pg -fprofile-arcs -ftest-coverage
@@ -254,13 +256,13 @@ ifdef ENABLE_LTO
 CXXFLAGS  += -flto
 endif
 ifdef ENABLE_UNITTEST
-DFLAGS  += -unittest -cov
+override DFLAGS  += -unittest -cov
 endif
 ifdef ENABLE_PROFILE
-DFLAGS  += -profile
+override DFLAGS  += -profile
 endif
 ifdef ENABLE_COVERAGE
-DFLAGS  += -cov -L-lgcov
+override DFLAGS  += -cov -L-lgcov
 CXXFLAGS += --coverage
 endif
 ifdef ENABLE_SANITIZERS
@@ -270,7 +272,7 @@ ifeq ($(HOST_DMD_KIND), dmd)
 HOST_CXX += -fsanitize=${ENABLE_SANITIZERS}
 endif
 ifneq (,$(findstring gdc,$(HOST_DMD_KIND))$(findstring ldc,$(HOST_DMD_KIND)))
-DFLAGS += -fsanitize=${ENABLE_SANITIZERS}
+override DFLAGS += -fsanitize=${ENABLE_SANITIZERS}
 endif
 
 endif


### PR DESCRIPTION
There are many predefined ways to build DMD, but AFAIK one can't easily
pass in its own `DFLAGS` without modifying the Makefile.
With this change the following is now possible:

```
make -f posix.mak DFLAGS="-version=FooBar"
```

Learn more about `override`: https://www.gnu.org/software/make/manual/make.html#Override-Directive