### PR TITLE
Fix dmd.root.filename : combine unittest on Windows

### DIFF
--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -391,7 +391,10 @@ nothrow:
 
     unittest
     {
-        assert(combine("foo"[], "bar"[]) == "foo/bar");
+        version (Windows)
+            assert(combine("foo"[], "bar"[]) == "foo\\bar");
+        else
+            assert(combine("foo"[], "bar"[]) == "foo/bar");
         assert(combine("foo/"[], "bar"[]) == "foo/bar");
     }
 


### PR DESCRIPTION
Unittest was failing because `combine` inserts backslash as path separator on Windows:
https://github.com/dlang/dmd/blob/0a2b61c06abed52cd2ef2d561e31a272ee638f36/src/dmd/root/filename.d#L363-L378