### PR TITLE
Fix Issue 18746 - function returning empty struct isn't called if used in equality expression

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2497,8 +2497,15 @@ elem *toElem(Expression e, IRState *irs)
 
             //printf("IdentityExp.toElem() %s\n", ie.toChars());
 
+            /* Fix Issue 18746 : https://issues.dlang.org/show_bug.cgi?id=18746
+             * Before skipping the comparison for empty structs
+             * it is necessary to check whether the expressions involved
+             * have any sideeffects
+             */
+
+            const canSkipCompare = isTrivialExp(ie.e1) && isTrivialExp(ie.e2);
             elem *e;
-            if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0)
+            if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0 && canSkipCompare)
             {
                 // we can skip the compare if the structs are empty
                 e = el_long(TYbool, ie.op == TOK.identity);

--- a/test/runnable/test18746.d
+++ b/test/runnable/test18746.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=18746
+
+struct S {}
+
+S f(ref int i)
+{
+    ++i;
+    return S();
+}
+
+void main()
+{
+    int i = 2;
+    assert(f(i) == S());
+    assert(i == 3); /* failed before patch, i = 2; should pass */
+}


### PR DESCRIPTION
```d
struct S {}

S f(ref int i)
{
    ++i;
    return S();
}

void main()
{
    int i = 2;
    assert(f(i) == S());
    assert(i == 3); /* fails, i = 2; should pass */
}
```

f(i) is not called because the struct is empty and an empty struct instance is going to always be equal to another. The problem is that no check for side effects is made. This patch checks that `f` is strongly pure before taking the decision to not call the function.

This may not be the best solution since if f is not strongly pure the code goes on the "do a compare" branch which is useless for empty structs. However, I am not very familiar with the e2ir code so suggestions to improve it are welcome.