### PR TITLE
fix issue 19307 - Variables moved to a closure show nonsense in debugger

### DIFF
--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -705,6 +705,8 @@ void cv8_outsym(Symbol *s)
         case_auto:
             base = cast(uint)Auto.size;
         L1:
+            if (s.Sscope) // local variables moved into the closure cannot be emitted directly
+                break;
 static if (1)
 {
             // Register relative addressing

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -2515,6 +2515,8 @@ else
             case_auto:
                 base = Auto.size;
             L1:
+                if (s.Sscope) // local variables moved into the closure cannot be emitted directly
+                    goto Lret;
                 TOWORD(debsym + 2,I32 ? S_BPREL32 : S_BPREL16);
                 if (config.fulltypes == CV4)
                 {   TOOFFSET(debsym + 4,s.Soffset + base + BPoff);

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -949,6 +949,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     {
         assert(!fd.vthis.csym);
         sthis = toSymbol(fd.vthis);
+        sthis.Stype = getParentClosureType(sthis, fd);
         irs.sthis = sthis;
         if (!(f.Fflags3 & Fnested))
             f.Fflags3 |= Fmember;

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -45,6 +45,7 @@ import dmd.backend.cdef;
 import dmd.backend.cgcv;
 import dmd.backend.code;
 import dmd.backend.cv4;
+import dmd.backend.dlist;
 import dmd.backend.dt;
 import dmd.backend.global;
 import dmd.backend.obj;
@@ -292,6 +293,33 @@ uint cv_align(ubyte *p, uint n)
     return n;
 }
 
+/*************************************
+ * write a UDT record to the object file
+ * Params:
+ *      id = name of user defined type
+ *      typidx = type index
+ */
+void cv_udt(const char* id, uint typidx)
+{
+    if (config.fulltypes == CV8)
+        cv8_udt(id, typidx);
+    else
+    {
+        const len = strlen(id);
+        ubyte *debsym = cast(ubyte *) alloca(39 + IDOHD + len);
+
+        // Output a 'user-defined type' for the tag name
+        TOWORD(debsym + 2,S_UDT);
+        TOIDX(debsym + 4,typidx);
+        uint length = 2 + 2 + cgcv.sz_idx;
+        length += cv_namestring(debsym + length,id);
+        TOWORD(debsym,length - 2);
+
+        assert(length <= 40 + len);
+        objmod.write_bytes(SegData[DEBSYM],length,debsym);
+    }
+}
+
 /* ==================================================================== */
 
 /****************************
@@ -309,23 +337,7 @@ void toDebug(EnumDeclaration ed)
     {
         const id = ed.toPrettyChars(true);
         const idx_t typidx = cv4_Denum(ed);
-        if (config.fulltypes == CV8)
-            cv8_udt(id, typidx);
-        else
-        {
-            const len = strlen(id);
-            ubyte *debsym = cast(ubyte *) alloca(39 + IDOHD + len);
-
-            // Output a 'user-defined type' for the tag name
-            TOWORD(debsym + 2,S_UDT);
-            TOIDX(debsym + 4,typidx);
-            uint length = 2 + 2 + cgcv.sz_idx;
-            length += cv_namestring(debsym + length,id);
-            TOWORD(debsym,length - 2);
-
-            assert(length <= 40 + len);
-            objmod.write_bytes(SegData[DEBSYM],length,cast(void*)debsym);
-        }
+        cv_udt(id, typidx);
     }
 }
 
@@ -498,23 +510,7 @@ void toDebug(StructDeclaration sd)
 
 //    cv4_outsym(s);
 
-    if (config.fulltypes == CV8)
-        cv8_udt(id, typidx);
-    else
-    {
-        const idlen = strlen(id);
-        ubyte *debsym = cast(ubyte *) alloca(39 + IDOHD + idlen);
-
-        // Output a 'user-defined type' for the tag name
-        TOWORD(debsym + 2,S_UDT);
-        TOIDX(debsym + 4,typidx);
-        uint length = 2 + 2 + cgcv.sz_idx;
-        length += cv_namestring(debsym + length,id);
-        TOWORD(debsym,length - 2);
-
-        assert(length <= 40 + idlen);
-        objmod.write_bytes(SegData[DEBSYM],length,debsym);
-    }
+    cv_udt(id, typidx);
 
 //    return typidx;
 }
@@ -727,27 +723,120 @@ void toDebug(ClassDeclaration cd)
 
 //    cv4_outsym(s);
 
-    if (config.fulltypes == CV8)
-        cv8_udt(id, typidx);
-    else
-    {
-        const idlen = strlen(id);
-        ubyte *debsym = cast(ubyte *) alloca(39 + IDOHD + idlen);
-
-        // Output a 'user-defined type' for the tag name
-        TOWORD(debsym + 2,S_UDT);
-        TOIDX(debsym + 4,typidx);
-        uint length = 2 + 2 + cgcv.sz_idx;
-        length += cv_namestring(debsym + length,id);
-        TOWORD(debsym,length - 2);
-
-        assert(length <= 40 + idlen);
-        objmod.write_bytes(SegData[DEBSYM],length,debsym);
-    }
+    cv_udt(id, typidx);
 
 //    return typidx;
 }
 
+private uint writeField(ubyte* p, const char* id, uint attr, uint typidx, uint offset)
+{
+    if (config.fulltypes == CV8)
+    {
+        TOWORD(p,LF_MEMBER_V3);
+        TOWORD(p + 2,attr);
+        TOLONG(p + 4,typidx);
+        cv4_storenumeric(p + 8, offset);
+        uint len = 8 + cv4_numericbytes(offset);
+        len += cv_namestring(p + len, id);
+        return cv_align(p + len, len);
+    }
+    else
+    {
+        TOWORD(p,LF_MEMBER);
+        TOWORD(p + 2,typidx);
+        TOWORD(p + 4,attr);
+        cv4_storenumeric(p + 6, offset);
+        uint len = 6 + cv4_numericbytes(offset);
+        return len + cv_namestring(p + len, id);
+    }
+}
+
+void toDebugClosure(Symbol* closstru)
+{
+    //printf("toDebugClosure('%s')\n", fd.toChars());
+
+    assert(config.fulltypes >= CV4);
+
+    uint leaf = config.fulltypes == CV8 ? LF_STRUCTURE_V3 : LF_STRUCTURE;
+    uint numidx = leaf == LF_STRUCTURE ? 12 : 18;
+    uint structsize = cast(uint)(closstru.Sstruct.Sstructsize);
+    const char* closname = closstru.Sident.ptr;
+
+    const len1 = numidx + cv4_numericbytes(structsize);
+    debtyp_t *d = debtyp_alloc(len1 + cv_stringbytes(closname));
+    cv4_storenumeric(d.data.ptr + numidx, structsize);
+    const uint len = len1 + cv_namestring(d.data.ptr + len1, closname);
+
+    if (leaf == LF_STRUCTURE)
+    {
+        TOWORD(d.data.ptr + 8,0);          // dList
+        TOWORD(d.data.ptr + 10,0);         // vshape is 0 (no virtual functions)
+    }
+    else // LF_STRUCTURE_V3
+    {
+        TOLONG(d.data.ptr + 10,0);         // dList
+        TOLONG(d.data.ptr + 14,0);         // vshape is 0 (no virtual functions)
+    }
+    TOWORD(d.data.ptr,leaf);
+
+    // Assign a number to prevent infinite recursion if a struct member
+    // references the same struct.
+    const length_save = d.length;
+    d.length = 0;                      // so cv_debtyp() will allocate new
+    const idx_t typidx = cv_debtyp(d);
+    d.length = length_save;            // restore length
+
+    // Compute the number of fields (nfields), and the length of the fieldlist record (flistlen)
+    uint nfields = 0;
+    uint flistlen = 2;
+    for (auto sl = closstru.Sstruct.Sfldlst; sl; sl = list_next(sl))
+    {
+        Symbol *sf = list_symbol(sl);
+        uint thislen = (config.fulltypes == CV8 ? 8 : 6);
+        thislen += cv4_numericbytes(cast(uint)sf.Smemoff);
+        thislen += cv_stringbytes(sf.Sident.ptr);
+        thislen = cv_align(null, thislen);
+
+        if (config.fulltypes != CV8 && flistlen + thislen > CV4_NAMELENMAX)
+            break; // Too long, fail gracefully
+
+        flistlen += thislen;
+        nfields++;
+    }
+
+    // Generate fieldlist type record
+    debtyp_t *dt = debtyp_alloc(flistlen);
+    ubyte *p = dt.data.ptr;
+
+    // And fill it in
+    TOWORD(p, config.fulltypes == CV8 ? LF_FIELDLIST_V2 : LF_FIELDLIST);
+    uint flistoff = 2;
+    for (auto sl = closstru.Sstruct.Sfldlst; sl && flistoff < flistlen; sl = list_next(sl))
+    {
+        Symbol *sf = list_symbol(sl);
+        idx_t vtypidx = cv_typidx(sf.Stype);
+        flistoff += writeField(p + flistoff, sf.Sident.ptr, 3 /*public*/, vtypidx, cast(uint)sf.Smemoff);
+    }
+
+    //dbg_printf("fnamelen = %d, p-dt.data.ptr = %d\n",fnamelen,p-dt.data.ptr);
+    assert(flistoff == flistlen);
+    const idx_t fieldlist = cv_debtyp(dt);
+
+    uint property = 0;
+    TOWORD(d.data.ptr + 2, nfields);
+    if (config.fulltypes == CV8)
+    {
+        TOWORD(d.data.ptr + 4,property);
+        TOLONG(d.data.ptr + 6,fieldlist);
+    }
+    else
+    {
+        TOWORD(d.data.ptr + 4,fieldlist);
+        TOWORD(d.data.ptr + 6,property);
+    }
+
+    cv_udt(closname, typidx);
+}
 
 /* ===================================================================== */
 
