### PR TITLE
Improve compile_output regex

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -747,7 +747,7 @@ int tryMain(string[] args)
             }
 
             compile_output = compile_output.unifyNewLine();
-            compile_output = std.regex.replace(compile_output, regex(`^DMD v2\.[0-9]+.*\n DEBUG$`, "m"), "");
+            compile_output = std.regex.replace(compile_output, regex(`^DMD v2\.[0-9]+.*\n? DEBUG$`, "m"), "");
             compile_output = std.string.strip(compile_output);
 
             auto m = std.regex.match(compile_output, `Internal error: .*$`);


### PR DESCRIPTION
See also: https://github.com/dlang/dmd/pull/8389#issuecomment-399076936

CC @jacob-carlborg

I can't reproduce your issue on my Linux system, but maybe this fixes it for you?