### PR TITLE
Remove compatibility support for D 2.06x

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -57,7 +57,6 @@ enum LF = '\n';             // \n into \r and \r into \n.  The translator versio
 enum CR_STR = "\r";
 enum LF_STR = "\n";
 
-enum SCMAX_ = SCMAX; // workaround gdc build failure (can be removed if gdc > 2.068)
 extern __gshared
 {
     uint[32] mask;                  // bit masks
@@ -70,7 +69,7 @@ extern __gshared
     symtab_t globsym;
 
 //    Config config;                  // precompiled part of configuration
-    char[SCMAX_] sytab;
+    char[SCMAX] sytab;
 
     extern (C) /*volatile*/ int controlc_saw;    // a control C was seen
     uint maxblks;                   // array max for all block stuff
@@ -396,9 +395,6 @@ Symbol *out_readonly_sym(tym_t ty, void *p, int len);
 Symbol *out_string_literal(const(char)* str, uint len, uint sz);
 
 /* blockopt.c */
-// Workaround 2.066.x bug by resolving the TYMAX value before using it as dimension.
-static if (__VERSION__ <= 2066)
-    private enum computeEnumValue = BCMAX;
 extern __gshared uint[BCMAX] bc_goal;
 
 block* block_calloc();

--- a/src/dmd/backend/oper.d
+++ b/src/dmd/backend/oper.d
@@ -305,10 +305,6 @@ int convidx(OPER op) { return op - CNVOPMIN; }
  *      OTboolnop       operation is a nop if boolean result is desired
  */
 
-// Workaround 2.066.x bug by resolving the TYMAX value before using it as dimension.
-static if (__VERSION__ <= 2066)
-    private enum computeEnumValue = OPMAX;
-
 extern (C)
 {
     extern __gshared ubyte[OPMAX] optab1;

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -321,10 +321,6 @@ uint tyfarfunc(tym_t ty) { return tytab[ty & 0xFF] & TYFLfarfunc; }
 // Determine if parameter is a SIMD vector type
 uint tysimd(tym_t ty) { return tytab[ty & 0xFF] & TYFLsimd; }
 
-// Workaround 2.066.x bug by resolving the TYMAX value before using it as dimension.
-static if (__VERSION__ <= 2066)
-    private enum computeEnumValue = TYMAX;
-
 /* Determine relaxed type       */
 extern __gshared ubyte[TYMAX] _tyrelax;
 uint tyrelax(tym_t ty) { return _tyrelax[tybasic(ty)]; }

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -116,10 +116,6 @@ void type_debug(type* t)
     debug assert(t.id == t.IDtype);
 }
 
-// Workaround 2.066.x bug by resolving the TYMAX value before using it as dimension.
-static if (__VERSION__ <= 2066)
-    private enum computeEnumValue = TYMAX;
-
 // Return name mangling of type
 mangle_t type_mangle(type *t) { return t.Tmangle; }
 

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -393,21 +393,7 @@ UnionExp Div(const ref Loc loc, Type type, Expression e1, Expression e2)
         {
             if (e1.type.isreal())
             {
-                version (all)
-                {
-                    // Work around redundant REX.W prefix breaking Valgrind
-                    // when built with affected versions of DMD.
-                    // https://issues.dlang.org/show_bug.cgi?id=14952
-                    // This can be removed once compiling with DMD 2.068 or
-                    // older is no longer supported.
-                    const r1 = e1.toReal();
-                    const r2 = e2.toReal();
-                    emplaceExp!(RealExp)(&ue, loc, r1 / r2, type);
-                }
-                else
-                {
-                    emplaceExp!(RealExp)(&ue, loc, e1.toReal() / e2.toReal(), type);
-                }
+                emplaceExp!(RealExp)(&ue, loc, e1.toReal() / e2.toReal(), type);
                 return ue;
             }
             const r = e2.toReal();

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1363,7 +1363,6 @@ version (Windows)
         static const(char)* findLatestSDKDir(const(char)* baseDir, const(char)* testfile)
         {
             auto allfiles = FileName.combine(baseDir, "*");
-            static if (!is(WIN32_FIND_DATAA)) alias WIN32_FIND_DATAA = WIN32_FIND_DATA; // support dmd 2.068
             WIN32_FIND_DATAA fileinfo;
             HANDLE h = FindFirstFileA(allfiles, &fileinfo);
             if (h == INVALID_HANDLE_VALUE)

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -927,22 +927,8 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             // If e2 *could* have been an integer, make it one.
             if (e.e2.op == TOK.float64)
             {
-                version (all)
-                {
-                    // Work around redundant REX.W prefix breaking Valgrind
-                    // when built with affected versions of DMD.
-                    // https://issues.dlang.org/show_bug.cgi?id=14952
-                    // This can be removed once compiling with DMD 2.068 or
-                    // older is no longer supported.
-                    const r = e.e2.toReal();
-                    if (r == real_t(cast(sinteger_t)r))
-                        e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
-                }
-                else
-                {
-                    if (e.e2.toReal() == cast(sinteger_t)e.e2.toReal())
-                        e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
-                }
+                if (e.e2.toReal() == cast(sinteger_t)e.e2.toReal())
+                    e.e2 = new IntegerExp(e.loc, e.e2.toInteger(), Type.tint64);
             }
             if (e.e1.isConst() == 1 && e.e2.isConst() == 1)
             {


### PR DESCRIPTION
Only versions beginning from 2.07x and later are actively tested.