### PR TITLE
[RFC] An alternative directory structure

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -172,6 +172,7 @@ extern (C++) final class Import : Dsymbol
                     }
                     if (!mod)
                     {
+                        // FIXME confusing error messages
                         .error(loc, "can only import from a module, not from package `%s.%s`", p.toPrettyChars(), id.toChars());
                     }
                 }

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -663,7 +663,8 @@ extern (C++) final class Module : Package
         const(char)* srcname = srcfile.name.toChars();
         //printf("Module::parse(srcname = '%s')\n", srcname);
         isPackageFile = (strcmp(srcfile.name.name(), "package.d") == 0 ||
-                         strcmp(srcfile.name.name(), "package.di") == 0);
+                         strcmp(srcfile.name.name(), "package.di") == 0 ||
+                         FileName.exists(FileName.removeExt(srcfile.name.str)) == 2);
         char* buf = cast(char*)srcfile.buffer;
         size_t buflen = srcfile.len;
         if (buflen >= 2)

--- a/test/compilable/imports/newpkg.d
+++ b/test/compilable/imports/newpkg.d
@@ -1,0 +1,2 @@
+module newpkg;
+import newpkg.sub1;

--- a/test/compilable/imports/newpkg/sub1.d
+++ b/test/compilable/imports/newpkg/sub1.d
@@ -1,0 +1,1 @@
+module newpkg.sub1;


### PR DESCRIPTION
Previously package file is looked for at `mod/package.d`. Now,
we will consider `mod.d` as a package file as well if directory
`mod/` exists.