### PR TITLE
Fix Issue 19180 - Expose dmd.mtype.Type.isZeroInit as __traits(isZeroInit, T)

### DIFF
--- a/changelog/isZeroInit.dd
+++ b/changelog/isZeroInit.dd
@@ -1,0 +1,32 @@
+Expose `__traits(isZeroInit, T)`
+
+Takes one argument which must be a type. If the type's
+$(DDSUBLINK spec/property, init, default initializer) has no non-zero
+bits then `true` is returned, otherwise `false`. `isZeroInit` will
+always return `true` for a class `C` because `C.init` is a null
+reference.
+
+This property was already being computed internally by the compiler
+so exposing it via `__traits` is more efficient than re-implementing
+it in library code.
+
+---
+struct S1
+{
+    int x;
+}
+
+struct S2
+{
+    int x = -1;
+}
+
+static assert(__traits(isZeroInit, S1));
+static assert(!__traits(isZeroInit, S2));
+
+void test()
+{
+    int x = 3;
+    static assert(__traits(isZeroInit, typeof(x)));
+}
+---

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -403,6 +403,7 @@ immutable Msgtable[] msgtable =
     { "getVirtualIndex" },
     { "getPointerBitmap" },
     { "isReturnOnStack" },
+    { "isZeroInit" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -147,9 +147,10 @@ shared static this()
         "getUnitTests",
         "getVirtualIndex",
         "getPointerBitmap",
+        "isZeroInit",
     ];
 
-    traitsStringTable._init(40);
+    traitsStringTable._init(48);
 
     foreach (s; names)
     {
@@ -1729,6 +1730,23 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
     if (e.ident == Id.getPointerBitmap)
     {
         return pointerBitmap(e);
+    }
+    if (e.ident == Id.isZeroInit)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        auto o = (*e.args)[0];
+        Type t = isType(o);
+        if (!t)
+        {
+            e.error("type expected as second argument of __traits `%s` instead of `%s`",
+                e.ident.toChars(), o.toChars());
+            return new ErrorExp();
+        }
+
+        Type tb = t.baseElemOf();
+        return tb.isZeroInit(e.loc) ? True() : False();
     }
 
     extern (D) void* trait_search_fp(const(char)* seed, ref int cost)

--- a/test/compilable/isZeroInit.d
+++ b/test/compilable/isZeroInit.d
@@ -1,0 +1,78 @@
+alias AliasSeq(T...) = T;
+
+struct Holder(T, ubyte val)
+{
+    T x = val;
+}
+
+struct SArrayHolder(T, ubyte val)
+{
+    T[2] x = val;
+}
+
+static foreach (T; AliasSeq!(bool, byte, short, int, long,
+                             ubyte, ushort, uint, ulong,
+                             char, wchar, dchar,
+                             float, double, real))
+{
+    static assert(__traits(isZeroInit, T) == (T.init is T(0)));
+    static assert(__traits(isZeroInit, T[2]) == (T.init is T(0)));
+
+    static assert(!__traits(isZeroInit, Holder!(T, 1)));
+    static assert(__traits(isZeroInit, Holder!(T, 0)));
+
+    static assert(__traits(isZeroInit, SArrayHolder!(T, 0)));
+    static assert(!__traits(isZeroInit, SArrayHolder!(T, 1)));
+
+}
+
+static assert(__traits(isZeroInit, void)); // For initializing arrays of element type `void`.
+static assert(__traits(isZeroInit, void*));
+static assert(__traits(isZeroInit, void[]));
+static assert(__traits(isZeroInit, float[]));
+static assert(__traits(isZeroInit, Object));
+class C1 : Object
+{
+    int x = 1;
+}
+static assert(__traits(isZeroInit, C1)); // An Object's fields are irrelevant.
+
+struct S1
+{
+    int[] a;
+    int b;
+}
+static assert(__traits(isZeroInit, S1));
+
+struct S2
+{
+    alias H = Holder!(int, 1);
+    H h;
+    int a;
+}
+static assert(!__traits(isZeroInit, S2));
+
+struct S3
+{
+    S1 h;
+    float f = 0;
+}
+static assert(__traits(isZeroInit, S3));
+
+struct S4
+{
+    S2 h = S2(S2.H(0), 0);
+    int a;
+}
+static assert(__traits(isZeroInit, S4));
+
+struct S5
+{
+    Object o = null;
+}
+static assert(__traits(isZeroInit, S5));
+
+version(D_SIMD):
+import core.simd : int4;
+static assert(__traits(isZeroInit, Holder!(int4, 0)));
+static assert(!__traits(isZeroInit, Holder!(int4, 1)));

--- a/test/fail_compilation/fail_isZeroInit.d
+++ b/test/fail_compilation/fail_isZeroInit.d
@@ -1,0 +1,12 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_isZeroInit.d(11): Error: type expected as second argument of __traits `isZeroInit` instead of `a`
+---
+*/
+void test()
+{
+    int a = 3;
+    // Providing a specific variable rather than a type isn't allowed.
+    enum bool az = __traits(isZeroInit, a);
+}


### PR DESCRIPTION
It's useful to identify at compile time types with 0 initializers. Doing this with CTFE and templates is slow and memory-hungry[1] and runs into errors[2][3]. The compiler already has its own check for this that we can expose instead.

Proposed syntax is `__traits(isZeroInit, T)` where the second argument must resolve to the type T itself instead of being any expression whose result is an instance of T. This would be to prevent someone from mistakenly thinking he can use `__traits(isInitZero, x)` to test whether some variable `x` was explicitly initialized as zero.

[1] https://github.com/dlang/phobos/pull/6537
[2] https://github.com/dlang/phobos/pull/6670#issuecomment-414111649
[3] https://github.com/dlang/phobos/pull/6461