### PR TITLE
improve try-finally handling of nofallthru

### DIFF
--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -2027,11 +2027,14 @@ extern (C++) final class TryFinallyStatement : Statement
     Statement _body;
     Statement finalbody;
 
+    bool bodyFallsThru;         // true if _body falls through to finally
+
     extern (D) this(const ref Loc loc, Statement _body, Statement finalbody)
     {
         super(loc);
         this._body = _body;
         this.finalbody = finalbody;
+        this.bodyFallsThru = true;      // assume true until statementSemantic()
     }
 
     static TryFinallyStatement create(Loc loc, Statement _body, Statement finalbody)

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -579,6 +579,8 @@ public:
     Statement *_body;
     Statement *finalbody;
 
+    bool bodyFallsThru;         // true if _body falls through to finally
+
     static TryFinallyStatement *create(Loc loc, Statement *body, Statement *finalbody);
     Statement *syntaxCopy();
     bool hasBreak();

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3837,6 +3837,7 @@ else
             result = new CompoundStatement(tfs.loc, tfs._body, tfs.finalbody);
             return;
         }
+        tfs.bodyFallsThru = (blockexit & BE.fallthru) != 0;
         result = tfs;
     }
 


### PR DESCRIPTION
If the try-body does not fall-through to the finally-body, we can improve the code generation by marking that block as an exit node (treated as a does-not-get-here node). Saves a few instructions in generated code.