### PR TITLE
cppmangle.d: Fix substitution logic in writeBasicType()

### DIFF
--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -503,6 +503,19 @@ struct Target
     }
 
     /**
+     * Checks whether type is a vendor-specific fundamental type.
+     * Params:
+     *      t = type to inspect
+     *      isFundamental = where to store result
+     * Returns:
+     *      true if isFundamental was set by function
+     */
+    extern (C++) bool cppFundamentalType(const Type t, ref bool isFundamental)
+    {
+        return false;
+    }
+
+    /**
      * Default system linkage for the target.
      * Returns:
      *      `LINK` to use for `extern(System)`

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -727,6 +727,19 @@ void test16()
     static assert(0);
 }
 
+/****************************************/
+/+ FIXME: Requires C++11 compiler.
+alias nullptr_t = typeof(null);
+
+extern (C++) void testnull(nullptr_t);
+extern (C++) void testnullnull(nullptr_t, nullptr_t);
+
+void test17()
+{
+    testnull(null);
+    testnullnull(null, null);
+}
++/
 
 /****************************************/
 
@@ -1611,6 +1624,7 @@ void main()
     test13289();
     test15();
     test16();
+    //test17();
     func13707();
     func13932(S13932!(-1)(0));
     foo13337(S13337());

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -465,6 +465,20 @@ unsigned long testul(unsigned long ul)
 }
 
 /******************************************/
+/* FIXME: Requires C++11 compiler.
+void testnull(nullptr_t n)
+{
+  assert(n == NULL);
+}
+
+void testnullnull(nullptr_t n1, nullptr_t n2)
+{
+  assert(n1 == NULL);
+  assert(n2 == NULL);
+}
+*/
+
+/******************************************/
 
 struct S13707
 {


### PR DESCRIPTION
Specifically fixes nullptr_t and target-specific built-in type mangling (correcting patch in #9129) @JohanEngelen.

Later on, this will also work for char16_t and char32_t as well.