### PR TITLE
Add dcompat.h to the C++ front-end test

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -415,7 +415,7 @@ SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
 	version.h visitor.h libomf.d scanomf.d libmscoff.d scanmscoff.d)         \
 	$(DMD_SRCS)
 
-ROOT_SRC = $(addprefix $(ROOT)/, array.h ctfloat.h file.h filename.h \
+ROOT_SRC = $(addprefix $(ROOT)/, array.h ctfloat.h dcompat.h file.h filename.h \
 	longdouble.h newdelete.c object.h outbuffer.h port.h \
 	rmem.h root.h stringtable.h)
 

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -10,6 +10,7 @@
 
 #include "root/array.h"
 #include "root/ctfloat.h"
+#include "root/dcompat.h"
 #include "root/file.h"
 #include "root/filename.h"
 #include "root/longdouble.h"


### PR DESCRIPTION
So that any changes are at least validated for correct syntax.