### PR TITLE
[trivial] d_do_test.d: show a warning when auto-updating the TEST_OUTPUT failed.

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -817,13 +817,20 @@ int tryMain(string[] args)
             if (envData.autoUpdate)
             if (auto ce = cast(CompareException) e)
             {
+                // remove the output file in test_results as its outdated
+                output_file.remove();
+
                 auto existingText = input_file.readText;
                 auto updatedText = existingText.replace(ce.expected, ce.actual);
-                std.file.write(input_file, updatedText);
-                // remove the output file in test_results as its outdated
-                f.close();
-                output_file.remove();
-                writefln("==> `TEST_OUTPUT` of %s has been updated", input_file);
+                if (existingText != updatedText)
+                {
+                    std.file.write(input_file, updatedText);
+                    writefln("==> `TEST_OUTPUT` of %s has been updated", input_file);
+                }
+                else
+                {
+                    writefln("WARNING: %s has multiple `TEST_OUTPUT` blocks and can't be auto-updated", input_file);
+                }
                 return Result.return0;
             }
 


### PR DESCRIPTION
It's non-trivial to automatically update the `TEST_OUTPUT` block when the test file has multiple blocks (i.e. a new error message appeared - to which block should it go?)
Sure, in theory that could be solved, but for now I think it's better to display a nice warning, s.t. a "user" isn't confused.