### PR TITLE
 Partial fix for Issue 18472 - permit using typeid at compile-time in betterC

### DIFF
--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -24,6 +24,7 @@ struct S
 extern (C) void main()
 {
     test(1);
+    test18472();
 }
 
 /*******************************************/
@@ -36,3 +37,19 @@ extern (C) void test17605()
     a = 1;
 }
 
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18472
+
+void test18472()
+{
+    version(D_LP64)
+    {
+        enum b = typeid(size_t) is typeid(ulong);
+    }
+    else
+    {
+        enum b = typeid(size_t) is typeid(uint);
+    }
+
+    assert(b);
+}


### PR DESCRIPTION
When compiling with `-betterC`, `TypeInfo` is not usable at runtime, but it should still be usable at compile-time.