### PR TITLE
build.d: Remove redundant appending of backend object files

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -793,12 +793,7 @@ auto sourceFiles()
                 .array,
     };
     sources.dmd = sources.frontend ~ sources.backendHeaders;
-    version(OSX)
-        sources.backendObjects ~= env["G"].buildPath("machobj.o");
-    else version(Posix)
-        sources.backendObjects ~= env["G"].buildPath("elfobj.o");
-    else version(Windows)
-        assert(0, "TODO");
+
     return sources;
 }
 


### PR DESCRIPTION
Due to file globbing, these object files were already added.  In fact, rather than appending object files, we should probably be removing some.