### PR TITLE
OutBuffer: add ability to write slices

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -2057,7 +2057,7 @@ static int generate_comdat(Symbol *s, bool is_readonly_comdat)
     tym_t ty;
 
     symbol_debug(s);
-    obj.reset_symbuf.write(&s, s.sizeof);
+    obj.reset_symbuf.write((&s)[0 .. 1]);
     ty = s.ty();
     isfunc = tyfunc(ty) != 0 || is_readonly_comdat;
 
@@ -2668,7 +2668,7 @@ void OmfObj_pubdef(int seg,Symbol *s,targ_size_t offset)
     uint ti;
 
     assert(offset < 100000000);
-    obj.reset_symbuf.write(&s, s.sizeof);
+    obj.reset_symbuf.write((&s)[0 .. 1]);
 
     int idx = SegData[seg].segidx;
     if (obj.pubdatai + 1 + (IDMAX + IDOHD) + 4 + 2 > obj.pubdata.sizeof ||
@@ -2741,7 +2741,7 @@ int OmfObj_external(Symbol *s)
 {
     //printf("OmfObj_external('%s', %d)\n",s.Sident.ptr, obj.extidx + 1);
     symbol_debug(s);
-    obj.reset_symbuf.write(&s, s.sizeof);
+    obj.reset_symbuf.write((&s)[0 .. 1]);
     if (obj.extdatai + (IDMAX + IDOHD) + 3 > obj.extdata.sizeof)
         outextdata();
 
@@ -2808,7 +2808,7 @@ int OmfObj_common_block(Symbol *s,int flag,targ_size_t size,targ_size_t count)
   uint ti;
 
     //printf("OmfObj_common_block('%s',%d,%d,%d, %d)\n",s.Sident.ptr,flag,size,count, obj.extidx + 1);
-    obj.reset_symbuf.write(&s, s.sizeof);
+    obj.reset_symbuf.write((&s)[0 .. 1]);
     outextdata();               // borrow the extdata[] storage
     i = cast(uint)OmfObj_mangle(s,obj.extdata.ptr);
 
@@ -2944,7 +2944,7 @@ private void obj_modend()
         // Turn startaddress into a fixup.
         // Borrow heavilly from OmfObj_reftoident()
 
-        obj.reset_symbuf.write(&s, s.sizeof);
+        obj.reset_symbuf.write((&s)[0 .. 1]);
         symbol_debug(s);
         offset = 0;
         ty = s.ty();

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -1142,7 +1142,7 @@ printf("fwd struct ref\n");
         s.Stypidx = cv_debtyp(d);
         d.length = cast(ushort)len;    // restore length
     }
-    reset_symbuf.write(&s, (s).sizeof);
+    reset_symbuf.write((&s)[0 .. 1]);
 
     if (refonly)                        // if reference only
     {
@@ -1689,7 +1689,7 @@ static if (SYMDEB_TDB)
         s.Stypidx = cv_debtyp(d);
         d.length = cast(ushort)len;           // restore length
     }
-    reset_symbuf.write(&s, (s).sizeof);
+    reset_symbuf.write((&s)[0 .. 1]);
 
     // Compute the number of fields, and the length of the fieldlist record
     nfields = 0;
@@ -2682,7 +2682,7 @@ static if (1)
 {
             case SCtypedef:
                 s.Stypidx = typidx;
-                reset_symbuf.write(&s, (s).sizeof);
+                reset_symbuf.write((&s)[0 .. 1]);
                 goto L4;
 
             case SCstruct:

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -501,7 +501,7 @@ private IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, uint sz,
         sym.st_info = cast(ubyte)ELF64_ST_INFO(cast(ubyte)bind,cast(ubyte)typ);
         sym.st_other = visibility;
         sym.st_shndx = cast(ushort)sec;
-        SYMbuf.write(&sym,sym.sizeof);
+        SYMbuf.write((&sym)[0 .. 1]);
     }
     else
     {
@@ -520,7 +520,7 @@ private IDXSYM elf_addsym(IDXSTR nam, targ_size_t val, uint sz,
         sym.st_info = ELF32_ST_INFO(cast(ubyte)bind,cast(ubyte)typ);
         sym.st_other = visibility;
         sym.st_shndx = cast(ushort)sec;
-        SYMbuf.write(&sym,sym.sizeof);
+        SYMbuf.write((&sym)[0 .. 1]);
     }
     if (bind == STB_LOCAL)
         local_cnt++;
@@ -1375,7 +1375,7 @@ debug
             s.sh_info      = p.sh_info;
             s.sh_addralign = p.sh_addralign;
             s.sh_entsize   = p.sh_entsize;
-            fobjbuf.write(&s, s.sizeof);
+            fobjbuf.write((&s)[0 .. 1]);
         }
         foffset += sz;
     }
@@ -1760,7 +1760,7 @@ static if (!ELF_COMDAT)
 }
 else
 {
-        reset_symbuf.write(&s, s.sizeof);
+        reset_symbuf.write((&s)[0 .. 1]);
 
         const(char)* p = cpp_mangle2(s);
 
@@ -2468,7 +2468,7 @@ void Obj_pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsize)
     //symbol_print(s);
 
     symbol_debug(s);
