### PR TITLE
build.d: Get path to vswhere

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -968,9 +968,10 @@ version(Windows)
             return where.output;
 
         // Check if vswhere.exe is in the standard location
-        auto standardPath = ["cmd", "/C", "echo", `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`].execute.output;
-        standardPath = standardPath.replace(`"`, "");    // Remove quotes surrounding the path
-        standardPath = standardPath.replace("\r\n", ""); // Remove trailing newline characters
+        const standardPath = ["cmd", "/C", "echo", `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`]
+            .execute.output       // Execute command and return standard output
+            .replace(`"`, "")     // Remove quotes surrounding the path
+            .replace("\r\n", ""); // Remove trailing newline characters
         if (standardPath.exists)
             return standardPath;
 
@@ -984,7 +985,7 @@ version(Windows)
             return outputPath;
 
         // Could not find or obtain vswhere.exe
-        throw new Exception("Could not obtain vswhere.exe.  Consider downloading it from https://github.com/Microsoft/vswhere and placing it in your PATH");
+        throw new Exception("Could not obtain vswhere.exe. Consider downloading it from https://github.com/Microsoft/vswhere and placing it in your PATH");
     }
 }
 

--- a/src/build.d
+++ b/src/build.d
@@ -566,6 +566,9 @@ void parseEnvironment()
         exit(1);
     }
 
+    version(Windows)
+        env.getDefault("HOST_VSWHERE", getHostVSWhere(env["G"]));
+
     env.getDefault("HOST_CXX", getHostCXX);
     env.getDefault("CXX_KIND", getHostCXXKind);
 
@@ -911,6 +914,61 @@ auto getHostDMDPath(string hostDmd)
         return ["where", hostDmd].execute.output;
     else
         static assert(false, "Unrecognized or unsupported OS.");
+}
+
+version(Windows)
+{
+    /*
+    Gets the absolute path to the host's vshwere executable
+
+    Params:
+        outputFolder = this build's output folder
+    Returns: a string that is the absolute path of the host's vswhere executable
+    */
+    auto getHostVSWhere(string outputFolder)
+    {
+        // Check if vswhere.exe can be found in the host's PATH
+        const where = ["where", "vswhere"].execute;
+        if (where.status == 0)
+            return where.output;
+
+        // Check if vswhere.exe is in the standard location
+        auto standardPath = ["cmd", "/C", "echo", `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`].execute.output;
+        standardPath = standardPath.replace(`"`, "");    // Remove quotes surrounding the path
+        standardPath = standardPath.replace("\r\n", ""); // Remove trailing newline characters
+        if (standardPath.exists)
+            return standardPath;
+
+        // Check if it has already been dowloaded to this build's output folder
+        const outputPath = outputFolder.buildPath("vswhere").exeName;
+        if (outputPath.exists)
+            return outputPath;
+
+        // try to download it
+        immutable url = "https://github.com/Microsoft/vswhere/releases/download/2.5.2/vswhere.exe";
+        enum tries = 3;
+        foreach(i; 0..tries)
+        {
+            import std.net.curl : download, HTTPStatusException;
+            try
+            {
+                log("Downloading %s ...", url);
+                download(url, outputPath);
+                return outputPath;
+            }
+            catch(HTTPStatusException e) 
+            {
+                if (e.status == 404) throw e;
+                else 
+                {
+                    log("Failed to download %s (Attempt %s of %s)", url, i + 1, tries);
+                    continue;
+                }
+            }
+        }
+
+        throw new Exception("Could not obtain vswhere.exe.  Consider downloading it from https://github.com/Microsoft/vswhere and placing it in your PATH");
+    }
 }
 
 // Add the executable filename extension to the given `name` for the current OS.


### PR DESCRIPTION
This gets the path to _vswhere_:  https://github.com/Microsoft/vswhere

_vswhere_ is a single executable for locating Visual Studio installations and components.  It's installed automatically by Visual Studio 2017 v15.2+ to a standard location at `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`.  It is also downloadable from the GitHub repository linked above.

I intend to use it at https://github.com/dlang/dmd/blob/3d289d3ea100bda6a2b25c5e43779d7dd487281f/src/vcbuild/msvc-dmc.d#L17-L21 and https://github.com/dlang/dmd/blob/3d289d3ea100bda6a2b25c5e43779d7dd487281f/src/vcbuild/msvc-lib.d#L14-L16 I think that code has a typo:  notice that the path begins with `\Program Files` without a drive letter.  Anyway, that code doesn't even work on my computer, so I can't get a build.  I think `vswhere` will be a better solution for locating `cl.exe` and `lib.exe`.

_msvc-dmc_ and _msvc_lib_ will check the environment variable `HOST_VSWHERE` and execute it to locate  `cl.exe` and `lib.exe`.  _build.d_ is responsible for setting `HOST_VSWHERE`, and that's what this PR does.

cc @rainers for your expertise