### PR TITLE
de-virtualize cgobj.c and mscoffobj.c

### DIFF
--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -223,7 +223,7 @@ void cv8_termfile(const(char)* objfilename)
     /* Write out the debug info sections.
      */
 
-    int seg = MsCoffObj.seg_debugS();
+    int seg = MsCoffObj_seg_debugS();
 
     uint value = 4;
     objmod.bytes(seg,0,4,&value);
@@ -269,7 +269,7 @@ void cv8_termfile(const(char)* objfilename)
         int f2seg = seg;
         if (symbol_iscomdat(fd.sfunc))
         {
-            f2seg = MsCoffObj.seg_debugS_comdat(fd.sfunc);
+            f2seg = MsCoffObj_seg_debugS_comdat(fd.sfunc);
             objmod.bytes(f2seg,0,4,&value);
         }
 

--- a/src/dmd/backend/obj.d
+++ b/src/dmd/backend/obj.d
@@ -44,83 +44,506 @@ version (Windows)
     }
 }
 
+version (Windows)
+{
+    Obj  OmfObj_init(Outbuffer *, const(char)* filename, const(char)* csegname);
+    void OmfObj_initfile(const(char)* filename, const(char)* csegname, const(char)* modname);
+    void OmfObj_termfile();
+    void OmfObj_term(const(char)* objfilename);
+    size_t OmfObj_mangle(Symbol *s,char *dest);
+    void OmfObj_import(elem *e);
+    void OmfObj_linnum(Srcpos srcpos, int seg, targ_size_t offset);
+    int  OmfObj_codeseg(char *name,int suffix);
+    void OmfObj_dosseg();
+    void OmfObj_startaddress(Symbol *);
+    bool OmfObj_includelib(const(char)* );
+    bool OmfObj_linkerdirective(const(char)* );
+    bool OmfObj_allowZeroSize();
+    void OmfObj_exestr(const(char)* p);
+    void OmfObj_user(const(char)* p);
+    void OmfObj_compiler();
+    void OmfObj_wkext(Symbol *,Symbol *);
+    void OmfObj_lzext(Symbol *,Symbol *);
+    void OmfObj_alias(const(char)* n1,const(char)* n2);
+    void OmfObj_theadr(const(char)* modname);
+    void OmfObj_segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
+    void OmfObj_staticctor(Symbol *s,int dtor,int seg);
+    void OmfObj_staticdtor(Symbol *s);
+    void OmfObj_setModuleCtorDtor(Symbol *s, bool isCtor);
+    void OmfObj_ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
+    void OmfObj_ehsections();
+    void OmfObj_moduleinfo(Symbol *scc);
+    int  OmfObj_comdat(Symbol *);
+    int  OmfObj_comdatsize(Symbol *, targ_size_t symsize);
+    int  OmfObj_readonly_comdat(Symbol *s);
+    void OmfObj_setcodeseg(int seg);
+    seg_data* OmfObj_tlsseg();
+    seg_data* OmfObj_tlsseg_bss();
+    seg_data* OmfObj_tlsseg_data();
+    int  OmfObj_fardata(char *name, targ_size_t size, targ_size_t *poffset);
+    void OmfObj_export_symbol(Symbol *s, uint argsize);
+    void OmfObj_pubdef(int seg, Symbol *s, targ_size_t offset);
+    void OmfObj_pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize);
+    int  OmfObj_external_def(const(char)* );
+    int  OmfObj_data_start(Symbol *sdata, targ_size_t datasize, int seg);
+    int  OmfObj_external(Symbol *);
+    int  OmfObj_common_block(Symbol *s, targ_size_t size, targ_size_t count);
+    int  OmfObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count);
+    void OmfObj_lidata(int seg, targ_size_t offset, targ_size_t count);
+    void OmfObj_write_zeros(seg_data *pseg, targ_size_t count);
+    void OmfObj_write_byte(seg_data *pseg, uint _byte);
+    void OmfObj_write_bytes(seg_data *pseg, uint nbytes, void *p);
+    void OmfObj_byte(int seg, targ_size_t offset, uint _byte);
+    uint OmfObj_bytes(int seg, targ_size_t offset, uint nbytes, void *p);
+    void OmfObj_ledata(int seg, targ_size_t offset, targ_size_t data, uint lcfd, uint idx1, uint idx2);
+    void OmfObj_write_long(int seg, targ_size_t offset, uint data, uint lcfd, uint idx1, uint idx2);
+    void OmfObj_reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags);
+    void OmfObj_reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags);
+    void OmfObj_reftocodeseg(int seg, targ_size_t offset, targ_size_t val);
+    int  OmfObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags);
+    void OmfObj_far16thunk(Symbol *s);
+    void OmfObj_fltused();
+    int  OmfObj_data_readonly(char *p, int len, int *pseg);
+    int  OmfObj_data_readonly(char *p, int len);
+    int  OmfObj_string_literal_segment(uint sz);
+    Symbol* OmfObj_sym_cdata(tym_t, char *, int);
+    void OmfObj_func_start(Symbol *sfunc);
+    void OmfObj_func_term(Symbol *sfunc);
+    void OmfObj_write_pointerRef(Symbol* s, uint off);
+    int  OmfObj_jmpTableSegment(Symbol* s);
+    Symbol* OmfObj_tlv_bootstrap();
+    void OmfObj_gotref(Symbol *s);
+    int  OmfObj_seg_debugT();           // where the symbolic debug type data goes
+
+    Obj  MsCoffObj_init(Outbuffer *, const(char)* filename, const(char)* csegname);
+    void MsCoffObj_initfile(const(char)* filename, const(char)* csegname, const(char)* modname);
+    void MsCoffObj_termfile();
+    void MsCoffObj_term(const(char)* objfilename);
+//    size_t MsCoffObj_mangle(Symbol *s,char *dest);
+//    void MsCoffObj_import(elem *e);
+    void MsCoffObj_linnum(Srcpos srcpos, int seg, targ_size_t offset);
+    int  MsCoffObj_codeseg(char *name,int suffix);
+//    void MsCoffObj_dosseg();
+    void MsCoffObj_startaddress(Symbol *);
+    bool MsCoffObj_includelib(const(char)* );
+    bool MsCoffObj_linkerdirective(const(char)* );
+    bool MsCoffObj_allowZeroSize();
+    void MsCoffObj_exestr(const(char)* p);
+    void MsCoffObj_user(const(char)* p);
+    void MsCoffObj_compiler();
+    void MsCoffObj_wkext(Symbol *,Symbol *);
+//    void MsCoffObj_lzext(Symbol *,Symbol *);
+    void MsCoffObj_alias(const(char)* n1,const(char)* n2);
+//    void MsCoffObj_theadr(const(char)* modname);
+//    void MsCoffObj_segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
+    void MsCoffObj_staticctor(Symbol *s,int dtor,int seg);
+    void MsCoffObj_staticdtor(Symbol *s);
+    void MsCoffObj_setModuleCtorDtor(Symbol *s, bool isCtor);
+    void MsCoffObj_ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
+    void MsCoffObj_ehsections();
+    void MsCoffObj_moduleinfo(Symbol *scc);
+    int  MsCoffObj_comdat(Symbol *);
+    int  MsCoffObj_comdatsize(Symbol *, targ_size_t symsize);
+    int  MsCoffObj_readonly_comdat(Symbol *s);
+    void MsCoffObj_setcodeseg(int seg);
+    seg_data* MsCoffObj_tlsseg();
+    seg_data* MsCoffObj_tlsseg_bss();
+    seg_data* MsCoffObj_tlsseg_data();
+//    int  MsCoffObj_fardata(char *name, targ_size_t size, targ_size_t *poffset);
+    void MsCoffObj_export_symbol(Symbol *s, uint argsize);
+    void MsCoffObj_pubdef(int seg, Symbol *s, targ_size_t offset);
+    void MsCoffObj_pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize);
+    int  MsCoffObj_external_def(const(char)* );
+    int  MsCoffObj_data_start(Symbol *sdata, targ_size_t datasize, int seg);
+    int  MsCoffObj_external(Symbol *);
+    int  MsCoffObj_common_block(Symbol *s, targ_size_t size, targ_size_t count);
+    int  MsCoffObj_common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count);
+    void MsCoffObj_lidata(int seg, targ_size_t offset, targ_size_t count);
+    void MsCoffObj_write_zeros(seg_data *pseg, targ_size_t count);
+    void MsCoffObj_write_byte(seg_data *pseg, uint _byte);
+    void MsCoffObj_write_bytes(seg_data *pseg, uint nbytes, void *p);
+    void MsCoffObj_byte(int seg, targ_size_t offset, uint _byte);
+    uint MsCoffObj_bytes(int seg, targ_size_t offset, uint nbytes, void *p);
+//    void MsCoffObj_ledata(int seg, targ_size_t offset, targ_size_t data, uint lcfd, uint idx1, uint idx2);
+//    void MsCoffObj_write_long(int seg, targ_size_t offset, uint data, uint lcfd, uint idx1, uint idx2);
+    void MsCoffObj_reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags);
+//    void MsCoffObj_reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags);
+    void MsCoffObj_reftocodeseg(int seg, targ_size_t offset, targ_size_t val);
+    int  MsCoffObj_reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags);
+    void MsCoffObj_far16thunk(Symbol *s);
+    void MsCoffObj_fltused();
+    int  MsCoffObj_data_readonly(char *p, int len, int *pseg);
+    int  MsCoffObj_data_readonly(char *p, int len);
+    int  MsCoffObj_string_literal_segment(uint sz);
+    Symbol* MsCoffObj_sym_cdata(tym_t, char *, int);
+    void MsCoffObj_func_start(Symbol *sfunc);
+    void MsCoffObj_func_term(Symbol *sfunc);
+    void MsCoffObj_write_pointerRef(Symbol* s, uint off);
+    int  MsCoffObj_jmpTableSegment(Symbol* s);
+    Symbol* MsCoffObj_tlv_bootstrap();
+//    void MsCoffObj_gotref(Symbol *s);
+    int  MsCoffObj_seg_debugT();           // where the symbolic debug type data goes
+
+    int  MsCoffObj_getsegment(const(char)* sectname, uint flags);
+    int  MsCoffObj_getsegment2( uint shtidx);
+    uint MsCoffObj_addScnhdr(const(char)* scnhdr_name, uint flags);
+    void MsCoffObj_addrel(int seg, targ_size_t offset, Symbol *targsym,
+                          uint targseg, int rtype, int val);
+    int  MsCoffObj_seg_drectve();
+    int  MsCoffObj_seg_pdata();
+    int  MsCoffObj_seg_xdata();
+    int  MsCoffObj_seg_pdata_comdat(Symbol *sfunc);
+    int  MsCoffObj_seg_xdata_comdat(Symbol *sfunc);
+    int  MsCoffObj_seg_debugS();
+    int  MsCoffObj_seg_debugS_comdat(Symbol *sfunc);
+}
+
 version (OMF)
 {
     class Obj
     {
       static
       {
-        Obj init(Outbuffer *, const(char)* filename, const(char)* csegname);
-        void initfile(const(char)* filename, const(char)* csegname, const(char)* modname);
-        void termfile();
-        void term(const(char)* objfilename);
-        size_t mangle(Symbol *s,char *dest);
-        void _import(elem *e);
-        void linnum(Srcpos srcpos, int seg, targ_size_t offset);
-        int codeseg(char *name,int suffix);
-        void dosseg();
-        void startaddress(Symbol *);
-        bool includelib(const(char)* );
-        bool linkerdirective(const char *);
-        bool allowZeroSize();
-        void exestr(const(char)* p);
-        void user(const(char)* p);
-        void compiler();
-        void wkext(Symbol *,Symbol *);
-        void lzext(Symbol *,Symbol *);
-        void _alias(const(char)* n1,const(char)* n2);
-        void theadr(const(char)* modname);
-        void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
-        void staticctor(Symbol *s,int dtor,int seg);
-        void staticdtor(Symbol *s);
-        void setModuleCtorDtor(Symbol *s, bool isCtor);
-        void ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
-        void ehsections();
-        void moduleinfo(Symbol *scc);
-      }
-        final int comdat(Symbol *);
-        final int comdatsize(Symbol *, targ_size_t symsize);
-        final int readonly_comdat(Symbol *s);
-      static
-      {
-        void setcodeseg(int seg);
-        seg_data *tlsseg();
-        seg_data *tlsseg_bss();
-        seg_data *tlsseg_data();
-        int  fardata(char *name, targ_size_t size, targ_size_t *poffset);
-        void export_symbol(Symbol *s, uint argsize);
-        void pubdef(int seg, Symbol *s, targ_size_t offset);
-        void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize);
-        int external_def(const(char)* );
-        int data_start(Symbol *sdata, targ_size_t datasize, int seg);
-        int external(Symbol *);
-        int common_block(Symbol *s, targ_size_t size, targ_size_t count);
-        int common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count);
-        void lidata(int seg, targ_size_t offset, targ_size_t count);
-        void write_zeros(seg_data *pseg, targ_size_t count);
-        void write_byte(seg_data *pseg, uint _byte);
-        void write_bytes(seg_data *pseg, uint nbytes, void *p);
-        void _byte(int seg, targ_size_t offset, uint _byte);
-        uint bytes(int seg, targ_size_t offset, uint nbytes, void *p);
-        void ledata(int seg, targ_size_t offset, targ_size_t data, uint lcfd, uint idx1, uint idx2);
-        void write_long(int seg, targ_size_t offset, uint data, uint lcfd, uint idx1, uint idx2);
-        void reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags);
-        void reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags);
-        void reftocodeseg(int seg, targ_size_t offset, targ_size_t val);
-        int reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags);
-        void far16thunk(Symbol *s);
-        void fltused();
-        int data_readonly(char *p, int len, int *pseg);
-        int data_readonly(char *p, int len);
-        int string_literal_segment(uint sz);
-        Symbol *sym_cdata(tym_t, char *, int);
-        void func_start(Symbol *sfunc);
-        void func_term(Symbol *sfunc);
-        void write_pointerRef(Symbol* s, uint off);
-        int jmpTableSegment(Symbol* s);
-        Symbol *tlv_bootstrap();
-        void gotref(Symbol *s);
-        int seg_debugT();           // where the symbolic debug type data goes
+        Obj init(Outbuffer* objbuf, const(char)* filename, const(char)* csegname)
+        {
+            return OmfObj_init(objbuf, filename, csegname);
+        }
+
+        void initfile(const(char)* filename, const(char)* csegname, const(char)* modname)
+        {
+            return OmfObj_initfile(filename, csegname, modname);
+        }
+
+        void termfile()
+        {
+            return OmfObj_termfile();
+        }
+
+        void term(const(char)* objfilename)
+        {
+            return OmfObj_term(objfilename);
+        }
+
+        size_t mangle(Symbol *s,char *dest)
+        {
+            return OmfObj_mangle(s, dest);
+        }
+
+        void _import(elem *e)
+        {
+            return OmfObj_import(e);
+        }
+
+        void linnum(Srcpos srcpos, int seg, targ_size_t offset)
+        {
+            return OmfObj_linnum(srcpos, seg, offset);
+        }
+
+        int codeseg(char *name,int suffix)
+        {
+            return OmfObj_codeseg(name, suffix);
+        }
+
+        void dosseg()
+        {
+            return OmfObj_dosseg();
+        }
+
+        void startaddress(Symbol *s)
+        {
+            return OmfObj_startaddress(s);
+        }
+
+        bool includelib(const(char)* name)
+        {
+            return OmfObj_includelib(name);
+        }
+
+        bool linkerdirective(const(char)* p)
+        {
+            return OmfObj_linkerdirective(p);
+        }
+
+        bool allowZeroSize()
+        {
+            return OmfObj_allowZeroSize();
+        }
+
+        void exestr(const(char)* p)
+        {
+            return OmfObj_exestr(p);
+        }
+
+        void user(const(char)* p)
+        {
+            return OmfObj_user(p);
+        }
+
+        void compiler()
+        {
+            return OmfObj_compiler();
+        }
+
+        void wkext(Symbol* s1, Symbol* s2)
+        {
+            return OmfObj_wkext(s1, s2);
+        }
+
+        void lzext(Symbol* s1, Symbol* s2)
+        {
+            return OmfObj_lzext(s1, s2);
+        }
+
+        void _alias(const(char)* n1,const(char)* n2)
+        {
+            return OmfObj_alias(n1, n2);
+        }
+
+        void theadr(const(char)* modname)
+        {
+            return OmfObj_theadr(modname);
+        }
+
+        void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize)
+        {
+            return OmfObj_segment_group(codesize, datasize, cdatasize, udatasize);
+        }
+
+        void staticctor(Symbol *s,int dtor,int seg)
+        {
+            return OmfObj_staticctor(s, dtor, seg);
+        }
+
+        void staticdtor(Symbol *s)
+        {
+            return OmfObj_staticdtor(s);
+        }
+
+        void setModuleCtorDtor(Symbol *s, bool isCtor)
+        {
+            return OmfObj_setModuleCtorDtor(s, isCtor);
+        }
+
+        void ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
+        {
+            return OmfObj_ehtables(sfunc, size, ehsym);
+        }
+
+        void ehsections()
+        {
+            return OmfObj_ehsections();
+        }
+
+        void moduleinfo(Symbol *scc)
+        {
+            return OmfObj_moduleinfo(scc);
+        }
+
+        int comdat(Symbol *s)
+        {
+            return OmfObj_comdat(s);
+        }
+
+        int comdatsize(Symbol *s, targ_size_t symsize)
+        {
+            return OmfObj_comdatsize(s, symsize);
+        }
+
+        int readonly_comdat(Symbol *s)
+        {
+            return OmfObj_comdat(s);
+        }
+
+        void setcodeseg(int seg)
+        {
+            return OmfObj_setcodeseg(seg);
+        }
+
+        seg_data *tlsseg()
+        {
+            return OmfObj_tlsseg();
+        }
+
+        seg_data *tlsseg_bss()
+        {
+            return OmfObj_tlsseg_bss();
+        }
+
+        seg_data *tlsseg_data()
+        {
+            return OmfObj_tlsseg_data();
+        }
+
+        int  fardata(char *name, targ_size_t size, targ_size_t *poffset)
+        {
+            return OmfObj_fardata(name, size, poffset);
+        }
+
+        void export_symbol(Symbol *s, uint argsize)
+        {
+            return OmfObj_export_symbol(s, argsize);
+        }
+
+        void pubdef(int seg, Symbol *s, targ_size_t offset)
+        {
+            return OmfObj_pubdef(seg, s, offset);
+        }
+
+        void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
+        {
+            return OmfObj_pubdefsize(seg, s, offset, symsize);
+        }
+
+        int external_def(const(char)* name)
+        {
+            return OmfObj_external_def(name);
+        }
+
+        int data_start(Symbol *sdata, targ_size_t datasize, int seg)
+        {
+            return OmfObj_data_start(sdata, datasize, seg);
+        }
+
+        int external(Symbol *s)
+        {
+            return OmfObj_external(s);
+        }
+
+        int common_block(Symbol *s, targ_size_t size, targ_size_t count)
+        {
+            return OmfObj_common_block(s, size, count);
+        }
+
+        int common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count)
+        {
+            return OmfObj_common_block(s, flag, size, count);
+        }
+
+        void lidata(int seg, targ_size_t offset, targ_size_t count)
+        {
+            return OmfObj_lidata(seg, offset, count);
+        }
+
+        void write_zeros(seg_data *pseg, targ_size_t count)
+        {
+            return OmfObj_write_zeros(pseg, count);
+        }
+
+        void write_byte(seg_data *pseg, uint _byte)
+        {
+            return OmfObj_write_byte(pseg, _byte);
+        }
+
+        void write_bytes(seg_data *pseg, uint nbytes, void *p)
+        {
+            return OmfObj_write_bytes(pseg, nbytes, p);
+        }
+
+        void _byte(int seg, targ_size_t offset, uint _byte)
+        {
+            return OmfObj_byte(seg, offset, _byte);
+        }
+
+        uint bytes(int seg, targ_size_t offset, uint nbytes, void *p)
+        {
+            return OmfObj_bytes(seg, offset, nbytes, p);
+        }
+
+        void ledata(int seg, targ_size_t offset, targ_size_t data, uint lcfd, uint idx1, uint idx2)
+        {
+            return OmfObj_ledata(seg, offset, data, lcfd, idx1, idx2);
+        }
+
+        void write_long(int seg, targ_size_t offset, uint data, uint lcfd, uint idx1, uint idx2)
+        {
+            return OmfObj_write_long(seg, offset, data, lcfd, idx1, idx2);
+        }
+
+        void reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags)
+        {
+            return OmfObj_reftodatseg(seg, offset, val, targetdatum, flags);
+        }
+
+        void reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags)
+        {
+            return OmfObj_reftofarseg(seg, offset, val, farseg, flags);
+        }
+
+        void reftocodeseg(int seg, targ_size_t offset, targ_size_t val)
+        {
+            return OmfObj_reftocodeseg(seg, offset, val);
+        }
+
+        int reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags)
+        {
+            return OmfObj_reftoident(seg, offset, s, val, flags);
+        }
+
+        void far16thunk(Symbol *s)
+        {
+            return OmfObj_far16thunk(s);
+        }
+
+        void fltused()
+        {
+            return OmfObj_fltused();
+        }
+
+        int data_readonly(char *p, int len, int *pseg)
+        {
+            return OmfObj_data_readonly(p, len, pseg);
+        }
+
+        int data_readonly(char *p, int len)
+        {
+            return OmfObj_data_readonly(p, len);
+        }
+
+        int string_literal_segment(uint sz)
+        {
+            return OmfObj_string_literal_segment(sz);
+        }
+
+        Symbol *sym_cdata(tym_t ty, char *p, int len)
+        {
+            return OmfObj_sym_cdata(ty, p, len);
+        }
+
+        void func_start(Symbol *sfunc)
+        {
+            return OmfObj_func_start(sfunc);
+        }
+
+        void func_term(Symbol *sfunc)
+        {
+            return OmfObj_func_term(sfunc);
+        }
+
+        void write_pointerRef(Symbol* s, uint off)
+        {
+            return OmfObj_write_pointerRef(s, off);
+        }
+
+        int jmpTableSegment(Symbol* s)
+        {
+            return OmfObj_jmpTableSegment(s);
+        }
+
+        Symbol *tlv_bootstrap()
+        {
+            return OmfObj_tlv_bootstrap();
+        }
+
+        void gotref(Symbol *s)
+        {
+            return OmfObj_gotref(s);
+        }
+
+        int seg_debugT()           // where the symbolic debug type data goes
+        {
+            return OmfObj_seg_debugT();
+        }
+
       }
     }
 }
