### PR TITLE
Adapt dmd.root.longdouble to LDC

### DIFF
--- a/src/dmd/root/longdouble.h
+++ b/src/dmd/root/longdouble.h
@@ -117,21 +117,21 @@ struct longdouble_soft
     void set(unsigned long long d) { ld_setull(this, d); }
     void set(bool               d) { ld_set(this, d); }
 
-    operator float             () { return ld_read(this); }
-    operator double            () { return ld_read(this); }
+    operator float             () const { return ld_read(this); }
+    operator double            () const { return ld_read(this); }
 
-    operator signed char       () { return ld_read(this); }
-    operator short             () { return ld_read(this); }
-    operator int               () { return ld_read(this); }
-    operator long              () { return ld_read(this); }
-    operator long long         () { return ld_readll(this); }
+    operator signed char       () const { return ld_read(this); }
+    operator short             () const { return ld_read(this); }
+    operator int               () const { return ld_read(this); }
+    operator long              () const { return ld_read(this); }
+    operator long long         () const { return ld_readll(this); }
 
-    operator unsigned char     () { return ld_read(this); }
-    operator unsigned short    () { return ld_read(this); }
-    operator unsigned int      () { return ld_read(this); }
-    operator unsigned long     () { return ld_read(this); }
-    operator unsigned long long() { return ld_readull(this); }
-    operator bool              () { return mantissa != 0 || exponent != 0; } // correct?
+    operator unsigned char     () const { return ld_read(this); }
+    operator unsigned short    () const { return ld_read(this); }
+    operator unsigned int      () const { return ld_read(this); }
+    operator unsigned long     () const { return ld_read(this); }
+    operator unsigned long long() const { return ld_readull(this); }
+    operator bool              () const { return mantissa != 0 || exponent != 0; } // correct?
 };
 
 #pragma pack(pop)
@@ -236,17 +236,21 @@ inline longdouble_soft sqrt (longdouble_soft ld) { return sqrtl(ld); }
 #define LDBL_MAX_10_EXP 4932
 #define LDBL_MIN_10_EXP (-4932)
 
-extern longdouble_soft ld_zero;
-extern longdouble_soft ld_one;
-extern longdouble_soft ld_pi;
-extern longdouble_soft ld_log2t;
-extern longdouble_soft ld_log2e;
-extern longdouble_soft ld_log2;
-extern longdouble_soft ld_ln2;
+extern const longdouble_soft ld_qnan;
+extern const longdouble_soft ld_snan;
+extern const longdouble_soft ld_inf;
 
-extern longdouble_soft ld_inf;
-extern longdouble_soft ld_qnan;
-extern longdouble_soft ld_snan;
+extern const longdouble_soft ld_zero;
+extern const longdouble_soft ld_one;
+extern const longdouble_soft ld_pi;
+extern const longdouble_soft ld_log2t;
+extern const longdouble_soft ld_log2e;
+extern const longdouble_soft ld_log2;
+extern const longdouble_soft ld_ln2;
+
+extern const longdouble_soft ld_pi2;
+extern const longdouble_soft ld_piOver2;
+extern const longdouble_soft ld_piOver4;
 
 size_t ld_sprint(char* str, int fmt, longdouble_soft x);
 


### PR DESCRIPTION
* For LDC, prefer more robust & safe LLVM inline assembly over DMD-style `asm`.
* Fix unittest compile errors (must not be pure as it accesses mutable globals) by moving the block before module-level `pure:`.
* Remove packed-ness of `longdouble_soft` struct (`align(2)`) and prefer natural alignment (`long.alignof` = 8 bytes on Win32/64, so a size of 16 bytes). Just my personal preference wrt. non-bad practices after having had to deal with numerous alignment issues for LDC on non-x86 architectures.