### PR TITLE
Bump the version for AUTO_BOOTSTRAPPING to 2.079.1

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -137,7 +137,7 @@ ifeq (,$(AUTO_BOOTSTRAP))
 else
   # Auto-bootstrapping, will download dmd automatically
   # Keep var below in sync with other occurrences of that variable, e.g. in circleci.sh
-  HOST_DMD_VER=2.074.1
+  HOST_DMD_VER=2.079.1
   HOST_DMD_ROOT=$(GENERATED)/host_dmd-$(HOST_DMD_VER)
   # dmd.2.072.2.osx.zip or dmd.2.072.2.linux.tar.xz
   HOST_DMD_BASENAME=dmd.$(HOST_DMD_VER).$(OS)$(if $(filter $(OS),freebsd),-$(MODEL),)


### PR DESCRIPTION
All other CIs have been upgraded to 2.079.1 (or newer).
That's why https://github.com/dlang/dmd/pull/8412 failed.
However, it seems that the AUTO_BOOTSTRAPPING=1 is no longer directly tested here.
Thus, this is required to make the other CIs happy (e.g. https://github.com/dlang/dlang.org/pull/2405)