### PR TITLE
Fix Issue 18767 - __xtoHash memberwise hashing shouldn't just sum the member hashes

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -765,7 +765,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
     const(char)* code =
         "size_t h = 0;" ~
         "foreach (i, T; typeof(p.tupleof))" ~
-        "    h += typeid(T).getHash(cast(const void*)&p.tupleof[i]);" ~
+        "    h = h * 33 + typeid(T).getHash(cast(const void*)&p.tupleof[i]);" ~
         "return h;";
     fop.fbody = new CompileStatement(loc, new StringExp(loc, cast(char*)code));
     Scope* sc2 = sc.push();


### PR DESCRIPTION
This PR doesn't add anything clever. It just makes the automatically generated non-bitwise `__xtoHash` a bit closer to what you'd find in something like https://projectlombok.org/features/EqualsAndHashCode