### PR TITLE
enfranchise VoidInitExp

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -119,31 +119,6 @@ extern (C++) final class ClassReferenceExp : Expression
     }
 }
 
-/***********************************************************
- * An uninitialized value
- */
-extern (C++) final class VoidInitExp : Expression
-{
-    VarDeclaration var;
-
-    extern (D) this(VarDeclaration var)
-    {
-        super(var.loc, TOK.void_, __traits(classInstanceSize, VoidInitExp));
-        this.var = var;
-        this.type = var.type;
-    }
-
-    override const(char)* toChars() const
-    {
-        return "void";
-    }
-
-    override void accept(Visitor v)
-    {
-        v.visit(this);
-    }
-}
-
 /*************************
  * Same as getFieldIndex, but checks for a direct match with the VarDeclaration
  * Returns:

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1812,6 +1812,35 @@ extern (C++) final class ErrorExp : Expression
     extern (C++) __gshared ErrorExp errorexp; // handy shared value
 }
 
+
+/***********************************************************
+ * An uninitialized value,
+ * generated from void initializers.
+ */
+extern (C++) final class VoidInitExp : Expression
+{
+    VarDeclaration var; /// the variable from where the void value came from, null if not known
+                        /// Useful for error messages
+
+    extern (D) this(VarDeclaration var)
+    {
+        super(var.loc, TOK.void_, __traits(classInstanceSize, VoidInitExp));
+        this.var = var;
+        this.type = var.type;
+    }
+
+    override const(char)* toChars() const
+    {
+        return "void";
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+
 /***********************************************************
  */
 extern (C++) final class RealExp : Expression

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2413,6 +2413,11 @@ public:
         buf.writestring("__error");
     }
 
+    override void visit(VoidInitExp e)
+    {
+        buf.writestring("__void");
+    }
+
     void floatToBuffer(Type type, real_t value)
     {
         /** sizeof(value)*3 is because each byte of mantissa is max


### PR DESCRIPTION
I need to find a way to solve https://issues.dlang.org/show_bug.cgi?id=11331 , a long standing problem. After much study, the best way to proceed is to expand the role of `VoidInitExp` which will represent the initializer for a void initialized field.

This is the first step - move the definition of it to expression.d, and allow it to be printed by hdrgen.d.