### PR TITLE
[dmd-cxx] Backport: Don't pass null pointer as format parameter to errorSupplemental

### DIFF
--- a/src/dmodule.c
+++ b/src/dmodule.c
@@ -312,7 +312,8 @@ bool Module::read(Loc loc)
         {
             ::error(loc, "cannot find source code for runtime library file 'object.d'");
             errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-            errorSupplemental(loc, "config file: %s", FileName::canonicalName(global.inifilename));
+            const char *dmdConfFile = FileName::canonicalName(global.inifilename);
+            errorSupplemental(loc, "config file: %s", dmdConfFile ? dmdConfFile : "not found");
         }
         else
         {


### PR DESCRIPTION
Backported from #8534