### PR TITLE
Point users to Bugzilla on ICEs

### DIFF
--- a/src/dmd/backend/util2.c
+++ b/src/dmd/backend/util2.c
@@ -38,6 +38,8 @@ void *ph_calloc(size_t nbytes);
 void ph_free(void *p);
 void *ph_realloc(void *p , size_t nbytes);
 
+extern "C" void printInternalFailure(FILE* stream); // from dmd/mars.d
+
 
 void util_exit(int exitcode);
 
@@ -52,6 +54,7 @@ void file_progress()
 void util_assert(const char *file, int line)
 {
     fflush(stdout);
+    printInternalFailure(stdout);
     printf("Internal error: %s %d\n",file,line);
     err_exit();
 #if __clang__

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -70,6 +70,25 @@ private void logo()
     printf("DMD%llu D Compiler %s\n%s %s\n", cast(ulong)size_t.sizeof * 8, global._version, global.copyright, global.written);
 }
 
+/**
+Print DMD's logo with more debug information and error-reporting pointers.
+
+Params:
+    stream = output stream to print the information on
+*/
+extern(C) void printInternalFailure(FILE* stream)
+{
+    fputs(("---\n" ~
+    "ERROR: This is a compiler bug.\n" ~
+            "Please report it via https://issues.dlang.org/enter_bug.cgi\n" ~
+            "with, preferably, a reduced, reproducible example and the information below.\n" ~
+    "DustMite (https://github.com/CyberShadow/DustMite/wiki) can help with the reduction.\n" ~
+    "---\n").ptr, stream);
+    stream.fprintf("DMD %s\n", global._version);
+    stream.printPredefinedVersions;
+    stream.printGlobalConfigs();
+    fputs("---\n".ptr, stream);
+}
 
 /**
  * Print DMD's usage message on stdout
@@ -495,40 +514,10 @@ private int tryMain(size_t argc, const(char)** argv)
     Objc._init();
     builtin_init();
 
-    printPredefinedVersions();
-
     if (global.params.verbose)
     {
-        message("binary    %s", global.params.argv0);
-        message("version   %s", global._version);
-        message("config    %s", global.inifilename ? global.inifilename : "(none)");
-        // Print DFLAGS environment variable
-        {
-            Strings dflags;
-            getenv_setargv(readFromEnv(&environment, "DFLAGS"), &dflags);
-            OutBuffer buf;
-            foreach (flag; dflags.asDArray)
-            {
-                bool needsQuoting;
-                for (auto flagp = flag; flagp; flagp++)
-                {
-                    auto c = flagp[0];
-                    if (!(isalnum(c) || c == '_'))
-                    {
-                        needsQuoting = true;
-                        break;
-                    }
-                }
-
-                if (flag.strchr(' '))
-                    buf.printf("'%s' ", flag);
-                else
-                    buf.printf("%s ", flag);
-            }
-
-            auto res = buf.peekSlice() ? buf.peekSlice()[0 .. $ - 1] : "(none)";
-            message("DFLAGS    %.*s", res.length, res.ptr);
-        }
+        stdout.printPredefinedVersions();
+        stdout.printGlobalConfigs();
     }
     //printf("%d source files\n",files.dim);
 
@@ -1094,6 +1083,8 @@ int main()
         dmd_coverSetMerge(true);
     }
 
+    scope(failure) stderr.printInternalFailure;
+
     auto args = Runtime.cArgs();
     return tryMain(args.argc, cast(const(char)**)args.argv);
 }
@@ -1406,9 +1397,9 @@ void addDefaultVersionIdentifiers()
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
 }
 
-private void printPredefinedVersions()
+private void printPredefinedVersions(FILE* stream)
 {
-    if (global.params.verbose && global.versionids)
+    if (global.versionids)
     {
         OutBuffer buf;
         foreach (const str; *global.versionids)
@@ -1416,10 +1407,45 @@ private void printPredefinedVersions()
             buf.writeByte(' ');
             buf.writestring(str.toChars());
         }
-        message("predefs  %s", buf.peekString());
+        stream.fprintf("predefs  %s", buf.peekString());
     }
 }
 
+extern(C) void printGlobalConfigs(FILE* stream)
+{
+    stream.fprintf("binary    %s\n", global.params.argv0);
+    stream.fprintf("version   %s\n", global._version);
+    stream.fprintf("config    %s\n", global.inifilename ? global.inifilename : "(none)");
+    // Print DFLAGS environment variable
+    {
+        StringTable environment;
+        environment._init(0);
+        Strings dflags;
+        getenv_setargv(readFromEnv(&environment, "DFLAGS"), &dflags);
+        environment.reset(1);
+        OutBuffer buf;
+        foreach (flag; dflags[])
+        {
+            bool needsQuoting;
+            foreach (c; flag[0 .. strlen(flag)])
+            {
+                if (!(isalnum(c) || c == '_'))
+                {
+                    needsQuoting = true;
+                    break;
+                }
+            }
+
+            if (flag.strchr(' '))
+                buf.printf("'%s' ", flag);
+            else
+                buf.printf("%s ", flag);
+        }
+
+        auto res = buf.peekSlice() ? buf.peekSlice()[0 .. $ - 1] : "(none)";
+        stream.fprintf("DFLAGS    %.*s\n", res.length, res.ptr);
+    }
+}
 
 /****************************************
  * Determine the instruction set to be used.

--- a/test/runnable/test18141.sh
+++ b/test/runnable/test18141.sh
@@ -6,4 +6,5 @@ else
     expected="Posix"
 fi
 
-echo "void main(){}" | "${DMD}" -v -o- - | grep "predefs" | grep "${expected}"
+out=$(echo "void main(){}" | "${DMD}" -v -o- -)
+echo "$out" | grep "predefs" | grep "${expected}"


### PR DESCRIPTION
Revival of https://github.com/dlang/dmd/pull/6103.

While there's still a bit of hold-up on [DIP1006](https://github.com/dlang/DIPs/pull/54) being implemente see e.g. https://github.com/dlang/dmd/pull/7980, we can already prepare the codebase today.

Also LDC already allows to selectively enable assert's in `-release` today.

ICEs to test this:

Frontend
--------

```
///
template allSameType()
{
    static foreach (idx; T)
            enum allSameType ;
}
```

(from: https://issues.dlang.org/show_bug.cgi?id=18721)


```
> dmd -D
This is a compiler bug, please report it via https://issues.dlang.org/enter_bug.cgi
core.exception.AssertError@dmd/cond.d(378): Assertion failure
----------------
??:? _d_assertp [0x4f6c81b5]
??:? pure nothrow @nogc @safe void dmd.cond.StaticForeach.prepare(dmd.dscope.Scope*).__require() [0x4f4bb637]
??:? void dmd.cond.StaticForeach.prepare(dmd.dscope.Scope*) [0x4f4bb4f4]
??:? _ZN24StaticForeachDeclaration7includeEP5Scope [0x4f4b4b5b]
...
```

Backend
--------

```d
alias A = Complex!double;

struct Complex(T)
{
    double re, im;

    Complex!double baz()
    {
        return Complex!double(re).blah;
    }

    ref Complex!double blah()
    {
        im = re;
        return this;
    }
}
```

(from: https://issues.dlang.org/show_bug.cgi?id=15206)

```
> dmd -c -inline -O -m64
tym = x1d
Internal error: dmd/backend/cgxmm.c 684
This is a compiler bug, please report it via https://issues.dlang.org/enter_bug.cgi
```

Other ideas:
-----------

How about dumping all `global` data too? (or just a long variant of `--version`)?