### PR TITLE
Lower array literals to object.__arrayLiteral template

### DIFF
--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -417,6 +417,8 @@ immutable Msgtable[] msgtable =
     { "FALSE" },
     { "unsigned" },
     { "wchar_t" },
+
+    { "__arrayLiteral" },
 ];
 
 


### PR DESCRIPTION
@andralex @WalterBright et al.

This is my attempt at picking up where @somzzz left off, trying to replace runtime hooks that depend on runtime `TypeInfo` with templates.

For now `__arrayLiteral` is just a replacement for `_d_arrayLiteralTX` to verify the compiler/runtime interface is correct.  `__arrayLiteral` needs to be refactored to no longer rely on `TypeInfo`, but I want to get the compler/runtime interface implemented first and passing all tests.  Then I can refactor `__arrayLiteral` to no longer rely on runtime information.

I could use some direction on this.  I'm not sure about naming conventions, where these templates should reside in the source tree, etc...

This requires https://github.com/dlang/druntime/pull/2181