### PR TITLE
Adds a proper initializer + deinitializer process for the lexer

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -19,6 +19,7 @@ subPackage {
   sourcePaths
 
   sourceFiles \
+    "src/dmd/compiler.d" \
     "src/dmd/console.d" \
     "src/dmd/entity.d" \
     "src/dmd/errors.d" \

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -12,7 +12,59 @@
 
 module dmd.compiler;
 
+///
 struct Compiler
 {
-    const(char)* vendor; // Compiler backend name
+    /// Compiler backend name
+    const(char)* vendor;
+}
+
+/**
+ * Initializes the dmd lexer and all required components in order
+ *
+ * It is templated (so D only) to prevent
+ *  errors on local imports to things that may not exist.
+ *
+ * See_Also:
+ *     lexerDeinit
+ */
+void lexerInit()()
+{
+    import dmd.globals : global;
+    import dmd.id : Id;
+    import dmd.tokens : Token;
+    import dmd.identifier : Identifier;
+
+    global._init();
+    Identifier.initTable();
+
+    // Id MUST be initialized after Token
+    Token.initialize();
+    Id.initialize();
+}
+
+/**
+ * Deinitializers the dmd lexer and all required components in order
+ *
+ * It is templated (so D only) to prevent
+ *  errors on local imports to things that may not exist.
+ *
+ * See_Also:
+ *     lexerInit
+ */
+void lexerDeinit()()
+{
+    import dmd.globals : global, Global;
+    import dmd.id : Id;
+    import dmd.tokens : Token;
+    import dmd.identifier : Identifier;
+
+    Id.deinitialize();
+    Token.deinitialize();
+    Identifier.deinitTable();
+
+    // we reset this manually, just to prevent any chance of pinning memory
+    // but this approach does currently leak when !version(GC)
+    // which is quite a problem... but out of scope for now
+    global = Global.init;
 }

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -39,6 +39,11 @@ struct Id
     {
         mixin(msgtable.generate(&initializer));
     }
+
+    extern(C++) void deinitialize()
+    {
+        mixin(msgtable.generate(&deinitializer));
+    }
 }
 
 private:
@@ -476,4 +481,10 @@ string identifier(Msgtable m)
 string initializer(Msgtable m)
 {
     return m.ident ~ ` = Identifier.idPool("` ~ m.name ~ `");`;
+}
+
+// Used to generate the code for each deinitializer, to prevent pinning.
+string deinitializer(Msgtable m)
+{
+    return m.ident ~ ` = null;`;
 }

--- a/src/dmd/id.h
+++ b/src/dmd/id.h
@@ -18,6 +18,7 @@
 struct Id
 {
     static void initialize();
+    static void deinitialize();
 };
 
 #endif /* DMD_ID_H */

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -208,4 +208,9 @@ nothrow:
     {
         stringtable._init(28000);
     }
+
+    static void deinitTable()
+    {
+        stringtable.reset();
+    }
 }

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -48,6 +48,7 @@ public:
     static bool isValidIdentifier(const char *p);
     static Identifier *lookup(const char *s, size_t len);
     static void initTable();
+    static void deinitTable();
 };
 
 #endif /* DMD_IDENTIFIER_H */

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -174,6 +174,11 @@ private int tryMain(size_t argc, const(char)** argv)
     Strings files;
     Strings libmodules;
     global._init();
+
+    // Temporary: removed module constructor (dmd.tokens) which initialized Identifier
+    Identifier.initTable();
+    Token.initialize();
+
     debug
     {
         printf("DMD %s DEBUG\n", global._version);

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -703,14 +703,26 @@ extern (C++) struct Token
         return true;
     }());
 
+    // this is currently only here as a workaround for non-dmd code
     shared static this()
     {
         Identifier.initTable();
+        Token.initialize();
+    }
+
+    static void initialize()
+    {
         foreach (kw; keywords)
         {
             //printf("keyword[%d] = '%s'\n",kw, tochars[kw].ptr);
             Identifier.idPool(tochars[kw].ptr, tochars[kw].length, cast(uint)kw);
         }
+    }
+
+    static void deinitialize()
+    {
+        // we reset this manually, just to prevent any chance of pinning memory
+        Token.freelist = null;
     }
 
     __gshared Token* freelist = null;

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -218,6 +218,9 @@ struct Token
 
     static const char *tochars[TOKMAX];
 
+    static void initialize();
+    static void deinitialize();
+
     static Token *freelist;
     static Token *alloc();
     void free();

--- a/test/dub_package/lexer.d
+++ b/test/dub_package/lexer.d
@@ -6,6 +6,7 @@ void main()
 {
     import dmd.lexer;
     import dmd.tokens;
+    import dmd.compiler;
 
     immutable expected = [
         TOK.void_,
@@ -17,15 +18,25 @@ void main()
     ];
 
     immutable sourceCode = "void test() {} // foobar";
-    scope lexer = new Lexer("test", sourceCode.ptr, 0, sourceCode.length, 0, 0);
-    lexer.nextToken;
-
-    TOK[] result;
-
-    do
+    
+    // We execute the example multiple times,
+    // just to show, that yes, the lexer can in theory be reset.
+    foreach(i; 0 .. 10)
     {
-        result ~= lexer.token.value;
-    } while (lexer.nextToken != TOK.endOfFile);
+        lexerInit();
+        
+        scope lexer = new Lexer("test", sourceCode.ptr, 0, sourceCode.length, 0, 0);
+        lexer.nextToken;
 
-    assert(result == expected);
+        TOK[] result;
+
+        do
+        {
+            result ~= lexer.token.value;
+        } while (lexer.nextToken != TOK.endOfFile);
+
+        assert(result == expected);
+        
+        lexerDeinit();
+    }
 }


### PR DESCRIPTION
If dmd is to be used as a library, we need a single central point where all initialization + deinitialization is to occur for the separate components of dmd. This PR does it for the lexer.

It should not break dmd as an executable (see mars.d for switch from module constructor to initializer). This should be temporary, and only one call should be made inside that module, once the initializer process is complete. But right now it is as-is compatibility wise.