### PR TITLE
Fix Issue 13552 - Type deduction doesn't fall back to alias this if postblit is disabled

### DIFF
--- a/test/compilable/test13552.d
+++ b/test/compilable/test13552.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=13552
+
+struct S
+{
+    int x;
+    @disable this(this);
+    alias x this;
+}
+
+void main() {
+    S s;
+    int i = s;
+    auto j = s;
+    static assert(is(typeof(j) == int));
+}


### PR DESCRIPTION
```d
    struct S {
        int x;
        @disable this(this);
        alias x this;
    }

    void main() {
        S s;
        int i = s;  // works
        auto j = s;   // error : struct S is not copyable
     }
```
I know this is a narrow case, but it is a cool thing to have type deduction fallback to alias this.
I made the PR to see what your opinions are on this.