### PR TITLE
Add proper toArgTypes() for System V x86_64 ABI

### DIFF
--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -22,7 +22,10 @@ import dmd.visitor;
 
 private bool isDMDx64Target()
 {
-    return global.params.is64bit;
+    version (MARS)
+        return global.params.is64bit;
+    else
+        return false;
 }
 
 /****************************************************

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -20,6 +20,11 @@ import dmd.globals;
 import dmd.mtype;
 import dmd.visitor;
 
+private bool isDMDx64Target()
+{
+    return global.params.is64bit;
+}
+
 /****************************************************
  * This breaks a type down into 'simpler' types that can be passed to a function
  * in registers, and returned in registers.
@@ -34,7 +39,7 @@ import dmd.visitor;
  *  For 64 bit code, follows Itanium C++ ABI 1.86 Chapter 3
  *  http://refspecs.linux-foundation.org/cxxabi-1.86.html#calls
  */
-TypeTuple toArgTypes(Type t)
+extern (C++) TypeTuple toArgTypes(Type t)
 {
     extern (C++) final class ToArgTypes : Visitor
     {
@@ -108,7 +113,7 @@ TypeTuple toArgTypes(Type t)
                 t1 = Type.tfloat80;
                 break;
             case Tcomplex32:
-                if (global.params.is64bit)
+                if (isDMDx64Target())
                     t1 = Type.tfloat64;
                 else
                 {
@@ -257,7 +262,7 @@ TypeTuple toArgTypes(Type t)
             /* Should be done as if it were:
              * struct S { size_t length; void* ptr; }
              */
-            if (global.params.is64bit && !global.params.isLP64)
+            if (isDMDx64Target() && !global.params.isLP64)
             {
                 // For AMD64 ILP32 ABI, D arrays fit into a single integer register.
                 const offset = cast(uint)Type.tsize_t.size(Loc.initial);
@@ -275,7 +280,7 @@ TypeTuple toArgTypes(Type t)
             /* Should be done as if it were:
              * struct S { void* funcptr; void* ptr; }
              */
-            if (global.params.is64bit && !global.params.isLP64)
+            if (isDMDx64Target() && !global.params.isLP64)
             {
                 // For AMD64 ILP32 ABI, delegates fit into a single integer register.
                 const offset = cast(uint)Type.tsize_t.size(Loc.initial);
@@ -357,7 +362,7 @@ TypeTuple toArgTypes(Type t)
             if (nfields == 0)
                 return memory();
 
-            if (global.params.is64bit)
+            if (isDMDx64Target())
             {
                 if (sz == 0 || sz > 16)
                     return memory();

--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -1,0 +1,401 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
+ * Authors:     Martin Kinkelin
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/argtypes_sysv_x64.d, _argtypes_sysv_x64.d)
+ * Documentation:  https://dlang.org/phobos/dmd_argtypes_sysv_x64.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/argtypes_sysv_x64.d
+ */
+
+module dmd.argtypes_sysv_x64;
+
+import dmd.declaration;
+import dmd.globals;
+import dmd.mtype;
+import dmd.visitor;
+
+/****************************************************
+ * This breaks a type down into 'simpler' types that can be passed to a function
+ * in registers, and returned in registers.
+ * This is the implementation for the x86_64 System V ABI (not used for Win64),
+ * based on https://www.uclibc.org/docs/psABI-x86_64.pdf.
+ * Params:
+ *      t = type to break down
+ * Returns:
+ *      tuple of types, each element can be passed in a register.
+ *      A tuple of zero length means the type cannot be passed/returned in registers.
+ *      null indicates a `void`.
+ */
+extern (C++) TypeTuple toArgTypes_sysv_x64(Type t)
+{
+    if (t == Type.terror)
+        return new TypeTuple(t);
+
+    const size = cast(size_t) t.size();
+    if (size == 0)
+        return null;
+    if (size > 32)
+        return new TypeTuple();
+
+    const classification = classify(t, size);
+    const classes = classification.slice();
+    const c0 = classes[0];
+
+    if (c0 == Class.Memory)
+         return new TypeTuple();
+    if (c0 == Class.X87)
+        return new TypeTuple(Type.tfloat80);
+    if (c0 == Class.ComplexX87)
+        return new TypeTuple(Type.tfloat80, Type.tfloat80);
+
+    if (classes.length > 2 ||
+        (classes.length == 2 && classes[1] == Class.SSEUp))
+    {
+        assert(c0 == Class.SSE);
+        foreach (c; classes[1 .. $])
+            assert(c == Class.SSEUp);
+
+        assert(size % 8 == 0);
+        return new TypeTuple(new TypeVector(Type.tfloat64.sarrayOf(classes.length)));
+    }
+
+    assert(classes.length >= 1 && classes.length <= 2);
+    Type[2] argtypes;
+    foreach (i, c; classes)
+    {
+        // the last eightbyte may be filled partially only
+        auto sizeInEightbyte = (i < classes.length - 1) ? 8 : size % 8;
+        if (sizeInEightbyte == 0)
+            sizeInEightbyte = 8;
+
+        if (c == Class.Integer)
+        {
+            argtypes[i] =
+                sizeInEightbyte > 4 ? Type.tint64 :
+                sizeInEightbyte > 2 ? Type.tint32 :
+                sizeInEightbyte > 1 ? Type.tint16 :
+                                      Type.tint8;
+        }
+        else if (c == Class.SSE)
+        {
+            argtypes[i] =
+                sizeInEightbyte > 4 ? Type.tfloat64 :
+                                      Type.tfloat32;
+        }
+        else
+            assert(0, "Unexpected class");
+    }
+
+    return classes.length == 1
+        ? new TypeTuple(argtypes[0])
+        : new TypeTuple(argtypes[0], argtypes[1]);
+}
+
+
+private:
+
+// classification per eightbyte (64-bit chunk)
+enum Class : ubyte
+{
+    Integer,
+    SSE,
+    SSEUp,
+    X87,
+    X87Up,
+    ComplexX87,
+    NoClass,
+    Memory
+}
+
+Class merge(Class a, Class b)
+{
+    if (a == b)
+        return a;
+    if (a == Class.NoClass)
+        return b;
+    if (b == Class.NoClass)
+        return a;
+    if (a == Class.Memory || b == Class.Memory)
+        return Class.Memory;
+    if (a == Class.Integer || b == Class.Integer)
+        return Class.Integer;
+    if (a == Class.X87 || b == Class.X87 ||
+        a == Class.X87Up || b == Class.X87Up ||
+        a == Class.ComplexX87 || b == Class.ComplexX87)
+        return Class.Memory;
+    return Class.SSE;
+}
+
+struct Classification
+{
+    Class[4] classes;
+    int numEightbytes;
+
+    const(Class[]) slice() const { return classes[0 .. numEightbytes]; }
+}
+
+Classification classify(Type t, size_t size)
+{
+    scope v = new ToClassesVisitor(size);
+    t.accept(v);
+    return Classification(v.result, v.numEightbytes);
+}
+
+extern (C++) final class ToClassesVisitor : Visitor
+{
+    const size_t size;
+    int numEightbytes;
+    Class[4] result = Class.NoClass;
+
+    this(size_t size)
+    {
+        assert(size > 0);
+        this.size = size;
+        this.numEightbytes = cast(int) ((size + 7) / 8);
+    }
+
+    void memory()
+    {
+        result[0 .. numEightbytes] = Class.Memory;
+    }
+
+    void one(Class a)
+    {
+        result[0] = a;
+    }
+
+    void two(Class a, Class b)
+    {
+        result[0] = a;
+        result[1] = b;
+    }
+
+    alias visit = Visitor.visit;
+
+    override void visit(Type)
+    {
+        assert(0, "Unexpected type");
+    }
+
+    override void visit(TypeEnum t)
+    {
+        t.toBasetype().accept(this);
+    }
+
+    override void visit(TypeBasic t)
+    {
+        switch (t.ty)
+        {
+        case Tvoid:
+        case Tbool:
+        case Tint8:
+        case Tuns8:
+        case Tint16:
+        case Tuns16:
+        case Tint32:
+        case Tuns32:
+        case Tint64:
+        case Tuns64:
+        case Tchar:
+        case Twchar:
+        case Tdchar:
+            return one(Class.Integer);
+
+        case Tint128:
+        case Tuns128:
+            return two(Class.Integer, Class.Integer);
+
+        case Tfloat80:
+        case Timaginary80:
+            return two(Class.X87, Class.X87Up);
+
+        case Tfloat32:
+        case Tfloat64:
+        case Timaginary32:
+        case Timaginary64:
+        case Tcomplex32: // struct { float a, b; }
+            return one(Class.SSE);
+
+        case Tcomplex64: // struct { double a, b; }
+            return two(Class.SSE, Class.SSE);
+
+        case Tcomplex80: // struct { real a, b; }
+            result[0 .. 4] = Class.ComplexX87;
+            return;
+
+        default:
+            assert(0, "Unexpected basic type");
+        }
+    }
+
+    override void visit(TypeVector t)
+    {
+        result[0] = Class.SSE;
+        result[1 .. numEightbytes] = Class.SSEUp;
+    }
+
+    override void visit(TypeAArray)
+    {
+        return one(Class.Integer);
+    }
+
+    override void visit(TypePointer)
+    {
+        return one(Class.Integer);
+    }
+
+    override void visit(TypeNull)
+    {
+        return one(Class.Integer);
+    }
+
+    override void visit(TypeClass)
+    {
+        return one(Class.Integer);
+    }
+
+    override void visit(TypeDArray)
+    {
+        if (!global.params.isLP64)
+            return one(Class.Integer);
+        return two(Class.Integer, Class.Integer);
+    }
+
+    override void visit(TypeDelegate)
+    {
+        if (!global.params.isLP64)
+            return one(Class.Integer);
+        return two(Class.Integer, Class.Integer);
+    }
+
+    override void visit(TypeSArray t)
+    {
+        // treat as struct with N fields
+
+        Type baseElemType = t.next.toBasetype();
+        if (baseElemType.ty == Tstruct && !(cast(TypeStruct) baseElemType).sym.isPOD())
+            return memory();
+
+        classifyStaticArrayElements(0, t);
+        finalizeAggregate();
+    }
+
+    override void visit(TypeStruct t)
+    {
+        if (!t.sym.isPOD())
+            return memory();
+
+        classifyStructFields(0, t);
+        finalizeAggregate();
+    }
+
+    void classifyStructFields(uint baseOffset, TypeStruct t)
+    {
+        extern(D) Type getNthField(size_t n, out uint offset, out uint typeAlignment)
+        {
+            auto field = t.sym.fields[n];
+            offset = field.offset;
+            typeAlignment = field.type.alignsize();
+            return field.type;
+        }
+
+        classifyFields(baseOffset, t.sym.fields.dim, &getNthField);
+    }
+
+    void classifyStaticArrayElements(uint baseOffset, TypeSArray t)
+    {
+        Type elemType = t.next;
+        const elemSize = elemType.size();
+        const elemTypeAlignment = elemType.alignsize();
+
+        extern(D) Type getNthElement(size_t n, out uint offset, out uint typeAlignment)
+        {
+            offset = cast(uint)(n * elemSize);
+            typeAlignment = elemTypeAlignment;
+            return elemType;
+        }
+
+        classifyFields(baseOffset, cast(size_t) t.dim.toInteger(), &getNthElement);
+    }
+
+    extern(D) void classifyFields(uint baseOffset, size_t nfields, Type delegate(size_t, out uint, out uint) getFieldInfo)
+    {
+        if (nfields == 0)
+            return memory();
+
+        // classify each field (recursively for aggregates) and merge all classes per eightbyte
+        foreach (n; 0 .. nfields)
+        {
+            uint foffset_relative;
+            uint ftypeAlignment;
+            Type ftype = getFieldInfo(n, foffset_relative, ftypeAlignment);
+            const fsize = cast(size_t) ftype.size();
+
+            const foffset = baseOffset + foffset_relative;
+            if (foffset & (ftypeAlignment - 1)) // not aligned
+                return memory();
+
+            if (ftype.ty == Tstruct)
+                classifyStructFields(foffset, cast(TypeStruct) ftype);
+            else if (ftype.ty == Tsarray)
+                classifyStaticArrayElements(foffset, cast(TypeSArray) ftype);
+            else
+            {
+                const fEightbyteStart = foffset / 8;
+                const fEightbyteEnd = (foffset + fsize + 7) / 8;
+                if (ftype.ty == Tcomplex32) // may lie in 2 eightbytes
+                {
+                    assert(foffset % 4 == 0);
+                    foreach (ref existingClass; result[fEightbyteStart .. fEightbyteEnd])
+                        existingClass = merge(existingClass, Class.SSE);
+                }
+                else
+                {
+                    assert(foffset % 8 == 0 ||
+                        fEightbyteEnd - fEightbyteStart <= 1,
+                        "Field not aligned at eightbyte boundary but contributing to multiple eightbytes?"
+                    );
+                    foreach (i, fclass; classify(ftype, fsize).slice())
+                    {
+                        Class* existingClass = &result[fEightbyteStart + i];
+                        *existingClass = merge(*existingClass, fclass);
+                    }
+                }
+            }
+        }
+    }
+
+    void finalizeAggregate()
+    {
+        foreach (i, ref c; result)
+        {
+            if (c == Class.Memory ||
+                (c == Class.X87Up && !(i > 0 && result[i - 1] == Class.X87)))
+                return memory();
+
+            if (c == Class.SSEUp && !(i > 0 &&
+                (result[i - 1] == Class.SSE || result[i - 1] == Class.SSEUp)))
+                c = Class.SSE;
+        }
+
+        if (numEightbytes > 2)
+        {
+            if (result[0] != Class.SSE)
+                return memory();
+
+            foreach (c; result[1 .. numEightbytes])
+                if (c != Class.SSEUp)
+                    return memory();
+        }
+
+        // Undocumented special case for aggregates with the 2nd eightbyte
+        // consisting of padding only (`struct S { align(16) int a; }`).
+        // clang only passes the first eightbyte in that case, so let's do the
+        // same.
+        if (numEightbytes == 2 && result[1] == Class.NoClass)
+            numEightbytes = 1;
+    }
+}

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -416,7 +416,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         }
 
         auto tt = target.toArgTypes(type);
-        size_t dim = tt.arguments.dim;
+        size_t dim = tt ? tt.arguments.dim : 0;
         if (dim >= 1)
         {
             assert(dim <= 2);

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -543,9 +543,12 @@ struct Target
      * Returns:
      *      tuple of types if type is passed in one or more registers
      *      empty tuple if type is always passed on the stack
+     *      null if the type is a `void` or argtypes aren't supported by the target
      */
     extern (C++) TypeTuple toArgTypes(Type t)
     {
+        if (global.params.is64bit && global.params.isWindows)
+            return null;
         return .toArgTypes(t);
     }
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -310,7 +310,7 @@ endif
 
 ######## DMD frontend source files
 
-FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes arrayop	\
+FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes argtypes_sysv_x64 arrayop	\
 	arraytypes astcodegen ast_node attrib builtin canthrow cli clone compiler complex cond constfold	\
 	cppmangle cppmanglewin ctfeexpr ctorflow dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -150,7 +150,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 ############################### Rule Variables ###############################
 
 # D front end
-FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
+FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/argtypes_sysv_x64.d $D/arrayop.d	\
 	$D/arraytypes.d $D/astcodegen.d $D/ast_node.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/cli.d $D/clone.d $D/compiler.d $D/complex.d	\
 	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/ctorflow.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\

--- a/test/runnable/testargtypes.d
+++ b/test/runnable/testargtypes.d
@@ -30,52 +30,93 @@ void chkPair(T,U,V)()
     chkArgTypes!(S, V)();
 }
 
-version (X86_64)
+version (Posix) version (X86_64) version = Posix_X86_64;
+
+version (Posix_X86_64)
 {
     int main()
     {
         chkIdentity!byte();
-        chkIdentity!ubyte();
         chkIdentity!short();
-        chkIdentity!ushort();
         chkIdentity!int();
-        chkIdentity!uint();
         chkIdentity!long();
-        chkIdentity!ulong();
-        chkSingle!(char,ubyte)();
-        chkSingle!(wchar,ushort)();
-        chkSingle!(dchar,uint)();
+
+        version (DigitalMars)
+        {
+            chkIdentity!ubyte();
+            chkIdentity!ushort();
+            chkIdentity!uint();
+            chkIdentity!ulong();
+
+            chkSingle!(char,  ubyte)();
+            chkSingle!(wchar, ushort)();
+            chkSingle!(dchar, uint)();
+        }
+        else
+        {
+            chkSingle!(ubyte,  byte)();
+            chkSingle!(ushort, short)();
+            chkSingle!(uint,   int)();
+            chkSingle!(ulong,  long)();
+
+            chkSingle!(char,  byte)();
+            chkSingle!(wchar, short)();
+            chkSingle!(dchar, int)();
+        }
 
         chkIdentity!float();
         chkIdentity!double();
         chkIdentity!real();
 
-        chkIdentity!(void*)();
+        version (DigitalMars)
+            chkIdentity!(void*)();
+        else
+            chkSingle!(void*, ptrdiff_t)();
 
-        chkIdentity!(__vector(byte[16]))();
-        chkIdentity!(__vector(ubyte[16]))();
-        chkIdentity!(__vector(short[8]))();
-        chkIdentity!(__vector(ushort[8]))();
-        chkIdentity!(__vector(int[4]))();
-        chkIdentity!(__vector(uint[4]))();
-        chkIdentity!(__vector(long[2]))();
-        chkIdentity!(__vector(ulong[2]))();
+        version (DigitalMars)
+        {
+            chkIdentity!(__vector(byte[16]))();
+            chkIdentity!(__vector(ubyte[16]))();
+            chkIdentity!(__vector(short[8]))();
+            chkIdentity!(__vector(ushort[8]))();
+            chkIdentity!(__vector(int[4]))();
+            chkIdentity!(__vector(uint[4]))();
+            chkIdentity!(__vector(long[2]))();
+            chkIdentity!(__vector(ulong[2]))();
 
-        chkIdentity!(__vector(float[4]))();
-        chkIdentity!(__vector(double[2]))();
+            chkIdentity!(__vector(float[4]))();
+            chkIdentity!(__vector(double[2]))();
+        }
+        else
+        {
+            chkSingle!(__vector(byte[16]),  __vector(double[2]))();
+            chkSingle!(__vector(ubyte[16]), __vector(double[2]))();
+            chkSingle!(__vector(short[8]),  __vector(double[2]))();
+            chkSingle!(__vector(ushort[8]), __vector(double[2]))();
+            chkSingle!(__vector(int[4]),    __vector(double[2]))();
+            chkSingle!(__vector(uint[4]),   __vector(double[2]))();
+            chkSingle!(__vector(long[2]),   __vector(double[2]))();
+            chkSingle!(__vector(ulong[2]),  __vector(double[2]))();
 
-        chkPair!(byte,byte,short);
-        chkPair!(ubyte,ubyte,short);
-        chkPair!(short,short,int);
-        chkPair!(int,int,long);
+            chkSingle!(__vector(float[4]),  __vector(double[2]))();
+            chkSingle!(__vector(double[2]), __vector(double[2]))();
 
-        chkPair!(byte,short,int);
-        chkPair!(short,byte,int);
+            version (D_AVX)
+                chkSingle!(__vector(int[8]), __vector(double[4]))();
+        }
 
-        chkPair!(int,float,long);
-        chkPair!(float,int,long);
-        chkPair!(byte,float,long);
-        chkPair!(float,short,long);
+        chkPair!(byte,  byte,  short);
+        chkPair!(ubyte, ubyte, short);
+        chkPair!(short, short, int);
+        chkPair!(int,   int,   long);
+
+        chkPair!(byte,  short, int);
+        chkPair!(short, byte,  int);
+
+        chkPair!(int,   float, long);
+        chkPair!(float, int,   long);
+        chkPair!(byte,  float, long);
+        chkPair!(float, short, long);
 
         struct S1 { long a; long b; }
         chkArgTypes!(S1, long, long)();
@@ -108,7 +149,31 @@ version (X86_64)
         struct S10 { int[3] a; }
         chkArgTypes!(S10, long, int)();
 
+        struct S11 { float a; struct { float b; float c; } }
+        chkArgTypes!(S11, double, float)();
+
+        struct RGB { ubyte r, g, b; }
+        chkArgTypes!(RGB, int)();
+
         chkArgTypes!(int[3], long, int)();
+
+        struct S12 { align(16) int a; }
+        version (DigitalMars)
+            chkArgTypes!(S12, int)();
+        else
+            chkArgTypes!(S12, long)();
+
+        version (DigitalMars)
+        {
+        }
+        else
+        {
+            struct S13 { short a; cfloat b; }
+            chkArgTypes!(S13, long, float)();
+
+            struct S13957 { double a; ulong b; }
+            chkArgTypes!(S13957, double, long)();
+        }
 
         return 0;
     }


### PR DESCRIPTION
Depart from the IMO hopeless attempt of incorporating the SysV ABI complexity into existing generic `argtypes.d`:

* Strip 64-bit code from `argtypes.d` and rename it to `argtypes_x86.d`.
* Provide a new separate SysV implementation, closely following the algorithm laid out in the [spec](https://www.uclibc.org/docs/psABI-x86_64.pdf).
* Don't needlessly compute a struct's argtypes for Win64, that ABI is totally different.

I went with unsigned argtypes (`ubyte`, `ushort`, `uint`, `ulong`) to represent GP registers, and `float`/`double`/`__vector(double[N])` for vector registers (SSE + AVX); integer signedness and vector element type are arbitrary.