### PR TITLE
convert tk/mem.h to memh.d

### DIFF
--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -39,16 +39,7 @@ import dmd.backend.type;
 
 import dmd.backend.dlist;
 import dmd.backend.dvec;
-
-version (SCPP)
-    import tk.mem;
-else
-{
-    extern (C)
-    {
-        void *mem_calloc(size_t);
-    }
-}
+import dmd.backend.memh;
 
 char symbol_isintab(Symbol *s) { return sytab[s.Sclass] & SCSS; }
 

--- a/src/dmd/backend/memh.d
+++ b/src/dmd/backend/memh.d
@@ -1,0 +1,52 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1985-1998 by Symantec
+ *              Copyright (C) 2000-2018 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/memh.d, backend/memh.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/memh.d
+ */
+
+
+module dmd.backend.memh;
+
+
+extern (C):
+
+nothrow:
+@nogc:
+
+char *mem_strdup(const(char) *);
+void *mem_malloc(size_t);
+void *mem_calloc(size_t);
+void *mem_realloc(void *,size_t);
+void mem_free(void *);
+void mem_init();
+void mem_term();
+
+extern (C++)
+{
+    void mem_free_cpp(void *);
+    alias mem_freefp = mem_free_cpp;
+}
+
+enum MEM_E { MEM_ABORTMSG, MEM_ABORT, MEM_RETNULL, MEM_CALLFP, MEM_RETRY }
+void mem_setexception(MEM_E,...);
+
+version (MEM_DEBUG)
+{
+    alias mem_fstrdup = mem_strdup;
+    alias mem_fcalloc = mem_calloc;
+    alias mem_fmalloc = mem_malloc;
+    alias mem_ffree   = mem_free;
+}
+else
+{
+    char *mem_fstrdup(const(char) *);
+    void *mem_fcalloc(size_t);
+    void *mem_fmalloc(size_t);
+    void mem_ffree(void *) { }
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -398,7 +398,7 @@ BACK_SRC = \
 	$C/xmm.h $C/obj.h $C/pdata.c $C/cv8.c $C/backconfig.c $C/divcoeff.d \
 	$C/varstats.c $C/varstats.h $C/dvec.d \
 	$C/md5.c $C/md5.h \
-	$C/ph2.c $C/util2.c $C/dwarfeh.c $C/goh.d \
+	$C/ph2.c $C/util2.c $C/dwarfeh.c $C/goh.d $C/memh.d \
 	$(TARGET_CH)
 
 TK_SRC = \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -180,7 +180,7 @@ GLUE_SRCS=$D/irstate.d $D/toctype.d $D/glue.d $D/gluelayer.d $D/todt.d $D/tocsym
 BACK_HDRS=$C/cc.d $C/cdef.d $C/cgcv.d $C/code.d $C/cv4.d $C/dt.d $C/el.d $C/global.d \
 	$C/obj.d $C/oper.d $C/outbuf.d $C/rtlsym.d $C/code_x86.d $C/iasm.d \
 	$C/ty.d $C/type.d $C/exh.d $C/mach.d $C/md5.di $C/mscoff.d $C/dwarf.d $C/dwarf2.d $C/xmm.d \
-	$C/dlist.d $C/goh.d
+	$C/dlist.d $C/goh.d $C/memh.d
 
 TK_HDRS=
 


### PR DESCRIPTION
Should use .di files, but gave up on that due to non-makefile build systems can't handle it. So call it memh.d instead.