### PR TITLE
Remove OBJ from exported_vars.sh

### DIFF
--- a/test/tools/exported_vars.sh
+++ b/test/tools/exported_vars.sh
@@ -9,8 +9,6 @@ export EXTRA_FILES=${TEST_DIR}/extra-files # reference to the extra files direct
 
 if [ "$OS" == "win32" ] || [ "$OS" == "win64" ]; then
     export LIBEXT=.lib
-    export OBJ=.obj
 else
     export LIBEXT=.a
-    export OBJ=.o
 fi


### PR DESCRIPTION
This variable is already defined by the Makefile.