### PR TITLE
Frontend lib: remove assertion for parsing errors

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -17,9 +17,32 @@ module dmd.frontend;
 import dmd.dmodule : Module;
 import std.range.primitives : isInputRange, ElementType;
 import std.traits : isNarrowString;
+import std.typecons : Tuple;
 
 version (Windows) private enum sep = ";", exe = ".exe";
 version (Posix) private enum sep = ":", exe = "";
+
+/// Contains aggregated diagnostics information.
+immutable struct Diagnostics
+{
+    /// Number of errors diagnosed
+    uint errors;
+
+    /// Number of warnings diagnosed
+    uint warnings;
+
+    /// Returns: `true` if errors have been diagnosed
+    bool hasErrors()
+    {
+        return errors > 0;
+    }
+
+    /// Returns: `true` if warnings have been diagnosed
+    bool hasWarnings()
+    {
+        return warnings > 0;
+    }
+}
 
 /*
 Initializes the global variables of the DMD compiler.
@@ -215,22 +238,23 @@ Params:
 
 Returns: the parsed module object
 */
-Module parseModule(const(char)[] fileName, const(char)[] code = null)
+Tuple!(Module, "module_", Diagnostics, "diagnostics") parseModule(const(char)[] fileName, const(char)[] code = null)
 {
     import dmd.astcodegen : ASTCodegen;
-    import dmd.globals : Loc;
+    import dmd.globals : Loc, global;
     import dmd.parse : Parser;
     import dmd.identifier : Identifier;
     import dmd.tokens : TOK;
     import std.string : toStringz;
+    import std.typecons : tuple;
 
     static auto parse(Module m, const(char)[] code)
     {
         scope p = new Parser!ASTCodegen(m, code, false);
         p.nextToken; // skip the initial token
         auto members = p.parseModule;
-        assert(!p.errors, "Parsing error occurred.");
-        assert(p.token.value == TOK.endOfFile, "Didn't reach the end token. Did an error occur?");
+        if (p.errors)
+            ++global.errors;
         return members;
     }
 
@@ -244,7 +268,12 @@ Module parseModule(const(char)[] fileName, const(char)[] code = null)
         m.parse();
     }
 
-    return m;
+    Diagnostics diagnostics = {
+        errors: global.errors,
+        warnings: global.warnings
+    };
+
+    return typeof(return)(m, diagnostics);
 }
 
 /**

--- a/test/dub_package/frontend.d
+++ b/test/dub_package/frontend.d
@@ -13,15 +13,18 @@ void main()
     initDMD;
     findImportPaths.each!addImport;
 
-    auto m = parseModule("test.d", q{
+    auto t = parseModule("test.d", q{
         void foo()
         {
             foreach (i; 0..10) {}
         }
     });
 
-    m.fullSemantic;
-    auto generated = m.prettyPrint;
+    assert(!t.diagnostics.hasErrors);
+    assert(!t.diagnostics.hasWarnings);
+
+    t.module_.fullSemantic;
+    auto generated = t.module_.prettyPrint;
 
     auto expected =q{import object;
 void foo()

--- a/test/dub_package/frontend_file.d
+++ b/test/dub_package/frontend_file.d
@@ -35,10 +35,14 @@ void main()
     };
     fileName.fwrite(sourceCode);
 
-    auto m = fileName.parseModule;
+    auto t = fileName.parseModule;
 
-    m.fullSemantic;
-    auto generated = m.prettyPrint;
+
+    assert(!t.diagnostics.hasErrors);
+    assert(!t.diagnostics.hasWarnings);
+
+    t.module_.fullSemantic;
+    auto generated = t.module_.prettyPrint;
 
     auto expected =q{module foo;
 import object;


### PR DESCRIPTION
Previously the `dmd.frontend.parseModule` function asserted if a parsing error had occurred. This makes it impossible to use when building a tool based on the DMD frontend. With this change a tuple containing the parsed `Module` and diagnostic information is returned instead. This allows for the tool, using the DMD frontend, to do whatever it sees fit with an error.

This will also make the `dmd.frontend.parseModule` function behave consistently both when a file with the code is passed or when the code is passed directly to the function.