### PR TITLE
fix Issue 18115 - [REG2.078-b1] case where && is not shortcut anymore…

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1339,8 +1339,11 @@ extern (C++) UnionExp Slice(Type type, Expression e1, Expression lwr, Expression
         uinteger_t iupr = upr.toInteger();
         if (iupr > es1.len || ilwr > iupr)
         {
-            e1.error("string slice `[%llu .. %llu]` is out of bounds", ilwr, iupr);
-            emplaceExp!(ErrorExp)(&ue);
+            // https://issues.dlang.org/show_bug.cgi?id=18115
+            emplaceExp!(CTFEExp)(&ue, TOK.cantExpression);
+            return ue;
+            //e1.error("string slice `[%llu .. %llu]` is out of bounds", ilwr, iupr);
+            //emplaceExp!(ErrorExp)(&ue);
         }
         else
         {

--- a/test/compilable/test18115.d
+++ b/test/compilable/test18115.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=18115
+
+int test()
+{
+    if (test.stringof.length > 6 &&
+        test.stringof[$-7..$] == "1234567") {}
+    return 0;
+}
+
+enum a = test();


### PR DESCRIPTION
… in CTFE

Try not constant-folding expressions that produce errors.