### PR TITLE
Fix issue ... - Corrupted result from float array concatenation

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -770,22 +770,7 @@ elem *array_toDarray(Type t, elem *e)
                 {
                     // Copy expression to a variable and take the
                     // address of that variable.
-                    Symbol *stmp;
-                    tym_t ty = tybasic(e.Ety);
-
-                    if (ty == TYstruct)
-                    {   uint sz = cast(uint)type_size(e.ET);
-                        if (sz <= 4)
-                            ty = TYint;
-                        else if (sz <= 8)
-                            ty = TYllong;
-                        else if (sz <= 16)
-                            ty = TYcent;
-                    }
-                    e.Ety = ty;
-                    stmp = symbol_genauto(type_fake(ty));
-                    e = el_bin(OPeq, e.Ety, el_var(stmp), e);
-                    e = el_bin(OPcomma, TYnptr, e, el_una(OPaddr, TYnptr, el_var(stmp)));
+                    e = addressElem(e, t);
                     break;
                 }
             }

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -318,7 +318,6 @@ void D_test2()
         assert( s2[0].i == 6 );
         assert( s2[1].i == 1 );
 
-/+      // These Fail on Mainline DMD64 ( Should pass! )
         assert( s3.length == 2 );
         assert( s3[0].i == 6 );
         assert( s3[1].i == 1 );
@@ -326,7 +325,7 @@ void D_test2()
         assert( s4.length == 2 );
         assert( s4[0].i == 6 );
         assert( s4[1].i == 1 );
-+/
+
         assert( s5.length == 2 );
         assert( s5[0].i == 6 );
         assert( s5[1].i == 1 );


### PR DESCRIPTION
The fix is to use the existing facilities for taking the address of an element instead of a lousy replication.
After checking, this turned out to be the reason why these commented out
test cases used to fail.