### PR TITLE
dmd.mtype: Remove Type.error and Type.warning

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -940,7 +940,7 @@ private final class CppMangleVisitor : Visitor
             if (t.ty == Tsarray)
             {
                 // Static arrays in D are passed by value; no counterpart in C++
-                t.error(loc, "Internal Compiler Error: unable to pass static array `%s` to extern(C++) function, use pointer instead",
+                .error(loc, "Internal Compiler Error: unable to pass static array `%s` to extern(C++) function, use pointer instead",
                     t.toChars());
                 fatal();
             }
@@ -968,7 +968,7 @@ private final class CppMangleVisitor : Visitor
             p = "`shared` ";
         else
             p = "";
-        t.error(loc, "Internal Compiler Error: %stype `%s` can not be mapped to C++\n", p, t.toChars());
+        .error(loc, "Internal Compiler Error: %stype `%s` can not be mapped to C++\n", p, t.toChars());
         fatal(); //Fatal, because this error should be handled in frontend
     }
 

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -64,7 +64,7 @@ private bool checkImmutableShared(Type type)
 {
     if (type.isImmutable() || type.isShared())
     {
-        type.error(Loc.initial, "Internal Compiler Error: `shared` or `immutable` types can not be mapped to C++ (%s)", type.toChars());
+        error(Loc.initial, "Internal Compiler Error: `shared` or `immutable` types can not be mapped to C++ (%s)", type.toChars());
         fatal();
         return true;
     }
@@ -128,7 +128,7 @@ public:
         if (checkImmutableShared(type))
             return;
 
-        type.error(Loc.initial, "Internal Compiler Error: type `%s` can not be mapped to C++\n", type.toChars());
+        error(Loc.initial, "Internal Compiler Error: type `%s` can not be mapped to C++\n", type.toChars());
         fatal(); //Fatal, because this error should be handled in frontend
     }
 
@@ -1288,8 +1288,8 @@ private:
                 }
                 if (t.ty == Tsarray)
                 {
-                    t.error(Loc.initial, "Internal Compiler Error: unable to pass static array to `extern(C++)` function.");
-                    t.error(Loc.initial, "Use pointer instead.");
+                    error(Loc.initial, "Internal Compiler Error: unable to pass static array to `extern(C++)` function.");
+                    error(Loc.initial, "Use pointer instead.");
                     assert(0);
                 }
                 tmp.flags &= ~IS_NOT_TOP_TYPE;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -199,7 +199,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
  */
 extern (C++) void ObjectNotFound(Identifier id)
 {
-    Type.error(Loc.initial, "`%s` not found. object.d may be incorrectly installed or corrupt.", id.toChars());
+    error(Loc.initial, "`%s` not found. object.d may be incorrectly installed or corrupt.", id.toChars());
     fatal();
 }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2699,22 +2699,6 @@ extern (C++) abstract class Type : RootObject
         return false;
     }
 
