### PR TITLE
Fixes Issue 19212 - Add versions for C++ runtimes.

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -653,6 +653,11 @@ extern (C++) final class VersionCondition : DVCondition
             case "CRuntime_Microsoft":
             case "CRuntime_Musl":
             case "CRuntime_UClibc":
+            case "CppRuntime_Clang":
+            case "CppRuntime_DigitalMars":
+            case "CppRuntime_Gcc":
+            case "CppRuntime_Microsoft":
+            case "CppRuntime_Sun":
             case "unittest":
             case "assert":
             case "all":

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1307,18 +1307,30 @@ void addDefaultVersionIdentifiers(const ref Param params)
     if (params.isWindows)
     {
         VersionCondition.addPredefinedGlobalIdent("Windows");
+        if (global.params.mscoff)
+        {
+            VersionCondition.addPredefinedGlobalIdent("CRuntime_Microsoft");
+            VersionCondition.addPredefinedGlobalIdent("CppRuntime_Microsoft");
+        }
+        else
+        {
+            VersionCondition.addPredefinedGlobalIdent("CRuntime_DigitalMars");
+            VersionCondition.addPredefinedGlobalIdent("CppRuntime_DigitalMars");
+        }
     }
     else if (params.isLinux)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("linux");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
+        VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
     else if (params.isOSX)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OSX");
-
+        VersionCondition.addPredefinedGlobalIdent("CppRuntime_Clang");
         // For legacy compatibility
         VersionCondition.addPredefinedGlobalIdent("darwin");
     }
@@ -1327,24 +1339,28 @@ void addDefaultVersionIdentifiers(const ref Param params)
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("FreeBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        VersionCondition.addPredefinedGlobalIdent("CppRuntime_Clang");
     }
     else if (params.isOpenBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("OpenBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
     else if (params.isDragonFlyBSD)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("DragonFlyBSD");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        VersionCondition.addPredefinedGlobalIdent("CppRuntime_Gcc");
     }
     else if (params.isSolaris)
     {
         VersionCondition.addPredefinedGlobalIdent("Posix");
         VersionCondition.addPredefinedGlobalIdent("Solaris");
         VersionCondition.addPredefinedGlobalIdent("ELFv1");
+        VersionCondition.addPredefinedGlobalIdent("CppRuntime_Sun");
     }
     else
     {
@@ -1381,18 +1397,6 @@ void addDefaultVersionIdentifiers(const ref Param params)
         {
             VersionCondition.addPredefinedGlobalIdent("Win32");
         }
-    }
-
-    if (params.isWindows)
-    {
-        if (params.mscoff)
-            VersionCondition.addPredefinedGlobalIdent("CRuntime_Microsoft");
-        else
-            VersionCondition.addPredefinedGlobalIdent("CRuntime_DigitalMars");
-    }
-    else if (params.isLinux)
-    {
-        VersionCondition.addPredefinedGlobalIdent("CRuntime_Glibc");
     }
 
     if (params.isLP64)

--- a/test/fail_compilation/reserved_version.d
+++ b/test/fail_compilation/reserved_version.d
@@ -100,6 +100,11 @@ fail_compilation/reserved_version.d(201): Error: version identifier `none` is re
 fail_compilation/reserved_version.d(202): Error: version identifier `AsmJS` is reserved and cannot be set
 fail_compilation/reserved_version.d(203): Error: version identifier `Emscripten` is reserved and cannot be set
 fail_compilation/reserved_version.d(204): Error: version identifier `WebAssembly` is reserved and cannot be set
+fail_compilation/reserved_version.d(205): Error: version identifier `CppRuntime_Clang` is reserved and cannot be set
+fail_compilation/reserved_version.d(206): Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
+fail_compilation/reserved_version.d(207): Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
+fail_compilation/reserved_version.d(208): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
+fail_compilation/reserved_version.d(209): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
 ---
 */
 
@@ -206,6 +211,11 @@ version = none;
 version = AsmJS;
 version = Emscripten;
 version = WebAssembly;
+version = CppRuntime_Clang;
+version = CppRuntime_DigitalMars;
+version = CppRuntime_Gcc;
+version = CppRuntime_Microsoft;
+version = CppRuntime_Sun;
 
 // This should work though
 debug = DigitalMars;
@@ -285,6 +295,11 @@ debug = CRuntime_Glibc;
 debug = CRuntime_Microsoft;
 debug = CRuntime_Musl;
 debug = CRuntime_UClibc;
+debug = CppRuntime_Clang;
+debug = CppRuntime_DigitalMars;
+debug = CppRuntime_Gcc;
+debug = CppRuntime_Microsoft;
+debug = CppRuntime_Sun;
 debug = D_Coverage;
 debug = D_Ddoc;
 debug = D_InlineAsm_X86;

--- a/test/fail_compilation/reserved_version_switch.d
+++ b/test/fail_compilation/reserved_version_switch.d
@@ -77,6 +77,11 @@
 // REQUIRED_ARGS: -version=CRuntime_Microsoft
 // REQUIRED_ARGS: -version=CRuntime_Musl
 // REQUIRED_ARGS: -version=CRuntime_UClibc
+// REQUIRED_ARGS: -version=CppRuntime_Clang
+// REQUIRED_ARGS: -version=CppRuntime_DigitalMars
+// REQUIRED_ARGS: -version=CppRuntime_Gcc
+// REQUIRED_ARGS: -version=CppRuntime_Microsoft
+// REQUIRED_ARGS: -version=CppRuntime_Sun
 // REQUIRED_ARGS: -version=D_Coverage
 // REQUIRED_ARGS: -version=D_Ddoc
 // REQUIRED_ARGS: -version=D_InlineAsm_X86
@@ -168,6 +173,11 @@
 // REQUIRED_ARGS: -debug=CRuntime_Microsoft
 // REQUIRED_ARGS: -debug=CRuntime_Musl
 // REQUIRED_ARGS: -debug=CRuntime_UClibc
+// REQUIRED_ARGS: -debug=CppRuntime_Clang
+// REQUIRED_ARGS: -debug=CppRuntime_DigitalMars
+// REQUIRED_ARGS: -debug=CppRuntime_Gcc
+// REQUIRED_ARGS: -debug=CppRuntime_Microsoft
+// REQUIRED_ARGS: -debug=CppRuntime_Sun
 // REQUIRED_ARGS: -debug=D_Coverage
 // REQUIRED_ARGS: -debug=D_Ddoc
 // REQUIRED_ARGS: -debug=D_InlineAsm_X86
@@ -264,6 +274,11 @@ Error: version identifier `CRuntime_Glibc` is reserved and cannot be set
 Error: version identifier `CRuntime_Microsoft` is reserved and cannot be set
 Error: version identifier `CRuntime_Musl` is reserved and cannot be set
 Error: version identifier `CRuntime_UClibc` is reserved and cannot be set
+Error: version identifier `CppRuntime_Clang` is reserved and cannot be set
+Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
+Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
+Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
+Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
 Error: version identifier `D_Coverage` is reserved and cannot be set
 Error: version identifier `D_Ddoc` is reserved and cannot be set
 Error: version identifier `D_InlineAsm_X86` is reserved and cannot be set


### PR DESCRIPTION
Necessary for `std::` stuff

Spec: https://github.com/dlang/dlang.org/pull/2461