### PR TITLE
fix Issue 19035 - Escape in scope inference, improve scope inference

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1088,6 +1088,8 @@ extern (C++) class VarDeclaration : Declaration
     Expression edtor;               // if !=null, does the destruction of the variable
     IntRange* range;                // if !=null, the variable is known to be within the range
 
+    VarDeclarations* maybes;        // STC.maybescope variables that are assigned to this STC.maybescope variable
+
     final extern (D) this(Loc loc, Type type, Identifier id, Initializer _init, StorageClass storage_class = STC.undefined_)
     {
         super(id);
@@ -1631,6 +1633,23 @@ extern (C++) class VarDeclaration : Declaration
     final bool enclosesLifetimeOf(VarDeclaration v) const pure
     {
         return sequenceNumber < v.sequenceNumber;
+    }
+
+    /***************************************
+     * Add variable to maybes[].
+     * When a maybescope variable `v` is assigned to a maybescope variable `this`,
+     * we cannot determine if `this` is actually scope until the semantic
+     * analysis for the function is completed. Thus, we save the data
+     * until then.
+     * Params:
+     *  v = an STC.maybescope variable that was assigned to `this`
+     */
+    final void addMaybe(VarDeclaration v)
+    {
+        //printf("add %s to %s's list of dependencies\n", v.toChars(), toChars());
+        if (!maybes)
+            maybes = new VarDeclarations();
+        maybes.push(v);
     }
 }
 

--- a/test/fail_compilation/retscope6.d
+++ b/test/fail_compilation/retscope6.d
@@ -21,3 +21,120 @@ int* test() @safe
     arr[0] ~= &i;
     return arr[0][0];
 }
+
+/* TEST_OUTPUT:
+---
+fail_compilation/retscope6.d(7034): Error: reference to local variable `i` assigned to non-scope parameter `_param_1` calling retscope6.S.emplace!(int*).emplace
+fail_compilation/retscope6.d(7035): Error: reference to local variable `i` assigned to non-scope parameter `_param_0` calling retscope6.S.emplace2!(int*).emplace2
+fail_compilation/retscope6.d(7024): Error: scope variable `_param_2` assigned to `s` with longer lifetime
+fail_compilation/retscope6.d(7025): Error: scope variable `_param_2` assigned to `t` with longer lifetime
+fail_compilation/retscope6.d(7037): Error: template instance `retscope6.S.emplace4!(int*)` error instantiating
+---
+*/
+
+#line 7000
+
+alias T = int*;
+
+struct S
+{
+    T payload;
+
+    static void emplace(Args...)(ref S s, Args args) @safe
+    {
+        s.payload = args[0];
+    }
+
+    void emplace2(Args...)(Args args) @safe
+    {
+        payload = args[0];
+    }
+
+    static void emplace3(Args...)(S s, Args args) @safe
+    {
+        s.payload = args[0];
+    }
+
+    static void emplace4(Args...)(scope ref S s, scope out S t, scope Args args) @safe
+    {
+        s.payload = args[0];
+        t.payload = args[0];
+    }
+
+}
+
+void foo() @safe
+{
+    S s;
+    int i;
+    s.emplace(s, &i);
+    s.emplace2(&i);
+    s.emplace3(s, &i);
+    s.emplace4(s, s, &i);
+}
+
+
+/* TEST_OUTPUT:
+---
+fail_compilation/retscope6.d(8016): Error: reference to local variable `i` assigned to non-scope parameter `s` calling retscope6.frank!().frank
+fail_compilation/retscope6.d(8031): Error: reference to local variable `i` assigned to non-scope parameter `p` calling retscope6.betty!().betty
+fail_compilation/retscope6.d(8031): Error: reference to local variable `j` assigned to non-scope parameter `q` calling retscope6.betty!().betty
+fail_compilation/retscope6.d(8048): Error: reference to local variable `j` assigned to non-scope parameter `q` calling retscope6.archie!().archie
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=19035
+
+#line 8000
+@safe
+{
+
+void escape(int*);
+
+/**********************/
+
+void frank()(ref scope int* p, int* s)
+{
+    p = s;  // should error here
+}
+
+void testfrankly()
+{
+    int* p;
+    int i;
+    frank(p, &i);
+}
+
+/**********************/
+
+void betty()(int* p, int* q)
+{
+     p = q;
+     escape(p);
+}
+
+void testbetty()
+{
+    int i;
+    int j;
+    betty(&i, &j); // should error on i and j
+}
+
+/**********************/
+
+void archie()(int* p, int* q, int* r)
+{
+     p = q;
+     r = p;
+     escape(q);
+}
+
+void testarchie()
+{
+    int i;
+    int j;
+    int k;
+    archie(&i, &j, &k); // should error on j
+}
+
+}


### PR DESCRIPTION
I.e. when two or more parameters are mutually dependent on each other for `scope` inference, this detects more cases.