### PR TITLE
Fix issue 19163: don't count declarations in coverage analysis

### DIFF
--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -837,9 +837,13 @@ private extern (C++) class S2irVisitor : Visitor
         Blockx *blx = irs.blx;
 
         //printf("ExpStatement.toIR(), exp = %s\n", s.exp ? s.exp.toChars() : "");
-        incUsage(irs, s.loc);
         if (s.exp)
+        {
+            if (s.exp.hasCode)
+                incUsage(irs, s.loc);
+
             block_appendexp(blx.curblock, toElemDtor(s.exp, irs));
+        }
     }
 
     /**************************************

--- a/test/runnable/extra-files/runnable-test19163.lst
+++ b/test/runnable/extra-files/runnable-test19163.lst
@@ -1,0 +1,27 @@
+       |// PERMUTE_ARGS:
+       |// POST_SCRIPT: runnable/extra-files/coverage-postscript.sh
+       |// REQUIRED_ARGS: -cov
+       |// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
+       |
+       |extern(C) void dmd_coverDestPath(string pathname);
+       |
+       |void main(string[] args)
+       |{
+      1|    dmd_coverDestPath(args[1]);
+       |
+      1|    if (false)
+       |    {
+       |        static if (2 == 2)
+       |        {
+       |        }
+       |        else
+       |        {
+       |        }
+       |        alias type = int;
+       |        enum k = 2;
+       |        enum array = [1, 2];
+       |        static foreach (i; array)
+       |        {
+       |        }
+       |    }
+       |}

--- a/test/runnable/test19163.d
+++ b/test/runnable/test19163.d
@@ -1,0 +1,27 @@
+// PERMUTE_ARGS:
+// POST_SCRIPT: runnable/extra-files/coverage-postscript.sh
+// REQUIRED_ARGS: -cov
+// EXECUTE_ARGS: ${RESULTS_DIR}/runnable
+
+extern(C) void dmd_coverDestPath(string pathname);
+
+void main(string[] args)
+{
+    dmd_coverDestPath(args[1]);
+
+    if (false)
+    {
+        static if (2 == 2)
+        {
+        }
+        else
+        {
+        }
+        alias type = int;
+        enum k = 2;
+        enum array = [1, 2];
+        static foreach (i; array)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Consider this code:

```
module test;

void main()
{
    if (false)
    {
        static if (2 == 2)
        {
        }
        else
        {
        }
        alias type = int;
        enum k = 2;
        enum array = [1, 2];
        static foreach (i; array)
        {
        }
    }
}
```

When run with `dmd -cov -run test.d`, the `alias`, `enum` and `static foreach` are given coverage counts of 0, despite the fact that they contain no executable code.

This PR fixes that, by only counting coverage for expressions that actually do work at runtime.