### PR TITLE
refactor: Move Condition syntaxCopy into a visitor class

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -31,6 +31,7 @@ import dmd.mtype;
 import dmd.root.outbuffer;
 import dmd.target;
 import dmd.tokens;
+import dmd.syntaxcopy;
 import dmd.visitor;
 
 /***********************************************************

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -54,8 +54,6 @@ extern (C++) abstract class Condition : RootObject
         this.loc = loc;
     }
 
-    abstract Condition syntaxCopy();
-
     abstract int include(Scope* sc);
 
     DebugCondition isDebugCondition()
@@ -428,11 +426,6 @@ extern (C++) class DVCondition : Condition
         this.mod = mod;
         this.level = level;
         this.ident = ident;
-    }
-
-    override final Condition syntaxCopy()
-    {
-        return this; // don't need to copy
     }
 
     override void accept(Visitor v)
@@ -820,11 +813,6 @@ extern (C++) final class StaticIfCondition : Condition
     {
         super(loc);
         this.exp = exp;
-    }
-
-    override Condition syntaxCopy()
-    {
-        return new StaticIfCondition(loc, exp.syntaxCopy());
     }
 
     override int include(Scope* sc)

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -32,7 +32,6 @@ public:
     // 2: do not include
     int inc;
 
-    virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
@@ -58,7 +57,6 @@ public:
     Identifier *ident;
     Module *mod;
 
-    Condition *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -88,7 +86,6 @@ public:
     Expression *exp;
     int nest;         // limit circular dependencies
 
-    Condition *syntaxCopy();
     int include(Scope *sc);
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -45,6 +45,7 @@ import dmd.root.rootobject;
 import dmd.sapply;
 import dmd.sideeffect;
 import dmd.staticassert;
+import dmd.syntaxcopy;
 import dmd.tokens;
 import dmd.visitor;
 

--- a/src/dmd/syntaxcopy.d
+++ b/src/dmd/syntaxcopy.d
@@ -1,0 +1,55 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/syntaxcopy.d, _syntaxcopy.d)
+ * Documentation:  https://dlang.org/phobos/dmd_syntaxcopy.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/syntaxcopy.d
+ */
+
+module dmd.syntaxcopy;
+
+import dmd.cond;
+import dmd.visitor;
+
+package:
+
+/**
+ * Make a deep copy of a front end AST node.
+ * Params:
+ *      from = AST node to make a new copy of
+ * Returns:
+ *      the resulting copy
+ */
+Condition syntaxCopy(Condition from)
+{
+    scope SyntaxCopyVisitor scv = new SyntaxCopyVisitor();
+    from.accept(scv);
+    return scv.condition;
+}
+
+private:
+
+extern (C++) final class SyntaxCopyVisitor : Visitor
+{
+    alias visit = Visitor.visit;
+
+    Condition condition;
+
+    extern(D) this()
+    {
+    }
+
+    override void visit(DVCondition from)
+    {
+        condition = from; // don't need to copy
+    }
+
+    override void visit(StaticIfCondition from)
+    {
+        condition = new StaticIfCondition(from.loc, from.exp.syntaxCopy());
+    }
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -315,7 +315,7 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 	json lambdacomp lib libelf libmach link mars mtype nogc nspace objc opover optimize parse permissivevisitor sapply templateparamsem	\
 	sideeffect statement staticassert target typesem traits transitivevisitor parsetimevisitor visitor	\
 	typinf utils scanelf scanmach statement_rewrite_walker statementsem staticcond safe blockexit printast \
-	semantic2 semantic3))
+	semantic2 semantic3 syntaxcopy))
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors globals id identifier lexer tokens utf))
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -163,7 +163,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 	$D/safe.d $D/blockexit.d $D/permissivevisitor.d $D/transitivevisitor.d $D/parsetimevisitor.d $D/printast.d $D/typesem.d \
 	$D/traits.d $D/utils.d $D/visitor.d $D/libomf.d $D/scanomf.d $D/templateparamsem.d $D/typinf.d \
 	$D/libmscoff.d $D/scanmscoff.d $D/statement_rewrite_walker.d $D/statementsem.d $D/staticcond.d \
-	$D/semantic2.d $D/semantic3.d
+	$D/semantic2.d $D/semantic3.d $D/syntaxcopy.d
 
 LEXER_SRCS=$D/console.d $D/entity.d $D/errors.d $D/globals.d $D/id.d $D/identifier.d \
 	$D/lexer.d $D/tokens.d $D/utf.d


### PR DESCRIPTION
This initial commit adds code, but overall there should be around 200 less lines post removal of all.

@Geod24 visitorizing virtual functions that the glue doesn't need to know about is another easy win for cleaning up the extern(C++) interface.  Here's a nice list of stuff if you want to have a look at, the majority of which is not used outside of dtemplate.d. ;-)

https://github.com/dlang/dmd/blob/3eaf73cfc8b1bb240ffb18ad278e2518047bbda9/src/dmd/template.h#L142-L156