### PR TITLE
Fix Issue 18753 - chunkBy compile error causes ICE

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3985,7 +3985,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             default:
                 assert(0);
             }
-            goto Lyes;
+
+            // https://issues.dlang.org/show_bug.cgi?id=18753
+            if (tded)
+                goto Lyes;
+            goto Lno;
         }
         else if (e.tspec && !e.id && !(e.parameters && e.parameters.dim))
         {

--- a/test/fail_compilation/ice18753.d
+++ b/test/fail_compilation/ice18753.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice18753.d(21): Error: variable `ice18753.isInputRange!(Group).isInputRange` type `void` is inferred from initializer `ReturnType(func...)`, and variables cannot be of type `void`
-fail_compilation/ice18753.d(25): Error: template instance `ice18753.isInputRange!(Group)` error instantiating
-fail_compilation/ice18753.d(17):        instantiated from here: `isForwardRange!(Group)`
-fail_compilation/ice18753.d(17):        while evaluating: `static assert(isForwardRange!(Group))`
+fail_compilation/ice18753.d(23): Error: template instance `ice18753.isInputRange!(Group)` error instantiating
+fail_compilation/ice18753.d(18):        instantiated from here: `isForwardRange!(Group)`
+fail_compilation/ice18753.d(18):        while evaluating: `static assert(isForwardRange!(Group))`
 ---
 */
 

--- a/test/fail_compilation/ice18753.d
+++ b/test/fail_compilation/ice18753.d
@@ -10,21 +10,17 @@ fail_compilation/ice18753.d(17):        while evaluating: `static assert(isForwa
 
 // https://issues.dlang.org/show_bug.cgi?id=18753
 
-struct ChunkByImpl{
+struct ChunkByImpl
+{
     struct Group
-    {
-    }
+    { }
+    
     static assert(isForwardRange!Group);
-
 }
 
-enum isInputRange(R) =
-ReturnType;
+enum isInputRange(R) = ReturnType;
 
-
-enum isForwardRange(R) = isInputRange!R
-is(ReturnType!(() => r) );
-
+enum isForwardRange(R) = isInputRange!R is ReturnType!(() => r);
 
 template ReturnType(func...)
 {
@@ -32,15 +28,12 @@ template ReturnType(func...)
         ReturnType R;
 }
 
-
 template FunctionTypeOf(func...)
 {
     static if (is(typeof(func[0]) T))
         static if (is(T Fptr ) )
-        alias FunctionTypeOf = Fptr;
+            alias FunctionTypeOf = Fptr;
 }
-
 
 template Select()
-{
-}
+{ }

--- a/test/fail_compilation/ice18753.d
+++ b/test/fail_compilation/ice18753.d
@@ -1,0 +1,46 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice18753.d(21): Error: variable `ice18753.isInputRange!(Group).isInputRange` type `void` is inferred from initializer `ReturnType(func...)`, and variables cannot be of type `void`
+fail_compilation/ice18753.d(25): Error: template instance `ice18753.isInputRange!(Group)` error instantiating
+fail_compilation/ice18753.d(17):        instantiated from here: `isForwardRange!(Group)`
+fail_compilation/ice18753.d(17):        while evaluating: `static assert(isForwardRange!(Group))`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=18753
+
+struct ChunkByImpl{
+    struct Group
+    {
+    }
+    static assert(isForwardRange!Group);
+
+}
+
+enum isInputRange(R) =
+ReturnType;
+
+
+enum isForwardRange(R) = isInputRange!R
+is(ReturnType!(() => r) );
+
+
+template ReturnType(func...)
+{
+    static if (is(FunctionTypeOf!func R == return))
+        ReturnType R;
+}
+
+
+template FunctionTypeOf(func...)
+{
+    static if (is(typeof(func[0]) T))
+        static if (is(T Fptr ) )
+        alias FunctionTypeOf = Fptr;
+}
+
+
+template Select()
+{
+}


### PR DESCRIPTION
I haven't added a test since the bug report contains code from phobos and the ice is present when the code errors (wrongfully). The test case errors on phobos lines of code which may differ depending on the version of phobos used so I cannot safely add the test in the fail_compilation directory. Any ideas on how we can test this ice?

Later edit: Thanks @wilzbach . I added the test.