### PR TITLE
Fix Issue 14245 - Immutable reference to immutable field in constructor allows breaking type system

### DIFF
--- a/test/fail_compilation/fail14245.d
+++ b/test/fail_compilation/fail14245.d
@@ -1,0 +1,31 @@
+// https://issues.dlang.org/show_bug.cgi?id=14245
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail14245.d(16): Error: cannot take address of uninitialized `immutable` field `this.x`
+fail_compilation/fail14245.d(28): Error: cannot take address of uninitialized `immutable` field `this.a`
+---
+*/
+
+struct S
+{
+    immutable int x;
+    this(int a)
+    {
+        immutable int* b = &this.x;
+        this.x = a;
+     }
+}
+
+immutable(int)* g;
+
+struct X
+{
+    int a = 10;
+    immutable this(int x)
+    {
+        g = &a;
+        a = 42;
+    }
+}


### PR DESCRIPTION
```d
immutable(int)* g;

struct X {
    int a = 10;
    immutable this(int x) {
        g = &a;
        a = 42;
    }
}

void main() {
    auto x = immutable X();
}
```
Taking the address of an immutable field before initialization should error since it will cause the violation of immutable once the field is initialized (g will point to a memory location which will first have the value of 10 and then 42).

This patch checks that if the address of an immutable field is taken before initialization (no matter what the reason is) the compiler will issue an error ("the address of an immutable field may not be taken before initialization").