### PR TITLE
Fix Issue 13392 and 11294 -  class + alias this + cast(void*) == overzealous cast

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -828,10 +828,10 @@ Expression op_overload(Expression e, Scope* sc)
                     /* Rewrite op(e1) as:
                      *      op(e1.aliasthis)
                      */
-                    Expression e1 = new DotIdExp(e.loc, e.e1, ad.aliasthis.ident);
+                    Expression e1 = resolveAliasThis(sc, e.e1);
                     result = e.copy();
                     (cast(UnaExp)result).e1 = e1;
-                    result = result.trySemantic(sc);
+                    result = result.op_overload(sc);
                     return;
                 }
             }

--- a/test/runnable/testaliascast.d
+++ b/test/runnable/testaliascast.d
@@ -1,0 +1,63 @@
+// https://issues.dlang.org/show_bug.cgi?id=11294
+
+string result;
+
+extern(C) void rt_finalize(void *ptr, bool det=true);
+void clear(T)(T obj) if (is(T == class))
+{
+    rt_finalize(cast(void*)obj);
+}
+
+class A
+{
+    ~this() { result ~= "A"; }
+    string dummy = "0";
+}
+
+class B
+{
+    A a;
+    string dummy = "0";
+    alias a this;
+    ~this() { result ~= "B"; }
+}
+
+void test11294()
+{
+    auto a = new A;
+    auto b = new B;
+    b.a = a;
+    result ~= b.dummy;
+    clear(b);
+    result ~= a.dummy;
+    result ~= "END";
+    clear(a);
+
+    assert(result == "0B0ENDA");
+}
+
+
+// https://issues.dlang.org/show_bug.cgi?id=13392
+void foo(T)(T t)
+{
+    void* p = cast(void*) t; //Callas alias this
+}
+
+class X {}
+
+class Y
+{
+  alias a this;
+  @property X a(){assert(0);} //Here
+}
+
+void test13392()
+{
+    foo(B.init);
+}
+
+void main()
+{
+    test11294();
+    test13392();
+}


### PR DESCRIPTION
Again op_overload mixes semantics. Before this patch when op_overload was called for a cast expression,
the result could mean 2 things: either an opCast exists or there is an alias this to be used for casting. 2 different semantics squashed in the same function call.