### PR TITLE
Support markdown headings

### DIFF
--- a/res/default_ddoc_theme.ddoc
+++ b/res/default_ddoc_theme.ddoc
@@ -11,6 +11,12 @@ ESCAPES =
   />/&gt;/
   /&/&amp;/
 
+H1 = <h1>$0</h1>
+H2 = <h2>$0</h2>
+H3 = <h3>$0</h3>
+H4 = <h4>$0</h4>
+H5 = <h5>$0</h5>
+H6 = <h6>$0</h6>
 B = <b>$0</b>
 I = <i>$0</i>
 EM = <em>$0</em>
@@ -83,6 +89,13 @@ DDOC =
         padding: 0;
         vertical-align: baseline;
       }
+
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
 
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
@@ -171,7 +184,7 @@ DDOC =
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/ddoc_markdown_headings.d
+++ b/test/compilable/ddoc_markdown_headings.d
@@ -1,0 +1,71 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=markdown
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+
+/++
+# ATX-Style Headings
+
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+
+ ### headings
+  ## with initial
+   # spaces
+
+## heading with *emphasis*
+
+## heading with trailing `#`'s #######
+## heading with trailing literal ##'s
+## heading with another trailing literal#
+## heading with backslash-escaped trailing #\##
+
+## Some empty headers:
+##
+#
+### ###
+
+Setext-Style Headings
+=====================
+
+H1
+==
+$(P
+H1
+=
+
+H2
+**
+)
+
+Multi-*line
+heading*
+***
+
+heading with initial spaces
+   ***
+and text directly after
+
+
+# Not Headings
+
+#hashtag not a heading because there's no space after the `#`
+
+####### Not a heading because it has more than 6 `#`'s
+
+\## Not a heading because of the preceeding backslash
+
+Not a heading because of spaces within
+= =
+
+Not a heading because of spaces within
+*** *
+
+Not a heading because backslash-escaped
+\***
+
++/
+module ddoc_markdown_headings;

--- a/test/compilable/ddoc_markdown_headings_verbose.d
+++ b/test/compilable/ddoc_markdown_headings_verbose.d
@@ -1,0 +1,23 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -transition=markdown -transition=vmarkdown
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+
+/*
+TEST_OUTPUT:
+----
+compilable/ddoc_markdown_headings_verbose.d(23): Ddoc: added heading 'Heading'
+compilable/ddoc_markdown_headings_verbose.d(23): Ddoc: added heading 'Another Heading'
+compilable/ddoc_markdown_headings_verbose.d(23): Ddoc: added heading 'And Another'
+----
+*/
+
+/++
+# Heading
+
+Another Heading
+===============
+
+And Another
+***********
++/
+module ddoc_markdown_headings_verbose;

