### PR TITLE
Fix issue 19081 - defining enum with UDA at statements level

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4173,8 +4173,19 @@ final class Parser(AST) : Lexer
                 goto L1;
 
             case TOK.enum_:
-                stc = AST.STC.manifest;
-                goto L1;
+                {
+                    Token* t = peek(&token);
+                    if (t.value == TOK.leftCurly || t.value == TOK.colon)
+                        break;
+                    else if (t.value == TOK.identifier)
+                    {
+                        t = peek(t);
+                        if (t.value == TOK.leftCurly || t.value == TOK.colon || t.value == TOK.semicolon)
+                            break;
+                    }
+                    stc = AST.STC.manifest;
+                    goto L1;
+                }
 
             case TOK.at:
                 {
@@ -4434,7 +4445,23 @@ final class Parser(AST) : Lexer
 
         parseStorageClasses(storage_class, link, setAlignment, ealign, udas);
 
-        if (token.value == TOK.struct_ ||
+        if (token.value == TOK.enum_)
+        {
+            AST.Dsymbol d = parseEnum();
+            auto a = new AST.Dsymbols();
+            a.push(d);
+
+            if (udas)
+            {
+                d = new AST.UserAttributeDeclaration(udas, a);
+                a = new AST.Dsymbols();
+                a.push(d);
+            }
+
+            addComment(d, comment);
+            return a;
+        }
+        else if (token.value == TOK.struct_ ||
             token.value == TOK.union_ ||
             token.value == TOK.class_ ||
             token.value == TOK.interface_)

--- a/test/compilable/test19081.d
+++ b/test/compilable/test19081.d
@@ -1,0 +1,14 @@
+void main() {
+    @(1) enum { A }
+    /// comment
+    @(1) enum X { A }
+    @(2) enum Y;
+    @(1) @(2) enum Z { A }
+
+    struct Test { int test; }
+    @Test(1) enum W { A }
+    @(1) enum V: int { A }
+    X a;
+    static assert(__traits(getAttributes, X).length == 1);
+    static assert(__traits(getAttributes, X)[0] == 1);
+}


### PR DESCRIPTION
Don't treat 'enum' as storage class if it's followed by ':', '{' or an
identifier and '{'.

P.S. I don't think this an optimal fix. Please take over if you have a better one.