### PR TITLE
add type parameter to ArrayLiteralExp constructors

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1386,8 +1386,7 @@ extern (C++) UnionExp Slice(Type type, Expression e1, Expression lwr, Expression
         {
             auto elements = new Expressions(cast(size_t)(iupr - ilwr));
             memcpy(elements.tdata(), es1.elements.tdata() + ilwr, cast(size_t)(iupr - ilwr) * ((*es1.elements)[0]).sizeof);
-            emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elements);
-            ue.exp().type = type;
+            emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elements);
         }
     }
     else
@@ -1497,6 +1496,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
                 utf_encode(sz, s, cast(dchar)v);
             emplaceExp!(StringExp)(&ue, loc, s, len);
             StringExp es = cast(StringExp)ue.exp();
+            es.type = type;
             es.sz = sz;
             es.committed = 1;
         }
@@ -1505,9 +1505,8 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
             // Create an ArrayLiteralExp
             auto elements = new Expressions();
             elements.push(e);
-            emplaceExp!(ArrayLiteralExp)(&ue, e.loc, elements);
+            emplaceExp!(ArrayLiteralExp)(&ue, e.loc, type, elements);
         }
-        ue.exp().type = type;
         assert(ue.exp().type);
         return ue;
     }
@@ -1518,8 +1517,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
             // Handle null ~= null
             if (t1.ty == Tarray && t2 == t1.nextOf())
             {
-                emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, e2);
-                ue.exp().type = type;
+                emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, e2);
                 assert(ue.exp().type);
                 return ue;
             }
@@ -1579,9 +1577,8 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         {
             (*elems)[i] = ea.getElement(i);
         }
-        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elems);
         ArrayLiteralExp dest = cast(ArrayLiteralExp)ue.exp();
-        dest.type = type;
         sliceAssignArrayLiteralFromString(dest, es, ea.elements.dim);
         assert(ue.exp().type);
         return ue;
@@ -1597,9 +1594,8 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         {
             (*elems)[es.len + i] = ea.getElement(i);
         }
-        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elems);
         ArrayLiteralExp dest = cast(ArrayLiteralExp)ue.exp();
-        dest.type = type;
         sliceAssignArrayLiteralFromString(dest, es, 0);
         assert(ue.exp().type);
         return ue;
@@ -1653,7 +1649,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         // Concatenate the arrays
         auto elems = ArrayLiteralExp.copyElements(e1, e2);
 
-        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, cast(Type)null, elems);
 
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
@@ -1677,7 +1673,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         // Concatenate the array with null
         auto elems = ArrayLiteralExp.copyElements(e);
 
-        emplaceExp!(ArrayLiteralExp)(&ue, e.loc, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, e.loc, cast(Type)null, elems);
 
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
@@ -1695,7 +1691,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
                 ? ArrayLiteralExp.copyElements(e1) : new Expressions();
         elems.push(e2);
 
