### PR TITLE
Fix typo in dmd.expression apparently causing sporadic frontend crashes

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2120,7 +2120,7 @@ extern (C++) abstract class Expression : RootObject
 
         if (v.type.ty == Tstruct)
         {
-            StructDeclaration sd = (cast(TypeStruct)type).sym;
+            StructDeclaration sd = (cast(TypeStruct)v.type).sym;
             if (sd.hasNoFields)
                 return false;
         }


### PR DESCRIPTION
Seems to fix sporadic segfaults reported in https://issues.dlang.org/show_bug.cgi?id=18864.