### PR TITLE
fix offset of captured variables in debug info

### DIFF
--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1127,7 +1127,10 @@ void buildCapture(FuncDeclaration fd)
             Symbol *vsym = toSymbol(v);
 
             /* Add variable as capture type member */
-            symbol_struct_addField(capturestru.Ttag, &vsym.Sident[0], vsym.Stype, cast(uint)vsym.Soffset);
+            auto soffset = vsym.Soffset;
+            if (fd.vthis)
+                soffset -= toSymbol(fd.vthis).Soffset; // see toElem.ToElemVisitor.visit(SymbolExp)
+            symbol_struct_addField(capturestru.Ttag, &vsym.Sident[0], vsym.Stype, cast(uint)soffset);
             //printf("capture field %s: offset: %i\n", &vsym.Sident[0], v.offset);
         }
 


### PR DESCRIPTION
This is a fixup for #8906. As reported [here](https://forum.dlang.org/post/fatjqwpjbhtdvnwcbxxv@forum.dlang.org) this code generates debug info wrong offsets for captured variables
```
class X
{
    auto foo()
    {
        int x = 0;
        auto bar()
        {
            int y = 0;
            x++;
            y++;
        }
        bar();
    }
}
```
No idea how to test correct offsets in debug info, though.