### PR TITLE
Error for implicit catch statement

### DIFF
--- a/changelog/implicit_catch_error.dd
+++ b/changelog/implicit_catch_error.dd
@@ -1,0 +1,23 @@
+Implicit `catch` statements will now result in an error
+
+See the $(LINK2 $(ROOT_DIR)deprecate.html#Implicit catch statement, Deprecated Features)
+for more information.
+
+Implicit `catch` statements were deprecated in 2.072.  Starting with this release, implicit
+`catch` statements will cause the compiler to emit an error.
+
+---
+import std.stdio;
+
+void main()
+{
+    int[] arr = new int[](10);
+    // This will throw a RangeError
+    try { arr[42]++; }
+    catch  // Error: `catch` statement without an exception specification is deprecated;
+           // use `catch(Throwable)` for old behavior
+    {
+        writeln("An error was caught and ignored");
+    }
+}
+---

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4105,8 +4105,9 @@ void catchSemantic(Catch c, Scope* sc)
 
     if (!c.type)
     {
-        deprecation(c.loc, "`catch` statement without an exception " ~
-            "specification is deprecated; use `catch(Throwable)` for old behavior");
+        error(c.loc, "`catch` statement without an exception specification is deprecated");
+        errorSupplemental(c.loc, "use `catch(Throwable)` for old behavior");
+        c.errors = true;
 
         // reference .object.Throwable
         c.type = getThrowable();

--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -275,7 +275,7 @@ void main()
     try
     {
     }
-    catch
+    catch(.object.Throwable)
     {
     }
 }

--- a/test/compilable/test602.d
+++ b/test/compilable/test602.d
@@ -42,7 +42,7 @@ static assert(!__traits(compiles, (bool b)
     label: {}
         assert(!x);
     }
-    catch
+    catch(Throwable)
     {
     }
 }));
@@ -54,7 +54,7 @@ static assert(!__traits(compiles, (bool b)
     try
     {
     }
-    catch
+    catch(Throwable)
     {
         int x;
     label: {}

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -811,7 +811,7 @@ void test13840() nothrow
             func13840();        // throwable function call
         }
     }
-    catch
+    catch(Throwable)
     {}
 }
 

--- a/test/fail_compilation/test12558.d
+++ b/test/fail_compilation/test12558.d
@@ -2,8 +2,10 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/test12558.d(16): Deprecation: `catch` statement without an exception specification is deprecated; use `catch(Throwable)` for old behavior
-compilable/test12558.d(21): Deprecation: `catch` statement without an exception specification is deprecated; use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(18): Error: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(18):        use `catch(Throwable)` for old behavior
+fail_compilation/test12558.d(23): Error: `catch` statement without an exception specification is deprecated
+fail_compilation/test12558.d(23):        use `catch(Throwable)` for old behavior
 ---
 */
 

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -675,7 +675,7 @@ void test45()
    assert(foo45(0)==2);
    try{
       foo45(1);
-   }catch{
+   }catch(Throwable){
       return cast(void)0;
    }
    assert(0);

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -696,7 +696,7 @@ void test38()
        printf("Count: %d\n", count);
         assert(count == 1028);
     }
-    catch
+    catch(Throwable)
     {
        printf("Exception: %d\n", k);
         assert(0);

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -511,7 +511,7 @@ int foo17()
         }catch(Error e){
             assert(e);
             return 0;
-        }catch{
+        }catch(Throwable){
             assert(0);
         }
         assert(0);

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -413,7 +413,7 @@ void test19()
 {
         try{
                 throw new Alias19();
-        }catch{
+        }catch(Throwable){
                 return;
         }
         assert(0);
@@ -483,7 +483,7 @@ void test23()
 {
         try{
                 foo23();
-        }catch{
+        }catch(Throwable){
         }
         assert(status23==-1);
 }
@@ -514,7 +514,7 @@ void test24()
         assert(status24==0);
         try{
                 check24();
-        }catch{
+        }catch(Throwable){
                 assert(status24==1);
                 status24-=5;
         }
@@ -830,7 +830,7 @@ void test40()
         try{
                 assert(!checked40);
                 GrandChild40 gc = new GrandChild40();
-        }catch{
+        }catch(Throwable){
                 assert(checked40);
                 return;
         }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5340,7 +5340,7 @@ void fun12503()
             b = null;
             return;
         }
-        catch
+        catch(Throwable)
         {
         }
     }


### PR DESCRIPTION
See https://dlang.org/deprecate.html#Implicit%20catch%20statement

This PR moves a deprecation forward, further narrowing the gap between specification and implementation.

Update to deprecated features table:  https://github.com/dlang/dlang.org/pull/2365