### PR TITLE
run_individual_tests print make command

### DIFF
--- a/test/run_individual_tests
+++ b/test/run_individual_tests
@@ -37,5 +37,8 @@ done
 # allows the script to be called from anywhere
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
-echo ${PROCS}
-${MAKE:-make} "${files[@]}" -j${PROCS}
+function echorun {
+    echo $@
+    $@
+}
+echorun ${MAKE:-make} "${files[@]}" -j${PROCS}


### PR DESCRIPTION
`run_individual_tests` was previously printing a single number which was confusing.  Turns out it was the number of processors.  Useful info, but makes more sense when paired with the full make command that ends up being executed.