### PR TITLE
Add D_ModuleInfo D_Exceptions and D_TypeInfo version identifiers

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1388,7 +1388,16 @@ void addDefaultVersionIdentifiers()
     if (global.params.useArrayBounds == CHECKENABLE.off)
         VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
     if (global.params.betterC)
+    {
         VersionCondition.addPredefinedGlobalIdent("D_BetterC");
+    }
+    else
+    {
+        VersionCondition.addPredefinedGlobalIdent("D_ModuleInfo");
+        VersionCondition.addPredefinedGlobalIdent("D_Exceptions");
+        VersionCondition.addPredefinedGlobalIdent("D_TypeInfo");
+    }
+
 
     VersionCondition.addPredefinedGlobalIdent("D_HardFloat");
 }

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -15,12 +15,3 @@ int foo(int[] a, int i)
 {
     return a[i];
 }
-
-// https://issues.dlang.org/show_bug.cgi?id=17787
-version (D_BetterC)
-{
-}
-else
-{
-    static assert(0);
-}

--- a/test/compilable/betterc.d
+++ b/test/compilable/betterc.d
@@ -1,0 +1,27 @@
+/* REQUIRED_ARGS: -betterC
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=17787
+version (D_BetterC)
+{
+}
+else
+{
+    static assert(0);
+}
+
+// -betterC does not support `ModuleInfo`, `TypeInfo`, or exception handling
+version (D_ModuleInfo)
+{
+    static assert(0);
+}
+
+version (D_Exceptions)
+{
+    static assert(0);
+}
+
+version (D_TypeInfo)
+{
+    static assert(0);
+}

--- a/test/compilable/version.d
+++ b/test/compilable/version.d
@@ -1,0 +1,23 @@
+/* REQUIRED_ARGS:
+*/
+
+version (D_ModuleInfo)
+{ }
+else
+{
+    static assert(0);
+}
+
+version (D_Exceptions)
+{ }
+else
+{
+    static assert(0);
+}
+
+version (D_TypeInfo)
+{ }
+else
+{
+    static assert(0);
+}


### PR DESCRIPTION
I'm going to begin converting some runtime hooks to templates so they can be used in -betterC and other scenarios.  However, some of the existing implementations throw `Error`.  I need to special case those for -betterC to `assert` instead.

Examples: 
* [`core.exception.__switch_errorT`](https://github.com/dlang/druntime/blob/52d3fe02272d16d32c150ce6f78bc00241a9dd5d/src/core/exception.d#L584)
* [`_d_arrayCopy`](https://github.com/dlang/druntime/blob/9a8edfb48e4842180c706ee26ebd8edb10be53f4/src/rt/arraycat.d#L27) which throws through [`enforceRawArraysConformable`](https://github.com/dlang/druntime/blob/9a8edfb48e4842180c706ee26ebd8edb10be53f4/src/rt/util/array.d#L26)


I think it would be best to have a little more precision when doing runtime programming by mimicking the current implementation of the compiler with respect to [`global.params.useModuleInfo`](https://github.com/dlang/dmd/blob/033d324957ff5bee8e25c7335eab2c562d17e2b1/src/dmd/globals.d#L142), [`global.params.useExceptions`](https://github.com/dlang/dmd/blob/033d324957ff5bee8e25c7335eab2c562d17e2b1/src/dmd/globals.d#L144), and [`global.params.useTypeInfo`](https://github.com/dlang/dmd/blob/033d324957ff5bee8e25c7335eab2c562d17e2b1/src/dmd/globals.d#L143)

Also, this may be useful for other D compilers that expose compiler flags such as `-fno-exceptions`, and `fno-rtti`.

Spec change: https://github.com/dlang/dlang.org/pull/2431

cc @ibuclaw @klickverbot 