### PR TITLE
convert resolve() to symbolToExp()

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3115,7 +3115,7 @@ extern (C++) final class TemplateExp : Expression
             return Expression.toLvalue(sc, e);
 
         assert(sc);
-        return resolve(loc, sc, fd, true);
+        return symbolToExp(fd, loc, sc, true);
     }
 
     override bool checkType()

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -809,19 +809,19 @@ Expression resolvePropertiesOnly(Scope* sc, Expression e1)
 }
 
 /****************************************
- * Resolve a symbol `s` and wraps it in an expression object.
+ * Turn symbol `s` into the expression it represents.
  *
  * Params:
+ *      s = symbol to resolve
  *      loc = location of use of `s`
  *      sc = context
- *      s = symbol to resolve
  *      hasOverloads = applies if `s` represents a function.
  *          true means it's overloaded and will be resolved later,
  *          false means it's the exact function symbol.
  * Returns:
  *      `s` turned into an expression, `ErrorExp` if an error occurred
  */
-Expression resolve(const ref Loc loc, Scope *sc, Dsymbol s, bool hasOverloads)
+Expression symbolToExp(Dsymbol s, const ref Loc loc, Scope *sc, bool hasOverloads)
 {
     static if (LOGSEMANTIC)
     {
@@ -2440,7 +2440,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     }
                 }
                 // Haven't done overload resolution yet, so pass 1
-                e = resolve(exp.loc, sc, s, true);
+                e = symbolToExp(s, exp.loc, sc, true);
             }
             result = e;
             return;
@@ -2537,7 +2537,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(DsymbolExp e)
     {
-        result = resolve(e.loc, sc, e.s, e.hasOverloads);
+        result = symbolToExp(e.s, e.loc, sc, e.hasOverloads);
     }
 
     override void visit(ThisExp e)
@@ -2994,7 +2994,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         else if (s)
         {
             //printf("s = %s %s\n", s.kind(), s.toChars());
-            e = resolve(exp.loc, sc, s, true);
+            e = symbolToExp(s, exp.loc, sc, true);
         }
         else
             assert(0);
@@ -3120,7 +3120,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             //printf("s = %s, '%s'\n", s.kind(), s.toChars());
-            auto e = resolve(exp.loc, sc, s, true);
+            auto e = symbolToExp(s, exp.loc, sc, true);
             //printf("-1ScopeExp::semantic()\n");
             result = e;
             return;
@@ -4887,7 +4887,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (ea)
         {
             if (auto sym = getDsymbol(ea))
-                ea = resolve(exp.loc, sc, sym, false);
+                ea = symbolToExp(sym, exp.loc, sc, false);
             else
                 ea = ea.expressionSemantic(sc);
             ea = resolveProperties(sc, ea);
@@ -5684,7 +5684,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             if (fd.isNested() || fd.isFuncLiteralDeclaration())
             {
                 // (e1, fd)
-                auto e = resolve(exp.loc, sc, fd, false);
+                auto e = symbolToExp(fd, exp.loc, sc, false);
                 result = Expression.combine(exp.e1, e);
                 return;
             }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1085,7 +1085,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             if (funcdecl.isStatic())
                             {
                                 // The monitor is in the ClassInfo
-                                vsync = new DotIdExp(funcdecl.loc, resolve(funcdecl.loc, sc2, cd, false), Id.classinfo);
+                                vsync = new DotIdExp(funcdecl.loc, symbolToExp(cd, funcdecl.loc, sc2, false), Id.classinfo);
                             }
                             else
                             {
@@ -1396,7 +1396,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             ti.dsymbolSemantic(sc3);
             ti.semantic2(sc3);
             ti.semantic3(sc3);
-            auto e = resolve(Loc.initial, sc3, ti.toAlias(), false);
+            auto e = symbolToExp(ti.toAlias(), Loc.initial, sc3, false);
 
             sc3.endCTFE();
 

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -827,7 +827,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 return ex.expressionSemantic(sc);
             }
         }
-        return resolve(e.loc, sc, s, false);
+        return symbolToExp(s, e.loc, sc, false);
     }
     if (e.ident == Id.hasMember ||
         e.ident == Id.getMember ||

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -119,8 +119,8 @@ private void resolveTupleIndex(TypeQualified mt, const ref Loc loc, Scope* sc, D
         if (tindex)
             eindex = new TypeExp(loc, tindex);
         else if (sindex)
-            eindex = dmd.expressionsem.resolve(loc, sc, sindex, false);
-        Expression e = new IndexExp(loc, dmd.expressionsem.resolve(loc, sc, s, false), eindex);
+            eindex = symbolToExp(sindex, loc, sc, false);
+        Expression e = new IndexExp(loc, symbolToExp(s, loc, sc, false), eindex);
         e = e.expressionSemantic(sc);
         mt.resolveExp(e, pt, pe, ps);
         return;
@@ -130,7 +130,7 @@ private void resolveTupleIndex(TypeQualified mt, const ref Loc loc, Scope* sc, D
     if (tindex)
         tindex.resolve(loc, sc, &eindex, &tindex, &sindex);
     if (sindex)
-        eindex = dmd.expressionsem.resolve(loc, sc, sindex, false);
+        eindex = symbolToExp(sindex, loc, sc, false);
     if (!eindex)
     {
         .error(loc, "index `%s` is not an expression", oindex.toChars());
@@ -290,7 +290,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
                     VarDeclaration v = s.isVarDeclaration();
                     FuncDeclaration f = s.isFuncDeclaration();
                     if (intypeid || !v && !f)
-                        e = dmd.expressionsem.resolve(loc, sc, s, true);
+                        e = symbolToExp(s, loc, sc, true);
                     else
                         e = new VarExp(loc, s.isDeclaration(), true);
 
@@ -3721,7 +3721,7 @@ private extern(C++) final class DotExpVisitor : Visitor
 
         if (s.isImport() || s.isModule() || s.isPackage())
         {
-            e = dmd.expressionsem.resolve(e.loc, sc, s, false);
+            e = symbolToExp(s, e.loc, sc, false);
             result = e;
             return;
         }
@@ -4213,7 +4213,7 @@ private extern(C++) final class DotExpVisitor : Visitor
 
         if (s.isImport() || s.isModule() || s.isPackage())
         {
-            e = dmd.expressionsem.resolve(e.loc, sc, s, false);
+            e = symbolToExp(s, e.loc, sc, false);
             result = e;
             return;
         }


### PR DESCRIPTION
Tired of overload collisions with other `resolve()` functions that have nothing to do with this one. Also moved `s` to the front so it can be used with UFCS.