### PR TITLE
Allow classes and interfaces with only static members to be used in -betterC

### DIFF
--- a/changelog/min_runtime_classes.dd
+++ b/changelog/min_runtime_classes.dd
@@ -1,14 +1,14 @@
-Interfaces and classes can be used without the runtime if only static fields are utilized
+Interfaces and classes can be used without the runtime or in -betterC if only `static` members are utilized
 
-Prior to this release any attempt to use interfaces and/or classes without the runtime would result
+Prior to this release any attempt to use interfaces and/or classes without the runtime or in -betterC would result
 in compile-time errors due to the lack of `TypeInfo`.  However, as long as classes are not instantiated
 there is no need for `TypeInfo`.
 
 Beginning with this release the compiler will no longer emit errors about missing `TypeInfo` when
-using interfaces and/or classes as long as they are not instantiated and only `shared static` members are
+using interfaces and/or classes as long as they are not instantiated and only `static` members are
 utilized.
 
-$(B Example 1)
+$(B Example 1 - Minimal Runtime)
 ---
 module object
 
@@ -48,12 +48,42 @@ size main
    1867    1208      32    3107     c23 main
 )
 
+$(B Example 2 - -betterC)
+---
+interface I
+{
+    shared static int i;
+}
+
+class A : I
+{
+    shared static int a;
+}
+
+class B : A
+{
+    shared static int b;
+}
+
+extern(C) void main()
+{
+    B.b = B.a + B.i;
+}
+---
+
+$(CONSOLE
+dmd -betterC main.d
+size main
+   text	   data	    bss	    dec	    hex	filename
+   2738	   1200	     32	   3970	    f82	main
+)
+
 Non-shared static members can also be used, but will require a thread-local storage (TLS) implementation.
 For example, on Linux the TLS implementation is already supplied by the C runtime and C
 standard library, so, since dmd automatically calls gcc to link the final executable, it will automatically
 bring in the TLS implementation.
 
-$(B Example 2)
+$(B Example 3 - Minimal Runtime)
 ---
 module object
 
@@ -93,8 +123,45 @@ size main
    2123    1296      28    3447     d77 main
 )
 
+$(B Example 4 - -betterC)
+---
+interface I
+{
+    static int i;
+}
+
+class A : I
+{
+    static int a;
+}
+
+class B : A
+{
+    static int b;
+}
+
+void main()
+{
+    B.b = B.a + B.i;
+}
+---
+
+$(CONSOLE
+dmd -conf= -defaultlib= main.d object.d -of=main
+size main
+   text    data     bss     dec     hex filename
+   2123    1296      28    3447     d77 main
+)
+
+$(CONSOLE
+dmd -betterC main.d
+size main
+   text	   data	    bss	    dec	    hex	filename
+   3063	   1312	     28	   4403	   1133	main
+)
+
 Some platforms may require some TLS implementation code or some specialized build procedures to link
 in a TLS implementation.
 
-This will hopefully reduce friction for those using D without the runtime, porting D to new platforms,
-or using D from other langauges, while enabling more features and idioms of D to be used in those use cases.
+This will hopefully reduce friction for those using D in -betterC or without the runtime, porting D to new platforms,
+or using D from other languages, and enable more features and idioms of D to be used in those use cases.

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -294,103 +294,81 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.dtypeinfo = this;
                 }
                 if (id == Id.TypeInfo_Class)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfoclass = this;
                 }
                 if (id == Id.TypeInfo_Interface)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfointerface = this;
                 }
                 if (id == Id.TypeInfo_Struct)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfostruct = this;
                 }
                 if (id == Id.TypeInfo_Pointer)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfopointer = this;
                 }
                 if (id == Id.TypeInfo_Array)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfoarray = this;
-                }
-                if (id == Id.TypeInfo_StaticArray)
-                {
-                    //if (!inObject)
-                    //    Type.typeinfostaticarray.error("%s", msg);
-                    Type.typeinfostaticarray = this;
                 }
                 if (id == Id.TypeInfo_AssociativeArray)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfoassociativearray = this;
                 }
                 if (id == Id.TypeInfo_Enum)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfoenum = this;
                 }
                 if (id == Id.TypeInfo_Function)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfofunction = this;
                 }
                 if (id == Id.TypeInfo_Delegate)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfodelegate = this;
                 }
                 if (id == Id.TypeInfo_Tuple)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfotypelist = this;
                 }
                 if (id == Id.TypeInfo_Const)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfoconst = this;
                 }
                 if (id == Id.TypeInfo_Invariant)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfoinvariant = this;
                 }
                 if (id == Id.TypeInfo_Shared)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfoshared = this;
                 }
                 if (id == Id.TypeInfo_Wild)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfowild = this;
                 }
                 if (id == Id.TypeInfo_Vector)
                 {
                     if (!inObject)
                         error("%s", msg);
-                    Type.typeinfovector = this;
                 }
             }
 
@@ -398,32 +376,27 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             {
                 if (!inObject)
                     error("%s", msg);
-                object = this;
             }
 
             if (id == Id.Throwable)
             {
                 if (!inObject)
                     error("%s", msg);
-                throwable = this;
             }
             if (id == Id.Exception)
             {
                 if (!inObject)
                     error("%s", msg);
-                exception = this;
             }
             if (id == Id.Error)
             {
                 if (!inObject)
                     error("%s", msg);
-                errorException = this;
             }
             if (id == Id.cpp_type_info_ptr)
             {
                 if (!inObject)
                     error("%s", msg);
-                cpp_type_info_ptr = this;
             }
         }
         baseok = Baseok.none;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1953,7 +1953,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         for (size_t i = 0; i < m.members.dim; i++)
         {
             Dsymbol s = (*m.members)[i];
-            //printf("\tModule('%s'): '%s'.dsymbolSemantic()\n", toChars(), s.toChars());
+            // printf("\tModule('%s'): '%s'.dsymbolSemantic()\n", m.toChars(), s.toChars());
             s.dsymbolSemantic(sc);
             m.runDeferredSemantic();
         }
