### PR TITLE
refactor: add Scope.detach()

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -233,6 +233,17 @@ struct Scope
         return enc;
     }
 
+    /*************************
+     * Similar to pop(), but the results in `this` are not folded
+     * into `enclosing`.
+     */
+    extern (D) void detach()
+    {
+        ctorflow.freeFieldinit();
+        enclosing = null;
+        pop();
+    }
+
     extern (C++) Scope* startCTFE()
     {
         Scope* sc = this.push();

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -18,7 +18,6 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.canthrow;
-import dmd.ctorflow;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dscope;
@@ -1424,9 +1423,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             // Carefully detach the scope from the parent and throw it away as
             // we only need it to evaluate the expression
             // https://issues.dlang.org/show_bug.cgi?id=15428
-            sc2.ctorflow.freeFieldinit();
-            sc2.enclosing = null;
-            sc2.pop();
+            sc2.detach();
 
             if (global.endGagging(errors) || err)
             {


### PR DESCRIPTION
This removes the unfortunate dependency of `traits.d` on `ctorflow.d`