### PR TITLE
[RFC] Allow passing a string literal to an extern(C) variadic parameter

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -880,6 +880,10 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                 }
                 if (tf.varargs == 1)
                 {
+                    // string literal -> implicit .ptr
+                    if (arg.toStringExp)
+                        arg = arg.castTo(sc, Type.tstring).castTo(sc, Type.tvoidptr);
+
                     const(char)* p = tf.linkage == LINK.c ? "extern(C)" : "extern(C++)";
                     if (arg.type.ty == Tarray)
                     {

--- a/test/runnable/varargstringlit.d
+++ b/test/runnable/varargstringlit.d
@@ -1,0 +1,19 @@
+extern(C) void vf(int x, ...)
+{
+    import core.stdc.stdarg;
+    va_list args;
+
+    va_start(args, x);
+    auto s = va_arg!(const(char)*)(args);
+    assert(s[0..2] == "hi");
+    va_end(args);
+}
+
+void main()
+{
+    vf(0, "hi");
+
+    string s;
+    static assert(!__traits(compiles, vf(0, s)));
+}
+


### PR DESCRIPTION
As a string literal can be implicitly passed to a `const(char)*` parameter, passing one to an `extern(C)` variadic parameter can also be supported. In both cases, the string is cast to a pointer. (String literals are always `\0`-terminated). This is handy for C string compatibility.

I'll update the spec and changelog if comments are positive.