### PR TITLE
Fix issue 14086 - Invalid extern C++ name for constructor

### DIFF
--- a/changelog/mangle_ctor.dd
+++ b/changelog/mangle_ctor.dd
@@ -1,0 +1,4 @@
+`extern (C++)` now mangles class constructor's correctly.
+
+`extern (C++)` mangling of class constructor is working, also virtual and non-virtual destructors mangle correctly too.
+C++ semantics are not yet perfectly matching, but some simple cases are working.

--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -41,7 +41,7 @@ private:
     dt_t** pTail;
 
 public:
-    this()
+    extern (D) this()
     {
         pTail = &head;
     }

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -590,7 +590,9 @@ private final class CppMangleVisitor : Visitor
                 buf.writeByte('N');
                 CV_qualifiers(d.type);
                 prefix_name(p);
-                if (d.isDtorDeclaration())
+                if (d.isCtorDeclaration())
+                    buf.writestring("C1");
+                else if (d.isDtorDeclaration())
                     buf.writestring("D1");
                 else
                     source_name(ti);
@@ -621,7 +623,11 @@ private final class CppMangleVisitor : Visitor
                 prefix_name(p);
                 //printf("p: %s\n", buf.peekString());
 
-                if (d.isDtorDeclaration())
+                if (d.isCtorDeclaration())
+                {
+                    buf.writestring("C1");
+                }
+                else if (d.isDtorDeclaration())
                 {
                     buf.writestring("D1");
                 }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -538,7 +538,7 @@ private:
             // Pivate methods always non-virtual in D and it should be mangled as non-virtual in C++
             //printf("%s: isVirtualMethod = %d, isVirtual = %d, vtblIndex = %d, interfaceVirtual = %p\n",
                 //d.toChars(), d.isVirtualMethod(), d.isVirtual(), cast(int)d.vtblIndex, d.interfaceVirtual);
-            if (d.isVirtual() && (d.vtblIndex != -1 || d.interfaceVirtual || d.overrideInterface()))
+            if ((d.isVirtual() && (d.vtblIndex != -1 || d.interfaceVirtual || d.overrideInterface())) || (d.isDtorDeclaration() && d.parent.isClassDeclaration() && !d.isFinal()))
             {
                 switch (d.protection.kind)
                 {
@@ -671,7 +671,12 @@ private:
         //printf("mangleName('%s')\n", sym.toChars());
         const(char)* name = null;
         bool is_dmc_template = false;
-        if (sym.isDtorDeclaration())
+        if (sym.isCtorDeclaration())
+        {
+            buf.writestring("?0");
+            return;
+        }
+        else if (sym.isDtorDeclaration())
         {
             buf.writestring("?1");
             return;

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -463,3 +463,46 @@ version (Windows)
 {
     static assert(test15388.mangleof == "?test15388@@YAX$$T@Z");
 }
+
+/**************************************/
+// https://issues.dlang.org/show_bug.cgi?id=14086
+
+extern (C++) class Test14086
+{
+    this();
+    ~this();
+}
+extern (C++) class Test14086_2
+{
+    final ~this();
+}
+extern (C++) struct Test14086_S
+{
+    this(int);
+    ~this();
+}
+
+version(Posix)
+{
+    static assert(Test14086.__ctor.mangleof == "_ZN9Test14086C1Ev");
+    static assert(Test14086.__dtor.mangleof == "_ZN9Test14086D1Ev");
+    static assert(Test14086_2.__dtor.mangleof == "_ZN11Test14086_2D1Ev");
+    static assert(Test14086_S.__ctor.mangleof == "_ZN11Test14086_SC1Ei");
+    static assert(Test14086_S.__dtor.mangleof == "_ZN11Test14086_SD1Ev");
+}
+version(Win32)
+{
+    static assert(Test14086.__ctor.mangleof == "??0Test14086@@QAE@XZ");
+    static assert(Test14086.__dtor.mangleof == "??1Test14086@@UAE@XZ");
+    static assert(Test14086_2.__dtor.mangleof == "??1Test14086_2@@QAE@XZ");
+    static assert(Test14086_S.__ctor.mangleof == "??0Test14086_S@@QAE@H@Z");
+    static assert(Test14086_S.__dtor.mangleof == "??1Test14086_S@@QAE@XZ");
+}
+version(Win64)
+{
+    static assert(Test14086.__ctor.mangleof == "??0Test14086@@QEAA@XZ");
+    static assert(Test14086.__dtor.mangleof == "??1Test14086@@UEAA@XZ");
+    static assert(Test14086_2.__dtor.mangleof == "??1Test14086_2@@QEAA@XZ");
+    static assert(Test14086_S.__ctor.mangleof == "??0Test14086_S@@QEAA@H@Z");
+    static assert(Test14086_S.__dtor.mangleof == "??1Test14086_S@@QEAA@XZ");
+}


### PR DESCRIPTION
Destructor mangles correctly, but constructor does not.
This has wasted a lot of time with people trying to understand link problems with `extern(C++)`.

As with the dtor, the ABI appears to be perfectly compatible... so, mangling correctly.
Also, fixed the virtual-ness mangling of the destructor. Windows dtor mangling only half-worked.