### PR TITLE
Fix issue 19225 - Confusing error message on `static else`

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3686,6 +3686,8 @@ final class Parser(AST) : Lexer
 
         default:
             error("basic type expected, not `%s`", token.toChars());
+            if (token.value == TOK.else_)
+                errorSupplemental(token.loc, "There's no `static else`, use `else` instead.");
             t = AST.Type.terror;
             break;
         }
@@ -4558,7 +4560,7 @@ final class Parser(AST) : Lexer
             bool isThis = (t.ty == AST.Tident && (cast(AST.TypeIdentifier)t).ident == Id.This && token.value == TOK.assign);
             if (ident)
                 checkCstyleTypeSyntax(loc, t, alt, ident);
-            else if (!isThis)
+            else if (!isThis && (t != AST.Type.terror))
                 error("no identifier for declarator `%s`", t.toChars());
 
             if (tok == TOK.alias_)

--- a/test/fail_compilation/diag19225.d
+++ b/test/fail_compilation/diag19225.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag19225.d(14): Error: basic type expected, not `else`
+fail_compilation/diag19225.d(14):        There's no `static else`, use `else` instead.
+fail_compilation/diag19225.d(14): Error: found `else` without a corresponding `if`, `version` or `debug` statement
+fail_compilation/diag19225.d(15): Error: unrecognized declaration
+---
+*/
+
+void main()
+{
+    static if (true) {}
+    static else {}
+}


### PR DESCRIPTION
So users assuming `static else` is fine get a helpful error message.

This might need some further fine-tuning, though.
Since it will trigger on faulty code like this:
```d
module mymod;
static else i = 0;
static int j = 0;
```