### PR TITLE
fix Issue 19097 - Extend Return Scope Semantics

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -87,16 +87,18 @@ bool checkAssocArrayLiteralEscape(Scope *sc, AssocArrayLiteralExp ae, bool gag)
  * Params:
  *      sc = used to determine current function and module
  *      fdc = function being called, `null` if called indirectly
- *      par = identifier of function parameter
+ *      par = function parameter ('this' if null)
  *      arg = initializer for param
  *      gag = do not print error messages
  * Returns:
  *      true if pointers to the stack can escape via assignment
  */
-bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier par, Expression arg, bool gag)
+bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Parameter par, Expression arg, bool gag)
 {
     enum log = false;
-    if (log) printf("checkParamArgumentEscape(arg: %s par: %s)\n", arg ? arg.toChars() : "null", par ? par.toChars() : "null");
+    if (log) printf("checkParamArgumentEscape(arg: %s par: %s)\n",
+        arg ? arg.toChars() : "null",
+        par ? par.toChars() : "this");
     //printf("type = %s, %d\n", arg.type.toChars(), arg.type.hasPointers());
 
     if (!arg.type.hasPointers())
@@ -120,7 +122,7 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier par, Ex
             if (!gag)
                 error(arg.loc, "%s `%s` assigned to non-scope parameter `%s` calling %s",
                     desc, v.toChars(),
-                    par ? par.toChars() : "unnamed",
+                    par ? par.toChars() : "this",
                     fdc ? fdc.toPrettyChars() : "indirectly");
             result = true;
         }
@@ -171,6 +173,9 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier par, Ex
 
         if ((v.storage_class & (STC.ref_ | STC.out_)) == 0 && p == sc.func)
         {
+            if (par && (par.storageClass & (STC.scope_ | STC.return_)) == STC.scope_)
+                continue;
+
             unsafeAssign(v, "reference to local variable");
             continue;
         }
@@ -206,12 +211,102 @@ bool checkParamArgumentEscape(Scope* sc, FuncDeclaration fdc, Identifier par, Ex
             if (!gag)
                 error(ee.loc, "reference to stack allocated value returned by `%s` assigned to non-scope parameter `%s`",
                     ee.toChars(),
-                    par ? par.toChars() : "unnamed");
+                    par ? par.toChars() : "this");
             result = true;
         }
     }
 
     return result;
