### PR TITLE
Test with gdc-7 and gdc-8

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -158,17 +158,17 @@ download_install_sh() {
 
 install_d() {
   if [ "${DMD:-dmd}" == "gdc" ] || [ "${DMD:-dmd}" == "gdmd" ] ; then
-    export DMD=gdmd-8
-    if [ ! -e ~/dlang/gdc-8/activate ] ; then
+    export DMD=gdmd-${GDC_VERSION}
+    if [ ! -e ~/dlang/gdc-${GDC_VERSION}/activate ] ; then
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         sudo apt-get update
-        sudo apt-get install -y gdc-8
+        sudo apt-get install -y gdc-${GDC_VERSION}
         # fetch the dmd-like wrapper
-        sudo wget https://raw.githubusercontent.com/D-Programming-GDC/GDMD/master/dmd-script -O /usr/bin/gdmd-8
-        sudo chmod +x /usr/bin/gdmd-8
+        sudo wget https://raw.githubusercontent.com/D-Programming-GDC/GDMD/master/dmd-script -O /usr/bin/gdmd-${GDC_VERSION}
+        sudo chmod +x /usr/bin/gdmd-${GDC_VERSION}
         # fake install script and create a fake 'activate' script
-        mkdir -p ~/dlang/gdc-8
-        echo "deactivate(){ echo;}" > ~/dlang/gdc-8/activate
+        mkdir -p ~/dlang/gdc-${GDC_VERSION}
+        echo "deactivate(){ echo;}" > ~/dlang/gdc-${GDC_VERSION}/activate
     fi
   else
     local install_sh="install.sh"


### PR DESCRIPTION
See also:
- https://github.com/D-Programming-GDC/GDC/pull/704#issuecomment-410694849
- https://github.com/dlang/dmd/pull/8540 (recent removal of in contracts in DMD for GDC-7 support)

CC @ibuclaw

I already configured another gdc-7 job at SemaphoreCI.
With the free plan we can only run four jobs in parallel, but this seems to be important to the GDC project and also the long-term plan is to migrate all SemaphoreCI tests to Buildkite runners (e.g. https://github.com/dlang/ci/pull/261) where we can just arbitrarily (and cheaply!) add new runners (we already have ten agents there).

I know that this way of hacking with the Ubuntu PPA isn't ideal, but as long as the install.sh doesn't support newer GDC binaries, this is an easy workaround.