### PR TITLE
Rename Compiler.loadModule to onParseModule, move call to Module.parseModule

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -128,7 +128,7 @@ extern (C++) struct Compiler
      * modules whose source are empty, but code gets injected
      * immediately after loading.
      */
-    extern (C++) static void loadModule(Module m)
+    extern (C++) static void onParseModule(Module m)
     {
     }
 

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -35,6 +35,6 @@ struct Compiler
     // CTFE support for cross-compilation.
     static Expression *paintAsType(UnionExp *, Expression *, Type *);
     // Backend
-    static void loadModule(Module *);
     static bool onImport(Module *);
+    static void onParseModule(Module *);
 };

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -596,8 +596,6 @@ extern (C++) final class Module : Package
             m.importedFrom = m;
             assert(m.isRoot());
         }
-
-        Compiler.loadModule(m);
         return m;
     }
 
@@ -1115,6 +1113,7 @@ extern (C++) final class Module : Package
             // Add to global array of all modules
             amodules.push(this);
         }
+        Compiler.onParseModule(this);
         return this;
     }
 


### PR DESCRIPTION
It makes more sense to have it here, as it should be called once for each module.  In the gdc driver, this means there's one less invocation of this to handle.
```
for (size_t i = 0; i < modules.dim; i++)
  {
     Module *m = modules[i];
     m->importedFrom = m;
     m->parse ();
     Compiler::loadModule (m);  // <-- here.
  }
```