### PR TITLE
Apply auto-tester's patching to upstream and avoid the need for it

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -586,7 +586,7 @@ int tryMain(string[] args)
         switch (envData.os)
         {
             case "win32": envData.ccompiler = "dmc"; break;
-            case "win64": envData.ccompiler = `\"Program Files (x86)"\"Microsoft Visual Studio 10.0"\VC\bin\amd64\cl.exe`; break;
+            case "win64": envData.ccompiler = environment.get("VCBIN_DIR") ~ `\cl.exe`; break;
             default:      envData.ccompiler = "c++"; break;
         }
     }

--- a/win32.mak
+++ b/win32.mak
@@ -1,13 +1,12 @@
-MAKE=make
 
 auto-tester-build:
 	cd src
-	$(MAKE) -f win32.mak auto-tester-build
+	make -f win32.mak auto-tester-build
 	cd ..
 
 auto-tester-test:
 	cd test
-	$(MAKE)
+	gmake -j$(PARALLELISM)
 	cd ..
 	cd samples
 	gmake -f win32.mak DMD=..\src\dmd.exe MODEL=$(MODEL) "LIB=..\..\phobos;$(LIB)" \


### PR DESCRIPTION
Applies https://github.com/braddr/at-client/blob/master/src/diff-dmd-win64.diff to master.
and thus ideally this removes the need for the auto-tester to do its patching.

I wasn't sure what to do about via patching disabled [`runnable/test15779.d`](https://github.com/dlang/dmd/blob/master/test/) test as it passes on AppVeyor. Is this still an issue?

@braddr - I guess at the moment this will fail and that's why https://github.com/braddr/at-client/pull/8 would be useful, s.t. (1) this can be tested before and (2) `master` and `stable` don't need to be upgraded in lockstep.
However, I guess simply disabling the patching would work fine too. `stable` isn't particularily busy and I can back-port these changes to `stable` in a quick follow-up PR.
If you want we can also do all three repos in one stroke (making similar PRs for druntime + phobos's patching shouldn't be too hard once it's disabled).

-----

@ other reviewers: this PR depends on Brad and changes in the auto-tester infrastructure. Please do _not_ merge without his feedback and approval.

edit: don't get confused by "Pass: 8" on the auto-tester - it didn't run the tests on Windows:

![image](https://user-images.githubusercontent.com/4370550/38344833-00a77c64-388c-11e8-89fb-0482f0c12777.png)