### PR TITLE
use special enums for __c_long, etc. instead of special structs

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -974,6 +974,15 @@ public:
         if (t.isImmutable() || t.isShared())
             return error(t);
 
+        /* __c_long and __c_ulong get special mangling
+         */
+        const id = t.sym.ident;
+        //printf("struct id = '%s'\n", id.toChars());
+        if (id == Id.__c_long)
+            return writeBasicType(t, 0, 'l');
+        else if (id == Id.__c_ulong)
+            return writeBasicType(t, 0, 'm');
+
         doSymbol(t);
     }
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1434,8 +1434,19 @@ uint totym(Type tx)
             break;
 
         case Tenum:
-            t = totym(tx.toBasetype());
+        {
+            Type tb = tx.toBasetype();
+            const id = tx.toDsymbol(null).ident;
+            if (id == Id.__c_long)
+                t = tb.ty == Tint32 ? TYlong : TYllong;
+            else if (id == Id.__c_ulong)
+                t = tb.ty == Tuns32 ? TYulong : TYullong;
+            else if (id == Id.__c_long_double)
+                t = TYdouble;
+            else
+                t = totym(tb);
             break;
+        }
 
         case Tident:
         case Ttypeof:

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3377,6 +3377,19 @@ extern (C++) final class TypeBasic : Type
             TypeVector tv = cast(TypeVector)to;
             tob = tv.elementType();
         }
+        else if (to.ty == Tenum)
+        {
+            EnumDeclaration ed = (cast(TypeEnum)to).sym;
+            if (ed.isSpecial())
+            {
+                /* Special enums that allow implicit conversions to them
+                 * with a MATCH.convert
+                 */
+                tob = to.toBasetype().isTypeBasic();
+            }
+            else
+                return MATCH.nomatch;
+        }
         else
             tob = to.isTypeBasic();
         if (!tob)

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -19,6 +19,7 @@ import dmd.backend.ty;
 import dmd.backend.type;
 
 import dmd.declaration;
+import dmd.denum;
 import dmd.dstruct;
 import dmd.globals;
 import dmd.glue;
@@ -170,18 +171,26 @@ public:
         //printf("TypeEnum::toCtype() '%s'\n", t.sym.toChars());
         if (t.mod == 0)
         {
-            if (!t.sym.memtype)
+            EnumDeclaration sym = t.sym;
+            auto symMemtype = sym.memtype;
+            if (!symMemtype)
             {
                 // https://issues.dlang.org/show_bug.cgi?id=13792
                 t.ctype = Type_toCtype(Type.tvoid);
             }
-            else if (t.sym.memtype.toBasetype().ty == Tint32)
+            else if (sym.ident == Id.__c_long)
             {
-                t.ctype = type_enum(t.sym.toPrettyChars(true), Type_toCtype(t.sym.memtype));
+                t.ctype = type_fake(totym(t));
+                t.ctype.Tcount++;
+                return;
+            }
+            else if (symMemtype.toBasetype().ty == Tint32)
+            {
+                t.ctype = type_enum(sym.toPrettyChars(true), Type_toCtype(symMemtype));
             }
             else
             {
-                t.ctype = Type_toCtype(t.sym.memtype);
+                t.ctype = Type_toCtype(symMemtype);
             }
 
             if (global.params.symdebugref)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3380,7 +3380,13 @@ private extern(C++) final class DotExpVisitor : Visitor
             mt.sym.dsymbolSemantic(null);
         if (!mt.sym.members)
         {
-            if (!(flag & 1))
+            if (mt.sym.isSpecial())
+            {
+                /* Special enums forward to the base type
+                 */
+                e = mt.sym.memtype.dotExp(sc, e, ident, flag);
+            }
+            else if (!(flag & 1))
             {
                 mt.sym.error("is forward referenced when looking for `%s`", ident.toChars());
                 e = new ErrorExp();

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -g
+// PERMUTE_ARGS: -g -version=PULL8152
 // EXTRA_CPP_SOURCES: cppb.cpp
 
 import core.stdc.stdio;
@@ -605,13 +605,19 @@ extern(C++)
 
 version (CRuntime_Microsoft)
 {
-    struct __c_long_double
+    version (PULL8152)
     {
-        this(double d) { ld = d; }
-        double ld;
-        alias ld this;
+        enum __c_long_double : double;
     }
-
+    else
+    {
+        struct __c_long_double
+        {
+            this(double d) { ld = d; }
+            double ld;
+            alias ld this;
+        }
+    }
     alias __c_long_double myld;
 }
 else
@@ -648,18 +654,26 @@ else
   }
 }
 
-struct __c_long
+version (PULL8152)
 {
-    this(x_long d) { ld = d; }
-    x_long ld;
-    alias ld this;
+    enum __c_long : x_long;
+    enum __c_ulong : x_ulong;
 }
-
-struct __c_ulong
+else
 {
-    this(x_ulong d) { ld = d; }
-    x_ulong ld;
-    alias ld this;
+    struct __c_long
+    {
+        this(x_long d) { ld = d; }
+        x_long ld;
+        alias ld this;
+    }
+
+    struct __c_ulong
+    {
+        this(x_ulong d) { ld = d; }
+        x_ulong ld;
+        alias ld this;
+    }
 }
 
 alias __c_long mylong;
@@ -674,6 +688,7 @@ void test16()
   {
     mylong ld = 5;
     ld = testl(ld);
+    printf("ld = %lld, mylong.sizeof = %lld\n", cast(long)ld, cast(long)mylong.sizeof);
     assert(ld == 5 + mylong.sizeof);
   }
   {
@@ -681,7 +696,54 @@ void test16()
     ld = testul(ld);
     assert(ld == 5 + myulong.sizeof);
   }
+
+    version (PULL8152)
+    {
+        static if (__c_long.sizeof == long.sizeof)
+        {
+            static assert(__c_long.max == long.max);
+            static assert(__c_long.min == long.min);
+            static assert(__c_long.init == long.init);
+
+            static assert(__c_ulong.max == ulong.max);
+            static assert(__c_ulong.min == ulong.min);
+            static assert(__c_ulong.init == ulong.init);
+
+            __c_long cl = 0;
+            cl = cl + 1;
+            long l = cl;
+            cl = l;
+
+            __c_ulong cul = 0;
+            cul = cul + 1;
+            ulong ul = cul;
+            cul = ul;
+        }
+        else static if (__c_long.sizeof == int.sizeof)
+        {
+            static assert(__c_long.max == int.max);
+            static assert(__c_long.min == int.min);
+            static assert(__c_long.init == int.init);
+
+            static assert(__c_ulong.max == uint.max);
+            static assert(__c_ulong.min == uint.min);
+            static assert(__c_ulong.init == uint.init);
+
+            __c_long cl = 0;
+            cl = cl + 1;
+            int i = cl;
+            cl = i;
+
+            __c_ulong cul = 0;
+            cul = cul + 1;
+            uint u = cul;
+            cul = u;
+        }
+        else
+            static assert(0);
+    }
 }
+
 
 /****************************************/
 


### PR DESCRIPTION
The existing mechanism is in core.stdc.config, which uses a struct named __c_long. This change enables using an enum instead, which has some advantages:

* enums are a lot closer to typedefs
* we can allow implicit conversion of other integers to these special enums
* linking with druntime will not be required

Later we can do away with core.stdc.config entirely and just predefine these enums in the compiler.

The tests will be when core.stdc.config is redone using enums, which will be the egg (or the chicken?).