### PR TITLE
[REG master] Partially revert #8623

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -169,7 +169,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     {
         if (_scope)
             dsymbolSemantic(this, null);
-        if (fields.dim > 0)
+        if (sizeok != Sizeok.none)
             return true;
 
         //printf("determineFields() %s, fields.dim = %d\n", toChars(), fields.dim);


### PR DESCRIPTION
In the following test, the front-end wrongly adds an extra field as of #8623. Which trips the tight asserts present during code gen.
```
// 1684

template Test1684( uint memberOffset ){}

class MyClass1684 {
    int flags2;
    mixin Test1684!(cast(uint)flags2.offsetof) t1; // compiles ok
    mixin Test1684!(cast(int)flags2.offsetof)  t2; // compiles ok
    mixin Test1684!(flags2.offsetof)           t3; // Error: no property 'offsetof' for type 'int'
}
```