### PR TITLE
Deprecate opDot

### DIFF
--- a/changelog/deprecate-opDot.dd
+++ b/changelog/deprecate-opDot.dd
@@ -1,0 +1,51 @@
+Deprecatie usage of `opDot`
+
+`opDot` was the D1 analog to `alias this`.
+However, `alias this` covers all use cases of `opDot`, but ensures safety.
+
+---
+struct S
+{
+    int a, b;
+}
+struct T
+{
+    S s;
+
+    S* opDot()
+    {
+        return &s;
+    }
+}
+
+void main()
+{
+    T t;
+    t.a = 4;
+    assert(t.a == 4);
+    t.b = 5;
+}
+---
+
+With `alias this`:
+
+---
+struct S
+{
+    int a, b;
+}
+struct T
+{
+    S s;
+
+    alias s this;
+}
+
+void main() @safe
+{
+    T t;
+    t.a = 4;
+    assert(t.a == 4);
+    t.b = 5;
+}
+---

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3397,6 +3397,8 @@ private extern(C++) final class DotExpVisitor : Visitor
                  *  e.opDot().ident
                  */
                 e = build_overload(e.loc, sc, e, null, fd);
+                // @@@DEPRECATED_2.087@@@.
+                e.deprecation("`opDot` is deprecated. Use `alias this`");
                 e = new DotIdExp(e.loc, e, ident);
                 return returnExp(e.expressionSemantic(sc));
             }

--- a/test/fail_compilation/deprecateopdot.d
+++ b/test/fail_compilation/deprecateopdot.d
@@ -1,0 +1,30 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/deprecateopdot.d(27): Deprecation: `opDot` is deprecated. Use `alias this`
+fail_compilation/deprecateopdot.d(28): Deprecation: `opDot` is deprecated. Use `alias this`
+fail_compilation/deprecateopdot.d(29): Deprecation: `opDot` is deprecated. Use `alias this`
+---
+*/
+struct S6
+{
+    int a, b;
+}
+struct T6
+{
+    S6 s;
+
+    S6* opDot()
+    {
+        return &s;
+    }
+}
+
+void test6()
+{
+    T6 t;
+    t.a = 4;
+    assert(t.a == 4);
+    t.b = 5;
+}


### PR DESCRIPTION
I just found this [very old post about `opDot`](https://stackoverflow.com/questions/9880064/d2-what-are-semantics-of-opdot) from 2012.
The gist:

> opDot has been scheduled for deprecation. That's why it isn't documented. Don't use it. Use alias this instead.

I think it's more than time to actually trigger the deprecation!