### PR TITLE
fix compilation on OSX with dmd-2.082

### DIFF
--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -241,6 +241,8 @@ enum EXIT_BREAK = 255;     // aborted compile with ^C
  * Target machine data types as they appear on the host.
  */
 
+import core.stdc.stdint : int64_t, uint64_t;
+
 alias targ_char = byte;
 alias targ_uchar = ubyte;
 alias targ_schar = byte;
@@ -248,8 +250,8 @@ alias targ_short = short;
 alias targ_ushort= ushort;
 alias targ_long = int;
 alias targ_ulong = uint;
-alias targ_llong = long;
-alias targ_ullong = ulong;
+alias targ_llong = int64_t;
+alias targ_ullong = uint64_t;
 alias targ_float = float;
 alias targ_double = double;
 public import dmd.root.longdouble : targ_ldouble = longdouble;
@@ -301,8 +303,8 @@ else version (HTOD)
 else
 {
     // Support 64 bit targets
-    alias targ_ptrdiff_t = targ_llong;  // ptrdiff_t for target machine
-    alias targ_size_t = targ_ullong;    // size_t for the target machine
+    alias targ_ptrdiff_t = int64_t;  // ptrdiff_t for target machine
+    alias targ_size_t = uint64_t;    // size_t for the target machine
 }
 
 /* Enable/disable various features

--- a/src/dmd/backend/cdef.h
+++ b/src/dmd/backend/cdef.h
@@ -501,26 +501,9 @@ typedef unsigned short  targ_ushort;
 typedef int             targ_long;
 typedef unsigned        targ_ulong;
 
-/** HACK: Prefer UINTMAX_TYPE on OSX (unsigned long for LP64) to workaround
- * https://issues.dlang.org/show_bug.cgi?id=16536. In D ulong uses the mangling
- * of unsigned long on LP64. Newer versions of XCode/clang introduced the
- * __UINT64_TYPE__ definition so the below rules would pick unsigned long long
- * instead. This has a different mangling on OSX and causes a mismatch w/ C++
- * ABIs using ulong.
- *
- * As a proper fix we should use uint64_t on both sides, which is always unsigned long long.
- */
-// This MUST MATCH typedef ullong in divcoeff.c.
-#if defined(__UINT64_TYPE__) && !defined(__APPLE__)
-typedef __INT64_TYPE__     targ_llong;
-typedef __UINT64_TYPE__    targ_ullong;
-#elif defined(__UINTMAX_TYPE__)
-typedef __INTMAX_TYPE__    targ_llong;
-typedef __UINTMAX_TYPE__   targ_ullong;
-#else
-typedef long long          targ_llong;
-typedef unsigned long long targ_ullong;
-#endif
+// This MUST MATCH typedef ullong in divcoeff.d.
+typedef int64_t         targ_llong;
+typedef uint64_t        targ_ullong;
 
 typedef float           targ_float;
 typedef double          targ_double;
@@ -552,7 +535,6 @@ enum
 #define FPTRSIZE        _tysize[TYfptr]
 #define REGMASK         0xFFFF
 
-// targ_llong is also used to store host pointers, so it should have at least their size
 #if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYBSD || TARGET_SOLARIS || TARGET_OSX || MARS
 typedef int64_t         targ_ptrdiff_t; /* ptrdiff_t for target machine  */
 typedef uint64_t        targ_size_t;    /* size_t for the target machine */

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -2073,7 +2073,7 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         {
             // only zero-extension from 32-bits is available for 'or'
         }
-        else if (I64 && v2 != cast(targ_llong)cast(targ_long)v2)
+        else if (I64 && cast(targ_llong)v2 != cast(targ_llong)cast(targ_long)v2)
         {
             // only sign-extension from 32-bits is available for 'and'
         }

--- a/src/dmd/backend/divcoeff.d
+++ b/src/dmd/backend/divcoeff.d
@@ -17,7 +17,8 @@ import core.stdc.stdio;
 
 extern (C++):
 
-alias ullong = ulong;
+import core.stdc.stdint : uint64_t;
+alias ullong = uint64_t;
 
 /* unsigned 128 bit math
  */

--- a/src/dmd/backend/util2.d
+++ b/src/dmd/backend/util2.d
@@ -18,6 +18,7 @@ module dmd.backend.util2;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
+import core.stdc.stdint : uint64_t;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
@@ -283,7 +284,7 @@ int binary(const(char)* p, size_t len, const(char)** table, int high)
  * If c is a power of 2, return that power else -1.
  */
 
-int ispow2(ulong c)
+int ispow2(uint64_t c)
 {       int i;
 
         if (c == 0 || (c & (c - 1)))


### PR DESCRIPTION
**This blocks the upcoming 2.083 beta/release**

- mangling D's long/ulong as C++'s int64_t/uint64_t was reverted with 2.082
  due to breaking interop of C++'s and D's size_t/ptrdiff_t
- this revert unveiled a mismatch in dmd's backend where the C++ side
  uses int64_t/uint64_t as targ_ptrdiff_t/targ_size_t while the D side
  uses long/ulong, thus 2.082 cannot compile dmd on OSX-64
- fixed by using int64_t/uint64_t everywhere
- druntime's int64_t/uint64_t are correctly mangled as
  long long/unsigned long long since OSX-64 2.079

Related:
long/ulong as int64_t/uint64_t approach https://github.com/dlang/dmd/pull/7416
reverted with https://github.com/dlang/dmd/pull/8285
druntime cpp_longlong/cpp_ulonglong definitions https://github.com/dlang/druntime/pull/2187