### PR TITLE
Print output on segfault in the testsuite

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -867,9 +867,8 @@ int tryMain(string[] args)
             if (e.msg.canFind("exited with rc == 139"))
             {
                 auto gdbCommand = "gdb -q -n -ex 'set backtrace limit 100' -ex run -ex bt -batch -args " ~ command;
-                import std.process : executeShell;
-                auto res = executeShell(gdbCommand);
-                res.output.writeln;
+                import std.process : spawnShell;
+                spawnShell(gdbCommand).wait;
             }
 
             return Result.return1;


### PR DESCRIPTION
The default `system` shell command which runs each test has a buffer and won't print the stdout output when a segfault occurs.
However, as we rerun the test with gdb anyhow, we can simply use `spawnShell` which directly prints to `stdout` and avoids the internal buffering issues of `executeShell` and `gdb`.