### PR TITLE
Fix Issue 18970 - DMD segfault due to opDispatch

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4023,7 +4023,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
     override void visit(StructDeclaration sd)
     {
-        //printf("StructDeclaration::semantic(this=%p, '%s', sizeok = %d)\n", this, toPrettyChars(), sizeok);
+        //printf("StructDeclaration::semantic(this=%p, '%s', sizeok = %d)\n", sd, sd.toPrettyChars(), sd.sizeok);
 
         //static int count; if (++count == 20) assert(0);
 
@@ -4186,7 +4186,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         Module.dprogress++;
         sd.semanticRun = PASS.semanticdone;
-        //printf("-StructDeclaration::semantic(this=%p, '%s')\n", this, toChars());
+        //printf("-StructDeclaration::semantic(this=%p, '%s')\n", sd, sd.toChars());
 
         sc2.pop();
 
@@ -5190,7 +5190,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
 void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions* fargs)
 {
-    //printf("[%s] TemplateInstance.dsymbolSemantic('%s', this=%p, gag = %d, sc = %p)\n", loc.toChars(), toChars(), this, global.gag, sc);
+    //printf("[%s] TemplateInstance.dsymbolSemantic('%s', this=%p, gag = %d, sc = %p)\n", tempinst.loc.toChars(), tempinst.toChars(), tempinst, global.gag, sc);
     version (none)
     {
         for (Dsymbol s = tempinst; s; s = s.parent)
@@ -5736,7 +5736,7 @@ Laftersemantic:
 // function used to perform semantic on AliasDeclaration
 void aliasSemantic(AliasDeclaration ds, Scope* sc)
 {
-    //printf("AliasDeclaration::semantic() %s\n", toChars());
+    //printf("AliasDeclaration::semantic() %s\n", ds.toChars());
     if (ds.aliassym)
     {
         auto fd = ds.aliassym.isFuncLiteralDeclaration();

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -9282,14 +9282,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
  */
 Expression trySemantic(Expression exp, Scope* sc)
 {
-    //printf("+trySemantic(%s)\n", toChars());
+    //printf("+trySemantic(%s)\n", exp.toChars());
     uint errors = global.startGagging();
     Expression e = expressionSemantic(exp, sc);
     if (global.endGagging(errors))
     {
         e = null;
     }
-    //printf("-trySemantic(%s)\n", toChars());
+    //printf("-trySemantic(%s)\n", exp.toChars());
     return e;
 }
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2342,6 +2342,12 @@ private extern(C++) final class ResolveVisitor : Visitor
 
         //printf("TypeTypeof::resolve(this = %p, sc = %p, idents = '%s')\n", mt, sc, mt.toChars());
         //static int nest; if (++nest == 50) *(char*)0=0;
+        if (sc is null)
+        {
+            *pt = Type.terror;
+            error(loc, "Invalid scope.");
+            return;
+        }
         if (mt.inuse)
         {
             mt.inuse = 2;
@@ -2361,7 +2367,7 @@ private extern(C++) final class ResolveVisitor : Visitor
          * }
          * void main() {
          *   alias X = typeof(S!int());
-         *   assert(typeid(X).xtoString(null) == "x");
+         *   assert(typeid(X).toString() == "x");
          * }
          */
         Scope* sc2 = sc.push();

--- a/test/fail_compilation/fail18970.d
+++ b/test/fail_compilation/fail18970.d
@@ -1,0 +1,37 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18970.d(22): Error: no property `y` for type `S`
+fail_compilation/fail18970.d(29): Error: no property `yyy` for type `S2`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=18970
+
+struct S
+{
+    auto opDispatch(string name)(int)
+    {
+        alias T = typeof(x);
+        static assert(!is(T.U));
+        return 0;
+    }
+}
+void f()
+{
+    S().y(1);
+}
+
+struct S2
+{
+    this(int)
+    {
+        this.yyy;
+    }
+
+    auto opDispatch(string name)()
+    {
+        alias T = typeof(x);
+        static if(is(T.U)) {}
+    }
+}


### PR DESCRIPTION
The error doesn't get displayed, because for `opDispatch`  gagging is activated:

https://github.com/dlang/dmd/blob/ecc8d829b473e8477110305a6666759e568d94c5/src/dmd/typesem.d#L3056-L3063

(gets called from `TypeStruct::dotExp(e = 'S()', ident = 'y')` via `semanticY` and `resolveUFCS`)