### PR TITLE
Fix Issue 19415 - return non-copyable struct fails if member function has return attribute

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5506,7 +5506,9 @@ extern (C++) final class TypeStruct : Type
         // Probably should cache this information in sym rather than recompute
         StructDeclaration s = sym;
 
-        sym.size(Loc.initial); // give error for forward references
+        if (sym.members && !sym.determineFields() && sym.type != Type.terror)
+            error(sym.loc, "no size because of forward references");
+
         foreach (VarDeclaration v; s.fields)
         {
             if (v.storage_class & STC.ref_ || v.hasPointers())

--- a/test/compilable/test19145.d
+++ b/test/compilable/test19145.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=19415
+
+struct S
+{
+   int x;
+   S foo() return { return S(x); }
+   this(this) @disable;
+}
+
+S bar()
+{
+   S s;
+   return s; // Error: struct `S` is not copyable because it is annotated with @disable
+}


### PR DESCRIPTION
```d
struct S
{
   int x;
   S foo() return { return S(x); }
   this(this) @disable;
}

S bar()
{
   S s;
   return s; // Error: struct `S` is not copyable because it is annotated with @disable
}
```

When `struct S` is semantically analyzed, the field StructDeclaration.postblit is null. Before actually building the postblit and setting StructDeclaration.postblit to point to it, all the members of `struct S` are semantically analyzed. This results in the fact that at the time when foo is analyzed, the struct does not appear to have a postblit. During the semantic analysis of foo, this line [1] is executed in order to delete the `return` attribute from the function. The code path is : TypeStruct.hasPointers() -> AggregateDeclaration.size() -> AggregateDeclaration.determineSize() -> StructDeclaration.finalizeSize(). At the end of finalizeSize this is done: [2]. The code path is: toArgTypes -> StructDeclaration.isPOD. Although the struct is not pod because it has a postblit, because the struct has not been semantically analyzed completely, it appears as it is POD, messing with the size of the struct and ultimately making it wrongfully not usable with NRVO.

The fix makes it so that AggregateDeclaration.size() is not called anymore to verify forward references. This should also improve performance since a lot of unnecessary checks are avoided.

This has truly been an adventure.

[1] https://github.com/dlang/dmd/pull/8346/files#diff-64d4abe08ba2355c2b95cb22e46b8572R876
[2] https://github.com/dlang/dmd/blob/master/src/dmd/dstruct.d#L429