### PR TITLE
Emit error for implicit comparison of different enums

### DIFF
--- a/changelog/implicit_enum_comparison_error.dd
+++ b/changelog/implicit_enum_comparison_error.dd
@@ -1,0 +1,21 @@
+Implicit comparison of different enums will now result in an error
+
+See the $(LINK2 $(ROOT_DIR)deprecate.html#Implicit comparison of different enums, Deprecated Features) for more information.
+
+Implicit comparison of different enums was deprecated in 2.075.  Starting with this release, implicit comparison of different
+enums will cause the compiler to emit an error.
+
+---
+enum Status
+{
+    good,
+    bad
+}
+enum OtherStatus
+{
+    ok,
+    no
+}
+static assert(Status.good == OtherStatus.ok); // Error: Comparison between different enumeration types `Status` and `OtherStatus`;
+                                              // If this behavior is intended consider using `std.conv.asOriginalType`
+---

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8931,7 +8931,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto t1 = exp.e1.type;
             auto t2 = exp.e2.type;
             if (t1.ty == Tenum && t2.ty == Tenum && !t1.equivalent(t2))
-                exp.deprecation("Comparison between different enumeration types `%s` and `%s`; If this behavior is intended consider using `std.conv.asOriginalType`",
+                exp.error("Comparison between different enumeration types `%s` and `%s`; If this behavior is intended consider using `std.conv.asOriginalType`",
                     t1.toChars(), t2.toChars());
         }
 

--- a/test/compilable/b6227.d
+++ b/test/compilable/b6227.d
@@ -1,9 +1,3 @@
-/* TEST_OUTPUT:
----
-compilable/b6227.d(17): Deprecation: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
-compilable/b6227.d(18): Deprecation: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
----
-*/
 enum X {
     O,
     R
@@ -14,5 +8,3 @@ enum Y {
 static assert( (X.O == cast(const)X.O));
 static assert( (X.O == X.O));
 static assert( (X.O != X.R));
-static assert(!(X.O != Y.U));
-static assert( (X.O == Y.U));

--- a/test/fail_compilation/b6227.d
+++ b/test/fail_compilation/b6227.d
@@ -1,0 +1,17 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/b6227.d(16): Error: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
+fail_compilation/b6227.d(16):        while evaluating: `static assert(!false)`
+fail_compilation/b6227.d(17): Error: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
+fail_compilation/b6227.d(17):        while evaluating: `static assert(cast(X)0 == cast(Y)0)`
+---
+*/
+enum X {
+    O,
+    R
+}
+enum Y {
+    U
+}
+static assert(!(X.O != Y.U));
+static assert( (X.O == Y.U));

--- a/test/fail_compilation/fail109.d
+++ b/test/fail_compilation/fail109.d
@@ -34,7 +34,7 @@ enum E1 : short
 /* Bugzilla 14950
 TEST_OUTPUT:
 ---
-fail_compilation/fail109.d(50): Deprecation: Comparison between different enumeration types `B` and `C`; If this behavior is intended consider using `std.conv.asOriginalType`
+fail_compilation/fail109.d(50): Error: Comparison between different enumeration types `B` and `C`; If this behavior is intended consider using `std.conv.asOriginalType`
 fail_compilation/fail109.d(50): Error: enum member `fail109.B.end` initialization with `B.start+1` causes overflow for type `C`
 ---
 */

--- a/test/runnable/testenum.d
+++ b/test/runnable/testenum.d
@@ -189,7 +189,6 @@ void test2407()
         b = ES.b,
         c = ES.c,
     }
-    static assert(EES.init == ES.init);
     static assert(EES.init == S(1));
     static assert(!__traits(compiles, EES.min));
     static assert(!__traits(compiles, EES.max));


### PR DESCRIPTION
See https://dlang.org/deprecate.html#Implicit%20comparison%20of%20different%20enums

This PR moves a deprecation forward, further narrowing the gap between specification and implementation.

Update to deprecated features table: https://github.com/dlang/dlang.org/pull/2360