### PR TITLE
Fix issue 16479: No namespace substitution for C++ mangling on POSIX

### DIFF
--- a/changelog/posix_cpp_template_mangling.dd
+++ b/changelog/posix_cpp_template_mangling.dd
@@ -1,0 +1,4 @@
+Templates are now mangled correctly on POSIX
+
+Before this version, anything including `extern(C++)` templates
+was not correctly mangled on OSX, Linux, and FreeBSD, leading to linker errors.

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -416,6 +416,8 @@ extern (C++, std)
         uint foof();
     }
 
+    struct vector (T);
+
     struct test18957 {}
 }
 
@@ -771,3 +773,165 @@ version(Windows)
       "??$test19043b@U?$test19043@$$CBD@@@@YAXU?$test19043@$$CBD@@@Z");
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=16479
+//  Missing substitution while mangling C++ template parameter for functions
+version (Posix) extern (C++)
+{
+    // Make sure aliases are still resolved
+    alias Alias16479 = int;
+    Alias16479 func16479_0 (FuncT1) (FuncT1, Alias16479);
+    static assert(func16479_0!(int).mangleof == `_Z11func16479_0IiEiT_i`);
+
+    // Simple substitution on return type
+    FuncT1* func16479_1 (FuncT1) ();
+    static assert(func16479_1!(int).mangleof == `_Z11func16479_1IiEPT_v`);
+
+    // Simple substitution on parameter
+    void    func16479_2 (FuncT1) (FuncT1);
+    static assert(func16479_2!(int).mangleof == `_Z11func16479_2IiEvT_`);
+
+    // Make sure component substition is prefered over template parameter
+    FuncT1* func16479_3 (FuncT1) (FuncT1);
+    static assert(func16479_3!(int).mangleof == `_Z11func16479_3IiEPT_S0_`);
+
+    struct Array16479 (Arg) { Arg* data; }
+    struct Array16479_2 (Arg, int Size) { Arg[Size] data; }
+    struct Value16479 (int Value1, int Value2) { int data; }
+
+    // Make sure template parameter substitution happens on templated return
+    Array16479!(FuncT2) func16479_4 (FuncT1, FuncT2) (FuncT1);
+    static assert(func16479_4!(int, float).mangleof
+                  == `_Z11func16479_4IifE10Array16479IT0_ET_`);
+
+    // Make sure template parameter substitution happens with values
+    Value16479!(Value2, Value1)* func16479_5 (int Value1, int Value2) ();
+    static assert(func16479_5!(1, 1).mangleof
+                  == `_Z11func16479_5ILi1ELi1EEP10Value16479IXT0_EXT_EEv`);
+
+    // But make sure it's not substituting *too many* values
+    Value16479!(1, 1)* func16479_6 (int Value1, int Value2) ();
+    static assert(func16479_6!(1, 1).mangleof
+                  == `_Z11func16479_6ILi1ELi1EEP10Value16479ILi1ELi1EEv`);
+
+    // Or too many types
+    Array16479!(int) func16479_7 (FuncT1, FuncT2) (FuncT1);
+    static assert(func16479_7!(int, int).mangleof
+                  == `_Z11func16479_7IiiE10Array16479IiET_`);
+
+    // Also must check the parameters for template param substitution
+    void func16479_8 (FuncT1) (Array16479!(FuncT1));
+    static assert(func16479_8!(int).mangleof
+                  == `_Z11func16479_8IiEv10Array16479IT_E`);
+
+    // And non-substitution
+    void func16479_9 (FuncT1) (Array16479!(int));
+    static assert(func16479_9!(int).mangleof
+                  == `_Z11func16479_9IiEv10Array16479IiE`);
+
+    // Now let's have a bit of fun with alias parameters,
+    // starting with C functions
+    // TODO: Why is this mangled by g++:
+    /*
+      extern "C"
+      {
+        void externC16479 (int);
+      }
+
+      template<void (*Print)(int)>
+      void func16479_10 ();
+
+      void foo () { func16479_10<externC16479>(); }
+     */
+    extern (C) void externC16479 (int);
+    void func16479_10 (alias Print) ();
+    static assert(func16479_10!(externC16479).mangleof
+                  == `_Z12func16479_10IXadL_Z12externC16479EEEvv`);
+
+    /**
+     * Let's not exclude C++ functions
+     * Note:
+     *   Passing a function as template parameter has an implicit
+     *   `&` operator prepended to it, so the following code:
+     * ---
+     * void CPPPrinter16479(const char*);
+     * template<void (*Print)(const char*)> void func16479_11 ();
+     * void foo () { func16479_11<CPPPrinter16479>(); }
+     * ---
+     * Gets mangled as `func16479_11<&CPPPrinter16479>()` would,
+     * which means the expression part of the template argument is
+     * mangled as `XadL_Z[...]E` not `XL_Z[...]E`
+     * (expressions always begin with a code anyway).
+     */
+    extern(C++) void CPPPrinter16479(const(char)*);
+    extern(C++, Namespace16479) void CPPPrinterNS16479(const(char)*);
+    void func16479_11 (alias Print) ();
+    static assert(func16479_11!(CPPPrinter16479).mangleof
+                  == `_Z12func16479_11IXadL_Z15CPPPrinter16479PKcEEEvv`);
+    static assert(func16479_11!(CPPPrinterNS16479).mangleof
+                  == `_Z12func16479_11IXadL_ZN14Namespace1647917CPPPrinterNS16479EPKcEEEvv`);
+
+    // Functions are fine, but templates are finer
+    // ---
+    // template<template<typename, int> class Container, typename T, int Val>
+    // Container<T, Val> func16479_12 ();
+    // ---
+    Container!(T, Val) func16479_12 (alias Container, T, int Val) ();
+    static assert(func16479_12!(Array16479_2, int, 42).mangleof
+                  == `_Z12func16479_12I12Array16479_2iLi42EET_IT0_XT1_EEv`);
+
+    // Substitution needs to happen on the most specialized type
+    // Iow, `ref T identity (T) (ref T v);` should be mangled as
+    // `_Z8identityIiET_*S1_*`, not as `_Z8identityIiET_*RS0_*`
+    ref FuncT1 func16479_13_1 (FuncT1) (ref FuncT1);
+    FuncT1*    func16479_13_2 (FuncT1) (FuncT1*);
+    void       func16479_13_3 (FuncT1) (FuncT1*, FuncT1*);
+    FuncT1**   func16479_13_4 (FuncT1) (FuncT1*, FuncT1);
+    FuncT1     func16479_13_5 (FuncT1) (FuncT1*, FuncT1**);
+    static assert(func16479_13_1!(int).mangleof == `_Z14func16479_13_1IiERT_S1_`);
+    static assert(func16479_13_2!(float).mangleof == `_Z14func16479_13_2IfEPT_S1_`);
+    static assert(func16479_13_3!(int).mangleof == `_Z14func16479_13_3IiEvPT_S1_`);
+    static assert(func16479_13_4!(int).mangleof == `_Z14func16479_13_4IiEPPT_S1_S0_`);
+    static assert(func16479_13_5!(int).mangleof == `_Z14func16479_13_5IiET_PS0_PS1_`);
+
+    // Opaque types result in a slightly different AST
+    vector!T* func16479_14 (T) (T v);
+    static assert(func16479_14!(int).mangleof == `_Z12func16479_14IiEPSt6vectorIT_ES1_`);
+
+    struct Foo16479_15 (T);
+    struct Baguette16479_15 (T);
+    struct Bar16479_15 (T);
+    struct FooBar16479_15 (A, B);
+    void inst16479_15_2 (A, B) ();
+    void inst16479_15_3 (A, B, C) ();
+
+    static assert(inst16479_15_2!(Bar16479_15!int, int).mangleof
+                  == `_Z14inst16479_15_2I11Bar16479_15IiEiEvv`);
+    static assert(inst16479_15_2!(int, Bar16479_15!int).mangleof
+                  == `_Z14inst16479_15_2Ii11Bar16479_15IiEEvv`);
+    static assert(inst16479_15_2!(Bar16479_15!int, FooBar16479_15!(Bar16479_15!int, Foo16479_15!(Bar16479_15!(Foo16479_15!int)))).mangleof
+                  == `_Z14inst16479_15_2I11Bar16479_15IiE14FooBar16479_15IS1_11Foo16479_15IS0_IS3_IiEEEEEvv`);
+    static assert(inst16479_15_3!(int, Bar16479_15!int, FooBar16479_15!(Bar16479_15!int, Foo16479_15!(Bar16479_15!(Foo16479_15!int)))).mangleof
+                  == `_Z14inst16479_15_3Ii11Bar16479_15IiE14FooBar16479_15IS1_11Foo16479_15IS0_IS3_IiEEEEEvv`);
+
+    static import cppmangle2;
+    cppmangle2.Struct18922* func16479_16_1 (T) (T*);
+    static assert(func16479_16_1!int.mangleof == `_Z14func16479_16_1IiEPN14Namespace1892211Struct18922EPT_`);
+    T* func16479_16_2 (T) (T*);
+    static assert(func16479_16_2!int.mangleof == `_Z14func16479_16_2IiEPT_S1_`);
+    static assert(func16479_16_2!(cppmangle2.vector!int).mangleof == `_Z14func16479_16_2ISt6vectorIiEEPT_S3_`);
+    static assert(func16479_16_2!(cppmangle2.vector!int).mangleof
+                  == func16479_16_2!(cppmangle2.vector!int).mangleof);
+    cppmangle2.vector!T* func16479_16_3 (T) (T*);
+    static assert(func16479_16_3!int.mangleof == `_Z14func16479_16_3IiEPSt6vectorIiEPT_`);
+
+    extern(C++, `fakestd`) {
+        extern (C++, `__1`) {
+            struct allocator16479 (T);
+            struct vector16479(T, alloc = allocator16479!T);
+        }
+    }
+    vector16479!(T, allocator16479!T)* func16479_17_1(T)();
+    vector16479!(T)* func16479_17_2(T)();
+    static assert(func16479_17_1!int.mangleof == `_Z14func16479_17_1IiEPN7fakestd3__111vector16479IT_NS1_14allocator16479IS3_EEEEv`);
+    static assert(func16479_17_2!int.mangleof == `_Z14func16479_17_2IiEPN7fakestd3__111vector16479IT_NS1_14allocator16479IS3_EEEEv`);
+}

