### PR TITLE
[chore] Cleanup build.d after DMD backend conversion

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -804,16 +804,15 @@ auto sourceFiles()
             "obj",
         ].map!(e => env["C"].buildPath(e ~ ".d")).array,
         backendC:
-            // all backend files
-            dirEntries(env["C"], "*.{c,d,h}", SpanMode.shallow)
-                .map!(e => e.name)
-                .filter!(e => !e.canFind("stub", "optabgen.c"))
-                .chain(targetCH.only)
+            // all backend files in C
+            ["fp", "strtold", "tk"]
+                .map!(a => env["G"].buildPath(a).objName)
                 .array,
         backendObjects: ["fp", "strtold", "tk"]
                 .map!(a => env["G"].buildPath(a).objName)
                 .array,
     };
+    sources.backendC.writeln;
     sources.dmd = sources.frontend ~ sources.backendHeaders;
 
     return sources;

--- a/src/build.d
+++ b/src/build.d
@@ -216,7 +216,6 @@ auto opTabGen()
         args ~= flags["DFLAGS"];
 
         writefln("(DC) BUILD_OPTABGEN");
-        writeln(args);
         args.runCanThrow;
 
         writefln("(RUN) OPTABBIN %-(%s, %)", opTabFiles);

--- a/src/build.d
+++ b/src/build.d
@@ -172,7 +172,6 @@ auto lexer()
             "-of$@",
             "-lib",
             "-J"~env["G"], "-J../res",
-            "-L-lstdc++",
         ].chain(flags["DFLAGS"], "$<".only).array
     };
     return dependency;
@@ -407,7 +406,6 @@ auto buildDMD(string[] extraFlags...)
             "-vtls",
             "-J"~env["G"],
             "-J../res",
-            "-L-lstdc++",
         ].chain(extraFlags).chain(flags["DFLAGS"], "$<".only).array
     };
     dependency.run;

--- a/src/build.d
+++ b/src/build.d
@@ -166,7 +166,7 @@ auto lexer()
         target: env["G"].buildPath("lexer").libName,
         sources: sources.lexer,
         rebuildSources: configFiles,
-        name: "(CC) D_LEXER_OBJ",
+        name: "(DC) D_LEXER_OBJ",
         command: [
             env["HOST_DMD_RUN"],
             "-of$@",
@@ -216,11 +216,11 @@ auto opTabGen()
         auto args = [env["HOST_DMD_RUN"], opTabSourceFile, "-of" ~ opTabBin];
         args ~= flags["DFLAGS"];
 
-        writefln("(CC) BUILD_OPTABGEN");
+        writefln("(DC) BUILD_OPTABGEN");
         writeln(args);
         args.runCanThrow;
 
-        writefln("(CC) RUN_OPTABBIN %-(%s, %)", opTabFiles);
+        writefln("(RUN) OPTABBIN %-(%s, %)", opTabFiles);
         [opTabBin].runCanThrow;
 
         // move the generated files to the generated folder
@@ -292,7 +292,7 @@ auto dBackend()
     Dependency dependency = {
         target: env["G"].buildPath("dbackend").objName,
         sources: sources.backend,
-        name: "(CC) D_BACK_OBJS %-(%s %)".format(sources.backend),
+        name: "(DC) D_BACK_OBJS %-(%s %)".format(sources.backend),
         command: [
             env["HOST_DMD_RUN"],
             "-c",
@@ -400,7 +400,7 @@ auto buildDMD(string[] extraFlags...)
         // newdelete.o + lexer.a + backend.a
         sources: sources.dmd.chain(sources.root, dependencies[0].targets, dependencies[1].targets, backend.targets).array,
         target: env["DMD_PATH"],
-        name: "(CC) MAIN_DMD_BUILD",
+        name: "(DC) MAIN_DMD_BUILD",
         command: [
             env["HOST_DMD_RUN"],
             "-of$@",

--- a/src/build.d
+++ b/src/build.d
@@ -159,7 +159,7 @@ auto newDelete()
     return dependency;
 }
 
-/// Returns: the depedency that builds the lexer
+/// Returns: the dependency that builds the lexer
 auto lexer()
 {
     Dependency dependency = {

--- a/src/build.d
+++ b/src/build.d
@@ -745,7 +745,7 @@ auto sourceFiles()
     struct Sources
     {
         string[] frontend, lexer, root, glue, dmd, backend;
-        string[] backendHeaders, backendC, tkC, backendObjects;
+        string[] backendHeaders, backendC, backendObjects;
     }
     string targetCH;
     string[] targetObjs;
@@ -811,15 +811,7 @@ auto sourceFiles()
                 .filter!(e => !e.canFind("stub", "optabgen.c"))
                 .chain(targetCH.only)
                 .array,
-        tkC:
-            dirEntries(env["C"], "*.{c,h}", SpanMode.shallow)
-            .map!(e => e.name)
-            .array,
-        backendObjects:
-            dirEntries(env["C"], "*.c", SpanMode.shallow)
-                .map!(e => e.baseName.stripExtension)
-                .filter!(e => !e.canFind("stub", "optabgen", "cgcv", "cgobj", "newman"))
-                .chain(targetObjs)
+        backendObjects: ["fp", "strtold", "tk"]
                 .map!(a => env["G"].buildPath(a).objName)
                 .array,
     };


### PR DESCRIPTION
There are still three files (`fp.c`, `strtold.c` and `tk.c`) for which the C++ compiler is required, but apart from that we can already start with cleaning up the `build.d`.