### PR TITLE
split off sizecheck.c from backconfig.c

### DIFF
--- a/src/dmd/backend/backconfig.c
+++ b/src/dmd/backend/backconfig.c
@@ -476,27 +476,3 @@ void util_set64()
     TYdarray = TYucent;
 }
 
-// cc.d
-unsigned Srcpos::sizeCheck() { return sizeof(Srcpos); }
-unsigned Pstate::sizeCheck() { return sizeof(Pstate); }
-unsigned Cstate::sizeCheck() { return sizeof(Cstate); }
-unsigned Blockx::sizeCheck() { return sizeof(Blockx); }
-unsigned block::sizeCheck()  { return sizeof(block);  }
-unsigned func_t::sizeCheck() { return sizeof(func_t); }
-unsigned baseclass_t::sizeCheck() { return sizeof(baseclass_t); }
-unsigned template_t::sizeCheck() { return sizeof(template_t); }
-unsigned struct_t::sizeCheck() { return sizeof(struct_t); }
-unsigned Symbol::sizeCheck() { return sizeof(Symbol); }
-unsigned param_t::sizeCheck() { return sizeof(param_t); }
-unsigned Declar::sizeCheck() { return sizeof(Declar); }
-unsigned dt_t::sizeCheck() { return sizeof(dt_t); }
-
-// cdef.d
-unsigned Config::sizeCheck() { return sizeof(Config); }
-unsigned Configv::sizeCheck() { return sizeof(Configv); }
-unsigned eve::sizeCheck() { return sizeof(eve); }
-
-// el.d
-
-// type.d
-unsigned TYPE::sizeCheck() { return sizeof(type); }

--- a/src/dmd/backend/sizecheck.c
+++ b/src/dmd/backend/sizecheck.c
@@ -1,0 +1,51 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (c) 2000-2017 by Digital Mars, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/sizecheck.c, backend/sizecheck.c)
+ */
+
+// Configure the back end (optimizer and code generator)
+
+#include        <stdio.h>
+#include        <ctype.h>
+#include        <string.h>
+#include        <stdlib.h>
+#include        <time.h>
+
+#include        "cc.h"
+#include        "global.h"
+#include        "oper.h"
+#include        "code.h"
+#include        "type.h"
+#include        "dt.h"
+#include        "cgcv.h"
+
+
+// cc.d
+unsigned Srcpos::sizeCheck() { return sizeof(Srcpos); }
+unsigned Pstate::sizeCheck() { return sizeof(Pstate); }
+unsigned Cstate::sizeCheck() { return sizeof(Cstate); }
+unsigned Blockx::sizeCheck() { return sizeof(Blockx); }
+unsigned block::sizeCheck()  { return sizeof(block);  }
+unsigned func_t::sizeCheck() { return sizeof(func_t); }
+unsigned baseclass_t::sizeCheck() { return sizeof(baseclass_t); }
+unsigned template_t::sizeCheck() { return sizeof(template_t); }
+unsigned struct_t::sizeCheck() { return sizeof(struct_t); }
+unsigned Symbol::sizeCheck() { return sizeof(Symbol); }
+unsigned param_t::sizeCheck() { return sizeof(param_t); }
+unsigned Declar::sizeCheck() { return sizeof(Declar); }
+unsigned dt_t::sizeCheck() { return sizeof(dt_t); }
+
+// cdef.d
+unsigned Config::sizeCheck() { return sizeof(Config); }
+unsigned Configv::sizeCheck() { return sizeof(Configv); }
+unsigned eve::sizeCheck() { return sizeof(eve); }
+
+// el.d
+
+// type.d
+unsigned TYPE::sizeCheck() { return sizeof(type); }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -351,7 +351,7 @@ BACK_OBJS = \
 	dt.o \
 	outbuf.o \
 	aa.o ti_achar.o \
-	ti_pvoid.o backconfig.o \
+	ti_pvoid.o backconfig.o sizecheck.o \
 	dwarf.o dwarfeh.o varstats.o \
 	ph2.o tk.o strtold.o \
 	$(TARGET_OBJS)