+}
+
+/*****************************************************
+ * Function argument initializes a `return` parameter,
+ * and that parameter gets assigned to `firstArg`.
+ * Essentially, treat as `firstArg = arg;`
+ * Params:
+ *      sc = used to determine current function and module
+ *      firstArg = ref argument through which arg may be assigned
+ *      arg = initializer for param
+ *      gag = do not print error messages
+ * Returns:
+ *      true if assignment to firstArg would cause an error
+ */
+bool checkParamArgumentReturn(Scope* sc, Expression firstArg, Expression arg, bool gag)
+{
+    enum log = false;
+    if (log) printf("checkParamArgumentReturn(firstArg: %s arg: %s)\n",
+        firstArg.toChars(), arg.toChars());
+    //printf("type = %s, %d\n", arg.type.toChars(), arg.type.hasPointers());
+
+    if (!arg.type.hasPointers())
+        return false;
+
+    scope e = new AssignExp(arg.loc, firstArg, arg);
+    return checkAssignEscape(sc, e, gag);
+}
+
+/*****************************************************
+ * Check struct constructor of the form s.this(args), by
+ * checking each `return` parameter to see if it gets
+ * assigned to `s`.
+ * Params:
+ *      sc = used to determine current function and module
+ *      ce = constructor call of the form s.this(args)
+ *      gag = do not print error messages
+ * Returns:
+ *      true if construction would cause an escaping reference error
+ */
+bool checkConstructorEscape(Scope* sc, CallExp ce, bool gag)
+{
+    enum log = false;
+    if (log) printf("checkConstructorEscape(%s, %s)\n", ce.toChars(), ce.type.toChars());
+    Type tthis = ce.type.toBasetype();
+    assert(tthis.ty == Tstruct);
+    if (!tthis.hasPointers())
+        return false;
+
+    if (!ce.arguments && ce.arguments.dim)
+        return false;
+
+    assert(ce.e1.op == TOK.dotVariable);
+    DotVarExp dve = cast(DotVarExp)ce.e1;
+    CtorDeclaration ctor = dve.var.isCtorDeclaration();
+    assert(ctor);
+    assert(ctor.type.ty == Tfunction);
+    TypeFunction tf = cast(TypeFunction)ctor.type;
+
+    const nparams = tf.parameterList.length;
+    const n = ce.arguments.dim;
+
+    // j=1 if _arguments[] is first argument
+    const j = (tf.linkage == LINK.d && tf.parameterList.varargs == VarArg.variadic);
+
+    /* Attempt to assign each `return` arg to the `this` reference
+     */
+    foreach (const i; 0 .. n)
+    {
+        Expression arg = (*ce.arguments)[i];
+        if (!arg.type.hasPointers())
+            return false;
+
+        //printf("\targ[%d]: %s\n", i, arg.toChars());
+
+        if (i - j < nparams && i >= j)
+        {
+            Parameter p = tf.parameterList[i - j];
+
+            if (p.storageClass & STC.return_)
+            {
+                /* Fake `dve.e1 = arg;` and look for scope violations
+                 */
+                scope e = new AssignExp(arg.loc, dve.e1, arg);
+                if (checkAssignEscape(sc, e, gag))
+                    return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 /****************************************
@@ -289,6 +384,31 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
     // Determine if va is a parameter that is an indirect reference
     const bool vaIsRef = va && va.storage_class & STC.parameter &&
         (va.storage_class & (STC.ref_ | STC.out_) || va.type.toBasetype().ty == Tclass);
+    if (log && vaIsRef) printf("va is ref `%s`\n", va.toChars());
+
+    /* Determine if va is the first parameter, through which other 'return' parameters
+     * can be assigned.
+     */
+    bool isFirstRef()
+    {
+        if (!vaIsRef)
+            return false;
+        Dsymbol p = va.toParent2();
+        FuncDeclaration fd = sc.func;
+        if (p == fd && fd.type && fd.type.ty == Tfunction)
+        {
+            TypeFunction tf = cast(TypeFunction)fd.type;
+            if (!tf.nextOf() || (tf.nextOf().ty != Tvoid && !fd.isCtorDeclaration()))
+                return false;
+            if (va == fd.vthis)
+                return true;
+            if (fd.parameters && fd.parameters.dim && (*fd.parameters)[0] == va)
+                return true;
+        }
+        return false;
+    }
+    const bool vaIsFirstRef = isFirstRef();
+    if (log && vaIsFirstRef) printf("va is first ref `%s`\n", va.toChars());
 
     bool result = false;
     foreach (VarDeclaration v; er.byvalue)
@@ -317,6 +437,12 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
         if (v.isScope())
         {
+            if (vaIsFirstRef && v.isParameter())
+            {
+                if (va.isScope() && v.storage_class & STC.return_)
+                    continue;
+            }
+
             if (va && va.isScope() && va.storage_class & STC.return_ && !(v.storage_class & STC.return_) &&
                 sc.func.setUnsafe())
             {
@@ -443,6 +569,8 @@ ByRef:
                 }
                 continue;
             }
+            if (e1.op == TOK.structLiteral)
+                continue;
             if (sc.func.setUnsafe())
             {
                 if (!gag)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1642,7 +1642,10 @@ private bool checkDefCtor(Loc loc, Type t)
  *      4. add hidden _arguments[] argument
  *      5. call copy constructor for struct value arguments
  * Params:
+ *      loc       = location of function call
+ *      sc        = context
  *      tf        = type of the function
+ *      ethis     = `this` argument, `null` if none or not known
  *      tthis     = type of `this` argument, `null` if no `this` argument
  *      arguments = array of actual arguments to function call
  *      fd        = the function being called, `null` if called indirectly
@@ -1652,7 +1655,8 @@ private bool checkDefCtor(Loc loc, Type t)
  *      true    errors happened
  */
 private bool functionParameters(const ref Loc loc, Scope* sc,
-    TypeFunction tf, Type tthis, Expressions* arguments, FuncDeclaration fd, Type* prettype, Expression* peprefix)
+    TypeFunction tf, Expression ethis, Type tthis, Expressions* arguments, FuncDeclaration fd,
+    Type* prettype, Expression* peprefix)
 {
     //printf("functionParameters() %s\n", fd ? fd.toChars() : "");
     assert(arguments);
@@ -1881,6 +1885,12 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             return errorInout(wildmatch);
     }
 
+    Expression firstArg = ((tf.next && tf.next.ty == Tvoid || isCtorCall) &&
+                           tthis &&
+                           tthis.isMutable() && tthis.toBasetype().ty == Tstruct &&
+                           tthis.hasPointers())
+                          ? ethis : null;
+
     assert(nargs >= nparams);
     foreach (const i, arg; (*arguments)[0 .. nargs])
     {
@@ -1934,13 +1944,21 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             //printf("type: %s\n", arg.type.toChars());
             //printf("param: %s\n", p.toChars());
 
-            if (tf.parameterEscapes(tthis, p))
+            if (firstArg && p.storageClass & STC.return_)
+            {
+                /* Argument value can be assigned to firstArg.
+                 * Check arg to see if it matters.
+                 */
+                if (global.params.vsafe)
+                    err |= checkParamArgumentReturn(sc, firstArg, arg, false);
+            }
+            else if (tf.parameterEscapes(tthis, p))
             {
                 /* Argument value can escape from the called function.
                  * Check arg to see if it matters.
                  */
                 if (global.params.vsafe)
-                    err |= checkParamArgumentEscape(sc, fd, p.ident, arg, false);
+                    err |= checkParamArgumentEscape(sc, fd, p, arg, false);
             }
             else
             {
@@ -1977,6 +1995,19 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 }
             }
             arg = arg.optimize(WANTvalue, (p.storageClass & (STC.ref_ | STC.out_)) != 0);
+
+            /* Determine if this parameter is the "first reference" parameter through which
+             * later "return" arguments can be stored.
+             */
+            if (i == 0 && !tthis && p.storageClass & (STC.ref_ | STC.out_) && p.type &&
+                (tf.next && tf.next.ty == Tvoid || isCtorCall))
+            {
+                Type tb = p.type.baseElemOf();
+                if (tb.isMutable() && tb.hasPointers())
+                {
+                    firstArg = arg;
+                }
+            }
         }
         else
         {
@@ -3373,7 +3404,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 TypeFunction tf = cast(TypeFunction)f.type;
                 Type rettype;
-                if (functionParameters(exp.loc, sc, tf, null, exp.newargs, f, &rettype, &newprefix))
+                if (functionParameters(exp.loc, sc, tf, null, null, exp.newargs, f, &rettype, &newprefix))
                     return setError();
 
                 exp.allocator = f.isNewDeclaration();
@@ -3400,7 +3431,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 TypeFunction tf = cast(TypeFunction)f.type;
                 if (!exp.arguments)
                     exp.arguments = new Expressions();
-                if (functionParameters(exp.loc, sc, tf, exp.type, exp.arguments, f, &exp.type, &exp.argprefix))
+                if (functionParameters(exp.loc, sc, tf, null, exp.type, exp.arguments, f, &exp.type, &exp.argprefix))
                     return setError();
 
                 exp.member = f.isCtorDeclaration();
@@ -3447,7 +3478,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
                 TypeFunction tf = cast(TypeFunction)f.type;
                 Type rettype;
-                if (functionParameters(exp.loc, sc, tf, null, exp.newargs, f, &rettype, &newprefix))
+                if (functionParameters(exp.loc, sc, tf, null, null, exp.newargs, f, &rettype, &newprefix))
                     return setError();
 
                 exp.allocator = f.isNewDeclaration();
@@ -3474,7 +3505,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 TypeFunction tf = cast(TypeFunction)f.type;
                 if (!exp.arguments)
                     exp.arguments = new Expressions();
-                if (functionParameters(exp.loc, sc, tf, exp.type, exp.arguments, f, &exp.type, &exp.argprefix))
+                if (functionParameters(exp.loc, sc, tf, null, exp.type, exp.arguments, f, &exp.type, &exp.argprefix))
                     return setError();
 
                 exp.member = f.isCtorDeclaration();
@@ -4305,7 +4336,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tthis = ue.e1.type;
                 if (!(exp.f.type.ty == Tfunction && (cast(TypeFunction)exp.f.type).isscope))
                 {
-                    if (global.params.vsafe && checkParamArgumentEscape(sc, exp.f, Id.This, ethis, false))
+                    if (global.params.vsafe && checkParamArgumentEscape(sc, exp.f, null, ethis, false))
                         return setError();
                 }
             }
@@ -4695,7 +4726,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         Expression argprefix;
         if (!exp.arguments)
             exp.arguments = new Expressions();
-        if (functionParameters(exp.loc, sc, cast(TypeFunction)t1, tthis, exp.arguments, exp.f, &exp.type, &argprefix))
+        if (functionParameters(exp.loc, sc, cast(TypeFunction)t1, ethis, tthis, exp.arguments, exp.f, &exp.type, &argprefix))
             return setError();
 
         if (!exp.type)
@@ -7873,6 +7904,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         dvx.e1 = e1x;
                         auto cx = cast(CallExp)ce.copy();
                         cx.e1 = dvx;
+                        if (global.params.vsafe && checkConstructorEscape(sc, cx, false))
+                            return setError();
 
                         Expression e0;
                         Expression.extractLast(e2x, e0);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1287,7 +1287,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                         if (tf.isref)
                         {
                         }
-                        else if (tf.next && !tf.next.hasPointers())
+                        else if (tf.next && !tf.next.hasPointers() && tf.next.toBasetype().ty != Tvoid)
                         {
                             fparam.storageClass &= ~STC.return_;   // https://issues.dlang.org/show_bug.cgi?id=18963
                         }

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -455,7 +455,7 @@ fail_compilation/retscope.d(1311): Error: scope variable `u2` assigned to `ek` w
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1405): Error: reference to local variable `buf` assigned to non-scope parameter `unnamed` calling retscope.myprintf
+fail_compilation/retscope.d(1405): Error: reference to local variable `buf` assigned to non-scope parameter `__anonymous_param` calling retscope.myprintf
 ---
 */
 
@@ -473,7 +473,7 @@ fail_compilation/retscope.d(1405): Error: reference to local variable `buf` assi
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope.d(1509): Error: reference to stack allocated value returned by `(*fp15)()` assigned to non-scope parameter `unnamed`
+fail_compilation/retscope.d(1509): Error: reference to stack allocated value returned by `(*fp15)()` assigned to non-scope parameter `__anonymous_param`
 ---
 */
 

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -87,8 +87,8 @@ fail_compilation/retscope2.d(504): Error: scope variable `c` may not be returned
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/retscope2.d(604): Error: scope variable `_param_0` assigned to non-scope parameter `unnamed` calling retscope2.foo600
-fail_compilation/retscope2.d(604): Error: scope variable `_param_1` assigned to non-scope parameter `unnamed` calling retscope2.foo600
+fail_compilation/retscope2.d(604): Error: scope variable `_param_0` assigned to non-scope parameter `__anonymous_param` calling retscope2.foo600
+fail_compilation/retscope2.d(604): Error: scope variable `_param_1` assigned to non-scope parameter `__anonymous_param` calling retscope2.foo600
 fail_compilation/retscope2.d(614): Error: template instance `retscope2.test600!(int*, int*)` error instantiating
 ---
 */

--- a/test/fail_compilation/test19097.d
+++ b/test/fail_compilation/test19097.d
@@ -1,0 +1,56 @@
+/* REQUIRED_ARGS: -dip1000
+ * TEST_OUTPUT:
+---
+fail_compilation/test19097.d(35): Error: scope variable `s` may not be returned
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=19097
+
+@safe:
+
+void betty(ref scope int* r, return scope int* p)
+{
+    r = p;
+}
+
+void freddy(out scope int* r, return scope int* p)
+{
+    r = p;
+}
+
+struct S
+{
+    int* a;
+    this(return scope int* b) scope { a = b; }
+
+    int* c;
+    void mem(return scope int* d) scope { c = d; }
+}
+
+S thorin()
+{
+    int i;
+    S s = S(&i); // should infer scope for s
+    return s;    // so this should error
+}
+
+/************************/
+
+struct S2(T)
+{
+    int* p;
+
+    void silent(lazy void dg);
+
+    void foo()
+    {
+        char[] name;
+        silent(name = parseType());
+    }
+
+    char[] parseType(char[] name = null);
+}
+
+S2!int s2;
+


### PR DESCRIPTION
See enhancement request for details.

To keep this PR from being too complex, I didn't do `return` inference. That'll be on a follow-on later.

This will be necessary to get Phobos to compile with -dip1000. Hence the Vision label.