### PR TITLE
add backend.barray.d - encapsulate array allocations

### DIFF
--- a/src/dmd/backend/barray.d
+++ b/src/dmd/backend/barray.d
@@ -1,0 +1,85 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 2018 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/barrayf.d, backend/barray.d)
+ * Documentation: https://dlang.org/phobos/dmd_backend_barray.html
+ */
+
+module dmd.backend.barray;
+
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.stdc.string;
+
+nothrow:
+
+extern (C++): void err_nomem();
+
+/*************************************
+ * A reusable array that ratchets up in capacity.
+ */
+struct Barray(T)
+{
+    /**********************
+     * Set useable length of array.
+     * Params:
+     *  length = minimum number of elements in array
+     */
+    void setLength(size_t length)
+    {
+        if (capacity < length)
+        {
+            if (capacity == 0)
+                capacity = length;
+            else
+                capacity = length + (length >> 1);
+            capacity = (capacity + 15) & ~15;
+            T* p = cast(T*)realloc(array.ptr, capacity * T.sizeof);
+            if (length && !p)
+            {
+                version (unittest)
+                    assert(0);
+                else
+                    err_nomem();
+            }
+            array = p[0 .. length];
+        }
+        else
+            array = array.ptr[0 .. length];
+    }
+
+    /******************
+     * Release all memory used.
+     */
+    void dtor()
+    {
+        free(array.ptr);
+        array = null;
+        capacity = 0;
+    }
+
+    alias array this;
+    T[] array;
+
+  private:
+    size_t capacity;
+}
+
+unittest
+{
+    Barray!int a;
+    a.setLength(10);
+    assert(a.length == 10);
+    a.setLength(4);
+    assert(a.length == 4);
+    foreach (i, ref v; a[])
+        v = i * 2;
+    foreach (i, ref const v; a[])
+        assert(v == i * 2);
+    a.dtor();
+    assert(a.length == 0);
+}

--- a/src/dmd/backend/gflow.d
+++ b/src/dmd/backend/gflow.d
@@ -35,6 +35,7 @@ import dmd.backend.outbuf;
 import dmd.backend.ty;
 import dmd.backend.type;
 
+import dmd.backend.barray;
 import dmd.backend.dlist;
 import dmd.backend.dvec;
 
@@ -171,13 +172,9 @@ private void rdgenkill()
      */
     const size_t numbits = go.deftop;
     const size_t dim = (numbits + (VECBITS - 1)) >> VECSHIFT;
-    const uint sz = cast(uint)((dim + 2) * num_unambig_def);
-    if (sz > go.dnunambigmax)
-    {
-        go.dnunambigmax = sz;
-        go.dnunambig = cast(vec_base_t *) util_realloc(go.dnunambig, sz, vec_base_t.sizeof);
-    }
-    memset(go.dnunambig, 0, go.dnunambigmax * vec_base_t.sizeof);
+    const sz = (dim + 2) * num_unambig_def;
+    go.dnunambig.setLength(sz);
+    go.dnunambig[] = 0;
 
     const uint deftopsave = go.deftop;
     go.deftop = 0;
@@ -297,7 +294,7 @@ private void initDNunambigVectors()
             go.defnod[i].DNunambig = v;
         }
     }
