### PR TITLE
Turn globals.argv0 into a DArray

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -79,11 +79,7 @@ string findDMDConfig(const(char)[] dmdFilePath)
     import dmd.dinifile : findConfFile;
     import std.string : fromStringz, toStringz;
 
-    auto f = findConfFile(dmdFilePath.toStringz, "dmd.conf");
-    if (f is null)
-        return null;
-
-    return f.fromStringz.idup;
+    return findConfFile(dmdFilePath, "dmd.conf").idup;
 }
 
 /**

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -173,7 +173,7 @@ struct Param
 
     uint errorLimit = 20;
 
-    const(char)* argv0;                 // program name
+    const(char)[] argv0;                // program name
     Array!(const(char)*)* modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array!(const(char)*)* imppath;      // array of char*'s of where to look for import modules
     Array!(const(char)*)* fileImppath;  // array of char*'s of where to look for file import modules

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -140,7 +140,7 @@ struct Param
 
     unsigned errorLimit;
 
-    const char *argv0;    // program name
+    DArray<const char>  argv0;    // program name
     Array<const char *> *modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array<const char *> *imppath;     // array of char*'s of where to look for import modules
     Array<const char *> *fileImppath; // array of char*'s of where to look for file import modules

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -22,6 +22,7 @@ import dmd.root.rootobject;
 import dmd.root.stringtable;
 import dmd.tokens;
 import dmd.utf;
+import dmd.utils;
 
 
 /***********************************************************
@@ -169,9 +170,8 @@ nothrow:
         import dmd.root.filename: absPathThen;
 
         // see below for why we use absPathThen
-        return loc.filename.absPathThen!((absPath)
+        return loc.filename.toDString().absPathThen!((absPath)
         {
-
             // this block generates the "regular" identifier, i.e. if there are no collisions
             OutBuffer idBuf;
             idBuf.writestring(prefix);
@@ -197,13 +197,13 @@ nothrow:
             if (absPath)
             {
                 // replace characters that demangle can't handle
-                for (auto ptr = absPath; *ptr != '\0'; ++ptr)
+                foreach (ref c; absPath)
                 {
                     // see dmd.dmangle.isValidMangling
                     // Unfortunately importing it leads to either build failures or cyclic dependencies
                     // between modules.
-                    if (*ptr == '/' || *ptr == '\\' || *ptr == '.' || *ptr == '?' || *ptr == ':')
-                        *ptr = '_';
+                    if (c == '/' || c == '\\' || c == '.' || c == '?' || c == ':')
+                        c = '_';
                 }
 
                 fullPathIdBuf.writestring(absPath);

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -922,7 +922,7 @@ public:
     {
         objectStart();
         requiredProperty("cwd", getcwd(null, 0).toDString);
-        requiredProperty("argv0", global.params.argv0.toDString);
+        requiredProperty("argv0", global.params.argv0);
         requiredProperty("config", global.inifilename.toDString);
         requiredProperty("libName", global.params.libname.toDString);
 

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1056,8 +1056,8 @@ version (Windows)
 
             // search PATH to avoid createProcess preferring "link.exe" from the dmd folder
             Strings* paths = FileName.splitPath(getenv("PATH"));
-            if (auto p = FileName.searchPath(paths, "link.exe", false))
-                return p;
+            if (auto p = FileName.searchPath(paths, "link.exe"[], false))
+                return p.ptr;
             return "link.exe";
         }
 
@@ -1359,8 +1359,8 @@ version (Windows)
 
             // try mingw fallback relative to phobos library folder that's part of LIB
             Strings* libpaths = FileName.splitPath(getenv("LIB"));
-            if (auto p = FileName.searchPath(libpaths, r"mingw\kernel32.lib", false))
-                return FileName.path(p);
+            if (auto p = FileName.searchPath(libpaths, r"mingw\kernel32.lib"[], false))
+                return FileName.path(p).ptr;
 
             return null;
         }

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -824,16 +824,15 @@ version (Windows)
 {
     private int executearg0(const(char)* cmd, const(char)* args)
     {
-        const(char)* file;
-        const(char)* argv0 = global.params.argv0;
+        const argv0 = global.params.argv0;
         //printf("argv0='%s', cmd='%s', args='%s'\n",argv0,cmd,args);
         // If cmd is fully qualified, we don't do this
         if (FileName.absolute(cmd))
             return -1;
-        file = FileName.replaceName(argv0, cmd);
+        const file = FileName.replaceName(argv0, cmd.toDString);
         //printf("spawning '%s'\n",file);
         // spawnlp returns intptr_t in some systems, not int
-        return spawnl(0, file, file, args, null);
+        return spawnl(0, file.ptr, file.ptr, args, null);
     }
 }
 
@@ -1049,9 +1048,9 @@ version (Windows)
             char[MAX_PATH + 1] dmdpath = void;
             if (GetModuleFileNameA(null, dmdpath.ptr, dmdpath.length) <= MAX_PATH)
             {
-                auto lldpath = FileName.replaceName(dmdpath.ptr, "lld-link.exe");
+                auto lldpath = FileName.replaceName(dmdpath, "lld-link.exe");
                 if (FileName.exists(lldpath))
-                    return lldpath;
+                    return lldpath.ptr;
             }
 
             // search PATH to avoid createProcess preferring "link.exe" from the dmd folder

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -218,7 +218,7 @@ private int tryMain(size_t argc, const(char)** argv)
     //for (size_t i = 0; i < arguments.dim; ++i) printf("arguments[%d] = '%s'\n", i, arguments[i]);
     files.reserve(arguments.dim - 1);
     // Set default values
-    global.params.argv0 = arguments[0];
+    global.params.argv0 = arguments[0].toDString;
 
     // Temporary: Use 32 bits as the default on Windows, for config parsing
     static if (TARGET.Windows)
@@ -235,11 +235,11 @@ private int tryMain(size_t argc, const(char)** argv)
     {
         version (Windows)
         {
-            global.inifilename = findConfFile(global.params.argv0, "sc.ini");
+            global.inifilename = findConfFile(global.params.argv0, "sc.ini").ptr;
         }
         else version (Posix)
         {
-            global.inifilename = findConfFile(global.params.argv0, "dmd.conf");
+            global.inifilename = findConfFile(global.params.argv0, "dmd.conf").ptr;
         }
         else
         {
@@ -1415,7 +1415,7 @@ private void printPredefinedVersions(FILE* stream)
 
 extern(C) void printGlobalConfigs(FILE* stream)
 {
-    stream.fprintf("binary    %s\n", global.params.argv0);
+    stream.fprintf("binary    %.*s\n", global.params.argv0.length, global.params.argv0.ptr);
     stream.fprintf("version   %s\n", global._version);
     stream.fprintf("config    %s\n", global.inifilename ? global.inifilename : "(none)");
     // Print DFLAGS environment variable

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -20,6 +20,7 @@ import core.sys.posix.unistd;
 import core.sys.windows.windows;
 import dmd.root.filename;
 import dmd.root.rmem;
+import dmd.utils;
 
 /***********************************************************
  */
