### PR TITLE
Fix issue 15589 - extern(C++) virtual destructors are not put in vtbl[]

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -285,6 +285,7 @@ public:
     TypeInfoClassDeclaration *vclassinfo;       // the ClassInfo object for this ClassDeclaration
     bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
     bool stack;                         // true if this is a scope class
+    int cppDtorVtblIndex;               // slot reserved for the virtual destructor [extern(C++)]
     bool inuse;                         // to prevent recursive attempts
     bool isActuallyAnonymous;           // true if this class has an identifier, but was originally declared anonymous
                                         // used in support of https://issues.dlang.org/show_bug.cgi?id=17371

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -603,7 +603,7 @@ private:
             // <flags> ::= Y <calling convention flag>
             buf.writeByte('Y');
         }
-        const(char)* args = mangleFunctionType(cast(TypeFunction)d.type, d.needThis(), d.isCtorDeclaration() || d.isDtorDeclaration());
+        const(char)* args = mangleFunctionType(cast(TypeFunction)d.type, d.needThis(), d.isCtorDeclaration() || d.isDtorDeclaration(), d.isDtorDeclaration() !is null);
         buf.writestring(args);
     }
 
@@ -1144,7 +1144,7 @@ private:
         cur.accept(this);
     }
 
-    const(char)* mangleFunctionType(TypeFunction type, bool needthis = false, bool noreturn = false)
+    const(char)* mangleFunctionType(TypeFunction type, bool needthis = false, bool noreturn = false, bool noargs = false)
     {
         scope VisualCPPMangler tmp = new VisualCPPMangler(this);
         // Calling convention
@@ -1204,7 +1204,7 @@ private:
             rettype.accept(tmp);
             tmp.flags &= ~MANGLE_RETURN_TYPE;
         }
-        if (!type.parameters || !type.parameters.dim)
+        if (!type.parameters || !type.parameters.dim || noargs)
         {
             if (type.varargs == 1)
                 tmp.buf.writeByte('Z');

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -214,6 +214,9 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     /// true if this is a scope class
     bool stack;
 
+    /// if this is a C++ class, this is the slot reserved for the virtual destructor
+    int cppDtorVtblIndex = -1;
+
     /// to prevent recursive attempts
     private bool inuse;
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4783,6 +4783,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         // reserve the dtor slot for the destructor (which we'll create later)
                         cldec.cppDtorVtblIndex = cast(int)cldec.vtbl.dim;
                         cldec.vtbl.push(s);
+                        if (Target.cppDeletingDestructor)
+                            cldec.vtbl.push(s); // deleting destructor uses a second slot
                     }
                 }
             }
@@ -4878,6 +4880,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // now we've built the aggregate destructor, we'll make it virtual and assign it to the reserved vtable slot
             cldec.dtor.vtblIndex = cldec.cppDtorVtblIndex;
             cldec.vtbl[cldec.cppDtorVtblIndex] = cldec.dtor;
+
+            if (Target.cppDeletingDestructor)
+            {
+                // TODO: create a C++ compatible deleting destructor (call out to `operator delete`)
+                //       for the mooment, we'll call the non-deleting destructor and leak
+                cldec.vtbl[cldec.cppDtorVtblIndex + 1] = cldec.dtor;
+            }
         }
 
         if (auto f = hasIdentityOpAssign(cldec, sc2))

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3735,7 +3735,17 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dd.ident == Id.dtor && dd.semanticRun < PASS.semantic)
             ad.dtors.push(dd);
         if (!dd.type)
