### PR TITLE
Fix issue 18890 - extern(C++) mangles all destructors the same

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -64,6 +64,19 @@ const(char)* cppTypeInfoMangleItanium(Dsymbol s)
     return buf.extractString();
 }
 
+/******************************
+* Determine if a symbol is the 'primary' destructor, that is, the most-aggregate destructor (the one that is defined as __xdtor)
+*/
+package bool isPrimaryDtor(Dsymbol sym)
+{
+    DtorDeclaration d = sym.isDtorDeclaration();
+    if (!d)
+        return false;
+    auto ad = sym.parent.isAggregateDeclaration();
+    assert(ad);
+    return d == ad.dtor;
+}
+
 private final class CppMangleVisitor : Visitor
 {
     alias visit = Visitor.visit;
@@ -592,7 +605,7 @@ private final class CppMangleVisitor : Visitor
                 prefix_name(p);
                 if (d.isCtorDeclaration())
                     buf.writestring("C1");
-                else if (d.isDtorDeclaration())
+                else if (d.isPrimaryDtor())
                     buf.writestring("D1");
                 else
                     source_name(ti);
@@ -627,7 +640,7 @@ private final class CppMangleVisitor : Visitor
                 {
                     buf.writestring("C1");
                 }
-                else if (d.isDtorDeclaration())
+                else if (d.isPrimaryDtor())
                 {
                     buf.writestring("D1");
                 }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -15,6 +15,7 @@ import core.stdc.string;
 import core.stdc.stdio;
 
 import dmd.arraytypes;
+import dmd.cppmangle : isPrimaryDtor;
 import dmd.declaration;
 import dmd.dsymbol;
 import dmd.dtemplate;
@@ -676,7 +677,7 @@ private:
             buf.writestring("?0");
             return;
         }
-        else if (sym.isDtorDeclaration())
+        else if (sym.isPrimaryDtor())
         {
             buf.writestring("?1");
             return;

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -536,6 +536,45 @@ version(Win64)
 }
 
 /**************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18890
+
+extern (C++) class C18890
+{
+    ~this() {}
+}
+extern (C++) class C18890_2
+{
+    ~this() {}
+    extern (C++) struct Agg
+    {
+        ~this() {}
+    }
+    Agg s;
+}
+
+version (Posix)
+{
+    static assert(C18890.__dtor.mangleof == "_ZN6C18890D1Ev");
+    static assert(C18890.__xdtor.mangleof == "_ZN6C18890D1Ev");
+    static assert(C18890_2.__dtor.mangleof == "_ZN8C18890_26__dtorEv");
+    static assert(C18890_2.__xdtor.mangleof == "_ZN8C18890_2D1Ev");
+}
+version (Win32)
+{
+    static assert(C18890.__dtor.mangleof == "??1C18890@@UAE@XZ");
+    static assert(C18890.__xdtor.mangleof == "??1C18890@@UAE@XZ");
+    static assert(C18890_2.__dtor.mangleof == "?__dtor@C18890_2@@UAE@XZ");
+    static assert(C18890_2.__xdtor.mangleof == "??1C18890_2@@UAE@XZ");
+}
+version (Win64)
+{
+    static assert(C18890.__dtor.mangleof == "??1C18890@@UEAA@XZ");
+    static assert(C18890.__xdtor.mangleof == "??1C18890@@UEAA@XZ");
+    static assert(C18890_2.__dtor.mangleof == "?__dtor@C18890_2@@UEAA@XZ");
+    static assert(C18890_2.__xdtor.mangleof == "??1C18890_2@@UEAA@XZ");
+}
+
+/**************************************/
 // https://issues.dlang.org/show_bug.cgi?id=18891
 
 extern (C++) class C18891


### PR DESCRIPTION
With `extern(C++)`, classes with multiple destructors were all mangling the same.
This patch only mangles the full-destructor as extern(C++), which is the behaviour C++ expects.