### PR TITLE
Fix Issue 18572 - AliasSeq default arguments are broken

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1452,8 +1452,20 @@ private extern (C++) final class TypeSemanticVisitor : Visitor
                                 stc = stc1 | (stc & ~(STC.ref_ | STC.out_ | STC.lazy_));
                             }
 
+                            /* https://issues.dlang.org/show_bug.cgi?id=18572
+                             *
+                             * If a tuple parameter has a default argument, when expanding the parameter
+                             * tuple the default argument tuple must also be expanded.
+                             */
+                            Expression paramDefaultArg = narg.defaultArg;
+                            if (fparam.defaultArg)
+                            {
+                                auto te = cast(TupleExp)(fparam.defaultArg);
+                                paramDefaultArg = (*te.exps)[j];
+                            }
+
                             (*newparams)[j] = new Parameter(
-                                stc, narg.type, narg.ident, narg.defaultArg, narg.userAttribDecl);
+                                stc, narg.type, narg.ident, paramDefaultArg, narg.userAttribDecl);
                         }
                         fparam.type = new TypeTuple(newparams);
                     }

--- a/test/compilable/test18572.d
+++ b/test/compilable/test18572.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=18572
+
+alias Seq(T...) = T;
+void func(Seq!(int, int, int) args = Seq!(1, 2, 3)) {}
+void func2(Seq!(int, int, int) args = Seq!(1,2,3), Seq!(int, int) args2 = Seq!(4, 5)) {}
+
+void main(){
+    Seq!(int,int,int) args = Seq!(1, 2, 3); // ok
+    func(); // error
+    func(args); // ok
+
+    Seq!(int, int) args2 = Seq!(4, 5);
+    func2();
+    func2(args);
+    func2(args, args2);
+}


### PR DESCRIPTION
More specifically, the tuple which is the default argument expression does not get expanded. I added the missing bits.

cc @mdparker -> this is a dbugfix campaign issue