### PR TITLE
add handy spec links to statement.d

### DIFF
--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -637,6 +637,7 @@ private Statement toStatement(Dsymbol s)
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#ExpressionStatement
  */
 extern (C++) class ExpStatement : Statement
 {
@@ -1126,6 +1127,7 @@ extern (C++) final class ForwardingStatement : Statement
 
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#while-statement
  */
 extern (C++) final class WhileStatement : Statement
 {
@@ -1166,6 +1168,7 @@ extern (C++) final class WhileStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#do-statement
  */
 extern (C++) final class DoStatement : Statement
 {
@@ -1206,6 +1209,7 @@ extern (C++) final class DoStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#for-statement
  */
 extern (C++) final class ForStatement : Statement
 {
@@ -1324,6 +1328,7 @@ extern (C++) final class ForeachStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#foreach-range-statement
  */
 extern (C++) final class ForeachRangeStatement : Statement
 {
@@ -1369,6 +1374,7 @@ extern (C++) final class ForeachRangeStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#if-statement
  */
 extern (C++) final class IfStatement : Statement
 {
@@ -1411,6 +1417,7 @@ extern (C++) final class IfStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/version.html#ConditionalStatement
  */
 extern (C++) final class ConditionalStatement : Statement
 {
@@ -1459,6 +1466,7 @@ extern (C++) final class ConditionalStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/version.html#StaticForeachStatement
  * Static foreach statements, like:
  *      void main()
  *      {
@@ -1514,6 +1522,7 @@ extern (C++) final class StaticForeachStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#pragma-statement
  */
 extern (C++) final class PragmaStatement : Statement
 {
@@ -1541,6 +1550,7 @@ extern (C++) final class PragmaStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/version.html#StaticAssert
  */
 extern (C++) final class StaticAssertStatement : Statement
 {
@@ -1564,12 +1574,13 @@ extern (C++) final class StaticAssertStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#switch-statement
  */
 extern (C++) final class SwitchStatement : Statement
 {
     Expression condition;           /// switch(condition)
     Statement _body;                ///
-    bool isFinal;                   ///
+    bool isFinal;                   /// https://dlang.org/spec/statement.html#final-switch-statement
 
     DefaultStatement sdefault;      /// default:
     TryFinallyStatement tf;         ///
@@ -1644,6 +1655,7 @@ extern (C++) final class SwitchStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#CaseStatement
  */
 extern (C++) final class CaseStatement : Statement
 {
@@ -1683,6 +1695,7 @@ extern (C++) final class CaseStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#CaseRangeStatement
  */
 extern (C++) final class CaseRangeStatement : Statement
 {
@@ -1710,6 +1723,7 @@ extern (C++) final class CaseRangeStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#DefaultStatement
  */
 extern (C++) final class DefaultStatement : Statement
 {
@@ -1739,6 +1753,7 @@ extern (C++) final class DefaultStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#GotoStatement
  */
 extern (C++) final class GotoDefaultStatement : Statement
 {
@@ -1766,6 +1781,7 @@ extern (C++) final class GotoDefaultStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#GotoStatement
  */
 extern (C++) final class GotoCaseStatement : Statement
 {
@@ -1818,6 +1834,7 @@ extern (C++) final class SwitchErrorStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#return-statement
  */
 extern (C++) final class ReturnStatement : Statement
 {
@@ -1847,6 +1864,7 @@ extern (C++) final class ReturnStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#break-statement
  */
 extern (C++) final class BreakStatement : Statement
 {
@@ -1875,6 +1893,7 @@ extern (C++) final class BreakStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#continue-statement
  */
 extern (C++) final class ContinueStatement : Statement
 {
@@ -1898,6 +1917,7 @@ extern (C++) final class ContinueStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#SynchronizedStatement
  */
 extern (C++) final class SynchronizedStatement : Statement
 {
@@ -1933,6 +1953,7 @@ extern (C++) final class SynchronizedStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#with-statement
  */
 extern (C++) final class WithStatement : Statement
 {
@@ -1961,6 +1982,7 @@ extern (C++) final class WithStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#try-statement
  */
 extern (C++) final class TryCatchStatement : Statement
 {
@@ -1996,6 +2018,7 @@ extern (C++) final class TryCatchStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#Catch
  */
 extern (C++) final class Catch : RootObject
 {
@@ -2028,6 +2051,7 @@ extern (C++) final class Catch : RootObject
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#try-statement
  */
 extern (C++) final class TryFinallyStatement : Statement
 {
@@ -2071,6 +2095,7 @@ extern (C++) final class TryFinallyStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#scope-guard-statement
  */
 extern (C++) final class OnScopeStatement : Statement
 {
@@ -2142,6 +2167,7 @@ extern (C++) final class OnScopeStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#throw-statement
  */
 extern (C++) final class ThrowStatement : Statement
 {
@@ -2206,6 +2232,7 @@ extern (C++) final class DebugStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#goto-statement
  */
 extern (C++) final class GotoStatement : Statement
 {
@@ -2292,6 +2319,7 @@ extern (C++) final class GotoStatement : Statement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#LabeledStatement
  */
 extern (C++) final class LabelStatement : Statement
 {
@@ -2390,6 +2418,7 @@ extern (C++) final class LabelDsymbol : Dsymbol
 }
 
 /***********************************************************
+ * https://dlang.org/spec/statement.html#asm
  */
 extern (C++) class AsmStatement : Statement
 {
@@ -2506,6 +2535,7 @@ extern (C++) final class CompoundAsmStatement : CompoundStatement
 }
 
 /***********************************************************
+ * https://dlang.org/spec/module.html#ImportDeclaration
  */
 extern (C++) final class ImportStatement : Statement
 {


### PR DESCRIPTION
By making comparisons convenient, this will help keep the spec and the code in sync.