### PR TITLE
refactor: redo CSX merge logic layout and names

### DIFF
--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -91,7 +91,7 @@ struct CtorFlow
      * Params:
      *  ctorflow = bits to OR in
      */
-    void OR(const ref CtorFlow ctorflow)
+    void OR(const ref CtorFlow ctorflow) pure nothrow
     {
         callSuper |= ctorflow.callSuper;
         if (fieldinit.length && ctorflow.fieldinit.length)
@@ -105,56 +105,120 @@ struct CtorFlow
 
 
 /****************************************
- * Merge fi flow analysis results into fieldInit.
+ * Merge `b` flow analysis results into `a`.
  * Params:
- *      fieldInit = the path to merge fi into
- *      fi = the other path
+ *      a = the path to merge `b` into
+ *      b = the other path
  * Returns:
- *      false means either fieldInit or fi skips initialization
+ *      false means one of the paths skips construction
  */
-bool mergeFieldInitX(ref CSX fieldInit, const CSX fi)
+bool mergeCallSuper(ref CSX a, const CSX b) pure nothrow
 {
-    if (fi != fieldInit)
+    // This does a primitive flow analysis to support the restrictions
+    // regarding when and how constructors can appear.
+    // It merges the results of two paths.
+    // The two paths are `a` and `b`; the result is merged into `a`.
+    if (b == a)
+        return true;
+
+    // Have ALL branches called a constructor?
+    const aAll = (a & (CSX.this_ctor | CSX.super_ctor)) != 0;
+    const bAll = (b & (CSX.this_ctor | CSX.super_ctor)) != 0;
+    // Have ANY branches called a constructor?
+    const aAny = (a & CSX.any_ctor) != 0;
+    const bAny = (b & CSX.any_ctor) != 0;
+    // Have any branches returned?
+    const aRet = (a & CSX.return_) != 0;
+    const bRet = (b & CSX.return_) != 0;
+    // Have any branches halted?
+    const aHalt = (a & CSX.halt) != 0;
+    const bHalt = (b & CSX.halt) != 0;
+    if (aHalt && bHalt)
     {
-        // Have any branches returned?
-        bool aRet = (fi & CSX.return_) != 0;
-        bool bRet = (fieldInit & CSX.return_) != 0;
-        // Have any branches halted?
-        bool aHalt = (fi & CSX.halt) != 0;
-        bool bHalt = (fieldInit & CSX.halt) != 0;
-        bool ok;
-        if (aHalt && bHalt)
-        {
-            ok = true;
-            fieldInit = CSX.halt;
-        }
-        else if (!aHalt && aRet)
-        {
-            ok = (fi & CSX.this_ctor);
-            fieldInit = fieldInit;
-        }
-        else if (!bHalt && bRet)
-        {
-            ok = (fieldInit & CSX.this_ctor);
-            fieldInit = fi;
-        }
-        else if (aHalt)
-        {
-            ok = (fieldInit & CSX.this_ctor);
-            fieldInit = fieldInit;
-        }
-        else if (bHalt)
-        {
-            ok = (fi & CSX.this_ctor);
-            fieldInit = fi;
-        }
-        else
-        {
-            ok = !((fieldInit ^ fi) & CSX.this_ctor);
-            fieldInit |= fi;
-        }
-        return ok;
+        a = CSX.halt;
+    }
+    else if ((!bHalt && bRet && !bAny && aAny) || (!aHalt && aRet && !aAny && bAny))
+    {
+        // If one has returned without a constructor call, there must not
+        // be ctor calls in the other.
+        return false;
+    }
+    else if (bHalt || bRet && bAll)
+    {
+        // If one branch has called a ctor and then exited, anything the
+        // other branch has done is OK (except returning without a
+        // ctor call, but we already checked that).
+        a |= b & (CSX.any_ctor | CSX.label);
+    }
+    else if (aHalt || aRet && aAll)
+    {
+        a = cast(CSX)(b | (a & (CSX.any_ctor | CSX.label)));
+    }
+    else if (aAll != bAll) // both branches must have called ctors, or both not
+        return false;
+    else
+    {
+        // If one returned without a ctor, remember that
+        if (bRet && !bAny)
+            a |= CSX.return_;
+        a |= b & (CSX.any_ctor | CSX.label);
     }
     return true;
+}
+
+
+/****************************************
+ * Merge `b` flow analysis results into `a`.
+ * Params:
+ *      a = the path to merge `b` into
+ *      b = the other path
+ * Returns:
+ *      false means either `a` or `b` skips initialization
+ */
+bool mergeFieldInit(ref CSX a, const CSX b) pure nothrow
+{
+    if (b == a)
+        return true;
+
+    // Have any branches returned?
+    const aRet = (a & CSX.return_) != 0;
+    const bRet = (b & CSX.return_) != 0;
+    // Have any branches halted?
+    const aHalt = (a & CSX.halt) != 0;
+    const bHalt = (b & CSX.halt) != 0;
+
+    if (aHalt && bHalt)
+    {
+        a = CSX.halt;
+        return true;
+    }
+
+    bool ok;
+    if (!bHalt && bRet)
+    {
+        ok = (b & CSX.this_ctor);
+        a = a;
+    }
+    else if (!aHalt && aRet)
+    {
+        ok = (a & CSX.this_ctor);
+        a = b;
+    }
+    else if (bHalt)
+    {
+        ok = (a & CSX.this_ctor);
+        a = a;
+    }
+    else if (aHalt)
+    {
+        ok = (b & CSX.this_ctor);
+        a = b;
+    }
+    else
+    {
+        ok = !((a ^ b) & CSX.this_ctor);
+        a |= b;
+    }
+    return ok;
 }
 

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -267,82 +267,6 @@ struct Scope
         return pop();
     }
 
