### PR TITLE
Fix issue 18803: when failing to parse a module without errors, don't call semantic3

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1333,9 +1333,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         imp.semanticRun = PASS.semantic;
 
         // Load if not already done so
+        bool loadErrored = false;
         if (!imp.mod)
         {
+            const errors = global.errors;
             imp.load(sc);
+            loadErrored = global.errors != errors;
             if (imp.mod)
                 imp.mod.importAll(null);
         }
@@ -1382,7 +1385,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 scopesym.addAccessiblePackage(imp.mod, imp.protection); // d
             }
 
-            imp.mod.dsymbolSemantic(null);
+            if (!loadErrored)
+            {
+                imp.mod.dsymbolSemantic(null);
+            }
+
             if (imp.mod.needmoduleinfo)
             {
                 //printf("module4 %s because of %s\n", sc.module.toChars(), mod.toChars());

--- a/test/fail_compilation/ice18803a.d
+++ b/test/fail_compilation/ice18803a.d
@@ -1,0 +1,1 @@
+void main() { import ice18803b; }

--- a/test/fail_compilation/ice18803b.d
+++ b/test/fail_compilation/ice18803b.d
@@ -1,0 +1,1 @@
+static if


### PR DESCRIPTION
The existing code is trivially wrong; it constructs with null but checks for `TOK.error`.