### PR TITLE
dmd/hdrgen: Remove HdrGenState from headers, remove C++ linkage from helper functions

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3236,26 +3236,26 @@ public:
     }
 }
 
-extern (C++) void toCBuffer(Statement s, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(Statement s, OutBuffer* buf, HdrGenState* hgs)
 {
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     s.accept(v);
 }
 
-extern (C++) void toCBuffer(Type t, OutBuffer* buf, Identifier ident, HdrGenState* hgs)
+void toCBuffer(Type t, OutBuffer* buf, Identifier ident, HdrGenState* hgs)
 {
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     v.typeToBuffer(t, ident);
 }
 
-extern (C++) void toCBuffer(Dsymbol s, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(Dsymbol s, OutBuffer* buf, HdrGenState* hgs)
 {
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     s.accept(v);
 }
 
 // used from TemplateInstance::toChars() and TemplateMixin::toChars()
-extern (C++) void toCBufferInstance(TemplateInstance ti, OutBuffer* buf, bool qualifyTypes = false)
+void toCBufferInstance(TemplateInstance ti, OutBuffer* buf, bool qualifyTypes = false)
 {
     HdrGenState hgs;
     hgs.fullQual = qualifyTypes;
@@ -3263,13 +3263,13 @@ extern (C++) void toCBufferInstance(TemplateInstance ti, OutBuffer* buf, bool qu
     v.visit(ti);
 }
 
-extern (C++) void toCBuffer(Initializer iz, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(Initializer iz, OutBuffer* buf, HdrGenState* hgs)
 {
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     iz.accept(v);
 }
 
-extern (C++) bool stcToBuffer(OutBuffer* buf, StorageClass stc)
+bool stcToBuffer(OutBuffer* buf, StorageClass stc)
 {
     bool result = false;
     if ((stc & (STC.return_ | STC.scope_)) == (STC.return_ | STC.scope_))
@@ -3484,7 +3484,7 @@ extern (D) string protectionToString(Prot.Kind kind)
 }
 
 // Print the full function signature with correct ident, attributes and template args
-extern (C++) void functionToBufferFull(TypeFunction tf, OutBuffer* buf, Identifier ident, HdrGenState* hgs, TemplateDeclaration td)
+void functionToBufferFull(TypeFunction tf, OutBuffer* buf, Identifier ident, HdrGenState* hgs, TemplateDeclaration td)
 {
     //printf("TypeFunction::toCBuffer() this = %p\n", this);
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
@@ -3492,14 +3492,14 @@ extern (C++) void functionToBufferFull(TypeFunction tf, OutBuffer* buf, Identifi
 }
 
 // ident is inserted before the argument list and will be "function" or "delegate" for a type
-extern (C++) void functionToBufferWithIdent(TypeFunction tf, OutBuffer* buf, const(char)* ident)
+void functionToBufferWithIdent(TypeFunction tf, OutBuffer* buf, const(char)* ident)
 {
     HdrGenState hgs;
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, &hgs);
     v.visitFuncIdentWithPostfix(tf, ident);
 }
 
-extern (C++) void toCBuffer(Expression e, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(Expression e, OutBuffer* buf, HdrGenState* hgs)
 {
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     e.accept(v);
@@ -3508,7 +3508,7 @@ extern (C++) void toCBuffer(Expression e, OutBuffer* buf, HdrGenState* hgs)
 /**************************************************
  * Write out argument types to buf.
  */
-extern (C++) void argExpTypesToCBuffer(OutBuffer* buf, Expressions* arguments)
+void argExpTypesToCBuffer(OutBuffer* buf, Expressions* arguments)
 {
     if (!arguments || !arguments.dim)
         return;
@@ -3522,13 +3522,13 @@ extern (C++) void argExpTypesToCBuffer(OutBuffer* buf, Expressions* arguments)
     }
 }
 
-extern (C++) void toCBuffer(TemplateParameter tp, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(TemplateParameter tp, OutBuffer* buf, HdrGenState* hgs)
 {
     scope PrettyPrintVisitor v = new PrettyPrintVisitor(buf, hgs);
     tp.accept(v);
 }
 
-extern (C++) void arrayObjectsToBuffer(OutBuffer* buf, Objects* objects)
+void arrayObjectsToBuffer(OutBuffer* buf, Objects* objects)
 {
     if (!objects || !objects.dim)
         return;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -81,6 +81,19 @@ extern (C++) void genhdrfile(Module m)
     writeFile(m.loc, m.hdrfile);
 }
 
+/**
+ * Dumps the full contents of module `m` to `buf`.
+ * Params:
+ *   buf = buffer to write to.
+ *   m = module to visit all members of.
+ */
+extern (C++) void moduleToBuffer(OutBuffer* buf, Module m)
+{
+    HdrGenState hgs;
+    hgs.fullDump = true;
+    toCBuffer(m, buf, &hgs);
+}
+
 extern (C++) final class PrettyPrintVisitor : Visitor
 {
     alias visit = Visitor.visit;

--- a/src/dmd/hdrgen.h
+++ b/src/dmd/hdrgen.h
@@ -26,6 +26,7 @@ class TemplateDeclaration;
 class TypeFunction;
 
 void genhdrfile(Module *m);
+void moduleToBuffer(OutBuffer *buf, Module *m);
 
 struct HdrGenState
 {

--- a/src/dmd/hdrgen.h
+++ b/src/dmd/hdrgen.h
@@ -10,55 +10,14 @@
 
 #pragma once
 
-#include <string.h>                     // memset()
-
 #include "globals.h"
 #include "arraytypes.h"
 
-class Expression;
-class Initializer;
 class Module;
-class Statement;
-class Dsymbol;
-class TemplateParameter;
-class TemplateInstance;
-class TemplateDeclaration;
-class TypeFunction;
 
 void genhdrfile(Module *m);
 void moduleToBuffer(OutBuffer *buf, Module *m);
 
-struct HdrGenState
-{
-    bool hdrgen;        // true if generating header file
-    bool ddoc;          // true if generating Ddoc file
-    bool fullDump;      // true if generating a full AST dump file
-    bool fullQual;      // fully qualify types when printing
-    int tpltMember;
-    int autoMember;
-    int forStmtInit;
-
-    HdrGenState() { memset(this, 0, sizeof(HdrGenState)); }
-};
-
-void toCBuffer(Statement *s, OutBuffer *buf, HdrGenState *hgs);
-void toCBuffer(Type *t, OutBuffer *buf, Identifier *ident, HdrGenState *hgs);
-void toCBuffer(Dsymbol *s, OutBuffer *buf, HdrGenState *hgs);
-void toCBuffer(Initializer *iz, OutBuffer *buf, HdrGenState *hgs);
-void toCBuffer(Expression *e, OutBuffer *buf, HdrGenState *hgs);
-void toCBuffer(TemplateParameter *tp, OutBuffer *buf, HdrGenState *hgs);
-
-void toCBufferInstance(TemplateInstance *ti, OutBuffer *buf, bool qualifyTypes = false);
-
-void functionToBufferFull(TypeFunction *tf, OutBuffer *buf, Identifier *ident, HdrGenState* hgs, TemplateDeclaration *td);
-void functionToBufferWithIdent(TypeFunction *t, OutBuffer *buf, const char *ident);
-
-void argExpTypesToCBuffer(OutBuffer *buf, Expressions *arguments);
-
-void arrayObjectsToBuffer(OutBuffer *buf, Objects *objects);
-
 const char *parametersTypeToChars(Parameters *parameters, int varargs);
-
-bool stcToBuffer(OutBuffer *buf, StorageClass stc);
 const char *stcToChars(StorageClass& stc);
 const char *linkageToChars(LINK linkage);

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -790,10 +790,7 @@ private int tryMain(size_t argc, const(char)** argv)
         {
             auto buf = OutBuffer();
             buf.doindent = 1;
-            scope HdrGenState hgs;
-            hgs.fullDump = 1;
-            scope PrettyPrintVisitor ppv = new PrettyPrintVisitor(&buf, &hgs);
-            mod.accept(ppv);
+            moduleToBuffer(&buf, mod);
 
             // write the output to $(filename).cg
             auto cgFilename = FileName.addExt(mod.srcfile.toString(), "cg");


### PR DESCRIPTION
There was only one user of `HdrGenState`, so wrapped it in a function and made everything else private to D.