### PR TITLE
[WIP][Needs Approval] Debug Logging in DMD

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -12,6 +12,7 @@
 
 module dmd.access;
 
+import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.dclass;
 import dmd.declaration;
@@ -34,7 +35,7 @@ private enum LOG = false;
 private Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
 {
     Prot access_ret = Prot(Prot.Kind.none);
-    static if (LOG)
+    if (LOG)
     {
         printf("+AggregateDeclaration::getAccess(this = '%s', smember = '%s')\n", ad.toChars(), smember.toChars());
     }
@@ -75,7 +76,7 @@ private Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
             }
         }
     }
-    static if (LOG)
+    if (LOG)
     {
         printf("-AggregateDeclaration::getAccess(this = '%s', smember = '%s') = %d\n", ad.toChars(), smember.toChars(), access_ret);
     }
@@ -139,14 +140,14 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
 {
     FuncDeclaration f = sc.func;
     AggregateDeclaration cdscope = sc.getStructClassScope();
-    static if (LOG)
+    if (LOG)
     {
         printf("AggregateDeclaration::checkAccess() for %s.%s in function %s() in scope %s\n", ad.toChars(), smember.toChars(), f ? f.toChars() : null, cdscope ? cdscope.toChars() : null);
     }
     Dsymbol smemberparent = smember.toParent();
     if (!smemberparent || !smemberparent.isAggregateDeclaration())
     {
-        static if (LOG)
+        if (LOG)
         {
             printf("not an aggregate member\n");
         }
@@ -160,7 +161,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
     {
         access = smember.prot();
         result = access.kind >= Prot.Kind.public_ || hasPrivateAccess(ad, f) || isFriendOf(ad, cdscope) || (access.kind == Prot.Kind.package_ && hasPackageAccess(sc, smember)) || ad.getAccessModule() == sc._module;
-        static if (LOG)
+        if (LOG)
         {
             printf("result1 = %d\n", result);
         }
@@ -168,7 +169,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
     else if ((access = getAccess(ad, smember)).kind >= Prot.Kind.public_)
     {
         result = true;
-        static if (LOG)
+        if (LOG)
         {
             printf("result2 = %d\n", result);
         }
@@ -176,7 +177,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
     else if (access.kind == Prot.Kind.package_ && hasPackageAccess(sc, ad))
     {
         result = true;
-        static if (LOG)
+        if (LOG)
         {
             printf("result3 = %d\n", result);
         }
@@ -184,7 +185,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
     else
     {
         result = isAccessible(smember, f, ad, cdscope);
-        static if (LOG)
+        if (LOG)
         {
             printf("result4 = %d\n", result);
         }
@@ -204,7 +205,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
  */
 private bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
 {
-    static if (LOG)
+    if (LOG)
     {
         printf("AggregateDeclaration::isFriendOf(this = '%s', cd = '%s')\n", ad.toChars(), cd ? cd.toChars() : "null");
     }
@@ -214,13 +215,13 @@ private bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
     //if (toParent() == cd.toParent())
     if (cd && ad.getAccessModule() == cd.getAccessModule())
     {
-        static if (LOG)
+        if (LOG)
         {
             printf("\tin same module\n");
         }
         return true;
     }
-    static if (LOG)
+    if (LOG)
     {
         printf("\tnot friend\n");
     }
@@ -237,7 +238,7 @@ private bool hasPackageAccess(Scope* sc, Dsymbol s)
 
 private bool hasPackageAccess(Module mod, Dsymbol s)
 {
-    static if (LOG)
+    if (LOG)
     {
         printf("hasPackageAccess(s = '%s', mod = '%s', s.protection.pkg = '%s')\n", s.toChars(), mod.toChars(), s.prot().pkg ? s.prot().pkg.toChars() : "NULL");
     }
@@ -266,7 +267,7 @@ private bool hasPackageAccess(Module mod, Dsymbol s)
                 break;
         }
     }
-    static if (LOG)
+    if (LOG)
     {
         if (pkg)
             printf("\tsymbol access binds to package '%s'\n", pkg.toChars());
@@ -275,7 +276,7 @@ private bool hasPackageAccess(Module mod, Dsymbol s)
     {
         if (pkg == mod.parent)
         {
-            static if (LOG)
+            if (LOG)
             {
                 printf("\tsc is in permitted package for s\n");
             }
@@ -283,7 +284,7 @@ private bool hasPackageAccess(Module mod, Dsymbol s)
         }
         if (pkg.isPackageMod() == mod)
         {
-            static if (LOG)
+            if (LOG)
             {
                 printf("\ts is in same package.d module as sc\n");
             }
@@ -294,7 +295,7 @@ private bool hasPackageAccess(Module mod, Dsymbol s)
         {
             if (ancestor == pkg)
             {
-                static if (LOG)
+                if (LOG)
                 {
                     printf("\tsc is in permitted ancestor package for s\n");
                 }
@@ -302,7 +303,7 @@ private bool hasPackageAccess(Module mod, Dsymbol s)
             }
         }
     }
-    static if (LOG)
+    if (LOG)
     {
         printf("\tno package access\n");
     }
@@ -339,13 +340,13 @@ private bool hasPrivateAccess(AggregateDeclaration ad, Dsymbol smember)
         Dsymbol smemberparent = smember.toParent();
         if (smemberparent)
             cd = smemberparent.isAggregateDeclaration();
-        static if (LOG)
+        if (LOG)
         {
             printf("AggregateDeclaration::hasPrivateAccess(class %s, member %s)\n", ad.toChars(), smember.toChars());
         }
         if (ad == cd) // smember is a member of this class
         {
-            static if (LOG)
+            if (LOG)
             {
                 printf("\tyes 1\n");
             }
@@ -362,7 +363,7 @@ private bool hasPrivateAccess(AggregateDeclaration ad, Dsymbol smember)
         }
         if (!cd && ad.toParent() == smember.toParent())
         {
-            static if (LOG)
+            if (LOG)
             {
                 printf("\tyes 2\n");
             }
@@ -370,14 +371,14 @@ private bool hasPrivateAccess(AggregateDeclaration ad, Dsymbol smember)
         }
         if (!cd && ad.getAccessModule() == smember.getAccessModule())
         {
-            static if (LOG)
+            if (LOG)
             {
                 printf("\tyes 3\n");
             }
             return true;
         }
     }
-    static if (LOG)
+    if (LOG)
     {
         printf("\tno\n");
     }
@@ -392,7 +393,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
 {
     if (sc.flags & SCOPE.noaccesscheck)
         return false;
-    static if (LOG)
+    if (LOG)
     {
         if (e)
         {

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -35,6 +35,8 @@ import dmd.semantic3;
 import dmd.tokens;
 import dmd.visitor;
 
+private enum LOG = false;
+
 enum Sizeok : int
 {
     none,           // size of aggregate is not yet able to compute
@@ -148,7 +150,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         if (sizeok != Sizeok.none)
             return true;
 
-        //printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);
+        if (LOG) printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);
         // determineFields can be called recursively from one of the fields's v.semantic
         fields.setDim(0);
 
@@ -221,7 +223,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final bool determineSize(Loc loc)
     {
-        //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
+        if (LOG) printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
         // The previous instance size finalizing had:
         if (type.ty == Terror)
@@ -276,9 +278,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     override final d_uns64 size(const ref Loc loc)
     {
-        //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
+        if (LOG) printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
         bool ok = determineSize(loc);
-        //printf("-AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
+        if (LOG) printf("-AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
         return ok ? structsize : SIZE_INVALID;
     }
 
@@ -290,7 +292,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final bool checkOverlappedFields()
     {
-        //printf("AggregateDeclaration::checkOverlappedFields() %s\n", toChars());
+        if (LOG) printf("AggregateDeclaration::checkOverlappedFields() %s\n", toChars());
         assert(sizeok == Sizeok.done);
         size_t nfields = fields.dim;
         if (isNested())
@@ -365,7 +367,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final bool fill(Loc loc, Expressions* elements, bool ctorinit)
     {
-        //printf("AggregateDeclaration::fill() %s\n", toChars());
+        if (LOG) printf("AggregateDeclaration::fill() %s\n", toChars());
         assert(sizeok == Sizeok.done);
         assert(elements);
         size_t nfields = fields.dim - isNested();
@@ -518,7 +520,8 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     static void alignmember(structalign_t alignment, uint size, uint* poffset) pure nothrow @safe
     {
-        //printf("alignment = %d, size = %d, offset = %d\n",alignment,size,offset);
+        // log statement broken, printf is not pure and not trusted
+        // if (LOG) printf("alignment = %d, size = %d, offset = %d\n",alignment,size, poffset ? *poffset : -1);
         switch (alignment)
         {
         case cast(structalign_t)1:
@@ -646,7 +649,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         }
         if (enclosing)
         {
-            //printf("makeNested %s, enclosing = %s\n", toChars(), enclosing.toChars());
+            if (LOG) printf("makeNested %s, enclosing = %s\n", toChars(), enclosing.toChars());
             assert(t);
             if (t.ty == Tstruct)
                 t = Type.tvoidptr; // t should not be a ref type

--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -12,10 +12,13 @@
 
 module dmd.apply;
 
+import core.stdc.stdio;
 import dmd.arraytypes;
 import dmd.dtemplate;
 import dmd.expression;
 import dmd.visitor;
+
+private enum LOG = false;
 
 /**************************************
  * An Expression tree walker that will visit each Expression e in the tree,
@@ -68,13 +71,13 @@ public:
 
     override void visit(NewExp e)
     {
-        //printf("NewExp::apply(): %s\n", toChars());
+        if (LOG) printf("NewExp::apply(): %s\n", e.toChars());
         doCond(e.thisexp) || doCond(e.newargs) || doCond(e.arguments) || applyTo(e);
     }
 
     override void visit(NewAnonClassExp e)
     {
-        //printf("NewAnonClassExp::apply(): %s\n", toChars());
+        if (LOG) printf("NewAnonClassExp::apply(): %s\n", e.toChars());
         doCond(e.thisexp) || doCond(e.newargs) || doCond(e.arguments) || applyTo(e);
     }
 
@@ -95,19 +98,19 @@ public:
 
     override void visit(AssertExp e)
     {
-        //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        if (LOG) printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", e.toChars());
         doCond(e.e1) || doCond(e.msg) || applyTo(e);
     }
 
     override void visit(CallExp e)
     {
-        //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        if (LOG) printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", e.toChars());
         doCond(e.e1) || doCond(e.arguments) || applyTo(e);
     }
 
     override void visit(ArrayExp e)
     {
-        //printf("ArrayExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        if (LOG) printf("ArrayExp::apply(apply_fp_t fp, void *param): %s\n", e.toChars());
         doCond(e.e1) || doCond(e.arguments) || applyTo(e);
     }
 


### PR DESCRIPTION
Reopened https://github.com/dlang/dmd/pull/8154

Current implementation is based on Walter's preference for logging described here: 

https://github.com/dlang/dmd/pull/7198#discussion_r143397225

This PR introduces following logging pattern:
```D
import core.stdc.stdio;

private enum LOG = false;

if (LOG) printf(...);
```

This replaces the current pattern of commented printf statements:
```D
// printf(...);
```

The new pattern makes it easier to turn log statements on and keeps log statements from breaking since having them uncommented forces their arguments to be analyzed.  It also keeps developers from removing the `import core.stdc.stdio` because doing so will break the log statements now. Note that `if (LOG)` should be used instead of `static if (LOG)`, otherwise, the statements don't get analyzed when they are disabled.

PR currently introduces the pattern in the first 3 modules `access.d` and `aggregate.d`  and `apply.d` (determined alphabetically) to show proof of concept.  Note that 2 out of the first 3 modules had errors in their printf statements...