### PR TITLE
dmd.dsymbol: Remove C++ linkage from static member functions

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -325,7 +325,7 @@ struct ASTBase
             return true;
         }
 
-        static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
+        extern (D) static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
         {
             Dsymbol s = null;
             if (members)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -468,7 +468,7 @@ extern (C++) class Dsymbol : RootObject
     /*************************************
      * Do syntax copy of an array of Dsymbol's.
      */
-    static Dsymbols* arraySyntaxCopy(Dsymbols* a)
+    extern (D) static Dsymbols* arraySyntaxCopy(Dsymbols* a)
     {
         Dsymbols* b = null;
         if (a)
@@ -869,7 +869,7 @@ extern (C++) class Dsymbol : RootObject
     /*****************************************
      * Same as Dsymbol::oneMember(), but look at an array of Dsymbols.
      */
-    static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
+    extern (D) static bool oneMembers(Dsymbols* members, Dsymbol* ps, Identifier ident)
     {
         //printf("Dsymbol::oneMembers() %d\n", members ? members.dim : 0);
         Dsymbol s = null;

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -185,8 +185,6 @@ public:
     // kludge for template.isSymbol()
     int dyncast() const { return DYNCAST_DSYMBOL; }
 
-    static Dsymbols *arraySyntaxCopy(Dsymbols *a);
-
     virtual Identifier *getIdent();
     virtual const char *toPrettyChars(bool QualifyTypes = false);
     virtual const char *kind() const;
@@ -216,7 +214,6 @@ public:
     virtual Prot prot();
     virtual Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees
     virtual bool oneMember(Dsymbol **ps, Identifier *ident);
-    static bool oneMembers(Dsymbols *members, Dsymbol **ps, Identifier *ident);
     virtual void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();


### PR DESCRIPTION
And make them all free functions.

ASTBase is a horrid mess that duplicates too much.