### PR TITLE
Reduce global state

### DIFF
--- a/src/dmd/backend/dwarf.c
+++ b/src/dmd/backend/dwarf.c
@@ -1091,9 +1091,9 @@ void dwarf_initfile(const char *filename)
     }
 #endif
 #if 0 && MARS
-    for (int i = 0; i < global.params.imppath->dim; i++)
+    for (int i = 0; i < global().params.imppath->dim; i++)
     {
-        debug_line.buf->writeString((*global.params.imppath)[i]);
+        debug_line.buf->writeString((*global().params.imppath)[i]);
         debug_line.buf->writeByte(0);
     }
 #endif
@@ -1144,12 +1144,12 @@ void dwarf_initfile(const char *filename)
     debug_info.buf->writeuLEB128(1);                   // abbreviation code
 #if MARS
     debug_info.buf->write("Digital Mars D ");
-    debug_info.buf->writeString(global.version);       // DW_AT_producer
+    debug_info.buf->writeString(global().version);       // DW_AT_producer
     // DW_AT_language
     debug_info.buf->writeByte((config.fulltypes == CVDWARF_D) ? DW_LANG_D : DW_LANG_C89);
 #elif SCPP
     debug_info.buf->write("Digital Mars C ");
-    debug_info.buf->writeString(global.version);       // DW_AT_producer
+    debug_info.buf->writeString(global().version);       // DW_AT_producer
     debug_info.buf->writeByte(DW_LANG_C89);            // DW_AT_language
 #else
     assert(0);

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -319,9 +319,8 @@ extern (C++) Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* ar
     return new RealExp(loc, result, arg0.type);
 }
 
-package StringTable initializeBuiltins()
+package void initializeBuiltins(ref StringTable builtins)
 {
-    StringTable builtins;
     builtins._init(47);
 
     void add_builtin(const(char)* mangle, builtin_fp fp)
@@ -473,8 +472,6 @@ package StringTable initializeBuiltins()
     // @safe @nogc pure nothrow int function(ulong)
     if (global.params.is64bit)
         add_builtin("_D4core5bitop7_popcntFNaNbNiNfmZi", &eval_popcnt);
-
-    return builtins;
 }
 
 /**********************************

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -40,16 +40,9 @@ private:
  */
 extern (C++) alias builtin_fp = Expression function(Loc loc, FuncDeclaration fd, Expressions* arguments);
 
-__gshared StringTable builtins;
-
-public extern (C++) void add_builtin(const(char)* mangle, builtin_fp fp)
-{
-    builtins.insert(mangle, strlen(mangle), cast(void*)fp);
-}
-
 builtin_fp builtin_lookup(const(char)* mangle)
 {
-    if (const sv = builtins.lookup(mangle, strlen(mangle)))
+    if (const sv = compilerInvocation.builtins.lookup(mangle, strlen(mangle)))
         return cast(builtin_fp)sv.ptrvalue;
     return null;
 }
@@ -326,9 +319,16 @@ extern (C++) Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* ar
     return new RealExp(loc, result, arg0.type);
 }
 
-public extern (C++) void builtin_init()
+package StringTable initializeBuiltins()
 {
+    StringTable builtins;
     builtins._init(47);
+
+    void add_builtin(const(char)* mangle, builtin_fp fp)
+    {
+        builtins.insert(mangle, strlen(mangle), cast(void*)fp);
+    }
+
     // @safe @nogc pure nothrow real function(real)
     add_builtin("_D4core4math3sinFNaNbNiNfeZe", &eval_sin);
     add_builtin("_D4core4math3cosFNaNbNiNfeZe", &eval_cos);
@@ -473,6 +473,8 @@ public extern (C++) void builtin_init()
     // @safe @nogc pure nothrow int function(ulong)
     if (global.params.is64bit)
         add_builtin("_D4core5bitop7_popcntFNaNbNiNfmZi", &eval_popcnt);
+
+    return builtins;
 }
 
 /**********************************

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -216,17 +216,15 @@ extern (C++) final class CTFEExp : Expression
             CTFEExp gotoexp;
         }
 
-        static SharedState initialize()
-        {
-            auto state = SharedState.init;
+        @disable this(this);
 
+        static void initialize(ref SharedState state)
+        {
             state.cantexp = new CTFEExp(TOK.cantExpression);
             state.voidexp = new CTFEExp(TOK.voidExpression);
             state.breakexp = new CTFEExp(TOK.break_);
             state.continueexp = new CTFEExp(TOK.continue_);
             state.gotoexp = new CTFEExp(TOK.goto_);
-
-            return state;
         }
     }
 

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -205,6 +205,33 @@ extern (C++) final class ThrownExceptionExp : Expression
  */
 extern (C++) final class CTFEExp : Expression
 {
+    extern (D) package static struct SharedState
+    {
+        @generateForwarder
+        {
+            CTFEExp cantexp;
+            CTFEExp voidexp;
+            CTFEExp breakexp;
+            CTFEExp continueexp;
+            CTFEExp gotoexp;
+        }
+
+        static SharedState initialize()
+        {
+            auto state = SharedState.init;
+
+            state.cantexp = new CTFEExp(TOK.cantExpression);
+            state.voidexp = new CTFEExp(TOK.voidExpression);
+            state.breakexp = new CTFEExp(TOK.break_);
+            state.continueexp = new CTFEExp(TOK.continue_);
+            state.gotoexp = new CTFEExp(TOK.goto_);
+
+            return state;
+        }
+    }
+
+    mixin(generateForwarders!(SharedState, "ctfeExpressionState"));
+
     extern (D) this(TOK tok)
     {
         super(Loc.initial, tok, __traits(classInstanceSize, CTFEExp));
@@ -229,12 +256,6 @@ extern (C++) final class CTFEExp : Expression
             assert(0);
         }
     }
