### PR TITLE
Fixes Issue 19194 - version for `-mscrtlib` specification

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -658,6 +658,11 @@ extern (C++) final class VersionCondition : DVCondition
             case "CppRuntime_Gcc":
             case "CppRuntime_Microsoft":
             case "CppRuntime_Sun":
+            case "MSRuntime_None":
+            case "MSRuntime_Static":
+            case "MSRuntime_Dynamic":
+            case "MSRuntime_Debug":
+            case "MSRuntime_Release":
             case "unittest":
             case "assert":
             case "all":

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1202,6 +1202,34 @@ void addDefaultVersionIdentifiers(const ref Param params)
         {
             VersionCondition.addPredefinedGlobalIdent("CRuntime_Microsoft");
             VersionCondition.addPredefinedGlobalIdent("CppRuntime_Microsoft");
+            if (!global.params.mscrtlib || !global.params.mscrtlib[0])
+            {
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_None");
+            }
+            else if (FileName.equals(global.params.mscrtlib, "libcmt"))
+            {
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Static");
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Release");
+            }
+            else if (FileName.equals(global.params.mscrtlib, "libcmtd"))
+            {
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Static");
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Debug");
+            }
+            else if (FileName.equals(global.params.mscrtlib, "msvcrt") || FileName.equals(global.params.mscrtlib, "msvcrt100"))
+            {
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Dynamic");
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Release");
+            }
+            else if (FileName.equals(global.params.mscrtlib, "msvcrtd"))
+            {
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Dynamic");
+                VersionCondition.addPredefinedGlobalIdent("MSRuntime_Debug");
+            }
+            else
+            {
+                assert(0, "unexpected mscrtlib");
+            }
         }
         else
         {

--- a/test/fail_compilation/reserved_version.d
+++ b/test/fail_compilation/reserved_version.d
@@ -105,6 +105,11 @@ fail_compilation/reserved_version.d(206): Error: version identifier `CppRuntime_
 fail_compilation/reserved_version.d(207): Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
 fail_compilation/reserved_version.d(208): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
 fail_compilation/reserved_version.d(209): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
+fail_compilation/reserved_version.d(210): Error: version identifier `MSRuntime_None` is reserved and cannot be set
+fail_compilation/reserved_version.d(211): Error: version identifier `MSRuntime_Static` is reserved and cannot be set
+fail_compilation/reserved_version.d(212): Error: version identifier `MSRuntime_Dynamic` is reserved and cannot be set
+fail_compilation/reserved_version.d(213): Error: version identifier `MSRuntime_Debug` is reserved and cannot be set
+fail_compilation/reserved_version.d(214): Error: version identifier `MSRuntime_Release` is reserved and cannot be set
 ---
 */
 
@@ -216,6 +221,11 @@ version = CppRuntime_DigitalMars;
 version = CppRuntime_Gcc;
 version = CppRuntime_Microsoft;
 version = CppRuntime_Sun;
+version = MSRuntime_None;
+version = MSRuntime_Static;
+version = MSRuntime_Dynamic;
+version = MSRuntime_Debug;
+version = MSRuntime_Release;
 
 // This should work though
 debug = DigitalMars;
@@ -300,6 +310,11 @@ debug = CppRuntime_DigitalMars;
 debug = CppRuntime_Gcc;
 debug = CppRuntime_Microsoft;
 debug = CppRuntime_Sun;
+debug = MSRuntime_None;
+debug = MSRuntime_Static;
+debug = MSRuntime_Dynamic;
+debug = MSRuntime_Debug;
+debug = MSRuntime_Release;
 debug = D_Coverage;
 debug = D_Ddoc;
 debug = D_InlineAsm_X86;

--- a/test/fail_compilation/reserved_version_switch.d
+++ b/test/fail_compilation/reserved_version_switch.d
@@ -82,6 +82,11 @@
 // REQUIRED_ARGS: -version=CppRuntime_Gcc
 // REQUIRED_ARGS: -version=CppRuntime_Microsoft
 // REQUIRED_ARGS: -version=CppRuntime_Sun
+// REQUIRED_ARGS: -version=MSRuntime_None
+// REQUIRED_ARGS: -version=MSRuntime_Static
+// REQUIRED_ARGS: -version=MSRuntime_Dynamic
+// REQUIRED_ARGS: -version=MSRuntime_Debug
+// REQUIRED_ARGS: -version=MSRuntime_Release
 // REQUIRED_ARGS: -version=D_Coverage
 // REQUIRED_ARGS: -version=D_Ddoc
 // REQUIRED_ARGS: -version=D_InlineAsm_X86
@@ -178,6 +183,11 @@
 // REQUIRED_ARGS: -debug=CppRuntime_Gcc
 // REQUIRED_ARGS: -debug=CppRuntime_Microsoft
 // REQUIRED_ARGS: -debug=CppRuntime_Sun
+// REQUIRED_ARGS: -debug=MSRuntime_None
+// REQUIRED_ARGS: -debug=MSRuntime_Static
+// REQUIRED_ARGS: -debug=MSRuntime_Dynamic
+// REQUIRED_ARGS: -debug=MSRuntime_Debug
+// REQUIRED_ARGS: -debug=MSRuntime_Release
 // REQUIRED_ARGS: -debug=D_Coverage
 // REQUIRED_ARGS: -debug=D_Ddoc
 // REQUIRED_ARGS: -debug=D_InlineAsm_X86
@@ -279,6 +289,11 @@ Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
 Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
 Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
 Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
+Error: version identifier `MSRuntime_None` is reserved and cannot be set
+Error: version identifier `MSRuntime_Static` is reserved and cannot be set
+Error: version identifier `MSRuntime_Dynamic` is reserved and cannot be set
+Error: version identifier `MSRuntime_Debug` is reserved and cannot be set
+Error: version identifier `MSRuntime_Release` is reserved and cannot be set
 Error: version identifier `D_Coverage` is reserved and cannot be set
 Error: version identifier `D_Ddoc` is reserved and cannot be set
 Error: version identifier `D_InlineAsm_X86` is reserved and cannot be set


### PR DESCRIPTION
Necessary for `std::vector`, `std::string`, etc.

Spec https://github.com/dlang/dlang.org/pull/2462