### PR TITLE
[dmd-cxx] Backport Remove old support code for struct __c_long/ulong/long_double

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -952,15 +952,6 @@ public:
         if (t->isImmutable() || t->isShared())
             return error(t);
 
-        /* __c_long and __c_ulong get special mangling
-         */
-        Identifier *id = t->sym->ident;
-        //printf("struct id = '%s'\n", id->toChars());
-        if (id == Id::__c_long)
-            return writeBasicType(t, 0, 'l');
-        else if (id == Id::__c_ulong)
-            return writeBasicType(t, 0, 'm');
-
         //printf("TypeStruct %s\n", t->toChars());
         doSymbol(t);
     }

--- a/src/cppmanglewin.c
+++ b/src/cppmanglewin.c
@@ -305,46 +305,15 @@ public:
 
     void visit(TypeStruct *type)
     {
-        Identifier *id = type->sym->ident;
-        char c;
-        if (id == Id::__c_long_double)
-            c = 'O';                    // VC++ long double
-        else if (id == Id::__c_long)
-            c = 'J';                    // VC++ long
-        else if (id == Id::__c_ulong)
-            c = 'K';                    // VC++ unsigned long
+        if (checkTypeSaved(type))
+            return;
+        //printf("visit(TypeStruct); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));
+        mangleModifier(type);
+        if (type->sym->isUnionDeclaration())
+            buf.writeByte('T');
         else
-            c = 0;
-
-        if (c)
-        {
-            if (type->isImmutable() || type->isShared())
-            {
-                visit((Type*)type);
-                return;
-            }
-
-            if (type->isConst() && ((flags & IS_NOT_TOP_TYPE) || (flags & IS_DMC)))
-            {
-                if (checkTypeSaved(type))
-                    return;
-            }
-
-            mangleModifier(type);
-            buf.writeByte(c);
-        }
-        else
-        {
-            if (checkTypeSaved(type))
-                return;
-            //printf("visit(TypeStruct); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));
-            mangleModifier(type);
-            if (type->sym->isUnionDeclaration())
-                buf.writeByte('T');
-            else
-                buf.writeByte(type->cppmangle == CPPMANGLEclass ? 'V' : 'U');
-            mangleIdent(type->sym);
-        }
+            buf.writeByte(type->cppmangle == CPPMANGLEclass ? 'V' : 'U');
+        mangleIdent(type->sym);
         flags &= ~IS_NOT_TOP_TYPE;
         flags &= ~IGNORE_CONST;
     }
@@ -1016,7 +985,12 @@ private:
             if (type->isref)
                 rettype = rettype->referenceTo();
             flags &= ~IGNORE_CONST;