--- a/test/compilable/cppmangle2.d
+++ b/test/compilable/cppmangle2.d
@@ -4,3 +4,8 @@ extern(C++, Namespace18922)
 {
     struct Struct18922 { int i; }
 }
+
+extern(C++, std)
+{
+    struct vector (T);
+}

--- a/test/runnable/cpp_stdlib.d
+++ b/test/runnable/cpp_stdlib.d
@@ -1,0 +1,59 @@
+// DISABLED: win32 win64 osx32
+// EXTRA_CPP_SOURCES: cpp_stdlib.cpp
+// CXXFLAGS: -std=c++11
+import core.stdc.stdio;
+
+// Disabled on windows because it needs bindings
+// Disabled on osx32 because size_t is not properly mangled
+
+version (CppRuntime_Clang)
+{
+    extern(C++, `std`, `__1`)
+    {
+        struct allocator(T);
+        struct vector (T, A = allocator!T);
+        struct array (T, size_t N);
+    }
+}
+else
+{
+    extern(C++, `std`)
+    {
+        struct allocator(T);
+        struct vector (T, A = allocator!T);
+        struct array (T, size_t N);
+    }
+}
+
+extern(C++):
+
+ref T identity (T) (ref T v);
+T** identityPP (T) (T** v);
+vector!T* getVector (T) (size_t length, const T* ptr);
+array!(T, N)* getArray(T, size_t N) (const T* ptr);
+
+void main ()
+{
+    int i = 42;
+    float f = 21.0f;
+
+    int* pi = &i;
+    float* pf = &f;
+
+    assert(42 == identity(i));
+    assert(21.0f == identity(f));
+    assert(&pi == identityPP(&pi));
+    assert(&pf == identityPP(&pf));
+
+    auto vi = getVector(1, &i);
+    auto vf = getVector(3, [f, f, f].ptr);
+    assert(vi !is null);
+    assert(vf !is null);
+
+    auto ai = getArray!(int, 4)([2012, 10, 11, 42].ptr);
+    auto af = getArray!(float, 4)([42.0f, 21.0f, 14.0f, 1957.0f].ptr);
+    assert(ai !is null);
+    assert(af !is null);
+
+    printf("Success\n");
+}

