### PR TITLE
Fix Issue 18493 - [betterC] Can't use aggregated type with postblit (+More)

### DIFF
--- a/changelog/betterC_requires_nothrow.dd
+++ b/changelog/betterC_requires_nothrow.dd
@@ -1,0 +1,14 @@
+`nothrow` required when compiling in an environment that doesn't support exceptions (e.g. -betterC)
+
+Prior to this release, when compiling in an environment that does not support exceptions
+(e.g. -betterC or a minimal runtime with `Throwable` support), the compiler permitted
+non-nothrow functions despite the fact that such functions could never throw, nor handle
+exceptions thrown by called functions.
+
+Starting with this release , when compiling in an environment that does not support
+exceptions, the compiler will emit an error for any function not attributed with `nothrow`.
+This has been done to enforce the principle that compiler flags should not change language.
+
+This will break existing code, but the fix is simple:  Add a `nothrow:` attribution to the top
+of all modules.  Users should already be doing this anyway when compiling in a no-exceptions
+environment.

--- a/src/dmd/backend/divcoeff.d
+++ b/src/dmd/backend/divcoeff.d
@@ -15,6 +15,9 @@
 
 import core.stdc.stdio;
 
+nothrow:
+@nogc:
+
 extern (C++):
 
 alias ullong = ulong;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3049,6 +3049,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         f = cast(TypeFunction)funcdecl.type;
 
+        if ((!global.params.useExceptions || !ClassDeclaration.throwable) && !f.isnothrow)
+            funcdecl.error("must be `nothrow` if compiling without support for exceptions (e.g. -betterC)");
+
         if ((funcdecl.storage_class & STC.auto_) && !f.isref && !funcdecl.inferRetType)
             funcdecl.error("storage class `auto` has no effect if return type is not inferred");
 

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -4,6 +4,8 @@
 
 import core.stdc.stdio;
 