@@ -128,171 +551,546 @@ else version (OMFandMSCOFF)
 {
     class Obj
     {
-      public:
-        static Obj init(Outbuffer *, const(char)* filename, const(char)* csegname);
-        void initfile(const(char)* filename, const(char)* csegname, const(char)* modname);
-        void termfile();
-        void term(const(char)* objfilename);
-        size_t mangle(Symbol *s,char *dest);
-        void _import(elem *e);
-        void linnum(Srcpos srcpos, int seg, targ_size_t offset);
-        int codeseg(char *name,int suffix);
-        void dosseg();
-        void startaddress(Symbol *);
-        bool includelib(const(char)* );
-        bool linkerdirective(const(char)* );
-        bool allowZeroSize();
-        void exestr(const(char)* p);
-        void user(const(char)* p);
-        void compiler();
-        void wkext(Symbol *,Symbol *);
-        void lzext(Symbol *,Symbol *);
-        void _alias(const(char)* n1,const(char)* n2);
+      static
+      {
+        Obj init(Outbuffer* objbuf, const(char)* filename, const(char)* csegname)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_init(objbuf, filename, csegname)
+                :    OmfObj_init(objbuf, filename, csegname);
+        }
 
-        void theadr(const(char)* modname);
-        void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
-        void staticctor(Symbol *s,int dtor,int seg);
-        void staticdtor(Symbol *s);
-        void setModuleCtorDtor(Symbol *s, bool isCtor);
-        void ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
-        void ehsections();
-        void moduleinfo(Symbol *scc);
-        int comdat(Symbol *);
-        int comdatsize(Symbol *, targ_size_t symsize);
-        int readonly_comdat(Symbol *s);
-        void setcodeseg(int seg);
-        seg_data *tlsseg();
-        seg_data *tlsseg_bss();
-        seg_data *tlsseg_data();
-        static int  fardata(char *name, targ_size_t size, targ_size_t *poffset);
-        void export_symbol(Symbol *s, uint argsize);
-        void pubdef(int seg, Symbol *s, targ_size_t offset);
-        void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize);
-        int external_def(const(char)* );
-        int data_start(Symbol *sdata, targ_size_t datasize, int seg);
-        int external(Symbol *);
-        int common_block(Symbol *s, targ_size_t size, targ_size_t count);
-        int common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count);
-        void lidata(int seg, targ_size_t offset, targ_size_t count);
-        void write_zeros(seg_data *pseg, targ_size_t count);
-        void write_byte(seg_data *pseg, uint _byte);
-        void write_bytes(seg_data *pseg, uint nbytes, void *p);
-        void _byte(int seg, targ_size_t offset, uint _byte);
-        uint bytes(int seg, targ_size_t offset, uint nbytes, void *p);
-        void ledata(int seg, targ_size_t offset, targ_size_t data, uint lcfd, uint idx1, uint idx2);
-        void write_long(int seg, targ_size_t offset, uint data, uint lcfd, uint idx1, uint idx2);
-        void reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags);
-        void reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags);
-        void reftocodeseg(int seg, targ_size_t offset, targ_size_t val);
-        int reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags);
-        void far16thunk(Symbol *s);
-        void fltused();
-        int data_readonly(char *p, int len, int *pseg);
-        int data_readonly(char *p, int len);
-        int string_literal_segment(uint sz);
-        Symbol *sym_cdata(tym_t, char *, int);
-        void func_start(Symbol *sfunc);
-        void func_term(Symbol *sfunc);
-        void write_pointerRef(Symbol* s, uint off);
-        int jmpTableSegment(Symbol* s);
+        void initfile(const(char)* filename, const(char)* csegname, const(char)* modname)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_initfile(filename, csegname, modname)
+                :    OmfObj_initfile(filename, csegname, modname);
+        }
 
