### PR TITLE
DScanner: Add a minimal .dscanner.ini + start to fix easy DScanner issues

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -50,6 +50,6 @@ check-clean-git:
 	fi
 
 style:
-	@echo "To be done"
+	$(QUIET)$(MAKE) -C src -f posix.mak style
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/src/.dscanner.ini
+++ b/src/.dscanner.ini
@@ -1,0 +1,118 @@
+; Configure which static analysis checks are enabled
+[analysis.config.StaticAnalysisConfig]
+; Check variable, class, struct, interface, union, and function names against
+; the Phobos style guide
+style_check="disabled"
+; Check for array literals that cause unnecessary allocation
+enum_array_literal_check="enabled"
+; Check for poor exception handling practices
+exception_check="enabled"
+; Check for use of the deprecated 'delete' keyword
+delete_check="enabled"
+; Check for use of the deprecated floating point operators
+float_operator_check="enabled"
+; Check number literals for readability
+number_style_check="disabled"
+; Checks that opEquals, opCmp, toHash, and toString are either const, immutable
+; , or inout.
+object_const_check="enabled"
+; Checks for .. expressions where the left side is larger than the right.
+backwards_range_check="enabled"
+; Checks for if statements whose 'then' block is the same as the 'else' block
+if_else_same_check="enabled"
+; Checks for some problems with constructors
+constructor_check="enabled"
+; Checks for unused variables and function parameters
+unused_variable_check="disabled"
+; Checks for unused labels
+unused_label_check="disabled"
+; Checks for duplicate attributes
+duplicate_attribute="enabled"
+; Checks that opEquals and toHash are both defined or neither are defined
+opequals_tohash_check="disabled"
+; Checks for subtraction from .length properties
+length_subtraction_check="disabled"
+; Checks for methods or properties whose names conflict with built-in propertie
+; s
+builtin_property_names_check="enabled"
+; Checks for confusing code in inline asm statements
+asm_style_check="enabled"
+; Checks for confusing logical operator precedence
+logical_precedence_check="disabled"
+; Checks for undocumented public declarations
+undocumented_declaration_check="disabled"
+; Checks for poor placement of function attributes
+function_attribute_check="enabled"
+; Checks for use of the comma operator
+comma_expression_check="enabled"
+; Checks for local imports that are too broad
+local_import_check="disabled"
+; Checks for variables that could be declared immutable
+could_be_immutable_check="disabled"
+; Checks for redundant expressions in if statements
+redundant_if_check="enabled"
+; Checks for redundant parenthesis
+redundant_parens_check="disabled"
+; Checks for mismatched argument and parameter names
+mismatched_args_check="disabled"
+; Checks for labels with the same name as variables
+label_var_same_name_check="disabled"
+; Checks for lines longer than 120 characters
+long_line_check="disabled"
+; Checks for assignment to auto-ref function parameters
+auto_ref_assignment_check="disabled"
+; Checks for incorrect infinite range definitions
+incorrect_infinite_range_check="enabled"
+; Checks for asserts that are always true
+useless_assert_check="enabled"
+; Check for uses of the old-style alias syntax
+alias_syntax_check="disabled"
+; Checks for else if that should be else static if
+static_if_else_check="enabled"
+; Check for unclear lambda syntax
+lambda_return_check="enabled"
+; Check for auto function without return statement
+auto_function_check="enabled"
+; Check for sortedness of imports
+imports_sortedness="disabled"
+; Check for explicitly annotated unittests
+explicitly_annotated_unittests="disabled"
+; Check for properly documented public functions (Returns, Params)
+properly_documented_public_functions="disabled"
+; Check for useless usage of the final attribute
+final_attribute_check="disabled"
+; Check for virtual calls in the class constructors
+vcall_in_ctor="enabled"
+; Check for useless user defined initializers
+useless_initializer="disabled"
+; Check allman brace style
+allman_braces_check="disabled"
+; Check for redundant attributes
+redundant_attributes_check="disabled"
+; Check for public declarations without a documented unittest
+has_public_example="disabled"
+; Check for asserts without an explanatory message
+assert_without_msg="disabled"
+; Check indent of if constraints
+if_constraints_indent="enabled"
+; Check for @trusted applied to a bigger scope than a single function
+trust_too_much="enabled"
+; Check for redundant storage classes on variable declarations")
+redundant_storage_classes="enabled"
+
+; Configure which modules are checked with a specific checker
+; Please help to extend these checks onto more Phobos modules
+; Process:
+; - Pick your favorite check
+; - Remove a module from the blacklist
+; - Run DScanner
+; - Fix the warnings
+; - Submit a PR to DMD
+; - GOTO: Remove a module
+;
+; Some checks are currently disabled.
+[analysis.config.ModuleFilters]
+redundant_storage_classes="-dmd.id,-dmd.toir,-dmd.tokens"
+trust_too_much="-dmd.root.longdouble"
+builtin_property_names_check="-dmd.backend.obj,-dmd.backend.code,-dmd.backend.cc"
+object_const_check="-dmd.dtemplate,-dmd.backend.outbuf"

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -60,14 +60,11 @@ extern (C++) bool isArrayOpValid(Expression e)
             BinExp be = cast(BinExp)e;
             return be.e1.op == TOK.slice && isArrayOpValid(be.e2);
         }
