### PR TITLE
Fix Issue 18688 - Constructors shouldn't have implicit super call if it throws

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3264,7 +3264,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
 
-            if (!sc.intypeof && !(sc.callSuper & CSX.halt))
+            if (!sc.intypeof)
             {
                 if (sc.noctor || sc.callSuper & CSX.label)
                     exp.error("constructor calls not allowed in loops or after labels");
@@ -3301,7 +3301,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
 
-            if (!sc.intypeof && !(sc.callSuper & CSX.halt))
+            if (!sc.intypeof)
             {
                 if (sc.noctor || sc.callSuper & CSX.label)
                     exp.error("constructor calls not allowed in loops or after labels");

--- a/test/compilable/test18688.d
+++ b/test/compilable/test18688.d
@@ -1,0 +1,43 @@
+// https://issues.dlang.org/show_bug.cgi?id=18688
+
+class A
+{
+    this(int x){}
+    @disable this();
+}
+
+class B: A
+{
+    this(int x)
+    {
+        super(x);
+    }
+
+    this(string b)
+    {
+        switch(b)
+        {
+            case "a":break;
+            default: assert(false);
+        }
+        this(1);
+    }
+}
+
+class C: A
+{
+    this(int x)
+    {
+        super(x);
+    }
+
+    this(string b)
+    {
+        switch(b)
+        {
+            case "a":break;
+            default: assert(false);
+        }
+        super(1);
+    }
+}


### PR DESCRIPTION
The problem with this is that if an `assert(false);` is encountered the scope of the function in which the assert is located is marked as `halt` no matter where the assert is located. Let's take for example the bug report:

```d
class A {
    this(int x){}
    @disable this();
}
class B: A {
    this(int x) {
        super(x);
    }
    this(string b) {
        switch(b) {
            case "a":break;
            default: assert(false);
        }
        this(1);
    }
}
``` 

When `this(1)` is semantically analyzed, the scope is not updated to reflect that a constructor call is issued because it is considered that the line is not reachable, due to the `assert(false)`. This is obviously wrong since the code is reachable in some situations. The fix makes it so that the scope is updated to reflect that a this/super call is issued even if inside a halt scope.

 