### PR TITLE
Fix Issue 19182 - missing semicolon crashes compiler

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2374,6 +2374,11 @@ else
 
         if (ps._body)
         {
+            if (ps.ident == Id.msg || ps.ident == Id.startaddress)
+            {
+                ps.error("`pragma(%s)` is missing a terminating `;`", ps.ident.toChars());
+                return setError();
+            }
             ps._body = ps._body.statementSemantic(sc);
         }
         result = ps._body;

--- a/test/fail_compilation/fail19182.d
+++ b/test/fail_compilation/fail19182.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -c
+/*
+TEST_OUTPUT:
+---
+gigi
+fail_compilation/fail19182.d(12): Error: `pragma(msg)` is missing a terminating `;`
+---
+*/
+
+void foo()
+{
+    pragma(msg, "gigi") // Here
+    static foreach (e; [])
+    {
+        pragma(msg, "lili");
+    }
+
+}


### PR DESCRIPTION
The grammar for pragma statements states that a pragma is either followed by a `;` or a statement, however, predefined pragma's like `msg`, `startaddress` and `lib`, as far as I could tell, are always ended with a `;`. The fix eagerly checks that the `;` is presented at parse time.