-    extern (C++) void mergeCallSuper(const ref Loc loc, CSX cs)
-    {
-        // This does a primitive flow analysis to support the restrictions
-        // regarding when and how constructors can appear.
-        // It merges the results of two paths.
-        // The two paths are ctorflow.callSuper and cs; the result is merged into ctorflow.callSuper.
-        if (cs != ctorflow.callSuper)
-        {
-            // Have ALL branches called a constructor?
-            int aAll = (cs & (CSX.this_ctor | CSX.super_ctor)) != 0;
-            int bAll = (ctorflow.callSuper & (CSX.this_ctor | CSX.super_ctor)) != 0;
-            // Have ANY branches called a constructor?
-            bool aAny = (cs & CSX.any_ctor) != 0;
-            bool bAny = (ctorflow.callSuper & CSX.any_ctor) != 0;
-            // Have any branches returned?
-            bool aRet = (cs & CSX.return_) != 0;
-            bool bRet = (ctorflow.callSuper & CSX.return_) != 0;
-            // Have any branches halted?
-            bool aHalt = (cs & CSX.halt) != 0;
-            bool bHalt = (ctorflow.callSuper & CSX.halt) != 0;
-            bool ok = true;
-            if (aHalt && bHalt)
-            {
-                ctorflow.callSuper = CSX.halt;
-            }
-            else if ((!aHalt && aRet && !aAny && bAny) || (!bHalt && bRet && !bAny && aAny))
-            {
-                // If one has returned without a constructor call, there must be never
-                // have been ctor calls in the other.
-                ok = false;
-            }
-            else if (aHalt || aRet && aAll)
-            {
-                // If one branch has called a ctor and then exited, anything the
-                // other branch has done is OK (except returning without a
-                // ctor call, but we already checked that).
-                ctorflow.callSuper |= cs & (CSX.any_ctor | CSX.label);
-            }
-            else if (bHalt || bRet && bAll)
-            {
-                ctorflow.callSuper = cast(CSX)(cs | (ctorflow.callSuper & (CSX.any_ctor | CSX.label)));
-            }
-            else
-            {
-                // Both branches must have called ctors, or both not.
-                ok = (aAll == bAll);
-                // If one returned without a ctor, we must remember that
-                // (Don't bother if we've already found an error)
-                if (ok && aRet && !aAny)
-                    ctorflow.callSuper |= CSX.return_;
-                ctorflow.callSuper |= cs & (CSX.any_ctor | CSX.label);
-            }
-            if (!ok)
-                error(loc, "one path skips constructor");
-        }
-    }
-
-    extern (D) void mergeFieldInit(const ref Loc loc, const CSX[] fies)
-    {
-        if (ctorflow.fieldinit.length && fies.length)
-        {
-            FuncDeclaration f = func;
-            if (fes)
-                f = fes.func;
-            auto ad = f.isMember2();
-            assert(ad);
-            foreach (i, v; ad.fields)
-            {
-                bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                if (!mergeFieldInitX(ctorflow.fieldinit[i], fies[i]) && mustInit)
-                {
-                    .error(loc, "one path skips field `%s`", v.toChars());
-                }
-            }
-        }
-    }
 
     /*******************************
      * Merge results of `ctorflow` into `this`.
@@ -352,8 +276,26 @@ struct Scope
      */
     extern (D) void merge(const ref Loc loc, const ref CtorFlow ctorflow)
     {
-        mergeCallSuper(loc, ctorflow.callSuper);
-        mergeFieldInit(loc, ctorflow.fieldinit);
+        if (!mergeCallSuper(this.ctorflow.callSuper, ctorflow.callSuper))
+            error(loc, "one path skips constructor");
+
+        const fies = ctorflow.fieldinit;
+        if (this.ctorflow.fieldinit.length && fies.length)
+        {
+            FuncDeclaration f = func;
+            if (fes)
+                f = fes.func;
+            auto ad = f.isMember2();
+            assert(ad);
+            foreach (i, v; ad.fields)
+            {
+                bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
+                if (!mergeFieldInit(this.ctorflow.fieldinit[i], fies[i]) && mustInit)
+                {
+                    error(loc, "one path skips field `%s`", v.toChars());
+                }
+            }
+        }
     }
 
     extern (C++) Module instantiatingModule()


### PR DESCRIPTION
The idea is to:

* push CSX logic into ctorflow.d
* push error handling into dscope.d
* use `a` and `b` for left and right branches