### PR TITLE
Remove unused dmd.mars imports.

### DIFF
--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -46,7 +46,6 @@ import dmd.identifier;
 import dmd.init;
 import dmd.initsem;
 import dmd.hdrgen;
-import dmd.mars;
 import dmd.mtype;
 import dmd.nogc;
 import dmd.nspace;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -47,7 +47,6 @@ import dmd.identifier;
 import dmd.init;
 import dmd.initsem;
 import dmd.hdrgen;
-import dmd.mars;
 import dmd.mtype;
 import dmd.nogc;
 import dmd.nspace;


### PR DESCRIPTION
Part of https://issues.dlang.org/show_bug.cgi?id=15374

But there's still one module importing dmd.mars for genCmain.