### PR TITLE
Set `global.params.mscoff` to `true` if compiling for 64 bit

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -368,9 +368,12 @@ struct Global
         {
             static assert(0, "fix this");
         }
+        static if (TARGET.Windows)
+        {
+            params.mscoff = params.is64bit;
+        }
         _version = (import("VERSION") ~ '\0').ptr;
         vendor = "Digital Mars D";
-        params.mscoff = params.is64bit;
     }
 
     /**

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -370,6 +370,7 @@ struct Global
         }
         _version = (import("VERSION") ~ '\0').ptr;
         vendor = "Digital Mars D";
+        params.mscoff = params.is64bit;
     }
 
     /**


### PR DESCRIPTION
Otherwise the correct version identifiers will not be set when building an application that uses the Dub package.