### PR TITLE
Fixes Issue 19195 - Support pragma to specify linker directives

### DIFF
--- a/src/dmd/backend/cgobj.c
+++ b/src/dmd/backend/cgobj.c
@@ -1225,6 +1225,19 @@ bool Obj::includelib(const char *name)
     return true;
 }
 
+/*******************************
+* Output linker directive.
+* Output:
+*      directive is modified
+* Returns:
+*      true if operation is supported
+*/
+
+bool Obj::linkerdirective(const char *name)
+{
+    return false;
+}
+
 /**********************************
  * Do we allow zero sized objects?
  */

--- a/src/dmd/backend/elfobj.c
+++ b/src/dmd/backend/elfobj.c
@@ -1566,6 +1566,15 @@ bool Obj::includelib(const char *name)
     return false;
 }
 
+/*******************************
+* Output linker directive.
+*/
+
+bool Obj::linkerdirective(const char *name)
+{
+    return false;
+}
+
 /**********************************
  * Do we allow zero sized objects?
  */

--- a/src/dmd/backend/machobj.c
+++ b/src/dmd/backend/machobj.c
@@ -1603,6 +1603,15 @@ bool Obj::includelib(const char *name)
     return false;
 }
 
+/*******************************
+* Output linker directive.
+*/
+
+bool Obj::linkerdirective(const char *name)
+{
+    return false;
+}
+
 /**********************************
  * Do we allow zero sized objects?
  */

--- a/src/dmd/backend/mscoffobj.c
+++ b/src/dmd/backend/mscoffobj.c
@@ -1060,6 +1060,19 @@ bool MsCoffObj::includelib(const char *name)
     return true;
 }
 
+/*******************************
+* Output linker directive name.
+*/
+
+bool MsCoffObj::linkerdirective(const char *directive)
+{
+    int seg = seg_drectve();
+    //dbg_printf("MsCoffObj::linkerdirective(directive *%s)\n",directive);
+    SegData[seg]->SDbuf->writeByte(' ');
+    SegData[seg]->SDbuf->write(directive, strlen(directive));
+    return true;
+}
+
 /**********************************
  * Do we allow zero sized objects?
  */

--- a/src/dmd/backend/obj.d
+++ b/src/dmd/backend/obj.d
@@ -61,6 +61,7 @@ version (OMF)
         void dosseg();
         void startaddress(Symbol *);
         bool includelib(const(char)* );
+        bool linkerdirective(const char *);
         bool allowZeroSize();
         void exestr(const(char)* p);
         void user(const(char)* p);
@@ -139,6 +140,7 @@ else version (OMFandMSCOFF)
         void dosseg();
         void startaddress(Symbol *);
         bool includelib(const(char)* );
+        bool linkerdirective(const(char)* );
         bool allowZeroSize();
         void exestr(const(char)* p);
         void user(const(char)* p);
@@ -215,6 +217,7 @@ else version (OMFandMSCOFF)
         //override size_t mangle(Symbol *s,char *dest);
         override void startaddress(Symbol *);
         override bool includelib(const(char)* );
+        override bool linkerdirective(const(char)* );
         override void _alias(const(char)* n1,const(char)* n2);
         override void user(const(char)* p);
     //    void _import(elem *e);
@@ -306,6 +309,7 @@ else version (Posix)
         static void dosseg();
         static void startaddress(Symbol *);
         static bool includelib(const(char)* );
+        static bool linkerdirective(const char *);
         static size_t mangle(Symbol *s,char *dest);
         static void _alias(const(char)* n1,const(char)* n2);
         static void user(const(char)* p);

--- a/src/dmd/backend/obj.h
+++ b/src/dmd/backend/obj.h
@@ -49,6 +49,7 @@ struct seg_data;
         static void dosseg(void);
         static void startaddress(Symbol *);
         static bool includelib(const char *);
+        static bool linkerdirective(const char *);
         static bool allowZeroSize();
         static void exestr(const char *p);
         static void user(const char *p);
@@ -135,6 +136,7 @@ class Obj
     VIRTUAL void dosseg(void);
     VIRTUAL void startaddress(Symbol *);
     VIRTUAL bool includelib(const char *);
+    VIRTUAL bool linkerdirective(const char *);
     VIRTUAL bool allowZeroSize();
     VIRTUAL void exestr(const char *p);
     VIRTUAL void user(const char *p);
@@ -246,6 +248,7 @@ class MsCoffObj : public Obj
 //    VIRTUAL void dosseg(void);
     VIRTUAL void startaddress(Symbol *);
     VIRTUAL bool includelib(const char *);