@@ -404,7 +404,7 @@ BACK_SRC = \
 	$C/dwarf.c $C/dwarf.h $C/aa.h $C/aa.c $C/tinfo.h $C/ti_achar.c \
 	$C/ti_pvoid.c $C/platform_stub.c $C/code_x86.h $C/code_stub.h \
 	$C/machobj.c $C/mscoffobj.c \
-	$C/xmm.h $C/obj.h $C/pdata.d $C/cv8.d $C/backconfig.c $C/divcoeff.d \
+	$C/xmm.h $C/obj.h $C/pdata.d $C/cv8.d $C/backconfig.c $C/sizecheck.c $C/divcoeff.d \
 	$C/varstats.c $C/varstats.h $C/dvec.d \
 	$C/md5.d $C/md5.h \
 	$C/ph2.c $C/util2.d $C/dwarfeh.c $C/goh.d $C/memh.d \

--- a/src/vcbuild/dmd_backend.vcxproj
+++ b/src/vcbuild/dmd_backend.vcxproj
@@ -103,6 +103,7 @@
     <ClCompile Include="..\dmd\backend\outbuf.c" />
     <ClCompile Include="..\dmd\backend\ptrntab.c" />
     <ClCompile Include="..\dmd\backend\rtlsym.c" />
+    <ClCompile Include="..\dmd\backend\sizecheck.c" />
     <ClCompile Include="..\dmd\backend\strtold.c" />
     <ClCompile Include="..\dmd\backend\ti_achar.c" />
     <ClCompile Include="..\dmd\backend\ti_pvoid.c" />

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -199,7 +199,7 @@ GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.o
 	$G/debugprint.obj $G/dcode.obj $G/cg87.obj $G/cgxmm.obj $G/cgsched.obj $G/ee.obj $G/symbol.obj \
 	$G/cgcod.obj $G/cod1.obj $G/cod2.obj $G/cod3.obj $G/cod4.obj $G/cod5.obj $G/outbuf.obj \
 	$G/bcomplex.obj $G/ptrntab.obj $G/aa.obj $G/ti_achar.obj $G/md5.obj \
-	$G/ti_pvoid.obj $G/mscoffobj.obj $G/pdata.obj $G/cv8.obj $G/backconfig.obj \
+	$G/ti_pvoid.obj $G/mscoffobj.obj $G/pdata.obj $G/cv8.obj $G/backconfig.obj $G/sizecheck.obj \
 	$G/divcoeff.obj $G/dwarf.obj $G/compress.obj $G/varstats.obj \
 	$G/ph2.obj $G/util2.obj $G/tk.obj $G/gsroa.obj $G/dvec.obj \
 
@@ -242,7 +242,7 @@ BACKSRC= $C\cdef.h $C\cc.h $C\oper.h $C\ty.h $C\optabgen.c \
 	$C\dwarf.c $C\dwarf.h $C\machobj.c \
 	$C\strtold.c $C\aa.h $C\aa.c $C\tinfo.h $C\ti_achar.c \
 	$C\md5.h $C\md5.d $C\ti_pvoid.c $C\xmm.h $C\ph2.c $C\util2.d \
-	$C\mscoffobj.c $C\obj.h $C\pdata.d $C\cv8.d $C\backconfig.c \
+	$C\mscoffobj.c $C\obj.h $C\pdata.d $C\cv8.d $C\backconfig.c $C\sizecheck.c \
 	$C\divcoeff.d $C\dwarfeh.c $C\varstats.c $C\varstats.h \
 	$C\dvec.d $C\backend.txt
 
@@ -609,6 +609,9 @@ $G/ptrntab.obj : $C\iasm.h $C\ptrntab.c
 
 $G/rtlsym.obj : $C\rtlsym.h $C\rtlsym.c
 	$(CC) -c -o$@ $(MFLAGS) $C\rtlsym
+
+$G/sizecheck.obj : $C\sizecheck.c
+	$(CC) -c -o$@ $(MFLAGS) $C\sizecheck
 
 $G/strtold.obj : $C\strtold.c
 	$(CC) -c -o$@ -cpp $C\strtold


### PR DESCRIPTION
Because the sizecheck code needs to remain in C++ for the time being, and the remainder of backconfig.c can be converted to D.

This is just a cut-and-paste job.