### PR TITLE
build.d: Remove redundant backend target objects

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -720,7 +720,6 @@ auto sourceFiles()
     if (env["TARGET_CPU"] == "X86")
     {
         targetCH = "code_x86.h";
-        targetObjs = ["cgxmm", "cod1", "cod2", "cod3", "cod4", "ptrntab"];
     }
     else if (env["TARGET_CPU"] == "stub")
     {


### PR DESCRIPTION
These files are already being added with the code at https://github.com/dlang/dmd/blob/c3f6320d59ec14d6fa81a18f92b59393671b346a/src/build.d#L787-L793

They are currently being built twice.