### PR TITLE
Fix issue 12694 - Better error message for function call matching more than two overloads

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2780,19 +2780,11 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
     }
     else if (m.nextf)
     {
-        TypeFunction tf1 = m.lastf.type.toTypeFunction();
-        TypeFunction tf2 = m.nextf.type.toTypeFunction();
-        const(char)* lastprms = parametersTypeToChars(tf1.parameters, tf1.varargs);
-        const(char)* nextprms = parametersTypeToChars(tf2.parameters, tf2.varargs);
-
-        const(char)* mod1 = prependSpace(MODtoChars(tf1.mod));
-        const(char)* mod2 = prependSpace(MODtoChars(tf2.mod));
-
-        .error(loc, "`%s.%s` called with argument types `%s` matches both:\n%s:     `%s%s%s`\nand:\n%s:     `%s%s%s`",
+        .error(loc, "call to `%s.%s` with argument types `%s` matches more than one overload, candidates are:",
             s.parent.toPrettyChars(), s.ident.toChars(),
-            fargsBuf.peekString(),
-            m.lastf.loc.toChars(), m.lastf.toPrettyChars(), lastprms, mod1,
-            m.nextf.loc.toChars(), m.nextf.toPrettyChars(), nextprms, mod2);
+            fargsBuf.peekString());
+
+        printCandidates(loc, fd);
     }
     return null;
 }


### PR DESCRIPTION
Prior to this change, when a function call matched more than one overload, only 2 matching function overloads were printed. Now, up to 5 are shown, or all of them, when using the `-v` flag.
Also, as a side note, due to using the [new function `printCandidates`](https://github.com/dlang/dmd/pull/8746/), the formatting of the error message is now in line with the other "x matches multiple overloads" types of error messages.