### PR TITLE
fix Issue 19318 - Variables captured from outer functions not visible in debugger

### DIFF
--- a/src/dmd/backend/cgcv.d
+++ b/src/dmd/backend/cgcv.d
@@ -66,6 +66,8 @@ debtyp_t* debtyp_alloc(uint length);
 int cv_stringbytes(const(char)* name);
 uint cv4_numericbytes(uint value);
 void cv4_storenumeric(ubyte* p, uint value);
+uint cv4_signednumericbytes(int value);
+void cv4_storesignednumeric(ubyte* p, int value);
 idx_t cv_debtyp(debtyp_t* d);
 int cv_namestring(ubyte* p, const(char)* name, int length = -1);
 uint cv4_typidx(type* t);

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -661,6 +661,48 @@ void cv4_storenumeric(ubyte *p, uint value)
     }
 }
 
+/***********************************
+ * Return number of bytes required to store a signed numeric leaf.
+ * Params:
+ *   value = value to store
+ * Returns:
+ *   number of bytes required for storing value
+ */
+uint cv4_signednumericbytes(int value)
+{
+    uint u;
+    if (value >= 0 && value < 0x8000)
+        u = 2;
+    else if (value == cast(short)value)
+        u = 4;
+    else
+        u = 6;
+    return u;
+}
+
+/********************************
+ * Store signed numeric leaf.
+ * Must use exact same number of bytes as cv4_signednumericbytes().
+ * Params:
+ *   p = address where to store value
+ *   value = value to store
+ */
+void cv4_storesignednumeric(ubyte *p, int value)
+{
+    if (value >= 0 && value < 0x8000)
+        TOWORD(p, value);
+    else if (value == cast(short)value)
+    {
+        TOWORD(p, LF_SHORT);
+        TOWORD(p + 2, value);
+    }
+    else
+    {
+        TOWORD(p,LF_LONG);
+        TOLONG(p + 2, value);
+    }
+}
+
 /*********************************
  * Generate a type index for a parameter list.
  */

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1234,6 +1234,9 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     }
 
     writefunc(s);
+
+    buildCapture(fd);
+
     // Restore symbol table
     cstate.CSpsymtab = symtabsave;
 

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -735,8 +735,8 @@ private uint writeField(ubyte* p, const char* id, uint attr, uint typidx, uint o
         TOWORD(p,LF_MEMBER_V3);
         TOWORD(p + 2,attr);
         TOLONG(p + 4,typidx);
-        cv4_storenumeric(p + 8, offset);
-        uint len = 8 + cv4_numericbytes(offset);
+        cv4_storesignednumeric(p + 8, offset);
+        uint len = 8 + cv4_signednumericbytes(offset);
         len += cv_namestring(p + len, id);
         return cv_align(p + len, len);
     }
@@ -745,8 +745,8 @@ private uint writeField(ubyte* p, const char* id, uint attr, uint typidx, uint o
         TOWORD(p,LF_MEMBER);
         TOWORD(p + 2,typidx);
         TOWORD(p + 4,attr);
-        cv4_storenumeric(p + 6, offset);
-        uint len = 6 + cv4_numericbytes(offset);
+        cv4_storesignednumeric(p + 6, offset);
+        uint len = 6 + cv4_signednumericbytes(offset);
         return len + cv_namestring(p + len, id);
     }
 }
@@ -793,7 +793,7 @@ void toDebugClosure(Symbol* closstru)
     {
         Symbol *sf = list_symbol(sl);
         uint thislen = (config.fulltypes == CV8 ? 8 : 6);
-        thislen += cv4_numericbytes(cast(uint)sf.Smemoff);
+        thislen += cv4_signednumericbytes(cast(uint)sf.Smemoff);
         thislen += cv_stringbytes(sf.Sident.ptr);
         thislen = cv_align(null, thislen);
 

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1060,6 +1060,52 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
     }
 }
 
+/*************************************
+ * build a debug info struct for variables captured by nested functions,
+ * but not in a closure.
+ * must be called after generating the function to fill stack offsets
+ * Params:
+ *      fd = function
+ */
+void buildCapture(FuncDeclaration fd)
+{
+    if (!global.params.symdebug)
+        return;
+    if (!global.params.mscoff)  // toDebugClosure only implemented for CodeView,
+        return;                 //  but optlink crashes for negative field offsets
+
+    if (fd.closureVars.dim && !fd.needsClosure)
+    {
+        /* Generate type name for struct with captured variables */
+        const char *name1 = "CAPTURE.";
+        const char *name2 = fd.toPrettyChars();
+        size_t namesize = strlen(name1)+strlen(name2)+1;
+        char *capturename = cast(char *) calloc(namesize, char.sizeof);
+        strcat(strcat(capturename, name1), name2);
+
+        /* Build type for struct */
+        type *capturestru = type_struct_class(capturename, Target.ptrsize, 0, null, null, false, false, true, false);
+        free(capturename);
+
+        foreach (v; fd.closureVars)
+        {
+            Symbol *vsym = toSymbol(v);
+
+            /* Add variable as capture type member */
+            symbol_struct_addField(capturestru.Ttag, &vsym.Sident[0], vsym.Stype, cast(uint)vsym.Soffset);
+            //printf("capture field %s: offset: %i\n", &vsym.Sident[0], v.offset);
+        }
+
+        // generate pseudo symbol to put into functions' Sscope
+        Symbol *scapture = symbol_name("__captureptr", SCalias, type_pointer(capturestru));
+        scapture.Sflags |= SFLtrue | SFLfree;
+        //symbol_add(scapture);
+        fd.csym.Sscope = scapture;
+
+        toDebugClosure(capturestru.Ttag);
+    }
+}
+
 
 /***************************
  * Determine return style of function - whether in registers or

--- a/test/runnable/testpdb.d
+++ b/test/runnable/testpdb.d
@@ -215,6 +215,34 @@ void test19307(IDiaSession session, IDiaSymbol globals)
 }
 
 ///////////////////////////////////////////////
+// https://issues.dlang.org/show_bug.cgi?id=19318
+// variables captured from outer functions not visible in debugger
+int foo19318(int z) @nogc
+{
+	int x = 7;
+	auto nested() scope
+	{
+		int nested2()
+		{
+			return x + z;
+		}
+		return nested2();
+	}
+	return nested();
+}
+
+void test19318(IDiaSession session, IDiaSymbol globals)
+{
+    foo19318(5);
+
+    testClosureVar(globals, "testpdb.foo19318", "x");
+    testClosureVar(globals, "testpdb.foo19318.nested", "this", "x");
+    testClosureVar(globals, "testpdb.foo19318.nested", "this", "z");
+    testClosureVar(globals, "testpdb.foo19318.nested.nested2", "this", "x");
+    testClosureVar(globals, "testpdb.foo19318.nested.nested2", "this", "z");
+}
+
+///////////////////////////////////////////////
 import core.stdc.stdio;
 import core.stdc.wchar_;
 


### PR DESCRIPTION
create struct type corresponding to the stack variables that are captured by nested functions and assign it to the context pointer in the nested function.