### PR TITLE
dlist.d cleanup: call va_end in list_build

### DIFF
--- a/src/dmd/backend/dlist.d
+++ b/src/dmd/backend/dlist.d
@@ -563,7 +563,7 @@ list_t list_build(void *p,...)
             pe = &list.next;
         }
     }
-    //va_end(ap);
+    va_end(ap);
     return alist;
 }
 


### PR DESCRIPTION
It compiles fine for me and AFAICT it's recommended to call it to avoid potential stack corruption:

https://stackoverflow.com/questions/587128/what-exactly-is-va-end-for-is-it-always-necessary-to-call-it

See also: https://github.com/dlang/dmd/pull/8317#discussion_r195918874