### PR TITLE
dmd.expression: Remove C++ linkage from static member functions

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -810,28 +810,28 @@ extern (C++) abstract class Expression : RootObject
     }
 
     /**********************************
-     * If 'e' is a tree of commas, returns the leftmost expression
+     * If 'e' is a tree of commas, returns the rightmost expression
      * by stripping off it from the tree. The remained part of the tree
-     * is returned via *pe0.
-     * Otherwise 'e' is directly returned and *pe0 is set to NULL.
+     * is returned via e0.
+     * Otherwise 'e' is directly returned and e0 is set to NULL.
      */
-    extern (D) static Expression extractLast(Expression e, Expression* pe0)
+    extern (D) static Expression extractLast(Expression e, out Expression e0)
     {
         if (e.op != TOK.comma)
         {
-            *pe0 = null;
+            e0 = null;
             return e;
         }
 
         CommaExp ce = cast(CommaExp)e;
         if (ce.e2.op != TOK.comma)
         {
-            *pe0 = ce.e1;
+            e0 = ce.e1;
             return ce.e2;
         }
         else
         {
-            *pe0 = e;
+            e0 = e;
 
             Expression* pce = &ce.e2;
             while ((cast(CommaExp)(*pce)).e2.op == TOK.comma)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -784,7 +784,7 @@ extern (C++) abstract class Expression : RootObject
     /**********************************
      * Combine e1 and e2 by CommaExp if both are not NULL.
      */
-    static Expression combine(Expression e1, Expression e2)
+    extern (D) static Expression combine(Expression e1, Expression e2)
     {
         if (e1)
         {
@@ -799,12 +799,12 @@ extern (C++) abstract class Expression : RootObject
         return e1;
     }
 
-    static Expression combine(Expression e1, Expression e2, Expression e3)
+    extern (D) static Expression combine(Expression e1, Expression e2, Expression e3)
     {
         return combine(combine(e1, e2), e3);
     }
 
-    static Expression combine(Expression e1, Expression e2, Expression e3, Expression e4)
+    extern (D) static Expression combine(Expression e1, Expression e2, Expression e3, Expression e4)
     {
         return combine(combine(e1, e2), combine(e3, e4));
     }
@@ -815,7 +815,7 @@ extern (C++) abstract class Expression : RootObject
      * is returned via *pe0.
      * Otherwise 'e' is directly returned and *pe0 is set to NULL.
      */
-    static Expression extractLast(Expression e, Expression* pe0)
+    extern (D) static Expression extractLast(Expression e, Expression* pe0)
     {
         if (e.op != TOK.comma)
         {
@@ -846,7 +846,7 @@ extern (C++) abstract class Expression : RootObject
         }
     }
 
-    static Expressions* arraySyntaxCopy(Expressions* exps)
+    extern (D) static Expressions* arraySyntaxCopy(Expressions* exps)
     {
         Expressions* a = null;
         if (exps)
@@ -2719,49 +2719,6 @@ extern (C++) final class ArrayLiteralExp : Expression
         if (!el)
             el = basis;
         return el;
-    }
-
-    /** Copy element `Expressions` in the parameters when they're `ArrayLiteralExp`s.
-     * Params:
-     *      e1  = If it's ArrayLiteralExp, its `elements` will be copied.
-     *            Otherwise, `e1` itself will be pushed into the new `Expressions`.
-     *      e2  = If it's not `null`, it will be pushed/appended to the new
-     *            `Expressions` by the same way with `e1`.
-     * Returns:
-     *      Newly allocated `Expressions`. Note that it points to the original
-     *      `Expression` values in e1 and e2.
-     */
-    static Expressions* copyElements(Expression e1, Expression e2 = null)
-    {
-        auto elems = new Expressions();
-
-        void append(ArrayLiteralExp ale)
-        {
-            if (!ale.elements)
-                return;
-            auto d = elems.dim;
-            elems.append(ale.elements);
-            foreach (ref el; (*elems)[d .. elems.dim])
-            {
-                if (!el)
-                    el = ale.basis;
-            }
-        }
-
-        if (e1.op == TOK.arrayLiteral)
-            append(cast(ArrayLiteralExp)e1);
-        else
-            elems.push(e1);
-
-        if (e2)
-        {
-            if (e2.op == TOK.arrayLiteral)
-                append(cast(ArrayLiteralExp)e2);
-            else
-                elems.push(e2);
-        }
-
-        return elems;
     }
 
     override bool isBool(bool result)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -129,13 +129,6 @@ public:
     void warning(const char *format, ...) const;
     void deprecation(const char *format, ...) const;
 
-    // creates a single expression which is effectively (e1, e2)
-    // this new expression does not necessarily need to have valid D source code representation,
-    // for example, it may include declaration expressions
-    static Expression *combine(Expression *e1, Expression *e2);
-    static Expression *extractLast(Expression *e, Expression **pe0);
-    static Expressions *arraySyntaxCopy(Expressions *exps);
-
     virtual dinteger_t toInteger();
     virtual uinteger_t toUInteger();
     virtual real_t toReal();
@@ -365,7 +358,6 @@ public:
     Expression *syntaxCopy();
     bool equals(RootObject *o);
     Expression *getElement(d_size_t i);
-    static Expressions* copyElements(Expression *e1, Expression *e2 = NULL);
     bool isBool(bool result);
     StringExp *toStringExp();
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -112,7 +112,7 @@ StringExp semanticString(Scope *sc, Expression exp, const char* s)
 private Expression extractOpDollarSideEffect(Scope* sc, UnaExp ue)
 {
     Expression e0;
-    Expression e1 = Expression.extractLast(ue.e1, &e0);
+    Expression e1 = Expression.extractLast(ue.e1, e0);
     // https://issues.dlang.org/show_bug.cgi?id=12585
     // Extract the side effect part if ue.e1 is comma.
 
@@ -7287,7 +7287,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (!(cast(CommaExp)exp.e2).isGenerated)
                 exp.error("Using the result of a comma expression is not allowed");
             Expression e0;
-            exp.e2 = Expression.extractLast(exp.e2, &e0);
+            exp.e2 = Expression.extractLast(exp.e2, e0);
             Expression e = Expression.combine(e0, exp);
             result = e.expressionSemantic(sc);
             return;
@@ -7696,7 +7696,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         cx.e1 = dvx;
 
                         Expression e0;
-                        Expression.extractLast(e2x, &e0);
+                        Expression.extractLast(e2x, e0);
 
                         auto e = Expression.combine(ae, cx);
                         e = Expression.combine(e0, e);
@@ -8397,7 +8397,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             Expression e0 = null;
             e = exp.reorderSettingAAElem(sc);
-            e = Expression.extractLast(e, &e0);
+            e = Expression.extractLast(e, e0);
             assert(e == exp);
 
             if (exp.e1.op == TOK.variable)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6181,8 +6181,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     e = new CallExp(exp.loc, new VarExp(exp.loc, f, false), e);
                     ec = e.expressionSemantic(sc);
                 }
-                ea = Expression.combine(ea, eb);
-                ea = Expression.combine(ea, ec);
+                ea = Expression.combine(ea, eb, ec);
                 assert(ea);
                 result = ea;
                 return;
@@ -7539,7 +7538,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 {
                     e = new IntegerExp(exp.loc, 0, Type.tint32);
                     e = new CastExp(exp.loc, e, Type.tvoid); // avoid "has no effect" error
-                    e = Expression.combine(Expression.combine(tup1.e0, tup2.e0), e);
+                    e = Expression.combine(tup1.e0, tup2.e0, e);
                 }
                 else
                 {
@@ -7698,8 +7697,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         Expression e0;
                         Expression.extractLast(e2x, e0);
 
-                        auto e = Expression.combine(ae, cx);
-                        e = Expression.combine(e0, e);
+                        auto e = Expression.combine(e0, ae, cx);
                         e = e.expressionSemantic(sc);
                         result = e;
                         return;

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1811,7 +1811,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
     if (ethis)
     {
         Expression e0;
-        ethis = Expression.extractLast(ethis, &e0);
+        ethis = Expression.extractLast(ethis, e0);
         if (ethis.op == TOK.variable)
         {
             vthis = (cast(VarExp)ethis).var.isVarDeclaration();

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -2007,9 +2007,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             e.type = Type.tvoid;
         }
 
-        eresult = Expression.combine(eresult, eret);
-        eresult = Expression.combine(eresult, ethis);
-        eresult = Expression.combine(eresult, eparams);
+        eresult = Expression.combine(eresult, eret, ethis, eparams);
         eresult = Expression.combine(eresult, e);
 
         static if (EXPANDINLINE_LOG)

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1297,7 +1297,7 @@ Expression op_overload(Expression e, Scope* sc)
                     }
                     assert(result);
                 }
-                result = Expression.combine(Expression.combine(tup1.e0, tup2.e0), result);
+                result = Expression.combine(tup1.e0, tup2.e0, result);
                 result = result.expressionSemantic(sc);
 
                 return;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3068,7 +3068,7 @@ else
                 rs.exp = new ErrorExp();
 
             // Extract side-effect part
-            rs.exp = Expression.extractLast(rs.exp, &e0);
+            rs.exp = Expression.extractLast(rs.exp, e0);
             if (rs.exp.op == TOK.call)
                 rs.exp = valueNoDtor(rs.exp);
 


### PR DESCRIPTION
The `extractLast` function can use an `out` parameter instead of accepting a pointer.  I also noticed that the documentation seems to be wrong (it returns the rightmost, not the leftmost part).

Also noticed there are a few places where `combine(combine(...), ...)` was being used instead of one of the helper functions.