### PR TITLE
Fix Issue 12764 - Disabled struct default construction circumvented when field is written to

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6600,7 +6600,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          */
         if (exp.op == TOK.assign && exp.e1.checkModifiable(sc) == 2)
         {
-            //printf("[%s] change to init - %s\n", loc.toChars(), toChars());
+            //printf("[%s] change to init - %s\n", exp.loc.toChars(), exp.toChars());
             exp.op = TOK.construct;
 
             // https://issues.dlang.org/show_bug.cgi?id=13515

--- a/test/fail_compilation/fail12764.d
+++ b/test/fail_compilation/fail12764.d
@@ -1,0 +1,26 @@
+// https://issues.dlang.org/show_bug.cgi?id=12764
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12764.d(20): Error: field `s` must be initialized in constructor
+---
+*/
+
+struct S
+{
+    @disable this();
+
+    this(string) { }
+    int f;
+}
+
+class C
+{
+    this(int)
+    {
+        s.f = 1;  // circumvents default ctor!
+    }
+
+    S s;
+}


### PR DESCRIPTION
```d
struct S
{
    @disable this();

    this(string) { }
    int f;
}

class C
{
    this(int)
    {
        s.f = 1;  // circumvents default ctor!
    }

    S s;
}
```
`f` cannot be initialized before the object was constructed and since no call to the constructor was made, `s` can be partially initialized. The fix makes it so that if `s` does not have a default initializer (`S s = S("some string");` ) or a constructor call wasn't made in the constructor an error is issued.
