### PR TITLE
Initial pure D build script

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1,0 +1,892 @@
+#!/usr/bin/env rdmd
+/**
+DMD builder
+
+Usage:
+  ./build.d dmd
+
+TODO:
+- add different ENABLE modes
+- add all posix.mak Makefile targets
+- support 32-bit builds
+- test on OSX
+- test on Windows
+- allow appending DFLAGS via the environment
+- test the script with LDC or GDC as host compiler
+*/
+
+version(CoreDdoc) {} else:
+
+import std.algorithm, std.conv, std.datetime, std.exception, std.file, std.format,
+       std.getopt, std.parallelism, std.path, std.process, std.range, std.stdio, std.string;
+import core.stdc.stdlib : exit;
+
+const thisBuildScript = __FILE_FULL_PATH__;
+const srcDir = thisBuildScript.dirName.buildNormalizedPath;
+shared bool verbose; // output verbose logging
+shared bool force; // always build everything (ignores timestamp checking)
+
+__gshared string[string] env;
+__gshared string[][string] flags;
+__gshared typeof(sourceFiles()) sources;
+
+void main(string[] args)
+{
+    int jobs = totalCPUs;
+    auto res = getopt(args,
+        "j|jobs", "Specifies the number of jobs (commands) to run simultaneously (default: %d)".format(totalCPUs), &jobs,
+        "v", "Verbose command output", (cast(bool*) &verbose),
+        "f", "Force run (ignore timestamps and always run all tests)", (cast(bool*) &force),
+    );
+    if (res.helpWanted)
+    {
+        defaultGetoptPrinter(`./build.d <targets>...
+
+Examples:
+
+    ./build.d dmd                                                  # build DMD
+    ./build.d unittest                                             # runs internal unittests
+    ./build.d clean                                                # remove all generated files
+
+Options:
+`, res.options);
+        "\nSee the README.md for a more in-depth explanation of the build script.".writeln;
+        return;
+    }
+
+    // parse arguments
+    args.popFront;
+    args2Environment(args);
+
+    // bootstrap all needed environment variables
+    env = getEnvironment;
+
+    // get all sources
+    sources = sourceFiles;
+
+    // default target
+    if (!args.length)
+        args = ["all"];
+
+    auto targets = args
+        .predefinedTargets // preprocess
+        .array;
+
+    if (targets.length > 0)
+    {
+        if (verbose)
+        {
+            log("================================================================================");
+            foreach (key, value; env)
+                log("%s=%s", key, value);
+            log("================================================================================");
+        }
+    }
+}
+
+/**
+D build dependencies
+====================
+
+The strategy of this script is to emulate what the Makefile is doing,
+but without a complicated dependency and dependency system.
+The "dependency system" used here is rather naive and only parallelizes the
+build of the backend and lexer (writing a few config files doesn't take much time).
+However, it does skip steps when the source files are younger than the target
+and thus supports partial rebuilds.
+
+Below all individual dependencies of DMD are defined.
+They have a target path, sources paths and an optional name.
+When a dependency is needed either its command or custom commandFunction is executed.
+A dependency will be skipped if all targets are older than all sources.
+This script is by default part of the sources and thus any change to the build script,
+will trigger a full rebuild.
+
+The function buildDMD defines the build order of its dependencies.
+*/
+
+// TODO: newdelete is probably not needed anymore
+auto newDelete()
+{
+    Dependency dependency = {
+        target: env["G"].buildPath("newdelete").objName,
+        sources: [env["ROOT"].buildPath("newdelete.c")],
+        name: "(CC) NEW_DELETE",
+        command: [env["HOST_CXX"], "-c", "-o$@", "$<"]
+    };
+    return dependency;
+}
+
+// Builds the lexer as a separate library
+auto lexer()
+{
+    Dependency dependency = {
+        target: env["G"].buildPath("lexer").libName,
+        sources: sources.lexer,
+        rebuildSources: configFiles,
+        name: "(CC) D_LEXER_OBJ",
+        command: [
+            env["HOST_DMD_RUN"],
+            "-of$@",
+            "-lib",
+            "-J"~env["G"], "-J../res",
+            "-L-lstdc++",
+        ].chain(flags["DFLAGS"], "$<".only).array
+    };
+    return dependency;
+}
+
+// Generates a dmd.conf file in the generated folder
+auto dmdConf()
+{
+    // TODO: add support for Windows
+    string exportDynamic;
+    version(OSX) {} else
+        exportDynamic = " -L--export-dynamic";
+
+    auto conf = `[Environment32]
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/32{exportDynamic}
+
+[Environment64]
+DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/64{exportDynamic} -fPIC`.replace("{exportDynamic}", exportDynamic);
+
+    auto target = env["G"].buildPath("dmd.conf");
+    auto commandFunction = (){
+        conf.toFile(target);
+    }; // defined separately to support older D compilers
+    Dependency dependency = {
+        target: target,
+        name: "(TX) DMD_CONF",
+        commandFunction: commandFunction,
+    };
+    return dependency;
+}
+
+/*
+optabgen generates a few C++ files.
+Thus it first needs to be built and the executed.
+*/
+auto opTabGen()
+{
+    auto opTabFiles = ["debtab.c", "optab.c", "cdxxx.c", "elxxx.c", "fltables.c", "tytab.c"];
+    auto opTabFilesBin = opTabFiles.map!(e => env["G"].buildPath(e)).array;
+    auto opTabBin = env["G"].buildPath("optabgen").exeName;
+    auto opTabSourceFile = env["C"].buildPath("optabgen.c");
+
+    auto commandFunction = (){
+        auto args = [env["HOST_CXX"], "-I"~env["TK"], opTabSourceFile, "-o", opTabBin];
+        args ~= flags["CXXFLAGS"];
+
+        writefln("(CC) BUILD_OPTABGEN");
+        args.runCanThrow;
+
+        writefln("(CC) RUN_OPTABBIN %-(%s, %)", opTabFiles);
+        [opTabBin].runCanThrow;
+
+        // move the generated files to the generated folder
+        opTabFiles.map!(a => srcDir.buildPath(a)).zip(opTabFilesBin).each!(a => a.expand.rename);
+    }; // defined separately to support older D compilers
+    Dependency dependency = {
+        targets: opTabFilesBin,
+        sources: [opTabSourceFile],
+        commandFunction: commandFunction,
+    };
+    return dependency;
+}
+
+// Build individual CXX objects of the backend
+auto buildCXX(string obj, string fileName)
+{
+    Dependency dependency = {
+        target: obj,
+        sources: [fileName],
+        rebuildSources: sources.backendC ~ configFiles,
+        name: "(CC) BACK_OBJS %s".format(fileName),
+        command: [env["HOST_CXX"], "-c", "-o$@"].chain(flags["CXXFLAGS"], flags["BACK_FLAGS"], "$<".only).array
+    };
+    return dependency;
+}
+
+// Build the D part of the backend
+auto dBackend()
+{
+    Dependency dependency = {
+        target: env["G"].buildPath("dbackend").objName,
+        sources: sources.backend,
+        name: "(CC) D_BACK_OBJS %-(%s %)".format(sources.backend),
+        command: [
+            env["HOST_DMD_RUN"],
+            "-c",
+            "-of$@",
+            "-betterC",
+        ].chain(flags["DFLAGS"], "$<".only).array
+    };
+    return dependency;
+}
+
+// Build the CXX objects of the backend
+auto cxxBackend()
+{
+    Dependency[] dependencys;
+    foreach (obj; sources.backendObjects)
+        dependencys ~= buildCXX(obj, env["C"].buildPath(obj.baseName.stripExtension ~ ".c"));
+
+    return dependencys;
+}
+
+// Execute the sub-dependencys of the backend and pack everything into one object file
+auto buildBackend()
+{
+    opTabGen.run;
+
+    Dependency[] dependencys = cxxBackend();
+    dependencys ~= dBackend;
+    foreach (dependency; dependencys.parallel(1))
+        dependency.run;
+
+    // Pack the backend
+    Dependency dependency = {
+        sources: sources.backendObjects.chain(env["G"].buildPath("dbackend").objName.only).array,
+        target: env["G"].buildPath("backend").libName,
+        command: [env["AR"], "rcs", "$@", "$<"],
+    };
+    dependency.run;
+    return dependency;
+}
+
+// Generate required string files: VERSION and SYSCONFDIR.imp
+auto buildStringFiles()
+{
+    const versionFile = env["G"].buildPath("VERSION");
+    auto commandFunction = (){
+        "(TX) VERSION".writeln;
+        ["git", "describe", "--dirty"].runCanThrow.toFile(versionFile);
+    };
+    Dependency versionDependency = {
+        target: versionFile,
+        commandFunction: commandFunction,
+    };
+    const sysconfDirFile = env["G"].buildPath("SYSCONFDIR.imp");
+    commandFunction = (){
+        "(TX) SYSCONFDIR".writeln;
+        env["SYSCONFDIR"].toFile(sysconfDirFile);
+    };
+    Dependency sysconfDirDependency = {
+        sources: [thisBuildScript],
+        target: sysconfDirFile,
+        commandFunction: commandFunction,
+    };
+    return [versionDependency, sysconfDirDependency];
+}
+
+// Returns a list of config files that are required by the DMD build
+auto configFiles()
+{
+    return buildStringFiles.map!(a => a.target).array ~ dmdConf.target;
+}
+
+/**
+Main build routine for the DMD compiler.
+Defines the required order for the build dependencys, runs all these dependency dependencys
+and afterwards builds the DMD compiler.
+*/
+auto buildDMD()
+{
+    // The string files are required by most targets
+    Dependency[] dependencys = buildStringFiles();
+    foreach (dependency; dependencys.parallel(1))
+        dependency.run;
+
+    dependencys = [lexer, newDelete, dmdConf];
+    foreach (ref dependency; dependencys.parallel(1))
+        dependency.run;
+
+    auto backend = buildBackend();
+
+    // Main DMD build dependency
+    Dependency dependency = {
+        // newdelete.o + lexer.a + backend.a
+        sources: sources.dmd.chain(sources.root, dependencys[0].targets, dependencys[1].targets, backend.targets).array,
+        target: env["G"].buildPath("dmd").exeName,
+        name: "(CC) MAIN_DMD_BUILD",
+        command: [
+            env["HOST_DMD_RUN"],
+            "-of$@",
+            "-vtls",
+            "-J"~env["G"],
+            "-J../res",
+            "-L-lstdc++",
+        ].chain(flags["DFLAGS"], "$<".only).array
+    };
+    dependency.run;
+}
+
+/**
+Goes through the target list and replaces short-hand targets with their expanded version.
+Special targets:
+- clean -> removes generated directory + immediately stops the builder
+*/
+auto predefinedTargets(string[] targets)
+{
+    Appender!(string[]) newTargets;
+    foreach (t; targets)
+    {
+        t = t.buildNormalizedPath; // remove trailing slashes
+        switch (t)
+        {
+            case "auto-tester-build":
+                "TODO: auto-tester-all".writeln; // TODO
+                break;
+
+            case "toolchain-info":
+                "TODO: info".writeln; // TODO
+                break;
+
+            case "unittest":
+                "TODO: unittest".writeln; // TODO
+                break;
+
+            case "cxx-unittest":
+                "TODO: cxx-unittest".writeln; // TODO
+                break;
+
+            case "check-examples":
+                "TODO: cxx-unittest".writeln; // TODO
+                break;
+
+            case "build-examples":
+                "TODO: build-examples".writeln; // TODO
+                break;
+
+            case "checkwhitespace":
+                "TODO: checkwhitespace".writeln; // TODO
+                break;
+
+            case "html":
+                "TODO: html".writeln; // TODO
+                break;
+
+            case "install":
+                "TODO: install".writeln; // TODO
+                break;
+
+            case "man":
+                "TODO: man".writeln; // TODO
+                break;
+
+            dmd:
+            case "dmd":
+                buildDMD();
+                break;
+
+            case "clean":
+                if (env["G"].exists)
+                    env["G"].rmdirRecurse;
+                exit(0);
+                break;
+
+            default:
+            case "all":
+                goto dmd;
+                break;
+        }
+    }
+    return newTargets.data;
+}
+
+// Sets the environment variables
+string[string] getEnvironment()
+{
+    string[string] env;
+
+    env.getDefault("TARGET_CPU", "X86");
+    auto os = env.getDefault("OS", detectOS);
+    auto build = env.getDefault("BUILD", "release");
+    enforce(build.among("release", "debug"), "BUILD must be 'debug' or 'release'");
+
+    // detect Model
+    auto model = env.getDefault("MODEL", detectModel);
+    env["MODEL_FLAG"] = "-m" ~ env["MODEL"];
+
+    // detect PIC
+    version(Posix)
+    {
+        // default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+        // Note that shared libraries and C files are always compiled with PIC.
+        bool pic;
+        version(X86_64)
+            pic = true;
+        else version(X86)
+            pic = false;
+        if (environment.get("PIC", "0") == "1")
+            pic = true;
+
+        env["PIC_FLAG"]  = pic ? "-fPIC" : "";
+    }
+    else
+    {
+        env["PIC_FLAG"] = "";
+    }
+
+    env.getDefault("GIT_HOME", "https://github.com/dlang");
+    env.getDefault("SYSCONFDIR", "/etc");
+    env.getDefault("TMP", "/tmp");
+    env.getDefault("PGO_DIR", srcDir.buildPath("pgo"));
+    auto d = env.getDefault("D", srcDir.buildPath("dmd"));
+    env.getDefault("C", d.buildPath("backend"));
+    env.getDefault("TK", d.buildPath("tk"));
+    env.getDefault("ROOT", d.buildPath("root"));
+    env.getDefault("EX", d.buildPath("examples"));
+    auto generated = env.getDefault("GENERATED", srcDir.dirName.buildPath("generated"));
+    auto g = env.getDefault("G", generated.buildPath(os, build, model));
+    mkdirRecurse(g);
+
+    env.getDefault("HOST_CXX", "c++");
+    env.getDefault("AR", "ar");
+    env.getDefault("GIT", "git");
+    auto cxxVersion = execute([env["HOST_CXX"], "--version"]).output;
+    env.getDefault("CXX_KIND", !cxxVersion.find("gcc", "Free Software")[0].empty ? "g++" : "clang++");
+
+    env.getDefault("HOST_DMD", "dmd");
+
+    // Auto-bootstrapping of a specific host compiler
+    if (env.getDefault("AUTO_BOOTSTRAP", "0") != "0")
+    {
+        auto hostDMDVer = "2.074.1";
+        writefln("Using Bootstrap compiler: %s", hostDMDVer);
+        auto hostDMDRoot = env["G"].buildPath("host_dmd-"~hostDMDVer);
+        auto hostDMDBase = hostDMDVer~"."~os;
+        auto hostDMDURL = "http://downloads.dlang.org/releases/2.x/"~hostDMDVer~"/dmd."~hostDMDBase;
+        env["HOST_DMD"] = hostDMDRoot.buildPath("dmd2", os, os == "osx" ? "bin" : "bin"~model, "dmd");
+        env["HOST_DMD_PATH"] = env["HOST_DMD"];
+        // TODO: use dmd.conf from the host too (in case there's a global or user-level dmd.conf)
+        env["HOST_DMD_RUN"] = env["HOST_DMD"];
+        if (!env["HOST_DMD"].exists)
+        {
+            writefln("Downloading DMD %s", hostDMDVer);
+            auto curlFlags = "-fsSL --retry 5 --retry-max-time 120 --connect-timeout 5 --speed-time 30 --speed-limit 1024";
+            hostDMDRoot.mkdirRecurse;
+            ("curl " ~ curlFlags ~ " " ~ hostDMDURL~".tar.xz | tar -C "~hostDMDRoot~" -Jxf - || rm -rf "~hostDMDRoot).spawnShell.wait;
+        }
+    }
+    else
+    {
+        env["HOST_DMD_PATH"] = ["which", env["HOST_DMD"]].execute.output.strip;
+        env["HOST_DMD_RUN"] = env["HOST_DMD"];
+    }
+
+    if (!env["HOST_DMD_PATH"].exists)
+    {
+        stderr.writefln("No DMD compiler is installed. Try AUTO_BOOTSTRAP=1 or manually set the D host compiler with HOST_DMD");
+        exit(1);
+    }
+
+    auto hostDMDVersion = [env["HOST_DMD_RUN"], "--version"].execute.output;
+    if (hostDMDVersion.find("DMD"))
+        env["HOST_DMD_KIND"] = "dmd";
+    else if (hostDMDVersion.find("LDC"))
+        env["HOST_DMD_KIND"] = "ldc";
+    else if (!hostDMDVersion.find("GDC", "gdmd")[0].empty)
+        env["HOST_DMD_KIND"] = "gdc";
+    else
+        enforce(0, "Invalid Host DMD found: " ~ hostDMDVersion);
+
+    env.getDefault("ENABLE_WARNINGS", "0");
+    string[] warnings;
+    if (env["ENABLE_WARNINGS"] != "0")
+    {
+        warnings = ["-Wall", "-Wextra", "-Werror",
+            "-Wno-attributes",
+            "-Wno-char-subscripts",
+            "-Wno-deprecated",
+            "-Wno-empty-body",
+            "-Wno-format",
+            "-Wno-missing-braces",
+            "-Wno-missing-field-initializers",
+            "-Wno-overloaded-virtual",
+            "-Wno-parentheses",
+            "-Wno-reorder",
+            "-Wno-return-type",
+            "-Wno-sign-compare",
+            "-Wno-strict-aliasing",
+            "-Wno-switch",
+            "-Wno-type-limits",
+            "-Wno-unknown-pragmas",
+            "-Wno-unused-function",
+            "-Wno-unused-label",
+            "-Wno-unused-parameter",
+            "-Wno-unused-value",
+            "-Wno-unused-variable",
+        ];
+        if (env["CXX_KIND"] == "g++")
+            warnings ~= [
+                "-Wno-logical-op",
+                "-Wno-narrowing",
+                "-Wno-unused-but-set-variable",
+                "-Wno-uninitialized",
+                "-Wno-class-memaccess",
+                "-Wno-implicit-fallthrough",
+            ];
+    }
+    else
+    {
+        // default warnings
+        warnings = ["-Wno-deprecated", "-Wstrict-aliasing", "-Werror"];
+        if (env["CXX_KIND"] == "clang++")
+            warnings ~= "-Wno-logical-op-parentheses";
+    }
+
+    auto targetCPU = "X86";
+    auto cxxFlags = warnings;
+    cxxFlags ~= [
+        "-fno-exceptions", "-fno-rtti",
+        "-D__pascal=", "-DMARS=1", "-DTARGET_"~os.toUpper~"=1",
+        "-DDM_TARGET_CPU_"~targetCPU~"=1",
+        env["MODEL_FLAG"],
+        env["PIC_FLAG"],
+    ];
+    if (env["CXX_KIND"] == "g++")
+        cxxFlags ~= ["-std=gnu++98"];
+    if (env["CXX_KIND"] == "clang++")
+        cxxFlags ~= ["-xc++"];
+
+    flags["CXXFLAGS"] = cxxFlags;
+
+    // TODO: allow adding new flags from the environment
+    string[] dflags;
+    flags["DFLAGS"] ~= ["-version=MARS", "-w", "-de", env["PIC_FLAG"], env["MODEL_FLAG"]];
+    // TODO: add different ENABLE modes
+
+    flags["BACK_FLAGS"] = ["-I"~env["ROOT"], "-I"~env["TK"], "-I"~env["C"], "-I"~env["G"], "-I"~env["D"], "-DDMDV2=1"];
+
+    // TODO: add support for dObjc
+    auto dObjc = false;
+    version(OSX) version(X86_64)
+        dObjc = true;
+
+    return env;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// D source files
+////////////////////////////////////////////////////////////////////////////////
+
+auto sourceFiles()
+{
+    struct Sources
+    {
+        string[] frontend, lexer, root, glue, dmd, backend;
+        string[] backendHeaders, backendC, tkC, backendObjects;
+    }
+    string targetCH;
+    string[] targetObjs;
+    if (env["TARGET_CPU"] == "X86")
+    {
+        targetCH = "code_x86.h";
+        targetObjs = ["cg87", "cgxmm", "cgsched", "cod1", "cod2", "cod3", "cod4", "ptrntab"];
+    }
+    else if (env["TARGET_CPU"] == "stub")
+    {
+        targetCH = "code_stub.h";
+        targetObjs = ["platform_stub"];
+    }
+    else
+    {
+        assert(0, "Unknown TARGET_CPU: " ~ env["TARGET_CPU"]);
+    }
+    Sources sources = {
+        frontend:
+            dirEntries(env["D"], "*.d", SpanMode.shallow)
+                .map!(e => e.name)
+                .filter!(e => !e.canFind("frontend.d"))
+                .array,
+        lexer: [
+            "console",
+            "entity",
+            "errors",
+            "globals",
+            "id",
+            "identifier",
+            "lexer",
+            "tokens",
+            "utf",
+        ].map!(e => env["D"].buildPath(e ~ ".d")).chain([
+            "array",
+            "ctfloat",
+            "file",
+            "filename",
+            "hash",
+            "outbuffer",
+            "port",
+            "rmem",
+            "rootobject",
+            "stringtable",
+        ].map!(e => env["ROOT"].buildPath(e ~ ".d"))).array,
+        root:
+            dirEntries(env["ROOT"], "*.d", SpanMode.shallow)
+                .map!(e => e.name)
+                .array,
+        backend:
+            dirEntries(env["C"], "*.d", SpanMode.shallow)
+                .map!(e => e.name)
+                .filter!(e => !e.canFind("dt.d", "obj.d"))
+                .array,
+        backendHeaders: [
+            // can't be built with -betterC
+            "dt",
+            "obj",
+        ].map!(e => env["C"].buildPath(e ~ ".d")).array,
+        backendC:
+            // all backend files
+            dirEntries(env["C"], "*.{c,d,h}", SpanMode.shallow)
+                .map!(e => e.name)
+                .filter!(e => !e.canFind("stub"))
+                .chain(targetCH.only)
+                .array,
+        tkC:
+            dirEntries(env["C"], "*.{c,h}", SpanMode.shallow)
+            .map!(e => e.name)
+            .array,
+        backendObjects:
+            dirEntries(env["C"], "*.c", SpanMode.shallow)
+                .map!(e => e.baseName.stripExtension)
+                .filter!(e => !e.canFind("stub") && !e.canFind("cgcv", "cgobj", "newman"))
+                .chain(targetObjs)
+                .map!(a => env["G"].buildPath(a).objName)
+                .array,
+    };
+    sources.dmd = sources.frontend ~ sources.backendHeaders;
+    version(OSX)
+        sources.backendObjects ~= env["G"].buildPath("machobj.o");
+    else version(Posix)
+        sources.backendObjects ~= env["G"].buildPath("elfobj.o");
+    else version(Windows)
+        assert(0, "TODO");
+    return sources;
+}
+
+/*
+Detects the host OS.
+
+Returns: a string from `{windows, osx,linux,freebsd,openbsd,netbsd,dragonflybsd,solaris}`
+*/
+string detectOS()
+{
+    version(Windows)
+        return "windows";
+    else version(OSX)
+        return "osx";
+    else version(linux)
+        return "linux";
+    else version(FreeBSD)
+        return "freebsd";
+    else version(OpenBSD)
+        return "openbsd";
+    else version(NetBSD)
+        return "netbsd";
+    else version(DragonFlyBSD)
+        return "dragonflybsd";
+    else version(Solaris)
+        return "solaris";
+    else
+        static assert(0, "Unrecognized or unsupported OS.");
+}
+
+/*
+Detects the host model
+
+Returns: 32, 64 or throws an Exception
+*/
+auto detectModel()
+{
+    string uname;
+    if (detectOS == "solaris")
+        uname = ["isainfo", "-n"].execute.output;
+    else
+        uname = ["uname", "-m"].execute.output;
+
+    if (!uname.find("x86_64", "amd64")[0].empty)
+        return "64";
+    if (!uname.find("i386", "i586", "i686")[0].empty)
+        return "32";
+
+    throw new Exception("Cannot figure 32/64 model from uname -m: " ~ uname);
+}
+
+// Add the executable filename extension to the given `name` for the current OS.
+auto exeName(T)(T name)
+{
+    version(Windows)
+        return name ~ ".exe";
+    return name;
+}
+
+// Add the object file extension to the given `name` for the current OS.
+auto objName(T)(T name)
+{
+    version(Windows)
+        return name ~ ".obj";
+    return name ~ ".o";
+}
+// Add the library file extension to the given `name` for the current OS.
+auto libName(T)(T name)
+{
+    version(Windows)
+        return name ~ ".dll";
+    return name ~ ".a";
+}
+
+// Add additional make-like assignments to the environment
+// e.g. ./build.d ARGS=foo -> sets ARGS to 'foo'
+void args2Environment(ref string[] args)
+{
+    bool tryToAdd(string arg)
+    {
+        if (!arg.canFind("="))
+            return false;
+
+        auto sp = arg.splitter("=");
+        environment[sp.front] = sp.dropOne.front;
+        return true;
+    }
+    args = args.filter!(a => !tryToAdd(a)).array;
+}
+
+/**
+Checks whether the environment already contains a value for key and if so, sets
+the found value to the new environment object.
+Otherwise uses the `default_` value as fallback.
+
+Params:
+    env = environment to write the check to
+    key = key to check for existence and write into the new env
+    default_ = fallback value if the key doesn't exist in the global environment
+*/
+auto getDefault(ref string[string] env, string key, string default_)
+{
+    if (key in environment)
+        env[key] = environment[key];
+    else
+        env[key] = default_;
+
+    return env[key];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Mini build system
+////////////////////////////////////////////////////////////////////////////////
+
+auto isUpToDate(string target, string source)
+{
+    return isUpToDate(target, [source]);
+}
+
+auto isUpToDate(string target, string[][] sources...)
+{
+    return isUpToDate([target], sources);
+}
+
+// checks whether any of the targets are older than the sources
+auto isUpToDate(string[] targets, string[][] sources...)
+{
+    if (force)
+        return false;
+
+    foreach (target; targets)
+    {
+        auto sourceTime = target.timeLastModified.ifThrown(SysTime.init);
+        // if a target has no sources, it only needs to be built once
+        if (sources.empty || sources.length == 1 && sources.front.empty)
+            return sourceTime > SysTime.init;
+        foreach (arg; sources)
+            foreach (a; arg)
+                if (sourceTime < a.timeLastModified.ifThrown(SysTime.init + 1.seconds))
+                    return false;
+    }
+
+    return true;
+}
+
+/*
+A dependency has one or more sources and yields one or more targets.
+It knows how to build these target by invoking either the external command or
+the commandFunction.
+
+If a run fails, the entire build stops.
+
+Command strings support the Make-like $@ (target path) and $< (source path)
+shortcut variables.
+*/
+struct Dependency
+{
+    string target; // path to the resulting target file (if target is used, it will set targets)
+    string[] targets; // list of all target files
+    string[] sources; // list of all source files
+    string[] rebuildSources; // Optional list of files that trigger a rebuild of this dependency
+    string[] command; // the dependency command
+    void delegate() commandFunction; // a custom dependency command which gets called instead of command
+    string name; // name of the dependency that is e.g. written to the CLI when it's executed
+    string[] trackSources;
+
+    auto run()
+    {
+        // allow one or multiple targets
+        if (target !is null)
+            targets = [target];
+
+        if (targets.isUpToDate(sources, [thisBuildScript], rebuildSources))
+        {
+            if (sources !is null)
+                log("Skipping build of %-(%s%) as it's newer than %-(%s%)", targets, sources);
+            return;
+        }
+
+        if (commandFunction !is null)
+            return commandFunction();
+
+        resolveShorthands();
+
+        // Display the execution of the dependency
+        if (name)
+            name.writeln;
+
+        command.runCanThrow;
+    }
+
+    // Resolves variables shorthands like $@ (target) and $< (source)
+    void resolveShorthands()
+    {
+        // Support $@ (shortcut for the target path)
+        foreach (i, c; command)
+            command[i] = c.replace("$@", target);
+
+        // Support $< (shortcut for the source path)
+        if (command[$ - 1].find("$<"))
+            command = command.remove(command.length - 1) ~ sources;
+    }
+}
+
+// Logging primitive
+auto log(T...)(T args)
+{
+    if (verbose)
+        writefln(args);
+}
+
+// Run a command and optionally log the invocation
+auto run(T)(T args)
+{
+    log("Run: %s", args.join(" "));
+    return execute(args, null, Config.none, size_t.max, srcDir);
+}
+
+/*
+Wrapper around execute that logs the execution
+and throws an exception for a non-zero exit code.
+*/
+auto runCanThrow(T)(T args)
+{
+    auto res = run(args);
+    enforce(!res.status, res.output);
+    return res.output;
+}


### PR DESCRIPTION
(inspired by @JinShil's [recent dream on the NG](https://forum.dlang.org/post/dwnirthzzwtzmxypvizp@forum.dlang.org) about being able to build DMD easily on any platform)

Similarly to the `test/run.d`, this allows building DMD from source without depending on the Makefile.
At the moment it's a simplistic translation of more or the less the bare minimum of the `posix.mak` which is needed to build DMD, but the following is intended (not in this PR though):
- support all OS (getting rid of the win32/win64.mak files is a major motivation)
- allow this script to be used by dub (this should allow to build/expose full DMD via DUB)
- target compatibility with the posix.mak Makefile (i.e. all targets that are supported in posix.mak should be supported here)

I opened this PR to avoid duplicated efforts and give others already a sneak-peek at this.
This already compiles DMD on Linux and even supports partial and parallel compilation (almost as good the Make build).

I kept the rule system as simplistic as possible to avoid adding a huge chunk of code that we would have to maintain + it's not really needed here anyhow.
Also the builder script got quite long, because instead of using one text blob for the source files, I used single lines for each file to avoid the merge conflicts that sometimes happen (though I have no strong feeling on this style).

Why such a naive approach and not cmake, ninja, reggae, ...?
-----------------------------------------------------------------------------------

There has never been a consensus on which third-party build system should be used.
Using a pure D script avoids any further dependencies and after all, D should be powerful to handle any task!
Also the dependency flow is rather simplistic here. The backend and lexer need to be built before the main DMD built, but they can be built in parallel once the initial dependencies have been generated.

But the Makefile is working so nicely
------------------------------------------------

Well, I guess I'm one of the very few persons who understands the `posix.mak` (it looks more scary than it is), but I doubt many others do.
Also we there have been numerous complaints about the more or less unmaintained win32.mak and win64.mak files.
For now, like `run.d` this is an experiment and only intended to slowly replace the Makefiles once it has been thoroughly tested.

But isn't depending on D another dependency?
--------------------------------------------------------------

Nope, D requires a host D compiler since 2015. The Makefile comes with an AUTO_BOOTSTRAP option to automatically download a D compiler. While I added support for this in `build.d` too (it makes sense when you want to lock the D compiler version to a specific one), it's only of limited help to someone on a fresh machine without a D compiler.
Imho we can expect a D compiler dev to have a working D installation, but if this AUTO_BOOTSTRAP option is convenient for some (I think the Jenkins CI uses it), we could opt to add a small Bash bootstrapping script around it (or keep this part of the Makefile).

What's missing from this PR?
---------------------------------------

This PR contains everything essential to use the `build.d` script on x86_64 Linux.
Though there's still much work that needs to be done in future PRs.
Check the TODO header.

What won't be part of this PR?
----------------------------------------

I don't plan to support Windows nor all targets of posix.mak in this initial PR.