### PR TITLE
Remove duplicate cpp_mangle

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -105,7 +105,7 @@ Symbol *asm_define_label(const(char)* id);
 version (SCPP)
     char* cpp_mangle(Symbol* s);
 else version (MARS)
-    char* cpp_mangle(Symbol* s);
+    const(char)* cpp_mangle(Symbol* s);
 else
     char* cpp_mangle(Symbol* s) { return &s.Sident[0]; }
 

--- a/src/dmd/backend/newman.d
+++ b/src/dmd/backend/newman.d
@@ -502,6 +502,9 @@ char *cpp_typetostring(type *t,char *prefix)
     return mangle.buf.ptr;
 }
 
+version (MARS) { } else
+{
+
 /********************************
  * 'Mangle' a name for output.
  * Returns:
@@ -539,6 +542,7 @@ version (SCPPorHTOD)
     }
 }
 
+}
 ///////////////////////////////////////////////////////
 
 /*********************************

--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -1418,7 +1418,7 @@ version (SCPP)
 }
 else static if (TARGET_WINDOS)
 {
-                objmod.codeseg(cpp_mangle(funcsym_p),1);
+                objmod.codeseg(cast(char*)cpp_mangle(funcsym_p),1);
 }
 else
 {


### PR DESCRIPTION
The `cpp_mangle` function has 2 definitions in `src/dmd/backend/cgobj.d` and `src/dmd/backend/newman.d`.  The one in `cgobj.d` is inside a `version (MARS)`, so I've just put the one in `newman.d` inside a `version (MARS) { } else { ... }`.  This way you'll only get one definition in the backend.

The 2 function signatures only differ in return value `char*` vs `const(char)*`.  Interestingly, dmd ignores the redefinition while LDC prints a warning.  Since they only differ in return value, they are mangled the same (`_Z10cpp_mangleP6Symbol`).  Note that the fact that DMD ignores this could be a bug, not sure.