### PR TITLE
dinterpret.d: move public interface to top of file

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -226,7 +226,7 @@ extern (C++) class FuncDeclaration : Declaration
     ILS inlineStatusExp = ILS.uninitialized;
     PINLINE inlining = PINLINE.default_;
 
-    CompiledCtfeFunction* ctfeCode;     /// Compiled code for interpreter (not actually)
+    CompiledCtfeFunctionPimpl ctfeCode; /// Local data (i.e. CompileCtfeFunction*) for module dinterpret
     int inlineNest;                     /// !=0 if nested inline
     bool isArrayOp;                     /// true if array operation
     bool eh_none;                       /// true if no exception unwinding is needed


### PR DESCRIPTION
C/C++ code tends to fall an inverted pattern, with the private code on top and the public at the bottom. This comes about because of no forward referencing.

But D has forward referencing, so the public interface should be at the top of the file and everything else "below the fold" which is completely hidden from other modules.