### PR TITLE
[PoC] In-place struct initialization

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6161,6 +6161,22 @@ struct ASTBase
         }
     }
 
+    extern (C++) final class StructLiteralExp2 : Expression
+    {
+        StructInitializer _init;
+
+        extern (D) this(Loc loc, StructInitializer _init)
+        {
+            super(loc, TOK.structLiteral2, __traits(classInstanceSize, StructLiteralExp2));
+            this._init = _init;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
     extern (C++) final class ArrayInitializer : Initializer
     {
         Expressions index;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2934,6 +2934,7 @@ extern (C++) final class StructLiteralExp2 : Expression
 
     override Expression syntaxCopy()
     {
+        import dmd.init : syntaxCopy;
         return new StructLiteralExp2(loc, cast(StructInitializer) _init.syntaxCopy());
     }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2915,6 +2915,34 @@ enum stageApply             = 0x8;  /// apply is running
 enum stageInlineScan        = 0x10; /// inlineScan is running
 enum stageToCBuffer         = 0x20; /// toCBuffer is running
 
+
+extern (C++) final class StructLiteralExp2 : Expression
+{
+    import dmd.init : StructInitializer;
+    StructInitializer _init;
+
+    extern (D) this(const ref Loc loc, StructInitializer _init)
+    {
+        super(loc, TOK.structLiteral2, __traits(classInstanceSize, StructLiteralExp2));
+        this._init = _init;
+    }
+
+    override bool equals(RootObject o)
+    {
+        return false; // TODO
+    }
+
+    override Expression syntaxCopy()
+    {
+        return new StructLiteralExp2(loc, cast(StructInitializer) _init.syntaxCopy());
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
 /***********************************************************
  * sd( e1, e2, e3, ... )
  */
@@ -2949,6 +2977,7 @@ extern (C++) final class StructLiteralExp : Expression
     extern (D) this(const ref Loc loc, StructDeclaration sd, Expressions* elements, Type stype = null)
     {
         super(loc, TOK.structLiteral, __traits(classInstanceSize, StructLiteralExp));
+
         this.sd = sd;
         if (!elements)
             elements = new Expressions();

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4165,7 +4165,25 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* It's a struct literal
                  */
             Lx:
-                Expression e = new StructLiteralExp(exp.loc, sd, exp.arguments, exp.e1.type);
+                Expression e;
+                if (exp.arguments !is null &&
+                    exp.arguments.dim > 0 &&
+                    (*exp.arguments)[0].op == TOK.structLiteral2)
+                {
+                    import dmd.init, dmd.initsem;
+                    auto exp2 = cast(StructLiteralExp2) (*exp.arguments)[0];
+                    auto ie = buildStruct(sd, exp2._init, exp.e1.type, NeedInterpret.INITinterpret, sd._scope, false);
+                    if (ie.isErrorInitializer())
+                    {
+                        result = e = new ErrorExp();
+                        return;
+                    }
+                    e = (cast(ExpInitializer) ie).exp;
+                }
+                else
+                {
+                    e = new StructLiteralExp(exp.loc, sd, exp.arguments, exp.e1.type);
+                }
                 e = e.expressionSemantic(sc);
                 result = e;
                 return;

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -412,6 +412,15 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
         //printf("-ExpInitializer::semantic(): "); i.exp.print();
         return i;
     }
+
+    final switch (init.kind)
+    {
+        case InitKind.void_:   return visitVoid  (cast(  VoidInitializer)init);
+        case InitKind.error:   return visitError (cast( ErrorInitializer)init);
+        case InitKind.struct_: return visitStruct(cast(StructInitializer)init);
+        case InitKind.array:   return visitArray (cast( ArrayInitializer)init);
+        case InitKind.exp:     return visitExp   (cast(   ExpInitializer)init);
+    }
 }
 
 package Initializer buildStruct(StructDeclaration sd, StructInitializer i,

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -8461,7 +8461,25 @@ final class Parser(AST) : Lexer
                 break;
 
             case TOK.leftParentheses:
-                e = new AST.CallExp(loc, e, parseArguments());
+                auto nextTok = peek(&token);
+                auto nextTok2 = peek(nextTok);
+                auto nextTok3 = peek(nextTok2);
+                // TODO: choose which struct initialization format to pick
+                if (nextTok.value == TOK.leftCurly &&
+                    nextTok2.value == TOK.identifier &&
+                    nextTok3.value == TOK.colon
+                    )
+                 {
+                    nextToken();
+                    auto _init = cast(AST.StructInitializer) parseInitializer();
+                    auto sl = new AST.StructLiteralExp2(loc, _init);
+                    e = new AST.CallExp(loc, e, sl);
+                    nextToken();
+                }
+                else
+                {
+                    e = new AST.CallExp(loc, e, parseArguments());
+                }
                 continue;
 
             case TOK.leftBracket:

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -288,6 +288,8 @@ enum TOK : int
     objcClassReference,
 
     max_,
+
+    structLiteral2,
 }
 
 // Assert that all token enum members have consecutive values and

--- a/test/fail_compilation/structinit.d
+++ b/test/fail_compilation/structinit.d
@@ -1,0 +1,69 @@
+/+
+TEST_OUTPUT:
+---
+fail_compilation/structinit.d(21): Error: `z` is not a member of `Foo`
+fail_compilation/structinit.d(23): Error: duplicate initializer for field `a`
+fail_compilation/structinit.d(44): Error: constructor `structinit.FooDisabled.this` cannot be used because it is annotated with `@disable`
+fail_compilation/structinit.d(45): Error: constructor `structinit.FooDisabled.this` cannot be used because it is annotated with `@disable`
+fail_compilation/structinit.d(46): Error: constructor `structinit.FooDisabled.this` cannot be used because it is annotated with `@disable`
+---
++/
+
+struct Foo
+{
+    int a;
+    bool b;
+    float c;
+}
+
+void test1()
+{
+    bar(Foo({z: 1}));
+    bar(Foo({a: "error"})); // TODO
+    bar(Foo({a: 1, a:1}));
+    bar(Foo({a:1, 1}));
+    bar(Foo({c: 0.1, b: true, a: 2}));
+}
+
+void test1a()
+{
+    enum f = Foo({a: 1, b: true, c: 0.5});
+    static assert(f.a == 1);
+    static assert(f.b == true);
+    static assert(f.c == 0.5);
+}
+
+struct FooDisabled
+{
+    @disable this();
+    int a;
+}
+
+void test2()
+{
+    bar(FooDisabled({a: 1}));
+    bar(FooDisabled({a: true}));
+    bar(FooDisabled({b: 1}));
+}
+
+struct FooDefault
+{
+    this(int a);
+    int a;
+}
+
+// TODO
+//void test3()
+//{
+    //bar(FooDefault({a: 1}));
+    //bar(FooDefault({a: true}));
+    //bar(FooDefault({b: 1}));
+//}
+
+void bar(Foo foo);
+
+//void totallyInvalid()
+//{
+    ////bar(Foo({1}));
+    ////bar(Foo({1));
+//}

--- a/test/fail_compilation/structinit.d
+++ b/test/fail_compilation/structinit.d
@@ -1,11 +1,14 @@
 /+
 TEST_OUTPUT:
 ---
-fail_compilation/structinit.d(21): Error: `z` is not a member of `Foo`
-fail_compilation/structinit.d(23): Error: duplicate initializer for field `a`
-fail_compilation/structinit.d(44): Error: constructor `structinit.FooDisabled.this` cannot be used because it is annotated with `@disable`
-fail_compilation/structinit.d(45): Error: constructor `structinit.FooDisabled.this` cannot be used because it is annotated with `@disable`
-fail_compilation/structinit.d(46): Error: constructor `structinit.FooDisabled.this` cannot be used because it is annotated with `@disable`
+fail_compilation/structinit.d(24): Error: `z` is not a member of `Foo`
+fail_compilation/structinit.d(26): Error: duplicate initializer for field `a`
+fail_compilation/structinit.d(47): Error: constructor `structinit.FooDisabled.this()` is not callable using argument types `(void)`
+fail_compilation/structinit.d(47):        expected 0 argument(s), not 1
+fail_compilation/structinit.d(48): Error: constructor `structinit.FooDisabled.this()` is not callable using argument types `(void)`
+fail_compilation/structinit.d(48):        expected 0 argument(s), not 1
+fail_compilation/structinit.d(49): Error: constructor `structinit.FooDisabled.this()` is not callable using argument types `(void)`
+fail_compilation/structinit.d(49):        expected 0 argument(s), not 1
 ---
 +/
 

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -1474,6 +1474,25 @@ void test17622()
     s.fun();
 }
 
+
+void testStructLiteral()
+{
+    struct StructFoo
+    {
+        int a;
+    }
+
+    void bar(StructFoo foo)
+    {
+        assert(foo.a == 3);
+    }
+
+    StructFoo f = {a: 1};
+    f = StructFoo({a: 2});
+    assert(f.a == 2);
+    bar(StructFoo({a: 3}));
+}
+
 /********************************************/
 
 int main()
@@ -1522,6 +1541,7 @@ int main()
     test13021();
     test14556();
     test17622();
+    testStructLiteral();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
So this is my WIP hack to have in-place struct initialization into DMD.
As during the parsing stage we don't have much information about the struct and can only parse a `StructInitializer`, I created an intermediate `StructLiteralExp2` that will be converted into a `StructLiteralExp` during expression semantic.
I would like to have a more elegant solution and this still needs a lot of work, but it already passes the test suite for the common cases of this DIP and I thought it's good to show that it's possible to do this in dmd for submitting the DIP. Also I get to see what the CIs say.

What's in-place struct initialization?
-------------------------------------------

Full DIP: https://github.com/dlang/DIPs/pull/71

tl;dr:

```d
struct StructFoo
{
    int a;
}

void bar(StructFoo foo)
{
    assert(foo.a == 3);
}

StructFoo f = {a: 1};
f = StructFoo({a: 2});
assert(f.a == 2);
bar(StructFoo({a: 3}));
```