### PR TITLE
Fix Issue 12885 - const union wrongly converts implicitly to mutable

### DIFF
--- a/test/fail_compilation/fail12885.d
+++ b/test/fail_compilation/fail12885.d
@@ -1,0 +1,36 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail12885.d(19): Error: cannot implicitly convert expression `c` of type `const(U)` to `U`
+fail_compilation/fail12885.d(34): Error: cannot implicitly convert expression `cr` of type `const(R11257)` to `R11257`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=12885
+union U
+{
+    int i;
+    int* p;
+}
+
+void test12885()
+{
+    const U c;
+    U m = c;
+}
+
+struct R11257
+{
+    union
+    {
+        const(Object) original;
+        Object stripped;
+    }
+}
+
+void test11257()
+{
+    const(R11257) cr;
+    R11257 mr = cr;  // Error: cannot implicitly convert expression (cr) of type const(R) to R
+}
+

--- a/test/runnable/testassign.d
+++ b/test/runnable/testassign.d
@@ -35,7 +35,6 @@ void test2()
 }
 
 /***************************************************/
-
 struct S31A
 {
     union
@@ -54,8 +53,9 @@ struct S31B
         int field2;
     }
 
-    enum result = true;
+    enum result = false;
 }
+
 struct S31C
 {
     union
@@ -64,7 +64,7 @@ struct S31C
         immutable int field2;
     }
 
-    enum result = true;
+    enum result = false;
 }
 struct S31D
 {
@@ -86,7 +86,7 @@ struct S32A
         int field2;
     }
 
-    enum result = true;
+    enum result = false;
 }
 struct S32B
 {
@@ -110,7 +110,7 @@ struct S32C
     }
     int dummy1;
 
-    enum result = true;
+    enum result = false;
 }
 struct S32D
 {

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -3534,23 +3534,6 @@ void test11226()
 }
 
 /************************************/
-// https://issues.dlang.org/show_bug.cgi?id=11257
-
-struct R11257
-{
-    union
-    {
-        const(Object) original;
-        Object stripped;
-    }
-}
-void test11257()
-{
-    const(R11257) cr;
-    R11257 mr = cr;  // Error: cannot implicitly convert expression (cr) of type const(R) to R
-}
-
-/************************************/
 // https://issues.dlang.org/show_bug.cgi?id=11215
 
 shared(inout(void)**) f11215(inout int);


### PR DESCRIPTION
Tests fail because of std.typecons.rebindable.