### PR TITLE
Fix Issue 18771 - Identical overload sets in different modules have different identities

### DIFF
--- a/test/compilable/imports/test18771a.d
+++ b/test/compilable/imports/test18771a.d
@@ -1,0 +1,3 @@
+module imports.test18771a;
+
+void foo(int) {}

--- a/test/compilable/imports/test18771b.d
+++ b/test/compilable/imports/test18771b.d
@@ -1,0 +1,3 @@
+module imports.test18771b;
+
+void foo(string) {}

--- a/test/compilable/imports/test18771c.d
+++ b/test/compilable/imports/test18771c.d
@@ -1,0 +1,4 @@
+module imports.test18771c;
+
+import imports.test18771a, imports.test18771b;
+alias fooC = foo;

--- a/test/compilable/imports/test18771d.d
+++ b/test/compilable/imports/test18771d.d
@@ -1,0 +1,4 @@
+module imports.test18771d;
+
+import imports.test18771b, imports.test18771a;
+alias fooD = foo;

--- a/test/compilable/test18771.d
+++ b/test/compilable/test18771.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS : -c
+// https://issues.dlang.org/show_bug.cgi?id=18771
+
+import imports.test18771c, imports.test18771d;
+
+static assert(__traits(isSame, fooC, fooD));


### PR DESCRIPTION
__traits(isSame) simply follows the alias chain and sees if the symbols resolve to the same AST node. In the case of overload sets in different files that does not work anymore and the components of the overload sets need to be compared for equality. The current patch compares the overload sets by comparing each element of an one to each of the elements of the other in O(n*n) complexity; that is because the elements of the overload set are stored in an array of Dsymbols. A smarter approach would be to use a hashtable for the components of the overload set, but that would lead to major refactorizations.