### PR TITLE
Use ANSI sequences in colored output on Windows

### DIFF
--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -204,7 +204,7 @@ extern (C++) void message(const(char)* format, ...)
 private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* header,
         const(char)* format, va_list ap, const(char)* p1 = null, const(char)* p2 = null)
 {
-    Console* con = cast(Console*)global.console;
+    Console con = cast(Console)global.console;
     const p = loc.toChars();
     if (con)
         con.setColorBright(true);
@@ -552,7 +552,7 @@ private void colorHighlightCode(OutBuffer* buf)
  * Params:
  *      buf = highlighted text
  */
-private void writeHighlights(Console* con, const OutBuffer *buf)
+private void writeHighlights(Console con, const OutBuffer *buf)
 {
     bool colors;
     scope (exit)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -294,7 +294,7 @@ private int tryMain(size_t argc, const(char)** argv)
     }
 
     if (global.params.color)
-        global.console = Console.create(core.stdc.stdio.stderr);
+        global.console = cast(void*)Console.create(core.stdc.stdio.stderr);
 
     setTarget(global.params);           // set target operating system
     setTargetCPU(global.params);


### PR DESCRIPTION
Split Console to Windows specific and ANSI capable implementations, and detect the supported type at runtime. When no terminal is detected with `-color=on` option, ANSI colors will be used in order to prevent color information getting lost when output is redirected to other process.

Replaces #8618