### PR TITLE
Fix Issue 17626 - Same name variable assignment should raise a compile-time warning

### DIFF
--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -115,7 +115,6 @@ bool mergeFieldInitX(ref CSX fieldInit, const CSX fi)
         else if (!aHalt && aRet)
         {
             ok = (fi & CSX.this_ctor);
-            fieldInit = fieldInit;
         }
         else if (!bHalt && bRet)
         {
@@ -125,7 +124,6 @@ bool mergeFieldInitX(ref CSX fieldInit, const CSX fi)
         else if (aHalt)
         {
             ok = (fieldInit & CSX.this_ctor);
-            fieldInit = fieldInit;
         }
         else if (bHalt)
         {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6264,6 +6264,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         //printf("exp.e1.op = %d, '%s'\n", exp.e1.op, Token.toChars(exp.e1.op));
         //printf("exp.e2.op = %d, '%s'\n", exp.e2.op, Token.toChars(exp.e2.op));
+        if (exp.e1.op == TOK.identifier && exp.e2.op == TOK.identifier)
+        {
+            auto ident1 = cast(IdentifierExp) exp.e1;
+            auto ident2 = cast(IdentifierExp) exp.e2;
+            if (ident1 !is null && ident2 !is null &&
+                ident1.ident !is null && ident2.ident !is null &&
+                ident1.ident.toString == ident2.ident.toString)
+                exp.deprecation("Assignment of `%s` has no effect", ident1.ident.toChars);
+        }
         if (exp.type)
         {
             result = exp;

--- a/test/compilable/derivedarray.d
+++ b/test/compilable/derivedarray.d
@@ -12,7 +12,7 @@ void dynamicarrays()
     immutable(C)[] e;
     immutable(D)[] f;
 
-    static assert( __traits(compiles, a = a));
+    static assert( __traits(compiles, {typeof(a) a2; a2 = a;}));
     static assert(!__traits(compiles, a = b));
     static assert(!__traits(compiles, a = c));
     static assert(!__traits(compiles, a = d));
@@ -20,7 +20,7 @@ void dynamicarrays()
     static assert(!__traits(compiles, a = f));
 
     static assert(!__traits(compiles, b = a));
-    static assert( __traits(compiles, b = b));
+    static assert( __traits(compiles, {typeof(b) b2; b2 = b;}));
     static assert(!__traits(compiles, b = c));
     static assert(!__traits(compiles, b = d));
     static assert(!__traits(compiles, b = e));
@@ -28,7 +28,7 @@ void dynamicarrays()
 
     static assert( __traits(compiles, c = a));
     static assert( __traits(compiles, c = b));
-    static assert( __traits(compiles, c = c));
+    static assert( __traits(compiles, {typeof(a) c2; c2 = c;}));
     static assert( __traits(compiles, c = d));
     static assert( __traits(compiles, c = e));
     static assert( __traits(compiles, c = f));
@@ -36,7 +36,7 @@ void dynamicarrays()
     static assert(!__traits(compiles, d = a));
     static assert( __traits(compiles, d = b));
     static assert(!__traits(compiles, d = c));
-    static assert( __traits(compiles, d = d));
+    static assert( __traits(compiles, {typeof(a) d2; d2 = d;}));
     static assert(!__traits(compiles, d = e));
     static assert( __traits(compiles, d = f));
 
@@ -44,7 +44,7 @@ void dynamicarrays()
     static assert(!__traits(compiles, e = b));
     static assert(!__traits(compiles, e = c));
     static assert(!__traits(compiles, e = d));
-    static assert( __traits(compiles, e = e));
+    static assert( __traits(compiles, {typeof(a) e2; e2 = e;}));
     static assert( __traits(compiles, e = f));
 
     static assert(!__traits(compiles, f = a));
@@ -52,7 +52,7 @@ void dynamicarrays()
     static assert(!__traits(compiles, f = c));
     static assert(!__traits(compiles, f = d));
     static assert(!__traits(compiles, f = e));
-    static assert( __traits(compiles, f = f));
+    static assert( __traits(compiles, {typeof(a) f2; f2 = f;}));
 }
 
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -6223,7 +6223,7 @@ struct Chunk13831
 {
     this(Coord13831)
     {
-        coord = coord;
+        this.coord = coord;
     }
 
     Coord13831 coord;

--- a/test/compilable/testfptr.d
+++ b/test/compilable/testfptr.d
@@ -17,35 +17,35 @@ void bug3797()
     const(int) function() cv;
     immutable(int) function() xv;
 
-    static assert( is(typeof( vv = vv )));
+    static assert( is(typeof( {typeof(vv) vv2; vv2 = vv;} )));
     static assert(!is(typeof( vv = vi )));
     static assert(!is(typeof( vv = iv )));
     static assert(!is(typeof( vv = cv )));
     static assert(!is(typeof( vv = xv )));
 
     static assert(!is(typeof( vi = vv )));
-    static assert( is(typeof( vi = vi )));
+    static assert( is(typeof( {typeof(vi) vi2; vi2 = vi;} )));
     static assert(!is(typeof( vi = iv )));
     static assert(!is(typeof( vi = cv )));
     static assert(!is(typeof( vi = cx )));
 
     static assert(!is(typeof( iv = vv )));
     static assert(!is(typeof( iv = vi )));
-    static assert( is(typeof( iv = iv )));
+    static assert( is(typeof( {typeof(iv) iv2; iv2 = iv;} )));
     static assert( is(typeof( iv = cv )));
     static assert( is(typeof( iv = xv )));
 
     static assert(!is(typeof( cv = vv )));
     static assert( is(typeof( cv = iv )));
     static assert(!is(typeof( cv = vi )));
-    static assert( is(typeof( cv = cv )));
+    static assert( is(typeof( {typeof(cv) cv2; cv2 = cv;} )));
     static assert( is(typeof( cv = xv )));
 
     static assert(!is(typeof( xv = vv )));
     static assert( is(typeof( xv = iv )));
     static assert(!is(typeof( xv = vi )));
     static assert( is(typeof( xv = cv )));
-    static assert( is(typeof( xv = xv )));
+    static assert( is(typeof( {typeof(xv) xv2; xv2 = xv;} )));
 
     int* function() ipfunc;
     const(int*) function() cipfunc;
@@ -160,35 +160,35 @@ void bug3797dg()
     const(int) delegate() cv;
     immutable(int) delegate() xv;
 
-    static assert( is(typeof( vv = vv )));
+    static assert( is(typeof( {typeof(vv) vv2; vv2 = vv;} )));
     static assert(!is(typeof( vv = vi )));
     static assert(!is(typeof( vv = iv )));
     static assert(!is(typeof( vv = cv )));
     static assert(!is(typeof( vv = xv )));
 
     static assert(!is(typeof( vi = vv )));
-    static assert( is(typeof( vi = vi )));
+    static assert( is(typeof( {typeof(vi) vi2; vi2 = vi;} )));
     static assert(!is(typeof( vi = iv )));
     static assert(!is(typeof( vi = cv )));
     static assert(!is(typeof( vi = cx )));
 
     static assert(!is(typeof( iv = vv )));
     static assert(!is(typeof( iv = vi )));
-    static assert( is(typeof( iv = iv )));
+    static assert( is(typeof( {typeof(iv) iv2; iv2 = iv;} )));
     static assert( is(typeof( iv = cv )));
     static assert( is(typeof( iv = xv )));
 
     static assert(!is(typeof( cv = vv )));
     static assert( is(typeof( cv = iv )));
     static assert(!is(typeof( cv = vi )));
-    static assert( is(typeof( cv = cv )));
+    static assert( is(typeof( {typeof(cv) cv2; cv2 = cv;} )));
     static assert( is(typeof( cv = xv )));
 
     static assert(!is(typeof( xv = vv )));
     static assert( is(typeof( xv = iv )));
     static assert(!is(typeof( xv = vi )));
     static assert( is(typeof( xv = cv )));
-    static assert( is(typeof( xv = xv )));
+    static assert( is(typeof( {typeof(xv) xv2; xv2 = xv;} )));
 
     int* delegate() ipfunc;
     const(int*) delegate() cipfunc;

--- a/test/compilable/testfwdref.d
+++ b/test/compilable/testfwdref.d
@@ -646,8 +646,8 @@ struct Array15726y(T)
 void test15726y()
 {
     alias Range = RangeT15726y!(Array15726y!int);
-    Range r;
-    r = r;  // opAssign
+    Range r, r2;
+    r2 = r;  // opAssign
 }
 
 /***************************************************/

--- a/test/fail_compilation/fail10964.d
+++ b/test/fail_compilation/fail10964.d
@@ -1,13 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10964.d(28): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(29): Error: function `fail10964.S.__postblit` is not `nothrow`
+fail_compilation/fail10964.d(30): Deprecation: Assignment of `ss` has no effect
+fail_compilation/fail10964.d(32): Deprecation: Assignment of `sa` has no effect
 fail_compilation/fail10964.d(30): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(33): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(34): Error: function `fail10964.S.__postblit` is not `nothrow`
+fail_compilation/fail10964.d(31): Error: function `fail10964.S.__postblit` is not `nothrow`
+fail_compilation/fail10964.d(32): Error: function `fail10964.S.__postblit` is not `nothrow`
 fail_compilation/fail10964.d(35): Error: function `fail10964.S.__postblit` is not `nothrow`
-fail_compilation/fail10964.d(22): Error: `nothrow` function `fail10964.foo` may throw
+fail_compilation/fail10964.d(36): Error: function `fail10964.S.__postblit` is not `nothrow`
+fail_compilation/fail10964.d(37): Error: function `fail10964.S.__postblit` is not `nothrow`
+fail_compilation/fail10964.d(24): Error: `nothrow` function `fail10964.foo` may throw
 ---
 */
 

--- a/test/fail_compilation/fail10968.d
+++ b/test/fail_compilation/fail10968.d
@@ -1,18 +1,29 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(33): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(33): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(34): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(34): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(35): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(35): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(38): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(38): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(39): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(39): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(40): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(40): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(44): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(45): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(46): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(46): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(49): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(49): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(49): Error: declaration `fail10968.bar.ss2` is already defined
+fail_compilation/fail10968.d(50): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(50): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(50): Error: declaration `fail10968.bar.sa2` is already defined
+fail_compilation/fail10968.d(51): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(51): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(65): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(66): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(67): Error: cannot implicitly convert expression `sa` of type `SD[1]` to `SA[]`
+fail_compilation/fail10968.d(70): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(70): Error: declaration `fail10968.baz.ss2` is already defined
+fail_compilation/fail10968.d(71): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(71): Error: declaration `fail10968.baz.sa2` is already defined
+fail_compilation/fail10968.d(72): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+
 ---
 */
 
@@ -30,27 +41,15 @@ void bar() pure @safe
     SA[1] sa;
 
     // TOKassign
-    ss = ss;
+    auto ss2 = ss;
     sa = ss;
-    sa = sa;
+    SA[1] sa2 = sa;
 
     // TOKconstruct
     SA    ss2 = ss;
     SA[1] sa2 = ss;
     SA[1] sa3 = sa;
 }
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail10968.d(66): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(67): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(68): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(71): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(72): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(73): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
----
-*/
 
 struct SD
 {
@@ -63,9 +62,9 @@ void baz()
     SD[1] sa;
 
     // TOKassign
-    ss = ss;
+    auto ss2 = ss;
     sa = ss;
-    sa = sa;
+    SA[1] sa2 = sa;
 
     // TOKconstruct
     SD    ss2 = ss;

--- a/test/fail_compilation/fail15044.d
+++ b/test/fail_compilation/fail15044.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15044.d(30): Error: generated function `fail15044.V.opAssign` is not callable because it is annotated with `@disable`
+fail_compilation/fail15044.d(31): Deprecation: Assignment of `v` has no effect
+fail_compilation/fail15044.d(31): Error: generated function `fail15044.V.opAssign` is not callable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail17626.d
+++ b/test/fail_compilation/fail17626.d
@@ -1,0 +1,34 @@
+// REQUIRED_ARGS: -de
+/* TEST_OUTPUT:
+---
+fail_compilation/fail17626.d(13): Deprecation: Assignment of `ptr` has no effect
+fail_compilation/fail17626.d(21): Deprecation: Assignment of `f` has no effect
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=17626
+struct FuncPtr{
+    void* ptr;
+    this(void* ptr){
+        ptr = ptr;
+    }
+}
+
+struct Foo
+{
+    this(int f)
+    {
+        f = f; // oops
+    }
+
+    int f;
+
+}
+void test()
+{
+    auto foo = Foo(42);
+}
+
+// https://github.com/libmir/mir-algorithm/blob/f22937fe70970a220d970d27df1026becdf63f5a/source/mir/ndslice/sorting.d#L181
+enum naive_est = 64;
+enum size_t naive = 32 > naive_est ? 32 : naive_est;

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -593,7 +593,9 @@ void foo18()
 
 @safe void foo19(C)(ref C[] str)  // infer 'scope' for 'str'
 {
-    str = str;
+    typeof(str) str2;
+    str2 = str;
+    str = str2;
     str = str[1 .. str.length];
 }
 

--- a/test/fail_compilation/warn7444.d
+++ b/test/fail_compilation/warn7444.d
@@ -4,7 +4,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/warn7444.d(23): Error: cannot implicitly convert expression `e` of type `int` to `int[]`
+fail_compilation/warn7444.d(25): Error: cannot implicitly convert expression `e` of type `int` to `int[]`
+fail_compilation/warn7444.d(29): Deprecation: Assignment of `sa` has no effect
+fail_compilation/warn7444.d(45): Deprecation: Assignment of `da` has no effect
 ---
 */
 

--- a/test/runnable/testassign.d
+++ b/test/runnable/testassign.d
@@ -129,7 +129,7 @@ void test3()
     foreach (S; TypeTuple!(S31A,S31B,S31C,S31D, S32A,S32B,S32C,S32D))
     {
         S s;
-        static assert(__traits(compiles, s = s) == S.result);
+        static assert(__traits(compiles, {S s2; s2 = s;}) == S.result);
     }
 }
 
@@ -524,22 +524,22 @@ void test6216a()
 
         pragma(msg,
                 is(X==void) ? "-" : X.stringof,
-                "\t", __traits(compiles, (s1  = s1)),
-                "\t", __traits(compiles, (s2a = s2a)),
-                "\t", __traits(compiles, (s2b = s2b)),
-                "\t", __traits(compiles, (s3a = s3a)),
-                "\t", __traits(compiles, (s3b = s3b)),
-                "\t", __traits(compiles, (s4a = s4a)),
-                "\t", __traits(compiles, (s4b = s4b))  );
+                "\t", __traits(compiles, {auto s1_  = s1;}),
+                "\t", __traits(compiles, {auto s2a_ = s2a;}),
+                "\t", __traits(compiles, {auto s2b_ = s2b;}),
+                "\t", __traits(compiles, {auto s3a_ = s3a;}),
+                "\t", __traits(compiles, {auto s3b_ = s3b;}),
+                "\t", __traits(compiles, {auto s4a_ = s4a;}),
+                "\t", __traits(compiles, {auto s4b_ = s4b;})  );
 
         static assert(result[i] ==
-            [   __traits(compiles, (s1  = s1)),
-                __traits(compiles, (s2a = s2a)),
-                __traits(compiles, (s2b = s2b)),
-                __traits(compiles, (s3a = s3a)),
-                __traits(compiles, (s3b = s3b)),
-                __traits(compiles, (s4a = s4a)),
-                __traits(compiles, (s4b = s4b))  ]);
+            [   __traits(compiles, {auto s1_  = s1;}),
+                __traits(compiles, {auto s2a_ = s2a;}),
+                __traits(compiles, {auto s2b_ = s2b;}),
+                __traits(compiles, {auto s3a_ = s3a;}),
+                __traits(compiles, {auto s3b_ = s3b;}),
+                __traits(compiles, {auto s4a_ = s4a;}),
+                __traits(compiles, {auto s4b_ = s4b;})  ]);
     }
 }
 