-        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, cast(Type)null, elems);
 
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
@@ -1711,7 +1707,7 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
     {
         auto elems = ArrayLiteralExp.copyElements(e1, e2);
 
-        emplaceExp!(ArrayLiteralExp)(&ue, e2.loc, elems);
+        emplaceExp!(ArrayLiteralExp)(&ue, e2.loc, cast(Type)null, elems);
 
         e = ue.exp();
         if (type.toBasetype().ty == Tsarray)
@@ -1739,9 +1735,8 @@ extern (C++) UnionExp Cat(Type type, Expression e1, Expression e2)
         {
             auto expressions = new Expressions();
             expressions.push(e);
-            emplaceExp!(ArrayLiteralExp)(&ue, loc, expressions);
+            emplaceExp!(ArrayLiteralExp)(&ue, loc, t, expressions);
             e = ue.exp();
-            e.type = t;
         }
         else
         {

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -331,10 +331,9 @@ extern (C++) UnionExp copyLiteral(Expression e)
         auto ale = cast(ArrayLiteralExp)e;
         auto elements = copyLiteralArray(ale.elements, ale.basis);
 
-        emplaceExp!(ArrayLiteralExp)(&ue, e.loc, elements);
+        emplaceExp!(ArrayLiteralExp)(&ue, e.loc, e.type, elements);
 
         ArrayLiteralExp r = cast(ArrayLiteralExp)ue.exp();
-        r.type = e.type;
         r.ownedByCtfe = OwnedBy.ctfe;
         return ue;
     }
@@ -625,8 +624,7 @@ extern (C++) ArrayLiteralExp createBlockDuplicatedArrayLiteral(const ref Loc loc
     {
         el = mustCopy && i ? copyLiteral(elem).copy() : elem;
     }
-    auto ale = new ArrayLiteralExp(loc, elements);
-    ale.type = type;
+    auto ale = new ArrayLiteralExp(loc, type, elements);
     ale.ownedByCtfe = OwnedBy.ctfe;
     return ale;
 }
@@ -1486,10 +1484,9 @@ extern (C++) UnionExp ctfeCat(const ref Loc loc, Type type, Expression e1, Expre
         //  [ e1 ] ~ [ e2 ] ---> [ e1, e2 ]
         ArrayLiteralExp es1 = cast(ArrayLiteralExp)e1;
         ArrayLiteralExp es2 = cast(ArrayLiteralExp)e2;
-        emplaceExp!(ArrayLiteralExp)(&ue, es1.loc, copyLiteralArray(es1.elements));
+        emplaceExp!(ArrayLiteralExp)(&ue, es1.loc, type, copyLiteralArray(es1.elements));
         es1 = cast(ArrayLiteralExp)ue.exp();
         es1.elements.insert(es1.elements.dim, copyLiteralArray(es2.elements));
-        es1.type = type;
         return ue;
     }
     if (e1.op == TOK.arrayLiteral && e2.op == TOK.null_ && t1.nextOf().equals(t2.nextOf()))
@@ -1767,9 +1764,8 @@ extern (C++) UnionExp changeArrayLiteralLength(const ref Loc loc, TypeArray arra
             foreach (size_t i; copylen .. newlen)
                 (*elements)[i] = defaultElem;
         }
-        emplaceExp!(ArrayLiteralExp)(&ue, loc, elements);
+        emplaceExp!(ArrayLiteralExp)(&ue, loc, arrayType, elements);
         ArrayLiteralExp aae = cast(ArrayLiteralExp)ue.exp();
-        aae.type = arrayType;
         aae.ownedByCtfe = OwnedBy.ctfe;
     }
     return ue;
@@ -1993,9 +1989,8 @@ extern (C++) UnionExp voidInitLiteral(Type t, VarDeclaration var)
                 elem = copyLiteral(elem).copy();
             (*elements)[i] = elem;
         }
-        emplaceExp!(ArrayLiteralExp)(&ue, var.loc, elements);
+        emplaceExp!(ArrayLiteralExp)(&ue, var.loc, tsa, elements);
         ArrayLiteralExp ae = cast(ArrayLiteralExp)ue.exp();
-        ae.type = tsa;
         ae.ownedByCtfe = OwnedBy.ctfe;
     }
     else if (t.ty == Tstruct)

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2728,9 +2728,8 @@ public:
                 result = CTFEExp.cantexp;
                 return;
             }
-            emplaceExp!(ArrayLiteralExp)(pue, e.loc, basis, expsx);
+            emplaceExp!(ArrayLiteralExp)(pue, e.loc, e.type, basis, expsx);
             auto ale = cast(ArrayLiteralExp)pue.exp();
-            ale.type = e.type;
             ale.ownedByCtfe = OwnedBy.ctfe;
             result = ale;
         }
@@ -2928,8 +2927,7 @@ public:
             auto elements = new Expressions(len);
             for (size_t i = 0; i < len; i++)
                 (*elements)[i] = copyLiteral(elem).copy();
-            auto ae = new ArrayLiteralExp(loc, elements);
-            ae.type = newtype;
+            auto ae = new ArrayLiteralExp(loc, newtype, elements);
             ae.ownedByCtfe = OwnedBy.ctfe;
             return ae;
         }
@@ -3097,8 +3095,7 @@ public:
             // Create a CTFE pointer &[newval][0]
             auto elements = new Expressions(1);
             (*elements)[0] = newval;