--- a/test/runnable/extra-files/cpp_stdlib.cpp
+++ b/test/runnable/extra-files/cpp_stdlib.cpp
@@ -1,0 +1,53 @@
+#include <array>
+#include <string>
+#include <vector>
+
+template<typename T>
+T& identity (T& v) { return v; }
+template<typename T>
+T** identityPP (T** v) { return v; }
+
+template<typename T>
+std::vector<T>* getVector(size_t len, const T* ptr)
+{
+    std::vector<T>* ret = new std::vector<T>(len);
+    for (size_t i = 0; i < len; ++i)
+        (*ret)[i] = ptr[i];
+    return ret;
+}
+
+std::string* getString(int len, const char* ptr)
+{
+    return new std::string(ptr, len);
+}
+
+template<typename T, size_t N>
+std::array<T, N>* getArray(const T* ptr)
+{
+    std::array<T, N>* ret = new std::array<T, N>();
+    for (size_t x = 0; x < N; ++x)
+        (*ret)[x] = ptr[x];
+    return ret;
+}
+
+// This function should never be called
+void instantiate ()
+{
+    int i;
+    float f;
+    int* pi;
+    float* pf;
+
+    identityPP(&pi);
+    identityPP(&pf);
+    identity(i);
+    identity(f);
+
+    getVector<int>(0, 0);
+    getVector<float>(0, 0);
+    getVector<std::vector<float> >(0, 0);
+
+    getArray<int, 4>(0);
+    getArray<float, 4>(0);
+    //getArray<Foo<int, 42>, 4>(0);
+}

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -64,6 +64,7 @@ struct TestArgs
     bool     link;
     string   executeArgs;
     string   dflags;
