### PR TITLE
[dmd-cxx] Add root/system.h header for wrapping system includes

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -7,10 +7,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/access.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
 #include "root/rmem.h"
 

--- a/src/aliasthis.c
+++ b/src/aliasthis.c
@@ -163,7 +163,7 @@ void AliasThis::semantic(Scope *sc)
     semanticRun = PASSsemanticdone;
 }
 
-const char *AliasThis::kind()
+const char *AliasThis::kind() const
 {
     return "alias this";
 }

--- a/src/aliasthis.c
+++ b/src/aliasthis.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/aliasthis.c
  */
 
-#include <stdio.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "identifier.h"

--- a/src/apply.c
+++ b/src/apply.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/apply.c
  */
 
-#include <stdio.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "expression.h"

--- a/src/argtypes.c
+++ b/src/argtypes.c
@@ -8,9 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/argtypes.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/checkedint.h"
 
 #include "mars.h"

--- a/src/arrayop.c
+++ b/src/arrayop.c
@@ -8,10 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/arrayop.c
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 #include "root/aav.h"
 

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -8,11 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/attrib.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>                     // memcpy()
-
+#include "root/dsystem.h"               // memcmp()
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -9,9 +9,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/builtin.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-#include <string.h>                     // strcmp()
+#include "root/dsystem.h"               // strcmp()
 #include <math.h>
 
 #include "mars.h"

--- a/src/canthrow.c
+++ b/src/canthrow.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/canthrow.c
  */
 
-#include <stdio.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "init.h"

--- a/src/clone.c
+++ b/src/clone.c
@@ -8,11 +8,9 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/clone.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-#include <new>
-
+#include "root/dsystem.h"
 #include "root/root.h"
+
 #include "aggregate.h"
 #include "scope.h"
 #include "mtype.h"

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -9,8 +9,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/compiler.c
  */
 
-#include <assert.h>
-#include <limits> // for std::numeric_limits
+#include "root/dsystem.h" // for std::numeric_limits
 
 #include "expression.h"
 #include "id.h"

--- a/src/cond.c
+++ b/src/cond.c
@@ -8,9 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/cond.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-#include <string.h>                     // strcmp()
+#include "root/dsystem.h"               // strcmp()
 
 #include "mars.h"
 #include "id.h"

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -8,12 +8,11 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/constfold.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>                     // mem{cpy|set|cmp}()
+#include "root/dsystem.h"               // mem{cpy|set|cmp}()
+
+#ifndef IN_GCC
 #include <math.h>
-#include <new>
+#endif
 
 #include "root/rmem.h"
 #include "root/root.h"

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -21,9 +21,7 @@
  *  enter `C++, mangling` as the keywords.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "dsymbol.h"

--- a/src/ctfeexpr.c
+++ b/src/ctfeexpr.c
@@ -8,12 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/ctfeexpr.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>                     // mem{cpy|set}()
-#include <new>
-
+#include "root/dsystem.h"               // mem{cpy|set}()
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/dcast.c
+++ b/src/dcast.c
@@ -8,10 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/cast.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-#include <string.h>                     // mem{set|cpy}()
-
+#include "root/dsystem.h"               // mem{set|cpy}()
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/dclass.c
+++ b/src/dclass.c
@@ -1389,7 +1389,7 @@ int ClassDeclaration::vtblOffset() const
 /****************************************
  */
 
-const char *ClassDeclaration::kind()
+const char *ClassDeclaration::kind() const
 {
     return "class";
 }
@@ -1827,7 +1827,7 @@ bool InterfaceDeclaration::isCPPinterface() const
 /*******************************************
  */
 
-const char *InterfaceDeclaration::kind()
+const char *InterfaceDeclaration::kind() const
 {
     return "interface";
 }

--- a/src/dclass.c
+++ b/src/dclass.c
@@ -8,11 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/class.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>                     // mem{cpy|set}()
-
+#include "root/dsystem.h"               // mem{cpy|set}()
 #include "root/root.h"
 #include "root/rmem.h"
 

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -8,9 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/declaration.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/checkedint.h"
 
 #include "errors.h"

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -87,7 +87,7 @@ void Declaration::semantic(Scope *)
 {
 }
 
-const char *Declaration::kind()
+const char *Declaration::kind() const
 {
     return "declaration";
 }
@@ -188,7 +188,7 @@ Dsymbol *TupleDeclaration::syntaxCopy(Dsymbol *)
     return NULL;
 }
 
