### PR TITLE
[C++] Add declaration for ClassDeclaration::vtblSymbol.

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -325,6 +325,7 @@ public:
 
     // Back end
     Dsymbol *vtblsym;
+    Dsymbol *vtblSymbol();
 
     ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
     void accept(Visitor *v) { v->visit(this); }


### PR DESCRIPTION
As per #8362, this function also needs calling from the backend also.