@@ -4313,6 +4313,104 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (cldec.semanticRun >= PASS.semanticdone)
             return;
         int errors = global.errors;
+
+        if (cldec.ident)
+        {
+            // BUG: What if this is the wrong TypeInfo, i.e. it is nested?
+            if (cldec.ident.toChars()[0] == 'T')
+            {
+                if (cldec.ident == Id.TypeInfo)
+                {
+                    Type.dtypeinfo = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Class)
+                {
+                    Type.typeinfoclass = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Interface)
+                {
+                    Type.typeinfointerface = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Struct)
+                {
+                    Type.typeinfostruct = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Pointer)
+                {
+                    Type.typeinfopointer = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Array)
+                {
+                    Type.typeinfoarray = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_StaticArray)
+                {
+                    Type.typeinfostaticarray = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_AssociativeArray)
+                {
+                    Type.typeinfoassociativearray = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Enum)
+                {
+                    Type.typeinfoenum = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Function)
+                {
+                    Type.typeinfofunction = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Delegate)
+                {
+                    Type.typeinfodelegate = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Tuple)
+                {
+                    Type.typeinfotypelist = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Const)
+                {
+                    Type.typeinfoconst = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Invariant)
+                {
+                    Type.typeinfoinvariant = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Shared)
+                {
+                    Type.typeinfoshared = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Wild)
+                {
+                    Type.typeinfowild = cldec;
+                }
+                if (cldec.ident == Id.TypeInfo_Vector)
+                {
+                    Type.typeinfovector = cldec;
+                }
+            }
+
+            if (cldec.ident == Id.Object)
+            {
+                cldec.object = cldec;
+            }
+
+            if (cldec.ident == Id.Throwable)
+            {
+                cldec.throwable = cldec;
+            }
+            if (cldec.ident == Id.Exception)
+            {
+                cldec.exception = cldec;
+            }
+            if (cldec.ident == Id.Error)
+            {
+                cldec.errorException = cldec;
+            }
+            if (cldec.ident == Id.cpp_type_info_ptr)
+            {
+                cldec.cpp_type_info_ptr = cldec;
+            }
+        }
 
         //printf("+ClassDeclaration.dsymbolSemantic(%s), type = %p, sizeok = %d, this = %p\n", toChars(), type, sizeok, this);
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -783,8 +783,6 @@ private int tryMain(size_t argc, const(char)** argv)
     if (global.errors)
         fatal();
 
-    backend_init();
-
     // Do semantic analysis
     foreach (m; modules)
     {
@@ -792,6 +790,9 @@ private int tryMain(size_t argc, const(char)** argv)
             message("semantic  %s", m.toChars());
         m.dsymbolSemantic(null);
     }
+
+    backend_init();
+
     //if (global.errors)
     //    fatal();
     Module.dprogress = 1;

--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -26,6 +26,7 @@ extern (C) void main()
     test(1);
     test18472();
     testRuntimeLowerings();
+    testInterfacesAndClasses();
 }
 
 /*******************************************/
@@ -96,7 +97,7 @@ void testRuntimeLowerings()
 
         assert(a1[0..3] == a1[3..$]);
     }
-    
+
     test__equals!int;
     test__equals!uint;
     test__equals!long;
@@ -129,7 +130,7 @@ void testRuntimeLowerings()
     test__cmp!byte;
     test__cmp!dchar;
     test__cmp!wchar;
-    
+
 
     // __cmp currently requires runtime support from `core.internal.string : dstrcmp`.
     // If that runtime dependency can be removed, the following code might work.
@@ -147,4 +148,38 @@ void testRuntimeLowerings()
     //     default:
     //         break;
     // }
+}
+
+/******************************************************
+ * tests to ensure -betterC supports interface sand classes
+ * that contain only `shared` and `static`` members
+ */
+interface I
+{
+    shared static int i;
+}
+
+class A : I
+{
+    shared static int a;
+}
+
+class B : A
+{
+    shared static int b;
+
+    static int sumAll()
+    {
+        return b + a + i;
+    }
+}
+
+void testInterfacesAndClasses()
+{
+    B.i = 32;
+    B.a = 42;
+    B.b = 52;
+
+    assert(B.i == 32 || B.a == 42 || B.b == 52);
+    assert(B.sumAll() == (32 + 42 + 52));
 }


### PR DESCRIPTION
This is a followup to https://github.com/dlang/dmd/pull/8204, but for -betterC.

https://github.com/dlang/druntime/pull/2194 was merged, which prevents -betterC from importing symbols that -betterC cannot utilize.  This means the logic added for https://github.com/dlang/dmd/pull/8204 can now be utilized for -betterC builds as well.

However, with -betterC builds, object.d is still imported and parsed in its entirety; `TypeInfo`, `ModuleInfo`, and other unsupported features are just versioned out.  Therefore, I had to move the logic for setting the special `ClassDeclaration`s, out of the parsing phase and into the symbol semantic phase.