### PR TITLE
Accept const(char)[] instead of string in dmd.frontend

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -54,7 +54,7 @@ Add import path to the `global.path`.
 Params:
     path = import to add
 */
-void addImport(string path)
+void addImport(const(char)[] path)
 {
     import dmd.globals : global;
     import dmd.arraytypes : Strings;
@@ -74,7 +74,7 @@ Params:
 
 Returns: full path to the found `dmd.conf`, `null` otherwise.
 */
-string findDMDConfig(string dmdFilePath)
+string findDMDConfig(const(char)[] dmdFilePath)
 {
     import dmd.dinifile : findConfFile;
     import std.string : fromStringz, toStringz;
@@ -94,7 +94,7 @@ Params:
 
 Returns: full path to the found `ldc2.conf`, `null` otherwise.
 */
-string findLDCConfig(string ldcFilePath)
+string findLDCConfig(const(char)[] ldcFilePath)
 {
     import std.file : getcwd;
     import std.path : buildPath, dirName;
@@ -153,7 +153,7 @@ Params:
 
 Returns: forward range of import paths found in `iniFile`
 */
-auto parseImportPathsFromConfig(string iniFile, string execDir)
+auto parseImportPathsFromConfig(const(char)[] iniFile, const(char)[] execDir)
 {
     import std.algorithm, std.range, std.regex;
     import std.stdio : File;
@@ -218,7 +218,7 @@ Params:
 
 Returns: the parsed module object
 */
-Module parseModule(string fileName, string code = null)
+Module parseModule(const(char)[] fileName, const(char)[] code = null)
 {
     import dmd.astcodegen : ASTCodegen;
     import dmd.globals : Loc;
@@ -227,7 +227,7 @@ Module parseModule(string fileName, string code = null)
     import dmd.tokens : TOK;
     import std.string : toStringz;
 
-    auto parse(Module m, string code)
+    static auto parse(Module m, const(char)[] code)
     {
         scope p = new Parser!ASTCodegen(m, code, false);
         p.nextToken; // skip the initial token


### PR DESCRIPTION
```
We shouldn't use string when immutability is not required.
In this case, while the functions don't change their input,
they don't require it to never change either.
```