### PR TITLE
fix issue 16098 - Occasional runtime segfault of programs with SIMD 32 bytes

### DIFF
--- a/src/dmd/backend/cg.d
+++ b/src/dmd/backend/cg.d
@@ -49,5 +49,6 @@ regm_t  DOUBLEREGS = DOUBLEREGS_16;
 Symbol *localgot;               // reference to GOT for this function
 Symbol *tls_get_addr_sym;       // function __tls_get_addr
 
-int STACKALIGN = 2;             // default for 16 bit code
+int TARGET_STACKALIGN = 2;      // default for 16 bit code
+int STACKALIGN = 2;             // varies for each function
 }

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -1075,6 +1075,8 @@ Lagain:
     else
         assert((localsize | Alloca.size) == 0 || (usednteh & NTEHjmonitor));
     EBPtoESP += xlocalsize;
+    if (hasframe)
+        EBPtoESP += REGSIZE;
 
     /* Win64 unwind needs the amount of code generated so far
      */

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -232,6 +232,7 @@ tryagain:
     cgstate.stackclean = 1;
     cgstate.funcarg.init();
     cgstate.funcargtos = ~0;
+    STACKALIGN = TARGET_STACKALIGN;
 
     regsave.reset();
     memset(_8087elems.ptr,0,_8087elems.sizeof);

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -897,7 +897,8 @@ Lagain:
      * and the overriding function, and so bias should be the same too.
     */
 
-    int bias = cast(int)(Para.size + (needframe ? 0 : REGSIZE));
+    int bias = enforcealign ? 0 : cast(int)(Para.size + (needframe ? 0 : REGSIZE));
+
     if (Fast.alignment < REGSIZE)
         Fast.alignment = REGSIZE;
 

