### PR TITLE
Fix Issue 19018 - lexer do not allow invalid integer literal

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1803,6 +1803,8 @@ class Lexer : ErrorHandler
         int d;
         bool err = false;
         bool overflow = false;
+        bool anyBinaryDigitsUS = false;
+        bool anyHexDigitsNoSingleUS = false;
         dchar c = *p;
         if (c == '0')
         {
@@ -1861,6 +1863,10 @@ class Lexer : ErrorHandler
             {
             case '0':
             case '1':
+                if (base == 2 && !anyBinaryDigitsUS)
+                    anyBinaryDigitsUS = true;
+                else if (base == 16 && !anyHexDigitsNoSingleUS)
+                    anyHexDigitsNoSingleUS = true;
                 ++p;
                 d = c - '0';
                 break;
@@ -1870,6 +1876,8 @@ class Lexer : ErrorHandler
             case '5':
             case '6':
             case '7':
+                if (base == 16 && !anyHexDigitsNoSingleUS)
+                    anyHexDigitsNoSingleUS = true;
                 if (base == 2 && !err)
                 {
                     error("binary digit expected");
@@ -1880,6 +1888,8 @@ class Lexer : ErrorHandler
                 break;
             case '8':
             case '9':
+                if (base == 16 && !anyHexDigitsNoSingleUS)
+                    anyHexDigitsNoSingleUS = true;
                 ++p;
                 if (base < 10 && !err)
                 {
@@ -1900,6 +1910,8 @@ class Lexer : ErrorHandler
             case 'D':
             case 'E':
             case 'F':
+                if (base == 16 && !anyHexDigitsNoSingleUS)
+                    anyHexDigitsNoSingleUS = true;
                 ++p;
                 if (base != 16)
                 {
@@ -1933,6 +1945,8 @@ class Lexer : ErrorHandler
                 p = start;
                 return inreal(t);
             case '_':
+                if (base == 2 && !anyBinaryDigitsUS)
+                    anyBinaryDigitsUS = true;
                 ++p;
                 continue;
             default:
@@ -1955,6 +1969,9 @@ class Lexer : ErrorHandler
             error("integer overflow");
             err = true;
         }
+        if ((base == 2 && !anyBinaryDigitsUS) ||
+            (base == 16 && !anyHexDigitsNoSingleUS))
+            deprecation("`%.*s` isn't a valid integer literal, use `%.*s0` instead", cast(int)(p - start), start, 2, start);
         enum FLAGS : int
         {
             none = 0,

--- a/test/fail_compilation/fix19018.d
+++ b/test/fail_compilation/fix19018.d
@@ -1,0 +1,22 @@
+/* REQUIRED_ARGS: -de
+ * PERMUTE_ARGS:
+ * TEST_OUTPUT:
+---
+fail_compilation/fix19018.d(17): Deprecation: `0b` isn't a valid integer literal, use `0b0` instead
+fail_compilation/fix19018.d(18): Deprecation: `0B` isn't a valid integer literal, use `0B0` instead
+fail_compilation/fix19018.d(19): Deprecation: `0x` isn't a valid integer literal, use `0x0` instead
+fail_compilation/fix19018.d(20): Deprecation: `0X` isn't a valid integer literal, use `0X0` instead
+fail_compilation/fix19018.d(21): Deprecation: `0x_` isn't a valid integer literal, use `0x0` instead
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=19018
+
+void foo()
+{
+    auto a = 0b;
+    auto b = 0B;
+    auto c = 0x;
+    auto d = 0X;
+    auto e = 0x_;
+}


### PR DESCRIPTION
This is blocked by https://github.com/dlang/druntime/pull/2232