### PR TITLE
dmd.expression: Remove Expression.op_overload member function

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1541,11 +1541,6 @@ extern (C++) abstract class Expression : RootObject
         return false;
     }
 
-    final Expression op_overload(Scope* sc)
-    {
-        return .op_overload(this, sc);
-    }
-
     bool hasCode()
     {
         return true;

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -124,7 +124,6 @@ public:
     Expression *ctfeInterpret();
     int isConst();
     virtual bool isBool(bool result);
-    Expression *op_overload(Scope *sc);
 
     virtual bool hasCode()
     {


### PR DESCRIPTION
Front-end only function, and it only forwards to the free function in opover.d.

Might as well remove it and let UFCS take care of the rest.