### PR TITLE
Convert warnings and useDeprecated byte values into an enum

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -299,7 +299,7 @@ extern (C++) class Dsymbol : RootObject
 
     final bool checkDeprecated(const ref Loc loc, Scope* sc)
     {
-        if (global.params.useDeprecated != 1 && isDeprecated())
+        if (global.params.useDeprecated != Diagnostic.off && isDeprecated())
         {
             // Don't complain if we're inside a deprecated symbol's scope
             if (sc.isDeprecated())

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -296,12 +296,12 @@ extern (C++) void verrorSupplemental(const ref Loc loc, const(char)* format, va_
  */
 extern (C++) void vwarning(const ref Loc loc, const(char)* format, va_list ap)
 {
-    if (global.params.warnings)
+    if (global.params.warnings != Diagnostic.off)
     {
         if (!global.gag)
         {
             verrorPrint(loc, Classification.warning, "Warning: ", format, ap);
-            if (global.params.warnings == 1)
+            if (global.params.warnings == Diagnostic.error)
                 global.warnings++;
         }
         else
@@ -320,7 +320,7 @@ extern (C++) void vwarning(const ref Loc loc, const(char)* format, va_list ap)
  */
 extern (C++) void vwarningSupplemental(const ref Loc loc, const(char)* format, va_list ap)
 {
-    if (global.params.warnings && !global.gag)
+    if (global.params.warnings != Diagnostic.off && !global.gag)
         verrorPrint(loc, Classification.warning, "       ", format, ap);
 }
 
@@ -336,9 +336,9 @@ extern (C++) void vwarningSupplemental(const ref Loc loc, const(char)* format, v
 extern (C++) void vdeprecation(const ref Loc loc, const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null)
 {
     __gshared const(char)* header = "Deprecation: ";
-    if (global.params.useDeprecated == 0)
+    if (global.params.useDeprecated == Diagnostic.error)
         verror(loc, format, ap, p1, p2, header);
-    else if (global.params.useDeprecated == 2)
+    else if (global.params.useDeprecated == Diagnostic.inform)
     {
         if (!global.gag)
         {
@@ -382,9 +382,9 @@ extern (C++) void vmessage(const ref Loc loc, const(char)* format, va_list ap)
  */
 extern (C++) void vdeprecationSupplemental(const ref Loc loc, const(char)* format, va_list ap)
 {
-    if (global.params.useDeprecated == 0)
+    if (global.params.useDeprecated == Diagnostic.error)
         verrorSupplemental(loc, format, ap);
-    else if (global.params.useDeprecated == 2 && !global.gag)
+    else if (global.params.useDeprecated == Diagnostic.inform && !global.gag)
         verrorPrint(loc, Classification.deprecation, "       ", format, ap);
 }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8311,7 +8311,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
             }
 
-            if (0 && global.params.warnings && !global.gag && exp.op == TOK.assign &&
+            if (0 && global.params.warnings != Diagnostic.off && !global.gag && exp.op == TOK.assign &&
                 e2x.op != TOK.slice && e2x.op != TOK.assign &&
                 e2x.op != TOK.arrayLiteral && e2x.op != TOK.string_ &&
                 !(e2x.op == TOK.add || e2x.op == TOK.min ||
@@ -8375,7 +8375,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else
         {
-            if (0 && global.params.warnings && !global.gag && exp.op == TOK.assign &&
+            if (0 && global.params.warnings != Diagnostic.off && !global.gag && exp.op == TOK.assign &&
                 t1.ty == Tarray && t2.ty == Tsarray &&
                 e2x.op != TOK.slice &&
                 t2.implicitConvTo(t1))

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -34,6 +34,13 @@ enum TARGET : bool
     DragonFlyBSD = xversion!`DragonFlyBSD`,
 }
 
+enum Diagnostic : ubyte
+{
+    error,        // generate an error
+    inform,       // generate a warning
+    off,          // disable diagnostic
+}
+
 enum CHECKENABLE : ubyte
 {
     _default,     // initial value
@@ -115,10 +122,7 @@ struct Param
     bool isSolaris;         // generate code for Solaris
     bool hasObjectiveC;     // target supports Objective-C
     bool mscoff = false;    // for Win32: write MsCoff object files instead of OMF
-    // 0: don't allow use of deprecated features
-    // 1: silently allow use of deprecated features
-    // 2: warn about the use of deprecated features
-    byte useDeprecated = 2;
+    Diagnostic useDeprecated = Diagnostic.inform;  // how use of deprecated features are handled
     bool useInvariants = true;  // generate class invariant checks
     bool useIn = true;          // generate precondition checks
     bool useOut = true;         // generate postcondition checks
@@ -128,10 +132,7 @@ struct Param
     bool useDIP25;          // implement http://wiki.dlang.org/DIP25
     bool release;           // build release version
     bool preservePaths;     // true means don't strip path from source file
-    // 0: disable warnings
-    // 1: warnings as errors
-    // 2: informational warnings (no errors)
-    byte warnings;
+    Diagnostic warnings = Diagnostic.off;  // how compiler warnings are handled
     bool pic;               // generate position-independent-code for shared libs
     bool color = true;      // use ANSI colors in console output
     bool cov;               // generate code coverage data

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -19,6 +19,14 @@
 // Can't include arraytypes.h here, need to declare these directly.
 template <typename TYPE> struct Array;
 
+typedef unsigned char Diagnostic;
+enum
+{
+    DIAGNOSTICerror,  // generate an error
+    DIAGNOSTICinform, // generate a warning
+    DIAGNOSTICoff     // disable diagnostic
+};
+
 // The state of array bounds checking
 typedef unsigned char CHECKENABLE;
 enum
@@ -89,10 +97,7 @@ struct Param
     bool isSolaris;     // generate code for Solaris
     bool hasObjectiveC; // target supports Objective-C
     bool mscoff;        // for Win32: write COFF object files instead of OMF
-    // 0: don't allow use of deprecated features
-    // 1: silently allow use of deprecated features
-    // 2: warn about the use of deprecated features
-    char useDeprecated;
+    Diagnostic useDeprecated;
     bool useInvariants; // generate class invariant checks
     bool useIn;         // generate precondition checks
     bool useOut;        // generate postcondition checks
@@ -102,10 +107,7 @@ struct Param
     bool useDIP25;      // implement http://wiki.dlang.org/DIP25
     bool release;       // build release version
     bool preservePaths; // true means don't strip path from source file
-    // 0: disable warnings
-    // 1: warnings as errors
-    // 2: informational warnings (no errors)
-    char warnings;
+    Diagnostic warnings;
     bool pic;           // generate position-independent-code for shared libs
     bool color;         // use ANSI colors in console output
     bool cov;           // generate code coverage data

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2272,7 +2272,7 @@ class Lexer : ErrorHandler
         va_start(ap, format);
         .vdeprecation(token.loc, format, ap);
         va_end(ap);
-        if (global.params.useDeprecated == 0)
+        if (global.params.useDeprecated == Diagnostic.error)
             errors = true;
     }
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1429,11 +1429,11 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
         if (arg == "-allinst")               // https://dlang.org/dmd.html#switch-allinst
             params.allInst = true;
         else if (arg == "-de")               // https://dlang.org/dmd.html#switch-de
-            params.useDeprecated = 0;
+            params.useDeprecated = Diagnostic.error;
         else if (arg == "-d")                // https://dlang.org/dmd.html#switch-d
-            params.useDeprecated = 1;
+            params.useDeprecated = Diagnostic.off;
         else if (arg == "-dw")               // https://dlang.org/dmd.html#switch-dw
-            params.useDeprecated = 2;
+            params.useDeprecated = Diagnostic.inform;
         else if (arg == "-c")                // https://dlang.org/dmd.html#switch-c
             params.link = false;
         else if (startsWith(p + 1, "color")) // https://dlang.org/dmd.html#switch-color
@@ -1695,9 +1695,9 @@ private bool parseCommandLine(const ref Strings arguments, const size_t argc, re
                 goto Lerror;
         }
         else if (arg == "-w")   // https://dlang.org/dmd.html#switch-w
-            params.warnings = 1;
+            params.warnings = Diagnostic.error;
         else if (arg == "-wi")  // https://dlang.org/dmd.html#switch-wi
-            params.warnings = 2;
+            params.warnings = Diagnostic.inform;
         else if (arg == "-O")   // https://dlang.org/dmd.html#switch-O
             params.optimize = true;
         else if (p[1] == 'o')

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1380,7 +1380,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
         // don't do it for unused deprecated types
         // or error ypes
-        if (!ad.getRTInfo && Type.rtinfo && (!ad.isDeprecated() || global.params.useDeprecated) && (ad.type && ad.type.ty != Terror))
+        if (!ad.getRTInfo && Type.rtinfo && (!ad.isDeprecated() || global.params.useDeprecated != Diagnostic.error) && (ad.type && ad.type.ty != Terror))
         {
             // Evaluate: RTinfo!type
             auto tiargs = new Objects();

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -251,7 +251,7 @@ bool discardValue(Expression e)
         }
     case TOK.call:
         /* Issue 3882: */
-        if (global.params.warnings && !global.gag)
+        if (global.params.warnings != Diagnostic.off && !global.gag)
         {
             CallExp ce = cast(CallExp)e;
             if (e.type.ty == Tvoid)


### PR DESCRIPTION
This came up as a request during gcc patch review.