### PR TITLE
doc: Re-add C++ linkage back to gendocfile

### DIFF
--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -359,7 +359,7 @@ private immutable ddoc_decl_dd_e = ")\n";
 
 /****************************************************
  */
-void gendocfile(Module m)
+extern(C++) void gendocfile(Module m)
 {
     __gshared OutBuffer mbuf;
     __gshared int mbuf_done;

--- a/src/dmd/doc.h
+++ b/src/dmd/doc.h
@@ -1,0 +1,22 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/dmd/doc.h
+ */
+
+#ifndef DMD_DOC_H
+#define DMD_DOC_H
+
+#ifdef __DMC__
+#pragma once
+#endif /* __DMC__ */
+
+class Module;
+
+void gendocfile(Module *m);
+
+#endif

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -407,7 +407,7 @@ TK_SRC = \
 ######## CXX header files (only needed for cxx-unittest)
 
 SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
-	attrib.h compiler.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
+	attrib.h compiler.h complex_t.h cond.h ctfe.h ctfe.h declaration.h doc.h dsymbol.h	\
 	enum.h errors.h expression.h globals.h hdrgen.h identifier.h \
 	id.h import.h init.h intrange.h json.h \
 	mars.h module.h mtype.h nspace.h objc.h                         \

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -30,6 +30,7 @@
 #include "cond.h"
 #include "ctfe.h"
 #include "declaration.h"
+#include "doc.h"
 #include "dsymbol.h"
 #include "enum.h"
 #include "errors.h"


### PR DESCRIPTION
As this is called from the compiler main function.