-            auto ae = new ArrayLiteralExp(e.loc, elements);
-            ae.type = e.newtype.arrayOf();
+            auto ae = new ArrayLiteralExp(e.loc, e.newtype.arrayOf(), elements);
             ae.ownedByCtfe = OwnedBy.ctfe;
 
             auto ei = new IndexExp(e.loc, ae, new IntegerExp(Loc.initial, 0, Type.tsize_t));
@@ -6570,9 +6567,8 @@ private Expression interpret_keys(InterState* istate, Expression earg, Type retu
         return null;
     assert(earg.op == TOK.assocArrayLiteral);
     AssocArrayLiteralExp aae = cast(AssocArrayLiteralExp)earg;
-    auto ae = new ArrayLiteralExp(aae.loc, aae.keys);
+    auto ae = new ArrayLiteralExp(aae.loc, returnType, aae.keys);
     ae.ownedByCtfe = aae.ownedByCtfe;
-    ae.type = returnType;
     return copyLiteral(ae).copy();
 }
 
@@ -6591,9 +6587,8 @@ private Expression interpret_values(InterState* istate, Expression earg, Type re
         return null;
     assert(earg.op == TOK.assocArrayLiteral);
     AssocArrayLiteralExp aae = cast(AssocArrayLiteralExp)earg;
-    auto ae = new ArrayLiteralExp(aae.loc, aae.values);
+    auto ae = new ArrayLiteralExp(aae.loc, returnType, aae.values);
     ae.ownedByCtfe = aae.ownedByCtfe;
-    ae.type = returnType;
     //printf("result is %s\n", e.toChars());
     return copyLiteral(ae).copy();
 }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2619,34 +2619,39 @@ extern (C++) final class ArrayLiteralExp : Expression
     Expressions* elements;
     OwnedBy ownedByCtfe = OwnedBy.code;
 
-    extern (D) this(const ref Loc loc, Expressions* elements)
+
+    extern (D) this(const ref Loc loc, Type type, Expressions* elements)
     {
         super(loc, TOK.arrayLiteral, __traits(classInstanceSize, ArrayLiteralExp));
+        this.type = type;
         this.elements = elements;
     }
 
-    extern (D) this(const ref Loc loc, Expression e)
+    extern (D) this(const ref Loc loc, Type type, Expression e)
     {
         super(loc, TOK.arrayLiteral, __traits(classInstanceSize, ArrayLiteralExp));
+        this.type = type;
         elements = new Expressions();
         elements.push(e);
     }
 
-    extern (D) this(const ref Loc loc, Expression basis, Expressions* elements)
+    extern (D) this(const ref Loc loc, Type type, Expression basis, Expressions* elements)
     {
         super(loc, TOK.arrayLiteral, __traits(classInstanceSize, ArrayLiteralExp));
+        this.type = type;
         this.basis = basis;
         this.elements = elements;
     }
 
     static ArrayLiteralExp create(Loc loc, Expressions* elements)
     {
-        return new ArrayLiteralExp(loc, elements);
+        return new ArrayLiteralExp(loc, null, elements);
     }
 
     override Expression syntaxCopy()
     {
         return new ArrayLiteralExp(loc,
+            null,
             basis ? basis.syntaxCopy() : null,
             arraySyntaxCopy(elements));
     }
@@ -2976,8 +2981,7 @@ extern (C++) final class StructLiteralExp : Expression
                     auto z = new Expressions(length);
                     foreach (ref q; *z)
                         q = e.copy();
-                    e = new ArrayLiteralExp(loc, z);
-                    e.type = type;
+                    e = new ArrayLiteralExp(loc, type, z);
                 }
                 else
                 {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1586,8 +1586,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                          * is now optimized.
                          * https://issues.dlang.org/show_bug.cgi?id=2356
                          */
-                        Type tbn = (cast(TypeArray)tb).next;
-                        Type tsa = tbn.sarrayOf(nargs - i);
+                        Type tbn = (cast(TypeArray)tb).next;    // array element type
 
                         auto elements = new Expressions(nargs - i);
                         foreach (u; 0 .. elements.dim)
@@ -1605,8 +1604,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                         }
                         // https://issues.dlang.org/show_bug.cgi?id=14395
                         // Convert to a static array literal, or its slice.
