### PR TITLE
Remove deprecated or errored command line switches

### DIFF
--- a/changelog/deprecated_switch_gc.dd
+++ b/changelog/deprecated_switch_gc.dd
@@ -1,0 +1,6 @@
+Deprecated CLI switch `-gc` have been removed
+
+This switch was deprecated in v2.075.0 and is now removed,
+meaning DMD will complain about an unrecognized switch.
+`-gc` used to pretend to be C, but debuggers have been
+D-aware for around a decade.

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1568,12 +1568,6 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             params.multiobj = true;
         else if (arg == "-g") // https://dlang.org/dmd.html#switch-g
             params.symdebug = 1;
-        else if (arg == "-gc")  // https://dlang.org/dmd.html#switch-gc
-        {
-            Loc loc;
-            deprecation(loc, "use -g instead of -gc");
-            params.symdebug = 2;
-        }
         else if (arg == "-gf")
         {
             if (!params.symdebug)
@@ -1584,11 +1578,6 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             params.alwaysframe = true;
         else if (arg == "-gx")  // https://dlang.org/dmd.html#switch-gx
             params.stackstomp = true;
-        else if (arg == "-gt")
-        {
-            error("use -profile instead of -gt");
-            params.trace = true;
-        }
         else if (arg == "-m32") // https://dlang.org/dmd.html#switch-m32
         {
             static if (TARGET.DragonFlyBSD) {


### PR DESCRIPTION
'-gc' was deprecated over a year ago, in PR #4766 (released as part of DMD 2.075.0)
As for '-gt', it was turned into an error over 9 years ago according to the git history,
sometime between DMD 0.050 and DMD 0.120...