### PR TITLE
Add support for IRETQ instruction in inline assembler

### DIFF
--- a/changelog/iretq.dd
+++ b/changelog/iretq.dd
@@ -1,0 +1,17 @@
+`IRETQ` is now supported in inline assembler.
+
+`IRETQ` is the 64-bit version of the already supported `IRET` instruction. With
+its inclusion, it is now possible to write 64-bit interrupt service routines
+in pure D.
+
+---
+void isr()
+{
+    asm
+    {
+        naked;
+        // ...
+        iretq;
+    }
+}
+---

--- a/src/dmd/backend/ptrntab.c
+++ b/src/dmd/backend/ptrntab.c
@@ -64,6 +64,7 @@ OPTABLE0(INTO,    0xce,_i64_bit);
 OPTABLE0(INVD,    0x0f08,_I386);               // Actually a 486 only instruction
 OPTABLE0(IRET,    0xcf,_16_bit);
 OPTABLE0(IRETD,   0xcf,_32_bit | _I386);
+OPTABLE0(IRETQ,   0xcf,_64_bit | _I386);
 OPTABLE0(LAHF,    0x9f,_modax);
 OPTABLE0(LEAVE,   0xc9,_I386);
 OPTABLE0(LOCK,    0xf0,0);
@@ -5023,6 +5024,7 @@ PTRNTAB2 aptb2SHA256MSG2[] = /* SHA256MSG2 */ {
         X("invlpg",     1,              aptb1INVLPG )               \
         X("iret",       0,              aptb0IRET )                 \
         X("iretd",      0,              aptb0IRETD )                \
+        X("iretq",      0,              aptb0IRETQ )                \
         X("ja",         ITjump | 1,     aptb1JNBE )                 \
         X("jae",        ITjump | 1,     aptb1JNB )                  \
         X("jb",         ITjump | 1,     aptb1JB )                   \

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -3605,6 +3605,10 @@ void test50()
         0xCD, 0x67,     // int  067h
 //      0xCE,           // into
         0x66, 0xCF,     // iret
+        0x48, 0xCF,     // iretq
+        0x90, 0x90,     // nop;nop - put instructions above this or L10 changes
+                        //           address, which changes all the jump
+                        //           instructions and breaks the test case.
         0x77, 0xFC,     // ja   L30
         0x77, 0xFA,     // ja   L30
         0x73, 0xF8,     // jae  L30
@@ -3727,7 +3731,11 @@ void test50()
         int     3       ;
         int     0x67    ;
         //into          ;
-L10:    iret            ;
+        iret            ;
+        iretq           ;
+L10:    nop; nop;         // put instructions above this or L10 changes
+                          // address, which changes all the jump instructions
+                          // and breaks the test case.
         ja      L10     ;
         jnbe    L10     ;
         jae     L10     ;


### PR DESCRIPTION
DMD currently supports `IRET` and `IRETD`, with `IRETQ` missing for no apparent reason. Adding it allows writing interrupt service routines for AMD64-compatible CPUs with nothing more than D and it's inline assembler.