### PR TITLE
add ctorflow.d - begin encapsulation of flow analysis of constructors

### DIFF
--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -1,0 +1,122 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Manage flow analysis for constructors.
+ *
+ * Copyright:   Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/ctorflow.d, _ctorflow.d)
+ * Documentation:  https://dlang.org/phobos/dmd_ctorflow.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/ctorflow.d
+ */
+
+module dmd.ctorflow;
+
+import core.stdc.stdio;
+
+import dmd.root.rmem;
+
+enum CSX : ubyte
+{
+    none            = 0,
+    this_ctor       = 0x01,     /// called this()
+    super_ctor      = 0x02,     /// called super()
+    this_           = 0x04,     /// referenced this
+    super_          = 0x08,     /// referenced super
+    label           = 0x10,     /// seen a label
+    return_         = 0x20,     /// seen a return statement
+    any_ctor        = 0x40,     /// either this() or super() was called
+    halt            = 0x80,     /// assert(0)
+}
+
+/***********
+ * Primitive flow analysis for constructors
+ */
+struct CtorFlow
+{
+    CSX callSuper;      /// state of calling other constructors
+
+    CSX[] fieldinit;    /// state of field initializations
+
+    void allocFieldinit(size_t dim)
+    {
+        fieldinit = (cast(CSX*)mem.xcalloc(CSX.sizeof, dim))[0 .. dim];
+    }
+
+    void freeFieldinit()
+    {
+        if (fieldinit.ptr)
+            mem.xfree(fieldinit.ptr);
+        fieldinit = null;
+    }
+
+    CSX[] saveFieldInit()
+    {
+        CSX[] fi = null;
+        if (fieldinit.length) // copy
+        {
+            const dim = fieldinit.length;
+            fi = (cast(CSX*)mem.xmalloc(CSX.sizeof * dim))[0 .. dim];
+            fi[] = fieldinit[];
+        }
+        return fi;
+    }
+}
+
+
+/****************************************
+ * Merge fi flow analysis results into fieldInit.
+ * Params:
+ *      fieldInit = the path to merge fi into
+ *      fi = the other path
+ * Returns:
+ *      false means either fieldInit or fi skips initialization
+ */
+bool mergeFieldInitX(ref CSX fieldInit, const CSX fi)
+{
+    if (fi != fieldInit)
+    {
+        // Have any branches returned?
+        bool aRet = (fi & CSX.return_) != 0;
+        bool bRet = (fieldInit & CSX.return_) != 0;
+        // Have any branches halted?
+        bool aHalt = (fi & CSX.halt) != 0;
+        bool bHalt = (fieldInit & CSX.halt) != 0;
+        bool ok;
+        if (aHalt && bHalt)
+        {
+            ok = true;
+            fieldInit = CSX.halt;
+        }
+        else if (!aHalt && aRet)
+        {
+            ok = (fi & CSX.this_ctor);
+            fieldInit = fieldInit;
+        }
+        else if (!bHalt && bRet)
+        {
+            ok = (fieldInit & CSX.this_ctor);
+            fieldInit = fi;
+        }
+        else if (aHalt)
+        {
+            ok = (fieldInit & CSX.this_ctor);
+            fieldInit = fieldInit;
+        }
+        else if (bHalt)
+        {
+            ok = (fi & CSX.this_ctor);
+            fieldInit = fi;
+        }
+        else
+        {
+            ok = !((fieldInit ^ fi) & CSX.this_ctor);
+            fieldInit |= fi;
+        }
+        return ok;
+    }
+    return true;
+}
+

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -14,6 +14,7 @@ module dmd.declaration;
 
 import dmd.aggregate;
 import dmd.arraytypes;
+import dmd.ctorflow;
 import dmd.dclass;
 import dmd.delegatize;
 import dmd.dscope;
@@ -95,13 +96,13 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
             var.ctorinit = true;
             //printf("setting ctorinit\n");
 
