### PR TITLE
de-virtualize elfobj.c and machobj.c

### DIFF
--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -548,14 +548,14 @@ void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset)
         buf.writeByte(LEA);
         buf.writeByte(modregrm(0,AX,5));
         codeOffset += 3;
-        codeOffset += ElfObj.writerel(seg, codeOffset, R_X86_64_PC32, 3 /*STI_DATA*/, refOffset - 4);
+        codeOffset += Obj.writerel(seg, codeOffset, R_X86_64_PC32, 3 /*STI_DATA*/, refOffset - 4);
 
         // MOV RCX,_DmoduleRef@GOTPCREL[RIP]
         buf.writeByte(REX | REX_W);
         buf.writeByte(0x8B);
         buf.writeByte(modregrm(0,CX,5));
         codeOffset += 3;
-        codeOffset += ElfObj.writerel(seg, codeOffset, R_X86_64_GOTPCREL, Obj.external_def("_Dmodule_ref"), -4);
+        codeOffset += Obj.writerel(seg, codeOffset, R_X86_64_GOTPCREL, Obj.external_def("_Dmodule_ref"), -4);
     }
     else
     {
@@ -563,12 +563,12 @@ void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset)
         buf.writeByte(0xB8);
         codeOffset += 1;
         const uint reltype = I64 ? R_X86_64_32 : R_386_32;
-        codeOffset += ElfObj.writerel(seg, codeOffset, reltype, 3 /*STI_DATA*/, refOffset);
+        codeOffset += Obj.writerel(seg, codeOffset, reltype, 3 /*STI_DATA*/, refOffset);
 
         /* movl _Dmodule_ref, %ecx */
         buf.writeByte(0xB9);
         codeOffset += 1;
-        codeOffset += ElfObj.writerel(seg, codeOffset, reltype, Obj.external_def("_Dmodule_ref"), 0);
+        codeOffset += Obj.writerel(seg, codeOffset, reltype, Obj.external_def("_Dmodule_ref"), 0);
     }
 
     if (I64)

--- a/src/dmd/backend/obj.d
+++ b/src/dmd/backend/obj.d
@@ -1128,10 +1128,10 @@ else version (Posix)
         static void moduleinfo(Symbol *scc);
         static int comdat(Symbol *);
         static int comdatsize(Symbol *, targ_size_t symsize);
-        int readonly_comdat(Symbol *s);
+        static int readonly_comdat(Symbol *s);
         static void setcodeseg(int seg);
-        seg_data *tlsseg();
-        seg_data *tlsseg_bss();
+        static seg_data *tlsseg();
+        static seg_data *tlsseg_bss();
         static seg_data *tlsseg_data();
         static int  fardata(char *name, targ_size_t size, targ_size_t *poffset);
         static void export_symbol(Symbol *s, uint argsize);
@@ -1172,37 +1172,22 @@ else version (Posix)
         static  uint addstr(Outbuffer *strtab, const(char)* );
         static Symbol *getGOTsym();
         static void refGOTsym();
-    }
 
-    version (OSX)
-    {
-        class MachObj : Obj
+        version (OSX)
         {
-          public:
             static int getsegment(const(char)* sectname, const(char)* segname,
-                int  _align, int flags);
+                                  int  _align, int flags);
             static void addrel(int seg, targ_size_t offset, Symbol *targsym,
-                 uint targseg, int rtype, int val = 0);
+                               uint targseg, int rtype, int val = 0);
         }
-
-        class MachObj64 : MachObj
+        else
         {
-          public:
-            override seg_data *tlsseg();
-            override seg_data *tlsseg_bss();
-        }
-    }
-    else
-    {
-        class ElfObj : Obj
-        {
-          public:
             static int getsegment(const(char)* name, const(char)* suffix,
-                int type, int flags, int  _align);
+                                  int type, int flags, int  _align);
             static void addrel(int seg, targ_size_t offset, uint type,
-                                uint symidx, targ_size_t val);
+                               uint symidx, targ_size_t val);
             static size_t writerel(int targseg, size_t offset, uint type,
-                                    uint symidx, targ_size_t val);
+                                   uint symidx, targ_size_t val);
         }
     }
 }

--- a/src/dmd/backend/obj.h
+++ b/src/dmd/backend/obj.h
@@ -154,10 +154,10 @@ class Obj
     VIRTUAL void moduleinfo(Symbol *scc);
     VIRTUAL int  comdat(Symbol *);
     VIRTUAL int  comdatsize(Symbol *, targ_size_t symsize);
-    virtual int readonly_comdat(Symbol *s);
+    VIRTUAL int readonly_comdat(Symbol *s);
     VIRTUAL void setcodeseg(int seg);
-    virtual seg_data *tlsseg();
-    virtual seg_data *tlsseg_bss();
+    VIRTUAL seg_data *tlsseg();
+    VIRTUAL seg_data *tlsseg_bss();
     VIRTUAL seg_data *tlsseg_data();
     static int  fardata(char *name, targ_size_t size, targ_size_t *poffset);
     VIRTUAL void export_symbol(Symbol *s, unsigned argsize);
@@ -204,33 +204,21 @@ class Obj
 #if TARGET_WINDOS
     VIRTUAL int seg_debugT();           // where the symbolic debug type data goes
 #endif
-};
 
-class ElfObj : public Obj
-{
-  public:
+#if TARGET_OSX
+    static int getsegment(const char *sectname, const char *segname,
+                          int align, int flags);
+    static void addrel(int seg, targ_size_t offset, symbol *targsym,
+                       unsigned targseg, int rtype, int val = 0);
+#endif
+#if TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYBSD || TARGET_SOLARIS
     static int getsegment(const char *name, const char *suffix,
-        int type, int flags, int align);
+                          int type, int flags, int align);
     static void addrel(int seg, targ_size_t offset, unsigned type,
                        unsigned symidx, targ_size_t val);
     static size_t writerel(int targseg, size_t offset, unsigned type,
                            unsigned symidx, targ_size_t val);
-};
-
-class MachObj : public Obj
-{
-  public:
-    static int getsegment(const char *sectname, const char *segname,
-        int align, int flags);
-    static void addrel(int seg, targ_size_t offset, symbol *targsym,
-        unsigned targseg, int rtype, int val = 0);
-};
-
-class MachObj64 : public MachObj
-{
-  public:
-    seg_data *tlsseg();
-    seg_data *tlsseg_bss();
+#endif
 };
 
 class MsCoffObj : public Obj
@@ -266,7 +254,7 @@ class MsCoffObj : public Obj
     VIRTUAL void moduleinfo(Symbol *scc);
     virtual int  comdat(Symbol *);
     virtual int  comdatsize(Symbol *, targ_size_t symsize);
-    virtual int readonly_comdat(Symbol *s);
+    VIRTUAL int readonly_comdat(Symbol *s);
     VIRTUAL void setcodeseg(int seg);
     virtual seg_data *tlsseg();
     virtual seg_data *tlsseg_bss();

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -193,7 +193,7 @@ struct Segments
 
         version (OSX)
         {
-            segmentsPtr[id] = MachObj.getsegment(
+            segmentsPtr[id] = Obj.getsegment(
                 seg.sectionName,
                 seg.segmentName,
                 seg.alignment,


### PR DESCRIPTION
A step towards converting elfobj.c and machobj.d to D. It removes the ElfObj, MachObj, and MachObj64 classes.