### PR TITLE
src/posix.mak: use rm -f to fix the nightlies

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -479,7 +479,7 @@ build-examples: $(EXAMPLES)
 ######## Manual cleanup
 
 clean:
-	rm -R $(GENERATED)
+	rm -Rf $(GENERATED)
 	rm -f $(addprefix $D/backend/, $(optabgen_output))
 	@[ ! -d ${PGO_DIR} ] || echo You should issue manually: rm -rf ${PGO_DIR}
 


### PR DESCRIPTION
```
Running: make MODEL=32 HOST_DC=/home/vagrant/old-dmd/dmd2/linux/bin64/dmd LATEST=master -fposix.mak clean
rm -r generated
rm: cannot remove `generated': No such file or directory
make: *** [clean] Error 1
```

http://nightlies.dlang.org/dmd-master-2018-03-27/build.html

(not sure why this appeared now, but using `-f` doesn't hurt here)

See also: https://github.com/dlang/tools/pull/342