### PR TITLE
remove dependency on rtlsym.h

### DIFF
--- a/src/dmd/backend/dwarf.c
+++ b/src/dmd/backend/dwarf.c
@@ -54,7 +54,6 @@ application if debug info is needed when the application is deployed.
 #include        "cv4.h"
 #include        "cgcv.h"
 #include        "dt.h"
-#include        "rtlsym.h"
 
 #include        "aa.h"
 #include        "tinfo.h"
@@ -98,6 +97,7 @@ IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, uint sz,
 void addSegmentToComdat(segidx_t seg, segidx_t comdatseg);
 #endif
 
+Symbol* getRtlsymPersonality();
 
 static Outbuffer  *reset_symbuf;        // Keep pointers to reset symbols
 

--- a/src/dmd/backend/rtlsym.d
+++ b/src/dmd/backend/rtlsym.d
@@ -7,11 +7,10 @@
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/rtlsym.d, backend/_rtlsym.d)
+ * Documentation: https://dlang.org/phobos/dmd_backend_rtlsym.html
  */
 
 module dmd.backend.rtlsym;
-
-// Online documentation: https://dlang.org/phobos/dmd_backend_rtlsym.html
 
 import dmd.backend.cc : Symbol;
 
@@ -181,3 +180,5 @@ extern (C++):
 
 extern __gshared Symbol*[RTLSYM_MAX] rtlsym;
 Symbol *getRtlsym(int i) { return rtlsym[i]; }
+
+Symbol* getRtlsymPersonality() { return rtlsym[RTLSYM_PERSONALITY]; }


### PR DESCRIPTION
So that rtlsym.h/.c can be converted to D.