### PR TITLE
Fix Issue 18964 - `-m32` should mean COFF, default is surprising

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -377,21 +377,23 @@ dmd -cov -unittest myprog.d
         Option("m32",
             "generate 32 bit code",
             `$(UNIX Compile a 32 bit executable. This is the default for the 32 bit dmd.)
-            $(WINDOWS Compile a 32 bit executable. This is the default.
-            The generated object code is in OMF and is meant to be used with the
-            $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars C/C++ compiler)).`,
+            $(WINDOWS Compile 32 bit MS-COFF and is meant to be used with the
+            $(LINK2 https://msdn.microsoft.com/en-us/library/dd831853(v=vs.100).aspx, Microsoft Visual Studio 10)
+            or later compiler. This is the default for the 32 bit dmd.`,
             (TargetOS.all & ~TargetOS.dragonFlyBSD)  // available on all OS'es except DragonFly, which does not support 32-bit binaries
         ),
-        Option("m32mscoff",
-            "generate 32 bit code and write MS-COFF object files",
-            TargetOS.windows
+        Option("m32omf",
+            "generate 32 bit code and write OMF object files",
+            `The generated object code is in OMF and is meant to be used with the
+            $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars C/C++ compiler)).`,
+            (TargetOS.windows)  // only applicable to windows
         ),
         Option("m64",
             "generate 64 bit code",
             `$(UNIX Compile a 64 bit executable. This is the default for the 64 bit dmd.)
-            $(WINDOWS The generated object code is in MS-COFF and is meant to be used with the
+            $(WINDOWS Compile 64 bit MS-COFF and is meant to be used with the
             $(LINK2 https://msdn.microsoft.com/en-us/library/dd831853(v=vs.100).aspx, Microsoft Visual Studio 10)
-            or later compiler.`,
+            or later compiler. This is the default for the 64 bit dmd.`,
         ),
         Option("main",
             "add default main() (e.g. for unittesting)",
@@ -445,7 +447,7 @@ dmd -cov -unittest myprog.d
         ),
         Option("mscrtlib=<name>",
             "MS C runtime library to reference from main/WinMain/DllMain",
-            "If building MS-COFF object files with -m64 or -m32mscoff, embed a reference to
+            "If not building OMF object files with -m32omf, embed a reference to
             the given C runtime library $(I libname) into the object file containing `main`,
             `DllMain` or `WinMain` for automatic linking. The default is $(TT libcmt)
             (release version with static linkage), the other usual alternatives are


### PR DESCRIPTION
I mostly just want to see how fast this gets shut-down.
I feel this is important.