### PR TITLE
Fix Issue 19284 - alias this not used in nested functions of a method

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2357,7 +2357,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (ad && ad.aliasthis)
             {
                 Expression e;
-                e = new IdentifierExp(exp.loc, Id.This);
+                e = new ThisExp(exp.loc);
                 e = new DotIdExp(exp.loc, e, ad.aliasthis.ident);
                 e = new DotIdExp(exp.loc, e, exp.ident);
                 e = e.trySemantic(sc);

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1972,6 +1972,74 @@ struct S15292
 
 /***************************************************/
 
+struct S19284a { int x; }
+struct S19284b
+{
+    S19284a s;
+    alias s this;
+    int t;
+    void f()
+    {
+        void wrapped()
+        {
+            x = 1;
+            t = 1;
+        }
+        wrapped(); // <-- 'x' not found, whereas 's.x' works fine
+    }
+
+    void f1()
+    {
+        x = 2;
+    }
+
+    void f2()
+    {
+        int x;
+        void wrapped()
+        {
+            x = 7;
+        }
+        wrapped();
+        assert(x == 7);
+    }
+
+    void f3()
+    {
+        void wrapped()
+        {
+            void wrapped2()
+            {
+                x = 5;
+            }
+            wrapped2();
+        }
+        wrapped();
+    }
+}
+
+void test19284()
+{
+    S19284b t;
+
+    // nested function modifies alias this
+    t.f();
+    assert(t.x == 1);
+    assert(t.t == 1);
+
+    // member function modifies alias this
+    t.f1();
+    assert(t.x == 2);
+
+    // nested function does not modify alias this when it is shadowd by a local variable
+    t.f2();
+    assert(t.x == 2);
+
+    // multiple levels of nesting
+    t.f3();
+    assert(t.x == 5);
+}
+
 int main()
 {
     test1();
@@ -2028,6 +2096,7 @@ int main()
     test13490();
     test11355();
     test14806();
+    test19284();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
When IdentifierExp(Id.This) was used, after useless extra-processing, `this` was resolved to the nested function context pointer. Now that ThisExp is used (and it is correct since at this point if the alias this was shadowed by a local variable, the alias this branch would not be taken), the extra processing is avoided and this is correctly resolved to the struct pointer.