### PR TITLE
Fix Issue 19185 - [ICE] Nested struct segfaults when using variable from outer scope

### DIFF
--- a/test/runnable/test19185.d
+++ b/test/runnable/test19185.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=19185
+
+int fun()
+{
+    int x = 2;
+    struct A
+    {
+        int a;
+        this(int a)
+        {
+            this.a = a + x;      // segault here
+        }
+    }
+
+    A a = 5;
+    return a.a;
+}
+
+void main()
+{
+    assert(fun() == 7);
+}


### PR DESCRIPTION
The context pointer was not initialized when when the nested struct was constructed implicitly.