### PR TITLE
Fix Issue 10665 - The documentation produced by ddoc should clearly list all public imports of a module

### DIFF
--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -24,6 +24,7 @@ import dmd.cond;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.denum;
+import dmd.dimport;
 import dmd.dmacro;
 import dmd.dmodule;
 import dmd.dscope;
@@ -744,27 +745,96 @@ private void emitAnchor(OutBuffer* buf, Dsymbol s, Scope* sc, bool forHeader = f
     // cache anchor name
     sc.prevAnchor = ident;
     auto macroName = forHeader ? "DDOC_HEADER_ANCHOR" : "DDOC_ANCHOR";
-    auto symbolName = ident.toString();
-    buf.printf("$(%.*s %.*s", cast(int) macroName.length, macroName.ptr,
-        cast(int) symbolName.length, symbolName.ptr);
-    // only append count once there's a duplicate
-    if (count > 1)
-        buf.printf(".%u", count);
 
-    if (forHeader)
+    if (auto imp = s.isImport())
     {
-        Identifier shortIdent;
+        // For example: `public import core.stdc.string : memcpy, memcmp;`
+        if (imp.aliases.dim > 0)
         {
-            OutBuffer anc;
-            emitAnchorName(&anc, s, skipNonQualScopes(sc), false);
-            shortIdent = Identifier.idPool(anc.peekSlice());
+            for(int i = 0; i < imp.aliases.dim; i++)
+            {
+                // Need to distinguish between
+                // `public import core.stdc.string : memcpy, memcmp;` and
+                // `public import core.stdc.string : copy = memcpy, compare = memcmp;`
+                auto a = imp.aliases[i];
+                auto id = a ? a : imp.names[i];
+                auto loc = Loc.init;
+                if (auto symFromId = sc.search(loc, id, null))
+                {
+                    emitAnchor(buf, symFromId, sc, forHeader);
+                }
+            }
+        }
+        else
+        {
+            // For example: `public import str = core.stdc.string;`
+            if (imp.aliasId)
+            {
+                auto symbolName = imp.aliasId.toString();
+
+                buf.printf("$(%.*s %.*s", cast(int) macroName.length, macroName.ptr,
+                    cast(int) symbolName.length, symbolName.ptr);
+
+                if (forHeader)
+                {
+                    buf.printf(", %.*s", cast(int) symbolName.length, symbolName.ptr);
+                }
+            }
+            else
+            {
+                // The general case:  `public import core.stdc.string;`
+
+                // fully qualify imports so `core.stdc.string` doesn't appear as `core`
+                void printFullyQualifiedImport()
+                {
+                    if (imp.packages && imp.packages.dim)
+                    {
+                        foreach (const pid; *imp.packages)
+                        {
+                            buf.printf("%s.", pid.toChars());
+                        }
+                    }
+                    buf.writestring(imp.id.toString());
+                }
+
+                buf.printf("$(%.*s ", cast(int) macroName.length, macroName.ptr);
+                printFullyQualifiedImport();
+
+                if (forHeader)
+                {
+                    buf.printf(", ");
+                    printFullyQualifiedImport();
+                }
+            }
+
+            buf.writeByte(')');
+        }
+    }
+    else
+    {
+        auto symbolName = ident.toString();
+        buf.printf("$(%.*s %.*s", cast(int) macroName.length, macroName.ptr,
+            cast(int) symbolName.length, symbolName.ptr);
+
+        // only append count once there's a duplicate
+        if (count > 1)
+            buf.printf(".%u", count);
+
+        if (forHeader)
+        {
+            Identifier shortIdent;
+            {
+                OutBuffer anc;
+                emitAnchorName(&anc, s, skipNonQualScopes(sc), false);
+                shortIdent = Identifier.idPool(anc.peekSlice());
+            }
+
+            auto shortName = shortIdent.toString();
+            buf.printf(", %.*s", cast(int) shortName.length, shortName.ptr);
         }
 
-        auto shortName = shortIdent.toString();
-        buf.printf(", %.*s", cast(int) shortName.length, shortName.ptr);
+        buf.writeByte(')');
     }
-
-    buf.writeByte(')');
 }
 
 /******************************* emitComment **********************************/
@@ -844,13 +914,26 @@ private void emitMemberComments(ScopeDsymbol sds, OutBuffer* buf, Scope* sc)
         buf.writestring(")");
 }
 