-        if (e.op == TOK.call)
-        {
-            return false; // TODO: Decide if [] is required after arrayop calls.
-        }
-        else
-        {
-            return false;
-        }
+        // if (e.op == TOK.call)
+        // {
+        // TODO: Decide if [] is required after arrayop calls.
+        // }
+        return false;
     }
     return true;
 }

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1441,7 +1441,7 @@ struct ASTBase
 
     extern (C++) final class Module : Package
     {
-        extern (C++) static __gshared AggregateDeclaration moduleinfo;
+        extern (C++) __gshared AggregateDeclaration moduleinfo;
 
         File* srcfile;
         const(char)* arg;
@@ -1520,7 +1520,7 @@ struct ASTBase
 
             super(loc, id);
 
-            static __gshared const(char)* msg = "only object.d can define this reserved class name";
+            __gshared const(char)* msg = "only object.d can define this reserved class name";
 
             if (baseclasses)
             {
@@ -2549,67 +2549,67 @@ struct ASTBase
         MOD mod;
         char* deco;
 
-        extern (C++) static __gshared Type tvoid;
-        extern (C++) static __gshared Type tint8;
-        extern (C++) static __gshared Type tuns8;
-        extern (C++) static __gshared Type tint16;
-        extern (C++) static __gshared Type tuns16;
-        extern (C++) static __gshared Type tint32;
-        extern (C++) static __gshared Type tuns32;
-        extern (C++) static __gshared Type tint64;
-        extern (C++) static __gshared Type tuns64;
-        extern (C++) static __gshared Type tint128;
-        extern (C++) static __gshared Type tuns128;
-        extern (C++) static __gshared Type tfloat32;
-        extern (C++) static __gshared Type tfloat64;
-        extern (C++) static __gshared Type tfloat80;
-        extern (C++) static __gshared Type timaginary32;
-        extern (C++) static __gshared Type timaginary64;
-        extern (C++) static __gshared Type timaginary80;
-        extern (C++) static __gshared Type tcomplex32;
-        extern (C++) static __gshared Type tcomplex64;
-        extern (C++) static __gshared Type tcomplex80;
-        extern (C++) static __gshared Type tbool;
-        extern (C++) static __gshared Type tchar;
-        extern (C++) static __gshared Type twchar;
-        extern (C++) static __gshared Type tdchar;
+        extern (C++) __gshared Type tvoid;
+        extern (C++) __gshared Type tint8;
+        extern (C++) __gshared Type tuns8;
+        extern (C++) __gshared Type tint16;
+        extern (C++) __gshared Type tuns16;
+        extern (C++) __gshared Type tint32;
+        extern (C++) __gshared Type tuns32;
+        extern (C++) __gshared Type tint64;
+        extern (C++) __gshared Type tuns64;
+        extern (C++) __gshared Type tint128;
+        extern (C++) __gshared Type tuns128;
+        extern (C++) __gshared Type tfloat32;
+        extern (C++) __gshared Type tfloat64;
+        extern (C++) __gshared Type tfloat80;
+        extern (C++) __gshared Type timaginary32;
+        extern (C++) __gshared Type timaginary64;
+        extern (C++) __gshared Type timaginary80;
+        extern (C++) __gshared Type tcomplex32;
+        extern (C++) __gshared Type tcomplex64;
+        extern (C++) __gshared Type tcomplex80;
+        extern (C++) __gshared Type tbool;
+        extern (C++) __gshared Type tchar;
+        extern (C++) __gshared Type twchar;
+        extern (C++) __gshared Type tdchar;
 
-        extern (C++) static __gshared Type[TMAX] basic;
+        extern (C++) __gshared Type[TMAX] basic;
 
-        extern (C++) static __gshared Type tshiftcnt;
-        extern (C++) static __gshared Type tvoidptr;    // void*
-        extern (C++) static __gshared Type tstring;     // immutable(char)[]
-        extern (C++) static __gshared Type twstring;    // immutable(wchar)[]
-        extern (C++) static __gshared Type tdstring;    // immutable(dchar)[]
-        extern (C++) static __gshared Type tvalist;     // va_list alias
-        extern (C++) static __gshared Type terror;      // for error recovery
-        extern (C++) static __gshared Type tnull;       // for null type
+        extern (C++) __gshared Type tshiftcnt;
+        extern (C++) __gshared Type tvoidptr;    // void*
+        extern (C++) __gshared Type tstring;     // immutable(char)[]
+        extern (C++) __gshared Type twstring;    // immutable(wchar)[]
+        extern (C++) __gshared Type tdstring;    // immutable(dchar)[]
+        extern (C++) __gshared Type tvalist;     // va_list alias
+        extern (C++) __gshared Type terror;      // for error recovery
+        extern (C++) __gshared Type tnull;       // for null type
 
-        extern (C++) static __gshared Type tsize_t;     // matches size_t alias
-        extern (C++) static __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
-        extern (C++) static __gshared Type thash_t;     // matches hash_t alias
+        extern (C++) __gshared Type tsize_t;     // matches size_t alias
+        extern (C++) __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
+        extern (C++) __gshared Type thash_t;     // matches hash_t alias
 
 
 
-        extern (C++) static __gshared ClassDeclaration dtypeinfo;
-        extern (C++) static __gshared ClassDeclaration typeinfoclass;
-        extern (C++) static __gshared ClassDeclaration typeinfointerface;
-        extern (C++) static __gshared ClassDeclaration typeinfostruct;
-        extern (C++) static __gshared ClassDeclaration typeinfopointer;
-        extern (C++) static __gshared ClassDeclaration typeinfoarray;
-        extern (C++) static __gshared ClassDeclaration typeinfostaticarray;
-        extern (C++) static __gshared ClassDeclaration typeinfoassociativearray;
-        extern (C++) static __gshared ClassDeclaration typeinfovector;
-        extern (C++) static __gshared ClassDeclaration typeinfoenum;
-        extern (C++) static __gshared ClassDeclaration typeinfofunction;
-        extern (C++) static __gshared ClassDeclaration typeinfodelegate;
-        extern (C++) static __gshared ClassDeclaration typeinfotypelist;
-        extern (C++) static __gshared ClassDeclaration typeinfoconst;
-        extern (C++) static __gshared ClassDeclaration typeinfoinvariant;
-        extern (C++) static __gshared ClassDeclaration typeinfoshared;
-        extern (C++) static __gshared ClassDeclaration typeinfowild;
-        extern (C++) static __gshared StringTable stringtable;
-        extern (C++) static __gshared ubyte[TMAX] sizeTy = ()
+        extern (C++) __gshared ClassDeclaration dtypeinfo;
+        extern (C++) __gshared ClassDeclaration typeinfoclass;
+        extern (C++) __gshared ClassDeclaration typeinfointerface;
+        extern (C++) __gshared ClassDeclaration typeinfostruct;
+        extern (C++) __gshared ClassDeclaration typeinfopointer;
+        extern (C++) __gshared ClassDeclaration typeinfoarray;
+        extern (C++) __gshared ClassDeclaration typeinfostaticarray;
+        extern (C++) __gshared ClassDeclaration typeinfoassociativearray;
+        extern (C++) __gshared ClassDeclaration typeinfovector;
+        extern (C++) __gshared ClassDeclaration typeinfoenum;
+        extern (C++) __gshared ClassDeclaration typeinfofunction;
+        extern (C++) __gshared ClassDeclaration typeinfodelegate;
+        extern (C++) __gshared ClassDeclaration typeinfotypelist;
+        extern (C++) __gshared ClassDeclaration typeinfoconst;
+        extern (C++) __gshared ClassDeclaration typeinfoinvariant;
+        extern (C++) __gshared ClassDeclaration typeinfoshared;
+        extern (C++) __gshared ClassDeclaration typeinfowild;
+        extern (C++) __gshared StringTable stringtable;
+        extern (C++) __gshared ubyte[TMAX] sizeTy = ()
             {
                 ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
                 sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);
@@ -2666,7 +2666,7 @@ struct ASTBase
             stringtable._init(14000);
 
             // Set basic types
-            static __gshared TY* basetab =
+            __gshared TY* basetab =
             [
                 Tvoid,
                 Tint8,
@@ -6236,7 +6236,7 @@ struct ASTBase
             const(char)* id;
         }
 
-        static __gshared SCstring* table =
+        __gshared SCstring* table =
         [
             SCstring(STC.auto_, TOK.auto_),
             SCstring(STC.scope_, TOK.scope_),
@@ -6314,7 +6314,7 @@ struct ASTBase
 
     struct Target
     {
-        extern (C++) static __gshared int ptrsize;
+        extern (C++) __gshared int ptrsize;
 
         extern (C++) static Type va_listType()
         {

--- a/src/dmd/backend/blockopt.d
+++ b/src/dmd/backend/blockopt.d
@@ -1547,7 +1547,7 @@ private void blreturn()
                     }
                     continue;
                 }
-            L1: ;
+            L1:
             }
             if (b.Belem)
             {   /* Split b into a goto and a b  */
@@ -1748,7 +1748,7 @@ private void bltailmerge()
                     } while (el_match(e,en));
                 }
             }
