### PR TITLE
Fix Issue 19336 - [ICE] segfault on invalid code

### DIFF
--- a/test/fail_compilation/fail19336.d
+++ b/test/fail_compilation/fail19336.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19336.d(14): Error: template instance `Template!()` template `Template` is not defined
+fail_compilation/fail19336.d(14): Error: recursive type
+fail_compilation/fail19336.d(17): Error: recursive type
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=19336
+
+struct Foo
+{
+        Template!() a(a.x);
+}
+
+int b(b.x);


### PR DESCRIPTION
Given this code:

```d
int a(a.x);
```

When the compiler analyzes the above code it has to do semantic on the parameter type `a.x`; in order to do so it has to do semantic on function `a`; now it has to analyze the function again, thus creating an infinite recursive check.