### PR TITLE
Add different ENABLE + unittest modes to build.d

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -113,9 +113,14 @@ coverage()
     if [ -f ~/dlang/install.sh ] ; then
         source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
     fi
+    RDMD="$(type -p rdmd)"
 
     # build dmd, druntime, and phobos
-    make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD BUILD=$BUILD ENABLE_WARNINGS=1 PIC="$PIC" all
+    if [ "$MODEL" == "64" ] ; then
+        "$RDMD" ./src/build.d MODEL=$MODEL HOST_DMD=$DMD BUILD=$BUILD ENABLE_WARNINGS=1 PIC="$PIC" all
+    else
+        make -j$N -C src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD BUILD=$BUILD ENABLE_WARNINGS=1 PIC="$PIC" all
+    fi
     make -j$N -C ../druntime -f posix.mak MODEL=$MODEL PIC="$PIC"
     make -j$N -C ../phobos -f posix.mak MODEL=$MODEL PIC="$PIC"
 

--- a/src/dmd/asttypename.d
+++ b/src/dmd/asttypename.d
@@ -112,6 +112,6 @@ public :
 unittest
 {
     import dmd.globals : Loc;
-    Expression e = new TypeidExp(Loc.init, null);
+    Expression e = new TypeidExp(Loc.initial, null);
     assert(e.astTypeName == "TypeidExp");
 }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -231,15 +231,6 @@ override DFLAGS += -version=MARS $(PIC)
 # Enable D warnings
 override DFLAGS += -w -de
 
-ifneq (,$(DEBUG))
-ENABLE_DEBUG := 1
-$(error 'DEBUG=1 has been removed. Please use ENABLE_DEBUG=1')
-endif
-ifneq (,$(RELEASE))
-ENABLE_RELEASE := 1
-$(error 'RELEASE=1 has been removed. Please use ENABLE_RELEASE=1')
-endif
-
 # Append different flags for debugging, profiling and release.
 ifdef ENABLE_DEBUG
 CXXFLAGS += -g -g3 -DDEBUG=1 -DUNITTEST

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -4,18 +4,19 @@
 #
 # HOST_CXX:             Host C++ compiler to use (g++,clang++)
 # HOST_DMD:             Host D compiler to use for bootstrapping
-# AUTO_BOOTSTRAP:       Enable auto-boostrapping by download a stable DMD binary
+# AUTO_BOOTSTRAP:       Enable auto-boostrapping by downloading a stable DMD binary
 # INSTALL_DIR:          Installation folder to use
+# MODEL:                Target architecture to build for (32,64) - defaults to the host architecture
 #
 ################################################################################
 # Build modes:
 # ------------
-# BUILD: release (default) | debug (enabled a build with debug symbols)
+# BUILD: release (default) | debug (enabled a build with debug instructions)
 #
 # Opt-in build features:
 #
-# ENABLE_RELEASE:       Optimized release built (set by BUILD=release)
-# ENABLE_DEBUG:         Add debug instructions and symbols (set by BUILD=debug)
+# ENABLE_RELEASE:       Optimized release built
+# ENABLE_DEBUG:         Add debug instructions and symbols (set if ENABLE_RELEASE isn't set)
 # ENABLE_WARNINGS:      Enable C++ build warnings
 # ENABLE_PROFILING:     Build dmd with a profiling recorder (C++)
 # ENABLE_PGO_USE:       Build dmd with existing profiling information (C++)


### PR DESCRIPTION
Moving more bits from the `posix.mak` to `build.d`.
Depends on https://github.com/dlang/dmd/pull/8417.