### PR TITLE
Remove support for setext headings

### DIFF
--- a/test/compilable/ddoc_markdown_headings.d
+++ b/test/compilable/ddoc_markdown_headings.d
@@ -28,28 +28,6 @@
 #
 ### ###
 
-Setext-Style Headings
-=====================
-
-H1
-==
-$(P
-H1
-=
-
-H2
-**
-)
-
-Multi-*line
-heading*
-***
-
-heading with initial spaces
-   ***
-and text directly after
-
-
 # Not Headings
 
 #hashtag not a heading because there's no space after the `#`
@@ -57,15 +35,5 @@ and text directly after
 ####### Not a heading because it has more than 6 `#`'s
 
 \## Not a heading because of the preceeding backslash
-
-Not a heading because of spaces within
-= =
-
-Not a heading because of spaces within
-*** *
-
-Not a heading because backslash-escaped
-\***
-
 +/
 module ddoc_markdown_headings;

--- a/test/compilable/ddoc_markdown_headings_verbose.d
+++ b/test/compilable/ddoc_markdown_headings_verbose.d
@@ -5,19 +5,11 @@
 /*
 TEST_OUTPUT:
 ----
-compilable/ddoc_markdown_headings_verbose.d(23): Ddoc: added heading 'Heading'
-compilable/ddoc_markdown_headings_verbose.d(23): Ddoc: added heading 'Another Heading'
-compilable/ddoc_markdown_headings_verbose.d(23): Ddoc: added heading 'And Another'
+compilable/ddoc_markdown_headings_verbose.d(15): Ddoc: added heading 'Heading'
 ----
 */
 
 /++
 # Heading
-
-Another Heading
-===============
-
-And Another
-***********
 +/
 module ddoc_markdown_headings_verbose;

--- a/test/compilable/extra-files/ddoc_markdown_headings.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings.html
@@ -504,21 +504,6 @@
 <h1></h1>
 <h3></h3>
 
-<h1>Setext-Style Headings</h1>
-
-<h1>H1</h1>
-<p><h1>H1</h1>
-
-<h2>H2</h2>
-</p>
-<br><br>
-<h2>Multi-<em>line
-heading</em></h2>
-
-<h2>heading with initial spaces</h2>
-and text directly after
-<br><br>
-
 <h1>Not Headings</h1>
 
 #hashtag not a heading because there's no space after the <code class="code">#</code>
@@ -526,15 +511,6 @@ and text directly after
 ####### Not a heading because it has more than 6 <code class="code">#</code>'s
 <br><br>
 ## Not a heading because of the preceeding backslash
-<br><br>
-Not a heading because of spaces within
-= =
-<br><br>
-Not a heading because of spaces within
-*** *
-<br><br>
-Not a heading because backslash-escaped
-***
   </p>
 </div>
 

--- a/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
@@ -475,15 +475,6 @@
   <div class="ddoc_summary">
   <p class="para">
     <h1>Heading</h1>
-
-  </p>
-</div>
-<div class="ddoc_description">
-  <h4>Discussion</h4>
-  <p class="para">
-    <h1>Another Heading</h1>
-
-<h2>And Another</h2>
   </p>
 </div>
 


### PR DESCRIPTION
Per @WalterBright's [comment](https://github.com/dlang/dmd/pull/8952#issuecomment-439338688) on the Markdown headings PR, this PR is to remove support for setext headings in Ddoc.

Please note that per [my comment](https://github.com/dlang/dmd/pull/8952#issuecomment-438867860) in the same PR I disagree with this PR to remove setext headings—I believe keeping them offers wider compatibility with Ddoc alternatives.