--- a/test/compilable/extra-files/ddoc1.html
+++ b/test/compilable/extra-files/ddoc1.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc10.html
+++ b/test/compilable/extra-files/ddoc10.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc10325.html
+++ b/test/compilable/extra-files/ddoc10325.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc10334.html
+++ b/test/compilable/extra-files/ddoc10334.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc10366.html
+++ b/test/compilable/extra-files/ddoc10366.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc10367.html
+++ b/test/compilable/extra-files/ddoc10367.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc10869.html
+++ b/test/compilable/extra-files/ddoc10869.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc10870.html
+++ b/test/compilable/extra-files/ddoc10870.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc11.html
+++ b/test/compilable/extra-files/ddoc11.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc11479.html
+++ b/test/compilable/extra-files/ddoc11479.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc11511.html
+++ b/test/compilable/extra-files/ddoc11511.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc11823.html
+++ b/test/compilable/extra-files/ddoc11823.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc12.html
+++ b/test/compilable/extra-files/ddoc12.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc12706.html
+++ b/test/compilable/extra-files/ddoc12706.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc12745.html
+++ b/test/compilable/extra-files/ddoc12745.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc13.html
+++ b/test/compilable/extra-files/ddoc13.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc13270.html
+++ b/test/compilable/extra-files/ddoc13270.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc13645.html
+++ b/test/compilable/extra-files/ddoc13645.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc14.html
+++ b/test/compilable/extra-files/ddoc14.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc14383.html
+++ b/test/compilable/extra-files/ddoc14383.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc14413.html
+++ b/test/compilable/extra-files/ddoc14413.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc14778.html
+++ b/test/compilable/extra-files/ddoc14778.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc15475.html
+++ b/test/compilable/extra-files/ddoc15475.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc17697.html
+++ b/test/compilable/extra-files/ddoc17697.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc198.html
+++ b/test/compilable/extra-files/ddoc198.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc2.html
+++ b/test/compilable/extra-files/ddoc2.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc2273.html
+++ b/test/compilable/extra-files/ddoc2273.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc3.html
+++ b/test/compilable/extra-files/ddoc3.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc4.html
+++ b/test/compilable/extra-files/ddoc4.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc4162.html
+++ b/test/compilable/extra-files/ddoc4162.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc5.html
+++ b/test/compilable/extra-files/ddoc5.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc5446.html
+++ b/test/compilable/extra-files/ddoc5446.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc6.html
+++ b/test/compilable/extra-files/ddoc6.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc648.html
+++ b/test/compilable/extra-files/ddoc648.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc6491.html
+++ b/test/compilable/extra-files/ddoc6491.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc7.html
+++ b/test/compilable/extra-files/ddoc7.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc7555.html
+++ b/test/compilable/extra-files/ddoc7555.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc7656.html
+++ b/test/compilable/extra-files/ddoc7656.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc7715.html
+++ b/test/compilable/extra-files/ddoc7715.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc7795.html
+++ b/test/compilable/extra-files/ddoc7795.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc8.html
+++ b/test/compilable/extra-files/ddoc8.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc8271.html
+++ b/test/compilable/extra-files/ddoc8271.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9.html
+++ b/test/compilable/extra-files/ddoc9.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9037.html
+++ b/test/compilable/extra-files/ddoc9037.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9155.html
+++ b/test/compilable/extra-files/ddoc9155.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9305.html
+++ b/test/compilable/extra-files/ddoc9305.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9369.html
+++ b/test/compilable/extra-files/ddoc9369.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9475.html
+++ b/test/compilable/extra-files/ddoc9475.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9497a.html
+++ b/test/compilable/extra-files/ddoc9497a.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9497b.html
+++ b/test/compilable/extra-files/ddoc9497b.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9497c.html
+++ b/test/compilable/extra-files/ddoc9497c.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9497d.html
+++ b/test/compilable/extra-files/ddoc9497d.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9676a.html
+++ b/test/compilable/extra-files/ddoc9676a.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9676b.html
+++ b/test/compilable/extra-files/ddoc9676b.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9727.html
+++ b/test/compilable/extra-files/ddoc9727.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9789.html
+++ b/test/compilable/extra-files/ddoc9789.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc9903.html
+++ b/test/compilable/extra-files/ddoc9903.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddocYear.html
+++ b/test/compilable/extra-files/ddocYear.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;
@@ -492,7 +499,7 @@
   <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
-    __YEAR__
+    2018
   </p>
 </div>
 

--- a/test/compilable/extra-files/ddoc_markdown_emphasis.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc_markdown_escapes.html
+++ b/test/compilable/extra-files/ddoc_markdown_escapes.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddoc_markdown_headings.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>ddoc8739</title>
+    <title>ddoc_markdown_headings</title>
     <style type="text/css" media="screen">
       html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
       blockquote, pre, a, abbr, address, cite, code, del, dfn, em, figure,
@@ -470,114 +470,74 @@
   <body id="ddoc_main" class="ddoc dlang">
     <div class="content_wrapper">
       <article class="module">
-        <h1 class="module_name">ddoc8739</h1>
-        <section id="module_content">
-<section class="section ddoc_module_members_section">
-  <div class="ddoc_module_members">
-    <ul class="ddoc_members">
-  <li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg" id="dg"><code class="code">dg</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg"></span>void delegate(int a) <code class="code">dg</code>;
+        <h1 class="module_name">ddoc_markdown_headings</h1>
+        <section id="module_content"><section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    <h1>ATX-Style Headings</h1>
 
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
+  </p>
 </div>
-<div class="ddoc_decl">
-  
+<div class="ddoc_description">
+  <h4>Discussion</h4>
+  <p class="para">
+    <h1>H1</h1>
+<h2>H2</h2>
+<h3>H3</h3>
+<h4>H4</h4>
+<h5>H5</h5>
+<h6>H6</h6>
 
-</div>
+<h3>headings</h3>
+<h2>with initial</h2>
+<h1>spaces</h1>
 
-</li><li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg2" id="dg2"><code class="code">dg2</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg2"></span>void delegate(int b) <code class="code">dg2</code>;
+<h2>heading with <em>emphasis</em></h2>
 
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  
+<h2>heading with trailing <code class="code">#</code>'s</h2>
+<h2>heading with trailing literal ##'s</h2>
+<h2>heading with another trailing literal#</h2>
+<h2>heading with backslash-escaped trailing ###</h2>
 
-</div>
+<h2>Some empty headers:</h2>
+<h2></h2>
+<h1></h1>
+<h3></h3>
 
-</li><li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg3" id="dg3"><code class="code">dg3</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg3"></span>void delegate(int c)[] <code class="code">dg3</code>;
+<h1>Setext-Style Headings</h1>
 
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  
+<h1>H1</h1>
+<p><h1>H1</h1>
 
