### PR TITLE
change size_t to uint for OSX 64 bit

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2289,7 +2289,7 @@ extern (C++) class FuncDeclaration : Declaration
      */
     static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, const(char)* name, StorageClass stc = 0)
     {
-        return genCfunc(fparams, treturn, Identifier.idPool(name, strlen(name)), stc);
+        return genCfunc(fparams, treturn, Identifier.idPool(name, cast(uint)strlen(name)), stc);
     }
 
     static FuncDeclaration genCfunc(Parameters* fparams, Type treturn, Identifier id, StorageClass stc = 0)

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -143,10 +143,10 @@ nothrow:
      */
     extern (D) static Identifier idPool(const(char)[] s)
     {
-        return idPool(s.ptr, s.length);
+        return idPool(s.ptr, cast(uint)s.length);
     }
 
-    static Identifier idPool(const(char)* s, size_t len)
+    static Identifier idPool(const(char)* s, uint len)
     {
         StringValue* sv = stringtable.update(s, len);
         Identifier id = cast(Identifier)sv.ptrvalue;

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -39,7 +39,7 @@ public:
     static StringTable stringtable;
     static Identifier *generateId(const char *prefix);
     static Identifier *generateId(const char *prefix, size_t i);
-    static Identifier *idPool(const char *s, d_size_t len);
+    static Identifier *idPool(const char *s, unsigned len);
 
     static inline Identifier *idPool(const char *s)
     {

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -494,7 +494,7 @@ class Lexer : ErrorHandler
                         }
                         break;
                     }
-                    Identifier id = Identifier.idPool(cast(char*)t.ptr, p - t.ptr);
+                    Identifier id = Identifier.idPool(cast(char*)t.ptr, cast(uint)(p - t.ptr));
                     t.ident = id;
                     t.value = cast(TOK)id.getValue();
                     anyToken = 1;

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -655,7 +655,7 @@ private int tryMain(size_t argc, const(char)** argv)
         /* At this point, name is the D source file name stripped of
          * its path and extension.
          */
-        auto id = Identifier.idPool(name, strlen(name));
+        auto id = Identifier.idPool(name, cast(uint)strlen(name));
         auto m = new Module(files[i], id, global.params.doDocComments, global.params.doHdrGeneration);
         modules.push(m);
         if (firstmodule)
@@ -2505,7 +2505,7 @@ private void parseModulePattern(const(char)* modulePattern, MatcherNode* dst, us
                 if (*modulePattern == '.')
                 {
                     assert(modulePattern > idStart, "empty module pattern");
-                    *dst = MatcherNode(Identifier.idPool(idStart, modulePattern - idStart));
+                    *dst = MatcherNode(Identifier.idPool(idStart, cast(uint)(modulePattern - idStart)));
                     modulePattern++;
                     idStart = modulePattern;
                     break;
@@ -2517,7 +2517,7 @@ private void parseModulePattern(const(char)* modulePattern, MatcherNode* dst, us
             if (*modulePattern == '\0')
             {
                 assert(modulePattern > idStart, "empty module pattern");
-                *lastNode = MatcherNode(Identifier.idPool(idStart, modulePattern - idStart));
+                *lastNode = MatcherNode(Identifier.idPool(idStart, cast(uint)(modulePattern - idStart)));
                 break;
             }
         }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5627,7 +5627,7 @@ extern (C++) abstract class TypeQualified : Type
             /* Look for what user might have intended
              */
             const p = mutableOf().unSharedOf().toChars();
-            auto id = Identifier.idPool(p, strlen(p));
+            auto id = Identifier.idPool(p, cast(uint)strlen(p));
             if (const n = importHint(p))
                 error(loc, "`%s` is not defined, perhaps `import %s;` ?", p, n);
             else if (auto s2 = sc.search_correct(id))


### PR DESCRIPTION
Because of:
```
Undefined symbols for architecture x86_64:
  "Identifier::idPool(char const*, unsigned long)", referenced from:
      test_visitors() in cxxfrontend.o
      test_semantic() in cxxfrontend.o
```
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3165089&isPull=true