### PR TITLE
dmd/intrange.d: shift exponent 64 is too large for ulong

### DIFF
--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -276,7 +276,7 @@ struct SignExtendedNumber
 
     SignExtendedNumber opBinary(string op : ">>")(SignExtendedNumber rhs)
     {
-        if (rhs.negative || rhs.value > 64)
+        if (rhs.negative || rhs.value > 63)
             return negative ? SignExtendedNumber(-1, true) : SignExtendedNumber(0);
         else if (isMinimum())
             return rhs.value == 0 ? this : SignExtendedNumber(-1UL << (64 - rhs.value), true);


### PR DESCRIPTION
Picked up by ubsan. The offending line is 285 (`x >>= rhs.value`).