### PR TITLE
fix issue 18928 - extern(C++) bad codegen on win64, wrong calling convention

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -267,7 +267,7 @@ private elem *callfunc(const ref Loc loc,
     objc.setupMethodSelector(fd, &esel);
     objc.setupEp(esel, &ep, left_to_right);
 
-    const retmethod = retStyle(tf);
+    const retmethod = retStyle(tf, fd && fd.needThis());
     if (retmethod == RET.stack)
     {
         if (!ehidden)
@@ -2890,7 +2890,7 @@ elem *toElem(Expression e, IRState *irs)
             {
                 CallExp ce = cast(CallExp)ae.e2;
                 TypeFunction tf = cast(TypeFunction)ce.e1.type.toBasetype();
-                if (tf.ty == Tfunction && retStyle(tf) == RET.stack)
+                if (tf.ty == Tfunction && retStyle(tf, ce.f && ce.f.needThis()) == RET.stack)
                 {
                     elem *ehidden = e1;
                     ehidden = el_una(OPaddr, TYnptr, ehidden);

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -908,7 +908,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
 
     assert(fd.type.ty == Tfunction);
     TypeFunction tf = cast(TypeFunction)fd.type;
-    RET retmethod = retStyle(tf);
+    RET retmethod = retStyle(tf, fd.needThis());
     if (retmethod == RET.stack)
     {
         // If function returns a struct, put a pointer to that
@@ -1507,7 +1507,7 @@ uint totym(Type tx)
                     if (global.params.isWindows)
                     {
                     }
-                    else if (!global.params.is64bit && retStyle(tf) == RET.stack)
+                    else if (!global.params.is64bit && retStyle(tf, false) == RET.stack)
                         t = TYhfunc;
                     break;
 

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -719,7 +719,7 @@ private extern (C++) class S2irVisitor : Visitor
             assert(func.type.ty == Tfunction);
             TypeFunction tf = cast(TypeFunction)(func.type);
 
-            RET retmethod = retStyle(tf);
+            RET retmethod = retStyle(tf, func.needThis());
             if (retmethod == RET.stack)
             {
                 elem *es;
@@ -745,7 +745,7 @@ private extern (C++) class S2irVisitor : Visitor
                         Type t = ce.e1.type.toBasetype();
                         if (t.ty == Tdelegate)
                             t = t.nextOf();
-                        if (t.ty == Tfunction && retStyle(cast(TypeFunction)t) == RET.stack)
+                        if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, ce.f && ce.f.needThis()) == RET.stack)
                         {
                             irs.ehidden = el_var(irs.shidden);
                             e = toElemDtor(s.exp, irs);
@@ -769,7 +769,7 @@ private extern (C++) class S2irVisitor : Visitor
                         Type t = ce.e1.type.toBasetype();
                         if (t.ty == Tdelegate)
                             t = t.nextOf();
-                        if (t.ty == Tfunction && retStyle(cast(TypeFunction)t) == RET.stack)
+                        if (t.ty == Tfunction && retStyle(cast(TypeFunction)t, fd && fd.needThis()) == RET.stack)
                         {
                             irs.ehidden = el_var(irs.shidden);
                             e = toElemDtor(s.exp, irs);

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -573,7 +573,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                 }
 
-                if (!funcdecl.inferRetType && !Target.isReturnOnStack(f))
+                if (!funcdecl.inferRetType && !Target.isReturnOnStack(f, funcdecl.needThis()))
                     funcdecl.nrvo_can = 0;
 
                 bool inferRef = (f.isref && (funcdecl.storage_class & STC.auto_));
@@ -627,7 +627,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (funcdecl.storage_class & STC.auto_)
                         funcdecl.storage_class &= ~STC.auto_;
                 }
-                if (!Target.isReturnOnStack(f))
+                if (!Target.isReturnOnStack(f, funcdecl.needThis()))
                     funcdecl.nrvo_can = 0;
 
                 if (funcdecl.fbody.isErrorStatement())

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -21,6 +21,7 @@ import dmd.dmodule;
 import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.expression;
+import dmd.func;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -589,12 +590,15 @@ struct Target
     }
 
     /**
+     * Determine return style of function - whether in registers or
+     * through a hidden pointer to the caller's stack.
      * Params:
      *   tf = function type to check
+     *   needsThis = true if the function type is for a non-static member function
      * Returns:
      *   true if return value from function is on the stack
      */
-    extern (C++) static bool isReturnOnStack(TypeFunction tf)
+    extern (C++) static bool isReturnOnStack(TypeFunction tf, bool needsThis)
     {
         if (tf.isref)
         {
@@ -621,6 +625,8 @@ struct Target
                 StructDeclaration sd = (cast(TypeStruct)tns).sym;
                 if (sd.ident == Id.__c_long_double)
                     return false;
+                if (tf.linkage == LINK.cpp && needsThis)
+                    return true;
                 if (!sd.isPOD() || sz > 8)
                     return true;
                 if (sd.fields.dim == 0)
@@ -638,6 +644,8 @@ struct Target
                 StructDeclaration sd = (cast(TypeStruct)tb).sym;
                 if (sd.ident == Id.__c_long_double)
                     return false;
+                if (tf.linkage == LINK.cpp && needsThis)
+                    return true;
             }
         }
 

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1029,9 +1029,14 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
 /***************************
  * Determine return style of function - whether in registers or
  * through a hidden pointer to the caller's stack.
+ * Params:
+ *   tf = function type to check
+ *   needsThis = true if the function type is for a non-static member function
+ * Returns:
+ *   RET.stack if return value from function is on the stack, RET.regs otherwise
  */
-RET retStyle(TypeFunction tf)
+RET retStyle(TypeFunction tf, bool needsThis)
 {
     //printf("TypeFunction.retStyle() %s\n", toChars());
-    return Target.isReturnOnStack(tf) ? RET.stack : RET.regs;
+    return Target.isReturnOnStack(tf, needsThis) ? RET.stack : RET.regs;
 }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1149,7 +1149,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             return new ErrorExp();
         }
 
-        bool value = Target.isReturnOnStack(tf);
+        bool value = Target.isReturnOnStack(tf, fd && fd.needThis());
         return new IntegerExp(e.loc, value, Type.tbool);
     }
     if (e.ident == Id.getFunctionVariadicStyle)

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1309,6 +1309,36 @@ void test15589()
 
 /****************************************/
 
+// https://issues.dlang.org/show_bug.cgi?id=18928
+// Win64: extern(C++) bad codegen, wrong calling convention
+
+extern(C++) struct Small18928
+{
+    int x;
+}
+
+extern(C++) class CC18928
+{
+    Small18928 getVirtual(); // { return S(3); }
+    final Small18928 getFinal(); // { return S(4); }
+    static Small18928 getStatic(); // { return S(5); }
+}
+
+extern(C++) CC18928 newCC18928();
+
+void test18928()
+{
+    auto cc = newCC18928();
+    Small18928 v = cc.getVirtual();
+    assert(v.x == 3);
+    Small18928 f = cc.getFinal();
+    assert(f.x == 4);
+    Small18928 s = cc.getStatic();
+    assert(s.x == 5);
+}
+
+/****************************************/
+
 void main()
 {
     test1();
@@ -1352,6 +1382,7 @@ void main()
     test15802();
     test16536();
     test15589();
+    test18928();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -837,3 +837,28 @@ void test15589b(A15589 *p)
     assert(((B15589*)p)->bar() == 200);
     p->~A15589();
 }
+
+/****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18928
+
+struct Small18928
+{
+    int x;
+};
+
+class CC18928
+{
+public:
+    virtual Small18928 getVirtual();
+    Small18928 getFinal();
+    static Small18928 getStatic();
+};
+
+Small18928 CC18928::getVirtual() { Small18928 s = {3}; return s; }
+Small18928 CC18928::getFinal()   { Small18928 s = {4}; return s; }
+Small18928 CC18928::getStatic()  { Small18928 s = {5}; return s; }
+
+CC18928* newCC18928()
+{
+    return new CC18928();
+}


### PR DESCRIPTION
With the VC x64 ABI, a member function always returns a struct on the stack no matter its size.

This doesn't yet take into account that delegates are still incompatible. To avoid having to create another linkage attribute, a stub should be generated in that case to convert the ABIs.