### PR TITLE
[WIP] Fix Issue 18721 - ICE in dmd/cond.d(378) when compiling static foreach with -D

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1080,6 +1080,13 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         {
             return cache;
         }
+        if (!_scope)
+        {
+            import dmd.errors : error;
+            error(sfe.loc, "`static foreach` can't be lowered.");
+            return null;
+        }
+
         sfe.prepare(_scope); // lower static foreach aggregate
         if (!sfe.ready())
         {

--- a/test/fail_compilation/fail18721.d
+++ b/test/fail_compilation/fail18721.d
@@ -1,0 +1,14 @@
+/*
+REQUIRED_ARGS: -D
+TEST_OUTPUT:
+---
+fail_compilation/fail18721.d(12): Error: `static foreach` can't be lowered.
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=18721
+///
+template allSameType()
+{
+    static foreach (idx; T)
+            enum allSameType = 1;
+}


### PR DESCRIPTION
Okay, so yet another noobish attempt.
The ICE is caused by the invalid template never been instantiated and run through semantic.
DDoc, however, tries to inspect the template with `getEponymousMember` and thus obviously spectactuarly fails.

Has anyone a better idea to tackle this?