### PR TITLE
Add ability to use enums without the runtime

### DIFF
--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1009,7 +1009,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
             else if (global.params.symdebug)
                 toDebug(ed);
 
-            if (global.params.useTypeInfo)
+            if (global.params.useTypeInfo && Type.dtypeinfo)
                 genTypeInfo(ed.loc, ed.type, null);
 
             TypeEnum tc = cast(TypeEnum)ed.type;

--- a/test/compilable/minimal.d
+++ b/test/compilable/minimal.d
@@ -3,10 +3,16 @@
 // POST_SCRIPT: compilable/extra-files/minimal/verify_symbols.sh
 // REQUIRED_ARGS: -defaultlib= runnable/extra-files/minimal/object.d
 
-// This test ensures an empty main with a struct, built with a minimal runtime,
-// does not generate ModuleInfo or exception handling code, and does not
+// This test ensures an empty main with a struct and enum, built with a minimal
+// runtime, does not generate ModuleInfo or exception handling code, and does not
 // require TypeInfo
 
 struct S { }
+
+enum E 
+{
+    e0 = 0,
+    e1 = 1
+}
 
 void main() { }


### PR DESCRIPTION
This is a followup to #7799.  I overlooked enums.