### PR TITLE
Emit error for implicit string concatenation

### DIFF
--- a/changelog/implicit_string_concatenation_error.dd
+++ b/changelog/implicit_string_concatenation_error.dd
@@ -1,0 +1,13 @@
+Implicit string concatenation will now result in an error
+
+See the $(LINK2 $(ROOT_DIR)deprecate.html#Implicit%20string%20concatenation, Deprecated Features) for more information.
+
+Implicit string concatenation was deprecated in 2.072.  Starting with this release, implicit string concatenation will cause the compiler
+to emit an error.
+
+---
+void main()
+{
+    string s = "Hello" ", World!";  // Error: Implicit string concatenation is deprecated, use "" ~ "" instead
+}
+---

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7471,7 +7471,7 @@ final class Parser(AST) : Lexer
                             postfix = token.postfix;
                         }
 
-                        deprecation("Implicit string concatenation is deprecated, use %s ~ %s instead",
+                        error("Implicit string concatenation is deprecated, use %s ~ %s instead",
                                     prev.toChars(), token.toChars());
 
                         const len1 = len;

--- a/test/compilable/test15019.d
+++ b/test/compilable/test15019.d
@@ -42,15 +42,15 @@ alias mat4x4 mat4;
 string definePostfixAliases(string type)
 {
     return "alias " ~ type ~ "!byte "   ~ type ~ "b;\n"
-"alias " ~ type ~ "!ubyte "  ~ type ~ "ub;\n"
-"alias " ~ type ~ "!short "  ~ type ~ "s;\n"
-"alias " ~ type ~ "!ushort " ~ type ~ "us;\n"
-"alias " ~ type ~ "!int "    ~ type ~ "i;\n"
-"alias " ~ type ~ "!uint "   ~ type ~ "ui;\n"
-"alias " ~ type ~ "!long "   ~ type ~ "l;\n"
-"alias " ~ type ~ "!ulong "  ~ type ~ "ul;\n"
-"alias " ~ type ~ "!float "  ~ type ~ "f;\n"
-"alias " ~ type ~ "!double " ~ type ~ "d;\n";
+~ "alias " ~ type ~ "!ubyte "  ~ type ~ "ub;\n"
+~ "alias " ~ type ~ "!short "  ~ type ~ "s;\n"
+~ "alias " ~ type ~ "!ushort " ~ type ~ "us;\n"
+~ "alias " ~ type ~ "!int "    ~ type ~ "i;\n"
+~ "alias " ~ type ~ "!uint "   ~ type ~ "ui;\n"
+~ "alias " ~ type ~ "!long "   ~ type ~ "l;\n"
+~ "alias " ~ type ~ "!ulong "  ~ type ~ "ul;\n"
+~ "alias " ~ type ~ "!float "  ~ type ~ "f;\n"
+~ "alias " ~ type ~ "!double " ~ type ~ "d;\n";
 }
 
 // define a lot of type names

--- a/test/fail_compilation/diag10805.d
+++ b/test/fail_compilation/diag10805.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag10805.d(11): Error: delimited string must end in FOO"
 fail_compilation/diag10805.d(13): Error: unterminated string constant starting at fail_compilation/diag10805.d(13)
-fail_compilation/diag10805.d(13): Deprecation: Implicit string concatenation is deprecated, use "" ~ "" instead
+fail_compilation/diag10805.d(13): Error: Implicit string concatenation is deprecated, use "" ~ "" instead
 fail_compilation/diag10805.d(14): Error: semicolon expected following auto declaration, not `End of File`
 ---
 */

--- a/test/fail_compilation/issue3827.d
+++ b/test/fail_compilation/issue3827.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/issue3827.d(12): Deprecation: Implicit string concatenation is deprecated, use "Hello" ~ "World" instead
-fail_compilation/issue3827.d(13): Deprecation: Implicit string concatenation is deprecated, use "A" ~ "B" instead
+fail_compilation/issue3827.d(12): Error: Implicit string concatenation is deprecated, use "Hello" ~ "World" instead
+fail_compilation/issue3827.d(13): Error: Implicit string concatenation is deprecated, use "A" ~ "B" instead
 ---
 */
 

--- a/test/runnable/template8.d
+++ b/test/runnable/template8.d
@@ -36,17 +36,17 @@ private string CreateAccessors(
             static assert(len == 1);
             // getter
             result ~= "bool " ~ name ~ "(){ return "
-                "("~store~" & "~toStringSfx(maskAllElse)~") != 0;}";
+                ~ "("~store~" & "~toStringSfx(maskAllElse)~") != 0;}";
             // setter
             result ~= "void " ~ name ~ "(bool v){"
-                "if (v) "~store~" |= "~toStringSfx(maskAllElse)~";"
-                "else "~store~" &= "~toStringSfx(maskMyself)~";}";
+                ~ "if (v) "~store~" |= "~toStringSfx(maskAllElse)~";"
+                ~ "else "~store~" &= "~toStringSfx(maskMyself)~";}";
         }
         else
         {
             // getter
             result ~= T.stringof ~ " " ~ name ~ "(){ auto result = "
-                "("~store~" & "
+                ~ "("~store~" & "
                 ~ toStringSfx(maskAllElse) ~ ") >>"
                 ~ toStringSfx(offset) ~ ";";
             static if (T.min < 0)

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1084,17 +1084,17 @@ void test71()
 {
     size_t s = Foo71!(
 "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-"When dealing with complex template tuples, it's very easy to overflow the
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "helloabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+~ "When dealing with complex template tuples, it's very easy to overflow the
 maximum symbol length allowed by OPTLINK.  This is, simply put, a damn shame,
 because it prevents otherwise completely legal code from compiling and linking
 with DMDWin, whereas it works perfectly fine when using DMDNix or GDC.


### PR DESCRIPTION
See https://dlang.org/deprecate.html#Implicit%20string%20concatenation

This PR moves a deprecation forward, further narrowing the gap between specification and implementation.

Update to deprecated features table:  https://github.com/dlang/dlang.org/pull/2359