### PR TITLE
dmd.dsymbol: Remove ScopeDsymbol.dim and getNth

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1604,47 +1604,6 @@ public:
         return false;
     }
 
-    /***************************************
-     * Determine number of Dsymbols, folding in AttribDeclaration members.
-     */
-    static size_t dim(Dsymbols* members)
-    {
-        size_t n = 0;
-        int dimDg(size_t idx, Dsymbol s)
-        {
-            ++n;
-            return 0;
-        }
-
-        _foreach(null, members, &dimDg, &n);
-        return n;
-    }
-
-    /***************************************
-     * Get nth Dsymbol, folding in AttribDeclaration members.
-     * Returns:
-     *      Dsymbol*        nth Dsymbol
-     *      NULL            not found, *pn gets incremented by the number
-     *                      of Dsymbols
-     */
-    static Dsymbol getNth(Dsymbols* members, size_t nth, size_t* pn = null)
-    {
-        Dsymbol sym = null;
-
-        int getNthSymbolDg(size_t n, Dsymbol s)
-        {
-            if (n == nth)
-            {
-                sym = s;
-                return 1;
-            }
-            return 0;
-        }
-
-        int res = _foreach(null, members, &getNthSymbolDg);
-        return res ? sym : null;
-    }
-
     extern (D) alias ForeachDg = int delegate(size_t idx, Dsymbol s);
 
     /***************************************

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -307,9 +307,6 @@ public:
     virtual Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     bool hasStaticCtorOrDtor();
 
-    static size_t dim(Dsymbols *members);
-    static Dsymbol *getNth(Dsymbols *members, size_t nth, size_t *pn = NULL);
-
     ScopeDsymbol *isScopeDsymbol() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
There are no users of these functions.  I'm not aware of any use cases for keeping them.