### PR TITLE
fix Issue 18868 - nondeterministic static ctor/dtor

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -864,9 +864,7 @@ struct ASTBase
 
         extern (D) this(Loc loc, Loc endloc, StorageClass stc, char* codedoc)
         {
-            OutBuffer buf;
-            buf.printf("__unittestL%u_", loc.linnum);
-            super(loc, endloc, Identifier.generateId(buf.peekString()), stc, null);
+            super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
             this.codedoc = codedoc;
         }
 
@@ -914,11 +912,11 @@ struct ASTBase
     {
         final extern (D) this(Loc loc, Loc endloc, StorageClass stc)
         {
-            super(loc, endloc, Identifier.generateId("_staticCtor"), STC.static_ | stc, null);
+            super(loc, endloc, Identifier.generateIdWithLoc("_staticCtor", loc), STC.static_ | stc, null);
         }
-        final extern (D) this(Loc loc, Loc endloc, const(char)* name, StorageClass stc)
+        final extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
         {
-            super(loc, endloc, Identifier.generateId(name), STC.static_ | stc, null);
+            super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
         }
 
         override void accept(Visitor v)
@@ -931,11 +929,11 @@ struct ASTBase
     {
         final extern (D) this()(Loc loc, Loc endloc, StorageClass stc)
         {
-            super(loc, endloc, Identifier.generateId("__staticDtor"), STC.static_ | stc, null);
+            super(loc, endloc, Identifier.generateIdWithLoc("__staticDtor", loc), STC.static_ | stc, null);
         }
-        final extern (D) this(Loc loc, Loc endloc, const(char)* name, StorageClass stc)
+        final extern (D) this(Loc loc, Loc endloc, string name, StorageClass stc)
         {
-            super(loc, endloc, Identifier.generateId(name), STC.static_ | stc, null);
+            super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
         }
 
         override void accept(Visitor v)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3406,12 +3406,12 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
 {
     extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
     {
-        super(loc, endloc, Identifier.generateId("_staticCtor"), STC.static_ | stc, null);
+        super(loc, endloc, Identifier.generateIdWithLoc("_staticCtor", loc), STC.static_ | stc, null);
     }
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, const(char)* name, StorageClass stc)
+    extern (D) this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
     {
-        super(loc, endloc, Identifier.generateId(name), STC.static_ | stc, null);
+        super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
@@ -3492,12 +3492,12 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
 
     extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
     {
-        super(loc, endloc, Identifier.generateId("_staticDtor"), STC.static_ | stc, null);
+        super(loc, endloc, Identifier.generateIdWithLoc("_staticDtor", loc), STC.static_ | stc, null);
     }
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, const(char)* name, StorageClass stc)
+    extern (D) this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
     {
-        super(loc, endloc, Identifier.generateId(name), STC.static_ | stc, null);
+        super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
@@ -3625,7 +3625,7 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
 
     extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, char* codedoc)
     {
-        super(loc, endloc, createIdentifier(loc), stc, null);
+        super(loc, endloc, Identifier.generateIdWithLoc("__unittest", loc), stc, null);
         this.codedoc = codedoc;
     }
 
@@ -3634,17 +3634,6 @@ extern (C++) final class UnitTestDeclaration : FuncDeclaration
         assert(!s);
         auto utd = new UnitTestDeclaration(loc, endloc, storage_class, codedoc);
         return FuncDeclaration.syntaxCopy(utd);
-    }
-
-    /***********************************************************
-     * Generate unique unittest function Id so we can have multiple
-     * instances per module.
-     */
-    private static Identifier createIdentifier(const ref Loc loc)
-    {
-        OutBuffer buf;
-        buf.printf("__unittest_L%u_C%u", loc.linnum, loc.charnum);
-        return Identifier.idPool(buf.peekSlice());
     }
 
     override inout(AggregateDeclaration) isThis() inout

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -10,7 +10,7 @@
                 "endline": 8,
                 "kind": "function",
                 "line": 8,
-                "name": "_staticCtor1",
+                "name": "_staticCtor_L8_C1",
                 "storageClass": [
                     "static"
                 ]
@@ -22,7 +22,7 @@
                 "endline": 10,
                 "kind": "function",
                 "line": 10,
-                "name": "_staticDtor2",
+                "name": "_staticDtor_L10_C1",
                 "storageClass": [
                     "static"
                 ]

--- a/test/runnable/extra-files/test18868_a.d
+++ b/test/runnable/extra-files/test18868_a.d
@@ -1,0 +1,3 @@
+shared static this() { }
+import imports.test18868_fls;
+alias floop = FLS!(int);

--- a/test/runnable/extra-files/test18868_b.d
+++ b/test/runnable/extra-files/test18868_b.d
@@ -1,0 +1,3 @@
+import imports.test18868_fls;
+alias floop = FLS!(int);
+void main() {}

--- a/test/runnable/imports/test18868_fls.d
+++ b/test/runnable/imports/test18868_fls.d
@@ -1,0 +1,33 @@
+module imports.test18868_fls;
+
+template FLS(T)
+{
+    int ctorcount = 0;
+    int dtorcount = 0;
+    int sharedctorcount = 0;
+    int shareddtorcount = 0;
+
+    static this()
+    {
+        assert(ctorcount == 0);
+        ctorcount += 1;
+    }
+
+    static ~this()
+    {
+        assert(dtorcount == 0);
+        dtorcount += 1;
+    }
+
+    shared static this()
+    {
+        assert(sharedctorcount == 0);
+        sharedctorcount += 1;
+    }
+
+    shared static ~this()
+    {
+        assert(shareddtorcount == 0);
+        shareddtorcount += 1;
+    }
+}

--- a/test/runnable/test18868.sh
+++ b/test/runnable/test18868.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -c ${EXTRA_FILES}/test18868_a.d
+
+$DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -c ${EXTRA_FILES}/test18868_b.d
+
+$DMD -m${MODEL} -of${OUTPUT_BASE}${EXE} ${TEST_DIR}/imports/test18868_fls.d ${OUTPUT_BASE}_a${OBJ} ${OUTPUT_BASE}_b${OBJ}
+
+${OUTPUT_BASE}${EXE}
+
+rm ${OUTPUT_BASE}{${OBJ},_a${OBJ},_b${OBJ},${EXE}}

--- a/test/runnable/test18868_2.d
+++ b/test/runnable/test18868_2.d
@@ -1,0 +1,13 @@
+mixin(genCtor("666")); mixin(genCtor("777"));
+
+int i;
+
+string genCtor(string a)
+{
+    return "static this() { i += " ~ a ~ "; }";
+}
+
+void main()
+{
+    assert(i == 0 + 666 + 777);
+}

--- a/test/runnable/test18868_3.d
+++ b/test/runnable/test18868_3.d
@@ -1,0 +1,16 @@
+static foreach(s; ["666", "777", "888"])
+{
+    mixin(genCtor(s));
+}
+
+int i;
+
+string genCtor(string a)
+{
+    return "static this() { i += " ~ a ~ "; }";
+}
+
+void main()
+{
+    assert(i == 0 + 666 + 777 + 888);
+}

--- a/test/runnable/test18880.d
+++ b/test/runnable/test18880.d
@@ -1,0 +1,20 @@
+/* REQUIRED_ARGS: -unittest
+   PERMUTE_ARGS:
+ */
+
+static foreach(s; ["666", "777", "888"])
+{
+    mixin(genTest(s));
+}
+
+int i;
+
+string genTest(string a)
+{
+    return "unittest { i += " ~ a ~ "; }";
+}
+
+void main()
+{
+    assert(i == 0 + 666 + 777 + 888);
+}


### PR DESCRIPTION
Instead of using a counter to create unique static ctor and dtor function identifiers, use the deterministic line+column location that is also used for generating unittest function identifiers.