### PR TITLE
Add test coverage for c-style cast parser error

### DIFF
--- a/test/fail_compilation/ccast.d
+++ b/test/fail_compilation/ccast.d
@@ -1,0 +1,9 @@
+/* 
+TEST_OUTPUT:
+---
+fail_compilation/ccast.d(9): Error: C style cast illegal, use `cast(byte)i`
+---
+*/
+
+int i;
+byte b = (byte)i;


### PR DESCRIPTION
Just adding missing test coverage.  Will also add coverage for #8218.