### PR TITLE
dmd.identifier: Remove C++ linkage from static members

### DIFF
--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -128,7 +128,7 @@ nothrow:
         return DYNCAST.identifier;
     }
 
-    extern (C++) __gshared StringTable stringtable;
+    private extern (D) __gshared StringTable stringtable;
 
     /**
        A secondary string table is used to guarantee that we generate unique
@@ -140,7 +140,7 @@ nothrow:
        https://issues.dlang.org/show_bug.cgi?id=18868
        https://issues.dlang.org/show_bug.cgi?id=19058.
      */
-    private extern (C++) __gshared StringTable fullPathStringTable;
+    private extern (D) __gshared StringTable fullPathStringTable;
 
     static Identifier generateId(const(char)* prefix)
     {
@@ -308,7 +308,7 @@ nothrow:
         return false;
     }
 
-    static Identifier lookup(const(char)* s, size_t len)
+    extern (D) static Identifier lookup(const(char)* s, size_t len)
     {
         auto sv = stringtable.lookup(s, len);
         if (!sv)
@@ -316,7 +316,7 @@ nothrow:
         return cast(Identifier)sv.ptrvalue;
     }
 
-    static void initTable()
+    extern (D) static void initTable()
     {
         enum size = 28_000;
         stringtable._init(size);

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -12,7 +12,6 @@
 
 #include "root/dcompat.h"
 #include "root/root.h"
-#include "root/stringtable.h"
 
 class Identifier : public RootObject
 {
@@ -29,8 +28,6 @@ public:
     const char *toHChars2();
     int dyncast() const;
 
-    static StringTable stringtable;
-    static StringTable fullPathStringTable;
     static Identifier *generateId(const char *prefix);
     static Identifier *generateId(const char *prefix, size_t i);
     static Identifier *idPool(const char *s, unsigned len);
@@ -41,6 +38,4 @@ public:
     }
 
     static bool isValidIdentifier(const char *p);
-    static Identifier *lookup(const char *s, size_t len);
-    static void initTable();
 };


### PR DESCRIPTION
Make static variables private to module.