### PR TITLE
Fix Issue 16214 - [REG2.069] ICE: Assertion fd->semanticRun == PASSsemantic3done failed

### DIFF
--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -136,7 +136,7 @@ extern (C++) void semanticTypeInfo(Scope* sc, Type t)
                 // https://issues.dlang.org/show_bug.cgi?id=15149
                 // if the typeid operand type comes from a
                 // result of auto function, it may be yet speculative.
-                unSpeculative(sc, sd);
+                // unSpeculative(sc, sd);
             }
 
             /* Step 2: If the TypeInfo generation requires sd.semantic3, run it later.

--- a/test/compilable/imports/test16214b.d
+++ b/test/compilable/imports/test16214b.d
@@ -1,0 +1,10 @@
+module test16214b;
+import test16214a;
+
+struct Appender() { int[] arr; }
+struct Tuple() { alias A = Appender!(); }
+
+class EventLoop
+{
+    auto f() { auto x = [Tuple!().init]; }
+}

--- a/test/compilable/test16214a.d
+++ b/test/compilable/test16214a.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -Icompilable/imports
+
+module test16214a;
+import test16214b;
+
+class LibasyncEventLoop : EventLoop {}


### PR DESCRIPTION
The commented line was added by [1] to fix [2]. However, the example compiles just fine without it; moreover it seems to introduce a regression.

Since it is an old regression, I didn't target stable. This has the advantage that buildkite and appveyor may test it (those are broken on stable).

[1] #5166
[2] https://issues.dlang.org/show_bug.cgi?id=15149