### PR TITLE
Fix Issue 18672 - Error in @safe transitive propagation with associative arrays

### DIFF
--- a/test/compilable/test18672.d
+++ b/test/compilable/test18672.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=18672
+
+void main() @safe
+{
+    struct ThrowingElement
+    {
+        ~this() {}
+    }
+
+    ThrowingElement aa;
+    aa = aa;
+}

--- a/test/fail_compilation/fail18672.d
+++ b/test/fail_compilation/fail18672.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=18672
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail18672.d(15): Error: cannot take address of local `a` in `@safe` function `fun`
+---
+*/
+
+void fun2() @safe
+{
+    void fun()
+    {
+            int a;
+            int* b = &a;                  // totally unsafe
+    }
+}


### PR DESCRIPTION
When `opAssign` is generated, the destructor has only been through semantic1, therefore no attributes were generated (an empty destructor that is not marked as @safe will be seen as @system). In order to overcome this, when opAssign is in semantic3, a check is performed to see if the destructor has been considered @safe in the meantime.