### PR TITLE
[WIP] Allow implicit conversion to shared.

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -504,6 +504,7 @@ enum MATCH : int
 {
     nomatch,   // no match
     convert,   // match with conversions
+    shared_,   // match with conversion to shared
     constant,  // match with conversion to const
     exact,     // exact match
 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -79,7 +79,6 @@ bool MODimplicitConv(MOD modfrom, MOD modto) pure nothrow @nogc @safe
     case X(MODFlags.wild, MODFlags.const_):
     case X(MODFlags.wild, MODFlags.wildconst):
     case X(MODFlags.wildconst, MODFlags.const_):
-    case X(0, 0):
         // Casting to shared is fine, but otherwise casting from shared is not.
         return (modto & MODFlags.shared_) || !(modfrom & MODFlags.shared_);
 
@@ -117,6 +116,9 @@ MATCH MODmethodConv(MOD modfrom, MOD modto) pure nothrow @nogc @safe
     case X(MODFlags.shared_ | MODFlags.const_, MODFlags.shared_ | MODFlags.wild):
     case X(MODFlags.shared_ | MODFlags.wildconst, MODFlags.shared_ | MODFlags.wild):
         return MATCH.constant;
+
+    case X(0,MODFlags.shared_):
+        return MATCH.shared_;
 
     default:
         return MATCH.nomatch;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -79,7 +79,9 @@ bool MODimplicitConv(MOD modfrom, MOD modto) pure nothrow @nogc @safe
     case X(MODFlags.wild, MODFlags.const_):
     case X(MODFlags.wild, MODFlags.wildconst):
     case X(MODFlags.wildconst, MODFlags.const_):
-        return (modfrom & MODFlags.shared_) == (modto & MODFlags.shared_);
+    case X(0, 0):
+        // Casting to shared is fine, but otherwise casting from shared is not.
+        return (modto & MODFlags.shared_) || !(modfrom & MODFlags.shared_);
 
     case X(MODFlags.immutable_, MODFlags.const_):
     case X(MODFlags.immutable_, MODFlags.wildconst):


### PR DESCRIPTION
so that methods that are shared can be called using unshared objects. This is fine because any extra synchronisation done as a result of being shared will not cause race conditions, see https://forum.dlang.org/thread/mailman.4068.1538360998.29801.digitalmars-d@puremagic.com

This probably doesn't catch all edge cases of this change, hence WIP. Also test cases etc.