### PR TITLE
Export CC to the test shell environment

### DIFF
--- a/test/compilable/issue15574.sh
+++ b/test/compilable/issue15574.sh
@@ -1,8 +1,6 @@
 #! /usr/bin/env bash
 
-
 if [[ $OS = *"win"* ]]; then exit 0; fi
-
 
 if [ $LIBEXT = ".a" ]; then
     LIB_PREFIX=lib
@@ -46,9 +44,7 @@ int main() {
 }
 EOF
 
-if [ -z ${CC+x} ]; then CC=cc; fi
-
-$CC -m${MODEL} -c -o ${C_FILE}${OBJ} $C_FILE
+cc -m${MODEL} -c -o ${C_FILE}${OBJ} $C_FILE
 ar rcs ${C_LIB} ${C_FILE}${OBJ}
 
 ${DMD} -m${MODEL} -lib -of${D_LIB} ${D_FILE}

--- a/test/tools/exported_vars.sh
+++ b/test/tools/exported_vars.sh
@@ -12,3 +12,9 @@ if [ "$OS" == "win32" ] || [ "$OS" == "win64" ]; then
 else
     export LIBEXT=.a
 fi
+
+# Default to DigitalMars C++ on Win32
+if [ "$OS" == "win32" ] && [ -z "${CC+set}" ] ; then
+    CC="dmc"
+fi
+export CC="${CC:-c++}" # C++ compiler to use


### PR DESCRIPTION
Useful for e.g. https://github.com/dlang/dmd/pull/8342

This performs what `d_do_test` already does today:

https://github.com/dlang/dmd/blob/cce909b19a1e6b03a182d2a1d488841e2cc64b53/test/tools/d_do_test.d#L588-L596

(though the win64 case isn't really used anymore)