### PR TITLE
Fix issue 19494: Remove implicit `Class` member for Objective-C interfaces

### DIFF
--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -523,7 +523,5 @@ if (is(T == ClassDeclaration) || is(T == InterfaceDeclaration))
         objc.metaclass.storage_class |= STC.static_;
         objc.metaclass.classKind = ClassKind.objc;
         objc.metaclass.objc.isMeta = true;
-        objc.metaclass.members = new Dsymbols();
-        members.push(objc.metaclass);
     }
 }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1726,8 +1726,11 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
          */
-        // instead, parent should be set correctly
-        assert(mtype.sym.parent);
+        // instead, parent should be set correctly, except for Objective-C
+        // metaclasses which don't have a parent since they're not directly
+        // accessible in the code.
+        assert((mtype.sym.classKind == ClassKind.objc && mtype.sym.objc.isMeta)
+            || mtype.sym.parent !is null);
 
         if (mtype.sym.type.ty == Terror)
             return error();

--- a/test/compilable/objc_interface.d
+++ b/test/compilable/objc_interface.d
@@ -6,3 +6,9 @@ interface A
     void oneTwo(int a, int b) pure @selector("one:two:");
     void test(int a, int b, int c) @selector("test:::");
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=19494
+extern (Objective-C) interface NSObject
+{
+    extern (Objective-C) interface Class {}
+}


### PR DESCRIPTION
The issue was that when support for Objective-C class methods was added, the metaclass was accidentally exposed as the `.Class` member for all Objective-C interfaces.