-    assert(j <= go.dnunambigmax);
+    assert(j <= go.dnunambig.length);
 }
 
 /*************************************

--- a/src/dmd/backend/goh.d
+++ b/src/dmd/backend/goh.d
@@ -25,6 +25,7 @@ import dmd.backend.el;
 import dmd.backend.ty;
 import dmd.backend.type;
 
+import dmd.backend.barray;
 import dmd.backend.dlist;
 import dmd.backend.dvec;
 
@@ -81,8 +82,7 @@ struct GlobalOptimizer
     uint defmax;        // capacity of defnod[]
     uint unambigtop;    // number of unambiguous defininitions ( <= deftop )
 
-    vec_base_t *dnunambig;  // pool to allocate DNunambig vectors from
-    uint    dnunambigmax;   // capacity of dnunambig[]
+    Barray!(vec_base_t) dnunambig;  // pool to allocate DNunambig vectors from
 
     elem **expnod;      // array of expression elems
     uint exptop;        // top of expnod[]

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -358,7 +358,7 @@ BACK_DOBJS = bcomplex.o evalu8.o divcoeff.o dvec.o go.o gsroa.o glocal.o gdag.o 
 	gloop.o compress.o cgelem.o cgcs.o ee.o cod4.o cod5.o nteh.o blockopt.o memh.o cg.o cgreg.o \
 	dtype.o debugprint.o symbol.o elem.o dcode.o cgsched.o cg87.o cgxmm.o cgcod.o cod1.o cod2.o \
 	cod3.o cv8.o dcgcv.o pdata.o util2.o var.o md5.o backconfig.o ph2.o drtlsym.o dwarfeh.o ptrntab.o \
-	aarray.o dvarstats.o dwarfdbginf.o elfobj.o cgen.o os.o
+	aarray.o dvarstats.o dwarfdbginf.o elfobj.o cgen.o os.o goh.o barray.o
 
 G_OBJS  = $(addprefix $G/, $(BACK_OBJS))
 G_DOBJS = $(addprefix $G/, $(BACK_DOBJS))
@@ -402,7 +402,7 @@ BACK_SRC = \
 	$C/machobj.d $C/mscoffobj.d \
 	$C/pdata.d $C/cv8.d $C/backconfig.d $C/divcoeff.d \
 	$C/dvarstats.d $C/dvec.d \
-	$C/md5.d \
+	$C/md5.d $C/barray.d \
 	$C/ph2.d $C/util2.d $C/dwarfeh.d $C/goh.d $C/memh.d $C/filespec.d \
 	$(TARGET_CH)
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -180,7 +180,7 @@ GLUE_SRCS=$D/irstate.d $D/toctype.d $D/glue.d $D/gluelayer.d $D/todt.d $D/tocsym
 BACK_HDRS=$C/cc.d $C/cdef.d $C/cgcv.d $C/code.d $C/cv4.d $C/dt.d $C/el.d $C/global.d \
 	$C/obj.d $C/oper.d $C/outbuf.d $C/rtlsym.d $C/code_x86.d $C/iasm.d $C/codebuilder.d \
 	$C/ty.d $C/type.d $C/exh.d $C/mach.d $C/mscoff.d $C/dwarf.d $C/dwarf2.d $C/xmm.d \
-	$C/dlist.d $C/goh.d $C/memh.d $C/melf.d $C/varstats.di
+	$C/dlist.d $C/goh.d $C/memh.d $C/melf.d $C/varstats.di $C/barray.d
 
 TK_HDRS=
 
@@ -198,7 +198,7 @@ GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.o
 	$G/blockopt.obj $G/cgobj.obj $G/cg.obj $G/dcgcv.obj $G/dtype.obj \
 	$G/debugprint.obj $G/dcode.obj $G/cg87.obj $G/cgxmm.obj $G/cgsched.obj $G/ee.obj $G/symbol.obj \
 	$G/cgcod.obj $G/cod1.obj $G/cod2.obj $G/cod3.obj $G/cod4.obj $G/cod5.obj \
-	$G/bcomplex.obj $G/ptrntab.obj $G/md5.obj \
+	$G/bcomplex.obj $G/ptrntab.obj $G/md5.obj $G/barray.obj $G/goh.obj \
 	$G/mscoffobj.obj $G/pdata.obj $G/cv8.obj $G/backconfig.obj \
 	$G/divcoeff.obj $G/dwarfdbginf.obj $G/compress.obj $G/dvarstats.obj \
 	$G/ph2.obj $G/util2.obj $G/tk.obj $G/gsroa.obj $G/dvec.obj $G/filespec.obj \
@@ -236,7 +236,7 @@ BACKSRC= $C\optabgen.d \
 	$C\nteh.d $C\os.d $C\out.d $C\ptrntab.d $C\drtlsym.d \
 	$C\dtype.d \
 	$C\elfobj.d \
-	$C\dwarfdbginf.d $C\machobj.d $C\aarray.d \
+	$C\dwarfdbginf.d $C\machobj.d $C\aarray.d $C\barray.d \
 	$C\strtold.c \
 	$C\md5.d $C\ph2.d $C\util2.d \
 	$C\mscoffobj.d $C\pdata.d $C\cv8.d $C\backconfig.d \
@@ -454,6 +454,9 @@ $G\VERSION : ..\VERSION $G
 $G/backconfig.obj : $C\backconfig.d
 	$(HOST_DC) -c -betterC -of$@ $(DFLAGS) -mv=dmd.backend=$C $C\backconfig
 
+$G/barray.obj : $C\barray.d
+	$(HOST_DC) -c -betterC -of$@ $(DFLAGS) -mv=dmd.backend=$C $C\barray
+
 $G/bcomplex.obj : $C\bcomplex.d
 	$(HOST_DC) -c -betterC -of$@ $(DFLAGS) -mv=dmd.backend=$C $C\bcomplex
 
@@ -552,6 +555,9 @@ $G/fp.obj : $C\fp.c
 
 $G/go.obj : $C\go.d
 	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\go
+
+$G/goh.obj : $C\goh.d
+	$(HOST_DC) -c -betterC -of$@ $(DFLAGS) -mv=dmd.backend=$C $C\goh
 
 $G/gflow.obj : $C\gflow.d
 	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\gflow


### PR DESCRIPTION
The back end allocates a number of arrays. This consolidates the various variables and strategies into one template. Using it for just one array for starters.