### PR TITLE
alias_syntax_check: remove uses of the old alias syntax

### DIFF
--- a/src/.dscanner.ini
+++ b/src/.dscanner.ini
@@ -66,7 +66,7 @@ incorrect_infinite_range_check="enabled"
 ; Checks for asserts that are always true
 useless_assert_check="enabled"
 ; Check for uses of the old-style alias syntax
-alias_syntax_check="disabled"
+alias_syntax_check="enabled"
 ; Checks for else if that should be else static if
 static_if_else_check="enabled"
 ; Check for unclear lambda syntax

--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -254,7 +254,7 @@ version (HTOD)
 
 //#include "token.h"
 
-alias uint stflags_t;
+alias stflags_t = uint;
 enum
 {
     PFLpreprocessor  = 1,       // in preprocessor
@@ -278,7 +278,7 @@ enum
     PFLmfc           = 0x10000, // something will affect MFC compatibility
 }
 
-alias char sthflags_t;
+alias sthflags_t = char;
 enum
 {
     FLAG_INPLACE    = 0,       // in place hydration
@@ -417,7 +417,7 @@ enum
 //char symbol_isintab(Symbol *s) { return sytab[s.Sclass] & SCSS; }
 
 //version (Windows)
-    alias char enum_SC;
+    alias enum_SC = char;
 //else
 //    alias SC enum_SC;
 
@@ -428,9 +428,9 @@ enum
  *      in a function. startblock heads the list.
  */
 
-alias void* ClassDeclaration_;
-alias void* Declaration_;
-alias void* Module_;
+alias ClassDeclaration_ = void*;
+alias Declaration_ = void*;
+alias Module_ = void*;
 
 struct Blockx
 {
@@ -454,7 +454,7 @@ struct Blockx
   }
 }
 
-alias ushort bflags_t;
+alias bflags_t = ushort;
 enum
 {
     BFLvisited       = 1,       // set if block is visited
@@ -704,7 +704,7 @@ struct symtab_t
     Symbol **tab;               // local Symbol table
 }
 
-alias uint func_flags_t;
+alias func_flags_t = uint;
 enum
 {
     Fpending    = 1,           // if function has been queued for being written
@@ -739,7 +739,7 @@ enum
     Fsurrogate  = 0x4000000,   // surrogate call function
 }
 
-alias uint func_flags3_t;
+alias func_flags3_t = uint;
 enum
 {
     Fvtblgen         = 1,       // generate vtbl[] when this function is defined
@@ -846,7 +846,7 @@ struct meminit_t
                                 // called for it
 }
 
-alias uint baseclass_flags_t;
+alias baseclass_flags_t = uint;
 enum
 {
      BCFpublic     = 1,         // base class is public
@@ -896,7 +896,7 @@ void baseclass_free(baseclass_t *b) { }
  * For virtual tables.
  */
 
-alias char mptr_flags_t;
+alias mptr_flags_t = char;
 enum
 {
     MPTRvirtual     = 1,       // it's an offset to a virtual base
@@ -1030,7 +1030,7 @@ struct template_t
  * Special information for enums.
  */
 
-alias uint enum_flags_t;
+alias enum_flags_t = uint;
 enum
 {
     SENnotagname  = 1,       // no tag name for enum
@@ -1050,7 +1050,7 @@ struct enum_t
  * Special information for structs.
  */
 
-alias uint struct_flags_t;
+alias struct_flags_t = uint;
 enum
 {
     STRanonymous     = 1,          // set for unions with no tag names
@@ -1541,7 +1541,7 @@ version (MARS)
  *      Psym            SCtemplate for template-template-argument
  */
 
-alias uint pflags_t;
+alias pflags_t = uint;
 enum
 {
     PFexplicit = 1,       // this template argument was explicit, i.e. in < >
@@ -1753,7 +1753,7 @@ extern __gshared EEcontext eecontext;
 
 
 // Different goals for el_optimize()
-alias uint goal_t;
+alias goal_t = uint;
 enum
 {
     GOALnone        = 0,       // evaluate for side effects only

--- a/src/dmd/backend/cgcv.d
+++ b/src/dmd/backend/cgcv.d
@@ -23,7 +23,7 @@ extern (C++):
 @nogc:
 nothrow:
 
-alias LIST* symlist_t;
+alias symlist_t = LIST*;
 
 extern char* ftdbname;
 
@@ -37,7 +37,7 @@ uint cv4_struct(Classsym*, int);
 
 /* =================== Added for MARS compiler ========================= */
 
-alias uint idx_t;        // type of type index
+alias idx_t = uint;        // type of type index
 
 /* Data structure for a type record     */
 

--- a/src/dmd/backend/dlist.d
+++ b/src/dmd/backend/dlist.d
@@ -42,13 +42,13 @@ struct LIST
         }
 }
 
-alias LIST* list_t;             /* pointer to a list entry              */
+alias list_t = LIST*;             /* pointer to a list entry              */
 
 /* FPNULL is a null function pointer designed to be an argument to
  * list_free().
  */
 
-alias void function(void*) @nogc nothrow list_free_fp;
+alias list_free_fp = void function(void*) @nogc nothrow;
 
 enum FPNULL = cast(list_free_fp)null;
 

--- a/src/dmd/backend/dvec.d
+++ b/src/dmd/backend/dvec.d
@@ -23,8 +23,8 @@ extern (C):
 nothrow:
 @nogc:
 
-alias size_t vec_base_t;                     // base type of vector
-alias vec_base_t* vec_t;
+alias vec_base_t = size_t;                     // base type of vector
+alias vec_t = vec_base_t*;
 
 enum VECBITS = vec_base_t.sizeof * 8;        // # of bits per entry
 enum VECMASK = VECBITS - 1;                  // mask for bit position

--- a/src/dmd/backend/el.d
+++ b/src/dmd/backend/el.d
@@ -26,13 +26,13 @@ nothrow:
 
 /* Routines to handle elems.                            */
 
-alias ubyte eflags_t;
+alias eflags_t = ubyte;
 enum
 {
     EFLAGS_variadic = 1,   // variadic function call
 }
 
-alias uint pef_flags_t;
+alias pef_flags_t = uint;
 enum
 {
     PEFnotlvalue    = 1,       // although elem may look like
@@ -44,7 +44,7 @@ enum
     PEFmember       = 0x100,   // was a class member access
 }
 
-alias ubyte nflags_t;
+alias nflags_t = ubyte;
 enum
 {
     NFLli     = 1,     // loop invariant

--- a/src/dmd/backend/iasm.d
+++ b/src/dmd/backend/iasm.d
@@ -169,7 +169,7 @@ else
 // Operand flags - usOp1, usOp2, usOp3
 //
 
-alias uint opflag_t;
+alias opflag_t = uint;
 
 // Operand flags for normal opcodes
 enum

--- a/src/dmd/backend/oper.d
+++ b/src/dmd/backend/oper.d
@@ -17,7 +17,7 @@ extern (C++):
 @nogc:
 nothrow:
 
-alias int OPER;
+alias OPER = int;
 enum
 {
         OPunde,                 // place holder for undefined operator


### PR DESCRIPTION
Yet another low-hanging DScanner fruit.