### PR TITLE
Replace all header guards with pragma once

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/aggregate.h
  */
 
-#ifndef DMD_AGGREGATE_H
-#define DMD_AGGREGATE_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 
@@ -350,5 +345,3 @@ public:
     InterfaceDeclaration *isInterfaceDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_AGGREGATE_H */

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/aliasthis.h
  */
 
-#ifndef DMD_ALIASTHIS_H
-#define DMD_ALIASTHIS_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "mars.h"
 #include "dsymbol.h"
@@ -31,5 +26,3 @@ public:
     AliasThis *isAliasThis() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif

--- a/src/dmd/arraytypes.h
+++ b/src/dmd/arraytypes.h
@@ -8,13 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/arraytypes.h
  */
 
-#ifndef DMD_ARRAYTYPES_H
-#define DMD_ARRAYTYPES_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
-
 
 #include "root/root.h"
 
@@ -70,5 +64,3 @@ typedef Array<class GotoStatement *> GotoStatements;
 typedef Array<class TemplateInstance *> TemplateInstances;
 
 typedef Array<struct Ensure> Ensures;
-
-#endif

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/attrib.h
  */
 
-#ifndef DMD_ATTRIB_H
-#define DMD_ATTRIB_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "dsymbol.h"
 
@@ -252,5 +247,3 @@ public:
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_ATTRIB_H */

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -8,8 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/compiler.h
  */
 
-#ifndef DMD_COMPILER_H
-#define DMD_COMPILER_H
+#pragma once
 
 // This file contains a data structure that describes a back-end compiler
 // and implements compiler-specific actions.
@@ -18,5 +17,3 @@ struct Compiler
 {
     const char *vendor;     // Compiler backend name
 };
-
-#endif /* DMD_COMPILER_H */

--- a/src/dmd/complex_t.h
+++ b/src/dmd/complex_t.h
@@ -8,8 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/complex_t.h
  */
 
-#ifndef DMD_COMPLEX_T_H
-#define DMD_COMPLEX_T_H
+#pragma once
 
 #include "root/ctfloat.h"
 
@@ -70,5 +69,3 @@ inline real_t cimagl(complex_t x)
 {
     return x.im;
 }
-
-#endif

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -8,8 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/cond.h
  */
 
-#ifndef DMD_DEBCOND_H
-#define DMD_DEBCOND_H
+#pragma once
 
 #include "globals.h"
 #include "visitor.h"
@@ -95,5 +94,3 @@ public:
     int include(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/ctfe.h
  */
 
-#ifndef DMD_CTFE_H
-#define DMD_CTFE_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "tokens.h"
 #include "expression.h"
@@ -81,5 +76,3 @@ public:
     static bool isCantExp(Expression *e) { return e && e->op == TOKcantexp; }
     static bool isGotoExp(Expression *e) { return e && e->op == TOKgoto; }
 };
-
-#endif /* DMD_CTFE_H */

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/declaration.h
  */
 
-#ifndef DMD_DECLARATION_H
-#define DMD_DECLARATION_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "dsymbol.h"
 #include "mtype.h"
@@ -851,5 +846,3 @@ public:
     DeleteDeclaration *isDeleteDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_DECLARATION_H */

--- a/src/dmd/doc.h
+++ b/src/dmd/doc.h
@@ -8,15 +8,8 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/doc.h
  */
 
-#ifndef DMD_DOC_H
-#define DMD_DOC_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 class Module;
 
 void gendocfile(Module *m);
-
-#endif

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/dsymbol.h
  */
 
-#ifndef DMD_DSYMBOL_H
-#define DMD_DSYMBOL_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 #include "root/stringtable.h"
@@ -394,5 +389,3 @@ public:
     Dsymbol *update(Dsymbol *s);
     Dsymbol *insert(Identifier const * const ident, Dsymbol *s);     // when ident and s are not the same
 };
-
-#endif /* DMD_DSYMBOL_H */

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/enum.h
  */
 
-#ifndef DMD_ENUM_H
-#define DMD_ENUM_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 #include "dsymbol.h"
@@ -94,5 +89,3 @@ public:
     EnumMember *isEnumMember() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_ENUM_H */

--- a/src/dmd/errors.h
+++ b/src/dmd/errors.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/mars.h
  */
 
-#ifndef DMD_ERRORS_H
-#define DMD_ERRORS_H
-
-#ifdef __DMC__
 #pragma once
-#endif
 
 #include "mars.h"
 
