### PR TITLE
Fix Issue 19107 - -de produces compilation error, -dw does not

### DIFF
--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -299,12 +299,18 @@ extern (C++) void verrorSupplemental(const ref Loc loc, const(char)* format, va_
  */
 extern (C++) void vwarning(const ref Loc loc, const(char)* format, va_list ap)
 {
-    if (global.params.warnings && !global.gag)
+    if (global.params.warnings)
     {
-        verrorPrint(loc, Classification.warning, "Warning: ", format, ap);
-        //halt();
-        if (global.params.warnings == 1)
-            global.warnings++; // warnings don't count if gagged
+        if (!global.gag)
+        {
+            verrorPrint(loc, Classification.warning, "Warning: ", format, ap);
+            if (global.params.warnings == 1)
+                global.warnings++;
+        }
+        else
+        {
+            global.gaggedWarnings++;
+        }
     }
 }
 
@@ -335,8 +341,17 @@ extern (C++) void vdeprecation(const ref Loc loc, const(char)* format, va_list a
     static __gshared const(char)* header = "Deprecation: ";
     if (global.params.useDeprecated == 0)
         verror(loc, format, ap, p1, p2, header);
-    else if (global.params.useDeprecated == 2 && !global.gag)
-        verrorPrint(loc, Classification.deprecation, header, format, ap, p1, p2);
+    else if (global.params.useDeprecated == 2)
+    {
+        if (!global.gag)
+        {
+            verrorPrint(loc, Classification.deprecation, header, format, ap, p1, p2);
+        }
+        else
+        {
+            global.gaggedWarnings++;
+        }
+    }
 }
 
 /**

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -264,6 +264,7 @@ struct Global
     uint warnings;          // number of warnings reported so far
     uint gag;               // !=0 means gag reporting of errors & warnings
     uint gaggedErrors;      // number of errors reported while gagged
+    uint gaggedWarnings;    // number of warnings reported while gagged
 
     void* console;         // opaque pointer to console for controlling text attributes
 
@@ -275,6 +276,7 @@ struct Global
     extern (C++) uint startGagging()
     {
         ++gag;
+        gaggedWarnings = 0;
         return gaggedErrors;
     }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -909,11 +909,22 @@ extern (C++) abstract class Type : RootObject
     final Type trySemantic(const ref Loc loc, Scope* sc)
     {
         //printf("+trySemantic(%s) %d\n", toChars(), global.errors);
+
+        // Needed to display any deprecations that were gagged
+        auto tcopy = this.syntaxCopy();
+
         uint errors = global.startGagging();
         Type t = typeSemantic(this, loc, sc);
         if (global.endGagging(errors) || t.ty == Terror) // if any errors happened
         {
             t = null;
+        }
+        else
+        {
+            // If `typeSemantic` succeeded, that's great, but there may have been deprecations
+            // that were gagged due the the `startGagging` above.  Run again to display those
+            // deprecations.  https://issues.dlang.org/show_bug.cgi?id=19107
+            typeSemantic(tcopy, loc, sc);
         }
         //printf("-trySemantic(%s) %d\n", toChars(), global.errors);
         return t;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -921,10 +921,11 @@ extern (C++) abstract class Type : RootObject
         }
         else
         {
-            // If `typeSemantic` succeeded, that's great, but there may have been deprecations
-            // that were gagged due the the `startGagging` above.  Run again to display those
-            // deprecations.  https://issues.dlang.org/show_bug.cgi?id=19107
-            typeSemantic(tcopy, loc, sc);
+            // If `typeSemantic` succeeded, there may have been deprecations that
+            // were gagged due the the `startGagging` above.  Run again to display
+            // those deprecations.  https://issues.dlang.org/show_bug.cgi?id=19107
+            if (global.gaggedWarnings > 0)
+                typeSemantic(tcopy, loc, sc);
         }
         //printf("-trySemantic(%s) %d\n", toChars(), global.errors);
         return t;

--- a/test/compilable/imports/test19107a.d
+++ b/test/compilable/imports/test19107a.d
@@ -1,0 +1,3 @@
+module imports.test19107a.d;
+
+alias I(alias A) = A;

--- a/test/compilable/imports/test19107b.d
+++ b/test/compilable/imports/test19107b.d
@@ -1,0 +1,3 @@
+module imports.test19107b;
+
+import imports.test19107a : I;

--- a/test/compilable/test19107.d
+++ b/test/compilable/test19107.d
@@ -1,0 +1,20 @@
+// REQUIRED_ARGS: -dw
+/*
+TEST_OUTPUT:
+---
+compilable/test19107.d(14): Deprecation: `imports.test19107b.I` is not visible from module `test19107`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=19107
+
+import imports.test19107b;
+
+void all(alias pred, T)(T t)
+    if (is(typeof(I!pred(t))))
+{ }
+
+void main(string[] args)
+{
+    args.all!(c => c);
+}


### PR DESCRIPTION
Due to the error gagging, deprecations are not being displayed in `typeSemantic`.  This PR remedies that by running `typeSemantic` again without gagging if it previously succeeded.  It's not a very elegant solution, but I don't think there's any other way without a major DMD refactor.

See discussion in the following PRs for more context:
https://github.com/CyberShadow/ae/pull/33
https://github.com/dlang/dmd/pull/8443

cc @CyberShadow 