### PR TITLE
Remove RootObject.print method

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -389,8 +389,6 @@ UnionExp Div(const ref Loc loc, Type type, Expression e1, Expression e2)
     if (type.isfloating())
     {
         auto c = complex_t(CTFloat.zero);
-        //e1.type.print();
-        //e2.type.print();
         if (e2.type.isreal())
         {
             if (e1.type.isreal())

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2757,9 +2757,6 @@ Lagain:
         t2 = Type.basic[ty2];
         e1 = e1.castTo(sc, t1);
         e2 = e2.castTo(sc, t2);
-        //printf("after typeCombine():\n");
-        //print();
-        //printf("ty = %d, ty1 = %d, ty2 = %d\n", ty, ty1, ty2);
         goto Lret;
     }
 
@@ -3322,7 +3319,6 @@ Lret:
             printf("\tt2 = %s\n", e2.type.toChars());
         printf("\ttype = %s\n", t.toChars());
     }
-    //print();
     return true;
 
 Lt1:

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -848,7 +848,6 @@ extern (C++) class Dsymbol : RootObject
      */
     Dsymbol syntaxCopy(Dsymbol s)
     {
-        print();
         printf("%s %s\n", kind(), toChars());
         assert(0);
     }
@@ -2118,21 +2117,6 @@ extern (C++) final class DsymbolTable : RootObject
             return null; // already in table
         *ps = s;
         return s;
-    }
-
-    debug
-    {
-        /**
-        print the symbol table contents
-        */
-        override void print()
-        {
-            printf("SYMBOL TABLE (%d entries)\n------------------------------\n", tab.length);
-            foreach (keyValue; tab.asRange)
-            {
-                printf("%s\n", keyValue.key.toChars());
-            }
-        }
     }
 
     // Look for Dsymbol in table. If there, return it. If not, insert s and return that.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4951,7 +4951,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Module.dprogress++;
         cldec.semanticRun = PASS.semanticdone;
         //printf("-ClassDeclaration.dsymbolSemantic(%s), type = %p\n", toChars(), type);
-        //members.print();
 
         sc2.pop();
 
@@ -5309,7 +5308,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Module.dprogress++;
         idec.semanticRun = PASS.semanticdone;
         //printf("-InterfaceDeclaration.dsymbolSemantic(%s), type = %p\n", toChars(), type);
-        //members.print();
 
         sc2.pop();
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2070,10 +2070,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         }
         else
         {
-            debug
-            {
-                o.print();
-            }
             assert(0);
         }
         d.storage_class |= STC.templateparameter;
