### PR TITLE
Use supplemental error message for called function

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2303,8 +2303,12 @@ extern (C++) abstract class Expression : RootObject
             {
                 if (!loc.isValid()) // e.g. implicitly generated dtor
                     loc = sc.func.loc;
-                error("`@safe` %s `%s` cannot call `@system` %s `%s` declared at %s",
-                    sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars(), f.loc.toChars());
+
+                const prettyChars = f.toPrettyChars();
+                error("`@safe` %s `%s` cannot call `@system` %s `%s`",
+                    sc.func.kind(), sc.func.toPrettyChars(), f.kind(),
+                    prettyChars);
+                errorSupplemental(f.loc, "`%s` is declared here", prettyChars);
                 return true;
             }
         }

--- a/test/fail_compilation/diag10319.d
+++ b/test/fail_compilation/diag10319.d
@@ -1,13 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10319.d(25): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
-fail_compilation/diag10319.d(25): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo` declared at fail_compilation/diag10319.d(14)
-fail_compilation/diag10319.d(26): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
-fail_compilation/diag10319.d(26): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar` declared at fail_compilation/diag10319.d(16)
-fail_compilation/diag10319.d(25): Error: function `diag10319.foo` is not `nothrow`
-fail_compilation/diag10319.d(26): Error: function `diag10319.bar!int.bar` is not `nothrow`
-fail_compilation/diag10319.d(23): Error: `nothrow` function `D main` may throw
+fail_compilation/diag10319.d(27): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
+fail_compilation/diag10319.d(27): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
+fail_compilation/diag10319.d(16):        `diag10319.foo` is declared here
+fail_compilation/diag10319.d(28): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(28): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(18):        `diag10319.bar!int.bar` is declared here
+fail_compilation/diag10319.d(27): Error: function `diag10319.foo` is not `nothrow`
+fail_compilation/diag10319.d(28): Error: function `diag10319.bar!int.bar` is not `nothrow`
+fail_compilation/diag10319.d(25): Error: `nothrow` function `D main` may throw
 ---
 */
 

--- a/test/fail_compilation/diag7050a.d
+++ b/test/fail_compilation/diag7050a.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7050a.d(14): Error: `@safe` function `diag7050a.foo` cannot call `@system` constructor `diag7050a.Foo.this` declared at fail_compilation/diag7050a.d(10)
+fail_compilation/diag7050a.d(15): Error: `@safe` function `diag7050a.foo` cannot call `@system` constructor `diag7050a.Foo.this`
+fail_compilation/diag7050a.d(11):        `diag7050a.Foo.this` is declared here
 ---
 */
 

--- a/test/fail_compilation/diag7050c.d
+++ b/test/fail_compilation/diag7050c.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag7050c.d(13): Error: `@safe` destructor `diag7050c.B.~this` cannot call `@system` destructor `diag7050c.A.~this` declared at fail_compilation/diag7050c.d(10)
+fail_compilation/diag7050c.d(14): Error: `@safe` destructor `diag7050c.B.~this` cannot call `@system` destructor `diag7050c.A.~this`
+fail_compilation/diag7050c.d(11):        `diag7050c.A.~this` is declared here
 ---
 */
 

--- a/test/fail_compilation/fail10254.d
+++ b/test/fail_compilation/fail10254.d
@@ -1,10 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10254.d(18): Error: `pure` function `fail10254.foo` cannot call impure constructor `fail10254.C.this`
-fail_compilation/fail10254.d(18): Error: `@safe` function `fail10254.foo` cannot call `@system` constructor `fail10254.C.this` declared at fail_compilation/fail10254.d(13)
-fail_compilation/fail10254.d(19): Error: `pure` function `fail10254.foo` cannot call impure constructor `fail10254.S.this`
-fail_compilation/fail10254.d(19): Error: `@safe` function `fail10254.foo` cannot call `@system` constructor `fail10254.S.this` declared at fail_compilation/fail10254.d(14)
+fail_compilation/fail10254.d(20): Error: `pure` function `fail10254.foo` cannot call impure constructor `fail10254.C.this`
+fail_compilation/fail10254.d(20): Error: `@safe` function `fail10254.foo` cannot call `@system` constructor `fail10254.C.this`
+fail_compilation/fail10254.d(15):        `fail10254.C.this` is declared here
+fail_compilation/fail10254.d(21): Error: `pure` function `fail10254.foo` cannot call impure constructor `fail10254.S.this`
+fail_compilation/fail10254.d(21): Error: `@safe` function `fail10254.foo` cannot call `@system` constructor `fail10254.S.this`
+fail_compilation/fail10254.d(16):        `fail10254.S.this` is declared here
 ---
 */
 

