### PR TITLE
Partial DIP66, interoperation alias this and inheritance.

### DIFF
--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -13,6 +13,7 @@
 module dmd.aliasthis;
 
 import core.stdc.stdio;
+import core.stdc.string;
 import dmd.aggregate;
 import dmd.dscope;
 import dmd.dsymbol;
@@ -24,6 +25,16 @@ import dmd.mtype;
 import dmd.opover;
 import dmd.tokens;
 import dmd.visitor;
+import dmd.root.outbuffer;
+import dmd.dclass;
+import dmd.declaration;
+import dmd.func;
+import dmd.denum;
+import dmd.dtemplate;
+import dmd.arraytypes;
+import dmd.errors;
+import dmd.statement;
+import dmd.statementsem;
 
 /***********************************************************
  * alias ident this;
@@ -61,14 +72,25 @@ extern (C++) final class AliasThis : Dsymbol
     }
 }
 
-extern (C++) Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false)
+
+/*
+ * Resolves alias this of an expression: e -> e.aliasthissym
+ * Resolves alias this symbol as property or template if needed.
+ * Params:
+ *      sc = scope
+ *      e = expression to resolve
+ * Returns:
+ *      Result expression with resolved alias this symbol.
+ */
+private Expression resolveAliasThis(Scope* sc, Expression e)
 {
     AggregateDeclaration ad = isAggregate(e.type);
     if (ad && ad.aliasthis)
     {
-        uint olderrors = gag ? global.startGagging() : 0;
         Loc loc = e.loc;
         Type tthis = (e.op == TOK.type ? e.type : null);
+        e = e.expressionSemantic(sc);
+
         e = new DotIdExp(loc, e, ad.aliasthis.ident);
         e = e.expressionSemantic(sc);
         if (tthis && ad.aliasthis.needThis())
@@ -105,8 +127,1066 @@ extern (C++) Expression resolveAliasThis(Scope* sc, Expression e, bool gag = fal
             e = e.expressionSemantic(sc);
         }
         e = resolveProperties(sc, e);
-        if (gag && global.endGagging(olderrors))
-            e = null;
     }
     return e;
+}
+
+/*
+ * Similar resolveAliasThis, but it doesn't resolve properties and templates.
+ */
+private Expression resolveAliasThis2(Scope* sc, Expression e)
+{
+    AggregateDeclaration ad = isAggregate(e.type);
+    if (ad && ad.aliasthis)
+    {
+        Loc loc = e.loc;
+        Type tthis = (e.op == TOK.type ? e.type : null);
+        e = e.expressionSemantic(sc);
+        e = new DotIdExp(loc, e, ad.aliasthis.ident);
+        e = e.expressionSemantic(sc);
+    }
+    return e;
+}
+
+/**
+ * iterateAliasThis resolves alias this subtypes for `e` and applies it to `dg`.
+ * dg should return true, if appropriate subtype has been found.
+ * Otherwise it should returns false.
+ * `dg` can return result expression through  `outexpr` parameter, and if it is not
+ * null, it will be pushed to `ret` array.
+ * At the first stage iterateAliasThis checks direct alias this and pushes non-null
+ * `outexpr` to `ret`. If `dg` for direct "alias this" returns true then
+ * `iterateAliasThis` breaks at this stage and returns true through return value and
+ * returned by `dg` expression array through `ret`.
+ *
+ * If direct alias this did not return true iterateAliasThis
+ * is recursive applied to direct alias and base classes and interfaces.
+ * If one of those `iterateAliasThis` calls returns true our `iterateAliasThis` will return true.
+ * Otherwise it will return false.
+ *
+ * The last argument is needed for internal using and should be null in user call.
+ * It contains a hash table of visited types and used for avoiding of infinity recursion if
+ * processed type has a circular alias this subtyping:
+ * class A
+ * {
+ *      B b;
+ *      alias b this;
+ * }
+ *
+ * class B
+ * {
+ *      C c;
+ *      alias c this;
+ * }
+ *
+ * class C
+ * {
+ *      A a;
+ *      alias a this;
+ * }
+ *
+ * Params:
+ *      sc = Scope.
+ *      e = Expression to resolve subtypes.
+ *      dg = Delegate, which is applies to every subtype expression of e.
+ *           Takes scope, subtype expression and returns result expression through `outexpr`.
+ *           Returns true if subtypes expression is applied successfully, otherwise false.
+ *      ret = Result array of expressions, which returned by dg through `outexpr`.
+ *      resolve_at = Does need to resolve properties and templates for alias this.
+ *      gagerrors = Does need to gag errors.
+ *      directtypes = Inner parameter, table of passed types. Need to avoid circle recursion.
+ *                    Should be always null in caller code.
+ * Returns:
+ *      Result expression with resolved alias this symbol.
+ */
+bool iterateAliasThis(Scope* sc, Expression e, bool delegate(Scope* sc, Expression aliasexpr, ref Expression outexpr) dg,
+                      ref Expression[] ret, bool resolve_at = true, bool gagerrors = false, bool[string] directtypes = null)
+{
+    // printf("iterateAliasThis(%s)\n", e.toChars());
+    Dsymbol aliasThisSymbol = null;
+    Type baseType = e.type.toBasetype();
+    if (baseType.ty == Tstruct)
+    {
+        TypeStruct ts = cast(TypeStruct)baseType;
+        aliasThisSymbol = ts.sym.aliasthis;
+    }
+    else if (baseType.ty == Tclass)
+    {
+        TypeClass ts = cast(TypeClass)baseType;
+        aliasThisSymbol = ts.sym.aliasthis;
+    }
+    else
+    {
+        return false;
+    }
+
+    string deco = e.type.deco[0 .. strlen(e.type.deco)].idup;
+
+    bool *depth_counter = deco in directtypes;
+    if (!depth_counter)
+    {
+        directtypes[deco] = true;
+    }
+    else
+    {
+        return false; //This type has already been visited.
+    }
+
+    bool r = false;
+
+    if (aliasThisSymbol)
+    {
+        uint olderrors = 0;
+        if (gagerrors)
+            olderrors = global.startGagging();
+        Expression e1;
+        if (resolve_at)
+            e1 = resolveAliasThis(sc, e);
+        else
+            e1 = resolveAliasThis2(sc, e);
+
+        // printf("iterateAliasThis(%s) => %s\n", e.toChars(), e1.toChars());
+        if (!(gagerrors && global.endGagging(olderrors)) && e1 && e1.type && e1.type.ty != Terror)
+        {
+            assert(e1.type.deco);
+
+            Expression e2 = null;
+            // printf("iterateAliasThis(%s) dg(%s)\n", e.toChars(), e1.toChars());
+            int success = dg(sc, e1, e2);
+            r = r || success;
+
+            if (e2)
+            {
+                ret ~= e2;
+            }
+
+            if (!success)
+            {
+                if (!resolve_at)
+                {
+                    if (gagerrors)
+                        olderrors = global.startGagging();
+                    Expression eres = resolveAliasThis(sc, e);
+                    if (!(gagerrors && global.endGagging(olderrors)) && eres && eres.type && eres.type.ty != Terror)
+                    {
+                        e1 = eres;
+                    }
+                }
+                r = iterateAliasThis(sc, e1, dg, ret, resolve_at, gagerrors, directtypes) || r;
+            }
+        }
+    }
+
+    if (r)
+        return r; // direct alias this should hide inherited alias this for backward compatibility.
+
+    if (e.type.ty == Tclass)
+    {
+        ClassDeclaration cd = (cast(TypeClass)e.type).sym;
+        assert(cd.baseclasses);
+        for (size_t i = 0; i < cd.baseclasses.dim; ++i)
+        {
+            ClassDeclaration bd = (*cd.baseclasses)[i].sym;
+            Type bt = bd.type;
+            Expression e1 = e.castTo(sc, bt);
+            r = iterateAliasThis(sc, e1, dg, ret, resolve_at, gagerrors, directtypes) || r;
+        }
+    }
+
+    directtypes.remove(deco);
+    return r;
+}
+
+/**
+ * Returns the type of the alias this symbol of the type `t`.
+* If the `islvalue` is not null, `aliasThisOf` sets `*islvalue` to true
+ * if alias this symbol may be resolved to a L-value (if it variable of ref-property),
+ * otherwise it sets `*islvalue` to false.
+ * Params:
+ *      t = type.
+ *      islvalue = optional parameter. Needs to return if alias this of t is a l-value.
+ * Returns:
+ *      Type of alias this.
+ */
+
+Type aliasThisOf(Type t, bool* islvalue = null)
+{
+    bool dummy;
+    if (!islvalue)
+        islvalue = &dummy;
+    *islvalue = false;
+    AggregateDeclaration ad = isAggregate(t);
+    if (ad && ad.aliasthis)
+    {
+        Dsymbol s = ad.aliasthis;
+        if (s.isAliasDeclaration())
+            s = s.toAlias();
+        Declaration d = s.isDeclaration();
+        if (d && !d.isTupleDeclaration())
+        {
+            assert(d.type);
+            Type t2 = d.type;
+            if (d.isVarDeclaration() && d.needThis())
+            {
+                t2 = t2.addMod(t.mod);
+                *islvalue = true; //Variable is always l-value
+            }
+            else if (d.isFuncDeclaration())
+            {
+                FuncDeclaration fd = resolveFuncCall(Loc.initial, null, d, null, t, null, 1);
+                if (fd && fd.errors)
+                    return Type.terror;
+                if (fd && !fd.type.nextOf() && !fd.functionSemantic())
+                    fd = null;
+                if (fd)
+                {
+                    t2 = fd.type.nextOf();
+                    if (!t2) // issue 14185
+                        return Type.terror;
+                    t2 = t2.substWildTo(t.mod == 0 ? MODFlags.mutable : t.mod);
+                    if ((cast(TypeFunction)fd.type).isref)
+                        *islvalue = true;
+                }
+                else
+                    return Type.terror;
+            }
+            return t2;
+        }
+        EnumDeclaration ed = s.isEnumDeclaration();
+        if (ed)
+        {
+            Type t2 = ed.type;
+            return t2;
+        }
+        TemplateDeclaration td = s.isTemplateDeclaration();
+        if (td)
+        {
+            assert(td._scope);
+            FuncDeclaration fd = resolveFuncCall(Loc.initial, null, td, null, t, null, 1);
+            if (fd && fd.errors)
+                return Type.terror;
+            if (fd && fd.functionSemantic())
+            {
+                Type t2 = fd.type.nextOf();
+                t2 = t2.substWildTo(t.mod == 0 ? MODFlags.mutable : t.mod);
+                if ((cast(TypeFunction)fd.type).isref)
+                    *islvalue = true;
+                return t2;
+            }
+            else
+                return Type.terror;
+        }
+        //printf("%s\n", s.kind());
+    }
+    return null;
+}
+
+/**
+ * Walks over `from` basetype tree and search types,
+ * which can be converted (without alias this subtyping) to `to`.
+ * If there are many ways to convert `from` to `to`, this function
+ * raises an error and prints all those ways.
+ * To prevent infinity loop in types with circular subtyping,
+ * pattern "check a flag, lock a flag, do work is a flag wasn't locked, return flag back" is used.
+ * `root_from`, `full_symbol_name`, `state` and `matchname` are needed for internal
+ * using and should be null if the initial call.
+ *
+ * `full_symbol_name` contains the current symbol name like `TypeA.symbolX.symbolY` and needed
+ * for the error message creating.
+ * `state` contains current state of the lookup: no matches, there is one match,
+ * there are many matches: even if we have found two matches and we are know that
+ * we will raise the error, we should find remaining matches for the correct error message.
+ * `matchname` contains the full name of the found alias this symbol. It is needed,
+ * if we will find anothers matches and will need to raise an error.
+ * Params:
+ *      loc = Location
+ *      from = Type which need to be converted from
+ *      to = Type which need to be converted to
+ *      root_from = Initial `from` type and it is needed for correct error message creating.
+ *      full_symbol_name = Internal parameter, should be null in initial call.
+ *                         Accumulates the name of aliasthis-ed symbol e.g. from.aliasthis1.aliasthis2
+ *      state = Internal parameter, should be null in initial call.
+ *              Need to return state of searching from the recursion chain.
+ *      matchname = Internal parameter, should be null in initial call.
+ *                  Needs to contian name of matched symbol.
+ * Returns:
+ *      Is `from` can be converted to `to`
+ **/
+MATCH implicitConvToWithAliasThis(Loc loc, Type from, Type to, Type root_from = null, OutBuffer* full_symbol_name = null,
+                                  int* state = null, OutBuffer* matchname = null)
+{
+    //printf("implicitConvToWithAliasThis, %s . %s\n", from.toChars(), to.toChars());
+    if (from.aliasthislock & AliasThisRec.RECtracing)
+        return MATCH.nomatch;
+
+    uint oldatlock = from.aliasthislock;
+    from.aliasthislock |= AliasThisRec.RECtracing;
+    if (!full_symbol_name)
+    {
+        full_symbol_name = new OutBuffer();
+        full_symbol_name.writestring(from.toChars());
+    }
+    int st = 0; //0 - no match
+                //1 - match
+                //2 - many matches
+    if (!state)
+        state = &st;
+
+    if (!matchname)
+    {
+        matchname = new OutBuffer();
+    }
+
+    if (!root_from)
+    {
+        root_from = from;
+    }
+
+    AggregateDeclaration ad = isAggregate(from);
+    if (!ad)
+        return MATCH.nomatch;
+    AggregateDeclaration err_ad = isAggregate(root_from);
+    assert(err_ad);
+
+    MATCH mret = MATCH.nomatch;
+    if (ad && ad.aliasthis)
+    {
+        bool islvalue = false;
+        Type a = aliasThisOf(from, &islvalue);
+        if (a)
+        {
+            uint tatt = a.aliasthislock;
+            a.aliasthislock |= AliasThisRec.RECtracing;
+            MATCH m = a.implicitConvTo(to);
+            a.aliasthislock = tatt;
+
+            if (m != MATCH.nomatch)
+            {
+                if (*state == 0)
+                {
+                    // the first match
+                    *state = 1;
+                    mret = m;
+                    matchname.printf("%s.%s", full_symbol_name.peekString(), ad.aliasthis.toChars());
+                }
+                else if (*state == 1)
+                {
+                    // the second match
+                    *state = 2;
+                    err_ad.error(loc, "There are many candidates for cast %s to %s; Candidates:",
+                                  root_from.toChars(), to.toChars());
+                    err_ad.error(loc, " => %s", matchname.extractString());
+                    matchname.printf("%s.%s", full_symbol_name.peekString(), ad.aliasthis.toChars());
+                    err_ad.error(loc, " => %s", matchname.extractString());
+                }
+                else
+                {
+                    matchname.printf("%s.%s", full_symbol_name.peekString(), ad.aliasthis.toChars());
+                    err_ad.error(loc, " => %s", matchname.extractString());
+                }
+            }
+            else if (!(a.aliasthislock & AliasThisRec.RECtracing))
+            {
+                OutBuffer next_buff;
+                next_buff.printf("%s.%s", full_symbol_name.peekString(), ad.aliasthis.toChars());
+
+                MATCH m2 = implicitConvToWithAliasThis(loc, a, to, root_from, &next_buff, state, matchname);
+
+                if (mret == MATCH.nomatch)
+                    mret = m2;
+            }
+        }
+    }
+
+    if (ClassDeclaration cd = ad ? ad.isClassDeclaration() : null)
+    {
+        for (size_t i = 0; i < cd.baseclasses.dim; i++)
+        {
+            ClassDeclaration bd = (*cd.baseclasses)[i].sym;
+            Type bt = (*cd.baseclasses)[i].type;
+            if (!bt)
+                bt = bd.type;
+            if (!(bt.aliasthislock & AliasThisRec.RECtracing))
+            {
+                OutBuffer next_buff;
+                next_buff.printf("(cast(%s)%s)", bt.toChars(), full_symbol_name.peekString());
+
+                MATCH m2 = implicitConvToWithAliasThis(loc, bt, to, root_from, &next_buff, state, matchname);
+
+                if (mret == MATCH.nomatch)
+                    mret = m2;
+            }
+        }
+    }
+    from.aliasthislock = oldatlock;
+    return mret;
+}
+
+/***
+ * Returns (through `ret`) all subtypes of `t`, which can be implied via
+ * alias this mechanism.
+ * The `islvalues` contains the array of bool values: the one value for a
+ * one `ret` value.
+ * This value is true if appropriate type from `ret` refers to L-value symbol,
+ * otherwise this value if false.
+ * Params:
+ *      t = Initial type.
+ *      ret = Array of subtypes of `t`.
+ *      islvalues = Contains information for each type from `ret` if it is l-value.
+ */
+void getAliasThisTypes(Type t, ref Type[] ret, ref bool[] islvalues)
+{
+    AggregateDeclaration ad = isAggregate(t);
+    if (ad && ad.aliasthis)
+    {
+        bool islvalue = false;
+        Type a = aliasThisOf(t, &islvalue);
+        if (a)
+        {
+            bool duplicate = false;
+
+            for (size_t j = 0; j < ret.length; ++j)
+            {
+                if (ret[j].equals(a))
+                {
+                    duplicate = true;
+                    break;
+                }
+            }
+            if (!duplicate)
+            {
+                ret ~= a;
+                islvalues ~= islvalue;
+                getAliasThisTypes(a, ret, islvalues);
+            }
+        }
+    }
+
+    if (ClassDeclaration cd = ad ? ad.isClassDeclaration() : null)
+    {
+        for (size_t i = 0; i < cd.baseclasses.dim; i++)
+        {
+            ClassDeclaration bd = (*cd.baseclasses)[i].sym;
+            Type bt = (*cd.baseclasses)[i].type;
+            if (!bt)
+                bt = bd.type;
+            getAliasThisTypes(bt, ret, islvalues);
+        }
+    }
+}
+
+/***
+ * Enforces that results has only one element. Otherwise raises an error and prints
+ * all results.
+ * Params:
+ *      results = Expression array to check.
+ *      loc = Location for error.
+ *      fmt = Format string for error message.
+ *      args = parameters for error message.
+ * Returns:
+ *      results[0] if results contains only one element, ErrorExp, if results
+ *      contains many elements, otherwise null.
+ */
+Expression enforceOneResult(T...)(Expression[] results, Loc loc, const(char)* fmt, T args)
+{
+    if (results.length == 1)
+    {
+        return results[0];
+    }
+    else if (results.length > 1)
+    {
+        .error(loc, fmt, args);
+        for (size_t j = 0; j < results.length; ++j)
+        {
+            .errorSupplemental(loc, "%s", results[j].toChars());
+        }
+        return new ErrorExp();
+    }
+    return null;
+}
+
+
+struct TypeAliasThisCtx
+{
+    Type t;
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute a next subtype expression and check
+     * if it convertable to the target type.
+     * Returns true if the exactly matching has been found.
+     * Otherwise returns false.
+     */
+    bool castTo(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        uint oldatt = e.type.aliasthislock;
+        e.type.aliasthislock |= AliasThisRec.RECtracing;
+        MATCH m = e.type.implicitConvTo(t);
+        e.type.aliasthislock = oldatt;
+
+        if (m == MATCH.exact)
+        {
+            outexpr = e;
+            return true;
+        }
+        else if (m != MATCH.nomatch)
+        {
+            outexpr = e;
+            return false;
+        }
+
+        outexpr = null;
+        return false;
+    }
+
+    /**
+     * Should be called by iterateAliasThis.
+     * Similar castTo, but gags errors and accepts any kind of match with target type.
+     */
+    bool findType(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        uint errors = global.startGagging();
+        bool is_val = e.checkValue();
+        if (!global.endGagging(errors) && !is_val && e.type.implicitConvTo(t) != MATCH.nomatch)
+        {
+            outexpr = e;
+            return true;
+        }
+        return false;
+    }
+}
+
+struct FindMemberAliasThisCtx
+{
+    Loc loc;
+    Identifier ident;
+    int flags;
+    Dsymbol[] candidates;
+
+    this (Loc loc, Identifier ident, int flags)
+    {
+        this.loc = loc;
+        this.ident = ident;
+        this.flags = flags;
+    }
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to an DotIdExp inside an WithStatement.
+     * with(e) { ident } -> with(e) { aliasthisX.ident }
+     */
+    bool findMember(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        Dsymbol s = null;
+        if (e.op == TOK.import_)
+        {
+            s = (cast(ScopeExp)e).sds;
+        }
+        else if (e.op == TOK.type)
+        {
+            s = e.type.toDsymbol(null);
+        }
+        else
+        {
+            Type t = e.type.toBasetype();
+            s = t.toDsymbol(null);
+        }
+        if (s)
+        {
+            s = s.search(loc, ident);
+            if (s)
+            {
+                candidates ~= s;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+struct DeduceFunctionAliasThisCtx
+{
+    TemplateDeclaration td;
+    TemplateInstance ti;
+    Scope* sc;
+    FuncDeclaration fd;
+    Type tthis;
+    Expressions* fargs;
+    size_t idx;
+    FuncDeclaration[] ret_fd = [];
+
+    /**
+     * Should be called by iterateAliasThis.
+     * Deduce function from temeplate declaration, tries to apple alias this of parameters.
+     */
+    bool deduce(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        Expressions* fargs2 = fargs.copy();
+        (*fargs2)[idx] = e;
+        e.aliasthislock = true;
+        MATCH m = td.deduceFunctionTemplateMatch(ti, sc, fd, tthis, fargs2);
+        if (m != MATCH.nomatch)
+        {
+            outexpr = e;
+            ret_fd ~= fd;
+            return true;
+        }
+        return false;
+    }
+}
+
+struct UnaAliasThisCtx
+{
+
+    UnaExp ctx;
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to an UnaExp.
+     * una(e) -> una(e.aliasthisX)
+     */
+    bool atUna(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        // printf("atUna(%s); ue:  %s\n", e.toChars(), ctx.toChars());
+        UnaExp ue = cast(UnaExp)ctx.copy();
+        ue.aliasthislock = true;
+        ue.e1 = e; //replace op(e1) with op(e1.%aliasthis%)
+        Expression e2 = ue.trySemantic(sc);
+        if (e2)
+        {
+            outexpr = e2;
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to an UnaExp inside an UnaExp.
+     * una(una(e)) -> una(una(e.aliasthisX))
+     */
+    bool atUnaUna(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        UnaExp ue = cast(UnaExp)ctx.copy();
+        UnaExp ae = cast(UnaExp)ue.e1.copy();
+        ue.aliasthislock = true;
+        ae.e1 = e;
+        ue.e1 = ae;
+        Expression e2 = ue.trySemantic(sc);
+        if (e2)
+        {
+            outexpr = e2;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to an DotIdExp inside an UnaExp.
+     * una(e.ident) -> una(e.aliasthisX.ident)
+     */
+    bool atUnaDotId(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        UnaExp ue = cast(UnaExp)ctx.copy();
+        if (ue.e1.op != TOK.dotIdentifier)
+        {
+            printf("%s\n", Token.toChars(ue.e1.op));
+        }
+        assert(ue.e1.op == TOK.dotIdentifier || ue.e1.op == TOK.dotTemplateInstance);
+        UnaExp die = cast(UnaExp)ue.e1.copy();
+        ue.aliasthislock = true;
+        die.e1 = e;
+        Expression ey;
+
+        if (ue.e1.op == TOK.dotIdentifier)
+            ey = (cast(DotIdExp)die).semanticY(sc, 1);
+        else if (ue.e1.op == TOK.dotTemplateInstance)
+            ey = (cast(DotTemplateInstanceExp)die).semanticY(sc, 1);
+        else
+            assert(0);
+
+        if (!ey)
+            return false;
+        ue.e1 = ey;
+        Expression e2 = ue.trySemantic(sc);
+        if (e2)
+        {
+            outexpr = e2;
+            return true;
+        }
+        return false;
+    }
+
+}
+
+struct BinAliasThisCtx
+{
+
+    BinExp ctx;
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to an UnaExp inside a BinExp.
+     * bin(una(e), x) -> bin(una(e.aliasthisX), x)
+     */
+    bool atBinUna(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        BinExp e1 = cast(BinExp)ctx.copy();
+        UnaExp ae1 = cast(UnaExp)e1.e1;
+        ae1 = cast(UnaExp)ae1.copy();
+        e1.aliasthislock = true;
+        e1.e2 =  e1.e2.expressionSemantic(sc);
+        if (e1.e2.op == TOK.error)
+        {
+            return false;
+        }
+        ae1.e1 = e; //replace bin(una(e1), ...) with bin(una(e1.%aliasthis%), ...)
+        e1.e1 = ae1;
+        ae1.aliasthislock = true;
+        Expression e2 = e1.trySemantic(sc);
+        if (e2)
+        {
+            outexpr = e2;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Issue 11355:
+     * Should be called by iterateAliasThis.
+     * It substitutes subtyped expression to an rhs of a BinExp, if it converts to the lhs type.
+     * bin(x, e) -> bin(x, e.aliasthisX))
+     */
+    bool atBinRhsConv(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        BinExp e1 = cast(BinExp)ctx.copy();
+        e1.e2 = e.expressionSemantic(sc);
+        assert(e1.e1.type);
+        assert(e1.e2.type);
+        uint oldatlock1 = e1.e1.type.aliasthislock;
+        uint oldatlock2 = e1.e2.type.aliasthislock;
+        e1.e1.type.aliasthislock |= AliasThisRec.RECtracing;
+        e1.e2.type.aliasthislock |= AliasThisRec.RECtracing;
+        MATCH conv = e1.e1.type.implicitConvTo(e1.e2.type);
+        e1.e2.type.aliasthislock = oldatlock2;
+        e1.e1.type.aliasthislock = oldatlock1;
+        if (conv != MATCH.nomatch)
+        {
+            outexpr = e1.expressionSemantic(sc);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to a lhs of a BinExp.
+     * While it is working, it locks another term of the BinExp to prevent alias this resolving for it.
+     * bin(e, x) -> bin(e.aliasthis, x)
+     */
+    bool atBinLhs(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        BinExp be = cast(BinExp)ctx.copy();
+        be.e1 = e;
+        be.aliasthislock = true;
+        uint oldatlock1 = be.e1.type.aliasthislock;
+        uint oldatlock2 = be.e2.type.aliasthislock;
+        e.type.aliasthislock |= AliasThisRec.RECtracing;
+        be.e2.type.aliasthislock |= AliasThisRec.RECtracing;
+        be.e1.aliasthislock = true;
+        be.e2.aliasthislock = true;
+        Expression eret = be.trySemantic(sc);
+        be.e2.type.aliasthislock = oldatlock2;
+        e.type.aliasthislock = oldatlock1;
+        if (eret)
+        {
+            outexpr = eret;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to a rhs of a BinExp.
+     * While it is working, it locks another term of the BinExp to prevent alias this resolving for it.
+     * bin(x, e) -> bin(x, e.aliasthis)
+     */
+    bool atBinRhs(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        BinExp be = cast(BinExp)ctx.copy();
+        be.e2 = e;
+        be.aliasthislock = true;
+        uint oldatlock1 = be.e1.type.aliasthislock;
+        uint oldatlock2 = be.e2.type.aliasthislock;
+        be.e1.type.aliasthislock |= AliasThisRec.RECtracing;
+        be.e2.type.aliasthislock |= AliasThisRec.RECtracing;
+        Expression eret = be.trySemantic(sc);
+        be.e2.type.aliasthislock = oldatlock2;
+        be.e1.type.aliasthislock = oldatlock1;
+        if (eret)
+        {
+            outexpr = eret;
+            return true;
+        }
+        return false;
+    }
+}
+
+
+struct EmptyAliasThisCtx
+{
+    /**
+     * Should be called by iterateAliasThis
+     * It tries to cast subtyped expression to a bool value.
+     */
+    bool castToBool(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        uint errors = global.startGagging();
+        bool err = false;
+        Type etb = e.type.toBasetype();
+        uint oldatlock = etb.aliasthislock;
+        etb.aliasthislock |= AliasThisRec.RECtracing;
+        Expression eret = e.toBoolean(sc);
+        etb.aliasthislock = oldatlock;
+        if (eret && eret.op == TOK.error)
+            err = true;
+        if (!global.endGagging(errors) && !err)
+        {
+            outexpr = eret;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Should be called by iterateAliasThis
+     * It checks if subtyped expression is a value.
+     */
+    bool findType(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        uint errors = global.startGagging();
+        bool is_val = e.checkValue();
+        if (!global.endGagging(errors) && !is_val)
+        {
+            outexpr = e;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to a switch statement.
+     * switch(e) -> switch(e.aliasthis)
+     */
+    bool findSwitch(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        e.aliasthislock = true;
+        Statement _body = new DefaultStatement(Loc.initial, new BreakStatement(Loc.initial, null));
+        SwitchStatement ss = new SwitchStatement(Loc.initial, e, _body, false);
+        uint errors = global.startGagging();
+        Statement ss2 = statementSemantic(ss, sc);
+        if (!global.endGagging(errors))
+        {
+            outexpr = e;
+            return true;
+        }
+        return false;
+    }
+}
+
+struct IdentifierAliasThisCtx
+{
+    Identifier ident;
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to create DotIdExp from subtyped expression.
+     * una(e) -> una(e.aliasthisX)
+     */
+    bool findIdent(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        Expression e1 = new DotIdExp(e.loc, e, ident);
+        e1 = e1.trySemantic(sc);
+        if (e1)
+        {
+            outexpr = e1;
+            return true;
+        }
+        return false;
+    }
+}
+
+struct FindDotIdAliasThisCtx
+{
+    Identifier ident;
+    bool gagError;
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to an DotIdExp.
+     * e.ident -> e.aliasthisX.ident
+     */
+    bool findDotId(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        /* Rewrite e.ident as:
+         *  e.aliasthis.ident
+         */
+        DotIdExp die = new DotIdExp(e.loc, e, ident);
+        uint errors = gagError ? 0 : global.startGagging();
+        uint oldatlock = e.type.aliasthislock;
+        e.type.aliasthislock |= AliasThisRec.RECtracing;
+        Expression eret = die.semanticY(sc, gagError);
+        if (!gagError)
+        {
+            global.endGagging(errors);
+            if (eret && eret.op == TOK.error)
+                eret = null;
+        }
+        e.type.aliasthislock = oldatlock;
+
+        if (eret)
+        {
+            outexpr = eret;
+            return true;
+        }
+        return false;
+    }
+}
+
+struct BinExpBothAliasThisCtx
+{
+    Expression[]* results;
+    BinExp be;
+
+    /**
+     * Should be called by iterateAliasThis inside resolveAliasThisForBinExp.
+     * It tries to substitute subtyped expression to a lhs of a BinExp and apply all rhs subtypes to it.
+     * bin(x, e) -> bin(x, e.aliasthis)
+     */
+    bool atBinBoth(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        BinExp be1 = cast(BinExp)be.copy();
+        be1.e1 = e;
+        e.aliasthislock = true;
+        // e1.aliasthis op e2 => e1.aliasthis op e2.aliasthis
+        int ret = iterateAliasThis(sc, be1.e2, &BinAliasThisCtx(be1).atBinRhs, *results, true, true);
+
+        if (ret) //we don't need write to results: previous call have done it.
+            return true;
+        return false;
+    }
+};
+
+/**
+ * Search all conversions from binary expressions `be` using alias this.
+ * Prefer conversions which changes only one term of `be`
+ * Params:
+ *      sc = Scope.
+ *      be = binary expression to resolve.
+ *      check_lvl = Does need to convert left term of be using alias this.
+ *      check_rvl = Does need to convert right term of be using alias this.
+ * Returns:
+ *      Result expression if only one conversion has been found, ErrorExp if many results
+ *      have been found, null if no results.
+ */
+Expression resolveAliasThisForBinExp(Scope *sc, BinExp be, bool check_lvl, bool check_rvl)
+{
+    // printf("resolveAliasThisForBinExp(%s); %d, %d\n", be.toChars(), cast(int)check_lvl, cast(int)check_rvl);
+    Expression[] ret;
+    if (check_lvl)
+    {
+        // e1 op e2 => e1.aliasthis op e2
+        // don't resolve left alias this to property call
+        iterateAliasThis(sc, be.e1, &BinAliasThisCtx(be).atBinLhs, ret, false, true);
+    }
+
+    Expression[] right_ret;
+    if (check_rvl)
+    {
+        // e1 op e2 => e1 op e2.aliasthis
+        iterateAliasThis(sc, be.e2, &BinAliasThisCtx(be).atBinRhs, right_ret, true, true);
+    }
+
+    if (ret.length == 1 && right_ret.length > 0)
+    {
+        be.deprecation("binary expression %s is resolved as %s; however there are other ways:", be.toChars(), ret[0].toChars());
+        for (size_t j = 0; j < right_ret.length; ++j)
+        {
+            .deprecationSupplemental(be.loc, "%s", right_ret[j].toChars());
+        }
+        return ret[0];
+    }
+
+    ret ~= right_ret;
+    if (ret.length == 1)
+    {
+        //if we have a one result - return it
+        return ret[0];
+    }
+    else if (ret.length > 1)
+    {
+        //if we have many results - raise a error
+        be.error("unable to unambiguously resolve %s; candidates:", be.toChars());
+        for (size_t j = 0; j < ret.length; ++j)
+        {
+            .errorSupplemental(be.loc, "%s", ret[j].toChars());
+        }
+        return new ErrorExp();
+    }
+
+    if (check_lvl && check_rvl)
+    {
+        //if we haven't results try to compile e1.aliasthis op e2.aliasthis
+        // e1 op e2 -> e1.aliasthis op e2.aliasthis
+        // don't resolve left alias this to property call
+        iterateAliasThis(sc, be.e1, &BinExpBothAliasThisCtx(&ret, be).atBinBoth, ret, false, true);
+    }
+    if (ret.length == 1)
+    {
+        //if we have a one result - return it
+        return ret[0];
+    }
+    else if (ret.length > 1)
+    {
+        //if we have many results - raise a error
+        be.error("unable to unambiguously resolve %s; candidates:", be.toChars());
+        for (size_t j = 0; j < ret.length; ++j)
+        {
+            .errorSupplemental(be.loc, "%s", ret[j].toChars());
+        }
+        return new ErrorExp();
+    }
+
+    return null;
+}
+
+struct ForeachAliasThisCtx
+{
+    Scope* sc;
+    bool isForeach;
+
+    /**
+     * Should be called by iterateAliasThis.
+     * It tries to substitute subtyped expression to a foreach statement.
+     * foreach(...; e) -> foreach(...; e.aliasthis)
+     */
+    bool findForeach(Scope *sc, Expression e, ref Expression outexpr)
+    {
+        Dsymbol sapply = null;
+        uint oldatlock = e.type.aliasthislock;
+        e.type.aliasthislock |= AliasThisRec.RECtracing;
+        bool ret = inferForeachAggregate(sc, isForeach, e, sapply);
+        e.type.aliasthislock = oldatlock;
+        if (ret)
+        {
+            outexpr = e;
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2966,6 +2966,20 @@ Lagain:
     t1 = t1b;
     t2 = t2b;
 
+    bool tryToMergeAliasThis(Scope *sc, Type *pt, TOK op, Expression *pe1, Expression *pe2)
+    {
+        bool r = mergeAliasThis(sc, pt, op, pe1, pe2);
+        if (r)
+        {
+            e1 = *pe1;
+            e2 = *pe2;
+            t1 = e1.type;
+            t2 = e2.type;
+            t = *pt;
+        }
+        return r;
+    }
+
     if (t1.ty == Ttuple || t2.ty == Ttuple)
         goto Lincompatible;
 
@@ -3181,6 +3195,7 @@ Lagain:
     else if (t1.ty == Tclass || t2.ty == Tclass)
     {
     Lcc:
+
         while (1)
         {
             MATCH i1 = e2.implicitConvTo(t1);
@@ -3232,16 +3247,7 @@ Lagain:
                     Expression te1 = e1;
                     Expression te2 = e2;
                     Type tt1 = t;
-                    int r = mergeAliasThis(sc, &tt1, op, &te1, &te2);
-                    if (r)
-                    {
-                        e1 = te1;
-                        e2 = te2;
-                        t1 = e1.type;
-                        t2 = e2.type;
-                        t = tt1;
-                    }
-                    else
+                    if (!tryToMergeAliasThis(sc, &tt1, op, &te1, &te2))
                     {
                         goto Lincompatible;
                     }
@@ -3251,39 +3257,12 @@ Lagain:
                     goto Lincompatible;
                 }
             }
-            else if ((t1.ty == Tstruct || t1.ty == Tclass) && checkaliastthis)
+            else if ((t1.ty == Tstruct || t1.ty == Tclass || t2.ty == Tstruct || t2.ty == Tclass) && checkaliastthis)
             {
                 Expression te1 = e1;
                 Expression te2 = e2;
                 Type tt1 = *pt;
-                int r = mergeAliasThis(sc, &tt1, op, &te1, &te2);
-                if (r)
-                {
-                    e1 = te1;
-                    e2 = te2;
-                    t1 = e1.type;
-                    t2 = e2.type;
-                }
-                else
-                {
-                    goto Lincompatible;
-                }
-                continue;
-            }
-            else if ((t2.ty == Tstruct || t2.ty == Tclass) && checkaliastthis)
-            {
-                Expression te1 = e1;
-                Expression te2 = e2;
-                Type tt1 = *pt;
-                int r = mergeAliasThis(sc, &tt1, op, &te1, &te2);
-                if (r)
-                {
-                    e1 = te1;
-                    e2 = te2;
-                    t1 = e1.type;
-                    t2 = e2.type;
-                }
-                else
+                if (!tryToMergeAliasThis(sc, &tt1, op, &te1, &te2))
                 {
                     goto Lincompatible;
                 }
@@ -3316,14 +3295,8 @@ Lagain:
             Expression te1 = e1;
             Expression te2 = e2;
             Type tt1 = t;
-            int r = mergeAliasThis(sc, &tt1, op, &te1, &te2);
-            if (r)
+            if (tryToMergeAliasThis(sc, &tt1, op, &te1, &te2))
             {
-                e1 = te1;
-                e2 = te2;
-                t1 = e1.type;
-                t2 = e2.type;
-                t = tt1;
                 goto Lagain;
             }
         }

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1747,6 +1747,7 @@ extern (C++) final class WithScopeSymbol : ScopeDsymbol
         FindMemberAliasThisCtx ctx = FindMemberAliasThisCtx(loc, ident, flags);
         iterateAliasThis(_scope, e, &ctx.findMember, results);
 
+        assert(ctx.candidates.length == results.length);
         if (ctx.candidates.length == 1)
         {
             return ctx.candidates[0];
@@ -1754,9 +1755,9 @@ extern (C++) final class WithScopeSymbol : ScopeDsymbol
         else if (ctx.candidates.length > 1)
         {
             e.error("there are many candidates to %s.%s resolve:", e.toChars(), ident.toChars());
-            for (size_t j = 0; j < results.length; ++j)
+            for (size_t j = 0; j < ctx.candidates.length; ++j)
             {
-                .errorSupplemental(e.loc, "%s", results[j].toChars());
+                .errorSupplemental(e.loc, "%s.%s", results[j].toChars(), ctx.candidates[j].toChars());
             }
         }
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -533,7 +533,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             assert(t);
             if (ad.type.implicitConvTo(t) > MATCH.nomatch)
             {
-                error(dsym.loc, "alias this is not reachable as `%s` already converts to `%s`", ad.toChars(), t.toChars());
+                deprecation(dsym.loc, "alias this is not reachable as `%s` already converts to `%s`", ad.toChars(), t.toChars());
             }
         }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1263,7 +1263,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     hasttp = true;
 
                     Type t = new TypeIdentifier(Loc.initial, ttp.ident);
-                    MATCH m = deduceType(tthis, paramscope, t, parameters, dedtypes);
+                    MATCH m = deduceType(ti.loc, tthis, paramscope, t, parameters, dedtypes);
                     if (m <= MATCH.nomatch)
                         goto Lnomatch;
                     if (m < match)
@@ -1560,7 +1560,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     if (farg.op == TOK.error || farg.type.ty == Terror)
                         goto Lnomatch;
 
-                    Type att = null;
                 Lretry:
                     version (none)
                     {
@@ -1630,7 +1629,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         goto Lvarargs;
 
                     uint wm = 0;
-                    MATCH m = deduceType(oarg, paramscope, prmtype, parameters, dedtypes, &wm, inferStart);
+                    MATCH m = deduceType(ti.loc, oarg, paramscope, prmtype, parameters, dedtypes, &wm, inferStart);
                     //printf("\tL%d deduceType m = %d, wm = x%x, wildmatch = x%x\n", __LINE__, m, wm, wildmatch);
                     wildmatch |= wm;
 
@@ -1642,19 +1641,24 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                     if (m == MATCH.nomatch)
                     {
+
                         AggregateDeclaration ad = isAggregate(farg.type);
-                        if (ad && ad.aliasthis && argtype != att)
+                        if (ad && !farg.aliasthislock)
                         {
-                            if (!att && argtype.checkAliasThisRec())   // https://issues.dlang.org/show_bug.cgi?id=12537
-                                att = argtype;
-                            /* If a semantic error occurs while doing alias this,
-                             * eg purity(https://issues.dlang.org/show_bug.cgi?id=7295),
-                             * just regard it as not a match.
-                             */
-                            if (auto e = resolveAliasThis(sc, farg, true))
+                            // iterate all alias this options:
+                            Expression[] results;
+                            DeduceFunctionAliasThisCtx ctx = DeduceFunctionAliasThisCtx(this, ti, sc, fd, tthis, fargs, argi);
+
+                            iterateAliasThis(sc, farg, &ctx.deduce, results, true, true);
+                            if (results.length == 1)
                             {
-                                farg = e;
+                                farg = results[0];
+                                fd = ctx.ret_fd[0];
                                 goto Lretry;
+                            }
+                            else if (results.length > 1)
+                            {
+                                goto Lnomatch;
                             }
                         }
                     }
@@ -1809,7 +1813,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                             else
                             {
                                 uint wm = 0;
-                                m = deduceType(arg, paramscope, ta.next, parameters, dedtypes, &wm, inferStart);
+                                m = deduceType(ti.loc, arg, paramscope, ta.next, parameters, dedtypes, &wm, inferStart);
                                 wildmatch |= wm;
                             }
                             if (m == MATCH.nomatch)
@@ -3195,7 +3199,7 @@ __gshared Expression emptyArrayElement = null;
  * Output:
  *      dedtypes = [ int ]      // Array of Expression/Type's
  */
-MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm = null, size_t inferStart = 0)
+MATCH deduceType(Loc l, RootObject o, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm = null, size_t inferStart = 0)
 {
     extern (C++) final class DeduceType : Visitor
     {
@@ -3207,9 +3211,10 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         Objects* dedtypes;
         uint* wm;
         size_t inferStart;
+        Loc loc;
         MATCH result;
 
-        extern (D) this(Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm, size_t inferStart)
+        extern (D) this(Loc loc, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm, size_t inferStart)
         {
             this.sc = sc;
             this.tparam = tparam;
@@ -3217,6 +3222,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             this.dedtypes = dedtypes;
             this.wm = wm;
             this.inferStart = inferStart;
+            this.loc = loc;
             result = MATCH.nomatch;
         }
 
@@ -3259,7 +3265,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                      */
                     tparam = tparam.typeSemantic(loc, sc);
                     assert(tparam.ty != Tident);
-                    result = deduceType(t, sc, tparam, parameters, dedtypes, wm);
+                    result = deduceType(loc, t, sc, tparam, parameters, dedtypes, wm);
                     return;
                 }
 
@@ -3436,36 +3442,39 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         goto Lnomatch;
                 }
 
+                uint oldatlock1 = t.aliasthislock;
+                t.aliasthislock |= AliasThisRec.RECtracing;
                 MATCH m = t.implicitConvTo(tparam);
+                t.aliasthislock = oldatlock1;
                 if (m == MATCH.nomatch)
                 {
-                    if (t.ty == Tclass)
+                    m = implicitConvToWithAliasThis(loc, t, tparam);
+                }
+                if (m == MATCH.nomatch)
+                {
+                    if (!(tparam.aliasthislock & AliasThisRec.RECtracingDT))
                     {
-                        TypeClass tc = cast(TypeClass)t;
-                        if (tc.sym.aliasthis && !(tc.att & AliasThisRec.tracingDT))
+                        //do not call deduceType (with alias this) recursively.
+                        Type[] basetypes;
+                        bool[] islvalues;
+                        getAliasThisTypes(t, basetypes, islvalues);
+
+                        for (size_t i = 0; i < basetypes.length; i++)
                         {
-                            if (auto ato = t.aliasthisOf())
+                            uint oldatlock2 = tparam.aliasthislock;
+                            tparam.aliasthislock |= AliasThisRec.RECtracingDT;
+                            m = deduceType(loc, basetypes[i], sc, tparam, parameters, dedtypes, wm);
+                            tparam.aliasthislock = oldatlock2;
+                            if (m != MATCH.nomatch)
                             {
-                                tc.att = cast(AliasThisRec)(tc.att | AliasThisRec.tracingDT);
-                                m = deduceType(ato, sc, tparam, parameters, dedtypes, wm);
-                                tc.att = cast(AliasThisRec)(tc.att & ~AliasThisRec.tracingDT);
-                            }
-                        }
-                    }
-                    else if (t.ty == Tstruct)
-                    {
-                        TypeStruct ts = cast(TypeStruct)t;
-                        if (ts.sym.aliasthis && !(ts.att & AliasThisRec.tracingDT))
-                        {
-                            if (auto ato = t.aliasthisOf())
-                            {
-                                ts.att = cast(AliasThisRec)(ts.att | AliasThisRec.tracingDT);
-                                m = deduceType(ato, sc, tparam, parameters, dedtypes, wm);
-                                ts.att = cast(AliasThisRec)(ts.att & ~AliasThisRec.tracingDT);
+                                //Ok, now test, is there only one way exists
+                                m = implicitConvToWithAliasThis(loc, t, basetypes[i]);
+                                break;
                             }
                         }
                     }
                 }
+
                 result = m;
                 return;
             }
@@ -3486,7 +3495,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     tpn = tpn.substWildTo(MODFlags.mutable);
                 }
 
-                result = deduceType(t.nextOf(), sc, tpn, parameters, dedtypes, wm);
+                result = deduceType(loc, t.nextOf(), sc, tpn, parameters, dedtypes, wm);
                 return;
             }
 
@@ -3515,7 +3524,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             if (tparam.ty == Tvector)
             {
                 TypeVector tp = cast(TypeVector)tparam;
-                result = deduceType(t.basetype, sc, tp.basetype, parameters, dedtypes, wm);
+                result = deduceType(loc, t.basetype, sc, tp.basetype, parameters, dedtypes, wm);
                 return;
             }
             visit(cast(Type)t);
@@ -3550,7 +3559,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             {
                 if (tparam.ty == Tarray)
                 {
-                    MATCH m = deduceType(t.next, sc, tparam.nextOf(), parameters, dedtypes, wm);
+                    MATCH m = deduceType(loc, t.next, sc, tparam.nextOf(), parameters, dedtypes, wm);
                     result = (m >= MATCH.constant) ? MATCH.convert : MATCH.nomatch;
                     return;
                 }
@@ -3588,7 +3597,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 }
                 if (tp && tp.matchArg(sc, t.dim, i, parameters, dedtypes, null) || edim && edim.toInteger() == t.dim.toInteger())
                 {
-                    result = deduceType(t.next, sc, tparam.nextOf(), parameters, dedtypes, wm);
+                    result = deduceType(loc, t.next, sc, tparam.nextOf(), parameters, dedtypes, wm);
                     return;
                 }
             }
@@ -3610,7 +3619,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             if (tparam && tparam.ty == Taarray)
             {
                 TypeAArray tp = cast(TypeAArray)tparam;
-                if (!deduceType(t.index, sc, tp.index, parameters, dedtypes))
+                if (!deduceType(loc, t.index, sc, tp.index, parameters, dedtypes))
                 {
                     result = MATCH.nomatch;
                     return;
@@ -3746,7 +3755,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     Parameter ap = Parameter.getNth(tp.parameters, i);
 
                     if (!a.isCovariant(t.isref, ap) ||
-                        !deduceType(a.type, sc, ap.type, parameters, dedtypes))
+                        !deduceType(loc, a.type, sc, ap.type, parameters, dedtypes))
                     {
                         result = MATCH.nomatch;
                         return;
@@ -3953,7 +3962,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
                     if (t1 && t2)
                     {
-                        if (!deduceType(t1, sc, t2, parameters, dedtypes))
+                        if (!deduceType(loc, t1, sc, t2, parameters, dedtypes))
                             goto Lnomatch;
                     }
                     else if (e1 && e2)
@@ -4059,7 +4068,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 if (ti && ti.toAlias() == t.sym)
                 {
                     auto tx = new TypeInstance(Loc.initial, ti);
-                    result = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
+                    result = deduceType(loc, tx, sc, tparam, parameters, dedtypes, wm);
                     return;
                 }
 
@@ -4078,7 +4087,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                             /* Slice off the .foo in S!(T).foo
                              */
                             tpi.idents.dim--;
-                            result = deduceType(tparent, sc, tpi, parameters, dedtypes, wm);
+                            result = deduceType(loc, tparent, sc, tpi, parameters, dedtypes, wm);
                             tpi.idents.dim++;
                             return;
                         }
@@ -4097,7 +4106,15 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     result = MATCH.constant;
                     return;
                 }
+
+                uint oldatlock = t.aliasthislock;
+                t.aliasthislock |= AliasThisRec.RECtracing;
                 result = t.implicitConvTo(tp);
+                t.aliasthislock = oldatlock;
+                if (!result)
+                {
+                    result = implicitConvToWithAliasThis(loc, t, tp);
+                }
                 return;
             }
             visit(cast(Type)t);
@@ -4118,7 +4135,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             Type tb = t.toBasetype();
             if (tb.ty == tparam.ty || tb.ty == Tsarray && tparam.ty == Taarray)
             {
-                result = deduceType(tb, sc, tparam, parameters, dedtypes, wm);
+                result = deduceType(loc, tb, sc, tparam, parameters, dedtypes, wm);
                 return;
             }
             visit(cast(Type)t);
@@ -4142,7 +4159,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
          * If a match occurs, numBaseClassMatches is incremented, and the new deduced
          * types are ANDed with the current 'best' estimate for dedtypes.
          */
-        static void deduceBaseClassParameters(ref BaseClass b, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, Objects* best, ref int numBaseClassMatches)
+        static void deduceBaseClassParameters(Loc loc, ref BaseClass b, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, Objects* best, ref int numBaseClassMatches)
         {
             TemplateInstance parti = b.sym ? b.sym.parent.isTemplateInstance() : null;
             if (parti)
@@ -4152,7 +4169,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 memcpy(tmpdedtypes.tdata(), dedtypes.tdata(), dedtypes.dim * (void*).sizeof);
 
                 auto t = new TypeInstance(Loc.initial, parti);
-                MATCH m = deduceType(t, sc, tparam, parameters, tmpdedtypes);
+                MATCH m = deduceType(loc, t, sc, tparam, parameters, tmpdedtypes);
                 if (m > MATCH.nomatch)
                 {
                     // If this is the first ever match, it becomes our best estimate
@@ -4173,7 +4190,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             // Now recursively test the inherited interfaces
             foreach (ref bi; b.baseInterfaces)
             {
-                deduceBaseClassParameters(bi, sc, tparam, parameters, dedtypes, best, numBaseClassMatches);
+                deduceBaseClassParameters(loc, bi, sc, tparam, parameters, dedtypes, best, numBaseClassMatches);
             }
         }
 
@@ -4192,7 +4209,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 if (ti && ti.toAlias() == t.sym)
                 {
                     auto tx = new TypeInstance(Loc.initial, ti);
-                    MATCH m = deduceType(tx, sc, tparam, parameters, dedtypes, wm);
+                    MATCH m = deduceType(loc, tx, sc, tparam, parameters, dedtypes, wm);
                     // Even if the match fails, there is still a chance it could match
                     // a base class.
                     if (m != MATCH.nomatch)
@@ -4217,7 +4234,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                             /* Slice off the .foo in S!(T).foo
                              */
                             tpi.idents.dim--;
-                            result = deduceType(tparent, sc, tpi, parameters, dedtypes, wm);
+                            result = deduceType(loc, tparent, sc, tpi, parameters, dedtypes, wm);
                             tpi.idents.dim++;
                             return;
                         }
@@ -4243,12 +4260,12 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 while (s && s.baseclasses.dim > 0)
                 {
                     // Test the base class
-                    deduceBaseClassParameters(*(*s.baseclasses)[0], sc, tparam, parameters, dedtypes, best, numBaseClassMatches);
+                    deduceBaseClassParameters(loc, *(*s.baseclasses)[0], sc, tparam, parameters, dedtypes, best, numBaseClassMatches);
 
                     // Test the interfaces inherited by the base class
                     foreach (b; s.interfaces)
                     {
-                        deduceBaseClassParameters(*b, sc, tparam, parameters, dedtypes, best, numBaseClassMatches);
+                        deduceBaseClassParameters(loc, *b, sc, tparam, parameters, dedtypes, best, numBaseClassMatches);
                     }
                     s = (*s.baseclasses)[0].sym;
                 }
@@ -4276,7 +4293,14 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     result = MATCH.constant;
                     return;
                 }
+                uint oldatlock = t.aliasthislock;
+                t.aliasthislock |= AliasThisRec.RECtracing;
                 result = t.implicitConvTo(tp);
+                t.aliasthislock = oldatlock;
+                if (!result)
+                {
+                    result = implicitConvToWithAliasThis(loc, t, tp);
+                }
                 return;
             }
             visit(cast(Type)t);
@@ -4291,7 +4315,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 if (e == emptyArrayElement && tparam.ty == Tarray)
                 {
                     Type tn = (cast(TypeNext)tparam).next;
-                    result = deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
+                    result = deduceType(loc, emptyArrayElement, sc, tn, parameters, dedtypes, wm);
                     return;
                 }
                 e.type.accept(this);
@@ -4454,7 +4478,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             assert(tparam.ty == Tarray);
 
             Type tn = (cast(TypeNext)tparam).next;
-            return deduceType(emptyArrayElement, sc, tn, parameters, dedtypes, wm);
+            return deduceType(loc, emptyArrayElement, sc, tn, parameters, dedtypes, wm);
         }
 
         override void visit(NullExp e)
@@ -4495,7 +4519,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 result = MATCH.exact;
                 if (e.basis)
                 {
-                    MATCH m = deduceType(e.basis, sc, tn, parameters, dedtypes, wm);
+                    MATCH m = deduceType(loc, e.basis, sc, tn, parameters, dedtypes, wm);
                     if (m < result)
                         result = m;
                 }
@@ -4506,7 +4530,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     auto el = (*e.elements)[i];
                     if (!el)
                         continue;
-                    MATCH m = deduceType(el, sc, tn, parameters, dedtypes, wm);
+                    MATCH m = deduceType(loc, el, sc, tn, parameters, dedtypes, wm);
                     if (m < result)
                         result = m;
                 }
@@ -4531,12 +4555,12 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 result = MATCH.exact;
                 for (size_t i = 0; i < e.keys.dim; i++)
                 {
-                    MATCH m1 = deduceType((*e.keys)[i], sc, taa.index, parameters, dedtypes, wm);
+                    MATCH m1 = deduceType(loc, (*e.keys)[i], sc, taa.index, parameters, dedtypes, wm);
                     if (m1 < result)
                         result = m1;
                     if (result <= MATCH.nomatch)
                         break;
-                    MATCH m2 = deduceType((*e.values)[i], sc, taa.next, parameters, dedtypes, wm);
+                    MATCH m2 = deduceType(loc, (*e.values)[i], sc, taa.next, parameters, dedtypes, wm);
                     if (m2 < result)
                         result = m2;
                     if (result <= MATCH.nomatch)
@@ -4649,7 +4673,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         }
     }
 
-    scope DeduceType v = new DeduceType(sc, tparam, parameters, dedtypes, wm, inferStart);
+    scope DeduceType v = new DeduceType(l, sc, tparam, parameters, dedtypes, wm, inferStart);
     if (Type t = isType(o))
         t.accept(v);
     else
@@ -5236,7 +5260,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
                 goto Lnomatch;
 
             //printf("\tcalling deduceType(): ta is %s, specType is %s\n", ta.toChars(), specType.toChars());
-            MATCH m2 = deduceType(ta, sc, specType, parameters, dedtypes);
+            MATCH m2 = deduceType(loc, ta, sc, specType, parameters, dedtypes);
             if (m2 <= MATCH.nomatch)
             {
                 //printf("\tfailed deduceType\n");
@@ -5723,7 +5747,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
                     goto Lnomatch;
 
                 Type t = new TypeInstance(Loc.initial, ti);
-                MATCH m2 = deduceType(t, sc, talias, parameters, dedtypes);
+                MATCH m2 = deduceType(loc, t, sc, talias, parameters, dedtypes);
                 if (m2 <= MATCH.nomatch)
                     goto Lnomatch;
             }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1522,7 +1522,10 @@ extern (C++) abstract class Expression : RootObject
                 if (ret)
                 {
                     if (ret.op == TOK.error)
+                    {
+                        // can not be tested now, bacause structs with multiple alias this are not implemented yet
                         return ret;
+                    }
                     e = ret;
                     t = e.type;
                     tb = e.type.toBasetype();

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -69,7 +69,6 @@ bool arrayExpressionSemantic(Expressions *exps, Scope *sc, bool preserveErrors =
 TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 Expression *valueNoDtor(Expression *e);
 int modifyFieldVar(Loc loc, Scope *sc, VarDeclaration *var, Expression *e1);
-Expression *resolveAliasThis(Scope *sc, Expression *e, bool gag = false);
 Expression *doCopyOrMove(Scope *sc, Expression *e);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, Expression **pe0);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, IntervalExp *ie, Expression **pe0);
@@ -129,6 +128,7 @@ public:
     TOK op;                     // to minimize use of dynamic_cast
     unsigned char size;         // # of bytes in Expression so we can copy() it
     unsigned char parens;       // if this is a parenthesized expression
+    bool aliasthislock;         // used to prevent alias this resolving
 
     static void _init();
     Expression *copy();
@@ -683,7 +683,6 @@ class UnaExp : public Expression
 {
 public:
     Expression *e1;
-    Type *att1; // Save alias this type to detect recursion
 
     Expression *syntaxCopy();
     Expression *incompatibleTypes();
@@ -700,9 +699,6 @@ class BinExp : public Expression
 public:
     Expression *e1;
     Expression *e2;
-
-    Type *att1; // Save alias this type to detect recursion
-    Type *att2; // Save alias this type to detect recursion
 
     Expression *syntaxCopy();
     Expression *incompatibleTypes();
@@ -1266,7 +1262,8 @@ public:
 class EqualExp : public BinExp
 {
 public:
-
+    Type *tupleComparingLockL;    // used to prevent struct .tupleof comparing
+    Type *tupleComparingLockR;    // used to prevent struct .tupleof comparing
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3981,7 +3981,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // overload of opCall, therefore it's a call
                 if (exp.e1.op != TOK.type)
                 {
-                    if (!exp.aliasthislock) //we don't need the recursion. On recursion done in iterateAliasThis
+                    if (!exp.aliasthislock) //we don't need the recursion. Recursion is done in iterateAliasThis
                     {
                         exp.aliasthislock = true;
                         Expression[] results;

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1391,6 +1391,9 @@ void addDefaultVersionIdentifiers()
         VersionCondition.addPredefinedGlobalIdent("D_BetterC");
 
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
+
+    // temporary version for the soft transition
+    VersionCondition.addPredefinedGlobalIdent("__NewAliasThis");
 }
 
 private void printPredefinedVersions(FILE* stream)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -49,6 +49,7 @@ import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
+import dmd.aliasthis;
 
 enum LOGDOTEXP = 0;         // log ::dotExp()
 enum LOGDEFAULTINIT = 0;    // log ::defaultInit()
@@ -363,6 +364,14 @@ enum DotExpFlag
     noDeref = 2,    // the use of the expression will not attempt a dereference
 }
 
+// Whether alias this dependency is recursive or not.
+enum AliasThisRec
+{
+    RECinit      = 0x0,
+    RECtracing   = 0x1, // mark in progress of implicitConvTo/deduceWild
+    RECtracingDT = 0x2, // mark in progress of deduceType
+}
+
 /***********************************************************
  */
 extern (C++) abstract class Type : RootObject
@@ -370,6 +379,10 @@ extern (C++) abstract class Type : RootObject
     TY ty;
     MOD mod; // modifiers MODxxxx
     char* deco;
+    /* This field is a bit-mask of AliasThisRec values.
+     * It is used to prevent alias this resolving.
+     */
+    uint aliasthislock = AliasThisRec.RECinit;
 
     /* These are cached values that are lazily evaluated by constOf(), immutableOf(), etc.
      * They should not be referenced by anybody but mtype.c.
@@ -1130,10 +1143,7 @@ extern (C++) abstract class Type : RootObject
         t.swcto = null;
         t.vtinfo = null;
         t.ctype = null;
-        if (t.ty == Tstruct)
-            (cast(TypeStruct)t).att = AliasThisRec.fwdref;
-        if (t.ty == Tclass)
-            (cast(TypeClass)t).att = AliasThisRec.fwdref;
+        t.aliasthislock = AliasThisRec.RECinit;
         return t;
     }
 
@@ -2000,86 +2010,6 @@ extern (C++) abstract class Type : RootObject
         t = t.addMod(mod);
         t = t.merge();
         return t;
-    }
-
-    final Type aliasthisOf()
-    {
-        auto ad = isAggregate(this);
-        if (!ad || !ad.aliasthis)
-            return null;
-
-        auto s = ad.aliasthis;
-        if (s.isAliasDeclaration())
-            s = s.toAlias();
-
-        if (s.isTupleDeclaration())
-            return null;
-
-        if (auto vd = s.isVarDeclaration())
-        {
-            auto t = vd.type;
-            if (vd.needThis())
-                t = t.addMod(this.mod);
-            return t;
-        }
-        if (auto fd = s.isFuncDeclaration())
-        {
-            fd = resolveFuncCall(Loc.initial, null, fd, null, this, null, 1);
-            if (!fd || fd.errors || !fd.functionSemantic())
-                return Type.terror;
-
-            auto t = fd.type.nextOf();
-            if (!t) // issue 14185
-                return Type.terror;
-            t = t.substWildTo(mod == 0 ? MODFlags.mutable : mod);
-            return t;
-        }
-        if (auto d = s.isDeclaration())
-        {
-            assert(d.type);
-            return d.type;
-        }
-        if (auto ed = s.isEnumDeclaration())
-        {
-            return ed.type;
-        }
-        if (auto td = s.isTemplateDeclaration())
-        {
-            assert(td._scope);
-            auto fd = resolveFuncCall(Loc.initial, null, td, null, this, null, 1);
-            if (!fd || fd.errors || !fd.functionSemantic())
-                return Type.terror;
-
-            auto t = fd.type.nextOf();
-            if (!t)
-                return Type.terror;
-            t = t.substWildTo(mod == 0 ? MODFlags.mutable : mod);
-            return t;
-        }
-
-        //printf("%s\n", s.kind());
-        return null;
-    }
-
-    final bool checkAliasThisRec()
-    {
-        Type tb = toBasetype();
-        AliasThisRec* pflag;
-        if (tb.ty == Tstruct)
-            pflag = &(cast(TypeStruct)tb).att;
-        else if (tb.ty == Tclass)
-            pflag = &(cast(TypeClass)tb).att;
-        else
-            return false;
-
-        AliasThisRec flag = cast(AliasThisRec)(*pflag & AliasThisRec.typeMask);
-        if (flag == AliasThisRec.fwdref)
-        {
-            Type att = aliasthisOf();
-            flag = att && att.implicitConvTo(this) ? AliasThisRec.yes : AliasThisRec.no;
-        }
-        *pflag = cast(AliasThisRec)(flag | (*pflag & ~AliasThisRec.typeMask));
-        return flag == AliasThisRec.yes;
     }
 
     Type makeConst()
@@ -4833,16 +4763,77 @@ extern (C++) final class TypeFunction : TypeNext
                      * https://issues.dlang.org/show_bug.cgi?id=15674
                      * Allow on both ref and out parameters.
                      */
-                    while (1)
+                    if (ta.toBasetype().ty == Tclass || ta.toBasetype().ty == Tstruct)
                     {
-                        Type tab = ta.toBasetype();
-                        Type tat = tab.aliasthisOf();
-                        if (!tat || !tat.implicitConvTo(tprm))
-                            break;
-                        if (tat == tab)
-                            break;
-                        ta = tat;
+                        Type[] basetypes;
+                        bool[] islvalues;
+                        Type[] results_exact;
+                        Type[] results_convert;
+                        bool last_exact_l_value = 0;
+                        bool last_convert_l_value = 0;
+
+                        getAliasThisTypes(arg.type, basetypes, islvalues);
+
+                        for (size_t i = 0; i < basetypes.length; i++)
+                        {
+                            if (basetypes[i].equals(arg.type))
+                            {
+                                continue;
+                            }
+                            uint oldatlock = basetypes[i].aliasthislock;
+                            basetypes[i].aliasthislock |= AliasThisRec.RECtracing;
+                            MATCH mx = basetypes[i].implicitConvTo(tprm);
+                            basetypes[i].aliasthislock = oldatlock;
+                            if (mx == MATCH.exact)
+                            {
+                                results_exact ~= basetypes[i];
+                                last_exact_l_value = islvalues[i];
+                            }
+                            else if (mx != MATCH.nomatch)
+                            {
+                                results_convert ~= basetypes[i];
+                                last_convert_l_value = islvalues[i];
+                            }
+                        }
+
+                        if (results_exact.length == 1)
+                        {
+                            if (p.storageClass & STC.ref_ && !last_exact_l_value)
+                            {
+                                goto Nomatch;
+                            }
+                            ta = results_exact[0];
+                        }
+                        else if (results_exact.length > 1)
+                        {
+                            arg.error("unable to unambiguously represent %s as %s; candidates:",
+                                       arg.type.toChars(), tprm.toChars());
+                            for (size_t j = 0; j < results_exact.length; ++j)
+                            {
+                                .errorSupplemental(arg.loc, "%s", results_exact[j].toChars());
+                            }
+                            goto Nomatch;
+                        }
+                        else if (results_convert.length == 1)
+                        {
+                            if (p.storageClass & STC.ref_ && !last_convert_l_value)
+                            {
+                                goto Nomatch;
+                            }
+                            ta = results_convert[0];
+                        }
+                        else if (results_convert.length > 1)
+                        {
+                            arg.error("unable to unambiguously represent %s as %s; candidates:",
+                                       arg.type.toChars(), tprm.toChars());
+                            for (size_t j = 0; j < results_convert.length; ++j)
+                            {
+                                .errorSupplemental(arg.loc, "%s", results_convert[j].toChars());
+                            }
+                            goto Nomatch;
+                        }
                     }
+
 
                     /* A ref variable should work like a head-const reference.
                      * e.g. disallows:
@@ -5361,23 +5352,11 @@ extern (C++) final class TypeReturn : TypeQualified
     }
 }
 
-// Whether alias this dependency is recursive or not.
-enum AliasThisRec : int
-{
-    no           = 0,    // no alias this recursion
-    yes          = 1,    // alias this has recursive dependency
-    fwdref       = 2,    // not yet known
-    typeMask     = 3,    // mask to read no/yes/fwdref
-    tracing      = 0x4,  // mark in progress of implicitConvTo/deduceWild
-    tracingDT    = 0x8,  // mark in progress of deduceType
-}
-
 /***********************************************************
  */
 extern (C++) final class TypeStruct : Type
 {
     StructDeclaration sym;
-    AliasThisRec att = AliasThisRec.fwdref;
     CPPMANGLE cppmangle = CPPMANGLE.def;
 
     extern (D) this(StructDeclaration sym)
@@ -5630,19 +5609,29 @@ extern (C++) final class TypeStruct : Type
                 }
             }
         }
-        else if (sym.aliasthis && !(att & AliasThisRec.tracing))
+        else if (!(aliasthislock & AliasThisRec.RECtracing))
         {
-            if (auto ato = aliasthisOf())
+            Type[] candidates;
+            bool[] lvalues;
+            getAliasThisTypes(this, candidates, lvalues);
+
+            m = MATCH.nomatch;
+            for (size_t i = 0; i < candidates.length; i++)
             {
-                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
-                m = ato.implicitConvTo(to);
-                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
+                uint oldatlock = candidates[i].aliasthislock;
+                candidates[i].aliasthislock |= AliasThisRec.RECtracing;
+                MATCH m2 = candidates[i].implicitConvTo(to);
+                candidates[i].aliasthislock = oldatlock;
+                if (m2 > m)
+                {
+                    m = m2;
+                }
             }
-            else
-                m = MATCH.nomatch; // no match
         }
         else
-            m = MATCH.nomatch; // no match
+        {
+            m = MATCH.nomatch;       // no match
+        }
         return m;
     }
 
@@ -5662,16 +5651,21 @@ extern (C++) final class TypeStruct : Type
 
         ubyte wm = 0;
 
-        if (t.hasWild() && sym.aliasthis && !(att & AliasThisRec.tracing))
+        if (t.hasWild() && !(aliasthislock & AliasThisRec.RECtracing))
         {
-            if (auto ato = aliasthisOf())
+            Type[] candidates;
+            bool[] lvalues;
+            getAliasThisTypes(this, candidates, lvalues);
+
+            for (size_t i = 0; i < candidates.length; i++)
             {
-                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
-                wm = ato.deduceWild(t, isRef);
-                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
+                uint oldatlock = candidates[i].aliasthislock;
+                candidates[i].aliasthislock |= AliasThisRec.RECtracing;
+                wm = candidates[i].deduceWild(t, isRef);
+                candidates[i].aliasthislock = oldatlock;
+                break;
             }
         }
-
         return wm;
     }
 
@@ -5847,7 +5841,6 @@ extern (C++) final class TypeEnum : Type
 extern (C++) final class TypeClass : Type
 {
     ClassDeclaration sym;
-    AliasThisRec att = AliasThisRec.fwdref;
     CPPMANGLE cppmangle = CPPMANGLE.def;
 
     extern (D) this(ClassDeclaration sym)
@@ -5915,13 +5908,23 @@ extern (C++) final class TypeClass : Type
         }
 
         m = MATCH.nomatch;
-        if (sym.aliasthis && !(att & AliasThisRec.tracing))
+        if (!(aliasthislock & AliasThisRec.RECtracing))
         {
-            if (auto ato = aliasthisOf())
+            Type[] candidates;
+            bool[] lvalues;
+            getAliasThisTypes(this, candidates, lvalues);
+
+            m = MATCH.nomatch;
+            for (size_t i = 0; i < candidates.length; i++)
             {
-                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
-                m = ato.implicitConvTo(to);
-                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
+                uint oldatlock = candidates[i].aliasthislock;
+                candidates[i].aliasthislock |= AliasThisRec.RECtracing;
+                MATCH m2 = candidates[i].implicitConvTo(to);
+                candidates[i].aliasthislock = oldatlock;
+                if (m2 > m)
+                {
+                    m = m2;
+                }
             }
         }
 
@@ -5958,13 +5961,19 @@ extern (C++) final class TypeClass : Type
 
         ubyte wm = 0;
 
-        if (t.hasWild() && sym.aliasthis && !(att & AliasThisRec.tracing))
+        if (t.hasWild() && !(aliasthislock & AliasThisRec.RECtracing))
         {
-            if (auto ato = aliasthisOf())
+            Type[] candidates;
+            bool[] lvalues;
+            getAliasThisTypes(this, candidates, lvalues);
+
+            for (size_t i = 0; i < candidates.length; i++)
             {
-                att = cast(AliasThisRec)(att | AliasThisRec.tracing);
-                wm = ato.deduceWild(t, isRef);
-                att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
+                uint oldatlock = candidates[i].aliasthislock;
+                candidates[i].aliasthislock |= AliasThisRec.RECtracing;
+                wm = candidates[i].deduceWild(t, isRef);
+                candidates[i].aliasthislock = oldatlock;
+                break;
             }
         }
 

--- a/test/fail_compilation/aliasthis_scope.d
+++ b/test/fail_compilation/aliasthis_scope.d
@@ -1,9 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/aliasthis_scope.d(55): Error: There are many candidates to t.a resolve:
-fail_compilation/aliasthis_scope.d(55):        (cast(ITest)t).getTest1().a
-fail_compilation/aliasthis_scope.d(55):        (cast(ITest2)t).getTest2().a
+fail_compilation/aliasthis_scope.d(57): Error: there are many candidates to t.a resolve:
+fail_compilation/aliasthis_scope.d(57):        (cast(ITest)t).getTest1().a
+fail_compilation/aliasthis_scope.d(57):        (cast(ITest2)t).getTest2().a
+fail_compilation/aliasthis_scope.d(57): Error: there are many candidates to t.a resolve:
+fail_compilation/aliasthis_scope.d(57):        (cast(ITest)t).getTest1().a
+fail_compilation/aliasthis_scope.d(57):        (cast(ITest2)t).getTest2().a
+fail_compilation/aliasthis_scope.d(59): Error: undefined identifier `a`
 ---
 */
 
@@ -52,6 +56,6 @@ void main()
 
     with(t)
     {
-        long x = t.a;
+        long x = a;
     }
 }

--- a/test/fail_compilation/aliasthis_scope.d
+++ b/test/fail_compilation/aliasthis_scope.d
@@ -1,0 +1,57 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/aliasthis_scope.d(55): Error: There are many candidates to t.a resolve:
+fail_compilation/aliasthis_scope.d(55):        (cast(ITest)t).getTest1().a
+fail_compilation/aliasthis_scope.d(55):        (cast(ITest2)t).getTest2().a
+---
+*/
+
+struct Test1
+{
+    int a;
+}
+
+struct Test2
+{
+    short a;
+}
+
+
+interface ITest
+{
+    @property ref Test1 getTest1();
+    alias getTest1 this;
+}
+
+interface ITest2
+{
+    @property ref Test2 getTest2();
+    alias getTest2 this;
+}
+
+class Test: ITest, ITest2
+{
+    Test1 t1;
+    Test2 t2;
+
+    override @property ref Test1 getTest1()
+    {
+        return t1;
+    }
+
+    override @property ref Test2 getTest2()
+    {
+        return t2;
+    }
+}
+
+void main()
+{
+    Test t = new Test();
+
+    with(t)
+    {
+        long x = t.a;
+    }
+}

--- a/test/fail_compilation/aliasthis_static_init.d
+++ b/test/fail_compilation/aliasthis_static_init.d
@@ -1,0 +1,45 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/aliasthis_static_init.d(44): Error: unable to represent Test as initializer; candidates:
+fail_compilation/aliasthis_static_init.d(44):        (cast(ITest)(Test) , getTest1)()
+fail_compilation/aliasthis_static_init.d(44):        (cast(ITest2)(Test) , getTest2)()
+---
+*/
+
+struct Test1
+{
+    int a;
+}
+
+struct Test2
+{
+    short a;
+}
+
+interface ITest
+{
+    static @property Test1 getTest1()
+    {
+        return Test1();
+    }
+    static alias getTest1 this;
+}
+
+interface ITest2
+{
+    static @property Test2 getTest2()
+    {
+        return Test2();
+    }
+    static alias getTest2 this;
+}
+
+class Test: ITest, ITest2
+{
+}
+
+void main()
+{
+    auto x = Test;
+}

--- a/test/fail_compilation/aliasthis_switch.d
+++ b/test/fail_compilation/aliasthis_switch.d
@@ -1,0 +1,47 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/aliasthis_switch.d(42): Error: unable to represent t as switch condition; candidates:
+fail_compilation/aliasthis_switch.d(42):        (cast(ITest)t).getInt()
+fail_compilation/aliasthis_switch.d(42):        (cast(ITest2)t).getChar()
+---
+*/
+
+interface ITest
+{
+    @property ref int getInt();
+    alias getInt this;
+}
+
+interface ITest2
+{
+    @property ref char getChar();
+    alias getChar this;
+}
+
+class Test: ITest, ITest2
+{
+    int a;
+    char b;
+
+    override @property ref int getInt()
+    {
+        return a;
+    }
+
+    override @property ref char getChar()
+    {
+        return b;
+    }
+}
+
+void main()
+{
+    Test t = new Test();
+
+    switch (t)
+    {
+        default:
+            break;
+    }
+}

--- a/test/fail_compilation/fail5851.d
+++ b/test/fail_compilation/fail5851.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -de
 
 class Foo
 {

--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -133,7 +133,7 @@ void test13959()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(144): Error: cannot cast expression `mi.x` of type `int` to `MyUbyte14154`
+fail_compilation/fail_casting.d(144): Error: cannot cast expression `mi` of type `MyInt14154` to `MyUbyte14154` because of different sizes
 ---
 */
 struct MyUbyte14154 { ubyte x; alias x this; }
@@ -147,8 +147,7 @@ void test14154()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(179): Error: cannot cast expression `__tup$n$.__expand_field_0` of type `int` to `object.Object`
-fail_compilation/fail_casting.d(179): Error: cannot cast expression `__tup$n$.__expand_field_1` of type `int` to `object.Object`
+fail_compilation/fail_casting.d(179): Error: cannot cast expression `point` of type `Tuple14093!(int, "x", int, "y")` to `object.Object`
 ---
 */
 alias TypeTuple14093(T...) = T;
@@ -173,6 +172,7 @@ struct Tuple14093(T...)
         alias expand this;
     }
 }
+
 void test14093()
 {
     Tuple14093!(int, "x", int, "y") point;

--- a/test/fail_compilation/fail_opover.d
+++ b/test/fail_compilation/fail_opover.d
@@ -3,8 +3,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_opover.d(13): Error: no `[]` operator overload for type `object.Object`
-fail_compilation/fail_opover.d(17): Error: no `[]` operator overload for type `TestS`
+fail_compilation/fail_opover.d(13): Error: undefined identifier `error`, did you mean class `Error`?
+fail_compilation/fail_opover.d(17): Error: undefined identifier `error`, did you mean class `Error`?
 ---
 */
 void test1()

--- a/test/fail_compilation/ice10727a.d
+++ b/test/fail_compilation/ice10727a.d
@@ -2,6 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/imports/foo10727a.d(14): Error: no property `length` for type `CirBuff!(Foo)`
+fail_compilation/imports/foo10727a.d(26): Error: template instance `foo10727a.CirBuff!(Foo)` error instantiating
+fail_compilation/imports/foo10727a.d(31):        instantiated from here: `Bar!(Foo)`
 fail_compilation/imports/foo10727a.d(34): Error: undefined identifier `Frop`
 ---
 */

--- a/test/fail_compilation/ice10727b.d
+++ b/test/fail_compilation/ice10727b.d
@@ -2,6 +2,9 @@
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/imports/foo10727b.d(9): Error: no property `length` for type `CirBuff!(Foo)`
+fail_compilation/imports/foo10727b.d(17): Error: template instance `foo10727b.CirBuff!(Foo)` error instantiating
+fail_compilation/imports/foo10727b.d(22):        instantiated from here: `Bar!(Foo)`
 fail_compilation/imports/foo10727b.d(25): Error: undefined identifier `Frop`
 ---
 */

--- a/test/fail_compilation/test17380spec.d
+++ b/test/fail_compilation/test17380spec.d
@@ -1,8 +1,8 @@
 /* REQUIRED_ARGS: -verrors=spec
 TEST_OUTPUT:
 ---
-(spec:1) fail_compilation/test17380spec.d(14): Error: cannot resolve identifier `ThisTypeDoesNotExistAndCrashesTheCompiler`
 (spec:1) fail_compilation/test17380spec.d(14): Error: no property `ThisTypeDoesNotExistAndCrashesTheCompiler` for type `Uint128`
+(spec:1) fail_compilation/test17380spec.d(14): Error: no property `ThisTypeDoesNotExistAndCrashesTheCompiler` for type `Int128`
 fail_compilation/test17380spec.d(14): Error: undefined identifier `ThisTypeDoesNotExistAndCrashesTheCompiler`
 ---
  */

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -2809,6 +2809,50 @@ void test21()
 
 /***************************************************/
 
+struct Test22a
+{
+    int a;
+}
+
+struct Test22b
+{
+    short a;
+}
+
+interface ITest22a
+{
+    static @property Test22a getTest22a()
+    {
+        return Test22a(42);
+    }
+    static alias getTest22a this;
+}
+
+interface ITest22b
+{
+    static @property Test22b getTest22b()
+    {
+        return Test22b(24);
+    }
+    static alias getTest22b this;
+}
+
+class Test22: ITest22a, ITest22b
+{
+}
+
+Test22b test22x()
+{
+    return Test22;
+}
+
+void test22()
+{
+    assert(test22x().a == 24);
+}
+
+/***************************************************/
+
 int main()
 {
     test1();
@@ -2878,6 +2922,7 @@ int main()
     test19();
     test20();
     test21();
+    test22();
     printf("Success\n");
     return 0;
 }


### PR DESCRIPTION
This PR partially revives #3998, which implements [DIP66](https://wiki.dlang.org/DIP66) (Three years have passed :))
It doesn't introduce multiple alias this (for the same class or struct)  yet, however it implements interoperability with inheritance. Now we may implement multiple alias this through multiple inheritance of interfaces and properties.
I deliberately moved multiple alias this out of bounds of this PR, because I want to reduce atomic changes size.
Also this PR doesn't touch interoperation alias this and tuples (It is goal of the next PR).
If (When) this PR will be approved, I easily introduce multiple alias this without complex changes.