### PR TITLE
Fix issue 17968 - Use typeid(Object) instead of typeid(T) to avoid pulling in unused symbols

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -765,6 +765,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
     const(char)* code =
         "size_t h = 0;" ~
         "foreach (i, T; typeof(p.tupleof))" ~
+        // workaround https://issues.dlang.org/show_bug.cgi?id=17968
         "    static if(is(T* : const(Object)*)) " ~
         "        h = h * 33 + typeid(const(Object)).getHash(cast(const void*)&p.tupleof[i]);" ~
         "    else " ~

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -765,7 +765,10 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
     const(char)* code =
         "size_t h = 0;" ~
         "foreach (i, T; typeof(p.tupleof))" ~
-        "    h = h * 33 + typeid(T).getHash(cast(const void*)&p.tupleof[i]);" ~
+        "    static if(is(T* : const(Object)*)) " ~
+        "        h = h * 33 + typeid(const(Object)).getHash(cast(const void*)&p.tupleof[i]);" ~
+        "    else " ~
+        "        h = h * 33 + typeid(T).getHash(cast(const void*)&p.tupleof[i]);" ~
         "return h;";
     fop.fbody = new CompileStatement(loc, new StringExp(loc, cast(char*)code));
     Scope* sc2 = sc.push();

--- a/test/runnable/extra-files/test17968.d
+++ b/test/runnable/extra-files/test17968.d
@@ -1,0 +1,12 @@
+import test17968a;
+
+void main()
+{
+    auto r = fun2.fun1;
+    // just check that getHash works (doesn't throw).
+    typeid(r).getHash(&r);
+
+    // try gethash when member is null.
+    r.t = null;
+    typeid(r).getHash(&r);
+}

--- a/test/runnable/extra-files/test17968a.d
+++ b/test/runnable/extra-files/test17968a.d
@@ -1,0 +1,16 @@
+struct S(T)
+{
+    T t;
+}
+
+class C(T) { }
+
+auto fun1(T)(T t)
+{
+    return S!T(t);
+}
+
+auto fun2()
+{
+    return new C!int;
+}

--- a/test/runnable/test17968.sh
+++ b/test/runnable/test17968.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}a${OBJ} -c ${EXTRA_FILES}${SEP}test17968a.d
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}${SEP}test17968.d ${OUTPUT_BASE}a${OBJ}
+
+${OUTPUT_BASE}${EXE}
+
+rm ${OUTPUT_BASE}{a${OBJ},${EXE}}


### PR DESCRIPTION
The root cause of this problem still isn't fixed, I'll open a new bug report to demonstrate the original issue. This is a workaround, but since it's generated code by the compiler, it shouldn't really affect anything (except allow linking).

Note that using `typeid(Object)` instead of `typeid(T)` on the tuple member is fine as long as it's really an `Object`. `TypeInfo_Class.getHash` *always* casts its argument to `Object` and calls `toHash` on it, no matter what the actual type is.

ping @MartinNowak this is the bug that prevents `iopipe` from using `io`. Thanks to @tgehr, @jacob-carlborg , @thewilsonator, @rainers, @RazvanN7 for helping me figure this out at dconf!