### PR TITLE
Fix Issue 19409 - static if (__traits(compiles, __traits(identifier, ...) )) evaluates to false even though the expression alone evaluates to true

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -847,12 +847,10 @@ extern (C++) final class StaticIfCondition : Condition
                 return 0;
             }
 
-            sc = sc.push(sc.scopesym);
-
             import dmd.staticcond;
             bool errors;
             bool result = evalStaticCondition(sc, exp, exp, errors);
-            sc.pop();
+
             // Prevent repeated condition evaluation.
             // See: fail_compilation/fail7815.d
             if (inc != 0)

--- a/test/compilable/test19409.d
+++ b/test/compilable/test19409.d
@@ -1,0 +1,6 @@
+// https://issues.dlang.org/show_bug.cgi?id=19409
+
+module test.foo;
+
+static if (__traits(compiles,  __traits(identifier, test.foo))) {} // fails
+else { static assert(0); }


### PR DESCRIPTION
evalStaticCondition calls Scope.startCTFE which does a scope push which is redundant with the scope push in StaticIfCondition.include.