### PR TITLE
Fix Issue 17674 - [REG 2.064] Simultaneous opBinary and opBinaryRight is not rejected

### DIFF
--- a/test/fail_compilation/fail17674.d
+++ b/test/fail_compilation/fail17674.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail17674.d(21): Error: overloads `pure nothrow @nogc @safe int(S2 other)` and `pure nothrow @nogc @safe int(S1 other)` both match argument list for `opBinary`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=17674
+struct S1
+{
+    int opBinary(string op)(S2 other) { return 3; }
+}
+
+struct S2
+{
+    int opBinaryRight(string op)(S1 other) { return 4; }
+}
+
+void main()
+{
+    auto x = S1.init + S2.init;
+}


### PR DESCRIPTION
The problem is that the same Match object is used to check both opBinary and opBinaryRight and the last match will always be taken into account without comparing the result with the previous match. `functionResolve` cannot be used successively with the same Match object if the parameters differ, because the match count will always be reset to 1 when a better one is found.

The fix is to use different match objects and then aggregate them accordingly.