### PR TITLE
Fix Issue 19103 - Can imports symbols in module to a struct with mixin

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1318,7 +1318,10 @@ public:
                     // compatibility with -transition=import
                     // https://issues.dlang.org/show_bug.cgi?id=15925
                     // SearchLocalsOnly should always get set for new lookup rules
-                    sflags |= (flags & SearchLocalsOnly);
+                    if (global.params.check10378)
+                        sflags |= (flags & SearchLocalsOnly);
+                    else
+                        sflags |= SearchLocalsOnly;
                 }
 
                 /* Don't find private members if ss is a module

--- a/test/fail_compilation/fail19103.d
+++ b/test/fail_compilation/fail19103.d
@@ -1,0 +1,36 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19103.d(12): Error: no property `writeln` for type `fail19103.C`
+fail_compilation/fail19103.d(14): Error: no property `writeln` for type `S1`
+fail_compilation/fail19103.d(16): Error: no property `writeln` for type `S2`, did you mean `std.stdio.writeln(T...)(T args)`?
+---
+*/
+
+void main()
+{
+    (new C).writeln("OK."); // Error: no property writeln for type test.C, did you mean std.stdio.writeln(T...)(T args)?
+    S1 s1;
+    s1.writeln("Hey?"); // It can be compiled and runs!
+    S2 s2;
+    s2.writeln("OK."); //  Error: no property writeln for type S2, did you mean std.stdio.writeln(T...)(T args)?
+}
+
+mixin template T()
+{
+    import std.stdio;
+}
+
+class C
+{
+    mixin T;
+}
+struct S1
+{
+    mixin T;
+}
+
+struct S2
+{
+    import std.stdio;
+}


### PR DESCRIPTION
Imports should never be checked when inside a mixin template. I think we can skip the deprecation for this one.