### PR TITLE
Disable `.offsetof`/`.tupleof` for fields of Objective-C classes

### DIFF
--- a/changelog/objc_offsetof_tupleof.dd
+++ b/changelog/objc_offsetof_tupleof.dd
@@ -1,0 +1,14 @@
+`.offsetof` and `.tupleof` for fields of Objective-C classes have now been disabled
+
+To solve the fragile base class problem [1] in Objective-C, fields have a
+dynamic offset instead of a static offset. The compiler outputs a statically
+known offset which later the dynamic loader can update, if necessary, when the
+application is loaded. Due to this behavior it doesn't make sense to be able to
+get the offset of a field at compile time, because this offset might not
+actually be the same at runtime.
+
+To get the offset or value of a field, that is correct at runtime, functionality
+from the Objective-C runtime can be used instead [2].
+
+[1] $(LINK2 Fragile Binary Interface Problem, https://en.wikipedia.org/wiki/Fragile_binary_interface_problem)
+[2] $(LINK2 Objective-C Runtime, https://developer.apple.com/documentation/objectivec/objective_c_runtime)

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -191,7 +191,7 @@ extern (C++) final class ThrownExceptionExp : Expression
          * (eg, in ScopeStatement)
          */
         if (loc.isValid() && !loc.equals(thrown.loc))
-            errorSupplemental(loc, "thrown from here");
+            .errorSupplemental(loc, "thrown from here");
     }
 
     override void accept(Visitor v)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -755,6 +755,17 @@ extern (C++) abstract class Expression : RootObject
         }
     }
 
+    final void errorSupplemental(const(char)* format, ...)
+    {
+        if (type == Type.terror)
+            return;
+
+        va_list ap;
+        va_start(ap, format);
+        .verrorSupplemental(loc, format, ap);
+        va_end(ap);
+    }
+
     final void warning(const(char)* format, ...) const
     {
         if (type != Type.terror)
@@ -1346,7 +1357,7 @@ extern (C++) abstract class Expression : RootObject
                 error("`@safe` %s `%s` cannot call `@system` %s `%s`",
                     sc.func.kind(), sc.func.toPrettyChars(), f.kind(),
                     prettyChars);
-                errorSupplemental(f.loc, "`%s` is declared here", prettyChars);
+                .errorSupplemental(f.loc, "`%s` is declared here", prettyChars);
                 return true;
             }
         }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -46,6 +46,7 @@ import dmd.init;
 import dmd.initsem;
 import dmd.visitor;
 import dmd.mtype;
+import dmd.objc;
 import dmd.opover;
 import dmd.root.ctfloat;
 import dmd.root.rmem;
@@ -2966,6 +2967,7 @@ private extern(C++) final class DotExpVisitor : Visitor
                 if (v.isField())
                 {
                     auto ad = v.toParent().isAggregateDeclaration();
+                    objc.checkOffsetof(e, ad);
                     ad.size(e.loc);
                     if (ad.sizeok != Sizeok.done)
                     {
@@ -3822,6 +3824,8 @@ private extern(C++) final class DotExpVisitor : Visitor
          */
         if (ident == Id._tupleof)
         {
+            objc.checkTupleof(e, mt);
+
             /* Create a TupleExp
              */
             e = e.expressionSemantic(sc); // do this before turning on noaccesscheck

--- a/test/fail_compilation/objc_offsetof.d
+++ b/test/fail_compilation/objc_offsetof.d
@@ -1,0 +1,13 @@
+// EXTRA_OBJC_SOURCES
+/* TEST_OUTPUT:
+---
+fail_compilation/objc_offsetof.d(13): Error: no property `offsetof` for member `a` of type `int`
+fail_compilation/objc_offsetof.d(13):        `offsetof` is not available for members of Objective-C classes. Please use the Objective-C runtime instead
+---
+*/
+extern (Objective-C) class Foo
+{
+    int a;
+}
+
+enum o = Foo.a.offsetof;

--- a/test/fail_compilation/objc_tupleof.d
+++ b/test/fail_compilation/objc_tupleof.d
@@ -1,0 +1,17 @@
+// EXTRA_OBJC_SOURCES
+/* TEST_OUTPUT:
+---
+fail_compilation/objc_tupleof.d(16): Error: no property `tupleof` for type `objc_tupleof.Foo`
+fail_compilation/objc_tupleof.d(16):        `tupleof` is not available for members of Objective-C classes. Please use the Objective-C runtime instead
+---
+*/
+extern (Objective-C) class Foo
+{
+    int a;
+}
+
+void bar()
+{
+    Foo foo;
+    auto a = foo.tupleof[0];
+}


### PR DESCRIPTION
To solve the fragile base class problem [1] in Objective-C, fields have a dynamic offset instead of a static offset. The compiler outputs a statically known offset which later the dynamic loader can update,
if necessary, when the application is loaded. Due to this behavior it doesn't make sense to be able to get the offset of a field at compile time, because this offset might not actually be the same at runtime.

To get the offset or value of a field that is correct at runtime, functionality from the Objective-C runtime can be used instead [2].

No deprecation is necessary since Objective-C classes are currently not supported (only interfaces).

Spec PR https://github.com/dlang/dlang.org/pull/2443.

[1] https://en.wikipedia.org/wiki/Fragile_binary_interface_problem
[2] https://developer.apple.com/documentation/objectivec/objective_c_runtime