### PR TITLE
[C++] Fix order of virtual functions in Dsymbol

### DIFF
--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -280,8 +280,8 @@ public:
     virtual DeleteDeclaration *isDeleteDeclaration() { return NULL; }
     virtual SymbolDeclaration *isSymbolDeclaration() { return NULL; }
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
-    virtual ProtDeclaration *isProtDeclaration() { return NULL; }
     virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
+    virtual ProtDeclaration *isProtDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
From #7806.

Order in dsymbol.d is:
```
isAttribDeclaration()
isAnonDeclaration()
isProtDeclaration()
isOverloadSet()
```

However order put in headers was:
```
isAttribDeclaration()
isProtDeclaration()
isAnonDeclaration()
isOverloadSet()
```