### PR TITLE
Fix Issue 19520 - assert(TypeExp is TypeExp): compiles with empty structs

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -10307,6 +10307,12 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (f1 || f2)
             return setError();
 
+        if (exp.e1.op == TOK.type || exp.e2.op == TOK.type)
+        {
+            result = exp.incompatibleTypes();
+            return;
+        }
+
         exp.type = Type.tbool;
 
         if (exp.e1.type != exp.e2.type && exp.e1.type.isfloating() && exp.e2.type.isfloating())

--- a/test/fail_compilation/fail19520.d
+++ b/test/fail_compilation/fail19520.d
@@ -1,0 +1,21 @@
+/* https://issues.dlang.org/show_bug.cgi?id=19520
+TEST_OUTPUT:
+---
+fail_compilation/fail19520.d(17): Error: incompatible types for `(Empty) is (Empty)`: cannot use `is` with types
+fail_compilation/fail19520.d(17):        while evaluating: `static assert((Empty) is (Empty))`
+fail_compilation/fail19520.d(18): Error: incompatible types for `(WithSym) is (WithSym)`: cannot use `is` with types
+fail_compilation/fail19520.d(18):        while evaluating: `static assert((WithSym) is (WithSym))`
+fail_compilation/fail19520.d(19): Error: incompatible types for `(Empty) is (Empty)`: cannot use `is` with types
+fail_compilation/fail19520.d(20): Error: incompatible types for `(WithSym) is (WithSym)`: cannot use `is` with types
+---
+*/
+struct Empty { }
+struct WithSym { int i; }
+
+void test()
+{
+    static assert(Empty is Empty);
+    static assert(WithSym is WithSym);
+    assert(Empty is Empty);
+    assert(WithSym is WithSym);
+}

--- a/test/runnable/e7804.d
+++ b/test/runnable/e7804.d
@@ -70,7 +70,7 @@ TmpPrm!(__traits(getMember, Foo, "MyInt")) tpt = TmpPrm!(__traits(getMember, Foo
         assert(vm[0](42) == 42);
         alias attribs = __traits(getAttributes, Class);
         assert(attribs.length == 2);
-        assert(attribs[0] is Foo);
+        assert(is(typeof(attribs[0]()) == Foo));
         assert(attribs[1] == 1);
 
         alias objectAll = __traits(allMembers, Object);


### PR DESCRIPTION
Reject it as invalid code, and fix-up the test that exposed the bug.