### PR TITLE
Fix Issue 19074: Internal error: dmd/backend/el.c 1760

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2906,6 +2906,7 @@ public:
             auto sle = cast(StructLiteralExp)pue.exp();
             sle.type = e.type;
             sle.ownedByCtfe = OwnedBy.ctfe;
+            sle.origin = e.origin;
             result = sle;
         }
         else

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -7742,3 +7742,20 @@ struct RBNode(T)
 
 static assert(!__traits(compiles, { alias bug18057 = RBNode!int; }));
 
+/**************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19074
+
+struct S19074a { }
+
+struct S19074b
+{
+    S19074a field;
+    this(S19074a) { }
+
+    static const S19074b* data = new S19074b(S19074a());
+}
+
+void test19074()
+{
+    auto var = S19074b.data;
+}


### PR DESCRIPTION
StructLiteralExp has a self referenced field named `origin`.  If an instance is allocated on the stack, and shallow copied to memory, this reference is garbage by the time it reaches the codegen pass.  In this case, `toElemVisitor::visit(AddrExp)` was attempting to use this data.

The intention of `origin` was that if any copies of a struct literal were made, this is the reference to the original copy.  This patch adds in that missing reference.