### PR TITLE
Remove -property compiler switch

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -139,7 +139,6 @@ struct Param
     ubyte covPercent;       // 0..100 code coverage percentage required
     bool nofloat;           // code should not pull in floating point support
     bool ignoreUnsupportedPragmas;  // rather than error on them
-    bool enforcePropertySyntax;
     bool useModuleInfo = true;   // generate runtime module information
     bool useTypeInfo = true;     // generate runtime type information
     bool useExceptions = true;   // support exception handling

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -116,7 +116,6 @@ struct Param
     unsigned char covPercent;   // 0..100 code coverage percentage required
     bool nofloat;       // code should not pull in floating point support
     bool ignoreUnsupportedPragmas;      // rather than error on them
-    bool enforcePropertySyntax;
     bool useModuleInfo; // generate runtime module information
     bool useTypeInfo;   // generate runtime type information
     bool useExceptions; // support exception handling

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -361,23 +361,7 @@ private int tryMain(size_t argc, const(char)** argv)
     global.params.cpu = setTargetCPU(global.params.cpu);
     if (global.params.is64bit != is64bit)
         error(Loc.initial, "the architecture must not be changed in the %s section of %s", envsection.ptr, global.inifilename);
-    if (global.params.enforcePropertySyntax)
-    {
-        /*NOTE: -property used to disallow calling non-properties
-         without parentheses. This behaviour has fallen from grace.
-         Phobos dropped support for it while dmd still recognized it, so
-         that the switch has effectively not been supported. Time to
-         remove it from dmd.
-         Step 1 (2.069): Deprecate -property and ignore it. */
-        Loc loc;
-        deprecation(loc, "The -property switch is deprecated and has no " ~
-            "effect anymore.");
-        /* Step 2: Remove -property. Throw an error when it's set.
-         Do this by removing global.params.enforcePropertySyntax and the code
-         above that sets it. Let it be handled as an unrecognized switch.
-         Step 3: Possibly reintroduce -property with different semantics.
-         Any new semantics need to be decided on first. */
-    }
+
     // Target uses 64bit pointers.
     global.params.isLP64 = global.params.is64bit;
     if (global.errors)
@@ -1980,8 +1964,6 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             }
             else if (arg == "-ignore")      // https://dlang.org/dmd.html#switch-ignore
                 params.ignoreUnsupportedPragmas = true;
-            else if (arg == "-property")
-                params.enforcePropertySyntax = true;
             else if (arg == "-inline")      // https://dlang.org/dmd.html#switch-inline
             {
                 params.useInline = true;

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -inline -O -property
+// PERMUTE_ARGS: -inline -O
 // REQUIRED_ARGS: -dip25
 
 // Test operator overloading

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -1,21 +1,10 @@
-// PERMUTE_ARGS: -property
-
 extern (C) int printf(const char* fmt, ...);
-
-// Is -property option specified?
-enum enforceProperty = !__traits(compiles, {
-    int prop(){ return 1; }
-    int n = prop;
-});
 
 /*******************************************/
 
 template select(alias v1, alias v2)
 {
-    static if (enforceProperty)
-        enum select = v1;
-    else
-        enum select = v2;
+    enum select = v2;
 }
 
 struct Test(int N)
@@ -28,32 +17,28 @@ struct Test(int N)
         ref foo(){ getset = 1; return value; }
 
         enum result = select!(0, 1);
-        // -property    test.d(xx): Error: not a property foo
-        // (no option)  prints "getter"
+        // prints "getter"
     }
     static if (N == 1)
     {
         ref foo(int x){ getset = 2; value = x; return value; }
 
         enum result = select!(0, 2);
-        // -property    test.d(xx): Error: not a property foo
-        // (no option)  prints "setter"
+        // prints "setter"
     }
     static if (N == 2)
     {
         @property ref foo(){ getset = 1; return value; }
 
         enum result = select!(1, 1);
-        // -property    prints "getter"
-        // (no option)  prints "getter"
+        // prints "getter"
     }
     static if (N == 3)
     {
         @property ref foo(int x){ getset = 2; value = x; return value; }
 
         enum result = select!(2, 2);
-        // -property    prints "setter"
-        // (no option)  prints "setter"
+        // prints "setter"
     }
 
 
@@ -63,8 +48,7 @@ struct Test(int N)
         ref foo(int x){ getset = 2; value = x; return value; }
 
         enum result = select!(0, 2);
-        // -property    test.d(xx): Error: not a property foo
-        // (no option)  prints "setter"
+        // prints "setter"
     }
     static if (N == 5)
     {
@@ -72,8 +56,7 @@ struct Test(int N)
                   ref foo(int x){ getset = 2; value = x; return value; }
 
         enum result = select!(0, 0);
-        // -property    test.d(xx): Error: cannot overload both property and non-property functions
-        // (no option)  test.d(xx): Error: cannot overload both property and non-property functions
+        // test.d(xx): Error: cannot overload both property and non-property functions
     }
     static if (N == 6)
     {
@@ -81,8 +64,7 @@ struct Test(int N)
         @property ref foo(int x){ getset = 2; value = x; return value; }
 
         enum result = select!(0, 0);
-        // -property    test.d(xx): Error: cannot overload both property and non-property functions
-        // (no option)  test.d(xx): Error: cannot overload both property and non-property functions
+        // test.d(xx): Error: cannot overload both property and non-property functions
     }
     static if (N == 7)
     {
@@ -90,8 +72,7 @@ struct Test(int N)
         @property ref foo(int x){ getset = 2; value = x; return value; }
 
         enum result = select!(2, 2);
-        // -property    prints "setter"
-        // (no option)  prints "setter"
+        // prints "setter"
     }
 }
 
@@ -141,10 +122,7 @@ void spam7722(Foo7722 f) {}
 void test7722()
 {
     auto f = new Foo7722;
-    static if (enforceProperty)
-        static assert(!__traits(compiles, f.spam7722));
-    else
-        f.spam7722;
+    f.spam7722;
 }
 
 /*******************************************/
@@ -159,10 +137,7 @@ void test7722()
             assert(dg(0) == v);
     }
 
-    static if (enforceProperty)
-        checkImpl!(v1)();
-    else
-        checkImpl!(v2)();
+    checkImpl!(v2)();
 }
 
 struct S {}


### PR DESCRIPTION
The *-property* switch was deprecated in 2.069.  Time to clean house.