### PR TITLE
Fix Issue 8161 - deprecate invalid property function definitions

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -597,7 +597,7 @@ struct Scope
     }
 
     /********************************************
-     * Search enclosing scopes for ClassDeclaration.
+     * Search enclosing scopes for Struct/ClassDeclaration.
      */
     extern (C++) AggregateDeclaration getStructClassScope()
     {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1150,10 +1150,16 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         {
             const np = Parameter.dim(tf.parameters);
             if (tf.varargs || np > 2 || (np == 2 && sc.getStructClassScope))
+            {
                 mtype.error(loc, "setter property can only have one %s",
-                    sc.getStructClassScope ? "parameter".ptr : "or two parameters".ptr), errors = true;
-            else if (np == 0 && tf.next && tf.next.ty == Tvoid)
-                mtype.error(loc, "getter properties must not return void"), errors = true;
+                    sc.getStructClassScope ? "parameter".ptr : "or two parameters".ptr);
+                errors = true;
+            }
+            else if (np == 0 && tf.next && tf.next.ty == Tvoid && !tf.isref)
+            {
+                mtype.error(loc, "getter properties must not return void");
+                errors = true;
+            }
         }
 
         if (tf.varargs == 1 && tf.linkage != LINK.d && Parameter.dim(tf.parameters) == 0)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1148,17 +1148,20 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
         if (tf.isproperty)
         {
+            // Deprecated in 2018-06.
+            // Change both to error in 2019-06 and uncomment the `errors =` lines.
+            // @@@DEPRECATED_2019-06@@@.
             const np = Parameter.dim(tf.parameters);
             if (tf.varargs || np > 2 || (np == 2 && sc.getStructClassScope))
             {
-                mtype.error(loc, "setter property can only have one %s",
+                deprecation(loc, "setter property can only have one %s",
                     sc.getStructClassScope ? "parameter".ptr : "or two parameters".ptr);
-                errors = true;
+                //errors = true;
             }
             else if (np == 0 && tf.next && tf.next.ty == Tvoid && !tf.isref)
             {
-                mtype.error(loc, "getter properties must not return void");
-                errors = true;
+                deprecation(loc, "getter properties must not return void");
+                //errors = true;
             }
         }
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1146,10 +1146,14 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             errors = true;
         }
 
-        if (tf.isproperty && (tf.varargs || Parameter.dim(tf.parameters) > 2))
+        if (tf.isproperty)
         {
-            mtype.error(loc, "properties can only have zero, one, or two parameter");
-            errors = true;
+            const np = Parameter.dim(tf.parameters);
+            if (tf.varargs || np > 2 || (np == 2 && sc.getStructClassScope))
+                mtype.error(loc, "setter property can only have one %s",
+                    sc.getStructClassScope ? "parameter".ptr : "or two parameters".ptr), errors = true;
+            else if (np == 0 && tf.next && tf.next.ty == Tvoid)
+                mtype.error(loc, "getter properties must not return void"), errors = true;
         }
 
         if (tf.varargs == 1 && tf.linkage != LINK.d && Parameter.dim(tf.parameters) == 0)

--- a/test/fail_compilation/fail334.d
+++ b/test/fail_compilation/fail334.d
@@ -1,11 +1,28 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail334.d(10): Error: properties can only have zero, one, or two parameter
+fail_compilation/fail334.d(15): Error: setter property can only have one parameter
+fail_compilation/fail334.d(16): Error: setter property can only have one parameter
+fail_compilation/fail334.d(17): Error: setter property can only have one parameter
+fail_compilation/fail334.d(19): Error: getter properties must not return void
+fail_compilation/fail334.d(26): Error: setter property can only have one or two parameters
+fail_compilation/fail334.d(27): Error: getter properties must not return void
 ---
 */
 
 struct S
 {
     @property int foo(int a, int b, int c) { return 1; }
+    @property void set(int, int) {}
+    @property void set(...) {}
+    @property void set(int) {} // OK
+    @property void get() {}
 }
+
+// OK
+@property ufcs_set(Object obj, int val) {}
+@property void set(int) {}
+
+@property void set(int[]...) {}
+@property void get() {}
+

--- a/test/fail_compilation/fail334.d
+++ b/test/fail_compilation/fail334.d
@@ -1,12 +1,13 @@
+// REQUIRED_ARGS: -de
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail334.d(15): Error: setter property can only have one parameter
-fail_compilation/fail334.d(16): Error: setter property can only have one parameter
-fail_compilation/fail334.d(17): Error: setter property can only have one parameter
-fail_compilation/fail334.d(19): Error: getter properties must not return void
-fail_compilation/fail334.d(27): Error: setter property can only have one or two parameters
-fail_compilation/fail334.d(28): Error: getter properties must not return void
+fail_compilation/fail334.d(16): Deprecation: setter property can only have one parameter
+fail_compilation/fail334.d(17): Deprecation: setter property can only have one parameter
+fail_compilation/fail334.d(18): Deprecation: setter property can only have one parameter
+fail_compilation/fail334.d(20): Deprecation: getter properties must not return void
+fail_compilation/fail334.d(28): Deprecation: setter property can only have one or two parameters
+fail_compilation/fail334.d(29): Deprecation: getter properties must not return void
 ---
 */
 

--- a/test/fail_compilation/fail334.d
+++ b/test/fail_compilation/fail334.d
@@ -5,8 +5,8 @@ fail_compilation/fail334.d(15): Error: setter property can only have one paramet
 fail_compilation/fail334.d(16): Error: setter property can only have one parameter
 fail_compilation/fail334.d(17): Error: setter property can only have one parameter
 fail_compilation/fail334.d(19): Error: getter properties must not return void
-fail_compilation/fail334.d(26): Error: setter property can only have one or two parameters
-fail_compilation/fail334.d(27): Error: getter properties must not return void
+fail_compilation/fail334.d(27): Error: setter property can only have one or two parameters
+fail_compilation/fail334.d(28): Error: getter properties must not return void
 ---
 */
 
@@ -22,6 +22,7 @@ struct S
 // OK
 @property ufcs_set(Object obj, int val) {}
 @property void set(int) {}
+@property ref void get() {}
 
 @property void set(int[]...) {}
 @property void get() {}


### PR DESCRIPTION
Add error for void getter or aggregate setter method with 2 params.