### PR TITLE
Add buildkite-test target

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -12,6 +12,8 @@ auto-tester-build: toolchain-info
 
 auto-tester-test: test
 
+buildkite-test: test
+
 toolchain-info:
 	$(QUIET)$(MAKE) -C src -f posix.mak toolchain-info
 


### PR DESCRIPTION
tl;dr: there are some things which are really hard to add to the auto-tester, but should really run on all dmd,druntime and phobos repositories. Adding such tests separately to the existing CircleCi setups is painful (and we want to retire CircleCi anyhow), so we want to be able run the full testsuite on Buildkite too (and do customizations to it.)

For now, it's equivalent to auto-tester's target though.

See also:
- https://github.com/dlang/ci/pull/287
- https://github.com/dlang/phobos/pull/6669
- https://github.com/dlang/druntime/pull/2282