### PR TITLE
fix Issue 18211 - Access violation when generating JSON on static foreach

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1080,7 +1080,10 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         {
             return cache;
         }
-        sfe.prepare(_scope); // lower static foreach aggregate
+        if (_scope)
+        {
+            sfe.prepare(_scope); // lower static foreach aggregate
+        }
         if (!sfe.ready())
         {
             return null; // TODO: ok?

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -416,7 +416,7 @@ extern (C++) final class StaticForeach : RootObject
      */
     final extern(D) bool ready()
     {
-        return aggrfe && aggrfe.aggr && aggrfe.aggr.type.toBasetype().ty == Ttuple;
+        return aggrfe && aggrfe.aggr && aggrfe.aggr.type && aggrfe.aggr.type.toBasetype().ty == Ttuple;
     }
 }
 

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -923,6 +923,20 @@
                 "line": 194,
                 "linkage": "objc",
                 "name": "flinkageObjc"
+            },
+            {
+                "char": 7,
+                "kind": "template",
+                "line": 196,
+                "members": [],
+                "name": "test18211",
+                "parameters": [
+                    {
+                        "deco": "VALUE_REMOVED_FOR_TEST",
+                        "kind": "value",
+                        "name": "n"
+                    }
+                ]
             }
         ],
         "name": "json"

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -192,3 +192,12 @@ extern(C++) int flinkageCpp();
 extern(Windows) int flinkageWindows();
 extern(Pascal) int flinkagePascal();
 extern(Objective-C) int flinkageObjc();
+
+mixin template test18211(int n)
+{
+    static foreach (i; 0 .. n>10 ? 10 : n)
+    {
+        mixin("enum x" ~ cast(char)('0' + i));
+    }
+    static if (true) {}
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=18211

This makes `static foreach` behave the same as `static if` with the -X flag.