### PR TITLE
Fix building Dub package on Windows due to duplicated symbols

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -62,5 +62,5 @@ subPackage {
   versions "MARS"
   sourcePaths "src/dmd"
   excludedSourceFiles "src/dmd/backend/*"
-  excludedSourceFiles "src/dmd/{e2ir,eh,glue,iasm,iasmdmd,iasmgcc,objc_glue,s2ir,tocsym,toctype,toobj,todt,toir}.d"
+  excludedSourceFiles "src/dmd/{dmsc,e2ir,eh,glue,iasm,iasmdmd,iasmgcc,objc_glue,s2ir,tocsym,toctype,toobj,todt,toir}.d"
 }


### PR DESCRIPTION
Building the Dub package on Windows results in the following duplicated symbols: `?backend_init@@YAXXZ` and `?backend_term@@YAXXZ`. This is solved by excluding the `dmsc.d` file from the Dub package. The `backend_init` and `backend_term` symbols are both defined in `gluelayer.d` (when the `NoBackend` version is defined) and `dmsc.d`.

Needs https://github.com/dlang/dmd/pull/8881 to come to this stage.