### PR TITLE
Make __traits(getAliasThis) return empty tuple for non-aggregate types

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1071,14 +1071,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto o = (*e.args)[0];
         auto s = getDsymbol(o);
         auto ad = s ? s.isAggregateDeclaration() : null;
-        if (!ad)
-        {
-            e.error("argument is not an aggregate type");
-            return new ErrorExp();
-        }
 
         auto exps = new Expressions();
-        if (ad.aliasthis)
+        if (ad && ad.aliasthis)
             exps.push(new StringExp(e.loc, cast(char*)ad.aliasthis.ident.toChars()));
         Expression ex = new TupleExp(e.loc, exps);
         ex = ex.expressionSemantic(sc);

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1456,6 +1456,10 @@ void test11711()
     static assert(__traits(getAliasThis, S2) == TypeTuple!("var"));
     static assert(is(typeof(__traits(getMember, S2.init, __traits(getAliasThis, S2)[0]))
                 == TypeTuple!(int, string)));
+
+    // https://issues.dlang.org/show_bug.cgi?id=19439
+    // Return empty tuple for non-aggregate types.
+    static assert(__traits(getAliasThis, int).length == 0);
 }
 
 


### PR DESCRIPTION
It is frequently necessary to verify that aliasing is not occurring. Checking that the result of `__traits(getAliasThis)` has length 0 is a concise and natural way of doing this. Unfortunately it is currently disallowed to `getAliasThis` a non-aggregate type. Returning an empty tuple instead of raising a compile-time error would also be convenient for using `getAliasThis` in type-generic code. It should not make DMD slower to change this behavior: not raising an error slightly simplifies the logic.