### PR TITLE
Add missing field to SwitchErrorStatement

### DIFF
--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -479,6 +479,7 @@ public:
 class SwitchErrorStatement : public Statement
 {
 public:
+    Expression *exp;
 
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
Needed to generated new code in C++-based backends.