### PR TITLE
Add FreeBSDxx version identifiers.

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1303,6 +1303,20 @@ void addDefaultVersionIdentifiers()
         VersionCondition.addPredefinedGlobalIdent("FreeBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
         global.params.isFreeBSD = true;
+
+        import core.sys.posix.sys.utsname : uname, utsname;
+        utsname utsn;
+        if (uname(&utsn) == 0)
+        {
+            foreach (i, c; utsn.release)
+            {
+                if (c >= '0' && c <= '9')
+                    continue;
+                if (c == '.')
+                    VersionCondition.addPredefinedGlobalIdent("FreeBSD" ~ utsn.release[0 .. i]);
+                break;
+            }
+        }
     }
     else static if (TARGET.OpenBSD)
     {


### PR DESCRIPTION
On FreeBSD, this adds a version identifer corresponding to the major OS
version that the code is currently being compiled on (e.g. FreeBSD11 for
FreeBSD 11.x or FreeBSD12 for FreeBSD 12.x). This will make it possible
to version the druntime OS bindings based on the OS version, which is
not currently possible in spite of the fact that the actual C
definitions sometimes change from OS version to OS version.

This is particularly critical for the transition from FreeBSD 11 to
FreeBSD 12, since several, very important types related to file
operations had their definitions changed in incompatible ways, making it
so that it's not possible to use the same bindings for both OS versions,
which will make transitioning to supporting FreeBSD 12 difficult and
error-prone. Even if we only want to officially support the latest
release of FreeBSD, it will be much easier to deal with changes between
versions if in the cases where they don't match, we can version the
bindings according to the version of FreeBSD they go with rather than
being stuck with only one version of the bindings.

Without version identifers for specific OS versions (or a similar
mechanism that can be used to differentiate bindings based on the OS
version), we're stuck having dmd, druntime, and Phobos being tied to a
specific OS version, whereas C/C++ does not have this problem. We have
usually gotten away with this thanks to the fact that most OS API
symbols do not change often, but it does sometimes bite us, and at least
in the case of FreeBSD, this is easily remedied, because FreeBSD has
very clearcut version numbers which are easily fetched with uname, and
FreeBSD normally maintains ABI and API compatibility across all minor
versions within a major version.

This change relates to https://issues.dlang.org/show_bug.cgi?id=17596,
though druntime will need to be updated with versioned bindings to
actually fix the bug. These changes simply make that possible.