### PR TITLE
Temporarily revert SemaphoreCI to ldc v1.11.0

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -41,6 +41,8 @@ source ci.sh
 # See https://github.com/dlang/dub/issues/1551
 if [ "$DMD" == "dmd" ]; then
     install_d "dmd-2.081.2"
+elif  [ "$DMD" == "ldc" ]; then
+    install_d "ldc-1.11.0"
 else
     install_d "$DMD"
 fi


### PR DESCRIPTION
Same reason as 84c9a5601696f848cb5c231e743793123c8a24dd.
The PR to fix DUB has yet to be merged, but a new release of LDC was made recently,
which include the broken DUB.