### PR TITLE
switch from Target. to instance target.

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -362,7 +362,7 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
     {
         super(decl);
         //printf("LinkDeclaration(linkage = %d, decl = %p)\n", p, decl);
-        linkage = (p == LINK.system) ? Target.systemLinkage() : p;
+        linkage = (p == LINK.system) ? target.systemLinkage() : p;
     }
 
     static LinkDeclaration create(LINK p, Dsymbols* decl)

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -1007,7 +1007,7 @@ DtorDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
 
     ad.primaryDtor = xdtor;
 
-    if (xdtor && xdtor.linkage == LINK.cpp && !Target.twoDtorInVtable)
+    if (xdtor && xdtor.linkage == LINK.cpp && !target.twoDtorInVtable)
         xdtor = buildWindowsCppDtor(ad, xdtor, sc);
 
     // Add an __xdtor alias to make the inclusive dtor accessible

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -593,7 +593,7 @@ UnionExp Pow(const ref Loc loc, Type type, Expression e1, Expression e2)
         // x ^^ y for x < 0 and y not an integer is not defined; so set result as NaN
         if (e1.toReal() < CTFloat.zero)
         {
-            emplaceExp!(RealExp)(&ue, loc, Target.RealProperties.nan, type);
+            emplaceExp!(RealExp)(&ue, loc, target.RealProperties.nan, type);
         }
         else
             cantExp(ue);

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1018,7 +1018,7 @@ private final class CppMangleVisitor : Visitor
 
         int paramsCppMangleDg(size_t n, Parameter fparam)
         {
-            Type t = Target.cppParameterType(fparam);
+            Type t = target.cppParameterType(fparam);
             if (t.ty == Tsarray)
             {
                 // Static arrays in D are passed by value; no counterpart in C++
@@ -1116,7 +1116,7 @@ private final class CppMangleVisitor : Visitor
         CV_qualifiers(t);
 
         // Handle any target-specific struct types.
-        if (auto tm = Target.cppTypeMangle(t))
+        if (auto tm = target.cppTypeMangle(t))
         {
             buf.writestring(tm);
         }
@@ -1272,10 +1272,10 @@ extern(C++):
             case Tuns32:                c = 'j';        break;
             case Tfloat32:              c = 'f';        break;
             case Tint64:
-                c = Target.c_longsize == 8 ? 'l' : 'x';
+                c = target.c_longsize == 8 ? 'l' : 'x';
                 break;
             case Tuns64:
-                c = Target.c_longsize == 8 ? 'm' : 'y';
+                c = target.c_longsize == 8 ? 'm' : 'y';
                 break;
             case Tint128:                c = 'n';       break;
             case Tuns128:                c = 'o';       break;
@@ -1294,7 +1294,7 @@ extern(C++):
 
             default:
                 // Handle any target-specific basic types.
-                if (auto tm = Target.cppTypeMangle(t))
+                if (auto tm = target.cppTypeMangle(t))
                 {
                     if (substitute(t))
                         return;
@@ -1320,7 +1320,7 @@ extern(C++):
         CV_qualifiers(t);
 
         // Handle any target-specific vector types.
-        if (auto tm = Target.cppTypeMangle(t))
+        if (auto tm = target.cppTypeMangle(t))
         {
             buf.writestring(tm);
         }

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -432,7 +432,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             /* This enables us to use COM objects under Linux and
              * work with things like XPCOM
              */
-            sc2.linkage = Target.systemLinkage();
+            sc2.linkage = target.systemLinkage();
         }
         return sc2;
     }
@@ -595,16 +595,16 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         {
             if (interfaces.length == 0)
             {
-                alignsize = Target.ptrsize;
-                structsize = Target.ptrsize;      // allow room for __vptr
+                alignsize = target.ptrsize;
+                structsize = target.ptrsize;      // allow room for __vptr
             }
         }
         else
         {
-            alignsize = Target.ptrsize;
-            structsize = Target.ptrsize;      // allow room for __vptr
+            alignsize = target.ptrsize;
+            structsize = target.ptrsize;      // allow room for __vptr
             if (classKind != ClassKind.cpp)
-                structsize += Target.ptrsize; // allow room for __monitor
+                structsize += target.ptrsize; // allow room for __monitor
         }
 
         //printf("finalizeSize() %s, sizeok = %d\n", toChars(), sizeok);
@@ -632,7 +632,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                 assert(b.sym.sizeok == Sizeok.done);
 
                 if (!b.sym.alignsize)
-                    b.sym.alignsize = Target.ptrsize;
+                    b.sym.alignsize = target.ptrsize;
                 alignmember(b.sym.alignsize, b.sym.alignsize, &offset);
                 assert(bi < vtblInterfaces.dim);
 

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1204,7 +1204,7 @@ extern (C++) class VarDeclaration : Declaration
         const sz = t.size(loc);
         assert(sz != SIZE_INVALID && sz < uint.max);
         uint memsize = cast(uint)sz;                // size of member
-        uint memalignsize = Target.fieldalign(t);   // size of member for alignment purposes
+        uint memalignsize = target.fieldalign(t);   // size of member for alignment purposes
         offset = AggregateDeclaration.placeField(
             poffset,
             memsize, memalignsize, alignment,
@@ -1700,7 +1700,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         storage_class = STC.static_ | STC.gshared;
         protection = Prot(Prot.Kind.public_);
         linkage = LINK.c;
-        alignment = Target.ptrsize;
+        alignment = target.ptrsize;
     }
 
     static TypeInfoDeclaration create(Type tinfo)

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -558,7 +558,7 @@ public:
                     return d.ident.toString();
                 case LINK.cpp:
                 {
-                    const p = Target.toCppMangle(d);
+                    const p = target.toCppMangle(d);
                     return p[0 .. strlen(p)];
                 }
                 case LINK.default_:

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -435,7 +435,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             }
         }
 
