### PR TITLE
Fix Issue 8663 - AliasThis is not used in comparison

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1617,12 +1617,35 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id)
         if (lastf && m.lastf == lastf || !s_r && m.last <= MATCH.nomatch)
         {
             // Rewrite (e1 op e2) as e1.opfunc(e2)
+            uint errors = global.startGagging();
+            result = build_overload(e.loc, sc, e.e1, e.e2, m.lastf ? m.lastf : s);
+            if (global.endGagging(errors))
+            {
+                result = checkAliasThisForLhs(ad1, sc, e);
+                if (result)
+                    return result;
+                result = checkAliasThisForRhs(ad2, sc, e);
+                if (result)
+                    return result;
+            }
             result = build_overload(e.loc, sc, e.e1, e.e2, m.lastf ? m.lastf : s);
         }
         else
         {
             // Rewrite (e1 op e2) as e2.opfunc_r(e1)
+            uint errors = global.startGagging();
             result = build_overload(e.loc, sc, e.e2, e.e1, m.lastf ? m.lastf : s_r);
+            if (global.endGagging(errors))
+            {
+                result = checkAliasThisForLhs(ad1, sc, e);
+                if (result)
+                    return result;
+                result = checkAliasThisForRhs(ad2, sc, e);
+                if (result)
+                    return result;
+            }
+            result = build_overload(e.loc, sc, e.e2, e.e1, m.lastf ? m.lastf : s_r);
+
             // When reversing operands of comparison operators,
             // need to reverse the sense of the op
             switch (e.op)

--- a/test/compilable/test8663.d
+++ b/test/compilable/test8663.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=8663
+
+void main()
+{
+	C c = C("foo");	
+	assert(c == "foo");
+}
+
+struct C
+{
+	string v;
+	
+	// This does not work
+	alias v this;
+	
+	this(string val) { v = val; }
+}


### PR DESCRIPTION
The function compare_overload searches for opCmp or opEquals and if it finds a user defined one it picks, however, for classes it always finds the one defined in object.d and it does not check the alias this.