-const char *TupleDeclaration::kind()
+const char *TupleDeclaration::kind() const
 {
     return "tuple";
 }
@@ -575,7 +575,7 @@ bool AliasDeclaration::overloadInsert(Dsymbol *s)
     return true;
 }
 
-const char *AliasDeclaration::kind()
+const char *AliasDeclaration::kind() const
 {
     return "alias";
 }
@@ -705,7 +705,7 @@ OverDeclaration::OverDeclaration(Identifier *ident, Dsymbol *s, bool hasOverload
     }
 }
 
-const char *OverDeclaration::kind()
+const char *OverDeclaration::kind() const
 {
     return "overload alias";    // todo
 }
@@ -1770,7 +1770,7 @@ void VarDeclaration::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset,
     //printf(" addField '%s' to '%s' at offset %d, size = %d\n", toChars(), ad->toChars(), offset, memsize);
 }
 
-const char *VarDeclaration::kind()
+const char *VarDeclaration::kind() const
 {
     return "variable";
 }

--- a/src/delegatize.c
+++ b/src/delegatize.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/delegatize.c
  */
 
-#include <stdio.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "expression.h"

--- a/src/denum.c
+++ b/src/denum.c
@@ -8,10 +8,9 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/enum.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
+
 #include "errors.h"
 #include "enum.h"
 #include "mtype.h"

--- a/src/denum.c
+++ b/src/denum.c
@@ -457,7 +457,7 @@ Type *EnumDeclaration::getType()
     return type;
 }
 
-const char *EnumDeclaration::kind()
+const char *EnumDeclaration::kind() const
 {
     return "enum";
 }
@@ -515,7 +515,7 @@ Dsymbol *EnumMember::syntaxCopy(Dsymbol *s)
         origType ? origType->syntaxCopy() : NULL);
 }
 
-const char *EnumMember::kind()
+const char *EnumMember::kind() const
 {
     return "enum member";
 }

--- a/src/dimport.c
+++ b/src/dimport.c
@@ -8,10 +8,9 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/import.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
+
 #include "mars.h"
 #include "dsymbol.h"
 #include "import.h"

--- a/src/dimport.c
+++ b/src/dimport.c
@@ -70,7 +70,7 @@ void Import::addAlias(Identifier *name, Identifier *alias)
     aliases.push(alias);
 }
 
-const char *Import::kind()
+const char *Import::kind() const
 {
     return isstatic ? "static import" : "import";
 }

