### PR TITLE
expression: Remove bodies of functions that forward to free functions

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -49,7 +49,7 @@ enum LOG = false;
  * Do an implicit cast.
  * Issue error if it can't be done.
  */
-extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
+Expression implicitCastTo(Expression e, Scope* sc, Type t)
 {
     extern (C++) final class ImplicitCastTo : Visitor
     {
@@ -178,7 +178,7 @@ extern (C++) Expression implicitCastTo(Expression e, Scope* sc, Type t)
  * Return MATCH level of implicitly converting e to type t.
  * Don't do the actual cast; don't change e.
  */
-extern (C++) MATCH implicitConvTo(Expression e, Type t)
+MATCH implicitConvTo(Expression e, Type t)
 {
     extern (C++) final class ImplicitConvTo : Visitor
     {
@@ -1406,7 +1406,7 @@ extern (C++) Type toStaticArrayType(SliceExp e)
  * Do an explicit cast.
  * Assume that the 'this' expression does not have any indirections.
  */
-extern (C++) Expression castTo(Expression e, Scope* sc, Type t)
+Expression castTo(Expression e, Scope* sc, Type t)
 {
     extern (C++) final class CastTo : Visitor
     {

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -52,7 +52,7 @@ import dmd.visitor;
  * functions and may invoke a function that contains `ErrorStatement` in its body.
  * If that, the "CTFE failed because of previous errors" error is raised.
  */
-public extern (C++) Expression ctfeInterpret(Expression e)
+public Expression ctfeInterpret(Expression e)
 {
     if (e.op == TOK.error)
         return e;

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -75,7 +75,6 @@ Expression *integralPromotions(Expression *e, Scope *sc);
 bool discardValue(Expression *e);
 bool isTrivialExp(Expression *e);
 
-int isConst(Expression *e);
 Expression *toDelegate(Expression *e, Type* t, Scope *sc);
 AggregateDeclaration *isAggregate(Type *t);
 bool checkNonAssignmentArrayOp(Expression *e, bool suggestion = false);
@@ -87,13 +86,7 @@ Expression *arrayOp(BinExp *e, Scope *sc);
 Expression *arrayOp(BinAssignExp *e, Scope *sc);
 bool hasSideEffect(Expression *e);
 bool canThrow(Expression *e, FuncDeclaration *func, bool mustNotThrow);
-Expression *Expression_optimize(Expression *e, int result, bool keepLvalue);
-MATCH implicitConvTo(Expression *e, Type *t);
-Expression *implicitCastTo(Expression *e, Scope *sc, Type *t);
-Expression *castTo(Expression *e, Scope *sc, Type *t);
-Expression *ctfeInterpret(Expression *);
 Expression *inlineCopy(Expression *e, Scope *sc);
-Expression *op_overload(Expression *e, Scope *sc);
 Type *toStaticArrayType(SliceExp *e);
 Expression *scaleFactor(BinExp *be, Scope *sc);
 Expression *typeCombine(BinExp *be, Scope *sc);
@@ -156,18 +149,9 @@ public:
     virtual bool isLvalue();
     virtual Expression *toLvalue(Scope *sc, Expression *e);
     virtual Expression *modifiableLvalue(Scope *sc, Expression *e);
-    Expression *implicitCastTo(Scope *sc, Type *t)
-    {
-        return ::implicitCastTo(this, sc, t);
-    }
-    MATCH implicitConvTo(Type *t)
-    {
-        return ::implicitConvTo(this, t);
-    }
-    Expression *castTo(Scope *sc, Type *t)
-    {
-        return ::castTo(this, sc, t);
-    }
+    Expression *implicitCastTo(Scope *sc, Type *t);
+    MATCH implicitConvTo(Type *t);
+    Expression *castTo(Scope *sc, Type *t);
     virtual Expression *resolveLoc(const Loc &loc, Scope *sc);
     virtual bool checkType();
     virtual bool checkValue();
@@ -190,24 +174,14 @@ public:
     Expression *addressOf();
     Expression *deref();
 
-    Expression *optimize(int result, bool keepLvalue = false)
-    {
-        return Expression_optimize(this, result, keepLvalue);
-    }
+    Expression *optimize(int result, bool keepLvalue = false);
 
     // Entry point for CTFE.
     // A compile-time result is required. Give an error if not possible
-    Expression *ctfeInterpret()
-    {
-        return ::ctfeInterpret(this);
-    }
-
-    int isConst() { return ::isConst(this); }
+    Expression *ctfeInterpret();
+    int isConst();
     virtual bool isBool(bool result);
-    Expression *op_overload(Scope *sc)
-    {
-        return ::op_overload(this, sc);
-    }
+    Expression *op_overload(Scope *sc);
 
     virtual bool hasCode()
     {

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -445,7 +445,7 @@ extern (C++) Objects* opToArg(Scope* sc, TOK op)
  * with function call.
  * Return NULL if not an operator overload.
  */
-extern (C++) Expression op_overload(Expression e, Scope* sc)
+Expression op_overload(Expression e, Scope* sc)
 {
     extern (C++) final class OpOverload : Visitor
     {

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -262,7 +262,7 @@ package void setLengthVarIfKnown(VarDeclaration lengthVar, Type type)
  * Returns:
  *      Constant folded version of `e`
  */
-extern (C++) Expression Expression_optimize(Expression e, int result, bool keepLvalue)
+Expression Expression_optimize(Expression e, int result, bool keepLvalue)
 {
     extern (C++) final class OptimizeVisitor : Visitor
     {

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -219,12 +219,25 @@ void test_semantic()
 
 /**********************************/
 
+void test_expression()
+{
+    Loc loc;
+    IntegerExp *ie = IntegerExp::createi(loc, 42, Type::tint32);
+    Expression *e = ie->ctfeInterpret();
+
+    assert(e);
+    assert(e->isConst());
+}
+
+/**********************************/
+
 int main(int argc, char **argv)
 {
     frontend_init();
 
     test_visitors();
     test_semantic();
+    test_expression();
 
     frontend_term();
 


### PR DESCRIPTION
Remove extern(C++) linkage from these free functions.

I had unwittingly broke build by removing C++ linkage from `isConst(Expression*)`, so removing the body that calls it from the header, along with others that do the same kind of forwarding calls.