### PR TITLE
getLinkage on class

### DIFF
--- a/changelog/getlinkage_for_classes.dd
+++ b/changelog/getlinkage_for_classes.dd
@@ -1,0 +1,12 @@
+__traits(getLinkage, ...) now works on classes and interfaces.
+
+It is now possible to detect the language ABI specified for a class or interface.
+
+---
+class MyClass {}
+extern (C++) class MyCPPClass {}
+extern (C++) interface MyCPPInterface {}
+static assert(__traits(getLinkage, MyClass) == "D");
+static assert(__traits(getLinkage, MyCPPClass) == "C++");
+static assert(__traits(getLinkage, MyCPPInterface) == "C++");
+---

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1284,12 +1284,26 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             auto s = getDsymbol(o);
             Declaration d;
-            if (!s || (d = s.isDeclaration()) is null)
+            ClassDeclaration c;
+            if (!s || ((d = s.isDeclaration()) is null && (c = s.isClassDeclaration()) is null))
             {
                 e.error("argument to `__traits(getLinkage, %s)` is not a declaration", o.toChars());
                 return new ErrorExp();
             }
-            link = d.linkage;
+            if (d !is null)
+                link = d.linkage;
+            else final switch (c.classKind)
+            {
+                case ClassKind.d:
+                    link = LINK.d;
+                    break;
+                case ClassKind.cpp:
+                    link = LINK.cpp;
+                    break;
+                case ClassKind.objc:
+                    link = LINK.objc;
+                    break;
+            }
         }
         auto linkage = linkageToChars(link);
         auto se = new StringExp(e.loc, cast(char*)linkage);

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -35,3 +35,19 @@ void bar()
     void nested() { }
     static assert(__traits(getLinkage, typeof(&nested)) == "D");
 }
+
+class FooD {}
+interface FooDInterface {}
+extern (C++) class FooCpp {}
+extern (C++) interface FooCppInterface {}
+
+static assert(__traits(getLinkage, FooD) == "D");
+static assert(__traits(getLinkage, FooDInterface) == "D");
+static assert(__traits(getLinkage, FooCpp) == "C++");
+static assert(__traits(getLinkage, FooCppInterface) == "C++");
+
+version (D_ObjectiveC)
+{
+    extern (Objective-C) interface FooObjC {}
+    static assert(__traits(getLinkage, FooObjC) == "Objective-C");
+}


### PR DESCRIPTION
Fix issue [17972 __traits(getLinkage) doesn't work for classes](https://issues.dlang.org/show_bug.cgi?id=17972)

Support `__traits(getLinkage)` on classes.
We have no way to detect if a class is `extern(C++)` or not.

And with this, I can fix this: [14536 - Calling destroy() on a on an extern(C++) class causes a segfault](https://issues.dlang.org/show_bug.cgi?id=14536)

Doco: dlang/dlang.org#2361