### PR TITLE
Support magic __c_(u)longlong enums (for C++ mangling)

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -982,14 +982,18 @@ public:
         if (t.isImmutable() || t.isShared())
             return error(t);
 
-        /* __c_long and __c_ulong get special mangling
+        /* __c_(u)long(long) get special mangling
          */
         const id = t.sym.ident;
-        //printf("struct id = '%s'\n", id.toChars());
+        //printf("enum id = '%s'\n", id.toChars());
         if (id == Id.__c_long)
             return writeBasicType(t, 0, 'l');
         else if (id == Id.__c_ulong)
             return writeBasicType(t, 0, 'm');
+        else if (id == Id.__c_longlong)
+            return writeBasicType(t, 0, 'x');
+        else if (id == Id.__c_ulonglong)
+            return writeBasicType(t, 0, 'y');
 
         doSymbol(t);
     }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -417,16 +417,18 @@ public:
     {
         //printf("visit(TypeEnum); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));
         const id = type.sym.ident;
-        char c;
+        string c;
         if (id == Id.__c_long_double)
-            c = 'O'; // VC++ long double
+            c = "O"; // VC++ long double
         else if (id == Id.__c_long)
-            c = 'J'; // VC++ long
+            c = "J"; // VC++ long
         else if (id == Id.__c_ulong)
-            c = 'K'; // VC++ unsigned long
-        else
-            c = 0;
-        if (c)
+            c = "K"; // VC++ unsigned long
+        else if (id == Id.__c_longlong)
+            c = "_J"; // VC++ long long
+        else if (id == Id.__c_ulonglong)
+            c = "_K"; // VC++ unsigned long long
+        if (c.length)
         {
             if (type.isImmutable() || type.isShared())
             {
@@ -439,7 +441,7 @@ public:
                     return;
             }
             mangleModifier(type);
-            buf.writeByte(c);
+            buf.writestring(c);
         }
         else
         {
@@ -1052,7 +1054,8 @@ private:
             if (rettype.ty == Tstruct || rettype.ty == Tenum)
             {
                 const id = rettype.toDsymbol(null).ident;
-                if (id != Id.__c_long_double && id != Id.__c_long && id != Id.__c_ulong)
+                if (id != Id.__c_long_double && id != Id.__c_long && id != Id.__c_ulong &&
+                    id != Id.__c_longlong && id != Id.__c_ulonglong)
                 {
                     tmp.buf.writeByte('?');
                     tmp.buf.writeByte('A');

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -267,6 +267,8 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
     {
         return (ident == Id.__c_long ||
                 ident == Id.__c_ulong ||
+                ident == Id.__c_longlong ||
+                ident == Id.__c_ulonglong ||
                 ident == Id.__c_long_double) && memtype;
     }
 

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -58,6 +58,7 @@ public:
     bool isDeprecated();                // is Dsymbol deprecated?
     Prot prot();
     Expression *getMaxMinValue(const Loc &loc, Identifier *id);
+    bool isSpecial() const;
     Expression *getDefaultValue(const Loc &loc);
     Type *getMemtype(const Loc &loc);
 

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -110,6 +110,8 @@ immutable Msgtable[] msgtable =
     { "gate", "__gate" },
     { "__c_long" },
     { "__c_ulong" },
+    { "__c_longlong" },
+    { "__c_ulonglong" },
     { "__c_long_double" },
     { "cpp_type_info_ptr", "__cpp_type_info_ptr" },
     { "_assert", "assert" },

--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -124,6 +124,11 @@ interface Module
 
 ulong testlongmangle(int a, uint b, long c, ulong d);
 
+import core.stdc.config;
+cpp_ulong testCppLongMangle(cpp_long a, cpp_ulong b);
+//cpp_ulonglong testCppLongLongMangle(cpp_longlong a, cpp_ulonglong b);
+cpp_size_t testCppSizeTMangle(cpp_ptrdiff_t a, cpp_size_t b);
+
 __gshared extern int[2][2][2] test31;
 __gshared extern int* test32;
 
@@ -280,6 +285,9 @@ void main()
     assert(Module.dim(&arr2) == 20);
 
     assert(testlongmangle(1, 2, 3, 4) == 10);
+    assert(testCppLongMangle(1, 2) == 3);
+    //assert(testCppLongLongMangle(3, 4) == 7);
+    //assert(testCppSizeTMangle(3, 4) == 7);
     assert(test31 == [[[1, 1], [1, 1]], [[1, 1], [1, 1]]]);
     assert(test32 == null);
 

--- a/test/runnable/extra-files/externmangle.cpp
+++ b/test/runnable/extra-files/externmangle.cpp
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdint.h>
 
 template<class X>
@@ -197,6 +198,21 @@ int Module::dim(Array<Module*>* arr)
 uint64_t testlongmangle(int a, unsigned int b, int64_t c, uint64_t d)
 {
     return a + b + c + d;
+}
+
+unsigned long testCppLongMangle(long a, unsigned long b)
+{
+    return a + b;
+}
+
+unsigned long long testCppLongLongMangle(long long a, unsigned long long b)
+{
+    return a + b;
+}
+
+size_t testCppSizeTMangle(ptrdiff_t a, size_t b)
+{
+    return a + b;
 }
 
 int test31[2][2][2] = {1, 1, 1, 1, 1, 1, 1, 1};


### PR DESCRIPTION
Make C++ `long long` representable in D on non-Apple 64-bit POSIX targets.

The commented-out tests require druntime changes, PR incoming.