### PR TITLE
Fix Issue 19022 - CTorFlow: Show the line of the duplicated initialization for const/immutable fields

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -191,7 +191,7 @@ struct Scope
         }
         s.slabel = null;
         s.nofree = false;
-        s.ctorflow.fieldinit = ctorflow.saveFieldInit();
+        s.ctorflow.fieldinit = ctorflow.fieldinit.arraydup;
         s.flags = (flags & SCOPEpush);
         s.lastdc = null;
         assert(&this != s);
@@ -290,7 +290,11 @@ struct Scope
             foreach (i, v; ad.fields)
             {
                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                if (!mergeFieldInit(this.ctorflow.fieldinit[i], fies[i]) && mustInit)
+                auto fieldInit = &this.ctorflow.fieldinit[i];
+                const fiesCurrent = fies[i];
+                if (fieldInit.loc == Loc.init)
+                    fieldInit.loc = fiesCurrent.loc;
+                if (!mergeFieldInit(this.ctorflow.fieldinit[i].csx, fiesCurrent.csx) && mustInit)
                 {
                     error(loc, "one path skips field `%s`", v.toChars());
                 }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5429,7 +5429,7 @@ extern (C++) final class DotVarExp : UnaExp
                     {
                         if (f == vd)
                         {
-                            if (!(sc.ctorflow.fieldinit[i] & CSX.this_ctor))
+                            if (!(sc.ctorflow.fieldinit[i].csx & CSX.this_ctor))
                             {
                                 /* If the address of vd is taken, assume it is thereby initialized
                                  * https://issues.dlang.org/show_bug.cgi?id=15869

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3290,7 +3290,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // initialized after this call.
                 foreach (ref field; sc.ctorflow.fieldinit)
                 {
-                    field |= CSX.this_ctor | CSX.deprecate_18719;
+                    field.csx |= CSX.this_ctor | CSX.deprecate_18719;
                 }
             }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -432,7 +432,7 @@ struct Loc
     static immutable Loc initial;       /// use for default initialization of const ref Loc's
 
 nothrow:
-    extern (D) this(const(char)* filename, uint linnum, uint charnum)
+    extern (D) this(const(char)* filename, uint linnum, uint charnum) pure
     {
         this.linnum = linnum;
         this.charnum = charnum;

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -242,18 +242,68 @@ else
         }
     }
 }
+/**
+Makes a null-terminated copy of the given string on newly allocated memory.
+The null-terminator won't be part of the returned string slice. It will be
+at position `n` where `n` is the length of the input string.
 
-extern (D) static char[] xarraydup(const(char)[] s) nothrow
+Params:
+    s = string to copy
+
+Returns: A null-terminated copy of the input array.
+*/
+extern (D) char[] xarraydup(const(char)[] s) nothrow
 {
-    if (s)
-    {
-        auto p = cast(char*)mem.xmalloc(s.length + 1);
-        char[] a = p[0 .. s.length];
-        a[] = s[0 .. s.length];
-        p[s.length] = 0;    // preserve 0 terminator semantics
-        return a;
-    }
-    return null;
+    if (!s)
+        return null;
+
+    auto p = cast(char*)mem.xmalloc(s.length + 1);
+    char[] a = p[0 .. s.length];
+    a[] = s[0 .. s.length];
+    p[s.length] = 0;    // preserve 0 terminator semantics
+    return a;
 }
 
+///
+unittest
+{
+    auto s1 = "foo";
+    auto s2 = s1.xarraydup;
+    s2[0] = 'b';
+    assert(s1 == "foo");
+    assert(s2 == "boo");
+    assert(*(s2.ptr + s2.length) == '\0');
+    string sEmpty;
+    assert(sEmpty.xarraydup is null);
+}
 
+/**
+Makes a copy of the given array on newly allocated memory.
+
+Params:
+    s = array to copy
+
+Returns: A copy of the input array.
+*/
+extern (D) T[] arraydup(T)(const scope T[] s) nothrow
+{
+    if (!s)
+        return null;
+
+    const dim = s.length;
+    auto p = (cast(T*)mem.xmalloc(T.sizeof * dim))[0 .. dim];
+    p[] = s;
+    return p;
+}
+
+///
+unittest
+{
+    auto s1 = [0, 1, 2];
+    auto s2 = s1.arraydup;
+    s2[0] = 4;
+    assert(s1 == [0, 1, 2]);
+    assert(s2 == [4, 1, 2]);
+    string sEmpty;
+    assert(sEmpty.arraydup is null);
+}

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -673,7 +673,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             else
                             {
                                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                                if (mustInit && !(sc2.ctorflow.fieldinit[i] & CSX.this_ctor))
+                                if (mustInit && !(sc2.ctorflow.fieldinit[i].csx & CSX.this_ctor))
                                 {
                                     funcdecl.error("field `%s` must be initialized but skipped", v.toChars());
                                 }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3236,7 +3236,7 @@ else
             foreach (i, v; ad.fields)
             {
                 bool mustInit = (v.storage_class & STC.nodefaultctor || v.type.needsNested());
-                if (mustInit && !(sc.ctorflow.fieldinit[i] & CSX.this_ctor))
+                if (mustInit && !(sc.ctorflow.fieldinit[i].csx & CSX.this_ctor))
                 {
                     rs.error("an earlier `return` statement skips field `%s` initialization", v.toChars());
                     errors = true;

--- a/test/fail_compilation/diag12678.d
+++ b/test/fail_compilation/diag12678.d
@@ -1,9 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag12678.d(19): Error: const field `cf1` initialized multiple times
-fail_compilation/diag12678.d(22): Error: immutable field `if1` initialized multiple times
-fail_compilation/diag12678.d(25): Error: const field `cf2` initialization is not allowed in loops or after labels
+fail_compilation/diag12678.d(21): Error: const field `cf1` initialized multiple times
+fail_compilation/diag12678.d(20):        Previous initialization is here.
+fail_compilation/diag12678.d(24): Error: immutable field `if1` initialized multiple times
+fail_compilation/diag12678.d(23):        Previous initialization is here.
+fail_compilation/diag12678.d(27): Error: const field `cf2` initialization is not allowed in loops or after labels
 ---
 */
 

--- a/test/fail_compilation/diag19022.d
+++ b/test/fail_compilation/diag19022.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag19022.d(16): Error: immutable field `b` initialized multiple times
+fail_compilation/diag19022.d(15):        Previous initialization is here.
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=19022
+
+struct Foo
+{
+    immutable int b;
+    this(int a)
+    {
+        b = 2;
+        b = 2;
+    }
+}

--- a/test/fail_compilation/fail18719.d
+++ b/test/fail_compilation/fail18719.d
@@ -4,7 +4,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18719.d(29): Deprecation: immutable field `x` initialized multiple times
+fail_compilation/fail18719.d(29): Deprecation: immutable field `x` was initialized in a previous constructor call
 ---
 */
 

--- a/test/fail_compilation/fail9665a.d
+++ b/test/fail_compilation/fail9665a.d
@@ -1,15 +1,41 @@
 // REQUIRED_ARGS:
 // PERMUTE_ARGS:
+/+
+TEST_OUTPUT:
+---
+fail_compilation/fail9665a.d(45): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(44):        Previous initialization is here.
+fail_compilation/fail9665a.d(55): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(54):        Previous initialization is here.
+fail_compilation/fail9665a.d(60): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(59):        Previous initialization is here.
+fail_compilation/fail9665a.d(65): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(64):        Previous initialization is here.
+fail_compilation/fail9665a.d(75): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(74):        Previous initialization is here.
+fail_compilation/fail9665a.d(80): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(79):        Previous initialization is here.
+fail_compilation/fail9665a.d(85): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(84):        Previous initialization is here.
+fail_compilation/fail9665a.d(98): Error: immutable field `v` initialization is not allowed in loops or after labels
+fail_compilation/fail9665a.d(103): Error: immutable field `v` initialization is not allowed in loops or after labels
+fail_compilation/fail9665a.d(108): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(107):        Previous initialization is here.
+fail_compilation/fail9665a.d(113): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(112):        Previous initialization is here.
+fail_compilation/fail9665a.d(118): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(117):        Previous initialization is here.
+fail_compilation/fail9665a.d(132): Error: immutable field `v` initialized multiple times
+fail_compilation/fail9665a.d(131):        Previous initialization is here.
+fail_compilation/fail9665a.d(136): Error: immutable field `w` initialized multiple times
+fail_compilation/fail9665a.d(135):        Previous initialization is here.
+fail_compilation/fail9665a.d(150): Error: static assert:  `__traits(compiles, this.v = 1)` is false
+---
++/
 
 /***************************************************/
 // immutable field
 
-/+
-TEST_OUTPUT:
----
-fail_compilation/fail9665a.d(19): Error: immutable field `v` initialized multiple times
----
-+/
 struct S1A
 {
     immutable int v;
@@ -20,14 +46,6 @@ struct S1A
     }
 }
 
-/+
-TEST_OUTPUT:
----
-fail_compilation/fail9665a.d(37): Error: immutable field `v` initialized multiple times
-fail_compilation/fail9665a.d(42): Error: immutable field `v` initialized multiple times
-fail_compilation/fail9665a.d(47): Error: immutable field `v` initialized multiple times
----
-+/
 struct S1B
 {
     immutable int v;
@@ -48,14 +66,6 @@ struct S1B
     }
 }
 
-/+
-TEST_OUTPUT:
----
-fail_compilation/fail9665a.d(65): Error: immutable field `v` initialized multiple times
-fail_compilation/fail9665a.d(70): Error: immutable field `v` initialized multiple times
-fail_compilation/fail9665a.d(75): Error: immutable field `v` initialized multiple times
----
-+/
 struct S1C
 {
     immutable int v;
@@ -79,16 +89,6 @@ struct S1C
 /***************************************************/
 // with control flow
 
-/+
-TEST_OUTPUT:
----
-fail_compilation/fail9665a.d(98): Error: immutable field `v` initialization is not allowed in loops or after labels
-fail_compilation/fail9665a.d(103): Error: immutable field `v` initialization is not allowed in loops or after labels
-fail_compilation/fail9665a.d(108): Error: immutable field `v` initialized multiple times
-fail_compilation/fail9665a.d(113): Error: immutable field `v` initialized multiple times
-fail_compilation/fail9665a.d(118): Error: immutable field `v` initialized multiple times
----
-+/
 struct S2
 {
     immutable int v;
@@ -122,13 +122,6 @@ struct S2
 /***************************************************/
 // with immutable constructor
 
-/+
-TEST_OUTPUT:
----
-fail_compilation/fail9665a.d(139): Error: immutable field `v` initialized multiple times
-fail_compilation/fail9665a.d(143): Error: immutable field `w` initialized multiple times
----
-+/
 struct S3
 {
     int v;
@@ -147,12 +140,6 @@ struct S3
 /***************************************************/
 // in __traits(compiles)
 
-/+
-TEST_OUTPUT:
----
-fail_compilation/fail9665a.d(163): Error: static assert:  `__traits(compiles, this.v = 1)` is false
----
-+/
 struct S4
 {
     immutable int v;


### PR DESCRIPTION
I wasn't sure on the best way to save this information.
Is it okay to use an additional array here?