### PR TITLE
fix issue 19381 - capture pointer in nested function should not be called "this"

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -476,8 +476,8 @@ extern (C++) class FuncDeclaration : Declaration
              * enclosing function's stack frame.
              * Note that nested functions and member functions are disjoint.
              */
-            VarDeclaration v = new ThisDeclaration(loc, Type.tvoid.pointerTo());
-            v.storage_class |= STC.parameter;
+            VarDeclaration v = new VarDeclaration(loc, Type.tvoid.pointerTo(), Id.capture, null);
+            v.storage_class |= STC.parameter | STC.nodtor;
             if (type.ty == Tfunction)
             {
                 TypeFunction tf = cast(TypeFunction)type;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -76,6 +76,7 @@ immutable Msgtable[] msgtable =
     { "unitTest", "__unitTest" },
     { "require", "__require" },
     { "ensure", "__ensure" },
+    { "capture", "__capture" },
     { "_init", "init" },
     { "__sizeof", "sizeof" },
     { "__xalignof", "alignof" },

--- a/test/runnable/testpdb.d
+++ b/test/runnable/testpdb.d
@@ -205,13 +205,13 @@ void test19307(IDiaSession session, IDiaSymbol globals)
     foo19307();
 
     testClosureVar(globals, "testpdb.foo19307", "__closptr", "x");
-    testClosureVar(globals, "testpdb.foo19307.nested", "this", "x");
+    testClosureVar(globals, "testpdb.foo19307.nested", "__capture", "x");
     testClosureVar(globals, "testpdb.foo19307.nested", "__closptr", "y");
-    testClosureVar(globals, "testpdb.foo19307.nested.nested2", "this", "__chain", "x");
+    testClosureVar(globals, "testpdb.foo19307.nested.nested2", "__capture", "__chain", "x");
 
     testClosureVar(globals, "testpdb.Struct.foo", "__closptr", "this", "member");
-    testClosureVar(globals, "testpdb.Struct.foo.nested", "this", "localOfMethod");
-    testClosureVar(globals, "testpdb.Struct.foo.nested", "this", "__chain", "member");
+    testClosureVar(globals, "testpdb.Struct.foo.nested", "__capture", "localOfMethod");
+    testClosureVar(globals, "testpdb.Struct.foo.nested", "__capture", "__chain", "member");
 }
 
 ///////////////////////////////////////////////
@@ -236,10 +236,10 @@ void test19318(IDiaSession session, IDiaSymbol globals)
     foo19318(5);
 
     testClosureVar(globals, "testpdb.foo19318", "x");
-    testClosureVar(globals, "testpdb.foo19318.nested", "this", "x");
-    testClosureVar(globals, "testpdb.foo19318.nested", "this", "z");
-    testClosureVar(globals, "testpdb.foo19318.nested.nested2", "this", "x");
-    testClosureVar(globals, "testpdb.foo19318.nested.nested2", "this", "z");
+    testClosureVar(globals, "testpdb.foo19318.nested", "__capture", "x");
+    testClosureVar(globals, "testpdb.foo19318.nested", "__capture", "z");
+    testClosureVar(globals, "testpdb.foo19318.nested.nested2", "__capture", "x");
+    testClosureVar(globals, "testpdb.foo19318.nested.nested2", "__capture", "z");
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
rename the context pointer to the closure or the outer functions stack frame to '__capture'