-        Symbol *tlv_bootstrap();
+        void termfile()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_termfile()
+                :    OmfObj_termfile();
+        }
 
-        static void gotref(Symbol *s);
+        void term(const(char)* objfilename)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_term(objfilename)
+                :    OmfObj_term(objfilename);
+        }
 
-        int seg_debugT();           // where the symbolic debug type data goes
-    }
+        size_t mangle(Symbol *s,char *dest)
+        {
+            assert(config.objfmt == OBJ_OMF);
+            return OmfObj_mangle(s, dest);
+        }
 
+        void _import(elem *e)
+        {
+            assert(config.objfmt == OBJ_OMF);
+            return OmfObj_import(e);
+        }
 
-    class MsCoffObj : Obj
-    {
-      public:
-        static MsCoffObj init(Outbuffer *, const(char)* filename, const(char)* csegname);
-        override void initfile(const(char)* filename, const(char)* csegname, const(char)* modname);
-        override void termfile();
-        override void term(const(char)* objfilename);
-        override void compiler();
-        override void exestr(const(char)* p);
-        //override void dosseg();
-        //override size_t mangle(Symbol *s,char *dest);
-        override void startaddress(Symbol *);
-        override bool includelib(const(char)* );
-        override bool linkerdirective(const(char)* );
-        override void _alias(const(char)* n1,const(char)* n2);
-        override void user(const(char)* p);
-    //    void _import(elem *e);
-        override void linnum(Srcpos srcpos, int seg, targ_size_t offset);
-        override int codeseg(char *name,int suffix);
-        override bool allowZeroSize();
-        override void wkext(Symbol *,Symbol *);
-    //    void lzext(Symbol *,Symbol *);
-    //    void theadr(const(char)* modname);
-    //    void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize);
-        override void staticctor(Symbol *s,int dtor,int seg);
-        override void staticdtor(Symbol *s);
-        override void setModuleCtorDtor(Symbol *s, bool isCtor);
-        override void ehtables(Symbol *sfunc,uint size,Symbol *ehsym);
-        override void ehsections();
-        override void moduleinfo(Symbol *scc);
-        override int comdat(Symbol *);
-        override int comdatsize(Symbol *, targ_size_t symsize);
-        override int readonly_comdat(Symbol *s);
-        override void setcodeseg(int seg);
-        override seg_data *tlsseg();
-        override seg_data *tlsseg_bss();
-        override seg_data *tlsseg_data();
-        override void export_symbol(Symbol *s, uint argsize);
-        override void pubdef(int seg, Symbol *s, targ_size_t offset);
-        override void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize);
-    //    int external(const(char)* );
-        override int external_def(const(char)* );
-        override int data_start(Symbol *sdata, targ_size_t datasize, int seg);
-        override int external(Symbol *);
-        override int common_block(Symbol *s, targ_size_t size, targ_size_t count);
-        override int common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count);
-        override void lidata(int seg, targ_size_t offset, targ_size_t count);
-        override void write_zeros(seg_data *pseg, targ_size_t count);
-        override void write_byte(seg_data *pseg, uint _byte);
-        override void write_bytes(seg_data *pseg, uint nbytes, void *p);
-        override void _byte(int seg, targ_size_t offset, uint _byte);
-        override uint bytes(int seg, targ_size_t offset, uint nbytes, void *p);
-    //    void ledata(int seg, targ_size_t offset, targ_size_t data, uint lcfd, uint idx1, uint idx2);
-    //    void write_long(int seg, targ_size_t offset, uint data, uint lcfd, uint idx1, uint idx2);
-        override void reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags);
-    //    void reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags);
-        override void reftocodeseg(int seg, targ_size_t offset, targ_size_t val);
-        override int reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags);
-        override void far16thunk(Symbol *s);
-        override void fltused();
-        override int data_readonly(char *p, int len, int *pseg);
-        override int data_readonly(char *p, int len);
-        override int string_literal_segment(uint sz);
-        override Symbol *sym_cdata(tym_t, char *, int);
-        static  uint addstr(Outbuffer *strtab, const(char)* );
-        static void func_start(Symbol *sfunc);
-        static void func_term(Symbol *sfunc);
-        override void write_pointerRef(Symbol* s, uint off);
-        override int jmpTableSegment(Symbol* s);
+        void linnum(Srcpos srcpos, int seg, targ_size_t offset)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_linnum(srcpos, seg, offset)
+                :    OmfObj_linnum(srcpos, seg, offset);
+        }
 
