### PR TITLE
Fix buffer overflow in test/runnable/cppa.d

### DIFF
--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1389,7 +1389,7 @@ mixin template scopeAllocCpp(C)
         scope C ptr = new C;
     else
     {
-        ubyte[C.sizeof] data;
+        ubyte[__traits(classInstanceSize, C)] data;
         C ptr = (){ auto p = cast(C) data.ptr; p.__ctor(); return p; }();
     }
 }


### PR DESCRIPTION
This fixes reproducible `cppa` segfaults for LDC CI on 32/64-bit macOS.