-            if (var.isField() && sc.fieldinit.length && !sc.intypeof)
+            if (var.isField() && sc.ctorflow.fieldinit.length && !sc.intypeof)
             {
                 assert(e1);
                 auto mustInit = ((var.storage_class & STC.nodefaultctor) != 0 ||
                                  var.type.needsNested());
 
-                const dim = sc.fieldinit.length;
+                const dim = sc.ctorflow.fieldinit.length;
                 auto ad = fd.isMember2();
                 assert(ad);
                 size_t i;
@@ -111,7 +112,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                         break;
                 }
                 assert(i < dim);
-                const fi = sc.fieldinit[i];
+                const fi = sc.ctorflow.fieldinit[i];
 
                 if (fi & CSX.this_ctor)
                 {
@@ -134,7 +135,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                     }
                 }
 
-                sc.fieldinit[i] |= CSX.this_ctor;
+                sc.ctorflow.fieldinit[i] |= CSX.this_ctor;
                 if (var.overlapped) // https://issues.dlang.org/show_bug.cgi?id=15258
                 {
                     foreach (j, v; ad.fields)
@@ -142,7 +143,7 @@ private int modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1
                         if (v is var || !var.isOverlappedWith(v))
                             continue;
                         v.ctorinit = true;
-                        sc.fieldinit[j] = CSX.this_ctor;
+                        sc.ctorflow.fieldinit[j] = CSX.this_ctor;
                     }
                 }
             }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -23,6 +23,7 @@ import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astcodegen;
 import dmd.canthrow;
+import dmd.ctorflow;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.declaration;
@@ -1452,7 +1453,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         if (!sc.intypeof)
-            sc.callSuper |= CSX.this_;
+            sc.ctorflow.callSuper |= CSX.this_;
         result = e;
         return;
 
@@ -1536,7 +1537,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         if (!sc.intypeof)
-            sc.callSuper |= CSX.super_;
+            sc.ctorflow.callSuper |= CSX.super_;
         result = e;
         return;
 
@@ -3266,13 +3267,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             if (!sc.intypeof)
             {
-                if (sc.noctor || sc.callSuper & CSX.label)
+                if (sc.noctor || sc.ctorflow.callSuper & CSX.label)
                     exp.error("constructor calls not allowed in loops or after labels");
-                if (sc.callSuper & (CSX.super_ctor | CSX.this_ctor))
+                if (sc.ctorflow.callSuper & (CSX.super_ctor | CSX.this_ctor))
                     exp.error("multiple constructor calls");
-                if ((sc.callSuper & CSX.return_) && !(sc.callSuper & CSX.any_ctor))
+                if ((sc.ctorflow.callSuper & CSX.return_) && !(sc.ctorflow.callSuper & CSX.any_ctor))
                     exp.error("an earlier `return` statement skips constructor");
-                sc.callSuper |= CSX.any_ctor | CSX.super_ctor;
+                sc.ctorflow.callSuper |= CSX.any_ctor | CSX.super_ctor;
             }
 
             tthis = cd.type.addMod(sc.func.type.mod);
@@ -3303,13 +3304,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             if (!sc.intypeof)
             {
-                if (sc.noctor || sc.callSuper & CSX.label)
+                if (sc.noctor || sc.ctorflow.callSuper & CSX.label)
                     exp.error("constructor calls not allowed in loops or after labels");
-                if (sc.callSuper & (CSX.super_ctor | CSX.this_ctor))
+                if (sc.ctorflow.callSuper & (CSX.super_ctor | CSX.this_ctor))
                     exp.error("multiple constructor calls");
-                if ((sc.callSuper & CSX.return_) && !(sc.callSuper & CSX.any_ctor))
+                if ((sc.ctorflow.callSuper & CSX.return_) && !(sc.ctorflow.callSuper & CSX.any_ctor))
                     exp.error("an earlier `return` statement skips constructor");
-                sc.callSuper |= CSX.any_ctor | CSX.this_ctor;
+                sc.ctorflow.callSuper |= CSX.any_ctor | CSX.this_ctor;
             }
 
             tthis = ad.type.addMod(sc.func.type.mod);
