### PR TITLE
 Add predefined version identifier `D_BoundsChecks`

### DIFF
--- a/changelog/d_boundscheck.dd
+++ b/changelog/d_boundscheck.dd
@@ -1,0 +1,29 @@
+Add version identifier `D_BoundsChecks`
+
+One stylistic rule of D is that version identifier should be positive.
+`D_NoBoundsChecks` stands out as an exception in this regard.
+This version adds the opposite `D_BoundsChecks` so that code have at least
+one release to transition to it, before `D_NoBoundsChecks` is deprecated.
+
+---
+/// Before
+void func (ubyte[] arr, size_t idx)
+{
+  version (D_NoBoundsCheck) {}
+  else
+  {
+    assert(idx < arr.length);
+  }
+  // ...
+}
+
+/// After
+void func (ubyte[] arr, size_t idx)
+{
+  version (D_BoundsCheck)
+  {
+    assert(idx < arr.length);
+  }
+  // ...
+}
+---

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1297,6 +1297,8 @@ void addDefaultVersionIdentifiers(const ref Param params)
         VersionCondition.addPredefinedGlobalIdent("assert");
     if (params.useArrayBounds == CHECKENABLE.off)
         VersionCondition.addPredefinedGlobalIdent("D_NoBoundsChecks");
+    else // Introduced in 2.083.0 - Deprecate `D_NoBoundsChecks` later
+        VersionCondition.addPredefinedGlobalIdent("D_BoundsChecks");
     if (params.betterC)
     {
         VersionCondition.addPredefinedGlobalIdent("D_BetterC");

--- a/test/fail_compilation/reserved_version.d
+++ b/test/fail_compilation/reserved_version.d
@@ -105,10 +105,9 @@ fail_compilation/reserved_version.d(206): Error: version identifier `CppRuntime_
 fail_compilation/reserved_version.d(207): Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
 fail_compilation/reserved_version.d(208): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
 fail_compilation/reserved_version.d(209): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
+fail_compilation/reserved_version.d(210): Error: version identifier `D_BoundsChecks` is reserved and cannot be set
 ---
 */
-
-// Some extra empty lines to help fixup the manual line numbering after adding new version identifiers
 
 #line 105
 version = MSP430;
@@ -216,6 +215,7 @@ version = CppRuntime_DigitalMars;
 version = CppRuntime_Gcc;
 version = CppRuntime_Microsoft;
 version = CppRuntime_Sun;
+version = D_BoundsChecks;
 
 // This should work though
 debug = DigitalMars;
@@ -318,3 +318,4 @@ debug = all;
 debug = none;
 debug = D_P16;
 debug = MSP430;
+debug = D_BoundsChecks;

--- a/test/fail_compilation/reserved_version_switch.d
+++ b/test/fail_compilation/reserved_version_switch.d
@@ -94,6 +94,7 @@
 // REQUIRED_ARGS: -version=D_SIMD
 // REQUIRED_ARGS: -version=D_Version2
 // REQUIRED_ARGS: -version=D_NoBoundsChecks
+// REQUIRED_ARGS: -version=D_BoundsChecks
 // REQUIRED_ARGS: -version=unittest
 // REQUIRED_ARGS: -version=assert
 // REQUIRED_ARGS: -version=all
@@ -190,6 +191,7 @@
 // REQUIRED_ARGS: -debug=D_SIMD
 // REQUIRED_ARGS: -debug=D_Version2
 // REQUIRED_ARGS: -debug=D_NoBoundsChecks
+// REQUIRED_ARGS: -debug=D_BoundsChecks
 // REQUIRED_ARGS: -debug=unittest
 // REQUIRED_ARGS: -debug=assert
 // REQUIRED_ARGS: -debug=all
@@ -291,6 +293,7 @@ Error: version identifier `D_PIC` is reserved and cannot be set
 Error: version identifier `D_SIMD` is reserved and cannot be set
 Error: version identifier `D_Version2` is reserved and cannot be set
 Error: version identifier `D_NoBoundsChecks` is reserved and cannot be set
+Error: version identifier `D_BoundsChecks` is reserved and cannot be set
 Error: version identifier `unittest` is reserved and cannot be set
 Error: version identifier `assert` is reserved and cannot be set
 Error: version identifier `all` is reserved and cannot be set


### PR DESCRIPTION
```
One stylistic rule that is strictly enforced in D is that
version identifier and CLI switch should be positive.
`D_NoBoundsChecks` stands out as an exception in this regard.
This PR just adds `D_BoundsChecks` so that code have at least
one release to transition to it, before `D_NoBoundsChecks` is deprecated.
```