### PR TITLE
adjust d_size_t for OSX 64 bit

### DIFF
--- a/src/dmd/backend/cdef.h
+++ b/src/dmd/backend/cdef.h
@@ -235,11 +235,15 @@ char *strupr(char *);
 
 #include <stddef.h>     // for size_t
 
-#if __APPLE__ && __i386__
+#if __APPLE__
     /* size_t is 'unsigned long', which makes it mangle differently
      * than D's 'uint'
      */
+#if __i386__
     typedef unsigned d_size_t;
+#else
+    typedef unsigned long long d_size_t;
+#endif
 #else
     typedef size_t d_size_t;
 #endif

--- a/src/dmd/backend/dt.h
+++ b/src/dmd/backend/dt.h
@@ -5,11 +5,15 @@
 
 #include <stddef.h>     // for size_t
 
-#if __APPLE__ && __i386__
+#if __APPLE__
     /* size_t is 'unsigned long', which makes it mangle differently
      * than D's 'uint'
      */
+#if __i386__
     typedef unsigned d_size_t;
+#else
+    typedef unsigned long long d_size_t;
+#endif
 #else
     typedef size_t d_size_t;
 #endif

--- a/src/dmd/backend/outbuf.h
+++ b/src/dmd/backend/outbuf.h
@@ -15,11 +15,15 @@
 
 #include <stddef.h>     // for size_t
 
-#if __APPLE__ && __i386__
+#if __APPLE__
     /* size_t is 'unsigned long', which makes it mangle differently
      * than D's 'uint'
      */
+#if __i386__
     typedef unsigned d_size_t;
+#else
+    typedef unsigned long long d_size_t;
+#endif
 #else
     typedef size_t d_size_t;
 #endif

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -23,6 +23,17 @@ import dmd.root.stringtable;
 import dmd.tokens;
 import dmd.utf;
 
+version (OSX)
+{
+    // size_t is unsigned long on OSX, which results in name mangling issues
+    version (D_LP64)
+        alias d_size_t = ulong;
+    else
+        alias d_size_t = uint;
+}
+else
+    alias d_size_t = size_t;
+
 /***********************************************************
  */
 extern (C++) final class Identifier : RootObject
@@ -146,7 +157,7 @@ nothrow:
         return idPool(s.ptr, s.length);
     }
 
-    static Identifier idPool(const(char)* s, size_t len)
+    static Identifier idPool(const(char)* s, d_size_t len)
     {
         StringValue* sv = stringtable.update(s, len);
         Identifier id = cast(Identifier)sv.ptrvalue;

--- a/src/dmd/root/rmem.h
+++ b/src/dmd/root/rmem.h
@@ -12,11 +12,15 @@
 
 #include <stddef.h>     // for size_t
 
-#if __APPLE__ && __i386__
+#if __APPLE__
     /* size_t is 'unsigned long', which makes it mangle differently
      * than D's 'uint'
      */
+#if __i386__
     typedef unsigned d_size_t;
+#else
+    typedef unsigned long long d_size_t;
+#endif
 #else
     typedef size_t d_size_t;
 #endif

--- a/src/dmd/tk/mem.h
+++ b/src/dmd/tk/mem.h
@@ -12,11 +12,15 @@
 
 #include <stdio.h> // for size_t
 
-#if __APPLE__ && __i386__
+#if __APPLE__
     /* size_t is 'unsigned long', which makes it mangle differently
      * than D's 'uint'
      */
+#if __i386__
     typedef unsigned d_size_t;
+#else
+    typedef unsigned long long d_size_t;
+#endif
 #else
     typedef size_t d_size_t;
 #endif


### PR DESCRIPTION
Because of:
```
Undefined symbols for architecture x86_64:
  "Identifier::idPool(char const*, unsigned long)", referenced from:
      test_visitors() in cxxfrontend.o
      test_semantic() in cxxfrontend.o
```
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3165089&isPull=true