### PR TITLE
Deprecate scope as a type constraint

### DIFF
--- a/changelog/deprecate_scope_type.dd
+++ b/changelog/deprecate_scope_type.dd
@@ -1,0 +1,8 @@
+`scope` as a type constraint is deprecated.
+
+`scope` as a type constraint has been deprecated for quite some time.  However,
+starting with this release, the compiler will emit a deprecation warning if used.
+
+---
+scope class C { }  // Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+---

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1029,6 +1029,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 dsym.error("globals, statics, fields, manifest constants, ref and out parameters cannot be `scope`");
             }
+
+            // @@@DEPRECATED_v2.087_REMOVAL@@@.
+            // https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
             if (!(dsym.storage_class & STC.scope_))
             {
                 if (!(dsym.storage_class & STC.parameter) && dsym.ident != Id.withSym)
@@ -4322,6 +4325,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
         assert(sd.type.ty != Tstruct || (cast(TypeStruct)sd.type).sym == sd);
+
+        // @@@DEPRECATED_v2.087_REMOVAL@@@.
+        // https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
+        if (sd.storage_class & STC.scope_)
+            deprecation(sd.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
     }
 
     final void interfaceSemantic(ClassDeclaration cd)
@@ -4969,6 +4978,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             cldec.deferred.semantic3(sc);
         }
         //printf("-ClassDeclaration.dsymbolSemantic(%s), type = %p, sizeok = %d, this = %p\n", toChars(), type, sizeok, this);
+
+        // @@@DEPRECATED_v2.087_REMOVAL@@@.
+        // https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
+        if (cldec.storage_class & STC.scope_)
+            deprecation(cldec.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
     }
 
     override void visit(InterfaceDeclaration idec)
@@ -5287,6 +5302,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
         assert(idec.type.ty != Tclass || (cast(TypeClass)idec.type).sym == idec);
+
+        // @@@DEPRECATED_v2.087_REMOVAL@@@.
+        // https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
+        if (idec.storage_class & STC.scope_)
+            deprecation(idec.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
     }
 }
 

--- a/test/fail_compilation/scope_class.d
+++ b/test/fail_compilation/scope_class.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/scope_class.d(10): Error: functions cannot return `scope scope_class.C`
+fail_compilation/scope_class.d(9): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_class.d(11): Error: functions cannot return `scope scope_class.C`
 ---
 */
 

--- a/test/fail_compilation/scope_type.d
+++ b/test/fail_compilation/scope_type.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/scope_type.d(11): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(12): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(13): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+---
+*/
+
+scope class C { }
+scope struct S { }
+scope interface I { }

--- a/test/fail_compilation/typeerrors.d
+++ b/test/fail_compilation/typeerrors.d
@@ -2,21 +2,22 @@
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/typeerrors.d(36): Error: tuple index 4 exceeds 4
-fail_compilation/typeerrors.d(38): Error: variable `x` cannot be read at compile time
-fail_compilation/typeerrors.d(39): Error: cannot have array of `void()`
-fail_compilation/typeerrors.d(40): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(32): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/typeerrors.d(37): Error: tuple index 4 exceeds 4
+fail_compilation/typeerrors.d(39): Error: variable `x` cannot be read at compile time
+fail_compilation/typeerrors.d(40): Error: cannot have array of `void()`
 fail_compilation/typeerrors.d(41): Error: cannot have array of scope `typeerrors.C`
-fail_compilation/typeerrors.d(44): Error: `int[5]` is not an expression
-fail_compilation/typeerrors.d(46): Error: `x` is used as a type
-fail_compilation/typeerrors.d(47): Error: cannot have associative array key of `void()`
-fail_compilation/typeerrors.d(48): Error: cannot have associative array key of `void`
-fail_compilation/typeerrors.d(49): Error: cannot have array of scope `typeerrors.C`
-fail_compilation/typeerrors.d(50): Error: cannot have associative array of `void`
-fail_compilation/typeerrors.d(51): Error: cannot have associative array of `void()`
-fail_compilation/typeerrors.d(53): Error: cannot have parameter of type `void`
-fail_compilation/typeerrors.d(55): Error: slice `[1..5]` is out of range of [0..4]
-fail_compilation/typeerrors.d(56): Error: slice `[2..1]` is out of range of [0..4]
+fail_compilation/typeerrors.d(42): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(45): Error: `int[5]` is not an expression
+fail_compilation/typeerrors.d(47): Error: `x` is used as a type
+fail_compilation/typeerrors.d(48): Error: cannot have associative array key of `void()`
+fail_compilation/typeerrors.d(49): Error: cannot have associative array key of `void`
+fail_compilation/typeerrors.d(50): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(51): Error: cannot have associative array of `void`
+fail_compilation/typeerrors.d(52): Error: cannot have associative array of `void()`
+fail_compilation/typeerrors.d(54): Error: cannot have parameter of type `void`
+fail_compilation/typeerrors.d(56): Error: slice `[1..5]` is out of range of [0..4]
+fail_compilation/typeerrors.d(57): Error: slice `[2..1]` is out of range of [0..4]
 ---
 */
 

--- a/test/runnable/sctor.d
+++ b/test/runnable/sctor.d
@@ -403,19 +403,6 @@ class C15258
 }
 
 /***************************************************/
-// 15665
-
-scope class C15665 (V)
-{
-    this () {}
-}
-
-void test15665()
-{
-    scope foo = new C15665!int;
-}
-
-/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=15869
 
 struct Set {
@@ -455,7 +442,6 @@ int main()
     test13515();
     test14450();
     test14944();
-    test15665();
     test15869();
 
     printf("Success\n");

--- a/test/runnable/sctor2.d
+++ b/test/runnable/sctor2.d
@@ -1,0 +1,19 @@
+// PERMUTE_ARGS: -w -d -dw
+
+/***************************************************/
+// 15665
+
+scope class C15665 (V)
+{
+    this () {}
+}
+
+void test15665()
+{
+    scope foo = new C15665!int;
+}
+
+void main()
+{
+    test15665();
+}


### PR DESCRIPTION
Followup to https://github.com/dlang/dlang.org/pull/2027

See https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint

Update to the deprecations table: https://github.com/dlang/dlang.org/pull/2397