### PR TITLE
Add `deinitializeDMD` function to deinitialize the front end

### DIFF
--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -425,6 +425,17 @@ public extern (C++) void builtin_init()
         add_builtin("_D4core5bitop7_popcntFNaNbNiNfmZi", &eval_popcnt);
 }
 
+/**
+ * Deinitializes the global state of the compiler.
+ *
+ * This can be used to restore the state set by `builtin_init` to its original
+ * state.
+ */
+public void builtinDeinitialize()
+{
+    builtins = builtins.init;
+}
+
 /**********************************
  * Determine if function is a builtin one that we can
  * evaluate at compile time.

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -299,6 +299,17 @@ extern (C++) final class Module : Package
         modules = new DsymbolTable();
     }
 
+    /**
+     * Deinitializes the global state of the compiler.
+     *
+     * This can be used to restore the state set by `_init` to its original
+     * state.
+     */
+    static void deinitialize()
+    {
+        modules = modules.init;
+    }
+
     extern (C++) __gshared AggregateDeclaration moduleinfo;
 
     const(char)* arg;           // original argument name

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -640,6 +640,22 @@ extern (C++) abstract class Expression : RootObject
         CTFEExp.showcontext = new CTFEExp(TOK.showCtfeContext);
     }
 
+    /**
+     * Deinitializes the global state of the compiler.
+     *
+     * This can be used to restore the state set by `_init` to its original
+     * state.
+     */
+    static void deinitialize()
+    {
+        CTFEExp.cantexp = CTFEExp.cantexp.init;
+        CTFEExp.voidexp = CTFEExp.voidexp.init;
+        CTFEExp.breakexp = CTFEExp.breakexp.init;
+        CTFEExp.continueexp = CTFEExp.continueexp.init;
+        CTFEExp.gotoexp = CTFEExp.gotoexp.init;
+        CTFEExp.showcontext = CTFEExp.showcontext.init;
+    }
+
     /*********************************
      * Does *not* do a deep copy.
      */

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -77,6 +77,35 @@ void initDMD()
 }
 
 /**
+Deinitializes the global variables of the DMD compiler.
+
+This can be used to restore the state set by `initDMD` to its original state.
+Useful if there's a need for multiple sessions of the DMD compiler in the same
+application.
+*/
+void deinitializeDMD()
+{
+    import dmd.builtin : builtinDeinitialize;
+    import dmd.dmodule : Module;
+    import dmd.expression : Expression;
+    import dmd.globals : global;
+    import dmd.id : Id;
+    import dmd.mtype : Type;
+    import dmd.objc : Objc;
+    import dmd.target : target;
+
+    global.deinitialize();
+
+    Type.deinitialize();
+    Id.deinitialize();
+    Module.deinitialize();
+    target.deinitialize();
+    Expression.deinitialize();
+    Objc.deinitialize();
+    builtinDeinitialize();
+}
+
+/**
 Add import path to the `global.path`.
 Params:
     path = import to add

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -405,6 +405,17 @@ struct Global
     }
 
     /**
+     * Deinitializes the global state of the compiler.
+     *
+     * This can be used to restore the state set by `_init` to its original
+     * state.
+     */
+    void deinitialize()
+    {
+        this = this.init;
+    }
+
+    /**
     Returns: the version as the number that would be returned for __VERSION__
     */
     extern(C++) uint versionNumber()

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -39,6 +39,17 @@ struct Id
     {
         mixin(msgtable.generate(&initializer));
     }
+
+    /**
+     * Deinitializes the global state of the compiler.
+     *
+     * This can be used to restore the state set by `initialize` to its original
+     * state.
+     */
+    void deinitialize()
+    {
+        mixin(msgtable.generate(&deinitializer));
+    }
 }
 
 private:
@@ -486,4 +497,10 @@ string identifier(Msgtable m)
 string initializer(Msgtable m)
 {
     return m.ident ~ ` = Identifier.idPool("` ~ m.name ~ `");`;
+}
+
+// Used to generate the code for each deinitializer.
+string deinitializer(Msgtable m)
+{
+    return m.ident ~ " = Identifier.init;";
 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -905,6 +905,17 @@ extern (C++) abstract class Type : RootObject
         thash_t = tsize_t;
     }
 
+    /**
+     * Deinitializes the global state of the compiler.
+     *
+     * This can be used to restore the state set by `_init` to its original
+     * state.
+     */
+    static void deinitialize()
+    {
+        stringtable = stringtable.init;
+    }
+
     final d_uns64 size()
     {
         return size(Loc.initial);

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -188,6 +188,17 @@ extern(C++) abstract class Objc
             _objc = new Unsupported;
     }
 
