### PR TITLE
Remove CRLF newlines from cppb.h

### DIFF
--- a/test/runnable/extra-files/cppb.h
+++ b/test/runnable/extra-files/cppb.h
@@ -21,7 +21,7 @@ class Cpp15589BaseVirtual
 {
 public:
     virtual void beforeDtor() {}
-    
+
     Cpp15589BaseVirtual();
     virtual ~Cpp15589BaseVirtual();
 
@@ -36,7 +36,7 @@ public:
     virtual ~Cpp15589DerivedVirtual();
 
     virtual void afterDtor() {}
-    
+
     int d;
 };
 
@@ -47,7 +47,7 @@ public:
     virtual void beforeIntroducedVirtual() {}
     virtual ~Cpp15589IntroducingVirtual();
     virtual void afterIntroducedVirtual(int) {}
-    
+
     int e;
 };
 


### PR DESCRIPTION
The mixed used of both CR and CRLF just makes it horrible to edit.