### PR TITLE
This .editorconfig is incompatible with git on windows.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ root = true
 # + remove whitespace at the end of lines
 [*]
 charset = utf-8
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
git `core.autocrlf` works, and it is default. This setting constantly makes a mess of files, and it's really annoying.