-    static void error(const ref Loc loc, const(char)* format, ...)
-    {
-        va_list ap;
-        va_start(ap, format);
-        .verror(loc, format, ap);
-        va_end(ap);
-    }
-
-    static void warning(const ref Loc loc, const(char)* format, ...)
-    {
-        va_list ap;
-        va_start(ap, format);
-        .vwarning(loc, format, ap);
-        va_end(ap);
-    }
-
     // For eliminating dynamic_cast
     TypeBasic isTypeBasic()
     {

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -326,9 +326,6 @@ public:
     virtual bool needsNested();
     bool checkComplexTransition(const Loc &loc, Scope *sc);
 
-    static void error(const Loc &loc, const char *format, ...);
-    static void warning(const Loc &loc, const char *format, ...);
-
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();
     virtual void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -666,7 +666,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
     {
         if (t.ty == Tint128 || t.ty == Tuns128)
         {
-            t.error(loc, "`cent` and `ucent` types not implemented");
+            .error(loc, "`cent` and `ucent` types not implemented");
             return error();
         }
 
@@ -682,7 +682,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         mtype.basetype = mtype.basetype.toBasetype().mutableOf();
         if (mtype.basetype.ty != Tsarray)
         {
-            mtype.error(loc, "T in __vector(T) must be a static array, not `%s`", mtype.basetype.toChars());
+            .error(loc, "T in __vector(T) must be a static array, not `%s`", mtype.basetype.toChars());
             return error();
         }
         TypeSArray t = cast(TypeSArray)mtype.basetype;
@@ -695,12 +695,12 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
         case 1:
             // no support at all
-            mtype.error(loc, "SIMD vector types not supported on this platform");
+            .error(loc, "SIMD vector types not supported on this platform");
             return error();
 
         case 2:
             // invalid base type
-            mtype.error(loc, "vector type `%s` is not supported on this platform", mtype.toChars());
+            .error(loc, "vector type `%s` is not supported on this platform", mtype.toChars());
             return error();
 
         case 3:
@@ -709,7 +709,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                 deprecation(loc, "%d byte vector types are only supported with -mcpu=avx", sz, mtype.toChars());
             else
             {
-                mtype.error(loc, "%d byte vector type `%s` is not supported on this platform", sz, mtype.toChars());
+                .error(loc, "%d byte vector type `%s` is not supported on this platform", sz, mtype.toChars());
                 return error();
             }
             break;
@@ -735,14 +735,14 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             uinteger_t d = mtype.dim.toUInteger();
             if (d >= tup.objects.dim)
             {
-                mtype.error(loc, "tuple index %llu exceeds %llu", cast(ulong)d, cast(ulong)tup.objects.dim);
+                .error(loc, "tuple index %llu exceeds %llu", cast(ulong)d, cast(ulong)tup.objects.dim);
                 return error();
             }
 
             RootObject o = (*tup.objects)[cast(size_t)d];
             if (o.dyncast() != DYNCAST.type)
             {
-                mtype.error(loc, "`%s` is not a type", mtype.toChars());
+                .error(loc, "`%s` is not a type", mtype.toChars());
                 return error();
             }
             result = (cast(Type)o).addMod(mtype.mod);
@@ -786,7 +786,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
             void overflowError()
             {
-                mtype.error(loc, "`%s` size %llu * %llu exceeds 0x%llx size limit for static array",
+                .error(loc, "`%s` size %llu * %llu exceeds 0x%llx size limit for static array",
                         mtype.toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1, Target.maxStaticDataSize);
                 return error();
             }
@@ -821,7 +821,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                 uinteger_t d = mtype.dim.toUInteger();
                 if (d >= tt.arguments.dim)
                 {
-                    mtype.error(loc, "tuple index %llu exceeds %llu", cast(ulong)d, cast(ulong)tt.arguments.dim);
+                    .error(loc, "tuple index %llu exceeds %llu", cast(ulong)d, cast(ulong)tt.arguments.dim);
                     return error();
                 }
                 Type telem = (*tt.arguments)[cast(size_t)d].type;
@@ -831,7 +831,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
         case Tfunction:
         case Tnone:
-            mtype.error(loc, "cannot have array of `%s`", tbn.toChars());
+            .error(loc, "cannot have array of `%s`", tbn.toChars());
             return error();
 
         default:
@@ -839,7 +839,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         }
         if (tbn.isscope())
         {
-            mtype.error(loc, "cannot have array of scope `%s`", tbn.toChars());
+            .error(loc, "cannot have array of scope `%s`", tbn.toChars());
             return error();
         }
 
@@ -863,7 +863,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
         case Tfunction:
         case Tnone:
-            mtype.error(loc, "cannot have array of `%s`", tbn.toChars());
+            .error(loc, "cannot have array of `%s`", tbn.toChars());
             return error();
 
         case Terror:
@@ -874,7 +874,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         }
         if (tn.isscope())
         {
-            mtype.error(loc, "cannot have array of scope `%s`", tn.toChars());
+            .error(loc, "cannot have array of scope `%s`", tn.toChars());
             return error();
         }
         mtype.next = tn;
@@ -916,7 +916,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                 mtype.index = t.typeSemantic(loc, sc);
             else
             {
-                mtype.index.error(loc, "index is not a type or an expression");
+                .error(loc, "index is not a type or an expression");
                 return error();
             }
         }
@@ -947,7 +947,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         case Tvoid:
         case Tnone:
         case Ttuple:
