### PR TITLE
fix Issue 19447 - [REG2.066] fixed size slice assignment in ctfe lose…

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -740,12 +740,14 @@ private void ctfeCompile(FuncDeclaration fd)
 
 /*************************************
  * Attempt to interpret a function given the arguments.
- * Input:
- *      istate     state for calling function (NULL if none)
- *      arguments  function arguments
- *      thisarg    'this', if a needThis() function, NULL if not.
+ * Params:
+ *      fd        = function being called
+ *      istate    = state for calling function (NULL if none)
+ *      arguments = function arguments
+ *      thisarg   = 'this', if a needThis() function, NULL if not.
  *
- * Return result expression if successful, TOK.cantExpression if not,
+ * Returns:
+ * result expression if successful, TOK.cantExpression if not,
  * or CTFEExp if function returned void.
  */
 private Expression interpretFunction(FuncDeclaration fd, InterState* istate, Expressions* arguments, Expression thisarg)
@@ -878,7 +880,8 @@ private Expression interpretFunction(FuncDeclaration fd, InterState* istate, Exp
         }
         ctfeStack.push(v);
 
-        if ((fparam.storageClass & (STC.out_ | STC.ref_)) && earg.op == TOK.variable && (cast(VarExp)earg).var.toParent2() == fd)
+        if ((fparam.storageClass & (STC.out_ | STC.ref_)) && earg.op == TOK.variable &&
+            (cast(VarExp)earg).var.toParent2() == fd)
         {
             VarDeclaration vx = (cast(VarExp)earg).var.isVarDeclaration();
             if (!vx)
@@ -2428,11 +2431,15 @@ public:
                 result = CTFEExp.cantexp;
                 return;
             }
+
             if (v && (v.storage_class & (STC.out_ | STC.ref_)) && hasValue(v))
             {
                 // Strip off the nest of ref variables
                 Expression ev = getValue(v);
-                if (ev.op == TOK.variable || ev.op == TOK.index || ev.op == TOK.dotVariable)
+                if (ev.op == TOK.variable ||
+                    ev.op == TOK.index ||
+                    ev.op == TOK.slice ||
+                    ev.op == TOK.dotVariable)
                 {
                     result = interpret(pue, ev, istate, goal);
                     return;
@@ -5235,13 +5242,19 @@ public:
             e1 = (cast(VectorExp)e1).e1;
 
         // Set the $ variable, and find the array literal to modify
-        if (e1.op != TOK.arrayLiteral && e1.op != TOK.string_ && e1.op != TOK.slice)
+        dinteger_t len;
+        if (e1.op == TOK.variable && e1.type.toBasetype().ty == Tsarray)
+            len = e1.type.toBasetype().isTypeSArray().dim.toInteger();
+        else
         {
-            e.error("cannot determine length of `%s` at compile time", e.e1.toChars());
-            return false;
+            if (e1.op != TOK.arrayLiteral && e1.op != TOK.string_ && e1.op != TOK.slice)
+            {
+                e.error("cannot determine length of `%s` at compile time", e.e1.toChars());
+                return false;
+            }
+            len = resolveArrayLength(e1);
         }
 
-        dinteger_t len = resolveArrayLength(e1);
         if (e.lengthVar)
         {
             Expression dollarExp = new IntegerExp(e.loc, len, Type.tsize_t);
@@ -5480,7 +5493,16 @@ public:
             return;
         }
 
-        Expression e1 = interpret(e.e1, istate);
+        CtfeGoal goal1 = ctfeNeedRvalue;
+        if (goal == ctfeNeedLvalue)
+        {
+            if (e.e1.type.toBasetype().ty == Tsarray)
+                if (auto ve = e.e1.isVarExp())
+                    if (auto vd = ve.var.isVarDeclaration())
+                        if (vd.storage_class & STC.ref_)
+                            goal1 = ctfeNeedLvalue;
+        }
+        Expression e1 = interpret(e.e1, istate, goal1);
         if (exceptionOrCant(e1))
             return;
 
@@ -5490,15 +5512,24 @@ public:
             return;
         }
 
+        /* Set dollar to the length of the array
+         */
+        uinteger_t dollar;
+        if (e1.op == TOK.variable && e1.type.toBasetype().ty == Tsarray)
+            dollar = e1.type.toBasetype().isTypeSArray().dim.toInteger();
+        else
+        {
+            if (e1.op != TOK.arrayLiteral && e1.op != TOK.string_ && e1.op != TOK.null_ && e1.op != TOK.slice)
+            {
+                e.error("cannot determine length of `%s` at compile time", e1.toChars());
+                result = CTFEExp.cantexp;
+                return;
+            }
+            dollar = resolveArrayLength(e1);
+        }
+
         /* Set the $ variable
          */
-        if (e1.op != TOK.arrayLiteral && e1.op != TOK.string_ && e1.op != TOK.null_ && e1.op != TOK.slice)
-        {
-            e.error("cannot determine length of `%s` at compile time", e1.toChars());
-            result = CTFEExp.cantexp;
-            return;
-        }
-        uinteger_t dollar = resolveArrayLength(e1);
         if (e.lengthVar)
         {
             auto dollarExp = new IntegerExp(e.loc, dollar, Type.tsize_t);

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -7738,3 +7738,37 @@ void test19074()
 {
     auto var = S19074b.data;
 }
+
+/************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19447
+
+bool f19447()
+{
+    int[3] c=1;
+    assert(c[0]==1);
+    g19447(c[0..2]);
+    assert(c[0]!=1); //fails
+    assert(c[0]==2);
+    return true;
+}
+void g19447(ref int[2] a)
+{
+    int[2] b=2;
+    a=b;
+    //a[]=b;            // works
+    //a[] = b[];                // works
+    assert(a[0]==2);
+}
+static assert(f19447());
+
+/***/
+
+char[] mangle19447(char[] dst)
+{
+   dst.length = 10;
+   size_t i = "_D".length;
+   dst[0 .. i] = "_D";
+   return dst;
+}
+
+static char[] x19447 = mangle19447(null);

--- a/test/fail_compilation/fail19447.d
+++ b/test/fail_compilation/fail19447.d
@@ -1,0 +1,19 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/fail19447.d(110): Error: static variable `mh` cannot be read at compile time
+fail_compilation/fail19447.d(110):        called from here: `g19447(mh)`
+---
+ */
+
+#line 100
+
+int [2] mh = [1, 2];
+int g19447(ref int[2] a)
+{
+    int[2] b=2;
+    a=b;
+    assert(a[0]==2);
+    return 1;
+}
+
+immutable int i = g19447(mh);


### PR DESCRIPTION
…s connection with array

The difficulty was that the interpreter failed to recognize a slice of a static array as being an lvalue.