### PR TITLE
[refactor] scopeForTemplateParameters

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -794,6 +794,31 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         return result;
     }
 
+    /******************************
+     * Create a scope for the parameters of the TemplateInstance
+     * ti in the parent scope sc from the ScopeDsymbol paramsym.
+     *
+     * If paramsym is null a new ScopeDsymbol is used in place of
+     * paramsym.
+     * Params:
+     *      ti         = the TemplateInstance whose parameters to generate the scope for.
+     *      sc         = the parent scope of ti
+     *      paramsym   = the ScopeDsymbol to create the scope under
+     * Returns:
+     *      a scope for the parameters of ti
+     */
+    Scope* scopeForTemplateParameters(TemplateInstance ti, Scope* sc, ScopeDsymbol paramsym)
+    {
+        if (!paramsym) paramsym = new ScopeDsymbol();
+        paramsym.parent = _scope.parent;
+        Scope* paramscope = _scope.push(paramsym);
+        paramscope.tinst = ti;
+        paramscope.minst = sc.minst;
+        paramscope.callsc = sc;
+        paramscope.stc = 0;
+        return paramscope;
+    }
+
     /***************************************
      * Given that ti is an instance of this TemplateDeclaration,
      * deduce the types of the parameters to this, and store
@@ -846,12 +871,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         // Set up scope for template parameters
         auto paramsym = new ScopeDsymbol();
-        paramsym.parent = _scope.parent;
-        Scope* paramscope = _scope.push(paramsym);
-        paramscope.tinst = ti;
-        paramscope.minst = sc.minst;
-        paramscope.callsc = sc;
-        paramscope.stc = 0;
+        Scope* paramscope = scopeForTemplateParameters(ti,sc,paramsym);
 
         // Attempt type deduction
         m = MATCH.exact;
@@ -1124,12 +1144,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         // Set up scope for parameters
         auto paramsym = new ScopeDsymbol();
-        paramsym.parent = _scope.parent; // should use hasnestedArgs and enclosing?
-        Scope* paramscope = _scope.push(paramsym);
-        paramscope.tinst = ti;
-        paramscope.minst = sc.minst;
-        paramscope.callsc = sc;
-        paramscope.stc = 0;
+        Scope* paramscope = scopeForTemplateParameters(ti,sc,paramsym);
 
         TemplateTupleParameter tp = isVariadic();
         Tuple declaredTuple = null;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -796,20 +796,19 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
     /******************************
      * Create a scope for the parameters of the TemplateInstance
-     * ti in the parent scope sc from the ScopeDsymbol paramsym.
+     * `ti` in the parent scope sc from the ScopeDsymbol paramsym.
      *
      * If paramsym is null a new ScopeDsymbol is used in place of
      * paramsym.
      * Params:
-     *      ti         = the TemplateInstance whose parameters to generate the scope for.
-     *      sc         = the parent scope of ti
-     *      paramsym   = the ScopeDsymbol to create the scope under
+     *      ti = the TemplateInstance whose parameters to generate the scope for.
+     *      sc = the parent scope of ti
      * Returns:
      *      a scope for the parameters of ti
      */
-    Scope* scopeForTemplateParameters(TemplateInstance ti, Scope* sc, ScopeDsymbol paramsym)
+    Scope* scopeForTemplateParameters(TemplateInstance ti, Scope* sc)
     {
-        if (!paramsym) paramsym = new ScopeDsymbol();
+        ScopeDsymbol paramsym = new ScopeDsymbol();
         paramsym.parent = _scope.parent;
         Scope* paramscope = _scope.push(paramsym);
         paramscope.tinst = ti;
@@ -870,8 +869,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         assert(_scope);
 
         // Set up scope for template parameters
-        auto paramsym = new ScopeDsymbol();
-        Scope* paramscope = scopeForTemplateParameters(ti,sc,paramsym);
+        Scope* paramscope = scopeForTemplateParameters(ti,sc);
 
         // Attempt type deduction
         m = MATCH.exact;
@@ -1143,8 +1141,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             return MATCH.nomatch;
 
         // Set up scope for parameters
-        auto paramsym = new ScopeDsymbol();
-        Scope* paramscope = scopeForTemplateParameters(ti,sc,paramsym);
+        Scope* paramscope = scopeForTemplateParameters(ti,sc);
 
         TemplateTupleParameter tp = isVariadic();
         Tuple declaredTuple = null;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1979,9 +1979,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         // Partially instantiate function for constraint and fd.leastAsSpecialized()
         {
-            assert(paramsym);
+            assert(paramscope.scopesym);
             Scope* sc2 = _scope;
-            sc2 = sc2.push(paramsym);
+            sc2 = sc2.push(paramscope.scopesym);
             sc2 = sc2.push(ti);
             sc2.parent = ti;
             sc2.tinst = ti;


### PR DESCRIPTION
This is to reduce the diff against my template constraints DIP, which uses this.

Not sure what to do about the "// should use hasnestedArgs and enclosing?" comment, but it possibly applies to the other section.