### PR TITLE
Fix Issue 19246 - Binary literal `0b_` allowed

### DIFF
--- a/changelog/deprecated_binary_literals.dd
+++ b/changelog/deprecated_binary_literals.dd
@@ -1,0 +1,9 @@
+Deprecate invalid binary literals
+
+Prior to this release, binary literals without any digits after the prefix `0b`
+were considered valid. This has now been deprecated.
+---
+auto foo = 0b;   // deprecated
+auto bar = 0b_;  // deprecated
+auto baz = 0b0;  // conforming equivalent
+---

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1821,7 +1821,7 @@ class Lexer : ErrorHandler
         int d;
         bool err = false;
         bool overflow = false;
-        bool anyBinaryDigitsUS = false;
+        bool anyBinaryDigitsNoSingleUS = false;
         bool anyHexDigitsNoSingleUS = false;
         dchar c = *p;
         if (c == '0')
@@ -1932,7 +1932,6 @@ class Lexer : ErrorHandler
                 p = start;
                 return inreal(t);
             case '_':
-                anyBinaryDigitsUS = true;
                 ++p;
                 continue;
             default:
@@ -1940,7 +1939,7 @@ class Lexer : ErrorHandler
             }
             // got a digit here, set any necessary flags, check for errors
             anyHexDigitsNoSingleUS = true;
-            anyBinaryDigitsUS = true;
+            anyBinaryDigitsNoSingleUS = true;
             if (!err && d >= base)
             {
                 error("%s digit expected, not `%c`", base == 2 ? "binary".ptr :
@@ -1968,7 +1967,7 @@ class Lexer : ErrorHandler
         // Deprecated in 2018-06.
         // Change to error in 2019-06.
         // @@@DEPRECATED_2019-06@@@
-        if ((base == 2 && !anyBinaryDigitsUS) ||
+        if ((base == 2 && !anyBinaryDigitsNoSingleUS) ||
             (base == 16 && !anyHexDigitsNoSingleUS))
             deprecation("`%.*s` isn't a valid integer literal, use `%.*s0` instead", cast(int)(p - start), start, 2, start);
         enum FLAGS : int

--- a/test/fail_compilation/fix19246.d
+++ b/test/fail_compilation/fix19246.d
@@ -2,9 +2,10 @@
  * PERMUTE_ARGS:
  * TEST_OUTPUT:
 ---
-fail_compilation/fix19246.d(15): Deprecation: `0b_` isn't a valid integer literal, use `0b0` instead
-fail_compilation/fix19246.d(16): Deprecation: `0B_` isn't a valid integer literal, use `0B0` instead
-fail_compilation/fix19246.d(17): Deprecation: `0b` isn't a valid integer literal, use `0b0` instead
+fail_compilation/fix19246.d(16): Deprecation: `0b_` isn't a valid integer literal, use `0b0` instead
+fail_compilation/fix19246.d(17): Deprecation: `0B_` isn't a valid integer literal, use `0B0` instead
+fail_compilation/fix19246.d(18): Deprecation: `0b` isn't a valid integer literal, use `0b0` instead
+fail_compilation/fix19246.d(19): Deprecation: `0B` isn't a valid integer literal, use `0B0` instead
 ---
  */
 
@@ -15,4 +16,5 @@ void foo()
     auto a = 0b_;
     auto b = 0B_;
     auto c = 0b;
+    auto d = 0B;
 }

--- a/test/fail_compilation/fix19246.d
+++ b/test/fail_compilation/fix19246.d
@@ -1,0 +1,18 @@
+/* REQUIRED_ARGS: -de
+ * PERMUTE_ARGS:
+ * TEST_OUTPUT:
+---
+fail_compilation/fix19246.d(15): Deprecation: `0b_` isn't a valid integer literal, use `0b0` instead
+fail_compilation/fix19246.d(16): Deprecation: `0B_` isn't a valid integer literal, use `0B0` instead
+fail_compilation/fix19246.d(17): Deprecation: `0b` isn't a valid integer literal, use `0b0` instead
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=19246
+
+void foo()
+{
+    auto a = 0b_;
+    auto b = 0B_;
+    auto c = 0b;
+}


### PR DESCRIPTION
... not anymore!
`0b_` and `0B_` will now trigger a deprecation warning.