+nothrow:
+
 extern (C) int main(char** argv, int argc) {
     printf("hello world\n");
     int[3] a;

--- a/test/compilable/minimal.d
+++ b/test/compilable/minimal.d
@@ -7,9 +7,11 @@
 // runtime, does not generate ModuleInfo or exception handling code, and does not
 // require TypeInfo
 
+nothrow:
+
 struct S { }
 
-enum E 
+enum E
 {
     e0 = 0,
     e1 = 1

--- a/test/compilable/minimal2.d
+++ b/test/compilable/minimal2.d
@@ -7,6 +7,8 @@
 // This should compile, but will not link and run properly without
 // a thread-local storage (TLS) implementation.
 
+nothrow:
+
 interface I
 {
     static int i;

--- a/test/compilable/test18099.d
+++ b/test/compilable/test18099.d
@@ -8,10 +8,10 @@ struct D
 {
     static struct V
     {
-        ~this() { }
+        ~this() nothrow { }
     }
 
-    V get()
+    V get() nothrow
     {
         V v;
         return v;

--- a/test/fail_compilation/betterc.d
+++ b/test/fail_compilation/betterc.d
@@ -1,11 +1,13 @@
 /* REQUIRED_ARGS: -betterC
  * TEST_OUTPUT:
 ---
-fail_compilation/betterc.d(12): Error: Cannot use `throw` statements with -betterC
-fail_compilation/betterc.d(17): Error: Cannot use try-catch statements with -betterC
-fail_compilation/betterc.d(29): Error: `TypeInfo` cannot be used with -betterC
+fail_compilation/betterc.d(14): Error: Cannot use `throw` statements with -betterC
+fail_compilation/betterc.d(19): Error: Cannot use try-catch statements with -betterC
+fail_compilation/betterc.d(31): Error: `TypeInfo` cannot be used with -betterC
 ---
 */
+
+nothrow:
 
 void test()
 {

--- a/test/fail_compilation/betterc2.d
+++ b/test/fail_compilation/betterc2.d
@@ -1,0 +1,14 @@
+/* REQUIRED_ARGS: -betterC
+ * TEST_OUTPUT:
+---
+fail_compilation/betterc2.d(9): Error: function `betterc2.notNoThrow` must be `nothrow` if compiling without support for exceptions (e.g. -betterC)
+fail_compilation/betterc2.d(13): Error: function `betterc2.S.notNowThrow` must be `nothrow` if compiling without support for exceptions (e.g. -betterC)
+---
+*/
+
+void notNoThrow() {}
+
+struct S
+{
+    void notNowThrow() { }
+}

--- a/test/fail_compilation/no_Throwable.d
+++ b/test/fail_compilation/no_Throwable.d
@@ -1,12 +1,14 @@
-/* 
+/*
 DFLAGS:
 REQUIRED_ARGS: -c -I=fail_compilation/extra-files/no_Throwable/
 TEST_OUTPUT:
 ---
-fail_compilation/no_Throwable.d(13): Error: Cannot use `throw` statements because `object.Throwable` was not declared
-fail_compilation/no_Throwable.d(18): Error: Cannot use try-catch statements because `object.Throwable` was not declared
+fail_compilation/no_Throwable.d(15): Error: Cannot use `throw` statements because `object.Throwable` was not declared
+fail_compilation/no_Throwable.d(20): Error: Cannot use try-catch statements because `object.Throwable` was not declared
 ---
 */
+
+nothrow:
 
 void test()
 {

--- a/test/fail_compilation/no_Throwable2.d
+++ b/test/fail_compilation/no_Throwable2.d
@@ -1,0 +1,16 @@
+/*
+DFLAGS:
+REQUIRED_ARGS: -c -I=fail_compilation/extra-files/no_Throwable/
+TEST_OUTPUT:
+---
+fail_compilation/no_Throwable2.d(11): Error: function `no_Throwable2.notNoThrow` must be `nothrow` if compiling without support for exceptions (e.g. -betterC)
+fail_compilation/no_Throwable2.d(15): Error: function `no_Throwable2.S.notNowThrow` must be `nothrow` if compiling without support for exceptions (e.g. -betterC)
+---
+*/
+
+void notNoThrow() {}
+
+struct S
+{
+    void notNowThrow() { }
+}

--- a/test/fail_compilation/no_TypeInfo.d
+++ b/test/fail_compilation/no_TypeInfo.d
@@ -1,11 +1,13 @@
-/* 
+/*
 DFLAGS:
 REQUIRED_ARGS: -c -I=fail_compilation/extra-files/no_TypeInfo/
 TEST_OUTPUT:
 ---
-fail_compilation/no_TypeInfo.d(13): Error: `object.TypeInfo` could not be found, but is implicitly used
+fail_compilation/no_TypeInfo.d(15): Error: `object.TypeInfo` could not be found, but is implicitly used
 ---
 */
+
+nothrow:
 
 void test()
 {

--- a/test/fail_compilation/test18312.d
+++ b/test/fail_compilation/test18312.d
@@ -8,7 +8,7 @@ fail_compilation/test18312.d(14): Error: array concatenation of expression `"[" 
 
 // https://issues.dlang.org/show_bug.cgi?id=18312
 
-extern (C) void main()
+extern (C) void main() nothrow
 {
     scope string s;
     s = "[" ~ s ~ "]";

--- a/test/runnable/bcraii2.d
+++ b/test/runnable/bcraii2.d
@@ -4,6 +4,8 @@
 
 import core.stdc.stdio;
 
+nothrow:
+
 extern (C) int main()
 {
     auto j = test(1);

--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -2,6 +2,7 @@
    PERMUTE_ARGS:
  */
 
+nothrow:
 
 void test(int ij)
 {
@@ -62,7 +63,7 @@ struct S18493
 {
     this(this) nothrow { }  // Since this is attributed with `nothrow` there should be no error about using
                             // try-catch with -betterC
-    ~this() { }
+    ~this() nothrow { }
 }
 
 struct S18493_2

--- a/test/runnable/extra-files/minimal/object.d
+++ b/test/runnable/extra-files/minimal/object.d
@@ -1,7 +1,7 @@
 module object;
 
-private alias extern(C) int function(char[][] args) MainFunc;
-private extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
+private alias extern(C) int function(char[][] args) nothrow MainFunc;
+private extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc) nothrow
 {
     return mainFunc(null);
 }

--- a/test/runnable/minimal.d
+++ b/test/runnable/minimal.d
@@ -4,4 +4,4 @@
 
 // This test ensures an empty main can be built and executed with a minimal runtime
 
-void main() { }
+void main() nothrow { }

--- a/test/runnable/test17868.d
+++ b/test/runnable/test17868.d
@@ -3,6 +3,7 @@
 import core.stdc.stdio;
 
 extern(C):
+nothrow:
 
 pragma(crt_constructor)
 void init()


### PR DESCRIPTION
### Overview
[Issue 18493](https://issues.dlang.org/show_bug.cgi?id=18493) revealed an oversight in the implementation of betterC:  -betterC does not support throwing exceptions, but does not require a `nothrow` environment.  #8184 provided a fix to the auto-generated try-catches implicitly added to an aggregate's field postblits, but the fundamental issue remains.  This PR attempts to fix that fundamental issue.

I discussed this with @andralex and @WalterBright privately in an e-mail exchange:

  * Me:  Is it your intention to make -betterC work with reference counted exceptions in the future, or will -betterC *always* imply a `nothrow` environment?
  * WB:  For the foreseeable future, betterC means nothrow.
  * AA:  If we want betterC to only work with nothrow, we should restrict it as such, i.e. reject any code that is not marked with "nothrow". Code semantics should not depend on the compilation switch used.
  * WB:  It's reasonable for betterC to assume nothrow. It diagnoses an error when any attempts are made to throw, and it already assumes nothrow.
  * AA:  How does that interact with linking -betterC code with non-betterC code?
  * WB:  There's no purpose to doing that. The point of betterC is to not require druntime - linking it with non-betterC code will require druntime.  If you do it anyway, it will be like linking in C code to your D code. It'll be totally unaware of thrown exceptions - it won't catch them, and won't execute finally blocks or destructors as the stack is unwound.
  * Me:  What about DIP1008?  Are there any plans to make that usable in -betterC?
  * WB:  No, because the exception unwinding code in druntime is still required, and is not there in the standard C libraries.

I've chosen to side with @andralex for this PR as I agree with the principle that:

> Code semantics should not depend on the compilation switch used.

That is, when compiling in -betterC, or with a minimal runtime that does not support `Throwable`, the compiler will require all functions to be attributed with `nothrow` (which users should already be doing anyway).

### Breaking Changes
This will break existing -betterC code for sure, but I think that's OK:
  * -betterC is a relatively new feature of D and we're still sorting out issues with it.
  * according to [the 2018 State of D Survey](https://dlang.typeform.com/report/H1GTak/PY9NhHkcBFG0t6ig) -betterC is only being used by 4% of respondents, so the impact should be very minimal.
  * the fix is extremely simple in most cases:  Add a `nothrow:` attribution to the top of the module.  Users should already be doing this anyway when compiling without support for exceptions.
 
### DRuntime Changes
To make this work druntime's object.d also needed to be modified (See https://github.com/dlang/druntime/pull/2184).  This is because, despite the fact the -betterC does not link with druntime or phobos, it still imports object.d.  There is a large amount of code in object.d that not utilized when compiling with -betterC, but it is not `version`ed out like it should be, and that causes compiler errors with the changes in this PR.  The druntime PR will also enable other planned features for -betterC including using classes with `static memebers`, so it is also forward-looking.

Adding the "Vision" label as this is congruent with item 4 of [Vision 2018H1](https://wiki.dlang.org/Vision/2018H1)

> 4. Improve interoperability with other languages: Finishing -betterC should improve incremental migration of C and C++. 