### PR TITLE
Remove usage of initializerToExpression from parse.d

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6216,11 +6216,6 @@ struct ASTBase
         return result;
     }
 
-    static extern (C++) Expression initializerToExpression(Initializer i)
-    {
-        return i.toExpression;
-    }
-
     static extern (C++) Expression typeToExpression(Type t)
     {
         return t.toExpression;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6489,7 +6489,9 @@ final class Parser(AST) : Lexer
                     if (token.value == TOK.colon)
                     {
                         nextToken();
-                        e = AST.initializerToExpression(value);
+                        AST.ExpInitializer expInit = value.isExpInitializer();
+                        assert(expInit);
+                        e = expInit.exp;
                         value = parseInitializer();
                     }
                     else


### PR DESCRIPTION
`initializerToExpression` does a lot of type processing (which requires dependencies used at semantic time) so there is no need to be used in the parser. This further separates the parser from the semantic methods and leads the way to getting rid of the duplication in ASTBase