-    nextb:  ;
+    nextb:
         }
 
         /* Recombine elem lists into expression trees   */
@@ -1815,11 +1815,11 @@ private void brmin()
             go.changes++;
             break;
 
-        L2: ;
+        L2:
         }
 
 
-    L1: ;
+    L1:
     }
 }
 
@@ -2107,7 +2107,6 @@ void funcsideeffects()
 
       Lside:
         //printf("  function '%s' has side effects\n",funcsym_p.Sident);
-        ;
     }
 }
 

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -1691,7 +1691,6 @@ private elem *elor(elem *e, goal_t goal)
         }
     }
   L1:
-    ;
 
     if (OPTIMIZER)
     {
@@ -1754,7 +1753,7 @@ private elem *elor(elem *e, goal_t goal)
             return e;
         }
 
-      L2: ;
+      L2:
     }
 
     return elbitwise(e, goal);
@@ -3618,7 +3617,7 @@ static if (0)
             e2.Eoper = OPxor;
             return optelem(e,GOALvalue);
 
-        L8: ;
+        L8:
         }
 
         // Replace (a=(r1 pair r2)) with (a1=r1), (a2=r2)

--- a/src/dmd/backend/cgreg.d
+++ b/src/dmd/backend/cgreg.d
@@ -967,7 +967,7 @@ static if (0 && TARGET_LINUX)
                 u.reglsw = reg;
                 u.regmsw = regmsw;
             }
-Ltried:     ;
+Ltried:
         }
 
         if (u.benefit > t.benefit)

--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -75,5 +75,5 @@ else
     void repeat(dt_t* dt, uint count);
     uint length();
     bool isZeroLength();
-};
+}
 

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -642,7 +642,7 @@ private int looprotate(loop *l)
                         goto L2;
                     }
                 assert(0);
-        L2:     ;
+        L2:
             }
             else
                 pbln = &((*pbl).next);      // next predecessor in list
@@ -937,7 +937,7 @@ restart:
             }
             // if i dom (all exit blocks)
             domexit = 1;
-        L1:     ;
+        L1:
             if (dfo[i].Belem)
             {   // If there is any hope of making an improvement
                 if (domexit || l.Llis)
@@ -1849,7 +1849,6 @@ L3:
             goto Lret;
 
         Lpass:
-            ;
         }
     }
 
@@ -1948,7 +1947,7 @@ L3:
     list_prepend(&l.Llis,ne);
 
 Lret:
-    ;
+
 }
 
 /***************************
@@ -2260,7 +2259,7 @@ private void findbasivs(loop *l)
         assert(0);                      /* should have found it         */
         /* NOTREACHED */
 
-    L1: ;
+    L1:
     }
 
     vec_free(poss);
@@ -2403,7 +2402,6 @@ private void findopeqs(loop *l)
         // NOTREACHED
 
     Lcont:
-        ;
     }
 
     vec_free(poss);
@@ -3228,7 +3226,6 @@ private void elimbasivs(loop *l)
             go.changes++;
             doflow = true;                  /* redo flow analysis   */
           L1:
-            ;
         }
     } /* for */
 }
@@ -3285,7 +3282,6 @@ private void elimopeqs(loop *l)
             go.changes++;
             doflow = true;                      // redo flow analysis
         L1:
-            ;
         }
     }
 }

--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -737,7 +737,7 @@ private void eqeqranges()
             e.EV.Vint = (e.Eoper == OPeqeq) ? result : result ^ 1;
             e.Eoper = OPconst;
         }
-    L1: ;
+    L1:
     }
 }
 
@@ -910,7 +910,6 @@ private void intranges()
         }
 
       nextrel:
-        ;
     }
 }
 
@@ -1337,7 +1336,6 @@ private void cpwalk(elem *n,vec_t IN)
         }
         //else printf("not found\n");
     noprop:
-        ;
     }
 }
 
@@ -1962,7 +1960,7 @@ void verybusyexp()
                     goto L2;
             }
             vec_clearbit(j,b.Bout);        /* thar ain't no path   */
-        L2: ;
+        L2:
         }
 
 

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -655,7 +655,6 @@ debug
    /* not in table, so insert into table        */
    *parent = s;                         /* link new symbol into tree    */
 L1:
-   ;
 }
 
 }
@@ -1889,7 +1888,7 @@ else
                 outcommon(s,type_size(s.Stype));
             }
         }
-  L1:   ;
+  L1:
     } // for
 debug
 {

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -203,7 +203,7 @@ enum
 //#else
     mTYTFF          = 0xFF000000,
 //#endif
-};
+}
 
 pure
 tym_t tybasic(tym_t ty) { return ty & mTYbasic; }
@@ -231,7 +231,7 @@ enum
     TYFLsimd        = 0x20000,    // SIMD vector type
     TYFLfarfunc     = 0x100,      // __far functions (for segmented architectures)
     TYFLxmmreg      = 0x10000,    // can be put in XMM register
