### PR TITLE
Fix C++ mangling for repeated basic types that are target-specific.

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1296,10 +1296,14 @@ extern(C++):
                 // Handle any target-specific basic types.
                 if (auto tm = Target.cppTypeMangle(t))
                 {
-                    if (substitute(t))
-                        return;
-                    else
-                        append(t);
+                    // Only do substitution for mangles that are longer than 1 character.
+                    if (tm[1] != 0 || t.isConst())
+                    {
+                        if (substitute(t))
+                            return;
+                        else
+                            append(t);
+                    }
                     CV_qualifiers(t);
                     buf.writestring(tm);
                     return;

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -625,6 +625,7 @@ else
     alias c_long_double myld;
 
 extern (C++) myld testld(myld);
+extern (C++) myld testldld(myld, myld);
 
 
 void test15()
@@ -632,6 +633,10 @@ void test15()
     myld ld = 5.0;
     ld = testld(ld);
     assert(ld == 6.0);
+
+    myld ld2 = 5.0;
+    ld2 = testldld(ld2, ld2);
+    assert(ld2 == 6.0);
 }
 
 /****************************************/

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -446,6 +446,12 @@ long double testld(long double ld)
     return ld + 1;
 }
 
+long double testldld(long double ld1, long double ld2)
+{
+    assert(ld1 == 5);
+    return ld2 + 1;
+}
+
 long testl(long lng)
 {
     assert(lng == 5);


### PR DESCRIPTION
See LDC issue: https://github.com/ldc-developers/ldc/issues/2954

https://github.com/dlang/dmd/pull/7250 introduced substitution for target-specific basic types, which is helpful (e.g. with target specific `Tcomplex80`) but should only be done when multiple characters are used for the mangle. (So basically duplicating `writeBasicType` behavior).