@@ -54,5 +49,3 @@ D_ATTRIBUTE_FORMAT(2, 0) void vmessage(const Loc& loc, const char *format, va_li
 // Called after printing out fatal error messages.
 D_ATTRIBUTE_NORETURN void fatal();
 D_ATTRIBUTE_NORETURN void halt();
-
-#endif /* DMD_ERRORS_H */

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -8,8 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/expression.h
  */
 
-#ifndef DMD_EXPRESSION_H
-#define DMD_EXPRESSION_H
+#pragma once
 
 #include "mars.h"
 #include "identifier.h"
@@ -1391,5 +1390,3 @@ class ObjcClassReferenceExp : public Expression
 
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_EXPRESSION_H */

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/globals.h
  */
 
-#ifndef DMD_GLOBALS_H
-#define DMD_GLOBALS_H
-
-#ifdef __DMC__
 #pragma once
-#endif
 
 #include "root/dcompat.h"
 #include "root/ctfloat.h"
@@ -348,5 +343,3 @@ enum PINLINE
 };
 
 typedef uinteger_t StorageClass;
-
-#endif /* DMD_GLOBALS_H */

--- a/src/dmd/hdrgen.h
+++ b/src/dmd/hdrgen.h
@@ -8,6 +8,8 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/hdrgen.h
  */
 
+#pragma once
+
 #include <string.h>                     // memset()
 
 #include "dsymbol.h"

--- a/src/dmd/id.h
+++ b/src/dmd/id.h
@@ -8,16 +8,9 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/id.h
  */
 
-#ifndef DMD_ID_H
-#define DMD_ID_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 struct Id
 {
     static void initialize();
 };
-
-#endif /* DMD_ID_H */

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/identifier.h
  */
 
-#ifndef DMD_IDENTIFIER_H
-#define DMD_IDENTIFIER_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 #include "root/rmem.h"
@@ -51,5 +46,3 @@ public:
     static Identifier *lookup(const char *s, size_t len);
     static void initTable();
 };
-
-#endif /* DMD_IDENTIFIER_H */

--- a/src/dmd/import.h
+++ b/src/dmd/import.h
@@ -8,15 +8,9 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/import.h
  */
 
-#ifndef DMD_IMPORT_H
-#define DMD_IMPORT_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "dsymbol.h"
-
 
 class Identifier;
 struct Scope;
@@ -60,5 +54,3 @@ public:
     Import *isImport() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_IMPORT_H */

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -8,8 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/init.h
  */
 
-#ifndef INIT_H
-#define INIT_H
+#pragma once
 
 #include "root/root.h"
 
@@ -112,5 +111,3 @@ public:
 };
 
 Expression *initializerToExpression(Initializer *init, Type *t = NULL);
-
-#endif

--- a/src/dmd/json.h
+++ b/src/dmd/json.h
@@ -8,18 +8,10 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/json.h
  */
 
-#ifndef DMD_JSON_H
-#define DMD_JSON_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "arraytypes.h"
 
 struct OutBuffer;
 
 void json_generate(OutBuffer *, Modules *);
-
-#endif /* DMD_JSON_H */
-

--- a/src/dmd/mars.h
+++ b/src/dmd/mars.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/mars.h
  */
 
-#ifndef DMD_MARS_H
-#define DMD_MARS_H
-
-#ifdef __DMC__
 #pragma once
-#endif
 
 /*
 It is very important to use version control macros correctly - the
@@ -100,5 +95,3 @@ void ensurePathToNameExists(Loc loc, const char *name);
 const char *importHint(const char *s);
 /// Little helper function for writing out deps.
 void escapePath(OutBuffer *buf, const char *fname);
-
-#endif /* DMD_MARS_H */

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/module.h
  */
 
-#ifndef DMD_MODULE_H
-#define DMD_MODULE_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 #include "dsymbol.h"
@@ -179,5 +174,3 @@ struct ModuleDeclaration
 
     const char *toChars() const;
 };
-
-#endif /* DMD_MODULE_H */

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/mtype.h
  */
 
-#ifndef DMD_MTYPE_H
-#define DMD_MTYPE_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 #include "root/stringtable.h"
@@ -841,5 +836,3 @@ public:
 
 bool arrayTypeCompatible(Loc loc, Type *t1, Type *t2);
 bool arrayTypeCompatibleWithoutCasting(Type *t1, Type *t2);
-
-#endif /* DMD_MTYPE_H */

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/nspace.h
  */
 
-#ifndef DMD_NSPACE_H
-#define DMD_NSPACE_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "dsymbol.h"
 
@@ -36,5 +31,3 @@ class Nspace : public ScopeDsymbol
     Nspace *isNspace() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_NSPACE_H */

--- a/src/dmd/objc.h
+++ b/src/dmd/objc.h
@@ -8,8 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/objc.h
  */
 
-#ifndef DMD_OBJC_H
-#define DMD_OBJC_H
+#pragma once
 
 #include "root/root.h"
 #include "root/stringtable.h"
@@ -66,5 +65,3 @@ public:
     virtual void setMetaclass(ClassDeclaration* id) = 0;
     virtual ClassDeclaration* getRuntimeMetaclass(ClassDeclaration* cd) = 0;
 };
