### PR TITLE
run floating point paranoia test via CTFE

### DIFF
--- a/test/runnable/paranoia.sh
+++ b/test/runnable/paranoia.sh
@@ -1,14 +1,33 @@
 
+echo ======== Testing Single Precision ========
 $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Single -of${OUTPUT_BASE}${EXE}
 ${OUTPUT_BASE}${EXE}
 
+echo ======== Testing Double Precision ========
 $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Double -of${OUTPUT_BASE}${EXE}
 ${OUTPUT_BASE}${EXE}
 
-$DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended -of${OUTPUT_BASE}${EXE}
-${OUTPUT_BASE}${EXE}
-
+if [ "PR" == "8169" ]; then
 # needs PR 8169
-# $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=ExtendedSoft ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}${EXE}
-# ${OUTPUT_BASE}${EXE}
+# if [ "${OS}" == "win64" -o "${MODEL}" == "32mscoff" ]; then
+    echo ======== Testing Extended Precision ========
+    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}${EXE}
+    ${OUTPUT_BASE}${EXE}
 
+    echo ======== Testing ExtendedSoft Precision ========
+    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=ExtendedSoft ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}${EXE}
+    ${OUTPUT_BASE}${EXE}
+else
+    echo ======== Testing Extended Precision ========
+    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended -of${OUTPUT_BASE}${EXE}
+    ${OUTPUT_BASE}${EXE}
+fi
+
+echo ======== Testing CTFE Single Precision ========
+$DMD -m${MODEL} -c ${EXTRA_FILES}/paranoia.d -version=Single -version=CTFE -of${OUTPUT_BASE}${EXE}
+
+echo ======== Testing CTFE Double Precision ========
+$DMD -m${MODEL} -c ${EXTRA_FILES}/paranoia.d -version=Double -version=CTFE -of${OUTPUT_BASE}${EXE}
+
+echo ======== Testing CTFE Extended Precision ========
+$DMD -m${MODEL} -c ${EXTRA_FILES}/paranoia.d -version=Extended -version=CTFE -of${OUTPUT_BASE}${EXE}

--- a/test/runnable/paranoia.sh
+++ b/test/runnable/paranoia.sh
@@ -1,33 +1,36 @@
 
 echo ======== Testing Single Precision ========
-$DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Single -of${OUTPUT_BASE}${EXE}
-${OUTPUT_BASE}${EXE}
+$DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Single -of${OUTPUT_BASE}_1${EXE}
+${OUTPUT_BASE}_1${EXE}
 
 echo ======== Testing Double Precision ========
-$DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Double -of${OUTPUT_BASE}${EXE}
-${OUTPUT_BASE}${EXE}
+$DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Double -of${OUTPUT_BASE}_2${EXE}
+${OUTPUT_BASE}_2${EXE}
 
 if [ "PR" == "8169" ]; then
 # needs PR 8169
 # if [ "${OS}" == "win64" -o "${MODEL}" == "32mscoff" ]; then
     echo ======== Testing Extended Precision ========
-    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}${EXE}
-    ${OUTPUT_BASE}${EXE}
+    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}_3${EXE}
+    ${OUTPUT_BASE}_3${EXE}
 
     echo ======== Testing ExtendedSoft Precision ========
-    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=ExtendedSoft ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}${EXE}
-    ${OUTPUT_BASE}${EXE}
+    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=ExtendedSoft ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}_4${EXE}
+    ${OUTPUT_BASE}_4${EXE}
 else
     echo ======== Testing Extended Precision ========
-    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended -of${OUTPUT_BASE}${EXE}
-    ${OUTPUT_BASE}${EXE}
+    $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended -of${OUTPUT_BASE}_3${EXE}
+    ${OUTPUT_BASE}_3${EXE}
 fi
 
 echo ======== Testing CTFE Single Precision ========
-$DMD -m${MODEL} -c ${EXTRA_FILES}/paranoia.d -version=Single -version=CTFE -of${OUTPUT_BASE}${EXE}
+$DMD -m${MODEL} -c -o- ${EXTRA_FILES}/paranoia.d -version=Single -version=CTFE
 
 echo ======== Testing CTFE Double Precision ========
-$DMD -m${MODEL} -c ${EXTRA_FILES}/paranoia.d -version=Double -version=CTFE -of${OUTPUT_BASE}${EXE}
+$DMD -m${MODEL} -c -o- ${EXTRA_FILES}/paranoia.d -version=Double -version=CTFE
 
 echo ======== Testing CTFE Extended Precision ========
-$DMD -m${MODEL} -c ${EXTRA_FILES}/paranoia.d -version=Extended -version=CTFE -of${OUTPUT_BASE}${EXE}
+$DMD -m${MODEL} -c -o- ${EXTRA_FILES}/paranoia.d -version=Extended -version=CTFE
+
+rm ${OUTPUT_BASE}_[1-4]${EXE}
+rm ${OUTPUT_BASE}_[1-4]${OBJ}


### PR DESCRIPTION
While investigating the FP failures in #8193 I noticed that they go away when replacing core.stdc.math with std.math. There is a single "flaw" left for `double` with respect to rounding.

Running paranoia at compile time shows unexpected precision (all FP types calculated as reals) and similar results as the runtime tests before because dmd uses core.stdc.math for `sqrt` and `pow`.
