### PR TITLE
Link with clang runtime when doing coverage

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -266,7 +266,15 @@ ifdef ENABLE_PROFILE
 override DFLAGS  += -profile
 endif
 ifdef ENABLE_COVERAGE
-override DFLAGS  += -cov -L-lgcov
+ifeq ($(OS),osx)
+# OSX uses libclang_rt.profile_osx for coverage, not libgcov
+# Attempt to find it by parsing `clang`'s output
+CLANG_LIB_SEARCH_DIR := $(shell clang -print-search-dirs | grep libraries | cut -d= -f2)
+COVERAGE_LINK_FLAGS := -L-L$(CLANG_LIB_SEARCH_DIR)/lib/darwin/ -L-lclang_rt.profile_osx
+else
+COVERAGE_LINK_FLAGS := -L-lgcov
+endif
+override DFLAGS  += -cov $(COVERAGE_LINK_FLAGS)
 CXXFLAGS += --coverage
 endif
 ifdef ENABLE_SANITIZERS


### PR DESCRIPTION
```
Using -lgcov does not work on OSX, libclang_rt.profile_osx is the library to link.
```

Before, running `make -C src -f posix.mak unittest ENABLE_COVERAGE=1` would not link because of:
```
[...]
/usr/local/opt/dmd/include/dlang/dmd/core/exception.d(684): `_store` is thread local
ld: library not found for -lgcov
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error: linker exited with status 1
make: *** [../generated/osx/release/64/dmd-unittest] Error 1
```

I think this is a bit brittle as it only supports one entry in the `libraries` field, but it's still better than the current state (not linking).
Since I'm not 100% sure this is the right approach please leave the merge to @jacob-carlborg 