### PR TITLE
fix Issue 19086 - Bad stack trace for exceptions

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3725,6 +3725,13 @@ static if (0)
         // If stack needs cleanup
         if  (s && s.Sflags & SFLexit)
         {
+            if (config.fulltypes && TARGET_WINDOS)
+            {
+                // the stack walker evaluates the return address, not a byte of the
+                // call instruction, so ensure there is an instruction byte after
+                // the call that still has the same line number information
+                cdb.gen1(config.target_cpu >= TARGET_80286 ? UD2 : INT3);
+            }
             /* Function never returns, so don't need to generate stack
              * cleanup code. But still need to log the stack cleanup
              * as if it did return.

--- a/test/runnable/test19086.d
+++ b/test/runnable/test19086.d
@@ -1,0 +1,64 @@
+// REQUIRED_ARGS: -g
+// REQUIRED_ARGS(linux freebsd dragonflybsd): -L-export-dynamic
+// PERMUTE_ARGS:
+// DISABLED: osx
+
+void run19086()
+{
+	long x = 1;
+	int y = 0;
+#line 20
+    throw newException();
+}
+
+// moved here to keep run19086 short
+Exception newException() { return new Exception("hi"); }
+
+void test19086()
+{
+	try
+	{
+		run19086();
+	}
+	catch(Exception e)
+	{
+		int line = findLineStackTrace(e.toString(), "run19086");
+		assert(line >= 20 && line <= 21);
+	}
+}
+
+int findLineStackTrace(string msg, string func)
+{
+    // find line number of _Dmain in stack trace
+    // on linux:   file.d:line _Dmain [addr]
+    // on windows: addr in _Dmain at file.d(line)
+    int line = 0;
+    bool found = false;
+    for (size_t pos = 0; pos + func.length < msg.length; pos++)
+    {
+        if (msg[pos] == '\n')
+        {
+            line = 0;
+            found = false;
+        }
+        else if ((msg[pos] == ':' || msg[pos] == '(') && line == 0)
+        {
+            for (pos++; pos < msg.length && msg[pos] >= '0' && msg[pos] <= '9'; pos++)
+                line = line * 10 + msg[pos] - '0';
+            if (line > 0 && found)
+                return line;
+        }
+        else if (msg[pos .. pos + func.length] == func)
+        {
+            found = true;
+            if (line > 0 && found)
+                return line;
+        }
+    }
+    return 0;
+}
+
+void main()
+{
+	test19086();
+}


### PR DESCRIPTION
When building with debug info, add ud2 instruction after call to functions that never return. This allows the stack walker to find the correct source line