### PR TITLE
Fix Issue 19471 - Duplicate error messages when trying to use an inaccessible package symbol

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -511,8 +511,6 @@ struct Scope
                 if (!s)
                     s = searchScopes(flags | SearchImportsOnly | IgnoreSymbolVisibility);
 
-                if (s && !(flags & IgnoreErrors))
-                    .deprecation(loc, "`%s` is not visible from module `%s`", s.toPrettyChars(), _module.toChars());
                 version (LOGSEARCH) if (s) printMsg("-Scope.search() found imported private symbol", s);
             }
         }

--- a/test/fail_compilation/fail313.d
+++ b/test/fail_compilation/fail313.d
@@ -1,11 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail313.d(17): Error: module `imports.b313` is not accessible here, perhaps add `static import imports.b313;`
-fail_compilation/fail313.d(24): Deprecation: `imports.a313.core` is not visible from module `test313`
-fail_compilation/fail313.d(24): Error: package `core.stdc` is not accessible here
-fail_compilation/fail313.d(24): Error: module `core.stdc.stdio` is not accessible here, perhaps add `static import core.stdc.stdio;`
-fail_compilation/fail313.d(29): Error: package `imports.pkg313` is not accessible here, perhaps add `static import imports.pkg313;`
+fail_compilation/fail313.d(16): Error: module `imports.b313` is not accessible here, perhaps add `static import imports.b313;`
+fail_compilation/fail313.d(23): Error: package `core.stdc` is not accessible here
+fail_compilation/fail313.d(23): Error: module `core.stdc.stdio` is not accessible here, perhaps add `static import core.stdc.stdio;`
+fail_compilation/fail313.d(28): Error: package `imports.pkg313` is not accessible here, perhaps add `static import imports.pkg313;`
 ---
 */
 module test313;


### PR DESCRIPTION
This is actually a followup to #8443.  It removes what appears to be a redundant deprecation message in https://github.com/dlang/dmd/blob/987012be68b00e3350655157db6cf7375ef07459/test/fail_compilation/fail313.d#L5

It also happens to solve [Issue 19014](https://issues.dlang.org/show_bug.cgi?id=19014).  I didn't add a test specific to Issue 19014 because the changes to fail313.d seem to cover it.

cc @RazvanN7 