### PR TITLE
Fix Issue 18955 - extern(C++) default struct mangling is overridden when interacting with a cppmangle = class template

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1672,8 +1672,6 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             {
                 if (mtype.cppmangle == CPPMANGLE.def)
                     mtype.cppmangle = sc.cppmangle;
-                else
-                    assert(mtype.cppmangle == sc.cppmangle);
             }
             result = mtype;
             return;
@@ -1688,8 +1686,11 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         if (mtype.sym.type.ty == Terror)
             return error();
 
-        if (sc)
+        if (sc && sc.cppmangle != CPPMANGLE.def)
             mtype.cppmangle = sc.cppmangle;
+        else
+            mtype.cppmangle = CPPMANGLE.asStruct;
+
         result = merge(mtype);
     }
 
@@ -1708,8 +1709,6 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             {
                 if (mtype.cppmangle == CPPMANGLE.def)
                     mtype.cppmangle = sc.cppmangle;
-                else
-                    assert(mtype.cppmangle == sc.cppmangle);
             }
             result = mtype;
             return;
@@ -1724,8 +1723,11 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         if (mtype.sym.type.ty == Terror)
             return error();
 
-        if (sc)
+        if (sc && sc.cppmangle != CPPMANGLE.def)
             mtype.cppmangle = sc.cppmangle;
+        else
+            mtype.cppmangle = CPPMANGLE.asClass;
+
         result = merge(mtype);
     }
 

--- a/test/compilable/test18955.d
+++ b/test/compilable/test18955.d
@@ -1,0 +1,24 @@
+version(Windows)
+{
+    extern (C++, std)
+    {
+        struct char_traits(Char)
+        {
+        }
+        extern (C++, class) struct basic_string(T, Traits)
+        {
+        }
+        alias test_string = basic_string!(char, char_traits!char);
+    }
+    extern (C++) void test(ref const(std.test_string) str) {}
+
+    version(D_LP64)
+        static assert(test.mangleof == "?test@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@@std@@@Z");
+    else
+    {
+        version(CRuntime_DigitalMars)
+            static assert(test.mangleof == "?test@@YAXABV?$basic_string@std@DU?$char_traits@std@D@1@@std@@@Z");
+        else
+            static assert(test.mangleof == "?test@@YAXABV?$basic_string@DU?$char_traits@D@std@@@std@@@Z");
+    }
+}


### PR DESCRIPTION
I'm not all that confident in this fix.  If this isn't the right fix, please help me with some advise.  Thanks.