### PR TITLE
[REG] Fix Issue 19076 - dmd 2.081 crashed by getVirtualFunctions for a interface extended interface

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1010,7 +1010,7 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             // If the symbol passed as a parameter is an
             // interface that inherits other interfaces
             overloadApply(f, &dg);
-            if (ifd && ifd.interfaces)
+            if (ifd && ifd.interfaces && f)
             {
                 // check the overloads of each inherited interface individually
                 foreach (bc; ifd.interfaces)

--- a/test/fail_compilation/fail19076.d
+++ b/test/fail_compilation/fail19076.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19076.d(11): Error: no property `V` for type `fail19076.I`
+fail_compilation/fail19076.d(11): Error: `(I).V` cannot be resolved
+---
+*/
+
+interface P { }
+interface I : P { }
+auto F = __traits(getVirtualFunctions, I, "V");


### PR DESCRIPTION
When traits(getVirtualMethods) is called, first, semantic is performed on the expression. If the provided aggregate does not contain the provided method an error is issued, but the function does not return [1]. 
I would argue that the function should return an empty tuple, but I do not know the reason why it doesn't, so according to Chesterton's fence, I will leave it be. 

https://github.com/dlang/dmd/blob/master/src/dmd/traits.d#L927