-            mtype.error(loc, "cannot have associative array key of `%s`", mtype.index.toBasetype().toChars());
+            .error(loc, "cannot have associative array key of `%s`", mtype.index.toBasetype().toChars());
             goto case Terror;
         case Terror:
             return error();
@@ -990,11 +990,11 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             {
                 if (search_function(sd, Id.eq))
                 {
-                    mtype.error(loc, "%sAA key type `%s` does not have `bool opEquals(ref const %s) const`", s, sd.toChars(), sd.toChars());
+                    .error(loc, "%sAA key type `%s` does not have `bool opEquals(ref const %s) const`", s, sd.toChars(), sd.toChars());
                 }
                 else
                 {
-                    mtype.error(loc, "%sAA key type `%s` does not support const equality", s, sd.toChars());
+                    .error(loc, "%sAA key type `%s` does not support const equality", s, sd.toChars());
                 }
                 return error();
             }
@@ -1002,11 +1002,11 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             {
                 if (search_function(sd, Id.eq))
                 {
-                    mtype.error(loc, "%sAA key type `%s` should have `size_t toHash() const nothrow @safe` if `opEquals` defined", s, sd.toChars());
+                    .error(loc, "%sAA key type `%s` should have `size_t toHash() const nothrow @safe` if `opEquals` defined", s, sd.toChars());
                 }
                 else
                 {
-                    mtype.error(loc, "%sAA key type `%s` supports const equality but doesn't support const hashing", s, sd.toChars());
+                    .error(loc, "%sAA key type `%s` supports const equality but doesn't support const hashing", s, sd.toChars());
                 }
                 return error();
             }
@@ -1030,7 +1030,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
             if (!ClassDeclaration.object)
             {
-                mtype.error(Loc.initial, "missing or corrupt object.d");
+                .error(Loc.initial, "missing or corrupt object.d");
                 fatal();
             }
 
@@ -1052,7 +1052,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                     if (fcmp.vtblIndex < cd.vtbl.dim && cd.vtbl[fcmp.vtblIndex] != fcmp)
                     {
                         const(char)* s = (mtype.index.toBasetype().ty != Tclass) ? "bottom of " : "";
-                        mtype.error(loc, "%sAA key type `%s` now requires equality rather than comparison", s, cd.toChars());
+                        .error(loc, "%sAA key type `%s` now requires equality rather than comparison", s, cd.toChars());
                         errorSupplemental(loc, "Please override `Object.opEquals` and `Object.toHash`.");
                     }
                 }
@@ -1067,7 +1067,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         case Tvoid:
         case Tnone:
         case Ttuple:
-            mtype.error(loc, "cannot have associative array of `%s`", mtype.next.toChars());
+            .error(loc, "cannot have associative array of `%s`", mtype.next.toChars());
             goto case Terror;
         case Terror:
             return error();
@@ -1076,7 +1076,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         }
         if (mtype.next.isscope())
         {
-            mtype.error(loc, "cannot have array of scope `%s`", mtype.next.toChars());
+            .error(loc, "cannot have array of scope `%s`", mtype.next.toChars());
             return error();
         }
         result = merge(mtype);
