### PR TITLE
Fix Issue 6777 - alias this disables casting for classes

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5540,11 +5540,10 @@ extern (C++) final class TypeStruct : Type
         return false;
     }
 
-    override MATCH implicitConvTo(Type to)
+    MATCH implicitConvToWithoutAliasThis(Type to)
     {
         MATCH m;
 
-        //printf("TypeStruct::implicitConvTo(%s => %s)\n", toChars(), to.toChars());
         if (ty == to.ty && sym == (cast(TypeStruct)to).sym)
         {
             m = MATCH.exact; // exact match
@@ -5596,7 +5595,13 @@ extern (C++) final class TypeStruct : Type
                 }
             }
         }
-        else if (sym.aliasthis && !(att & AliasThisRec.tracing))
+        return m;
+    }
+
+    MATCH implicitConvToThroughAliasThis(Type to)
+    {
+        MATCH m;
+        if (!(ty == to.ty && sym == (cast(TypeStruct)to).sym) && sym.aliasthis && !(att & AliasThisRec.tracing))
         {
             if (auto ato = aliasthisOf())
             {
@@ -5607,9 +5612,14 @@ extern (C++) final class TypeStruct : Type
             else
                 m = MATCH.nomatch; // no match
         }
-        else
-            m = MATCH.nomatch; // no match
         return m;
+    }
+
+    override MATCH implicitConvTo(Type to)
+    {
+        //printf("TypeStruct::implicitConvTo(%s => %s)\n", toChars(), to.toChars());
+        MATCH m = implicitConvToWithoutAliasThis(to);
+        return m ? m : implicitConvToThroughAliasThis(to);
     }
 
     override MATCH constConv(Type to)
@@ -5862,9 +5872,8 @@ extern (C++) final class TypeClass : Type
         return false;
     }
 
-    override MATCH implicitConvTo(Type to)
+    MATCH implicitConvToWithoutAliasThis(Type to)
     {
-        //printf("TypeClass::implicitConvTo(to = '%s') %s\n", to.toChars(), toChars());
         MATCH m = constConv(to);
         if (m > MATCH.nomatch)
             return m;
@@ -5883,8 +5892,12 @@ extern (C++) final class TypeClass : Type
                 return MATCH.convert;
             }
         }
+        return MATCH.nomatch;
+    }
 
-        m = MATCH.nomatch;
+    MATCH implicitConvToThroughAliasThis(Type to)
+    {
+        MATCH m;
         if (sym.aliasthis && !(att & AliasThisRec.tracing))
         {
             if (auto ato = aliasthisOf())
@@ -5894,8 +5907,14 @@ extern (C++) final class TypeClass : Type
                 att = cast(AliasThisRec)(att & ~AliasThisRec.tracing);
             }
         }
-
         return m;
+    }
+
+    override MATCH implicitConvTo(Type to)
+    {
+        //printf("TypeClass::implicitConvTo(to = '%s') %s\n", to.toChars(), toChars());
+        MATCH m = implicitConvToWithoutAliasThis(to);
+        return m ? m : implicitConvToThroughAliasThis(to);
     }
 
     override MATCH constConv(Type to)

--- a/test/compilable/test6777.d
+++ b/test/compilable/test6777.d
@@ -1,0 +1,11 @@
+struct S {}
+
+class C {
+    S s;
+    alias s this;
+}
+
+void main() {
+    auto c = new C;
+    auto p = cast(void*) c;
+}

--- a/test/fail_compilation/fail_casting.d
+++ b/test/fail_compilation/fail_casting.d
@@ -133,7 +133,7 @@ void test13959()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(144): Error: cannot cast expression `mi.x` of type `int` to `MyUbyte14154`
+fail_compilation/fail_casting.d(144): Error: cannot cast expression `mi` of type `MyInt14154` to `MyUbyte14154` because of different sizes
 ---
 */
 struct MyUbyte14154 { ubyte x; alias x this; }
@@ -147,10 +147,10 @@ void test14154()
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail_casting.d(179): Error: cannot cast expression `__tup$n$.__expand_field_0` of type `int` to `object.Object`
-fail_compilation/fail_casting.d(179): Error: cannot cast expression `__tup$n$.__expand_field_1` of type `int` to `object.Object`
+fail_compilation/fail_casting.d(179): Error: cannot cast expression `point` of type `Tuple14093!(int, "x", int, "y")` to `object.Object`
 ---
 */
+
 alias TypeTuple14093(T...) = T;
 struct Tuple14093(T...)
 {


### PR DESCRIPTION
The alias this was performed eagerly, before any checks. Now, alias this is performed only if the casting failed for the aggregate.

Besides this, it is unclear what the precedence of alias this is in relation with some language features (for example: https://issues.dlang.org/show_bug.cgi?id=5363)