### PR TITLE
dmd/declaration.h: Remove functionResolve and resolveFuncCall

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -94,16 +94,6 @@ const StorageClass STCStorageClass = (STCauto | STCscope | STCstatic | STCextern
     STCmanifest | STCimmutable | STCshared | STCwild | STCnothrow | STCnogc | STCpure | STCref | STCreturn | STCtls |
     STCgshared | STCproperty | STCsafe | STCtrusted | STCsystem | STCdisable | STClocal);
 
-struct Match
-{
-    int count;                  // number of matches found
-    MATCH last;                 // match level of lastf
-    FuncDeclaration *lastf;     // last matching function we found
-    FuncDeclaration *nextf;     // current matching function
-    FuncDeclaration *anyf;      // pick a func, any func, to use for error recovery
-};
-
-void functionResolve(Match *m, Dsymbol *fd, Loc loc, Scope *sc, Objects *tiargs, Type *tthis, Expressions *fargs);
 int overloadApply(Dsymbol *fstart, void *param, int (*fp)(void *, Dsymbol *));
 
 void ObjectNotFound(Identifier *id);
@@ -642,12 +632,6 @@ public:
     virtual FuncDeclaration *toAliasFunc() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
-
-FuncDeclaration *resolveFuncCall(const Loc &loc, Scope *sc, Dsymbol *s,
-        Objects *tiargs,
-        Type *tthis,
-        Expressions *arguments,
-        int flags = 0);
 
 class FuncAliasDeclaration : public FuncDeclaration
 {

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2630,7 +2630,7 @@ private const(char)* prependSpace(const(char)* str)
  * Returns:
  *      if match is found, then function symbol, else null
  */
-extern (C++) FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
+FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
     Objects* tiargs, Type tthis, Expressions* fargs, int flags = 0)
 {
     if (!s)


### PR DESCRIPTION
`functionResolve` is already extern(D), `resolveFuncCall` is unused by the back-end.