### PR TITLE
Fix Issue 19419 - [REG2.080.1] @disabled this() will print wrong error if calling non-default constructor with wrong parameters

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2749,7 +2749,8 @@ extern (C++) FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymb
         {
             assert(fd);
 
-            if (fd.checkDisabled(loc, sc))
+            // remove when deprecation period of class allocators and deallocators is over
+            if (fd.isNewDeclaration() && fd.checkDisabled(loc, sc))
                 return null;
 
             bool hasOverloads = fd.overnext !is null;

--- a/test/fail_compilation/fail19419.d
+++ b/test/fail_compilation/fail19419.d
@@ -1,0 +1,21 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19419.d(20): Error: none of the overloads of `this` are callable using argument types `(int)`, candidates are:
+fail_compilation/fail19419.d(12):        `fail19419.B.this()`
+fail_compilation/fail19419.d(14):        `fail19419.B.this(string s)`
+---
+*/
+
+struct B
+{
+    @disable this();
+
+    this(string s)
+    {}
+}
+
+void main()
+{
+    auto b = B(3);
+}


### PR DESCRIPTION
Introduced by [1]. The check for disabled should only be made for NewDeclarations, for all other functions that is being taken care of before.

[1] https://github.com/dlang/dmd/pull/8042