### PR TITLE
Automatically print the segtrace for segfaulting tests

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -748,6 +748,8 @@ int tryMain(string[] args)
 
             auto m = std.regex.match(compile_output, `Internal error: .*$`);
             enforce(!m, m.hit);
+            m = std.regex.match(compile_output, `core.exception.AssertError@dmd.*`);
+            enforce(!m, m.hit);
 
             if (testArgs.compileOutput !is null)
             {


### PR DESCRIPTION
Useful because
- CIs: if a test segfaults on a CI --> we automatically get the stack trace
- local development: when something segfaults, you probably want to look at the stack trace

An alternative would be to use `coredumpctl gdb -1`, but that's systemd-only and I don't know whether all CIs support this.

So what do you think about this?