### PR TITLE
Fix Issue 13953 - AA .remove pseudo-method doesn't work via alias this

### DIFF
--- a/test/compilable/test13953.d
+++ b/test/compilable/test13953.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=13953
+
+struct S
+{
+    string[string] aa;
+    alias aa this;
+}
+
+void main()
+{
+    S s;
+    s["foo"] = "bar";
+    s.remove("foo");
+}


### PR DESCRIPTION
```d
struct S
{
    string[string] aa;
    alias aa this;
}

void main()
{
    S s;
    s["foo"] = "bar";
    s.remove("foo");   // Error: no property remove for type S
    s.clear();         // works
}
```
It seems that when clear is used the symbol resolution manages to find clear from druntime and after that the alias this is expanded so finally `s.aa.clear()` is called. In the case of remove it seems that a different mechanism is employed: the function is looked up only from within a RemoveExp ast node.

The fix that I implemented is to try alias this in resolveUFCS only after the normal lookup has failed. It might not be the best solution, but I couldn't figure a better one. The only place where a RemoveExp is created is in resolveUFCS, so i find it natural that this narrow fix is put in there.

If any of you reviewers out there have a better solution, I await your suggestions.