-    reset_symbuf.write(&s, s.sizeof);
+    reset_symbuf.write((&s)[0 .. 1]);
     IDXSTR namidx = elf_addmangled(s);
     //printf("\tnamidx %d,section %d\n",namidx,MAP_SEG2SECIDX(seg));
     if (tyfunc(s.ty()))
@@ -2521,7 +2521,7 @@ int Obj_external(Symbol *s)
 
     //dbg_printf("Obj_external('%s') %x\n",s.Sident.ptr,s.Svalue);
     symbol_debug(s);
-    reset_symbuf.write(&s, s.sizeof);
+    reset_symbuf.write((&s)[0 .. 1]);
     IDXSTR namidx = elf_addmangled(s);
 
 version (SCPP)

--- a/src/dmd/backend/machobj.d
+++ b/src/dmd/backend/machobj.d
@@ -1066,7 +1066,7 @@ version (SCPP)
                             srel.r_pcrel = 0;
                             srel.r_length = 2;
                             srel.r_value = targ_address;
-                            fobjbuf.write(&srel, srel.sizeof);
+                            fobjbuf.write((&srel)[0 .. 1]);
                             foffset += srel.sizeof;
                             ++nreloc;
 
@@ -2345,21 +2345,21 @@ void Obj_pubdef(int seg, Symbol *s, targ_size_t offset)
     {
         case SCglobal:
         case SCinline:
-            public_symbuf.write(&s, s.sizeof);
+            public_symbuf.write((&s)[0 .. 1]);
             break;
         case SCcomdat:
         case SCcomdef:
-            public_symbuf.write(&s, s.sizeof);
+            public_symbuf.write((&s)[0 .. 1]);
             break;
         case SCstatic:
             if (s.Sflags & SFLhidden)
             {
-                public_symbuf.write(&s, s.sizeof);
+                public_symbuf.write((&s)[0 .. 1]);
                 break;
             }
             goto default;
         default:
-            local_symbuf.write(&s, s.sizeof);
+            local_symbuf.write((&s)[0 .. 1]);
             break;
     }
     //printf("%p\n", *cast(void**)public_symbuf.buf);
@@ -2400,7 +2400,7 @@ int Obj_external(Symbol *s)
 {
     //printf("Obj_external('%s') %x\n",s.Sident.ptr,s.Svalue);
     symbol_debug(s);
-    extern_symbuf.write(&s, s.sizeof);
+    extern_symbuf.write((&s)[0 .. 1]);
     s.Sxtrnnum = 1;
     return 0;
 }
@@ -2753,7 +2753,7 @@ static if (0)
                 pseg.SDbuf.write(halts.ptr, 5);
 
                 // Add symbol s to indirectsymbuf1
-                indirectsymbuf1.write(&s, (Symbol *).sizeof);
+                indirectsymbuf1.write((&s)[0 .. 1]);
              L1:
                 val -= offset + 4;
                 Obj_addrel(seg, offset, null, jumpTableSeg, RELrel);
@@ -2797,7 +2797,7 @@ static if (0)
                 pseg.SDbuf.writezeros(_tysize[TYnptr]);
 
                 // Add symbol s to indirectsymbuf2
-                indirectsymbuf2.write(&s, (Symbol *).sizeof);
+                indirectsymbuf2.write((&s)[0 .. 1]);
 
              L2:
                 //printf("Obj_reftoident: seg = %d, offset = x%x, s = %s, val = x%x, pointersSeg = %d\n", seg, (int)offset, s.Sident.ptr, (int)val, pointersSeg);

--- a/src/dmd/backend/mscoffobj.d
+++ b/src/dmd/backend/mscoffobj.d
@@ -567,7 +567,7 @@ void write_sym(SymbolTable32* sym, bool bigobj)
     assert((*sym).sizeof == 20);
     if (bigobj)
     {
-        syment_buf.write(sym, (*sym).sizeof);
+        syment_buf.write(sym[0 .. 1]);
     }
     else
     {
@@ -842,12 +842,12 @@ version (SCPP)
     // Write the header
     if (bigobj)
     {
-        fobjbuf.write(&header, (header).sizeof);
+        fobjbuf.write((&header)[0 .. 1]);
         foffset = (header).sizeof;
     }
     else
     {
-        fobjbuf.write(&header_old, (header_old).sizeof);
+        fobjbuf.write((&header_old)[0 .. 1]);
         foffset = (header_old).sizeof;
     }
 
@@ -1040,7 +1040,7 @@ version (SCPP)
                 //assert(rel.r_symndx <= 20000);
 
                 assert(rel.r_type <= 0x14);
-                fobjbuf.write(&rel, (rel).sizeof);
+                fobjbuf.write((&rel)[0 .. 1]);
                 foffset += (rel).sizeof;
             }
         }
