### PR TITLE
[stable] Fix typo in dmd.expression apparently causing sporadic frontend crashes

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2119,7 +2119,7 @@ extern (C++) abstract class Expression : RootObject
 
         if (v.type.ty == Tstruct)
         {
-            StructDeclaration sd = (cast(TypeStruct)type).sym;
+            StructDeclaration sd = (cast(TypeStruct)v.type).sym;
             if (sd.hasNoFields)
                 return false;
         }


### PR DESCRIPTION
Cherry-pick of #8294 for `stable`; sorry for targeting the wrong branch.