### PR TITLE
convert cod1.c to D

### DIFF
--- a/src/dmd/backend/code.h
+++ b/src/dmd/backend/code.h
@@ -682,6 +682,10 @@ struct FuncParamRegs
     const unsigned char* floatregs;     // map to fp register
 };
 
+FuncParamRegs FuncParamRegs_create(tym_t tyf);
+int FuncParamRegs_alloc(FuncParamRegs& fpr, type *t, tym_t ty, unsigned char *reg1, unsigned char *reg2);
+
+
 extern "C++" { extern const unsigned mask[32]; }
 
 inline regm_t Symbol::Spregm()

--- a/src/dmd/backend/out.c
+++ b/src/dmd/backend/out.c
@@ -1088,7 +1088,7 @@ STATIC void writefunc2(symbol *sfunc)
     //printf("globsym.top = %d\n", globsym.top);
 
 #if SCPP
-    FuncParamRegs fpr(tyf);
+    FuncParamRegs fpr = FuncParamRegs_create(tyf);
 #endif
 
     for (SYMIDX si = 0; si < globsym.top; si++)
@@ -1114,7 +1114,7 @@ STATIC void writefunc2(symbol *sfunc)
             case SCfastpar:
             case SCregpar:
             case SCparameter:
-                if (si == 0 && fpr.alloc(s->Stype, s->Stype->Tty, &s->Spreg, &s->Spreg2))
+                if (si == 0 && FuncParamRegs_alloc(fpr, s->Stype, s->Stype->Tty, &s->Spreg, &s->Spreg2))
                 {
                     assert(s->Spreg == ((tyf == TYmfunc) ? CX : AX));
                     assert(s->Spreg2 == NOREG);

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -327,7 +327,7 @@ DMD_SRCS=$(FRONT_SRCS) $(GLUE_SRCS) $(BACK_HDRS) $(TK_HDRS)
 
 ifeq (X86,$(TARGET_CPU))
     TARGET_CH = $C/code_x86.h
-    TARGET_OBJS = cod1.o cod3.o ptrntab.o
+    TARGET_OBJS = cod3.o ptrntab.o
 else
     ifeq (stub,$(TARGET_CPU))
         TARGET_CH = $C/code_stub.h
@@ -350,7 +350,7 @@ BACK_OBJS = var.o \
 
 BACK_DOBJS = bcomplex.o evalu8.o divcoeff.o dvec.o go.o gsroa.o glocal.o gdag.o gother.o gflow.o \
 	gloop.o compress.o cgelem.o cgcs.o ee.o cod4.o cod5.o nteh.o blockopt.o memh.o cg.o cgreg.o \
-	dtype.o debugprint.o symbol.o elem.o dcode.o cgsched.o cg87.o cgxmm.o cod2.o
+	dtype.o debugprint.o symbol.o elem.o dcode.o cgsched.o cg87.o cgxmm.o cod2.o cod1.o
 
 G_OBJS  = $(addprefix $G/, $(BACK_OBJS))
 G_DOBJS = $(addprefix $G/, $(BACK_DOBJS))
@@ -383,7 +383,7 @@ BACK_SRC = \
 	$C/bcomplex.d $C/blockopt.d $C/cg.d $C/cg87.d $C/cgxmm.d \
 	$C/cgcod.c $C/cgcs.d $C/cgcv.c $C/cgelem.d $C/cgen.c $C/cgobj.c \
 	$C/compress.d $C/cgreg.d $C/var.c $C/strtold.c \
-	$C/cgsched.d $C/cod1.c $C/cod2.d $C/cod3.c $C/cod4.d $C/cod5.d \
+	$C/cgsched.d $C/cod1.d $C/cod2.d $C/cod3.c $C/cod4.d $C/cod5.d \
 	$C/dcode.d $C/symbol.d $C/debugprint.d $C/dt.c $C/ee.d $C/elem.d \
 	$C/evalu8.d $C/fp.c $C/go.d $C/gflow.d $C/gdag.d \
 	$C/gother.d $C/glocal.d $C/gloop.d $C/gsroa.d $C/newman.c \

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -97,7 +97,6 @@
     <ClCompile Include="..\dmd\backend\cgcv.c" />
     <ClCompile Include="..\dmd\backend\cgen.c" />
     <ClCompile Include="..\dmd\backend\cgobj.c" />
-    <ClCompile Include="..\dmd\backend\cod1.c" />
     <ClCompile Include="..\dmd\backend\cod3.c" />
     <ClCompile Include="..\dmd\backend\dt.c" />
     <ClCompile Include="..\dmd\backend\dwarf.c" />

--- a/src/vcbuild/dmd_backend.vcxproj.filters
+++ b/src/vcbuild/dmd_backend.vcxproj.filters
@@ -39,9 +39,6 @@
     <ClCompile Include="..\dmd\backend\cgobj.c">
       <Filter>dmd\backend</Filter>
     </ClCompile>
-    <ClCompile Include="..\dmd\backend\cod1.c">
-      <Filter>dmd\backend</Filter>
-    </ClCompile>
     <ClCompile Include="..\dmd\backend\cod3.c">
       <Filter>dmd\backend</Filter>
     </ClCompile>

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -231,7 +231,7 @@ BACKSRC= $C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c \
 	$C\bcomplex.d $C\blockopt.d $C\cg.d $C\cg87.d $C\cgxmm.d \
 	$C\cgcod.c $C\cgcs.d $C\cgcv.c $C\cgelem.d $C\cgen.c $C\cgobj.c \
 	$C\compress.d $C\cgreg.d $C\var.c \
-	$C\cgsched.d $C\cod1.c $C\cod2.d $C\cod3.c $C\cod4.d $C\cod5.d \
+	$C\cgsched.d $C\cod1.d $C\cod2.d $C\cod3.c $C\cod4.d $C\cod5.d \
 	$C\dcode.d $C\symbol.d $C\debugprint.d $C\dt.c $C\ee.d $C\elem.d \
 	$C\evalu8.d $C\fp.c $C\go.d $C\gflow.d $C\gdag.d \
 	$C\gother.d $C\glocal.d $C\gloop.d $C\gsroa.d $C\newman.c \
@@ -493,8 +493,8 @@ $G/cgsched.obj : $C\cgsched.d
 $G/cgxmm.obj : $C\xmm.d $C\cgxmm.d
 	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\cgxmm
 
-$G/cod1.obj : $C\rtlsym.h $C\cod1.c
-	$(CC) -c -o$@ $(MFLAGS) $C\cod1
+$G/cod1.obj : $C\rtlsym.h $C\cod1.d
+	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\cod1
 
 $G/cod2.obj : $C\cod2.d
 	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\cod2


### PR DESCRIPTION
It turns out it's a lot easier to diff the C and D versions if you copy the C file to a temp, then do a global search/replace of -> to . and then diff the D version with temp.