### PR TITLE
Informative Assert Messages

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -185,7 +185,7 @@ struct Usage
                     $(LI $(B off): specified check is disabled.)
                 )`
         ),
-        Option("checkaction=D|C|halt",
+        Option("checkaction=D|C|halt|context",
             "behavior on assert/boundscheck/finalswitch failure",
             `Sets behavior when an assert fails, and array boundscheck fails,
              or a final switch errors.
@@ -193,6 +193,7 @@ struct Usage
                     $(LI $(B D): Default behavior, which throws an unrecoverable $(D Error).)
                     $(LI $(B C): Calls the C runtime library assert failure function.)
                     $(LI $(B halt): Executes a halt instruction, terminating the program.)
+                    $(LI $(B context): Prints the error context as part of the unrecoverable $(D Error).)
                 )`
         ),
         Option("color",

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -54,6 +54,7 @@ enum CHECKACTION : ubyte
     D,            // call D assert on failure
     C,            // call C assert on failure
     halt,         // cause program halt on failure
+    context,      // call D assert with the error context on failure
 }
 
 enum CPU

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -42,7 +42,8 @@ enum
 {
     CHECKACTION_D,        // call D assert on failure
     CHECKACTION_C,        // call C assert on failure
-    CHECKACTION_halt      // cause program halt on failure
+    CHECKACTION_halt,     // cause program halt on failure
+    CHECKACTION_context   // call D assert with the error context on failure
 };
 
 enum CPU

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -301,6 +301,7 @@ immutable Msgtable[] msgtable =
     { "__ArrayPostblit" },
     { "__ArrayDtor" },
     { "_d_delThrowable" },
+    { "_d_assert_fail" },
     { "dup" },
     { "_aaApply" },
     { "_aaApply2" },

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1433,6 +1433,8 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 params.checkAction = CHECKACTION.C;
             else if (strcmp(p + 13, "halt") == 0)
                 params.checkAction = CHECKACTION.halt;
+            else if (strcmp(p + 13, "context") == 0)
+                params.checkAction = CHECKACTION.context;
             else
                 goto Lerror;
         }

--- a/test/fail_compilation/fail145.d
+++ b/test/fail_compilation/fail145.d
@@ -1,8 +1,9 @@
 /*
+REQUIRED_ARGS: -checkaction=context
 TEST_OUTPUT:
 ---
-fail_compilation/fail145.d(13): Error: `assert(i < 0)` failed
-fail_compilation/fail145.d(26):        called from here: `bar(7)`
+fail_compilation/fail145.d(14): Error: `"assert(i && (i < 0)) failed"`
+fail_compilation/fail145.d(27):        called from here: `bar(7)`
 ---
 */
 
@@ -10,7 +11,7 @@ fail_compilation/fail145.d(26):        called from here: `bar(7)`
 
 int bar(int i)
 {
-    assert(i < 0);
+    assert(i && i < 0);
     foreach_reverse (k, v; "hello")
     {
         i <<= 1;
@@ -26,5 +27,5 @@ void main()
     static b = bar(7);
     auto c = bar(7);
     //printf("b = %d, %d\n", b, c);
-    assert(b == 674);
+    assert(b && b == 674);
 }

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -1,0 +1,44 @@
+/*
+REQUIRED_ARGS: -checkaction=context
+*/
+
+void test8765()
+{
+    string msg;
+    try
+    {
+        int a = 0;
+        assert(a);
+    }
+    catch (Throwable e)
+    {
+        // no-message -> assert expression
+        msg = e.msg;
+    }
+    assert(msg && msg == "assert(a) failed");
+}
+
+ void test9255()
+{
+    string file;
+    try
+    {
+        int x = 0;
+        assert(x);
+    }
+    catch (Throwable e)
+    {
+        file = e.file;
+    }
+
+    version(Windows)
+        assert(file && file == r"runnable\testassert.d");
+    else
+        assert(file && file == "runnable/testassert.d");
+}
+
+void main()
+{
+    test8765();
+    test9255();
+}


### PR DESCRIPTION
So I presume I probably have to write a DIP for this, but as there are many open question I thought I already start hacking with DMD to see what they are and how potential solutions could look like.

Motivation
-------------

__Informative__ assert messages that tell you why sth. failed. This is incredibly useful when the testsuite isn't run on your machine, but on a CI server or the assertion failed in production and you don't have a coredump.

tl;dr:

```d
int a = 1, b = 2;
assert(a == b); // ERROR: 1 != 2 
```

Also better just assert diagnostics is the number #7 features that people miss according to the recent State of D survey:

![image](https://user-images.githubusercontent.com/4370550/43100151-b9bed470-8ec4-11e8-96b5-356c8cfc16a4.png)

Moreover, a better debugging experience (and in fact DIP83) has been part of the bi-annual high level visions [since 2017](https://wiki.dlang.org/Vision/2017H2).

Lastly, this is based on top of https://github.com/dlang/dmd/pull/7575 which would already solve two very old issues.

What's the status quo?
----------------------------

```
core.exception.AssertError@onlineapp.d(4): Assertion failure
----------------
??:? _d_assertp [0x79a0dad5]
onlineapp.d:4 _Dmain [0x79a0da08]
```

https://run.dlang.io/is/b3RHNb

(for the example above)

Previous work:
------------------

- [Original DIP83](https://wiki.dlang.org/DIP83)
- [Improving assert-printing in DMD NG thread from 2015](https://forum.dlang.org/post/holdxspayjguauomrbcx@forum.dlang.org)
- [Original DMD PR](https://github.com/dlang/dmd/pull/263)
- [Issue 5547 - Improve assert to give information on values given to it when it fails](https://issues.dlang.org/show_bug.cgi?id=5547#c3)
- [assertPred - druntime PR](https://github.com/dlang/druntime/pull/41)

Main problems pointed out in the past
------------------------------------------------

1) druntime can't use `std.conv.to` or anything from Phobos.

Solution: some debug output is a lot better than none. All basic types can be formatted by libc, structs could just be recursively iterated over all their basic fields and for classes `.to!string` only calls `.toString` anyhow. Even just basic types would already be a huge improvement.

2) Performance / Bloat

As all formatting is done only in the non-release build and the actual string formatting happens lazily when the error is triggered, there's no performance overhead.
However, if a templated `_d_assert_fail` is chosen, there might be a bit of template bloat when a project uses many asserts with different types.
If this is really a concern, a minimal implementation could only go for basic types or define a  `extern(C)` interface. Though there's already lots of templated stuff in druntime, e.g. `destroy`,  `__delete`, `__cmp`, `__ArrayEq`, `__ArrayPostblit`, `__ArrayDtor`, `.dup`, `.idup`, `__switch`, `_arrayOp`, `hashOf`, `assumeSafeAppend`, `capacity`, `_postblitRecurse`, `update`, `require`, `get`, `values`, `keys`, `by{Key,Value,KeyValue}`, `rehash`, ...

3) This is yet another compiler magic

Yes, but as `assert` is already baked into the language, let's make use of the fact and by a moderately simple change we can vastly improve the debugging/testing experience of D.

Open questions
--------------------

This PR directly hacks the `lazy` string message that is provided to the `AssertError`. This has the advantage of making things easy. There could be a point made this isn't ideal because:

1) it makes lots of code that is currently `@nogc`, use the garbage collection for string formatting (and is potentially slower than directly printing the warning)

My take on this is that the cost only happens at most once and after which the program will be terminated anyhow (and catching errors is defined to result in UB). In fact, I think that these formatting calls can be marked as "@nogc" because either we can just use malloc and not worry about freeing or simply do the same with D's built-in concatenation.

2) Support/Integration with custom test runners  / custom formatting backends

Currently, custom test runners like [unit-threaded](https://github.com/atilaneves/unit-threaded) or [fluent-asserts](https://github.com/gedaiu/fluent-asserts) come with their own TDD or BDD style to work around the problem of not being able to catch the values of `assert(a == b)`, with e.g. `foo.should.equal(2)`

3) Name of the druntime function

TODO
--------

- [x] Add formatting support for more than ints (it's a PoC for now)
- [x] Add support for more than EqualExp
- [x] For now this is hidden behind a flag to simplify testing
- [x] Pass the token type to the formatting helper e.g. `_d_assert_failed!"=="(a, b)`
- [x] Add more tests
- [x] Check review from https://github.com/dlang/dmd/pull/7575
- [x] Move implementation `_d_assert_fail` to druntime