### PR TITLE
[Trivial] Enable commented-out C++ mangling tests wrt. cpp_{longlong,size_t}

### DIFF
--- a/test/runnable/externmangle.d
+++ b/test/runnable/externmangle.d
@@ -126,7 +126,7 @@ ulong testlongmangle(int a, uint b, long c, ulong d);
 
 import core.stdc.config;
 cpp_ulong testCppLongMangle(cpp_long a, cpp_ulong b);
-//cpp_ulonglong testCppLongLongMangle(cpp_longlong a, cpp_ulonglong b);
+cpp_ulonglong testCppLongLongMangle(cpp_longlong a, cpp_ulonglong b);
 cpp_size_t testCppSizeTMangle(cpp_ptrdiff_t a, cpp_size_t b);
 
 __gshared extern int[2][2][2] test31;
@@ -286,8 +286,8 @@ void main()
 
     assert(testlongmangle(1, 2, 3, 4) == 10);
     assert(testCppLongMangle(1, 2) == 3);
-    //assert(testCppLongLongMangle(3, 4) == 7);
-    //assert(testCppSizeTMangle(3, 4) == 7);
+    assert(testCppLongLongMangle(3, 4) == 7);
+    assert(testCppSizeTMangle(3, 4) == 7);
     assert(test31 == [[[1, 1], [1, 1]], [[1, 1], [1, 1]]]);
     assert(test32 == null);
 


### PR DESCRIPTION
As follow-up to #8262.