-            if (rettype->ty == Tstruct || rettype->ty == Tenum)
+            if (rettype->ty == Tstruct)
+            {
+                tmp.buf.writeByte('?');
+                tmp.buf.writeByte('A');
+            }
+            else if (rettype->ty == Tenum)
             {
                 Identifier *id = rettype->toDsymbol(NULL)->ident;
                 if (id != Id::__c_long_double &&

--- a/src/glue.c
+++ b/src/glue.c
@@ -1349,8 +1349,6 @@ unsigned totym(Type *tx)
 
         case Tstruct:
             t = TYstruct;
-            if (tx->toDsymbol(NULL)->ident == Id::__c_long_double)
-                t = TYdouble;
             break;
 
         case Tenum:

--- a/src/toctype.c
+++ b/src/toctype.c
@@ -148,12 +148,6 @@ public:
         else
         {
             StructDeclaration *sym = t->sym;
-            if (sym->ident == Id::__c_long_double)
-            {
-                t->ctype = type_fake(TYdouble);
-                t->ctype->Tcount++;
-                return;
-            }
             t->ctype = type_struct_class(sym->toPrettyChars(true), sym->alignsize, sym->structsize,
                     sym->arg1type ? Type_toCtype(sym->arg1type) : NULL,
                     sym->arg2type ? Type_toCtype(sym->arg2type) : NULL,

--- a/src/toir.c
+++ b/src/toir.c
@@ -936,8 +936,6 @@ RET retStyle(TypeFunction *tf)
         if (tns->ty == Tstruct)
         {
             StructDeclaration *sd = ((TypeStruct *)tns)->sym;
-            if (sd->ident == Id::__c_long_double)
-                return RETregs;
             if (!sd->isPOD() || sz > 8)
                 return RETstack;
             if (sd->fields.dim == 0)
@@ -946,16 +944,6 @@ RET retStyle(TypeFunction *tf)
         if (sz <= 16 && !(sz & (sz - 1)))
             return RETregs;
         return RETstack;
-    }
-    else if (global.params.isWindows && global.params.mscoff)
-    {
-        Type* tb = tns->baseElemOf();
-        if (tb->ty == Tstruct)
-        {
-            StructDeclaration *sd = ((TypeStruct *)tb)->sym;
-            if (sd->ident == Id::__c_long_double)
-                return RETregs;
-        }
     }
 
 Lagain:
@@ -994,9 +982,6 @@ L2:
         StructDeclaration *sd = ((TypeStruct *)tns)->sym;
         if (global.params.isLinux && tf->linkage != LINKd && !global.params.is64bit)
         {
-            if (sd->ident == Id::__c_long || sd->ident == Id::__c_ulong)
-                return RETregs;
-
             //printf("  2 RETstack\n");
             return RETstack;            // 32 bit C/C++ structs always on stack
         }
@@ -1004,9 +989,6 @@ L2:
                  sd->isPOD() && sd->ctor)
         {
             // win32 returns otherwise POD structs with ctors via memory
-            // unless it's not really a struct
-            if (sd->ident == Id::__c_long || sd->ident == Id::__c_ulong)
-                return RETregs;
             return RETstack;
         }
         if (sd->arg1type && !sd->arg2type)

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -612,13 +612,7 @@ extern(C++)
 
 version (CRuntime_Microsoft)
 {
-    struct __c_long_double
-    {
-        this(double d) { ld = d; }
-        double ld;
-        alias ld this;
-    }
-
+    enum __c_long_double : double;
     alias __c_long_double myld;
 }
 else
@@ -655,20 +649,8 @@ else
   }
 }
 
-struct __c_long
-{
-    this(x_long d) { ld = d; }
-    x_long ld;
-    alias ld this;
-}
-
-struct __c_ulong
-{
-    this(x_ulong d) { ld = d; }
-    x_ulong ld;
-    alias ld this;
-}
-
+enum __c_long : x_long;
+enum __c_ulong : x_ulong;
 alias __c_long mylong;
 alias __c_ulong myulong;
 
@@ -688,6 +670,43 @@ void test16()
     ld = testul(ld);
     assert(ld == 5 + myulong.sizeof);
   }
+
+  static if (__c_long.sizeof == long.sizeof)
+  {
+    static assert(__c_long.max == long.max);
+    static assert(__c_long.min == long.min);
+    static assert(__c_long.init == long.init);
+    static assert(__c_ulong.max == ulong.max);
+    static assert(__c_ulong.min == ulong.min);
+    static assert(__c_ulong.init == ulong.init);
+    __c_long cl = 0;
+    cl = cl + 1;
+    long l = cl;
+    cl = l;
+    __c_ulong cul = 0;
+    cul = cul + 1;
+    ulong ul = cul;
+    cul = ul;
+  }
+  else static if (__c_long.sizeof == int.sizeof)
+  {
+    static assert(__c_long.max == int.max);
+    static assert(__c_long.min == int.min);
+    static assert(__c_long.init == int.init);
+    static assert(__c_ulong.max == uint.max);
+    static assert(__c_ulong.min == uint.min);
+    static assert(__c_ulong.init == uint.init);
+    __c_long cl = 0;
+    cl = cl + 1;
+    int i = cl;
+    cl = i;
+    __c_ulong cul = 0;
+    cul = cul + 1;
+    uint u = cul;
+    cul = u;
+  }
+  else
+    static assert(0);
 }
 
 /****************************************/


### PR DESCRIPTION
GDC never fully supported the struct way, backport the removal of it.