### PR TITLE
refactor: use CSX instead of uint

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -111,7 +111,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                         break;
                 }
                 assert(i < dim);
-                uint fi = sc.fieldinit[i];
+                const fi = sc.fieldinit[i];
 
                 if (fi & CSX.this_ctor)
                 {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8632,7 +8632,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         e1x = resolveProperties(sc, e1x);
         e1x = e1x.toBoolean(sc);
-        uint cs1 = sc.callSuper;
+        CSX cs1 = sc.callSuper;
 
         if (sc.flags & SCOPE.condition)
         {
@@ -9114,13 +9114,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         ec = resolveProperties(sc, ec);
         ec = ec.toBoolean(sc);
 
-        uint cs0 = sc.callSuper;
+        const cs0 = sc.callSuper;
         auto fi0 = sc.saveFieldInit();
         Expression e1x = exp.e1.expressionSemantic(sc);
         e1x = resolveProperties(sc, e1x);
 
-        uint cs1 = sc.callSuper;
-        auto fi1 = sc.fieldinit;
+        const cs1 = sc.callSuper;
+        const fi1 = sc.fieldinit;
         sc.callSuper = cs0;
         sc.fieldinit = fi0;
         Expression e2x = exp.e2.expressionSemantic(sc);

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -319,7 +319,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             Scope* sc2 = sc.push(ss);
             sc2.func = funcdecl;
             sc2.parent = funcdecl;
-            sc2.callSuper = 0;
+            sc2.callSuper = CSX.none;
             sc2.sbreak = null;
             sc2.scontinue = null;
             sc2.sw = null;
@@ -684,7 +684,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                     if (cd && !(sc2.callSuper & CSX.any_ctor) && cd.baseClass && cd.baseClass.ctor)
                     {
-                        sc2.callSuper = 0;
+                        sc2.callSuper = CSX.none;
 
                         // Insert implicit super() at start of fbody
                         FuncDeclaration fd = resolveFuncCall(Loc.initial, sc2, cd.baseClass.ctor, null, funcdecl.vthis.type, null, 1);
@@ -1116,7 +1116,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             if (funcdecl.naked && (funcdecl.fensure || funcdecl.frequire))
                 funcdecl.error("naked assembly functions with contracts are not supported");
 
-            sc2.callSuper = 0;
+            sc2.callSuper = CSX.none;
             sc2.pop();
         }
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2124,10 +2124,10 @@ else
          */
 
         // Evaluate at runtime
-        uint cs0 = sc.callSuper;
-        uint cs1;
-        uint[] fi0 = sc.saveFieldInit();
-        uint[] fi1 = null;
+        CSX cs0 = sc.callSuper;
+        CSX cs1;
+        CSX[] fi0 = sc.saveFieldInit();
+        CSX[] fi1 = null;
 
         // check in syntax level
         ifs.condition = checkAssignmentAsCondition(ifs.condition);


### PR DESCRIPTION
which will reduce the brittleness of the code. Also refactored `mergeFieldInit()` a bit to reduce unnecessary dependencies.