### PR TITLE
Fix Issue 16633 - Case where an alias this is tried before the object itself

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -456,7 +456,14 @@ private Expression checkAliasThisForLhs(AggregateDeclaration ad, Scope* sc, BinE
     if (!be.att1 && e.e1.type.checkAliasThisRec())
         be.att1 = e.e1.type;
     be.e1 = e1;
-    return be.trySemantic(sc);
+
+    Expression result;
+    if (be.op == TOK.concatenateAssign)
+        result = be.op_overload(sc);
+    else
+        result = be.trySemantic(sc);
+
+    return result;
 }
 
 // Try alias this on second operand
@@ -475,7 +482,14 @@ private Expression checkAliasThisForRhs(AggregateDeclaration ad, Scope* sc, BinE
     if (!be.att2 && e.e2.type.checkAliasThisRec())
         be.att2 = e.e2.type;
     be.e2 = e2;
-    return be.trySemantic(sc);
+
+    Expression result;
+    if (be.op == TOK.concatenateAssign)
+        result = be.op_overload(sc);
+    else
+        result = be.trySemantic(sc);
+
+    return result;
 }
 
 /************************************

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -2057,6 +2057,25 @@ void test19284()
     assert(t.x == 5);
 }
 
+// 16633
+
+class Item
+{
+    alias children this;
+    Item[] children;
+    void populate()
+    {
+        children ~= new Item(); // Item is seen as []
+        assert(children.length == 1);
+    }
+}
+
+void test16633()
+{
+    Item root = new Item();
+    root.populate;
+}
+
 int main()
 {
     test1();
@@ -2114,6 +2133,7 @@ int main()
     test11355();
     test14806();
     test19284();
+    test16633();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
A few explanations: when a concatenateAssign operation (**~=**) is semantically analyzed (in `visit(CatAssignExp)`), the first thing that is done is a check if there's an opOpAssign overload that can take care of this. For this, the `op_overload` function is called in `opover.d`. op_overload for BinAssignExps first tries to match an overload with the current types and if this fails it also tries the alias thises of the 2 operands. Now here's the catch: when it tries the alias this it does not call op_overload recursively on the alias this, but calls `visit(CatAssignExp)` instead; if this yields a result, then it returns it, otherwise, null. The problem here is that this is wrong in terms of semantic, because it should call op_overload on the alias this (what we are supposed to check is if there is an opOpAssign overload, not if the alias this succeeds). In my opinion, the trySemantic check in op_overload should be replaced entirely with a recursive call to op_overload. I tried this, but unfortunately all other BinAssignExps rely on the fact that alias this is tried in op_overload. This should be fixed in a subsequent PR.