### PR TITLE
Enable putting structs with void field initializers into BSS segment

### DIFF
--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -401,6 +401,12 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         {
             if (vd._init)
             {
+                if (vd._init.isVoidInitializer())
+                    /* Treat as 0 for the purposes of putting the initializer
+                     * in the BSS segment, or doing a mass set to 0
+                     */
+                    continue;
+
                 // Zero size fields are zero initialized
                 if (vd.type.size(vd.loc) == 0)
                     continue;


### PR DESCRIPTION
Initializers can go into BSS if they are all zero, where the initialization happens essentially for free. For this purpose, treat void field initializations as zero. Also works for using a memset to initialize a struct instance to all zeros rather than doing a memcpy from the .init data.