--- a/src/dinterpret.c
+++ b/src/dinterpret.c
@@ -8,12 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/interpret.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>                     // mem{cpy|set}()
-#include <new>
-
+#include "root/dsystem.h"               // mem{cpy|set}()
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/dmacro.c
+++ b/src/dmacro.c
@@ -11,11 +11,7 @@
 /* Simple macro text processor.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-#include <ctype.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "errors.h"

--- a/src/dmangle.c
+++ b/src/dmangle.c
@@ -8,11 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/mangle.c
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
 
 #include "mangle.h"

--- a/src/dmodule.c
+++ b/src/dmodule.c
@@ -195,7 +195,7 @@ void Module::deleteObjFile()
         docfile->remove();
 }
 
-const char *Module::kind()
+const char *Module::kind() const
 {
     return "module";
 }
@@ -1221,7 +1221,7 @@ Package::Package(Identifier *ident)
 }
 
 
-const char *Package::kind()
+const char *Package::kind() const
 {
     return "package";
 }

--- a/src/dmodule.c
+++ b/src/dmodule.c
@@ -8,10 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/module.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 
 #include "mars.h"
@@ -25,14 +22,6 @@
 #include "expression.h"
 #include "lexer.h"
 #include "attrib.h"
-
-// For getcwd()
-#if _WIN32
-#include <direct.h>
-#endif
-#if POSIX
-#include <unistd.h>
-#endif
 
 AggregateDeclaration *Module::moduleinfo;
 

--- a/src/doc.c
+++ b/src/doc.c
@@ -10,12 +10,7 @@
 
 // This implements the Ddoc capability.
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-#include <ctype.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 #include "root/root.h"
 #include "root/port.h"

--- a/src/doc.h
+++ b/src/doc.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include "root/dsystem.h"
 
 class Module;
 struct OutBuffer;

--- a/src/dscope.c
+++ b/src/dscope.c
@@ -8,10 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/scope.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-#include <string.h>                     // strlen()
-
+#include "root/dsystem.h"               // strlen()
 #include "root/root.h"
 #include "root/rmem.h"
 #include "root/speller.h"

--- a/src/dstruct.c
+++ b/src/dstruct.c
@@ -1438,7 +1438,7 @@ bool StructDeclaration::isPOD()
     return (ispod == ISPODyes);
 }
 
-const char *StructDeclaration::kind()
+const char *StructDeclaration::kind() const
 {
     return "struct";
 }
@@ -1457,7 +1457,7 @@ Dsymbol *UnionDeclaration::syntaxCopy(Dsymbol *s)
     return StructDeclaration::syntaxCopy(ud);
 }
 
-const char *UnionDeclaration::kind()
+const char *UnionDeclaration::kind() const
 {
     return "union";
 }

--- a/src/dstruct.c
+++ b/src/dstruct.c
@@ -8,10 +8,9 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/struct.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
+
 #include "errors.h"
 #include "aggregate.h"
 #include "scope.h"

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -291,7 +291,7 @@ const char *Dsymbol::locToChars()
     return getLoc().toChars();
 }
 
-const char *Dsymbol::kind()
+const char *Dsymbol::kind() const
 {
     return "symbol";
 }
@@ -919,7 +919,7 @@ void OverloadSet::push(Dsymbol *s)
     a.push(s);
 }
 
-const char *OverloadSet::kind()
+const char *OverloadSet::kind() const
 {
     return "overloadset";
 }
@@ -1271,7 +1271,7 @@ void ScopeDsymbol::multiplyDefined(Loc loc, Dsymbol *s1, Dsymbol *s2)
     }
 }
 
-const char *ScopeDsymbol::kind()
+const char *ScopeDsymbol::kind() const
 {
     return "ScopeDsymbol";
 }

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -8,11 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/dsymbol.c
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
-#include <limits.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 #include "root/speller.h"
 #include "root/aav.h"

--- a/src/dtemplate.c
+++ b/src/dtemplate.c
@@ -10,9 +10,7 @@
 
 // Handle template implementation
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
 #include "root/aav.h"
 #include "root/rmem.h"

--- a/src/dtemplate.c
+++ b/src/dtemplate.c
@@ -689,7 +689,7 @@ void TemplateDeclaration::semantic(Scope *sc)
      */
 }
 
-const char *TemplateDeclaration::kind()
+const char *TemplateDeclaration::kind() const
 {
     return (onemember && onemember->isAggregateDeclaration())
                 ? onemember->kind()
@@ -7844,7 +7844,7 @@ Dsymbol *TemplateInstance::toAlias()
     return inst;
 }
 
-const char *TemplateInstance::kind()
+const char *TemplateInstance::kind() const
 {
     return "template instance";
 }
@@ -8530,7 +8530,7 @@ void TemplateMixin::semantic3(Scope *sc)
     }
 }
 
-const char *TemplateMixin::kind()
+const char *TemplateMixin::kind() const
 {
     return "mixin";
 }

--- a/src/dversion.c
+++ b/src/dversion.c
@@ -8,9 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/version.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
 
 #include "identifier.h"

--- a/src/dversion.c
+++ b/src/dversion.c
@@ -106,7 +106,7 @@ void DebugSymbol::semantic(Scope *)
         semanticRun = PASSsemanticdone;
 }
 
-const char *DebugSymbol::kind()
+const char *DebugSymbol::kind() const
 {
     return "debug";
 }
@@ -196,7 +196,7 @@ void VersionSymbol::semantic(Scope *)
         semanticRun = PASSsemanticdone;
 }
 
-const char *VersionSymbol::kind()
+const char *VersionSymbol::kind() const
 {
     return "version";
 }

--- a/src/entity.c
+++ b/src/entity.c
@@ -8,9 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/entity.c
  */
 
-#include <string.h>
-#include <ctype.h>
-
+#include "root/dsystem.h"
 #include "root/port.h"
 
 /*********************************************

--- a/src/errors.h
+++ b/src/errors.h
@@ -10,9 +10,7 @@
 
 #pragma once
 
-#include <stdarg.h>
-#include <stddef.h>
-
+#include "root/dsystem.h"
 #include "globals.h"
 
 bool isConsoleColorSupported();

--- a/src/expression.c
+++ b/src/expression.c
@@ -8,12 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/expression.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <math.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 #include "root/root.h"
 

--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -7,12 +7,7 @@
  * http://www.boost.org/LICENSE_1_0.txt
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <math.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 #include "root/root.h"
 

--- a/src/func.c
+++ b/src/func.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/func.c
  */
 
