### PR TITLE
needed compiler features to convert backend to D

### DIFF
--- a/src/dmd/backend/divcoeff.d
+++ b/src/dmd/backend/divcoeff.d
@@ -52,7 +52,7 @@ void u128Div(ullong xh, ullong xl, ullong yh, ullong yl, ullong *pqh, ullong *pq
 
     //ullong xxh = xh, xxl = xl, yyh = yh, yyl = yl;
 
-//    assert(yh || yl);           // no div-by-0 bugs
+    assert(yh || yl);           // no div-by-0 bugs
 
     // left justify y
     uint shiftcount = 1;
@@ -117,9 +117,9 @@ void u128Div(ullong xh, ullong xl, ullong yh, ullong yl, ullong *pqh, ullong *pq
 
 extern (C) bool choose_multiplier(int N, ullong d, int prec, ullong *pm, int *pshpost)
 {
-//    assert(N == 32 || N == 64);
-//    assert(prec <= N);
-//    assert(d > 1 && (d & (d - 1)));
+    assert(N == 32 || N == 64);
+    assert(prec <= N);
+    assert(d > 1 && (d & (d - 1)));
 
     // Compute b such that 2**(b-1) < d <= 2**b
     // which is the number of significant bits in d
@@ -205,8 +205,8 @@ extern (C) bool choose_multiplier(int N, ullong d, int prec, ullong *pm, int *ps
         *pm = mhighl;
         mhighbit = mhighh & 1;
     }
-//    else
-//        assert(0);
+    else
+        assert(0);
 
     *pshpost = shpost;
     return mhighbit;
@@ -243,7 +243,7 @@ extern (C) bool udiv_coefficients(int N, ullong d, int *pshpre, ullong *pm, int 
         }
         *pshpre = e;
         mhighbit = choose_multiplier(N, d, N - e, pm, pshpost);
-//        assert(mhighbit == false);
+        assert(mhighbit == false);
     }
     else
         *pshpre = 0;
@@ -290,10 +290,10 @@ unittest
         bool mhighbit = udiv_coefficients(ps.N, ps.d, &shpre, &m, &shpost);
 
         //printf("[%d] %d %d %llx %d\n", i, shpre, mhighbit, m, shpost);
-//        assert(shpre == ps.shpre);
-//        assert(mhighbit == ps.highbit);
-//        assert(m == ps.m);
-//        assert(shpost == ps.shpost);
+        assert(shpre == ps.shpre);
+        assert(mhighbit == ps.highbit);
+        assert(m == ps.m);
+        assert(shpost == ps.shpost);
     }
 }
 


### PR DESCRIPTION
Features needed:

1. support `-mv` compiler switch
2. support `-betterC` switch
3. send `assert` failures to C's assert failure function

dmd 2.074 does these.

This is the canary for those features. They're needed to convert the dmd backend to D.