### PR TITLE
Issue 18407 - debug should escape nothrow

### DIFF
--- a/changelog/debug-nothrow.dd
+++ b/changelog/debug-nothrow.dd
@@ -1,0 +1,14 @@
+Exception-throwing code can now be used in debug blocks
+
+When writing debug code, one isn't interested statically ensuring that a function block doesn't `throw`,
+but a pleasant debugging experience as e.g. writing to the console or logfiles typically can't be `nothrow`.
+DMD already allowed to escape `pure` and `@nogc` within `debug` statement.
+With this release, exception-throwing code can be called from `debug` statements too:
+
+---
+import std.stdio;
+void main() nothrow
+{
+    debug writeln("Your throwing log statement.");
+}
+---

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -76,6 +76,9 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
 
         override void visit(CallExp ce)
         {
+            if (ce.inDebugStatement)
+                return;
+
             if (global.errors && !ce.e1.type)
                 return; // error recovery
             /* If calling a function or delegate that is typed as nothrow,

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4841,6 +4841,7 @@ extern (C++) final class CallExp : UnaExp
     Expressions* arguments; // function arguments
     FuncDeclaration f;      // symbol to call
     bool directcall;        // true if a virtual call is devirtualized
+    bool inDebugStatement;  /// true if this was in a debug statement
     VarDeclaration vthis2;  // container for multi-context
 
     extern (D) this(const ref Loc loc, Expression e, Expressions* exps)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -797,6 +797,7 @@ public:
     Expressions *arguments;     // function arguments
     FuncDeclaration *f;         // symbol to call
     bool directcall;            // true if a virtual call is devirtualized
+    bool inDebugStatement;      // true if this was in a debug statement
     VarDeclaration *vthis2;     // container for multi-context
 
     static CallExp *create(Loc loc, Expression *e, Expressions *exps);

--- a/test/compilable/test16492.d
+++ b/test/compilable/test16492.d
@@ -40,3 +40,48 @@ void unsafeDIP1000Lifetime()(ref char[] p, scope char[] s)
 {
     p = s;
 }
+
+
+void test2() nothrow
+{
+    debug throw new Exception("");
+}
+
+void test3() nothrow
+{
+    debug {
+        foreach (_; 0 .. 10) {
+            if (1) {
+                throw new Exception("");
+            }
+        }
+    }
+}
+
+void test3() nothrow
+{
+    debug throwException();
+}
+
+void test4() nothrow
+{
+    debug willThrowException();
+}
+
+void willThrowException()()
+{
+    throwException();
+}
+
+void throwException()
+{
+    throw new Exception("");
+}
+
+void test5() nothrow
+{
+    debug
+    {
+        () {throw new Exception("");}();
+    }
+}


### PR DESCRIPTION
References:
- https://issues.dlang.org/show_bug.cgi?id=18407
- https://github.com/dlang/dmd/pull/7882
- https://github.com/dlang/dlang.org/pull/2209

I wasn't entirely sure on the best way to do this.
The problem is that `blockexit` checker runs so late in semantic3 that the DebugStatements are already flattened out.

I'm not proud of the current solution, so I'm more than open to better suggestions.