### PR TITLE
Remove contracts from StaticForEach

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -102,12 +102,9 @@ extern (C++) final class StaticForeach : RootObject
     bool needExpansion = false;
 
     extern (D) this(const ref Loc loc,ForeachStatement aggrfe,ForeachRangeStatement rangefe)
-    in
     {
         assert(!!aggrfe ^ !!rangefe);
-    }
-    do
-    {
+
         this.loc = loc;
         this.aggrfe = aggrfe;
         this.rangefe = rangefe;
@@ -373,12 +370,9 @@ extern (C++) final class StaticForeach : RootObject
      * `dmd.statementsem.makeTupleForeach`.
      */
     final extern(D) void prepare(Scope* sc)
-    in
     {
         assert(sc);
-    }
-    do
-    {
+
         if (aggrfe)
         {
             sc = sc.startCTFE();


### PR DESCRIPTION
There's no benefit to having them there over just having the assert as part of the body.

The use of `body` vs. `do` also prevents the frontend from being built by older compilers in the 2.07x series, such as what's used by the pre-built gdc-7 packages in Debian.