### PR TITLE
[RFC] Added __traits(isRootModule)

### DIFF
--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -373,6 +373,7 @@ immutable Msgtable[] msgtable =
     { "isOverrideFunction" },
     { "isStaticFunction" },
     { "isRef" },
+    { "isRootModule" },
     { "isOut" },
     { "isLazy" },
     { "hasMember" },

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -20,6 +20,7 @@ import dmd.arraytypes;
 import dmd.canthrow;
 import dmd.dclass;
 import dmd.declaration;
+import dmd.dmodule;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
@@ -122,6 +123,7 @@ shared static this()
         "isOut",
         "isLazy",
         "isReturnOnStack",
+        "isRootModule",
         "hasMember",
         "identifier",
         "getProtection",
@@ -1075,6 +1077,23 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
 
         bool value = Target.isReturnOnStack(tf);
         return new IntegerExp(e.loc, value, Type.tbool);
+    }
+    if (e.ident == Id.isRootModule)
+    {
+        Module mod;
+        if (dim == 0)
+        {
+            mod = sc.instantiatingModule();
+        }
+        else if (dim == 1)
+        {
+            e.error("__traits(isRootModule, <module>) not implemented");
+            return new ErrorExp();
+        }
+        else
+            return dimError(1);
+
+        return new IntegerExp(e.loc, mod.isRoot(), Type.tbool);
     }
     if (e.ident == Id.getFunctionVariadicStyle)
     {

--- a/test/compilable/extra-files/rootmodimport.d
+++ b/test/compilable/extra-files/rootmodimport.d
@@ -1,0 +1,10 @@
+module rootmodimport;
+
+static if (__traits(isRootModule))
+{
+    pragma(msg, "isRootModule 1");
+}
+else
+{
+    pragma(msg, "isRootModule 0");
+}

--- a/test/compilable/extra-files/rootmodmain.d
+++ b/test/compilable/extra-files/rootmodmain.d
@@ -1,0 +1,1 @@
+import rootmodimport;

--- a/test/compilable/isrootmod.sh
+++ b/test/compilable/isrootmod.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+$DMD -m$MODEL -o- -I=$EXTRA_FILES $EXTRA_FILES/rootmodmain.d 2>&1 | grep -q "isRootModule 0"
+$DMD -m$MODEL -o- -I=$EXTRA_FILES $EXTRA_FILES/rootmodmain.d $EXTRA_FILES/rootmodimport 2>&1 | grep -q "isRootModule 1"
+$DMD -m$MODEL -o- -I=$EXTRA_FILES $EXTRA_FILES/rootmodmain.d -i 2>&1 | grep -q "isRootModule 1"

--- a/test/fail_compilation/isrootmod.d
+++ b/test/fail_compilation/isrootmod.d
@@ -1,0 +1,10 @@
+/*
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/isrootmod.d(10): Error: __traits(isRootModule, <module>) not implemented
+fail_compilation/isrootmod.d(10):        while evaluating `pragma(msg, __traits(isRootModule, 0))`
+---
+*/
+
+pragma(msg, __traits(isRootModule, 0));


### PR DESCRIPTION
Exploring solutions to support faster compilation times.  The proposed trait `isRootModule` trait would return `true` if and only if the module is currently being "compiled" all the way to "object code".

This trait allows a module to include code ONLY when the module is being compiled.  One example of how this could be used is with #8124, you could create "unittest support code" that ONLY gets analyzed/instantiated when the module is being compiled, i.e.
```D
static if (__traits(isRootModule)) version (unittest)
{
    // a bunch of shared code that's only used by unittests in this module
}

unittest
{
   // use the code defined above
}
unittest
{
   // use the code defined above
}
unittest
...
```

To show a "real-world" example of where these semantics would be used, I looked at the `version(unittest)` blocks in `std.path`.  It has 3 of these blocks that define code to support various unittests in the module.  These blocks instantiate templates from other modules which be the cause of slow compilations times.  By prefixing these `version(unittest)` blocks with `static if (__traits(isRootModule))` it would allow applications to unittest their own code without having to analyze all the `version(unittest)` blocks in phobos and all their dependencies.