### PR TITLE
[perf] Don't allocate argument mismatch string when errors gagged

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4782,6 +4782,8 @@ extern (C++) final class TypeFunction : TypeNext
     // arguments get specially formatted
     private const(char)* getParamError(const(char)* format, Expression arg, Parameter par)
     {
+        if (global.gag && !global.params.showGaggedErrors)
+            return null;
         // show qualification when toChars() is the same but types are different
         auto at = arg.type.toChars();
         bool qual = !arg.type.equals(par.type) && strcmp(at, par.type.toChars()) == 0;


### PR DESCRIPTION
@Geod24 This should fix the high memory use found [here](https://github.com/dlang/dmd/pull/7554#issuecomment-386625022) (Note: #8232 already helped this somewhat).