### PR TITLE
Simplify number parsing in lexer, clean up error messages.

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1820,17 +1820,9 @@ class Lexer : ErrorHandler
             case '5':
             case '6':
             case '7':
-                n = c - '0';
-                ++p;
-                base = 8;
-                break;
             case '8':
             case '9':
-                n = c - '0';
-                ++p;
                 base = 8;
-                error("radix %d digit expected, not `%c`", base, c);
-                err = true;
                 break;
             case 'x':
             case 'X':
@@ -1871,39 +1863,15 @@ class Lexer : ErrorHandler
             {
             case '0':
             case '1':
-                if (base == 2 && !anyBinaryDigitsUS)
-                    anyBinaryDigitsUS = true;
-                else if (base == 16 && !anyHexDigitsNoSingleUS)
-                    anyHexDigitsNoSingleUS = true;
-                ++p;
-                d = c - '0';
-                break;
             case '2':
             case '3':
             case '4':
             case '5':
             case '6':
             case '7':
-                if (base == 16 && !anyHexDigitsNoSingleUS)
-                    anyHexDigitsNoSingleUS = true;
-                if (base == 2 && !err)
-                {
-                    error("binary digit expected");
-                    err = true;
-                }
-                ++p;
-                d = c - '0';
-                break;
             case '8':
             case '9':
-                if (base == 16 && !anyHexDigitsNoSingleUS)
-                    anyHexDigitsNoSingleUS = true;
                 ++p;
-                if (base < 10 && !err)
-                {
-                    error("radix %d digit expected, not `%c`", base, c);
-                    err = true;
-                }
                 d = c - '0';
                 break;
             case 'a':
@@ -1918,18 +1886,11 @@ class Lexer : ErrorHandler
             case 'D':
             case 'E':
             case 'F':
-                if (base == 16 && !anyHexDigitsNoSingleUS)
-                    anyHexDigitsNoSingleUS = true;
                 ++p;
                 if (base != 16)
                 {
                     if (c == 'e' || c == 'E' || c == 'f' || c == 'F')
                         goto Lreal;
-                    if (!err)
-                    {
-                        error("radix %d digit expected, not `%c`", base, c);
-                        err = true;
-                    }
                 }
                 if (c >= 'a')
                     d = c + 10 - 'a';
@@ -1953,12 +1914,21 @@ class Lexer : ErrorHandler
                 p = start;
                 return inreal(t);
             case '_':
-                if (base == 2 && !anyBinaryDigitsUS)
-                    anyBinaryDigitsUS = true;
+                anyBinaryDigitsUS = true;
                 ++p;
                 continue;
             default:
                 goto Ldone;
+            }
+            // got a digit here, set any necessary flags, check for errors
+            anyHexDigitsNoSingleUS = true;
+            anyBinaryDigitsUS = true;
+            if (!err && d >= base)
+            {
+                error("%s digit expected, not `%c`", base == 2 ? "binary".ptr :
+                                                     base == 8 ? "octal".ptr :
+                                                     "decimal".ptr, c);
+                err = true;
             }
             // Avoid expensive overflow check if we aren't at risk of overflow
             if (n <= 0x0FFF_FFFF_FFFF_FFFFUL)
@@ -2024,7 +1994,13 @@ class Lexer : ErrorHandler
             break;
         }
         if (base == 8 && n >= 8)
-            error("octal literals `0%llo%.*s` are no longer supported, use `std.conv.octal!%llo%.*s` instead", n, p - psuffix, psuffix, n, p - psuffix, psuffix);
+        {
+            if (err)
+                // can't translate invalid octal value, just show a generic message
+                error("octal literals larger than 7 are no longer supported");
+            else
+                error("octal literals `0%llo%.*s` are no longer supported, use `std.conv.octal!%llo%.*s` instead", n, p - psuffix, psuffix, n, p - psuffix, psuffix);
+        }
         TOK result;
         switch (flags)
         {

--- a/test/fail_compilation/fix19059.d
+++ b/test/fail_compilation/fix19059.d
@@ -2,10 +2,11 @@
  * PERMUTE_ARGS:
  * TEST_OUTPUT:
 ---
-fail_compilation/fix19059.d(16): Error: radix 8 digit expected, not `8`
-fail_compilation/fix19059.d(16): Error: octal literals `010` are no longer supported, use `std.conv.octal!10` instead
-fail_compilation/fix19059.d(17): Error: radix 8 digit expected, not `9`
-fail_compilation/fix19059.d(17): Error: octal literals `011` are no longer supported, use `std.conv.octal!11` instead
+fail_compilation/fix19059.d(17): Error: octal digit expected, not `8`
+fail_compilation/fix19059.d(17): Error: octal literals larger than 7 are no longer supported
+fail_compilation/fix19059.d(18): Error: octal digit expected, not `9`
+fail_compilation/fix19059.d(18): Error: octal literals larger than 7 are no longer supported
+fail_compilation/fix19059.d(19): Error: octal literals `010` are no longer supported, use `std.conv.octal!10` instead
 ---
  */
 
@@ -15,4 +16,5 @@ void foo()
 {
     auto a = 08;
     auto b = 09;
+    auto c = 010;
 }

--- a/test/fail_compilation/lexer4.d
+++ b/test/fail_compilation/lexer4.d
@@ -4,10 +4,10 @@ TEST_OUTPUT:
 fail_compilation/lexer4.d(22): Error: unterminated character constant
 fail_compilation/lexer4.d(24): Error: unterminated character constant
 fail_compilation/lexer4.d(25): Error: unterminated character constant
-fail_compilation/lexer4.d(26): Error: binary digit expected
-fail_compilation/lexer4.d(27): Error: radix 8 digit expected, not `8`
-fail_compilation/lexer4.d(27): Error: octal literals `0130` are no longer supported, use `std.conv.octal!130` instead
-fail_compilation/lexer4.d(28): Error: radix 10 digit expected, not `a`
+fail_compilation/lexer4.d(26): Error: binary digit expected, not `2`
+fail_compilation/lexer4.d(27): Error: octal digit expected, not `8`
+fail_compilation/lexer4.d(27): Error: octal literals larger than 7 are no longer supported
+fail_compilation/lexer4.d(28): Error: decimal digit expected, not `a`
 fail_compilation/lexer4.d(29): Error: unrecognized token
 fail_compilation/lexer4.d(30): Error: exponent required for hex float
 fail_compilation/lexer4.d(31): Error: lower case integer suffix 'l' is not allowed. Please use 'L' instead


### PR DESCRIPTION
This is a followup to #8451 to streamline the code in the lexer.

I've factored out all the checking of whether a digit is too big for the base into one place. I also fixed the messages to be always consistent based on the base instead of the digit being examined.

I wanted to go a step further and combine the 2 flags for hex and binary digits missing after the header, but curiously, D currently deprecates `0x_` but not `0b_`, so I'm not sure whether there's a valid reason for this or not. Relevant PR is #8396 

This should obsolete #8478 