### PR TITLE
[Trivial] Rename Identifier.string to Identifier.name to not clash with the `string` type.

### DIFF
--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -29,54 +29,54 @@ extern (C++) final class Identifier : RootObject
 {
 private:
     const int value;
-    const char* string;
+    const char* name;
     const size_t len;
 
 public:
 
-    extern (D) this(const(char)* string, size_t length, int value) nothrow
+    extern (D) this(const(char)* name, size_t length, int value) nothrow
     {
-        //printf("Identifier('%s', %d)\n", string, value);
-        this.string = string;
+        //printf("Identifier('%s', %d)\n", name, value);
+        this.name = name;
         this.value = value;
         this.len = length;
     }
 
-    extern (D) this(const(char)* string) nothrow
+    extern (D) this(const(char)* name) nothrow
     {
-        //printf("Identifier('%s', %d)\n", string, value);
-        this(string, strlen(string), TOK.identifier);
+        //printf("Identifier('%s', %d)\n", name, value);
+        this(name, strlen(name), TOK.identifier);
     }
 
-    static Identifier create(const(char)* string) nothrow
+    static Identifier create(const(char)* name) nothrow
     {
-        return new Identifier(string);
+        return new Identifier(name);
     }
 
     override bool equals(RootObject o) const
     {
-        return this == o || strncmp(string, o.toChars(), len + 1) == 0;
+        return this == o || strncmp(name, o.toChars(), len + 1) == 0;
     }
 
     override int compare(RootObject o) const
     {
-        return strncmp(string, o.toChars(), len + 1);
+        return strncmp(name, o.toChars(), len + 1);
     }
 
 nothrow:
     override void print() const
     {
-        fprintf(stderr, "%s", string);
+        fprintf(stderr, "%s", name);
     }
 
     override const(char)* toChars() const pure
     {
-        return string;
+        return name;
     }
 
     extern (D) final const(char)[] toString() const pure
     {
-        return string[0 .. len];
+        return name[0 .. len];
     }
 
     final int getValue() const pure


### PR DESCRIPTION
This will make it easier in future to refactor code to use D strings instead of C-style strings.