### PR TITLE
fix Issue 16652 - [Reg 2.071] returned rvalue destroyed too early

### DIFF
--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -883,7 +883,7 @@ void test34()
     for (int j = 0; j < xs.length; j++) {
         j++,j--;
         auto x = xs[j];
-        //foreach(x; xs) {
+        //foreach(x; xs)
         //printf("foreach x.i = %d\n", x[0].i);
         //assert(x[0].i == 1);
         printf("foreach x.i = %d\n", x.i);
@@ -4614,6 +4614,39 @@ class C66
 }
 
 /**********************************/
+// https://issues.dlang.org/show_bug.cgi?id=16652
+
+struct Vector
+{
+    this(ubyte a)
+    {
+        pragma(inline, false);
+        buf = a;
+    }
+
+    ~this()
+    {
+        pragma(inline, false);
+        buf = 0;
+    }
+
+    ubyte buf;
+}
+
+int bar16652(ubyte* v)
+{
+    pragma(inline, true);
+    assert(*v == 1);
+    return 0;
+}
+
+void test16652()
+{
+    bar16652(&Vector(1).buf);
+}
+
+
+/**********************************/
 
 int main()
 {
@@ -4747,6 +4780,7 @@ int main()
     test65();
     test15661();
     test18045();
+    test16652();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
This is an ugly bug that makes RAII unreliable.

The fix is to inline functions as expressions, not statements, when the arguments to the function generate temporaries that need destruction. The destruction has to happen after the function body executes, and the code generator handles that nicely when they are expressions.