-private void emitProtection(OutBuffer* buf, Prot prot)
+private void emitProtection(OutBuffer* buf, Import i)
 {
+    // imports are private by default, which is different from other declarations
+    // so they should explicitly show their protection
+    emitProtection(buf, i.protection);
+}
+
+private void emitProtection(OutBuffer* buf, Declaration d)
+{
+    auto prot = d.protection;
     if (prot.kind != Prot.Kind.undefined && prot.kind != Prot.Kind.public_)
     {
-        protectionToBuffer(buf, prot);
-        buf.writeByte(' ');
+        emitProtection(buf, prot);
     }
+}
+
+private void emitProtection(OutBuffer* buf, Prot prot)
+{
+    protectionToBuffer(buf, prot);
+    buf.writeByte(' ');
 }
 
 private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
@@ -962,6 +1045,14 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
                 dc.pmacrotable = &sc._module.macrotable;
                 sc.lastdc = dc;
             }
+        }
+
+        override void visit(Import imp)
+        {
+            if (imp.prot().kind != Prot.Kind.public_ && sc.protection.kind != Prot.Kind.export_)
+                return;
+
+            emit(sc, imp, imp.comment);
         }
 
         override void visit(Declaration d)
@@ -1157,7 +1248,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                 buf.writestring("deprecated ");
             if (Declaration d = s.isDeclaration())
             {
-                emitProtection(buf, d.protection);
+                emitProtection(buf, d);
                 if (d.isStatic())
                     buf.writestring("static ");
                 else if (d.isFinal())
@@ -1191,6 +1282,14 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                     buf.writestring("auto ");
                 }
             }
+        }
+
+        override void visit(Import i)
+        {
+            HdrGenState hgs;
+            hgs.ddoc = true;
+            emitProtection(buf, i);
+            .toCBuffer(i, buf, &hgs);
         }
 
         override void visit(Declaration d)
@@ -1258,7 +1357,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                 return;
             if (ad.isDeprecated())
                 buf.writestring("deprecated ");
