### PR TITLE
Fix Issue 19181: always error when an UFCS or opDispatch call has syntactically invalid arguments

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -509,6 +509,10 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
         }
         else
         {
+            // even opDispatch and ufcs must have valid arguments.
+            if (arrayExpressionSemantic(ce.arguments, sc))
+                return new ErrorExp();
+
             if (Expression ey = die.semanticY(sc, 1))
             {
                 if (ey.op == TOK.error)

--- a/test/fail_compilation/fail19181.d
+++ b/test/fail_compilation/fail19181.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19181.d(15): Error: undefined identifier `LanguageError`
+---
+*/
+struct S
+{
+    void opDispatch(string name, T)(T arg) { }
+}
+
+void main()
+{
+    S s;
+    s.foo(LanguageError);
+}

--- a/test/fail_compilation/ice14929.d
+++ b/test/fail_compilation/ice14929.d
@@ -75,7 +75,7 @@ template isComponentStorage(CS, C)
     {
         CS cs = CS.init;
         ulong eid;
-        cs.add(eid, c);
+        cs.add(eid, C.init);
     }));
 }
 


### PR DESCRIPTION
Repro:

```
$ dmd test.d
---
module test;

struct S {
    void opDispatch(string name, T)(T arg) { }
}

void main() {
    S s;
    s.foo(LanguageError);
}
```

Before:
    test.d(9): Error: no property foo for type S

After:
    test.d(9): Error: undefined identifier LanguageError
