### PR TITLE
Fix issue 19278 - extern(C++, "name") doesn't accept expressions

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1164,11 +1164,17 @@ struct ASTBase
          */
         bool mangleOnly;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* members, bool mangleOnly)
+        /**
+         * Namespace identifier resolved during semantic.
+         */
+        Expression identExp;
+
+        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
         {
             super(ident);
             this.loc = loc;
             this.members = members;
+            this.identExp = identExp;
             this.mangleOnly = mangleOnly;
         }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -840,6 +840,11 @@ extern (C++) abstract class Expression : RootObject
         return null;
     }
 
+    TupleExp toTupleExp()
+    {
+        return null;
+    }
+
     /***************************************
      * Return !=0 if expression is an lvalue.
      */
@@ -2536,6 +2541,11 @@ extern (C++) final class TupleExp : Expression
                 error("`%s` is not an expression", o.toChars());
             }
         }
+    }
+
+    override TupleExp toTupleExp()
+    {
+        return this;
     }
 
     override Expression syntaxCopy()

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -89,6 +89,7 @@ public:
     virtual real_t toImaginary();
     virtual complex_t toComplex();
     virtual StringExp *toStringExp();
+    virtual TupleExp *toTupleExp();
     virtual bool isLvalue();
     virtual Expression *toLvalue(Scope *sc, Expression *e);
     virtual Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -282,6 +283,7 @@ public:
      */
     Expressions *exps;
 
+    TupleExp *toTupleExp();
     Expression *syntaxCopy();
     bool equals(RootObject *o);
 

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -17,6 +17,7 @@ import dmd.arraytypes;
 import dmd.dscope;
 import dmd.dsymbol;
 import dmd.dsymbolsem;
+import dmd.expression;
 import dmd.globals;
 import dmd.identifier;
 import dmd.visitor;
@@ -35,18 +36,24 @@ extern (C++) final class Nspace : ScopeDsymbol
      */
     bool mangleOnly;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* members, bool mangleOnly)
+    /**
+     * Namespace identifier resolved during semantic.
+     */
+    Expression identExp;
+
+    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
     {
         super(ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());
         this.loc = loc;
         this.members = members;
+        this.identExp = identExp;
         this.mangleOnly = mangleOnly;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
-        auto ns = new Nspace(loc, ident, null, mangleOnly);
+        auto ns = new Nspace(loc, ident, identExp, null, mangleOnly);
         return ScopeDsymbol.syntaxCopy(ns);
     }
 

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -20,6 +20,7 @@ class Nspace : public ScopeDsymbol
 {
   public:
     bool mangleOnly;
+    Expression *identExp;
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -935,3 +935,41 @@ version (Posix) extern (C++)
     static assert(func16479_17_1!int.mangleof == `_Z14func16479_17_1IiEPN7fakestd3__111vector16479IT_NS1_14allocator16479IS3_EEEEv`);
     static assert(func16479_17_2!int.mangleof == `_Z14func16479_17_2IiEPN7fakestd3__111vector16479IT_NS1_14allocator16479IS3_EEEEv`);
 }