@@ -4375,8 +4376,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             FuncDeclaration fd = sc.parent.isFuncDeclaration();
             if (fd)
                 fd.hasReturnExp |= 4;
-            sc.callSuper |= CSX.halt;
-            foreach (ref u; sc.fieldinit)
+            sc.ctorflow.callSuper |= CSX.halt;
+            foreach (ref u; sc.ctorflow.fieldinit)
                 u |= CSX.halt;
 
             if (global.params.useAssert == CHECKENABLE.off)
@@ -8632,7 +8633,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         e1x = resolveProperties(sc, e1x);
         e1x = e1x.toBoolean(sc);
-        CSX cs1 = sc.callSuper;
+        CSX cs1 = sc.ctorflow.callSuper;
 
         if (sc.flags & SCOPE.condition)
         {
@@ -9114,15 +9115,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         ec = resolveProperties(sc, ec);
         ec = ec.toBoolean(sc);
 
-        const cs0 = sc.callSuper;
-        auto fi0 = sc.saveFieldInit();
+        const cs0 = sc.ctorflow.callSuper;
+        auto fi0 = sc.ctorflow.saveFieldInit();
         Expression e1x = exp.e1.expressionSemantic(sc);
         e1x = resolveProperties(sc, e1x);
 
-        const cs1 = sc.callSuper;
-        const fi1 = sc.fieldinit;
-        sc.callSuper = cs0;
-        sc.fieldinit = fi0;
+        const cs1 = sc.ctorflow.callSuper;
+        const fi1 = sc.ctorflow.fieldinit;
+        sc.ctorflow.callSuper = cs0;
+        sc.ctorflow.fieldinit = fi0;
         Expression e2x = exp.e2.expressionSemantic(sc);
         e2x = resolveProperties(sc, e2x);
 

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -100,8 +100,8 @@ struct Scope
     Module *minst;              // root module where the instantiated templates should belong to
     TemplateInstance *tinst;    // enclosing template instance
 
-    unsigned callSuper;         // primitive flow analysis for constructors
-    unsigned *fieldinit;
+    unsigned char callSuper;    // primitive flow analysis for constructors
+    unsigned char *fieldinit;
     size_t fieldinit_dim;
 
     AlignDeclaration *aligndecl;    // alignment for struct members

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -18,6 +18,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.canthrow;
+import dmd.ctorflow;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dscope;
@@ -1423,7 +1424,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             // Carefully detach the scope from the parent and throw it away as
             // we only need it to evaluate the expression
             // https://issues.dlang.org/show_bug.cgi?id=15428
-            sc2.freeFieldinit();
+            sc2.ctorflow.freeFieldinit();
             sc2.enclosing = null;
             sc2.pop();
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -300,7 +300,7 @@ endif
 
 FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes arrayop	\
 	arraytypes astcodegen attrib builtin canthrow cli clone compiler complex cond constfold	\
-	cppmangle cppmanglewin ctfeexpr dcast dclass declaration delegatize denum dimport	\
+	cppmangle cppmanglewin ctfeexpr ctorflow dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\
 	hdrgen id impcnvtab imphint init initsem inline inlinecost intrange	\

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -150,7 +150,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 # D front end
 FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
 	$D/arraytypes.d $D/astcodegen.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/cli.d $D/clone.d $D/compiler.d $D/complex.d	\
-	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/dcast.d $D/dclass.d		\
+	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/ctorflow.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d $D/dsymbolsem.d		\
 	$D/lambdacomp.d $D/dtemplate.d $D/dversion.d $D/escape.d			\


### PR DESCRIPTION
The logic of this is spread out over 5 files or so. This begins to pull it into one file, ctorflow.d. I haven't changed any logic in this, just moved code around and combined `superCall` and `fieldinit` into a struct.