-        static int getsegment(const(char)* sectname, uint flags);
-        static int getsegment2( uint shtidx);
-        static  uint addScnhdr(const(char)* scnhdr_name, uint flags);
+        int codeseg(char *name,int suffix)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_codeseg(name, suffix)
+                :    OmfObj_codeseg(name, suffix);
+        }
 
-        static void addrel(int seg, targ_size_t offset, Symbol *targsym,
-             uint targseg, int rtype, int val);
-    //    static void addrel(int seg, targ_size_t offset, uint type,
-    //                                         uint symidx, targ_size_t val);
+        void dosseg()
+        {
+            assert(config.objfmt == OBJ_OMF);
+            return OmfObj_dosseg();
+        }
 
-        static int seg_pdata();
-        static int seg_xdata();
-        static int seg_pdata_comdat(Symbol *sfunc);
-        static int seg_xdata_comdat(Symbol *sfunc);
+        void startaddress(Symbol *s)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_startaddress(s)
+                :    OmfObj_startaddress(s);
+        }
 
-        static int seg_debugS();
-        override int seg_debugT();
-        static int seg_debugS_comdat(Symbol *sfunc);
+        bool includelib(const(char)* name)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_includelib(name)
+                :    OmfObj_includelib(name);
+        }
 
-        override Symbol *tlv_bootstrap();
+        bool linkerdirective(const(char)* p)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_linkerdirective(p)
+                :    OmfObj_linkerdirective(p);
+        }
+
+        bool allowZeroSize()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_allowZeroSize()
+                :    OmfObj_allowZeroSize();
+        }
+
+        void exestr(const(char)* p)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_exestr(p)
+                :    OmfObj_exestr(p);
+        }
+
+        void user(const(char)* p)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_user(p)
+                :    OmfObj_user(p);
+        }
+
+        void compiler()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_compiler()
+                :    OmfObj_compiler();
+        }
+
+        void wkext(Symbol* s1, Symbol* s2)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_wkext(s1, s2)
+                :    OmfObj_wkext(s1, s2);
+        }
+
+        void lzext(Symbol* s1, Symbol* s2)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? assert(0)
+                : OmfObj_lzext(s1, s2);
+        }
+
+        void _alias(const(char)* n1,const(char)* n2)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_alias(n1, n2)
+                :    OmfObj_alias(n1, n2);
+        }
+
+        void theadr(const(char)* modname)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? assert(0)
+                : OmfObj_theadr(modname);
+        }
+
+        void segment_group(targ_size_t codesize, targ_size_t datasize, targ_size_t cdatasize, targ_size_t udatasize)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? assert(0)
+                : OmfObj_segment_group(codesize, datasize, cdatasize, udatasize);
+        }
+
+        void staticctor(Symbol *s,int dtor,int seg)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_staticctor(s, dtor, seg)
+                :    OmfObj_staticctor(s, dtor, seg);
+        }
+
+        void staticdtor(Symbol *s)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_staticdtor(s)
+                :    OmfObj_staticdtor(s);
+        }
+
+        void setModuleCtorDtor(Symbol *s, bool isCtor)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_setModuleCtorDtor(s, isCtor)
+                :    OmfObj_setModuleCtorDtor(s, isCtor);
+        }
+
+        void ehtables(Symbol *sfunc,uint size,Symbol *ehsym)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_ehtables(sfunc, size, ehsym)
+                :    OmfObj_ehtables(sfunc, size, ehsym);
+        }
+
+        void ehsections()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_ehsections()
+                :    OmfObj_ehsections();
+        }
+
+        void moduleinfo(Symbol *scc)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_moduleinfo(scc)
+                :    OmfObj_moduleinfo(scc);
+        }
+
+        int comdat(Symbol *s)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_comdat(s)
+                :    OmfObj_comdat(s);
+        }
+
+        int comdatsize(Symbol *s, targ_size_t symsize)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_comdatsize(s, symsize)
+                :    OmfObj_comdatsize(s, symsize);
+        }
+
+        int readonly_comdat(Symbol *s)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_comdat(s)
+                :    OmfObj_comdat(s);
+        }
+
+        void setcodeseg(int seg)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_setcodeseg(seg)
+                :    OmfObj_setcodeseg(seg);
+        }
+
+        seg_data *tlsseg()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_tlsseg()
+                :    OmfObj_tlsseg();
+        }
+
+        seg_data *tlsseg_bss()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_tlsseg_bss()
+                :    OmfObj_tlsseg_bss();
+        }
+
+        seg_data *tlsseg_data()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_tlsseg_data()
+                :    OmfObj_tlsseg_data();
+        }
+
+        int  fardata(char *name, targ_size_t size, targ_size_t *poffset)
+        {
+            assert(config.objfmt == OBJ_OMF);
+            return OmfObj_fardata(name, size, poffset);
+        }
+
+        void export_symbol(Symbol *s, uint argsize)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_export_symbol(s, argsize)
+                :    OmfObj_export_symbol(s, argsize);
+        }
+
+        void pubdef(int seg, Symbol *s, targ_size_t offset)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_pubdef(seg, s, offset)
+                :    OmfObj_pubdef(seg, s, offset);
+        }
+
+        void pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_pubdefsize(seg, s, offset, symsize)
+                :    OmfObj_pubdefsize(seg, s, offset, symsize);
+        }
+
+        int external_def(const(char)* name)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_external_def(name)
+                :    OmfObj_external_def(name);
+        }
+
+        int data_start(Symbol *sdata, targ_size_t datasize, int seg)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_data_start(sdata, datasize, seg)
+                :    OmfObj_data_start(sdata, datasize, seg);
+        }
+
+        int external(Symbol *s)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_external(s)
+                :    OmfObj_external(s);
+        }
+
+        int common_block(Symbol *s, targ_size_t size, targ_size_t count)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_common_block(s, size, count)
+                :    OmfObj_common_block(s, size, count);
+        }
+
+        int common_block(Symbol *s, int flag, targ_size_t size, targ_size_t count)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_common_block(s, flag, size, count)
+                :    OmfObj_common_block(s, flag, size, count);
+        }
+
+        void lidata(int seg, targ_size_t offset, targ_size_t count)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_lidata(seg, offset, count)
+                :    OmfObj_lidata(seg, offset, count);
+        }
+
+        void write_zeros(seg_data *pseg, targ_size_t count)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_write_zeros(pseg, count)
+                :    OmfObj_write_zeros(pseg, count);
+        }
+
+        void write_byte(seg_data *pseg, uint _byte)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_write_byte(pseg, _byte)
+                :    OmfObj_write_byte(pseg, _byte);
+        }
+
+        void write_bytes(seg_data *pseg, uint nbytes, void *p)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_write_bytes(pseg, nbytes, p)
+                :    OmfObj_write_bytes(pseg, nbytes, p);
+        }
+
+        void _byte(int seg, targ_size_t offset, uint _byte)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_byte(seg, offset, _byte)
+                :    OmfObj_byte(seg, offset, _byte);
+        }
+
+        uint bytes(int seg, targ_size_t offset, uint nbytes, void *p)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_bytes(seg, offset, nbytes, p)
+                :    OmfObj_bytes(seg, offset, nbytes, p);
+        }
+
+        void ledata(int seg, targ_size_t offset, targ_size_t data, uint lcfd, uint idx1, uint idx2)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? assert(0)
+                : OmfObj_ledata(seg, offset, data, lcfd, idx1, idx2);
+        }
+
+        void write_long(int seg, targ_size_t offset, uint data, uint lcfd, uint idx1, uint idx2)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? assert(0)
+                : OmfObj_write_long(seg, offset, data, lcfd, idx1, idx2);
+        }
+
+        void reftodatseg(int seg, targ_size_t offset, targ_size_t val, uint targetdatum, int flags)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_reftodatseg(seg, offset, val, targetdatum, flags)
+                :    OmfObj_reftodatseg(seg, offset, val, targetdatum, flags);
+        }
+
+        void reftofarseg(int seg, targ_size_t offset, targ_size_t val, int farseg, int flags)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? assert(0)
+                : OmfObj_reftofarseg(seg, offset, val, farseg, flags);
+        }
+
+        void reftocodeseg(int seg, targ_size_t offset, targ_size_t val)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_reftocodeseg(seg, offset, val)
+                :    OmfObj_reftocodeseg(seg, offset, val);
+        }
+
+        int reftoident(int seg, targ_size_t offset, Symbol *s, targ_size_t val, int flags)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_reftoident(seg, offset, s, val, flags)
+                :    OmfObj_reftoident(seg, offset, s, val, flags);
+        }
+
+        void far16thunk(Symbol *s)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_far16thunk(s)
+                :    OmfObj_far16thunk(s);
+        }
+
+        void fltused()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_fltused()
+                :    OmfObj_fltused();
+        }
+
+        int data_readonly(char *p, int len, int *pseg)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_data_readonly(p, len, pseg)
+                :    OmfObj_data_readonly(p, len, pseg);
+        }
+
+        int data_readonly(char *p, int len)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_data_readonly(p, len)
+                :    OmfObj_data_readonly(p, len);
+        }
+
+        int string_literal_segment(uint sz)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_string_literal_segment(sz)
+                :    OmfObj_string_literal_segment(sz);
+        }
+
+        Symbol *sym_cdata(tym_t ty, char *p, int len)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_sym_cdata(ty, p, len)
+                :    OmfObj_sym_cdata(ty, p, len);
+        }
+
+        void func_start(Symbol *sfunc)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_func_start(sfunc)
+                :    OmfObj_func_start(sfunc);
+        }
+
+        void func_term(Symbol *sfunc)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_func_term(sfunc)
+                :    OmfObj_func_term(sfunc);
+        }
+
+        void write_pointerRef(Symbol* s, uint off)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_write_pointerRef(s, off)
+                :    OmfObj_write_pointerRef(s, off);
+        }
+
+        int jmpTableSegment(Symbol* s)
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_jmpTableSegment(s)
+                :    OmfObj_jmpTableSegment(s);
+        }
+
+        Symbol *tlv_bootstrap()
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_tlv_bootstrap()
+                :    OmfObj_tlv_bootstrap();
+        }
+
+        void gotref(Symbol *s)
+        {
+        }
+
+        int seg_debugT()           // where the symbolic debug type data goes
+        {
+            return config.objfmt == OBJ_MSCOFF
+                ? MsCoffObj_seg_debugT()
+                :    OmfObj_seg_debugT();
+        }
+
+        /*******************************************/
+
+        int  getsegment(const(char)* sectname, uint flags)
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_getsegment(sectname, flags);
+        }
+
+        int  getsegment2(uint shtidx)
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_getsegment2(shtidx);
+        }
+
+        uint addScnhdr(const(char)* scnhdr_name, uint flags)
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_addScnhdr(scnhdr_name, flags);
+        }
+
+        void addrel(int seg, targ_size_t offset, Symbol *targsym,
+                              uint targseg, int rtype, int val)
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_addrel(seg, offset, targsym, targseg, rtype, val);
+        }
+
+        int  seg_drectve()
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_seg_drectve();
+        }
+
+        int  seg_pdata()
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_seg_pdata();
+        }
+
+        int  seg_xdata()
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_seg_xdata();
+        }
+
+        int  seg_pdata_comdat(Symbol *sfunc)
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_seg_pdata_comdat(sfunc);
+        }
+
+        int  seg_xdata_comdat(Symbol *sfunc)
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_seg_xdata_comdat(sfunc);
+        }
+
+        int  seg_debugS()
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_seg_debugS();
+        }
+
+        int  seg_debugS_comdat(Symbol *sfunc)
+        {
+            assert(config.objfmt == OBJ_MSCOFF);
+            return MsCoffObj_seg_debugS_comdat(sfunc);
+        }
+      }
     }
 }
 else version (Posix)
