### PR TITLE
[refactor] Simplify parameter mismatch error code

### DIFF
--- a/test/fail_compilation/bug15613.d
+++ b/test/fail_compilation/bug15613.d
@@ -16,3 +16,18 @@ void main()
     f(null);
     g(8);
 }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/bug15613.d(32): Error: function `bug15613.h(int[]...)` is not callable using argument types `(int, void function(int[]...))`
+fail_compilation/bug15613.d(32):        cannot pass argument `& h` of type `void function(int[]...)` to parameter `int[]...`
+---
+*/
+
+void h(int[]...);
+
+void test()
+{
+    h(7, &h);
+}


### PR DESCRIPTION
* Use one `OutBuffer` instead of 3, reducing memory allocations.
* Avoid repeating common string messages.
* Add a missing test for typesafe variadics.