### PR TITLE
Fix issue 7616 - aggregates don't inherit pure nothrow from outer scope

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -134,7 +134,9 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     Scope* newScope(Scope* sc)
     {
         auto sc2 = sc.push(this);
-        sc2.stc &= STC.safe | STC.trusted | STC.system;
+        sc2.stc &= (
+                STC.safe | STC.trusted | STC.system |
+                STC.nogc | STC.pure_ | STC.nothrow_);
         sc2.parent = this;
         if (isUnionDeclaration())
             sc2.inunion = true;

--- a/test/compilable/test7616.d
+++ b/test/compilable/test7616.d
@@ -1,0 +1,11 @@
+module test7616;
+
+@safe pure nothrow @nogc:
+struct Test
+{
+    void bar() {}
+    void staticBar() {}
+}
+
+static assert(is(typeof(&Test.init.bar) == void delegate() @safe pure nothrow @nogc));
+static assert(is(typeof(&Test.staticBar) == void function() @safe pure nothrow @nogc));


### PR DESCRIPTION
The STC enum is huge and only contains a few items that need to propagate. It might be cleaner to have a scope attributes enum that always propagates. However, that would be a large refactoring.