### PR TITLE
Fix Issue 18775, 12807: gently resolve alias this

### DIFF
--- a/test/compilable/test12807.d
+++ b/test/compilable/test12807.d
@@ -1,0 +1,16 @@
+void foo(T)(ref T t)
+{
+}
+
+struct S
+{
+    int impure() {assert(0);}
+    alias impure this;
+}
+
+void main() pure
+{
+    S s;
+    foo(s);
+    s.foo(); // triggering alias this violates purity, but ufcs matches
+}

--- a/test/compilable/test18775.d
+++ b/test/compilable/test18775.d
@@ -1,0 +1,20 @@
+// REQUIRED_ARGS: -de
+
+struct Foo { }
+
+struct Bar {
+    deprecated
+    @property Foo foo() { return Foo.init; }
+
+    alias foo this;
+}
+
+void test(Bar bar) { }
+
+void main()
+{
+    Bar bar;
+
+    // test lookup will be satisfied via ufcs, not alias, so it must not deprecation warn foo!
+    bar.test;
+}


### PR DESCRIPTION
Only emit warnings during alias this resolution if the alias this later actually turns out to lead to a valid property access.

This fixes issues where the impropriety of the alias this is reported as warnings or errors, even if the alias this doesn't actually end up being taken.

The underlying problem is that alias this competes with UFCS for property resolution, and is evaluated first. So UFCS to an alias this type always triggers the alias this, even if it doesn't match call types.

~~Maybe the better course of action would be to check UFCS before alias this, but I don't know how to do that.~~ No, alias this should correctly take priority.