-
-    extern (C++) static __gshared CTFEExp cantexp;
-    extern (C++) static __gshared CTFEExp voidexp;
-    extern (C++) static __gshared CTFEExp breakexp;
-    extern (C++) static __gshared CTFEExp continueexp;
-    extern (C++) static __gshared CTFEExp gotoexp;
 
     static bool isCantExp(const Expression e)
     {

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -633,7 +633,7 @@ extern (C++) final class Module : Package
 
     // read file, returns 'true' if succeed, 'false' otherwise.
     bool read(Loc loc)
-    {printf("*************** dmodule %s %p\n", global.inifilename, &global());
+    {
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
         if (srcfile.read())
         {

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -301,6 +301,8 @@ extern (C++) final class Module : Package
             AggregateDeclaration moduleinfo;
         }
 
+        @disable this(this);
+
         /**
          * A callback function that is called once an imported module is
          * parsed. If the callback returns true, then it tells the
@@ -308,13 +310,9 @@ extern (C++) final class Module : Package
          */
         extern (C++) bool function(Module mod) onImport;
 
-        static SharedState initialize()
+        static void initialize(ref SharedState state)
         {
-            auto state = SharedState.init;
-
             state.modules = new DsymbolTable();
-
-            return state;
         }
     }
 

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -284,26 +284,41 @@ extern (C++) class Package : ScopeDsymbol
  */
 extern (C++) final class Module : Package
 {
-    extern (C++) static __gshared Module rootModule;
-    extern (C++) static __gshared DsymbolTable modules; // symbol table of all modules
-    extern (C++) static __gshared Modules amodules;     // array of all modules
-    extern (C++) static __gshared Dsymbols deferred;    // deferred Dsymbol's needing semantic() run on them
-    extern (C++) static __gshared Dsymbols deferred2;   // deferred Dsymbol's needing semantic2() run on them
-    extern (C++) static __gshared Dsymbols deferred3;   // deferred Dsymbol's needing semantic3() run on them
-    extern (C++) static __gshared uint dprogress;       // progress resolving the deferred list
-    /**
-     * A callback function that is called once an imported module is
-     * parsed. If the callback returns true, then it tells the
-     * frontend that the driver intends on compiling the import.
-     */
-    extern (C++) static __gshared bool function(Module mod) onImport;
+    import dmd.root.array : Array;
 
-    static void _init()
+    extern (D) package static struct SharedState
     {
-        modules = new DsymbolTable();
+        @generateForwarder
+        {
+            Module rootModule;
+            DsymbolTable modules; // symbol table of all modules
+            Modules amodules;     // array of all modules
+            Dsymbols deferred;    // deferred Dsymbol's needing semantic() run on them
+            Dsymbols deferred2;   // deferred Dsymbol's needing semantic2() run on them
+            Dsymbols deferred3;   // deferred Dsymbol's needing semantic3() run on them
+            uint dprogress;       // progress resolving the deferred list
+
+            AggregateDeclaration moduleinfo;
+        }
+
+        /**
+         * A callback function that is called once an imported module is
+         * parsed. If the callback returns true, then it tells the
+         * frontend that the driver intends on compiling the import.
+         */
+        extern (C++) bool function(Module mod) onImport;
+
+        static SharedState initialize()
+        {
+            auto state = SharedState.init;
+
+            state.modules = new DsymbolTable();
+
+            return state;
+        }
     }
 
-    extern (C++) static __gshared AggregateDeclaration moduleinfo;
+    mixin(generateForwarders!(SharedState, "moduleState"));
 
     const(char)* arg;           // original argument name
     ModuleDeclaration* md;      // if !=null, the contents of the ModuleDeclaration declaration
@@ -531,9 +546,9 @@ extern (C++) final class Module : Package
         //!!!!!!!!!!!!!!!!!!!!!!!
         version(OSX)
         {
-            if (!m.isRoot() && onImport)
+            if (!m.isRoot() && compilerInvocation.moduleState.onImport)
             {
-                auto onImportResult = onImport(m);
+                auto onImportResult = compilerInvocation.moduleState.onImport(m);
                 if(onImportResult)
                 {
                     m.importedFrom = m;
@@ -543,7 +558,11 @@ extern (C++) final class Module : Package
         }
         else
         {
-            if (!m.isRoot() && onImport && onImport(m))
+            if (
+                !m.isRoot() &&
+                compilerInvocation.moduleState.onImport &&
+                compilerInvocation.moduleState.onImport(m)
+            )
             {
                 m.importedFrom = m;
                 assert(m.isRoot());
@@ -1195,7 +1214,7 @@ extern (C++) final class Module : Package
     {
         Module.runDeferredSemantic();
 
-        Dsymbols* a = &Module.deferred2;
+        Dsymbols* a = &Module.deferred2();
         for (size_t i = 0; i < a.dim; i++)
         {
             Dsymbol s = (*a)[i];
@@ -1212,7 +1231,7 @@ extern (C++) final class Module : Package
     {
         Module.runDeferredSemantic2();
 
-        Dsymbols* a = &Module.deferred3;
+        Dsymbols* a = &Module.deferred3();
         for (size_t i = 0; i < a.dim; i++)
         {
             Dsymbol s = (*a)[i];

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -633,7 +633,7 @@ extern (C++) final class Module : Package
 
     // read file, returns 'true' if succeed, 'false' otherwise.
     bool read(Loc loc)
-    {
+    {printf("*************** dmodule %s %p\n", global.inifilename, &global());
         //printf("Module::read('%s') file '%s'\n", toChars(), srcfile.toChars());
         if (srcfile.read())
         {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1648,15 +1648,6 @@ extern (C++) abstract class Expression : RootObject
         this.size = cast(ubyte)size;
     }
 
-    static void _init()
-    {
-        CTFEExp.cantexp = new CTFEExp(TOK.cantExpression);
-        CTFEExp.voidexp = new CTFEExp(TOK.voidExpression);
-        CTFEExp.breakexp = new CTFEExp(TOK.break_);
-        CTFEExp.continueexp = new CTFEExp(TOK.continue_);
-        CTFEExp.gotoexp = new CTFEExp(TOK.goto_);
-    }
-
     /*********************************
      * Does *not* do a deep copy.
      */

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -27,26 +27,8 @@ This needs to be done $(I before) calling any function.
 */
 void initDMD()
 {
-    import dmd.builtin : builtin_init;
-    import dmd.dmodule : Module;
-    import dmd.expression : Expression;
-    import dmd.globals : global;
-    import dmd.id : Id;
-    import dmd.mars : addDefaultVersionIdentifiers;
-    import dmd.mtype : Type;
-    import dmd.objc : Objc;
-    import dmd.target : Target;
-
-    global._init();
-    addDefaultVersionIdentifiers();
-
-    Type._init();
-    Id.initialize();
-    Module._init();
-    Target._init();
-    Expression._init();
-    Objc._init();
-    builtin_init();
+    import dmd.globals : CompilerInvocation;
+    CompilerInvocation.initialize();
 }
 
 /**

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -342,7 +342,27 @@ enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
 
 struct Global
 {
-    const(char)* inifilename;
+    import core.stdc.stdio;
+    const(char)* inifilename_;
+
+    // invariant
+    // {
+    //     assert(inifilename_);
+    // }
+
+    const(char)* inifilename()
+    {
+        printf("************** inifilename-getter %s\n", inifilename_);
+        return inifilename_;
+    }
+
+    const(char)* inifilename(const(char)* inifilename)
+    {
+        assert(inifilename);
+        printf("************** inifilename-setter %s\n", inifilename);
+        return inifilename_ = inifilename;
+    }
+
     const(char)* mars_ext = "d";
     const(char)* obj_ext;
     const(char)* lib_ext;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -39,7 +39,7 @@ package string generateForwarders(Type, string compilerInvocationFieldName)()
 
     static string generateGetter(string name)
     {
-        return q{extern (D) @property static auto } ~ name ~ "() " ~
+        return q{extern (D) @property static ref auto } ~ name ~ "() " ~
                "{ " ~
                        accessField(name) ~ "; " ~
                '}';
@@ -47,7 +47,7 @@ package string generateForwarders(Type, string compilerInvocationFieldName)()
 
     static string generateSetter(string type, string name)
     {
-        return q{extern (D) @property static auto } ~ name ~ '(' ~ type ~ ' ' ~ name ~ ") " ~
+        return q{extern (D) @property static auto } ~ name ~ "()(auto ref " ~ type ~ ' ' ~ name ~ ") " ~
               "{ " ~
                         accessField(name) ~ " = " ~ name ~ ';' ~
               '}';
@@ -77,10 +77,12 @@ class CompilerInvocation
 {
     import dmd.mtype : Type;
     import dmd.id : Id;
+    import dmd.dmodule : Module;
 
     Global global;
     Type.SharedState typeState;
     Id.SharedState idState;
+    Module.SharedState moduleState;
 
     extern (D) this()
     {
@@ -90,6 +92,7 @@ class CompilerInvocation
         addDefaultVersionIdentifiers();
         typeState = Type.SharedState.initialize();
         idState = Id.SharedState.initialize();
+        moduleState = Module.SharedState.initialize();
     }
 }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -48,9 +48,9 @@ package string generateForwarders(Type, string compilerInvocationFieldName)()
     static string generateSetter(string type, string name)
     {
         return q{extern (D) @property static auto } ~ name ~ "()(auto ref " ~ type ~ ' ' ~ name ~ ") " ~
-              "{ " ~
+               "{ " ~
                         accessField(name) ~ " = " ~ name ~ ';' ~
-              '}';
+               '}';
     }
 
     alias Fields = typeof(Type.tupleof);
@@ -75,14 +75,14 @@ package string generateForwarders(Type, string compilerInvocationFieldName)()
 
 class CompilerInvocation
 {
-    import dmd.mtype : Type;
-    import dmd.id : Id;
-    import dmd.dmodule : Module;
-    import dmd.target : Target;
     import dmd.ctfeexpr : CTFEExp;
+    import dmd.dmodule : Module;
+    import dmd.id : Id;
+    import dmd.mtype : Type;
     import dmd.objc : Objc;
     import dmd.root.stringtable : StringTable;
-    import dmd.builtin : initializeBuiltins;
+    import dmd.target : Target;
+    import dmd.traits : initializeTraits;
 
     Global global;
     Type.SharedState typeState;
@@ -94,8 +94,11 @@ class CompilerInvocation
     Objc objc;
     StringTable builtins;
 
+    StringTable traitsStringTable;
+
     extern (D) this()
     {
+        import dmd.builtin : initializeBuiltins;
         import dmd.mars : addDefaultVersionIdentifiers;
 
         global._init();
@@ -109,6 +112,13 @@ class CompilerInvocation
 
         objc = Objc.initialize();
         builtins = initializeBuiltins();
+
+        traitsStringTable = initializeTraits();
+    }
+
+    static void initialize()
+    {
+        compilerInvocation = new CompilerInvocation();
     }
 }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -78,11 +78,13 @@ class CompilerInvocation
     import dmd.mtype : Type;
     import dmd.id : Id;
     import dmd.dmodule : Module;
+    import dmd.target : Target;
 
     Global global;
     Type.SharedState typeState;
     Id.SharedState idState;
     Module.SharedState moduleState;
+    Target.SharedState targetState;
 
     extern (D) this()
     {
@@ -93,6 +95,7 @@ class CompilerInvocation
         typeState = Type.SharedState.initialize();
         idState = Id.SharedState.initialize();
         moduleState = Module.SharedState.initialize();
+        targetState = Target.SharedState.initialize();
     }
 }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -117,6 +117,11 @@ class CompilerInvocation
     }
 
     static void initialize()
+    in
+    {
+        assert(!compilerInvocation);
+    }
+    body
     {
         compilerInvocation = new CompilerInvocation();
         compilerInvocation._init();
@@ -342,27 +347,7 @@ enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
 
 struct Global
 {
-    import core.stdc.stdio;
-    const(char)* inifilename_;
-
-    // invariant
-    // {
-    //     assert(inifilename_);
-    // }
-
-    const(char)* inifilename()
-    {
-        printf("************** inifilename-getter %s\n", inifilename_);
-        return inifilename_;
-    }
-
-    const(char)* inifilename(const(char)* inifilename)
-    {
-        assert(inifilename);
-        printf("************** inifilename-setter %s\n", inifilename);
-        return inifilename_ = inifilename;
-    }
-
+    const(char)* inifilename;
     const(char)* mars_ext = "d";
     const(char)* obj_ext;
     const(char)* lib_ext;

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -79,12 +79,14 @@ class CompilerInvocation
     import dmd.id : Id;
     import dmd.dmodule : Module;
     import dmd.target : Target;
+    import dmd.ctfeexpr : CTFEExp;
 
     Global global;
     Type.SharedState typeState;
     Id.SharedState idState;
     Module.SharedState moduleState;
     Target.SharedState targetState;
+    CTFEExp.SharedState ctfeExpressionState;
 
     extern (D) this()
     {
@@ -92,10 +94,12 @@ class CompilerInvocation
 
         global._init();
         addDefaultVersionIdentifiers();
+
         typeState = Type.SharedState.initialize();
         idState = Id.SharedState.initialize();
         moduleState = Module.SharedState.initialize();
         targetState = Target.SharedState.initialize();
+        ctfeExpressionState = CTFEExp.SharedState.initialize();
     }
 }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -80,6 +80,7 @@ class CompilerInvocation
     import dmd.dmodule : Module;
     import dmd.target : Target;
     import dmd.ctfeexpr : CTFEExp;
+    import dmd.objc : Objc;
 
     Global global;
     Type.SharedState typeState;
@@ -87,6 +88,8 @@ class CompilerInvocation
     Module.SharedState moduleState;
     Target.SharedState targetState;
     CTFEExp.SharedState ctfeExpressionState;
+
+    Objc objc;
 
     extern (D) this()
     {
@@ -100,6 +103,8 @@ class CompilerInvocation
         moduleState = Module.SharedState.initialize();
         targetState = Target.SharedState.initialize();
         ctfeExpressionState = CTFEExp.SharedState.initialize();
+
+        objc = Objc.initialize();
     }
 }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -81,6 +81,8 @@ class CompilerInvocation
     import dmd.target : Target;
     import dmd.ctfeexpr : CTFEExp;
     import dmd.objc : Objc;
+    import dmd.root.stringtable : StringTable;
+    import dmd.builtin : initializeBuiltins;
 
     Global global;
     Type.SharedState typeState;
@@ -90,6 +92,7 @@ class CompilerInvocation
     CTFEExp.SharedState ctfeExpressionState;
 
     Objc objc;
+    StringTable builtins;
 
     extern (D) this()
     {
@@ -105,6 +108,7 @@ class CompilerInvocation
         ctfeExpressionState = CTFEExp.SharedState.initialize();
 
         objc = Objc.initialize();
+        builtins = initializeBuiltins();
     }
 }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -96,7 +96,7 @@ class CompilerInvocation
 
     StringTable traitsStringTable;
 
-    extern (D) this()
+    private void _init()
     {
         import dmd.builtin : initializeBuiltins;
         import dmd.mars : addDefaultVersionIdentifiers;
@@ -104,21 +104,22 @@ class CompilerInvocation
         global._init();
         addDefaultVersionIdentifiers();
 
-        typeState = Type.SharedState.initialize();
-        idState = Id.SharedState.initialize();
-        moduleState = Module.SharedState.initialize();
-        targetState = Target.SharedState.initialize();
-        ctfeExpressionState = CTFEExp.SharedState.initialize();
+        Type.SharedState.initialize(typeState);
+        Id.SharedState.initialize(idState);
+        Module.SharedState.initialize(moduleState);
+        Target.SharedState.initialize(targetState);
+        CTFEExp.SharedState.initialize(ctfeExpressionState);
 
         objc = Objc.initialize();
-        builtins = initializeBuiltins();
+        initializeBuiltins(builtins);
 
-        traitsStringTable = initializeTraits();
+        initializeTraits(traitsStringTable);
     }
 
     static void initialize()
     {
         compilerInvocation = new CompilerInvocation();
+        compilerInvocation._init();
     }
 }
 
@@ -616,5 +617,9 @@ enum PINLINE : int
 
 alias StorageClass = uinteger_t;
 
-extern (C++) __gshared Global global;
+extern (C++) ref Global global() nothrow
+{
+    return compilerInvocation.global;
+}
+
 extern (C++) __gshared CompilerInvocation compilerInvocation;

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -263,7 +263,7 @@ struct Global
     unsigned versionNumber();
 };
 
-extern Global global;
+Global& global();
 
 // Because int64_t and friends may be any integral type of the
 // correct size, we have to explicitly ask for the correct

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -40,13 +40,9 @@ struct Id
          * An identifier that corresponds to each static field in this struct will
          * be placed in the identifier pool.
          */
-        static SharedState initialize()
+        static void initialize(ref SharedState state)
         {
-            SharedState state = void;
-
             mixin(msgtable.generate(&initializer));
-
-            return state;
         }
     }
 
@@ -54,7 +50,6 @@ struct Id
 }
 
 private:
-
 
 /**
  * Each element in this array will generate one static field in the `Id` struct

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -248,7 +248,6 @@ private int tryMain(size_t argc, const(char)** argv)
             static assert(0, "fix this");
         }
     }
-    printf("*************** mars %s %p\n", global.inifilename, &global());
     // Read the configurarion file
     auto inifile = File(global.inifilename);
     inifile.read();
@@ -488,7 +487,6 @@ private int tryMain(size_t argc, const(char)** argv)
     setDefaultLibrary();
 
     // Initialization
-    CompilerInvocation.initialize();
     compilerInvocation.moduleState.onImport = &marsOnImport;
 
     if (global.params.verbose)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -487,8 +487,7 @@ private int tryMain(size_t argc, const(char)** argv)
     setDefaultLibrary();
 
     // Initialization
-    Module._init();
-    Module.onImport = &marsOnImport;
+    compilerInvocation.moduleState.onImport = &marsOnImport;
     Target._init();
     Expression._init();
     Objc._init();

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -193,7 +193,7 @@ private int tryMain(size_t argc, const(char)** argv)
     Strings files;
     Strings libmodules;
 
-    compilerInvocation = new CompilerInvocation();
+    CompilerInvocation.initialize();
     debug
     {
         printf("DMD %s DEBUG\n", global._version);

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -248,6 +248,7 @@ private int tryMain(size_t argc, const(char)** argv)
             static assert(0, "fix this");
         }
     }
+    printf("*************** mars %s %p\n", global.inifilename, &global());
     // Read the configurarion file
     auto inifile = File(global.inifilename);
     inifile.read();

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -488,7 +488,6 @@ private int tryMain(size_t argc, const(char)** argv)
 
     // Initialization
     compilerInvocation.moduleState.onImport = &marsOnImport;
-    builtin_init();
 
     if (global.params.verbose)
     {

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -487,6 +487,7 @@ private int tryMain(size_t argc, const(char)** argv)
     setDefaultLibrary();
 
     // Initialization
+    CompilerInvocation.initialize();
     compilerInvocation.moduleState.onImport = &marsOnImport;
 
     if (global.params.verbose)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -488,7 +488,6 @@ private int tryMain(size_t argc, const(char)** argv)
 
     // Initialization
     compilerInvocation.moduleState.onImport = &marsOnImport;
-    Objc._init();
     builtin_init();
 
     if (global.params.verbose)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -488,7 +488,6 @@ private int tryMain(size_t argc, const(char)** argv)
 
     // Initialization
     compilerInvocation.moduleState.onImport = &marsOnImport;
-    Target._init();
     Expression._init();
     Objc._init();
     builtin_init();

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -488,7 +488,6 @@ private int tryMain(size_t argc, const(char)** argv)
 
     // Initialization
     compilerInvocation.moduleState.onImport = &marsOnImport;
-    Expression._init();
     Objc._init();
     builtin_init();
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -192,7 +192,8 @@ private int tryMain(size_t argc, const(char)** argv)
 {
     Strings files;
     Strings libmodules;
-    global._init();
+
+    compilerInvocation = new CompilerInvocation();
     debug
     {
         printf("DMD %s DEBUG\n", global._version);
@@ -483,14 +484,9 @@ private int tryMain(size_t argc, const(char)** argv)
         foreach (charz; *global.params.debugids)
             DebugCondition.addGlobalIdent(charz[0 .. strlen(charz)]);
 
-    // Predefined version identifiers
-    addDefaultVersionIdentifiers();
-
     setDefaultLibrary();
 
     // Initialization
-    Type._init();
-    Id.initialize();
     Module._init();
     Module.onImport = &marsOnImport;
     Target._init();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -394,92 +394,203 @@ extern (C++) abstract class Type : RootObject
 
     type* ctype;                    // for back end
 
-    extern (C++) static __gshared Type tvoid;
-    extern (C++) static __gshared Type tint8;
-    extern (C++) static __gshared Type tuns8;
-    extern (C++) static __gshared Type tint16;
-    extern (C++) static __gshared Type tuns16;
-    extern (C++) static __gshared Type tint32;
-    extern (C++) static __gshared Type tuns32;
-    extern (C++) static __gshared Type tint64;
-    extern (C++) static __gshared Type tuns64;
-    extern (C++) static __gshared Type tint128;
-    extern (C++) static __gshared Type tuns128;
-    extern (C++) static __gshared Type tfloat32;
-    extern (C++) static __gshared Type tfloat64;
-    extern (C++) static __gshared Type tfloat80;
-    extern (C++) static __gshared Type timaginary32;
-    extern (C++) static __gshared Type timaginary64;
-    extern (C++) static __gshared Type timaginary80;
-    extern (C++) static __gshared Type tcomplex32;
-    extern (C++) static __gshared Type tcomplex64;
-    extern (C++) static __gshared Type tcomplex80;
-    extern (C++) static __gshared Type tbool;
-    extern (C++) static __gshared Type tchar;
-    extern (C++) static __gshared Type twchar;
-    extern (C++) static __gshared Type tdchar;
-
-    // Some special types
-    extern (C++) static __gshared Type tshiftcnt;
-    extern (C++) static __gshared Type tvoidptr;    // void*
-    extern (C++) static __gshared Type tstring;     // immutable(char)[]
-    extern (C++) static __gshared Type twstring;    // immutable(wchar)[]
-    extern (C++) static __gshared Type tdstring;    // immutable(dchar)[]
-    extern (C++) static __gshared Type tvalist;     // va_list alias
-    extern (C++) static __gshared Type terror;      // for error recovery
-    extern (C++) static __gshared Type tnull;       // for null type
-
-    extern (C++) static __gshared Type tsize_t;     // matches size_t alias
-    extern (C++) static __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
-    extern (C++) static __gshared Type thash_t;     // matches hash_t alias
-
-    extern (C++) static __gshared ClassDeclaration dtypeinfo;
-    extern (C++) static __gshared ClassDeclaration typeinfoclass;
-    extern (C++) static __gshared ClassDeclaration typeinfointerface;
-    extern (C++) static __gshared ClassDeclaration typeinfostruct;
-    extern (C++) static __gshared ClassDeclaration typeinfopointer;
-    extern (C++) static __gshared ClassDeclaration typeinfoarray;
-    extern (C++) static __gshared ClassDeclaration typeinfostaticarray;
-    extern (C++) static __gshared ClassDeclaration typeinfoassociativearray;
-    extern (C++) static __gshared ClassDeclaration typeinfovector;
-    extern (C++) static __gshared ClassDeclaration typeinfoenum;
-    extern (C++) static __gshared ClassDeclaration typeinfofunction;
-    extern (C++) static __gshared ClassDeclaration typeinfodelegate;
-    extern (C++) static __gshared ClassDeclaration typeinfotypelist;
-    extern (C++) static __gshared ClassDeclaration typeinfoconst;
-    extern (C++) static __gshared ClassDeclaration typeinfoinvariant;
-    extern (C++) static __gshared ClassDeclaration typeinfoshared;
-    extern (C++) static __gshared ClassDeclaration typeinfowild;
-
-    extern (C++) static __gshared TemplateDeclaration rtinfo;
-
-    extern (C++) static __gshared Type[TMAX] basic;
-    extern (C++) static __gshared StringTable stringtable;
-
-    extern (C++) static __gshared ubyte[TMAX] sizeTy = ()
+    extern (D) package static struct SharedState
+    {
+        @generateForwarder
         {
-            ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
-            sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);
-            sizeTy[Tarray] = __traits(classInstanceSize, TypeDArray);
-            sizeTy[Taarray] = __traits(classInstanceSize, TypeAArray);
-            sizeTy[Tpointer] = __traits(classInstanceSize, TypePointer);
-            sizeTy[Treference] = __traits(classInstanceSize, TypeReference);
-            sizeTy[Tfunction] = __traits(classInstanceSize, TypeFunction);
-            sizeTy[Tdelegate] = __traits(classInstanceSize, TypeDelegate);
-            sizeTy[Tident] = __traits(classInstanceSize, TypeIdentifier);
-            sizeTy[Tinstance] = __traits(classInstanceSize, TypeInstance);
-            sizeTy[Ttypeof] = __traits(classInstanceSize, TypeTypeof);
-            sizeTy[Tenum] = __traits(classInstanceSize, TypeEnum);
-            sizeTy[Tstruct] = __traits(classInstanceSize, TypeStruct);
-            sizeTy[Tclass] = __traits(classInstanceSize, TypeClass);
-            sizeTy[Ttuple] = __traits(classInstanceSize, TypeTuple);
-            sizeTy[Tslice] = __traits(classInstanceSize, TypeSlice);
-            sizeTy[Treturn] = __traits(classInstanceSize, TypeReturn);
-            sizeTy[Terror] = __traits(classInstanceSize, TypeError);
-            sizeTy[Tnull] = __traits(classInstanceSize, TypeNull);
-            sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
-            return sizeTy;
-        }();
+            Type tvoid;
+            Type tint8;
+            Type tuns8;
+            Type tint16;
+            Type tuns16;
+            Type tint32;
+            Type tuns32;
+            Type tint64;
+            Type tuns64;
+            Type tint128;
+            Type tuns128;
+            Type tfloat32;
+            Type tfloat64;
+            Type tfloat80;
+            Type timaginary32;
+            Type timaginary64;
+            Type timaginary80;
+            Type tcomplex32;
+            Type tcomplex64;
+            Type tcomplex80;
+            Type tbool;
+            Type tchar;
+            Type twchar;
+            Type tdchar;
+
+
+            Type tshiftcnt;
+            Type tvoidptr;    // void*
+            Type tstring;     // immutable(char)[]
+            Type twstring;    // immutable(wchar)[]
+            Type tdstring;    // immutable(dchar)[]
+            Type tvalist;     // va_list alias
+            Type terror;      // for error recovery
+            Type tnull;       // for null type
+
+            Type tsize_t;     // matches size_t alias
+            Type tptrdiff_t;  // matches ptrdiff_t alias
+            Type thash_t;     // matches hash_t alias
+
+            ClassDeclaration dtypeinfo;
+            ClassDeclaration typeinfoclass;
+            ClassDeclaration typeinfointerface;
+            ClassDeclaration typeinfostruct;
+            ClassDeclaration typeinfopointer;
+            ClassDeclaration typeinfoarray;
+            ClassDeclaration typeinfostaticarray;
+            ClassDeclaration typeinfoassociativearray;
+            ClassDeclaration typeinfovector;
+            ClassDeclaration typeinfoenum;
+            ClassDeclaration typeinfofunction;
+            ClassDeclaration typeinfodelegate;
+            ClassDeclaration typeinfotypelist;
+            ClassDeclaration typeinfoconst;
+            ClassDeclaration typeinfoinvariant;
+            ClassDeclaration typeinfoshared;
+            ClassDeclaration typeinfowild;
+
+            TemplateDeclaration rtinfo;
+
+            Type[TMAX] basic;
+            StringTable stringtable;
+
+            ubyte[TMAX] sizeTy = () {
+                ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
+                sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);
+                sizeTy[Tarray] = __traits(classInstanceSize, TypeDArray);
+                sizeTy[Taarray] = __traits(classInstanceSize, TypeAArray);
+                sizeTy[Tpointer] = __traits(classInstanceSize, TypePointer);
+                sizeTy[Treference] = __traits(classInstanceSize, TypeReference);
+                sizeTy[Tfunction] = __traits(classInstanceSize, TypeFunction);
+                sizeTy[Tdelegate] = __traits(classInstanceSize, TypeDelegate);
+                sizeTy[Tident] = __traits(classInstanceSize, TypeIdentifier);
+                sizeTy[Tinstance] = __traits(classInstanceSize, TypeInstance);
+                sizeTy[Ttypeof] = __traits(classInstanceSize, TypeTypeof);
+                sizeTy[Tenum] = __traits(classInstanceSize, TypeEnum);
+                sizeTy[Tstruct] = __traits(classInstanceSize, TypeStruct);
+                sizeTy[Tclass] = __traits(classInstanceSize, TypeClass);
+                sizeTy[Ttuple] = __traits(classInstanceSize, TypeTuple);
+                sizeTy[Tslice] = __traits(classInstanceSize, TypeSlice);
+                sizeTy[Treturn] = __traits(classInstanceSize, TypeReturn);
+                sizeTy[Terror] = __traits(classInstanceSize, TypeError);
+                sizeTy[Tnull] = __traits(classInstanceSize, TypeNull);
+                sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
+                return sizeTy;
+            }();
+        }
+
+        @disable this();
+
+        static SharedState initialize()
+        {
+            SharedState state = void;
+
+            state.stringtable._init(14000);
+
+            // Set basic types
+            static __gshared TY* basetab =
+            [
+                Tvoid,
+                Tint8,
+                Tuns8,
+                Tint16,
+                Tuns16,
+                Tint32,
+                Tuns32,
+                Tint64,
+                Tuns64,
+                Tint128,
+                Tuns128,
+                Tfloat32,
+                Tfloat64,
+                Tfloat80,
+                Timaginary32,
+                Timaginary64,
+                Timaginary80,
+                Tcomplex32,
+                Tcomplex64,
+                Tcomplex80,
+                Tbool,
+                Tchar,
+                Twchar,
+                Tdchar,
+                Terror
+            ];
+
+            for (size_t i = 0; basetab[i] != Terror; i++)
+            {
+                Type t = new TypeBasic(basetab[i]);
+                t = t.merge();
+                state.basic[basetab[i]] = t;
+            }
+            state.basic[Terror] = new TypeError();
+
+            state.tvoid = state.basic[Tvoid];
+            state.tint8 = state.basic[Tint8];
+            state.tuns8 = state.basic[Tuns8];
+            state.tint16 = state.basic[Tint16];
+            state.tuns16 = state.basic[Tuns16];
+            state.tint32 = state.basic[Tint32];
+            state.tuns32 = state.basic[Tuns32];
+            state.tint64 = state.basic[Tint64];
+            state.tuns64 = state.basic[Tuns64];
+            state.tint128 = state.basic[Tint128];
+            state.tuns128 = state.basic[Tuns128];
+            state.tfloat32 = state.basic[Tfloat32];
+            state.tfloat64 = state.basic[Tfloat64];
+            state.tfloat80 = state.basic[Tfloat80];
+
+            state.timaginary32 = state.basic[Timaginary32];
+            state.timaginary64 = state.basic[Timaginary64];
+            state.timaginary80 = state.basic[Timaginary80];
+
+            state.tcomplex32 = state.basic[Tcomplex32];
+            state.tcomplex64 = state.basic[Tcomplex64];
+            state.tcomplex80 = state.basic[Tcomplex80];
+
+            state.tbool = state.basic[Tbool];
+            state.tchar = state.basic[Tchar];
+            state.twchar = state.basic[Twchar];
+            state.tdchar = state.basic[Tdchar];
+
+            state.tshiftcnt = state.tint32;
+            state.terror = state.basic[Terror];
+            state.tnull = state.basic[Tnull];
+            state.tnull = new TypeNull();
+            state.tnull.deco = state.tnull.merge().deco;
+
+            state.tvoidptr = state.tvoid.pointerTo();
+            state.tstring = state.tchar.immutableOf().arrayOf();
+            state.twstring = state.twchar.immutableOf().arrayOf();
+            state.tdstring = state.tdchar.immutableOf().arrayOf();
+            state.tvalist = Target.va_listType();
+
+            if (global.params.isLP64)
+            {
+                Tsize_t = Tuns64;
+                Tptrdiff_t = Tint64;
+            }
+            else
+            {
+                Tsize_t = Tuns32;
+                Tptrdiff_t = Tint32;
+            }
+
+            state.tsize_t = state.basic[Tsize_t];
+            state.tptrdiff_t = state.basic[Tptrdiff_t];
+            state.thash_t = state.tsize_t;
+
+            return state;
+        }
+    }
+
+    mixin(generateForwarders!(SharedState, "typeState"));
 
     final extern (D) this(TY ty)
     {
@@ -790,104 +901,6 @@ extern (C++) abstract class Type : RootObject
 
         .toCBuffer(this, &buf, null, &hgs);
         return buf.extractString();
-    }
-
-    static void _init()
-    {
-        stringtable._init(14000);
-
-        // Set basic types
-        static __gshared TY* basetab =
-        [
-            Tvoid,
-            Tint8,
-            Tuns8,
-            Tint16,
-            Tuns16,
-            Tint32,
-            Tuns32,
-            Tint64,
-            Tuns64,
-            Tint128,
-            Tuns128,
-            Tfloat32,
-            Tfloat64,
-            Tfloat80,
-            Timaginary32,
-            Timaginary64,
-            Timaginary80,
-            Tcomplex32,
-            Tcomplex64,
-            Tcomplex80,
-            Tbool,
-            Tchar,
-            Twchar,
-            Tdchar,
-            Terror
-        ];
-
-        for (size_t i = 0; basetab[i] != Terror; i++)
-        {
-            Type t = new TypeBasic(basetab[i]);
-            t = t.merge();
-            basic[basetab[i]] = t;
-        }
-        basic[Terror] = new TypeError();
-
-        tvoid = basic[Tvoid];
-        tint8 = basic[Tint8];
-        tuns8 = basic[Tuns8];
-        tint16 = basic[Tint16];
-        tuns16 = basic[Tuns16];
-        tint32 = basic[Tint32];
-        tuns32 = basic[Tuns32];
-        tint64 = basic[Tint64];
-        tuns64 = basic[Tuns64];
-        tint128 = basic[Tint128];
-        tuns128 = basic[Tuns128];
-        tfloat32 = basic[Tfloat32];
-        tfloat64 = basic[Tfloat64];
-        tfloat80 = basic[Tfloat80];
-
-        timaginary32 = basic[Timaginary32];
-        timaginary64 = basic[Timaginary64];
-        timaginary80 = basic[Timaginary80];
-
-        tcomplex32 = basic[Tcomplex32];
-        tcomplex64 = basic[Tcomplex64];
-        tcomplex80 = basic[Tcomplex80];
-
-        tbool = basic[Tbool];
-        tchar = basic[Tchar];
-        twchar = basic[Twchar];
-        tdchar = basic[Tdchar];
-
-        tshiftcnt = tint32;
-        terror = basic[Terror];
-        tnull = basic[Tnull];
-        tnull = new TypeNull();
-        tnull.deco = tnull.merge().deco;
-
-        tvoidptr = tvoid.pointerTo();
-        tstring = tchar.immutableOf().arrayOf();
-        twstring = twchar.immutableOf().arrayOf();
-        tdstring = tdchar.immutableOf().arrayOf();
-        tvalist = Target.va_listType();
-
-        if (global.params.isLP64)
-        {
-            Tsize_t = Tuns64;
-            Tptrdiff_t = Tint64;
-        }
-        else
-        {
-            Tsize_t = Tuns32;
-            Tptrdiff_t = Tint32;
-        }
-
-        tsize_t = basic[Tsize_t];
-        tptrdiff_t = basic[Tptrdiff_t];
-        thash_t = tsize_t;
     }
 
     final d_uns64 size()

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -485,12 +485,10 @@ extern (C++) abstract class Type : RootObject
             }();
         }
 
-        @disable this();
+        @disable this(this);
 
-        static SharedState initialize()
+        static void initialize(ref SharedState state)
         {
-            SharedState state = void;
-
             state.stringtable._init(14000);
 
             // Set basic types
@@ -585,8 +583,6 @@ extern (C++) abstract class Type : RootObject
             state.tsize_t = state.basic[Tsize_t];
             state.tptrdiff_t = state.basic[Tptrdiff_t];
             state.thash_t = state.tsize_t;
-
-            return state;
         }
     }
 

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -126,13 +126,11 @@ struct ObjcSelector
     }
 }
 
-private __gshared Objc _objc;
-
 Objc objc()
 {
-    return _objc;
+    import dmd.globals : compilerInvocation;
+    return compilerInvocation.objc;
 }
-
 
 /**
  * Contains all data for a class declaration that is needed for the Objective-C
@@ -150,12 +148,12 @@ struct ObjcClassDeclaration
 // Should be an interface
 extern(C++) abstract class Objc
 {
-    static void _init()
+    static Objc initialize()
     {
         if (global.params.isOSX && global.params.is64bit)
-            _objc = new Supported;
+            return new Supported;
         else
-            _objc = new Unsupported;
+            return new Unsupported;
     }
 
     abstract void setObjc(ClassDeclaration cd);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -144,11 +144,6 @@ struct Target
 
             state.cppExceptions = global.params.isLinux || global.params.isFreeBSD ||
                 global.params.isDragonFlyBSD || global.params.isOSX;
-
-            state.int64Mangle  = global.params.isOSX ? 'x' : 'l';
-            state.uint64Mangle = global.params.isOSX ? 'y' : 'm';
-
-            return state;
         }
     }
 

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -64,13 +64,13 @@ struct Target
             bool twoDtorInVtable;     /// target C++ ABI puts deleting and non-deleting destructor into vtable
         }
 
-        static SharedState initialize()
+        @disable this(this);
+
+        static void initialize(ref SharedState state)
         {
             FloatProperties._init();
             DoubleProperties._init();
             RealProperties._init();
-
-            auto state = SharedState.init;
 
             // These have default values for 32 bit code, they get
             // adjusted for 64 bit code.
@@ -144,6 +144,9 @@ struct Target
 
             state.cppExceptions = global.params.isLinux || global.params.isFreeBSD ||
                 global.params.isDragonFlyBSD || global.params.isOSX;
+
+            state.int64Mangle  = global.params.isOSX ? 'x' : 'l';
+            state.uint64Mangle = global.params.isOSX ? 'y' : 'm';
 
             return state;
         }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -94,9 +94,12 @@ private Dsymbol getDsymbolWithoutExpCtx(RootObject oarg)
     return getDsymbol(oarg);
 }
 
-extern (C++) __gshared StringTable traitsStringTable;
+extern (C++) StringTable traitsStringTable()
+{
+    return compilerInvocation.traitsStringTable;
+}
 
-shared static this()
+package StringTable initializeTraits()
 {
     static immutable string[] names =
     [
@@ -149,6 +152,8 @@ shared static this()
         "getPointerBitmap",
     ];
 
+    StringTable traitsStringTable;
+
     traitsStringTable._init(40);
 
     foreach (s; names)
@@ -156,6 +161,8 @@ shared static this()
         auto sv = traitsStringTable.insert(s.ptr, s.length, cast(void*)s.ptr);
         assert(sv);
     }
+
+    return traitsStringTable;
 }
 
 /**

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -94,12 +94,12 @@ private Dsymbol getDsymbolWithoutExpCtx(RootObject oarg)
     return getDsymbol(oarg);
 }
 
-extern (C++) StringTable traitsStringTable()
+extern (C++) ref StringTable traitsStringTable()
 {
     return compilerInvocation.traitsStringTable;
 }
 
-package StringTable initializeTraits()
+package void initializeTraits(ref StringTable traitsStringTable)
 {
     static immutable string[] names =
     [
@@ -152,8 +152,6 @@ package StringTable initializeTraits()
         "getPointerBitmap",
     ];
 
-    StringTable traitsStringTable;
-
     traitsStringTable._init(40);
 
     foreach (s; names)
@@ -161,8 +159,6 @@ package StringTable initializeTraits()
         auto sv = traitsStringTable.insert(s.ptr, s.length, cast(void*)s.ptr);
         assert(sv);
     }
-
-    return traitsStringTable;
 }
 
 /**

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -455,7 +455,7 @@ $G/backend.a: $(G_OBJS) $(G_DOBJS) $(SRC_MAKE)
 	$(AR) rcs $@ $(G_OBJS) $(G_DOBJS)
 
 $G/lexer.a: $(LEXER_SRCS) $(LEXER_ROOT) $(HOST_DMD_PATH) $(SRC_MAKE)
-	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -lib -of$@ $(MODEL_FLAG) -J$G -L-lstdc++ $(DFLAGS) $(LEXER_SRCS) $(LEXER_ROOT)
+	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -lib -of$@ $(MODEL_FLAG) -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(LEXER_SRCS) $(LEXER_ROOT)
 
 $G/dmd_frontend: $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
 	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^) -version=NoBackend


### PR DESCRIPTION
This is a WIP PR on reducing the global state. It moves quite a lot of global state as in `__gshared` variables declared in classes to instance variables in a new class called `CompilerInvocation`. For backwards compatibility there's one global instance of `CompilerInvocation`. For each global state that was moved to `CompilerInvocation` property functions are generated to forward to the global instance of `CompilerInvocation`. Ideally this should not be needed at some point in the future. With this approach the global state is located in only one place and can easily be reset, just create a new instance of `CompilerInvocation`.

My plan for this is to hopefully start testing the compiler on a more unit test level, instead of the current end to end testing. For this it needs to be possible to reset the state of the compiler. This will hopefully speed up the testing since a new compiler process doesn't not need to be started for every test.

This will cause quite a lot of breakage for GDC and LDC since C++ doesn't support properties (although they can be emulated).

There are still some things that won't compile with this patch. I wanted some feedback on this to see if it's a good idea and if someone has any ideas why it's failing.