### PR TITLE
Apply const attributes on base member functions

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -695,7 +695,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         }
     }
 
-    override final bool isExport()
+    override final bool isExport() const
     {
         return protection.kind == Prot.Kind.export_;
     }

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -437,7 +437,7 @@ extern (C++) abstract class Declaration : Dsymbol
         return false;
     }
 
-    bool isCodeseg()
+    bool isCodeseg() const pure nothrow @nogc @safe
     {
         return false;
     }
@@ -1244,12 +1244,12 @@ extern (C++) class VarDeclaration : Declaration
         return isField();
     }
 
-    override final bool isExport()
+    override final bool isExport() const
     {
         return protection.kind == Prot.Kind.export_;
     }
 
-    override final bool isImportedSymbol()
+    override final bool isImportedSymbol() const
     {
         if (protection.kind == Prot.Kind.export_ && !_init && (storage_class & STC.static_ || parent.isModule()))
             return true;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -769,13 +769,13 @@ extern (C++) class Dsymbol : RootObject
     }
 
     // is Dsymbol exported?
-    bool isExport()
+    bool isExport() const
     {
         return false;
     }
 
     // is Dsymbol imported?
-    bool isImportedSymbol()
+    bool isImportedSymbol() const
     {
         return false;
     }


### PR DESCRIPTION
These functions have overrides that already have these attributes applied in FuncDeclaration, but nowhere else.