### PR TITLE
add Win_32_64 mapping

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -11,6 +11,10 @@ ifeq (Win_32,$(OS))
     OS:=win32
     MODEL:=32
 endif
+ifeq (Win_32_64,$(OS))
+    OS:=win64
+    MODEL:=64
+endif
 ifeq (Win_64,$(OS))
     OS:=win64
     MODEL:=64


### PR DESCRIPTION
The ought to merge with the on-tester diff cleanly, allowing a smooth migration.