### PR TITLE
Document EXTRA_CPP_SOURCES in test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -108,6 +108,9 @@ In-test variables
     EXTRA_SOURCES:       list of extra files to build and link along with the test
                          default: (none)
 
+    EXTRA_CPP_SOURCES:   list of extra C++ files to build and link along with the test
+                         default: (none).
+
     EXTRA_OBJC_SOURCES:  list of extra Objective-C files to build and link along with the test
                          default: (none). Test files with this variable will be ignored unless
                          the D_OBJC environment variable is set to "1"


### PR DESCRIPTION
It's apparentely a thing:

```
runnable/cppa.d
2:// EXTRA_CPP_SOURCES: cppb.cpp

runnable/externmangle2.d
1:// EXTRA_CPP_SOURCES: externmangle2.cpp

runnable/cabi1.d
2:// EXTRA_CPP_SOURCES: cabi2.cpp

runnable/cpp_abi_tests.d
1:// EXTRA_CPP_SOURCES: cpp_abi_tests.cpp

runnable/externmangle.d
1:// EXTRA_CPP_SOURCES: externmangle.cpp

runnable/test6716.d
1:// EXTRA_CPP_SOURCES: test6716.cpp
```

So let's better document it.