### PR TITLE
revert #7890 for x87 code gen

### DIFF
--- a/src/dmd/backend/cod1.c
+++ b/src/dmd/backend/cod1.c
@@ -4228,7 +4228,7 @@ void pushParams(CodeBuilder& cdb,elem *e,unsigned stackalign, tym_t tyf)
         {   // Avoid PUSH MEM on the Pentium when optimizing for speed
             break;
         }
-        else if (movOnly(e) || tyfloating(tym) || tyvector(tym))
+        else if (movOnly(e) || (tyxmmreg(tym) && config.fpxmmregs) || tyvector(tym))
             break;                      // no PUSH MEM
         else
         {


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/7890/ incorrectly changed x87 code generation, this restricts the change to only XMM code generation.