### PR TITLE
fix typo in cod3.d

### DIFF
--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -5597,7 +5597,7 @@ debug
   }
 
   debug
-  if (1 || debugc) {
+  if (debugc) {
       printf("-pinholeopt(%p)\n",cstart);
         for (c = cstart; c; c = code_next(c))
             code_print(c);


### PR DESCRIPTION
Otherwise, compiling with `-debug` is a bit unusable.