### PR TITLE
Make the old DEBUG=1 and RELEASE=1 makefile commands errors

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -232,9 +232,11 @@ override DFLAGS += -w -de
 
 ifneq (,$(DEBUG))
 ENABLE_DEBUG := 1
+$(error 'DEBUG=1 has been removed. Please use ENABLE_DEBUG=1')
 endif
 ifneq (,$(RELEASE))
 ENABLE_RELEASE := 1
+$(error 'RELEASE=1 has been removed. Please use ENABLE_RELEASE=1')
 endif
 
 # Append different flags for debugging, profiling and release.


### PR DESCRIPTION
Just checking whether any CI still uses them.
I doubt that triggering an `info` message will be seen by anyone.