### PR TITLE
[TRIVIAL] test/run.d: Add .exe extension to tools binaries for windows

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -115,9 +115,9 @@ void ensureToolsExists()
     ];
     foreach (tool; tools.parallel(1))
     {
-        auto targetBin = resultsDir.buildPath(tool);
+        auto targetBin = resultsDir.buildPath(tool).exeName;
         auto sourceFile = toolsDir.buildPath(tool ~ ".d");
-        if (targetBin.timeLastModified.ifThrown(SysTime.init) > sourceFile.timeLastModified)
+        if (targetBin.timeLastModified.ifThrown(SysTime.init) >= sourceFile.timeLastModified)
             writefln("%s is already up-to-date", tool);
         else
         {
@@ -349,4 +349,12 @@ auto log(T...)(T args)
 {
     if (verbose)
         writefln(args);
+}
+
+// Add the executable filename extension to the given `name` for the current OS.
+auto exeName(T)(T name)
+{
+    version(Windows)
+        name ~= ".exe";
+    return name;
 }


### PR DESCRIPTION
Noticed that `run.d` was always rebuilding the `d_do_test` and `sanitize_json` tools on windows. Added the `.exe` extension to the filename so that now it checks the correct filename of the executable.