### PR TITLE
Fix Semaphore stable branch detection

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -19,8 +19,7 @@ export OS_NAME=linux
 export FULL_BUILD="${PULL_REQUEST_NUMBER+false}"
 # SemaphoreCI doesn't provide a convenient way to the base branch (e.g. master or stable)
 if [ -n "${PULL_REQUEST_NUMBER:-}" ]; then
-    # detect master/stable without querying the rate-limited API
-    BRANCH="$(git describe --all | sed -E "s/.*\/([^-/]*)-.*/\1/")"
+    BRANCH=$((curl -fsSL https://api.github.com/repos/dlang/dmd/pulls/$PULL_REQUEST_NUMBER || echo) | jq -r '.base.ref')
     # check if the detected branch actually exists and fallback to master
     if ! git ls-remote --exit-code --heads https://github.com/dlang/dmd.git "$BRANCH" > /dev/null ; then
         echo "Invalid branch detected: ${BRANCH} - falling back to master"


### PR DESCRIPTION
The previously used detection didn't work which lead to the current problems of the wrong branch being checked out.

The GitHub API is rate-limited and thus this isn't ideal, but we already use the same workaround for the CircleCI:

https://github.com/dlang/dmd/blob/ecde30e29bbcb0f8205f7fc4be49ea4768f5c376/.circleci/run.sh#L84-L88