### PR TITLE
don't infer scope for locals with scoped destructor, fix issue 17934

### DIFF
--- a/test/fail_compilation/retscope3.d
+++ b/test/fail_compilation/retscope3.d
@@ -59,7 +59,7 @@ fail_compilation/retscope3.d(3027): Error: scope variable `l` assigned to `elem`
 
 #line 3000
 
-struct List
+scope struct List
 {
     Elem front() @safe return scope;
 


### PR DESCRIPTION
Need to find out why this inference was done.