### PR TITLE
Fix GDC build on SemaphoreCI

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -452,8 +452,7 @@ $G/glue.a: $(G_GLUE_OBJS) $(SRC_MAKE)
 	$(AR) rcs $@ $(G_GLUE_OBJS)
 
 $G/backend.a: $(G_OBJS) $(G_DOBJS) $(SRC_MAKE)
-	$(HOST_DMD_RUN) -lib -of$G/backend.a $(G_OBJS)
-	$(HOST_DMD_RUN) -lib -of$G/backend.a $@ $(G_DOBJS)
+	$(AR) rcs $@ $(G_OBJS) $(G_DOBJS)
 
 $G/lexer.a: $(LEXER_SRCS) $(LEXER_ROOT) $(HOST_DMD_PATH) $(SRC_MAKE)
 	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -lib -of$@ $(MODEL_FLAG) -J$G -L-lstdc++ $(DFLAGS) $(LEXER_SRCS) $(LEXER_ROOT)


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dmd/pull/7714

For some reason SemaphoreCI didn't want to run on this PR and it turns out that `gdmd` doesn't support `-lib`.

See e.g. https://semaphoreci.com/dlang/dmd-2/branches/master/builds/391