### PR TITLE
fix Issue 19319 - No line number when std.math is missing for x ^^ y

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3328,18 +3328,6 @@ elem *toElem(Expression e, IRState *irs)
         /***************************************
          */
 
-        override void visit(PowAssignExp e)
-        {
-            Type tb1 = e.e1.type.toBasetype();
-            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
-
-            e.error("`^^` operator is not supported");
-            result = el_long(totym(e.type), 0);  // error recovery
-        }
-
-        /***************************************
-         */
-
         override void visit(LogicalExp aae)
         {
             tym_t tym = totym(aae.type);
@@ -3361,18 +3349,6 @@ elem *toElem(Expression e, IRState *irs)
         override void visit(XorExp e)
         {
             result = toElemBin(e, OPxor);
-        }
-
-        /***************************************
-         */
-
-        override void visit(PowExp e)
-        {
-            Type tb1 = e.e1.type.toBasetype();
-            assert(tb1.ty != Tarray && tb1.ty != Tsarray);
-
-            e.error("`^^` operator is not supported");
-            result = el_long(totym(e.type), 0);  // error recovery
         }
 
         /***************************************

--- a/test/fail_compilation/extra-files/minimal/object.d
+++ b/test/fail_compilation/extra-files/minimal/object.d
@@ -1,0 +1,1 @@
+module object;

--- a/test/fail_compilation/fail19319a.d
+++ b/test/fail_compilation/fail19319a.d
@@ -1,0 +1,17 @@
+/*
+DFLAGS:
+REQUIRED_ARGS: -conf= -Ifail_compilation/extra-files/minimal
+TEST_OUTPUT:
+---
+fail_compilation/fail19319a.d(16): Error: `7 ^^ g19319` requires `std.math` for `^^` operators
+fail_compilation/fail19319a.d(17): Error: `g19319 ^^ 7` requires `std.math` for `^^` operators
+---
+*/
+
+__gshared int g19319 = 0;
+
+static assert(!__traits(compiles, 7 ^^ g19319));
+static assert(!__traits(compiles, g19319 ^^= 7));
+
+__gshared int e19319 = 7 ^^ g19319;
+__gshared int a19319 = g19319 ^^= 7;;

--- a/test/fail_compilation/fail19319b.d
+++ b/test/fail_compilation/fail19319b.d
@@ -1,0 +1,18 @@
+/*
+DFLAGS:
+REQUIRED_ARGS: -conf= -Ifail_compilation/extra-files/minimal
+TEST_OUTPUT:
+---
+fail_compilation/fail19319b.d(16): Error: `7 ^^ x` requires `std.math` for `^^` operators
+fail_compilation/fail19319b.d(17): Error: `x ^^ 7` requires `std.math` for `^^` operators
+---
+*/
+
+void test19319(int x)
+{
+    static assert(!__traits(compiles, 7 ^^ x));
+    static assert(!__traits(compiles, x ^^= 7));
+
+    int i = 7 ^^ x;
+    x ^^= 7;
+}


### PR DESCRIPTION
There's no gagging, and so loadStdMath will call fatal() if there's no std.math module available.

Leaving the code in, as gagging loadStdMath will be required if backend decides to do something with PowExp in the future.