### PR TITLE
[Trivial] Fix test/run.d on macOS

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -310,7 +310,7 @@ string[string] getEnvironment()
 
         version(OSX)
             version(X86_64)
-                env["D_OBJC"] = 1;
+                env["D_OBJC"] = "1";
     }
     return env;
 }


### PR DESCRIPTION
This fixes the compile error I otherwise get:
`run.d(313): Error: cannot implicitly convert expression 1 of type int to string`