### PR TITLE
dmd.globals: Move vendor string back to Global struct

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -12,7 +12,10 @@
 
 module dmd.compiler;
 
+/**
+ * A data structure that describes a back-end compiler and implements
+ * compiler-specific actions.
+ */
 struct Compiler
 {
-    const(char)* vendor; // Compiler backend name
 }

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -15,5 +15,4 @@
 
 struct Compiler
 {
-    const char *vendor;     // Compiler backend name
 };

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -16,7 +16,6 @@ import core.stdc.stdint;
 import dmd.root.array;
 import dmd.root.filename;
 import dmd.root.outbuffer;
-import dmd.compiler;
 import dmd.identifier;
 
 template xversion(string s)
@@ -259,8 +258,8 @@ struct Global
     Array!(const(char)*)* filePath;     // Array of char*'s which form the file import lookup path
 
     const(char)* _version;
+    const(char)* vendor;    // Compiler backend name
 
-    Compiler compiler;
     Param params;
     uint errors;            // number of errors reported so far
     uint warnings;          // number of warnings reported so far
@@ -363,7 +362,7 @@ struct Global
             static assert(0, "fix this");
         }
         _version = (import("VERSION") ~ '\0').ptr;
-        compiler.vendor = "Digital Mars D";
+        vendor = "Digital Mars D";
     }
 
     /**

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -850,7 +850,7 @@ public:
     private void generateCompilerInfo()
     {
         objectStart();
-        requiredProperty("vendor", global.compiler.vendor.toDString);
+        requiredProperty("vendor", global.vendor.toDString);
         requiredProperty("version", global._version.toDString);
         property("__VERSION__", global.versionNumber());
         requiredProperty("interface", determineCompilerInterface());
@@ -1090,13 +1090,13 @@ Determines and returns the compiler interface which is one of `dmd`, `ldc`,
 */
 private extern(D) string determineCompilerInterface()
 {
-    if (!strcmp(global.compiler.vendor, "Digital Mars D"))
+    if (!strcmp(global.vendor, "Digital Mars D"))
         return "dmd";
-    if (!strcmp(global.compiler.vendor, "LDC"))
+    if (!strcmp(global.vendor, "LDC"))
         return "ldc";
-    if (!strcmp(global.compiler.vendor, "GNU"))
+    if (!strcmp(global.vendor, "GNU"))
         return "gdc";
-    if (!strcmp(global.compiler.vendor, "SDC"))
+    if (!strcmp(global.vendor, "SDC"))
         return "sdc";
     return null;
 }

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -527,7 +527,7 @@ class Lexer : ErrorHandler
                         }
                         else if (id == Id.VENDOR)
                         {
-                            t.ustring = global.compiler.vendor;
+                            t.ustring = global.vendor;
                             goto Lstr;
                         }
                         else if (id == Id.TIMESTAMP)


### PR DESCRIPTION
This is blocking #7534 and #7559, due to the circular dependencies that happen between dmd.compiler and dmd.globals.