-#include <stdio.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "init.h"

--- a/src/func.c
+++ b/src/func.c
@@ -4254,7 +4254,7 @@ void FuncDeclaration::checkDmain()
         error("parameters must be main() or main(string[] args)");
 }
 
-const char *FuncDeclaration::kind()
+const char *FuncDeclaration::kind() const
 {
     return generated ? "generated function" : "function";
 }
@@ -4645,7 +4645,7 @@ FuncAliasDeclaration::FuncAliasDeclaration(Identifier *ident, FuncDeclaration *f
     userAttribDecl = funcalias->userAttribDecl;
 }
 
-const char *FuncAliasDeclaration::kind()
+const char *FuncAliasDeclaration::kind() const
 {
     return "function alias";
 }
@@ -4756,7 +4756,7 @@ void FuncLiteralDeclaration::modifyReturns(Scope *sc, Type *tret)
         ((TypeFunction *)type)->next = tret;
 }
 
-const char *FuncLiteralDeclaration::kind()
+const char *FuncLiteralDeclaration::kind() const
 {
     return (tok != TOKfunction) ? "delegate" : "function";
 }
@@ -4869,7 +4869,7 @@ void CtorDeclaration::semantic(Scope *sc)
     }
 }
 
-const char *CtorDeclaration::kind()
+const char *CtorDeclaration::kind() const
 {
     return "constructor";
 }
@@ -5039,7 +5039,7 @@ bool DtorDeclaration::addPostInvariant()
     return false;
 }
 
-const char *DtorDeclaration::kind()
+const char *DtorDeclaration::kind() const
 {
     return "destructor";
 }
@@ -5521,7 +5521,7 @@ void NewDeclaration::semantic(Scope *sc)
     FuncDeclaration::semantic(sc);
 }
 
-const char *NewDeclaration::kind()
+const char *NewDeclaration::kind() const
 {
     return "allocator";
 }
@@ -5600,7 +5600,7 @@ void DeleteDeclaration::semantic(Scope *sc)
     FuncDeclaration::semantic(sc);
 }
 
-const char *DeleteDeclaration::kind()
+const char *DeleteDeclaration::kind() const
 {
     return "deallocator";
 }

--- a/src/hdrgen.c
+++ b/src/hdrgen.c
@@ -10,11 +10,7 @@
 
 // Routines to emit header files
 
-#include <ctype.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/hdrgen.h
+++ b/src/hdrgen.h
@@ -10,8 +10,7 @@
 
 #pragma once
 
-#include <string.h>                     // memset()
-
+#include "root/dsystem.h"               // memset()
 #include "dsymbol.h"
 
 void genhdrfile(Module *m);

--- a/src/identifier.c
+++ b/src/identifier.c
@@ -8,11 +8,9 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/identifier.c
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
+
 #include "identifier.h"
 #include "mars.h"
 #include "id.h"

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -14,10 +14,7 @@
 //      id.h
 //      id.c
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 struct Msgtable
 {

--- a/src/impcnvgen.c
+++ b/src/impcnvgen.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/impcnvgen.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include "root/dsystem.h"
 
 #include "mtype.h"
 

--- a/src/imphint.c
+++ b/src/imphint.c
@@ -9,11 +9,7 @@
  */
 
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <assert.h>
-#include <string.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 

--- a/src/init.c
+++ b/src/init.c
@@ -8,10 +8,9 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/init.c
  */
 
-#include <stdio.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/checkedint.h"
+
 #include "mars.h"
 #include "init.h"
 #include "expression.h"

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/intrange.c
  */
 
-#include <stddef.h>
-#include <stdint.h>
+#include "root/dsystem.h"
 
 #include "intrange.h"
 #include "mars.h"

--- a/src/json.c
+++ b/src/json.c
@@ -10,10 +10,7 @@
 
 // This implements the JSON capability.
 
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -10,16 +10,7 @@
 
 /* Lexical Analyzer */
 
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <stdarg.h>
-#include <errno.h>
-#include <wchar.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <time.h>       // for time() and ctime()
-
+#include "root/dsystem.h" // for time() and ctime()
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/macro.h
+++ b/src/macro.h
@@ -10,11 +10,7 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-#include <ctype.h>
-
+#include "root/dsystem.h"
 #include "root/root.h"
 
 

--- a/src/mars.h
+++ b/src/mars.h
@@ -54,9 +54,7 @@ the target object file format:
  */
 
 
-#include <stdio.h>
-#include <stdint.h>
-#include <stdarg.h>
+#include "root/dsystem.h"
 
 #ifdef __DMC__
 #ifdef DEBUG

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -8,21 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/mtype.c
  */
 
-#define __C99FEATURES__ 1       // Needed on Solaris for NaN and more
-#define __USE_ISOC99 1          // so signbit() gets defined
-
-#include <math.h>
-#include <stdio.h>
-#include <assert.h>
-#include <float.h>
-
-#if _MSC_VER
-#include <malloc.h>
-#include <limits>
-#elif __MINGW32__
-#include <malloc.h>
-#endif
-
+#include "root/dsystem.h"
 #include "root/checkedint.h"
 #include "root/rmem.h"
 

--- a/src/nspace.c
+++ b/src/nspace.c
@@ -156,7 +156,7 @@ void Nspace::semantic3(Scope *sc)
     }
 }
 
