### PR TITLE
dmd.expression: Use align(8) for alignment of UnionExp

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -504,7 +504,8 @@ struct UnionExp
     }
 
 private:
-    union __AnonStruct__u
+    // Ensure that the union is suitably aligned.
+    align(8) union __AnonStruct__u
     {
         char[__traits(classInstanceSize, Expression)] exp;
         char[__traits(classInstanceSize, IntegerExp)] integerexp;
@@ -521,8 +522,6 @@ private:
         char[__traits(classInstanceSize, AddrExp)] addrexp;
         char[__traits(classInstanceSize, IndexExp)] indexexp;
         char[__traits(classInstanceSize, SliceExp)] sliceexp;
-        // Ensure that the union is suitably aligned.
-        real_t for_alignment_only;
     }
 
     __AnonStruct__u u;

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -1231,6 +1231,14 @@ struct UnionExp
     Expression *copy();
 
 private:
+    // Ensure that the union is suitably aligned.
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((aligned(8)))
+#elif defined(_MSC_VER)
+    __declspec(align(8))
+#elif defined(__DMC__)
+    #pragma pack(8)
+#endif
     union
     {
         char exp       [sizeof(Expression)];
@@ -1248,10 +1256,10 @@ private:
         char addrexp   [sizeof(AddrExp)];
         char indexexp  [sizeof(IndexExp)];
         char sliceexp  [sizeof(SliceExp)];
-
-        // Ensure that the union is suitably aligned.
-        real_t for_alignment_only;
     } u;
+#if defined(__DMC__)
+    #pragma pack()
+#endif
 };
 
 /****************************************************************/


### PR DESCRIPTION
SPARC port is killed with a sigbus error when building any module.  This was due to an unaligned load in `IntegerExp::toInteger` from inside interpret() where UnionExp is prevalent.

The reason is because `real_t` may itself be a struct that is not suitably aligned for accessing `dinteger_t` (8-bytes).

Just waiting to hear back that this is fine, otherwise the corrective action would be to add a `dinteger_t` field so that `UnionExp` is suitably aligned for both native `real_t` and `dinteger_t` types.

It would be nice if dmc++ supported `__attribute__(aligned(8)))` instead of having this here...