### PR TITLE
Add broken import order invariance tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -176,6 +176,8 @@ The following is a list of all available settings:
                          Optionally a MODEL suffix can used for further filtering, e.g.
                          win32 win64 linux32 linux64 osx32 osx64 freebsd32 freebsd64
 
+    BROKEN:              the test is broken. failure won't cause test suite to fail.
+
 Makefile Environment variables
 ------------------------------
 

--- a/test/fail_compilation/imports/import18517a.d
+++ b/test/fail_compilation/imports/import18517a.d
@@ -1,0 +1,1 @@
+module import18517b;

--- a/test/fail_compilation/imports/import18517b.d
+++ b/test/fail_compilation/imports/import18517b.d
@@ -1,0 +1,1 @@
+module import18517a;

--- a/test/fail_compilation/imports/import18517c.d
+++ b/test/fail_compilation/imports/import18517c.d
@@ -1,0 +1,1 @@
+import import18517a;

--- a/test/fail_compilation/imports/import18517d.d
+++ b/test/fail_compilation/imports/import18517d.d
@@ -1,0 +1,1 @@
+import import18517b;

--- a/test/fail_compilation/test18517a.d
+++ b/test/fail_compilation/test18517a.d
@@ -1,0 +1,19 @@
+/*
+REQUIRED_ARGS: -I=fail_compilation/imports
+PERMUTE_ARGS:
+BROKEN:
+TEST_OUTPUT:
+---
+fail_compilation/test18517a.d(19): Error: module `import18517a` from file fail_compilation/imports/import18517b.d conflicts with another module import18517b from file fail_compilation/imports/import18517a.d
+---
+*/
+
+/*
+The second import must fail because the module name of the first import is
+the same as the module name of the second import.  The compiler MUST cause
+this to fail, because if it doesn't then switching the import order would
+result in a different file being loaded for module import18517b breaking
+import order invarance.
+*/
+import import18517a;
+import import18517b;

--- a/test/fail_compilation/test18517b.d
+++ b/test/fail_compilation/test18517b.d
@@ -1,0 +1,19 @@
+/*
+REQUIRED_ARGS: -I=fail_compilation/imports
+PERMUTE_ARGS:
+BROKEN:
+TEST_OUTPUT:
+---
+fail_compilation/test18517b.d(19): Error: module `import18517b` from file fail_compilation/imports/import18517a.d conflicts with another module import18517a from file fail_compilation/imports/import18517b.d
+---
+*/
+
+/*
+The second import must fail because the module name of the first import is
+the same as the module name of the second import.  The compiler MUST cause
+this to fail, because if it doesn't then switching the import order would
+result in a different file being loaded for module import18517a breaking
+import order invarance.
+*/
+import import18517b;
+import import18517a;

--- a/test/fail_compilation/test18517c.d
+++ b/test/fail_compilation/test18517c.d
@@ -1,0 +1,10 @@
+/*
+BROKEN:
+REQUIRED_ARGS: -I=fail_compilation/imports fail_compilation/imports/import18517c.d fail_compilation/imports/import18517d.d
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/imports/import18517d.d(1): Error: module `import18517a` from file fail_compilation/imports/import18517b.d conflicts with another module import18517b from file fail_compilation/imports/import18517a.d
+---
+*/
+import import18517c, import18517d;

--- a/test/fail_compilation/test18517d.d
+++ b/test/fail_compilation/test18517d.d
@@ -1,0 +1,10 @@
+/*
+BROKEN:
+REQUIRED_ARGS: -I=fail_compilation/imports fail_compilation/imports/import18517d.d fail_compilation/imports/import18517c.d
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/imports/import18517c.d(1): Error: module `import18517b` from file fail_compilation/imports/import18517a.d conflicts with another module import18517a from file fail_compilation/imports/import18517b.d
+---
+*/
+import import18517c, import18517d;


### PR DESCRIPTION
Added tests to the DMD test suite that will pass once https://issues.dlang.org/show_bug.cgi?id=18517 is fixed (PR here https://github.com/dlang/dmd/pull/7900).  Added the `BROKEN:` setting to these tests to indicate that they are currently broken.

The tests that were added currently fail because import order invariance is broken.  One test has an example where imports in a different order in the same file will produce different results, while another has an example where modules passed in a different order on the command line will produce different results.