-const char *Nspace::kind()
+const char *Nspace::kind() const
 {
     return "namespace";
 }

--- a/src/nspace.c
+++ b/src/nspace.c
@@ -6,9 +6,7 @@
 // Source: https://github.com/D-Programming-Language/dmd/blob/master/src/nspace.c
 
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "dsymbol.h"

--- a/src/opover.c
+++ b/src/opover.c
@@ -8,12 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/opover.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <assert.h>
-#include <string.h>                     // memset()
-
+#include "root/dsystem.h"               // memset()
 #include "root/rmem.h"
 
 #include "mars.h"

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -8,10 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/optimize.c
  */
 
-#include <stdio.h>
-#include <ctype.h>
-#include <assert.h>
-#include <math.h>
+#include "root/dsystem.h"
 
 #include "root/checkedint.h"
 #include "lexer.h"

--- a/src/parse.c
+++ b/src/parse.c
@@ -10,11 +10,9 @@
 
 // This is the D parser
 
-#include <stdio.h>
-#include <assert.h>
-#include <string.h>                     // strlen(),memcpy()
-
+#include "root/dsystem.h"               // strlen(),memcpy()
 #include "root/rmem.h"
+
 #include "mars.h"
 #include "lexer.h"
 #include "parse.h"

--- a/src/root/aav.c
+++ b/src/root/aav.c
@@ -11,11 +11,7 @@
  *
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include "dsystem.h"
 #include "aav.h"
 #include "rmem.h"
 

--- a/src/root/aav.h
+++ b/src/root/aav.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include "dsystem.h"
 
 typedef void* Value;
 typedef void* Key;

--- a/src/root/array.h
+++ b/src/root/array.h
@@ -7,11 +7,7 @@
 
 #pragma once
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include "dsystem.h"
 #include "object.h"
 #include "rmem.h"
 

--- a/src/root/async.h
+++ b/src/root/async.h
@@ -14,7 +14,7 @@
 #pragma once
 #endif
 
-#include <stddef.h>
+#include "dsystem.h"
 
 struct File;
 

--- a/src/root/checkedint.c
+++ b/src/root/checkedint.c
@@ -27,8 +27,7 @@
  * Source:    https://github.com/D-Programming-Language/dmd/blob/master/src/root/checkedint.c
  */
 
-#include <assert.h>
-
+#include "dsystem.h"
 #include "checkedint.h"
 
 #ifdef __DMC__

--- a/src/root/checkedint.h
+++ b/src/root/checkedint.h
@@ -8,10 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/checkedint.h
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS 1
-#endif
-#include <stdint.h>
+#include "dsystem.h"
 
 
 int adds(int x, int y, bool& overflow);

--- a/src/root/dcompat.h
+++ b/src/root/dcompat.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include "dsystem.h"
 
 /// Represents a D [ ] array
 template<typename T>

--- a/src/root/dsystem.h
+++ b/src/root/dsystem.h
@@ -12,7 +12,7 @@
 
 // Get common system includes from the host.
 
-#define POSIX (__linux__ || __GLIBC__ || __gnu_hurd__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+#define POSIX (__linux__ || __GLIBC__ || __gnu_hurd__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __DragonFly__  || __sun)
 
 #define __C99FEATURES__ 1       // Needed on Solaris for NaN and more
 #define __USE_ISOC99 1          // so signbit() gets defined

