### PR TITLE
-betterC: Remove illegitimate dependency on TypeInfo for arrays of structs

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -144,7 +144,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
             visit(cast(Expression)e);
 
             Type tb = result.type.toBasetype();
-            if (tb.ty == Tarray)
+            if (tb.ty == Tarray && global.params.useTypeInfo && Type.dtypeinfo)
                 semanticTypeInfo(sc, (cast(TypeDArray)tb).next);
         }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2667,7 +2667,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
-        semanticTypeInfo(sc, e.type);
+        if (global.params.useTypeInfo && Type.dtypeinfo)
+            semanticTypeInfo(sc, e.type);
 
         result = e;
     }
@@ -9973,7 +9974,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (t.ty != Tstruct)
                 return false;
 
-            semanticTypeInfo(sc, t);
+            if (global.params.useTypeInfo && Type.dtypeinfo)
+                semanticTypeInfo(sc, t);
+
             return (cast(TypeStruct)t).sym.hasIdentityEquals;
         }
 

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1097,7 +1097,9 @@ extern (C++) Expression op_overload(Expression e, Scope* sc)
                     if (t.ty != Tstruct)
                         return false;
 
-                    semanticTypeInfo(sc, t);
+                    if (global.params.useTypeInfo && Type.dtypeinfo)
+                        semanticTypeInfo(sc, t);
+
                     return (cast(TypeStruct)t).sym.hasIdentityEquals;
                 }
 

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -34,7 +34,7 @@ import core.stdc.stdio;
  */
 extern (C++) void genTypeInfo(Loc loc, Type torig, Scope* sc)
 {
-    //printf("Type::genTypeInfo() %p, %s\n", this, toChars());
+    // printf("genTypeInfo() %s\n", torig.toChars());
 
     // Even when compiling without `useTypeInfo` (e.g. -betterC) we should
     // still be able to evaluate `TypeInfo` at compile-time, just not at runtime.

--- a/test/runnable/betterc.d
+++ b/test/runnable/betterc.d
@@ -81,10 +81,20 @@ mixin template initArray()
     {
         T[6] a1 = [true, false, true, true, false, true];
     }
+    else static if (is(T == Sint))
+    {
+        T[6] a1 = [Sint(1), Sint(2), Sint(3), Sint(1), Sint(2), Sint(3)];
+    }
     else
     {
         T[6] a1 = [1,2,3,1,2,3];
     }
+}
+
+struct Sint
+{
+    int x;
+    this(int v) { x = v;}
 }
 
 void testRuntimeLowerings()
@@ -110,6 +120,7 @@ void testRuntimeLowerings()
     test__equals!char;
     test__equals!(const char);
     test__equals!bool;
+    test__equals!Sint;
 
     // test call to `object.__cmp`
     void test__cmp(T)()
@@ -133,6 +144,7 @@ void testRuntimeLowerings()
     test__cmp!char;
     test__cmp!(const char);
     test__cmp!bool;
+    test__cmp!Sint;
 
     // test call to `object.__switch``
     auto s = "abc";


### PR DESCRIPTION
When using arrays of structs, the compiler was complaining about implicit usages of `TypeInfo` for array literals and comparisons, but the `TypeInfo` is never actually needed.  This stops the whining.