### PR TITLE
Fix Issue 17580 - Marking methods as synchronized is allowed despite spec

### DIFF
--- a/changelog/fix17580.dd
+++ b/changelog/fix17580.dd
@@ -1,0 +1,12 @@
+Deprecate marking class methods as `synchronized` while class is not synchronized
+
+The D language specification states that member functions of non-`synchronized` classes cannot be marked as `synchonized`, however the compiler does not reject such declarations. The following code compiled before the patch:
+
+---
+class S
+{
+    synchronized void fun() { }
+}
+---
+
+After applying the patch, the above code will issue a deprecation message

--- a/changelog/fix17580.dd
+++ b/changelog/fix17580.dd
@@ -1,6 +1,6 @@
 Deprecate marking class methods as `synchronized` while class is not synchronized
 
-The D language specification states that member functions of non-`synchronized` classes cannot be marked as `synchonized`, however the compiler does not reject such declarations. The following code compiled before the patch:
+The D language specification states that member functions of non-`synchronized` classes cannot be marked as `synchronized`, however the compiler does not reject such declarations. The following code compiled before this release:
 
 ---
 class S
@@ -9,4 +9,20 @@ class S
 }
 ---
 
-After applying the patch, the above code will issue a deprecation message
+To fix the deprecation message, make the class synchronized:
+
+---
+synchronized class S
+{
+    void fun() { }
+}
+---
+
+or mark the methods as `shared`:
+
+---
+class S
+{
+    shared void fun() { }
+}
+---

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1083,6 +1083,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     ClassDeclaration cd = funcdecl.isThis() ? funcdecl.isThis().isClassDeclaration() : funcdecl.parent.isClassDeclaration();
                     if (cd)
                     {
+                        // @@@DEPRECATED_2.091@@@
                         if (!(cd.storage_class & STC.synchronized_))
                             funcdecl.deprecation("cannot be marked as `synchronized` because it is a member of the non-`synchronized` class `%s`. The `synchronized` attribute must be applied to the class declaration itself", cd.toPrettyChars());
                         if (!global.params.is64bit && global.params.isWindows && !funcdecl.isStatic() && !sbody.usesEH() && !global.params.trace)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1083,6 +1083,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     ClassDeclaration cd = funcdecl.isThis() ? funcdecl.isThis().isClassDeclaration() : funcdecl.parent.isClassDeclaration();
                     if (cd)
                     {
+                        if (!(cd.storage_class & STC.synchronized_))
+                            funcdecl.deprecation("cannot be marked as `synchronized` because it is a member of the non-`synchronized` class `%s`. The `synchronized` attribute must be applied to the class declaration itself", cd.toPrettyChars());
                         if (!global.params.is64bit && global.params.isWindows && !funcdecl.isStatic() && !sbody.usesEH() && !global.params.trace)
                         {
                             /* The back end uses the "jmonitor" hack for syncing;

--- a/test/fail_compilation/fail17580.d
+++ b/test/fail_compilation/fail17580.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail17580.d(11): Deprecation: function `fail17580.S.fun` cannot be marked as `synchronized` because it is a member of the non-`synchronized` class `fail17580.S`. The `synchronized` attribute must be applied to the class declaration itself
+---
+*/
+
+class S
+{
+    synchronized void fun() { }
+}

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -832,9 +832,9 @@ void test11()
 /****************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=17481
 
-class C17481
+synchronized class C17481
 {
-    synchronized void trigger(){ new ubyte[1]; }
+    void trigger(){ new ubyte[1]; }
 }
 
 void test17481()

--- a/test/runnable/eh2.d
+++ b/test/runnable/eh2.d
@@ -11,7 +11,7 @@ class Abc : Throwable
     static int x;
     int a,b,c;
 
-    synchronized void test()
+    shared void test()
     {
         printf("test 1\n");
         x |= 1;

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -580,9 +580,9 @@ void test30()
 
 /************************************************/
 
-class C31
+synchronized class C31
 {
-    synchronized invariant() { int x; }
+    invariant() { int x; }
 }
 
 void test31()

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -446,10 +446,10 @@ int testx14(int x)
     }
 }
 
-class bar
+synchronized class bar
 {
-    int y;
-    synchronized int sync(int x)
+    private int y;
+    int sync(int x)
     {
         printf("in sync(%d) = %d\n", x, y + 3);
         return y + 3;
@@ -865,9 +865,9 @@ void test34()
 
 /* ================================ */
 
-class X35
+synchronized class X35
 {
-    final synchronized void foo()
+    final void foo()
     {
         for(;;)
         {

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -98,11 +98,11 @@ void test6453()
         nothrow shared invariant() {}
         @safe   shared invariant() {}
     }
-    static class C6453c
+    static synchronized class C6453c
     {
-        pure    synchronized invariant() {}
-        nothrow synchronized invariant() {}
-        @safe   synchronized invariant() {}
+        pure    invariant() {}
+        nothrow invariant() {}
+        @safe   invariant() {}
     }
 }
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1081,9 +1081,9 @@ void test54()
 
 /***************************************************/
 
-class Foo55
+synchronized class Foo55
 {
-    synchronized void noop1() { }
+    void noop1() { }
     void noop2() shared { }
 }
 


### PR DESCRIPTION
Looks like many tests took advantage of this spec violation. Maybe a deprecation cycle first?