--- a/src/root/dsystem.h
+++ b/src/root/dsystem.h
@@ -1,0 +1,65 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2018 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/dmd/root/dsystem.h
+ */
+
+#pragma once
+
+// Get common system includes from the host.
+
+#define POSIX (__linux__ || __GLIBC__ || __gnu_hurd__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
+
+#define __C99FEATURES__ 1       // Needed on Solaris for NaN and more
+#define __USE_ISOC99 1          // so signbit() gets defined
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS 1
+#endif
+
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+
+#include <new>
+
+#if POSIX
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#endif
+
+// For alloca()
+#if _MSC_VER
+#include <alloca.h>
+#endif
+#if defined (__sun)
+#include <alloca.h>
+#endif
+
+// For getcwd()
+#if _WIN32
+#include <direct.h>
+#endif
+#if POSIX
+#include <unistd.h>
+#endif
+
+// For malloc()
+#if _MSC_VER
+#include <malloc.h>
+#elif __MINGW32__
+#include <malloc.h>
+#endif

--- a/src/root/file.c
+++ b/src/root/file.c
@@ -89,7 +89,11 @@ bool File::read()
         goto err2;
     }
     size = (size_t)buf.st_size;
+#ifdef IN_GCC
+    buffer = (unsigned char *) ::xmalloc(size + 2);
+#else
     buffer = (unsigned char *) ::malloc(size + 2);
