### PR TITLE
Backend: Import dmd.errors.error where it is used

### DIFF
--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -73,7 +73,7 @@ int REGSIZE();
 
 version (MARS)
 {
-extern void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
+    import dmd.backend.errors;
 }
 
 /*****************************

--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -35,15 +35,14 @@ import dmd.backend.xmm;
 
 version (SCPP)
     import dmd.backend.exh;
-
+version (MARS)
+    import dmd.backend.errors;
 
 extern (C++):
 
 int REGSIZE();
 
 uint mask(uint m);
-
-void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
 
 /*******************************************
  * Is operator a store operator?

--- a/src/dmd/backend/errors.di
+++ b/src/dmd/backend/errors.di
@@ -1,0 +1,17 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/errors.d, _errors.d)
+ * Documentation:  https://dlang.org/phobos/dmd_errors.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/errors.d
+ */
+module dmd.backend.errors;
+
+/**
+   Print an error message, increasing the global error count
+ */
+extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -43,8 +43,8 @@ import scopeh;
 }
 
 extern (C++):
-
-extern void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
+version (MARS)
+    import dmd.backend.errors;
 
 // fp.c
 int testFE();

--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -45,8 +45,8 @@ extern (C++):
 
 version (SCPP)
     import parser;
-
-extern void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
+version (MARS)
+    import dmd.backend.errors;
 
 
 /**********************************************************************/

--- a/src/dmd/eh.d
+++ b/src/dmd/eh.d
@@ -18,6 +18,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.globals;
+import dmd.errors;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
@@ -33,8 +34,6 @@ import dmd.backend.type;
 extern (C++):
 
 // Support for D exception handling
-
-void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...);
 
 package(dmd) @property @nogc nothrow auto NPTRSIZE() { return _tysize[TYnptr]; }
 
@@ -378,4 +377,3 @@ void except_fillInEHTable(Symbol *s)
     assert(sz != 0);
     s.Sdt = dtb.finish();
 }
-


### PR DESCRIPTION
I'm not 100% sure of this one, but I don't see the reason to avoid this import in D.
There is also [this chunk of code](https://github.com/dlang/dmd/blob/ad921f0c42cf8f7cd430503d40402e7bd18d18c2/src/dmd/backend/cgobj.c#L32-L50) in a c++ file but [it's unused](https://github.com/dlang/dmd/blob/ad921f0c42cf8f7cd430503d40402e7bd18d18c2/src/dmd/backend/cgobj.c#L2367) so I didn't bother.