### PR TITLE
Fix issue 18888 - extern(C++) template arg/alias arg mangling issue

### DIFF
--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -686,8 +686,9 @@ private:
             scope VisualCPPMangler tmp = new VisualCPPMangler((flags & IS_DMC) ? true : false);
             tmp.buf.writeByte('?');
             tmp.buf.writeByte('$');
-            tmp.buf.writestring(ti.name.toChars());
-            tmp.saved_idents[0] = ti.name.toChars();
+            auto id = ti.tempdecl.ident;
+            tmp.buf.writestring(id.toChars());
+            tmp.saved_idents[0] = id.toChars();
             tmp.buf.writeByte('@');
             if (flags & IS_DMC)
             {

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -506,3 +506,31 @@ version(Win64)
     static assert(Test14086_S.__ctor.mangleof == "??0Test14086_S@@QEAA@H@Z");
     static assert(Test14086_S.__dtor.mangleof == "??1Test14086_S@@QEAA@XZ");
 }
+
+/**************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18888
+
+extern (C++)
+struct T18888(T)
+{
+	void fun();
+}
+
+extern (C++)
+struct S18888(alias arg = T18888)
+{
+	alias I = T18888!(arg!int);
+}
+
+version(Posix)
+{
+    static assert(S18888!().I.fun.mangleof == "_ZN6T18888IS_IiEE3funEv");
+}
+version(Win32)
+{
+    static assert(S18888!().I.fun.mangleof == "?fun@?$T18888@U?$T18888@H@@@@QAEXXZ");
+}
+version(Win64)
+{
+    static assert(S18888!().I.fun.mangleof == "?fun@?$T18888@U?$T18888@H@@@@QEAAXXZ");
+}


### PR DESCRIPTION
There was a problem where the name of the alias was being used instead of the name that the alias aliases...