### PR TITLE
prelude to PR 8357

### DIFF
--- a/src/dmd/backend/dlist.d
+++ b/src/dmd/backend/dlist.d
@@ -13,7 +13,7 @@
  *              Copyright (c) 1999-2016 by Digital Mars, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(DMDSRC backend/tk/_dlist.d)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dlist.d, backend/dlist.d)
  */
 
 module dmd.backend.dlist;

--- a/src/dmd/backend/dvec.d
+++ b/src/dmd/backend/dvec.d
@@ -10,7 +10,7 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/dvec.d, backend/dvec.d)
  */
 
-module dvec;
+module dmd.backend.dvec;
 
 import core.stdc.stdio;
 import core.stdc.stdlib;

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -139,7 +139,8 @@ void util_set32();
 void util_set64();
 int ispow2(uint64_t);
 
-//#if __GNUC__
+version (Posix)
+{
 //#define util_malloc(n,size) mem_malloc((n)*(size))
 //#define util_calloc(n,size) mem_calloc((n)*(size))
 //#define util_free       mem_free
@@ -149,7 +150,9 @@ int ispow2(uint64_t);
 //#define parc_realloc    mem_realloc
 //#define parc_strdup     mem_strdup
 //#define parc_free       mem_free
-//#else
+}
+else
+{
 void *util_malloc(uint n,uint size);
 void *util_calloc(uint n,uint size);
 void util_free(void *p);
@@ -159,7 +162,7 @@ void *parc_calloc(size_t len);
 void *parc_realloc(void *oldp,size_t len);
 char *parc_strdup(const(char)* s);
 void parc_free(void *p);
-//#endif
+}
 
 void swap(int *, int *);
 //void crlf(FILE *);

--- a/src/dmd/backend/os.c
+++ b/src/dmd/backend/os.c
@@ -815,6 +815,16 @@ Lfail:
 }
 
 /***********************************
+ * Returns:
+ *   result of C library clock()
+ */
+
+int os_clock()
+{
+    return clock();
+}
+
+/***********************************
  * Return size of OS critical section.
  * NOTE: can't use the sizeof() calls directly since cross compiling is
  * supported and would end up using the host sizes rather than the target

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -20,7 +20,6 @@ import dmd.backend.dlist;
 import dmd.backend.el : elem;
 import dmd.backend.ty;
 
-
 extern (C++):
 @nogc:
 nothrow:

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -300,7 +300,7 @@ endif
 
 ifneq (gdc, $(HOST_DMD_KIND))
  ifeq (,$(findstring 2.068,$(HOST_DMD_VERSION)))
-  BACK_BETTERC = -betterC
+  BACK_BETTERC = -mv=dmd.backend=$C -betterC
  endif
 endif
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -524,7 +524,7 @@ $G/dt.obj : $C\dt.h $C\dt.c
 	$(CC) -c -o$@ $(MFLAGS) $C\dt
 
 $G/dvec.obj : $C\dvec.d
-	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC $C\dvec
+	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\dvec
 
 $G/dwarf.obj : $C\dwarf.h $C\dwarf.c
 	$(CC) -c -o$@ $(MFLAGS) $C\dwarf


### PR DESCRIPTION
Since https://github.com/dlang/dmd/pull/8357 suffers from a heisenbug somewhere in the compiler, this PR pulls out all the non-`go.d` changes of more general interest, so at least we can isolate 8357.