### PR TITLE
Start deprecation period of identical functions in a single module

### DIFF
--- a/changelog/duplicate-implementations-deprecation.dd
+++ b/changelog/duplicate-implementations-deprecation.dd
@@ -1,0 +1,23 @@
+Usage of identical functions in a single module
+
+A binary should never contain multiple versions of a symbol.
+Before this version, it was allowed to provide multiple implementation for a function,
+even if they result in the same mangling, which can result in undefined behavior:
+
+---
+extern(C):
+void foo(int) { }
+void foo(double) { } // will error now
+---
+
+However, it's still allowed to have multiple declarations as long as there's at
+most one implementation:
+
+---
+extern(C):
+void foo(int) { }
+void foo(double);
+---
+
+Note that this change is only relevant for mangling schemes that do no support
+overloading like `extern(C)`.

--- a/changelog/duplicate-implementations-deprecation.dd
+++ b/changelog/duplicate-implementations-deprecation.dd
@@ -2,12 +2,15 @@ Usage of identical functions in a single module
 
 A binary should never contain multiple versions of a symbol.
 Before this version, it was allowed to provide multiple implementation for a function,
-even if they result in the same mangling, which can result in undefined behavior:
+even if they result in the same mangling, which can result in undefined behaviour:
 
 ---
 extern(C):
 void foo(int) { }
-void foo(double) { } // will error now
+void foo(double) { } // will issue a deprecation now
+
+void bar() {}
+void bar() {} // will raise an error
 ---
 
 However, it's still allowed to have multiple declarations as long as there's at

--- a/changelog/duplicate-implementations-deprecation.dd
+++ b/changelog/duplicate-implementations-deprecation.dd
@@ -1,26 +1,33 @@
-Usage of identical functions in a single module
+Diagnostics for conflicting function definitions within a module
 
-A binary should never contain multiple versions of a symbol.
-Before this version, it was allowed to provide multiple implementation for a function,
-even if they result in the same mangling, which can result in undefined behaviour:
+Previously, multiple definitions of identical functions within a module were not
+recognized, although they have the same mangling. This was problematic because a
+binary cannot contain multiple definitions of a symbol, which caused undefined
+behavior depending on the compiler backend.
+
+DMD will now raise an error message if there are conflicting implementations
+within a single module:
+
+---
+void foo() {}
+void foo() {} // error
+---
+
+Multiple declarations are still allowed as long as there is at most one definition:
+
+---
+void bar(int);
+void bar(int) { }
+void bar(int);
+---
+
+DMD will issue a deprecation for mangling schemes that don't support overloading
+(`extern(C|Windows|System)`):
 
 ---
 extern(C):
 void foo(int) { }
-void foo(double) { } // will issue a deprecation now
-
-void bar() {}
-void bar() {} // will raise an error
+void foo(double) { } // deprecation
 ---
 
-However, it's still allowed to have multiple declarations as long as there's at
-most one implementation:
-
----
-extern(C):
-void foo(int) { }
-void foo(double);
----
-
-Note that this change is only relevant for mangling schemes that do no support
-overloading like `extern(C)`.
+This deprecation will become an error in 2.105.

--- a/src/dmd/frontend.h
+++ b/src/dmd/frontend.h
@@ -5388,6 +5388,7 @@ public:
     bool isInOutQual() const;
     void isInOutQual(bool v);
     bool iswild() const;
+    bool attributesEqual(const TypeFunction* const other) const;
     void accept(Visitor* v);
 };
 

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -359,9 +359,6 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
         //printf("FuncDeclaration::semantic2 [%s] fd0 = %s %s\n", loc.toChars(), toChars(), type.toChars());
 
