### PR TITLE
Support typeof(null) mangling.

### DIFF
--- a/changelog/mangle_nullptr_t.dd
+++ b/changelog/mangle_nullptr_t.dd
@@ -1,0 +1,6 @@
+`extern (C++)` is now able to mangle `typeof(null)` (aka: `nullptr_t`) which often appears in C++ API's.
+
+---
+alias nullptr_t = typeof(null);
+extern (C++) void fun(nullptr_t);
+---

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -761,6 +761,14 @@ public:
         buf.writeByte(c);
     }
 
+    override void visit(TypeNull t)
+    {
+        if (t.isImmutable() || t.isShared())
+            return error(t);
+
+        writeBasicType(t, 'D', 'n');
+    }
+
     override void visit(TypeBasic t)
     {
         if (t.isImmutable() || t.isShared())

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -112,6 +112,18 @@ public:
         fatal(); //Fatal, because this error should be handled in frontend
     }
 
+    override void visit(TypeNull type)
+    {
+        if (type.isImmutable() || type.isShared())
+        {
+            visit(cast(Type)type);
+            return;
+        }
+        buf.writestring("$$T");
+        flags &= ~IS_NOT_TOP_TYPE;
+        flags &= ~IGNORE_CONST;
+    }
+
     override void visit(TypeBasic type)
     {
         //printf("visit(TypeBasic); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -450,3 +450,16 @@ version (Posix) // all non-Windows machines
     static assert(test37!int.mangleof == "_ZN5SPACE6test37IiEEiv");
 }
 
+/**************************************/
+// https://issues.dlang.org/show_bug.cgi?id=15388
+
+extern (C++) void test15388(typeof(null));
+
+version (Posix)
+{
+    static assert(test15388.mangleof == "_Z9test15388Dn");
+}
+version (Windows)
+{
+    static assert(test15388.mangleof == "?test15388@@YAX$$T@Z");
+}


### PR DESCRIPTION
Fix issue [15388 extern(C++) - typeof(null) should mangle as nullptr_t](https://issues.dlang.org/show_bug.cgi?id=15388)

`nullptr_t` didn't work. Now it does.

I don't understand the last 2 lines in the win implementation, but all the other functions had them, so I figured they were important ;)