### PR TITLE
Fix Issue 18951 - package static method masked by public static method in class

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3908,7 +3908,7 @@ private extern(C++) final class DotExpVisitor : Visitor
             if (auto fd = d.isFuncDeclaration())
             {
                 import dmd.access : mostVisibleOverload;
-                d = cast(Declaration)mostVisibleOverload(fd);
+                d = cast(Declaration)mostVisibleOverload(fd, sc._module);
             }
 
             checkAccess(e.loc, sc, e, d);

--- a/test/compilable/test18951a.d
+++ b/test/compilable/test18951a.d
@@ -1,0 +1,7 @@
+module compilable.test18951a;
+
+public class A
+{
+    package static void foo(Object) {}
+    public static void foo() {}
+}

--- a/test/compilable/test18951b.d
+++ b/test/compilable/test18951b.d
@@ -1,0 +1,8 @@
+module compilable.test18951b;
+
+import test18951a;
+
+void test()
+{
+    A.foo(new Object);
+}


### PR DESCRIPTION
When selecting the "most-visible" overload method to check access,
treat package methods as public if they're visible; otherwise, private.
This avoids package methods that are perfectly visible being passed over
in favor of public (numerically more visible) overloads appearing later
in the class.