### PR TITLE
Changed 'body' to 'do' x2

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -106,7 +106,7 @@ extern (C++) final class StaticForeach : RootObject
     {
         assert(!!aggrfe ^ !!rangefe);
     }
-    body
+    do
     {
         this.loc = loc;
         this.aggrfe = aggrfe;
@@ -377,7 +377,7 @@ extern (C++) final class StaticForeach : RootObject
     {
         assert(sc);
     }
-    body
+    do
     {
         if (aggrfe)
         {


### PR DESCRIPTION
I found two 'body' keywords in dmd/cond.d. I replaced them with 'do'.