### PR TITLE
Use --retry for AUTO_BOOTSTRAP=1

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -486,12 +486,13 @@ clean:
 ######## Download and install the last dmd buildable without dmd
 
 ifneq (,$(AUTO_BOOTSTRAP))
+CURL_FLAGS:=-fsSL --retry 5 --retry-max-time 120 --connect-timeout 5 --speed-time 30 --speed-limit 1024
 $(HOST_DMD_PATH):
 	mkdir -p ${HOST_DMD_ROOT}
 ifneq (,$(shell which xz 2>/dev/null))
-	curl -fsSL ${HOST_DMD_URL}.tar.xz | tar -C ${HOST_DMD_ROOT} -Jxf - || rm -rf ${HOST_DMD_ROOT}
+	curl ${CURL_FLAGS} ${HOST_DMD_URL}.tar.xz | tar -C ${HOST_DMD_ROOT} -Jxf - || rm -rf ${HOST_DMD_ROOT}
 else
-	TMPFILE=$$(mktemp deleteme.XXXXXXXX) &&	curl -fsSL ${HOST_DMD_URL}.zip > $${TMPFILE}.zip && \
+	TMPFILE=$$(mktemp deleteme.XXXXXXXX) &&	curl ${CURL_FLAGS} ${HOST_DMD_URL}.zip > $${TMPFILE}.zip && \
 		unzip -qd ${HOST_DMD_ROOT} $${TMPFILE}.zip && rm $${TMPFILE}.zip;
 endif
 endif


### PR DESCRIPTION
Make `AUTO_BOOTSTRAP=1` more resilient to temporary network errors.
This is useful when used in CI scripts, e.g. the Jenkins project tester uses `AUTO_BOOTSTRAP=1` to install DMD:

https://github.com/dlang/ci/blob/8fc7ddd221b96fbe715b4c0f9775a7ff9e8cbbdd/vars/runPipeline.groovy#L375