### PR TITLE
gsroa.d: modernize the code

### DIFF
--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -53,7 +53,13 @@ struct SymInfo
     SYMIDX si0;
 }
 
-private void sliceStructs_Gather(SymInfo *sia, elem *e)
+/********************************
+ * Gather information about slice-able variables by scanning e.
+ * Params:
+ *      e = expression to scan
+ *      sia = where to put gathered information
+ */
+extern (D) private void sliceStructs_Gather(SymInfo[] sia, const(elem)* e)
 {
     while (1)
     {
@@ -61,11 +67,11 @@ private void sliceStructs_Gather(SymInfo *sia, elem *e)
         {
             case OPvar:
             {
-                SYMIDX si = e.EV.Vsym.Ssymnum;
+                const si = e.EV.Vsym.Ssymnum;
                 if (si >= 0 && sia[si].canSlice)
                 {
                     assert(si < globsym.top);
-                    uint sz = tysize(e.Ety);
+                    const sz = tysize(e.Ety);
                     if (sz == 2 * REGSIZE && !tyfv(e.Ety))
                     {
                         // Rewritten as OPpair later
@@ -103,8 +109,8 @@ private void sliceStructs_Gather(SymInfo *sia, elem *e)
                     // Assignment to a whole var will disallow SROA
                     if (e.EV.E1.Eoper == OPvar)
                     {
-                        elem *e1 = e.EV.E1;
-                        SYMIDX si = e1.EV.Vsym.Ssymnum;
+                        const e1 = e.EV.E1;
+                        const si = e1.EV.Vsym.Ssymnum;
                         if (si >= 0 && sia[si].canSlice)
                         {
                             assert(si < globsym.top);
@@ -114,6 +120,8 @@ private void sliceStructs_Gather(SymInfo *sia, elem *e)
                                 sia[si].canSlice = false;
                             }
                             // Disable SROA on OSX32 (because XMM registers?)
+                            // https://issues.dlang.org/show_bug.cgi?id=15206
+                            // https://github.com/dlang/dmd/pull/8034
                             else if (!(config.exe & EX_OSX))
                             {
                                 sliceStructs_Gather(sia, e.EV.E1);
@@ -140,7 +148,13 @@ private void sliceStructs_Gather(SymInfo *sia, elem *e)
     }
 }
 
-private void sliceStructs_Replace(SymInfo *sia, elem *e)
+/***********************************
+ * Rewrite expression tree e based on info in sia[].
+ * Params:
+ *      sia = slicing info
+ *      e = expression tree to rewrite in place
+ */
+extern (D) private void sliceStructs_Replace(const SymInfo[] sia, elem *e)
 {
     while (1)
     {
@@ -149,7 +163,7 @@ private void sliceStructs_Replace(SymInfo *sia, elem *e)
             case OPvar:
             {
                 Symbol *s = e.EV.Vsym;
-                SYMIDX si = s.Ssymnum;
+                const si = s.Ssymnum;
                 //printf("e: %d %d\n", si, sia[si].canSlice);
                 //elem_print(e);
                 if (si >= 0 && sia[si].canSlice)
@@ -228,16 +242,28 @@ private void sliceStructs_Replace(SymInfo *sia, elem *e)
 void sliceStructs()
 {
     if (debugc) printf("sliceStructs()\n");
-    size_t sia_length = globsym.top;
+    const sia_length = globsym.top;
     /* 3 is because it is used for two arrays, sia[] and sia2[].
      * sia2[] can grow to twice the size of sia[], as symbols can get split into two.
      */
-    SymInfo *sia = cast(SymInfo *)malloc(3 * sia_length * SymInfo.sizeof);
-    assert(sia);
-    SymInfo *sia2 = sia + sia_length;
+    debug
+        enum tmp_length = 3;
+    else
+        enum tmp_length = 6;
+    SymInfo[tmp_length] tmp = void;
+    SymInfo* sip;
+    if (sia_length <= tmp.length / 3)
+        sip = tmp.ptr;
+    else
+    {
+        sip = cast(SymInfo *)malloc(3 * sia_length * SymInfo.sizeof);
+        assert(sip);
+    }
+    SymInfo[] sia = sip[0 .. sia_length];
+    SymInfo[] sia2 = sip[sia_length .. sia_length * 3];
 
     bool anySlice = false;
-    for (int si = 0; si < globsym.top; si++)
+    foreach (si; 0 .. globsym.top)
     {
         Symbol *s = globsym.tab[si];
         //printf("slice1: %s\n", s.Sident);
@@ -248,7 +274,7 @@ void sliceStructs()
             continue;
         }
 
-        targ_size_t sz = type_size(s.Stype);
+        const sz = type_size(s.Stype);
         if (sz != 2 * REGSIZE ||
             tyfv(s.Stype.Tty) || tybasic(s.Stype.Tty) == TYhptr)    // because there is no TYseg
         {
@@ -290,7 +316,7 @@ void sliceStructs()
     if (!anySlice)
         goto Ldone;
 
-    for (block *b = startblock; b; b = b.Bnext)
+    foreach (b; BlockRange(startblock))
     {
         if (b.BC == BCasm)
             goto Ldone;
@@ -301,7 +327,7 @@ void sliceStructs()
     {   // scope needed because of goto skipping declarations
         bool any = false;
         int n = 0;              // the number of symbols added
-        for (int si = 0; si < sia_length; si++)
+        foreach (si; 0 .. sia_length)
         {
             sia2[si + n].canSlice = false;
             if (sia[si].canSlice)
@@ -318,7 +344,7 @@ void sliceStructs()
                  */
                 Symbol *sold = globsym.tab[si + n];
 
-                size_t idlen = 2 + strlen(sold.Sident.ptr) + 2;
+                const idlen = 2 + strlen(sold.Sident.ptr) + 2;
                 char *id = cast(char *)malloc(idlen + 1);
                 assert(id);
                 sprintf(id, "__%s_%d", sold.Sident.ptr, REGSIZE);
@@ -340,7 +366,7 @@ void sliceStructs()
                 snew.Stype = type_fake(sia[si].ty1);
                 snew.Stype.Tcount++;
 
-                SYMIDX sinew = symbol_add(snew);
+                const sinew = symbol_add(snew);
                 for (int i = sinew; i > si + n + 1; --i)
                 {
                     globsym.tab[i] = globsym.tab[i - 1];
@@ -361,20 +387,21 @@ void sliceStructs()
             goto Ldone;
     }
 
-    for (int si = 0; si < globsym.top; si++)
+    foreach (si; 0 .. globsym.top)
     {
         Symbol *s = globsym.tab[si];
         assert(s.Ssymnum == si);
     }
 
-    for (block *b = startblock; b; b = b.Bnext)
+    foreach (b; BlockRange(startblock))
     {
         if (b.Belem)
             sliceStructs_Replace(sia2, b.Belem);
     }
 
 Ldone:
-    free(sia);
+    if (sip != tmp.ptr)
+        free(sip);
 }
 
 }


### PR DESCRIPTION
Use arrays instead of pointers, use `const` wherever possible, use `foreach` loops, and only `malloc` for larger temporaries.