-};
+}
 
 /* Array to give the size in bytes of a type, -1 means error    */
 extern __gshared byte[256] _tysize;

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -774,7 +774,7 @@ extern (C++) FuncDeclaration buildXtoHash(StructDeclaration sd, Scope* sc)
 {
     if (Dsymbol s = search_function(sd, Id.tohash))
     {
-        static __gshared TypeFunction tftohash;
+        __gshared TypeFunction tftohash;
         if (!tftohash)
         {
             tftohash = new TypeFunction(null, Type.thash_t, 0, LINK.d);

--- a/src/dmd/complex.d
+++ b/src/dmd/complex.d
@@ -83,12 +83,12 @@ struct complex_t
         }
     }
 
-    bool opCast(T : bool)()
+    bool opCast(T : bool)() const
     {
         return re || im;
     }
 
-    int opEquals(complex_t y)
+    int opEquals(complex_t y) const
     {
         return re == y.re && im == y.im;
     }

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -39,14 +39,14 @@ import dmd.visitor;
  */
 struct CtfeStatus
 {
-    extern (C++) static __gshared int callDepth = 0;        // current number of recursive calls
+    extern (C++) __gshared int callDepth = 0;        // current number of recursive calls
 
     // When printing a stack trace, suppress this number of calls
-    extern (C++) static __gshared int stackTraceCallsToSuppress = 0;
+    extern (C++) __gshared int stackTraceCallsToSuppress = 0;
 
-    extern (C++) static __gshared int maxCallDepth = 0;     // highest number of recursive calls
-    extern (C++) static __gshared int numArrayAllocs = 0;   // Number of allocated arrays
-    extern (C++) static __gshared int numAssignments = 0;   // total number of assignments executed
+    extern (C++) __gshared int maxCallDepth = 0;     // highest number of recursive calls
+    extern (C++) __gshared int numArrayAllocs = 0;   // Number of allocated arrays
+    extern (C++) __gshared int numAssignments = 0;   // total number of assignments executed
 }
 
 /***********************************************************
@@ -232,15 +232,15 @@ extern (C++) final class CTFEExp : Expression
         }
     }
 
-    extern (C++) static __gshared CTFEExp cantexp;
-    extern (C++) static __gshared CTFEExp voidexp;
-    extern (C++) static __gshared CTFEExp breakexp;
-    extern (C++) static __gshared CTFEExp continueexp;
-    extern (C++) static __gshared CTFEExp gotoexp;
+    extern (C++) __gshared CTFEExp cantexp;
+    extern (C++) __gshared CTFEExp voidexp;
+    extern (C++) __gshared CTFEExp breakexp;
+    extern (C++) __gshared CTFEExp continueexp;
+    extern (C++) __gshared CTFEExp gotoexp;
     /* Used when additional information is needed regarding
      * a ctfe error.
      */
-    extern (C++) static __gshared CTFEExp showcontext;
+    extern (C++) __gshared CTFEExp showcontext;
 
     static bool isCantExp(const Expression e)
     {

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2308,7 +2308,7 @@ extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
             {
                 printf("DelegateExp::castTo(this=%s, type=%s, t=%s)\n", e.toChars(), e.type.toChars(), t.toChars());
             }
-            static __gshared const(char)* msg = "cannot form delegate due to covariant return type";
+            __gshared const(char)* msg = "cannot form delegate due to covariant return type";
 
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -234,7 +234,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
         super(loc, id);
 
-        static __gshared const(char)* msg = "only object.d can define this reserved class name";
+        __gshared const(char)* msg = "only object.d can define this reserved class name";
 
         if (baseclasses)
         {

--- a/src/dmd/dmacro.d
+++ b/src/dmd/dmacro.d
@@ -81,8 +81,8 @@ public:
             printf("Buf is: '%.*s'\n", *pend - start, buf.data + start);
         }
         // limit recursive expansion
-        static __gshared int nest;
-        static __gshared const(int) nestLimit = 1000;
+        __gshared int nest;
+        __gshared const(int) nestLimit = 1000;
         if (nest > nestLimit)
         {
             error(Loc.initial, "DDoc macro expansion limit exceeded; more than %d expansions.", nestLimit);

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -284,26 +284,26 @@ extern (C++) class Package : ScopeDsymbol
  */
 extern (C++) final class Module : Package
 {
-    extern (C++) static __gshared Module rootModule;
-    extern (C++) static __gshared DsymbolTable modules; // symbol table of all modules
-    extern (C++) static __gshared Modules amodules;     // array of all modules
-    extern (C++) static __gshared Dsymbols deferred;    // deferred Dsymbol's needing semantic() run on them
-    extern (C++) static __gshared Dsymbols deferred2;   // deferred Dsymbol's needing semantic2() run on them
-    extern (C++) static __gshared Dsymbols deferred3;   // deferred Dsymbol's needing semantic3() run on them
-    extern (C++) static __gshared uint dprogress;       // progress resolving the deferred list
+    extern (C++) __gshared Module rootModule;
+    extern (C++) __gshared DsymbolTable modules; // symbol table of all modules
+    extern (C++) __gshared Modules amodules;     // array of all modules
+    extern (C++) __gshared Dsymbols deferred;    // deferred Dsymbol's needing semantic() run on them
+    extern (C++) __gshared Dsymbols deferred2;   // deferred Dsymbol's needing semantic2() run on them
+    extern (C++) __gshared Dsymbols deferred3;   // deferred Dsymbol's needing semantic3() run on them
+    extern (C++) __gshared uint dprogress;       // progress resolving the deferred list
     /**
      * A callback function that is called once an imported module is
      * parsed. If the callback returns true, then it tells the
      * frontend that the driver intends on compiling the import.
      */
-    extern (C++) static __gshared bool function(Module mod) onImport;
+    extern (C++) __gshared bool function(Module mod) onImport;
 
     static void _init()
     {
         modules = new DsymbolTable();
     }
 
-    extern (C++) static __gshared AggregateDeclaration moduleinfo;
+    extern (C++) __gshared AggregateDeclaration moduleinfo;
 
     const(char)* arg;           // original argument name
     ModuleDeclaration* md;      // if !=null, the contents of the ModuleDeclaration declaration
@@ -1146,7 +1146,7 @@ extern (C++) final class Module : Package
         if (dprogress == 0)
             return;
 
-        static __gshared int nested;
+        __gshared int nested;
         if (nested)
             return;
         //if (deferred.dim) printf("+Module::runDeferredSemantic(), len = %d\n", deferred.dim);

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -102,7 +102,7 @@ extern (C++) class Section
         assert(a.dim);
         if (namelen)
         {
-            static __gshared const(char)** table =
+            __gshared const(char)** table =
             [
                 "AUTHORS",
                 "BUGS",
@@ -362,8 +362,8 @@ extern (C++) __gshared const(char)* ddoc_decl_dd_e = ")\n";
  */
 extern (C++) void gendocfile(Module m)
 {
-    static __gshared OutBuffer mbuf;
-    static __gshared int mbuf_done;
+    __gshared OutBuffer mbuf;
+    __gshared int mbuf_done;
     OutBuffer buf;
     //printf("Module::gendocfile()\n");
     if (!mbuf_done) // if not already read the ddoc files
@@ -2417,7 +2417,7 @@ extern (C++) void highlightText(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t o
                 }
                 else
                 {
-                    static __gshared const(char)* d_code = "$(D_CODE ";
+                    __gshared const(char)* d_code = "$(D_CODE ";
                     inCode = 1;
                     codeIndent = istart - iLineStart; // save indent count
                     i = buf.insert(i, d_code, strlen(d_code));

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -125,7 +125,7 @@ struct Scope
     uint[void*] anchorCounts;  /// lookup duplicate anchor name count
     Identifier prevAnchor;     /// qualified symbol name of last doc anchor
 
-    extern (C++) static __gshared Scope* freelist;
+    extern (C++) __gshared Scope* freelist;
 
     extern (C++) static Scope* alloc()
     {

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -50,7 +50,7 @@ extern (C++) FuncDeclaration search_toString(StructDeclaration sd)
     FuncDeclaration fd = s ? s.isFuncDeclaration() : null;
     if (fd)
     {
-        static __gshared TypeFunction tftostring;
+        __gshared TypeFunction tftostring;
         if (!tftostring)
         {
             tftostring = new TypeFunction(null, Type.tstring, 0, LINK.d);
@@ -230,8 +230,8 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     FuncDeclaration xeq;        // TypeInfo_Struct.xopEquals
     FuncDeclaration xcmp;       // TypeInfo_Struct.xopCmp
     FuncDeclaration xhash;      // TypeInfo_Struct.xtoHash
-    extern (C++) static __gshared FuncDeclaration xerreq;   // object.xopEquals
-    extern (C++) static __gshared FuncDeclaration xerrcmp;  // object.xopCmp
+    extern (C++) __gshared FuncDeclaration xerreq;   // object.xopEquals
+    extern (C++) __gshared FuncDeclaration xerrcmp;  // object.xopCmp
 
     structalign_t alignment;    // alignment applied outside of the struct
     StructPOD ispod;            // if struct is POD

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1554,7 +1554,7 @@ public:
         version (none)
         {
             // Finish
-            static __gshared TypeFunction tfgetmembers;
+            __gshared TypeFunction tfgetmembers;
             if (!tfgetmembers)
             {
                 Scope sc;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2711,7 +2711,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Scope* sc2 = argscope.push(tm);
         //size_t deferred_dim = Module.deferred.dim;
 
-        static __gshared int nest;
+        __gshared int nest;
         //printf("%d\n", nest);
         if (++nest > 500)
         {
@@ -3566,7 +3566,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         funcdecl._scope = sc.copy();
         funcdecl._scope.setNoFree();
 
-        static __gshared bool printedMain = false; // semantic might run more than once
+        __gshared bool printedMain = false; // semantic might run more than once
         if (global.params.verbose && !printedMain)
         {
             const(char)* type = funcdecl.isMain() ? "main" : funcdecl.isWinMain() ? "winmain" : funcdecl.isDllMain() ? "dllmain" : cast(const(char)*)null;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5166,7 +5166,7 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
     Type specType;      // if !=null, this is the type specialization
     Type defaultType;
 
-    extern (C++) static __gshared Type tdummy = null;
+    extern (C++) __gshared Type tdummy = null;
 
     extern (D) this(const ref Loc loc, Identifier ident, Type specType, Type defaultType)
     {
@@ -5362,7 +5362,7 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
     Expression specValue;
     Expression defaultValue;
 
-    extern (D) static __gshared Expression[void*] edummies;
+    extern (D) __gshared Expression[void*] edummies;
 
     extern (D) this(const ref Loc loc, Identifier ident, Type valType,
         Expression specValue, Expression defaultValue)
@@ -5591,7 +5591,7 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
     RootObject specAlias;
     RootObject defaultAlias;
 
-    extern (C++) static __gshared Dsymbol sdummy = null;
+    extern (C++) __gshared Dsymbol sdummy = null;
 
     extern (D) this(const ref Loc loc, Identifier ident, Type specType, RootObject specAlias, RootObject defaultAlias)
     {
@@ -7493,7 +7493,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
     final void tryExpandMembers(Scope* sc2)
     {
-        static __gshared int nest;
+        __gshared int nest;
         // extracted to a function to allow windows SEH to work without destructors in the same function
         //printf("%d\n", nest);
         if (++nest > 500)
@@ -7511,7 +7511,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     final void trySemantic3(Scope* sc2)
     {
         // extracted to a function to allow windows SEH to work without destructors in the same function
-        static __gshared int nest;
+        __gshared int nest;
         //printf("%d\n", nest);
         if (++nest > 300)
         {

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -338,7 +338,7 @@ extern (C++) void vwarningSupplemental(const ref Loc loc, const(char)* format, v
  */
 extern (C++) void vdeprecation(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null)
 {
-    static __gshared const(char)* header = "Deprecation: ";
+    __gshared const(char)* header = "Deprecation: ";
     if (global.params.useDeprecated == 0)
         verror(loc, format, ap, p1, p2, header);
     else if (global.params.useDeprecated == 2)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1810,7 +1810,7 @@ extern (C++) final class ErrorExp : Expression
         v.visit(this);
     }
 
-    extern (C++) static __gshared ErrorExp errorexp; // handy shared value
+    extern (C++) __gshared ErrorExp errorexp; // handy shared value
 }
 
 /***********************************************************

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2088,7 +2088,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
 
 private Module loadStdMath()
 {
-    static __gshared Import impStdMath = null;
+    __gshared Import impStdMath = null;
     if (!impStdMath)
     {
         auto a = new Identifiers();
@@ -3837,7 +3837,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             else
             {
-                static __gshared int nest;
+                __gshared int nest;
                 if (++nest > 500)
                 {
                     exp.error("recursive evaluation of `%s`", exp.toChars());

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2296,7 +2296,7 @@ extern (C++) class FuncDeclaration : Declaration
         FuncDeclaration fd;
         TypeFunction tf;
         Dsymbol s;
-        static __gshared DsymbolTable st = null;
+        __gshared DsymbolTable st = null;
 
         //printf("genCfunc(name = '%s')\n", id.toChars());
         //printf("treturn\n\t"); treturn.print();

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -370,7 +370,7 @@ struct Global
     extern(C++) uint versionNumber()
     {
         import core.stdc.ctype;
-        __gshared static uint cached = 0;
+        __gshared uint cached = 0;
         if (cached == 0)
         {
             //

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3291,7 +3291,7 @@ extern (C++) const(char)* stcToChars(ref StorageClass stc)
         const(char)* id;
     }
 
-    static __gshared SCstring* table =
+    __gshared SCstring* table =
     [
         SCstring(STC.auto_, TOK.auto_),
         SCstring(STC.scope_, TOK.scope_),

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -1593,7 +1593,7 @@ code *asm_emit(Loc loc,
     {
         emit(opcode);
     }
-L3: ;
+L3:
 
     // If CALL, Jxx or LOOPx to a symbolic location
     if (/*asmstate.ucItype == ITjump &&*/

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -122,11 +122,11 @@ nothrow:
         return DYNCAST.identifier;
     }
 
-    extern (C++) static __gshared StringTable stringtable;
+    extern (C++) __gshared StringTable stringtable;
 
     static Identifier generateId(const(char)* prefix)
     {
-        static __gshared size_t i;
+        __gshared size_t i;
         return generateId(prefix, ++i);
     }
 

--- a/src/dmd/libelf.d
+++ b/src/dmd/libelf.d
@@ -268,9 +268,9 @@ final class LibElf : Library
             /* Mock things up for the object module file that never was
              * actually written out.
              */
-            static __gshared uid_t uid;
-            static __gshared gid_t gid;
-            static __gshared int _init;
+            __gshared uid_t uid;
+            __gshared gid_t gid;
+            __gshared int _init;
             if (!_init)
             {
                 _init = 1;

--- a/src/dmd/libmach.d
+++ b/src/dmd/libmach.d
@@ -221,9 +221,9 @@ final class LibMach : Library
             /* Mock things up for the object module file that never was
              * actually written out.
              */
-            static __gshared uid_t uid;
-            static __gshared gid_t gid;
-            static __gshared int _init;
+            __gshared uid_t uid;
+            __gshared gid_t gid;
+            __gshared int _init;
             if (!_init)
             {
                 _init = 1;
@@ -315,7 +315,7 @@ private:
         {
             printf("LibMach::WriteLibToBuffer()\n");
         }
-        static __gshared char* pad = [0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A];
+        __gshared char* pad = [0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A, 0x0A];
         /************* Scan Object Modules for Symbols ******************/
         for (size_t i = 0; i < objmodules.dim; i++)
         {

--- a/src/dmd/libomf.d
+++ b/src/dmd/libomf.d
@@ -133,7 +133,7 @@ final class LibOMF : Library
         {
             auto om = new OmfObjModule();
             om.base = cast(ubyte*)base;
-            om.page = om.page = cast(ushort)((om.base - pstart) / g_page_size);
+            om.page = cast(ushort)((om.base - pstart) / g_page_size);
             om.length = cast(uint)length;
             /* Determine the name of the module
              */
@@ -243,7 +243,7 @@ private:
         ndicpages = (bucksForHash > bucksForSize) ? bucksForHash : bucksForSize;
         //printf("ndicpages = %u\n",ndicpages);
         // Find prime number greater than ndicpages
-        static __gshared uint* primes =
+        __gshared uint* primes =
         [
             1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43,
             47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103,

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -112,11 +112,11 @@ version (Posix)
     {
         version (OSX)
         {
-            static __gshared const(char)* nmeErrorMessage = "`__Dmain`, referenced from:";
+            __gshared const(char)* nmeErrorMessage = "`__Dmain`, referenced from:";
         }
         else
         {
-            static __gshared const(char)* nmeErrorMessage = "undefined reference to `_Dmain`";
+            __gshared const(char)* nmeErrorMessage = "undefined reference to `_Dmain`";
         }
         FILE* stream = fdopen(fd, "r");
         if (stream is null)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -394,69 +394,69 @@ extern (C++) abstract class Type : RootObject
 
     type* ctype;                    // for back end
 
-    extern (C++) static __gshared Type tvoid;
-    extern (C++) static __gshared Type tint8;
-    extern (C++) static __gshared Type tuns8;
-    extern (C++) static __gshared Type tint16;
-    extern (C++) static __gshared Type tuns16;
-    extern (C++) static __gshared Type tint32;
-    extern (C++) static __gshared Type tuns32;
-    extern (C++) static __gshared Type tint64;
-    extern (C++) static __gshared Type tuns64;
-    extern (C++) static __gshared Type tint128;
-    extern (C++) static __gshared Type tuns128;
-    extern (C++) static __gshared Type tfloat32;
-    extern (C++) static __gshared Type tfloat64;
-    extern (C++) static __gshared Type tfloat80;
-    extern (C++) static __gshared Type timaginary32;
-    extern (C++) static __gshared Type timaginary64;
-    extern (C++) static __gshared Type timaginary80;
-    extern (C++) static __gshared Type tcomplex32;
-    extern (C++) static __gshared Type tcomplex64;
-    extern (C++) static __gshared Type tcomplex80;
-    extern (C++) static __gshared Type tbool;
-    extern (C++) static __gshared Type tchar;
-    extern (C++) static __gshared Type twchar;
-    extern (C++) static __gshared Type tdchar;
+    extern (C++) __gshared Type tvoid;
+    extern (C++) __gshared Type tint8;
+    extern (C++) __gshared Type tuns8;
+    extern (C++) __gshared Type tint16;
+    extern (C++) __gshared Type tuns16;
+    extern (C++) __gshared Type tint32;
+    extern (C++) __gshared Type tuns32;
+    extern (C++) __gshared Type tint64;
+    extern (C++) __gshared Type tuns64;
+    extern (C++) __gshared Type tint128;
+    extern (C++) __gshared Type tuns128;
+    extern (C++) __gshared Type tfloat32;
+    extern (C++) __gshared Type tfloat64;
+    extern (C++) __gshared Type tfloat80;
+    extern (C++) __gshared Type timaginary32;
+    extern (C++) __gshared Type timaginary64;
+    extern (C++) __gshared Type timaginary80;
+    extern (C++) __gshared Type tcomplex32;
+    extern (C++) __gshared Type tcomplex64;
+    extern (C++) __gshared Type tcomplex80;
+    extern (C++) __gshared Type tbool;
+    extern (C++) __gshared Type tchar;
+    extern (C++) __gshared Type twchar;
+    extern (C++) __gshared Type tdchar;
 
     // Some special types
-    extern (C++) static __gshared Type tshiftcnt;
-    extern (C++) static __gshared Type tvoidptr;    // void*
-    extern (C++) static __gshared Type tstring;     // immutable(char)[]
-    extern (C++) static __gshared Type twstring;    // immutable(wchar)[]
-    extern (C++) static __gshared Type tdstring;    // immutable(dchar)[]
-    extern (C++) static __gshared Type tvalist;     // va_list alias
-    extern (C++) static __gshared Type terror;      // for error recovery
-    extern (C++) static __gshared Type tnull;       // for null type
+    extern (C++) __gshared Type tshiftcnt;
+    extern (C++) __gshared Type tvoidptr;    // void*
+    extern (C++) __gshared Type tstring;     // immutable(char)[]
+    extern (C++) __gshared Type twstring;    // immutable(wchar)[]
+    extern (C++) __gshared Type tdstring;    // immutable(dchar)[]
+    extern (C++) __gshared Type tvalist;     // va_list alias
+    extern (C++) __gshared Type terror;      // for error recovery
+    extern (C++) __gshared Type tnull;       // for null type
 
-    extern (C++) static __gshared Type tsize_t;     // matches size_t alias
-    extern (C++) static __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
-    extern (C++) static __gshared Type thash_t;     // matches hash_t alias
+    extern (C++) __gshared Type tsize_t;     // matches size_t alias
+    extern (C++) __gshared Type tptrdiff_t;  // matches ptrdiff_t alias
+    extern (C++) __gshared Type thash_t;     // matches hash_t alias
 
-    extern (C++) static __gshared ClassDeclaration dtypeinfo;
-    extern (C++) static __gshared ClassDeclaration typeinfoclass;
-    extern (C++) static __gshared ClassDeclaration typeinfointerface;
-    extern (C++) static __gshared ClassDeclaration typeinfostruct;
-    extern (C++) static __gshared ClassDeclaration typeinfopointer;
-    extern (C++) static __gshared ClassDeclaration typeinfoarray;
-    extern (C++) static __gshared ClassDeclaration typeinfostaticarray;
-    extern (C++) static __gshared ClassDeclaration typeinfoassociativearray;
-    extern (C++) static __gshared ClassDeclaration typeinfovector;
-    extern (C++) static __gshared ClassDeclaration typeinfoenum;
-    extern (C++) static __gshared ClassDeclaration typeinfofunction;
-    extern (C++) static __gshared ClassDeclaration typeinfodelegate;
-    extern (C++) static __gshared ClassDeclaration typeinfotypelist;
-    extern (C++) static __gshared ClassDeclaration typeinfoconst;
-    extern (C++) static __gshared ClassDeclaration typeinfoinvariant;
-    extern (C++) static __gshared ClassDeclaration typeinfoshared;
-    extern (C++) static __gshared ClassDeclaration typeinfowild;
+    extern (C++) __gshared ClassDeclaration dtypeinfo;
+    extern (C++) __gshared ClassDeclaration typeinfoclass;
+    extern (C++) __gshared ClassDeclaration typeinfointerface;
+    extern (C++) __gshared ClassDeclaration typeinfostruct;
+    extern (C++) __gshared ClassDeclaration typeinfopointer;
+    extern (C++) __gshared ClassDeclaration typeinfoarray;
+    extern (C++) __gshared ClassDeclaration typeinfostaticarray;
+    extern (C++) __gshared ClassDeclaration typeinfoassociativearray;
+    extern (C++) __gshared ClassDeclaration typeinfovector;
+    extern (C++) __gshared ClassDeclaration typeinfoenum;
+    extern (C++) __gshared ClassDeclaration typeinfofunction;
+    extern (C++) __gshared ClassDeclaration typeinfodelegate;
+    extern (C++) __gshared ClassDeclaration typeinfotypelist;
+    extern (C++) __gshared ClassDeclaration typeinfoconst;
+    extern (C++) __gshared ClassDeclaration typeinfoinvariant;
+    extern (C++) __gshared ClassDeclaration typeinfoshared;
+    extern (C++) __gshared ClassDeclaration typeinfowild;
 
-    extern (C++) static __gshared TemplateDeclaration rtinfo;
+    extern (C++) __gshared TemplateDeclaration rtinfo;
 
-    extern (C++) static __gshared Type[TMAX] basic;
-    extern (C++) static __gshared StringTable stringtable;
+    extern (C++) __gshared Type[TMAX] basic;
+    extern (C++) __gshared StringTable stringtable;
 
-    extern (C++) static __gshared ubyte[TMAX] sizeTy = ()
+    extern (C++) __gshared ubyte[TMAX] sizeTy = ()
         {
             ubyte[TMAX] sizeTy = __traits(classInstanceSize, TypeBasic);
             sizeTy[Tsarray] = __traits(classInstanceSize, TypeSArray);
@@ -797,7 +797,7 @@ extern (C++) abstract class Type : RootObject
         stringtable._init(14000);
 
         // Set basic types
-        static __gshared TY* basetab =
+        __gshared TY* basetab =
         [
             Tvoid,
             Tint8,

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -35,9 +35,9 @@ import dmd.root.stringtable;
 struct ObjcSelector
 {
     // MARK: Selector
-    extern (C++) static __gshared StringTable stringtable;
-    extern (C++) static __gshared StringTable vTableDispatchSelectors;
-    extern (C++) static __gshared int incnum = 0;
+    extern (C++) __gshared StringTable stringtable;
+    extern (C++) __gshared StringTable vTableDispatchSelectors;
+    extern (C++) __gshared int incnum = 0;
     const(char)* stringvalue;
     size_t stringlen;
     size_t paramCount;
@@ -414,7 +414,7 @@ extern(C++) private final class Supported : Objc
  *  classDeclaration = the class/interface declaration to set the metaclass on
  */
 private void setMetaclass(alias newMetaclass, T)(T classDeclaration)
-    if (is(T == ClassDeclaration) || is(T == InterfaceDeclaration))
+if (is(T == ClassDeclaration) || is(T == InterfaceDeclaration))
 {
     static if (is(T == ClassDeclaration))
         enum errorType = "class";

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -159,9 +159,9 @@ struct Segments
 
     private
     {
-        __gshared static int[segmentData.length] segments;
+        __gshared int[segmentData.length] segments;
 
-        __gshared static Segments[__traits(allMembers, Id).length] segmentData = [
+        __gshared Segments[__traits(allMembers, Id).length] segmentData = [
             Segments("__objc_imageinfo", "__DATA", S_REGULAR | S_ATTR_NO_DEAD_STRIP, 0),
             Segments("__objc_methname", "__TEXT", S_CSTRING_LITERALS, 0),
             Segments("__objc_classlist", "__DATA", S_REGULAR | S_ATTR_NO_DEAD_STRIP, 3),

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -201,10 +201,10 @@ extern (C++) struct CTFloat
     }
 
     // Constant real values 0, 1, -1 and 0.5.
-    static __gshared real_t zero;
-    static __gshared real_t one;
-    static __gshared real_t minusone;
-    static __gshared real_t half;
+    __gshared real_t zero;
+    __gshared real_t one;
+    __gshared real_t minusone;
+    __gshared real_t half;
 
     static void initialize()
     {

--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -178,7 +178,7 @@ nothrow @nogc pure:
     static uint min_exp() { return -16381; }
     static uint max_10_exp() { return 4932; }
     static uint min_10_exp() { return -4932; }
-};
+}
 
 static assert(longdouble_soft.alignof == longdouble.alignof);
 static assert(longdouble_soft.sizeof == longdouble.sizeof);

--- a/src/dmd/root/speller.d
+++ b/src/dmd/root/speller.d
@@ -218,7 +218,7 @@ void* speller(const(char)* seed, scope dg_speller_t dg, const(char)* charset)
 
 unittest
 {
-    static __gshared const(char)*** cases =
+    __gshared const(char)*** cases =
     [
         ["hello", "hell", "y"],
         ["hello", "hel", "y"],

--- a/src/dmd/scanomf.d
+++ b/src/dmd/scanomf.d
@@ -254,7 +254,7 @@ void scanOmfObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
         case COMENT:
             // Recognize Phar Lap EASY-OMF format
             {
-                static __gshared ubyte* omfstr1 = [0x80, 0xAA, '8', '0', '3', '8', '6'];
+                __gshared ubyte* omfstr1 = [0x80, 0xAA, '8', '0', '3', '8', '6'];
                 if (recLen == (omfstr1).sizeof)
                 {
                     for (uint i = 0; i < (omfstr1).sizeof; i++)
@@ -267,7 +267,7 @@ void scanOmfObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol,
             }
             // Recognize .IMPDEF Import Definition Records
             {
-                static __gshared ubyte* omfstr2 = [0, 0xA0, 1];
+                __gshared ubyte* omfstr2 = [0, 0xA0, 1];
                 if (recLen >= 7)
                 {
                     p++;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -915,32 +915,35 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     return returnEarly();
                 }
             }
-            else if (!needExpansion)
-            {
-                // Declare value
-                if (!declareVariable(p.storageClass, p.type, p.ident, e, t))
-                {
-                    return returnEarly();
-                }
-            }
             else
-            { // expand tuples into multiple `static foreach` variables.
-                assert(e && !t);
-                auto ident = Identifier.generateId("__value");
-                declareVariable(0, e.type, ident, e, null);
-                import dmd.cond: StaticForeach;
-                auto field = Identifier.idPool(StaticForeach.tupleFieldName.ptr,StaticForeach.tupleFieldName.length);
-                Expression access = new DotIdExp(loc, e, field);
-                access = expressionSemantic(access, sc);
-                if (!tuple) return returnEarly();
-                //printf("%s\n",tuple.toChars());
-                foreach (l; 0 .. dim)
+            {
+                if (!needExpansion)
                 {
-                    auto cp = (*fs.parameters)[l];
-                    Expression init_ = new IndexExp(loc, access, new IntegerExp(loc, l, Type.tsize_t));
-                    init_ = init_.expressionSemantic(sc);
-                    assert(init_.type);
-                    declareVariable(p.storageClass, init_.type, cp.ident, init_, null);
+                    // Declare value
+                    if (!declareVariable(p.storageClass, p.type, p.ident, e, t))
+                    {
+                        return returnEarly();
+                    }
+                }
+                else
+                { // expand tuples into multiple `static foreach` variables.
+                    assert(e && !t);
+                    auto ident = Identifier.generateId("__value");
+                    declareVariable(0, e.type, ident, e, null);
+                    import dmd.cond: StaticForeach;
+                    auto field = Identifier.idPool(StaticForeach.tupleFieldName.ptr,StaticForeach.tupleFieldName.length);
+                    Expression access = new DotIdExp(loc, e, field);
+                    access = expressionSemantic(access, sc);
+                    if (!tuple) return returnEarly();
+                    //printf("%s\n",tuple.toChars());
+                    foreach (l; 0 .. dim)
+                    {
+                        auto cp = (*fs.parameters)[l];
+                        Expression init_ = new IndexExp(loc, access, new IntegerExp(loc, l, Type.tsize_t));
+                        init_ = init_.expressionSemantic(sc);
+                        assert(init_.type);
+                        declareVariable(p.storageClass, init_.type, cp.ident, init_, null);
+                    }
                 }
             }
 
@@ -1659,9 +1662,9 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                      *  extern(C) int _aaApply2(void*, in size_t, int delegate(void*, void*))
                      *      _aaApply2(aggr, keysize, flde)
                      */
-                    static __gshared const(char)** name = ["_aaApply", "_aaApply2"];
-                    static __gshared FuncDeclaration* fdapply = [null, null];
-                    static __gshared TypeDelegate* fldeTy = [null, null];
+                    __gshared const(char)** name = ["_aaApply", "_aaApply2"];
+                    __gshared FuncDeclaration* fdapply = [null, null];
+                    __gshared TypeDelegate* fldeTy = [null, null];
 
                     ubyte i = (dim == 2 ? 1 : 0);
                     if (!fdapply[i])
@@ -1703,7 +1706,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     /* Call:
                      *      _aApply(aggr, flde)
                      */
-                    static __gshared const(char)** fntab =
+                    __gshared const(char)** fntab =
                     [
                         "cc", "cw", "cd",
                         "wc", "cc", "wd",

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -67,7 +67,7 @@ struct Target
      */
     extern (C++) struct FPTypeProperties(T)
     {
-        static __gshared
+        __gshared
         {
             real_t max;                         /// largest representable value that's not infinity
             real_t min_normal;                  /// smallest representable normalized value that's not 0

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1033,9 +1033,9 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                 fatal();
             }
 
-            static __gshared FuncDeclaration feq = null;
-            static __gshared FuncDeclaration fcmp = null;
-            static __gshared FuncDeclaration fhash = null;
+            __gshared FuncDeclaration feq = null;
+            __gshared FuncDeclaration fcmp = null;
+            __gshared FuncDeclaration fhash = null;
             if (!feq)
                 feq = search_function(ClassDeclaration.object, Id.eq).isFuncDeclaration();
             if (!fcmp)
@@ -3278,7 +3278,7 @@ private extern(C++) final class DotExpVisitor : Visitor
         }
         if (ident == Id.length)
         {
-            static __gshared FuncDeclaration fd_aaLen = null;
+            __gshared FuncDeclaration fd_aaLen = null;
             if (fd_aaLen is null)
             {
                 auto fparams = new Parameters();
@@ -3353,7 +3353,7 @@ private extern(C++) final class DotExpVisitor : Visitor
 
         bool gagError = flag & 1;
 
-        static __gshared int nest;      // https://issues.dlang.org/show_bug.cgi?id=17380
+        __gshared int nest;      // https://issues.dlang.org/show_bug.cgi?id=17380
 
         static Expression returnExp(Expression e)
         {

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -97,6 +97,9 @@ GENERATED = ../generated
 G = $(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 $(shell mkdir -p $G)
 
+DSCANNER_HASH=3a859d39c4b59822b1bc0452b3ddcd598ef390a2
+DSCANNER_DIR=$G/dscanner-$(DSCANNER_HASH)
+
 ifeq (osx,$(OS))
     export MACOSX_DEPLOYMENT_TARGET=10.9
 endif
@@ -592,6 +595,28 @@ checkwhitespace: $(HOST_DMD_PATH) $(TOOLS_DIR)/checkwhitespace.d
 
 $(TOOLS_DIR)/checkwhitespace.d:
 	git clone --depth=1 ${GIT_HOME}/tools $(TOOLS_DIR)
+
+######################################################
+# DScanner
+######################################################
+
+style: dscanner
+
+$(DSCANNER_DIR):
+	git clone https://github.com/dlang-community/Dscanner $@
+	git -C $@ checkout $(DSCANNER_HASH)
+	git -C $@ submodule update --init --recursive
+
+$(DSCANNER_DIR)/dsc: $(HOST_DMD_PATH) | $(DSCANNER_DIR)
+	# debug build is faster, but disable 'missing import' messages (missing core from druntime)
+	sed 's/dparse_verbose/StdLoggerDisableWarning/' $(DSCANNER_DIR)/makefile > $(DSCANNER_DIR)/dscanner_makefile_tmp
+	mv $(DSCANNER_DIR)/dscanner_makefile_tmp $(DSCANNER_DIR)/makefile
+	DC=$(HOST_DMD_PATH) $(MAKE) -C $(DSCANNER_DIR) githash debug
+
+# runs static code analysis with Dscanner
+dscanner: $(DSCANNER_DIR)/dsc
+	@echo "Running DScanner"
+	$(DSCANNER_DIR)/dsc --config .dscanner.ini --styleCheck dmd -I.
 
 ######################################################
 


### PR DESCRIPTION
- redundant attributes
- redundant if/else
- empty declarations (required as libdparse's parser is a bit more strict.)
- misleading static if, else
 - equivalent assignment
- `const` on `opEquals` or `toHash`
- if constraint indentation

CC @BBasile 