### PR TITLE
Change deprecation to error for C-style array syntax

### DIFF
--- a/changelog/error_for_c-style_arrays.dd
+++ b/changelog/error_for_c-style_arrays.dd
@@ -1,0 +1,9 @@
+Deprecated C-style array declarations will now result in a compilation error
+
+The deprecation period for C-style array declarations has expired.  Beginning with this
+release, declaring arrays with C-style syntax will result in an error.
+
+---
+int a[2];  // Error: instead of C-style syntax, use D-style `int a[2]`
+int[2] b;  // OK
+---

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5030,10 +5030,7 @@ final class Parser(AST) : Lexer
 
         const(char)* sp = !ident ? "" : " ";
         const(char)* s = !ident ? "" : ident.toChars();
-        if (alt & 1) // contains C-style function pointer syntax
-            error(loc, "instead of C-style syntax, use D-style `%s%s%s`", t.toChars(), sp, s);
-        else
-           dmd.errors.deprecation(loc, "instead of C-style syntax, use D-style syntax `%s%s%s`", t.toChars(), sp, s);
+        error(loc, "instead of C-style syntax, use D-style `%s%s%s`", t.toChars(), sp, s);
     }
 
     /*****************************************

--- a/test/compilable/callconv.d
+++ b/test/compilable/callconv.d
@@ -4,7 +4,7 @@ import core.stdc.stdarg;
 
 struct ABC
 {
-	int x[4];
+	int[4] x;
 }
 
 ABC abc;

--- a/test/compilable/imports/test63a.d
+++ b/test/compilable/imports/test63a.d
@@ -4,7 +4,7 @@ private import test63;
 
 struct s {
 
-    char a[ SIZE ];
+    char[SIZE] a;
 
 }
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -4680,7 +4680,7 @@ static assert(bug6886());
 
 struct Block10198
 {
-    int val[3][4];
+    int[4][3] val;
 }
 
 int bug10198()
@@ -6431,7 +6431,7 @@ C73 test73 = func73();
 
 struct S74
 {
-    int n[1];
+    int[1] n;
     static S74 test(){ S74 ret = void; ret.n[0] = 0; return ret; }
 }
 
@@ -7266,7 +7266,7 @@ struct Matrix13827(T, uint N)
 {
     private static defaultMatrix()
     {
-        T arr[N];
+        T[N] arr;
         return arr;
     }
 

--- a/test/compilable/test66.d
+++ b/test/compilable/test66.d
@@ -11,7 +11,7 @@ enum
 
 struct Token
 {
-    static char[] tochars[TOKmax];
+    static char[][TOKmax] tochars;
 }
 
 class Lexer

--- a/test/fail_compilation/diag_cstyle.d
+++ b/test/fail_compilation/diag_cstyle.d
@@ -6,8 +6,8 @@ fail_compilation/diag_cstyle.d(14): Error: instead of C-style syntax, use D-styl
 fail_compilation/diag_cstyle.d(15): Error: instead of C-style syntax, use D-style `int function(int)* fp3`
 fail_compilation/diag_cstyle.d(17): Error: instead of C-style syntax, use D-style `int function(int) FP`
 fail_compilation/diag_cstyle.d(19): Error: instead of C-style syntax, use D-style `int function() fp`
-fail_compilation/diag_cstyle.d(19): Deprecation: instead of C-style syntax, use D-style syntax `int[] arr`
-fail_compilation/diag_cstyle.d(21): Deprecation: instead of C-style syntax, use D-style syntax `string[] result`
+fail_compilation/diag_cstyle.d(19): Error: instead of C-style syntax, use D-style `int[] arr`
+fail_compilation/diag_cstyle.d(21): Error: instead of C-style syntax, use D-style `string[] result`
 ---
 */
 

