### PR TITLE
Add debug symbols for all non-release builds

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -245,6 +245,9 @@ endif
 ifdef ENABLE_RELEASE
 CXXFLAGS += -O2
 override DFLAGS += -O -release -inline
+else
+# Add debug symbols for all non-release builds
+override DFLAGS += -g
 endif
 ifdef ENABLE_PROFILING
 CXXFLAGS  += -pg -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
Currently DMD has the following concepts and options:

- BUILD=release|debug (default: release)
- ENABLE_RELEASE=1
- ENABLE_DEBUG=1
- DEBUG=1 (legacy alias)
- RELEASE=1 (legacy alias)

Only with BUILD=debug or (ENABLE_DEBUG=1) the debug build gets triggered.
OTOH the release build only gets activated with ENABLE_RELEASE=1 (or RELEASE=1).

This means that there's this weird intermediate, default state which is neither a debug nor release build.
This PR adds -g to the default state as that's imho a sane default and often very useful.
This doesn't affect release builds.

I have already quickly talked with @MartinNowak about this at DConf and he agreed that this is a sensible thing to do.