### PR TITLE
[RFC]  Make the Outbuffer / message function tuple-variadic and slice-aware

### DIFF
--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -721,8 +721,7 @@ private void emitAnchor(OutBuffer* buf, Dsymbol s, Scope* sc, bool forHeader = f
     sc.prevAnchor = ident;
     auto macroName = forHeader ? "DDOC_HEADER_ANCHOR" : "DDOC_ANCHOR";
     auto symbolName = ident.toString();
-    buf.printf("$(%.*s %.*s", cast(int) macroName.length, macroName.ptr,
-        cast(int) symbolName.length, symbolName.ptr);
+    buf.printf("$(%.*s %.*s", macroName, symbolName);
     // only append count once there's a duplicate
     if (count > 1)
         buf.printf(".%u", count);
@@ -735,9 +734,7 @@ private void emitAnchor(OutBuffer* buf, Dsymbol s, Scope* sc, bool forHeader = f
             emitAnchorName(&anc, s, skipNonQualScopes(sc), false);
             shortIdent = Identifier.idPool(anc.peekSlice());
         }
-
-        auto shortName = shortIdent.toString();
-        buf.printf(", %.*s", cast(int) shortName.length, shortName.ptr);
+        buf.printf(", %.*s", shortIdent.toString());
     }
 
     buf.writeByte(')');

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -2,6 +2,19 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
+ * This module provides up to 3 kinds of overload to a given function:
+ * - A va_arg accepting function which will be the actual implementation
+ *   This overload is not always present
+ * - A C++ facing implementation, with the prefix which accept C-style varargs.
+ * - An `extern(D)` wrapper to the C++ implementation which accepts
+ *   variadic template arguments.
+ *   Those functions have a 'd' prefix, e.g. `derror`
+ *
+ *   The goal of the wrapper is to turn slices into the length/ptr pair that
+ *   is accepted by printf. This wrapper does not alter the format string,
+ *   and as such the user should call `dmessage("%.*s", my_string)`
+ *   and not `dmessage("%s", my_string)` as this could result in a SIGSEGV
+ *
  * Copyright:   Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
@@ -20,6 +33,7 @@ import dmd.globals;
 import dmd.root.outbuffer;
 import dmd.root.rmem;
 import dmd.console;
+import dmd.utils;
 
 /**
  * Color highlighting to classify messages
@@ -33,12 +47,20 @@ enum Classification
 }
 
 /**
- * Print an error message, increasing the global error count.
- * Params:
- *      loc    = location of error
- *      format = printf-style format specification
- *      ...    = printf-style variadic arguments
- */
+Print an error message, increasing the global error count.
+
+Params:
+loc    = location of error
+format = printf-style format specification
+args   = variadic list of arguments
+...    = printf-style variadic arguments
+*/
+void derror(Args...)(const ref Loc loc, const(char)* format, Args args)
+{
+    mixin("error(loc, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void error(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -69,8 +91,15 @@ extern (D) void error(Loc loc, const(char)* format, ...)
  *      linnum   = line in the source file
  *      charnum  = column number on the line
  *      format   = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...      = printf-style variadic arguments
  */
+void derror(Args...)(const(char)* filename, uint linnum, uint charnum, const(char)* format, Args args)
+{
+    mixin("error(filename, linnum, charnum, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
 {
     const loc = Loc(filename, linnum, charnum);
@@ -86,8 +115,15 @@ extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(
  * Params:
  *      loc    = location of error
  *      format = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...    = printf-style variadic arguments
  */
+void derrorSupplemental(Args...)(const ref Loc loc, const(char)* format, Args args)
+{
+    mixin("errorSupplemental(loc, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void errorSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -101,8 +137,15 @@ extern (C++) void errorSupplemental(const ref Loc loc, const(char)* format, ...)
  * Params:
  *      loc    = location of warning
  *      format = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...    = printf-style variadic arguments
  */
+void dwarning(Args...)(const ref Loc loc, const(char)* format, Args args)
+{
+    mixin("warning(loc, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -117,8 +160,15 @@ extern (C++) void warning(const ref Loc loc, const(char)* format, ...)
  * Params:
  *      loc    = location of warning
  *      format = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...    = printf-style variadic arguments
  */
+void dwarningSupplemental(Args...)(const ref Loc loc, const(char)* format, Args args)
+{
+    mixin("warningSupplemental(loc, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -133,8 +183,15 @@ extern (C++) void warningSupplemental(const ref Loc loc, const(char)* format, ..
  * Params:
  *      loc    = location of deprecation
  *      format = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...    = printf-style variadic arguments
  */
+void ddeprecation(Args...)(const ref Loc loc, const(char)* format, Args args)
+{
+    mixin("deprecation(loc, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void deprecation(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -149,8 +206,15 @@ extern (C++) void deprecation(const ref Loc loc, const(char)* format, ...)
  * Params:
  *      loc    = location of deprecation
  *      format = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...    = printf-style variadic arguments
  */
+void ddeprecationSupplemental(Args...)(const ref Loc loc, const(char)* format, Args args)
+{
+    mixin("deprecationSupplemental(loc, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -165,8 +229,15 @@ extern (C++) void deprecationSupplemental(const ref Loc loc, const(char)* format
  * Params:
  *      loc    = location of message
  *      format = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...    = printf-style variadic arguments
  */
+void dmessage(Args...)(const ref Loc loc, const(char)* format, Args args)
+{
+    mixin("message(loc, format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void message(const ref Loc loc, const(char)* format, ...)
 {
     va_list ap;
@@ -179,8 +250,15 @@ extern (C++) void message(const ref Loc loc, const(char)* format, ...)
  * Same as above, but doesn't take a location argument.
  * Params:
  *      format = printf-style format specification
+ *      args   = variadic list of arguments
  *      ...    = printf-style variadic arguments
  */
+void dmessage(Args...)(const(char)* format, Args args)
+{
+    mixin("message(format, " ~ mapSlices!Args() ~ ");");
+}
+
+/// ditto
 extern (C++) void message(const(char)* format, ...)
 {
     va_list ap;

--- a/src/dmd/root/outbuffer.h
+++ b/src/dmd/root/outbuffer.h
@@ -64,7 +64,7 @@ public:
     void write(RootObject *obj);
     void fill0(size_t nbytes);
     void vprintf(const char *format, va_list args);
-    void printf(const char *format, ...);
+    void cprintf(const char *format, ...);
     void bracket(char left, char right);
     size_t bracket(size_t i, const char *left, size_t j, const char *right);
     void spread(size_t offset, size_t nbytes);


### PR DESCRIPTION
This turn the ubiquitous first layer of `message`, `warning`,
`deprecation[Supplemental]`, `error` from C-style variadic into D-style variadic,
while moving the previous implementation as `cmessage`, `cwarning`, etc...

The intent is to make it easy to print a slice using those functions.
At the moment, when one which to print a slice, one can not rely on `\0` termination
of the slice, so the following code:
```
error(loc, "Identifier not found: %s", id.toChars());
```
has to be turned into:
```
error(loc, "Identifier not found: %.*s", cast(int)id.toString().length, id.toString().ptr);
```

This is obviously not convenient and a major burden on the call site.
Worse, some `toString` might perform some computation (e.g. strlen at the moment)
and calling it might not be trivial, which usually leads to storing the slice as an extra variable.

As the goal of our conversion from `char*` to `char[]` is to improve the code quality,
a better solution is obviously needed.
With this patchset, the previous call to `error` becomes:
```
error(loc, "Identifier not found: %.*s", id.toString());
```
As a result, only the format string has to be altered.