-        auto tt = Target.toArgTypes(type);
+        auto tt = target.toArgTypes(type);
         size_t dim = tt.arguments.dim;
         if (dim >= 1)
         {
@@ -499,8 +499,8 @@ extern (C++) class StructDeclaration : AggregateDeclaration
             const hasPointers = tb.hasPointers();
             if (hasPointers)
             {
-                if ((stype.alignment() < Target.ptrsize ||
-                     (v.offset & (Target.ptrsize - 1))) &&
+                if ((stype.alignment() < target.ptrsize ||
+                     (v.offset & (target.ptrsize - 1))) &&
                     (sc.func && sc.func.setUnsafe()))
                 {
                     .error(loc, "field `%s.%s` cannot assign to misaligned pointers in `@safe` code",

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3309,7 +3309,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                     //printf("\tintroducing function %s\n", toChars());
                     funcdecl.introducing = 1;
-                    if (cd.classKind == ClassKind.cpp && Target.reverseCppOverloads)
+                    if (cd.classKind == ClassKind.cpp && target.reverseCppOverloads)
                     {
                         /* Overloaded functions with same name are grouped and in reverse order.
                          * Search for first function of overload group, and insert
@@ -3850,7 +3850,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                         // reserve the dtor slot for the destructor (which we'll create later)
                         cldec.cppDtorVtblIndex = cast(int)cldec.vtbl.dim;
                         cldec.vtbl.push(dd);
-                        if (Target.twoDtorInVtable)
+                        if (target.twoDtorInVtable)
                             cldec.vtbl.push(dd); // deleting destructor uses a second slot
                     }
                 }
@@ -4947,7 +4947,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             cldec.dtor.vtblIndex = cldec.cppDtorVtblIndex;
             cldec.vtbl[cldec.cppDtorVtblIndex] = cldec.dtor;
 
-            if (Target.twoDtorInVtable)
+            if (target.twoDtorInVtable)
             {
                 // TODO: create a C++ compatible deleting destructor (call out to `operator delete`)
                 //       for the moment, we'll call the non-deleting destructor and leak

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3624,7 +3624,7 @@ elem *toElem(Expression e, IRState *irs)
                     assert(cast(int)vindex >= 0);
 
                     // Build *(ep + vindex * 4)
-                    ep = el_bin(OPadd,TYnptr,ep,el_long(TYsize_t, vindex * Target.ptrsize));
+                    ep = el_bin(OPadd,TYnptr,ep,el_long(TYsize_t, vindex * target.ptrsize));
                     ep = el_una(OPind,TYnptr,ep);
                 }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1828,9 +1828,9 @@ extern (C++) final class IntegerExp : Expression
             break;
 
         case Tpointer:
-            if (Target.ptrsize == 4)
+            if (target.ptrsize == 4)
                 result = cast(d_uns32)value;
-            else if (Target.ptrsize == 8)
+            else if (target.ptrsize == 8)
                 result = cast(d_uns64)value;
             else
                 assert(0);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5141,7 +5141,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                  * The results of this are highly platform dependent, and intended
                  * primarly for use in implementing va_arg().
                  */
-                tded = Target.toArgTypes(e.targ);
+                tded = target.toArgTypes(e.targ);
                 if (!tded)
                     goto Lno;
                 // not valid for a parameter
@@ -5370,7 +5370,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.e2 = exp.e2.castTo(sc, Type.tshiftcnt);
         }
 
-        if (!Target.isVectorOpSupported(exp.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(exp.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -6174,7 +6174,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
-        if (!Target.isVectorOpSupported(tb, exp.op))
+        if (!target.isVectorOpSupported(tb, exp.op))
         {
             result = exp.incompatibleTypes();
             return;
@@ -6203,7 +6203,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         fix16997(sc, exp);
-        if (!Target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op))
+        if (!target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op))
         {
             result = exp.incompatibleTypes();
             return;
@@ -6244,7 +6244,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
-        if (!Target.isVectorOpSupported(tb, exp.op))
+        if (!target.isVectorOpSupported(tb, exp.op))
         {
             result = exp.incompatibleTypes();
             return;
@@ -6286,7 +6286,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        if (!Target.isVectorOpSupported(e.e1.type.toBasetype(), e.op))
+        if (!target.isVectorOpSupported(e.e1.type.toBasetype(), e.op))
         {
             result = e.incompatibleTypes();
         }
@@ -8828,7 +8828,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         tb1 = exp.e1.type.toBasetype();
-        if (!Target.isVectorOpSupported(tb1, exp.op, tb2))
+        if (!target.isVectorOpSupported(tb1, exp.op, tb2))
         {
             result = exp.incompatibleTypes();
             return;
@@ -8979,7 +8979,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         t1 = exp.e1.type.toBasetype();
         t2 = exp.e2.type.toBasetype();
-        if (!Target.isVectorOpSupported(t1, exp.op, t2))
+        if (!target.isVectorOpSupported(t1, exp.op, t2))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9302,7 +9302,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.type = t1; // t1 is complex
             }
         }
-        else if (!Target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
+        else if (!target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9403,7 +9403,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 exp.type = t1; // t1 is complex
             }
         }
-        else if (!Target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
+        else if (!target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9448,7 +9448,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
-        if (!Target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9511,7 +9511,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.checkArithmeticBin())
             return setError();
 
-        if (!Target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9603,7 +9603,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.checkIntegralBin())
             return setError();
 
-        if (!Target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9639,7 +9639,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.checkIntegralBin())
             return setError();
 
-        if (!Target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9675,7 +9675,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.checkIntegralBin())
             return setError();
 
-        if (!Target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(exp.e1.type.toBasetype(), exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9732,7 +9732,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
-        if (!Target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9787,7 +9787,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
-        if (!Target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -9842,7 +9842,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = exp;
             return;
         }
-        if (!Target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
+        if (!target.isVectorOpSupported(tb, exp.op, exp.e2.type.toBasetype()))
         {
             result = exp.incompatibleTypes();
             return;
@@ -10038,7 +10038,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp.error("`%s` is not defined for associative arrays", Token.toChars(exp.op));
             return setError();
         }
-        else if (!Target.isVectorOpSupported(t1, exp.op, t2))
+        else if (!target.isVectorOpSupported(t1, exp.op, t2))
         {
             result = exp.incompatibleTypes();
             return;
@@ -10270,7 +10270,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             semanticTypeInfo(sc, exp.e1.type.toBasetype());
 
 
-        if (!Target.isVectorOpSupported(t1, exp.op, t2))
+        if (!target.isVectorOpSupported(t1, exp.op, t2))
         {
             result = exp.incompatibleTypes();
             return;
@@ -10317,7 +10317,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         auto tb1 = exp.e1.type.toBasetype();
         auto tb2 = exp.e2.type.toBasetype();
-        if (!Target.isVectorOpSupported(tb1, exp.op, tb2))
+        if (!target.isVectorOpSupported(tb1, exp.op, tb2))
         {
             result = exp.incompatibleTypes();
             return;

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -58,7 +58,7 @@ void initDMD()
     import dmd.mars : setTarget, addDefaultVersionIdentifiers;
     import dmd.mtype : Type;
     import dmd.objc : Objc;
-    import dmd.target : Target;
+    import dmd.target : target;
 
     global._init();
     setTarget(global.params);
@@ -67,7 +67,7 @@ void initDMD()
     Type._init();
     Id.initialize();
     Module._init();
-    Target._init(global.params);
+    target._init(global.params);
     Expression._init();
     Objc._init();
     builtin_init();

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2270,9 +2270,9 @@ public:
             if (cast(sinteger_t)uval >= 0)
             {
                 dinteger_t sizemax;
-                if (Target.ptrsize == 4)
+                if (target.ptrsize == 4)
                     sizemax = 0xFFFFFFFFU;
-                else if (Target.ptrsize == 8)
+                else if (target.ptrsize == 8)
                     sizemax = 0xFFFFFFFFFFFFFFFFUL;
                 else
                     assert(0);
@@ -2406,9 +2406,9 @@ public:
                 buf.writestring("cast(");
                 buf.writestring(t.toChars());
                 buf.writeByte(')');
-                if (Target.ptrsize == 4)
+                if (target.ptrsize == 4)
                     goto L3;
-                else if (Target.ptrsize == 8)
+                else if (target.ptrsize == 8)
                     goto L4;
                 else
                     assert(0);

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -1987,7 +1987,7 @@ opflag_t asm_float_type_size(Type ptype, opflag_t *pusFloat)
     if (ptype && ptype.isscalar())
     {
         int sz = cast(int)ptype.size();
-        if (sz == Target.realsize)
+        if (sz == target.realsize)
         {
             *pusFloat = _f80;
             return 0;

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -171,8 +171,8 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
                 }
                 if (vd.type.hasPointers)
                 {
-                    if ((t.alignment() < Target.ptrsize ||
-                         (vd.offset & (Target.ptrsize - 1))) &&
+                    if ((t.alignment() < target.ptrsize ||
+                         (vd.offset & (target.ptrsize - 1))) &&
                         sc.func && sc.func.setUnsafe())
                     {
                         error(i.loc, "field `%s.%s` cannot assign to misaligned pointers in `@safe` code",

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -337,7 +337,7 @@ private int tryMain(size_t argc, const(char)** argv)
     Type._init();
     Id.initialize();
     Module._init();
-    Target._init(global.params);
+    target._init(global.params);
     Expression._init();
     Objc._init();
     builtin_init();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -879,7 +879,7 @@ extern (C++) abstract class Type : RootObject
         tstring = tchar.immutableOf().arrayOf();
         twstring = twchar.immutableOf().arrayOf();
         tdstring = tdchar.immutableOf().arrayOf();
-        tvalist = Target.va_listType();
+        tvalist = target.va_listType();
 
         if (global.params.isLP64)
         {
@@ -3179,7 +3179,7 @@ extern (C++) final class TypeBasic : Type
 
         case Tfloat80:
         case Timaginary80:
-            size = Target.realsize;
+            size = target.realsize;
             break;
 
         case Tcomplex32:
@@ -3193,7 +3193,7 @@ extern (C++) final class TypeBasic : Type
             break;
 
         case Tcomplex80:
-            size = Target.realsize * 2;
+            size = target.realsize * 2;
             break;
 
         case Tvoid:
@@ -3226,7 +3226,7 @@ extern (C++) final class TypeBasic : Type
 
     override uint alignsize()
     {
-        return Target.alignsize(this);
+        return target.alignsize(this);
     }
 
     override bool isintegral()
@@ -3725,14 +3725,14 @@ extern (C++) final class TypeDArray : TypeArray
     override d_uns64 size(const ref Loc loc) const
     {
         //printf("TypeDArray::size()\n");
-        return Target.ptrsize * 2;
+        return target.ptrsize * 2;
     }
 
     override uint alignsize() const
     {
         // A DArray consists of two ptr-sized values, so align it on pointer size
         // boundary
-        return Target.ptrsize;
+        return target.ptrsize;
     }
 
     override bool isString()
@@ -3831,7 +3831,7 @@ extern (C++) final class TypeAArray : TypeArray
 
     override d_uns64 size(const ref Loc loc)
     {
-        return Target.ptrsize;
+        return target.ptrsize;
     }
 
     override bool isZeroInit(const ref Loc loc) const
@@ -3925,7 +3925,7 @@ extern (C++) final class TypePointer : TypeNext
 
     override d_uns64 size(const ref Loc loc) const
     {
-        return Target.ptrsize;
+        return target.ptrsize;
     }
 
     override MATCH implicitConvTo(Type to)
@@ -4058,7 +4058,7 @@ extern (C++) final class TypeReference : TypeNext
 
     override d_uns64 size(const ref Loc loc) const
     {
-        return Target.ptrsize;
+        return target.ptrsize;
     }
 
     override bool isZeroInit(const ref Loc loc) const
@@ -4949,12 +4949,12 @@ extern (C++) final class TypeDelegate : TypeNext
 
     override d_uns64 size(const ref Loc loc) const
     {
-        return Target.ptrsize * 2;
+        return target.ptrsize * 2;
     }
 
     override uint alignsize() const
     {
-        return Target.ptrsize;
+        return target.ptrsize;
     }
 
     override MATCH implicitConvTo(Type to)
@@ -5425,7 +5425,7 @@ extern (C++) final class TypeStruct : Type
         /* Copy from the initializer symbol for larger symbols,
          * otherwise the literals expressed as code get excessively large.
          */
-        if (size(loc) > Target.ptrsize * 4 && !needsNested())
+        if (size(loc) > target.ptrsize * 4 && !needsNested())
             structinit.useStaticInit = true;
 
         structinit.type = this;
@@ -5833,7 +5833,7 @@ extern (C++) final class TypeClass : Type
 
     override d_uns64 size(const ref Loc loc) const
     {
-        return Target.ptrsize;
+        return target.ptrsize;
     }
 
     override Type syntaxCopy()

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -1041,7 +1041,7 @@ private extern (C++) class S2irVisitor : Visitor
              * BCjcatch:
              *  __hander = __RDX;
              *  __exception_object = __RAX;
-             *  jcatchvar = *(__exception_object - Target.ptrsize); // old way
+             *  jcatchvar = *(__exception_object - target.ptrsize); // old way
              *  jcatchvar = __dmd_catch_begin(__exception_object);   // new way
              *  switch (__handler)
              *      case 1:     // first catch handler
@@ -1069,8 +1069,8 @@ private extern (C++) class S2irVisitor : Visitor
 
             version (none)
             {
-                // jcatchvar = *(__exception_object - Target.ptrsize)
-                elem *e = el_bin(OPmin, TYnptr, el_var(seo), el_long(TYsize_t, Target.ptrsize));
+                // jcatchvar = *(__exception_object - target.ptrsize)
+                elem *e = el_bin(OPmin, TYnptr, el_var(seo), el_long(TYsize_t, target.ptrsize));
                 elem *e3 = el_bin(OPeq, TYvoid, el_var(tryblock.jcatchvar), el_una(OPind, TYnptr, e));
             }
             else

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -74,8 +74,8 @@ bool checkUnsafeAccess(Scope* sc, Expression e, bool readonly, bool printmsg)
 
         if (hasPointers && v.type.toBasetype().ty != Tstruct)
         {
-            if ((ad.type.alignment() < Target.ptrsize ||
-                 (v.offset & (Target.ptrsize - 1))) &&
+            if ((ad.type.alignment() < target.ptrsize ||
+                 (v.offset & (target.ptrsize - 1))) &&
                 sc.func.setUnsafe())
             {
                 if (printmsg)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -563,7 +563,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     }
                 }
 
-                if (!funcdecl.inferRetType && !Target.isReturnOnStack(f, funcdecl.needThis()))
+                if (!funcdecl.inferRetType && !target.isReturnOnStack(f, funcdecl.needThis()))
                     funcdecl.nrvo_can = 0;
 
                 bool inferRef = (f.isref && (funcdecl.storage_class & STC.auto_));
@@ -617,7 +617,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (funcdecl.storage_class & STC.auto_)
                         funcdecl.storage_class &= ~STC.auto_;
                 }
-                if (!Target.isReturnOnStack(f, funcdecl.needThis()))
+                if (!target.isReturnOnStack(f, funcdecl.needThis()))
                     funcdecl.nrvo_can = 0;
 
                 if (funcdecl.fbody.isErrorStatement())

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1723,8 +1723,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     auto keysize = taa.index.size();
                     if (keysize == SIZE_INVALID)
                         goto case Terror;
-                    assert(keysize < keysize.max - Target.ptrsize);
-                    keysize = (keysize + (Target.ptrsize - 1)) & ~(Target.ptrsize - 1);
+                    assert(keysize < keysize.max - target.ptrsize);
+                    keysize = (keysize + (target.ptrsize - 1)) & ~(target.ptrsize - 1);
                     // paint delegate argument to the type runtime expects
                     Expression fexp = flde;
                     if (!fldeTy[i].equals(flde.type))
@@ -3610,7 +3610,7 @@ else
              *  try { body } finally { _d_criticalexit(&__critsec[0]); }
              */
             auto id = Identifier.generateId("__critsec");
-            auto t = Type.tint8.sarrayOf(Target.ptrsize + Target.critsecsize());
+            auto t = Type.tint8.sarrayOf(target.ptrsize + target.critsecsize());
             auto tmp = new VarDeclaration(ss.loc, t, id, null);
             tmp.storage_class |= STC.temp | STC.shared_ | STC.static_;
             Expression tmpExp = new VarExp(ss.loc, tmp);
@@ -3649,7 +3649,7 @@ else
             result = s.statementSemantic(sc);
 
             // set the explicit __critsec alignment after semantic()
-            tmp.alignment = Target.ptrsize;
+            tmp.alignment = target.ptrsize;
         }
     }
 
@@ -4193,7 +4193,7 @@ void catchSemantic(Catch c, Scope* sc)
         }
         else if (cd.isCPPclass())
         {
-            if (!Target.cppExceptions)
+            if (!target.cppExceptions)
             {
                 error(c.loc, "catching C++ class objects not supported for this target");
                 c.errors = true;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -200,7 +200,7 @@ struct Target
         case Tfloat80:
         case Timaginary80:
         case Tcomplex80:
-            return Target.realalignsize;
+            return target.realalignsize;
         case Tcomplex32:
             if (global.params.isLinux || global.params.isOSX || global.params.isFreeBSD || global.params.isOpenBSD ||
                 global.params.isDragonFlyBSD || global.params.isSolaris)
@@ -753,3 +753,5 @@ struct Target
         }
     }
 }
+
+extern (C++) __gshared Target target;

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -84,3 +84,5 @@ struct Target
     static d_uns64 parameterSize(const Loc& loc, Type *t);
     static Expression *getTargetInfo(const char* name, const Loc& loc);
 };
+
+extern Target target;

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -742,7 +742,7 @@ Symbol* toSymbolCpp(ClassDeclaration cd)
  */
 Symbol *toSymbolCppTypeInfo(ClassDeclaration cd)
 {
-    const id = Target.cppTypeInfoMangle(cd);
+    const id = target.cppTypeInfoMangle(cd);
     auto s = symbol_calloc(id, cast(uint)strlen(id));
     s.Sclass = SCextern;
     s.Sfl = FLextern;          // C++ code will provide the definition

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -998,7 +998,7 @@ int cvMember(Dsymbol s, ubyte *p)
                     q += cgcv.sz_idx;
                     if (fd.introducing)
                     {
-                        TOLONG(q, fd.vtblIndex * Target.ptrsize);
+                        TOLONG(q, fd.vtblIndex * target.ptrsize);
                         q += 4;
                     }
                 }

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -313,8 +313,8 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
                 case Timaginary80:
                 {
                     auto evalue = e.value;
-                    dtb.nbytes(Target.realsize - Target.realpad, cast(char*)&evalue);
-                    dtb.nzeros(Target.realpad);
+                    dtb.nbytes(target.realsize - target.realpad, cast(char*)&evalue);
+                    dtb.nzeros(target.realpad);
                     break;
                 }
 
@@ -350,11 +350,11 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
                 case Tcomplex80:
                 {
                     auto evalue = creall(e.value);
-                    dtb.nbytes(Target.realsize - Target.realpad, cast(char*)&evalue);
-                    dtb.nzeros(Target.realpad);
+                    dtb.nbytes(target.realsize - target.realpad, cast(char*)&evalue);
+                    dtb.nzeros(target.realpad);
                     evalue = cimagl(e.value);
-                    dtb.nbytes(Target.realsize - Target.realpad, cast(char*)&evalue);
-                    dtb.nzeros(Target.realpad);
+                    dtb.nbytes(target.realsize - target.realpad, cast(char*)&evalue);
+                    dtb.nzeros(target.realpad);
                     break;
                 }
 
@@ -696,7 +696,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
                     if (csymoffset != ~0)
                     {
                         dtb.xoff(toSymbol(cd2), csymoffset);
-                        offset += Target.ptrsize;
+                        offset += target.ptrsize;
                         break;
                     }
                 }
@@ -705,11 +705,11 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         else
         {
             dtb.xoff(toVtblSymbol(concreteType), 0);  // __vptr
-            offset = Target.ptrsize;
+            offset = target.ptrsize;
             if (cd.classKind != ClassKind.cpp)
             {
                 dtb.size(0);              // __monitor
-                offset += Target.ptrsize;
+                offset += target.ptrsize;
             }
         }
 
@@ -971,7 +971,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoDeclaration d)
     {
         //printf("TypeInfoDeclaration.toDt() %s\n", toChars());
-        verifyStructSize(Type.dtypeinfo, 2 * Target.ptrsize);
+        verifyStructSize(Type.dtypeinfo, 2 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.dtypeinfo), 0);        // vtbl for TypeInfo
         dtb.size(0);                                     // monitor
@@ -980,7 +980,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoConstDeclaration d)
     {
         //printf("TypeInfoConstDeclaration.toDt() %s\n", toChars());
-        verifyStructSize(Type.typeinfoconst, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfoconst, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoconst), 0);    // vtbl for TypeInfo_Const
         dtb.size(0);                                     // monitor
@@ -993,7 +993,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoInvariantDeclaration d)
     {
         //printf("TypeInfoInvariantDeclaration.toDt() %s\n", toChars());
-        verifyStructSize(Type.typeinfoinvariant, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfoinvariant, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoinvariant), 0);    // vtbl for TypeInfo_Invariant
         dtb.size(0);                                         // monitor
@@ -1006,7 +1006,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoSharedDeclaration d)
     {
         //printf("TypeInfoSharedDeclaration.toDt() %s\n", toChars());
-        verifyStructSize(Type.typeinfoshared, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfoshared, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoshared), 0);   // vtbl for TypeInfo_Shared
         dtb.size(0);                                     // monitor
@@ -1019,7 +1019,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoWildDeclaration d)
     {
         //printf("TypeInfoWildDeclaration.toDt() %s\n", toChars());
-        verifyStructSize(Type.typeinfowild, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfowild, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfowild), 0); // vtbl for TypeInfo_Wild
         dtb.size(0);                                 // monitor
@@ -1032,7 +1032,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoEnumDeclaration d)
     {
         //printf("TypeInfoEnumDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfoenum, 7 * Target.ptrsize);
+        verifyStructSize(Type.typeinfoenum, 7 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoenum), 0); // vtbl for TypeInfo_Enum
         dtb.size(0);                        // monitor
@@ -1083,7 +1083,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoPointerDeclaration d)
     {
         //printf("TypeInfoPointerDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfopointer, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfopointer, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfopointer), 0);  // vtbl for TypeInfo_Pointer
         dtb.size(0);                                     // monitor
@@ -1099,7 +1099,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoArrayDeclaration d)
     {
         //printf("TypeInfoArrayDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfoarray, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfoarray, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoarray), 0);    // vtbl for TypeInfo_Array
         dtb.size(0);                                     // monitor
@@ -1115,7 +1115,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoStaticArrayDeclaration d)
     {
         //printf("TypeInfoStaticArrayDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfostaticarray, 4 * Target.ptrsize);
+        verifyStructSize(Type.typeinfostaticarray, 4 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfostaticarray), 0);  // vtbl for TypeInfo_StaticArray
         dtb.size(0);                                         // monitor
@@ -1133,7 +1133,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoVectorDeclaration d)
     {
         //printf("TypeInfoVectorDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfovector, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfovector, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfovector), 0);   // vtbl for TypeInfo_Vector
         dtb.size(0);                                     // monitor
@@ -1149,7 +1149,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoAssociativeArrayDeclaration d)
     {
         //printf("TypeInfoAssociativeArrayDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfoassociativearray, 4 * Target.ptrsize);
+        verifyStructSize(Type.typeinfoassociativearray, 4 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoassociativearray), 0); // vtbl for TypeInfo_AssociativeArray
         dtb.size(0);                        // monitor
@@ -1168,7 +1168,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoFunctionDeclaration d)
     {
         //printf("TypeInfoFunctionDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfofunction, 5 * Target.ptrsize);
+        verifyStructSize(Type.typeinfofunction, 5 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfofunction), 0); // vtbl for TypeInfo_Function
         dtb.size(0);                                     // monitor
@@ -1193,7 +1193,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoDelegateDeclaration d)
     {
         //printf("TypeInfoDelegateDeclaration.toDt()\n");
-        verifyStructSize(Type.typeinfodelegate, 5 * Target.ptrsize);
+        verifyStructSize(Type.typeinfodelegate, 5 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfodelegate), 0); // vtbl for TypeInfo_Delegate
         dtb.size(0);                                     // monitor
@@ -1219,9 +1219,9 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     {
         //printf("TypeInfoStructDeclaration.toDt() '%s'\n", d.toChars());
         if (global.params.is64bit)
-            verifyStructSize(Type.typeinfostruct, 17 * Target.ptrsize);
+            verifyStructSize(Type.typeinfostruct, 17 * target.ptrsize);
         else
-            verifyStructSize(Type.typeinfostruct, 15 * Target.ptrsize);
+            verifyStructSize(Type.typeinfostruct, 15 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfostruct), 0); // vtbl for TypeInfo_Struct
         dtb.size(0);                        // monitor
@@ -1394,7 +1394,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoInterfaceDeclaration d)
     {
         //printf("TypeInfoInterfaceDeclaration.toDt() %s\n", tinfo.toChars());
-        verifyStructSize(Type.typeinfointerface, 3 * Target.ptrsize);
+        verifyStructSize(Type.typeinfointerface, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfointerface), 0);    // vtbl for TypeInfoInterface
         dtb.size(0);                                           // monitor
@@ -1413,7 +1413,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
     override void visit(TypeInfoTupleDeclaration d)
     {
         //printf("TypeInfoTupleDeclaration.toDt() %s\n", tinfo.toChars());
-        verifyStructSize(Type.typeinfotypelist, 4 * Target.ptrsize);
+        verifyStructSize(Type.typeinfotypelist, 4 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfotypelist), 0); // vtbl for TypeInfoInterface
         dtb.size(0);                                       // monitor

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -867,7 +867,7 @@ void setClosureVarOffset(FuncDeclaration fd)
 {
     if (fd.needsClosure())
     {
-        uint offset = Target.ptrsize;      // leave room for previous sthis
+        uint offset = target.ptrsize;      // leave room for previous sthis
 
         foreach (v; fd.closureVars)
         {
@@ -882,14 +882,14 @@ void setClosureVarOffset(FuncDeclaration fd)
                 /* Lazy variables are really delegates,
                  * so give same answers that TypeDelegate would
                  */
-                memsize = Target.ptrsize * 2;
+                memsize = target.ptrsize * 2;
                 memalignsize = memsize;
                 xalign = STRUCTALIGN_DEFAULT;
             }
             else if (v.storage_class & (STC.out_ | STC.ref_))
             {
                 // reference parameters are just pointers
-                memsize = Target.ptrsize;
+                memsize = target.ptrsize;
                 memalignsize = memsize;
                 xalign = STRUCTALIGN_DEFAULT;
             }
@@ -967,7 +967,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         strcat(strcat(closname, name1), name2);
 
         /* Build type for closure */
-        type *Closstru = type_struct_class(closname, Target.ptrsize, 0, null, null, false, false, true, false);
+        type *Closstru = type_struct_class(closname, target.ptrsize, 0, null, null, false, false, true, false);
         free(closname);
         auto chaintype = getParentClosureType(irs.sthis, fd);
         symbol_struct_addField(Closstru.Ttag, "__chain", chaintype, 0);
@@ -979,7 +979,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         irs.sclosure = sclosure;
 
         assert(fd.closureVars.dim);
-        assert(fd.closureVars[0].offset >= Target.ptrsize);
+        assert(fd.closureVars[0].offset >= target.ptrsize);
         foreach (v; fd.closureVars)
         {
             //printf("closure var %s\n", v.toChars());
@@ -1016,9 +1016,9 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         VarDeclaration  vlast = fd.closureVars[fd.closureVars.dim - 1];
         typeof(Type.size()) lastsize;
         if (vlast.storage_class & STC.lazy_)
-            lastsize = Target.ptrsize * 2;
+            lastsize = target.ptrsize * 2;
         else if (vlast.isRef() || vlast.isOut())
-            lastsize = Target.ptrsize;
+            lastsize = target.ptrsize;
         else
             lastsize = vlast.type.size();
         bool overflow;
@@ -1119,7 +1119,7 @@ void buildCapture(FuncDeclaration fd)
         strcat(strcat(capturename, name1), name2);
 
         /* Build type for struct */
-        type *capturestru = type_struct_class(capturename, Target.ptrsize, 0, null, null, false, false, true, false);
+        type *capturestru = type_struct_class(capturename, target.ptrsize, 0, null, null, false, false, true, false);
         free(capturename);
 
         foreach (v; fd.closureVars)
@@ -1157,5 +1157,5 @@ void buildCapture(FuncDeclaration fd)
 RET retStyle(TypeFunction tf, bool needsThis)
 {
     //printf("TypeFunction.retStyle() %s\n", toChars());
-    return Target.isReturnOnStack(tf, needsThis) ? RET.stack : RET.regs;
+    return target.isReturnOnStack(tf, needsThis) ? RET.stack : RET.regs;
 }

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -557,9 +557,9 @@ void toObjFile(Dsymbol ds, bool multiobj)
                 vd.error("size overflow");
                 return;
             }
-            if (sz64 >= Target.maxStaticDataSize)
+            if (sz64 >= target.maxStaticDataSize)
             {
-                vd.error("size of 0x%llx exceeds max allowed size 0x%llx", sz64, Target.maxStaticDataSize);
+                vd.error("size of 0x%llx exceeds max allowed size 0x%llx", sz64, target.maxStaticDataSize);
             }
             uint sz = cast(uint)sz64;
 
@@ -1098,8 +1098,8 @@ private bool finishVtbl(ClassDeclaration cd)
 uint baseVtblOffset(ClassDeclaration cd, BaseClass *bc)
 {
     //printf("ClassDeclaration.baseVtblOffset('%s', bc = %p)\n", cd.toChars(), bc);
-    uint csymoffset = Target.classinfosize;    // must be ClassInfo.size
-    csymoffset += cd.vtblInterfaces.dim * (4 * Target.ptrsize);
+    uint csymoffset = target.classinfosize;    // must be ClassInfo.size
+    csymoffset += cd.vtblInterfaces.dim * (4 * target.ptrsize);
 
     for (size_t i = 0; i < cd.vtblInterfaces.dim; i++)
     {
@@ -1107,7 +1107,7 @@ uint baseVtblOffset(ClassDeclaration cd, BaseClass *bc)
 
         if (b == bc)
             return csymoffset;
-        csymoffset += b.sym.vtbl.dim * Target.ptrsize;
+        csymoffset += b.sym.vtbl.dim * target.ptrsize;
     }
 
     // Put out the overriding interface vtbl[]s.
@@ -1127,7 +1127,7 @@ uint baseVtblOffset(ClassDeclaration cd, BaseClass *bc)
                     //printf("\tcsymoffset = x%x\n", csymoffset);
                     return csymoffset;
                 }
-                csymoffset += bs.sym.vtbl.dim * Target.ptrsize;
+                csymoffset += bs.sym.vtbl.dim * target.ptrsize;
             }
         }
     }
@@ -1158,7 +1158,7 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass *b, ref FuncDeclarations bv
     if (id.vtblOffset())
     {
         // First entry is struct Interface reference
-        dtb.xoff(toSymbol(pc), cast(uint)(Target.classinfosize + k * (4 * Target.ptrsize)), TYnptr);
+        dtb.xoff(toSymbol(pc), cast(uint)(target.classinfosize + k * (4 * target.ptrsize)), TYnptr);
         jstart = 1;
     }
 
@@ -1177,7 +1177,7 @@ private size_t emitVtbl(ref DtBuilder dtb, BaseClass *b, ref FuncDeclarations bv
         else
             dtb.size(0);
     }
-    return id_vtbl_dim * Target.ptrsize;
+    return id_vtbl_dim * target.ptrsize;
 }
 
 
@@ -1216,12 +1216,12 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
             //TypeInfo typeinfo;
        }
      */
-    uint offset = Target.classinfosize;    // must be ClassInfo.size
+    uint offset = target.classinfosize;    // must be ClassInfo.size
     if (Type.typeinfoclass)
     {
-        if (Type.typeinfoclass.structsize != Target.classinfosize)
+        if (Type.typeinfoclass.structsize != target.classinfosize)
         {
-            debug printf("Target.classinfosize = x%x, Type.typeinfoclass.structsize = x%x\n", offset, Type.typeinfoclass.structsize);
+            debug printf("target.classinfosize = x%x, Type.typeinfoclass.structsize = x%x\n", offset, Type.typeinfoclass.structsize);
             cd.error("mismatch between dmd and object.d or object.di found. Check installation and import paths with -v compiler switch.");
             fatal();
         }
@@ -1353,7 +1353,7 @@ Louter:
     // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
     // of the fixup (*)
 
-    offset += cd.vtblInterfaces.dim * (4 * Target.ptrsize);
+    offset += cd.vtblInterfaces.dim * (4 * target.ptrsize);
     for (size_t i = 0; i < cd.vtblInterfaces.dim; i++)
     {
         BaseClass *b = (*cd.vtblInterfaces)[i];
@@ -1412,7 +1412,7 @@ Louter:
     dtpatchoffset(pdtname, offset);
 
     dtb.nbytes(cast(uint)(namelen + 1), name);
-    const size_t namepad = -(namelen + 1) & (Target.ptrsize - 1); // align
+    const size_t namepad = -(namelen + 1) & (target.ptrsize - 1); // align
     dtb.nzeros(cast(uint)namepad);
 
     cd.csym.Sdt = dtb.finish();
@@ -1479,7 +1479,7 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
     dtb.size(0);
 
     // interfaces[]
-    uint offset = Target.classinfosize;
+    uint offset = target.classinfosize;
     dtb.size(id.vtblInterfaces.dim);
     if (id.vtblInterfaces.dim)
     {
@@ -1539,7 +1539,7 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
     // Put out (*vtblInterfaces)[]. Must immediately follow csym, because
     // of the fixup (*)
 
-    offset += id.vtblInterfaces.dim * (4 * Target.ptrsize);
+    offset += id.vtblInterfaces.dim * (4 * target.ptrsize);
     for (size_t i = 0; i < id.vtblInterfaces.dim; i++)
     {
         BaseClass *b = (*id.vtblInterfaces)[i];
@@ -1561,7 +1561,7 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
     dtpatchoffset(pdtname, offset);
 
     dtb.nbytes(cast(uint)(namelen + 1), name);
-    const size_t namepad =  -(namelen + 1) & (Target.ptrsize - 1); // align
+    const size_t namepad =  -(namelen + 1) & (target.ptrsize - 1); // align
     dtb.nzeros(cast(uint)namepad);
 
     id.csym.Sdt = dtb.finish();

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1171,7 +1171,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             return new ErrorExp();
         }
 
-        bool value = Target.isReturnOnStack(tf, fd && fd.needThis());
+        bool value = target.isReturnOnStack(tf, fd && fd.needThis());
         return new IntegerExp(e.loc, value, Type.tbool);
     }
     if (e.ident == Id.getFunctionVariadicStyle)
@@ -1777,7 +1777,7 @@ Lnext:
         }
         se = se.toUTF8(sc);
 
-        Expression r = Target.getTargetInfo(se.toPtr(), e.loc);
+        Expression r = target.getTargetInfo(se.toPtr(), e.loc);
         if (!r)
         {
             e.error("`getTargetInfo` key `\"%s\"` not supported by this implementation", se.toPtr());

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -652,7 +652,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
         }
         TypeSArray t = cast(TypeSArray)mtype.basetype;
         const sz = cast(int)t.size(loc);
-        final switch (Target.isVectorTypeSupported(sz, t.nextOf()))
+        final switch (target.isVectorTypeSupported(sz, t.nextOf()))
         {
         case 0:
             // valid
@@ -751,7 +751,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
             Type overflowError()
             {
                 .error(loc, "`%s` size %llu * %llu exceeds 0x%llx size limit for static array",
-                        mtype.toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1, Target.maxStaticDataSize);
+                        mtype.toChars(), cast(ulong)tbn.size(loc), cast(ulong)d1, target.maxStaticDataSize);
                 return error();
             }
 
@@ -771,7 +771,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                  * run on them for the size, since they may be forward referenced.
                  */
                 bool overflow = false;
-                if (mulu(tbn.size(loc), d2, overflow) >= Target.maxStaticDataSize || overflow)
+                if (mulu(tbn.size(loc), d2, overflow) >= target.maxStaticDataSize || overflow)
                     return overflowError();
             }
         }
@@ -2037,17 +2037,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                fvalue = Target.FloatProperties.max;
+                fvalue = target.FloatProperties.max;
                 goto Lfvalue;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                fvalue = Target.DoubleProperties.max;
+                fvalue = target.DoubleProperties.max;
                 goto Lfvalue;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                fvalue = Target.RealProperties.max;
+                fvalue = target.RealProperties.max;
                 goto Lfvalue;
             default:
                 break;
@@ -2105,17 +2105,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                fvalue = Target.FloatProperties.min_normal;
+                fvalue = target.FloatProperties.min_normal;
                 goto Lfvalue;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                fvalue = Target.DoubleProperties.min_normal;
+                fvalue = target.DoubleProperties.min_normal;
                 goto Lfvalue;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                fvalue = Target.RealProperties.min_normal;
+                fvalue = target.RealProperties.min_normal;
                 goto Lfvalue;
             default:
                 break;
@@ -2134,7 +2134,7 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tfloat32:
             case Tfloat64:
             case Tfloat80:
-                fvalue = Target.RealProperties.nan;
+                fvalue = target.RealProperties.nan;
                 goto Lfvalue;
             default:
                 break;
@@ -2153,7 +2153,7 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tfloat32:
             case Tfloat64:
             case Tfloat80:
-                fvalue = Target.RealProperties.infinity;
+                fvalue = target.RealProperties.infinity;
                 goto Lfvalue;
             default:
                 break;
@@ -2166,17 +2166,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                ivalue = Target.FloatProperties.dig;
+                ivalue = target.FloatProperties.dig;
                 goto Lint;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                ivalue = Target.DoubleProperties.dig;
+                ivalue = target.DoubleProperties.dig;
                 goto Lint;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                ivalue = Target.RealProperties.dig;
+                ivalue = target.RealProperties.dig;
                 goto Lint;
             default:
                 break;
@@ -2189,17 +2189,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                fvalue = Target.FloatProperties.epsilon;
+                fvalue = target.FloatProperties.epsilon;
                 goto Lfvalue;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                fvalue = Target.DoubleProperties.epsilon;
+                fvalue = target.DoubleProperties.epsilon;
                 goto Lfvalue;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                fvalue = Target.RealProperties.epsilon;
+                fvalue = target.RealProperties.epsilon;
                 goto Lfvalue;
             default:
                 break;
@@ -2212,17 +2212,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                ivalue = Target.FloatProperties.mant_dig;
+                ivalue = target.FloatProperties.mant_dig;
                 goto Lint;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                ivalue = Target.DoubleProperties.mant_dig;
+                ivalue = target.DoubleProperties.mant_dig;
                 goto Lint;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                ivalue = Target.RealProperties.mant_dig;
+                ivalue = target.RealProperties.mant_dig;
                 goto Lint;
             default:
                 break;
@@ -2235,17 +2235,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                ivalue = Target.FloatProperties.max_10_exp;
+                ivalue = target.FloatProperties.max_10_exp;
                 goto Lint;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                ivalue = Target.DoubleProperties.max_10_exp;
+                ivalue = target.DoubleProperties.max_10_exp;
                 goto Lint;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                ivalue = Target.RealProperties.max_10_exp;
+                ivalue = target.RealProperties.max_10_exp;
                 goto Lint;
             default:
                 break;
@@ -2258,17 +2258,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                ivalue = Target.FloatProperties.max_exp;
+                ivalue = target.FloatProperties.max_exp;
                 goto Lint;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                ivalue = Target.DoubleProperties.max_exp;
+                ivalue = target.DoubleProperties.max_exp;
                 goto Lint;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                ivalue = Target.RealProperties.max_exp;
+                ivalue = target.RealProperties.max_exp;
                 goto Lint;
             default:
                 break;
@@ -2281,17 +2281,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                ivalue = Target.FloatProperties.min_10_exp;
+                ivalue = target.FloatProperties.min_10_exp;
                 goto Lint;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                ivalue = Target.DoubleProperties.min_10_exp;
+                ivalue = target.DoubleProperties.min_10_exp;
                 goto Lint;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                ivalue = Target.RealProperties.min_10_exp;
+                ivalue = target.RealProperties.min_10_exp;
                 goto Lint;
             default:
                 break;
@@ -2304,17 +2304,17 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
             case Tcomplex32:
             case Timaginary32:
             case Tfloat32:
-                ivalue = Target.FloatProperties.min_exp;
+                ivalue = target.FloatProperties.min_exp;
                 goto Lint;
             case Tcomplex64:
             case Timaginary64:
             case Tfloat64:
-                ivalue = Target.DoubleProperties.min_exp;
+                ivalue = target.DoubleProperties.min_exp;
                 goto Lint;
             case Tcomplex80:
             case Timaginary80:
             case Tfloat80:
-                ivalue = Target.RealProperties.min_exp;
+                ivalue = target.RealProperties.min_exp;
                 goto Lint;
             default:
                 break;
@@ -4299,14 +4299,14 @@ Expression defaultInit(Type mt, const ref Loc loc)
         case Tfloat32:
         case Tfloat64:
         case Tfloat80:
-            return new RealExp(loc, Target.RealProperties.snan, mt);
+            return new RealExp(loc, target.RealProperties.snan, mt);
 
         case Tcomplex32:
         case Tcomplex64:
         case Tcomplex80:
             {
                 // Can't use fvalue + I*fvalue (the im part becomes a quiet NaN).
-                const cvalue = complex_t(Target.RealProperties.snan, Target.RealProperties.snan);
+                const cvalue = complex_t(target.RealProperties.snan, target.RealProperties.snan);
                 return new ComplexExp(loc, cvalue, mt);
             }
 


### PR DESCRIPTION
The idea is to turn all the individual `Target` globals into a single `target` instance, which then can be passed by reference. Follow-on PRs will convert the globals to fields. This PR creates the `target` global and then does a global search/replace.