### PR TITLE
Improve diagnostic with forward references and tupleof

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -167,7 +167,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
      */
     final bool determineFields()
     {
-        if (sizeok != Sizeok.none)
+        if (_scope)
+            dsymbolSemantic(this, null);
+        if (fields.dim > 0)
             return true;
 
         //printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3492,7 +3492,10 @@ private extern(C++) final class DotExpVisitor : Visitor
              */
             e = e.expressionSemantic(sc); // do this before turning on noaccesscheck
 
-            mt.sym.size(e.loc); // do semantic of type
+            if (!mt.sym.determineFields())
+            {
+                error(e.loc, "unable to determine fields of `%s` because of forward references", mt.toChars());
+            }
 
             Expression e0;
             Expression ev = e.op == TOK.type ? null : e;

--- a/test/fail_compilation/diag19196.d
+++ b/test/fail_compilation/diag19196.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag19196.d(11): Error: unable to determine fields of `B` because of forward references
+fail_compilation/diag19196.d(15): Error: template instance `diag19196.Foo!(B)` error instantiating
+---
+*/
+module diag19196;
+struct Foo(T)
+{
+    alias F = typeof(T.tupleof);
+}
+struct B
+{
+    Foo!B b;
+}


### PR DESCRIPTION
When using tupleof in a template forward reference context, dmd
emitted an error message complaining that it could not calculate the
size of the struct. This happened even in cases when the size was not
obviously required.

To make things less confusing and workarounds more obvious, the error
message now explicitly says that tupleof is the problem.

Relates to (but doesn't fix) issue 19196.