### PR TITLE
dmd/arraytypes.h: #include array header instead of root

### DIFF
--- a/src/dmd/arraytypes.h
+++ b/src/dmd/arraytypes.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "root/root.h"
+#include "root/array.h"
 
 typedef Array<class TemplateParameter *> TemplateParameters;
 


### PR DESCRIPTION
Leftover that didn't make it into #8733.