### PR TITLE
Avoid eager error message allocation with `functionResolve`

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2570,9 +2570,8 @@ extern (C++) FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymb
 
     Match m;
     m.last = MATCH.nomatch;
-
-    const(char)* failMessage;
-    functionResolve(&m, s, loc, sc, tiargs, tthis, fargs, &failMessage);
+    functionResolve(&m, s, loc, sc, tiargs, tthis, fargs, null);
+    auto orig_s = s;
 
     if (m.last > MATCH.nomatch && m.lastf)
     {
@@ -2699,6 +2698,9 @@ extern (C++) FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymb
                     .error(loc, "%s `%s%s%s` is not callable using argument types `%s`",
                         fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameters, tf.varargs),
                         tf.modToChars(), fargsBuf.peekString());
+                    // re-resolve to check for supplemental message
+                    const(char)* failMessage;
+                    functionResolve(&m, orig_s, loc, sc, tiargs, tthis, fargs, &failMessage);
                     if (failMessage)
                         errorSupplemental(loc, failMessage);
                 }


### PR DESCRIPTION
* Don't set `failMessage` with `functionResolve` until it's needed.

This is a less drastic fix than #8216. In particular, this pull does not cause problems for #7584. The latter pull is a good example of why `functionResolve` cannot just return a parameter index and create the error message on the caller side.