+<h2>H2</h2>
+</p>
+<br><br>
+<h2>Multi-<em>line
+heading</em></h2>
+
+<h2>heading with initial spaces</h2>
+and text directly after
+<br><br>
+
+<h1>Not Headings</h1>
+
+#hashtag not a heading because there's no space after the <code class="code">#</code>
+<br><br>
+####### Not a heading because it has more than 6 <code class="code">#</code>'s
+<br><br>
+## Not a heading because of the preceeding backslash
+<br><br>
+Not a heading because of spaces within
+= =
+<br><br>
+Not a heading because of spaces within
+*** *
+<br><br>
+Not a heading because backslash-escaped
+***
+  </p>
 </div>
 
-</li><li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg4" id="dg4"><code class="code">dg4</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg4"></span>void delegate(int d)* <code class="code">dg4</code>;
-
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  
-
-</div>
-
-</li>
-</ul>
-  </div>
 </section>
 </section>
       </article>

--- a/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>ddoc8739</title>
+    <title>ddoc_markdown_headings_verbose</title>
     <style type="text/css" media="screen">
       html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
       blockquote, pre, a, abbr, address, cite, code, del, dfn, em, figure,
@@ -470,114 +470,23 @@
   <body id="ddoc_main" class="ddoc dlang">
     <div class="content_wrapper">
       <article class="module">
-        <h1 class="module_name">ddoc8739</h1>
-        <section id="module_content">
-<section class="section ddoc_module_members_section">
-  <div class="ddoc_module_members">
-    <ul class="ddoc_members">
-  <li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg" id="dg"><code class="code">dg</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg"></span>void delegate(int a) <code class="code">dg</code>;
+        <h1 class="module_name">ddoc_markdown_headings_verbose</h1>
+        <section id="module_content"><section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    <h1>Heading</h1>
 
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
+  </p>
 </div>
-<div class="ddoc_decl">
-  
+<div class="ddoc_description">
+  <h4>Discussion</h4>
+  <p class="para">
+    <h1>Another Heading</h1>
 
+<h2>And Another</h2>
+  </p>
 </div>
 
-</li><li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg2" id="dg2"><code class="code">dg2</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg2"></span>void delegate(int b) <code class="code">dg2</code>;
-
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  
-
-</div>
-
-</li><li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg3" id="dg3"><code class="code">dg3</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg3"></span>void delegate(int c)[] <code class="code">dg3</code>;
-
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  
-
-</div>
-
-</li><li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#dg4" id="dg4"><code class="code">dg4</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="dg4"></span>void delegate(int d)* <code class="code">dg4</code>;
-
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  
-
-</div>
-
-</li>
-</ul>
-  </div>
 </section>
 </section>
       </article>

--- a/test/compilable/extra-files/ddocbackticks.html
+++ b/test/compilable/extra-files/ddocbackticks.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;

--- a/test/compilable/extra-files/ddocunittest.html
+++ b/test/compilable/extra-files/ddocunittest.html
@@ -19,6 +19,13 @@
         vertical-align: baseline;
       }
 
+      h1 { font-size: 200%; }
+      h2 { font-size: 160%; }
+      h3 { font-size: 120%; }
+      h4 { font-size: 100%; }
+      h5 { font-size: 80%; }
+      h6 { font-size: 80%; font-weight: normal; }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -106,7 +113,7 @@
         border-radius: 5px;
       }
 
-      #ddoc_main .ddoc_decl .section h4, #ddoc_main .section.ddoc_sections h4 {
+      #ddoc_main .ddoc_decl .section h4:first-of-type, #ddoc_main .section.ddoc_sections h4:first-of-type {
         font-size: 13px;
         line-height: 1.5;
         margin-top: 21px;


### PR DESCRIPTION
Adds support for Markdown headings. Note that many test HTML files were affected by the accompanying CSS changes.

Per the proposed documentation:

### Headings

A long documentation section can be subdivided by adding headings. Two styles of headings are available.

**ATX Headings:**
An ATX heading is a line of text that starts with one to six `#` characters followed by whitespace and then the heading text. The number of `#` characters determines the heading level. ATX headings may optionally end with any number of trailing `#` characters.
```
/**
 * # H1
 * ## H2
 * ### H3
 * #### H4 ###
 * ##### H5 ##
 * ###### H6 #
 */
```

**Setext Headings:**
A setext heading is one or more lines of text followed by a line of `=` or `*` characters. Those familiar with [Markdown](https://daringfireball.net/projects/markdown/syntax) will notice that Ddoc uses asterisks (`***`) instead of dashes (`---`) for second-level headings to avoid conflicting with [embedded code](https://dlang.org/spec/ddoc.html#embedded_code).
```
/**
 * H1
 * ==
 *
 * A long H2 heading that
 * spans more than one line
 * ************************
 */
```