### PR TITLE
resolveSlice(): store some results on the stack

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -179,7 +179,8 @@ extern (C++) final class ThrownExceptionExp : Expression
     // Generate an error message when this exception is not caught
     void generateUncaughtError()
     {
-        Expression e = resolveSlice((*thrown.value.elements)[0]);
+        UnionExp ue = void;
+        Expression e = resolveSlice((*thrown.value.elements)[0], &ue);
         StringExp se = e.toStringExp();
         thrown.error("uncaught CTFE exception `%s(%s)`", thrown.type.toChars(), se ? se.toChars() : e.toChars());
         /* Also give the line where the throw statement was. We won't have it
@@ -529,14 +530,28 @@ private UnionExp paintTypeOntoLiteralCopy(Type type, Expression lit)
     return ue;
 }
 
-extern (C++) Expression resolveSlice(Expression e)
+/*************************************
+ * If e is a SliceExp, constant fold it.
+ * Params:
+ *      e = expression to resolve
+ *      pue = if not null, store resulting expression here
+ * Returns:
+ *      resulting expression
+ */
+extern (C++) Expression resolveSlice(Expression e, UnionExp* pue = null)
 {
     if (e.op != TOK.slice)
         return e;
     SliceExp se = cast(SliceExp)e;
     if (se.e1.op == TOK.null_)
         return se.e1;
-    return Slice(e.type, se.e1, se.lwr, se.upr).copy();
+    if (pue)
+    {
+        *pue = Slice(e.type, se.e1, se.lwr, se.upr);
+        return pue.exp();
+    }
+    else
+        return Slice(e.type, se.e1, se.lwr, se.upr).copy();
 }
 
 /* Determine the array length, without interpreting it.

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -3504,7 +3504,8 @@ public:
                     Expression ekey = interpret(xe.e2, istate);
                     if (exceptionOrCant(ekey))
                         return;
-                    ekey = resolveSlice(ekey); // only happens with AA assignment
+                    UnionExp ekeyTmp = void;
+                    ekey = resolveSlice(ekey, &ekeyTmp); // only happens with AA assignment
 
                     // Look up this index in it up in the existing AA, to get the next level of AA.
                     AssocArrayLiteralExp newAA = cast(AssocArrayLiteralExp)findKeyInAA(e.loc, existingAA, ekey);
@@ -5296,7 +5297,8 @@ public:
             }
 
             assert(e1.op == TOK.assocArrayLiteral);
-            e2 = resolveSlice(e2);
+            UnionExp e2tmp = void;
+            e2 = resolveSlice(e2, &e2tmp);
             result = findKeyInAA(e.loc, cast(AssocArrayLiteralExp)e1, e2);
             if (!result)
             {
@@ -5550,6 +5552,7 @@ public:
         {
             printf("%s CatExp::interpret() %s\n", e.loc.toChars(), e.toChars());
         }
+        {
         Expression e1 = interpret(e.e1, istate);
         if (exceptionOrCant(e1))
             return;
@@ -5557,9 +5560,12 @@ public:
         if (exceptionOrCant(e2))
             return;
 
-        e1 = resolveSlice(e1);
-        e2 = resolveSlice(e2);
+        UnionExp e1tmp = void;
+        e1 = resolveSlice(e1, &e1tmp);
+        UnionExp e2tmp = void;
+        e2 = resolveSlice(e2, &e2tmp);
         result = ctfeCat(e.loc, e.type, e1, e2).copy();
+        }
         if (CTFEExp.isCantExp(result))
         {
             e.error("`%s` cannot be interpreted at compile time", e.toChars());


### PR DESCRIPTION
Place temporary results on the stack rather than in allocated memory for `resolveSlice()`.