### PR TITLE
Fix Issue 19251 - Alias this does not get called on struct qualified type

### DIFF
--- a/test/runnable/test19251.d
+++ b/test/runnable/test19251.d
@@ -1,0 +1,20 @@
+string result;
+
+struct A
+{
+    int[] a;
+    immutable(A) fun()
+    {
+        result ~= "Yo";
+        return immutable A([7]);
+    }
+
+    alias fun this;
+}
+
+void main()
+{
+    A a;
+    immutable A b = a;   // error: cannot implicitly convert expression a of type A to immutable(A)
+    assert(result == "Yo");
+}


### PR DESCRIPTION
On this branch [1] alias this isn't checked if implicit conversions cannot be done.

[1] https://github.com/dlang/dmd/pull/8711/files#diff-0c1aa1ff99402eb87e11cc3fa1b80da0R7664