### PR TITLE
Fix Issue 17656 - Enum member circular reference error

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2165,7 +2165,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (em.errors || em.semanticRun >= PASS.semanticdone)
             return;
-        if (em.semanticRun == PASS.semantic)
+        if (em.semanticRun == PASS.semantic && sc == em._scope)
         {
             em.error("circular reference to `enum` member");
             return errorReturn();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -54,7 +54,6 @@ import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
 
-enum LOGDOTEXP = 0;         // log ::dotExp()
 enum LOGDEFAULTINIT = 0;    // log ::defaultInit()
 
 extern (C++) __gshared int Tsize_t = Tuns32;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -56,6 +56,8 @@ import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
 
+enum LOGDOTEXP = 0;         // log ::dotExp()
+
 /************************************
  * Transitively search a type for all function types.
  * If any function types with parameters are found that have parameter identifiers

--- a/test/compilable/test17656.d
+++ b/test/compilable/test17656.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=17656
+
+enum E
+{
+    AAA = S.BBB
+}
+
+struct S
+{
+    enum SZAQ = E.AAA;
+    enum BBB = 8080;
+}


### PR DESCRIPTION
```d
enum E {
    AAA = S.BBB
}

struct S {
    enum SZAQ = E.AAA;
    enum BBB = 8080;
}
```

When `E` is semantically analyzed, each enum member has to go through the semantic pass. When `AAA = S.BBB` is reached, the compiler marks that `AAA` has started the first semantic pass [1]; if semantic1 is started again on AAA before the first attempt was finished, the compiler issues a "circular reference error" [2]. This is the correct behavior if we are dealing with circular references inside the enum declaration, but it is wrong on the general case, as this examples shows: part of the semantical analysis of `AAA` is to resolve `S.BBB`; when the compiler tries to resolve `BBB` it notices that semantic1 wasn't performed on S so it starts it. Now semantic1 is done for `enum SZAQ = E.AAA` which calls semantic1 for `E.AAA` so now we end up semantically analyzing AAA again thus hitting the error from [2].

The fix makes it so that the error in [2] is issued only for circular references to enum members inside the same enum, because the other cases are caught by other checks.

[1] https://github.com/dlang/dmd/blob/master/src/dmd/dsymbolsem.d#L2183
[2] https://github.com/dlang/dmd/blob/master/src/dmd/dsymbolsem.d#L2166