### PR TITLE
 Fix issue 19269: Cannot throw C++ exceptions from D

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1279,11 +1279,28 @@ extern (C++) final class Module : Package
         return this.importedFrom == this;
     }
 
-    // true if the module source file is directly
-    // listed in command line.
-    bool isCoreModule(Identifier ident)
+    /**
+     * Compare a provided list of identifier with this module
+     *
+     * Params:
+     *   idents = Identifiers to compare to, should be provided
+     *            in the "natural" order.
+     *            E.g. if this module is `core.attribute`,
+     *            use `attrmodule.isModuleName(Id.core, Id.attribute)`
+     *
+     * Returns:
+     *   `true` if this module correspond to the provided identifiers
+     */
+    extern(D) final bool isModuleName(scope Identifier[] idents...)
     {
-        return this.ident == ident && parent && parent.ident == Id.core && !parent.parent;
+        Dsymbol sym = this;
+        foreach_reverse (id; idents)
+        {
+            if (!sym || id != sym.ident)
+                return false;
+            sym = sym.parent;
+        }
+        return sym is null;
     }
 
     // Back end

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -97,6 +97,7 @@ immutable Msgtable[] msgtable =
     { "typeinfo" },
     { "outer" },
     { "Exception" },
+    { "cppException", "exception" },
     { "RTInfo" },
     { "Throwable" },
     { "Error" },
@@ -333,11 +334,12 @@ immutable Msgtable[] msgtable =
     // varargs implementation
     { "va_start" },
 
-    // Builtin functions
+    // Builtin functions / modules
     { "std" },
     { "core" },
     { "etc" },
     { "attribute" },
+    { "stdcpp" },
     { "math" },
     { "sin" },
     { "cos" },

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -136,9 +136,6 @@ public:
     int imports(Module *m);
 
     bool isRoot() { return this->importedFrom == this; }
-    // true if the module source file is directly
-    // listed in command line.
-    bool isCoreModule(Identifier *ident);
 
     // Back end
 

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -468,7 +468,7 @@ extern(C++) private final class Supported : Objc
         if (sd.ident != Id.udaSelector || !sd.parent)
             return false;
         Module _module = sd.parent.isModule();
-        return _module && _module.isCoreModule(Id.attribute);
+        return _module && _module.isModuleName(Id.core, Id.attribute);
     }
 }
 

--- a/test/fail_compilation/ice10651.d
+++ b/test/fail_compilation/ice10651.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10651.d(11): Error: can only throw class objects derived from `Throwable`, not type `int*`
+fail_compilation/ice10651.d(11): Error: can only throw class objects derived from `Throwable` or `core.stdcpp.exception.exception`, not type `int*`
 ---
 */
 

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -6,6 +6,8 @@ import core.stdc.stdarg;
 import core.stdc.config;
 import core.stdc.stdint;
 
+import core.stdcpp.exception;
+
 extern (C++)
         int foob(int i, int j, int k);
 
@@ -500,8 +502,6 @@ extern (C++, std)
         }
     }
 
-    class exception { }
-
     // 14956
     extern(C++, N14956)
     {
@@ -982,7 +982,7 @@ void testeh()
             {
                 throwit();
             }
-            catch (std.exception e)
+            catch (exception e)
             {
                 caught = true;
             }
@@ -1019,7 +1019,7 @@ version (linux)
             {
                 dFunction();
             }
-            catch(std.exception e)
+            catch(exception e)
             {
                 assert(raii_works);
             }
@@ -1047,7 +1047,7 @@ void testeh3()
             {
                throwle();
             }
-            catch (std.exception e)  //polymorphism test.
+            catch (exception e)  //polymorphism test.
             {
                 caught = true;
             }
@@ -1593,6 +1593,36 @@ void test19134()
     assert(d.foo() == 660);
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=19269
+extern(C++) void throwingDFunction19269()
+{
+    throw new exception();
+}
+
+extern(C++) void throwingDFunctionDerived19269()
+{
+    throw new CppException19269("Hello from the D world");
+}
+
+extern(C++) class CppException19269 : exception
+{
+    extern(D) this(const(char)[] m) { this.msg = m; }
+    const(char)[] msg;
+}
+
+extern(C++) bool catchThrowFromD19269();
+extern(C++) exception catchThrowFromDDerived19269();
+
+void test19269()
+{
+    assert(catchThrowFromD19269());
+    auto e = catchThrowFromDDerived19269();
+    assert(e);
+    auto cp = cast(CppException19269)e;
+    assert(cp.msg == "Hello from the D world");
+}
+
+
 /****************************************/
 
 void main()
@@ -1643,6 +1673,7 @@ void main()
     test18953();
     test18966();
     test19134();
+    test19269();
 
     printf("Success\n");
 }

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -933,3 +933,34 @@ void A18966::foo() { calledOverloads[i++] = 'A'; }
 
 B18966::B18966() { foo(); }
 void B18966::foo() { calledOverloads[i++] = 'B'; }
+
+
+//
+extern void throwingDFunction19269();
+extern void throwingDFunctionDerived19269();
+
+bool catchThrowFromD19269()
+{
+    try
+    {
+        throwingDFunction19269();
+    }
+    catch (std::exception& e)
+    {
+        return true;
+    }
+    return false;
+}
+
+std::exception* catchThrowFromDDerived19269()
+{
+    try
+    {
+        throwingDFunctionDerived19269();
+    }
+    catch (std::exception& e)
+    {
+        return &e;
+    }
+    return NULL;
+}


### PR DESCRIPTION
This allow D functions to throw C++ exceptions.

However, there is a big caveat to this: Since the `std::exception` definition is in druntime (`core.stdcpp.exception`), and throwing an exception pulls in the classinfo, it ties the druntime build to the C++ lib it was build against, which is something we should avoid (CC @TurkeyMan ).

I'm not so familiar with TypeInfo and what pulls it in, so I don't know for which reason it's pulled in here, if we can do away with it, or if we'll end up needing it anyway and we're just lucky that it worked without it so far.

As a result, this currently fails to link. Applying the following diff to druntime makes it link:
```diff
diff --git a/mak/SRCS b/mak/SRCS
index f998eb29..757d9d24 100644
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -46,6 +46,8 @@ SRCS=\
        src\core\stdc\time.d \
        src\core\stdc\wchar_.d \
        \
+       src\core\stdcpp\exception.d \
+       \
        src\core\sync\barrier.d \
        src\core\sync\condition.d \
        src\core\sync\config.d \
```

Note that this wouldn't be a problem if those bindings were not in Druntime.