### PR TITLE
dmd.dmodule: Remove C++ linkage from static members

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -172,7 +172,7 @@ extern (C++) class Package : ScopeDsymbol
      *      *pparent        the rightmost package, i.e. pkg2, or NULL if no packages
      *      *ppkg           the leftmost package, i.e. pkg1, or NULL if no packages
      */
-    static DsymbolTable resolve(Identifiers* packages, Dsymbol* pparent, Package* ppkg)
+    extern (D) static DsymbolTable resolve(Identifiers* packages, Dsymbol* pparent, Package* ppkg)
     {
         DsymbolTable dst = Module.modules;
         Dsymbol parent = null;

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -32,8 +32,6 @@ public:
 
     const char *kind() const;
 
-    static DsymbolTable *resolve(Identifiers *packages, Dsymbol **pparent, Package **ppkg);
-
     Package *isPackage() { return this; }
 
     bool isAncestorPackageOf(const Package * const pkg) const;


### PR DESCRIPTION
(Module is peculiar as the driver interacts with it, so is left alone for now...)