### PR TITLE
[STABLE] Temporarily revert SemaphoreCI to v2.081.2

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -36,7 +36,14 @@ source ci.sh
 # Always source a DMD instance
 ################################################################################
 
-install_d "$DMD"
+# FIXME: v2.082.0 has a broken DUB which fails the CI
+# Remove this when a fixed v2.082.1 is released
+# See https://github.com/dlang/dub/issues/1551
+if [ "$DMD" == "dmd" ]; then
+    install_d "dmd-2.081.2"
+else
+    install_d "$DMD"
+fi
 
 ################################################################################
 # Define commands


### PR DESCRIPTION
```
Because, as explained in the comment, v2.082.0's DUB is broken and is blocking development,
as SemaphoreCI is required to merge a PR.
```

#8661  to stable