### PR TITLE
Fix Issue 19393 - Structure dtor isn't called after passed to T[] argument. Memory leaks issue

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -661,6 +661,7 @@ private bool functionParameters(Loc loc, Scope* sc, TypeFunction tf, Type tthis,
                             }
                             else
                                 a = a.implicitCastTo(sc, tbn);
+                            a = a.addDtorHook(sc);
                             (*elements)[u] = a;
                         }
                         // https://issues.dlang.org/show_bug.cgi?id=14395

--- a/test/runnable/test19393.d
+++ b/test/runnable/test19393.d
@@ -1,0 +1,37 @@
+string result;
+
+struct S
+{
+    this(this)
+    {
+        result ~= "A";
+    }
+
+    ~this()
+    {
+        result ~= "B";
+    }
+}
+
+void foo(const(S)[] ar...)
+{
+    /* postblit gets called on this initialization,
+     * then when the function returns, the destructor
+     * gets called => result = "AB";
+     */
+    auto d = ar[0];
+}
+
+void bar()
+{
+    /* S(null) needs to be destroyed after the function call,
+     * that means that another `B` is appended => result = "ABB"
+     */
+    foo(S());
+}
+
+void main()
+{
+    bar();
+    assert(result == "ABB");
+}


### PR DESCRIPTION
The problem was that when the the array that is passed to the variadic function was created from the parameters, those parameters are not marked for destruction.