### PR TITLE
Refactor and document ensurePathExists

### DIFF
--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -95,7 +95,7 @@ extern (C++) void ensurePathToNameExists(Loc loc, const(char)* name)
     const(char)* pt = FileName.path(name);
     if (*pt)
     {
-        if (FileName.ensurePathExists(pt))
+        if (!FileName.ensurePathExists(pt))
         {
             error(loc, "cannot create directory %s", pt);
             fatal();


### PR DESCRIPTION
```
- Use early returns
- add DDOC and comments
- return `false` on failure, not `true`
```