@@ -1094,7 +1094,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         switch (n.toBasetype().ty)
         {
         case Ttuple:
-            mtype.error(loc, "cannot have pointer to `%s`", n.toChars());
+            .error(loc, "cannot have pointer to `%s`", n.toChars());
             goto case Terror;
         case Terror:
             return error();
@@ -1231,7 +1231,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             errors |= tf.checkRetType(loc);
             if (tf.next.isscope() && !(sc.flags & SCOPE.ctor))
             {
-                mtype.error(loc, "functions cannot return `scope %s`", tf.next.toChars());
+                .error(loc, "functions cannot return `scope %s`", tf.next.toChars());
                 errors = true;
             }
             if (tf.next.hasWild())
@@ -1279,7 +1279,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
                 if (t.ty == Tfunction)
                 {
-                    mtype.error(loc, "cannot have parameter of function type `%s`", fparam.type.toChars());
+                    .error(loc, "cannot have parameter of function type `%s`", fparam.type.toChars());
                     errors = true;
                 }
                 else if (!(fparam.storageClass & (STC.ref_ | STC.out_)) &&
@@ -1289,13 +1289,13 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                     if (tb2.ty == Tstruct && !(cast(TypeStruct)tb2).sym.members ||
                         tb2.ty == Tenum && !(cast(TypeEnum)tb2).sym.memtype)
                     {
-                        mtype.error(loc, "cannot have parameter of opaque type `%s` by value", fparam.type.toChars());
+                        .error(loc, "cannot have parameter of opaque type `%s` by value", fparam.type.toChars());
                         errors = true;
                     }
                 }
                 else if (!(fparam.storageClass & STC.lazy_) && t.ty == Tvoid)
                 {
-                    mtype.error(loc, "cannot have parameter of type `%s`", fparam.type.toChars());
+                    .error(loc, "cannot have parameter of type `%s`", fparam.type.toChars());
                     errors = true;
                 }
 
@@ -1314,7 +1314,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                         if (0 && !tf.isref)
                         {
                             auto stc = fparam.storageClass & (STC.ref_ | STC.out_);
-                            mtype.error(loc, "parameter `%s` is `return %s` but function does not return by `ref`",
+                            .error(loc, "parameter `%s` is `return %s` but function does not return by `ref`",
                                 fparam.ident ? fparam.ident.toChars() : "",
                                 stcToChars(stc));
                             errors = true;
@@ -1340,7 +1340,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                 {
                     if (ubyte m = fparam.type.mod & (MODFlags.immutable_ | MODFlags.const_ | MODFlags.wild))
                     {
-                        mtype.error(loc, "cannot have `%s out` parameter of type `%s`", MODtoChars(m), t.toChars());
+                        .error(loc, "cannot have `%s out` parameter of type `%s`", MODtoChars(m), t.toChars());
                         errors = true;
                     }
                     else
@@ -1350,7 +1350,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                             tv = tv.nextOf().toBasetype();
                         if (tv.ty == Tstruct && (cast(TypeStruct)tv).sym.noDefaultCtor)
                         {
-                            mtype.error(loc, "cannot have `out` parameter of type `%s` because the default construction is disabled", fparam.type.toChars());
+                            .error(loc, "cannot have `out` parameter of type `%s` because the default construction is disabled", fparam.type.toChars());
                             errors = true;
                         }
                     }
@@ -1440,7 +1440,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                                 OutBuffer buf1;  stcToBuffer(&buf1, stc1 | ((stc1 & STC.ref_) ? (fparam.storageClass & STC.auto_) : 0));
                                 OutBuffer buf2;  stcToBuffer(&buf2, stc2);
 
-                                mtype.error(loc, "incompatible parameter storage classes `%s` and `%s`",
+                                .error(loc, "incompatible parameter storage classes `%s` and `%s`",
                                     buf1.peekString(), buf2.peekString());
                                 errors = true;
                                 stc = stc1 | (stc & ~(STC.ref_ | STC.out_ | STC.lazy_));
@@ -1480,7 +1480,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                     }
                     else
                     {
-                        mtype.error(loc, "`auto` can only be used as part of `auto ref` for template function parameters");
+                        .error(loc, "`auto` can only be used as part of `auto ref` for template function parameters");
                         errors = true;
                     }
                 }
@@ -1495,27 +1495,27 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
 
         if (wildreturn && !wildparams)
         {
-            mtype.error(loc, "`inout` on `return` means `inout` must be on a parameter as well for `%s`", mtype.toChars());
+            .error(loc, "`inout` on `return` means `inout` must be on a parameter as well for `%s`", mtype.toChars());
             errors = true;
         }
         tf.iswild = wildparams;
 
         if (tf.inuse)
         {
-            mtype.error(loc, "recursive type");
+            .error(loc, "recursive type");
             tf.inuse = 0;
             errors = true;
         }
 
         if (tf.isproperty && (tf.varargs || Parameter.dim(tf.parameters) > 2))
         {
-            mtype.error(loc, "properties can only have zero, one, or two parameter");
+            .error(loc, "properties can only have zero, one, or two parameter");
             errors = true;
         }
 
         if (tf.varargs == 1 && tf.linkage != LINK.d && Parameter.dim(tf.parameters) == 0)
         {
-            mtype.error(loc, "variadic functions with non-D linkage must have at least one parameter");
+            .error(loc, "variadic functions with non-D linkage must have at least one parameter");
             errors = true;
         }
 
@@ -1583,15 +1583,15 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             {
                 auto td = s.isTemplateDeclaration;
                 if (td && td.onemember && td.onemember.isAggregateDeclaration)
-                    mtype.error(loc, "template %s `%s` is used as a type without instantiation"
+                    .error(loc, "template %s `%s` is used as a type without instantiation"
                         ~ "; to instantiate it use `%s!(arguments)`",
                         s.kind, s.toPrettyChars, s.ident.toChars);
                 else
-                    mtype.error(loc, "%s `%s` is used as a type", s.kind, s.toPrettyChars);
+                    .error(loc, "%s `%s` is used as a type", s.kind, s.toPrettyChars);
                 //assert(0);
             }
             else
-                mtype.error(loc, "`%s` is used as a type", mtype.toChars());
+                .error(loc, "`%s` is used as a type", mtype.toChars());
             return error();
         }
     }
@@ -1620,10 +1620,10 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             {
                 // if there was an error evaluating the symbol, it might actually
                 // be a type. Avoid misleading error messages.
-               mtype.error(loc, "`%s` had previous errors", mtype.toChars());
+               .error(loc, "`%s` had previous errors", mtype.toChars());
             }
             else
-               mtype.error(loc, "`%s` is used as a type", mtype.toChars());
+               .error(loc, "`%s` is used as a type", mtype.toChars());
             return error();
         }
         result = t;