--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -1567,9 +1567,10 @@ bool xmmIsAligned(elem *e)
     if (tyvector(e.Ety) && e.Eoper == OPvar)
     {
         Symbol *s = e.EV.Vsym;
-        if (Symbol_Salignsize(s) < 16 ||
-            e.EV.Voffset & (16 - 1) ||
-            tysize(e.Ety) > STACKALIGN
+        const alignsz = tyalignsize(e.Ety);
+        if (Symbol_Salignsize(s) < alignsz ||
+            e.EV.Voffset & (alignsz - 1) ||
+            alignsz > STACKALIGN
            )
             return false;       // definitely not aligned
     }

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -401,7 +401,7 @@ uint gensaverestore(regm_t regm,ref CodeBuilder cdbsave,ref CodeBuilder cdbresto
 void genstackclean(ref CodeBuilder cdb,uint numpara,regm_t keepmsk)
 {
     //dbg_printf("genstackclean(numpara = %d, stackclean = %d)\n",numpara,cgstate.stackclean);
-    if (numpara && (cgstate.stackclean || STACKALIGN == 16))
+    if (numpara && (cgstate.stackclean || STACKALIGN >= 16))
     {
 /+
         if (0 &&                                // won't work if operand of scodelem
@@ -2701,7 +2701,7 @@ void callclib(ref CodeBuilder cdb, elem* e, uint clib, regm_t* pretregs, regm_t 
         int nalign = 0;
         int pushebx = (cinfo.flags & INFpushebx) != 0;
         int pushall = (cinfo.flags & INFpusheabcdx) != 0;
-        if (STACKALIGN == 16)
+        if (STACKALIGN >= 16)
         {   // Align the stack (assume no args on stack)
             int npush = (npushed + pushebx + 4 * pushall) * REGSIZE + stackpush;
             if (npush & (STACKALIGN - 1))
@@ -3161,7 +3161,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
     /* Adjust start of the stack so after all args are pushed,
      * the stack will be aligned.
      */
-    if (!usefuncarg && STACKALIGN == 16 && (numpara + stackpush) & (STACKALIGN - 1))
+    if (!usefuncarg && STACKALIGN >= 16 && (numpara + stackpush) & (STACKALIGN - 1))
     {
         numalign = STACKALIGN - ((numpara + stackpush) & (STACKALIGN - 1));
         cod3_stackadj(cdb, numalign);

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3076,9 +3076,10 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         uint alignsize = el_alignsize(ep);
         parameters[i].numalign = 0;
         if (alignsize > stackalign &&
-            (I64 || (alignsize == 16 && tyvector(ep.Ety))))
+            (I64 || (alignsize >= 16 &&
+                (config.exe == EX_OSX && (tyaggregate(ep.Ety) || tyvector(ep.Ety))))))
         {
-            if (tyvector(ep.Ety) && alignsize > STACKALIGN)
+            if (alignsize > STACKALIGN)
             {
                 STACKALIGN = alignsize;
                 enforcealign = true;

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3078,6 +3078,11 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         if (alignsize > stackalign &&
             (I64 || (alignsize == 16 && tyvector(ep.Ety))))
         {
+            if (tyvector(ep.Ety) && alignsize > STACKALIGN)
+            {
+                STACKALIGN = alignsize;
+                enforcealign = true;
+            }
             uint newnumpara = (numpara + (alignsize - 1)) & ~(alignsize - 1);
             parameters[i].numalign = newnumpara - numpara;
             numpara = newnumpara;

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -5259,7 +5259,7 @@ void cdddtor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         if (config.flags3 & CFG3pic)
         {
             int nalign = 0;
-            if (STACKALIGN == 16)
+            if (STACKALIGN >= 16)
             {   nalign = STACKALIGN - REGSIZE;
                 cod3_stackadj(cdb, nalign);
             }

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -810,7 +810,7 @@ private code *callFinallyBlock(block *bf, regm_t retregs)
     calledFinally = true;
     uint npush = gensaverestore(retregs,cdbs,cdbr);
 
-    if (STACKALIGN == 16)
+    if (STACKALIGN >= 16)
     {   npush += REGSIZE;
         if (npush & (STACKALIGN - 1))
         {   nalign = STACKALIGN - (npush & (STACKALIGN - 1));

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -4828,6 +4828,20 @@ void assignaddrc(code *c)
                     c.Iflags = CFoff;
                     c.IFL1 = FLconst;
                     c.IEV1.Vuns = -EBPtoESP;
+                    if (enforcealign)
+                    {
+                        // AND ESP, -STACKALIGN
+                        code *cn = code_calloc();
+                        cn.Iop = 0x81;
+                        cn.Irm = modregrm(3, 4, SP);
+                        cn.Iflags = CFoff;
+                        cn.IFL2 = FLconst;
+                        cn.IEV2.Vsize_t = -STACKALIGN;
+                        if (I64)
+                            c.Irex |= REX_W;
+                        cn.next = c.next;
+                        c.next = cn;
+                    }
                 }
             }
             else if (c.Iop == (ESCAPE | ESCframeptr))

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -3311,7 +3311,7 @@ void prolog_saveregs(ref CodeBuilder cdb, regm_t topush, int cfa_offset)
         int xmmtopush = numbitsset(topush & XMMREGS);   // XMM regs take 16 bytes
         int gptopush = numbitsset(topush) - xmmtopush;  // general purpose registers to save
         targ_size_t xmmoffset = pushoff + BPoff;
-        if (!hasframe)
+        if (!hasframe || enforcealign)
             xmmoffset += EBPtoESP;
         targ_size_t gpoffset = xmmoffset + xmmtopush * 16;
         while (topush)
@@ -3320,7 +3320,7 @@ void prolog_saveregs(ref CodeBuilder cdb, regm_t topush, int cfa_offset)
             topush &= ~mask(reg);
             if (reg >= XMM0)
             {
-                if (hasframe)
+                if (hasframe && !enforcealign)
                 {
                     // MOVUPD xmmoffset[EBP],xmm
                     cdb.genc1(STOUPD,modregxrm(2,reg-XMM0,BPRM),FLconst,xmmoffset);
@@ -3334,7 +3334,7 @@ void prolog_saveregs(ref CodeBuilder cdb, regm_t topush, int cfa_offset)
             }
             else
             {
-                if (hasframe)
+                if (hasframe && !enforcealign)
                 {
                     // MOV gpoffset[EBP],reg
                     cdb.genc1(0x89,modregxrm(2,reg,BPRM),FLconst,gpoffset);
@@ -3413,7 +3413,7 @@ private void epilog_restoreregs(ref CodeBuilder cdb, regm_t topop)
         int xmmtopop = numbitsset(topop & XMMREGS);   // XMM regs take 16 bytes
         int gptopop = numbitsset(topop) - xmmtopop;   // general purpose registers to save
         targ_size_t xmmoffset = pushoff + BPoff;
-        if (!hasframe)
+        if (!hasframe || enforcealign)
             xmmoffset += EBPtoESP;
         targ_size_t gpoffset = xmmoffset + xmmtopop * 16;
         while (topop)
@@ -3422,7 +3422,7 @@ private void epilog_restoreregs(ref CodeBuilder cdb, regm_t topop)
             topop &= ~mask(reg);
             if (reg >= XMM0)
             {
-                if (hasframe)
+                if (hasframe && !enforcealign)
                 {
                     // MOVUPD xmm,xmmoffset[EBP]
                     cdb.genc1(LODUPD,modregxrm(2,reg-XMM0,BPRM),FLconst,xmmoffset);
@@ -3436,7 +3436,7 @@ private void epilog_restoreregs(ref CodeBuilder cdb, regm_t topop)
             }
             else
             {
-                if (hasframe)
+                if (hasframe && !enforcealign)
                 {
                     // MOV reg,gpoffset[EBP]
                     cdb.genc1(0x8B,modregxrm(2,reg,BPRM),FLconst,gpoffset);
@@ -3580,7 +3580,7 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t* namedargs)
 
     static immutable ubyte[vregnum] regs = [ DI,SI,DX,CX,R8,R9 ];
 
-    if (!hasframe)
+    if (!hasframe || enforcealign)
         voff += EBPtoESP;
     for (int i = 0; i < vregnum; i++)
     {
@@ -3588,7 +3588,7 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t* namedargs)
         if (!(mask(r) & *namedargs))         // named args are already dealt with
         {
             uint ea = (REX_W << 16) | modregxrm(2,r,BPRM);
-            if (!hasframe)
+            if (!hasframe || enforcealign)
                 ea = (REX_W << 16) | (modregrm(0,4,SP) << 8) | modregxrm(2,r,4);
             cdb.genc1(0x89,ea,FLconst,voff + i*8);
         }
@@ -3598,7 +3598,7 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t* namedargs)
     cdb.genc2(0xC1,modregrm(3,4,AX),2);                     // SHL EAX,2
     int raxoff = cast(int)(voff+6*8+0x7F);
     uint L2offset = (raxoff < -0x7F) ? 0x2D : 0x2A;
-    if (!hasframe)
+    if (!hasframe || enforcealign)
         L2offset += 1;                                      // +1 for sib byte
     // LEA R11,offset L2[RIP]
     cdb.genc1(LEA,(REX_W << 16) | modregxrm(0,R11,5),FLconst,L2offset);
@@ -3606,7 +3606,7 @@ void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t* namedargs)
     code_orrex(cdb.last(), REX_W);
     // LEA RAX,voff+vsize-6*8-16+0x7F[RBP]
     uint ea = (REX_W << 16) | modregrm(2,AX,BPRM);
-    if (!hasframe)
+    if (!hasframe || enforcealign)
         // add sib byte for [RSP] addressing
         ea = (REX_W << 16) | (modregrm(0,4,SP) << 8) | modregxrm(2,AX,4);
     cdb.genc1(LEA,ea,FLconst,raxoff);
@@ -3725,7 +3725,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, regm_t* n
                 if (s.Sclass == SCshadowreg)
                     offset = Para.size;
                 offset += s.Soffset;
-                if (!hasframe)
+                if (!hasframe || (enforcealign && s.Sclass != SCshadowreg))
                     offset += EBPtoESP;
 
                 uint preg = s.Spreg;
@@ -3737,7 +3737,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, regm_t* n
                         op = xmmstore(t.Tty);
                     if (!(pushalloc && preg == pushallocreg) || s.Sclass == SCshadowreg)
                     {
-                        if (hasframe)
+                        if (hasframe && (!enforcealign || s.Sclass == SCshadowreg))
                         {
                             // MOV x[EBP],preg
                             cdb.genc1(op,modregxrm(2,preg,BPRM),FLconst,offset);
@@ -4833,7 +4833,7 @@ void assignaddrc(code *c)
             else if (c.Iop == (ESCAPE | ESCframeptr))
             {   // Convert to load of frame pointer
                 // c.Irm is the register to use
-                if (hasframe)
+                if (hasframe && !enforcealign)
                 {   // MOV reg,EBP
                     c.Iop = 0x89;
                     if (c.Irm & 8)
@@ -4974,7 +4974,7 @@ void assignaddrc(code *c)
                     if (s.Sflags & SFLunambig)
                         c.Iflags |= CFunambig;
             L2:
-                    if (!hasframe)
+                    if (!hasframe || (enforcealign && c.IFL1 != FLpara))
                     {   /* Convert to ESP relative address instead of EBP */
                         assert(!I16);
                         c.IEV1.Vpointer += EBPtoESP;
@@ -5120,23 +5120,27 @@ void assignaddrc(code *c)
 
             case FLauto:
                 c.IEV2.Vpointer += s.Soffset + Auto.size + BPoff;
+            L3:
+                if (!hasframe || (enforcealign && c.IFL2 != FLpara))
+                    /* Convert to ESP relative address instead of EBP */
+                    c.IEV2.Vpointer += EBPtoESP;
                 break;
 
             case FLpara:
                 c.IEV2.Vpointer += s.Soffset + Para.size;
-                break;
+                goto L3;
 
             case FLfltreg:
                 c.IEV2.Vpointer += Foff + BPoff;
-                break;
+                goto L3;
 
             case FLallocatmp:
                 c.IEV2.Vpointer += Alloca.offset + BPoff;
-                break;
+                goto L3;
 
             case FLfuncarg:
                 c.IEV2.Vpointer += cgstate.funcarg.offset + BPoff;
-                break;
+                goto L3;
 
             case FLbprel:
                 c.IEV2.Vpointer += s.Soffset;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -3387,7 +3387,7 @@ void prolog_saveregs(ref CodeBuilder cdb, regm_t topush, int cfa_offset)
                     code *c = cdb.finish();
                     pinholeopt(c, null);
                     dwarf_CFA_set_loc(calcblksize(c));  // address after PUSH reg
-                    dwarf_CFA_offset(reg, -EBPtoESP - REGSIZE - cfa_offset);
+                    dwarf_CFA_offset(reg, -EBPtoESP - cfa_offset);
                     cdb.reset();
                     cdb.append(c);
                 }
@@ -4820,14 +4820,14 @@ void assignaddrc(code *c)
                 //printf("fix ESP\n");
                 if (hasframe)
                 {
-                    // LEA ESP,-EBPtoESP-REGSIZE[EBP]
+                    // LEA ESP,-EBPtoESP[EBP]
                     c.Iop = LEA;
                     if (c.Irm & 8)
                         c.Irex |= REX_R;
                     c.Irm = modregrm(2,SP,BP);
                     c.Iflags = CFoff;
                     c.IFL1 = FLconst;
-                    c.IEV1.Vuns = -EBPtoESP - REGSIZE;
+                    c.IEV1.Vuns = -EBPtoESP;
                 }
             }
             else if (c.Iop == (ESCAPE | ESCframeptr))

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -372,11 +372,11 @@ void cod3_set32()
 
 static if (TARGET_OSX)
 {
-    STACKALIGN = 16;   // 16 for OSX because OSX uses SIMD
+    TARGET_STACKALIGN = 16;   // 16 for OSX because OSX uses SIMD
 }
 else
 {
-    STACKALIGN = 4;
+    TARGET_STACKALIGN = 4;
 }
 }
 
@@ -403,7 +403,7 @@ else
     FLOATREGS = FLOATREGS_64;
     FLOATREGS2 = FLOATREGS2_64;
     DOUBLEREGS = DOUBLEREGS_64;
-    STACKALIGN = 16;
+    TARGET_STACKALIGN = 16;
 
     ALLREGS = mAX|mBX|mCX|mDX|mSI|mDI|  mR8|mR9|mR10|mR11|mR12|mR13|mR14|mR15;
     BYTEREGS = ALLREGS;
@@ -411,7 +411,7 @@ else
     for (uint i = 0x80; i < 0x90; i++)
         inssize2[i] = W|T|6;
 
-    STACKALIGN = 16;   // 16 rather than 8 because of SIMD alignment
+    TARGET_STACKALIGN = 16;   // 16 rather than 8 because of SIMD alignment
 }
 
 /*********************************

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -330,6 +330,7 @@ extern __gshared
         framehandleroffset;
     segidx_t cseg;
     int STACKALIGN;
+    int TARGET_STACKALIGN;
     LocalSection Para;
     LocalSection Fast;
     LocalSection Auto;

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -504,6 +504,7 @@ void cod3_align_bytes(int seg, size_t nbytes);
 void cod3_align(int seg);
 void cod3_buildmodulector(Outbuffer* buf, int codeOffset, int refOffset);
 void cod3_stackadj(ref CodeBuilder cdb, int nbytes);
+void cod3_stackalign(ref CodeBuilder cdb, int nbytes);
 regm_t regmask(tym_t tym, tym_t tyf);
 void cgreg_dst_regs(uint *dst_integer_reg, uint *dst_float_reg);
 void cgreg_set_priorities(tym_t ty, ubyte **pseq, ubyte **pseqmsw);
@@ -551,6 +552,7 @@ void code_dehydrate(code **pc);
 extern __gshared
 {
     int hasframe;            /* !=0 if this function has a stack frame */
+    bool enforcealign;       /* enforced stack alignment */
     targ_size_t spoff;
     targ_size_t Foff;        // BP offset of floating register
     targ_size_t CSoff;       // offset of common sub expressions
@@ -569,6 +571,7 @@ void prolog_frameadj(ref CodeBuilder cdb, tym_t tyf, uint xlocalsize, bool enter
 void prolog_frameadj2(ref CodeBuilder cdb, tym_t tyf, uint xlocalsize, bool* pushalloc);
 void prolog_setupalloca(ref CodeBuilder cdb);
 void prolog_saveregs(ref CodeBuilder cdb, regm_t topush, int cfa_offset);
+void prolog_stackalign(ref CodeBuilder cdb);
 void prolog_trace(ref CodeBuilder cdb, bool farfunc, uint* regsaved);
 void prolog_gen_win64_varargs(ref CodeBuilder cdb);
 void prolog_genvarargs(ref CodeBuilder cdb, Symbol* sv, regm_t* namedargs);

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -926,6 +926,15 @@ Lagain:
                 default:     r = RTLSYM_MEMSETN;    break;
             }
 
+            if (sz == 16 && !irs.params.is64bit && irs.params.isOSX && tyaggregate(evalue.Ety))
+            {
+                // cast to cdouble to match the parameter type
+                // otherwise it may not get the proper alignment
+                const tym = TYcdouble | (evalue.Ety & ~mTYbasic);
+                evalue = addressElem(evalue, tb);
+                evalue = el_una(OPind, tym, evalue);
+            }
+
             /* Determine if we need to do postblit
              */
             if (op != TOK.blit)

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1930,6 +1930,18 @@ void refIntrinsics()
 
 /*****************************************/
 
+void test6()
+{
+    version (D_AVX2)
+    {
+        // stack occasionally misaligned
+        long4 v;
+        v += 1;
+    }
+}
+
+/*****************************************/
+
 int main()
 {
     test1();
@@ -1969,6 +1981,8 @@ int main()
     test10447();
     test17344();
     test17356();
+
+    test6();
 
     return 0;
 }


### PR DESCRIPTION
The cause of these occasional failures is misalignment.