@@ -1271,7 +1271,7 @@ private void emitSectionBrace(const(char)* segname, const(char)* symname, int at
     Symbol *beg = symbol_name(name.ptr, SCglobal, tspvoid);
     beg.Sseg = seg_bg;
     beg.Soffset = 0;
-    symbuf.write(&beg, beg.sizeof);
+    symbuf.write((&beg)[0 .. 1]);
     if (coffZeroBytes) // unnecessary, but required by current runtime
         MsCoffObj_bytes(seg_bg, 0, I64 ? 8 : 4, null);
 
@@ -1281,7 +1281,7 @@ private void emitSectionBrace(const(char)* segname, const(char)* symname, int at
     Symbol *end = symbol_name(name.ptr, SCglobal, tspvoid);
     end.Sseg = seg_en;
     end.Soffset = 0;
-    symbuf.write(&end, (end).sizeof);
+    symbuf.write((&end)[0 .. 1]);
     if (coffZeroBytes) // unnecessary, but required by current runtime
         MsCoffObj_bytes(seg_en, 0, I64 ? 8 : 4, null);
 }
@@ -1329,7 +1329,7 @@ static if (0)
     Symbol *minfo_beg = symbol_name("_tlsstart", SCglobal, tspvoid);
     minfo_beg.Sseg = segbg;
     minfo_beg.Soffset = 0;
-    symbuf.write(&minfo_beg, (minfo_beg).sizeof);
+    symbuf.write((&minfo_beg)[0 .. 1]);
     MsCoffObj_bytes(segbg, 0, I64 ? 8 : 4, null);
 
     /* Create symbol _minfo_end that sits just after the .tls$AAB section
@@ -1337,7 +1337,7 @@ static if (0)
     Symbol *minfo_end = symbol_name("_tlsend", SCglobal, tspvoid);
     minfo_end.Sseg = segen;
     minfo_end.Soffset = 0;
-    symbuf.write(&minfo_end, (minfo_end).sizeof);
+    symbuf.write((&minfo_end)[0 .. 1]);
     MsCoffObj_bytes(segen, 0, I64 ? 8 : 4, null);
   }
 }
@@ -1945,14 +1945,14 @@ void MsCoffObj_pubdef(segidx_t seg, Symbol *s, targ_size_t offset)
     {
         case SCglobal:
         case SCinline:
-            symbuf.write(&s, (s).sizeof);
+            symbuf.write((&s)[0 .. 1]);
             break;
         case SCcomdat:
         case SCcomdef:
-            symbuf.write(&s, (s).sizeof);
+            symbuf.write((&s)[0 .. 1]);
             break;
         default:
-            symbuf.write(&s, (s).sizeof);
+            symbuf.write((&s)[0 .. 1]);
             break;
     }
     //printf("%p\n", *(void**)symbuf.buf);
@@ -1979,7 +1979,7 @@ int MsCoffObj_external_def(const(char)* name)
     //printf("MsCoffObj_external_def('%s')\n",name);
     assert(name);
     Symbol *s = symbol_name(name, SCextern, tspvoid);
-    symbuf.write(&s, (s).sizeof);
+    symbuf.write((&s)[0 .. 1]);
     return 0;
 }
 
@@ -1998,7 +1998,7 @@ int MsCoffObj_external(Symbol *s)
 {
     //printf("MsCoffObj_external('%s') %x\n",s.Sident.ptr,s.Svalue);
     symbol_debug(s);
-    symbuf.write(&s, (s).sizeof);
+    symbuf.write((&s)[0 .. 1]);
     s.Sxtrnnum = 1;
     return 1;
 }
@@ -2170,7 +2170,7 @@ void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
         targsym = symbol_generate(SCstatic, tstypes[TYint]);
         targsym.Sseg = targseg;
         targsym.Soffset = val;
-        symbuf.write(&targsym, (targsym).sizeof);
+        symbuf.write((&targsym)[0 .. 1]);
     }
 
     Relocation rel = void;
@@ -2186,7 +2186,7 @@ void MsCoffObj_addrel(segidx_t seg, targ_size_t offset, Symbol *targsym,
         pseg.SDrel = cast(Outbuffer*) calloc(1, Outbuffer.sizeof);
         assert(pseg.SDrel);
     }
-    pseg.SDrel.write(&rel, (rel).sizeof);
+    pseg.SDrel.write((&rel)[0 .. 1]);
 }
 
 /****************************************
@@ -2385,7 +2385,7 @@ static if (0)
                 pseg.SDbuf.writezeros(_tysize[TYnptr]);
 
                 // Add symbol s to indirectsymbuf2
-                indirectsymbuf2.write(&s, (Symbol *).sizeof);
+                indirectsymbuf2.write((&s)[0 .. 1]);
 
              L2:
                 //printf("MsCoffObj_reftoident: seg = %d, offset = x%x, s = %s, val = x%x, pointersSeg = %d\n", seg, offset, s.Sident.ptr, val, pointersSeg);
@@ -2520,7 +2520,7 @@ void MsCoffObj_write_pointerRef(Symbol* s, uint soff)
     }
 
     // defer writing pointer references until the symbols are written out
-    ptrref_buf.write(&s, (s).sizeof);
+    ptrref_buf.write((&s)[0 .. 1]);
     ptrref_buf.write32(soff);
 }
 


### PR DESCRIPTION
instead of pointer/length arguments. Also use size_t instead of uint now that we are no longer subject to mangling issues.