### PR TITLE
dmd.token: Remove C++ linkage from static members

### DIFF
--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -715,9 +715,9 @@ extern (C++) struct Token
         }
     }
 
-    __gshared Token* freelist = null;
+    extern (D) private __gshared Token* freelist = null;
 
-    static Token* alloc()
+    extern (D) static Token* alloc()
     {
         if (Token.freelist)
         {
@@ -918,7 +918,7 @@ extern (C++) struct Token
         return p;
     }
 
-    static const(char)* toChars(TOK value)
+    extern (D) static const(char)* toChars(TOK value)
     {
         return toString(value).ptr;
     }

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -212,14 +212,9 @@ struct Token
         Identifier *ident;
     };
 
-    static const char *tochars[TOKMAX];
-
-    static Token *freelist;
-    static Token *alloc();
     void free();
 
     Token() : next(NULL) {}
     int isKeyword();
     const char *toChars() const;
-    static const char *toChars(TOK);
 };


### PR DESCRIPTION
Removing said members from the headers.

(This is the last of the batch)