### PR TITLE
Support __traits(getLinkage) for structs

### DIFF
--- a/changelog/getlinkage_for_classes.dd
+++ b/changelog/getlinkage_for_classes.dd
@@ -1,12 +1,12 @@
-__traits(getLinkage, ...) now works on classes and interfaces.
+__traits(getLinkage, ...) now works on structs, classes, and interfaces.
 
-It is now possible to detect the language ABI specified for a class or interface.
+It is now possible to detect the language ABI specified for a struct, class, or interface.
 
 ---
 class MyClass {}
-extern (C++) class MyCPPClass {}
+extern (C++) struct MyCPPStruct {}
 extern (C++) interface MyCPPInterface {}
 static assert(__traits(getLinkage, MyClass) == "D");
-static assert(__traits(getLinkage, MyCPPClass) == "C++");
+static assert(__traits(getLinkage, MyCPPStruct) == "C++");
 static assert(__traits(getLinkage, MyCPPInterface) == "C++");
 ---

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -50,6 +50,22 @@ enum Baseok : int
     semanticdone,     // all base classes semantic done
 }
 
+/**
+ * The ClassKind enum is used in AggregateDeclaration AST nodes to
+ * specify the linkage type of the struct/class/interface or if it
+ * is an anonymous class. If the class is anonymous it is also
+ * considered to be a D class.
+ */
+enum ClassKind : int
+{
+    /// the aggregate is a d(efault) class
+    d,
+    /// the aggregate is a C++ struct/class/interface
+    cpp,
+    /// the aggregate is an Objective-C class/interface
+    objc,
+}
+
 /***********************************************************
  */
 extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
@@ -63,6 +79,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     Sizeok sizeok;          // set when structsize contains valid data
     Dsymbol deferred;       // any deferred semantic2() or semantic3() symbol
     bool isdeprecated;      // true if deprecated
+
+    /// specifies whether this is a D, C++, Objective-C or anonymous struct/class/interface
+    ClassKind classKind;
 
     /* !=null if is nested
      * pointing to the dsymbol that directly enclosing it.

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -75,6 +75,16 @@ FuncDeclaration *buildPostBlit(StructDeclaration *sd, Scope *sc);
 FuncDeclaration *buildDtor(AggregateDeclaration *ad, Scope *sc);
 FuncDeclaration *buildInv(AggregateDeclaration *ad, Scope *sc);
 
+enum ClassKind
+{
+    /// the aggregate is a d(efault) struct/class/interface
+    d,
+    /// the aggregate is a C++ struct/class/interface
+    cpp,
+    /// the aggregate is an Objective-C class/interface
+    objc
+};
+
 class AggregateDeclaration : public ScopeDsymbol
 {
 public:
@@ -87,6 +97,8 @@ public:
     Sizeok sizeok;              // set when structsize contains valid data
     Dsymbol *deferred;          // any deferred semantic2() or semantic3() symbol
     bool isdeprecated;          // true if deprecated
+
+    ClassKind classKind;        // specifies the linkage type
 
     /* !=NULL if is nested
      * pointing to the dsymbol that directly enclosing it.
@@ -246,16 +258,6 @@ struct ClassFlags
     };
 };
 
-enum ClassKind
-{
-    /// the class is a d(efault) class
-    d,
-    /// the class is a C++ interface
-    cpp,
-    /// the class is an Objective-C class/interface
-    objc
-};
-
 class ClassDeclaration : public AggregateDeclaration
 {
 public:
@@ -283,7 +285,6 @@ public:
     TypeInfoClassDeclaration *vclassinfo;       // the ClassInfo object for this ClassDeclaration
     bool com;                           // true if this is a COM class (meaning it derives from IUnknown)
     bool stack;                         // true if this is a scope class
-    ClassKind classKind;                // specifies the linkage type
     bool inuse;                         // to prevent recursive attempts
     bool isActuallyAnonymous;           // true if this class has an identifier, but was originally declared anonymous
                                         // used in support of https://issues.dlang.org/show_bug.cgi?id=17371

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -175,22 +175,6 @@ struct ClassFlags
     alias hasDtor = Enum.hasDtor;
 }
 
-/**
- * The ClassKind enum is used in ClassDeclaration AST nodes
- * to specify the linkage type of the class or if it is an
- * anonymous class. If the class is anonymous it is also
- * considered to be a D class.
- */
-enum ClassKind : int
-{
-    /// the class is a d(efault) class
-    d,
-    /// the class is a C++ interface
-    cpp,
-    /// the class is an Objective-C class/interface
-    objc,
-}
-
 /***********************************************************
  */
 extern (C++) class ClassDeclaration : AggregateDeclaration
@@ -229,9 +213,6 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
     /// true if this is a scope class
     bool stack;
-
-    /// specifies whether this is a D, C++, Objective-C or anonymous class/interface
-    ClassKind classKind;
 
     /// to prevent recursive attempts
     private bool inuse;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4129,6 +4129,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 sd.error("structs, unions cannot be `abstract`");
 
             sd.userAttribDecl = sc.userAttribDecl;
+
+            if (sc.linkage == LINK.cpp)
+                sd.classKind = ClassKind.cpp;
         }
         else if (sd.symtab && !scx)
             return;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1311,15 +1311,15 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
         {
             auto s = getDsymbol(o);
             Declaration d;
-            ClassDeclaration c;
-            if (!s || ((d = s.isDeclaration()) is null && (c = s.isClassDeclaration()) is null))
+            AggregateDeclaration agg;
+            if (!s || ((d = s.isDeclaration()) is null && (agg = s.isAggregateDeclaration()) is null))
             {
                 e.error("argument to `__traits(getLinkage, %s)` is not a declaration", o.toChars());
                 return new ErrorExp();
             }
             if (d !is null)
                 link = d.linkage;
-            else final switch (c.classKind)
+            else final switch (agg.classKind)
             {
                 case ClassKind.d:
                     link = LINK.d;

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -39,11 +39,13 @@ void bar()
 class FooD {}
 interface FooDInterface {}
 extern (C++) class FooCpp {}
+extern (C++) struct FooCppStruct {}
 extern (C++) interface FooCppInterface {}
 
 static assert(__traits(getLinkage, FooD) == "D");
 static assert(__traits(getLinkage, FooDInterface) == "D");
 static assert(__traits(getLinkage, FooCpp) == "C++");
+static assert(__traits(getLinkage, FooCppStruct) == "C++");
 static assert(__traits(getLinkage, FooCppInterface) == "C++");
 
 version (D_ObjectiveC)


### PR DESCRIPTION
This is required for the extern(C++) destructors patch, but I felt it was isolated enough to stand as a patch on its own.