### PR TITLE
Fix ddoc15475.d test to make sure compiler doesn't error during ddoc gen

### DIFF
--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -3404,7 +3404,7 @@ private void highlightCode3(Scope* sc, OutBuffer* buf, const(char)* p, const(cha
  */
 private void highlightCode2(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t offset)
 {
-    uint errorsave = global.errors;
+    uint errorsave = global.startGagging();
     scope Lexer lex = new Lexer(null, cast(char*)buf.data, 0, buf.offset - 1, 0, 1);
     OutBuffer res;
     const(char)* lastp = cast(char*)buf.data;
@@ -3468,7 +3468,7 @@ private void highlightCode2(Scope* sc, Dsymbols* a, OutBuffer* buf, size_t offse
     }
     buf.setsize(offset);
     buf.write(&res);
-    global.errors = errorsave;
+    global.endGagging(errorsave);
 }
 
 /****************************************

--- a/test/compilable/ddoc15475.d
+++ b/test/compilable/ddoc15475.d
@@ -1,6 +1,10 @@
-// PERMUTE_ARGS:
-// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
-// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+/* PERMUTE_ARGS:
+REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
+POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+TEST_OUTPUT:
+---
+---
+*/
 
 /**
 My module


### PR DESCRIPTION
After turning on ddoc tests in gdc/dejagnu, this test started failing.

Was clear to see why.
```
((e0e23b725...)) $ ./generated/linux/release/64/dmd test/compilable/ddoc15475.d -D -o-
Error: unterminated character constant
((e0e23b725...)) $ echo $?
0
```
Error occurred, but compiler still returns success.  Looking at `highlightCode2`, it just overwrites the error count before returning.  Seems to me that gagging was intended instead.