### PR TITLE
[stable] Fix -mixin output for CRLF input

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -241,12 +241,13 @@ bool writeMixin(const(char)[] s, ref Loc loc)
     size_t lastpos = 0;
     foreach (i,c; s)
     {
-        if(c == '\n')
+        // detect LF and CRLF
+        if (c == '\n' || (c == '\r' && i+1 < s.length && s[i+1] == '\n'))
         {
             ob.writestring(s[lastpos .. i]);
             ob.writenl();
             global.params.mixinLines++;
-            lastpos = i + 1;
+            lastpos = i + (c == '\r' ? 2 : 1);
         }
     }
 


### PR DESCRIPTION
The mixin string may contain Windows newlines, e.g., if the source file does and a multiline `q{ ... }` literal is used (e.g., `test/runnable/extra-files/mixin.d`). In that case, the old code would output CRLF on POSIX and CRCRLF on Windows instead of normalizing the output (LF/CRLF).