### PR TITLE
Put DMD's binary in 'generated' instead of TMP when using AUTO_BOOTSTRAP=1

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -137,7 +137,7 @@ else
   # Auto-bootstrapping, will download dmd automatically
   # Keep var below in sync with other occurrences of that variable, e.g. in circleci.sh
   HOST_DMD_VER=2.072.2
-  HOST_DMD_ROOT=$(TMP)/.host_dmd-$(HOST_DMD_VER)
+  HOST_DMD_ROOT=$(GENERATED)/host_dmd-$(HOST_DMD_VER)
   # dmd.2.072.2.osx.zip or dmd.2.072.2.linux.tar.xz
   HOST_DMD_BASENAME=dmd.$(HOST_DMD_VER).$(OS)$(if $(filter $(OS),freebsd),-$(MODEL),)
   # http://downloads.dlang.org/releases/2.x/2.072.2/dmd.2.072.2.linux.tar.xz


### PR DESCRIPTION
Motivation:

```
/bin/sh: 1: /tmp/.host_dmd-2.072.2/dmd2/linux/bin64/dmd: Text file busy
```

In CIs with multiple workers on the same machine.

e.g. https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fphobos/detail/PR-6384/2/pipeline