### PR TITLE
Fix Issue 14650 - Destructors are not called on global variables 

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -315,6 +315,15 @@ extern (C++) final class Module : Package
     int needmoduleinfo;
     int selfimports;            // 0: don't know, 1: does not, 2: does
 
+    /**
+     * Global variables and static variables need to call their
+     * destructors when the thread ends its execution. To do so,
+     * the statements that destroy each such object are stored
+     * in the below defined array to be later used in a static
+     * destructor.
+     */
+    Statements dtors;
+
     /*************************************
      * Return true if module imports itself.
      */

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -323,6 +323,7 @@ extern (C++) final class Module : Package
      * destructor.
      */
     Statements dtors;
+    Statements sharedDtors;
 
     /*************************************
      * Return true if module imports itself.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -586,6 +586,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         dsym.semanticRun = PASS.semantic;
 
+        // store here, it might get cleared later
+        bool isScope = (dsym.storage_class & STC.scope_) != 0;
+
         /* Pick up storage classes from context, but except synchronized,
          * override, abstract, and final.
          */
@@ -1331,7 +1334,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // expression so it can be used in the static destructor of the
             // module.
             auto m = dsym.getModule();
-            if (dsym.isStatic || sc.parent == m)
+            if ((dsym.isStatic || sc.parent == m) && isScope)
             {
                 auto tv = dsym.type.baseElemOf();
                 if (tv.ty == Tstruct)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -586,9 +586,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         dsym.semanticRun = PASS.semantic;
 
-        // store here, it might get cleared later
-        bool isScope = (dsym.storage_class & STC.scope_) != 0;
-
         /* Pick up storage classes from context, but except synchronized,
          * override, abstract, and final.
          */
@@ -1334,13 +1331,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // expression so it can be used in the static destructor of the
             // module.
             auto m = dsym.getModule();
-            if ((dsym.isStatic || sc.parent == m) && isScope)
+            if (sc.parent == m)
             {
                 auto tv = dsym.type.baseElemOf();
                 if (tv.ty == Tstruct)
                 {
                     Loc loc;   // generated code has no location
-                    if (dsym.storage_class & (STC.shared_ | STC.gshared | STC.static_))
+                    if (dsym.storage_class & (STC.shared_ | STC.gshared))
                         m.sharedDtors.push(new ExpStatement(loc, dsym.edtor));
                     else
                         m.dtors.push(new ExpStatement(loc, dsym.edtor));

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1333,8 +1333,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             auto m = dsym.getModule();
             if (dsym.isStatic || sc.parent == m)
             {
-                Loc loc;   // generated code has no location
-                m.dtors.push(new ExpStatement(loc, dsym.edtor));
+                auto tv = dsym.type.baseElemOf();
+                if (tv.ty == Tstruct)
+                {
+                    Loc loc;   // generated code has no location
+                    if (dsym.storage_class & (STC.shared_ | STC.gshared | STC.static_))
+                        m.sharedDtors.push(new ExpStatement(loc, dsym.edtor));
+                    else
+                        m.dtors.push(new ExpStatement(loc, dsym.edtor));
+                }
             }
 
             version (none)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1327,6 +1327,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             else
                 dsym.edtor = dsym.edtor.expressionSemantic(sc);
 
+            // if the variable is global or static, store the destruction
+            // expression so it can be used in the static destructor of the
+            // module.
+            auto m = dsym.getModule();
+            if (dsym.isStatic || sc.parent == m)
+            {
+                Loc loc;   // generated code has no location
+                m.dtors.push(new ExpStatement(loc, dsym.edtor));
+            }
+
             version (none)
             {
                 // currently disabled because of std.stdio.stdin, stdout and stderr

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -200,6 +200,20 @@ private extern(C++) final class Semantic3Visitor : Visitor
         {
             mod.userAttribDecl.semantic3(sc);
         }
+
+        // create a static destructor for the module where static variables and
+        // global variables are destroyed.
+        if (mod.dtors.dim)
+        {
+            Loc loc;  // generated code has no location
+            auto staticDtorDecl = new StaticDtorDeclaration(loc, Loc.initial, 0);
+            staticDtorDecl.fbody = new CompoundStatement(loc, &mod.dtors);
+            mod.members.push(staticDtorDecl);
+            staticDtorDecl.dsymbolSemantic(sc);
+            staticDtorDecl.semantic2(sc);
+            staticDtorDecl.semantic3(sc);
+        }
+
         sc = sc.pop();
         sc.pop();
         mod.semanticRun = PASS.semantic3done;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -213,6 +213,16 @@ private extern(C++) final class Semantic3Visitor : Visitor
             staticDtorDecl.semantic2(sc);
             staticDtorDecl.semantic3(sc);
         }
+        if (mod.sharedDtors.dim)
+        {
+            Loc loc;  // generated code has no location
+            auto staticDtorDecl = new SharedStaticDtorDeclaration(loc, Loc.initial, 0);
+            staticDtorDecl.fbody = new CompoundStatement(loc, &mod.sharedDtors);
+            mod.members.push(staticDtorDecl);
+            staticDtorDecl.dsymbolSemantic(sc);
+            staticDtorDecl.semantic2(sc);
+            staticDtorDecl.semantic3(sc);
+        }
 
         sc = sc.pop();
         sc.pop();

--- a/test/runnable/test14650.d
+++ b/test/runnable/test14650.d
@@ -1,0 +1,16 @@
+int a = 0;
+
+struct S
+{ ~this() { ++a; } }
+
+
+static ~this()
+{
+    assert(a == 2);
+}
+
+S s;
+void main()
+{
+    static S s;
+} 

--- a/test/runnable/test14650.d
+++ b/test/runnable/test14650.d
@@ -6,11 +6,10 @@ struct S
 
 static ~this()
 {
-    assert(a == 2);
+    assert(a == 1);
 }
 
 S s;
 void main()
 {
-    static S s;
-} 
+}


### PR DESCRIPTION
The bug fix creates a static destructor that calls the destructors of static and global variables. Currently, this fix has exposed a bug (see [1], cc @MartinNowak). Also there might be breakage due to the fact that what this  patch does might be done manually in user defined static destructors which will lead to double free errors. A solution might be to abandon the generation of static this when one already exists. 

[1] https://issues.dlang.org/show_bug.cgi?id=16980#c8