### PR TITLE
ParameterList: Fix opIndex signature and add C++ index operator

### DIFF
--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -539,7 +539,9 @@ struct ParameterList
     VarArg varargs;
 
     size_t length();
-    Parameter opIndex(size_t i);
+    Parameter *opIndex(size_t i);
+
+    Parameter *operator[](size_t i) { return opIndex(i); }
 };
 
 class TypeFunction : public TypeNext


### PR DESCRIPTION
With both this and `length()`, there is no reason for `Parameter::dim` and `Parameter::getNth` to be exposed in the C++ API.

I am open to instead having instead a conveniently named function specifically for C++ API that wraps around opIndex instead - marking opIndex as `extern(D)` whilst we're at it.