+    string   cxxflags;
     string[] sources;
     string[] compiledImports;
     string[] cppSources;
@@ -269,6 +270,7 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
             testArgs.compiledImports ~= input_dir ~ "/" ~ s;
     }
 
+    findTestParameter(envData, file, "CXXFLAGS", testArgs.cxxflags);
     string extraCppSourcesStr;
     findTestParameter(envData, file, "EXTRA_CPP_SOURCES", extraCppSourcesStr);
     testArgs.cppSources = [];
@@ -434,7 +436,9 @@ unittest
         == `fail_compilation\diag.d(2): Error: fail_compilation\imports\fail.d must be imported`);
 }
 
-bool collectExtraSources (in string input_dir, in string output_dir, in string[] extraSources, ref string[] sources, in EnvData envData, in string compiler)
+bool collectExtraSources (in string input_dir, in string output_dir, in string[] extraSources,
+                          ref string[] sources, in EnvData envData, in string compiler,
+                          const(char)[] cxxflags)
 {
     foreach (cur; extraSources)
     {
@@ -460,6 +464,8 @@ bool collectExtraSources (in string input_dir, in string output_dir, in string[]
         {
             command ~= " -m"~envData.model~" -c "~curSrc~" -o "~curObj;
         }
+        if (compiler == "c++" && cxxflags)
+            command ~= " " ~ cxxflags;
 
         auto rc = system(command);
         if(rc)
@@ -637,11 +643,11 @@ int tryMain(string[] args)
                 writeln("unknown compiler: "~envData.compiler);
                 return 1;
         }
-        if (!collectExtraSources(input_dir, output_dir, testArgs.cppSources, testArgs.sources, envData, envData.ccompiler))
+        if (!collectExtraSources(input_dir, output_dir, testArgs.cppSources, testArgs.sources, envData, envData.ccompiler, testArgs.cxxflags))
             return 1;
     }
     //prepare objc extra sources
-    if (!collectExtraSources(input_dir, output_dir, testArgs.objcSources, testArgs.sources, envData, "clang"))
+    if (!collectExtraSources(input_dir, output_dir, testArgs.objcSources, testArgs.sources, envData, "clang", null))
         return 1;
 
     writef(" ... %-30s %s%s(%s)",

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -624,8 +624,11 @@ int tryMain(string[] args)
         }
     }
 
