### PR TITLE
Fix Hack: Remove hasCheckedAttrs from VarExp

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -415,6 +415,11 @@ extern (C++) final class EnumMember : VarDeclaration
         if (errors)
             return new ErrorExp();
         checkDisabled(loc, sc);
+
+        if (depdecl && !depdecl._scope)
+            depdecl._scope = sc;
+        checkDeprecated(loc, sc);
+
         if (errors)
             return new ErrorExp();
         Expression e = new VarExp(loc, this);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3347,11 +3347,6 @@ extern (C++) final class SymOffExp : SymbolExp
  */
 extern (C++) final class VarExp : SymbolExp
 {
-    /**
-    * Semantic can be called multiple times for a single expression.
-    * This field is needed to ensure the deprecation message will be printed only once.
-    */
-    bool hasCheckedAttrs;
     extern (D) this(const ref Loc loc, Declaration var, bool hasOverloads = true)
     {
         if (var.isVarDeclaration())
@@ -3361,7 +3356,6 @@ extern (C++) final class VarExp : SymbolExp
         //printf("VarExp(this = %p, '%s', loc = %s)\n", this, var.toChars(), loc.toChars());
         //if (strcmp(var.ident.toChars(), "func") == 0) assert(0);
         this.type = var.type;
-        this.hasCheckedAttrs = false;
     }
 
     static VarExp create(Loc loc, Declaration var, bool hasOverloads = true)
@@ -3445,7 +3439,6 @@ extern (C++) final class VarExp : SymbolExp
     override Expression syntaxCopy()
     {
         auto ret = super.syntaxCopy();
-        (cast(VarExp)ret).hasCheckedAttrs = this.hasCheckedAttrs;
         return ret;
     }
 }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3454,16 +3454,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * variables as alias template parameters.
          */
         //checkAccess(loc, sc, NULL, var);
-        if (!e.hasCheckedAttrs && e.var.isEnumMember())
-        {
-            e.hasCheckedAttrs = true;
-            if (e.var.depdecl && !e.var.depdecl._scope)
-            {
-                e.var.depdecl._scope = sc;
-            }
-            e.checkDeprecated(sc, e.var);
-
-        }
 
         if (auto vd = e.var.isVarDeclaration())
         {


### PR DESCRIPTION
`hasCheckedAttrs` was a member variable of `VarExp` introduced in https://github.com/dlang/dmd/pull/8404 to avoid having the deprecation message printed multiple times as `expressionSemantic` could have been called on the same `VarExp` multiple times. 

While working on a bug fix recently, I discovered that we could avoid that hack by checking for deprecation in `EnumMember.GetVarExp`, as is done with `checkDisabled`.

This PR removes the hack and makes the code more consistent with the existing implementation.