### PR TITLE
Tweak utf_isValidDchar: put check for most common condition first

### DIFF
--- a/src/dmd/utf.d
+++ b/src/dmd/utf.d
@@ -18,16 +18,14 @@ nothrow pure @nogc:
 /// except the UTF-16 surrogate pairs in the range [0xD800,0xDFFF]
 bool utf_isValidDchar(dchar c)
 {
-    // TODO: Whether non-char code points should be rejected is pending review
-    // largest character code point
-    if (c > 0x10FFFF)
-        return false;
+    // TODO: Whether non-char code points should be rejected is pending review.
     // 0xFFFE and 0xFFFF are valid for internal use, like Phobos std.utf.isValidDChar
     // See also https://issues.dlang.org/show_bug.cgi?id=1357
-    // surrogate pairs
-    if (0xD800 <= c && c <= 0xDFFF)
-        return false;
-    return true;
+    if (c < 0xD800) // Almost all characters in a typical document.
+        return true;
+    if (c > 0xDFFF && c <= 0x10FFFF)
+        return true;
+    return false;
 }
 
 /*******************************


### PR DESCRIPTION
The function could be made entirely jumpless (`return (c < 0xD800) | ((c > 0xDFFF) & (c <= 0x10FFFF))`) but it's not clear if that would be an improvement since the first condition is almost always true.