### PR TITLE
Add functions used by compiler glue to C++ headers

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -74,6 +74,7 @@ FuncDeclaration *buildXtoHash(StructDeclaration *ad, Scope *sc);
 FuncDeclaration *buildPostBlit(StructDeclaration *sd, Scope *sc);
 DtorDeclaration *buildDtor(AggregateDeclaration *ad, Scope *sc);
 FuncDeclaration *buildInv(AggregateDeclaration *ad, Scope *sc);
+FuncDeclaration *search_toString(StructDeclaration *sd);
 
 struct ClassKind
 {

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -92,8 +92,6 @@ struct Ungag
 void dsymbolSemantic(Dsymbol *dsym, Scope *sc);
 void semantic2(Dsymbol *dsym, Scope *sc);
 void semantic3(Dsymbol *dsym, Scope* sc);
-const char *mangleExact(FuncDeclaration *fd);
-void mangleToBuffer(Dsymbol *s, OutBuffer* buf);
 
 struct Prot
 {

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -111,4 +111,6 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+Expression *initializerToExpression(Initializer *init, Type *t = NULL);
+
 #endif

--- a/src/dmd/mangle.h
+++ b/src/dmd/mangle.h
@@ -1,0 +1,33 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/dmd/mangle.h
+ */
+
+#pragma once
+
+class Dsymbol;
+class Expression;
+class FuncDeclaration;
+class TemplateInstance;
+class Type;
+struct OutBuffer;
+
+// In cppmangle.d
+const char *toCppMangleItanium(Dsymbol *s);
+const char *cppTypeInfoMangleItanium(Dsymbol *s);
+
+// In cppmanglewin.d
+const char *toCppMangleMSVC(Dsymbol *s);
+const char *cppTypeInfoMangleMSVC(Dsymbol *s);
+
+// In dmangle.d
+const char *mangleExact(FuncDeclaration *fd);
+void mangleToBuffer(Type *s, OutBuffer *buf);
+void mangleToBuffer(Expression *s, OutBuffer *buf);
+void mangleToBuffer(Dsymbol *s, OutBuffer *buf);
+void mangleToBuffer(TemplateInstance *s, OutBuffer *buf);

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -410,7 +410,7 @@ SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
 	attrib.h compiler.h complex_t.h cond.h ctfe.h ctfe.h declaration.h dsymbol.h	\
 	enum.h errors.h expression.h globals.h hdrgen.h identifier.h \
 	id.h import.h init.h intrange.h json.h \
-	mars.h module.h mtype.h nspace.h objc.h                         \
+	mangle.h mars.h module.h mtype.h nspace.h objc.h                \
 	scope.h statement.h staticassert.h target.h template.h tokens.h	\
 	version.h visitor.h libomf.d scanomf.d libmscoff.d scanmscoff.d)         \
 	$(DMD_SRCS)

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -43,6 +43,7 @@
 #include "intrange.h"
 #include "json.h"
 #include "mars.h"
+#include "mangle.h"
 #include "module.h"
 #include "mtype.h"
 #include "nspace.h"


### PR DESCRIPTION
The mangler entrypoints don't really have a home, so I invented one.

See https://github.com/D-Programming-GDC/GDC/blob/master/gcc/d/d-frontend.h

The above being where they are currently forward referenced for the benefit of gdc.