### PR TITLE
Update Objective-C glue layer for GDC.

### DIFF
--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -98,7 +98,10 @@ else version (IN_GCC)
     }
 
     // stubs
-    void objc_initSymbols() { }
+    extern(C++) abstract class ObjcGlue
+    {
+        static void initialize() {}
+    }
 }
 else
     static assert(false, "Unsupported compiler backend");


### PR DESCRIPTION
objc_initSymbols was replaced in #7513.