### PR TITLE
Avoid weird `!<ClassKind> == <ClassKind.cpp>`

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4620,7 +4620,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             cldec.baseok = Baseok.done;
 
             // If no base class, and this is not an Object, use Object as base class
-            if (!cldec.baseClass && cldec.ident != Id.Object && cldec.object && !cldec.classKind == ClassKind.cpp)
+            if (!cldec.baseClass && cldec.ident != Id.Object && cldec.object && cldec.classKind == ClassKind.d)
             {
                 void badObjectDotD()
                 {


### PR DESCRIPTION
... which doesn't translate to `<ClassKind> != <ClassKind.cpp>`, but to `<ClassKind> == <ClassKind.d>`! See https://run.dlang.io/is/tuYCPH.