### PR TITLE
Fix Issue 19099 - Struct with field that has postblit or destructor makes struct assignable

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5509,13 +5509,15 @@ extern (C++) final class TypeStruct : Type
         bool assignable = true;
         uint offset = ~0; // dead-store initialize to prevent spurious warning
 
+        sym.determineSize(sym.loc);
+
         /* If any of the fields are const or immutable,
          * then one cannot assign this struct.
          */
         for (size_t i = 0; i < sym.fields.dim; i++)
         {
             VarDeclaration v = sym.fields[i];
-            //printf("%s [%d] v = (%s) %s, v.offset = %d, v.parent = %s", sym.toChars(), i, v.kind(), v.toChars(), v.offset, v.parent.kind());
+            //printf("%s [%d] v = (%s) %s, v.offset = %d, v.parent = %s\n", sym.toChars(), i, v.kind(), v.toChars(), v.offset, v.parent.kind());
             if (i == 0)
             {
             }

--- a/test/fail_compilation/fail19099.d
+++ b/test/fail_compilation/fail19099.d
@@ -1,0 +1,27 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19099.d(26): Error: cannot modify struct instance `a` of type `A` because it contains `const` or `immutable` members
+---
+*/
+
+struct B
+{
+    this(this) {}
+    ~this() {}
+    int a;
+}
+
+struct A
+{
+    B b;
+    immutable int a;
+    this(int b) { a = b;}
+}
+
+void main()
+{
+    A a = A(2);
+    A b = A(3);
+    a = b;
+}


### PR DESCRIPTION
I know this requires a deprecation, it's just that it's a bit complicated to do it.