### PR TITLE
Don't pass null pointer as format parameter to errorSupplemental

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -624,7 +624,8 @@ extern (C++) final class Module : Package
             {
                 .error(loc, "cannot find source code for runtime library file 'object.d'");
                 errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-                errorSupplemental(loc, "config file: %s", FileName.canonicalName(global.inifilename));
+                const dmdConfFile = FileName.canonicalName(global.inifilename);
+                errorSupplemental(loc, "config file: %s", dmdConfFile ? dmdConfFile : "not found".ptr);
             }
             else
             {

--- a/test/fail_compilation/no_object.d
+++ b/test/fail_compilation/no_object.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 ---
 Error: cannot find source code for runtime library file 'object.d'
        dmd might not be correctly installed. Run 'dmd -man' for installation instructions.
-       config file: (null)
+       config file: not found
 import path[0] = fail_compilation
 ---
 */


### PR DESCRIPTION
Null pointer causes an ICE when used with gcc's diagnostic routines.