### PR TITLE
Sanitize Json import path to a relative path

### DIFF
--- a/test/tools/sanitize_json.d
+++ b/test/tools/sanitize_json.d
@@ -7,9 +7,11 @@ import std.uni : asCapitalized;
 import std.json;
 import std.getopt;
 import std.file : readText;
+import std.path : dirName;
 import std.stdio;
 
 bool keepDeco = false;
+enum rootDir = __FILE_FULL_PATH__.dirName.dirName;
 
 void usage()
 {
@@ -188,6 +190,8 @@ void sanitizeSemantics(ref JSONValue[string] semantics)
 
 auto normalizeFile(string file)
 {
+    import std.path : buildNormalizedPath, relativePath;
+    file = file.buildNormalizedPath.relativePath(rootDir);
     version(Windows)
         return file.replace("\\", "/");
     return file;


### PR DESCRIPTION
Depending on the build process, the import paths might be absolute.
The sanitizer can be smart enough to handle this.