@@ -3239,14 +3235,6 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(Type t)
         {
-            version (none)
-            {
-                printf("Type.deduceType()\n");
-                printf("\tthis   = %d, ", t.ty);
-                t.print();
-                printf("\ttparam = %d, ", tparam.ty);
-                tparam.print();
-            }
             if (!tparam)
                 goto Lnomatch;
 
@@ -3521,14 +3509,6 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(TypeVector t)
         {
-            version (none)
-            {
-                printf("TypeVector.deduceType()\n");
-                printf("\tthis   = %d, ", t.ty);
-                t.print();
-                printf("\ttparam = %d, ", tparam.ty);
-                tparam.print();
-            }
             if (tparam.ty == Tvector)
             {
                 TypeVector tp = cast(TypeVector)tparam;
@@ -3540,28 +3520,11 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(TypeDArray t)
         {
-            version (none)
-            {
-                printf("TypeDArray.deduceType()\n");
-                printf("\tthis   = %d, ", t.ty);
-                t.print();
-                printf("\ttparam = %d, ", tparam.ty);
-                tparam.print();
-            }
             visit(cast(Type)t);
         }
 
         override void visit(TypeSArray t)
         {
-            version (none)
-            {
-                printf("TypeSArray.deduceType()\n");
-                printf("\tthis   = %d, ", t.ty);
-                t.print();
-                printf("\ttparam = %d, ", tparam.ty);
-                tparam.print();
-            }
-
             // Extra check that array dimensions must match
             if (tparam)
             {
@@ -3614,15 +3577,6 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(TypeAArray t)
         {
-            version (none)
-            {
-                printf("TypeAArray.deduceType()\n");
-                printf("\tthis   = %d, ", t.ty);
-                t.print();
-                printf("\ttparam = %d, ", tparam.ty);
-                tparam.print();
-            }
-
             // Extra check that index type must match
             if (tparam && tparam.ty == Taarray)
             {
@@ -3638,10 +3592,6 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(TypeFunction t)
         {
-            //printf("TypeFunction.deduceType()\n");
-            //printf("\tthis   = %d, ", t.ty); t.print();
-            //printf("\ttparam = %d, ", tparam.ty); tparam.print();
-
             // Extra check that function characteristics must match
             if (tparam && tparam.ty == Tfunction)
             {
@@ -3672,8 +3622,6 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                         fparam.type = tx;
                     }
                 }
-                //printf("\t. this   = %d, ", t.ty); t.print();
-                //printf("\t. tparam = %d, ", tparam.ty); tparam.print();
 
                 size_t nfargs = Parameter.dim(t.parameters);
                 size_t nfparams = Parameter.dim(tp.parameters);
@@ -3794,14 +3742,6 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(TypeInstance t)
         {
-            version (none)
-            {
-                printf("TypeInstance.deduceType()\n");
-                printf("\tthis   = %d, ", t.ty);
-                t.print();
-                printf("\ttparam = %d, ", tparam.ty);
-                tparam.print();
-            }
             // Extra check
             if (tparam && tparam.ty == Tinstance && t.tempinst.tempdecl)
             {
@@ -4054,15 +3994,6 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
         override void visit(TypeStruct t)
         {
-            version (none)
-            {
-                printf("TypeStruct.deduceType()\n");
-                printf("\tthis.parent   = %s, ", t.sym.parent.toChars());
-                t.print();
-                printf("\ttparam = %d, ", tparam.ty);
-                tparam.print();
-            }
-
             /* If this struct is a template struct, and we're matching
              * it against a template instance, convert the struct type
              * to a template instance, too, and try again.

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -681,7 +681,7 @@ else
             break;
 
         default:
-            t.print();
+            printf("%s\n", t.toChars());
             assert(0);
     }
     return e;
@@ -1048,8 +1048,7 @@ elem *toElem(Expression e, IRState *irs)
 
         override void visit(Expression e)
         {
-            printf("[%s] %s ", e.loc.toChars(), Token.toChars(e.op));
-            e.print();
+            printf("[%s] %s: %s\n", e.loc.toChars(), Token.toChars(e.op), e.toChars());
             assert(0);
         }
 
@@ -1413,10 +1412,8 @@ elem *toElem(Expression e, IRState *irs)
                     break;
 
                 default:
-                    re.print();
-                    re.type.print();
-                    re.type.toBasetype().print();
-                    printf("ty = %d, tym = %x\n", re.type.ty, ty);
+                    printf("ty = %d, tym = %x, re=%s, re.type=%s, re.type.toBasetype=%s\n",
+                           re.type.ty, ty, re.toChars(), re.type.toChars(), re.type.toBasetype().toChars());
                     assert(0);
             }
             e.Ety = ty;
@@ -2189,12 +2186,6 @@ elem *toElem(Expression e, IRState *irs)
 
         override void visit(CatExp ce)
         {
-            version (none)
-            {
-                printf("CatExp.toElem()\n");
-                ce.print();
-            }
-
             /* Do this check during code gen rather than semantic() because concatenation is
              * allowed in CTFE, and cannot distinguish that in semantic().
              */
@@ -2296,7 +2287,7 @@ elem *toElem(Expression e, IRState *irs)
                 case TOK.notEqual: eop = OPne;   break;
 
                 default:
-                    ce.print();
+                    printf("%s\n", ce.toChars());
                     assert(0);
             }
             if (!t1.isfloating())
@@ -2348,7 +2339,7 @@ elem *toElem(Expression e, IRState *irs)
                 case TOK.equal:          eop = OPeqeq;   break;
                 case TOK.notEqual:       eop = OPne;     break;
                 default:
-                    ee.print();
+                    printf("%s\n", ee.toChars());
                     assert(0);
             }
 
@@ -2491,7 +2482,7 @@ elem *toElem(Expression e, IRState *irs)
                 case TOK.identity:       eop = OPeqeq;   break;
                 case TOK.notIdentity:    eop = OPne;     break;
                 default:
-                    ie.print();
+                    printf("%s\n", ie.toChars());
                     assert(0);
             }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -708,7 +708,6 @@ extern (C++) abstract class Expression : RootObject
             {
                 fprintf(stderr, "No expression copy for: %s\n", toChars());
                 printf("op = %d\n", op);
-                print();
             }
             assert(0);
         }
@@ -728,12 +727,6 @@ extern (C++) abstract class Expression : RootObject
     override final DYNCAST dyncast() const
     {
         return DYNCAST.expression;
-    }
-
-    override final void print()
-    {
-        fprintf(stderr, "%s\n", toChars());
-        fflush(stderr);
     }
 
     override const(char)* toChars()
@@ -1497,12 +1490,6 @@ extern (C++) abstract class Expression : RootObject
     Expression toBoolean(Scope* sc)
     {
         // Default is 'yes' - do nothing
-        debug
-        {
-            if (!type)
-                print();
-            assert(type);
-        }
         Expression e = this;
         Type t = type;
         Type tb = type.toBasetype();

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -128,7 +128,6 @@ public:
     // kludge for template.isExpression()
     int dyncast() const { return DYNCAST_EXPRESSION; }
 
-    void print();
     const char *toChars();
     void error(const char *format, ...) const;
     void warning(const char *format, ...) const;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3663,16 +3663,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return; // semantic() already run
         }
-        version (none)
-        {
-            if (exp.arguments && exp.arguments.dim)
-            {
-                Expression earg = (*exp.arguments)[0];
-                earg.print();
-                if (earg.type)
-                    earg.type.print();
-            }
-        }
 
         Type t1;
         Objects* tiargs = null; // initial list of template arguments
@@ -8828,11 +8818,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          *      ' ' ~ c;
          */
 
-        version (none)
-        {
-            exp.e1.type.print();
-            exp.e2.type.print();
-        }
         Type tb1next = tb1.nextOf();
         Type tb2next = tb2.nextOf();
 
@@ -8973,13 +8958,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             if (exp.checkPostblit(sc, tbn))
                 return setError();
-        }
-        version (none)
-        {
-            exp.e1.type.print();
-            exp.e2.type.print();
-            exp.type.print();
-            exp.print();
         }
         Type t1 = exp.e1.type.toBasetype();
         Type t2 = exp.e2.type.toBasetype();

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2278,7 +2278,6 @@ public:
         }
         assert(precedence[e.op] != PREC.zero);
         assert(pr != PREC.zero);
-        //if (precedence[e.op] == 0) e.print();
         /* Despite precedence, we don't allow a<b<c expressions.
          * They must be parenthesized.
          */
@@ -2398,10 +2397,6 @@ public:
                  */
                 if (!global.errors)
                 {
-                    debug
-                    {
-                        t.print();
-                    }
                     assert(0);
                 }
                 break;

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -75,11 +75,6 @@ public:
     }
 
 nothrow:
-    override void print() const
-    {
-        fprintf(stderr, "%.*s", cast(int)name.length, name.ptr);
-    }
-
     override const(char)* toChars() const pure
     {
         return name.ptr;

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -25,7 +25,6 @@ public:
     static Identifier* create(const char *string);
     bool equals(RootObject *o);
     int compare(RootObject *o);
-    void print();
     const char *toChars();
     int getValue() const;
     const char *toHChars2();

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1868,8 +1868,6 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             // Even if vto is STC.lazy_, `vto = arg` is handled correctly in glue layer.
             ei.exp = new BlitExp(vto.loc, vto, arg);
             ei.exp.type = vto.type;
-            //arg.type.print();
-            //ei.exp.print();
 
             ids.from.push(vfrom);
             ids.to.push(vto);
@@ -1958,9 +1956,6 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
         fd.inlineNest++;
         auto e = doInlineAs!Expression(fd.fbody, ids);
         fd.inlineNest--;
-        //e.type.print();
-        //e.print();
-        //e.print();
 
         // https://issues.dlang.org/show_bug.cgi?id=11322
         if (tf.isref)
@@ -2003,8 +1998,6 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             // Chain the two together:
             //   ( typeof(return) __inlineretval = ( inlined body )) , __inlineretval
             e = Expression.combine(de, new VarExp(callLoc, vd));
-
-            //fprintf(stderr, "CallExp.inlineScan: e = "); e.print();
         }
 
         // https://issues.dlang.org/show_bug.cgi?id=15210

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2218,8 +2218,6 @@ private bool includeImportedModuleCheck(ModuleComponentRange components)
                 if (range.empty || nodeOffset >= info.depth)
                 {
                     // MATCH
-                    //printf("matcher ");printMatcher(nodeIndex - 1);
-                    //printf(" MATCHES module '");components.print();printf("'\n");
                     return !info.isExclude;
                 }
                 if (!range.front.equals(matchNodes[nodeIndex + nodeOffset].id))
@@ -2229,8 +2227,6 @@ private bool includeImportedModuleCheck(ModuleComponentRange components)
                 nodeOffset++;
             }
         }
-        //printf("matcher ");printMatcher(nodeIndex-1);
-        //printf(" does not match module '");components.print();printf("'\n");
         nodeIndex += info.depth;
     }
     assert(nodeIndex == matchNodes.dim, "code bug");

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -500,8 +500,7 @@ extern (C++) abstract class Type : RootObject
 
     Type syntaxCopy()
     {
-        print();
-        fprintf(stderr, "ty = %d\n", ty);
+        fprintf(stderr, "this = %s, ty = %d\n", toChars(), ty);
         assert(0);
     }
 

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1691,9 +1691,6 @@ extern (C++) Expression build_overload(const ref Loc loc, Scope* sc, Expression 
 {
     assert(d);
     Expression e;
-    //printf("build_overload(id = '%s')\n", id.toChars());
-    //earg.print();
-    //earg.type.print();
     Declaration decl = d.isDeclaration();
     if (decl)
         e = new DotVarExp(loc, ethis, decl, false);

--- a/src/dmd/root/object.h
+++ b/src/dmd/root/object.h
@@ -50,8 +50,6 @@ public:
     /**
      * Pretty-print an Object. Useful for debugging the old-fashioned way.
      */
-    virtual void print();
-
     virtual const char *toChars();
     /// This function is `extern(D)` and should not be called from C++,
     /// as the ABI does not match on some platforms

--- a/src/dmd/root/rootobject.d
+++ b/src/dmd/root/rootobject.d
@@ -52,11 +52,6 @@ extern (C++) class RootObject
         assert(0);
     }
 
-    void print()
-    {
-        printf("%s %p\n", toChars(), this);
-    }
-
     const(char)* toChars()
     {
         assert(0);

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -180,7 +180,6 @@ private extern (C++) class S2irVisitor : Visitor
 
     override void visit(Statement s)
     {
-        s.print();
         assert(0);
     }
 
@@ -1587,7 +1586,6 @@ private extern (C++) class S2irVisitor : Visitor
                 default:
                     break;
             }
-            //c.print();
         }
 
         basm.bIasmrefparam = s.refparam;             // are parameters reference?
