### PR TITLE
Build __vtbl type as a static array of pointer type

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -965,7 +965,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
     {
         if (!vtblsym)
         {
-            auto vtype = Type.tvoidptr.immutableOf();
+            auto vtype = Type.tvoidptr.immutableOf().sarrayOf(vtbl.dim);
             auto var = new VarDeclaration(loc, vtype, Identifier.idPool("__vtbl"), null, STC.immutable_ | STC.static_);
             var.addMember(null, this);
             var.isdataseg = 1;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3625,7 +3625,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression tmpdecl = new DeclarationExp(loc, tmp);
 
                 auto dse = new DsymbolExp(loc, cd.vtblSymbol());
-                auto ase = new AddrExp(loc, dse);
+                auto ase = new AddrExp(loc, new IndexExp(loc, dse, new IntegerExp(loc, 0, Type.tsize_t)));
                 auto pte = new DotIdExp(loc, new ThisExp(loc), Id.__vptr);
                 auto ate = new AssignExp(loc, pte, ase);
 


### PR DESCRIPTION
So as it matches the data layout that the backend produces.

Taking the address of has been adjusted accordingly for `@safe` code.