### PR TITLE
fix different qualifiers on declarations

### DIFF
--- a/src/dmd/backend/cgcv.d
+++ b/src/dmd/backend/cgcv.d
@@ -25,7 +25,7 @@ nothrow:
 
 alias symlist_t = LIST*;
 
-extern char* ftdbname;
+extern __gshared char* ftdbname;
 
 void cv_init();
 uint cv_typidx(type* t);

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -334,7 +334,7 @@ uint tyrelax(tym_t ty) { return _tyrelax[tybasic(ty)]; }
 extern __gshared ubyte[TYMAX] tyequiv;
 
 /* Give an ascii string for a type      */
-extern (C) { extern __gshared const char*[TYMAX] tystring; }
+extern (C) { extern __gshared const(char)*[TYMAX] tystring; }
 
 /* Debugger value for type      */
 extern __gshared ubyte[TYMAX] dttab;


### PR DESCRIPTION
recent versions of LDC complain about mismatching IR.