### PR TITLE
fix Issue 19201 - func called with argument types (ulong) matches both: __c_long and __c_ulong

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3369,10 +3369,10 @@ extern (C++) final class TypeBasic : Type
             EnumDeclaration ed = (cast(TypeEnum)to).sym;
             if (ed.isSpecial())
             {
-                /* Special enums that allow implicit conversions to them
-                 * with a MATCH.convert
-                 */
+                /* Special enums that allow implicit conversions to them.  */
                 tob = to.toBasetype().isTypeBasic();
+                if (tob)
+                    return implicitConvTo(tob);
             }
             else
                 return MATCH.nomatch;

--- a/test/compilable/test19201.d
+++ b/test/compilable/test19201.d
@@ -1,0 +1,30 @@
+// https://issues.dlang.org/show_bug.cgi?id=19201
+enum __c_long : int;
+enum __c_ulong : uint;
+
+enum __c_longlong : long;
+enum __c_ulonglong : ulong;
+
+void test19201a(uint r);
+void test19201a(int r);
+
+void test19201b(ulong r);
+void test19201b(long r);
+
+void test19201c(__c_long r);
+void test19201c(__c_ulong r);
+
+void test19201d(__c_longlong r);
+void test19201d(__c_ulonglong r);
+
+void test19201()
+{
+    test19201a(0);
+    test19201a(0u);
+    test19201b(0L);
+    test19201b(0UL);
+    test19201c(0);
+    test19201c(0u);
+    test19201d(0L);
+    test19201d(0UL);
+}


### PR DESCRIPTION
I don't see any valid reason for the limitation, and gdc builds are broken.