@@ -1640,7 +1640,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             t = t.addMod(mtype.mod);
         if (!t)
         {
-            mtype.error(loc, "`%s` is used as a type", mtype.toChars());
+            .error(loc, "`%s` is used as a type", mtype.toChars());
             return error();
         }
         result = t;
@@ -1657,7 +1657,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
             t = t.addMod(mtype.mod);
         if (!t)
         {
-            mtype.error(loc, "`%s` is used as a type", mtype.toChars());
+            .error(loc, "`%s` is used as a type", mtype.toChars());
             return error();
         }
         result = t;
@@ -1753,7 +1753,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         Type tbn = tn.toBasetype();
         if (tbn.ty != Ttuple)
         {
-            mtype.error(loc, "can only slice tuple types, not `%s`", tbn.toChars());
+            .error(loc, "can only slice tuple types, not `%s`", tbn.toChars());
             return error();
         }
         TypeTuple tt = cast(TypeTuple)tbn;
@@ -1769,7 +1769,7 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
         uinteger_t i2 = mtype.upr.toUInteger();
         if (!(i1 <= i2 && i2 <= tt.arguments.dim))
         {
-            mtype.error(loc, "slice `[%llu..%llu]` is out of range of `[0..%llu]`",
+            .error(loc, "slice `[%llu..%llu]` is out of range of `[0..%llu]`",
                 cast(ulong)i1, cast(ulong)i2, cast(ulong)tt.arguments.dim);
             return error();
         }
@@ -2584,7 +2584,7 @@ private extern(C++) final class ResolveVisitor : Visitor
             else if (t)
                 mt.index = t;
             else
-                mt.index.error(loc, "index is not a type or an expression");
+                .error(loc, "index is not a type or an expression");
         }
         visit(cast(Type)mt);
     }

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -43,14 +43,14 @@ extern (C++) void genTypeInfo(Loc loc, Type torig, Scope* sc)
     {
         if (!global.params.useTypeInfo)
         {
-            torig.error(loc, "`TypeInfo` cannot be used with -betterC");
+            .error(loc, "`TypeInfo` cannot be used with -betterC");
             fatal();
         }
     }
 
     if (!Type.dtypeinfo)
     {
-        torig.error(loc, "`object.TypeInfo` could not be found, but is implicitly used");
+        .error(loc, "`object.TypeInfo` could not be found, but is implicitly used");
         fatal();
     }
 


### PR DESCRIPTION
These are identical to dmd.errors.error and warning, for what look to be no real benefit. 