### PR TITLE
[Refactor] Move mtype.Type.DotExpFlag out of class Type

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -9453,7 +9453,7 @@ Expression semanticX(DotIdExp exp, Scope* sc)
     if (exp.e1.op == TOK.variable && exp.e1.type.toBasetype().ty == Tsarray && exp.ident == Id.length)
     {
         // bypass checkPurity
-        return exp.e1.type.dotExp(sc, exp.e1, exp.ident, exp.noderef ? Type.DotExpFlag.noDeref : 0);
+        return exp.e1.type.dotExp(sc, exp.e1, exp.ident, exp.noderef ? DotExpFlag.noDeref : 0);
     }
 
     if (exp.e1.op == TOK.dot)
@@ -9782,13 +9782,13 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
             return null;
         e = new PtrExp(exp.loc, exp.e1);
         e = e.expressionSemantic(sc);
-        return e.type.dotExp(sc, e, exp.ident, flag | (exp.noderef ? Type.DotExpFlag.noDeref : 0));
+        return e.type.dotExp(sc, e, exp.ident, flag | (exp.noderef ? DotExpFlag.noDeref : 0));
     }
     else
     {
         if (exp.e1.op == TOK.type || exp.e1.op == TOK.template_)
             flag = 0;
-        e = exp.e1.type.dotExp(sc, exp.e1, exp.ident, flag | (exp.noderef ? Type.DotExpFlag.noDeref : 0));
+        e = exp.e1.type.dotExp(sc, exp.e1, exp.ident, flag | (exp.noderef ? DotExpFlag.noDeref : 0));
         if (e)
             e = e.expressionSemantic(sc);
         return e;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -397,6 +397,15 @@ enum MODFlags : int
 
 alias MOD = ubyte;
 
+/****************
+ * dotExp() bit flags
+ */
+enum DotExpFlag
+{
+    gag     = 1,    // don't report "not a property" error and just return null
+    noDeref = 2,    // the use of the expression will not attempt a dereference
+}
+
 /***********************************************************
  */
 extern (C++) abstract class Type : RootObject
@@ -2405,15 +2414,6 @@ extern (C++) abstract class Type : RootObject
     ClassDeclaration isClassHandle()
     {
         return null;
-    }
-
-    /****************
-     * dotExp() bit flags
-     */
-    enum DotExpFlag
-    {
-        gag     = 1,    // don't report "not a property" error and just return null
-        noDeref = 2,    // the use of the expression will not attempt a dereference
     }
 
     /************************************

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2625,7 +2625,7 @@ private extern(C++) final class DotExpVisitor : Visitor
             e = new StringExp(e.loc, cast(char*)s);
         }
         else
-            e = mt.getProperty(e.loc, ident, flag & mt.DotExpFlag.gag);
+            e = mt.getProperty(e.loc, ident, flag & DotExpFlag.gag);
 
     Lreturn:
         if (e)
@@ -2823,7 +2823,7 @@ private extern(C++) final class DotExpVisitor : Visitor
                 result = new ErrorExp();
                 return;
             }
-            else if (!(flag & mt.DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
+            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
                 result = new ErrorExp();
@@ -2878,7 +2878,7 @@ private extern(C++) final class DotExpVisitor : Visitor
         }
         else if (ident == Id.ptr)
         {
-            if (!(flag & mt.DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
+            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
                     result = new ErrorExp();
@@ -2950,7 +2950,7 @@ private extern(C++) final class DotExpVisitor : Visitor
         }
         else if (ident == Id.funcptr)
         {
-            if (!(flag & mt.DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
+            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe())
             {
                 e.error("`%s.funcptr` cannot be used in `@safe` code", e.toChars());
                 result = new ErrorExp();


### PR DESCRIPTION
To improve encapsulation and strip class Type a bit (which has ~2500 lines of code).