### PR TITLE
Fix Issue 17518 - [Reg 2.063] confusing error message with inout constructor/ctor

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2746,15 +2746,27 @@ FuncDeclaration resolveFuncCall(const ref Loc loc, Scope* sc, Dsymbol s,
                 }
                 else
                 {
-                    auto fullFdPretty = fd.toPrettyChars();
-                    .error(loc, "%smethod `%s` is not callable using a %sobject",
-                        funcBuf.peekString(), fullFdPretty,
-                        thisBuf.peekString());
+                    const(char)* failMessage;
+                    functionResolve(&m, orig_s, loc, sc, tiargs, tthis, fargs, &failMessage);
+                    if (failMessage)
+                    {
+                        .error(loc, "%s `%s%s%s` is not callable using argument types `%s`",
+                            fd.kind(), fd.toPrettyChars(), parametersTypeToChars(tf.parameterList),
+                            tf.modToChars(), fargsBuf.peekString());
+                        errorSupplemental(loc, failMessage);
+                    }
+                    else
+                    {
+                        auto fullFdPretty = fd.toPrettyChars();
+                        .error(loc, "%smethod `%s` is not callable using a %sobject",
+                            funcBuf.peekString(), fullFdPretty,
+                            thisBuf.peekString());
 
-                    if (mismatches.isNotShared)
-                        .errorSupplemental(loc, "Consider adding `shared` to %s", fullFdPretty);
-                    else if (mismatches.isMutable)
-                        .errorSupplemental(loc, "Consider adding `const` or `inout` to %s", fullFdPretty);
+                        if (mismatches.isNotShared)
+                            .errorSupplemental(loc, "Consider adding `shared` to %s", fullFdPretty);
+                        else if (mismatches.isMutable)
+                            .errorSupplemental(loc, "Consider adding `const` or `inout` to %s", fullFdPretty);
+                    }
                 }
             }
             else

--- a/test/fail_compilation/fail17518.d
+++ b/test/fail_compilation/fail17518.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail17518.d(21): Error: constructor `fail17518.S.this(inout(Correct) _param_0) inout` is not callable using argument types `(Wrong)`
+fail_compilation/fail17518.d(21):        cannot pass argument `Wrong()` of type `Wrong` to parameter `inout(Correct) _param_0`
+---
+*/
+
+struct S
+{
+    this(inout Correct) inout
+    {
+    }
+}
+
+struct Correct {}
+struct Wrong {}
+
+S bug()
+{
+    return S(Wrong());
+}


### PR DESCRIPTION
```d
struct S
{
    this(inout Correct) inout
    {
    }
}

struct Correct {}
struct Wrong {}

S bug()
{
    return S(Wrong());
}
```

Yields: `Error: inout method bug.S.this is not callable using a mutable object`, because the modifier is checked first althoug the error comes from the fact the type is different. The fix is to see if any supplemental errors exists (which is used only for parameter types); if that is the case, then print the new more relevant error, otherwise print the former error.