### PR TITLE
Don't fail test9287 with 'Device or resource busy'

### DIFF
--- a/test/runnable/test9287.sh
+++ b/test/runnable/test9287.sh
@@ -7,4 +7,4 @@ echo 'import std.stdio; void main() { writeln("Success"); }' | \
 
 ${OUTPUT_BASE}${EXE}
 
-rm -f ${OUTPUT_BASE}{${OBJ},${EXE}}
+rm -f ${OUTPUT_BASE}{${OBJ},${EXE}} || true


### PR DESCRIPTION
From: https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3234943&isPull=true

```
==============================
Test runnable/test9287.sh failed. The logged output:
Success
rm: cannot remove ‘test_results/runnable/test9287.exe’: Device or resource busy
==============================
Test runnable/test9287.sh failed. The xtrace output:
+ source runnable/test9287.sh
++ set -e
++ echo 'import std.stdio; void main() { writeln("Success"); }'
++ ../generated/windows/release/32/dmd.exe -m32 -oftest_results/runnable/test9287.exe -
++ test_results/runnable/test9287.exe
++ rm -f test_results/runnable/test9287.obj test_results/runnable/test9287.exe
+ finish 1
+ set +x
```

I guess the easiest is the `|| true` trick to avoid this spurious failure.