### PR TITLE
Add ability to use interfaces and classes without the runtime if they only contain static members

### DIFF
--- a/changelog/min_runtime_classes.dd
+++ b/changelog/min_runtime_classes.dd
@@ -1,0 +1,100 @@
+Interfaces and classes can be used without the runtime if only static fields are utilized
+
+Prior to this release any attempt to use interfaces and/or classes without the runtime would result
+in compile-time errors due to the lack of `TypeInfo`.  However, as long as classes are not instantiated
+there is no need for `TypeInfo`.
+
+Beginning with this release the compiler will no longer emit errors about missing `TypeInfo` when
+using interfaces and/or classes as long as they are not instantiated and only `shared static` members are
+utilized.
+
+$(B Example 1)
+---
+module object
+
+private alias extern(C) int function(char[][] args) MainFunc;
+private extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
+{
+    return mainFunc(null);  // assumes `void main()` for simplicity
+}
+---
+
+---
+interface I
+{
+    shared static int i;
+}
+
+class A : I
+{
+    shared static int a;
+}
+
+class B : A
+{
+    shared static int b;
+}
+
+void main()
+{
+    B.b = B.a + B.i;
+}
+---
+
+$(CONSOLE
+dmd -conf= -defaultlib= main.d object.d -of=main
+size main
+   text    data     bss     dec     hex filename
+   1867    1208      32    3107     c23 main
+)
+
+Non-shared static members can also be used, but will require a thread-local storage (TLS) implementation.
+For example, on Linux the TLS implementation is already supplied by the C runtime and C
+standard library, so, since dmd automatically calls gcc to link the final executable, it will automatically
+bring in the TLS implementation.
+
+$(B Example 2)
+---
+module object
+
+private alias extern(C) int function(char[][] args) MainFunc;
+private extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
+{
+    return mainFunc(null);  // assumes `void main()` for simplicity
+}
+---
+
+---
+interface I
+{
+    static int i;
+}
+
+class A : I
+{
+    static int a;
+}
+
+class B : A
+{
+    static int b;
+}
+
+void main()
+{
+    B.b = B.a + B.i;
+}
+---
+
+$(CONSOLE
+dmd -conf= -defaultlib= main.d object.d -of=main
+size main
+   text    data     bss     dec     hex filename
+   2123    1296      28    3447     d77 main
+)
+
+Some platforms may require some TLS implementation code or some specialized build procedures to link
+in a TLS implementation.
+
+This will hopefully reduce friction for those using D without the runtime, porting D to new platforms,
+or using D from other langauges, while enabling more features and idioms of D to be used in those use cases.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4535,7 +4535,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             cldec.baseok = Baseok.done;
 
             // If no base class, and this is not an Object, use Object as base class
-            if (!cldec.baseClass && cldec.ident != Id.Object && !cldec.classKind == ClassKind.cpp)
+            if (!cldec.baseClass && cldec.ident != Id.Object && cldec.object && !cldec.classKind == ClassKind.cpp)
             {
                 void badObjectDotD()
                 {

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -379,7 +379,8 @@ void toObjFile(Dsymbol ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            genTypeInfo(cd.loc, cd.type, null);
+            if (global.params.useTypeInfo && Type.dtypeinfo)
+                genTypeInfo(cd.loc, cd.type, null);
             //toObjFile(cd.type.vtinfo, multiobj);
 
             //////////////////////////////////////////////
@@ -678,8 +679,11 @@ void toObjFile(Dsymbol ds, bool multiobj)
             //////////////////////////////////////////////
 
             // Put out the TypeInfo
-            genTypeInfo(id.loc, id.type, null);
-            id.type.vtinfo.accept(this);
+            if (global.params.useTypeInfo && Type.dtypeinfo)
+            {
+                genTypeInfo(id.loc, id.type, null);
+                id.type.vtinfo.accept(this);
+            }
 
             //////////////////////////////////////////////
 

--- a/test/compilable/minimal2.d
+++ b/test/compilable/minimal2.d
@@ -1,0 +1,30 @@
+// DFLAGS:
+// REQUIRED_ARGS: -defaultlib= runnable/extra-files/minimal/object.d
+
+// This test ensures that interfaces and classes can be used in a minimal
+// runtime as long as they only contain static members.
+
+// This should compile, but will not link and run properly without
+// a thread-local storage (TLS) implementation.
+
+interface I
+{
+    static int i;
+}
+
+class A : I
+{
+    static int a;
+}
+
+class B : A
+{
+    static int b;
+}
+
+void main()
+{
+    B.i = 32;
+    B.a = 42;
+    B.b = 52;
+}

--- a/test/runnable/minimal2.d
+++ b/test/runnable/minimal2.d
@@ -1,0 +1,44 @@
+// DFLAGS:
+// REQUIRED_ARGS: -defaultlib= runnable/extra-files/minimal/object.d
+
+// This test ensures that interfaces and classes can be used in a minimal
+// runtime as long as they only contain shared static members.  Non-shared
+// static members would require a thread-local storage (TLS) implementation.
+
+interface I
+{
+    shared static int i;
+}
+
+class A : I
+{
+    shared static int a;
+}
+
+class B : A
+{
+    shared static int b;
+
+    static int sumAll()
+    {
+        return b + a + i;
+    }
+}
+
+void poorMansAssert(bool condition)
+{
+    if (!condition)
+    {
+        asm {hlt;}
+    }
+}
+
+void main()
+{
+    B.i = 32;
+    B.a = 42;
+    B.b = 52;
+
+    poorMansAssert(B.i == 32 || B.a == 42 || B.b == 52);
+    poorMansAssert(B.sumAll() == (32 + 42 + 52));
+}


### PR DESCRIPTION
This is a followup to the PRs previously released in 2.079 that enable users to use D without the runtime in a pay-as-you-go fashion

 * #7395 and #7768 for `ModuleInfo`
 * #7786 for `Throwable`
 * #7799 for `TypeInfo`

Currently, even with the above PRs, the following code will cause the compiler to emit an error about `TypeInfo` if compiled without the runtime.  However, `TypeInfo` is in no way required for such code because all interface/class members are static.

```D
interface I
{
    static int i;
}

class A : I
{
    static int a;
}

class B : A
{
    static int b;
}

void main() 
{ 
    B.i = 32;
    B.a = 42;
    B.b = 52;
}
```
This PR removes this arbitrary limitation enabling more features of D to be used without the runtime.

