### PR TITLE
[dmd-cxx] Backport intrange patches and fix ubsan errors

### DIFF
--- a/src/constfold.c
+++ b/src/constfold.c
@@ -446,13 +446,13 @@ UnionExp Div(Loc loc, Type *type, Expression *e1, Expression *e2)
         if (n2 == -1 && !type->isunsigned())
         {
             // Check for int.min / -1
-            if ((dinteger_t)n1 == 0xFFFFFFFF80000000UL && type->toBasetype()->ty != Tint64)
+            if ((dinteger_t)n1 == 0xFFFFFFFF80000000ULL && type->toBasetype()->ty != Tint64)
             {
                 e2->error("integer overflow: int.min / -1");
                 new(&ue) ErrorExp();
                 return ue;
             }
-            else if ((dinteger_t)n1 == 0x8000000000000000L) // long.min / -1
+            else if ((dinteger_t)n1 == 0x8000000000000000LL) // long.min / -1
             {
                 e2->error("integer overflow: long.min / -1");
                 new(&ue) ErrorExp();

--- a/src/dcast.c
+++ b/src/dcast.c
@@ -986,6 +986,19 @@ MATCH implicitConvTo(Expression *e, Type *t)
             visit((Expression *)e);
         }
 
+        void visit(AndExp *e)
+        {
+            visit((Expression *)e);
+            if (result != MATCHnomatch)
+                return;
+
+            MATCH m1 = e->e1->implicitConvTo(t);
+            MATCH m2 = e->e2->implicitConvTo(t);
+
+            // Pick the worst match
+            result = (m1 < m2) ? m1 : m2;
+        }
+
         void visit(OrExp *e)
         {
             visit((Expression *)e);

--- a/src/dsymbol.c
+++ b/src/dsymbol.c
@@ -1191,12 +1191,12 @@ void ScopeDsymbol::importScope(Dsymbol *s, Prot protection)
 
 static void bitArraySet(BitArray *array, size_t idx)
 {
-    array->ptr[idx / (sizeof(size_t) * CHAR_BIT)] |= 1 << (idx & (sizeof(size_t) * CHAR_BIT - 1));
+    array->ptr[idx / (sizeof(size_t) * CHAR_BIT)] |= 1ULL << (idx & (sizeof(size_t) * CHAR_BIT - 1));
 }
 
 static bool bitArrayGet(BitArray *array, size_t idx)
 {
-    return (array->ptr[idx / (sizeof(size_t) * CHAR_BIT)] & (1 << (idx & (sizeof(size_t) * CHAR_BIT - 1)))) != 0;
+    return (array->ptr[idx / (sizeof(size_t) * CHAR_BIT)] & (1ULL << (idx & (sizeof(size_t) * CHAR_BIT - 1)))) != 0;
 }
 
 static void bitArrayLength(BitArray *array, size_t len)

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -68,7 +68,10 @@ SignExtendedNumber& SignExtendedNumber::operator++()
 
 SignExtendedNumber SignExtendedNumber::operator~() const
 {
-    return SignExtendedNumber(~value);
+    if (~value == 0)
+        return SignExtendedNumber(~value);
+    else
+        return SignExtendedNumber(~value, !negative);
 }
 
 SignExtendedNumber SignExtendedNumber::operator-() const
@@ -79,26 +82,26 @@ SignExtendedNumber SignExtendedNumber::operator-() const
         return SignExtendedNumber(-value, !negative);
 }
 
-SignExtendedNumber SignExtendedNumber::operator&(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator&(const SignExtendedNumber& rhs) const
 {
-    return SignExtendedNumber(value & a.value);
+    return SignExtendedNumber(value & rhs.value);
 }
 
-SignExtendedNumber SignExtendedNumber::operator|(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator|(const SignExtendedNumber& rhs) const
 {
-    return SignExtendedNumber(value | a.value);
+    return SignExtendedNumber(value | rhs.value);
 }
 
-SignExtendedNumber SignExtendedNumber::operator^(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator^(const SignExtendedNumber& rhs) const
 {
-    return SignExtendedNumber(value ^ a.value);
+    return SignExtendedNumber(value ^ rhs.value);
 }
 
-SignExtendedNumber SignExtendedNumber::operator+(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator+(const SignExtendedNumber& rhs) const
 {
-    uinteger_t sum = value + a.value;
-    bool carry = sum < value && sum < a.value;
-    if (negative != a.negative)
+    uinteger_t sum = value + rhs.value;
+    bool carry = sum < value && sum < rhs.value;
+    if (negative != rhs.negative)
         return SignExtendedNumber(sum, !carry);
     else if (negative)
         return SignExtendedNumber(carry ? sum : 0, true);
@@ -106,15 +109,15 @@ SignExtendedNumber SignExtendedNumber::operator+(const SignExtendedNumber& a) co
         return SignExtendedNumber(carry ? UINT64_MAX : sum, false);
 }
 
-SignExtendedNumber SignExtendedNumber::operator-(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator-(const SignExtendedNumber& rhs) const
 {
-    if (a.isMinimum())
+    if (rhs.isMinimum())
         return negative ? SignExtendedNumber(value, false) : max();
     else
-        return *this + (-a);
+        return *this + (-rhs);
 }
 
-SignExtendedNumber SignExtendedNumber::operator*(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator*(const SignExtendedNumber& rhs) const
 {
     // perform *saturated* multiplication, otherwise we may get bogus ranges
     //  like 0x10 * 0x10 == 0x100 == 0.
@@ -129,19 +132,19 @@ SignExtendedNumber SignExtendedNumber::operator*(const SignExtendedNumber& a) co
     {
         if (!negative)
             return *this;
-        else if (a.negative)
+        else if (rhs.negative)
             return max();
         else
-            return a.value == 0 ? a : *this;
+            return rhs.value == 0 ? rhs : *this;
     }
-    else if (a.value == 0)
-        return a * *this;   // don't duplicate the symmetric case.
+    else if (rhs.value == 0)
+        return rhs * *this;   // don't duplicate the symmetric case.
 
     SignExtendedNumber rv;
     // these are != 0 now surely.
     uinteger_t tAbs = copySign(value, negative);
-    uinteger_t aAbs = copySign(a.value, a.negative);
-    rv.negative = negative != a.negative;
+    uinteger_t aAbs = copySign(rhs.value, rhs.negative);
+    rv.negative = negative != rhs.negative;
     if (UINT64_MAX / tAbs < aAbs)
         rv.value = rv.negative-1;
     else
@@ -149,7 +152,7 @@ SignExtendedNumber SignExtendedNumber::operator*(const SignExtendedNumber& a) co
     return rv;
 }
 
-SignExtendedNumber SignExtendedNumber::operator/(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator/(const SignExtendedNumber& rhs) const
 {
     /* special handling for zeros:
         INT65_MIN / INT65_MIN = 1
@@ -157,15 +160,15 @@ SignExtendedNumber SignExtendedNumber::operator/(const SignExtendedNumber& a) co
         + / 0 = INT65_MAX  (eh?)
         - / 0 = INT65_MIN  (eh?)
     */
-    if (a.value == 0)
+    if (rhs.value == 0)
     {
-        if (a.negative)
+        if (rhs.negative)
             return SignExtendedNumber(value == 0 && negative);
         else
             return extreme(negative);
     }
 
-    uinteger_t aAbs = copySign(a.value, a.negative);
+    uinteger_t aAbs = copySign(rhs.value, rhs.negative);
     uinteger_t rvVal;
 
     if (!isMinimum())
@@ -178,7 +181,7 @@ SignExtendedNumber SignExtendedNumber::operator/(const SignExtendedNumber& a) co
     else
     {
         if (aAbs == 1)
-            return extreme(!a.negative);
+            return extreme(!rhs.negative);
         rvVal = 1ULL << 63;
         aAbs >>= 1;
         if (aAbs & 0xAAAAAAAAAAAAAAAAULL) rvVal >>= 1;
@@ -188,18 +191,18 @@ SignExtendedNumber SignExtendedNumber::operator/(const SignExtendedNumber& a) co
         if (aAbs & 0xFFFF0000FFFF0000ULL) rvVal >>= 16;
         if (aAbs & 0xFFFFFFFF00000000ULL) rvVal >>= 32;
     }
-    bool rvNeg = negative != a.negative;
+    bool rvNeg = negative != rhs.negative;
     rvVal = copySign(rvVal, rvNeg);
 
     return SignExtendedNumber(rvVal, rvVal != 0 && rvNeg);
 }
 
-SignExtendedNumber SignExtendedNumber::operator%(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator%(const SignExtendedNumber& rhs) const
 {
-    if (a.value == 0)
-        return !a.negative ? a : isMinimum() ? SignExtendedNumber(0) : *this;
+    if (rhs.value == 0)
+        return !rhs.negative ? rhs : isMinimum() ? SignExtendedNumber(0) : *this;
 
-    uinteger_t aAbs = copySign(a.value, a.negative);
+    uinteger_t aAbs = copySign(rhs.value, rhs.negative);
     uinteger_t rvVal;
 
     // a % b == sgn(a) * abs(a) % abs(b).
@@ -217,13 +220,13 @@ SignExtendedNumber SignExtendedNumber::operator%(const SignExtendedNumber& a) co
     return SignExtendedNumber(rvVal, rvVal != 0 && negative);
 }
 
-SignExtendedNumber SignExtendedNumber::operator<<(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator<<(const SignExtendedNumber& rhs) const
 {
     // assume left-shift the shift-amount is always unsigned. Thus negative
     //  shifts will give huge result.
     if (value == 0)
         return *this;
-    else if (a.negative)
+    else if (rhs.negative)
         return extreme(negative);
 
     uinteger_t v = copySign(value, negative);
@@ -242,21 +245,21 @@ SignExtendedNumber SignExtendedNumber::operator<<(const SignExtendedNumber& a) c
                                            r |= (v >> 1);
 
     uinteger_t allowableShift = 63 - r;
-    if (a.value > allowableShift)
+    if (rhs.value > allowableShift)
         return extreme(negative);
     else
-        return SignExtendedNumber(value << a.value, negative);
+        return SignExtendedNumber(value << rhs.value, negative);
 }
 
-SignExtendedNumber SignExtendedNumber::operator>>(const SignExtendedNumber& a) const
+SignExtendedNumber SignExtendedNumber::operator>>(const SignExtendedNumber& rhs) const
 {
-    if (a.negative || a.value > 64)
+    if (rhs.negative || rhs.value > 64)
         return negative ? SignExtendedNumber(-1, true) : SignExtendedNumber(0);
     else if (isMinimum())
-        return a.value == 0 ? *this : SignExtendedNumber(-1ULL << (64-a.value), true);
+        return rhs.value == 0 ? *this : SignExtendedNumber(-1ULL << (64 - rhs.value), true);
 
     uinteger_t x = value ^ -negative;
-    x >>= a.value;
+    x >>= rhs.value;
     return SignExtendedNumber(x ^ -negative, negative);
 }
 
@@ -477,33 +480,38 @@ IntRange IntRange::operator-() const
     return IntRange(-imax, -imin);
 }
 
-IntRange IntRange::operator&(const IntRange& a) const
+IntRange IntRange::operator&(const IntRange& rhs) const
 {
     // unsigned or identical sign bits
-    if ((imin.negative ^ imax.negative) != 1 && (a.imin.negative ^ a.imax.negative) != 1)
+    if ((imin.negative ^ imax.negative) != 1 && (rhs.imin.negative ^ rhs.imax.negative) != 1)
     {
-        return IntRange(minAnd(*this, a), maxAnd(*this, a));
+        return IntRange(minAnd(*this, rhs), maxAnd(*this, rhs));
     }
 
     IntRange l = IntRange(*this);
-    IntRange r = IntRange(a);
+    IntRange r = IntRange(rhs);
 
     // both intervals span [-1,0]
-    if ((l.imin.negative ^ l.imax.negative) != 1 && (r.imin.negative ^ r.imax.negative) != 1)
+    if ((l.imin.negative ^ l.imax.negative) == 1 && (r.imin.negative ^ r.imax.negative) == 1)
     {
         // cannot be larger than either l.max or r.max, set the other one to -1
         SignExtendedNumber max = l.imax.value > r.imax.value ? l.imax : r.imax;
 
         // only negative numbers for minimum
         l.imax.value = -1;
+        l.imax.negative = true;
         r.imax.value = -1;
+        r.imax.negative = true;
 
         return IntRange(minAnd(l, r), max);
     }
     else
     {
         // only one interval spans [-1,0]
-        if ((l.imin.value ^ l.imax.value) < 0) swap(l, r); // r spans [-1,0]
+        if ((l.imin.negative ^ l.imax.negative) == 1)
+        {
+            swap(l, r); // r spans [-1,0]
+        }
 
         SignExtendedNumber minAndNeg = minAnd(l, IntRange(r.imin, SignExtendedNumber(-1)));
         SignExtendedNumber minAndPos = minAnd(l, IntRange(SignExtendedNumber(0), r.imax));
@@ -517,16 +525,16 @@ IntRange IntRange::operator&(const IntRange& a) const
     }
 }
 
-IntRange IntRange::operator|(const IntRange& a) const
+IntRange IntRange::operator|(const IntRange& rhs) const
 {
     // unsigned or identical sign bits:
-    if ((imin.negative ^ imax.negative) == 0 && (a.imin.negative ^ a.imax.negative) == 0)
+    if ((imin.negative ^ imax.negative) == 0 && (rhs.imin.negative ^ rhs.imax.negative) == 0)
     {
-        return IntRange(minOr(*this, a), maxOr(*this, a));
+        return IntRange(minOr(*this, rhs), maxOr(*this, rhs));
     }
 
     IntRange l = IntRange(*this);
-    IntRange r = IntRange(a);
+    IntRange r = IntRange(rhs);
 
     // both intervals span [-1,0]
     if ((l.imin.negative ^ l.imax.negative) == 1 && (r.imin.negative ^ r.imax.negative) == 1)
@@ -536,14 +544,19 @@ IntRange IntRange::operator|(const IntRange& a) const
 
         // only negative numbers for minimum
         l.imin.value = 0;
+        l.imin.negative = false;
         r.imin.value = 0;
+        r.imin.negative = false;
 
         return IntRange(min, maxOr(l, r));
     }
     else
     {
         // only one interval spans [-1,0]
-        if ((imin.negative ^ imax.negative) == 1) swap(l, r); // r spans [-1,0]
+        if ((imin.negative ^ imax.negative) == 1)
+        {
+            swap(l, r); // r spans [-1,0]
+        }
 
         SignExtendedNumber minOrNeg = minOr(l, IntRange(r.imin, SignExtendedNumber(-1)));
         SignExtendedNumber minOrPos = minOr(l, IntRange(SignExtendedNumber(0), r.imax));
@@ -557,68 +570,72 @@ IntRange IntRange::operator|(const IntRange& a) const
     }
 }
 
-IntRange IntRange::operator^(const IntRange& a) const
+IntRange IntRange::operator^(const IntRange& rhs) const
 {
-    return (*this & (~a)) | (~(*this) & a);
+    return (*this & (~rhs)) | (~(*this) & rhs);
 }
 
-IntRange IntRange::operator+(const IntRange& a) const
+IntRange IntRange::operator+(const IntRange& rhs) const
 {
-    return IntRange(imin + a.imin, imax + a.imax);
+    return IntRange(imin + rhs.imin, imax + rhs.imax);
 }
 
-IntRange IntRange::operator-(const IntRange& a) const
+IntRange IntRange::operator-(const IntRange& rhs) const
 {
-    return IntRange(imin - a.imax, imax - a.imin);
+    return IntRange(imin - rhs.imax, imax - rhs.imin);
 }
 
-IntRange IntRange::operator*(const IntRange& a) const
+IntRange IntRange::operator*(const IntRange& rhs) const
 {
     // [a,b] * [c,d] = [min (ac, ad, bc, bd), max (ac, ad, bc, bd)]
     SignExtendedNumber bdy[4];
-    bdy[0] = imin * a.imin;
-    bdy[1] = imin * a.imax;
-    bdy[2] = imax * a.imin;
-    bdy[3] = imax * a.imax;
+    bdy[0] = imin * rhs.imin;
+    bdy[1] = imin * rhs.imax;
+    bdy[2] = imax * rhs.imin;
+    bdy[3] = imax * rhs.imax;
     return IntRange::fromNumbers4(bdy);
 }
 
-IntRange IntRange::operator/(const IntRange& a) const
+IntRange IntRange::operator/(const IntRange& rhs) const
 {
     // Handle divide by 0
-    if (a.imax.value == 0 && a.imin.value == 0) return widest();
+    if (rhs.imax.value == 0 && rhs.imin.value == 0)
+        return widest();
 
-    IntRange ac = IntRange(a);
+    IntRange r = IntRange(rhs);
 
     // Don't treat the whole range as divide by 0 if only one end of a range is 0.
     // Issue 15289
-    if (ac.imax.value == 0) ac.imax.value--;
-    else if(ac.imin.value == 0) ac.imin.value++;
-
-    if (!imin.negative && !imax.negative && !ac.imin.negative && !ac.imax.negative)
+    if (r.imax.value == 0)
     {
-        IntRange res = IntRange(imin / ac.imax, imax / ac.imin);
-        return res;
+        r.imax.value--;
+    }
+    else if(r.imin.value == 0)
+    {
+        r.imin.value++;
+    }
+
+    if (!imin.negative && !imax.negative && !r.imin.negative && !r.imax.negative)
+    {
+        return IntRange(imin / r.imax, imax / r.imin);
     }
     else
     {
         // [a,b] / [c,d] = [min (a/c, a/d, b/c, b/d), max (a/c, a/d, b/c, b/d)]
         SignExtendedNumber bdy[4];
-        bdy[0] = imin / ac.imin;
-        bdy[1] = imin / ac.imax;
-        bdy[2] = imax / ac.imin;
-        bdy[3] = imax / ac.imax;
+        bdy[0] = imin / r.imin;
+        bdy[1] = imin / r.imax;
+        bdy[2] = imax / r.imin;
+        bdy[3] = imax / r.imax;
 
-        IntRange res = IntRange::fromNumbers4(bdy);
-        //printf("%u %u %d\n", res.imin.value, res.imax.value);
-        return res;
+        return IntRange::fromNumbers4(bdy);
     }
 }
 
-IntRange IntRange::operator%(const IntRange& a) const
+IntRange IntRange::operator%(const IntRange& rhs) const
 {
     IntRange irNum = *this;
-    IntRange irDen = a.absNeg();
+    IntRange irDen = rhs.absNeg();
 
     /*
      due to the rules of D (C)'s % operator, we need to consider the cases
@@ -639,9 +656,13 @@ IntRange IntRange::operator%(const IntRange& a) const
     irDen.imax = -irDen.imin;
 
     if (!irNum.imin.negative)
+    {
         irNum.imin.value = 0;
+    }
     else if (irNum.imin < irDen.imin)
+    {
         irNum.imin = irDen.imin;
+    }
 
     if (irNum.imax.negative)
     {
@@ -649,31 +670,37 @@ IntRange IntRange::operator%(const IntRange& a) const
         irNum.imax.value = 0;
     }
     else if (irNum.imax > irDen.imax)
+    {
         irNum.imax = irDen.imax;
+    }
 
     return irNum;
 }
 
-IntRange IntRange::operator<<(const IntRange& a) const
+IntRange IntRange::operator<<(const IntRange& rhs) const
 {
-    IntRange ac = IntRange(a);
-    if (ac.imin.negative)
-        ac = IntRange(SignExtendedNumber(0), SignExtendedNumber(64));
+    IntRange r = IntRange(rhs);
+    if (r.imin.negative)
+    {
+        r = IntRange(SignExtendedNumber(0), SignExtendedNumber(64));
+    }
 
-    SignExtendedNumber lower = imin << (imin.negative ? ac.imax : ac.imin);
-    SignExtendedNumber upper = imax << (imax.negative ? ac.imin : ac.imax);
+    SignExtendedNumber lower = imin << (imin.negative ? r.imax : r.imin);
+    SignExtendedNumber upper = imax << (imax.negative ? r.imin : r.imax);
 
     return IntRange(lower, upper);
 }
 
-IntRange IntRange::operator>>(const IntRange& a) const
+IntRange IntRange::operator>>(const IntRange& rhs) const
 {
-    IntRange ac = IntRange(a);
-    if (ac.imin.negative)
-        ac = IntRange(SignExtendedNumber(0), SignExtendedNumber(64));
+    IntRange r = IntRange(rhs);
+    if (r.imin.negative)
+    {
+        r = IntRange(SignExtendedNumber(0), SignExtendedNumber(64));
+    }
 
-    SignExtendedNumber lower = imin >> (imin.negative ? ac.imin : ac.imax);
-    SignExtendedNumber upper = imax >> (imax.negative ? ac.imax : ac.imin);
+    SignExtendedNumber lower = imin >> (imin.negative ? r.imin : r.imax);
+    SignExtendedNumber upper = imax >> (imax.negative ? r.imax : r.imin);
 
     return IntRange(lower, upper);
 }
@@ -681,10 +708,36 @@ IntRange IntRange::operator>>(const IntRange& a) const
 SignExtendedNumber IntRange::maxOr(const IntRange& lhs, const IntRange& rhs)
 {
     uinteger_t x = 0;
+    bool sign = false;
     uinteger_t xorvalue = lhs.imax.value ^ rhs.imax.value;
     uinteger_t andvalue = lhs.imax.value & rhs.imax.value;
     IntRange lhsc = IntRange(lhs);
     IntRange rhsc = IntRange(rhs);
+
+    // Sign bit not part of the .value so we need an extra iteration
+    if (lhsc.imax.negative ^ rhsc.imax.negative)
+    {
+        sign = true;
+        if (lhsc.imax.negative)
+        {
+            if (!lhsc.imin.negative)
+            {
+                lhsc.imin.value = 0;
+            }
+            if (!rhsc.imin.negative)
+            {
+                rhsc.imin.value = 0;
+            }
+        }
+    }
+    else if (lhsc.imin.negative & rhsc.imin.negative)
+    {
+        sign = true;
+    }
+    else if (lhsc.imax.negative & rhsc.imax.negative)
+    {
+        return SignExtendedNumber(-1, false);
+    }
 
     for (uinteger_t d = 1LU << (8 * sizeof(uinteger_t) - 1); d; d >>= 1)
     {
@@ -693,14 +746,23 @@ SignExtendedNumber IntRange::maxOr(const IntRange& lhs, const IntRange& rhs)
             x |= d;
             if (lhsc.imax.value & d)
             {
-                if (~lhsc.imin.value & d) lhsc.imin.value = 0;
+                if (~lhsc.imin.value & d)
+                {
+                    lhsc.imin.value = 0;
+                }
             }
             else
             {
-                if (~rhsc.imin.value & d) rhsc.imin.value = 0;
+                if (~rhsc.imin.value & d)
+                {
+                    rhsc.imin.value = 0;
+                }
             }
         }
-        else if (lhsc.imin.value & rhsc.imin.value & d) x |= d;
+        else if (lhsc.imin.value & rhsc.imin.value & d)
+        {
+            x |= d;
+        }
         else if (andvalue & d)
         {
             x |= (d << 1) - 1;
@@ -708,7 +770,7 @@ SignExtendedNumber IntRange::maxOr(const IntRange& lhs, const IntRange& rhs)
         }
     }
 
-  return SignExtendedNumber(x);
+    return SignExtendedNumber(x, sign);
 }
 
 SignExtendedNumber IntRange::minOr(const IntRange& lhs, const IntRange& rhs)
@@ -719,22 +781,40 @@ SignExtendedNumber IntRange::minOr(const IntRange& lhs, const IntRange& rhs)
 SignExtendedNumber IntRange::maxAnd(const IntRange& lhs, const IntRange& rhs)
 {
     uinteger_t x = 0;
+    bool sign = false;
     IntRange lhsc = IntRange(lhs);
     IntRange rhsc = IntRange(rhs);
 
-    for (uinteger_t d = 1LU << (8 * sizeof(uinteger_t)-  1); d; d >>= 1)
+    if (lhsc.imax.negative & rhsc.imax.negative)
+    {
+        sign = true;
+    }
+
+    for (uinteger_t d = 1LU << (8 * sizeof(uinteger_t) - 1); d; d >>= 1)
     {
         if (lhsc.imax.value & rhsc.imax.value & d)
         {
             x |= d;
-            if (~lhsc.imin.value & d) lhsc.imin.value = 0;
-            if (~rhsc.imin.value & d) rhsc.imin.value = 0;
+            if (~lhsc.imin.value & d)
+            {
+                lhsc.imin.value = 0;
+            }
+            if (~rhsc.imin.value & d)
+            {
+                rhsc.imin.value = 0;
+            }
         }
-        else if (~lhsc.imin.value & d && lhsc.imax.value & d) lhsc.imax.value |= d - 1;
-        else if (~rhsc.imin.value & d && rhsc.imax.value & d) rhsc.imax.value |= d - 1;
+        else if (~lhsc.imin.value & d && lhsc.imax.value & d)
+        {
+            lhsc.imax.value |= d - 1;
+        }
+        else if (~rhsc.imin.value & d && rhsc.imax.value & d)
+        {
+            rhsc.imax.value |= d - 1;
+        }
     }
 
-    return SignExtendedNumber(x);
+    return SignExtendedNumber(x, sign);
 }
 
 SignExtendedNumber IntRange::minAnd(const IntRange& lhs, const IntRange& rhs)

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -253,7 +253,7 @@ SignExtendedNumber SignExtendedNumber::operator<<(const SignExtendedNumber& rhs)
 
 SignExtendedNumber SignExtendedNumber::operator>>(const SignExtendedNumber& rhs) const
 {
-    if (rhs.negative || rhs.value > 64)
+    if (rhs.negative || rhs.value > 63)
         return negative ? SignExtendedNumber(-1, true) : SignExtendedNumber(0);
     else if (isMinimum())
         return rhs.value == 0 ? *this : SignExtendedNumber(-1ULL << (64 - rhs.value), true);

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -739,7 +739,7 @@ SignExtendedNumber IntRange::maxOr(const IntRange& lhs, const IntRange& rhs)
         return SignExtendedNumber(-1, false);
     }
 
-    for (uinteger_t d = 1LU << (8 * sizeof(uinteger_t) - 1); d; d >>= 1)
+    for (uinteger_t d = 1ULL << (8 * sizeof(uinteger_t) - 1); d; d >>= 1)
     {
         if (xorvalue & d)
         {
@@ -790,7 +790,7 @@ SignExtendedNumber IntRange::maxAnd(const IntRange& lhs, const IntRange& rhs)
         sign = true;
     }
 
-    for (uinteger_t d = 1LU << (8 * sizeof(uinteger_t) - 1); d; d >>= 1)
+    for (uinteger_t d = 1ULL << (8 * sizeof(uinteger_t) - 1); d; d >>= 1)
     {
         if (lhsc.imax.value & rhsc.imax.value & d)
         {

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -519,7 +519,7 @@ IntRange IntRange::operator&(const IntRange& rhs) const
         SignExtendedNumber maxAndPos = maxAnd(l, IntRange(SignExtendedNumber(0), r.imax));
 
         SignExtendedNumber min = minAndNeg < minAndPos ? minAndNeg : minAndPos;
-        SignExtendedNumber max = maxAndNeg > maxAndNeg ? maxAndNeg : maxAndPos;
+        SignExtendedNumber max = maxAndNeg > maxAndPos ? maxAndNeg : maxAndPos;
 
         return IntRange(min, max);
     }
@@ -563,8 +563,8 @@ IntRange IntRange::operator|(const IntRange& rhs) const
         SignExtendedNumber maxOrNeg = maxOr(l, IntRange(r.imin, SignExtendedNumber(-1)));
         SignExtendedNumber maxOrPos = maxOr(l, IntRange(SignExtendedNumber(0), r.imax));
 
-        SignExtendedNumber min = minOrNeg.value < minOrPos.value ? minOrNeg : minOrPos;
-        SignExtendedNumber max = maxOrNeg.value > maxOrNeg.value ? maxOrNeg : maxOrPos;
+        SignExtendedNumber min = minOrNeg < minOrPos ? minOrNeg : minOrPos;
+        SignExtendedNumber max = maxOrNeg > maxOrPos ? maxOrNeg : maxOrPos;
 
         return IntRange(min, max);
     }

--- a/src/intrange.h
+++ b/src/intrange.h
@@ -60,9 +60,19 @@ struct SignExtendedNumber
     bool operator<=(const SignExtendedNumber& a) const { return !(a < *this); }
     bool operator>=(const SignExtendedNumber& a) const { return !(*this < a); }
 
+    /// Increase the sign-extended number by 1 (saturated).
+    SignExtendedNumber& operator++();
+    /// Compute the saturated complement of a sign-extended number.
+    SignExtendedNumber operator~() const;
     /// Compute the saturated negation of a sign-extended number.
     SignExtendedNumber operator-() const;
 
+    /// Compute the saturated binary and of two sign-extended number.
+    SignExtendedNumber operator&(const SignExtendedNumber& a) const;
+    /// Compute the saturated binary or of two sign-extended number.
+    SignExtendedNumber operator|(const SignExtendedNumber& a) const;
+    /// Compute the saturated binary xor of two sign-extended number.
+    SignExtendedNumber operator^(const SignExtendedNumber& a) const;
     /// Compute the saturated sum of two sign-extended number.
     SignExtendedNumber operator+(const SignExtendedNumber&) const;
     /// Compute the saturated difference of two sign-extended number.
@@ -73,9 +83,6 @@ struct SignExtendedNumber
     SignExtendedNumber operator/(const SignExtendedNumber&) const;
     /// Compute the saturated modulus of two sign-extended number.
     SignExtendedNumber operator%(const SignExtendedNumber&) const;
-
-    /// Increase the sign-extended number by 1 (saturated).
-    SignExtendedNumber& operator++();
 
     /// Compute the saturated shifts of two sign-extended number.
     SignExtendedNumber operator<<(const SignExtendedNumber&) const;
@@ -146,4 +153,25 @@ struct IntRange
     /// Split the range into two nonnegative- and negative-only subintervals.
     void splitBySign(IntRange& negRange, bool& hasNegRange,
                      IntRange& nonNegRange, bool& hasNonNegRange) const;
+
+    /// Credits to Timon Gehr maxOr, minOr, maxAnd, minAnd
+    /// https://github.com/tgehr/d-compiler/blob/master/vrange.d
+    static SignExtendedNumber maxOr(const IntRange& lhs, const IntRange& rhs);
+    static SignExtendedNumber minOr(const IntRange& lhs, const IntRange& rhs);
+    static SignExtendedNumber maxAnd(const IntRange& lhs, const IntRange& rhs);
+    static SignExtendedNumber minAnd(const IntRange& lhs, const IntRange& rhs);
+    static void swap(IntRange& a, IntRange& b);
+
+    IntRange operator~() const;
+    IntRange operator-() const;
+    IntRange operator&(const IntRange& a) const;
+    IntRange operator|(const IntRange& a) const;
+    IntRange operator^(const IntRange& a) const;
+    IntRange operator+(const IntRange& a) const;
+    IntRange operator-(const IntRange& a) const;
+    IntRange operator*(const IntRange& a) const;
+    IntRange operator/(const IntRange& a) const;
+    IntRange operator%(const IntRange& a) const;
+    IntRange operator<<(const IntRange& a) const;
+    IntRange operator>>(const IntRange& a) const;
 };

--- a/src/intrange.h
+++ b/src/intrange.h
@@ -68,15 +68,15 @@ struct SignExtendedNumber
     SignExtendedNumber operator-() const;
 
     /// Compute the saturated binary and of two sign-extended number.
-    SignExtendedNumber operator&(const SignExtendedNumber& a) const;
+    SignExtendedNumber operator&(const SignExtendedNumber&) const;
     /// Compute the saturated binary or of two sign-extended number.
-    SignExtendedNumber operator|(const SignExtendedNumber& a) const;
+    SignExtendedNumber operator|(const SignExtendedNumber&) const;
     /// Compute the saturated binary xor of two sign-extended number.
-    SignExtendedNumber operator^(const SignExtendedNumber& a) const;
+    SignExtendedNumber operator^(const SignExtendedNumber&) const;
     /// Compute the saturated sum of two sign-extended number.
     SignExtendedNumber operator+(const SignExtendedNumber&) const;
     /// Compute the saturated difference of two sign-extended number.
-    SignExtendedNumber operator-(const SignExtendedNumber& a) const;
+    SignExtendedNumber operator-(const SignExtendedNumber&) const;
     /// Compute the saturated product of two sign-extended number.
     SignExtendedNumber operator*(const SignExtendedNumber&) const;
     /// Compute the saturated quotient of two sign-extended number.
@@ -156,22 +156,22 @@ struct IntRange
 
     /// Credits to Timon Gehr maxOr, minOr, maxAnd, minAnd
     /// https://github.com/tgehr/d-compiler/blob/master/vrange.d
-    static SignExtendedNumber maxOr(const IntRange& lhs, const IntRange& rhs);
-    static SignExtendedNumber minOr(const IntRange& lhs, const IntRange& rhs);
-    static SignExtendedNumber maxAnd(const IntRange& lhs, const IntRange& rhs);
-    static SignExtendedNumber minAnd(const IntRange& lhs, const IntRange& rhs);
-    static void swap(IntRange& a, IntRange& b);
+    static SignExtendedNumber maxOr(const IntRange&, const IntRange&);
+    static SignExtendedNumber minOr(const IntRange&, const IntRange&);
+    static SignExtendedNumber maxAnd(const IntRange&, const IntRange&);
+    static SignExtendedNumber minAnd(const IntRange&, const IntRange&);
+    static void swap(IntRange&, IntRange&);
 
     IntRange operator~() const;
     IntRange operator-() const;
-    IntRange operator&(const IntRange& a) const;
-    IntRange operator|(const IntRange& a) const;
-    IntRange operator^(const IntRange& a) const;
-    IntRange operator+(const IntRange& a) const;
-    IntRange operator-(const IntRange& a) const;
-    IntRange operator*(const IntRange& a) const;
-    IntRange operator/(const IntRange& a) const;
-    IntRange operator%(const IntRange& a) const;
-    IntRange operator<<(const IntRange& a) const;
-    IntRange operator>>(const IntRange& a) const;
+    IntRange operator&(const IntRange&) const;
+    IntRange operator|(const IntRange&) const;
+    IntRange operator^(const IntRange&) const;
+    IntRange operator+(const IntRange&) const;
+    IntRange operator-(const IntRange&) const;
+    IntRange operator*(const IntRange&) const;
+    IntRange operator/(const IntRange&) const;
+    IntRange operator%(const IntRange&) const;
+    IntRange operator<<(const IntRange&) const;
+    IntRange operator>>(const IntRange&) const;
 };

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -19,18 +19,32 @@ void leftShift()
 
 void leftShiftFail()
 {
-    ubyte x, y;
-    ushort z;
-    static assert(!__traits(compiles, z = x << y));
-    // 1 << 31 surely overflows the range of 'ushort'.
+    {
+        ubyte x, y;
+        ushort z;
+        static assert(!__traits(compiles, z = x << y));
+        // 1 << 31 surely overflows the range of 'ushort'.
+    }
+    {
+        ulong a, b;
+        int res;
+        static assert(!__traits(compiles, res = a << (b % 65U)));
+    }
 }
 
 void rightShiftFail()
 {
-    short x;
-    byte y, z;
-    static assert(!__traits(compiles, z = x >> y));
-    // [this passes in 2.053.]
+    {
+        short x;
+        byte y, z;
+        static assert(!__traits(compiles, z = x >> y));
+        // [this passes in 2.053.]
+    }
+    {
+        ulong a, b;
+        int res;
+        static assert(!__traits(compiles, res = a >> (b % 65U)));
+    }
 }
 
 void rightShift()

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -335,3 +335,26 @@ void test10310()
     int y;
     ubyte x = ((y & 252) ^ 2) + 1;
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=15289
+void test15289a()
+{
+    int [] arr = [1, 2, 3, 4];
+    uint foo = 50 / arr.length;
+}
+
+void test15289b()
+{
+    int [] arr = [1, 2, 3, 4];
+    uint foo = 50 % arr.length;
+}
+
+void testShiftRightOnNegative()
+{
+    int neg = -1;
+    uint[] arr = [1, 2, 3];
+    ubyte b;
+    // Shift with negative value returns value in range [0, ulong.max]
+    static assert(!__traits(compiles, b = arr.length >> neg));
+    static assert(!__traits(compiles, b = arr.length << neg));
+}

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -329,3 +329,9 @@ void test13001(bool unknown)
         static assert(!__traits(compiles, b = i + 254));
     }
 }
+
+void test10310()
+{
+    int y;
+    ubyte x = ((y & 252) ^ 2) + 1;
+}

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -187,15 +187,41 @@ void bitAnd()
 
 void bitAndTest()
 {
-    ushort a, b;
-    byte res = ((a % 7) - 6) & ((b % 7) - 6);
+    {
+        ushort a, b;
+        byte res = ((a % 7) - 6) & ((b % 7) - 6);
+    }
+    {
+        // rhs[-128..127] outside range of lhs[0..255]
+        //   -> calls byte.implicitConvTo(ubyte) => MATCH.convert
+        byte a, b;
+        ubyte res;
+
+        res = cast(byte)(a + 5) & b;
+        res = cast(byte)(a - 5) & b;
+        res = cast(byte)(a / 5) & b;
+        res = cast(byte)(a * 5) & b;
+        res = cast(byte)(a % 5) & b;
+    }
 }
 
 void bitOrFail()
 {
-    ubyte c;
-    static assert(!__traits(compiles, c = c | 0x100));
-    // [this passes in 2.053.]
+    {
+        ubyte c;
+        static assert(!__traits(compiles, c = c | 0x100));
+        // [this passes in 2.053.]
+    }
+    {
+        byte a, b;
+        ubyte res;
+
+        static assert(!__traits(compiles, res = (a + 5) | b)); // [-128..255]
+        static assert(!__traits(compiles, res = (a - 5) | b)); // [-133..127]
+        static assert(!__traits(compiles, res = (a / 5) | b)); // [-128..127]
+        static assert(!__traits(compiles, res = (a * 5) | b)); // [-640..639]
+        static assert(!__traits(compiles, res = (a % 5) | b)); // [-128..127]
+    }
 }
 
 void bitAndOr()
@@ -206,27 +232,81 @@ void bitAndOr()
 
 void bitOrTest()
 {
-    // Tests condition for different signs between min & max
-    // ((imin.negative ^ imax.negative) == 1 && (rhs.imin.negative ^ rhs.imax.negative) == 1
-    ushort a, b;
-    byte res = ((a % 127) - 126) | ((b % 6) - 5);
+    {
+        // Tests condition for different signs between min & max
+        // ((imin.negative ^ imax.negative) == 1 && (rhs.imin.negative ^ rhs.imax.negative) == 1
+        ushort a, b;
+        byte res = ((a % 127) - 126) | ((b % 6) - 5);
+    }
+    {
+        // rhs[-128..127] outside range of lhs[0..255]
+        //   -> calls byte.implicitConvTo(ubyte) => MATCH.convert
+        byte a, b, c;
+        ubyte res;
+
+        res = cast(byte)(a + 5) | b;
+        res = cast(byte)(a - 5) | b;
+        res = cast(byte)(a / 5) | b;
+        res = cast(byte)(a * 5) | b;
+        res = cast(byte)(a % 5) | b;
+    }
 }
 
 void bitAndFail()
 {
-    int d;
-    short s;
-    byte c;
-    static assert(!__traits(compiles, c = d & s));
-    static assert(!__traits(compiles, c = d & 256));
-    // [these pass in 2.053.]
+    {
+        int d;
+        short s;
+        byte c;
+        static assert(!__traits(compiles, c = d & s));
+        static assert(!__traits(compiles, c = d & 256));
+        // [these pass in 2.053.]
+    }
+    {
+        byte a, b;
+        ubyte res;
+
+        static assert(!__traits(compiles, res = (a + 5) & b)); // [-128..132]
+        static assert(!__traits(compiles, res = (a - 5) & b)); // [-256..127]
+        static assert(!__traits(compiles, res = (a / 5) & b)); // [-128..127]
+        static assert(!__traits(compiles, res = (a * 5) & b)); // [-640..635]
+        static assert(!__traits(compiles, res = (a % 5) & b)); // [-128..127]
+    }
 }
 
 void bitXor()
 {
-    ushort s;
-    ubyte c;
-    c = (0xffff << (s & 0)) ^ 0xff00;
+    {
+        ushort s;
+        ubyte c;
+        c = (0xffff << (s & 0)) ^ 0xff00;
+    }
+    {
+        // rhs[-128..127] outside range of lhs[0..255]
+        //   -> calls byte.implicitConvTo(ubyte) => MATCH.convert
+        byte a, b, c;
+        ubyte res;
+
+        res = cast(byte)(a + 5) ^ b;
+        res = cast(byte)(a - 5) ^ b;
+        res = cast(byte)(a / 5) ^ b;
+        res = cast(byte)(a * 5) ^ b;
+        res = cast(byte)(a % 5) ^ b;
+    }
+}
+
+void bitXorFail()
+{
+    {
+        byte a, b;
+        ubyte res;
+
+        static assert(!__traits(compiles, res = (a + 5) ^ b)); // [-256..255]
+        static assert(!__traits(compiles, res = (a - 5) ^ b)); // [-256..255]
+        static assert(!__traits(compiles, res = (a / 5) ^ b)); // [-128..127]
+        static assert(!__traits(compiles, res = (a * 5) ^ b)); // [-640..1023]
+        static assert(!__traits(compiles, res = (a % 5) ^ b)); // [-128..127]
+    }
 }
 
 void bitComplement()

--- a/test/compilable/testVRP.d
+++ b/test/compilable/testVRP.d
@@ -1,55 +1,66 @@
 // PERMUTE_ARGS: -O -inline
 
 // Test value-range propagation.
-// See Bug 3147, Bug 6000, Bug 5225.
+// https://issues.dlang.org/show_bug.cgi?id=3147
+// https://issues.dlang.org/show_bug.cgi?id=6000
+// https://issues.dlang.org/show_bug.cgi?id=5225
 
-void add() {
+void add()
+{
     byte x, y;
     short a = x + y;
 }
 
-void leftShift() {
+void leftShift()
+{
     byte x, y;
     short z = x << 1;
 }
 
-void leftShiftFail() {
+void leftShiftFail()
+{
     ubyte x, y;
     ushort z;
     static assert(!__traits(compiles, z = x << y));
     // 1 << 31 surely overflows the range of 'ushort'.
 }
 
-void rightShiftFail() {
+void rightShiftFail()
+{
     short x;
     byte y, z;
     static assert(!__traits(compiles, z = x >> y));
     // [this passes in 2.053.]
 }
 
-void rightShift() {
+void rightShift()
+{
     ushort x;
     ubyte y = x >> 16;
 }
 
-void unsignedRightShiftFail() {
+void unsignedRightShiftFail()
+{
     int x;
     ubyte y;
     static assert(!__traits(compiles, y = x >>> 2));
     // [this passes in 2.053.]
 }
 
-void subtract() {
+void subtract()
+{
     ubyte x, y;
     short z = x - y;
 }
 
-void multiply() {
+void multiply()
+{
     byte x, y;
     short z = x * y;
 }
 
-void subMulFail() {
+void subMulFail()
+{
     ubyte x, y;
     ubyte z;
     static assert(!__traits(compiles, z = x - y));
@@ -57,65 +68,82 @@ void subMulFail() {
     // [these pass in 2.053.]
 }
 
-void multiplyNeg1() {
+void multiplyNeg1()
+{
     byte b;
     b = -1 + (b * -1);
     static assert(!__traits(compiles, b = -1 + b * ulong.max));
 }
 
-void divide() {
+void divide()
+{
     short w;
     byte y = w / 300;
 }
 
-void divideFail() {
+void divideFail()
+{
     short w;
     byte y;
     static assert(!__traits(compiles, y = w / -1));
 }
 
-void plus1Fail() {
+void plus1Fail()
+{
     byte u, v;
     static assert(!__traits(compiles, v = u + 1));
     // [these pass in 2.053.]
 }
 
-void modulus() {
+void modulus()
+{
     int x;
     byte u = x % 128;
 }
 
-void modulus_bug6000a() {
+void modulus_bug6000a()
+{
     ulong t;
     uint u = t % 16;
 }
 
-void modulus_bug6000b() {
+void modulus_bug6000b()
+{
     long n = 10520;
     ubyte b;
     static assert(!__traits(compiles, b = n % 10));
 }
 
-void modulus2() {
+void modulus2()
+{
     short s;
     byte b = byte.max;
     byte c = s % b;
 }
 
-void modulus3() {
+void modulus3()
+{
     int i;
     short s = short.max;
     short t = i % s;
 }
 
-void modulus4() {
+void modulus4()
+{
     uint i;
     ushort s;
     short t;
     static assert(!__traits(compiles, t = i % s));
 }
 
-void modulusFail() {
+void modulus5()
+{
+    short a;
+    byte foo = (a - short.max - 1) % 127;
+}
+
+void modulusFail()
+{
     int i;
     short s;
     byte b;
@@ -124,7 +152,8 @@ void modulusFail() {
     // [these pass in 2.053.]
 }
 
-void bitwise() {
+void bitwise()
+{
     ubyte a, b, c;
     uint d;
     c = a & b;
@@ -134,25 +163,43 @@ void bitwise() {
     // [these pass in 2.053.]
 }
 
-void bitAnd() {
+void bitAnd()
+{
     byte c;
     int d;
     c = (0x3ff_ffffU << (0&c)) & (0x4000_0000U << (0&c));
     // the result of the above is always 0 :).
 }
 
-void bitOrFail() {
+void bitAndTest()
+{
+    ushort a, b;
+    byte res = ((a % 7) - 6) & ((b % 7) - 6);
+}
+
+void bitOrFail()
+{
     ubyte c;
     static assert(!__traits(compiles, c = c | 0x100));
     // [this passes in 2.053.]
 }
 
-void bitAndOr() {
+void bitAndOr()
+{
     ubyte c;
     c = (c | 0x1000) & ~0x1000;
 }
 
-void bitAndFail() {
+void bitOrTest()
+{
+    // Tests condition for different signs between min & max
+    // ((imin.negative ^ imax.negative) == 1 && (rhs.imin.negative ^ rhs.imax.negative) == 1
+    ushort a, b;
+    byte res = ((a % 127) - 126) | ((b % 6) - 5);
+}
+
+void bitAndFail()
+{
     int d;
     short s;
     byte c;
@@ -161,29 +208,34 @@ void bitAndFail() {
     // [these pass in 2.053.]
 }
 
-void bitXor() {
+void bitXor()
+{
     ushort s;
     ubyte c;
-    c = (0xffff << (s&0)) ^ 0xff00;
+    c = (0xffff << (s & 0)) ^ 0xff00;
 }
 
-void bitComplement() {
+void bitComplement()
+{
     int i;
     ubyte b = ~(i | ~0xff);
 }
 
-void bitComplementFail() {
+void bitComplementFail()
+{
     ubyte b;
     static assert(!__traits(compiles, b = ~(b | 1)));
     // [this passes in 2.053.]
 }
 
-void negation() {
+void negation()
+{
     int x;
     byte b = -(x & 0x7);
 }
 
-void negationFail() {
+void negationFail()
+{
     int x;
     byte b;
     static assert(!__traits(compiles, b = -(x & 255)));
@@ -200,7 +252,8 @@ short bug1977_comment5(byte i) {
   return o;
 }
 
-void testDchar() {
+void testDchar()
+{
     dchar d;
     uint i;
     /+
@@ -210,13 +263,15 @@ void testDchar() {
     d = i % 0x110000;
 }
 
-void bug1977_comment11() {
+void bug1977_comment11()
+{
     uint a;
     byte b = a & 1;
     // [this passes in 2.053.]
 }
 
-void bug1977_comment20() {
+void bug1977_comment20()
+{
     long a;
     int b = a % 1000;
 }


### PR DESCRIPTION
Backports from #7317, #7355, #7556, #9033, and #9044.

The last commit is local to the C++ branch, and fixes a couple small typos in D->C++ conversion, and a runtime error: `shift exponent 32 is too large for 32-bit type 'int'`