### PR TITLE
dmd/intrange.d: Fix self comparison in maxAndNeg/maxOrNeg conditions

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1094,6 +1094,19 @@ MATCH implicitConvTo(Expression e, Type t)
             visit(cast(Expression)e);
         }
 
+        override void visit(AndExp e)
+        {
+            visit(cast(Expression)e);
+            if (result != MATCH.nomatch)
+                return;
+
+            MATCH m1 = e.e1.implicitConvTo(t);
+            MATCH m2 = e.e2.implicitConvTo(t);
+
+            // Pick the worst match
+            result = (m1 < m2) ? m1 : m2;
+        }
+
         override void visit(OrExp e)
         {
             visit(cast(Expression)e);

--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -580,7 +580,7 @@ struct IntRange
             auto maxAndPos = maxAnd(l, IntRange(SignExtendedNumber(0), r.imax));
 
             auto min = minAndNeg < minAndPos ? minAndNeg : minAndPos;
-            auto max = maxAndNeg > maxAndNeg ? maxAndNeg : maxAndPos;
+            auto max = maxAndNeg > maxAndPos ? maxAndNeg : maxAndPos;
 
             auto range = IntRange(min, max);
             return range;
@@ -627,8 +627,8 @@ struct IntRange
             auto maxOrNeg = maxOr(l, IntRange(r.imin, SignExtendedNumber(-1)));
             auto maxOrPos = maxOr(l, IntRange(SignExtendedNumber(0), r.imax));
 
-            auto min = minOrNeg.value < minOrPos.value ? minOrNeg : minOrPos;
-            auto max = maxOrNeg.value > maxOrNeg.value ? maxOrNeg : maxOrPos;
+            auto min = minOrNeg < minOrPos ? minOrNeg : minOrPos;
+            auto max = maxOrNeg > maxOrPos ? maxOrNeg : maxOrPos;
 
             auto range = IntRange(min, max);
             return range;

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -19,18 +19,32 @@ void leftShift()
 
 void leftShiftFail()
 {
-    ubyte x, y;
-    ushort z;
-    static assert(!__traits(compiles, z = x << y));
-    // 1 << 31 surely overflows the range of 'ushort'.
+    {
+        ubyte x, y;
+        ushort z;
+        static assert(!__traits(compiles, z = x << y));
+        // 1 << 31 surely overflows the range of 'ushort'.
+    }
+    {
+        ulong a, b;
+        int res;
+        static assert(!__traits(compiles, res = a << (b % 65U)));
+    }
 }
 
 void rightShiftFail()
 {
-    short x;
-    byte y, z;
-    static assert(!__traits(compiles, z = x >> y));
-    // [this passes in 2.053.]
+    {
+        short x;
+        byte y, z;
+        static assert(!__traits(compiles, z = x >> y));
+        // [this passes in 2.053.]
+    }
+    {
+        ulong a, b;
+        int res;
+        static assert(!__traits(compiles, res = a >> (b % 65U)));
+    }
 }
 
 void rightShift()

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -173,15 +173,41 @@ void bitAnd()
 
 void bitAndTest()
 {
-    ushort a, b;
-    byte res = ((a % 7) - 6) & ((b % 7) - 6);
+    {
+        ushort a, b;
+        byte res = ((a % 7) - 6) & ((b % 7) - 6);
+    }
+    {
+        // rhs[-128..127] outside range of lhs[0..255]
+        //   -> calls byte.implicitConvTo(ubyte) => MATCH.convert
+        byte a, b;
+        ubyte res;
+
+        res = cast(byte)(a + 5) & b;
+        res = cast(byte)(a - 5) & b;
+        res = cast(byte)(a / 5) & b;
+        res = cast(byte)(a * 5) & b;
+        res = cast(byte)(a % 5) & b;
+    }
 }
 
 void bitOrFail()
 {
-    ubyte c;
-    static assert(!__traits(compiles, c = c | 0x100));
-    // [this passes in 2.053.]
+    {
+        ubyte c;
+        static assert(!__traits(compiles, c = c | 0x100));
+        // [this passes in 2.053.]
+    }
+    {
+        byte a, b;
+        ubyte res;
+
+        static assert(!__traits(compiles, res = (a + 5) | b)); // [-128..255]
+        static assert(!__traits(compiles, res = (a - 5) | b)); // [-133..127]
+        static assert(!__traits(compiles, res = (a / 5) | b)); // [-128..127]
+        static assert(!__traits(compiles, res = (a * 5) | b)); // [-640..639]
+        static assert(!__traits(compiles, res = (a % 5) | b)); // [-128..127]
+    }
 }
 
 void bitAndOr()
@@ -192,27 +218,81 @@ void bitAndOr()
 
 void bitOrTest()
 {
-    // Tests condition for different signs between min & max
-    // ((imin.negative ^ imax.negative) == 1 && (rhs.imin.negative ^ rhs.imax.negative) == 1
-    ushort a, b;
-    byte res = ((a % 127) - 126) | ((b % 6) - 5);
+    {
+        // Tests condition for different signs between min & max
+        // ((imin.negative ^ imax.negative) == 1 && (rhs.imin.negative ^ rhs.imax.negative) == 1
+        ushort a, b;
+        byte res = ((a % 127) - 126) | ((b % 6) - 5);
+    }
+    {
+        // rhs[-128..127] outside range of lhs[0..255]
+        //   -> calls byte.implicitConvTo(ubyte) => MATCH.convert
+        byte a, b, c;
+        ubyte res;
+
+        res = cast(byte)(a + 5) | b;
+        res = cast(byte)(a - 5) | b;
+        res = cast(byte)(a / 5) | b;
+        res = cast(byte)(a * 5) | b;
+        res = cast(byte)(a % 5) | b;
+    }
 }
 
 void bitAndFail()
 {
-    int d;
-    short s;
-    byte c;
-    static assert(!__traits(compiles, c = d & s));
-    static assert(!__traits(compiles, c = d & 256));
-    // [these pass in 2.053.]
+    {
+        int d;
+        short s;
+        byte c;
+        static assert(!__traits(compiles, c = d & s));
+        static assert(!__traits(compiles, c = d & 256));
+        // [these pass in 2.053.]
+    }
+    {
+        byte a, b;
+        ubyte res;
+
+        static assert(!__traits(compiles, res = (a + 5) & b)); // [-128..132]
+        static assert(!__traits(compiles, res = (a - 5) & b)); // [-256..127]
+        static assert(!__traits(compiles, res = (a / 5) & b)); // [-128..127]
+        static assert(!__traits(compiles, res = (a * 5) & b)); // [-640..635]
+        static assert(!__traits(compiles, res = (a % 5) & b)); // [-128..127]
+    }
 }
 
 void bitXor()
 {
-    ushort s;
-    ubyte c;
-    c = (0xffff << (s & 0)) ^ 0xff00;
+    {
+        ushort s;
+        ubyte c;
+        c = (0xffff << (s & 0)) ^ 0xff00;
+    }
+    {
+        // rhs[-128..127] outside range of lhs[0..255]
+        //   -> calls byte.implicitConvTo(ubyte) => MATCH.convert
+        byte a, b, c;
+        ubyte res;
+
+        res = cast(byte)(a + 5) ^ b;
+        res = cast(byte)(a - 5) ^ b;
+        res = cast(byte)(a / 5) ^ b;
+        res = cast(byte)(a * 5) ^ b;
+        res = cast(byte)(a % 5) ^ b;
+    }
+}
+
+void bitXorFail()
+{
+    {
+        byte a, b;
+        ubyte res;
+
+        static assert(!__traits(compiles, res = (a + 5) ^ b)); // [-256..255]
+        static assert(!__traits(compiles, res = (a - 5) ^ b)); // [-256..255]
+        static assert(!__traits(compiles, res = (a / 5) ^ b)); // [-128..127]
+        static assert(!__traits(compiles, res = (a * 5) ^ b)); // [-640..1023]
+        static assert(!__traits(compiles, res = (a % 5) ^ b)); // [-128..127]
+    }
 }
 
 void bitComplement()


### PR DESCRIPTION
1. Fix obviously wrong logic.

2. Fix regression exposed by correcting (1) where the following should compile without errors:
```
ubyte res = cast(byte)(a + 5) & b;
```
Added both compilable and fail tests for `&`, `|`, and `^` operators.

3. Add tests for prior change in #9033.