### PR TITLE
[RFC] Allow using if ! (condition)

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5653,8 +5653,14 @@ final class Parser(AST) : Lexer
             {
                 AST.Parameter param = null;
                 AST.Expression condition;
+                bool negateIf;
 
                 nextToken();
+                if (token.value == TOK.not)
+                {
+                    negateIf = true;
+                    nextToken();
+                }
                 check(TOK.leftParentheses);
 
                 StorageClass storageClass = 0;
@@ -5743,8 +5749,14 @@ final class Parser(AST) : Lexer
                 }
                 else
                     elsebody = null;
+
                 if (condition && ifbody)
+                {
+                    if (negateIf)
+                        condition = new AST.NotExp(condition.loc, condition);
+
                     s = new AST.IfStatement(loc, param, condition, ifbody, elsebody, token.loc);
+                }
                 else
                     s = null; // don't propagate parsing errors
                 break;

--- a/test/runnable/negateif.d
+++ b/test/runnable/negateif.d
@@ -1,0 +1,15 @@
+void main()
+{
+    if !(0) {}
+    else assert(0);
+
+    if !(1)
+        assert(0);
+
+    if !(1 * 100)
+        assert(0);
+
+    enum foo = true;
+    if !(foo || false)
+        assert(0);
+}


### PR DESCRIPTION
Timoses suggested allowing `if !(condition)` [on the NG recently](https://forum.dlang.org/post/tugdfxokfvoyfbjjujul@forum.dlang.org).
Instead of this:

```d
if (!(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq(t1, t2))
```

This shorthand would be allowed:

```d
if !(t1.ty == Tarray && t2.ty == Tarray && needsDirectEq(t1, t2))
```

So in other words it allows to avoid this awkward `(!(`.

I know that this might be controversial and will require a DIP, but as its such a simple change, I thought I put the PR forward.
I won't have much time for a DIP on this, so if you like this sugar, please go forward!