### PR TITLE
Fix Issue 18130 - ICE on zero-length `out` array parameter

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -955,7 +955,11 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         VarDeclaration v = (*funcdecl.parameters)[i];
                         if (v.storage_class & STC.out_)
                         {
-                            assert(v._init);
+                            if (!v._init)
+                            {
+                                v.error("Zero-length `out` parameters are not allowed.");
+                                return;
+                            }
                             ExpInitializer ie = v._init.isExpInitializer();
                             assert(ie);
                             if (ie.exp.op == TOK.construct)

--- a/test/fail_compilation/test18130.d
+++ b/test/fail_compilation/test18130.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test18130.d(8): Error: variable `test18130.foo.v` Zero-length `out` parameters are not allowed.
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=18130
+void foo(out byte[0] v)
+{
+}


### PR DESCRIPTION
Let's better error in such cases (instead of throwing a segfault to the user)?