### PR TITLE
[RFC] Debug Logging in DMD (Option 2)

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -12,7 +12,6 @@
 
 module dmd.aggregate;
 
-import core.stdc.stdio;
 import core.checkedint;
 
 import dmd.arraytypes;
@@ -29,6 +28,7 @@ import dmd.func;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
+import dmd.log;
 import dmd.mtype;
 import dmd.semantic2;
 import dmd.semantic3;
@@ -148,7 +148,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         if (sizeok != Sizeok.none)
             return true;
 
-        //printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);
+        logf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);
         // determineFields can be called recursively from one of the fields's v.semantic
         fields.setDim(0);
 
@@ -221,7 +221,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final bool determineSize(Loc loc)
     {
-        //printf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
+        logf("AggregateDeclaration::determineSize() %s, sizeok = %d\n", toChars(), sizeok);
 
         // The previous instance size finalizing had:
         if (type.ty == Terror)
@@ -276,9 +276,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     override final d_uns64 size(const ref Loc loc)
     {
-        //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
+        logf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
         bool ok = determineSize(loc);
-        //printf("-AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
+        logf("-AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
         return ok ? structsize : SIZE_INVALID;
     }
 
@@ -290,7 +290,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final bool checkOverlappedFields()
     {
-        //printf("AggregateDeclaration::checkOverlappedFields() %s\n", toChars());
+        logf("AggregateDeclaration::checkOverlappedFields() %s\n", toChars());
         assert(sizeok == Sizeok.done);
         size_t nfields = fields.dim;
         if (isNested())
@@ -365,7 +365,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final bool fill(Loc loc, Expressions* elements, bool ctorinit)
     {
-        //printf("AggregateDeclaration::fill() %s\n", toChars());
+        logf("AggregateDeclaration::fill() %s\n", toChars());
         assert(sizeok == Sizeok.done);
         assert(elements);
         size_t nfields = fields.dim - isNested();
@@ -518,7 +518,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     static void alignmember(structalign_t alignment, uint size, uint* poffset) pure nothrow @safe
     {
-        //printf("alignment = %d, size = %d, offset = %d\n",alignment,size,offset);
+        logf("alignment = %d, size = %d, offset = %d\n",alignment,size, poffset ? *poffset : -1);
         switch (alignment)
         {
         case cast(structalign_t)1:
@@ -646,7 +646,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         }
         if (enclosing)
         {
-            //printf("makeNested %s, enclosing = %s\n", toChars(), enclosing.toChars());
+            logf("makeNested %s, enclosing = %s\n", toChars(), enclosing.toChars());
             assert(t);
             if (t.ty == Tstruct)
                 t = Type.tvoidptr; // t should not be a ref type

--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -15,6 +15,7 @@ module dmd.apply;
 import dmd.arraytypes;
 import dmd.dtemplate;
 import dmd.expression;
+import dmd.log;
 import dmd.visitor;
 
 /**************************************
@@ -68,13 +69,13 @@ public:
 
     override void visit(NewExp e)
     {
-        //printf("NewExp::apply(): %s\n", toChars());
+        logf("NewExp::apply(): %s\n", e.toChars());
         doCond(e.thisexp) || doCond(e.newargs) || doCond(e.arguments) || applyTo(e);
     }
 
     override void visit(NewAnonClassExp e)
     {
-        //printf("NewAnonClassExp::apply(): %s\n", toChars());
+        logf("NewAnonClassExp::apply(): %s\n", e.toChars());
         doCond(e.thisexp) || doCond(e.newargs) || doCond(e.arguments) || applyTo(e);
     }
 
@@ -95,19 +96,19 @@ public:
 
     override void visit(AssertExp e)
     {
-        //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        logf("CallExp::apply(apply_fp_t fp, void *param): %s\n", e.toChars());
         doCond(e.e1) || doCond(e.msg) || applyTo(e);
     }
 
     override void visit(CallExp e)
     {
-        //printf("CallExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        logf("CallExp::apply(apply_fp_t fp, void *param): %s\n", e.toChars());
         doCond(e.e1) || doCond(e.arguments) || applyTo(e);
     }
 
     override void visit(ArrayExp e)
     {
-        //printf("ArrayExp::apply(apply_fp_t fp, void *param): %s\n", toChars());
+        logf("ArrayExp::apply(apply_fp_t fp, void *param): %s\n", e.toChars());
         doCond(e.e1) || doCond(e.arguments) || applyTo(e);
     }
 

--- a/src/dmd/log.d
+++ b/src/dmd/log.d
@@ -1,0 +1,60 @@
+/**
+This module defines symbols to support the recommended debug logging pattern for dmd.
+
+Example:
+---
+import dmd.log;
+
+void foo(int x)
+{
+    logf("foo was called with x = %d\n", x);
+
+    if (logEnabled)
+    {
+        // do some setup for the log message
+        logf(...);
+    }
+
+    // Use this if you want to log a message even when logging is not enabled.
+    forcelogf(...);
+}
+---
+*/
+module dmd.log;
+
+/** The global log switch. Affects all calls to `logf`. */
+private enum allLoggingEnabled = false;
+
+/**
+Call to see if logging is enabled for a particular module.
+*/
+bool logEnabled(string mod = __MODULE__)
+{
+    return false
+        // || mod == "dmd.access"
+        // || mod == "dmd.aggregate"
+        // || mod == "dmd.apply"
+        ;
+}
+
+// mark as pure/trusted so that logging can be done in pure/safe functions
+private extern (C) int printf(const(char)* format, ...) pure @trusted;
+
+/**
+Log if `logEnabled` is `true`.
+*/
+void logf(string mod = __MODULE__, T...)(string format, T args) pure @trusted
+{
+    static if (allLoggingEnabled || logEnabled(mod))
+    {
+        printf(format.ptr, args);
+    }
+}
+
+/**
+Forecefully log a message even if logging is not enabled.
+*/
+void forcelogf(T...)(string format, T args) pure @trusted
+{
+    printf(format, args);
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -306,7 +306,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\
 	hdrgen id impcnvtab imphint init initsem inline inlinecost intrange	\
-	json lambdacomp lib libelf libmach link mars mtype nogc nspace objc opover optimize parse permissivevisitor sapply templateparamsem	\
+	json lambdacomp lib libelf libmach link log mars mtype nogc nspace objc opover optimize parse permissivevisitor sapply templateparamsem	\
 	sideeffect statement staticassert target typesem traits transitivevisitor parsetimevisitor visitor	\
 	typinf utils scanelf scanmach statement_rewrite_walker statementsem staticcond safe blockexit printast \
 	semantic2 semantic3))

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -155,7 +155,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d $D/dsymbolsem.d		\
 	$D/lambdacomp.d $D/dtemplate.d $D/dversion.d $D/escape.d			\
 	$D/expression.d $D/expressionsem.d $D/func.d $D/hdrgen.d $D/id.d $D/imphint.d	\
-	$D/impcnvtab.d $D/init.d $D/initsem.d $D/inline.d $D/inlinecost.d $D/intrange.d $D/json.d $D/lib.d $D/link.d	\
+	$D/impcnvtab.d $D/init.d $D/initsem.d $D/inline.d $D/inlinecost.d $D/intrange.d $D/json.d $D/lib.d $D/link.d $D/log.d \
 	$D/mars.d $D/mtype.d $D/nogc.d $D/nspace.d $D/objc.d $D/opover.d $D/optimize.d $D/parse.d	\
 	$D/sapply.d $D/sideeffect.d $D/statement.d $D/staticassert.d $D/target.d	\
 	$D/safe.d $D/blockexit.d $D/permissivevisitor.d $D/transitivevisitor.d $D/parsetimevisitor.d $D/printast.d $D/typesem.d \


### PR DESCRIPTION
The "more liberal" alternative to https://github.com/dlang/dmd/pull/8156

This one defines the function `logf` as a wrapper around logging instead of having other modules call `printf` directly.

Instead of:
```D
if (LOG) printf(...);
```
You have
```D
logf(...);
```

In the case that you have "setup" to do for the log, you can do this
```D
if (logEnabled)
{
    // ... setup
    logf(...);
}
```

If you want to enable ALL log messages, you change the `allLoggingEnabled` enum in `dmd/log.d` to `true`.  If you want to turn on individual log statements you can change `logf` to `forcelogf`.
```D
forcelogf(...);
```

If you want to enable all the log statements in particular modules, you can do this in the `logEnabled` function in `log.d`.

Note that one advantage of this PR over #8156 is that it allows developers to customize all logging by changing code in a single location rather than having to change it in every call.  For example, sometimes you may want to log to `stderr` instead of `stdout` so that the log messages are in "order" with error messages, with this PR you could change this in one place rather than finding and changing every call.