@@ -1855,4 +1853,3 @@ void insertFinallyBlockGotos(block *startblock)
         printf("-------------------------\n");
     }
 }
-

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -245,15 +245,6 @@ private extern(C++) final class Semantic2Visitor : Visitor
         if (vd._init && !vd.toParent().isFuncDeclaration())
         {
             vd.inuse++;
-            version (none)
-            {
-                ExpInitializer ei = vd._init.isExpInitializer();
-                if (ei)
-                {
-                    ei.exp.print();
-                    printf("type = %p\n", ei.exp.type);
-                }
-            }
             // https://issues.dlang.org/show_bug.cgi?id=14166
             // Don't run CTFE for the temporary variables inside typeof
             vd._init = vd._init.initializerSemantic(sc, vd.type, sc.intypeof == 1 ? INITnointerpret : INITinterpret);

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -102,12 +102,6 @@ extern (C++) abstract class Statement : RootObject
         return b;
     }
 
-    override final void print()
-    {
-        fprintf(stderr, "%s\n", toChars());
-        fflush(stderr);
-    }
-
     override final const(char)* toChars()
     {
         HdrGenState hgs;
@@ -301,7 +295,6 @@ extern (C++) abstract class Statement : RootObject
     Statement scopeCode(Scope* sc, Statement* sentry, Statement* sexception, Statement* sfinally)
     {
         //printf("Statement::scopeCode()\n");
-        //print();
         *sentry = null;
         *sexception = null;
         *sfinally = null;
@@ -661,7 +654,6 @@ extern (C++) class ExpStatement : Statement
     override final Statement scopeCode(Scope* sc, Statement* sentry, Statement* sexception, Statement* sfinally)
     {
         //printf("ExpStatement::scopeCode()\n");
-        //print();
 
         *sentry = null;
         *sexception = null;
@@ -675,7 +667,6 @@ extern (C++) class ExpStatement : Statement
             {
                 if (v.needsScopeDtor())
                 {
-                    //printf("dtor is: "); v.edtor.print();
                     *sfinally = new DtorExpStatement(loc, v.edtor, v);
                     v.storage_class |= STC.nodtor; // don't add in dtor again
                 }
@@ -2079,7 +2070,6 @@ extern (C++) final class OnScopeStatement : Statement
     override Statement scopeCode(Scope* sc, Statement* sentry, Statement* sexception, Statement* sfinally)
     {
         //printf("OnScopeStatement::scopeCode()\n");
-        //print();
         *sentry = null;
         *sexception = null;
         *sfinally = null;

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -73,7 +73,6 @@ public:
 
     virtual Statement *syntaxCopy();
 
-    void print();
     const char *toChars();
 
     void error(const char *format, ...);

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -233,7 +233,6 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
             version (none)
             {
                 printf("Expression.toDt() %d\n", e.op);
-                print();
             }
             e.error("non-constant expression `%s`", e.toChars());
             dtb.nzeros(1);
@@ -326,8 +325,7 @@ extern (C++) void Expression_toDt(Expression e, DtBuilder dtb)
                 }
 
                 default:
-                    printf("%s\n", e.toChars());
-                    e.type.print();
+                    printf("%s, e.type=%s\n", e.toChars(), e.type.toChars());
                     assert(0);
             }
         }

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -745,14 +745,6 @@ extern (C++) struct Token
         return 0;
     }
 
-    debug
-    {
-        void print()
-        {
-            fprintf(stderr, "%s\n", toChars());
-        }
-    }
-
     /****
      * Set to contents of ptr[0..length]
      * Params:

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -220,9 +220,6 @@ struct Token
 
     Token() : next(NULL) {}
     int isKeyword();
-#ifdef DEBUG
-    void print();
-#endif
     const char *toChars() const;
     static const char *toChars(TOK);
 };

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -926,7 +926,6 @@ extern (C++) Expression semanticTraits(TraitsExp e, Scope* sc)
             ex = ex.expressionSemantic(scx);
             if (errors < global.errors)
                 e.error("`%s` cannot be resolved", eorig.toChars());
-            //ex.print();
 
             /* Create tuple of functions of ex
              */


### PR DESCRIPTION
Following a comment on a previous PR:

"Mixing I/O into a class is usually a failure of encapsulation."
> [Walter Bright](https://github.com/dlang/dmd/pull/8670#discussion_r215821235)

This removes a bunch of versioned/commented out code as well as the `print` method.
I could have left the uncompiled code in, but I might as well clean it up.
Some places (when it precedes an `assert(0)`), `printf` is used instead.