-
-#endif /* DMD_OBJC_H */

--- a/src/dmd/root/array.h
+++ b/src/dmd/root/array.h
@@ -6,12 +6,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/array.h
  */
 
-#ifndef ARRAY_H
-#define ARRAY_H
-
-#if __DMC__
 #pragma once
-#endif
 
 #include <assert.h>
 #include <stdio.h>
@@ -239,5 +234,3 @@ struct BitArray
 private:
     BitArray(const BitArray&);
 };
-
-#endif

--- a/src/dmd/root/ctfloat.h
+++ b/src/dmd/root/ctfloat.h
@@ -7,8 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/ctfloat.h
  */
 
-#ifndef CTFLOAT_H
-#define CTFLOAT_H
+#pragma once
 
 #include "longdouble.h"
 
@@ -63,5 +62,3 @@ struct CTFloat
 
     static void initialize();
 };
-
-#endif

--- a/src/dmd/root/dcompat.h
+++ b/src/dmd/root/dcompat.h
@@ -7,12 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/dcompat.h
  */
 
-#ifndef DMD_ROOT_DCOMPAT_H
-#define DMD_ROOT_DCOMPAT_H
-
-#ifdef __DMC__
 #pragma once
-#endif
 
 /// Represents a D [ ] array
 template<typename T>
@@ -21,5 +16,3 @@ struct DArray
     size_t length;
     T *ptr;
 };
-
-#endif /* DMD_ROOT_DCOMPAT_H */

--- a/src/dmd/root/file.h
+++ b/src/dmd/root/file.h
@@ -7,12 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/file.h
  */
 
-#ifndef FILE_H
-#define FILE_H
-
-#if __DMC__
 #pragma once
-#endif
 
 #include <stddef.h>
 
@@ -56,5 +51,3 @@ struct File
 
     void remove();              // delete file
 };
-
-#endif

--- a/src/dmd/root/filename.h
+++ b/src/dmd/root/filename.h
@@ -7,12 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/filename.h
  */
 
-#ifndef FILENAME_H
-#define FILENAME_H
-
-#if __DMC__
 #pragma once
-#endif
 
 #include "array.h"
 
@@ -53,5 +48,3 @@ struct FileName
     static void free(const char *str);
     const char *toChars() const;
 };
-
-#endif

--- a/src/dmd/root/longdouble.h
+++ b/src/dmd/root/longdouble.h
@@ -9,8 +9,7 @@
 
 // 80 bit floating point value implementation for Microsoft compiler
 
-#ifndef __LONG_DOUBLE_H__
-#define __LONG_DOUBLE_H__
+#pragma once
 
 #if !_MSC_VER // has native 10 byte doubles
 #include <stdio.h>
@@ -265,5 +264,3 @@ typedef longdouble_soft longdouble;
 typedef longdouble_soft volatile_longdouble;
 
 #endif // !_MSC_VER
-
-#endif // __LONG_DOUBLE_H__

--- a/src/dmd/root/object.h
+++ b/src/dmd/root/object.h
@@ -7,14 +7,9 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/object.h
  */
 
-#ifndef OBJECT_H
-#define OBJECT_H
+#pragma once
 
 #define POSIX (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __DragonFly__ || __sun)
-
-#if __DMC__
-#pragma once
-#endif
 
 #include "dcompat.h"
 #include <stddef.h>
@@ -69,5 +64,3 @@ public:
      */
     virtual int dyncast() const;
 };
-
-#endif

--- a/src/dmd/root/outbuffer.h
+++ b/src/dmd/root/outbuffer.h
@@ -7,8 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/outbuffer.h
  */
 
-#ifndef OUTBUFFER_H
-#define OUTBUFFER_H
+#pragma once
 
 #include <stdlib.h>
 #include <stdarg.h>
@@ -16,10 +15,6 @@
 #include <assert.h>
 #include "port.h"
 #include "rmem.h"
-
-#if __DMC__
-#pragma once
-#endif
 
 class RootObject;
 
@@ -80,5 +75,3 @@ public:
     // Append terminating null if necessary and take ownership of data
     char *extractString();
 };
-
-#endif

--- a/src/dmd/root/port.h
+++ b/src/dmd/root/port.h
@@ -7,8 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/port.h
  */
 
-#ifndef PORT_H
-#define PORT_H
+#pragma once
 
 // Portable wrapper around compiler/system specific things.
 // The idea is to minimize #ifdef's in the app code.
@@ -43,5 +42,3 @@ struct Port
     static unsigned readwordBE(void *buffer);
     static void valcpy(void *dst, uint64_t val, size_t size);
 };
-
-#endif

--- a/src/dmd/root/rmem.h
+++ b/src/dmd/root/rmem.h
@@ -7,8 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/rmem.h
  */
 