--- a/test/fail_compilation/fail10968.d
+++ b/test/fail_compilation/fail10968.d
@@ -1,18 +1,24 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(33): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(33): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit` declared at fail_compilation/fail10968.d(21)
-fail_compilation/fail10968.d(34): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(34): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit` declared at fail_compilation/fail10968.d(21)
-fail_compilation/fail10968.d(35): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(35): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit` declared at fail_compilation/fail10968.d(21)
-fail_compilation/fail10968.d(38): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(38): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit` declared at fail_compilation/fail10968.d(21)
 fail_compilation/fail10968.d(39): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(39): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit` declared at fail_compilation/fail10968.d(21)
+fail_compilation/fail10968.d(39): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
 fail_compilation/fail10968.d(40): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
-fail_compilation/fail10968.d(40): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit` declared at fail_compilation/fail10968.d(21)
+fail_compilation/fail10968.d(40): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(41): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(41): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(44): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(44): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(45): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(45): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
+fail_compilation/fail10968.d(46): Error: `pure` function `fail10968.bar` cannot call impure function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(46): Error: `@safe` function `fail10968.bar` cannot call `@system` function `fail10968.SA.__postblit`
+fail_compilation/fail10968.d(27):        `fail10968.SA.__postblit` is declared here
 ---
 */
 
@@ -43,12 +49,12 @@ void bar() pure @safe
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail10968.d(66): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(67): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(68): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
-fail_compilation/fail10968.d(71): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
 fail_compilation/fail10968.d(72): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
 fail_compilation/fail10968.d(73): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(74): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(77): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(78): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
+fail_compilation/fail10968.d(79): Error: struct `fail10968.SD` is not copyable because it is annotated with `@disable`
 ---
 */
 

--- a/test/fail_compilation/fail12622.d
+++ b/test/fail_compilation/fail12622.d
@@ -1,15 +1,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12622.d(25): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
-fail_compilation/fail12622.d(25): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
-fail_compilation/fail12622.d(25): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
-fail_compilation/fail12622.d(27): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
-fail_compilation/fail12622.d(27): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
-fail_compilation/fail12622.d(27): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
-fail_compilation/fail12622.d(29): Error: `pure` function `fail12622.foo` cannot call impure function `fail12622.bar`
-fail_compilation/fail12622.d(29): Error: `@safe` function `fail12622.foo` cannot call `@system` function `fail12622.bar` declared at fail_compilation/fail12622.d(19)
-fail_compilation/fail12622.d(29): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function `fail12622.bar`
+fail_compilation/fail12622.d(26): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
+fail_compilation/fail12622.d(26): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
+fail_compilation/fail12622.d(26): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
+fail_compilation/fail12622.d(28): Error: `pure` function `fail12622.foo` cannot call impure function pointer `fp`
+fail_compilation/fail12622.d(28): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function pointer `fp`
+fail_compilation/fail12622.d(28): Error: `@safe` function `fail12622.foo` cannot call `@system` function pointer `fp`
+fail_compilation/fail12622.d(30): Error: `pure` function `fail12622.foo` cannot call impure function `fail12622.bar`
+fail_compilation/fail12622.d(30): Error: `@safe` function `fail12622.foo` cannot call `@system` function `fail12622.bar`
+fail_compilation/fail12622.d(20):        `fail12622.bar` is declared here
+fail_compilation/fail12622.d(30): Error: `@nogc` function `fail12622.foo` cannot call non-@nogc function `fail12622.bar`
 ---
 */
 // Note that, today nothrow violation errors are accidentally hidden.

