### PR TITLE
Optimization: Don't generate try-catch for nothrow postblits

### DIFF
--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -36,3 +36,19 @@ extern (C) void test17605()
     a = 1;
 }
 
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18493
+
+struct S18493
+{
+    this(this) nothrow { }  // Since this is attributed with `nothrow` there should be no error about using
+                            // try-catch with -betterC
+    ~this() { }  
+}
+
+struct S18493_2
+{
+    S18493 s1;
+    S18493 s2;
+}
+

--- a/test/runnable/xpostblit.d
+++ b/test/runnable/xpostblit.d
@@ -70,8 +70,67 @@ void test2() @safe @nogc nothrow
     assert(Counter.cnt == 1);
 }
 
+/****************************************************************
+ This test is intended to verify the exception safety of field
+ postblits
+*/
+string trace = "";
+
+struct FieldThrow
+{
+    string name;
+    this(string n)
+    {
+        name = n;
+    }
+
+    bool throwExcept;
+    this(this)
+    { 
+        if (throwExcept)
+        {
+            throw new Exception("");
+        }
+    }
+
+    ~this() { trace ~= name ~ ".dtor"; }
+}
+
+struct S
+{
+    auto f1 = FieldThrow("f1");
+    FieldThrow[2] f2f3= [FieldThrow("f2"), FieldThrow("f3")];
+    auto f4 = FieldThrow("f4");
+}
+
+void test3()
+{
+    trace = "";
+
+    S s1;
+
+    // Cause `s1.f4`'s postblit to throw
+    s1.f4.throwExcept = true;
+
+    try
+    {
+        // `s`'s postblit will be a combination of `f1`, `f2f3`, and `f4`'s
+        // postblit in that order.  However, `f4`'s postblit will throw,
+        // causing `s1.f2f3` and `s1.f1`'s destructors to execute in that
+        // order
+        S s2 = s1;
+    }
+    catch(Exception ex){ }
+
+    // Confirm the field destructors were called and were called in the
+    // corrrect order
+    assert(trace == "f3.dtor" ~ "f2.dtor" ~ "f1.dtor");
+}
+/****************************************************************************/
+
 void main()
 {
     test1();
     test2();
+    test3();
 }


### PR DESCRIPTION
While researching [Issue 18493 - [betterC] Can't use aggregated type with postblit ](https://issues.dlang.org/show_bug.cgi?id=18493), I discovered that when the postblit is generated for an aggregate with 2 or more fields, the compiler adds try-catches around all but the first field postblit to ensure that if an exception is thrown in subsequent postblits the destructors are called for preceding successful postblits.  

In other words, for this code...

```D
struct S
{
    this(this) nothrow { }
    ~this() {  }
}

struct C
{
    S s1;
    S s2;
}
```
... the postblit for `C` looks like this:

```D
this.s1.__postblit();
try
{
    this.s2.__postblit();
}
catch(Throwable __o4)
{
    this.s1.~this();
    throw __o4;
}
```

I believe this is unnecessary if the field's postblit is attributed with `nothrow`. 

With the change in this PR, the code above will produce a postblit without the try-catch block like that shown below:

```D
this.s1.__postblit();
this.s2.__postblit(); 
```

This will also allow users of -betterC to attribute their postblits to avoid the error in [Issue 18493](https://issues.dlang.org/show_bug.cgi?id=18493),

It may be appropriate to omit the try-catches entirely for -betterC builds and runtimes without `Throwable` declared, but I will leave that to a future pull request depending on how this PR goes.
