### PR TITLE
Fix Issue 18762 - DMD should use a unique path/filename for __stdin.o

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -579,6 +579,16 @@ extern (C++) final class Module : Package
         else
         {
             const(char)* argdoc;
+            OutBuffer buf;
+            if (!strcmp(arg, "__stdin.d"))
+            {
+                version (Posix)
+                    import core.sys.posix.unistd : getpid;
+                else version (Windows)
+                    import core.sys.windows.windows : getpid = GetCurrentProcessId;
+                buf.printf("__stdin_%d.d", getpid());
+                arg = buf.peekString();
+            }
             if (global.params.preservePaths)
                 argdoc = arg;
             else


### PR DESCRIPTION
On my machine, this seems to allow building dlang.org reliably again.