### PR TITLE
Fix issue 3507: with -deps, emit depsUnused line on unused imports

### DIFF
--- a/src/dmd/arraytypes.h
+++ b/src/dmd/arraytypes.h
@@ -64,3 +64,5 @@ typedef Array<class GotoStatement *> GotoStatements;
 typedef Array<class TemplateInstance *> TemplateInstances;
 
 typedef Array<struct Ensure> Ensures;
+
+typedef Array<struct ImportInfo> Imports;

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -223,7 +223,7 @@ extern (C++) final class Import : Dsymbol
                     protection = sc.protection;
                 if (!isstatic && !aliasId && !names.dim)
                 {
-                    sc.scopesym.importScope(mod, protection);
+                    sc.scopesym.importScope(loc, mod, protection);
                 }
             }
         }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -105,6 +105,14 @@ struct Prot
     bool isSubsetOf(const Prot& other) const;
 };
 
+struct ImportInfo
+{
+    Dsymbol *symbol;
+    Prot::Kind kind;
+    const Loc loc;
+    bool used;
+};
+
 // in hdrgen.c
 void protectionToBuffer(OutBuffer *buf, Prot prot);
 const char *protectionToChars(Prot::Kind kind);
@@ -287,8 +295,8 @@ public:
     unsigned endlinnum;         // the linnumber of the statement after the scope (0 if unknown)
 
 private:
-    Dsymbols *importedScopes;   // imported Dsymbol's
-    Prot::Kind *prots;            // array of PROTKIND, one for each import
+
+    Imports imports;            // import info, protection, line number, usedness
 
     BitArray accessiblePackages, privateAccessiblePackages;
 
@@ -296,7 +304,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
     OverloadSet *mergeOverloadSet(Identifier *ident, OverloadSet *os, Dsymbol *s);
-    virtual void importScope(Dsymbol *s, Prot protection);
+    virtual void importScope(const Loc &loc, Dsymbol *s, Prot protection);
     void addAccessiblePackage(Package *p, Prot protection);
     virtual bool isPackageAccessible(Package *p, Prot protection, int flags = 0);
     bool isforwardRef();
@@ -364,7 +372,7 @@ class ForwardingScopeDsymbol : public ScopeDsymbol
 
     Dsymbol *symtabInsert(Dsymbol *s);
     Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
-    void importScope(Dsymbol *s, Prot protection);
+    void importScope(const Loc &loc, Dsymbol *s, Prot protection);
     const char *kind() const;
 
     ForwardingScopeDsymbol *isForwardingScopeDsymbol() { return this; }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1401,7 +1401,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
                 if (!imp.isstatic)
                 {
-                    scopesym.importScope(imp.mod, imp.protection);
+                    scopesym.importScope(imp.loc, imp.mod, imp.protection);
                 }
 
                 // Mark the imported packages as accessible from the current
@@ -2690,7 +2690,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             ScopeDsymbol sds = sce.scopesym;
             if (sds)
             {
-                sds.importScope(tm, Prot(Prot.Kind.public_));
+                sds.importScope(Loc.initial, tm, Prot(Prot.Kind.public_));
                 break;
             }
         }

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -64,7 +64,7 @@ extern (C++) final class Nspace : ScopeDsymbol
                 ScopeDsymbol sds2 = sce.scopesym;
                 if (sds2)
                 {
-                    sds2.importScope(this, Prot(Prot.Kind.public_));
+                    sds2.importScope(loc, this, Prot(Prot.Kind.public_));
                     break;
                 }
             }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -202,6 +202,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
         }
         sc = sc.pop();
         sc.pop();
+        mod.writeUnusedImports;
         mod.semanticRun = PASS.semantic3done;
     }
 


### PR DESCRIPTION
The purpose of this PR is to enable tools to warn on unused imports in user code.

To this end, a new line is added to the `-deps` output: `depsUnused`, of the format `depsUnused ::= ModuleFullyQualifiedName " (" FilePath "(" LineNumber ")) : " ModuleFullyQualifiedName`, listing first the module in which the import is located, and second the import that was not used.

Important note: all that this line indicates is that the import can be removed _given the current compiler invocation_. Imports that are used in code that is statically disabled, or that are used in templates that are never instantiated, or that are used in modules not listed on the commandline, will be listed as unused. This is unavoidable. Due to the Turing-complete nature of D metaprogramming, it is impossible to prove for an arbitrary program that an import is never used. All that can be shown is that an import was not used during compilation. However, imports that are themselves hidden in `template`s, `version`s or `static if`s will not be output.