### PR TITLE
[Trivial] Reverse Order of ifcondition to prevent endlessly recursing down dtemplate.needsCodegen()

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6275,7 +6275,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 return true;
             }
 
-            if (tnext && (tnext.minst || tnext.needsCodegen())) {
+            if (tnext && (tnext.minst || tnext.needsCodegen()))
+            {
                 minst = tnext.minst; // cache result
                 assert(minst);
                 return minst.isRoot() || minst.rootImports();

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6220,8 +6220,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         if (global.params.allInst)
         {
             //printf("%s minst = %s, enclosing (%s).isNonRoot = %d\n",
-            //    toPrettyChars(), minst ? minst.toChars() : NULL,
-            //    enclosing ? enclosing.toPrettyChars() : NULL, enclosing && enclosing.inNonRoot());
+            //    toPrettyChars(), minst ? minst.toChars() : null,
+            //    enclosing ? enclosing.toPrettyChars() : null, enclosing && enclosing.inNonRoot());
             if (enclosing)
             {
                 /* https://issues.dlang.org/show_bug.cgi?id=14588
@@ -6274,8 +6274,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 assert(minst.isRoot() || minst.rootImports());
                 return true;
             }
-            if (tnext && (tnext.needsCodegen() || tnext.minst))
-            {
+
+            if (tnext && (tnext.minst || tnext.needsCodegen())) {
                 minst = tnext.minst; // cache result
                 assert(minst);
                 return minst.isRoot() || minst.rootImports();


### PR DESCRIPTION
Ran into seemingly endless recursion when running phobos unittests for rbtree.d
Changing the order of this if condition fixes the issue and does not seem to have a negative side effects (AFAIK).

This might require some more attention, to make sure we are doing tail recursion at this location (if not we might/would be wasting a lot of stack memory).