### PR TITLE
Fix Issue 16206 - traits getOverloads fails when one of the overload is a templatized function

### DIFF
--- a/changelog/fix16206.dd
+++ b/changelog/fix16206.dd
@@ -1,0 +1,24 @@
+Support for iterating template overloads
+
+`__traits(getOverloads)` has been extended to return template overloads when passed an optional parameter with a true value.
+
+---
+struct S {
+    static int foo()() { return 0; }
+    static int foo()(int n) { return 1; }
+    static int foo(string s) { return 2; }
+    enum foo(int[] arr) = arr.length;
+}
+
+alias AliasSeq(T...) = T;
+
+alias allFoos = AliasSeq!(__traits(getOverloads, S, "foo", true));
+
+static assert(allFoos.length == 4);
+
+static assert(allFoos[0]("") == 2);
+static assert(allFoos[1]() == 0);
+static assert(allFoos[2](1) == 1);
+alias foo3 = allFoos[3];
+static assert(foo3!([]) == 0);
+---

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -824,7 +824,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         e.ident == Id.getVirtualMethods ||
         e.ident == Id.getVirtualFunctions)
     {
-        if (dim != 2)
+        if (dim != 2 && !(dim == 3 && e.ident == Id.getOverloads))
             return dimError(2);
 
         auto o = (*e.args)[0];
@@ -835,6 +835,19 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return new ErrorExp();
         }
         ex = ex.ctfeInterpret();
+
+        bool includeTemplates = false;
+        if (dim == 3 && e.ident == Id.getOverloads)
+        {
+            auto b = isExpression((*e.args)[2]);
+            b = b.ctfeInterpret();
+            if (!b.type.equals(Type.tbool))
+            {
+                e.error("`bool` expected as third argument of `__traits(getOverloads)`, not `%s` of type `%s`", b.toChars(), b.type.toChars());
+                return new ErrorExp();
+            }
+            includeTemplates = b.isBool(true);
+        }
 
         StringExp se = ex.toStringExp();
         if (!se || se.len == 0)
@@ -908,7 +921,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             /* Create tuple of functions of ex
              */
             auto exps = new Expressions();
-            FuncDeclaration f;
+            Dsymbol f;
             if (ex.op == TOK.variable)
             {
                 VarExp ve = cast(VarExp)ex;
@@ -924,9 +937,23 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
                 else
                     ex = dve.e1;
             }
+            else if (ex.op == TOK.template_)
+            {
+                VarExp ve = cast(VarExp)ex;
+                auto td = ve.var.isTemplateDeclaration();
+                f = td;
+                if (td && td.funcroot)
+                    f = td.funcroot;
+                ex = null;
+            }
 
             overloadApply(f, (Dsymbol s)
             {
+                if (includeTemplates)
+                {
+                    exps.push(new DsymbolExp(Loc.initial, s, false));
+                    return 0;
+                }
                 auto fd = s.isFuncDeclaration();
                 if (!fd)
                     return 0;

--- a/test/compilable/Test16206.d
+++ b/test/compilable/Test16206.d
@@ -1,0 +1,28 @@
+struct S {
+    static int foo()() { return 0; }
+    static int foo()(int n) { return 1; }
+    static int foo(string s) { return 2; }
+    enum foo(int[] arr) = arr.length;
+}
+
+alias AliasSeq(T...) = T;
+
+alias allFoos = AliasSeq!(__traits(getOverloads, S, "foo", true));
+
+static assert(allFoos.length == 4);
+
+static assert(allFoos[0]("") == 2);
+static assert(allFoos[1]() == 0);
+static assert(allFoos[2](1) == 1);
+alias foo3 = allFoos[3];
+static assert(foo3!([]) == 0);
+
+static assert(S.foo() == 0);
+static assert(S.foo(1) == 1);
+static assert(S.foo("") == 2);
+static assert(S.foo!([]) == 0);
+
+
+alias fooFuns = AliasSeq!(__traits(getOverloads, S, "foo"));
+static assert(fooFuns.length == 1);
+static assert(fooFuns[0]("") == 2);

--- a/test/fail_compilation/fail16206a.d
+++ b/test/fail_compilation/fail16206a.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail16206a.d(12): Error: `bool` expected as third argument of `__traits(getOverloads)`, not `"Not a bool"` of type `string`
+---
+*/
+
+struct S {
+    static int foo()() { return 0; }
+}
+alias AliasSeq(T...) = T;
+alias allFoos = AliasSeq!(__traits(getOverloads, S, "foo", "Not a bool"));

--- a/test/fail_compilation/fail16206b.d
+++ b/test/fail_compilation/fail16206b.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail16206b.d(12): Error: expected 2 arguments for `hasMember` but had 3
+---
+*/
+
+struct S {
+    static int foo()() { return 0; }
+}
+alias AliasSeq(T...) = T;
+alias allFoos = AliasSeq!(__traits(hasMember, S, "foo", true));


### PR DESCRIPTION
This adds templates to the result of `__traits(getOverloads)`, allowing them to be iterated and inspected.

There's a few issues other than 16206 that will be fixed by this - I'll have a look-see through bugzilla tomorrow to find them.

It's possible this breaks code by considering template overloads where only function overloads were expected earlier. I expect this to happen rarely in real code, but it's certainly possible. It might be that some templates in Phobos will require updating to handle mixed function/template overload sets.