### PR TITLE
Make sure register value is copied to memory prior to calling memsetn().

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -988,7 +988,7 @@ Lagain:
             if (r == RTLSYM_MEMSETN)
             {
                 // void *_memsetn(void *p, void *value, int dim, int sizelem)
-                evalue = el_una(OPaddr, TYnptr, evalue);
+                evalue = addressElem(evalue, tb);
                 elem *esz = el_long(TYsize_t, sz);
                 elem *e = el_params(esz, edim, evalue, eptr, null);
                 e = el_bin(OPcall,TYnptr,el_var(getRtlsym(r)),e);


### PR DESCRIPTION
Can't take the address of a register.
This is a prerequisite for PR #9013.
This is not causing any problems right now since structs and static arrays of sizes 3, 5, 7 an so on (for which memsetn is used) never end up in registers because DMD does not completely respect Posix 64 ABI yet. 