### PR TITLE
Aggregate extern(C++) changes into a single, more-detailed changelog.

### DIFF
--- a/changelog/extern_cpp_overhaul.dd
+++ b/changelog/extern_cpp_overhaul.dd
@@ -1,0 +1,24 @@
+`extern (C++)` construction, destruction, operators and other mangling improvements
+
+Many improvements have been made to the `extern(C++)` experience in this release cycle.
+
+Mangling improvements include:
+* Constructor/destructor mangling matches C++
+* Compatible D style operators now mangle as C++ operators
+* `nullptr_t` mangles correctly
+* Also various mangling bugs have been fixed
+
+`extern(C++)` APIs that use `nullptr_t` can use `typeof(null)` on the D side:
+---
+alias nullptr_t = typeof(null);
+extern (C++) void fun(nullptr_t);
+---
+
+`extern (C++)` mangling of operators is working for all operators that are semantically equivalent.
+This list includes all instantiations of `opUnary`, `opBinary`, `opAssign`, `opOpAssign`, `opCast`, `opEquals`, `opIndex`, `opCall`.
+Two notable exceptions are `opCmp`, and C++ `operator !`, which don't have compatible implementations.
+
+Mangling of `extern (C++) class` constructors and destructor are working.
+
+This release also includes ABI fixes where destructors are now correctly added to the virtual table, and constructor/destructor calling semantics now match C++.
+With this, mixed-language class hierarchies are working, with construction/destruction being supported in either language.

--- a/changelog/extern_cpp_overhaul.dd
+++ b/changelog/extern_cpp_overhaul.dd
@@ -3,10 +3,13 @@
 Many improvements have been made to the `extern(C++)` experience in this release cycle.
 
 Mangling improvements include:
-* Constructor/destructor mangling matches C++
-* Compatible D style operators now mangle as C++ operators
-* `nullptr_t` mangles correctly
-* Also various mangling bugs have been fixed
+
+$(UL
+  $(LI  Constructor/destructor mangling matches C++)
+  $(LI  Compatible D style operators now mangle as C++ operators)
+  $(LI  `nullptr_t` mangles correctly)
+  $(LI  Various mangling bugs have been fixed)
+)
 
 `extern(C++)` APIs that use `nullptr_t` can use `typeof(null)` on the D side:
 ---

--- a/changelog/mangle_ctor.dd
+++ b/changelog/mangle_ctor.dd
@@ -1,4 +1,0 @@
-`extern (C++)` now mangles class constructor's correctly.
-
-`extern (C++)` mangling of class constructor is working, also virtual and non-virtual destructors mangle correctly too.
-C++ semantics are not yet perfectly matching, but some simple cases are working.

--- a/changelog/mangle_nullptr_t.dd
+++ b/changelog/mangle_nullptr_t.dd
@@ -1,6 +1,0 @@
-`extern (C++)` is now able to mangle `typeof(null)` (aka: `nullptr_t`) which often appears in C++ API's.
-
----
-alias nullptr_t = typeof(null);
-extern (C++) void fun(nullptr_t);
----

--- a/changelog/mangle_operators.dd
+++ b/changelog/mangle_operators.dd
@@ -1,5 +1,0 @@
-`extern (C++)` operators now mangle correctly.
-
-`extern (C++)` mangling of operators is working for all operators that are semantically equivalent.
-This list includes all instantiations of `opUnary`, `opBinary`, `opAssign`, `opOpAssign`, `opCast`, `opEquals`, `opIndex`, `opCall`.
-Two notable exceptions are `opCmp`, and C++ `operator !`, which don't have compatible implementations.


### PR DESCRIPTION
I thought the release notes should make a better deal of these changes. They're massive for users interacting with C++ like myself.

Depends on Rainer's final patch in this suite of work being merged: https://github.com/dlang/dmd/pull/8362

Ideally this should land in 2.081