### PR TITLE
add -checkaction switch

### DIFF
--- a/changelog/checkaction.dd
+++ b/changelog/checkaction.dd
@@ -1,0 +1,8 @@
+Add `-checkaction=D|C|halt` compiler switch.
+
+It covers action taken when an assert fails, a bounds check fails,
+or a final switch error happens. D means the usual D behavior of
+throwing an `Error`, C means call the C runtime library assert failure
+function, and halt means halt the program execution.
+
+The halt is the main addition here, it enables very lightweight assert's.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -169,6 +169,16 @@ struct Usage
         Option("c",
             "compile only, do not link"
         ),
+        Option("checkaction=D|C|halt",
+            "behavior on assert/boundscheck/finalswitch failure",
+            `Sets behavior when an assert fails, and array boundscheck fails,
+             or a final switch errors.
+                $(UL
+                    $(LI $(I D): Default behavior, which throws an unrecoverable $(D Error).)
+                    $(LI $(I C): Calls the C runtime library assert failure function.)
+                    $(LI $(I halt): Executes a halt instruction, terminating the program.)
+                )`
+        ),
         Option("color",
             "turn colored console output on"
         ),

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -46,6 +46,7 @@ enum CHECKACTION : ubyte
 {
     D,            // call D assert on failure
     C,            // call C assert on failure
+    halt,         // cause program halt on failure
 }
 
 enum CPU

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1437,6 +1437,20 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
             params.useDeprecated = 2;
         else if (arg == "-c")                // https://dlang.org/dmd.html#switch-c
             params.link = false;
+        else if (startsWith(p + 1, "checkaction=")) // https://dlang.org/dmd.html#switch-checkaction
+        {
+            /* Parse:
+             *    -checkaction=D|C|halt
+             */
+            if (strcmp(p + 13, "D") == 0)
+                params.checkAction = CHECKACTION.D;
+            else if (strcmp(p + 13, "C") == 0)
+                params.checkAction = CHECKACTION.C;
+            else if (strcmp(p + 13, "halt") == 0)
+                params.checkAction = CHECKACTION.halt;
+            else
+                goto Lerror;
+        }
         else if (startsWith(p + 1, "color")) // https://dlang.org/dmd.html#switch-color
         {
             params.color = true;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2554,20 +2554,31 @@ else
             CompoundStatement cs;
             Statement s;
 
-            if (global.params.useSwitchError == CHECKENABLE.on)
+            if (global.params.useSwitchError == CHECKENABLE.on &&
+                global.params.checkAction != CHECKACTION.halt)
             {
-                Expression sl = new IdentifierExp(ss.loc, Id.empty);
-                sl = new DotIdExp(ss.loc, sl, Id.object);
-                sl = new DotIdExp(ss.loc, sl, Id.__switch_error);
+                if (global.params.checkAction == CHECKACTION.C)
+                {
+                    /* Rewrite as an assert(0) and let e2ir generate
+                     * the call to the C assert failure function
+                     */
+                    s = new ExpStatement(ss.loc, new AssertExp(ss.loc, new IntegerExp(ss.loc, 0, Type.tint32)));
+                }
+                else
+                {
+                    Expression sl = new IdentifierExp(ss.loc, Id.empty);
+                    sl = new DotIdExp(ss.loc, sl, Id.object);
+                    sl = new DotIdExp(ss.loc, sl, Id.__switch_error);
 
-                Expressions* args = new Expressions();
-                args.push(new StringExp(ss.loc, cast(char*) ss.loc.filename));
-                args.push(new IntegerExp(ss.loc.linnum));
+                    Expressions* args = new Expressions();
+                    args.push(new StringExp(ss.loc, cast(char*) ss.loc.filename));
+                    args.push(new IntegerExp(ss.loc.linnum));
 
-                sl = new CallExp(ss.loc, sl, args);
-                sl.expressionSemantic(sc);
+                    sl = new CallExp(ss.loc, sl, args);
+                    sl.expressionSemantic(sc);
 
-                s = new SwitchErrorStatement(ss.loc, sl);
+                    s = new SwitchErrorStatement(ss.loc, sl);
+                }
             }
             else
                 s = new ExpStatement(ss.loc, new HaltExp(ss.loc));


### PR DESCRIPTION
This adds a `-checkaction=D|C|halt` compiler switch. It covers action taken when an assert fails, a bounds check fails, or a final switch error happens. `D` means the usual D behavior of throwing an `Error`, `C` means call the C runtime library assert failure function, and `halt` means halt the program execution.

The `halt` is the main addition here, it enables very lightweight assert's.