### PR TITLE
dmd/hdrgen.h: Move declarations of functions defined in hdrgen here

### DIFF
--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -105,10 +105,6 @@ struct Prot
     bool isSubsetOf(const Prot& other) const;
 };
 
-// in hdrgen.c
-void protectionToBuffer(OutBuffer *buf, Prot prot);
-const char *protectionToChars(Prot::Kind kind);
-
 /* State of symbol in winding its way through the passes of the compiler
  */
 enum PASS

--- a/src/dmd/hdrgen.h
+++ b/src/dmd/hdrgen.h
@@ -11,7 +11,8 @@
 #pragma once
 
 #include "globals.h"
-#include "arraytypes.h"
+#include "dsymbol.h"
+#include "mtype.h"
 
 class Module;
 
@@ -20,4 +21,8 @@ void moduleToBuffer(OutBuffer *buf, Module *m);
 
 const char *parametersTypeToChars(Parameters *parameters, int varargs);
 const char *stcToChars(StorageClass& stc);
+void trustToBuffer(OutBuffer *buf, TRUST trust);
+const char *trustToChars(TRUST trust);
 const char *linkageToChars(LINK linkage);
+void protectionToBuffer(OutBuffer *buf, Prot prot);
+const char *protectionToChars(Prot::Kind kind);

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -521,10 +521,6 @@ enum TRUST
     TRUSTsafe = 3,      // @safe
 };
 
-// in hdrgen.c
-void trustToBuffer(OutBuffer *buf, TRUST trust);
-const char *trustToChars(TRUST trust);
-
 enum TRUSTformat
 {
     TRUSTformatDefault,  // do not emit @system when trust == TRUSTdefault


### PR DESCRIPTION
For consistency, extern(C++) functions in foo.d should have their equivalent in foo.h