### PR TITLE
split fp.c off from evalu8.c

### DIFF
--- a/src/dmd/backend/fp.c
+++ b/src/dmd/backend/fp.c
@@ -1,0 +1,123 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1985-1998 by Symantec
+ *              Copyright (C) 2000-2018 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/fp.c, backend/fp.c)
+ */
+
+#if !SPP
+
+#include        <math.h>
+#include        <float.h>
+
+#if defined __OpenBSD__
+    #include <sys/param.h>
+    #if OpenBSD < 201111 // 5.0
+        #define HAVE_FENV_H 0
+    #else
+        #define HAVE_FENV_H 1
+    #endif
+#elif _MSC_VER
+    #define HAVE_FENV_H 0
+#else
+    #define HAVE_FENV_H 1
+#endif
+
+#if HAVE_FENV_H
+#include        <fenv.h>
+#endif
+
+#if __DMC__
+#include        <fp.h>
+#endif
+
+#include        "cc.h"
+
+
+#if __DMC__
+    #define HAVE_FLOAT_EXCEPT 1
+
+    int statusFE() { return _status87(); }
+
+    int testFE()
+    {
+        return _status87() & 0x3F;
+    }
+
+    void clearFE()
+    {
+        _clear87();
+    }
+#elif HAVE_FENV_H
+    #define HAVE_FLOAT_EXCEPT 1
+
+    int statusFE() { return 0; }
+
+    int testFE()
+    {
+        return fetestexcept(FE_ALL_EXCEPT);
+    }
+
+    void clearFE()
+    {
+        feclearexcept(FE_ALL_EXCEPT);
+    }
+#elif defined _MSC_VER && TX86
+    #define HAVE_FLOAT_EXCEPT 1
+
+    int statusFE() { return 0; }
+
+    int testFE()
+    {
+        return (ld_statusfpu() | _statusfp()) & 0x3F;
+    }
+
+    void clearFE()
+    {
+        _clearfp();
+        ld_clearfpu();
+    }
+#else
+    #define HAVE_FLOAT_EXCEPT 0
+    int statusFE() { return 0; }
+    int  testFE() { return 1; }
+    void clearFE() { }
+#endif
+
+bool have_float_except() { return HAVE_FLOAT_EXCEPT; }
+
+/************************************
+ * Helper to do % for long doubles.
+ */
+
+targ_ldouble _modulo(targ_ldouble x, targ_ldouble y)
+{
+#if __DMC__
+    short sw;
+
+    __asm
+    {
+        fld     tbyte ptr y
+        fld     tbyte ptr x             // ST = x, ST1 = y
+FM1:    // We don't use fprem1 because for some inexplicable
+        // reason we get -5 when we do _modulo(15, 10)
+        fprem                           // ST = ST % ST1
+        fstsw   word ptr sw
+        fwait
+        mov     AH,byte ptr sw+1        // get msb of status word in AH
+        sahf                            // transfer to flags
+        jp      FM1                     // continue till ST < ST1
+        fstp    ST(1)                   // leave remainder on stack
+    }
+#elif __FreeBSD__ || __OpenBSD__ || __DragonFly__
+    return fmod(x, y);
+#else
+    return fmodl(x, y);
+#endif
+}
+
+#endif /* !SPP */

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -348,7 +348,7 @@ else
 endif
 
 BACK_OBJS = go.o gdag.o gother.o gflow.o gloop.o gsroa.o var.o el.o \
-	glocal.o os.o nteh.o evalu8.o cgcs.o \
+	glocal.o os.o nteh.o evalu8.o fp.o cgcs.o \
 	rtlsym.o cgelem.o cgen.o cgreg.o out.o \
 	blockopt.o cg.o type.o dt.o \
 	debug.o code.o ee.o symbol.o \
@@ -393,7 +393,7 @@ BACK_SRC = \
 	$C/compress.c $C/cgreg.c $C/var.c $C/strtold.c \
 	$C/cgsched.c $C/cod1.c $C/cod2.c $C/cod3.c $C/cod4.c $C/cod5.c \
 	$C/code.c $C/symbol.c $C/debug.c $C/dt.c $C/ee.c $C/el.c \