@@ -1050,6 +1139,7 @@ else
     import dmd.denum;
     import dmd.dstruct;
     import dmd.dclass;
+    import dmd.backend.cc;
 
     /****************************
      * Stub them out.
@@ -1065,6 +1155,10 @@ else
     }
 
     extern (C++) void toDebug(ClassDeclaration cd)
+    {
+    }
+
+    extern (C++) void toDebugClosure(Symbol* closstru)
     {
     }
 }

--- a/test/runnable/testpdb.d
+++ b/test/runnable/testpdb.d
@@ -41,6 +41,8 @@ void main(string[] args)
 
         S18984 s = test18984(session, globals);
 
+        test19307(session, globals);
+        
         source.Release();
         session.Release();
         globals.Release();
@@ -127,6 +129,89 @@ S18984 test18984(IDiaSession session, IDiaSymbol globals)
     S18984 s = S18984(1, 2, 3);
     s.a = 4;
     return s; // NRVO
+}
+
+///////////////////////////////////////////////
+// https://issues.dlang.org/show_bug.cgi?id=19307
+// variables moved to closure
+struct Struct
+{
+    int member = 1;
+    auto foo()
+    {
+        int localOfMethod = 2;
+        auto nested()
+        {
+            int localOfNested = 3;
+            return localOfNested + localOfMethod + member;
+        }
+        return &nested;
+    }
+}
+
+int foo19307()
+{
+    Struct s;
+    s.foo()();
+
+    int x = 7;
+    auto nested()
+    {
+        int y = 8;
+        auto nested2()
+        {
+            int z = 9;
+            return x + y + z;
+        }
+        return &nested2;
+    }
+    return nested()();
+}
+
+string toUTF8(wstring ws)
+{
+    string s;
+    foreach(dchar c; ws)
+        s ~= c;
+    return s;
+}
+
+IDiaSymbol testClosureVar(IDiaSymbol globals, wstring funcName, wstring[] varNames...)
+{
+    IDiaSymbol funcSym = searchSymbol(globals, funcName.ptr);
+    funcSym || assert(false, toUTF8(funcName ~ " not found"));
+
+    wstring varName = funcName;
+    IDiaSymbol parentSym = funcSym;
+    foreach(v, var; varNames)
+    {
+        varName ~= "." ~ var;
+        IDiaSymbol varSym = searchSymbol(parentSym, var.ptr);
+        varSym || assert(false, toUTF8(varName ~ " not found"));
+
+        if (v + 1 == varNames.length)
+            return varSym;
+            
+        IDiaSymbol varType;
+        varSym.get_type(&varType) == S_OK || assert(false, toUTF8(varName ~ ": no type"));
+        varType.get_type(&varType) == S_OK || assert(false, toUTF8(varName ~ ": no ptrtype"));
+        parentSym = varType;
+    }    
+    return parentSym;
+}
+
+void test19307(IDiaSession session, IDiaSymbol globals)
+{
+    foo19307();
+
+    testClosureVar(globals, "testpdb.foo19307", "__closptr", "x");
+    testClosureVar(globals, "testpdb.foo19307.nested", "this", "x");
+    testClosureVar(globals, "testpdb.foo19307.nested", "__closptr", "y");
+    testClosureVar(globals, "testpdb.foo19307.nested.nested2", "this", "__chain", "x");
+
+    testClosureVar(globals, "testpdb.Struct.foo", "__closptr", "this", "member");
+    testClosureVar(globals, "testpdb.Struct.foo.nested", "this", "localOfMethod");
+    testClosureVar(globals, "testpdb.Struct.foo.nested", "this", "__chain", "member");
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
This generates struct type debug information for allocated closures. 

AFAICT there is DWARF support for the local variables moved into the closure, but not for locals captured from outer functions.

Unfortunately CodeView doesn't have a way to emit a DWARF-like expressions with indirections to evaluate variables. (The S_DEFRANGE record allows a "program" to be evaluated, but no debugger or other tool seems to implement that).

The mago debugger can be adopted to merge members of "__closptr" and "this" with the local variables, but these variables can also be inspected without that.

This does not yet cover access to outer variables without an allocated closure.