### PR TITLE
Fix 19243 - [REG 2.081] Can no longer override pragma(lib) with -L switch

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -215,3 +215,6 @@ Along with the environment variables provided by the Makefile (see above), an ad
     EXTRA_FILES        directory for extra files of this test type, e.g. runnable/extra-files
 
     LIBEXT             platform-specific extension for library files, e.g. .a or .lib
+
+    SOEXT              platform-specific extension for shared object files (aka. dynamic libraries),
+                       e.g. .so, .dll or .dylib

--- a/test/compilable/issue19243.sh
+++ b/test/compilable/issue19243.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/env bash
+
+# bypassing this test:
+#  - on windows
+#  - on FreeBSD 32 bits
+#       test fails looling for liborig.so; don't know why but shouldn't block fixing all other platforms
+#  - on Circle CI with no_pic. (need PIC to run the test)
+if [[ $OS = *"win"* ]]; then exit 0; fi
+if [[ $OS = *"freebsd"* ]] && [[ $MODEL = *"32"* ]]; then exit 0; fi
+if [ ${PIC:-1} == "0" ]; then exit 0; fi
+
+TEST_DIR=${OUTPUT_BASE}
+ORIG_D=$TEST_DIR/orig.d
+ORIG_SO=$TEST_DIR/liborig${SOEXT}
+OVERRIDE_D=$TEST_DIR/override.d
+OVERRIDE_SO=$TEST_DIR/liboverride${SOEXT}
+APP_D=$TEST_DIR/app.d
+
+mkdir -p $TEST_DIR
+
+cat << EOF | $DMD -m$MODEL -fPIC -shared -of$ORIG_SO -
+import core.stdc.stdio;
+
+extern(C) int func()
+{
+    printf("liborig\n");
+    return 1;
+}
+EOF
+
+cat << EOF | $DMD -m$MODEL -fPIC -shared -of$OVERRIDE_SO -
+import core.stdc.stdio;
+
+extern(C) int func()
+{
+    printf("liboverride\n");
+    return 2;
+}
+EOF
+
+cat << EOF | LD_LIBRARY_PATH=$TEST_DIR $DMD -m$MODEL -L-L$TEST_DIR -L$OVERRIDE_SO -run -
+extern(C) int func();
+
+pragma(lib, "orig");
+
+void main()
+{
+    assert(func() == 2);
+}
+EOF

--- a/test/tools/exported_vars.sh
+++ b/test/tools/exported_vars.sh
@@ -13,6 +13,14 @@ else
     export LIBEXT=.a
 fi
 
+if [[ "$OS" == "win"* ]]; then
+    export SOEXT=.dll
+elif [[ "$OS" = "osx" ]]; then
+    export SOEXT=.dylib
+else
+    export SOEXT=.so
+fi
+
 # Default to DigitalMars C++ on Win32
 if [ "$OS" == "win32" ] && [ -z "${CC+set}" ] ; then
     CC="dmc"


### PR DESCRIPTION
See https://issues.dlang.org/show_bug.cgi?id=19243
What I do here is to keep *.a files at the start of linker command line to keep #8172 on working, but all other switches are back to their previous locations.