### PR TITLE
Fix more cases of bug 15475

### DIFF
--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -554,7 +554,8 @@ extern (C++) void escapeDdocString(OutBuffer* buf, size_t start)
 extern (C++) void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start)
 {
     uint par_open = 0;
-    bool inCode = 0;
+    char inCode = 0;
+    bool atLineStart = true;
     for (size_t u = start; u < buf.offset; u++)
     {
         char c = buf.data[u];
@@ -563,6 +564,7 @@ extern (C++) void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start)
         case '(':
             if (!inCode)
                 par_open++;
+            atLineStart = false;
             break;
         case ')':
             if (!inCode)
@@ -578,29 +580,41 @@ extern (C++) void escapeStrayParenthesis(Loc loc, OutBuffer* buf, size_t start)
                 else
                     par_open--;
             }
+            atLineStart = false;
             break;
+        case '\n':
+            atLineStart = true;
             version (none)
             {
                 // For this to work, loc must be set to the beginning of the passed
                 // text which is currently not possible
                 // (loc is set to the Loc of the Dsymbol)
-            case '\n':
                 loc.linnum++;
-                break;
             }
+            break;
+        case ' ':
+        case '\r':
+        case '\t':
+            break;
         case '-':
+        case '`':
             // Issue 15465: don't try to escape unbalanced parens inside code
             // blocks.
-            int numdash = 0;
-            while (u < buf.offset && buf.data[u] == '-')
+            int numdash = 1;
+            for (++u; u < buf.offset && buf.data[u] == '-'; ++u)
+                ++numdash;
+            --u;
+            if (c == '`' || (atLineStart && numdash >= 3))
             {
-                numdash++;
-                u++;
+                if (inCode == c)
+                    inCode = 0;
+                else if (!inCode)
+                    inCode = c;
             }
-            if (numdash >= 3)
-                inCode = !inCode;
+            atLineStart = false;
             break;
         default:
+            atLineStart = false;
             break;
         }
     }
@@ -2297,6 +2311,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                     codebuf.write(buf.peekSlice().ptr + iCodeStart + 1, i - (iCodeStart + 1));
                     // escape the contents, but do not perform highlighting except for DDOC_PSYMBOL
                     highlightCode(sc, a, &codebuf, 0);
+                    escapeStrayParenthesis(s ? s.loc : Loc.initial, &codebuf, 0);
                     buf.remove(iCodeStart, i - iCodeStart + 1); // also trimming off the current `
                     immutable pre = "$(DDOC_BACKQUOTED ";
                     i = buf.insert(iCodeStart, pre);
@@ -2394,6 +2409,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                         ++p;
                     }
                     highlightCode2(sc, a, &codebuf, 0);
+                    escapeStrayParenthesis(s ? s.loc : Loc.initial, &codebuf, 0);
                     buf.remove(iCodeStart, i - iCodeStart);
                     i = buf.insert(iCodeStart, codebuf.peekSlice());
                     i = buf.insert(i, ")\n");

--- a/test/compilable/ddoc15475.d
+++ b/test/compilable/ddoc15475.d
@@ -8,5 +8,25 @@ My module
    // Computes the interval [x,y)
    auto interval = computeInterval(x, y);
 ----
+
+Backslash-escape parentheses with `\(` and `\)`.
+
+---
+(
+---
+
+---
+)
+---
+
+---
+    Here are some nested `backticks`
+    // Another interval [x,y)
+---
+
+---
+    This won't end the code block: --- )
+    // Yet another interval [x,y)
+---
 */
 module ddoc15475;

--- a/test/compilable/extra-files/ddoc15475.html
+++ b/test/compilable/extra-files/ddoc15475.html
@@ -483,6 +483,63 @@
 
   </p>
 </div>
+<div class="ddoc_description">
+  <h4>Discussion</h4>
+  <p class="para">
+    Backslash-escape parentheses with <code class="code">\(</code> and <code class="code">\)</code>.
+<br><br>
+
+<section class="code_listing">
+  <div class="code_sample">
+    <div class="dlang">
+      <ol class="code_lines">
+        <li><code class="code">(
+</code></li>
+      </ol>
+    </div>
+  </div>
+</section>
+<br><br>
+
+<section class="code_listing">
+  <div class="code_sample">
+    <div class="dlang">
+      <ol class="code_lines">
+        <li><code class="code">)
+</code></li>
+      </ol>
+    </div>
+  </div>
+</section>
+<br><br>
+
+<section class="code_listing">
+  <div class="code_sample">
+    <div class="dlang">
+      <ol class="code_lines">
+        <li><code class="code">    Here are some nested <span class="string_literal">`backticks`</span>
+    <span class="comment">// Another interval [x,y)
+</span></code></li>
+      </ol>
+    </div>
+  </div>
+</section>
+<br><br>
+
+<section class="code_listing">
+  <div class="code_sample">
+    <div class="dlang">
+      <ol class="code_lines">
+        <li><code class="code">    This won't end the code block: --- )
+    <span class="comment">// Yet another interval [x,y)
+</span></code></li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+  </p>
+</div>
 
 </section>
 </section>


### PR DESCRIPTION
It turns out that parentheses in Ddoc code spans weren't properly escaped in a couple of other cases than those the original PR addressed. One is when they were in backtick-quoted code spans, and another is when they weren't part of some other D construct. This PR fixes these cases.