### PR TITLE
Remove extern(C++) or make private all declarations that aren't in headers

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -130,7 +130,7 @@ private bool isAccessible(Dsymbol smember, Dsymbol sfunc, AggregateDeclaration d
  * type of the 'this' pointer used to access smember.
  * Returns true if the member is not accessible.
  */
-extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
+bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
 {
     FuncDeclaration f = sc.func;
     AggregateDeclaration cdscope = sc.getStructClassScope();
@@ -471,7 +471,7 @@ extern (C++) bool checkAccess(Loc loc, Scope* sc, Package p)
  *  s = symbol to check for visibility
  * Returns: true if s is visible in mod
  */
-extern (C++) bool symbolIsVisible(Module mod, Dsymbol s)
+bool symbolIsVisible(Module mod, Dsymbol s)
 {
     // should sort overloads by ascending protection instead of iterating here
     s = mostVisibleOverload(s);
@@ -489,7 +489,7 @@ extern (C++) bool symbolIsVisible(Module mod, Dsymbol s)
 /**
  * Same as above, but determines the lookup module from symbols `origin`.
  */
-extern (C++) bool symbolIsVisible(Dsymbol origin, Dsymbol s)
+bool symbolIsVisible(Dsymbol origin, Dsymbol s)
 {
     return symbolIsVisible(origin.getAccessModule(), s);
 }
@@ -503,7 +503,7 @@ extern (C++) bool symbolIsVisible(Dsymbol origin, Dsymbol s)
  *  s = symbol to check for visibility
  * Returns: true if s is visible by origin
  */
-extern (C++) bool symbolIsVisible(Scope *sc, Dsymbol s)
+bool symbolIsVisible(Scope *sc, Dsymbol s)
 {
     s = mostVisibleOverload(s);
     return checkSymbolAccess(sc, s);
@@ -518,7 +518,7 @@ extern (C++) bool symbolIsVisible(Scope *sc, Dsymbol s)
  *  s = symbol to check for visibility
  * Returns: true if s is visible by origin
  */
-extern (C++) bool checkSymbolAccess(Scope *sc, Dsymbol s)
+bool checkSymbolAccess(Scope *sc, Dsymbol s)
 {
     final switch (s.prot().kind)
     {

--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -147,7 +147,7 @@ public:
     }
 }
 
-extern (C++) bool walkPostorder(Expression e, StoppableVisitor v)
+bool walkPostorder(Expression e, StoppableVisitor v)
 {
     scope PostorderExpressionVisitor pv = new PostorderExpressionVisitor(v);
     e.accept(pv);

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -32,7 +32,7 @@ import dmd.visitor;
 /**********************************************
  * Check that there are no uses of arrays without [].
  */
-extern (C++) bool isArrayOpValid(Expression e)
+bool isArrayOpValid(Expression e)
 {
     if (e.op == TOK.slice)
         return true;
@@ -69,7 +69,7 @@ extern (C++) bool isArrayOpValid(Expression e)
     return true;
 }
 
-extern (C++) bool isNonAssignmentArrayOp(Expression e)
+bool isNonAssignmentArrayOp(Expression e)
 {
     if (e.op == TOK.slice)
         return isNonAssignmentArrayOp((cast(SliceExp)e).e1);

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2679,7 +2679,7 @@ private bool isVoidArrayLiteral(Expression e, Type other)
  *      true    success
  *      false   failed
  */
-extern (C++) bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expression* pe2)
+bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expression* pe2)
 {
     //printf("typeMerge() %s op %s\n", pe1.toChars(), pe2.toChars());
 
@@ -3488,7 +3488,7 @@ extern (C++) bool arrayTypeCompatibleWithoutCasting(Type t1, Type t2)
  * This is used to determine if implicit narrowing conversions will
  * be allowed.
  */
-extern (C++) IntRange getIntRange(Expression e)
+IntRange getIntRange(Expression e)
 {
     extern (C++) final class IntRangeVisitor : Visitor
     {

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -45,7 +45,7 @@ import dmd.visitor;
  * accessible from the current scope.
  * Returns true if error occurs.
  */
-extern (C++) bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, size_t iStart = 0)
+bool checkFrameAccess(Loc loc, Scope* sc, AggregateDeclaration ad, size_t iStart = 0)
 {
     Dsymbol sparent = ad.toParent2();
     Dsymbol s = sc.func;

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -133,7 +133,7 @@ private void lambdaSetParent(Expression e, FuncDeclaration fd)
  * Returns:
  *      true if error occurs.
  */
-extern (C++) bool lambdaCheckForNestedRef(Expression e, Scope* sc)
+bool lambdaCheckForNestedRef(Expression e, Scope* sc)
 {
     extern (C++) final class LambdaCheckForNestedRef : StoppableVisitor
     {

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -336,7 +336,7 @@ private struct InterState
     Statement gotoTarget;
 }
 
-extern (C++) __gshared CtfeStack ctfeStack;
+private __gshared CtfeStack ctfeStack;
 
 /***********************************************************
  * CTFE-object code for a single function

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -175,7 +175,7 @@ Lno:
  * Returns:
  *      true means a `this` is needed
  */
-extern (C++) bool isNeedThisScope(Scope* sc, Declaration d)
+bool isNeedThisScope(Scope* sc, Declaration d)
 {
     if (sc.intypeof == 1)
         return false;
@@ -210,7 +210,7 @@ extern (C++) bool isNeedThisScope(Scope* sc, Declaration d)
  * check e is exp.opDispatch!(tiargs) or not
  * It's used to switch to UFCS the semantic analysis path
  */
-extern (C++) bool isDotOpDispatch(Expression e)
+bool isDotOpDispatch(Expression e)
 {
     return e.op == TOK.dotTemplateInstance && (cast(DotTemplateInstanceExp)e).ti.name == Id.opDispatch;
 }
@@ -533,7 +533,7 @@ private:
  * Regard NaN's as equivalent.
  * Regard +0 and -0 as different.
  */
-extern (C++) int RealEquals(real_t x1, real_t x2)
+int RealEquals(real_t x1, real_t x2)
 {
     return (CTFloat.isNaN(x1) && CTFloat.isNaN(x2)) || CTFloat.isIdentical(x1, x2);
 }

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2377,7 +2377,7 @@ extern (C++) class FuncDeclaration : Declaration
  * Returns:
  *      void expression that calls the invariant
  */
-extern (C++) Expression addInvariant(const ref Loc loc, Scope* sc, AggregateDeclaration ad, VarDeclaration vthis)
+Expression addInvariant(const ref Loc loc, Scope* sc, AggregateDeclaration ad, VarDeclaration vthis)
 {
     Expression e = null;
     // Call invariant directly only if it exists

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3566,7 +3566,7 @@ extern (C++) const(char)* parametersTypeToChars(Parameters* parameters, int vara
  *  fullQual = whether to fully qualify types.
  * Returns: Null-terminated string representing parameters.
  */
-extern (C++) const(char)* parameterToChars(Parameter parameter, TypeFunction tf, bool fullQual)
+const(char)* parameterToChars(Parameter parameter, TypeFunction tf, bool fullQual)
 {
     OutBuffer buf;
     HdrGenState hgs;

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -115,9 +115,9 @@ Where:
 }
 
 /// DMD-generated module `__entrypoint` where the C main resides
-extern (C++) __gshared Module entrypoint = null;
+private __gshared Module entrypoint = null;
 /// Module in which the D main is
-extern (C++) __gshared Module rootHasMain = null;
+private __gshared Module rootHasMain = null;
 
 
 /**
@@ -134,7 +134,7 @@ extern (C++) __gshared Module rootHasMain = null;
  *   sc = Scope which triggered the generation of the C main,
  *        used to get the module where the D main is.
  */
-extern (C++) void genCmain(Scope* sc)
+void genCmain(Scope* sc)
 {
     if (entrypoint)
         return;

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -39,7 +39,7 @@ import dmd.visitor;
  * Determine if operands of binary op can be reversed
  * to fit operator overload.
  */
-extern (C++) bool isCommutative(TOK op)
+bool isCommutative(TOK op)
 {
     switch (op)
     {
@@ -384,7 +384,7 @@ extern (C++) AggregateDeclaration isAggregate(Type t)
 /*******************************************
  * Helper function to turn operator into template argument list
  */
-extern (C++) Objects* opToArg(Scope* sc, TOK op)
+Objects* opToArg(Scope* sc, TOK op)
 {
     /* Remove the = from op=
      */

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -38,7 +38,7 @@ import dmd.visitor;
  *      null if not,
  *      ErrorExp if error
  */
-extern (C++) Expression expandVar(int result, VarDeclaration v)
+Expression expandVar(int result, VarDeclaration v)
 {
     //printf("expandVar(result = %d, v = %p, %s)\n", result, v, v ? v.toChars() : "null");
 

--- a/src/dmd/root/aav.d
+++ b/src/dmd/root/aav.d
@@ -15,7 +15,7 @@ module dmd.root.aav;
 import core.stdc.string;
 import dmd.root.rmem;
 
-extern (C++) size_t hash(size_t a)
+private size_t hash(size_t a)
 {
     a ^= (a >> 20) ^ (a >> 12);
     return a ^ (a >> 7) ^ (a >> 4);
@@ -51,7 +51,7 @@ struct AA
 /****************************************************
  * Determine number of entries in associative array.
  */
-extern (C++) size_t dmd_aaLen(const AA* aa) pure
+private size_t dmd_aaLen(const AA* aa) pure
 {
     return aa ? aa.nodes : 0;
 }
@@ -61,7 +61,7 @@ extern (C++) size_t dmd_aaLen(const AA* aa) pure
  * Add entry for key if it is not already there, returning a pointer to a null Value.
  * Create the associative array if it does not already exist.
  */
-extern (C++) Value* dmd_aaGet(AA** paa, Key key)
+private Value* dmd_aaGet(AA** paa, Key key)
 {
     //printf("paa = %p\n", paa);
     if (!*paa)
@@ -110,7 +110,7 @@ extern (C++) Value* dmd_aaGet(AA** paa, Key key)
  * Get value in associative array indexed by key.
  * Returns NULL if it is not already there.
  */
-extern (C++) Value dmd_aaGetRvalue(AA* aa, Key key)
+private Value dmd_aaGetRvalue(AA* aa, Key key)
 {
     //printf("_aaGetRvalue(key = %p)\n", key);
     if (aa)
@@ -218,7 +218,7 @@ debug
 /********************************************
  * Rehash an array.
  */
-extern (C++) void dmd_aaRehash(AA** paa)
+private void dmd_aaRehash(AA** paa)
 {
     //printf("Rehash\n");
     if (*paa)

--- a/src/dmd/sapply.d
+++ b/src/dmd/sapply.d
@@ -172,7 +172,7 @@ public:
     }
 }
 
-extern (C++) bool walkPostorder(Statement s, StoppableVisitor v)
+bool walkPostorder(Statement s, StoppableVisitor v)
 {
     scope PostorderStatementVisitor pv = new PostorderStatementVisitor(v);
     s.accept(pv);

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -92,7 +92,7 @@ extern (C++) bool hasSideEffect(Expression e)
  *      1   nothrow + constant purity
  *      2   nothrow + strong purity
  */
-extern (C++) int callSideEffectLevel(FuncDeclaration f)
+int callSideEffectLevel(FuncDeclaration f)
 {
     /* https://issues.dlang.org/show_bug.cgi?id=12760
      * ctor call always has side effects.
@@ -112,7 +112,7 @@ extern (C++) int callSideEffectLevel(FuncDeclaration f)
     return 0;
 }
 
-extern (C++) int callSideEffectLevel(Type t)
+int callSideEffectLevel(Type t)
 {
     t = t.toBasetype();
     TypeFunction tf;

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -484,7 +484,7 @@ extern (C++) final class PeelStatement : Statement
 /***********************************************************
  * Convert TemplateMixin members (== Dsymbols) to Statements.
  */
-extern (C++) Statement toStatement(Dsymbol s)
+private Statement toStatement(Dsymbol s)
 {
     extern (C++) final class ToStmt : Visitor
     {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -94,7 +94,7 @@ private Dsymbol getDsymbolWithoutExpCtx(RootObject oarg)
     return getDsymbol(oarg);
 }
 
-extern (C++) __gshared StringTable traitsStringTable;
+private __gshared StringTable traitsStringTable;
 
 shared static this()
 {
@@ -164,7 +164,7 @@ shared static this()
  *  if interpreted as the type given as argument
  * Returns: the size of the type in bytes, d_uns64.max on error
  */
-extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
+d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data)
 {
     d_uns64 sz;
     if (t.ty == Tclass && !(cast(TypeClass)t).sym.isInterfaceDeclaration())
@@ -387,7 +387,7 @@ extern (C++) d_uns64 getTypePointerBitmap(Loc loc, Type t, Array!(d_uns64)* data
  *
  *  Returns: [T.sizeof, pointerbit0-31/63, pointerbit32/64-63/128, ...]
  */
-extern (C++) Expression pointerBitmap(TraitsExp e)
+private Expression pointerBitmap(TraitsExp e)
 {
     if (!e.args || e.args.dim != 1)
     {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -591,7 +591,7 @@ private extern (C++) final class TypeToExpressionVisitor : Visitor
  * Redo it as an Expression.
  * NULL if cannot.
  */
-extern (C++) Expression typeToExpression(Type t)
+Expression typeToExpression(Type t)
 {
     scope v = new TypeToExpressionVisitor();
     t.accept(v);
@@ -601,7 +601,7 @@ extern (C++) Expression typeToExpression(Type t)
 /* Helper function for `typeToExpression`. Contains common code
  * for TypeQualified derived classes.
  */
-extern (C++) Expression typeToExpressionHelper(TypeQualified t, Expression e, size_t i = 0)
+Expression typeToExpressionHelper(TypeQualified t, Expression e, size_t i = 0)
 {
     //printf("toExpressionHelper(e = %s %s)\n", Token.toChars(e.op), e.toChars());
     foreach (id; t.idents[i .. t.idents.dim])
@@ -1865,7 +1865,7 @@ Type merge(Type type)
  *  ident = the identifier of the property
  *  flag = if flag & 1, don't report "not a property" error and just return NULL.
  */
-extern(C++) Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
+Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
 {
     scope v = new GetPropertyVisitor(loc, ident, flag);
     t.accept(v);
@@ -2412,7 +2412,7 @@ private extern (C++) final class GetPropertyVisitor : Visitor
  *  ps = is set if t is a symbol
  *  intypeid = true if in type id
  */
-extern(C++) void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Dsymbol* ps, bool intypeid = false)
+void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Dsymbol* ps, bool intypeid = false)
 {
     scope v = new ResolveVisitor(loc, sc, pe, pt, ps, intypeid);
     mt.accept(v);
@@ -2918,7 +2918,7 @@ private extern(C++) final class ResolveVisitor : Visitor
  * Returns:
  *  resulting expression with e.ident resolved
  */
-extern(C++) Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
+Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
 {
     scope v = new DotExpVisitor(sc, e, ident, flag);
     mt.accept(v);
@@ -4322,7 +4322,7 @@ private extern(C++) final class DotExpVisitor : Visitor
  * Returns:
  *  The initialization expression for the type.
  */
-extern(C++) Expression defaultInit(Type mt, const ref Loc loc)
+Expression defaultInit(Type mt, const ref Loc loc)
 {
     scope v = new DefaultInitVisitor(loc);
     mt.accept(v);

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -32,7 +32,7 @@ import core.stdc.stdio;
  *      torig = the type to generate the `TypeInfo` object for
  *      sc    = the scope
  */
-extern (C++) void genTypeInfo(Loc loc, Type torig, Scope* sc)
+void genTypeInfo(Loc loc, Type torig, Scope* sc)
 {
     // printf("genTypeInfo() %s\n", torig.toChars());
 
@@ -108,7 +108,7 @@ extern (C++) Type getTypeInfoType(Loc loc, Type t, Scope* sc)
     return t.vtinfo.type;
 }
 
-extern (C++) TypeInfoDeclaration getTypeInfoDeclaration(Type t)
+private TypeInfoDeclaration getTypeInfoDeclaration(Type t)
 {
     //printf("Type::getTypeInfoDeclaration() %s\n", t.toChars());
     switch (t.ty)
@@ -144,7 +144,7 @@ extern (C++) TypeInfoDeclaration getTypeInfoDeclaration(Type t)
     }
 }
 
-extern (C++) bool isSpeculativeType(Type t)
+bool isSpeculativeType(Type t)
 {
     extern (C++) final class SpeculativeTypeVisitor : Visitor
     {

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -33,7 +33,7 @@ import dmd.root.rmem;
  * Returns:
  *   A newly-allocated string with '/' turned into backslashes
  */
-extern (C++) const(char)* toWinPath(const(char)* src)
+const(char)* toWinPath(const(char)* src)
 {
     if (src is null)
         return null;


### PR DESCRIPTION
There are a few omissions, mostly functions with semantic in the name, of which probably _should_ be present in the headers for the sake of other potential client apps using the front-end (however most of these extern(C++) semantic functions are unused by at least gdc).