### PR TITLE
[testsuite] Remove leading forward slash from EXTRA_SOURCES path

### DIFF
--- a/test/compilable/ddoc9369.d
+++ b/test/compilable/ddoc9369.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// EXTRA_SOURCES: /extra-files/ddoc9369.ddoc
+// EXTRA_SOURCES: extra-files/ddoc9369.ddoc
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
 

--- a/test/compilable/ddoc9676a.d
+++ b/test/compilable/ddoc9676a.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// EXTRA_SOURCES: /extra-files/ddoc9676a.ddoc
+// EXTRA_SOURCES: extra-files/ddoc9676a.ddoc
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
 

--- a/test/compilable/depsOutput9948.d
+++ b/test/compilable/depsOutput9948.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -deps=${RESULTS_DIR}/compilable/depsOutput9948.deps
 // POST_SCRIPT: compilable/extra-files/depsOutput.sh 
-// EXTRA_SOURCES: /extra-files/depsOutput9948a.d
+// EXTRA_SOURCES: extra-files/depsOutput9948a.d
 
 module depsOutput9948;
 import depsOutput9948a;


### PR DESCRIPTION
This is not an absolute path.  Upstreamed from gdc for running the D2 testsuite under dejagnu.