### PR TITLE
rename OnScopeStatement to ScopeGuardStatement

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2135,7 +2135,7 @@ struct ASTBase
         }
     }
 
-    extern (C++) final class OnScopeStatement : Statement
+    extern (C++) final class ScopeGuardStatement : Statement
     {
         TOK tok;
         Statement statement;

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -461,7 +461,7 @@ int blockExit(Statement s, FuncDeclaration func, bool mustNotThrow)
             result |= finalresult & ~BE.fallthru;
         }
 
-        override void visit(OnScopeStatement s)
+        override void visit(ScopeGuardStatement s)
         {
             // At this point, this statement is just an empty placeholder
             result = BE.fallthru;

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -481,11 +481,11 @@ public:
             ctfeCompile(s.elsebody);
     }
 
-    override void visit(OnScopeStatement s)
+    override void visit(ScopeGuardStatement s)
     {
         debug (LOGCOMPILE)
         {
-            printf("%s OnScopeStatement::ctfeCompile\n", s.loc.toChars());
+            printf("%s ScopeGuardStatement::ctfeCompile\n", s.loc.toChars());
         }
         // rewritten to try/catch/finally
         assert(0);
@@ -1874,7 +1874,7 @@ public:
         result = new ThrownExceptionExp(s.loc, cast(ClassReferenceExp)e);
     }
 
-    override void visit(OnScopeStatement s)
+    override void visit(ScopeGuardStatement s)
     {
         assert(0);
     }

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -76,7 +76,7 @@ struct Scope
     LabelStatement slabel;          /// enclosing labelled statement
     SwitchStatement sw;             /// enclosing switch statement
     TryFinallyStatement tf;         /// enclosing try finally statement
-    OnScopeStatement os;            /// enclosing scope(xxx) statement
+    ScopeGuardStatement os;            /// enclosing scope(xxx) statement
     Statement sbreak;               /// enclosing statement that supports "break"
     Statement scontinue;            /// enclosing statement that supports "continue"
     ForeachStatement fes;           /// if nested function for ForeachStatement, this is it

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -193,7 +193,7 @@ private FuncDeclaration buildPostBlit(StructDeclaration sd, Scope* sc)
             }
 
             // put destructor calls in a `scope(failure)` block
-            postblitCalls.push(new OnScopeStatement(loc, TOK.onScopeFailure, new CompoundStatement(loc, dtors)));
+            postblitCalls.push(new ScopeGuardStatement(loc, TOK.onScopeFailure, new CompoundStatement(loc, dtors)));
         }
 
         // perform semantic on the member postblit in order to

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -633,7 +633,7 @@ public:
         }
     }
 
-    override void visit(OnScopeStatement s)
+    override void visit(ScopeGuardStatement s)
     {
         buf.writestring(Token.toString(s.tok));
         buf.writeByte(' ');

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -5887,7 +5887,7 @@ final class Parser(AST) : Lexer
                 nextToken();
                 check(TOK.rightParentheses);
                 AST.Statement st = parseStatement(ParseStatementFlags.scope_);
-                s = new AST.OnScopeStatement(loc, t, st);
+                s = new AST.ScopeGuardStatement(loc, t, st);
                 break;
             }
 

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -100,7 +100,7 @@ public:
     void visit(AST.ForeachRangeStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.ForeachStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.IfStatement s) { visit(cast(AST.Statement)s); }
-    void visit(AST.OnScopeStatement s) { visit(cast(AST.Statement)s); }
+    void visit(AST.ScopeGuardStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.ConditionalStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.StaticForeachStatement s) { visit(cast(AST.Statement)s); }
     void visit(AST.PragmaStatement s) { visit(cast(AST.Statement)s); }

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -186,7 +186,7 @@ private extern (C++) class S2irVisitor : Visitor
     /*************************************
      */
 
-    override void visit(OnScopeStatement s)
+    override void visit(ScopeGuardStatement s)
     {
     }
 

--- a/src/dmd/sapply.d
+++ b/src/dmd/sapply.d
@@ -156,7 +156,7 @@ public:
         doCond(s._body) || doCond(s.finalbody) || applyTo(s);
     }
 
-    override void visit(OnScopeStatement s)
+    override void visit(ScopeGuardStatement s)
     {
         doCond(s.statement) || applyTo(s);
     }

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -66,7 +66,7 @@ struct Scope
     LabelStatement *slabel;     // enclosing labelled statement
     SwitchStatement *sw;        // enclosing switch statement
     TryFinallyStatement *tf;    // enclosing try finally statement
-    OnScopeStatement *os;       // enclosing scope(xxx) statement
+    ScopeGuardStatement *os;       // enclosing scope(xxx) statement
     Statement *sbreak;          // enclosing statement that supports "break"
     Statement *scontinue;       // enclosing statement that supports "continue"
     ForeachStatement *fes;      // if nested function for ForeachStatement, this is it

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1309,7 +1309,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                  * Hopefully we can use this version someday when scope(failure) catches
                  * Exception instead of Throwable.
                  */
-                auto s = new OnScopeStatement(ctor.loc, TOK.onScopeFailure, ss);
+                auto s = new ScopeGuardStatement(ctor.loc, TOK.onScopeFailure, ss);
                 ctor.fbody = new CompoundStatement(ctor.loc, s, ctor.fbody);
             }
         }

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -199,7 +199,7 @@ extern (C++) abstract class Statement : RootObject
                 stop = true;
             }
 
