### PR TITLE
Remove duplicate builtins from std.math

### DIFF
--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -311,7 +311,7 @@ extern (C++) Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* ar
 
 public extern (C++) void builtin_init()
 {
-    builtins._init(84);
+    builtins._init(65);
     // @safe @nogc pure nothrow real function(real)
     add_builtin("_D4core4math3sinFNaNbNiNfeZe", &eval_sin);
     add_builtin("_D4core4math3cosFNaNbNiNfeZe", &eval_cos);
@@ -352,51 +352,17 @@ public extern (C++) void builtin_init()
     // @safe @nogc pure nothrow long function(real)
     add_builtin("_D4core4math6rndtolFNaNbNiNfeZl", &eval_unimp);
     // @safe @nogc pure nothrow real function(real)
-    add_builtin("_D3std4math3sinFNaNbNiNfeZe", &eval_sin);
-    add_builtin("_D3std4math3cosFNaNbNiNfeZe", &eval_cos);
     add_builtin("_D3std4math3tanFNaNbNiNfeZe", &eval_tan);
-    add_builtin("_D3std4math4sqrtFNaNbNiNfeZe", &eval_sqrt);
-    add_builtin("_D3std4math4fabsFNaNbNiNfeZe", &eval_fabs);
     add_builtin("_D3std4math5expm1FNaNbNiNfeZe", &eval_unimp);
     // @trusted @nogc pure nothrow real function(real)
-    add_builtin("_D3std4math3sinFNaNbNiNeeZe", &eval_sin);
-    add_builtin("_D3std4math3cosFNaNbNiNeeZe", &eval_cos);
     add_builtin("_D3std4math3tanFNaNbNiNeeZe", &eval_tan);
-    add_builtin("_D3std4math4sqrtFNaNbNiNeeZe", &eval_sqrt);
-    add_builtin("_D3std4math4fabsFNaNbNiNeeZe", &eval_fabs);
     add_builtin("_D3std4math3expFNaNbNiNeeZe", &eval_exp);
     add_builtin("_D3std4math5expm1FNaNbNiNeeZe", &eval_expm1);
     add_builtin("_D3std4math4exp2FNaNbNiNeeZe", &eval_exp2);
-    // @safe @nogc pure nothrow double function(double)
-    add_builtin("_D3std4math4sqrtFNaNbNiNfdZd", &eval_sqrt);
-    // @safe @nogc pure nothrow float function(float)
-    add_builtin("_D3std4math4sqrtFNaNbNiNffZf", &eval_sqrt);
     // @safe @nogc pure nothrow real function(real, real)
     add_builtin("_D3std4math5atan2FNaNbNiNfeeZe", &eval_unimp);
-    if (CTFloat.yl2x_supported)
-    {
-        add_builtin("_D3std4math4yl2xFNaNbNiNfeeZe", &eval_yl2x);
-    }
-    else
-    {
-        add_builtin("_D3std4math4yl2xFNaNbNiNfeeZe", &eval_unimp);
-    }
-    if (CTFloat.yl2xp1_supported)
-    {
-        add_builtin("_D3std4math6yl2xp1FNaNbNiNfeeZe", &eval_yl2xp1);
-    }
-    else
-    {
-        add_builtin("_D3std4math6yl2xp1FNaNbNiNfeeZe", &eval_unimp);
-    }
-    // @safe @nogc pure nothrow long function(real)
-    add_builtin("_D3std4math6rndtolFNaNbNiNfeZl", &eval_unimp);
-
     // @safe @nogc pure nothrow T function(T, int)
     add_builtin("_D4core4math5ldexpFNaNbNiNfeiZe", &eval_ldexp);
-    add_builtin("_D3std4math5ldexpFNaNbNiNfeiZe", &eval_ldexp);
-    add_builtin("_D3std4math5ldexpFNaNbNiNfdiZd", &eval_ldexp);
-    add_builtin("_D3std4math5ldexpFNaNbNiNffiZf", &eval_ldexp);
 
     add_builtin("_D3std4math3logFNaNbNiNfeZe", &eval_log);
 


### PR DESCRIPTION
```
A few years ago, we started moving builtins from Phobos to druntime,
as it is where the compiler dependencies should live.
This was never completed, and some dependencies still live in Phobos,
while other definitions are missing from `core.math`
(e.g. unimplemented builtins are not defined).

While completing this will take time, a trivial first step is to remove
the functions that just forwards to the builtins.
```

Note: I counted the builtins, and there are 65 after the removal (and not 68).

Now for the sake of the reviewers:
- [`std.math.sin`](https://github.com/dlang/phobos/blob/a7485d9857b980fbd9b13dda792217fee4000004/std/math.d#L793-L799)
- [`std.math.cos`](https://github.com/dlang/phobos/blob/a7485d9857b980fbd9b13dda792217fee4000004/std/math.d#L751-L757)
- [`std.math.sqrt`](https://github.com/dlang/phobos/blob/a7485d9857b980fbd9b13dda792217fee4000004/std/math.d#L2069-L2075)
- [`std.math.fabs`](https://github.com/dlang/phobos/blob/a7485d9857b980fbd9b13dda792217fee4000004/std/math.d#L4568-L4574)
- `std.math.yl2x` and `std.math.yl2xp1` are not even defined
- [`std.math.rndtol`](https://github.com/dlang/phobos/blob/a7485d9857b980fbd9b13dda792217fee4000004/std/math.d#L2007-L2013)
- [`std.math.ldexp`](https://github.com/dlang/phobos/blob/a7485d9857b980fbd9b13dda792217fee4000004/std/math.d#L3819-L3825)