### PR TITLE
[dmd-cxx] Use rmem instead of libc for malloc/strdup

### DIFF
--- a/src/dmodule.c
+++ b/src/dmodule.c
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include "root/rmem.h"
+
 #include "mars.h"
 #include "module.h"
 #include "parse.h"
@@ -1043,8 +1045,7 @@ void Module::runDeferredSemantic()
         }
         else
         {
-            todo = (Dsymbol **)malloc(len * sizeof(Dsymbol *));
-            assert(todo);
+            todo = (Dsymbol **)mem.xmalloc(len * sizeof(Dsymbol *));
             todoalloc = todo;
         }
         memcpy(todo, deferred.tdata(), len * sizeof(Dsymbol *));

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -241,9 +241,7 @@ const char *Dsymbol::toPrettyChars(bool QualifyTypes)
         ++complength;
 
     // Allocate temporary array comp[]
-    const char **comp = (const char **)malloc(complength * sizeof(char**));
-    if (!comp)
-        Mem::error();
+    const char **comp = (const char **)mem.xmalloc(complength * sizeof(char**));
 
     // Fill in comp[] and compute length of final result
     size_t length = 0;

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -2336,8 +2336,7 @@ Identifier *Type::getTypeInfoIdent()
     // Allocate buffer on stack, fail over to using malloc()
     char namebuf[128];
     size_t namelen = 19 + sizeof(len) * 3 + len + 1;
-    char *name = namelen <= sizeof(namebuf) ? namebuf : (char *)malloc(namelen);
-    assert(name);
+    char *name = namelen <= sizeof(namebuf) ? namebuf : (char *)mem.xmalloc(namelen);
 
     sprintf(name, "_D%lluTypeInfo_%s6__initZ", (unsigned long long) 9 + len, buf.data);
     //printf("%p, deco = %s, name = %s\n", this, deco, name);

--- a/src/utils.c
+++ b/src/utils.c
@@ -13,6 +13,7 @@
 #include "root/file.h"
 #include "root/filename.h"
 #include "root/outbuffer.h"
+#include "root/rmem.h"
 
 /**
  * Normalize path by turning forward slashes into backslashes
@@ -28,7 +29,7 @@ const char * toWinPath(const char *src)
     if (src == NULL)
         return NULL;
 
-    char *result = strdup(src);
+    char *result = mem.xstrdup(src);
     char *p = result;
     while (*p != '\0')
     {


### PR DESCRIPTION
As proper checking + error handling of the return value is managed.