-                        arg = new ArrayLiteralExp(loc, elements);
-                        arg.type = tsa;
+                        arg = new ArrayLiteralExp(loc, tbn.sarrayOf(nargs - i), elements);
                         if (tb.ty == Tarray)
                         {
                             arg = new SliceExp(loc, arg, null, null);
@@ -8872,8 +8870,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (tb2.ty == Tarray || tb2.ty == Tsarray)
                 {
                     // Make e2 into [e2]
-                    exp.e2 = new ArrayLiteralExp(exp.e2.loc, exp.e2);
-                    exp.e2.type = exp.type;
+                    exp.e2 = new ArrayLiteralExp(exp.e2.loc, exp.type, exp.e2);
                 }
                 else if (checkNewEscape(sc, exp.e2, false))
                     return setError();
@@ -8911,8 +8908,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 if (tb1.ty == Tarray || tb1.ty == Tsarray)
                 {
                     // Make e1 into [e1]
-                    exp.e1 = new ArrayLiteralExp(exp.e1.loc, exp.e1);
-                    exp.e1.type = exp.type;
+                    exp.e1 = new ArrayLiteralExp(exp.e1.loc, exp.type, exp.e1);
                 }
                 else if (checkNewEscape(sc, exp.e1, false))
                     return setError();

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -673,7 +673,7 @@ private extern(C++) final class InferTypeVisitor : Visitor
                 (*elements)[i] = (cast(ExpInitializer)iz).exp;
                 assert((*elements)[i].op != TOK.error);
             }
-            Expression e = new ArrayLiteralExp(init.loc, elements);
+            Expression e = new ArrayLiteralExp(init.loc, null, elements);
             auto ei = new ExpInitializer(init.loc, e);
             result = ei.inferType(sc);
             return;
@@ -898,8 +898,7 @@ private extern(C++) final class InitToExpressionVisitor : Visitor
                             auto elements2 = new Expressions(dim);
                             foreach (ref e2; *elements2)
                                 e2 = e;
-                            e = new ArrayLiteralExp(e.loc, elements2);
-                            e.type = tn;
+                            e = new ArrayLiteralExp(e.loc, tn, elements2);
                         }
                     }
                 }
@@ -917,8 +916,7 @@ private extern(C++) final class InitToExpressionVisitor : Visitor
                 }
             }
 
-            Expression e = new ArrayLiteralExp(init.loc, elements);
-            e.type = init.type;
+            Expression e = new ArrayLiteralExp(init.loc, init.type, elements);
             result = e;
             return;
         }
@@ -940,8 +938,7 @@ private extern(C++) final class InitToExpressionVisitor : Visitor
                 auto elements = new Expressions(d);
                 for (size_t j = 0; j < d; j++)
                     (*elements)[j] = e;
-                auto ae = new ArrayLiteralExp(e.loc, elements);
-                ae.type = itype;
+                auto ae = new ArrayLiteralExp(e.loc, itype, elements);
                 result = ae;
                 return;
             }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3711,8 +3711,7 @@ extern (C++) final class TypeSArray : TypeArray
         auto elements = new Expressions(d);
         for (size_t i = 0; i < d; i++)
             (*elements)[i] = null;
-        auto ae = new ArrayLiteralExp(Loc.initial, elementinit, elements);
-        ae.type = this;
+        auto ae = new ArrayLiteralExp(Loc.initial, this, elementinit, elements);
         return ae;
     }
 

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -7967,7 +7967,7 @@ final class Parser(AST) : Lexer
                 if (keys)
                     e = new AST.AssocArrayLiteralExp(loc, keys, values);
                 else
-                    e = new AST.ArrayLiteralExp(loc, values);
+                    e = new AST.ArrayLiteralExp(loc, null, values);
                 break;
             }
         case TOK.leftCurly:

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -411,8 +411,7 @@ extern (C++) Expression pointerBitmap(TraitsExp e)
     foreach (d_uns64 i; 0 .. data.dim)
         exps.push(new IntegerExp(e.loc, data[cast(size_t)i], Type.tsize_t));
 
-    auto ale = new ArrayLiteralExp(e.loc, exps);
-    ale.type = Type.tsize_t.sarrayOf(data.dim + 1);
+    auto ale = new ArrayLiteralExp(e.loc, Type.tsize_t.sarrayOf(data.dim + 1), exps);
     return ale;
 }
 


### PR DESCRIPTION
Most of the time the type parameter is needed, so add it.