### PR TITLE
Fix Issue 11742 - cannot inizialize void initialized static variable in static constructor

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1019,7 +1019,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        if (!dsym._init && !fd)
+        if ((!dsym._init || dsym._init.isVoidInitializer) && !fd)
         {
             // If not mutable, initializable by constructor only
             dsym.storage_class |= STC.ctorinit;

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -6132,6 +6132,18 @@ void test5332()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=11742
+
+const int x11472 = void;
+
+static this() { x11472 = 10; }
+
+void test11472()
+{
+    assert(x11472 == 10);
+}
+
+/***************************************************/
 
 int main()
 {
@@ -6433,6 +6445,7 @@ int main()
     test252();
     test7997();
     test5332();
+    test11472();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
If a non-mutable variable is initialized at module level, it cannot be modified in the module static constructor because that would invalidate the initial initialization. However, if the non-mutable variable is initialized with `void` this should not count as an initialization and the static constructor should be able to initialize it.