--- a/test/runnable/bitops.d
+++ b/test/runnable/bitops.d
@@ -7,7 +7,7 @@ import core.bitop;
 
 void test1()
 {
-    size_t array[2];
+    size_t[2] array;
     uint x;
 version (D_LP64)
     size_t bitToUse = 67;
@@ -94,7 +94,7 @@ void test4()
 
 void test5()
 {
-    size_t array[2];
+    size_t[2] array;
 
     array[0] = 2;
     array[1] = 0x100;

--- a/test/runnable/delegate.d
+++ b/test/runnable/delegate.d
@@ -227,8 +227,8 @@ void test10()
 class A12
 {
 public:
-  int delegate(int, int) dgs[4];
-  int function(int, int) fps[4];
+  int delegate(int, int)[4] dgs;
+  int function(int, int)[4] fps;
   int delegate(int, int) dg;
   int function(int, int) fp;
   int f(int x, int y) {

--- a/test/runnable/dhry.d
+++ b/test/runnable/dhry.d
@@ -355,13 +355,13 @@ alias int Enumeration;
 
 const int StrLen = 30;
 
-alias int     One_Thirty;
-alias int     One_Fifty;
-alias char    Capital_Letter;
-alias bool    Boolean;
-alias char    Str_30 [StrLen];
-alias int     Arr_1_Dim [50];
-alias int     Arr_2_Dim [50] [50];
+alias int           One_Thirty;
+alias int           One_Fifty;
+alias char          Capital_Letter;
+alias bool          Boolean;
+alias char[StrLen]  Str_30;
+alias int[50]       Arr_1_Dim;
+alias int[50][50]   Arr_2_Dim;
 
 struct record
 {
@@ -369,19 +369,19 @@ struct record
     Enumeration    Discr;
     union V {
           struct V1 {
-                  Enumeration Enum_Comp;
-                  int         Int_Comp;
-                  char        Str_Comp [StrLen];
+                  Enumeration   Enum_Comp;
+                  int           Int_Comp;
+                  char[StrLen]  Str_Comp;
                   }
           V1 var_1;
           struct V2 {
-                  Enumeration E_Comp_2;
-                  char        Str_2_Comp [StrLen];
+                  Enumeration   E_Comp_2;
+                  char [StrLen] Str_2_Comp;
                   }
           V2 var_2;
           struct V3 {
-                  char        Ch_1_Comp;
-                  char        Ch_2_Comp;
+                  char          Ch_1_Comp;
+                  char          Ch_2_Comp;
                   }
           V3 var_3;
           }
@@ -400,8 +400,8 @@ int             Int_Glob;
 Boolean         Bool_Glob;
 char            Ch_1_Glob,
                 Ch_2_Glob;
-int             Arr_1_Glob [50];
-int             Arr_2_Glob [50] [50];
+int[50]         Arr_1_Glob;
+int[50][50]     Arr_2_Glob;
 
 char[StrLen] Reg_Define = "Register option selected.";
 

--- a/test/runnable/foreach3.d
+++ b/test/runnable/foreach3.d
@@ -3,7 +3,7 @@ import core.stdc.stdio;
 
 struct Foo
 {
-    uint array[2];
+    uint[2] array;
 
     int opApply(int delegate(ref uint) dg)
     {

--- a/test/runnable/foreach4.d
+++ b/test/runnable/foreach4.d
@@ -8,7 +8,7 @@ alias bool bit;
 
 class Foo
 {
-    uint array[2];
+    uint[2] array;
 
     int opApply(int delegate(ref uint) dg)
     {
@@ -679,7 +679,7 @@ void test22()
 
 class Foo23
 {
-    int array[2];
+    int[2] array;
 
     int opApply(int delegate(ref int) dg)
     {
@@ -790,7 +790,7 @@ void test25()
 
 struct Foo26
 {
-    uint array[2];
+    uint[2] array;
 
     int forward(int delegate(ref uint) dg)
     {

--- a/test/runnable/imports/inline2a.d
+++ b/test/runnable/imports/inline2a.d
@@ -39,7 +39,7 @@ module imports.inline2a;
 class Primes
 {
         private
-         static const short primes[] =
+         static const short[] primes =
         [
            2,    3,    5,    7,   11,   13,   17,   19,   23,   29,
           31,   37,   41,   43,   47,   53,   59,   61,   67,   71,

--- a/test/runnable/imports/test11931d.d
+++ b/test/runnable/imports/test11931d.d
@@ -26,5 +26,5 @@ struct Signal(T, A...)
 
 private:
     alias D = T delegate(A);
-    D _arr[];
+    D[] _arr;
 }

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -945,7 +945,7 @@ void test45()
 
 /************************************************/
 
-const int foo46[5] = [0,1,2,3,4];
+const int[5] foo46 = [0,1,2,3,4];
 
 void test46()
 {
@@ -1108,7 +1108,7 @@ bool equals54(string a, string b)
 
 /************************************************/
 
-const string foo55[2] = ["a", "b"];
+const string[2] foo55 = ["a", "b"];
 string retsth55(int i) { return foo55[i]; }
 
 void test55()
@@ -1121,7 +1121,7 @@ void test55()
 
 string retsth56(int i)
 {
-    static const string foo[2] = ["a", "b"];
+    static const string[2] foo = ["a", "b"];
     return foo[i];
 }
 
@@ -2602,7 +2602,7 @@ int delegtest6()
 {
     DelegStruct s;
     s.a = 5;
-    FoolishStruct k[3];
+    FoolishStruct[3] k;
     DelegType u = &s.bar;
     k[1].z = u;
     return k[1].z(3);
@@ -3278,7 +3278,7 @@ void test9954()
 
 struct Bug10483
 {
-    int val[3][4];
+    int[3][4] val;
 }
 
 struct Outer10483

--- a/test/runnable/printargs.d
+++ b/test/runnable/printargs.d
@@ -3,7 +3,7 @@
 
 extern(C) int printf(const char*, ...);
 
-int main(char args[][])
+int main(char[][] args)
 {
     int i;
 

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -1620,7 +1620,7 @@ void test67()
 /******************************************/
 
 template T68(int a) {
-    int vec[a];
+    int[a] vec;
 }
 
 void test68()

--- a/test/runnable/template2.d
+++ b/test/runnable/template2.d
@@ -10,7 +10,7 @@ template VecTemplate(tfloat, int dim:3)
 {
  struct Vector
  {
-  tfloat d[dim];
+  tfloat[dim] d;
 
   version(none)
   {

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -3201,7 +3201,7 @@ void test11843()
 {
     struct Foo
     {
-        int x[string];
+        int[string] x;
     }
 
     struct Bar(alias foo) {}

--- a/test/runnable/test11.d
+++ b/test/runnable/test11.d
@@ -530,14 +530,14 @@ struct NODE27 {
     shared(NODE27) *next;
 }
 
-static shared NODE27 nodetbl[3] =
+static shared NODE27[3] nodetbl =
 [
     {   0,cast(shared(NODE27)*)nodetbl + 1},
     {   0,cast(shared(NODE27)*)nodetbl + 2},
     {   0,null}
 ];
 
-static shared NODE27 nodetbl2[3] = [
+static shared NODE27[3] nodetbl2 = [
     {   0,&nodetbl2[1]},
     {   0,&nodetbl2[2]},
     {   0,null}

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -204,8 +204,8 @@ class A15
         List2.rehash;
     }
   private:
-    int delegate(in int arg1) List1[char[]];
-    int  List2[char []];
+    int delegate(in int arg1)[char[]] List1;
+    int[char []]  List2;
 }
 
 void test15()
@@ -1042,9 +1042,9 @@ void test56()
 
 /************************************/
 
-void det(float mat[][])
+void det(float[][] mat)
 {
-    float newmat[][];
+    float[][] newmat;
 
     size_t i = newmat[0 .. (mat.length - 1)].length;
 }

--- a/test/runnable/test17.d
+++ b/test/runnable/test17.d
@@ -12,8 +12,8 @@ void ulog(string s)
 int open()
 {
     char *s;
-    char abs[2000];
-    char qu[100];
+    char[2000] abs;
+    char[100] qu;
     int a;
     ulog("reaches this only 9 times of 10!\n");
     return 0;
@@ -22,7 +22,7 @@ int open()
 
 int yhenda()
 {
-    char MEM[2200];
+    char[2200] MEM;
     int a;
     ulog("point(2.1) \n");
     open();

--- a/test/runnable/test19.d
+++ b/test/runnable/test19.d
@@ -128,8 +128,8 @@ int[] test6_1(int[] a)
 void test6()
 {
     printf("test6()\n");
-    int b[3];
-    int a[];
+    int[3] b;
+    int[] a;
 
     b[0] = 0;
     b[1] = 1;
@@ -144,7 +144,7 @@ void test6()
 
 class OutBuffer7
 {
-    char data[];
+    char[] data;
     uint offset;
 
     void write(const(char) *p, uint nbytes)

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -665,7 +665,7 @@ struct particle
     float yg;     /* Y Gravity       */
 }
 
-particle particles[10000];
+particle[10000] particles;
 
 void test32()
 {
@@ -1100,7 +1100,7 @@ body
 void test47()
 {
     real x = 3.1;
-    static real pp[] = [56.1, 32.7, 6];
+    static real[] pp = [56.1, 32.7, 6];
     real r;
 
     printf("The result should be %Lf\n",(56.1L + (32.7L + 6L * x) * x));

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -1054,7 +1054,7 @@ void func53(TestStruct[2] testarg)
     assert(testarg[1].dummy2 == 2);
 }
 
-TestStruct m53[2];
+TestStruct[2] m53;
 
 void test53()
 {

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -48,17 +48,17 @@ void test1()
 
 void test2()
 {
-    byte foo1[5];
-    ubyte foo2[6];
-    short foo3[7];
-    ushort foo4[8];
-    int foo5[9];
-    uint foo6[10];
-    long foo7[11];
-    ulong foo8[12];
-    float foo9[13];
-    double foo10[14];
-    real foo11[15];
+    byte[5] foo1;
+    ubyte[6] foo2;
+    short[7] foo3;
+    ushort[8] foo4;
+    int[9] foo5;
+    uint[10] foo6;
+    long[11] foo7;
+    ulong[12] foo8;
+    float[13] foo9;
+    double[14] foo10;
+    real[15] foo11;
 
     int i;
 
@@ -96,17 +96,17 @@ void test2()
 
 void test3()
 {
-    byte foo1[5] = 20;
-    ubyte foo2[6] = 21;
-    short foo3[7] = 22;
-    ushort foo4[8] = 23;
-    int foo5[9] = 24;
-    uint foo6[10] = 25;
-    long foo7[11] = 26;
-    ulong foo8[12] = 27;
-    float foo9[13] = 28;
-    double foo10[14] = 29;
-    real foo11[15] = 30;
+    byte[5] foo1 = 20;
+    ubyte[6] foo2 = 21;
+    short[7] foo3 = 22;
+    ushort[8] foo4 = 23;
+    int[9] foo5 = 24;
+    uint[10] foo6 = 25;
+    long[11] foo7 = 26;
+    ulong[12] foo8 = 27;
+    float[13] foo9 = 28;
+    double[14] foo10 = 29;
+    real[15] foo11 = 30;
 
     int i;
 
@@ -257,13 +257,13 @@ struct TestVectors
     string replace;
 };
 
-TestVectors tva[] =
+TestVectors[] tva =
 [
   {  pattern:"(a)\\1",  input:"abaab",  result:"y",     format:"&",     replace:"aa" },
   {  pattern:"abc",     input:"abc",    result:"y",     format:"&",     replace:"abc" },
 ];
 
-TestVectors tvs[2] =
+TestVectors[2] tvs =
 [
   {  pattern:"(a)\\1",  input:"abaab",  result:"y",     format:"&",     replace:"aa" },
   {  pattern:"abc",     input:"abc",    result:"y",     format:"&",     replace:"abc" },
@@ -360,8 +360,8 @@ const uint MAX_PATH1 = 260;
 enum { MAX_PATH2 = 261 }
 
 struct WIN32_FIND_DATA {
-    char   cFileName1[MAX_PATH1];
-    char   cFileName2[MAX_PATH2];
+    char[MAX_PATH1]   cFileName1;
+    char[MAX_PATH2]   cFileName2;
 }
 
 void test11()
@@ -502,10 +502,10 @@ void test15()
 
 struct GUID {          // size is 16
     align(1):
-        uint    Data1;
-        ushort  Data2;
-        ushort  Data3;
-        ubyte   Data4[8];
+        uint     Data1;
+        ushort   Data2;
+        ushort   Data3;
+        ubyte[8] Data4;
 }
 
 
@@ -562,7 +562,7 @@ void test17()
 
 /* ================================ */
 
-private const uint crc_table[256] = [
+private const uint[256] crc_table = [
     0x00000000u, 0x77073096u, 0xee0e612cu, 0x990951bau, 0x076dc419u,
     0x2d02ef8du
   ];

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1783,7 +1783,7 @@ void test108()
 
 void test109()
 {
-    double x[] = new double[1];
+    double[] x = new double[1];
     assert(x[0] != 0);
 }
 
@@ -1850,7 +1850,7 @@ struct VariantN
 
     void bar(int value, int i)
     {
-        int args[2] = [ VariantN(value), VariantN(i) ];
+        int[2] args = [ VariantN(value), VariantN(i) ];
     }
 }
 
@@ -2216,7 +2216,7 @@ void test135()
 
 void test136()
 {
-    struct S { int i[3]; }
+    struct S { int[3] i; }
     enum S s = S(8);
     const int i  = s.i[2];
     assert(i == 8);
@@ -3233,7 +3233,7 @@ void test200()
 // Bugzilla 2931
 
 struct Bug2931 {
-        int val[3][4];
+    int[4][3] val;
 }
 
 struct Outer2931 {
@@ -3983,10 +3983,10 @@ void test229() {
 
 /***************************************************/
 
-static immutable real negtab[14] =
+static immutable real[14] negtab =
     [ 1e-4096L,1e-2048L,1e-1024L,1e-512L,1e-256L,1e-128L,1e-64L,1e-32L,
             1e-16L,1e-8L,1e-4L,1e-2L,1e-1L,1.0L ];
-static immutable real postab[13] =
+static immutable real[13] postab =
     [ 1e+4096L,1e+2048L,1e+1024L,1e+512L,1e+256L,1e+128L,1e+64L,1e+32L,
             1e+16L,1e+8L,1e+4L,1e+2L,1e+1L ];
 

--- a/test/runnable/test48.d
+++ b/test/runnable/test48.d
@@ -38,6 +38,6 @@ void main()
     printf("offset2 = %d\n", offset2);
     assert(offset2 == 8);
 
-    int t1[S.tupleof.offsetof[1]];
+    int[S.tupleof.offsetof[1]] t1;
     assert(t1.length == 4);
 }

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -668,7 +668,7 @@ void test37()
 void test38()
 {
     int n = atoi("1");
-    static char flags[8192 + 1];
+    static char[8192 + 1] flags;
     long i, k;
     int count = 0;
 

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -10,7 +10,7 @@ import std.random;   // for uniform random numbers
 
 /************************************************/
 
-int nametable[char[]];
+int[char[]] nametable;
 
 void insert(string name, int value)
 {
@@ -315,7 +315,7 @@ void test13()
     string[] key = array.keys;
     assert(key.length==3);
 
-    bool have[3];
+    bool[3] have;
 
     assert(!have[0]);
     assert(!have[1]);
@@ -493,7 +493,7 @@ void dummy17()
 {
 }
 
-int bb17[string];
+int[string] bb17;
 
 int foo17()
 {

--- a/test/runnable/testaa2.d
+++ b/test/runnable/testaa2.d
@@ -4,12 +4,12 @@ extern(C) int printf(const char*, ...);
 
 /************************************************/
 
-int a[string];
+int[string] a;
 
 size_t foo(immutable char [3] s)
 {
     printf("foo()\n");
-    int b[string];
+    int[string] b;
     string[] key;
     int[] value;
     printf("foo() 2\n");
@@ -22,7 +22,7 @@ size_t foo(immutable char [3] s)
 
 void foo2()
 {
-    int c[string];
+    int[string] c;
     string[] key;
     int[] value;
     int i;

--- a/test/runnable/testdt.d
+++ b/test/runnable/testdt.d
@@ -2,7 +2,7 @@
 
 /******************************************/
 
-static int bigarray[100][100];
+static int[100][100] bigarray;
 
 void test1()
 {

--- a/test/runnable/testthread.d
+++ b/test/runnable/testthread.d
@@ -49,7 +49,7 @@ int main()
     assert(f.x == 3);
 
     int i;
-    Thread tx[5];
+    Thread[5] tx;
     for (i = 0; i < tx.length; i++)
         tx[i] = new Thread(&f.bar);
     for (i = 0; i < tx.length; i++)

--- a/test/runnable/traits_getPointerBitmap.d
+++ b/test/runnable/traits_getPointerBitmap.d
@@ -190,7 +190,7 @@ class N
 
 union U
 {
-    size_t data[4];
+    size_t[4] data;
     Large*[] arr; // { length, ptr }
 
     struct

--- a/test/runnable/untag.d
+++ b/test/runnable/untag.d
@@ -28,7 +28,7 @@ bool startsWithConsume(alias pred = "a == b", R1, R2)(ref R1 r1, R2 r2)
 
 uint bug = 1;
 
-int main(string args[]) {
+int main(string[] args) {
     getopt(args, "bug", &bug);
     enforce(bug <= 2);
     auto txt = readText("runnable/extra-files/untag.html");


### PR DESCRIPTION
Documentation update:  https://github.com/dlang/dlang.org/pull/2401