### PR TITLE
[~regression fix] fix Issue 19248 and reopened 18957

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1045,7 +1045,7 @@ private final class CppMangleVisitor : Visitor
             }
             if (!substitute(s))
             {
-                cpp_mangle_name(s, t.isConst());
+                cpp_mangle_name(s, false);
             }
         }
         if (t.isConst())
@@ -1091,7 +1091,7 @@ private final class CppMangleVisitor : Visitor
 
         if (!substitute(t.sym))
         {
-            cpp_mangle_name(t.sym, t.isConst());
+            cpp_mangle_name(t.sym, false);
         }
         if (t.isConst())
             append(null);  // C++ would have an extra type here

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -740,9 +740,17 @@ extern(C++, Namespace18922)
 
 version (Posix)
 {
+    // https://godbolt.org/z/C5T2LQ
+    /+
+    namespace std
+    {
+    struct test18957 {};
+    }
+    void test18957(const std::test18957& t) {}
+    +/
     extern (C++) void test18957(ref const(std.test18957) t) {}
 
-    static assert(test18957.mangleof == "_Z9test18957RKNSt9test18957E");
+    static assert(test18957.mangleof == "_Z9test18957RKSt9test18957");
 }
 
 /**************************************/

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -7,6 +7,11 @@ struct S
     float a = 1;
 }
 
+extern(C++, std)
+{
+    struct test19248 {int a = 34;}
+}
+
 bool   passthrough(bool   value);
 byte   passthrough(byte   value);
 ubyte  passthrough(ubyte  value);
@@ -21,6 +26,7 @@ ulong  passthrough(ulong  value);
 float  passthrough(float  value);
 double passthrough(double value);
 S      passthrough(S      value);
+std.test19248 passthrough(const(std.test19248) value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -36,6 +42,7 @@ ulong  passthrough_ptr(ulong  *value);
 float  passthrough_ptr(float  *value);
 double passthrough_ptr(double *value);
 S      passthrough_ptr(S      *value);
+std.test19248 passthrough_ptr(const(std.test19248)* value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -51,6 +58,7 @@ ulong  passthrough_ref(ref ulong  value);
 float  passthrough_ref(ref float  value);
 double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
+std.test19248 passthrough_ref(ref const(std.test19248) value);
 }
 
 template IsSigned(T)
@@ -154,4 +162,5 @@ void main()
     foreach(float val; values!float())   check(val);
     foreach(double val; values!double()) check(val);
     check(S());
+    check(std.test19248());
 }

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -2,6 +2,11 @@ struct S{
     float a;
 };
 
+namespace std
+{
+    struct test19248 {int a;};
+};
+
 bool               passthrough(bool                value)     { return value; }
 signed char        passthrough(signed char         value)     { return value; }
 unsigned char      passthrough(unsigned char       value)     { return value; }
@@ -18,6 +23,7 @@ unsigned long long passthrough(unsigned long long  value)     { return value; }
 float              passthrough(float               value)     { return value; }
 double             passthrough(double              value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
+std::test19248     passthrough(const std::test19248 value)     { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -35,6 +41,7 @@ unsigned long long passthrough_ptr(unsigned long long *value) { return *value; }
 float              passthrough_ptr(float              *value) { return *value; }
 double             passthrough_ptr(double             *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
+std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -52,6 +59,7 @@ unsigned long long passthrough_ref(unsigned long long &value) { return value; }
 float              passthrough_ref(float              &value) { return value; }
 double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
+std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
 
 // Uncomment when mangling is fixed
 // typedef void(*fn0)();


### PR DESCRIPTION
I am not sure if it is normal regression. The issue 18957 has been fixed, but partially. The example in the issue 18957 is wrong, and it looks like it caused the wrong test.