-            override void visit(OnScopeStatement s)
+            override void visit(ScopeGuardStatement s)
             {
                 stop = true;
             }
@@ -2072,7 +2072,7 @@ extern (C++) final class TryFinallyStatement : Statement
 
 /***********************************************************
  */
-extern (C++) final class OnScopeStatement : Statement
+extern (C++) final class ScopeGuardStatement : Statement
 {
     TOK tok;
     Statement statement;
@@ -2086,12 +2086,12 @@ extern (C++) final class OnScopeStatement : Statement
 
     override Statement syntaxCopy()
     {
-        return new OnScopeStatement(loc, tok, statement.syntaxCopy());
+        return new ScopeGuardStatement(loc, tok, statement.syntaxCopy());
     }
 
     override Statement scopeCode(Scope* sc, Statement* sentry, Statement* sexception, Statement* sfinally)
     {
-        //printf("OnScopeStatement::scopeCode()\n");
+        //printf("ScopeGuardStatement::scopeCode()\n");
         *sentry = null;
         *sexception = null;
         *sfinally = null;
@@ -2212,7 +2212,7 @@ extern (C++) final class GotoStatement : Statement
     Identifier ident;
     LabelDsymbol label;
     TryFinallyStatement tf;
-    OnScopeStatement os;
+    ScopeGuardStatement os;
     VarDeclaration lastVar;
 
     extern (D) this(const ref Loc loc, Identifier ident)
@@ -2298,7 +2298,7 @@ extern (C++) final class LabelStatement : Statement
     Identifier ident;
     Statement statement;
     TryFinallyStatement tf;
-    OnScopeStatement os;
+    ScopeGuardStatement os;
     VarDeclaration lastVar;
     Statement gotoTarget;       // interpret
     bool breaks;                // someone did a 'break ident'

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -577,7 +577,7 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class OnScopeStatement : public Statement
+class ScopeGuardStatement : public Statement
 {
 public:
     TOK tok;
@@ -618,7 +618,7 @@ public:
     Identifier *ident;
     LabelDsymbol *label;
     TryFinallyStatement *tf;
-    OnScopeStatement *os;
+    ScopeGuardStatement *os;
     VarDeclaration *lastVar;
 
     Statement *syntaxCopy();
@@ -632,7 +632,7 @@ public:
     Identifier *ident;
     Statement *statement;
     TryFinallyStatement *tf;
-    OnScopeStatement *os;
+    ScopeGuardStatement *os;
     VarDeclaration *lastVar;
     Statement *gotoTarget;      // interpret
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2187,7 +2187,7 @@ else
             if (ifs.match.edtor)
             {
                 Statement sdtor = new DtorExpStatement(ifs.loc, ifs.match.edtor, ifs.match);
-                sdtor = new OnScopeStatement(ifs.loc, TOK.onScopeExit, sdtor);
+                sdtor = new ScopeGuardStatement(ifs.loc, TOK.onScopeExit, sdtor);
                 ifs.ifbody = new CompoundStatement(ifs.loc, sdtor, ifs.ifbody);
                 ifs.match.storage_class |= STC.nodtor;
             }
@@ -3903,7 +3903,7 @@ else
         result = tfs;
     }
 
-    override void visit(OnScopeStatement oss)
+    override void visit(ScopeGuardStatement oss)
     {
         /* https://dlang.org/spec/statement.html#scope-guard-statement
          */

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -78,7 +78,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.ForeachRangeStatement) { assert(0); }
     override void visit(AST.ForeachStatement) { assert(0); }
     override void visit(AST.IfStatement) { assert(0); }
-    override void visit(AST.OnScopeStatement) { assert(0); }
+    override void visit(AST.ScopeGuardStatement) { assert(0); }
     override void visit(AST.ConditionalStatement) { assert(0); }
     override void visit(AST.PragmaStatement) { assert(0); }
     override void visit(AST.SwitchStatement) { assert(0); }

--- a/src/dmd/transitivevisitor.d
+++ b/src/dmd/transitivevisitor.d
@@ -272,9 +272,9 @@ package mixin template ParseVisitMethods(AST)
         s.finalbody.accept(this);
     }
 
-    override void visit(AST.OnScopeStatement s)
+    override void visit(AST.ScopeGuardStatement s)
     {
-        //printf("Visiting OnScopeStatement\n");
+        //printf("Visiting ScopeGuardStatement\n");
         s.statement.accept(this);
     }
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -46,7 +46,7 @@ class SynchronizedStatement;
 class WithStatement;
 class TryCatchStatement;
 class TryFinallyStatement;
-class OnScopeStatement;
+class ScopeGuardStatement;
 class ThrowStatement;
 class DebugStatement;
 class GotoStatement;
@@ -387,7 +387,7 @@ public:
     virtual void visit(ForeachRangeStatement *s) { visit((Statement *)s); }
     virtual void visit(ForeachStatement *s) { visit((Statement *)s); }
     virtual void visit(IfStatement *s) { visit((Statement *)s); }
-    virtual void visit(OnScopeStatement *s) { visit((Statement *)s); }
+    virtual void visit(ScopeGuardStatement *s) { visit((Statement *)s); }
     virtual void visit(ConditionalStatement *s) { visit((Statement *)s); }
     virtual void visit(StaticForeachStatement *s) { visit((Statement *)s); }
     virtual void visit(PragmaStatement *s) { visit((Statement *)s); }


### PR DESCRIPTION
so it matches the Specification.

https://dlang.org/spec/statement.html#scope-guard-statement

It's endlessly annoying that they don't match.