### PR TITLE
dmd.expression: Use 'out' parameter for extractLast

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -755,28 +755,27 @@ extern (C++) abstract class Expression : RootObject
     }
 
     /**********************************
-     * If 'e' is a tree of commas, returns the leftmost expression
+     * If 'e' is a tree of commas, returns the rightmost expression
      * by stripping off it from the tree. The remained part of the tree
-     * is returned via *pe0.
-     * Otherwise 'e' is directly returned and *pe0 is set to NULL.
+     * is returned via e0.
+     * Otherwise 'e' is directly returned and e0 is set to NULL.
      */
-    extern (D) static Expression extractLast(Expression e, Expression* pe0)
+    extern (D) static Expression extractLast(Expression e, out Expression e0)
     {
         if (e.op != TOK.comma)
         {
-            *pe0 = null;
             return e;
         }
 
         CommaExp ce = cast(CommaExp)e;
         if (ce.e2.op != TOK.comma)
         {
-            *pe0 = ce.e1;
+            e0 = ce.e1;
             return ce.e2;
         }
         else
         {
-            *pe0 = e;
+            e0 = e;
 
             Expression* pce = &ce.e2;
             while ((cast(CommaExp)(*pce)).e2.op == TOK.comma)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -112,7 +112,7 @@ StringExp semanticString(Scope *sc, Expression exp, const char* s)
 private Expression extractOpDollarSideEffect(Scope* sc, UnaExp ue)
 {
     Expression e0;
-    Expression e1 = Expression.extractLast(ue.e1, &e0);
+    Expression e1 = Expression.extractLast(ue.e1, e0);
     // https://issues.dlang.org/show_bug.cgi?id=12585
     // Extract the side effect part if ue.e1 is comma.
 
@@ -7377,7 +7377,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (!(cast(CommaExp)exp.e2).isGenerated)
                 exp.error("Using the result of a comma expression is not allowed");
             Expression e0;
-            exp.e2 = Expression.extractLast(exp.e2, &e0);
+            exp.e2 = Expression.extractLast(exp.e2, e0);
             Expression e = Expression.combine(e0, exp);
             result = e.expressionSemantic(sc);
             return;
@@ -7786,7 +7786,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         cx.e1 = dvx;
 
                         Expression e0;
-                        Expression.extractLast(e2x, &e0);
+                        Expression.extractLast(e2x, e0);
 
                         auto e = Expression.combine(e0, ae, cx);
                         e = e.expressionSemantic(sc);
@@ -8504,7 +8504,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             Expression e0 = null;
             e = exp.reorderSettingAAElem(sc);
-            e = Expression.extractLast(e, &e0);
+            e = Expression.extractLast(e, e0);
             assert(e == exp);
 
             if (exp.e1.op == TOK.variable)

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1811,7 +1811,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
     if (ethis)
     {
         Expression e0;
-        ethis = Expression.extractLast(ethis, &e0);
+        ethis = Expression.extractLast(ethis, e0);
         if (ethis.op == TOK.variable)
         {
             vthis = (cast(VarExp)ethis).var.isVarDeclaration();

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3068,7 +3068,7 @@ else
                 rs.exp = new ErrorExp();
 
             // Extract side-effect part
-            rs.exp = Expression.extractLast(rs.exp, &e0);
+            rs.exp = Expression.extractLast(rs.exp, e0);
             if (rs.exp.op == TOK.call)
                 rs.exp = valueNoDtor(rs.exp);
 


### PR DESCRIPTION
Fix documentation to match source.

Now that it's no longer bound to C++, can use D parameter types.