### PR TITLE
add 1 argument foreachDsymbol() overload

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -78,6 +78,27 @@ int foreachDsymbol(Dsymbols* symbols, scope int delegate(Dsymbol) dg)
     return 0;
 }
 
+/***************************************
+ * Calls dg(Dsymbol *sym) for each Dsymbol.
+ * Params:
+ *    symbols = Dsymbols
+ *    dg = delegate to call for each Dsymbol
+ */
+void foreachDsymbol(Dsymbols* symbols, scope void delegate(Dsymbol) dg)
+{
+    assert(dg);
+    if (symbols)
+    {
+        /* Do not use foreach, as the size of the array may expand during iteration
+         */
+        for (size_t i = 0; i < symbols.dim; ++i)
+        {
+            Dsymbol s = (*symbols)[i];
+            dg(s);
+        }
+    }
+}
+
 
 struct Ungag
 {

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -350,23 +350,21 @@ private FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
 
 private uint setMangleOverride(Dsymbol s, const(char)[] sym)
 {
-    AttribDeclaration ad = s.isAttribDeclaration();
-    if (ad)
-    {
-        Dsymbols* decls = ad.include(null);
-        uint nestedCount = 0;
-        if (decls && decls.dim)
-            for (size_t i = 0; i < decls.dim; ++i)
-                nestedCount += setMangleOverride((*decls)[i], sym);
-        return nestedCount;
-    }
-    else if (s.isFuncDeclaration() || s.isVarDeclaration())
+    if (s.isFuncDeclaration() || s.isVarDeclaration())
     {
         s.isDeclaration().mangleOverride = sym;
         return 1;
     }
-    else
-        return 0;
+
+    if (auto ad = s.isAttribDeclaration())
+    {
+        uint nestedCount = 0;
+
+        ad.include(null).foreachDsymbol( (s) { nestedCount += setMangleOverride(s, sym); } );
+
+        return nestedCount;
+    }
+    return 0;
 }
 
 /*************************************

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5132,10 +5132,9 @@ elem *toElem(Expression e, IRState *irs)
         {
             elem *e = null;
 
-            int symbolDg(Dsymbol s)
+            void symbolDg(Dsymbol s)
             {
                 e = el_combine(e, Dsymbol_toElem(s));
-                return 0;
             }
 
             //printf("Dsymbol_toElem() %s\n", s.toChars());

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -2214,10 +2214,9 @@ private bool argNeedsDtor(Expression arg)
              * perhaps they can be combined.
              */
 
-            int symbolDg(Dsymbol s)
+            void symbolDg(Dsymbol s)
             {
                 Dsymbol_needsDtor(s);
-                return 0;
             }
 
             if (auto vd = s.isVarDeclaration())

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -341,14 +341,10 @@ void toObjFile(Dsymbol ds, bool multiobj)
             enum_SC scclass = SCcomdat;
 
             // Put out the members
-            for (size_t i = 0; i < cd.members.dim; i++)
-            {
-                Dsymbol member = (*cd.members)[i];
-                /* There might be static ctors in the members, and they cannot
-                 * be put in separate obj files.
-                 */
-                member.accept(this);
-            }
+            /* There might be static ctors in the members, and they cannot
+             * be put in separate obj files.
+             */
+            cd.members.foreachDsymbol( (s) { s.accept(this); } );
 
             // If something goes wrong during this pass don't bother with the
             // rest as we may have incomplete info
@@ -447,11 +443,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 toDebug(id);
 
             // Put out the members
-            for (size_t i = 0; i < id.members.dim; i++)
-            {
-                Dsymbol member = (*id.members)[i];
-                visitNoMultiObj(member);
-            }
+            id.members.foreachDsymbol( (s) { visitNoMultiObj(s); } );
 
             // Generate C symbols
             toSymbol(id);
@@ -517,14 +509,10 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 outdata(sd.sinit);
 
                 // Put out the members
-                for (size_t i = 0; i < sd.members.dim; i++)
-                {
-                    Dsymbol member = (*sd.members)[i];
-                    /* There might be static ctors in the members, and they cannot
-                     * be put in separate obj files.
-                     */
-                    member.accept(this);
-                }
+                /* There might be static ctors in the members, and they cannot
+                 * be put in separate obj files.
+                 */
+                sd.members.foreachDsymbol( (s) { s.accept(this); } );
 
                 if (sd.xeq && sd.xeq != StructDeclaration.xerreq)
                     sd.xeq.accept(this);
@@ -840,11 +828,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 }
                 else
                 {
-                    for (size_t i = 0; i < ti.members.dim; i++)
-                    {
-                        Dsymbol s = (*ti.members)[i];
-                        s.accept(this);
-                    }
+                    ti.members.foreachDsymbol( (s) { s.accept(this); } );
                 }
             }
         }
@@ -852,13 +836,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
         override void visit(TemplateMixin tm)
         {
             //printf("TemplateMixin.toObjFile('%s')\n", tm.toChars());
-            if (!isError(tm) && tm.members)
+            if (!isError(tm))
             {
-                for (size_t i = 0; i < tm.members.dim; i++)
-                {
-                    Dsymbol s = (*tm.members)[i];
-                    s.accept(this);
-                }
+                tm.members.foreachDsymbol( (s) { s.accept(this); } );
             }
         }
 
@@ -878,11 +858,7 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 }
                 else
                 {
-                    for (size_t i = 0; i < ns.members.dim; i++)
-                    {
-                        Dsymbol s = (*ns.members)[i];
-                        s.accept(this);
-                    }
+                    ns.members.foreachDsymbol( (s) { s.accept(this); } );
                 }
             }
         }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1698,7 +1698,7 @@ Lnext:
         {
             bool[void*] uniqueUnitTests;
 
-            int symbolDg(Dsymbol s)
+            void symbolDg(Dsymbol s)
             {
                 if (auto ad = s.isAttribDeclaration())
                 {
@@ -1707,7 +1707,7 @@ Lnext:
                 else if (auto ud = s.isUnitTestDeclaration())
                 {
                     if (cast(void*)ud in uniqueUnitTests)
-                        return 0;
+                        return;
 
                     uniqueUnitTests[cast(void*)ud] = true;
 
@@ -1717,7 +1717,6 @@ Lnext:
                     auto e = new DsymbolExp(Loc.initial, ad, false);
                     exps.push(e);
                 }
-                return 0;
             }
 
             sds.members.foreachDsymbol(&symbolDg);


### PR DESCRIPTION
By creating an overload that always loops through every member, and using lambdas, this produces a nice drop in line count.