-        // https://issues.dlang.org/show_bug.cgi?id=18385
-        // Disable for 2.079, s.t. a deprecation cycle can be started with 2.080
-        if (0)
         if (fd.overnext && !fd.errors)
         {
             OutBuffer buf1;
@@ -414,7 +411,8 @@ private extern(C++) final class Semantic2Visitor : Visitor
                         return 0;
 
                     auto tf2 = cast(TypeFunction)f2.type;
-                    error(f2.loc, "%s `%s%s` cannot be overloaded with %s`extern(%s)` function at %s",
+                    // @@@DEPRECATED_2.092@@@
+                    f2.deprecation("%s `%s%s` cannot be overloaded with %s`extern(%s)` function at %s",
                             f2.kind(),
                             f2.toPrettyChars(),
                             parametersTypeToChars(tf2.parameterList),
@@ -435,7 +433,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 if (strcmp(s1, s2) == 0)
                 {
                     auto tf2 = cast(TypeFunction)f2.type;
-                    error(f2.loc, "%s `%s%s` conflicts with previous declaration at %s",
+                    f2.error("%s `%s%s` conflicts with previous declaration at %s",
                             f2.kind(),
                             f2.toPrettyChars(),
                             parametersTypeToChars(tf2.parameterList),

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -408,12 +408,9 @@ private extern(C++) final class Semantic2Visitor : Visitor
                 {
                     // @@@DEPRECATED_2.094@@@
                     // Deprecated in 2020-08, make this an error in 2.104
-                    deprecation(f2.loc, "%s `%s%s` cannot be overloaded with %s`extern(%s)` function at %s",
-                            f2.kind(),
-                            f2.toPrettyChars(),
-                            parametersTypeToChars(tf2.parameterList),
-                            (f1.linkage == f2.linkage ? "another " : "").ptr,
-                            linkageToChars(f1.linkage), f1.loc.toChars());
+                    f2.deprecation("cannot overload `extern(%s)` function at %s",
+                            linkageToChars(f1.linkage),
+                            f1.loc.toChars());
 
                     // Enable this when turning the deprecation into an error
                     // f2.type = Type.terror;

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -370,7 +370,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
             // Always starts the lookup from 'this', because the conflicts with
             // previous overloads are already reported.
-            auto f1 = fd;
+            alias f1 = fd;
             mangleToFuncSignature(buf1, f1);
 
             overloadApply(f1, (Dsymbol s)
@@ -380,7 +380,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     return 0;
 
                 // Don't have to check conflict between declaration and definition.
-                if ((f1.fbody !is null) != (f2.fbody !is null))
+                if (f2.fbody is null)
                     return 0;
 
                 /* Check for overload merging with base class member functions.
@@ -400,20 +400,6 @@ private extern(C++) final class Semantic2Visitor : Visitor
                     (f1.linkage != LINK.d && f1.linkage != LINK.cpp) &&
                     (f2.linkage != LINK.d && f2.linkage != LINK.cpp))
                 {
-                    /* Allow the hack that is actually used in druntime,
-                     * to ignore function attributes for extern (C) functions.
-                     * TODO: Must be reconsidered in the future.
-                     *  BUG: https://issues.dlang.org/show_bug.cgi?id=18206
-                     *
-                     *  extern(C):
-                     *  alias sigfn_t  = void function(int);
-                     *  alias sigfn_t2 = void function(int) nothrow @nogc;
-                     *  sigfn_t  bsd_signal(int sig, sigfn_t  func);
-                     *  sigfn_t2 bsd_signal(int sig, sigfn_t2 func) nothrow @nogc;  // no error
-                     */
-                    if (f1.fbody is null || f2.fbody is null)
-                        return 0;
-
                     auto tf2 = cast(TypeFunction)f2.type;
                     // @@@DEPRECATED_2.094@@@
                     // Deprecated in 2020-08, make this an error in 2.104

--- a/test/compilable/test18385.d
+++ b/test/compilable/test18385.d
@@ -7,13 +7,13 @@ see visit(FuncDeclaration) in semantic2.d for details.
 
 TEST_OUTPUT:
 ---
-compilable\test18385.d(23): Deprecation: function `test18385.is_paragraph_start(int)` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(22)
-compilable\test18385.d(26): Deprecation: function `test18385.foo(byte, char)` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(25)
-compilable\test18385.d(29): Deprecation: function `test18385.trust()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(28)
-compilable\test18385.d(32): Deprecation: function `test18385.purity()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(31)
-compilable\test18385.d(35): Deprecation: function `test18385.nogc()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(34)
-compilable\test18385.d(38): Deprecation: function `test18385.nothrow_()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(37)
-compilable\test18385.d(41): Deprecation: function `test18385.live()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(40)
+compilable/test18385.d(23): Deprecation: function `test18385.is_paragraph_start` cannot overload `extern(C)` function at compilable/test18385.d(22)
+compilable/test18385.d(26): Deprecation: function `test18385.foo` cannot overload `extern(C)` function at compilable/test18385.d(25)
+compilable/test18385.d(29): Deprecation: function `test18385.trust` cannot overload `extern(C)` function at compilable/test18385.d(28)
+compilable/test18385.d(32): Deprecation: function `test18385.purity` cannot overload `extern(C)` function at compilable/test18385.d(31)
+compilable/test18385.d(35): Deprecation: function `test18385.nogc` cannot overload `extern(C)` function at compilable/test18385.d(34)
+compilable/test18385.d(38): Deprecation: function `test18385.nothrow_` cannot overload `extern(C)` function at compilable/test18385.d(37)
+compilable/test18385.d(41): Deprecation: function `test18385.live` cannot overload `extern(C)` function at compilable/test18385.d(40)
 ---
 */
 

--- a/test/compilable/test18385.d
+++ b/test/compilable/test18385.d
@@ -1,0 +1,18 @@
+/*
+Reduced from the assertion failure in the glue layer when compiling DWT.
+A `compilable` test because it needs codegen.
+
+Remove this test once the deprecation for conflicting deprecations ends,
+see visit(FuncDeclaration) in semantic2.d for details.
+
+TEST_OUTPUT:
+---
+compilable/test18385.d(17): Deprecation: function `test18385.is_paragraph_start()` cannot be overloaded with another `extern(C)` function at compilable/test18385.d(16)
+---
+*/
+
+extern(C)
+{
+	uint is_paragraph_start(){ return 0; }
+	uint is_paragraph_start(){ return 0; }
+}

--- a/test/compilable/test18385.d
+++ b/test/compilable/test18385.d
@@ -7,12 +7,36 @@ see visit(FuncDeclaration) in semantic2.d for details.
 
 TEST_OUTPUT:
 ---
-compilable/test18385.d(17): Deprecation: function `test18385.is_paragraph_start()` cannot be overloaded with another `extern(C)` function at compilable/test18385.d(16)
+compilable\test18385.d(23): Deprecation: function `test18385.is_paragraph_start(int)` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(22)
+compilable\test18385.d(26): Deprecation: function `test18385.foo(byte, char)` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(25)
+compilable\test18385.d(29): Deprecation: function `test18385.trust()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(28)
+compilable\test18385.d(32): Deprecation: function `test18385.purity()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(31)
+compilable\test18385.d(35): Deprecation: function `test18385.nogc()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(34)
+compilable\test18385.d(38): Deprecation: function `test18385.nothrow_()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(37)
+compilable\test18385.d(41): Deprecation: function `test18385.live()` cannot be overloaded with another `extern(C)` function at compilable\test18385.d(40)
 ---
 */
 
 extern(C)
 {
 	uint is_paragraph_start(){ return 0; }
-	uint is_paragraph_start(){ return 0; }
+	uint is_paragraph_start(int){ return 0; }
+
+	void foo(char, bool) {}
+	void foo(byte, char) {}
+
+	void trust() {}
+	void trust() @safe {}
+
+	void purity() {}
+	void purity() pure {}
+
+	void nogc() {}
+	void nogc() @safe {}
+
+	void nothrow_() {}
+	void nothrow_() nothrow {}
+
+	void live() {}
+	void live() @live {}
 }

--- a/test/fail_compilation/fail17492.d
+++ b/test/fail_compilation/fail17492.d
@@ -1,11 +1,9 @@
 /*
-https://issues.dlang.org/show_bug.cgi?id=18385
-Disabled for 2.079, s.t. a deprecation cycle can be started with 2.080
-DISABLED: win32 win64 osx linux freebsd dragonflybsd
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail17492.d(20): Error: class `fail17492.C.testE.I` already exists at fail17492.d(13). Perhaps in another function with the same name?
-fail_compilation/fail17492.d(37): Error: struct `fail17492.S.testE.I` already exists at fail17492.d(30). Perhaps in another function with the same name?
+fail_compilation/fail17492.d(20): Error: function `fail17492.C.testE` function `fail17492.C.testE()` conflicts with previous declaration at fail_compilation/fail17492.d(13)
+fail_compilation/fail17492.d(37): Error: function `fail17492.S.testE` function `fail17492.S.testE()` conflicts with previous declaration at fail_compilation/fail17492.d(30)
 ---
 https://issues.dlang.org/show_bug.cgi?id=17492
 */

--- a/test/fail_compilation/fail17492.d
+++ b/test/fail_compilation/fail17492.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail17492.d(20): Error: function `fail17492.C.testE` function `fail17492.C.testE()` conflicts with previous declaration at fail_compilation/fail17492.d(13)
-fail_compilation/fail17492.d(37): Error: function `fail17492.S.testE` function `fail17492.S.testE()` conflicts with previous declaration at fail_compilation/fail17492.d(30)
+fail_compilation/fail17492.d(20): Error: function `fail17492.C.testE()` conflicts with previous declaration at fail_compilation/fail17492.d(13)
+fail_compilation/fail17492.d(37): Error: function `fail17492.S.testE()` conflicts with previous declaration at fail_compilation/fail17492.d(30)
 ---
 https://issues.dlang.org/show_bug.cgi?id=17492
 */

--- a/test/fail_compilation/fail2789.d
+++ b/test/fail_compilation/fail2789.d
@@ -1,11 +1,18 @@
 /*
-DISABLED: win32 win64 osx linux freebsd dragonflybsd
-https://issues.dlang.org/show_bug.cgi?id=18385
-Disabled for 2.079, s.t. a deprecation cycle can be started with 2.080
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/fail2789.d(15): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)
-fail_compilation/fail2789.d(25): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)
+fail_compilation/fail2789.d(25): Error: function `fail2789.A2789.m` function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(20)
+fail_compilation/fail2789.d(35): Error: function `fail2789.A2789.m` function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(20)
+fail_compilation/fail2789.d(47): Error: function `fail2789.f3` function `fail2789.f3()` conflicts with previous declaration at fail_compilation/fail2789.d(46)
+fail_compilation/fail2789.d(50): Error: function `fail2789.f4` function `fail2789.f4()` conflicts with previous declaration at fail_compilation/fail2789.d(49)
+fail_compilation/fail2789.d(53): Error: function `fail2789.f5` function `fail2789.f5()` conflicts with previous declaration at fail_compilation/fail2789.d(52)
+fail_compilation/fail2789.d(56): Error: function `fail2789.f6` function `fail2789.f6()` conflicts with previous declaration at fail_compilation/fail2789.d(55)
+fail_compilation/fail2789.d(60): Deprecation: function `fail2789.f_ExternC1` function `fail2789.f_ExternC1()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(59)
+fail_compilation/fail2789.d(63): Deprecation: function `fail2789.f_ExternC2` function `fail2789.f_ExternC2(int)` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(62)
+fail_compilation/fail2789.d(66): Deprecation: function `fail2789.f_ExternC3` function `fail2789.f_ExternC3()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(65)
+fail_compilation/fail2789.d(69): Error: function `fail2789.f_MixExtern1` function `fail2789.f_MixExtern1()` conflicts with previous declaration at fail_compilation/fail2789.d(68)
+fail_compilation/fail2789.d(90): Error: function `fail2789.mul14147` function `fail2789.mul14147(const(int[]) left, const(int[]) right)` conflicts with previous declaration at fail_compilation/fail2789.d(86)
 ---
 */
 class A2789
@@ -30,15 +37,6 @@ class A2789
     }
 }
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail2789.d(46): Error: function `fail2789.f3()` conflicts with previous declaration at fail_compilation/fail2789.d(45)
-fail_compilation/fail2789.d(49): Error: function `fail2789.f4()` conflicts with previous declaration at fail_compilation/fail2789.d(48)
-fail_compilation/fail2789.d(52): Error: function `fail2789.f5()` conflicts with previous declaration at fail_compilation/fail2789.d(51)
-fail_compilation/fail2789.d(55): Error: function `fail2789.f6()` conflicts with previous declaration at fail_compilation/fail2789.d(54)
----
-*/
 void f1();
 void f1() {}    // ok
 
@@ -57,15 +55,7 @@ void f5() @system {}    // conflict
 auto f6() { return 10; }    // int()
 auto f6() { return ""; }    // string(), conflict
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail2789.d(67): Error: function `fail2789.f_ExternC1()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(66)
-fail_compilation/fail2789.d(70): Error: function `fail2789.f_ExternC2(int)` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(69)
-fail_compilation/fail2789.d(73): Error: function `fail2789.f_ExternC3()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(72)
-fail_compilation/fail2789.d(76): Error: function `fail2789.f_MixExtern1()` conflicts with previous declaration at fail_compilation/fail2789.d(75)
----
-*/
+
 extern(C) void f_ExternC1() {}
 extern(C) void f_ExternC1() {}      // conflict
 
@@ -90,12 +80,6 @@ extern (C) void f_ExternC5(int sig) @nogc;      // no error
 extern (C) void f_ExternC6(int sig);
 extern (C) void f_ExternC6(int sig) @nogc {}    // no error
 
-/*
-TEST_OUTPUT:
----
-fail_compilation/fail2789.d(103): Error: function `fail2789.mul14147(const(int[]) left, const(int[]) right)` conflicts with previous declaration at fail_compilation/fail2789.d(99)
----
-*/
 struct S14147(alias func)
 {
 }

--- a/test/fail_compilation/fail2789.d
+++ b/test/fail_compilation/fail2789.d
@@ -1,20 +1,14 @@
 /*
-REQUIRED_ARGS: -de
+https://issues.dlang.org/show_bug.cgi?id=18385
+
 TEST_OUTPUT:
 ---
-fail_compilation/fail2789.d(25): Error: function `fail2789.A2789.m` function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(20)
-fail_compilation/fail2789.d(35): Error: function `fail2789.A2789.m` function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(20)
-fail_compilation/fail2789.d(47): Error: function `fail2789.f3` function `fail2789.f3()` conflicts with previous declaration at fail_compilation/fail2789.d(46)
-fail_compilation/fail2789.d(50): Error: function `fail2789.f4` function `fail2789.f4()` conflicts with previous declaration at fail_compilation/fail2789.d(49)
-fail_compilation/fail2789.d(53): Error: function `fail2789.f5` function `fail2789.f5()` conflicts with previous declaration at fail_compilation/fail2789.d(52)
-fail_compilation/fail2789.d(56): Error: function `fail2789.f6` function `fail2789.f6()` conflicts with previous declaration at fail_compilation/fail2789.d(55)
-fail_compilation/fail2789.d(60): Deprecation: function `fail2789.f_ExternC1` function `fail2789.f_ExternC1()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(59)
-fail_compilation/fail2789.d(63): Deprecation: function `fail2789.f_ExternC2` function `fail2789.f_ExternC2(int)` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(62)
-fail_compilation/fail2789.d(66): Deprecation: function `fail2789.f_ExternC3` function `fail2789.f_ExternC3()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(65)
-fail_compilation/fail2789.d(69): Error: function `fail2789.f_MixExtern1` function `fail2789.f_MixExtern1()` conflicts with previous declaration at fail_compilation/fail2789.d(68)
-fail_compilation/fail2789.d(90): Error: function `fail2789.mul14147` function `fail2789.mul14147(const(int[]) left, const(int[]) right)` conflicts with previous declaration at fail_compilation/fail2789.d(86)
+fail_compilation/fail2789.d(15): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)
+fail_compilation/fail2789.d(25): Error: function `fail2789.A2789.m()` conflicts with previous declaration at fail_compilation/fail2789.d(10)
 ---
 */
+#line 7
+
 class A2789
 {
     int m()
@@ -37,6 +31,15 @@ class A2789
     }
 }
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2789.d(49): Error: function `fail2789.f4()` conflicts with previous declaration at fail_compilation/fail2789.d(48)
+fail_compilation/fail2789.d(52): Error: function `fail2789.f5()` conflicts with previous declaration at fail_compilation/fail2789.d(51)
+fail_compilation/fail2789.d(55): Error: function `fail2789.f6()` conflicts with previous declaration at fail_compilation/fail2789.d(54)
+---
+*/
+
 void f1();
 void f1() {}    // ok
 
@@ -55,7 +58,15 @@ void f5() @system {}    // conflict
 auto f6() { return 10; }    // int()
 auto f6() { return ""; }    // string(), conflict
 
-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2789.d(67): Deprecation: function `fail2789.f_ExternC1()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(66)
+fail_compilation/fail2789.d(70): Deprecation: function `fail2789.f_ExternC2(int)` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(69)
+fail_compilation/fail2789.d(73): Deprecation: function `fail2789.f_ExternC3()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(72)
+fail_compilation/fail2789.d(76): Error: function `fail2789.f_MixExtern1()` conflicts with previous declaration at fail_compilation/fail2789.d(75)
+---
+*/
 extern(C) void f_ExternC1() {}
 extern(C) void f_ExternC1() {}      // conflict
 
@@ -80,6 +91,12 @@ extern (C) void f_ExternC5(int sig) @nogc;      // no error
 extern (C) void f_ExternC6(int sig);
 extern (C) void f_ExternC6(int sig) @nogc {}    // no error
 
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2789.d(103): Error: function `fail2789.mul14147(const(int[]) left, const(int[]) right)` conflicts with previous declaration at fail_compilation/fail2789.d(99)
+---
+*/
 struct S14147(alias func)
 {
 }

--- a/test/fail_compilation/fail2789.d
+++ b/test/fail_compilation/fail2789.d
@@ -62,8 +62,8 @@ auto f6() { return ""; }    // string(), conflict
 TEST_OUTPUT:
 ---
 fail_compilation/fail2789.d(67): Error: function `fail2789.f_ExternC1()` conflicts with previous declaration at fail_compilation/fail2789.d(66)
-fail_compilation/fail2789.d(70): Deprecation: function `fail2789.f_ExternC2(int)` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(69)
-fail_compilation/fail2789.d(73): Deprecation: function `fail2789.f_ExternC3()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(72)
+fail_compilation/fail2789.d(70): Deprecation: function `fail2789.f_ExternC2` cannot overload `extern(C)` function at fail_compilation/fail2789.d(69)
+fail_compilation/fail2789.d(73): Deprecation: function `fail2789.f_ExternC3` cannot overload `extern(C)` function at fail_compilation/fail2789.d(72)
 fail_compilation/fail2789.d(76): Error: function `fail2789.f_MixExtern1()` conflicts with previous declaration at fail_compilation/fail2789.d(75)
 ---
 */

--- a/test/fail_compilation/fail2789.d
+++ b/test/fail_compilation/fail2789.d
@@ -61,7 +61,7 @@ auto f6() { return ""; }    // string(), conflict
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail2789.d(67): Deprecation: function `fail2789.f_ExternC1()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(66)
+fail_compilation/fail2789.d(67): Error: function `fail2789.f_ExternC1()` conflicts with previous declaration at fail_compilation/fail2789.d(66)
 fail_compilation/fail2789.d(70): Deprecation: function `fail2789.f_ExternC2(int)` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(69)
 fail_compilation/fail2789.d(73): Deprecation: function `fail2789.f_ExternC3()` cannot be overloaded with another `extern(C)` function at fail_compilation/fail2789.d(72)
 fail_compilation/fail2789.d(76): Error: function `fail2789.f_MixExtern1()` conflicts with previous declaration at fail_compilation/fail2789.d(75)

--- a/test/fail_compilation/fail47.d
+++ b/test/fail_compilation/fail47.d
@@ -1,12 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail47.d(13): Error: variable `fail47._foo` is aliased to a function
-fail_compilation/fail47.d(13): Error: variable `fail47._foo` is aliased to a function
-fail_compilation/fail47.d(13): Error: variable `fail47._foo` is aliased to a function
-fail_compilation/fail47.d(18): Error: none of the overloads of `foo` are callable using argument types `(int)`, candidates are:
-fail_compilation/fail47.d(12):        `fail47.foo()`
-fail_compilation/fail47.d(13): Error: variable `fail47._foo` is aliased to a function
+fail_compilation/fail47.d(8): Error: variable `fail47._foo` is aliased to a function
 ---
 */
 void foo() {}

--- a/test/fail_compilation/fail5634.d
+++ b/test/fail_compilation/fail5634.d
@@ -1,9 +1,9 @@
 /*
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ----
-fail_compilation/fail5634.d(9): Error: only one `main`$?:windows=, `WinMain`, or `DllMain`$ allowed. Previously found `main` at fail_compilation/fail5634.d(8)
-----
+fail_compilation/fail5634.d(9): Error: function `D main` function `D main()` conflicts with previous declaration at fail_compilation/fail5634.d(8)
+---
 */
-
 void main() { }
 void main() { }

--- a/test/fail_compilation/fail5634.d
+++ b/test/fail_compilation/fail5634.d
@@ -1,9 +1,9 @@
 /*
-REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ----
-fail_compilation/fail5634.d(9): Error: function `D main` function `D main()` conflicts with previous declaration at fail_compilation/fail5634.d(8)
+fail_compilation/fail5634.d(9): Error: function `D main()` conflicts with previous declaration at fail_compilation/fail5634.d(8)
 ---
 */
+
 void main() { }
 void main() { }

--- a/test/fail_compilation/fail7443.d
+++ b/test/fail_compilation/fail7443.d
@@ -1,9 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7443.d(12): Error: `static` has no effect on a constructor inside a `static` block. Use `static this()`
-fail_compilation/fail7443.d(13): Error: `shared static` has no effect on a constructor inside a `shared static` block. Use `shared static this()`
-fail_compilation/fail7443.d(14): Error: constructor `fail7443.Foo.this` constructor `fail7443.Foo.this()` conflicts with previous declaration at fail_compilation/fail7443.d(12)
+fail_compilation/fail7443.d(11): Error: `static` has no effect on a constructor inside a `static` block. Use `static this()`
+fail_compilation/fail7443.d(12): Error: `shared static` has no effect on a constructor inside a `shared static` block. Use `shared static this()`
 ---
 */
 
@@ -11,5 +10,5 @@ class Foo
 {
     public static { this() {}}
     public shared static { this() {}}
-    public {this() {}}
+    public {this(int) {}}
 }

--- a/test/fail_compilation/fail7443.d
+++ b/test/fail_compilation/fail7443.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7443.d(11): Error: `static` has no effect on a constructor inside a `static` block. Use `static this()`
-fail_compilation/fail7443.d(12): Error: `shared static` has no effect on a constructor inside a `shared static` block. Use `shared static this()`
+fail_compilation/fail7443.d(12): Error: `static` has no effect on a constructor inside a `static` block. Use `static this()`
+fail_compilation/fail7443.d(13): Error: `shared static` has no effect on a constructor inside a `shared static` block. Use `shared static this()`
+fail_compilation/fail7443.d(14): Error: constructor `fail7443.Foo.this` constructor `fail7443.Foo.this()` conflicts with previous declaration at fail_compilation/fail7443.d(12)
 ---
 */
 

--- a/test/fail_compilation/test18282.d
+++ b/test/fail_compilation/test18282.d
@@ -46,7 +46,7 @@ S2000 bar2()
 }
 
 
-void bar2()
+void bar3()
 {
     int i;
     char c;

--- a/test/fail_compilation/test18385.d
+++ b/test/fail_compilation/test18385.d
@@ -1,0 +1,31 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/test18385.d(13): Deprecation: function `test18385.foo` function `test18385.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(12)
+fail_compilation/test18385.d(18): Deprecation: function `test18385.S.foo` function `test18385.S.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(17)
+---
+*/
+
+extern (C):
+
+void foo(int) { }
+void foo(double) { }
+
+struct S
+{
+    static void foo(int) {}
+    static void foo(double) {}
+}
+
+void foo2(int) { }
+extern(D) void foo2(double) { } // OK as it has a different mangling
+
+void foo3(int) { }
+void foo3(double); // duplicate declarations are allowed
+
+void foo4();
+void foo4() { }
+
+extern(D) void foo5();
+extern(D) void foo5() { }

--- a/test/fail_compilation/test18385.d
+++ b/test/fail_compilation/test18385.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/test18385.d(13): Deprecation: function `test18385.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(12)
-fail_compilation/test18385.d(18): Deprecation: function `test18385.S.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(17)
+fail_compilation/test18385.d(13): Deprecation: function `test18385.foo` cannot overload `extern(C)` function at fail_compilation/test18385.d(12)
+fail_compilation/test18385.d(18): Deprecation: function `test18385.S.foo` cannot overload `extern(C)` function at fail_compilation/test18385.d(17)
 ---
 */
 

--- a/test/fail_compilation/test18385.d
+++ b/test/fail_compilation/test18385.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/test18385.d(13): Deprecation: function `test18385.foo` function `test18385.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(12)
-fail_compilation/test18385.d(18): Deprecation: function `test18385.S.foo` function `test18385.S.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(17)
+fail_compilation/test18385.d(13): Deprecation: function `test18385.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(12)
+fail_compilation/test18385.d(18): Deprecation: function `test18385.S.foo(double)` cannot be overloaded with another `extern(C)` function at fail_compilation/test18385.d(17)
 ---
 */
 


### PR DESCRIPTION
Initially started in https://github.com/dlang/dmd/pull/7577, but reverted in https://github.com/dlang/dmd/pull/7969 due to the immediate 2.079 release and a reported issue for it (https://issues.dlang.org/show_bug.cgi?id=18385).

This now officially starts the deprecation period of identical functions in a single module.

The examples provided in 18385 are:

```d
extern (C):

void foo(int) { }
void foo(double) { }

struct S
{
    static void foo(int) {}
    static void foo(double) {}
}
```

They clearly can't work because the mangling of these functions is the same.
The deprecation period is ten releases after the new deprecation DIP.

Note that the following will still work:

```d
extern (C):

void foo(int) { }
extern(D) void foo(double) { } // OK as it has a different mangling
```

or:

```d
extern (C):

void foo(int) { }
void foo(double); // duplicate declarations are allowed
```

See also: https://github.com/dlang/dmd/pull/8428