### PR TITLE
Remove old support code for struct __c_long/ulong/long_double

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1425,16 +1425,6 @@ extern(C++):
     {
         if (t.isImmutable() || t.isShared())
             return error(t);
-
-        /* __c_long and __c_ulong get special mangling
-         */
-        const id = t.sym.ident;
-        //printf("struct id = '%s'\n", id.toChars());
-        if (id == Id.__c_long)
-            return writeBasicType(t, 0, 'l');
-        else if (id == Id.__c_ulong)
-            return writeBasicType(t, 0, 'm');
-
         //printf("TypeStruct %s\n", t.toChars());
         doSymbol(t);
     }

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1445,8 +1445,6 @@ uint totym(Type tx)
 
         case Tstruct:
             t = TYstruct;
-            if (tx.toDsymbol(null).ident == Id.__c_long_double)
-                t = TYdouble;
             break;
 
         case Tenum:

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -559,8 +559,6 @@ struct Target
             if (tns.ty == Tstruct)
             {
                 StructDeclaration sd = (cast(TypeStruct)tns).sym;
-                if (sd.ident == Id.__c_long_double)
-                    return false;
                 if (tf.linkage == LINK.cpp && needsThis)
                     return true;
                 if (!sd.isPOD() || sz > 8)
@@ -577,9 +575,6 @@ struct Target
             Type tb = tns.baseElemOf();
             if (tb.ty == Tstruct)
             {
-                StructDeclaration sd = (cast(TypeStruct)tb).sym;
-                if (sd.ident == Id.__c_long_double)
-                    return false;
                 if (tf.linkage == LINK.cpp && needsThis)
                     return true;
             }
@@ -621,9 +616,6 @@ struct Target
             StructDeclaration sd = (cast(TypeStruct)tns).sym;
             if (global.params.isLinux && tf.linkage != LINK.d && !global.params.is64bit)
             {
-                if (sd.ident == Id.__c_long || sd.ident == Id.__c_ulong)
-                    return false;
-
                 //printf("  2 true\n");
                 return true;            // 32 bit C/C++ structs always on stack
             }
@@ -631,9 +623,6 @@ struct Target
                      sd.isPOD() && sd.ctor)
             {
                 // win32 returns otherwise POD structs with ctors via memory
-                // unless it's not really a struct
-                if (sd.ident == Id.__c_long || sd.ident == Id.__c_ulong)
-                    return false;
                 return true;
             }
             if (sd.arg1type && !sd.arg2type)

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -155,12 +155,6 @@ public:
         {
             // Create a new backend type
             StructDeclaration sym = t.sym;
-            if (sym.ident == Id.__c_long_double)
-            {
-                t.ctype = type_fake(TYdouble);
-                t.ctype.Tcount++;
-                return;
-            }
             t.ctype = type_struct_class(sym.toPrettyChars(true), sym.alignsize, sym.structsize, sym.arg1type ? Type_toCtype(sym.arg1type) : null, sym.arg2type ? Type_toCtype(sym.arg2type) : null, sym.isUnionDeclaration() !is null, false, sym.isPOD() != 0, sym.hasNoFields);
             /* Add in fields of the struct
              * (after setting ctype to avoid infinite recursion)

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -1,4 +1,4 @@
-// PERMUTE_ARGS: -g -version=PULL8152
+// PERMUTE_ARGS: -g
 // EXTRA_CPP_SOURCES: cppb.cpp
 
 import core.stdc.stdio;
@@ -603,19 +603,7 @@ extern(C++)
 
 version (CRuntime_Microsoft)
 {
-    version (PULL8152)
-    {
-        enum __c_long_double : double;
-    }
-    else
-    {
-        struct __c_long_double
-        {
-            this(double d) { ld = d; }
-            double ld;
-            alias ld this;
-        }
-    }
+    enum __c_long_double : double;
     alias __c_long_double myld;
 }
 else
@@ -652,28 +640,8 @@ else
   }
 }
 
-version (PULL8152)
-{
-    enum __c_long : x_long;
-    enum __c_ulong : x_ulong;
-}
-else
-{
-    struct __c_long
-    {
-        this(x_long d) { ld = d; }
-        x_long ld;
-        alias ld this;
-    }
-
-    struct __c_ulong
-    {
-        this(x_ulong d) { ld = d; }
-        x_ulong ld;
-        alias ld this;
-    }
-}
-
+enum __c_long : x_long;
+enum __c_ulong : x_ulong;
 alias __c_long mylong;
 alias __c_ulong myulong;
 
@@ -695,51 +663,48 @@ void test16()
     assert(ld == 5 + myulong.sizeof);
   }
 
-    version (PULL8152)
-    {
-        static if (__c_long.sizeof == long.sizeof)
-        {
-            static assert(__c_long.max == long.max);
-            static assert(__c_long.min == long.min);
-            static assert(__c_long.init == long.init);
+  static if (__c_long.sizeof == long.sizeof)
+  {
+    static assert(__c_long.max == long.max);
+    static assert(__c_long.min == long.min);
+    static assert(__c_long.init == long.init);
 
-            static assert(__c_ulong.max == ulong.max);
-            static assert(__c_ulong.min == ulong.min);
-            static assert(__c_ulong.init == ulong.init);
+    static assert(__c_ulong.max == ulong.max);
+    static assert(__c_ulong.min == ulong.min);
+    static assert(__c_ulong.init == ulong.init);
 
-            __c_long cl = 0;
-            cl = cl + 1;
-            long l = cl;
-            cl = l;
+    __c_long cl = 0;
+    cl = cl + 1;
+    long l = cl;
+    cl = l;
 
-            __c_ulong cul = 0;
-            cul = cul + 1;
-            ulong ul = cul;
-            cul = ul;
-        }
-        else static if (__c_long.sizeof == int.sizeof)
-        {
-            static assert(__c_long.max == int.max);
-            static assert(__c_long.min == int.min);
-            static assert(__c_long.init == int.init);
+    __c_ulong cul = 0;
+    cul = cul + 1;
+    ulong ul = cul;
+    cul = ul;
+  }
+  else static if (__c_long.sizeof == int.sizeof)
+  {
+    static assert(__c_long.max == int.max);
+    static assert(__c_long.min == int.min);
+    static assert(__c_long.init == int.init);
 
-            static assert(__c_ulong.max == uint.max);
-            static assert(__c_ulong.min == uint.min);
-            static assert(__c_ulong.init == uint.init);
+    static assert(__c_ulong.max == uint.max);
+    static assert(__c_ulong.min == uint.min);
+    static assert(__c_ulong.init == uint.init);
 
-            __c_long cl = 0;
-            cl = cl + 1;
-            int i = cl;
-            cl = i;
+    __c_long cl = 0;
+    cl = cl + 1;
+    int i = cl;
+    cl = i;
 
-            __c_ulong cul = 0;
-            cul = cul + 1;
-            uint u = cul;
-            cul = u;
-        }
-        else
-            static assert(0);
-    }
+    __c_ulong cul = 0;
+    cul = cul + 1;
+    uint u = cul;
+    cul = u;
+  }
+  else
+    static assert(0);
 }
 
 


### PR DESCRIPTION
Library support is long gone.  And that the compiler still special cases it (and checks in the testsuite) is surprising.  I got caught out by the cppa test failing on i686.