### PR TITLE
final_attribute_check: remove useless usage of the final attribute

### DIFF
--- a/src/.dscanner.ini
+++ b/src/.dscanner.ini
@@ -80,7 +80,7 @@ explicitly_annotated_unittests="disabled"
 ; Check for properly documented public functions (Returns, Params)
 properly_documented_public_functions="disabled"
 ; Check for useless usage of the final attribute
-final_attribute_check="disabled"
+final_attribute_check="enabled"
 ; Check for virtual calls in the class constructors
 vcall_in_ctor="enabled"
 ; Check for useless user defined initializers
@@ -116,3 +116,4 @@ redundant_storage_classes="-dmd.id,-dmd.toir,-dmd.tokens"
 trust_too_much="-dmd.root.longdouble"
 builtin_property_names_check="-dmd.backend.obj,-dmd.backend.code,-dmd.backend.cc"
 object_const_check="-dmd.dtemplate,-dmd.backend.outbuf"
+final_attribute_check="-dmd.statement" ; https://github.com/dlang/dmd/pull/856

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -596,7 +596,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
         return buf.extractString();
     }
 
-    override final inout(ProtDeclaration) isProtDeclaration() inout
+    override inout(ProtDeclaration) isProtDeclaration() inout
     {
         return this;
     }
@@ -752,7 +752,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
         return (isunion ? "anonymous union" : "anonymous struct");
     }
 
-    override final inout(AnonDeclaration) isAnonDeclaration() inout
+    override inout(AnonDeclaration) isAnonDeclaration() inout
     {
         return this;
     }
@@ -1061,7 +1061,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
             Dsymbol.arraySyntaxCopy(decl));
     }
 
-    override final bool oneMember(Dsymbol* ps, Identifier ident)
+    override bool oneMember(Dsymbol* ps, Identifier ident)
     {
         // Required to support IFTI on a template that contains a
         // `static foreach` declaration.  `super.oneMember` calls
@@ -1126,7 +1126,7 @@ extern (C++) final class StaticForeachDeclaration : AttribDeclaration
         this.scopesym = sds;
     }
 
