### PR TITLE
-betterC: Add support for types when comparing arrays

### DIFF
--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -96,7 +96,7 @@ void testRuntimeLowerings()
 
         assert(a1[0..3] == a1[3..$]);
     }
-    
+
     test__equals!int;
     test__equals!uint;
     test__equals!long;
@@ -129,22 +129,18 @@ void testRuntimeLowerings()
     test__cmp!byte;
     test__cmp!dchar;
     test__cmp!wchar;
-    
+    test__cmp!ubyte;
+    test__cmp!char;
+    test__cmp!(const char);
+    test__cmp!bool;
 
-    // __cmp currently requires runtime support from `core.internal.string : dstrcmp`.
-    // If that runtime dependency can be removed, the following code might work.
-    //---------------------------------------------------------------------------------
-    // test__cmp!ubyte;
-    // test__cmp!char;
-    // test__cmp!(const char);
-    // test__cmp!bool;
-
-    // auto s = "abc";
-    // switch(s)                      // _switch
-    // {
-    //     case "abc":
-    //         break;
-    //     default:
-    //         break;
-    // }
+    // test call to `object.__switch``
+    auto s = "abc";
+    switch(s)
+    {
+        case "abc":
+            break;
+        default:
+            break;
+    }
 }


### PR DESCRIPTION
The actual implementation change is in the druntime PR at https://github.com/dlang/druntime/pull/2255.  This just adds the tests.  The druntime PR will need to be merged first before this will pass the CI.