### PR TITLE
Fix issue 19065: don't check struct invariant before destructor runs.

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3379,7 +3379,10 @@ extern (C++) final class DtorDeclaration : FuncDeclaration
 
     override bool addPreInvariant()
     {
-        return (isThis() && vthis && global.params.useInvariants);
+        bool thisIsStruct = vthis && vthis.type.ty == Tstruct;
+
+        // structs may be in T.init, which may violate invariants
+        return (isThis() && vthis && global.params.useInvariants && !thisIsStruct);
     }
 
     override bool addPostInvariant()

--- a/test/runnable/test19065.d
+++ b/test/runnable/test19065.d
@@ -1,0 +1,29 @@
+module test19065;
+
+struct S
+{
+    bool b = false;
+
+    invariant
+    {
+        assert(b == true);
+    }
+
+    @disable this();
+    @safe this(int)
+    {
+        b = true;
+    }
+
+    // Invariant may be violated in the destructor.
+    // This is because `this` may also be S.init.
+    // For this reason, the invariant must not be checked on struct entry.
+    @safe ~this()
+    {
+    }
+}
+
+@safe void main()
+{
+    S s = S.init;
+}

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -118,10 +118,10 @@ struct S13113
     }
 
     this(int) pure nothrow @safe @nogc {}
-    // post invaiant is called directly but doesn't interfere with constructor attributes
+    // post invariant is called directly but doesn't interfere with constructor attributes
 
     ~this() pure nothrow @safe @nogc {}
-    // pre invaiant is called directly but doesn't interfere with destructor attributes
+    // pre invariant is not called because we are a struct, and might be T.init
 
     void foo() pure nothrow @safe @nogc {}
     // pre & post invariant calls don't interfere with method attributes
@@ -136,7 +136,8 @@ void test13113()
         s.foo();
         assert(S13113.count == 3);
     }
-    assert(S13113.count == 4);
+    // no invariant check before constructor - struct could be in T.init state
+    assert(S13113.count == 3);
 }
 
 /***************************************************/


### PR DESCRIPTION
This follows up on https://github.com/dlang/dlang.org/pull/2410

Implicit in the implementation of `moveEmplace` is that T.init is always a valid value of T.

This isn't necessarily the case, but it isn't actually _necessary_ for it to be the case - all that's necessary is that T.init always be a valid value _to call `~this()` on_. This is because `~this()` is the only struct method whose invocation is utterly unavoidable.

Note that `moveEmplace` already makes this assumption.

Maybe a better fix would be checking for `this == typeof(this).init`, and running the invariant otherwise - but I don't know how to do that.