-    override final void addComment(const(char)* comment)
+    override void addComment(const(char)* comment)
     {
         // do nothing
         // change this to give semantics to documentation comments on static foreach declarations

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -369,7 +369,7 @@ extern (C++) final class StaticForeach : RootObject
      * to finally expand the `static foreach` using
      * `dmd.statementsem.makeTupleForeach`.
      */
-    final extern(D) void prepare(Scope* sc)
+    extern(D) void prepare(Scope* sc)
     {
         assert(sc);
 
@@ -408,7 +408,7 @@ extern (C++) final class StaticForeach : RootObject
      * Returns:
      *     `true` iff ready to call `dmd.statementsem.makeTupleForeach`.
      */
-    final extern(D) bool ready()
+    extern(D) bool ready()
     {
         return aggrfe && aggrfe.aggr && aggrfe.aggr.type && aggrfe.aggr.type.toBasetype().ty == Ttuple;
     }

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1020,7 +1020,7 @@ private final class CppMangleVisitor : Visitor
      * Params:
      *  t = TypeStruct or TypeEnum
      */
-    final void doSymbol(Type t)
+    void doSymbol(Type t)
     {
         if (substitute(t))
             return;

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -264,7 +264,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
      * Returns:
      *  true if special
      */
-    final bool isSpecial() const nothrow @nogc
+    bool isSpecial() const nothrow @nogc
     {
         return (ident == Id.__c_long ||
                 ident == Id.__c_ulong ||

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -191,7 +191,7 @@ public:
     * Params:
     *  pos           = relative position to encode
     */
-    final void writeBackRef(size_t pos)
+    void writeBackRef(size_t pos)
     {
         buf.writeByte('Q');
         enum base = 26;
@@ -221,7 +221,7 @@ public:
     *  true if the type was found. A back reference has been encoded.
     *  false if the type was not found. The current position is saved for later back references.
     */
-    final bool backrefType(Type t)
+    bool backrefType(Type t)
     {
         if (!t.isTypeBasic())
         {
@@ -249,7 +249,7 @@ public:
     *  true if the identifier was found. A back reference has been encoded.
     *  false if the identifier was not found. The current position is saved for later back references.
     */
-    final bool backrefIdentifier(Identifier id)
+    bool backrefIdentifier(Identifier id)
     {
         auto p = idents.getLvalue(id);
         if (*p)
@@ -261,18 +261,18 @@ public:
         return false;
     }
 
-    final void mangleSymbol(Dsymbol s)
+    void mangleSymbol(Dsymbol s)
     {
         s.accept(this);
     }
 
-    final void mangleType(Type t)
+    void mangleType(Type t)
     {
         if (!backrefType(t))
             t.accept(this);
     }
 
-    final void mangleIdentifier(Identifier id, Dsymbol s)
+    void mangleIdentifier(Identifier id, Dsymbol s)
     {
         if (!backrefIdentifier(id))
             toBuffer(id.toString(), s);
@@ -282,7 +282,7 @@ public:
     /**************************************************
      * Type mangling
      */
-    final void visitWithMask(Type t, ubyte modMask)
+    void visitWithMask(Type t, ubyte modMask)
     {
         if (modMask != t.mod)
         {
@@ -338,7 +338,7 @@ public:
         mangleFuncType(t, t, t.mod, t.next);
     }
 
-    final void mangleFuncType(TypeFunction t, TypeFunction ta, ubyte modMask, Type tret)
+    void mangleFuncType(TypeFunction t, TypeFunction ta, ubyte modMask, Type tret)
     {
         //printf("mangleFuncType() %s\n", t.toChars());
         if (t.inuse && tret)
@@ -456,7 +456,7 @@ public:
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    final void mangleDecl(Declaration sthis)
+    void mangleDecl(Declaration sthis)
     {
         mangleParent(sthis);
         assert(sthis.ident);
@@ -473,7 +473,7 @@ public:
             assert(0);
     }
 
-    final void mangleParent(Dsymbol s)
+    void mangleParent(Dsymbol s)
     {
         Dsymbol p;
         if (TemplateInstance ti = s.isTemplateInstance())
@@ -499,7 +499,7 @@ public:
         }
     }
 
-    final void mangleFunc(FuncDeclaration fd, bool inParent)
+    void mangleFunc(FuncDeclaration fd, bool inParent)
     {
         //printf("deco = '%s'\n", fd.type.deco ? fd.type.deco : "null");
         //printf("fd.type = %s\n", fd.type.toChars());
@@ -530,12 +530,12 @@ public:
     /************************************************************
      * Write length prefixed string to buf.
      */
-    final void toBuffer(const(char)* id, Dsymbol s)
+    void toBuffer(const(char)* id, Dsymbol s)
     {
         toBuffer(id[0 .. strlen(id)], s);
     }
 
-    extern (D) final void toBuffer(const(char)[] id, Dsymbol s)
+    extern (D) void toBuffer(const(char)[] id, Dsymbol s)
     {
         const len = id.length;
         if (buf.offset + len >= 8 * 1024 * 1024) // 8 megs ought be enough for anyone
@@ -672,7 +672,7 @@ public:
         visit(cast(Dsymbol)od);
     }
 
-    final void mangleExact(FuncDeclaration fd)
+    void mangleExact(FuncDeclaration fd)
     {
         assert(!fd.isFuncAliasDeclaration());
         if (fd.mangleOverride)
@@ -742,7 +742,7 @@ public:
             mangleTemplateInstance(ti);
     }
 
-    final void mangleTemplateInstance(TemplateInstance ti)
+    void mangleTemplateInstance(TemplateInstance ti)
     {
         TemplateDeclaration tempdecl = ti.tempdecl.isTemplateDeclaration();
         assert(tempdecl);
@@ -898,7 +898,7 @@ public:
         realToMangleBuffer(e.value);
     }
 
-    final void realToMangleBuffer(real_t value)
+    void realToMangleBuffer(real_t value)
     {
         /* Rely on %A to get portable mangling.
          * Must munge result to get only identifier characters.
@@ -1052,7 +1052,7 @@ public:
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    final void paramsToDecoBuffer(Parameters* parameters)
+    void paramsToDecoBuffer(Parameters* parameters)
     {
         //printf("Parameter.paramsToDecoBuffer()\n");
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4337,7 +4337,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
     }
 
-    final void interfaceSemantic(ClassDeclaration cd)
+    void interfaceSemantic(ClassDeclaration cd)
     {
         cd.vtblInterfaces = new BaseClasses();
         cd.vtblInterfaces.reserve(cd.interfaces.length);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2685,7 +2685,7 @@ extern (C++) final class ArrayLiteralExp : Expression
         return false;
     }
 
-    final Expression getElement(size_t i)
+    Expression getElement(size_t i)
     {
         auto el = (*elements)[i];
         if (!el)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1441,7 +1441,7 @@ extern (C++) class FuncDeclaration : Declaration
      *    which could have come from the function's parameters, mutable
      *    globals, or uplevel functions.
      */
-    private final bool isTypeIsolatedIndirect(Type t)
+    private bool isTypeIsolatedIndirect(Type t)
     {
         //printf("isTypeIsolatedIndirect(t: %s)\n", t.toChars());
         assert(t);

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -74,12 +74,12 @@ nothrow:
         return name;
     }
 
-    extern (D) final const(char)[] toString() const pure
+    extern (D) const(char)[] toString() const pure
     {
         return name[0 .. len];
     }
 
-    final int getValue() const pure
+    int getValue() const pure
     {
         return value;
     }

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2612,7 +2612,7 @@ class Lexer : ErrorHandler
     }
 
 private:
-    final void endOfLine()
+    void endOfLine()
     {
         scanloc.linnum++;
         line = p;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4421,7 +4421,7 @@ extern (C++) final class TypeFunction : TypeNext
      * Returns:
      *  storage class with STC.scope_ or STC.return_ OR'd in
      */
-    final StorageClass parameterStorageClass(Type tthis, Parameter p)
+    StorageClass parameterStorageClass(Type tthis, Parameter p)
     {
         //printf("parameterStorageClass(p: %s)\n", p.toChars());
         auto stc = p.storageClass;
@@ -6404,7 +6404,7 @@ extern (C++) final class Parameter : RootObject
      *  true = `this` can be used in place of `p`
      *  false = nope
      */
-    final bool isCovariant(bool returnByRef, const Parameter p) const pure nothrow @nogc @safe
+    bool isCovariant(bool returnByRef, const Parameter p) const pure nothrow @nogc @safe
     {
         enum stc = STC.ref_ | STC.in_ | STC.out_ | STC.lazy_;
         if ((this.storageClass & stc) != (p.storageClass & stc))

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -96,7 +96,7 @@ extern (C++) final class Nspace : ScopeDsymbol
         return Dsymbol.oneMember(ps, ident);
     }
 
-    override final Dsymbol search(const ref Loc loc, Identifier ident, int flags = SearchLocalsOnly)
+    override Dsymbol search(const ref Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
         //printf("%s.Nspace.search('%s')\n", toChars(), ident.toChars());
         if (_scope && !symtab)

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -121,7 +121,7 @@ struct ObjcSelector
         return lookup(cast(const(char)*)buf.data, buf.size, pcount);
     }
 
-    extern (D) final const(char)[] toString() const pure
+    extern (D) const(char)[] toString() const pure
     {
         return stringvalue[0 .. stringlen];
     }

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1588,7 +1588,7 @@ extern (C++) final class SwitchStatement : Statement
      * Returns:
      *  true if error
      */
-    final bool checkLabel()
+    bool checkLabel()
     {
         /*
          * Checks the scope of a label for existing variable declaration.
@@ -2214,7 +2214,7 @@ extern (C++) final class GotoStatement : Statement
         return new GotoStatement(loc, ident);
     }
 
-    final bool checkLabel()
+    bool checkLabel()
     {
         if (!label.statement)
         {

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -759,7 +759,7 @@ extern (C++) struct Token
      *  ptr = pointer to string
      *  length = length of string
      */
-    final void setString(const(char)* ptr, size_t length)
+    void setString(const(char)* ptr, size_t length)
     {
         auto s = cast(char*)mem.xmalloc(length + 1);
         memcpy(s, ptr, length);
@@ -774,7 +774,7 @@ extern (C++) struct Token
      * Params:
      *  buf = string (not zero terminated)
      */
-    final void setString(const ref OutBuffer buf)
+    void setString(const ref OutBuffer buf)
     {
         setString(cast(const(char)*)buf.data, buf.offset);
     }
@@ -782,7 +782,7 @@ extern (C++) struct Token
     /****
      * Set to empty string
      */
-    final void setString()
+    void setString()
     {
         ustring = "";
         len = 0;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3347,7 +3347,7 @@ private extern(C++) final class DotExpVisitor : Visitor
      *
      * If flag & 1, don't report "not a property" error and just return NULL.
      */
-    final Expression noMember(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
+    Expression noMember(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
     {
         //printf("Type.noMember(e: %s ident: %s flag: %d)\n", e.toChars(), ident.toChars(), flag);
 


### PR DESCRIPTION
A first and simple example on how DScanner can be incrementally used to upgrade DMD's codebase.

The more advanced checks are, of course, more work, though.
However, with `ModuleFilters` list, it can be done on a module-by-module basis.