+    if (testArgs.disabledPlatforms.any!(a => envData.os.chain(envData.model).canFind(a)))
+        testArgs.disabled = true;
+
     //prepare cpp extra sources
-    if (testArgs.cppSources.length)
+    if (!testArgs.disabled && testArgs.cppSources.length)
     {
         switch (envData.compiler)
         {
@@ -647,7 +650,7 @@ int tryMain(string[] args)
             return 1;
     }
     //prepare objc extra sources
-    if (!collectExtraSources(input_dir, output_dir, testArgs.objcSources, testArgs.sources, envData, "clang", null))
+    if (!testArgs.disabled && !collectExtraSources(input_dir, output_dir, testArgs.objcSources, testArgs.sources, envData, "clang", null))
         return 1;
 
     writef(" ... %-30s %s%s(%s)",
@@ -667,11 +670,8 @@ int tryMain(string[] args)
     }
 
     // allows partial matching, e.g. win for both win32 and win64
-    if (testArgs.disabledPlatforms.any!(a => envData.os.chain(envData.model).canFind(a)))
-    {
-        testArgs.disabled = true;
+    if (testArgs.disabled)
         writefln("!!! [DISABLED on %s]", envData.os);
-    }
     else
         write("\n");
 


### PR DESCRIPTION
```
The C++ ABI used by POSIX is the Itanium C++ ABI.
Reference document available here: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling

One important (and tricky) part of the ABI is the substitutions being done,
in order to reduce the bloat introduced by long symbol names,
a typical issue when using templates heavily (of which D was not exempt).

There are 2 kinds of substitutions: component substitution and template parameter substitution.
Component substitution replaces repeated parts of the symbol with `S[X]_`,
template parameter substitution replaces occurences of template parameters with `T[X]_`.
`X` represents a base36 index into the array of components or
template parameters already encountered so far, respectively.

This substitution is done on an identity basis, which means that the templated function
`template<typename T> int foo()` instantiated with `int` will be mangled as `_Z3fooIiE*i*v`
(asterisks are emphasis and not part of the mangling) while it would be mangled as `_Z3fooIiE*T_*v`
if the definition was `template<typename T> T foo()`.

Moreover, experience with C++ compilers shows that component substitution is prefered over
template parameter substitution, such as `template<typename T> T foo(T)` is mangled as
`_Z3fooIiET_S0_` when instantiated with `int` and not `_Z3fooIiET_T_` as would be the case
if template substitution was prefered.

This is just brushing the surface of the problem, since only template type parameters have been
mentioned so far, but other kind (aliases, values) are also concerned.
Substitution also needs to happen if a template parameter is part of another type,
such as the `template<typename T> array<T>* foo (T, int)`, which, when instantiated with `int`,
is mangled as `_Z3fooIiEP5arrayIT_ES1_i`.

For more detailed test cases, see `test/compilable/cppmangle.d`.

The main issue encountered while implementing this in DMD is that there's no easy way to know
if a type (which is part of the function's type, e.g. parameters and return value)
was a template parameter or not, as DMD merges types, so in the previously mentioned
`template<typename T> int foo()` vs `template<typename T> T foo()` the template instantiation
will come with the same exact two pointer to the singleton `int` type.

Moreover, DMD does destructive semantic analysis, meaning that objects gets mutated,
pointers get replaced, aliases get resolved, and information gets lost.

After different approaches where taken, the most practical and reliable approach devised was to
provide a `visit` overload for non-resolved AST type `TypeIdentifier` and `TypeInstance`,
and compare the identifier to that of the template definition.
Fallback to post-semantic type when it isn't found.

Note that no attempt has been made whatsoever to handle the mess that would result from
expressions themselves being mangled. The reference doc for the ABI mentions that
"[...] this mangling is quite similar to the source token stream. (C++ Standard reference 14.5.5.1p5.)".
Original quote:
https://itanium-cxx-abi.github.io/cxx-abi/abi.html#expressions (5.1.6 Expressions)
```

~Please don't merge yet, I want to attempt to port some std types to D and see if I'm missing something. But I think this is ready for reviews.~