### PR TITLE
fix issue 18953 - 32-bit: extern(C++) struct destructor not called cor…

### DIFF
--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1442,6 +1442,30 @@ void test18928()
 }
 
 /****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=18953
+// Win32: extern(C++) struct destructor not called correctly through runtime
+
+extern(C++) 
+struct S18953
+{
+    char x;
+    ~this() nothrow @nogc { traceBuf[traceBufPos++] = x; }
+}
+
+void test18953()
+{
+    traceBufPos = 0;
+    S18953[] arr = new S18953[3];
+    arr[1].x = '1';
+    arr[2].x = '2';
+    arr.length = 1;
+    assumeSafeAppend(arr); // destroys arr[1] and arr[2]
+    printf("traceBuf18953 %.*s\n", cast(int)traceBufPos, traceBuf.ptr);
+    assert(traceBuf[0..traceBufPos] == "21");
+}
+
+/****************************************/
+
 // https://issues.dlang.org/show_bug.cgi?id=18966
 
 extern(C++):
@@ -1535,6 +1559,7 @@ void main()
     test15589();
     test15589b();
     test18928();
+    test18953();
     test18966();
 
     printf("Success\n");


### PR DESCRIPTION
…rectly through runtime

mostly fixed by d08e0fb3bff6767bd28516f53393083d86f63045, but 32-bit platforms other than Win32 are affected, too. Also added function attribute inference for generated shim function.