-	$C/evalu8.c $C/go.c $C/gflow.c $C/gdag.c \
+	$C/evalu8.c $C/fp.c $C/go.c $C/gflow.c $C/gdag.c \
 	$C/gother.c $C/glocal.c $C/gloop.c $C/gsroa.c $C/newman.c \
 	$C/nteh.c $C/os.c $C/out.c $C/outbuf.c $C/ptrntab.c $C/rtlsym.c \
 	$C/type.c $C/melf.h $C/mach.h $C/mscoff.h $C/bcomplex.h \

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -121,6 +121,7 @@
     <ClCompile Include="..\dmd\backend\el.c" />
     <ClCompile Include="..\dmd\backend\elfobj.c" />
     <ClCompile Include="..\dmd\backend\evalu8.c" />
+    <ClCompile Include="..\dmd\backend\fp.c" />
     <ClCompile Include="..\dmd\backend\gdag.c" />
     <ClCompile Include="..\dmd\backend\gflow.c" />
     <ClCompile Include="..\dmd\backend\glocal.c" />

--- a/src/vcbuild/dmd_backend.vcxproj.filters
+++ b/src/vcbuild/dmd_backend.vcxproj.filters
@@ -105,6 +105,9 @@
     <ClCompile Include="..\dmd\backend\evalu8.c">
       <Filter>dmd\backend</Filter>
     </ClCompile>
+    <ClCompile Include="..\dmd\backend\fp.c">
+      <Filter>dmd\backend</Filter>
+    </ClCompile>
     <ClCompile Include="..\dmd\backend\gdag.c">
       <Filter>dmd\backend</Filter>
     </ClCompile>

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -192,7 +192,7 @@ GLUEOBJ=
 
 # D back end
 GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.obj $G/el.obj \
-	$G/newman.obj $G/glocal.obj $G/os.obj $G/nteh.obj $G/evalu8.obj $G/cgcs.obj \
+	$G/newman.obj $G/glocal.obj $G/os.obj $G/nteh.obj $G/evalu8.obj $G/fp.obj $G/cgcs.obj \
 	$G/rtlsym.obj $G/cgelem.obj $G/cgen.obj $G/cgreg.obj $G/out.obj \
 	$G/blockopt.obj $G/cgobj.obj $G/cg.obj $G/cgcv.obj $G/type.obj $G/dt.obj \
 	$G/debug.obj $G/code.obj $G/cg87.obj $G/cgxmm.obj $G/cgsched.obj $G/ee.obj $G/csymbol.obj \
@@ -232,7 +232,7 @@ BACKSRC= $C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c \
 	$C\compress.c $C\cgreg.c $C\var.c \
 	$C\cgsched.c $C\cod1.c $C\cod2.c $C\cod3.c $C\cod4.c $C\cod5.c \
 	$C\code.c $C\symbol.c $C\debug.c $C\dt.c $C\ee.c $C\el.c \
-	$C\evalu8.c $C\go.c $C\gflow.c $C\gdag.c \
+	$C\evalu8.c $C\fp.c $C\go.c $C\gflow.c $C\gdag.c \
 	$C\gother.c $C\glocal.c $C\gloop.c $C\gsroa.c $C\newman.c \
 	$C\nteh.c $C\os.c $C\out.c $C\outbuf.c $C\ptrntab.c $C\rtlsym.c \
 	$C\type.c $C\melf.h $C\mach.h $C\mscoff.h $C\bcomplex.h \
@@ -536,6 +536,9 @@ $G/el.obj : $C\rtlsym.h $C\el.h $C\el.c
 
 $G/evalu8.obj : $C\evalu8.c
 	$(CC) -c -o$@ $(MFLAGS) $C\evalu8
+
+$G/fp.obj : $C\fp.c
+	$(CC) -c -o$@ $(MFLAGS) $C\fp
 
 $G/go.obj : $C\go.c
 	$(CC) -c -o$@ $(MFLAGS) $C\go


### PR DESCRIPTION
Target platform dependent code should be isolated from the compiler logic.