### PR TITLE
pull symbol_insert() into its own function

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -357,6 +357,8 @@ baseclass_t *baseclass_find_nest(baseclass_t *bm,Classsym *sbase);
 int baseclass_nitems(baseclass_t *b);
 void symbol_free(Symbol *s);
 SYMIDX symbol_add(Symbol *s);
+SYMIDX symbol_add(symtab_t*, Symbol *s);
+SYMIDX symbol_insert(symtab_t*, Symbol *s, SYMIDX n);
 void freesymtab(Symbol **stab, SYMIDX n1, SYMIDX n2);
 Symbol *symbol_copy(Symbol *s);
 Symbol *symbol_searchlist(symlist_t sl, const(char)* vident);

--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -366,14 +366,8 @@ void sliceStructs()
                 snew.Stype = type_fake(sia[si].ty1);
                 snew.Stype.Tcount++;
 
-                const sinew = symbol_add(snew);
-                for (int i = sinew; i > si + n + 1; --i)
-                {
-                    globsym.tab[i] = globsym.tab[i - 1];
-                    globsym.tab[i].Ssymnum += 1;
-                }
-                globsym.tab[si + n + 1] = snew;
-                snew.Ssymnum = si + n + 1;
+                // insert snew into globsym.tab[si + n + 1]
+                symbol_insert(&globsym, snew, si + n + 1);
 
                 sia2[si + n].canSlice = true;
                 sia2[si + n].si0 = si + n;


### PR DESCRIPTION
The code is a lot easier to understand when outlined rather than inlined. Also removed global references from `symbol_add()`.