### PR TITLE
Fix issue 19066 - Allow using symbols Object inside a struct without a toHash override

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -772,8 +772,8 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
         "size_t h = 0;" ~
         "foreach (i, T; typeof(p.tupleof))" ~
         // workaround https://issues.dlang.org/show_bug.cgi?id=17968
-        "    static if(is(T* : const(Object)*)) " ~
-        "        h = h * 33 + typeid(const(Object)).getHash(cast(const void*)&p.tupleof[i]);" ~
+        "    static if(is(T* : const(.object.Object)*)) " ~
+        "        h = h * 33 + typeid(const(.object.Object)).getHash(cast(const void*)&p.tupleof[i]);" ~
         "    else " ~
         "        h = h * 33 + typeid(T).getHash(cast(const void*)&p.tupleof[i]);" ~
         "return h;";

--- a/test/compilable/test19066.d
+++ b/test/compilable/test19066.d
@@ -1,0 +1,13 @@
+class C {}
+
+int Object;
+
+struct S
+{
+    int object;
+    C Object;
+}
+
+void main()
+{
+}


### PR DESCRIPTION
#8222 introduced a regression. If you have a struct with a member named `Object`, the generated code that wants to use `typeid(const(Object))` added to work around the linker error actually looks at the local `Object` symbol instead of the global.

I tried `.Object`, but if you define a variable named `Object` outside the struct, it matches there.

I tried `object.Object`, but if you define a local `object` symbol, then it fails.

`.object.Object` works, because defining a variable named `object` outside the struct is always an error (thank god!).

The test added tests for all of these cases. Ping @jacob-carlborg 