### PR TITLE
Improve error message for invalid binary digit

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1880,7 +1880,7 @@ class Lexer : ErrorHandler
                     anyHexDigitsNoSingleUS = true;
                 if (base == 2 && !err)
                 {
-                    error("radix %d digit expected, not `%c`", base, c);
+                    error("radix 2 digit expected, not `%c`", c);
                     err = true;
                 }
                 ++p;

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1880,7 +1880,7 @@ class Lexer : ErrorHandler
                     anyHexDigitsNoSingleUS = true;
                 if (base == 2 && !err)
                 {
-                    error("binary digit expected");
+                    error("radix %d digit expected, not `%c`", base, c);
                     err = true;
                 }
                 ++p;

--- a/test/fail_compilation/lexer4.d
+++ b/test/fail_compilation/lexer4.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 fail_compilation/lexer4.d(22): Error: unterminated character constant
 fail_compilation/lexer4.d(24): Error: unterminated character constant
 fail_compilation/lexer4.d(25): Error: unterminated character constant
-fail_compilation/lexer4.d(26): Error: binary digit expected
+fail_compilation/lexer4.d(26): Error: radix 2 digit expected, not `2`
 fail_compilation/lexer4.d(27): Error: radix 8 digit expected, not `8`
 fail_compilation/lexer4.d(27): Error: octal literals `0130` are no longer supported, use `std.conv.octal!130` instead
 fail_compilation/lexer4.d(28): Error: radix 10 digit expected, not `a`


### PR DESCRIPTION
schveiguy pointed out [this strange difference in error messages](https://github.com/dlang/dmd/pull/8451#discussion_r200650308).