### PR TITLE
[C++ headers]: Remove declaration for non-existing member function

### DIFF
--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -72,7 +72,6 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void setScope(Scope *sc);
-    const char *getMessage();
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
`attrib.h` declares a `DeprecatedDeclaration::getMessage()` member function, but
no such function exists in the D definition of `DeprecatedDeclaration`, nor any
of of its base classes.

(The actual `getMessage` function is a free function defined in `dmd.dsymbolsem`: https://github.com/dlang/dmd/blob/58fde675fb69ea57da8902ddbabf87cf8b74e1f9/src/dmd/dsymbolsem.d#L410-L428)

CC @ibuclaw 