-#ifndef ROOT_MEM_H
-#define ROOT_MEM_H
+#pragma once
 
 #include <stddef.h>     // for size_t
 
@@ -35,5 +34,3 @@ struct Mem
 };
 
 extern Mem mem;
-
-#endif /* ROOT_MEM_H */

--- a/src/dmd/root/root.h
+++ b/src/dmd/root/root.h
@@ -7,12 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/root.h
  */
 
-#ifndef ROOT_H
-#define ROOT_H
-
-#if __DMC__
 #pragma once
-#endif
 
 #include "object.h"
 
@@ -23,5 +18,3 @@
 #include "outbuffer.h"
 
 #include "array.h"
-
-#endif

--- a/src/dmd/root/stringtable.h
+++ b/src/dmd/root/stringtable.h
@@ -7,12 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/stringtable.h
  */
 
-#ifndef STRINGTABLE_H
-#define STRINGTABLE_H
-
-#if __SC__
 #pragma once
-#endif
 
 #include "root.h"
 #include "rmem.h"   // for d_size_t
@@ -55,5 +50,3 @@ public:
     StringValue *update(const char *s, d_size_t len);
     int apply(int (*fp)(StringValue *));
 };
-
-#endif

--- a/src/dmd/root/thread.h
+++ b/src/dmd/root/thread.h
@@ -7,8 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/root/thread.h
  */
 
-#ifndef THREAD_H
-#define THREAD_H 1
+#pragma once
 
 typedef long ThreadId;
 
@@ -16,5 +15,3 @@ struct Thread
 {
     static ThreadId getId();
 };
-
-#endif

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/scope.h
  */
 
-#ifndef DMD_SCOPE_H
-#define DMD_SCOPE_H
-
-#ifdef __DMC__
 #pragma once
-#endif
 
 class Dsymbol;
 class ScopeDsymbol;
@@ -161,5 +156,3 @@ struct Scope
 
     bool isDeprecated();
 };
-
-#endif /* DMD_SCOPE_H */

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/statement.h
  */
 
-#ifndef DMD_STATEMENT_H
-#define DMD_STATEMENT_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 
@@ -734,5 +729,3 @@ public:
 
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_STATEMENT_H */

--- a/src/dmd/staticassert.h
+++ b/src/dmd/staticassert.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/staticassert.h
  */
 
-#ifndef DMD_STATICASSERT_H
-#define DMD_STATICASSERT_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "dsymbol.h"
 
@@ -31,5 +26,3 @@ public:
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -8,8 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/target.h
  */
 
-#ifndef TARGET_H
-#define TARGET_H
+#pragma once
 
 // This file contains a data structure that describes a back-end target.
 // At present it is incomplete, but in future it should grow to contain
@@ -88,5 +87,3 @@ struct Target
     static bool isReturnOnStack(TypeFunction *tf, bool needsThis);
     static d_uns64 parameterSize(const Loc& loc, Type *t);
 };
-
-#endif

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/template.h
  */
 
-#ifndef DMD_TEMPLATE_H
-#define DMD_TEMPLATE_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/root.h"
 #include "arraytypes.h"
@@ -367,5 +362,3 @@ Type *getType(RootObject *o);
 Dsymbol *getDsymbol(RootObject *o);
 
 RootObject *objectSyntaxCopy(RootObject *o);
-
-#endif /* DMD_TEMPLATE_H */

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/tokens.h
  */
 
-#ifndef DMD_TOKENS_H
-#define DMD_TOKENS_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "root/port.h"
 #include "mars.h"
@@ -231,5 +226,3 @@ struct Token
     const char *toChars() const;
     static const char *toChars(TOK);
 };
-
-#endif /* DMD_TOKENS_H */

--- a/src/dmd/version.h
+++ b/src/dmd/version.h
@@ -8,12 +8,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/version.h
  */
 
-#ifndef DMD_VERSION_H
-#define DMD_VERSION_H
-
-#ifdef __DMC__
 #pragma once
-#endif /* __DMC__ */
 
 #include "dsymbol.h"
 
@@ -42,5 +37,3 @@ public:
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
 };
-
-#endif /* DMD_VERSION_H */

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -7,8 +7,7 @@
  * https://github.com/dlang/dmd/blob/master/src/dmd/visitor.h
  */
 
-#ifndef DMD_VISITOR_H
-#define DMD_VISITOR_H
+#pragma once
 
 #include <assert.h>
 
@@ -637,5 +636,3 @@ public:
     bool stop;
     StoppableVisitor() : stop(false) {}
 };
-
-#endif /* DMD_VISITOR_H */


### PR DESCRIPTION
~Added guards where missing, and corrected names to be `DMD_NAME_H`~

~Though maybe we should drop DMC's `#pragma once`, I'm not sure.~

After discussing both here and with gcc maintainers, using `#pragma once` everywhere then.