### PR TITLE
Fix Issue 17864 - POD struct not equivalent to primitive type in comparison

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3056,8 +3056,6 @@ Lagain:
     {
         if (t1.mod != t2.mod)
         {
-            if (!t1.isImmutable() && !t2.isImmutable() && t1.isShared() != t2.isShared())
-                goto Lincompatible;
             ubyte mod = MODmerge(t1.mod, t2.mod);
             t1 = t1.castMod(mod);
             t2 = t2.castMod(mod);

--- a/test/compilable/test17864.d
+++ b/test/compilable/test17864.d
@@ -1,0 +1,10 @@
+// https://issues.dlang.org/show_bug.cgi?id=17864
+
+struct A { int a; }
+void g()
+{
+    shared A a;
+    A b;
+    a=b; //converts
+    assert(a==b); //fail
+}


### PR DESCRIPTION
I have to admit that I am terribly confused about `shared`. So this code:

```d
struct A { int a; }
void g()
{
	shared A a;
	A b;
	a=b; //converts
	assert(a==b); //fail
}
```

would print : "Error: incompatible types for ((a) is (b)): 'shared(A)' and 'A'", but the comparison succeeds if a's type qualifier is changed to `immutable` (and a = b is commented, obviously). Now, I am actually surprised that `a=b` compiles (from what I knew about shared, you were supposed to synchronize accesses to shared variables, although a is not global so it's not subject to concurrency issues). If a=b works there's no reason for a==b to fail compilation. The current fix is a noobish attempt from someone who doesn't really understand how shared works, so if there are any `shared` experts out there, please destroy!