+    VIRTUAL bool linkerdirective(const char *);
     VIRTUAL bool allowZeroSize();
     VIRTUAL void exestr(const char *p);
     VIRTUAL void user(const char *p);

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1616,6 +1616,24 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     {
         // Should be merged with PragmaStatement
         //printf("\tPragmaDeclaration::semantic '%s'\n", pd.toChars());
+        if (global.params.mscoff)
+        {
+            if (pd.ident == Id.linkerDirective)
+            {
+                if (!pd.args || pd.args.dim != 1)
+                    pd.error("one string argument expected for pragma(linkerDirective)");
+                else
+                {
+                    auto se = semanticString(sc, (*pd.args)[0], "linker directive");
+                    if (!se)
+                        goto Lnodecl;
+                    (*pd.args)[0] = se;
+                    if (global.params.verbose)
+                        message("linkopt   %.*s", cast(int)se.len, se.string);
+                }
+                goto Lnodecl;
+            }
+        }
         if (pd.ident == Id.msg)
         {
             if (pd.args)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -309,6 +309,11 @@ void obj_startaddress(Symbol *s)
     return objmod.startaddress(s);
 }
 
+bool obj_linkerdirective(const(char)* directive)
+{
+    return objmod.linkerdirective(directive);
+}
+
 
 /**************************************
  * Generate .obj file for Module.

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -304,6 +304,7 @@ immutable Msgtable[] msgtable =
     // For pragma's
     { "Pinline", "inline" },
     { "lib" },
+    { "linkerDirective" },
     { "mangle" },
     { "msg" },
     { "startaddress" },

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2300,6 +2300,13 @@ else
                 }
             }
         }
+        else if (ps.ident == Id.linkerDirective)
+        {
+            /* Should this be allowed?
+             */
+            ps.error("`pragma(linkerDirective)` not allowed as statement");
+            return setError();
+        }
         else if (ps.ident == Id.startaddress)
         {
             if (!ps.args || ps.args.dim != 1)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -770,6 +770,20 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 Symbol *s = toSymbol(f);
                 obj_startaddress(s);
             }
+            else if (pd.ident == Id.linkerDirective)
+            {
+                assert(pd.args && pd.args.dim == 1);
+
+                Expression e = (*pd.args)[0];
+
+                assert(e.op == TOK.string_);
+
+                StringExp se = cast(StringExp)e;
+                char *directive = cast(char *)mem.xmalloc(se.numberOfCodeUnits() + 1);
+                se.writeTo(directive, true);
+
+                obj_linkerdirective(directive);
+            }
 
             visit(cast(AttribDeclaration)pd);
 

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -ignore
 module foo.bar;
 
 import core.vararg;
@@ -5,6 +6,7 @@ import std.stdio;
 
 pragma(lib, "test");
 pragma(msg, "Hello World");
+pragma(linkerDirective, "/DEFAULTLIB:test2");
 
 static assert(true, "message");
 

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -3,6 +3,7 @@ import core.vararg;
 import std.stdio;
 pragma (lib, "test");
 pragma (msg, "Hello World");
+pragma (linkerDirective, "/DEFAULTLIB:test2");
 static assert(true, "message");
 alias mydbl = double;
 alias fl1 = function ()

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -3,6 +3,7 @@ import core.vararg;
 import std.stdio;
 pragma (lib, "test");
 pragma (msg, "Hello World");
+pragma (linkerDirective, "/DEFAULTLIB:test2");
 static assert(true, "message");
 alias mydbl = double;
 alias fl1 = function ()

--- a/test/compilable/testheader1.d
+++ b/test/compilable/testheader1.d
@@ -1,5 +1,5 @@
 // EXTRA_SOURCES: extra-files/header1.d
-// REQUIRED_ARGS: -o- -unittest -H -Hf${RESULTS_DIR}/compilable/testheader1.di
+// REQUIRED_ARGS: -o- -unittest -H -Hf${RESULTS_DIR}/compilable/testheader1.di -ignore
 // PERMUTE_ARGS: -d -dw
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
 

--- a/test/compilable/testheader1i.d
+++ b/test/compilable/testheader1i.d
@@ -1,5 +1,5 @@
 // EXTRA_SOURCES: extra-files/header1.d
-// REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/testheader1i.di -inline
+// REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/testheader1i.di -inline -ignore
 // PERMUTE_ARGS: -d -dw
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
 


### PR DESCRIPTION
Added pragma(linkerdirective, "string")

Necessary for `std::vector`, `std::string`, etc.

Spec: https://github.com/dlang/dlang.org/pull/2463