### PR TITLE
fix Issue 19140 - AssertError@dmd/ctfeexpr.d(229): Assertion failure

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -219,6 +219,8 @@ extern (C++) final class CTFEExp : Expression
             return "<cant>";
         case TOK.voidExpression:
             return "<void>";
+        case TOK.showCtfeContext:
+            return "<error>";
         case TOK.break_:
             return "<break>";
         case TOK.continue_:

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -182,6 +182,7 @@ enum TOK
         TOKinterval,
         TOKvoidexp,
         TOKcantexp,
+        TOKshowctfecontext,
 
         TOKobjc_class_reference,
 

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -7742,3 +7742,11 @@ struct RBNode(T)
 
 static assert(!__traits(compiles, { alias bug18057 = RBNode!int; }));
 
+/**************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19140
+
+void test19140()
+{
+    real f19140();
+    static if (__traits(compiles, (){ enum real r = f19140(); })) {}
+}


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=19140

When compiling with `-verrors=spec`
```
(spec:1) test/compilable/interpret3.d(7751): Error: f19140 cannot be interpreted at compile time, because it has no available source code
(spec:1) Error: cannot implicitly convert expression <error> of type void to real
```