### PR TITLE
Fix Issue 18871 & 18819 - DMD illegal hardware instruction crash

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4827,17 +4827,23 @@ public:
             {
                 assert(e.arguments.dim == 1);
                 Expression ea = (*e.arguments)[0];
-                //printf("1 ea = %s %s\n", ea.type.toChars(), ea.toChars());
+                // printf("1 ea = %s %s\n", ea.type.toChars(), ea.toChars());
                 if (ea.op == TOK.slice)
                     ea = (cast(SliceExp)ea).e1;
                 if (ea.op == TOK.cast_)
                     ea = (cast(CastExp)ea).e1;
 
-                //printf("2 ea = %s, %s %s\n", ea.type.toChars(), Token::toChars(ea.op), ea.toChars());
+                // printf("2 ea = %s, %s %s\n", ea.type.toChars(), Token.toChars(ea.op), ea.toChars());
                 if (ea.op == TOK.variable || ea.op == TOK.symbolOffset)
                     result = getVarExp(e.loc, istate, (cast(SymbolExp)ea).var, ctfeNeedRvalue);
                 else if (ea.op == TOK.address)
                     result = interpret((cast(AddrExp)ea).e1, istate);
+
+                // https://issues.dlang.org/show_bug.cgi?id=18871
+                // https://issues.dlang.org/show_bug.cgi?id=18819
+                else if (ea.op == TOK.arrayLiteral)
+                    result = interpret(cast(ArrayLiteralExp)ea, istate);
+
                 else
                     assert(0);
                 if (CTFEExp.isCantExp(result))

--- a/test/compilable/test18871.d
+++ b/test/compilable/test18871.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=18871
+// and https://issues.dlang.org/show_bug.cgi?id=18819
+
+struct Problem
+{
+    ~this() {}
+}
+struct S
+{
+    Problem[1] payload;
+}
+enum theTemplateB = {
+    static foreach (e; S.init.tupleof) {}
+    return true;
+}();


### PR DESCRIPTION
I'm still trying to create a reduced test case.  When I print out `ea.toChars()`, I get this:

```
CallExp::interpret() _ArrayDtor([Vector(), Vector()])
1 ea = Vector[] [Vector(), Vector()]
2 ea = Vector[], arrayliteral [Vector(), Vector()]
```

If someone knows how to get a reduced test case from that.  Please let me know.

