### PR TITLE
[C++]  Include globals.h instead of mars.h 

### DIFF
--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "mars.h"
+#include "globals.h"
 #include "dsymbol.h"
 
 /**************************************************************/

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -12,7 +12,6 @@
 
 #include "dsymbol.h"
 #include "mtype.h"
-#include "objc.h"
 
 class Expression;
 class Statement;

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -13,7 +13,7 @@
 #include "root/root.h"
 #include "root/stringtable.h"
 
-#include "mars.h"
+#include "globals.h"
 #include "arraytypes.h"
 #include "visitor.h"
 

--- a/src/dmd/errors.h
+++ b/src/dmd/errors.h
@@ -5,12 +5,12 @@
  * http://www.digitalmars.com
  * Distributed under the Boost Software License, Version 1.0.
  * http://www.boost.org/LICENSE_1_0.txt
- * https://github.com/dlang/dmd/blob/master/src/dmd/mars.h
+ * https://github.com/dlang/dmd/blob/master/src/dmd/errors.h
  */
 
 #pragma once
 
-#include "mars.h"
+#include "globals.h"
 
 bool isConsoleColorSupported();
 

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -10,7 +10,8 @@
 
 #pragma once
 
-#include "mars.h"
+#include "complex_t.h"
+#include "globals.h"
 #include "identifier.h"
 #include "arraytypes.h"
 #include "visitor.h"

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -12,7 +12,7 @@
 
 #include "root/root.h"
 
-#include "mars.h"
+#include "globals.h"
 #include "arraytypes.h"
 #include "visitor.h"
 

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -31,7 +31,7 @@ class TemplateInstance;
 
 #if __GNUC__
 // Requires a full definition for LINK
-#include "mars.h"
+#include "globals.h"
 #else
 enum LINK;
 enum PINLINE;

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "root/port.h"
-#include "mars.h"
+#include "globals.h"
 
 class Identifier;
 


### PR DESCRIPTION
The mars header doesn't need to be included everywhere any more.  Interfacing C++ programs should explicitly include the header if they want access to anything that is declared there.