### PR TITLE
dmd.init: Remove Initializer.arraySyntaxCopy

### DIFF
--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -49,18 +49,6 @@ extern (C++) class Initializer : RootObject
 
     abstract Initializer syntaxCopy();
 
-    static Initializers* arraySyntaxCopy(Initializers* ai)
-    {
-        Initializers* a = null;
-        if (ai)
-        {
-            a = new Initializers(ai.dim);
-            for (size_t i = 0; i < a.dim; i++)
-                (*a)[i] = (*ai)[i].syntaxCopy();
-        }
-        return a;
-    }
-
     override final const(char)* toChars()
     {
         OutBuffer buf;

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -31,7 +31,6 @@ public:
     Loc loc;
 
     virtual Initializer *syntaxCopy() = 0;
-    static Initializers *arraySyntaxCopy(Initializers *ai);
 
     const char *toChars();
 


### PR DESCRIPTION
This is dead code.