+
+/**************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19278
+// extern(C++, "name") doesn't accept expressions
+
+extern(C++, "hello" ~ "world")
+{
+    void test19278();
+}
+enum NS = "lookup";
+extern(C++, (NS))
+{
+    void test19278_2();
+}
+alias AliasSeq(Args...) = Args;
+alias Tup = AliasSeq!("hello", "world");
+extern(C++, (Tup))
+{
+    void test19278_3();
+}
+extern(C++, (AliasSeq!(Tup, "yay")))
+{
+    void test19278_4();
+}
+version(Win64)
+{
+    static assert(test19278.mangleof == "?test19278@helloworld@@YAXXZ");
+    static assert(test19278_2.mangleof == "?test19278_2@lookup@@YAXXZ");
+    static assert(test19278_3.mangleof == "?test19278_3@world@hello@@YAXXZ");
+    static assert(test19278_4.mangleof == "?test19278_4@yay@world@hello@@YAXXZ");
+}
+else version(Posix)
+{
+    static assert(test19278.mangleof == "_ZN10helloworld9test19278Ev");
+    static assert(test19278_2.mangleof == "_ZN6lookup11test19278_2Ev");
+    static assert(test19278_3.mangleof == "_ZN5hello5world11test19278_3Ev");
+    static assert(test19278_4.mangleof == "_ZN5hello5world3yay11test19278_4Ev");
+}

--- a/test/fail_compilation/cppmangle.d
+++ b/test/fail_compilation/cppmangle.d
@@ -1,9 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/cppmangle.d(10): Error: invalid zero length C++ namespace
-fail_compilation/cppmangle.d(14): Error: expected valid identifer for C++ namespace but got `0num`
-fail_compilation/cppmangle.d(18): Error: string expected following `,` for C++ namespace, not `)`
+fail_compilation/cppmangle.d(11): Error: expected valid identifer for C++ namespace but got ``
+fail_compilation/cppmangle.d(15): Error: expected valid identifer for C++ namespace but got `0num`
+fail_compilation/cppmangle.d(19): Error: expected string expression for namespace name, got `1 + 1`
+fail_compilation/cppmangle.d(23): Error: expected valid identifer for C++ namespace but got `invalid@namespace`
 ---
 */
 
@@ -15,9 +16,10 @@ extern(C++, "0num")
 {
 }
 
-extern(C++, "std", )
+extern(C++, 1+1)
 {
 }
 
-
-
+extern(C++, "invalid@namespace")
+{
+}

--- a/test/fail_compilation/cppmangle2.d
+++ b/test/fail_compilation/cppmangle2.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/cppmangle2.d(9): Error: namespace `cppmangle2.ns` conflicts with variable `cppmangle2.ns` at fail_compilation/cppmangle2.d(8)
+---
+*/
+
+enum ns = "ns";
+extern(C++, ns)
+{
+}

--- a/test/fail_compilation/ice17074.d
+++ b/test/fail_compilation/ice17074.d
@@ -2,18 +2,8 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice17074.d(9): Error: identifier expected for C++ namespace
-fail_compilation/ice17074.d(9): Error: found `cast` when expecting `)`
+fail_compilation/ice17074.d(9): Error: found `__overloadset` when expecting `)`
 fail_compilation/ice17074.d(9): Error: declaration expected, not `)`
----
-*/
-extern(C++, cast) void ice_keyword();
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice17074.d(19): Error: identifier expected for C++ namespace
-fail_compilation/ice17074.d(19): Error: found `__overloadset` when expecting `)`
-fail_compilation/ice17074.d(19): Error: declaration expected, not `)`
 ---
 */
 extern(C++, std.__overloadset) void ice_std_keyword();
@@ -21,19 +11,9 @@ extern(C++, std.__overloadset) void ice_std_keyword();
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice17074.d(29): Error: identifier expected for C++ namespace
-fail_compilation/ice17074.d(29): Error: found `...` when expecting `)`
-fail_compilation/ice17074.d(29): Error: declaration expected, not `)`
----
-*/
-extern(C++, ...) void ice_token();
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice17074.d(39): Error: identifier expected for C++ namespace
-fail_compilation/ice17074.d(39): Error: found `*` when expecting `)`
-fail_compilation/ice17074.d(39): Error: declaration expected, not `)`
+fail_compilation/ice17074.d(19): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(19): Error: found `*` when expecting `)`
+fail_compilation/ice17074.d(19): Error: declaration expected, not `)`
 ---
 */
 extern(C++, std.*) void ice_std_token();


### PR DESCRIPTION
Accept an expression, attempt to resolve in semantic.
Ambiguity with scoped namespace identifier can be defeated with parens.