--- a/test/fail_compilation/fail13120.d
+++ b/test/fail_compilation/fail13120.d
@@ -16,9 +16,10 @@ void g1(char[] s) pure @nogc
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13120.d(34): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
-fail_compilation/fail13120.d(34): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2` declared at fail_compilation/fail13120.d(26)
-fail_compilation/fail13120.d(34): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(27):        `fail13120.g2!().g2` is declared here
+fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
 ---
 */
 void f2() {}

--- a/test/fail_compilation/fail14407.d
+++ b/test/fail_compilation/fail14407.d
@@ -6,16 +6,16 @@ TEST_OUTPUT:
 fail_compilation/fail14407.d(23): Deprecation: class `imports.a14407.C` is deprecated
 fail_compilation/fail14407.d(23): Deprecation: allocator `imports.a14407.C.new` is deprecated
 fail_compilation/fail14407.d(23): Error: `pure` function `fail14407.testC` cannot call impure allocator `imports.a14407.C.new`
-fail_compilation/fail14407.d(23): Error: `@safe` function `fail14407.testC` cannot call `@system` allocator `imports.a14407.C.new` declared at fail_compilation/imports/a14407.d(5)
+fail_compilation/fail14407.d(23): Error: `@safe` function `fail14407.testC` cannot call `@system` allocator `imports.a14407.C.new`
+fail_compilation/imports/a14407.d(5):        `imports.a14407.C.new` is declared here
 fail_compilation/fail14407.d(23): Error: `@nogc` function `fail14407.testC` cannot call non-@nogc allocator `imports.a14407.C.new`
 fail_compilation/fail14407.d(23): Error: class `imports.a14407.C` member `new` is not accessible
 fail_compilation/fail14407.d(23): Error: `pure` function `fail14407.testC` cannot call impure constructor `imports.a14407.C.this`
-fail_compilation/fail14407.d(23): Error: `@safe` function `fail14407.testC` cannot call `@system` constructor `imports.a14407.C.this` declared at fail_compilation/imports/a14407.d(9)
+fail_compilation/fail14407.d(23): Error: `@safe` function `fail14407.testC` cannot call `@system` constructor `imports.a14407.C.this`
+fail_compilation/imports/a14407.d(9):        `imports.a14407.C.this` is declared here
 fail_compilation/fail14407.d(23): Error: `@nogc` function `fail14407.testC` cannot call non-@nogc constructor `imports.a14407.C.this`
 fail_compilation/fail14407.d(23): Error: class `imports.a14407.C` member `this` is not accessible
 fail_compilation/fail14407.d(23): Error: allocator `imports.a14407.C.new` is not `nothrow`
-fail_compilation/fail14407.d(23): Error: constructor `imports.a14407.C.this` is not `nothrow`
-fail_compilation/fail14407.d(21): Error: `nothrow` function `fail14407.testC` may throw
 ---
 */
 void testC() pure nothrow @safe @nogc
@@ -26,19 +26,23 @@ void testC() pure nothrow @safe @nogc
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14407.d(46): Deprecation: struct `imports.a14407.S` is deprecated
-fail_compilation/fail14407.d(46): Deprecation: allocator `imports.a14407.S.new` is deprecated
-fail_compilation/fail14407.d(46): Error: `pure` function `fail14407.testS` cannot call impure allocator `imports.a14407.S.new`
-fail_compilation/fail14407.d(46): Error: `@safe` function `fail14407.testS` cannot call `@system` allocator `imports.a14407.S.new` declared at fail_compilation/imports/a14407.d(14)
-fail_compilation/fail14407.d(46): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc allocator `imports.a14407.S.new`
-fail_compilation/fail14407.d(46): Error: struct `imports.a14407.S` member `new` is not accessible
-fail_compilation/fail14407.d(46): Error: `pure` function `fail14407.testS` cannot call impure constructor `imports.a14407.S.this`
-fail_compilation/fail14407.d(46): Error: `@safe` function `fail14407.testS` cannot call `@system` constructor `imports.a14407.S.this` declared at fail_compilation/imports/a14407.d(18)
-fail_compilation/fail14407.d(46): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc constructor `imports.a14407.S.this`
-fail_compilation/fail14407.d(46): Error: struct `imports.a14407.S` member `this` is not accessible
-fail_compilation/fail14407.d(46): Error: allocator `imports.a14407.S.new` is not `nothrow`
-fail_compilation/fail14407.d(46): Error: constructor `imports.a14407.S.this` is not `nothrow`
-fail_compilation/fail14407.d(44): Error: `nothrow` function `fail14407.testS` may throw
+fail_compilation/fail14407.d(23): Error: constructor `imports.a14407.C.this` is not `nothrow`
+fail_compilation/fail14407.d(21): Error: `nothrow` function `fail14407.testC` may throw
+fail_compilation/fail14407.d(50): Deprecation: struct `imports.a14407.S` is deprecated
+fail_compilation/fail14407.d(50): Deprecation: allocator `imports.a14407.S.new` is deprecated
+fail_compilation/fail14407.d(50): Error: `pure` function `fail14407.testS` cannot call impure allocator `imports.a14407.S.new`
+fail_compilation/fail14407.d(50): Error: `@safe` function `fail14407.testS` cannot call `@system` allocator `imports.a14407.S.new`
+fail_compilation/imports/a14407.d(14):        `imports.a14407.S.new` is declared here
+fail_compilation/fail14407.d(50): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc allocator `imports.a14407.S.new`
+fail_compilation/fail14407.d(50): Error: struct `imports.a14407.S` member `new` is not accessible
+fail_compilation/fail14407.d(50): Error: `pure` function `fail14407.testS` cannot call impure constructor `imports.a14407.S.this`
+fail_compilation/fail14407.d(50): Error: `@safe` function `fail14407.testS` cannot call `@system` constructor `imports.a14407.S.this`
+fail_compilation/imports/a14407.d(18):        `imports.a14407.S.this` is declared here
+fail_compilation/fail14407.d(50): Error: `@nogc` function `fail14407.testS` cannot call non-@nogc constructor `imports.a14407.S.this`
+fail_compilation/fail14407.d(50): Error: struct `imports.a14407.S` member `this` is not accessible
+fail_compilation/fail14407.d(50): Error: allocator `imports.a14407.S.new` is not `nothrow`
+fail_compilation/fail14407.d(50): Error: constructor `imports.a14407.S.this` is not `nothrow`
+fail_compilation/fail14407.d(48): Error: `nothrow` function `fail14407.testS` may throw
 ---
 */
 void testS() pure nothrow @safe @nogc

--- a/test/fail_compilation/fail14486.d
+++ b/test/fail_compilation/fail14486.d
@@ -3,18 +3,97 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail14486.d(23): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(24): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(25): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(29): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(30): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(31): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(35): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(36): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(37): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(41): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(42): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail14486.d(43): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(102): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(103): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(104): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(108): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(109): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(110): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(114): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(115): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(116): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(120): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(121): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(122): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail14486.d(126): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(126): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
+fail_compilation/fail14486.d(127): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(127): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(127): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(101):        `fail14486.C1a.~this` is declared here
+fail_compilation/fail14486.d(127): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
+fail_compilation/fail14486.d(128): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(128): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(128): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(102):        `fail14486.C2a.~this` is declared here
+fail_compilation/fail14486.d(128): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
+fail_compilation/fail14486.d(129): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(129): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(129): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(103):        `fail14486.C3a.delete` is declared here
+fail_compilation/fail14486.d(129): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
+fail_compilation/fail14486.d(130): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(130): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
+fail_compilation/fail14486.d(135): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(136): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(137): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(138): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(139): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(136): Error: destructor `fail14486.C1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(137): Error: destructor `fail14486.C2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(138): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(133): Error: `nothrow` function `fail14486.test1b` may throw
+fail_compilation/fail14486.d(144): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(144): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
+fail_compilation/fail14486.d(145): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(145): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(145): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(113):        `fail14486.S1a.~this` is declared here
+fail_compilation/fail14486.d(145): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(146): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(146): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(146): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(114):        `fail14486.S2a.~this` is declared here
+fail_compilation/fail14486.d(146): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(147): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(147): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(147): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(115):        `fail14486.S3a.delete` is declared here
+fail_compilation/fail14486.d(147): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
+fail_compilation/fail14486.d(148): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(153): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(154): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(155): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(156): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(157): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(154): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(155): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(156): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
+fail_compilation/fail14486.d(151): Error: `nothrow` function `fail14486.test2b` may throw
+fail_compilation/fail14486.d(162): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(162): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(163): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(163): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(163): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(113):        `fail14486.S1a.~this` is declared here
+fail_compilation/fail14486.d(163): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
+fail_compilation/fail14486.d(164): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(164): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(164): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(114):        `fail14486.S2a.~this` is declared here
+fail_compilation/fail14486.d(164): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
+fail_compilation/fail14486.d(165): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(165): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(166): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(166): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
+fail_compilation/fail14486.d(171): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(172): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(173): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(174): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(175): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+fail_compilation/fail14486.d(172): Error: destructor `fail14486.S1b.~this` is not `nothrow`
+fail_compilation/fail14486.d(173): Error: destructor `fail14486.S2b.~this` is not `nothrow`
+fail_compilation/fail14486.d(169): Error: `nothrow` function `fail14486.test3b` may throw
 ---
 */
 
@@ -42,27 +121,6 @@ struct S2b {                  ~this() {}           nothrow delete(void* p) {} }
 struct S3b {          nothrow ~this() {}                   delete(void* p) {} }
 struct S4b {          nothrow ~this() {}           nothrow delete(void* p) {} }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail14486.d(68): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(68): Error: `delete c0` is not `@safe` but is used in `@safe` function `test1a`
-fail_compilation/fail14486.d(69): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(69): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(69): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C1a.~this` declared at fail_compilation/fail14486.d(22)
-fail_compilation/fail14486.d(69): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C1a.~this`
-fail_compilation/fail14486.d(70): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(70): Error: `pure` function `fail14486.test1a` cannot call impure destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(70): Error: `@safe` function `fail14486.test1a` cannot call `@system` destructor `fail14486.C2a.~this` declared at fail_compilation/fail14486.d(23)
-fail_compilation/fail14486.d(70): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc destructor `fail14486.C2a.~this`
-fail_compilation/fail14486.d(71): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(71): Error: `pure` function `fail14486.test1a` cannot call impure deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(71): Error: `@safe` function `fail14486.test1a` cannot call `@system` deallocator `fail14486.C3a.delete` declared at fail_compilation/fail14486.d(24)
-fail_compilation/fail14486.d(71): Error: `@nogc` function `fail14486.test1a` cannot call non-@nogc deallocator `fail14486.C3a.delete`
-fail_compilation/fail14486.d(72): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(72): Error: `delete c4` is not `@safe` but is used in `@safe` function `test1a`
----
-*/
 void test1a() @nogc pure @safe
 {
     C0a   c0;  delete c0;   // error
@@ -72,20 +130,6 @@ void test1a() @nogc pure @safe
     C4a   c4;  delete c4;   // no error
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail14486.d(91): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(92): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(94): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(95): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(92): Error: destructor `fail14486.C1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(93): Error: destructor `fail14486.C2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(94): Error: deallocator `fail14486.C3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(89): Error: `nothrow` function `fail14486.test1b` may throw
----
-*/
 void test1b() nothrow
 {
     C0b   c0;  delete c0;    // no error
@@ -95,26 +139,6 @@ void test1b() nothrow
     C4b   c4;  delete c4;    // no error
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail14486.d(120): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(120): Error: `delete s0` is not `@safe` but is used in `@safe` function `test2a`
-fail_compilation/fail14486.d(121): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(121): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(121): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S1a.~this` declared at fail_compilation/fail14486.d(34)
-fail_compilation/fail14486.d(121): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(122): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(122): Error: `pure` function `fail14486.test2a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(122): Error: `@safe` function `fail14486.test2a` cannot call `@system` destructor `fail14486.S2a.~this` declared at fail_compilation/fail14486.d(35)
-fail_compilation/fail14486.d(122): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(123): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(123): Error: `pure` function `fail14486.test2a` cannot call impure deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(123): Error: `@safe` function `fail14486.test2a` cannot call `@system` deallocator `fail14486.S3a.delete` declared at fail_compilation/fail14486.d(36)
-fail_compilation/fail14486.d(123): Error: `@nogc` function `fail14486.test2a` cannot call non-@nogc deallocator `fail14486.S3a.delete`
-fail_compilation/fail14486.d(124): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
----
-*/
 void test2a() @nogc pure @safe
 {
     S0a*  s0;  delete s0;   // error
@@ -124,20 +148,6 @@ void test2a() @nogc pure @safe
     S4a*  s4;  delete s4;   // no error
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail14486.d(143): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(144): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(145): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(146): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(147): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(144): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(145): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(146): Error: deallocator `fail14486.S3b.delete` is not `nothrow`
-fail_compilation/fail14486.d(141): Error: `nothrow` function `fail14486.test2b` may throw
----
-*/
 void test2b() nothrow
 {
     S0b*  s0;  delete s0;    // no error
@@ -147,25 +157,6 @@ void test2b() nothrow
     S4b*  s4;  delete s4;    // no error
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail14486.d(171): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(171): Error: `delete a0` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(172): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(172): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(172): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S1a.~this` declared at fail_compilation/fail14486.d(34)
-fail_compilation/fail14486.d(172): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S1a.~this`
-fail_compilation/fail14486.d(173): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(173): Error: `pure` function `fail14486.test3a` cannot call impure destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(173): Error: `@safe` function `fail14486.test3a` cannot call `@system` destructor `fail14486.S2a.~this` declared at fail_compilation/fail14486.d(35)
-fail_compilation/fail14486.d(173): Error: `@nogc` function `fail14486.test3a` cannot call non-@nogc destructor `fail14486.S2a.~this`
-fail_compilation/fail14486.d(174): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(174): Error: `delete a3` is not `@safe` but is used in `@safe` function `test3a`
-fail_compilation/fail14486.d(175): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(175): Error: `delete a4` is not `@safe` but is used in `@safe` function `test3a`
----
-*/
 void test3a() @nogc pure @safe
 {
     S0a[] a0;  delete a0;   // error
@@ -175,19 +166,6 @@ void test3a() @nogc pure @safe
     S4a[] a4;  delete a4;   // error
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail14486.d(193): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(194): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(195): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(196): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(197): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
-fail_compilation/fail14486.d(194): Error: destructor `fail14486.S1b.~this` is not `nothrow`
-fail_compilation/fail14486.d(195): Error: destructor `fail14486.S2b.~this` is not `nothrow`
-fail_compilation/fail14486.d(191): Error: `nothrow` function `fail14486.test3b` may throw
----
-*/
 void test3b() nothrow
 {
     S0b[] a0;  delete a0;    // no error

--- a/test/fail_compilation/fail328.d
+++ b/test/fail_compilation/fail328.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail328.d(12): Error: `@safe` function `fail328.foo` cannot call `@system` function `fail328.bar` declared at fail_compilation/fail328.d(8)
+fail_compilation/fail328.d(13): Error: `@safe` function `fail328.foo` cannot call `@system` function `fail328.bar`
+fail_compilation/fail328.d(9):        `fail328.bar` is declared here
 ---
 */
 

--- a/test/fail_compilation/fail7848.d
+++ b/test/fail_compilation/fail7848.d
@@ -3,28 +3,32 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7848.d(45): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
-fail_compilation/fail7848.d(51): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
-fail_compilation/fail7848.d(37): Error: `pure` function `fail7848.C.__unittest_L35_C30` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(37): Error: `@safe` function `fail7848.C.__unittest_L35_C30` cannot call `@system` function `fail7848.func` declared at fail_compilation/fail7848.d(31)
-fail_compilation/fail7848.d(37): Error: `@nogc` function `fail7848.C.__unittest_L35_C30` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(37): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(35): Error: `nothrow` function `fail7848.C.__unittest_L35_C30` may throw
-fail_compilation/fail7848.d(42): Error: `pure` function `fail7848.C.__invariant1` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(42): Error: `@safe` function `fail7848.C.__invariant1` cannot call `@system` function `fail7848.func` declared at fail_compilation/fail7848.d(31)
-fail_compilation/fail7848.d(42): Error: `@nogc` function `fail7848.C.__invariant1` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(42): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(40): Error: `nothrow` function `fail7848.C.__invariant1` may throw
-fail_compilation/fail7848.d(47): Error: `pure` allocator `fail7848.C.new` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(47): Error: `@safe` allocator `fail7848.C.new` cannot call `@system` function `fail7848.func` declared at fail_compilation/fail7848.d(31)
-fail_compilation/fail7848.d(47): Error: `@nogc` allocator `fail7848.C.new` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(47): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(45): Error: `nothrow` allocator `fail7848.C.new` may throw
-fail_compilation/fail7848.d(53): Error: `pure` deallocator `fail7848.C.delete` cannot call impure function `fail7848.func`
-fail_compilation/fail7848.d(53): Error: `@safe` deallocator `fail7848.C.delete` cannot call `@system` function `fail7848.func` declared at fail_compilation/fail7848.d(31)
-fail_compilation/fail7848.d(53): Error: `@nogc` deallocator `fail7848.C.delete` cannot call non-@nogc function `fail7848.func`
-fail_compilation/fail7848.d(53): Error: function `fail7848.func` is not `nothrow`
-fail_compilation/fail7848.d(51): Error: `nothrow` deallocator `fail7848.C.delete` may throw
+fail_compilation/fail7848.d(49): Deprecation: class allocators have been deprecated, consider moving the allocation strategy outside of the class
+fail_compilation/fail7848.d(55): Deprecation: class deallocators have been deprecated, consider moving the deallocation strategy outside of the class
+fail_compilation/fail7848.d(41): Error: `pure` function `fail7848.C.__unittest_L39_C30` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(41): Error: `@safe` function `fail7848.C.__unittest_L39_C30` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(35):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(41): Error: `@nogc` function `fail7848.C.__unittest_L39_C30` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(41): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(39): Error: `nothrow` function `fail7848.C.__unittest_L39_C30` may throw
+fail_compilation/fail7848.d(46): Error: `pure` function `fail7848.C.__invariant1` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(46): Error: `@safe` function `fail7848.C.__invariant1` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(35):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(46): Error: `@nogc` function `fail7848.C.__invariant1` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(46): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(44): Error: `nothrow` function `fail7848.C.__invariant1` may throw
+fail_compilation/fail7848.d(51): Error: `pure` allocator `fail7848.C.new` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(51): Error: `@safe` allocator `fail7848.C.new` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(35):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(51): Error: `@nogc` allocator `fail7848.C.new` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(51): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(49): Error: `nothrow` allocator `fail7848.C.new` may throw
+fail_compilation/fail7848.d(57): Error: `pure` deallocator `fail7848.C.delete` cannot call impure function `fail7848.func`
+fail_compilation/fail7848.d(57): Error: `@safe` deallocator `fail7848.C.delete` cannot call `@system` function `fail7848.func`
+fail_compilation/fail7848.d(35):        `fail7848.func` is declared here
+fail_compilation/fail7848.d(57): Error: `@nogc` deallocator `fail7848.C.delete` cannot call non-@nogc function `fail7848.func`
+fail_compilation/fail7848.d(57): Error: function `fail7848.func` is not `nothrow`
+fail_compilation/fail7848.d(55): Error: `nothrow` deallocator `fail7848.C.delete` may throw
 ---
 */
 

--- a/test/fail_compilation/ice15441.d
+++ b/test/fail_compilation/ice15441.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice15441.d(24): Error: variable `ice15441.main.__front$n$` type `void` is inferred from initializer `__r$n$.front()`, and variables cannot be of type `void`
-fail_compilation/ice15441.d(24): Error: expression `__r$n$.front()` is `void` and has no value
+fail_compilation/ice15441.d(24): Error: variable `ice15441.main.__front3` type `void` is inferred from initializer `__r2.front()`, and variables cannot be of type `void`
+fail_compilation/ice15441.d(24): Error: expression `__r2.front()` is `void` and has no value
 fail_compilation/ice15441.d(24): Error: `s1.front` is `void` and has no value
 fail_compilation/ice15441.d(27): Error: cannot infer argument types, expected 1 argument, not 2
 ---


### PR DESCRIPTION
By using a supplemental error message the compiler will output the location of the called function on a separate line, with the same syntax as a regular error message. This allows editors and IDEs to generate links back to the source code without any special treatment for these messages.

The following example:

```d
void foo() {}

@safe void main()
{
    foo();
}
```

Will now generate the following error message when compiled:

```
main.d(5): Error: @safe function D main cannot call @system function main.foo
main.d(1):        main.foo is declared here
```