### PR TITLE
add optimizer test from DMC++

### DIFF
--- a/test/compilable/ccompile.d
+++ b/test/compilable/ccompile.d
@@ -1,0 +1,36 @@
+
+/* REQUIRED_ARGS: -O
+ */
+
+// Adapted from DMC++ test file test3/ccompile.c
+
+
+    struct HDS        {
+      char state;
+      uint done;
+      uint retry;
+      uint[15] tests;
+   }
+
+void funchds(char *p_adults)
+{
+   int cupx, chemx;
+   HDS *p_cup;
+
+   for (cupx = 1, p_cup = null; cupx <=  48 ; cupx ++, p_cup ++)
+   {
+         for (chemx = 0; chemx <  15 ; chemx++)
+         {
+            if (p_cup.done) {
+               if (p_cup.tests [chemx]) {
+                     *p_adults++ = 3;
+               }
+               if (p_cup.done && (p_cup.tests [chemx])) {
+                     *p_adults++ = 4;
+               }
+            }
+         }
+   }
+}
+
+


### PR DESCRIPTION
This test started failing when https://github.com/dlang/dmd/pull/9113 is added, so converted it to D and adding it to the D test suite.