### PR TITLE
Fix issue 15574 - wrong order of link arguments

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -569,25 +569,14 @@ public int runLINK()
             argv.push("-Xlinker");
             argv.push("--gc-sections");
         }
-        for (size_t i = 0; i < global.params.linkswitches.dim; i++)
-        {
-            const(char)* p = global.params.linkswitches[i];
-            if (!p || !p[0] || !(p[0] == '-' && (p[1] == 'l' || p[1] == 'L')))
-            {
-                // Don't need -Xlinker if switch starts with -l or -L.
-                // Eliding -Xlinker is significant for -L since it allows our paths
-                // to take precedence over gcc defaults.
-                argv.push("-Xlinker");
-            }
-            argv.push(p);
-        }
         /* Add each library, prefixing it with "-l".
          * The order of libraries passed is:
          *  1. any libraries passed with -L command line switch
          *  2. libraries specified on the command line
          *  3. libraries specified by pragma(lib), which were appended
          *     to global.params.libfiles.
-         *  4. standard libraries.
+         *  4. link switches, that may also contain -l libraries
+         *  5. standard libraries.
          */
         for (size_t i = 0; i < global.params.libfiles.dim; i++)
         {
@@ -607,6 +596,18 @@ public int runLINK()
         for (size_t i = 0; i < global.params.dllfiles.dim; i++)
         {
             const(char)* p = global.params.dllfiles[i];
+            argv.push(p);
+        }
+        for (size_t i = 0; i < global.params.linkswitches.dim; i++)
+        {
+            const(char)* p = global.params.linkswitches[i];
+            if (!p || !p[0] || !(p[0] == '-' && (p[1] == 'l' || p[1] == 'L')))
+            {
+                // Don't need -Xlinker if switch starts with -l or -L.
+                // Eliding -Xlinker is significant for -L since it allows our paths
+                // to take precedence over gcc defaults.
+                argv.push("-Xlinker");
+            }
             argv.push(p);
         }
         /* D runtime libraries must go after user specified libraries

--- a/test/compilable/issue15574.sh
+++ b/test/compilable/issue15574.sh
@@ -1,0 +1,58 @@
+#! /usr/bin/env bash
+
+
+if [[ $OS = *"win"* ]]; then exit 0; fi
+
+
+if [ $LIBEXT = ".a" ]; then
+    LIB_PREFIX=lib
+else
+    LIB_PREFIX=
+fi
+
+TEST_DIR=${OUTPUT_BASE}
+C_FILE=$TEST_DIR/square.c
+C_LIB=$TEST_DIR/${LIB_PREFIX}csquare${LIBEXT}
+D_FILE=$TEST_DIR/square.d
+D_LIB=$TEST_DIR/${LIB_PREFIX}dsquare${LIBEXT}
+APP_FILE=$TEST_DIR/app.d
+APP=$TEST_DIR/app${EXE}
+
+mkdir -p $TEST_DIR
+
+cat >$C_FILE <<EOF
+int square(int x) { return x*x; }
+EOF
+
+cat >$D_FILE <<EOF
+module square;
+
+extern(C) nothrow {
+    int square (int x);
+}
+
+bool testSquare() {
+    return square(2) == 4 && square(5) == 25;
+}
+EOF
+
+cat >$APP_FILE <<EOF
+module APP;
+
+import square;
+
+int main() {
+    return testSquare() ? 0 : 1;
+}
+EOF
+
+if [ -z ${CC+x} ]; then CC=cc; fi
+
+$CC -m${MODEL} -c -o ${C_FILE}${OBJ} $C_FILE
+ar rcs ${C_LIB} ${C_FILE}${OBJ}
+
+${DMD} -m${MODEL} -lib -of${D_LIB} ${D_FILE}
+
+${DMD} -m${MODEL} -of${APP} ${APP_FILE} -I${TEST_DIR} ${D_LIB} -L-L${TEST_DIR} -L-lcsquare
+
+${APP}


### PR DESCRIPTION
This essentially places *.a arguments before the -l and -L switches in
the linker command line.

This allows to link applications that link against a static archive *.a
that depends on -l lib switches.
Such dependency scheme is typical of the following situation:
  - have a D package that contains binding to a C library.
  - this D package is itself built as a static library (libdpackage.a).
  - the C library is built in the same build process as a static library
    (pathtoClib/libclib.a)
  - dmd is invoked in the following way:
```
  $ dmd ... libdpackage.a -L-LpathtoClib -L-lclib
```
Currently dmd reorders arguments and places *.a after -l linker switches
which causes link errors if the -l points to a static library.

This is especially useful with Dub, which can be configured to probe for
the C library, and build it as a static lib if not found system-wide.
In both cases, the C library is provided with "libs" json entry.

So this is not about keeping relative order of linker arguments, it is
about providing an order of linker arguments that is more sound than
the current one.