+#endif
     if (!buffer)
     {
         printf("\tmalloc error, errno = %d\n",errno);
@@ -140,7 +144,11 @@ err1:
     ref = 0;
 
     size = GetFileSize(h,NULL);
+#ifdef IN_GCC
+    buffer = (unsigned char *) ::xmalloc(size + 2);
+#else
     buffer = (unsigned char *) ::malloc(size + 2);
+#endif
     if (!buffer)
         goto err2;
 

--- a/src/root/file.c
+++ b/src/root/file.c
@@ -6,29 +6,14 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/file.c
  */
 
+#include "dsystem.h"
 #include "file.h"
-
-#if defined (__sun)
-#include <alloca.h>
-#endif
-
-#if _MSC_VER ||__MINGW32__
-#include <malloc.h>
-#include <string>
-#endif
 
 #if _WIN32
 #include <windows.h>
-#include <direct.h>
-#include <errno.h>
 #endif
 
 #if POSIX
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <unistd.h>
 #include <utime.h>
 #endif
 

--- a/src/root/file.h
+++ b/src/root/file.h
@@ -8,8 +8,7 @@
 
 #pragma once
 
-#include <stddef.h>
-
+#include "dsystem.h"
 #include "array.h"
 
 typedef Array<struct File *> Files;

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -6,37 +6,19 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/filename.c
  */
 
+#include "dsystem.h"
 #include "filename.h"
-
-#include <stdint.h>
-#include <ctype.h>
 
 #include "outbuffer.h"
 #include "array.h"
 #include "file.h"
 #include "rmem.h"
 
-#if defined (__sun)
-#include <alloca.h>
-#endif
-
-#if _MSC_VER ||__MINGW32__
-#include <malloc.h>
-#include <string>
-#endif
-
 #if _WIN32
 #include <windows.h>
-#include <direct.h>
-#include <errno.h>
 #endif
 
 #if POSIX
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <unistd.h>
 #include <utime.h>
 #endif
 

--- a/src/root/hash.h
+++ b/src/root/hash.h
@@ -10,8 +10,7 @@
 
 #pragma once
 
-#include <stdint.h>                     // uint{8|16|32}_t
-#include <stdlib.h>
+#include "dsystem.h"                    // uint{8|16|32}_t
 
 // MurmurHash2 was written by Austin Appleby, and is placed in the public
 // domain. The author hereby disclaims copyright to this source code.

--- a/src/root/object.h
+++ b/src/root/object.h
@@ -6,11 +6,9 @@
  * https://github.com/dlang/dmd/blob/master/src/root/object.h
  */
 
-#define POSIX (__linux__ || __GLIBC__ || __gnu_hurd__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
-
 #pragma once
 
-#include <stddef.h>
+#include "dsystem.h"
 
 typedef size_t hash_t;
 

--- a/src/root/outbuffer.c
+++ b/src/root/outbuffer.c
@@ -6,16 +6,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/outbuffer.c
  */
 
-#include <assert.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#if __sun
-#include <alloca.h>
-#endif
-
+#include "dsystem.h"
 #include "outbuffer.h"
 #include "object.h"
 

--- a/src/root/outbuffer.h
+++ b/src/root/outbuffer.h
@@ -8,10 +8,7 @@
 
 #pragma once
 
-#include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <assert.h>
+#include "dsystem.h"
 #include "port.h"
 #include "rmem.h"
 

--- a/src/root/port.h
+++ b/src/root/port.h
@@ -11,11 +11,9 @@
 // Portable wrapper around compiler/system specific things.
 // The idea is to minimize #ifdef's in the app code.
 
-#include <stdlib.h> // for alloca
-#include <stdint.h>
+#include "dsystem.h" // for alloca
 
 #if _MSC_VER
-#include <alloca.h>
 typedef __int64 longlong;
 typedef unsigned __int64 ulonglong;
 #else

--- a/src/root/rmem.c
+++ b/src/root/rmem.c
@@ -6,10 +6,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/rmem.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include "dsystem.h"
 #include "rmem.h"
 
 /* This implementation of the storage allocator uses the standard C allocation package.

--- a/src/root/rmem.c
+++ b/src/root/rmem.c
@@ -20,7 +20,11 @@ char *Mem::xstrdup(const char *s)
 
     if (s)
     {
+#ifdef IN_GCC
+        p = ::xstrdup(s);
+#else
         p = strdup(s);
+#endif
         if (p)
             return p;
         error();
@@ -35,7 +39,11 @@ void *Mem::xmalloc(size_t size)
         p = NULL;
     else
     {
+#ifdef IN_GCC
+        p = ::xmalloc(size);
+#else
         p = malloc(size);
+#endif
         if (!p)
             error();
     }
@@ -49,7 +57,11 @@ void *Mem::xcalloc(size_t size, size_t n)
         p = NULL;
     else
     {
+#ifdef IN_GCC
+        p = ::xcalloc(size, n);
+#else
         p = calloc(size, n);
+#endif
         if (!p)
             error();
     }
@@ -67,14 +79,22 @@ void *Mem::xrealloc(void *p, size_t size)
     }
     else if (!p)
     {
+#ifdef IN_GCC
+        p = ::xmalloc(size);
+#else
         p = malloc(size);
+#endif
         if (!p)
             error();
     }
     else
     {
         void *psave = p;
+#ifdef IN_GCC
+        p = ::xrealloc(psave, size);
+#else
         p = realloc(psave, size);
+#endif
         if (!p)
         {   xfree(psave);
             error();
@@ -96,7 +116,11 @@ void *Mem::xmallocdup(void *o, size_t size)
         p = NULL;
     else
     {
+#ifdef IN_GCC
+        p = ::xmalloc(size);
+#else
         p = malloc(size);
+#endif
         if (!p)
             error();
         else
@@ -140,7 +164,11 @@ extern "C" void *allocmemory(size_t m_size)
 
     if (m_size > CHUNK_SIZE)
     {
+#ifdef IN_GCC
+        void *p = xmalloc(m_size);
+#else
         void *p = malloc(m_size);
+#endif
         if (p)
             return p;
         printf("Error: out of memory\n");
@@ -149,7 +177,11 @@ extern "C" void *allocmemory(size_t m_size)
     }
 
     heapleft = CHUNK_SIZE;
+#ifdef IN_GCC
+    heapp = xmalloc(CHUNK_SIZE);
+#else
     heapp = malloc(CHUNK_SIZE);
+#endif
     if (!heapp)
     {
         printf("Error: out of memory\n");

--- a/src/root/rmem.h
+++ b/src/root/rmem.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <stddef.h>     // for size_t
+#include "dsystem.h"    // for size_t
 
 #if __APPLE__ && __i386__
     /* size_t is 'unsigned long', which makes it mangle differently

--- a/src/root/rootobject.c
+++ b/src/root/rootobject.c
@@ -5,8 +5,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/object.c
  */
 
-#include <stdio.h>
-
+#include "dsystem.h"
 #include "object.h"
 #include "outbuffer.h"
 

--- a/src/root/speller.c
+++ b/src/root/speller.c
@@ -6,16 +6,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/speller.c
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <limits.h>
-
-#if __sun || _MSC_VER
-#include <alloca.h>
-#endif
-
+#include "dsystem.h"
 #include "speller.h"
 
 const char idchars[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";

--- a/src/root/stringtable.c
+++ b/src/root/stringtable.c
@@ -6,11 +6,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/root/stringtable.c
  */
 
-#include <stdio.h>
-#include <stdint.h>                     // uint{8|16|32}_t
-#include <string.h>                     // memcpy()
-#include <stdlib.h>
-
+#include "dsystem.h"                    // uint{8|16|32}_t, memcpy()
 #include "root.h"
 #include "rmem.h"                       // mem
 #include "stringtable.h"

--- a/src/sapply.c
+++ b/src/sapply.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/sapply.c
  */
 
-#include <stdio.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "statement.h"

--- a/src/sideeffect.c
+++ b/src/sideeffect.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/sideeffect.c
  */
 
-#include <stdio.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "init.h"

--- a/src/statement.c
+++ b/src/statement.c
@@ -8,9 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/statement.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "statement.h"
 #include "errors.h"

--- a/src/statementsem.c
+++ b/src/statementsem.c
@@ -7,10 +7,7 @@
  * http://www.boost.org/LICENSE_1_0.txt
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 #include "root/checkedint.h"
 

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -8,9 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/staticassert.c
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
+#include "root/dsystem.h"
 
 #include "mars.h"
 #include "dsymbol.h"

--- a/src/staticassert.c
+++ b/src/staticassert.c
@@ -98,7 +98,7 @@ bool StaticAssert::oneMember(Dsymbol **ps, Identifier *)
     return true;
 }
 
-const char *StaticAssert::kind()
+const char *StaticAssert::kind() const
 {
     return "static assert";
 }

--- a/src/tokens.c
+++ b/src/tokens.c
@@ -8,8 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/lexer.c
  */
 
-#include <stdio.h>
-#include <ctype.h>
+#include "root/dsystem.h"
 
 #include "tokens.h"
 #include "root/rmem.h"

--- a/src/traits.c
+++ b/src/traits.c
@@ -8,12 +8,7 @@
  * https://github.com/D-Programming-Language/dmd/blob/master/src/traits.c
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <assert.h>
-#include <math.h>
-
+#include "root/dsystem.h"
 #include "root/rmem.h"
 #include "root/aav.h"
 #include "root/checkedint.h"

--- a/src/utf.c
+++ b/src/utf.c
@@ -17,8 +17,6 @@
 /// [3] http://unicode.org/faq/utf_bom.html
 /// [4] http://www.unicode.org/versions/Unicode6.1.0/ch03.pdf
 
-#include <assert.h>
-
 #include "utf.h"
 
 /* The following encodings are valid, except for the 5 and 6 byte

--- a/src/utf.h
+++ b/src/utf.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <stdlib.h>
+#include "root/dsystem.h"
 
 /// A UTF-8 code unit
 typedef unsigned char   utf8_t;

--- a/src/utils.c
+++ b/src/utils.c
@@ -7,7 +7,7 @@
  * http://www.boost.org/LICENSE_1_0.txt
  */
 
-#include <string.h>
+#include "root/dsystem.h"
 #include "mars.h"
 #include "globals.h"
 #include "root/file.h"

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <assert.h>
+#include "root/dsystem.h"
 
 class Statement;
 class ErrorStatement;


### PR DESCRIPTION
Portability of the front-end is not well covered for older targets.

For instance, while Solaris 11 can build just fine, Solaris 10 fails with:
```
/vol/gcc/src/hg/trunk/local/gcc/d/dmd/arrayop.c: In member function 'virtual void buildArrayIdent(Expression*, OutBuffer*, Expressions*)::BuildArrayIdentVisitor::visit(BinAssignExp*)':
/vol/gcc/src/hg/trunk/local/gcc/d/dmd/arrayop.c:336:29: error: 's' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  336 |             buf->writestring(s);
      |             ~~~~~~~~~~~~~~~~^~~

/vol/gcc/src/hg/trunk/local/gcc/d/dmd/ctfeexpr.c: In function 'int comparePointers(TOK, Expression*, dinteger_t, Expression*, dinteger_t)':
/vol/gcc/src/hg/trunk/local/gcc/d/dmd/ctfeexpr.c:925:13: error: 'n' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  925 |         int n;
      |     
```

This is because assert is not marked as noreturn in `<assert.h>`.

GCC itself provides a couple of headers that wrap around vagaries of the host system to provide a consistent interface for maximum portability.

This patch then moves most front-end system includes into a central place, allowing gdc to override and provide its own copy of this header that includes the gcc headers, or provide gcc-specific portability fixes to the C++ sources.

I need to first check this against gdc to make sure it actually fits well.