### PR TITLE
Some foreach related fixes

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1926,6 +1926,8 @@ else
         Expression flde = new FuncExp(fs.loc, fld);
         flde = flde.expressionSemantic(sc);
         fld.tookAddressOf = 0;
+        if (flde.op == TOK.error)
+            return null;
         return cast(FuncExp)flde;
     }
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1907,10 +1907,10 @@ else
             LcopyArg:
                 id = Identifier.generateId("__applyArg", cast(int)i);
 
-                Initializer ie = new ExpInitializer(Loc.initial, new IdentifierExp(Loc.initial, id));
-                auto v = new VarDeclaration(Loc.initial, p.type, p.ident, ie);
+                Initializer ie = new ExpInitializer(fs.loc, new IdentifierExp(fs.loc, id));
+                auto v = new VarDeclaration(fs.loc, p.type, p.ident, ie);
                 v.storage_class |= STC.temp;
-                Statement s = new ExpStatement(Loc.initial, v);
+                Statement s = new ExpStatement(fs.loc, v);
                 fs._body = new CompoundStatement(fs.loc, s, fs._body);
             }
             params.push(new Parameter(stc, p.type, id, null));
@@ -1921,7 +1921,7 @@ else
         auto tf = new TypeFunction(params, Type.tint32, 0, LINK.d, stc);
         fs.cases = new Statements();
         fs.gotos = new ScopeStatements();
-        auto fld = new FuncLiteralDeclaration(fs.loc, Loc.initial, tf, TOK.delegate_, fs);
+        auto fld = new FuncLiteralDeclaration(fs.loc, fs.endloc, tf, TOK.delegate_, fs);
         fld.fbody = fs._body;
         Expression flde = new FuncExp(fs.loc, fld);
         flde = flde.expressionSemantic(sc);

--- a/test/fail_compilation/fail18994.d
+++ b/test/fail_compilation/fail18994.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18994.d(19): Error: struct `fail18994.Type1` is not copyable because it is annotated with `@disable`
+---
+*/
+struct Type2
+{
+    int opApply(int delegate(ref Type1)) { return 0; }
+}
+
+struct Type1
+{
+    @disable this(this);
+}
+
+void test()
+{
+    foreach(b; Type2()) {}
+}


### PR DESCRIPTION
Side note: dmd doesn't generate a call to _d_dynamic_cast when casting a Expression to FuncExp. How do you make it do that? I don't even know you could turn it off.

Edit: OK, never mind. I guess type checking is not done when casting `extern(C++)` classes. Seems really unsafe, though. We should check to make sure there is no more case of blind casting in dmd.