### PR TITLE
Fix Issue 9274 and 11499 - is + alias this = wrong code

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -3208,7 +3208,7 @@ __gshared Expression emptyArrayElement = null;
  * Output:
  *      dedtypes = [ int ]      // Array of Expression/Type's
  */
-MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm = null, size_t inferStart = 0)
+MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm = null, size_t inferStart = 0, bool ignoreAliasThis = false)
 {
     extern (C++) final class DeduceType : Visitor
     {
@@ -3220,9 +3220,10 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         Objects* dedtypes;
         uint* wm;
         size_t inferStart;
+        bool ignoreAliasThis;
         MATCH result;
 
-        extern (D) this(Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm, size_t inferStart)
+        extern (D) this(Scope* sc, Type tparam, TemplateParameters* parameters, Objects* dedtypes, uint* wm, size_t inferStart, bool ignoreAliasThis)
         {
             this.sc = sc;
             this.tparam = tparam;
@@ -3230,6 +3231,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
             this.dedtypes = dedtypes;
             this.wm = wm;
             this.inferStart = inferStart;
+            this.ignoreAliasThis = ignoreAliasThis;
             result = MATCH.nomatch;
         }
 
@@ -3442,7 +3444,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                 }
 
                 MATCH m = t.implicitConvTo(tparam);
-                if (m == MATCH.nomatch)
+                if (m == MATCH.nomatch && !ignoreAliasThis)
                 {
                     if (t.ty == Tclass)
                     {
@@ -4595,7 +4597,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
         }
     }
 
-    scope DeduceType v = new DeduceType(sc, tparam, parameters, dedtypes, wm, inferStart);
+    scope DeduceType v = new DeduceType(sc, tparam, parameters, dedtypes, wm, inferStart, ignoreAliasThis);
     if (Type t = isType(o))
         t.accept(v);
     else

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5095,7 +5095,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             Objects dedtypes = Objects(e.parameters.dim);
             dedtypes.zero();
 
-            MATCH m = deduceType(e.targ, sc, e.tspec, e.parameters, &dedtypes);
+            MATCH m = deduceType(e.targ, sc, e.tspec, e.parameters, &dedtypes, null, 0, e.tok == TOK.equal);
             //printf("targ: %s\n", targ.toChars());
             //printf("tspec: %s\n", tspec.toChars());
             if (m <= MATCH.nomatch || (m != MATCH.exact && e.tok == TOK.equal))

--- a/test/compilable/test9274.d
+++ b/test/compilable/test9274.d
@@ -7,6 +7,8 @@ struct S
 
 static assert(!is(S == float[])); // ok
 static assert(!is(S == T[], T)); // fails
+static assert(is(S : float[]));
+static assert(is(S : T[], T));
 
 //https://issues.dlang.org/show_bug.cgi?id=9274
 struct A(T)
@@ -20,4 +22,5 @@ struct B
 
 static assert(!is(B == A!int)); // OK
 static assert(!is(B == A!X, X)); // assertion fails
-
+static assert(is(B : A!int));
+static assert(is(B : A!X, X));

--- a/test/compilable/test9274.d
+++ b/test/compilable/test9274.d
@@ -1,0 +1,23 @@
+// https://issues.dlang.org/show_bug.cgi?id=9274
+struct S
+{
+    float[] arr;
+    alias arr this;
+}
+
+static assert(!is(S == float[])); // ok
+static assert(!is(S == T[], T)); // fails
+
+//https://issues.dlang.org/show_bug.cgi?id=9274
+struct A(T)
+{}
+
+struct B
+{
+    A!int _a;
+    alias _a this;
+}
+
+static assert(!is(B == A!int)); // OK
+static assert(!is(B == A!X, X)); // assertion fails
+


### PR DESCRIPTION
deduceType does what its name suggests : it deduces types. While doing so, it also checks for alias this, but it leaves no trace of whether the argument was matched through alias this or not. IsExp semantic uses deduceType for complex patterns therefore when it analyzes the code in the bug report it bounds the deduced type to the alias this leaving no trace of this whatsoever.

@andralex @WalterBright this is yet another example where having an alias this match would prove useful, but since we do not have one, this workaround is employed. 