### PR TITLE
 Fix issue 18922: No substitutions for C++ namespaces in different module/file

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -243,6 +243,8 @@ extern (C++) class Dsymbol : RootObject
     {
         if (this == o)
             return true;
+        if (o.dyncast() != DYNCAST.dsymbol)
+            return false;
         Dsymbol s = cast(Dsymbol)o;
         // Overload sets don't have an ident
         if (s && ident && s.ident && ident.equals(s.ident))

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -689,3 +689,14 @@ version (Win64)
     static assert(TestOperators.opIndex.mangleof         == "??ATestOperators@@QEAAH_K@Z");
     static assert(TestOperators.opCall.mangleof          == "??RTestOperators@@QEAAHHM@Z");
 }
+
+extern(C++, Namespace18922)
+{
+    import cppmangle2;
+    void func18922(Struct18922) {}
+
+	version (Posix)
+		static assert(func18922.mangleof == "_ZN14Namespace189229func18922ENS_11Struct18922E");
+	else version(Windows)
+		static assert(func18922.mangleof == "?func18922@Namespace18922@@YAXUStruct18922@1@@Z");
+}

--- a/test/compilable/cppmangle2.d
+++ b/test/compilable/cppmangle2.d
@@ -1,0 +1,6 @@
+module cppmangle2;
+
+extern(C++, Namespace18922)
+{
+    struct Struct18922 { int i; }
+}


### PR DESCRIPTION
```
DMD was just comparing the object by their reference instead of their string value.
Obviously when a namespace is declared in another module, the reference is different.
```

There are two other small refactors in this PR, which can be taken out at will.
But since they are different commits, they shouldn't be a problem either for `git revert` or reviewers (juse review commit by commit and/or ignore whitespace).

Also tested it on a large C++ project I am porting to D (on Linux x64).