### PR TITLE
Fix issue 18946:  assert message can throw hijacking the assert failure

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5369,6 +5369,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 return;
             }
         }
+
+        // https://issues.dlang.org/show_bug.cgi?id=18946
+        if (exp.msg && canThrow(exp.msg,sc.func,false))
+            exp.msg.deprecation("`%s` assert error messages must not throw",exp.msg.toChars());
+
         exp.type = Type.tvoid;
         result = exp;
     }

--- a/test/fail_compilation/bug18946.d
+++ b/test/fail_compilation/bug18946.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/bug18743.d(15): Deprecation: `throwingFunc()` assert error messages must not throw
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=18946
+void main() {
+
+    static string throwingFunc()
+    {
+        throw new Exception("An exception");
+    }
+    assert(0, throwingFunc());
+}


### PR DESCRIPTION
I presume the protocol is to deprecate this first.