### PR TITLE
Preserve the `__debug_line` section on macOS in the final executable

### DIFF
--- a/src/dmd/backend/dwarf.c
+++ b/src/dmd/backend/dwarf.c
@@ -11,6 +11,21 @@
 
 // Emit Dwarf symbolic debug info
 
+/*
+Some generic information for debug info on macOS:
+
+The linker on macOS will remove any debug info, i.e. every section with the
+`S_ATTR_DEBUG` flag, this includes everything in the `__DWARF` section. By using
+the `S_REGULAR` flag the linker will not remove this section. This allows to get
+the filenames and line numbers for backtraces from the executable.
+
+Normally the linker removes all the debug info but adds a reference to the
+object files. The debugger can then read the object files to get filename and
+line number information. It's also possible to use an additional tool that
+generates a separate `.dSYM` file. This file can then later be deployed with the
+application if debug info is needed when the application is deployed.
+*/
+
 #if !SPP
 #include        <stdio.h>
 #include        <string.h>
@@ -115,12 +130,12 @@ bool doUnwindEhFrame()
 
 #define OFFSET_FAC REGSIZE
 
-int dwarf_getsegment(const char *name, int align)
+int dwarf_getsegment(const char *name, int align, int flags)
 {
 #if ELFOBJ
-    return ElfObj::getsegment(name, NULL, SHT_PROGBITS, 0, align * 4);
+    return ElfObj::getsegment(name, NULL, flags, 0, align * 4);
 #elif MACHOBJ
-    return MachObj::getsegment(name, "__DWARF", align * 2, S_ATTR_DEBUG);
+    return MachObj::getsegment(name, "__DWARF", align * 2, flags);
 #else
     assert(0);
     return 0;
@@ -458,12 +473,13 @@ struct Section
     IDXSEC secidx;
     Outbuffer *buf;
     const char *name;
+    int flags;
 
     /* Allocate and initialize Section
      */
     void initialize()
     {
-        const segidx_t segi = dwarf_getsegment(name, 0);
+        const segidx_t segi = dwarf_getsegment(name, 0, flags);
         seg = segi;
         secidx = SegData[segi]->SDshtidx;
         buf = SegData[segi]->SDbuf;
@@ -472,23 +488,25 @@ struct Section
 };
 
 #if MACHOBJ
-static Section debug_pubnames = { 0,0,0, "__debug_pubnames" };
-static Section debug_aranges  = { 0,0,0, "__debug_aranges" };
-static Section debug_ranges   = { 0,0,0, "__debug_ranges" };
-static Section debug_loc      = { 0,0,0, "__debug_loc" };
-static Section debug_abbrev   = { 0,0,0, "__debug_abbrev" };
-static Section debug_info     = { 0,0,0, "__debug_info" };
-static Section debug_str      = { 0,0,0, "__debug_str" };
-static Section debug_line     = { 0,0,0, "__debug_line" };
+static Section debug_pubnames = { 0,0,0, "__debug_pubnames", S_ATTR_DEBUG };
+static Section debug_aranges  = { 0,0,0, "__debug_aranges", S_ATTR_DEBUG };
+static Section debug_ranges   = { 0,0,0, "__debug_ranges", S_ATTR_DEBUG };
+static Section debug_loc      = { 0,0,0, "__debug_loc", S_ATTR_DEBUG };
+static Section debug_abbrev   = { 0,0,0, "__debug_abbrev", S_ATTR_DEBUG };
+static Section debug_info     = { 0,0,0, "__debug_info", S_ATTR_DEBUG };
+static Section debug_str      = { 0,0,0, "__debug_str", S_ATTR_DEBUG };
+// We use S_REGULAR to make sure the linker doesn't remove this section. Needed
+// for filenames and line numbers in backtraces.
+static Section debug_line     = { 0,0,0, "__debug_line", S_REGULAR };
 #elif ELFOBJ
-static Section debug_pubnames = { 0,0,0, ".debug_pubnames" };
-static Section debug_aranges  = { 0,0,0, ".debug_aranges" };
-static Section debug_ranges   = { 0,0,0, ".debug_ranges" };
-static Section debug_loc      = { 0,0,0, ".debug_loc" };
-static Section debug_abbrev   = { 0,0,0, ".debug_abbrev" };
-static Section debug_info     = { 0,0,0, ".debug_info" };
-static Section debug_str      = { 0,0,0, ".debug_str" };
-static Section debug_line     = { 0,0,0, ".debug_line" };
+static Section debug_pubnames = { 0,0,0, ".debug_pubnames", SHT_PROGBITS };
+static Section debug_aranges  = { 0,0,0, ".debug_aranges", SHT_PROGBITS };
+static Section debug_ranges   = { 0,0,0, ".debug_ranges", SHT_PROGBITS };
+static Section debug_loc      = { 0,0,0, ".debug_loc", SHT_PROGBITS };
+static Section debug_abbrev   = { 0,0,0, ".debug_abbrev", SHT_PROGBITS };
+static Section debug_info     = { 0,0,0, ".debug_info", SHT_PROGBITS };
+static Section debug_str      = { 0,0,0, ".debug_str", SHT_PROGBITS };
+static Section debug_line     = { 0,0,0, ".debug_line", SHT_PROGBITS };
 #endif
 
 #if MACHOBJ
@@ -1012,7 +1030,12 @@ void dwarf_initfile(const char *filename)
         return;
     if (config.ehmethod == EH_DM)
     {
-        int seg = dwarf_getsegment(debug_frame_name, 1);
+#if MACHOBJ
+        int flags = S_ATTR_DEBUG;
+#elif ELFOBJ
+        int flags = SHT_PROGBITS;
+#endif
+        int seg = dwarf_getsegment(debug_frame_name, 1, flags);
         Outbuffer *buf = SegData[seg]->SDbuf;
         buf->reserve(1000);
         writeDebugFrameHeader(buf);
@@ -1515,7 +1538,12 @@ void dwarf_func_term(Symbol *sfunc)
 
     if (ehmethod(sfunc) == EH_DM)
     {
-        IDXSEC dfseg = dwarf_getsegment(debug_frame_name, 1);
+#if MACHOBJ
+        int flags = S_ATTR_DEBUG;
+#elif ELFOBJ
+        int flags = SHT_PROGBITS;
+#endif
+        IDXSEC dfseg = dwarf_getsegment(debug_frame_name, 1, flags);
         writeDebugFrameFDE(dfseg, sfunc);
     }
 

--- a/src/dmd/backend/dwarf.c
+++ b/src/dmd/backend/dwarf.c
@@ -127,17 +127,12 @@ int dwarf_getsegment(const char *name, int align)
 #endif
 }
 
+#if ELFOBJ
 int dwarf_getsegment_alloc(const char *name, const char *suffix, int align)
 {
-#if ELFOBJ
     return ElfObj::getsegment(name, suffix, SHT_PROGBITS, SHF_ALLOC, align * 4);
-#elif MACHOBJ
-    return MachObj::getsegment(name, "__DWARF", align * 2, S_ATTR_DEBUG);
-#else
-    assert(0);
-    return 0;
-#endif
 }
+#endif
 
 int dwarf_except_table_alloc(Symbol *s)
 {

--- a/test/runnable/debug_info.d
+++ b/test/runnable/debug_info.d
@@ -1,0 +1,50 @@
+// REQUIRED_ARGS: -g
+
+void main()
+{
+    version(OSX) testDebugLineMacOS();
+}
+
+version (OSX):
+
+struct mach_header;
+struct mach_header_64;
+struct section;
+struct section_64;
+
+version (D_LP64)
+{
+    alias MachHeader = mach_header_64;
+    alias Section = section_64;
+}
+
+else
+{
+    alias MachHeader = mach_header;
+    alias Section = section;
+}
+
+extern (C)
+{
+    MachHeader* _dyld_get_image_header(uint image_index);
+    const(section)* getsectbynamefromheader(in mach_header* mhp, in char* segname, in char* sectname);
+    const(section_64)* getsectbynamefromheader_64(in mach_header_64* mhp, in char* segname, in char* sectname);
+}
+
+const(Section)* getSectByNameFromHeader(MachHeader* mhp, in char* segname, in char* sectname)
+{
+    version (D_LP64)
+        return getsectbynamefromheader_64(mhp, segname, sectname);
+    else
+        return getsectbynamefromheader(mhp, segname, sectname);
+}
+
+void testDebugLineMacOS()
+{
+    auto header = _dyld_get_image_header(0);
+    assert(header);
+
+    auto section = getSectByNameFromHeader(header, "__DWARF", "__debug_line");
+    // verify that the __debug_line section is present in the final executable
+    assert(section);
+}


### PR DESCRIPTION
The linker on macOS will remove any debug info, i.e. every section with the `S_ATTR_DEBUG` flag, this includes everything in the `__DWARF` section. By using the `S_REGULAR` flag the linker will not remove this section. This allows to get the filenames and line numbers for backtraces from the executable.

Normally the linker removes all the debug info but adds a reference to the object files. The debugger can then read the object files to get filename and line number information. It's also possible to use an additional tool that generates a separate `.dSYM` file. This file can then later be deployed with the application if debug info is needed when the application is deployed.