### PR TITLE
Iasmdmd: Reduce usage of string, use some immutable

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -13,7 +13,6 @@
 module dmd.expressionsem;
 
 import core.stdc.stdio;
-import core.stdc.string;
 
 import dmd.access;
 import dmd.aggregate;
@@ -10751,8 +10750,8 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         }
         else if (exp.ident == Id.stringof)
         {
-            const p = ie.toChars();
-            e = new StringExp(exp.loc, cast(char*)p, strlen(p));
+            const p = ie.toString();
+            e = new StringExp(exp.loc, cast(char*)p.ptr, p.length);
             e = e.expressionSemantic(sc);
             return e;
         }

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -3236,14 +3236,10 @@ void asm_token_trans(Token *tok)
         asmstate.tokValue = tok.value;
         if (asmstate.tokValue == TOK.identifier)
         {
-            size_t len;
-            const(char)* id;
-
-            id = tok.ident.toChars();
-            len = strlen(id);
-            if (len < 20)
+            const id = tok.ident.toString();
+            if (id.length < 20)
             {
-                ASMTK asmtk = cast(ASMTK) binary(id, cast(const(char)**)apszAsmtk.ptr, ASMTKmax);
+                ASMTK asmtk = cast(ASMTK) binary(id.ptr, cast(const(char)**)apszAsmtk.ptr, ASMTKmax);
                 if (cast(int)asmtk >= 0)
                     asmstate.tokValue = cast(TOK) (asmtk + TOK.max_ + 1);
             }

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -129,8 +129,14 @@ extern (C++)
     void init_optab();
 }
 
+/**
+ * Describes a register
+ *
+ * This struct is only used for manifest constant
+ */
 struct REG
 {
+immutable:
     char[6] regstr;
     ubyte val;
     opflag_t ty;
@@ -404,10 +410,10 @@ enum
 
 struct OPND
 {
-    const(REG) *base;        // if plain register
-    const(REG) *pregDisp1;   // if [register1]
-    const(REG) *pregDisp2;
-    const(REG) *segreg;      // if segment override
+    immutable(REG) *base;        // if plain register
+    immutable(REG) *pregDisp1;   // if [register1]
+    immutable(REG) *pregDisp2;
+    immutable(REG) *segreg;      // if segment override
     bool bOffset;            // if 'offset' keyword
     bool bSeg;               // if 'segment' keyword
     bool bPtr;               // if 'ptr' keyword
@@ -3184,7 +3190,7 @@ bool asm_match_float_flags(opflag_t usOp, opflag_t usTable)
 /*******************************
  */
 
-const(REG)* asm_reg_lookup(const(char)* s)
+immutable(REG)* asm_reg_lookup(const(char)* s)
 {
     //dbg_printf("asm_reg_lookup('%s')\n",s);
 
@@ -4119,7 +4125,7 @@ void asm_primary_exp(out OPND o1)
     Dsymbol s;
     Dsymbol scopesym;
 
-    const(REG)* regp;
+    immutable(REG)* regp;
 
     switch (asmstate.tokValue)
     {
@@ -4560,4 +4566,3 @@ private int ispow2(uint c)
         { }
     return i;
 }
-

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -137,7 +137,7 @@ extern (C++)
 struct REG
 {
 immutable:
-    char[6] regstr;
+    string regstr;
     ubyte val;
     opflag_t ty;
 
@@ -145,10 +145,10 @@ immutable:
     {
         // Be careful as these have the same val's as AH CH DH BH
         return ty == _r8 &&
-            ((val == _SIL && strcmp(regstr.ptr, "SIL") == 0) ||
-             (val == _DIL && strcmp(regstr.ptr, "DIL") == 0) ||
-             (val == _BPL && strcmp(regstr.ptr, "BPL") == 0) ||
-             (val == _SPL && strcmp(regstr.ptr, "SPL") == 0));
+            ((val == _SIL && regstr == "SIL") ||
+             (val == _DIL && regstr == "DIL") ||
+             (val == _BPL && regstr == "BPL") ||
+             (val == _SPL && regstr == "SPL"));
     }
 }
 
@@ -3190,13 +3190,13 @@ bool asm_match_float_flags(opflag_t usOp, opflag_t usTable)
 /*******************************
  */
 
-immutable(REG)* asm_reg_lookup(const(char)* s)
+immutable(REG)* asm_reg_lookup(const(char)[] s)
 {
     //dbg_printf("asm_reg_lookup('%s')\n",s);
 
     for (int i = 0; i < regtab.length; i++)
     {
-        if (strcmp(s,regtab[i].regstr.ptr) == 0)
+        if (s == regtab[i].regstr)
         {
             return &regtab[i];
         }
@@ -3205,7 +3205,7 @@ immutable(REG)* asm_reg_lookup(const(char)* s)
     {
         for (int i = 0; i < regtab64.length; i++)
         {
-            if (strcmp(s,regtab64[i].regstr.ptr) == 0)
+            if (s == regtab64[i].regstr)
             {
                 return &regtab64[i];
             }
@@ -4136,7 +4136,7 @@ void asm_primary_exp(out OPND o1)
 
         case TOK.this_:
         case TOK.identifier:
-            regp = asm_reg_lookup(asmstate.tok.ident.toChars());
+            regp = asm_reg_lookup(asmstate.tok.ident.toString());
             if (regp != null)
             {
                 asm_token();


### PR DESCRIPTION
Was looking at places where we had some superfluous stdc imports, and found some very low hanging fruits.