### PR TITLE
Deprecate extern(Pascal)

### DIFF
--- a/changelog/deprecated_extern_pascal.dd
+++ b/changelog/deprecated_extern_pascal.dd
@@ -1,0 +1,4 @@
+Deprecated `extern(Pascal)` linkage
+
+This linkage is completely unused, being an heritage from a few decades ago.
+Additionally, it's only supported by DMD and cause mangling ambiguity.

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2194,7 +2194,10 @@ final class Parser(AST) : Lexer
             if (id == Id.Windows)
                 link = LINK.windows;
             else if (id == Id.Pascal)
+            {
+                deprecation("`extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.");
                 link = LINK.pascal;
+            }
             else if (id == Id.D)
                 link = LINK.d;
             else if (id == Id.C)


### PR DESCRIPTION
```
The few tests have been left in place, as they don't currently fail.
They can be removed when the feature itself is removed.
The failure happens at parse time (not semantic),
as it's the stage the failure will trigger at when the feature is removed.
```

It already has been undocumented from dlang.org