@@ -199,8 +200,8 @@ nothrow:
 
             // work around Windows file path length limitation
             // (see documentation for extendedPathThen).
-            HANDLE h = name.extendedPathThen!
-                (p => CreateFileW(p,
+            HANDLE h = name.toDString.extendedPathThen!
+                (p => CreateFileW(p.ptr,
                                   GENERIC_READ,
                                   FILE_SHARE_READ,
                                   null,
@@ -274,8 +275,8 @@ nothrow:
             const(char)* name = this.name.toChars();
             // work around Windows file path length limitation
             // (see documentation for extendedPathThen).
-            HANDLE h = name.extendedPathThen!
-                (p => CreateFileW(p,
+            HANDLE h = name.toDString.extendedPathThen!
+                (p => CreateFileW(p.ptr,
                                   GENERIC_WRITE,
                                   0,
                                   null,

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -320,12 +320,6 @@ nothrow:
     /**************************************
      * Replace filename portion of path.
      */
-    extern (C++) static const(char)* replaceName(const(char)* path, const(char)* name)
-    {
-        return replaceName(path[0 .. strlen(path)], name[0 .. strlen(name)]).ptr;
-    }
-
-    /// Ditto
     extern (D) static const(char)[] replaceName(const(char)[] path, const(char)[] name)
     {
         if (absolute(name))

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -279,30 +279,42 @@ nothrow:
      */
     extern (C++) static const(char)* path(const(char)* str)
     {
-        const(char)* n = name(str);
-        size_t pathlen;
-        if (n > str)
+        return path(str.toDString).ptr;
+    }
+
+    /// Ditto
+    extern (D) static const(char)[] path(const(char)[] str)
+    {
+        const n = name(str);
+        bool hasTrailingSlash;
+        if (n.length < str.length)
         {
             version (Posix)
             {
-                if (n[-1] == '/')
-                    n--;
+                if (str[$ - n.length - 1] == '/')
+                    hasTrailingSlash = true;
             }
             else version (Windows)
             {
-                if (n[-1] == '\\' || n[-1] == '/')
-                    n--;
+                if (str[$ - n.length - 1] == '\\' || str[$ - n.length - 1] == '/')
+                    hasTrailingSlash = true;
             }
             else
             {
                 assert(0);
             }
         }
-        pathlen = n - str;
+        const pathlen = str.length - n.length - (hasTrailingSlash ? 1 : 0);
         char* path = cast(char*)mem.xmalloc(pathlen + 1);
-        memcpy(path, str, pathlen);
+        memcpy(path, str.ptr, pathlen);
         path[pathlen] = 0;
-        return path;
+        return path[0 .. pathlen];
+    }
+
+    unittest
+    {
+        assert(path("/foo/bar"[]) == "/foo");
+        assert(path("foo"[]) == "");
     }
 
     /**************************************

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -511,14 +511,30 @@ nothrow:
             return defaultExt(name, ext); // doesn't have one
     }
 
+    /// Returns:
+    ///   `true` if `name`'s extension is `ext`
     extern (C++) static bool equalsExt(const(char)* name, const(char)* ext) pure
     {
-        const(char)* e = FileName.ext(name);
-        if (!e && !ext)
+        return equalsExt(name.toDString, ext.toDString);
+    }
+
+    /// Ditto
+    extern (D) static bool equalsExt(const(char)[] name, const(char)[] ext) pure
+    {
+        auto e = FileName.ext(name);
+        if (!e.length && !ext.length)
             return true;
-        if (!e || !ext)
+        if (!e.length || !ext.length)
             return false;
         return FileName.equals(e, ext);
+    }
+
+    unittest
+    {
+        assert(!equalsExt("foo.bar"[], "d"));
+        assert(equalsExt("foo.bar"[], "bar"));
+        assert(equalsExt("object.d"[], "d"));
+        assert(!equalsExt("object"[], "d"));
     }
 
     /******************************

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -510,18 +510,31 @@ nothrow:
      */
     extern (C++) static const(char)* forceExt(const(char)* name, const(char)* ext)
     {
-        const(char)* e = FileName.ext(name);
-        if (e) // if already has an extension
+        return forceExt(name.toDString, ext.toDString).ptr;
+    }
+
+    /// Ditto
+    extern (D) static const(char)[] forceExt(const(char)[] name, const(char)[] ext)
+    {
+        auto e = FileName.ext(name);
+        if (e.length) // if already has an extension
         {
-            size_t len = e - name;
-            size_t extlen = strlen(ext);
-            char* s = cast(char*)mem.xmalloc(len + extlen + 1);
-            memcpy(s, name, len);
-            memcpy(s + len, ext, extlen + 1);
-            return s;
+            const len = name.length - e.length;
+            char* s = cast(char*)mem.xmalloc(len + ext.length + 1);
+            memcpy(s, name.ptr, len);
+            memcpy(s + len, ext.ptr, ext.length);
+            s[len + ext.length] = '\0';
+            return s[0 .. len + ext.length];
         }
         else
             return defaultExt(name, ext); // doesn't have one
+    }
+
+    unittest
+    {
+        assert(forceExt("/foo/object.d"[], "d") == "/foo/object.d");
+        assert(forceExt("/foo/object"[], "d") == "/foo/object.d");
+        assert(forceExt("/foo/bar.d"[], "o") == "/foo/bar.o");
     }
 
     /// Returns:

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -322,39 +322,18 @@ nothrow:
      */
     extern (C++) static const(char)* replaceName(const(char)* path, const(char)* name)
     {
-        size_t pathlen;
-        size_t namelen;
+        return replaceName(path[0 .. strlen(path)], name[0 .. strlen(name)]).ptr;
+    }
+
+    /// Ditto
+    extern (D) static const(char)[] replaceName(const(char)[] path, const(char)[] name)
+    {
         if (absolute(name))
             return name;
-        const(char)* n = FileName.name(path);
+        auto n = FileName.name(path);
         if (n == path)
             return name;
-        pathlen = n - path;
-        namelen = strlen(name);
-        char* f = cast(char*)mem.xmalloc(pathlen + 1 + namelen + 1);
-        memcpy(f, path, pathlen);
-        version (Posix)
-        {
-            if (path[pathlen - 1] != '/')
-            {
-                f[pathlen] = '/';
-                pathlen++;
-            }
-        }
-        else version (Windows)
-        {
-            if (path[pathlen - 1] != '\\' && path[pathlen - 1] != '/' && path[pathlen - 1] != ':')
-            {
-                f[pathlen] = '\\';
-                pathlen++;
-            }
-        }
-        else
-        {
-            assert(0);
-        }
-        memcpy(f + pathlen, name, namelen + 1);
-        return f;
+        return combine(path[0 .. $ - n.length], name);
     }
 
     /**

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -480,16 +480,29 @@ nothrow:
      */
     extern (C++) static const(char)* defaultExt(const(char)* name, const(char)* ext)
     {
-        const(char)* e = FileName.ext(name);
-        if (e) // if already has an extension
-            return mem.xstrdup(name);
-        size_t len = strlen(name);
-        size_t extlen = strlen(ext);
-        char* s = cast(char*)mem.xmalloc(len + 1 + extlen + 1);
-        memcpy(s, name, len);
-        s[len] = '.';
-        memcpy(s + len + 1, ext, extlen + 1);
-        return s;
+        return defaultExt(name.toDString, ext.toDString).ptr;
+    }
+
+    /// Ditto
+    extern (D) static const(char)[] defaultExt(const(char)[] name, const(char)[] ext)
+    {
+        auto e = FileName.ext(name);
+        if (e.length) // it already has an extension
+            return mem.xstrdup(name.ptr)[0 .. name.length];
+        const s_length = name.length + 1 + ext.length + 1;
+        auto s = cast(char*)mem.xmalloc(s_length);
+        memcpy(s, name.ptr, name.length);
+        s[name.length] = '.';
+        memcpy(s + name.length + 1, ext.ptr, ext.length);
+        s[s_length - 1] = '\0';
+        return s[0 .. s_length - 1];
+    }
+
+    unittest
+    {
+        assert(defaultExt("/foo/object.d"[], "d") == "/foo/object.d");
+        assert(defaultExt("/foo/object"[], "d") == "/foo/object.d");
+        assert(defaultExt("/foo/bar.d"[], "o") == "/foo/bar.d");
     }
 
     /***************************

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -640,12 +640,26 @@ nothrow:
         }
     }
 
+    /**
+       Check if the file the `path` points to exists
+
+       Returns:
+         0 if it does not exists
+         1 if it exists and is not a directory
+         2 if it exists and is a directory
+     */
     extern (C++) static int exists(const(char)* name)
+    {
+        return exists(name.toDString);
+    }
+
+    /// Ditto
+    extern (D) static int exists(const(char)[] name)
     {
         version (Posix)
         {
             stat_t st;
-            if (stat(name, &st) < 0)
+            if (name.toCStringThen!((v) => stat(v.ptr, &st)) < 0)
                 return 0;
             if (S_ISDIR(st.st_mode))
                 return 2;
@@ -653,7 +667,7 @@ nothrow:
         }
         else version (Windows)
         {
-            return name.toWStringzThen!((wname)
+            return name.toCStringThen!((cstr) => cstr.toWStringzThen!((wname)
             {
                 const dw = GetFileAttributesW(&wname[0]);
                 if (dw == -1)
@@ -662,7 +676,7 @@ nothrow:
                     return 2;
                 else
                     return 1;
-            });
+            }));
         }
         else
         {
@@ -719,7 +733,7 @@ nothrow:
         }
 
         version (Windows)
-            const r = _mkdir(path);
+            const r = _mkdir(path.toDString);
         version (Posix)
         {
             errno = 0;

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -136,34 +136,44 @@ nothrow:
      */
     extern (C++) static const(char)* ext(const(char)* str) pure
     {
-        size_t len = strlen(str);
-        const(char)* e = str + len;
-        for (;;)
+        return ext(str.toDString).ptr;
+    }
+
+    /// Ditto
+    extern (D) static const(char)[] ext(const(char)[] str) nothrow pure @safe @nogc
+    {
+        foreach_reverse (idx, char e; str)
         {
-            switch (*e)
+            switch (e)
             {
             case '.':
-                return e + 1;
-                version (Posix)
-                {
-                case '/':
-                    break;
-                }
-                version (Windows)
-                {
-                case '\\':
-                case ':':
-                case '/':
-                    break;
-                }
+                return str[idx + 1 .. $];
+            version (Posix)
+            {
+            case '/':
+                return null;
+            }
+            version (Windows)
+            {
+            case '\\':
+            case ':':
+            case '/':
+                return null;
+            }
             default:
-                if (e == str)
-                    break;
-                e--;
                 continue;
             }
-            return null;
         }
+        return null;
+    }
+
+    unittest
+    {
+        assert(ext("/foo/bar/dmd.conf"[]) == "conf");
+        assert(ext("object.o"[]) == "o");
+        assert(ext("/foo/bar/dmd"[]) == null);
+        assert(ext(".objdir.o/object"[]) == null);
+        assert(ext([]) == null);
     }
 
     extern (C++) const(char)* ext() const pure

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -225,46 +225,52 @@ nothrow:
      */
     extern (C++) static const(char)* name(const(char)* str) pure
     {
-        size_t len = strlen(str);
-        const(char)* e = str + len;
-        for (;;)
+        return name(str.toDString).ptr;
+    }
+
+    /// Ditto
+    extern (D) static const(char)[] name(const(char)[] str) pure
+    {
+        foreach_reverse (idx, char e; str)
         {
-            switch (*e)
+            switch (e)
             {
                 version (Posix)
                 {
                 case '/':
-                    return e + 1;
+                    return str[idx + 1 .. $];
                 }
                 version (Windows)
                 {
                 case '/':
                 case '\\':
-                    return e + 1;
+                    return str[idx + 1 .. $];
                 case ':':
                     /* The ':' is a drive letter only if it is the second
                      * character or the last character,
                      * otherwise it is an ADS (Alternate Data Stream) separator.
                      * Consider ADS separators as part of the file name.
                      */
-                    if (e == str + 1 || e == str + len - 1)
-                        return e + 1;
-                    goto default;
+                    if (idx == 1 || idx == str.length - 1)
+                        return str[idx + 1 .. $];
+                    break;
                 }
             default:
-                if (e == str)
-                    break;
-                e--;
-                continue;
+                break;
             }
-            return e;
         }
-        assert(0);
+        return str;
     }
 
     extern (C++) const(char)* name() const pure
     {
         return name(str);
+    }
+
+    unittest
+    {
+        assert(name("/foo/bar/object.d"[]) == "object.d");
+        assert(name("/foo/bar/frontend.di"[]) == "frontend.di");
     }
 
     /**************************************

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -81,18 +81,34 @@ nothrow:
      */
     extern (C++) static bool absolute(const(char)* name) pure
     {
+        return absolute(name.toDString);
+    }
+
+    /// Ditto
+    extern (D) static bool absolute(const(char)[] name) pure
+    {
+        if (!name.length)
+            return false;
+
         version (Windows)
         {
-            return (*name == '\\') || (*name == '/') || (*name && name[1] == ':');
+            return (name[0] == '\\') || (name[0] == '/')
+                || (name.length >= 2 && name[1] == ':');
         }
         else version (Posix)
         {
-            return (*name == '/');
+            return (name[0] == '/');
         }
         else
         {
             assert(0);
         }
+    }
+
+    unittest
+    {
+        assert(absolute("/"[]) == true);
+        assert(absolute(""[]) == false);
     }
 
     /**

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -183,23 +183,41 @@ nothrow:
 
     /********************************
      * Return file name without extension.
+     *
+     * TODO:
+     * Once slice are used everywhere and `\0` is not assumed,
+     * this can be turned into a simple slicing.
+     *
      * Params:
      *  str = file name
+     *
      * Returns:
      *  mem.xmalloc'd filename with extension removed.
      */
     extern (C++) static const(char)* removeExt(const(char)* str)
     {
-        const(char)* e = ext(str);
-        if (e)
+        return removeExt(str.toDString).ptr;
+    }
+
+    /// Ditto
+    extern (D) static const(char)[] removeExt(const(char)[] str)
+    {
+        auto e = ext(str);
+        if (e.length)
         {
-            size_t len = (e - str) - 1;
+            const len = (str.length - e.length) - 1; // -1 for the dot
             char* n = cast(char*)mem.xmalloc(len + 1);
-            memcpy(n, str, len);
+            memcpy(n, str.ptr, len);
             n[len] = 0;
-            return n;
+            return n[0 .. len];
         }
-        return mem.xstrdup(str);
+        return mem.xstrdup(str.ptr)[0 .. str.length];
+    }
+
+    unittest
+    {
+        assert(removeExt("/foo/bar/object.d"[]) == "/foo/bar/object");
+        assert(removeExt("/foo/bar/frontend.di"[]) == "/foo/bar/frontend");
     }
 
     /********************************

--- a/src/dmd/root/filename.h
+++ b/src/dmd/root/filename.h
@@ -29,7 +29,6 @@ struct FileName
     static const char *name(const char *);
     const char *name();
     static const char *path(const char *);
-    static const char *replaceName(const char *path, const char *name);
 
     static const char *combine(const char *path, const char *name);
     static Strings *splitPath(const char *path);

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -135,7 +135,7 @@ extern (C++) void escapePath(OutBuffer* buf, const(char)* fname)
 }
 
 /// Slices a `\0`-terminated C-string, excluding the terminator
-const(char)[] toDString (const(char)* s) pure nothrow @nogc
+inout(char)[] toDString (inout(char)* s) pure nothrow @nogc
 {
     return s ? s[0 .. strlen(s)] : null;
 }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -464,7 +464,7 @@ $G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/backend.a $G/lexer.a $(STRING
 	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT) $G/dmd.conf,$^)
 endif
 
-$G/dmd-unittest: $(DMD_SRCS) $(ROOT_SRCS) $G/newdelete.o $G/lexer.a $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
+$G/dmd-unittest: $(DMD_SRCS) $(ROOT_SRCS) $(LEXER_SRCS) $G/newdelete.o $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
 	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) -g -unittest -main -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
 
 unittest: $G/dmd-unittest


### PR DESCRIPTION
This is a step towards converting `globals` to use D array.

There is currently no way to call a function accepting a D string from C++ (thanks to ABI issues on i386 / Win64) but it does not matter for `globals` AFAICS.
So I resorted to providing trivial C++ wrapper to the D functions, and gradually removing the wrapper as they become unused, as can be seen in filename.