@@ -559,7 +559,8 @@ void test6216b()
     }
 
     S s;
-    s = s;
+    S s2;
+    s2 = s;
     assert(cnt == 1);
     // Built-in opAssign runs member's opAssign
 }
@@ -581,7 +582,7 @@ void test6216c()
 
     S s;
     const(S) cs;
-    s = s;
+    auto s2 = s;
     s = cs;     // cs is copied as mutable and assigned into s
     assert(cnt == 2);
     static assert(!__traits(compiles, cs = cs));
@@ -605,7 +606,8 @@ void test6216d()
 
     X mx;
     const X cx;
-    mx = mx;    // copying mx to const X is possible
+    X mx2;
+    mx2 = mx;    // copying mx to const X is possible
     assert(cnt == 1);
     mx = cx;
     assert(cnt == 2);
@@ -614,7 +616,7 @@ void test6216d()
 
     S s;
     const(S) cs;
-    s = s;
+    auto s2 = s;
     s = cs;
     //assert(cnt == 4);
     static assert(!__traits(compiles, cs = cs));
@@ -881,7 +883,7 @@ void test12211()
 void test4791()
 {
     int[2] na;
-    na = na;
+    int[2] na2 = na;
 
     static struct S
     {
@@ -895,13 +897,16 @@ void test4791()
         sa[0].n = 1, sa[1].n = 2, sa[2].n = 3;
 
         S.res = null;
-        sa = sa;
-        assert(S.res == "p2d1p3d2p4d3");
-        assert(sa[0].n == 2 && sa[1].n == 3 && sa[2].n == 4);
+        S[3] sa2;
+        sa2 = sa;
+        assert(S.res == "p2d0p3d0p4d0", S.res);
+        assert(sa[0].n == 1);
+        assert(sa[1].n == 2);
+        assert(sa[2].n == 3);
 
         S.res = null;
     }
-    assert(S.res == "d4d3d2");
+    assert(S.res == "d4d3d2d3d2d1");
 }
 
 /***************************************************/


### PR DESCRIPTION
This is a rather common error:

```d
struct Foo
{
    this(int f)
    {
        f = f; // oops, but no warning
    }

    int f;
}
```

~~~and I wanted to see if how much would be affected by this.~~~
~~~That's why it's using `error` instead of `deprecation` (for now) and has  some tests just commented out.~~~

edit: experimented with this check and it found three real bugs (one in dmd and two in the tested projects).