### PR TITLE
[STABLE] Switch AppVeyor to use downloads.dlang.org and v2.078.3

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -57,8 +57,10 @@ for proj in druntime phobos; do
             ! git ls-remote --exit-code --heads https://github.com/dlang/$proj.git $APPVEYOR_REPO_BRANCH > /dev/null; then
         # use master as fallback for other repos to test feature branches
         clone https://github.com/dlang/$proj.git $proj master
+        echo "+++ Switched $proj to branch master (APPVEYOR_REPO_BRANCH=$APPVEYOR_REPO_BRANCH)"
     else
         clone https://github.com/dlang/$proj.git $proj $APPVEYOR_REPO_BRANCH
+        echo "+++ Switched $proj to branch $APPVEYOR_REPO_BRANCH"
     fi
 done
 

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -44,8 +44,8 @@ if [ ! -f "gnumake/make.exe" ]; then
 fi
 
 if [ $D_COMPILER == "dmd" ]; then
-    #appveyor DownloadFile "http://downloads.dlang.org/releases/2.x/${D_VERSION}/dmd.${D_VERSION}.windows.7z" -FileName dmd2.7z
-    appveyor DownloadFile "http://nightlies.dlang.org/dmd-master-2017-12-22/dmd.master.windows.7z" -FileName dmd2.7z
+    appveyor DownloadFile "http://downloads.dlang.org/releases/2.x/${D_VERSION}/dmd.${D_VERSION}.windows.7z" -FileName dmd2.7z
+    #appveyor DownloadFile "http://nightlies.dlang.org/dmd-master-2017-12-22/dmd.master.windows.7z" -FileName dmd2.7z
     7z x dmd2.7z > /dev/null
     export PATH=$PWD/dmd2/windows/bin/:$PATH
     export DMD=/c/projects/dmd2/windows/bin/dmd.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ skip_commits:
 artifacts:
   - path: src/dmd.exe
     name: dmd 64-bit
-  - path: generated/Windows/Release/Win32/dmd.exe 
+  - path: generated/Windows/Release/Win32/dmd.exe
     name: dmd 32-bit built with LDC
 
 init:
@@ -43,7 +43,7 @@ build_script:
         If (-not (Test-Path $Env:LDC_DIR/bin/ldmd2.exe)) {
             echo "Unexpected LDC installation, $Env:LDC_INSTALLER/bin/ldmd2.exe missing"
         }
-        
+
   # Download & install Visual D (needs admin rights?)
   - set VISUALD_INSTALLER=VisualD-%VISUALD_VER%.exe
   - set VISUALD_URL=https://github.com/dlang/visuald/releases/download/%VISUALD_VER%/%VISUALD_INSTALLER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   matrix:
     - ARCH:                x64
       D_COMPILER:          dmd
-      D_VERSION:           2.077.1
+      D_VERSION:           2.079.1
       C_COMPILER:          MSVC
       VISUALD_VER:         v0.45.1-rc2
       LDC_VERSION:         1.8.0


### PR DESCRIPTION
```
    Because nightlies has been down for a few days
    Nightlies depended on an unreleased version of DMD:
    v2.077.1 was released November 29, and v2.078.0 January 1st,
    but AppVeyor fetched the nighly from 2017-12-22.

    Trying to go back to v2.077.1 produced an access violation,
    so the compiler has been upgrade to v2.078.3.
```