### PR TITLE
add `-std-c++=`

### DIFF
--- a/changelog/stdcpp.dd
+++ b/changelog/stdcpp.dd
@@ -1,0 +1,63 @@
+Ddoc
+
+$(H2 Transition to C++11 character types)
+  
+          With C++11 comes the advent of changed character type mangling.
+          D's default behavior will be to conform to this after a one 
+          release transition period. A new switch -stdc++={c++98,c++11} is 
+          added to control the version that compatibility is set to.
+          This switch sets `__traits(getTargetInfo, "cppStd")` to the value of 
+          `__cplusplus` that the corresponding version of the C++ standard defines.
+  
+          Of particular note is the new difference between wchar and wchar_t on
+          Windows. This will manifest itself as compile errors when
+          interfacing wchar* with wchar_t* code when calling the Windows API.
+          A cast will resolve the issue.
+  
+          Going forward we recommend using WCHAR instead of wchar or wchar_t
+          when interfacing to Windows API functions. (WCHAR is Microsoft
+          Windows' 16 bit character type.)
+  
+   $(H3 C++ Type Equivalence)
+  
+   $(H4 c++98 behavior:)
+  
+   $(TABLE
+   $(THEAD D       , Posix           , DMC++ Windows   , VC++ Windows)
+  
+   $(TROW  wchar   , unsigned short  , wchar_t         , wchar_t)
+   $(TROW  dchar   , wchar_t         , unsigned        , unsigned)
+   $(TROW  wchar_t , wchar_t         , wchar_t         , wchar_t)
+   $(TROW  WCHAR   , --              , wchar_t         , wchar_t))
+  
+   $(H4 c++11:)
+  
+   $(TABLE
+   $(THEAD D       , Posix           , DMC++ Windows   , VC++ Windows)
+  
+   $(TROW  wchar   , char16_t        , wchar_t         , char16_t)
+   $(TROW  dchar   , char32_t        , unsigned        , char32_t)
+   $(TROW  wchar_t , wchar_t         , wchar           , wchar_t)
+   $(TROW  WCHAR   , --              , wchar           , wchar_t))
+  
+   
+   $(H3 Name Mangling:)
+  
+   $(H4 c++98 behavior:)
+  
+   $(TABLE
+   $(THEAD D       , Posix   , DMC++ Windows   , VC++ Windows)
+  
+   $(TROW  wchar   , t       , _Y              , _W)
+   $(TROW  dchar   , w       , I               , I)
+   $(TROW  wchar_t , w       , _Y              , _W))
+  
+   $(H4 c++11:)
+  
+   $(TABLE
+   $(THEAD D       , Posix   , DMC++ Windows   , VC++ Windows)
+  
+   $(TROW  wchar   , Ds      , _Y              , _S)
+   $(TROW  dchar   , Di      , I               , _U)
+   $(TROW  wchar_t , w       , _Y              , _W))
+

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -561,6 +561,16 @@ dmd -cov -unittest myprog.d
             `$(UNIX Generate shared library)
              $(WINDOWS Generate DLL library)`,
         ),
+        Option("stdc++=<standard>",
+            "set c++ compatiblity with <standard>",
+            "Standards supported are:
+            $(UL
+                $(LI $(I c++98) (default): Use C++98 name mangling,
+                    Sets `__traits(getTargetInfo, \"cppStd\")` to `199711`)
+                $(LI $(I c++11): Use C++11 name mangling,
+                    Sets `__traits(getTargetInfo, \"cppStd\")` to `201103`)
+            )",
+        ),
         Option("transition=<id>",
             "help with language change identified by 'id'",
             `Show additional info about language change identified by $(I id)`,

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -89,6 +89,12 @@ enum JsonFieldFlags : uint
     semantics    = (1 << 3),
 }
 
+enum CppStdRevision : uint
+{
+    cpp98 = 199711,
+    cpp11 = 201103
+}
+
 // Put command line switches in here
 struct Param
 {
@@ -157,6 +163,9 @@ struct Param
     bool ehnogc;            // use @nogc exception handling
     bool dtorFields;        // destruct fields of partially constructed objects
                             // https://issues.dlang.org/show_bug.cgi?id=14246
+
+    CppStdRevision cplusplus = CppStdRevision.cpp98;    // version of C++ standard to support
+
     bool markdown;          // enable Markdown replacements in Ddoc
     bool vmarkdown;         // list instances of Markdown replacements in Ddoc
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -64,6 +64,12 @@ enum CPU
     native              // the machine the compiler is being run on
 };
 
+enum CppStdRevision
+{
+    CppStdRevisionCpp98 = 199711,
+    CppStdRevisionCpp11 = 201103
+};
+
 // Put command line switches in here
 struct Param
 {
@@ -127,6 +133,7 @@ struct Param
     bool ehnogc;        // use @nogc exception handling
     bool dtorFields;        // destruct fields of partially constructed objects
                             // https://issues.dlang.org/show_bug.cgi?id=14246
+    unsigned cplusplus;     // version of C++ name mangling to support
     bool markdown;          // enable Markdown replacements in Ddoc
     bool vmarkdown;         // list instances of Markdown replacements in Ddoc
     bool showGaggedErrors;  // print gagged errors anyway

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1645,6 +1645,15 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             else
                 goto Lerror;
         }
+        else if (startsWith(p + 1, "stdc++=")) // https://dlang.org/dmd.html#switch-std-c%2B%2B
+        {
+            if (strcmp(p + 8, "c++98") == 0)
+                params.cplusplus = CppStdRevision.cpp98;
+            else if (strcmp(p + 8, "c++11") == 0)
+                params.cplusplus = CppStdRevision.cpp11;
+            else
+                goto Lerror;
+        }
         else if (startsWith(p + 1, "transition") ) // https://dlang.org/dmd.html#switch-transition
         {
             // Parse:

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -702,6 +702,7 @@ struct Target
     private enum TargetInfoKeys
     {
         cppRuntimeLibrary,
+        cppStd,
         floatAbi,
         objectFormat,
     }
@@ -740,6 +741,9 @@ struct Target
                     return stringExp("snn");
                 }
                 return stringExp("");
+            case cppStd.stringof:
+                return new IntegerExp(cast(uint)global.params.cplusplus);
+
             default:
                 return null;
         }

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -1,3 +1,5 @@
+// REQUIRED_ARGS: -stdc++=c++98
+
 // This file is intended to contain all compilable traits-related tests in an
 // effort to keep the number of files in the `compilable` folder to a minimum.
 
@@ -27,3 +29,5 @@ version (OSX)
     static assert(__traits(getTargetInfo, "objectFormat") == "macho");
 version (linux)
     static assert(__traits(getTargetInfo, "objectFormat") == "elf");
+
+static assert(__traits(getTargetInfo, "cppStd") == 199711);


### PR DESCRIPTION
cc @TurkeyMan  @CyberShadow @jacob-carlborg @Geod24 @ibuclaw @WalterBright 

Alternative to #9029

~~(I haven't actually tested it because I can't build dmd (due to a lack of disk space I think, I'm working on it))~~  ~~Hmm, nope it jut keep OOMing.~~ No it doesn't like `-`s in `Option`s.

tested, it works.