### PR TITLE
Test fix broken semaphoreCI builds

### DIFF
--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -142,7 +142,7 @@ void Obj_refGOTsym()
     }
 }
 
-private void objfile_write(FILE *fd, void *buffer, uint len);
+//private void objfile_write(FILE *fd, void *buffer, uint len);
 
 // The object file is built is several separate pieces
 


### PR DESCRIPTION
I'm pretty sure #8867 is failing because of https://issues.dlang.org/show_bug.cgi?id=16563.

The front-end version matches at least (IIRC, gdc-7 compiler in CI is based on 2.072).