### PR TITLE
Fix issue 19038: when performing an op on two nested arrays that differ only in constness, try to make both const.

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -3302,6 +3302,21 @@ LmodCompare:
             e2 = tmp;
         }
     }
+    // constness1(T)[][] op constness2(T)[][]: maybe we can make them both const?
+    else if (t1.ty == Tarray && t2.ty == Tarray // two dynamic arrays
+        && t1.constOf().equals(t2.constOf()) // and they're unifiable as const
+        && (!t1.equals(t1.constOf()) || !t2.equals(t2.constOf())) // but they're not both const yet
+        && e1.implicitConvTo(t1.constOf()) >= MATCH.constant // but we can make them const
+        && e2.implicitConvTo(t2.constOf()) >= MATCH.constant)
+    {
+        e1 = e1.castTo(sc, t1.constOf());
+        e2 = e2.castTo(sc, t2.constOf());
+        t1 = e1.type;
+        t2 = e2.type;
+        t = t1;
+
+        goto Lagain;
+    }
     else
     {
     Lincompatible:

--- a/test/compilable/test19038.d
+++ b/test/compilable/test19038.d
@@ -1,0 +1,18 @@
+module test19038;
+
+void test()
+{
+    string mutableStr = "x";
+    const string constStr = mutableStr;
+
+    if ([[constStr]] == [[mutableStr]])
+    {
+    }
+
+    int mutableInt = 5;
+    const int constInt = mutableInt;
+
+    if ([[constInt]] == [[mutableInt]])
+    {
+    }
+}


### PR DESCRIPTION
Is `string[][]` implicitly convertible to `const(string)[][]`? `TypeDArray::implicitConvTo` calls `<string[]>.constConv(<const(string)[]>)`, which checks if `<string>.equals(<const(string)>)`; seeing that it doesn't, it returns `nomatch`.

Why not, at least in the simple case where constness is the same as the comparison type, just recurse instead?

Let's see what the tests say.