### PR TITLE
Stop eagerly generating error message for mismatch arguments

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -110,7 +110,7 @@ struct Match
     FuncDeclaration *anyf;      // pick a func, any func, to use for error recovery
 };
 
-void functionResolve(Match *m, Dsymbol *fd, Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs);
+void functionResolve(Match *m, Dsymbol *fd, Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs, size_t *failedInde = NULL);
 int overloadApply(Dsymbol *fstart, void *param, int (*fp)(void *, Dsymbol *));
 
 void ObjectNotFound(Identifier *id);

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2330,6 +2330,7 @@ extern (C++) final class TypeDeduced : Type
 /*************************************************
  * Given function arguments, figure out which template function
  * to expand, and return matching result.
+ *
  * Params:
  *      m           = matching result
  *      dstart      = the root of overloaded function templates
@@ -2338,10 +2339,10 @@ extern (C++) final class TypeDeduced : Type
  *      tiargs      = initial list of template arguments
  *      tthis       = if !NULL, the 'this' pointer argument
  *      fargs       = arguments to function
- *      pMessage    = address to store error message, or null
+ *      failedIndex = address to store argument index of first type mismatch
  */
 void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiargs,
-    Type tthis, Expressions* fargs, const(char)** pMessage = null)
+    Type tthis, Expressions* fargs, size_t* failedIndex = null)
 {
     version (none)
     {
@@ -2446,7 +2447,7 @@ void functionResolve(Match* m, Dsymbol dstart, Loc loc, Scope* sc, Objects* tiar
             else if (shared_this && !shared_dtor && tthis_fd !is null)
                 tf.mod = tthis_fd.mod;
         }
-        MATCH mfa = tf.callMatch(tthis_fd, fargs, 0, pMessage);
+        MATCH mfa = tf.callMatch(tthis_fd, fargs, 0, failedIndex);
         //printf("test1: mfa = %d\n", mfa);
         if (mfa > MATCH.nomatch)
         {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3426,8 +3426,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return setError();
             }
 
-            const(char)* failMessage;
-            if (!tf.callMatch(null, exp.arguments, 0, &failMessage))
+            size_t failIndex;
+            if (!tf.callMatch(null, exp.arguments, 0, &failIndex))
             {
                 OutBuffer buf;
                 buf.writeByte('(');
@@ -3439,8 +3439,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0].type.deco);
                 .error(exp.loc, "%s `%s%s` is not callable using argument types `%s`",
                     p, exp.e1.toChars(), parametersTypeToChars(tf.parameters, tf.varargs), buf.peekString());
-                if (failMessage)
-                    errorSupplemental(exp.loc, failMessage);
+                showArgMismatch(exp.loc, exp.arguments, tf, failIndex);
                 return setError();
             }
             // Purity and safety check should run after testing arguments matching
@@ -3500,8 +3499,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 exp.f = exp.f.toAliasFunc();
                 TypeFunction tf = cast(TypeFunction)exp.f.type;
-                const(char)* failMessage;
-                if (!tf.callMatch(null, exp.arguments, 0, &failMessage))
+                size_t failIndex;
+                if (!tf.callMatch(null, exp.arguments, 0, &failIndex))
                 {
                     OutBuffer buf;
                     buf.writeByte('(');
@@ -3511,8 +3510,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     //printf("tf = %s, args = %s\n", tf.deco, (*arguments)[0].type.deco);
                     .error(exp.loc, "%s `%s%s` is not callable using argument types `%s`",
                         exp.f.kind(), exp.f.toPrettyChars(), parametersTypeToChars(tf.parameters, tf.varargs), buf.peekString());
-                    if (failMessage)
-                        errorSupplemental(exp.loc, failMessage);
+                    showArgMismatch(exp.loc, exp.arguments, tf, failIndex);
                     exp.f = null;
                 }
             }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -593,7 +593,7 @@ public:
     int attributesApply(void *param, int (*fp)(void *, const char *), TRUSTformat trustFormat = TRUSTformatDefault);
 
     Type *substWildTo(unsigned mod);
-    MATCH callMatch(Type *tthis, Expressions *toargs, int flag = 0);
+    MATCH callMatch(Type *tthis, Expressions *toargs, int flag = 0, size_t *failedIndex = NULL);
     bool checkRetType(const Loc &loc);
 
     Expression *defaultInit(const Loc &loc) /*const*/;


### PR DESCRIPTION
```
This mostly reverts commit 15b1b503440caab6ba8d2879b80d3946d4d5ac23.

The aforementioned commit eagerly allocated the error message during call resolution,
resulting in a lot of garbage being generated for no reason.
Said garbage was never freed, and freeing it seemingly has no effect,
maybe because of DMD's memory allocation pattern.
```

Testing here since the testsuite doesn't pass on my machine ¯\_(ツ)_/¯
Also, targeting stable because I expect large project to suffer from this a lot.