### PR TITLE
Fix issue 17918 - Stop if the late semantic pass fails

### DIFF
--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1379,8 +1379,11 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
 
 /*********************************
- * Finish semantic analysis of functions in vtbl[],
- * check vtbl[] for errors and returns false if it does.
+ * Finish semantic analysis of functions in vtbl[].
+ * Params:
+ *    cd = class which has the vtbl[]
+ * Returns:
+ *    true for success (no errors)
  */
 private bool finishVtbl(ClassDeclaration cd)
 {

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -350,7 +350,13 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 member.accept(this);
             }
 
-            finishVtbl(cd);
+            // If something goes wrong during this pass don't bother with the
+            // rest as we may have incomplete info
+            // https://issues.dlang.org/show_bug.cgi?id=17918
+            if (!finishVtbl(cd))
+            {
+                return;
+            }
 
             // Generate C symbols
             toSymbol(cd);
@@ -1374,10 +1380,12 @@ void toObjFile(Dsymbol ds, bool multiobj)
 
 /*********************************
  * Finish semantic analysis of functions in vtbl[],
- * check vtbl[] for errors.
+ * check vtbl[] for errors and returns false if it does.
  */
-private void finishVtbl(ClassDeclaration cd)
+private bool finishVtbl(ClassDeclaration cd)
 {
+    bool hasError = false;
+
     foreach (i; cd.vtblOffset() .. cd.vtbl.dim)
     {
         FuncDeclaration fd = cd.vtbl[i].isFuncDeclaration();
@@ -1390,7 +1398,10 @@ private void finishVtbl(ClassDeclaration cd)
         }
         // Ensure function has a return value
         // https://issues.dlang.org/show_bug.cgi?id=4869
-        fd.functionSemantic();
+        if (!fd.functionSemantic())
+        {
+            hasError = true;
+        }
 
         if (!cd.isFuncHidden(fd) || fd.isFuture())
         {
@@ -1426,10 +1437,15 @@ private void finishVtbl(ClassDeclaration cd)
                     fd.toChars());
             }
             else
+            {
                 cd.error("use of `%s` is hidden by `%s`", fd.toPrettyChars(), cd.toChars());
+            }
+            hasError = true;
             break;
         }
     }
+
+    return !hasError;
 }
 
 

--- a/test/fail_compilation/b17918.d
+++ b/test/fail_compilation/b17918.d
@@ -1,9 +1,9 @@
-/*
-TEST_OUTPUT:
+/* TEST_OUTPUT:
 ---
 fail_compilation/imports/b17918a.d(7): Error: undefined identifier `_listMap`
 ---
 */
+// https://issues.dlang.org/show_bug.cgi?id=17918
 import imports.b17918a;
 
 class Derived : Base

--- a/test/fail_compilation/b17918.d
+++ b/test/fail_compilation/b17918.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/imports/b17918a.d(7): Error: undefined identifier `_listMap`
+---
+*/
+import imports.b17918a;
+
+class Derived : Base
+{
+}

--- a/test/fail_compilation/imports/b17918a.d
+++ b/test/fail_compilation/imports/b17918a.d
@@ -1,0 +1,9 @@
+module imports.b17918a;
+
+class Base
+{
+    auto byNode()
+    {
+        return _listMap;
+    }
+}


### PR DESCRIPTION
No matter what the outcome of finishVtbl was the old code kept building
the rest of the class. If the late semantic pass over the
FunctionDeclaration fails we should abort the codegen phase instead of
going on.