### PR TITLE
Fix Issue 5380 - alias this is not considered with superclass lookup

### DIFF
--- a/test/compilable/test5380.d
+++ b/test/compilable/test5380.d
@@ -1,0 +1,20 @@
+// https://issues.dlang.org/show_bug.cgi?id=5380
+
+class A
+{
+}
+
+class B
+{
+    A a;
+    alias a this;
+}
+
+class C : B
+{
+}
+
+void main()
+{
+    A a = new C; // error
+}


### PR DESCRIPTION
implicitConvTo did no check the baseclasses for an alias this. I added the missing bits.