+    /**
+     * Deinitializes the global state of the compiler.
+     *
+     * This can be used to restore the state set by `_init` to its original
+     * state.
+     */
+    static void deinitialize()
+    {
+        _objc = _objc.init;
+    }
+
     abstract void setObjc(ClassDeclaration cd);
     abstract void setObjc(InterfaceDeclaration);
 

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -181,6 +181,17 @@ struct Target
     }
 
     /**
+     * Deinitializes the global state of the compiler.
+     *
+     * This can be used to restore the state set by `_init` to its original
+     * state.
+     */
+    void deinitialize()
+    {
+        this = this.init;
+    }
+
+    /**
      * Requested target memory alignment size of the given type.
      * Params:
      *      type = type to inspect

--- a/test/unit/deinitialization.d
+++ b/test/unit/deinitialization.d
@@ -1,0 +1,166 @@
+module deinitialization;
+
+@("global.deinitialize")
+unittest
+{
+    import dmd.globals : global;
+
+    static void assertStructsEqual(T)(const ref T a, const ref T b) @nogc pure nothrow
+    if (is(T == struct))
+    {
+        foreach (i, _; typeof(a.tupleof))
+        {
+            enum name = __traits(identifier, a.tupleof[i]);
+
+            static if (is(typeof(a.tupleof[i]) == const(char*)))
+                assert(a.tupleof[i].fromStringz == b.tupleof[i].fromStringz, name);
+            else
+                assert(a.tupleof[i] == b.tupleof[i], name);
+        }
+    }
+
+    immutable init = global.init;
+    assertStructsEqual(global, init);
+
+    global._init();
+    global.deinitialize();
+
+    assert(global == global.init);
+}
+
+@("Type.deinitialize")
+unittest
+{
+    import dmd.mars : addDefaultVersionIdentifiers, setTarget;
+    import dmd.mtype : Type;
+    import dmd.globals : global;
+
+    assert(Type.stringtable == Type.stringtable.init);
+
+    global._init();
+    setTarget(global.params);
+
+    Type._init();
+    Type.deinitialize();
+
+    global.deinitialize();
+
+    assert(Type.stringtable == Type.stringtable.init);
+}
+
+@("Id.deinitialize")
+unittest
+{
+    import dmd.id : Id;
+
+    static void assertInitialState()
+    {
+        foreach (e ; __traits(allMembers, Id))
+        {
+            static if (!__traits(isStaticFunction, mixin("Id." ~ e)))
+                assert(__traits(getMember, Id, e) is null);
+        }
+    }
+
+    assertInitialState();
+
+    Id.initialize();
+    Id.deinitialize();
+
+    assertInitialState();
+}
+
+@("Module.deinitialize")
+unittest
+{
+    import dmd.dmodule : Module;
+
+    assert(Module.modules is Module.modules.init);
+
+    Module._init();
+    Module.deinitialize();
+
+    assert(Module.modules is Module.modules.init);
+}
+
+@("Target.deinitialize")
+unittest
+{
+    import dmd.globals : Param;
+    import dmd.mars : setTarget;
+    import dmd.target : target, Target;
+
+    static bool isFPTypeProperties(T)()
+    {
+        return is(T == const(typeof(Target.FloatProperties))) ||
+            is (T == const(typeof(Target.DoubleProperties))) ||
+            is (T == const(typeof(Target.RealProperties)));
+    }
+
+    static void assertStructsEqual(T)(const ref T a, const ref T b) @nogc pure nothrow
+    if (is(T == struct))
+    {
+        foreach (i, _; typeof(a.tupleof))
+        {
+            alias Type = typeof(a.tupleof[i]);
+            enum name = __traits(identifier, a.tupleof[i]);
+
+            static if (!isFPTypeProperties!Type)
+                assert(a.tupleof[i] == b.tupleof[i], name);
+        }
+    }
+
+    const init = target.init;
+    assertStructsEqual(target, init);
+
+    Param params;
+    setTarget(params);
+
+    target._init(params);
+    target.deinitialize();
+
+    assertStructsEqual(target, init);
+}
+
+@("Expression.deinitialize")
+unittest
+{
+    import dmd.ctfeexpr : CTFEExp;
+    import dmd.expression : Expression;
+
+    static void assertInitialState()
+    {
+        assert(CTFEExp.cantexp is null);
+        assert(CTFEExp.voidexp is null);
+        assert(CTFEExp.breakexp is null);
+        assert(CTFEExp.continueexp is null);
+        assert(CTFEExp.gotoexp is null);
+        assert(CTFEExp.showcontext is null);
+    }
+
+    assertInitialState();
+
+    Expression._init();
+    Expression.deinitialize();
+
+    assertInitialState();
+}
+
+@("Objc.deinitialize")
+unittest
+{
+    import dmd.objc : Objc, objc;
+
+    assert(objc is null);
+
+    Objc._init();
+    Objc.deinitialize();
+
+    assert(objc is null);
+}
+
+private inout(char)[] fromStringz(inout(char)* cString) @nogc @system pure nothrow
+{
+    import core.stdc.string : strlen;
+    return cString ? cString[0 .. strlen(cString)] : null;
+}

--- a/test/unit/self_test.d
+++ b/test/unit/self_test.d
@@ -10,8 +10,8 @@ import support : afterEach, beforeEach, defaultImportPaths;
 
 @afterEach deinitializeFrontend()
 {
-    // import dmd.frontend : deinitializeDMD;
-    // deinitializeDMD();
+    import dmd.frontend : deinitializeDMD;
+    deinitializeDMD();
 }
 
 @("self test")


### PR DESCRIPTION
This is a start of being able to restore the global state initialized by `initDMD` to its original state. It only deinitializes state initialized by `initDMD`, state store directly inside functions are not restored.

This is useful to invoke the compiler multiple times within the same application. This allows to write more fine grained tests for the compiler, more of a unit test style compared to the current end to end tests.