### PR TITLE
[stable] Fix Issue 19219 - Could not CTFE with std.math.exp

### DIFF
--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -124,6 +124,13 @@ extern (C++) Expression eval_log10(Loc loc, FuncDeclaration fd, Expressions* arg
     return new RealExp(loc, CTFloat.log10(arg0.toReal()), arg0.type);
 }
 
+extern (C++) Expression eval_exp(Loc loc, FuncDeclaration fd, Expressions* arguments)
+{
+    Expression arg0 = (*arguments)[0];
+    assert(arg0.op == TOK.float64);
+    return new RealExp(loc, CTFloat.exp(arg0.toReal()), arg0.type);
+}
+
 extern (C++) Expression eval_expm1(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
@@ -381,6 +388,7 @@ public extern (C++) void builtin_init()
     add_builtin("_D3std4math3tanFNaNbNiNeeZe", &eval_tan);
     add_builtin("_D3std4math4sqrtFNaNbNiNeeZe", &eval_sqrt);
     add_builtin("_D3std4math4fabsFNaNbNiNeeZe", &eval_fabs);
+    add_builtin("_D3std4math3expFNaNbNiNeeZe", &eval_exp);
     add_builtin("_D3std4math5expm1FNaNbNiNeeZe", &eval_expm1);
     add_builtin("_D3std4math4exp2FNaNbNiNeeZe", &eval_exp2);
     // @safe @nogc pure nothrow double function(double)

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -89,6 +89,7 @@ extern (C++) struct CTFloat
         static real_t log2(real_t x) { return real_t(cast(double)core.stdc.math.log2l(cast(double)x)); }
         static real_t log10(real_t x) { return real_t(cast(double)core.stdc.math.log10l(cast(double)x)); }
         static real_t pow(real_t x, real_t y) { return real_t(cast(double)core.stdc.math.powl(cast(double)x, cast(double)y)); }
+        static real_t exp(real_t x) { return real_t(cast(double)core.stdc.math.expl(cast(double)x)); }
         static real_t expm1(real_t x) { return real_t(cast(double)core.stdc.math.expm1l(cast(double)x)); }
         static real_t exp2(real_t x) { return real_t(cast(double)core.stdc.math.exp2l(cast(double)x)); }
         static real_t copysign(real_t x, real_t s) { return real_t(cast(double)core.stdc.math.copysignl(cast(double)x, cast(double)s)); }
@@ -103,6 +104,7 @@ extern (C++) struct CTFloat
         static real_t log2(real_t x) { return core.stdc.math.log2l(x); }
         static real_t log10(real_t x) { return core.stdc.math.log10l(x); }
         static real_t pow(real_t x, real_t y) { return core.stdc.math.powl(x, y); }
+        static real_t exp(real_t x) { return core.stdc.math.expl(x); }
         static real_t expm1(real_t x) { return core.stdc.math.expm1l(x); }
         static real_t exp2(real_t x) { return core.stdc.math.exp2l(x); }
         static real_t copysign(real_t x, real_t s) { return core.stdc.math.copysignl(x, s); }

--- a/test/compilable/test5227.d
+++ b/test/compilable/test5227.d
@@ -21,6 +21,8 @@ ceil()
 6.00000L
 trunc()
 5.00000L
+exp()
+244.692L
 expm1()
 243.692L
 exp2()
@@ -81,6 +83,11 @@ pragma(msg, "trunc()");
 enum truncf = trunc(5.5f); //pragma(msg, truncf);
 enum truncd = trunc(5.5 ); //pragma(msg, truncd);
 enum truncr = trunc(5.5L); pragma(msg, truncr);
+
+pragma(msg, "exp()");
+enum expf = exp(5.5f); //pragma(msg, expf);
+enum expd = exp(5.5 ); //pragma(msg, expd);
+enum expr = exp(5.5L); pragma(msg, expr);
 
 pragma(msg, "expm1()");
 enum expm1f = expm1(5.5f); //pragma(msg, expm1f);


### PR DESCRIPTION
The underlying issue is an apparent CTFE bug wrt. passing static immutable static arrays by (const) ref, see https://issues.dlang.org/show_bug.cgi?id=17351#c10. That makes this [poly() optimization](https://github.com/dlang/phobos/commit/e1d987dda6e61596fbdf67ede4f0e76a12badbec) not CTFE-able.