### PR TITLE
[dmd-cxx] Backport add toTypeFunction() to catch bad casts

### DIFF
--- a/src/dclass.c
+++ b/src/dclass.c
@@ -805,7 +805,7 @@ Lancestorsdone:
         if (fd && !fd->errors)
         {
             //printf("Creating default this(){} for class %s\n", toChars());
-            TypeFunction *btf = (TypeFunction *)fd->type;
+            TypeFunction *btf = fd->type->toTypeFunction();
             TypeFunction *tf = new TypeFunction(NULL, NULL, 0, LINKd, fd->storage_class);
             tf->mod = btf->mod;
             tf->purity = btf->purity;
@@ -1152,7 +1152,7 @@ int isf(void *param, Dsymbol *s)
 
 bool ClassDeclaration::isFuncHidden(FuncDeclaration *fd)
 {
-    //printf("ClassDeclaration::isFuncHidden(class = %s, fd = %s)\n", toChars(), fd->toChars());
+    //printf("ClassDeclaration::isFuncHidden(class = %s, fd = %s)\n", toChars(), fd->toPrettyChars());
     Dsymbol *s = search(Loc(), fd->ident, IgnoreAmbiguous | IgnoreErrors);
     if (!s)
     {
@@ -1749,6 +1749,7 @@ bool InterfaceDeclaration::isBaseOf(ClassDeclaration *cd, int *poffset)
         //printf("\tX base %s\n", b->sym->toChars());
         if (this == b->sym)
         {
+            //printf("\tfound at offset %d\n", b->offset);
             if (poffset)
             {
                 // don't return incorrect offsets https://issues.dlang.org/show_bug.cgi?id=16980
@@ -1882,8 +1883,7 @@ bool BaseClass::fillVtbl(ClassDeclaration *cd, FuncDeclarations *vtbl, int newin
 
         assert(ifd);
         // Find corresponding function in this class
-        tf = (ifd->type->ty == Tfunction) ? (TypeFunction *)(ifd->type) : NULL;
-        assert(tf);  // should always be non-null
+        tf = ifd->type->toTypeFunction();
         fd = cd->findFunc(ifd->ident, tf);
         if (fd && !fd->isAbstract())
         {

--- a/src/dstruct.c
+++ b/src/dstruct.c
@@ -46,7 +46,7 @@ FuncDeclaration *search_toString(StructDeclaration *sd)
         if (!tftostring)
         {
             tftostring = new TypeFunction(NULL, Type::tstring, 0, LINKd);
-            tftostring = (TypeFunction *)tftostring->merge();
+            tftostring = tftostring->merge()->toTypeFunction();
         }
 
         fd = fd->overloadExactMatch(tftostring);
@@ -92,6 +92,7 @@ void semanticTypeInfo(Scope *sc, Type *t)
         }
         void visit(TypeStruct *t)
         {
+            //printf("semanticTypeInfo::visit(TypeStruct = %s)\n", t->toChars());
             StructDeclaration *sd = t->sym;
 
             /* Step 1: create TypeInfoDeclaration

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -335,6 +335,7 @@ public:
     virtual bool needsDestruction();
     virtual bool needsNested();
     void checkComplexTransition(Loc loc);
+    TypeFunction *toTypeFunction();
 
     static void error(Loc loc, const char *format, ...);
     static void warning(Loc loc, const char *format, ...);


### PR DESCRIPTION
Backport from #6643. When running D2 testsuite with ubsan build, it was throwing errors in FuncDeclaration::semantic.

e.g:
```
fail_compilation/imports/a13311.d:8:5: error: undefined identifier ‘PieceTree’
func.c:557: runtime error: load of value 217, which is not a valid value for type 'bool'
func.c:562: runtime error: load of value 16384, which is not a valid value for type 'TRUST'
func.c:564: runtime error: load of value 16384, which is not a valid value for type 'TRUST'
func.c:565: runtime error: load of value 16384, which is not a valid value for type 'TRUST'
func.c:566: runtime error: load of value 16384, which is not a valid value for type 'TRUST'
func.c:583: runtime error: load of value 144, which is not a valid value for type 'bool'
```
This was because of blind casting from TypeError to TypeFunction, which was fixed in master by this PR.