@@ -309,7 +1107,7 @@ else version (Posix)
         static void dosseg();
         static void startaddress(Symbol *);
         static bool includelib(const(char)* );
-        static bool linkerdirective(const char *);
+        static bool linkerdirective(const(char)* p);
         static size_t mangle(Symbol *s,char *dest);
         static void _alias(const(char)* n1,const(char)* n2);
         static void user(const(char)* p);

--- a/src/dmd/backend/obj.h
+++ b/src/dmd/backend/obj.h
@@ -34,11 +34,11 @@ struct seg_data;
 #endif
 
 
-#if OMF
+#if OMF || OMFandMSCOFF
     class Obj
     {
       public:
-        static Obj *init(Outbuffer *, const char *filename, const char *csegname);
+//        static Obj *init(Outbuffer *, const char *filename, const char *csegname);
         static void initfile(const char *filename, const char *csegname, const char *modname);
         static void termfile();
         static void term(const char *objfilename);
@@ -65,9 +65,9 @@ struct seg_data;
         static void ehtables(Symbol *sfunc,unsigned size,Symbol *ehsym);
         static void ehsections();
         static void moduleinfo(Symbol *scc);
-        int  comdat(Symbol *);
-        int  comdatsize(Symbol *, targ_size_t symsize);
-        int readonly_comdat(Symbol *s);
+        static int  comdat(Symbol *);
+        static int  comdatsize(Symbol *, targ_size_t symsize);
+        static int readonly_comdat(Symbol *s);
         static void setcodeseg(int seg);
         static seg_data *tlsseg();
         static seg_data *tlsseg_bss();

--- a/src/dmd/backend/pdata.d
+++ b/src/dmd/backend/pdata.d
@@ -100,7 +100,7 @@ void win64_pdata(Symbol *sf)
     dtb.xoff(sunwind,0,TYint);
     spdata.Sdt = dtb.finish();
 
-    spdata.Sseg = symbol_iscomdat3(sf) ? MsCoffObj.seg_pdata_comdat(sf) : MsCoffObj.seg_pdata();
+    spdata.Sseg = symbol_iscomdat3(sf) ? MsCoffObj_seg_pdata_comdat(sf) : MsCoffObj_seg_pdata();
     spdata.Salignment = 4;
     outdata(spdata);
 
@@ -129,7 +129,7 @@ Symbol *win64_unwind(Symbol *sf)
     symbol_debug(sunwind);
 
     sunwind.Sdt = unwind_data();
-    sunwind.Sseg = symbol_iscomdat3(sf) ? MsCoffObj.seg_xdata_comdat(sf) : MsCoffObj.seg_xdata();
+    sunwind.Sseg = symbol_iscomdat3(sf) ? MsCoffObj_seg_xdata_comdat(sf) : MsCoffObj_seg_xdata();
     sunwind.Salignment = 1;
     outdata(sunwind);
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -257,8 +257,8 @@ void obj_start(const(char)* srcfile)
     {
         // Produce Ms COFF files for 64 bit code, OMF for 32 bit code
         assert(objbuf.size() == 0);
-        objmod = global.params.mscoff ? MsCoffObj.init(&objbuf, srcfile, null)
-                                      :       Obj.init(&objbuf, srcfile, null);
+        objmod = global.params.mscoff ? MsCoffObj_init(&objbuf, srcfile, null)
+                                      :    OmfObj_init(&objbuf, srcfile, null);
     }
     else
     {


### PR DESCRIPTION
This changes the member functions in obj.d from virtuals to statics. It's the most straightforward way to convert cgobj.c and mscoffobj.c to D. Will do the same treatment later to elfobj.c and machobj.c.