### PR TITLE
Allow to run_individual_tests from any directory

### DIFF
--- a/test/run_individual_tests
+++ b/test/run_individual_tests
@@ -11,6 +11,8 @@ set -euo pipefail
 
 # if PROCS is not set, auto-detect or fallback to 4
 PROCS="${PROCS:-$(nproc 2> /dev/null || sysctl -n hw.physicalcpu 2> /dev/null || echo 4)}"
+# path to the test directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ -z ${1:-} ] ; then
 	cat >&2 << EOF
@@ -30,12 +32,17 @@ files=()
 # normalize path to each test file
 for arg in "$@" ; do
 	file="$arg"
-	normalizedDir=$(cd "$(dirname "$file")" && pwd)
+	# allow to use either:
+    # - an existing path to the test file (e.g. cd test/runnable && ../run_individual_tests template2962.d)
+    # - the test's slug (test directory + filename - e.g. src && ../test/run_individual_tests runnable/template2962.d)
+	if [ -f $file ] ; then
+	    normalizedDir=$(cd "$(dirname "$file")" && pwd)
+	else
+	    normalizedDir=$(cd "$DIR/$(dirname "$file")" && pwd)
+	fi
 	files+=("test_results/$(basename "$normalizedDir" )/$(basename "$file").out")
 done
 
 # allows the script to be called from anywhere
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
-echo ${PROCS}
 ${MAKE:-make} "${files[@]}" -j${PROCS}

--- a/test/run_individual_tests
+++ b/test/run_individual_tests
@@ -15,7 +15,7 @@ PROCS="${PROCS:-$(nproc 2> /dev/null || sysctl -n hw.physicalcpu 2> /dev/null ||
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ -z ${1:-} ] ; then
-	cat >&2 << EOF
+    cat >&2 << EOF
 ./run_individual_tests <test-file>...
 
 Examples:
@@ -23,7 +23,7 @@ Examples:
     ./run_individual_tests runnable/template2962.d
     ./run_individual_tests runnable/template2962.d fail_compilation/fail282.d
 EOF
-	exit
+    exit
 fi
 
 # all test files to be run
@@ -31,16 +31,16 @@ files=()
 
 # normalize path to each test file
 for arg in "$@" ; do
-	file="$arg"
-	# allow to use either:
+    file="$arg"
+    # allow to use either:
     # - an existing path to the test file (e.g. cd test/runnable && ../run_individual_tests template2962.d)
     # - the test's slug (test directory + filename - e.g. src && ../test/run_individual_tests runnable/template2962.d)
-	if [ -f $file ] ; then
-	    normalizedDir=$(cd "$(dirname "$file")" && pwd)
-	else
-	    normalizedDir=$(cd "$DIR/$(dirname "$file")" && pwd)
-	fi
-	files+=("test_results/$(basename "$normalizedDir" )/$(basename "$file").out")
+    if [ -f $file ] ; then
+        normalizedDir=$(cd "$(dirname "$file")" && pwd)
+    else
+        normalizedDir=$(cd "$DIR/$(dirname "$file")" && pwd)
+    fi
+    files+=("test_results/$(basename "$normalizedDir" )/$(basename "$file").out")
 done
 
 # allows the script to be called from anywhere


### PR DESCRIPTION
If the `run_individual_tests` is used from another directory (e.g. the root or `src`), it currently doesn't allow to use `runnable/aliasthis.d`.
It's easy to check whether the file exists and I don't see any reason why we shouldn't.

### Current behavior:

```
cd ~/dlang/dmd
./test/run_individual_tests runnable/aliasthis.d # fails
./test/run_individual_tests test/runnable/aliasthis.d # works
./test/run_individual_tests foo # fails
cd test
./run_individual_tests runnable/aliasthis.d # works (main usage)
```

#### New behavior:

```
cd ~/dlang/dmd
./test/run_individual_tests runnable/aliasthis.d # works (changed behavior)
./test/run_individual_tests test/runnable/aliasthis.d # works
./test/run_individual_tests foo # fails
cd test
./run_individual_tests runnable/aliasthis.d # works (main usage)
```