### PR TITLE
cod4.d: fix warning about integral pr

### DIFF
--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -288,7 +288,7 @@ private void opnegassdbl(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 // Load EA into DOUBLEREGS
                 getregs(cdb,DOUBLEREGS_32);
                 cs.Iop = 0x8B;
-                cs.Irm &= ~modregrm(0,7,0);
+                cs.Irm &= ~cast(uint)modregrm(0,7,0);
                 cs.Irm |= modregrm(0,AX,0);
                 cdb.gen(&cs);
                 cs.Irm |= modregrm(0,DX,0);


### PR DESCRIPTION
From AppVeyor:
```
..\dmd\backend\cod4.d(291): Deprecation: integral promotion not done for `~modregrm(0u, 7u, 0u)`, use '-transition=intpromote' switch or `~cast(int)(modregrm(0u, 7u, 0u))`
```