### PR TITLE
[Trivial] Fix missing newline regression in -v predefs output

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1412,7 +1412,7 @@ private void printPredefinedVersions(FILE* stream)
             buf.writeByte(' ');
             buf.writestring(str.toChars());
         }
-        stream.fprintf("predefs  %s", buf.peekString());
+        stream.fprintf("predefs  %s\n", buf.peekString());
     }
 }
 


### PR DESCRIPTION
Fine with 2.080.0, but like this with 2.081.0:
```
predefs   DigitalMars Windows LittleEndian D_Version2 all D_InlineAsm D_InlineAsm_X86 X86 Win32 CRuntime_DigitalMars assert D_HardFloatbinary    C:\LDC\dmd2\windows\bin\dmd.exe
```