-            emitProtection(buf, ad.protection);
+            emitProtection(buf, ad);
             buf.printf("alias %s = ", ad.toChars());
             if (Dsymbol s = ad.aliassym) // ident alias
             {
@@ -1333,7 +1432,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                 return;
             version (none)
             {
-                emitProtection(buf, ad.protection);
+                emitProtection(buf, ad);
             }
             buf.printf("%s %s", ad.kind(), ad.toChars());
             buf.writestring(";\n");
@@ -1346,7 +1445,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                 return;
             version (none)
             {
-                emitProtection(buf, sd.protection);
+                emitProtection(buf, sd);
             }
             if (TemplateDeclaration td = getEponymousParent(sd))
             {
@@ -1366,7 +1465,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                 return;
             version (none)
             {
-                emitProtection(buf, cd.protection);
+                emitProtection(buf, cd);
             }
             if (TemplateDeclaration td = getEponymousParent(cd))
             {
@@ -1391,7 +1490,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                     buf.writestring(": ");
                     any = 1;
                 }
-                emitProtection(buf, Prot(Prot.Kind.public_));
+
                 if (bc.sym)
                 {
                     buf.printf("$(DDOC_PSUPER_SYMBOL %s)", bc.sym.toPrettyChars());
@@ -2080,6 +2179,65 @@ private size_t skippastident(OutBuffer* buf, size_t i)
 }
 
 /************************************************
+ * Scan forward past end of an identifier that might
+ * contain dots (e.g. `abc.def`)
+ */
+private size_t skipPastIdentWithDots(OutBuffer* buf, size_t i)
+{
+    const slice = buf.peekSlice();
+    bool lastCharWasDot;
+    while (i < slice.length)
+    {
+        dchar c;
+        size_t oi = i;
+        if (utf_decodeChar(slice.ptr, slice.length, i, c))
+        {
+            /* Ignore UTF errors, but still consume input
+             */
+            break;
+        }
+        if (c == '.')
+        {
+            // We need to distinguish between `abc.def`, abc..def`, and `abc.`
+            // Only `abc.def` is a valid identifier
+
+            if (lastCharWasDot)
+            {
+                i = oi;
+                break;
+            }
+
+            lastCharWasDot = true;
+            continue;
+        }
+        else
+        {
+            if (c >= 0x80)
+            {
+                if (isUniAlpha(c))
+                {
+                    lastCharWasDot = false;
+                    continue;
+                }
+            }
+            else if (isalnum(c) || c == '_')
+            {
+                lastCharWasDot = false;
+                continue;
+            }
+            i = oi;
+            break;
+        }
+    }
+
+    // if `abc.`
+    if (lastCharWasDot)
+        return i - 1;
+
+    return i;
+}
+
+/************************************************
  * Scan forward past URL starting at i.
  * We don't want to highlight parts of a URL.
  * Returns:
@@ -2434,8 +2592,41 @@ private bool isIdentifier(Dsymbols* a, const(char)* p, size_t len)
 {
     foreach (member; *a)
     {
-        if (p[0 .. len] == member.ident.toString())
-            return true;
+        if (auto imp = member.isImport())
+        {
+            // For example: `public import str = core.stdc.string;`
+            // This checks if `p` is equal to `str`
+            if (imp.aliasId)
+            {
+                if (p[0 .. len] == imp.aliasId.toString())
+                    return true;
+            }
+            else
+            {
+                // The general case:  `public import core.stdc.string;`
+
+                // fully qualify imports so `core.stdc.string` doesn't appear as `core`
+                string fullyQualifiedImport;
+                if (imp.packages && imp.packages.dim)
+                {
+                    foreach (const pid; *imp.packages)
+                    {
+                        fullyQualifiedImport ~= pid.toString() ~ ".";
+                    }
+                }
+                fullyQualifiedImport ~= imp.id.toString();
+
+                // Check if `p` == `core.stdc.string`
+                if (p[0 .. len] == fullyQualifiedImport)
+                    return true;
+            }
+        }
+        else if (member.ident)
+        {
+            if (p[0 .. len] == member.ident.toString())
+                return true;
+        }
+
     }
     return false;
 }
@@ -4880,14 +5071,35 @@ private void highlightText(Scope* sc, Dsymbols* a, Loc loc, OutBuffer* buf, size
  */
 private void highlightCode(Scope* sc, Dsymbol s, OutBuffer* buf, size_t offset)
 {
-    //printf("highlightCode(s = %s '%s')\n", s.kind(), s.toChars());
-    OutBuffer ancbuf;
-    emitAnchor(&ancbuf, s, sc);
-    buf.insert(offset, ancbuf.peekSlice());
-    offset += ancbuf.offset;
-    Dsymbols a;
-    a.push(s);
-    highlightCode(sc, &a, buf, offset);
+    auto imp = s.isImport();
+    if (imp && imp.aliases.dim > 0)
+    {
+        // For example: `public import core.stdc.string : memcpy, memcmp;`
+        for(int i = 0; i < imp.aliases.dim; i++)
+        {
+            // Need to distinguish between
+            // `public import core.stdc.string : memcpy, memcmp;` and
+            // `public import core.stdc.string : copy = memcpy, compare = memcmp;`
+            auto a = imp.aliases[i];
+            auto id = a ? a : imp.names[i];
+            auto loc = Loc.init;
+            if (auto symFromId = sc.search(loc, id, null))
+            {
+                highlightCode(sc, symFromId, buf, offset);
+            }
+        }
+    }
+    else
+    {
+        OutBuffer ancbuf;
+        emitAnchor(&ancbuf, s, sc);
+        buf.insert(offset, ancbuf.peekSlice());
+        offset += ancbuf.offset;
+
+        Dsymbols a;
+        a.push(s);
+        highlightCode(sc, &a, buf, offset);
+    }
 }
 
 /****************************************************
@@ -4911,7 +5123,18 @@ private void highlightCode(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t offset
         char* start = cast(char*)buf.data + i;
         if (isIdStart(start))
         {
-            size_t j = skippastident(buf, i);
+            size_t j = skipPastIdentWithDots(buf, i);
+            if (i < j)
+            {
+                size_t len = j - i;
+                if (isIdentifier(a, start, len))
+                {
+                    i = buf.bracket(i, "$(DDOC_PSYMBOL ", j, ")") - 1;
+                    continue;
+                }
+            }
+
+            j = skippastident(buf, i);
             if (i < j)
             {
                 size_t len = j - i;

--- a/test/compilable/ddocunittest.d
+++ b/test/compilable/ddocunittest.d
@@ -189,12 +189,6 @@ static import core.stdc.stdlib;
 unittest { fooStaticImport(); }
 
 ///
-void fooPublicImport() {}
-public import core.stdc.string;
-/// test
-unittest { fooPublicImport(); }
-
-///
 void fooSelectiveImport() {}
 import core.stdc.ctype : isalpha;
 /// test
@@ -205,6 +199,28 @@ void fooRenamedImport() {}
 import io = core.stdc.stdio;
 /// test
 unittest { fooRenamedImport(); }
+
+/// This is a public import
+public import core.stdc.string;
+
+/// This is a mutiple public import
+public import core.stdc.stdarg, core.stdc.stdlib;
+
+/// This is a public selective import
+public import core.stdc.string : memcpy;
+
+/// This is a public selective renamed import
+public import core.stdc.string : copy = memcpy;
+
+/// This is a public multiple selective import
+public import core.stdc.string : memcpy, memcmp;
+
+/// This is a public multiple selective renamed import
+public import core.stdc.string : copy = memcpy, compare = memcmp;
+
+/// This is a public renamed import
+public import str = core.stdc.string;
+
 
 // ------------------------------------
 // documented unittest after conditional declarations

--- a/test/compilable/extra-files/ddocunittest.html
+++ b/test/compilable/extra-files/ddocunittest.html
@@ -1149,50 +1149,6 @@
 </li><li class="ddoc_member">
   <div class="ddoc_member_header">
   <div class="ddoc_header_anchor">
-  <a href="#fooPublicImport" id="fooPublicImport"><code class="code">fooPublicImport</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="fooPublicImport"></span>void <code class="code">fooPublicImport</code>();
-
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  <section class="section ddoc_sections">
-  <div class="ddoc_examples">
-  <h4>Examples</h4>
-  <p class="para">
-    test
-
-<section class="code_listing">
-  <div class="code_sample">
-    <div class="dlang">
-      <ol class="code_lines">
-        <li><code class="code"><span class="psymbol">fooPublicImport</span>();
-</code></li>
-      </ol>
-    </div>
-  </div>
-</section>
-
-  </p>
-</div>
-</section>
-
-</div>
-
-</li><li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
   <a href="#fooSelectiveImport" id="fooSelectiveImport"><code class="code">fooSelectiveImport</code></a>
 </div>
 </div><div class="ddoc_decl">
@@ -1274,6 +1230,266 @@
 
   </p>
 </div>
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#core.stdc.string" id="core.stdc.string"><code class="code">core.stdc.string</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="core.stdc.string"></span>public import <code class="code">core.stdc.string</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a public import
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#core.stdc.stdarg" id="core.stdc.stdarg"><code class="code">core.stdc.stdarg</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="core.stdc.stdarg"></span>public import <code class="code">core.stdc.stdarg</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a mutiple public import
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#core.stdc.stdlib" id="core.stdc.stdlib"><code class="code">core.stdc.stdlib</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="core.stdc.stdlib"></span>public import <code class="code">core.stdc.stdlib</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a mutiple public import
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#memcpy" id="memcpy"><code class="code">memcpy</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="memcpy"></span>public import core.stdc.string : <code class="code">memcpy</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a public selective import
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#copy" id="copy"><code class="code">copy</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="copy"></span>public import core.stdc.string : <code class="code">copy</code> = memcpy;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a public selective renamed import
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#memcpy" id="memcpy"><code class="code">memcpy</code></a>
+</div><div class="ddoc_header_anchor">
+  <a href="#memcmp" id="memcmp"><code class="code">memcmp</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="memcmp"></span><span class="ddoc_anchor" id="memcpy.2"></span>public import core.stdc.string : <code class="code">memcpy</code>, <code class="code">memcmp</code>;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a public multiple selective import
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#copy" id="copy"><code class="code">copy</code></a>
+</div><div class="ddoc_header_anchor">
+  <a href="#compare" id="compare"><code class="code">compare</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="compare"></span><span class="ddoc_anchor" id="copy.2"></span>public import core.stdc.string : <code class="code">copy</code> = memcpy, <code class="code">compare</code> = memcmp;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a public multiple selective renamed import
+  </p>
+</div>
+
+</section>
+
+</div>
+
+</li><li class="ddoc_member">
+  <div class="ddoc_member_header">
+  <div class="ddoc_header_anchor">
+  <a href="#str" id="str"><code class="code">str</code></a>
+</div>
+</div><div class="ddoc_decl">
+  <section class="section">
+    <div class="declaration">
+      <h4>Declaration</h4>
+      <div class="dlang">
+        <p class="para">
+          <code class="code">
+            <span class="ddoc_anchor" id="str"></span>public import <code class="code">str</code> = core.stdc.string;
+
+          </code>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+<div class="ddoc_decl">
+  <section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    This is a public renamed import
+  </p>
+</div>
+
 </section>
 
 </div>


### PR DESCRIPTION
```d
/// This is module b
module b;

/// This is a function in module b
void bFunction() { }
```

```d
/// This is module c
module c;

/// This is a function in module c
void cFunction() { }
```

```d
/// This is module a
module a;

/// This is a public import comment
public import b;

/// This is a private import comment
private import c;

/// This is a function in module a
void aFunction() { }
```

![image](https://user-images.githubusercontent.com/6023641/49803659-c4e28700-fd93-11e8-83f4-b42f807e15f4.png)
