### PR TITLE
Change deprecation to error for redundant storage classes

### DIFF
--- a/changelog/redundant_stc_error.dd
+++ b/changelog/redundant_stc_error.dd
@@ -1,0 +1,8 @@
+Specifying redundant storage classes will now result in a compiler error
+
+Specifying redundant storage classes was deprecated long ago and was originally scheduled to emit a compiler error beginning with the 2.068 release.
+That promise has been fulfilled with this release.
+
+---
+@safe void f() @safe {}   // Error: redundant attribute `@safe`
+---

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1259,19 +1259,14 @@ final class Parser(AST) : Lexer
 
     /*********************************************
      * Give error on redundant/conflicting storage class.
-     *
-     * TODO: remove deprecation in 2.068 and keep only error
      */
-    StorageClass appendStorageClass(StorageClass storageClass, StorageClass stc, bool deprec = false)
+    StorageClass appendStorageClass(StorageClass storageClass, StorageClass stc)
     {
         if ((storageClass & stc) || (storageClass & AST.STC.in_ && stc & (AST.STC.const_ | AST.STC.scope_)) || (stc & AST.STC.in_ && storageClass & (AST.STC.const_ | AST.STC.scope_)))
         {
             OutBuffer buf;
             AST.stcToBuffer(&buf, stc);
-            if (deprec)
-                deprecation("redundant attribute `%s`", buf.peekString());
-            else
-                error("redundant attribute `%s`", buf.peekString());
+            error("redundant attribute `%s`", buf.peekString());
             return storageClass | stc;
         }
 
@@ -1433,7 +1428,7 @@ final class Parser(AST) : Lexer
             default:
                 return storageClass;
             }
-            storageClass = appendStorageClass(storageClass, stc, true);
+            storageClass = appendStorageClass(storageClass, stc);
             nextToken();
         }
     }

--- a/test/fail_compilation/parseStc3.d
+++ b/test/fail_compilation/parseStc3.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(10): Deprecation: redundant attribute `pure`
-fail_compilation/parseStc3.d(11): Deprecation: redundant attribute `nothrow`
-fail_compilation/parseStc3.d(12): Deprecation: redundant attribute `@nogc`
-fail_compilation/parseStc3.d(13): Deprecation: redundant attribute `@property`
+fail_compilation/parseStc3.d(10): Error: redundant attribute `pure`
+fail_compilation/parseStc3.d(11): Error: redundant attribute `nothrow`
+fail_compilation/parseStc3.d(12): Error: redundant attribute `@nogc`
+fail_compilation/parseStc3.d(13): Error: redundant attribute `@property`
 ---
 */
 pure      void f1() pure      {}
@@ -16,9 +16,9 @@ nothrow   void f2() nothrow   {}
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc3.d(24): Deprecation: redundant attribute `@safe`
-fail_compilation/parseStc3.d(25): Deprecation: redundant attribute `@system`
-fail_compilation/parseStc3.d(26): Deprecation: redundant attribute `@trusted`
+fail_compilation/parseStc3.d(24): Error: redundant attribute `@safe`
+fail_compilation/parseStc3.d(25): Error: redundant attribute `@system`
+fail_compilation/parseStc3.d(26): Error: redundant attribute `@trusted`
 ---
 */
 @safe     void f6() @safe    {}
@@ -49,11 +49,11 @@ TEST_OUTPUT:
 fail_compilation/parseStc3.d(59): Error: conflicting attribute `@system`
 fail_compilation/parseStc3.d(59): Error: conflicting attribute `@trusted`
 fail_compilation/parseStc3.d(60): Error: conflicting attribute `@system`
-fail_compilation/parseStc3.d(60): Deprecation: redundant attribute `@system`
+fail_compilation/parseStc3.d(60): Error: redundant attribute `@system`
 fail_compilation/parseStc3.d(61): Error: conflicting attribute `@safe`
-fail_compilation/parseStc3.d(61): Deprecation: redundant attribute `@system`
+fail_compilation/parseStc3.d(61): Error: redundant attribute `@system`
 fail_compilation/parseStc3.d(62): Error: conflicting attribute `@safe`
-fail_compilation/parseStc3.d(62): Deprecation: redundant attribute `@trusted`
+fail_compilation/parseStc3.d(62): Error: redundant attribute `@trusted`
 ---
 */
 @safe @system  void f15() @trusted {}

--- a/test/fail_compilation/parseStc4.d
+++ b/test/fail_compilation/parseStc4.d
@@ -2,11 +2,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc4.d(14): Deprecation: redundant attribute `pure`
-fail_compilation/parseStc4.d(14): Deprecation: redundant attribute `nothrow`
+fail_compilation/parseStc4.d(14): Error: redundant attribute `pure`
+fail_compilation/parseStc4.d(14): Error: redundant attribute `nothrow`
 fail_compilation/parseStc4.d(14): Error: conflicting attribute `@system`
-fail_compilation/parseStc4.d(14): Deprecation: redundant attribute `@nogc`
-fail_compilation/parseStc4.d(14): Deprecation: redundant attribute `@property`
+fail_compilation/parseStc4.d(14): Error: redundant attribute `@nogc`
+fail_compilation/parseStc4.d(14): Error: redundant attribute `@property`
 ---
 */
 pure nothrow @safe   @nogc @property
@@ -19,13 +19,13 @@ pure nothrow @system @nogc @property
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parseStc4.d(35): Deprecation: redundant attribute `const`
-fail_compilation/parseStc4.d(36): Deprecation: redundant attribute `const`
+fail_compilation/parseStc4.d(35): Error: redundant attribute `const`
+fail_compilation/parseStc4.d(36): Error: redundant attribute `const`
 fail_compilation/parseStc4.d(36): Deprecation: `const` postblit is deprecated. Please use an unqualified postblit.
-fail_compilation/parseStc4.d(37): Deprecation: redundant attribute `const`
-fail_compilation/parseStc4.d(39): Deprecation: redundant attribute `pure`
-fail_compilation/parseStc4.d(40): Deprecation: redundant attribute `@safe`
-fail_compilation/parseStc4.d(41): Deprecation: redundant attribute `nothrow`
+fail_compilation/parseStc4.d(37): Error: redundant attribute `const`
+fail_compilation/parseStc4.d(39): Error: redundant attribute `pure`
+fail_compilation/parseStc4.d(40): Error: redundant attribute `@safe`
+fail_compilation/parseStc4.d(41): Error: redundant attribute `nothrow`
 fail_compilation/parseStc4.d(42): Error: conflicting attribute `@trusted`
 ---
 */


### PR DESCRIPTION
Based on comments in the source code, this should have happened in 2.068.