### PR TITLE
C++,POSIX: Correct mangling of pointers with const

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1359,9 +1359,13 @@ extern(C++):
         if (t.isImmutable() || t.isShared())
             return error(t);
 
+        // Check for const - Since we cannot represent C++'s `char* const`,
+        // and `const char* const` (a.k.a `const(char*)` in D) is mangled
+        // the same as `const char*` (`const(char)*` in D), we need to add
+        // an extra `K` if `nextOf()` is `const`, before substitution
+        CV_qualifiers(t);
         if (substitute(t))
             return;
-        CV_qualifiers(t);
         buf.writeByte('P');
         auto prev = this.context.push(this.context.res.asType().nextOf());
         scope (exit) this.context.pop(prev);

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -146,6 +146,18 @@ T[] values(T)()
     return values;
 }
 
+extern(C++, `ns1`)
+ {
+    // C++: `const char*, const char**`
+    int constFunction1(const(char)*, const(char)**);
+    // C++: `const char*, const char* const*`
+    int constFunction2(const(char)*, const(char*)*);
+    // C++: `const char* const, const char* const* const*`
+    int constFunction3(const(char*), const(char**)*);
+    // C++: `const char* const, const char* const* const* const`
+    int constFunction4(const(char*), const(char***));
+}
+
 void main()
 {
     foreach(bool val; values!bool())     check(val);
@@ -163,4 +175,9 @@ void main()
     foreach(double val; values!double()) check(val);
     check(S());
     check(std.test19248());
+
+    assert(constFunction1(null, null) == 1);
+    assert(constFunction2(null, null) == 2);
+    assert(constFunction3(null, null) == 3);
+    assert(constFunction4(null, null) == 42);
 }

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -61,6 +61,18 @@ double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
 
+namespace ns1
+{
+    // D: `char*, const(char)**`
+    int constFunction1(const char*, const char**) { return 1; }
+    // D: `const(char)*, const(char*)*`
+    int constFunction2(const char*, const char* const*) { return 2; }
+    // D: `const(char*), const(char**)*`
+    int constFunction3(const char* const, const char* const* const*) { return 3; }
+    // D: `const(char*), const(char***)`
+    int constFunction4(const char* const, const char* const* const* const) { return 42; }
+};
+
 // Uncomment when mangling is fixed
 // typedef void(*fn0)();
 // fn0            passthrough_fn0   (fn0 value) { return value; }


### PR DESCRIPTION
Mangling of const pointer was not correct when substitution was involved.
This takes advantage of the fact that `char* const*` cannot be represented.

Superseeds #8288 