-            dd.type = new TypeFunction(null, Type.tvoid, false, LINK.d, dd.storage_class);
+        {
+            Parameters* params = null;
+            if (ad.classKind == ClassKind.cpp && !Target.cppDeletingDestructor)
+            {
+                // Windows doesn't use a deleting destructor, it takes an argument instead!
+                Parameter param = new Parameter(STC.undefined_, Type.tuns32, new Identifier("del"), new IntegerExp(Loc.initial, 0, Type.tuns32));
+                params = new Parameters;
+                (*params).push(param);
+            }
+            dd.type = new TypeFunction(params, Type.tvoid, false, LINK.d, dd.storage_class);
+        }
 
         sc = sc.push();
         sc.stc &= ~STC.static_; // not a static destructor

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3372,8 +3372,9 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
 
     override bool isVirtual() const
     {
-        // false so that dtor's don't get put into the vtbl[]
-        return false;
+        // D dtor's don't get put into the vtbl[]
+        // this is a hack so that extern(C++) destructors report as virtual, which are manually added to the vtable
+        return vtblIndex != -1;
     }
 
     override bool addPreInvariant()

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -60,6 +60,7 @@ struct Target
         bool cppExceptions;       /// set if catching C++ exceptions is supported
         char int64Mangle;         /// mangling character for C++ int64_t
         char uint64Mangle;        /// mangling character for C++ uint64_t
+        bool cppDeletingDestructor; /// target C++ ABI uses deleting destructor
     }
 
     /**
@@ -115,6 +116,9 @@ struct Target
         ptrsize = 4;
         classinfosize = 0x4C; // 76
 
+        // all systems but windows use deleting destructors
+        cppDeletingDestructor = true;
+
         /* gcc uses int.max for 32 bit compilations, and long.max for 64 bit ones.
          * Set to int.max for both, because the rest of the compiler cannot handle
          * 2^64-1 without some pervasive rework. The trouble is that much of the
@@ -148,6 +152,7 @@ struct Target
             realpad = 0;
             realalignsize = 2;
             reverseCppOverloads = true;
+            cppDeletingDestructor = false;
             c_longsize = 4;
             if (ptrsize == 4)
             {

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -45,6 +45,7 @@ struct Target
     static bool cppExceptions;          // set if catching C++ exceptions is supported
     static char int64Mangle;            // mangling character for C++ int64_t
     static char uint64Mangle;           // mangling character for C++ uint64_t
+    static bool cppDeletingDestructor;  // target C++ ABI uses deleting destructor
 
     template <typename T>
     struct FPTypeProperties

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -519,7 +519,7 @@ void test14200b(float a, int b, double c) {};
 
 namespace std {
     namespace N14956 {
-	struct S14956 { };
+    struct S14956 { };
     }
 }
 
@@ -762,7 +762,7 @@ int foo15372(int value)
 
 void test15372b()
 {
-	int t = foo15372<int>(1);
+    int t = foo15372<int>(1);
 }
 
 /****************************************/
@@ -793,7 +793,7 @@ public:
 
 void test15802b()
 {
-	int t = Foo15802<int>::boo(1);
+    int t = Foo15802<int>::boo(1);
 }
 
 
@@ -806,3 +806,34 @@ uint64_t pass16536(uint64_t a)
     return a;
 }
 #endif
+
+/****************************************/
+// 15589 - extern(C++) virtual destructors are not put in vtbl[]
+
+class A15589
+{
+public:
+    struct S
+    {
+    public:
+        int x;
+    };
+    virtual int foo();
+    virtual ~A15589();
+    S s1;
+    S s2;
+};
+class B15589 : public A15589
+{
+public:
+    virtual int bar();
+    virtual ~B15589();
+    S s3;
+};
+
+void test15589b(A15589 *p)
+{
+    assert(p->foo() == 100);
+    assert(((B15589*)p)->bar() == 200);
+    p->~A15589();
+}


### PR DESCRIPTION
I'm plumbing in support for virtual destructors in extern(C++) classes.
Can I please get some initial review to know that I'm on the right track, and that the approach is okay?

With this initial bit of code, `__xdtor` is made virtual and placed into the vtable.
Calling `__xdtor` correctly performs a virtual call and destructs derived types (supplied by C++).
Is it also possible to declare the a base-class in D, derive from it in C++, and the virtual destruction will correctly destruct the mixed-language hierarchy. 🎉

I haven't supported overriding yet (for derived types in D). That should be straight-forward.