### PR TITLE
Fix Issue 19014 - Compiler imports symbols that aren't actually imported

### DIFF
--- a/test/compilable/test19014.d
+++ b/test/compilable/test19014.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=19014
+
+import core.stdc.config;
+
+void main()
+{
+    if (true)
+    {
+    	static import core.stdc.math;
+    }
+    static assert(!__traits(compiles, core.stdc.math.cos(0))); 
+}


### PR DESCRIPTION
Adds a test to verify fix for https://issues.dlang.org/show_bug.cgi?id=19014  When this is pulled the bug can be closed.

@braddr The fix will be released with 2.084?  Any chance we can get the autotester updated with 2.084 at that time.  This bug is holding up https://github.com/dlang/druntime/pull/2399
