### PR TITLE
dmd.func: Remove C++ overloadApply from source and headers

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -88,8 +88,6 @@ struct IntRange;
 #define STCfuture        0x4000000000000LL // introducing new base class function
 #define STClocal         0x8000000000000LL // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
 
-int overloadApply(Dsymbol *fstart, void *param, int (*fp)(void *, Dsymbol *));
-
 void ObjectNotFound(Identifier *id);
 
 /**************************************************************/

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2522,11 +2522,6 @@ extern (D) int overloadApply(Dsymbol fstart, scope int delegate(Dsymbol) dg, Sco
     return 0;
 }
 
-extern (C++) int overloadApply(Dsymbol fstart, void* param, int function(void*, Dsymbol) fp)
-{
-    return overloadApply(fstart, s => (*fp)(param, s));
-}
-
 /**
 Checks for mismatching modifiers between `lhsMod` and `rhsMod` and prints the
 mismatching modifiers to `buf`.


### PR DESCRIPTION
Unused in both front-end and back-end.