### PR TITLE
Fix Issue 10692 - Deprecation isn't checked using alias this

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -108,8 +108,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     // it would be stored in TypeInfo_Class.defaultConstructor
     CtorDeclaration defaultCtor;
 
-    Dsymbol aliasthis;      // forward unresolved lookups to aliasthis
-    bool noDefaultCtor;     // no default construction
+    Dsymbol aliasthis;         // forward unresolved lookups to aliasthis
+    bool hasDeprecatedAliasThis;  // true if alias this is deprecated
+    bool noDefaultCtor;        // no default construction
 
     DtorDeclarations dtors; // Array of destructors
     DtorDeclaration dtor;   // aggregate destructor

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -16,6 +16,7 @@ import core.stdc.stdio;
 import dmd.aggregate;
 import dmd.dscope;
 import dmd.dsymbol;
+import dmd.declaration;
 import dmd.expression;
 import dmd.expressionsem;
 import dmd.globals;
@@ -31,18 +32,20 @@ import dmd.visitor;
 extern (C++) final class AliasThis : Dsymbol
 {
     Identifier ident;
+    StorageClass stc;
 
-    extern (D) this(const ref Loc loc, Identifier ident)
+    extern (D) this(const ref Loc loc, Identifier ident, StorageClass stc)
     {
         super(null);    // it's anonymous (no identifier)
         this.loc = loc;
         this.ident = ident;
+        this.stc = stc;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        return new AliasThis(loc, ident);
+        return new AliasThis(loc, ident, stc);
     }
 
     override const(char)* kind() const
@@ -107,6 +110,8 @@ Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false)
         e = resolveProperties(sc, e);
         if (gag && global.endGagging(olderrors))
             e = null;
+        else if (!gag && ad.hasDeprecatedAliasThis)
+            e.deprecation("accessing `alias this` of `%s %s` is deprecated", ad.kind(), ad.toChars());
     }
     return e;
 }

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -20,6 +20,7 @@ class AliasThis : public Dsymbol
 public:
    // alias Identifier this;
     Identifier *ident;
+    StorageClass stc;
 
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -459,12 +459,14 @@ struct ASTBase
     extern (C++) class AliasThis : Dsymbol
     {
         Identifier ident;
+        StorageClass stc;
 
-        extern (D) this(const ref Loc loc, Identifier ident)
+        extern (D) this(const ref Loc loc, Identifier ident, StorageClass stc)
         {
             super(null);
             this.loc = loc;
             this.ident = ident;
+            this.stc = stc;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -538,6 +538,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         ad.aliasthis = s;
+        if (dsym.stc & STC.deprecated_)
+            ad.hasDeprecatedAliasThis = true;
         dsym.semanticRun = PASS.semanticdone;
     }
 

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4325,7 +4325,7 @@ final class Parser(AST) : Lexer
              */
             if (token.value == TOK.identifier && peekNext() == TOK.this_)
             {
-                auto s = new AST.AliasThis(loc, token.ident);
+                auto s = new AST.AliasThis(loc, token.ident, pAttrs.storageClass);
                 nextToken();
                 check(TOK.this_);
                 check(TOK.semicolon);

--- a/test/fail_compilation/fail10692.d
+++ b/test/fail_compilation/fail10692.d
@@ -1,0 +1,28 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10692.d(26): Deprecation: accessing `alias this` of `struct A` is deprecated
+fail_compilation/fail10692.d(27): Deprecation: accessing `alias this` of `struct A` is deprecated
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=10692
+
+struct B
+{
+    int i;
+}
+
+struct A
+{
+    B b;
+    deprecated alias b this;
+}
+
+void main()
+{
+    A a;
+    a.i = 5; // Deprecated
+    assert(a.i == 5); // Deprecated
+}


### PR DESCRIPTION
Alias this is not considered a variable declaration so I had to manually add a storage class member to it. Unfortunately, I also had to add a new member to AggregateDeclaration, since it does not store anything about the AliasThis AST node; it simply stores the symbol that is alias this'ed.

If the implementation is not how you would picture, suggestions are welcome.