### PR TITLE
Properly version or remove X86 inline assembly in runnable tests

### DIFF
--- a/test/runnable/ctorpowtests.d
+++ b/test/runnable/ctorpowtests.d
@@ -2,19 +2,19 @@
 
 int magicVariable()
 {
-  if (__ctfe)
-   return 3;
+    if (__ctfe)
+        return 3;
 
-  asm { nop; }
-  return 2;
+    shared int var = 2;
+    return var;
 }
 
 static assert(magicVariable()==3);
 
 void main()
 {
-  assert(!__ctfe);
-  assert(magicVariable()==2);
+    assert(!__ctfe);
+    assert(magicVariable()==2);
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=991 -- invalid.
@@ -112,10 +112,14 @@ struct StructWithCtor
     float x;
 }
 
-int containsAsm() {
-       asm { nop; }
-       return 0;
-    }
+int containsAsm()
+{
+    version (D_InlineAsm_X86)
+        asm { nop; }
+    else version (D_InlineAsm_X86_64)
+        asm { nop; }
+    return 0;
+}
 
 enum A = StructWithCtor(1);
 enum B = StructWithCtor(7, 2.3);

--- a/test/runnable/test23.d
+++ b/test/runnable/test23.d
@@ -357,6 +357,13 @@ void test16()
 
 void test17()
 {
+    version(D_InlineAsm_X86_64)
+        enum AsmX86 = true;
+    else version(D_InlineAsm_X86)
+        enum AsmX86 = true;
+    else
+        enum AsmX86 = false;
+
     version (OSX)
     {
     }
@@ -365,9 +372,17 @@ void test17()
         const f = 1.2f;
         float g = void;
 
-        asm{
+        static if (AsmX86)
+        {
+            asm
+            {
                 fld f;  // doesn't work with PIC
                 fstp g;
+            }
+        }
+        else
+        {
+            g = f;
         }
         assert(g == 1.2f);
     }

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -697,18 +697,18 @@ void test34()
 
 void foo35()
 {
-        uint a;
-        uint b;
-        uint c;
-        extern (Windows) int function(int i, int j, int k) xxx;
+    uint a;
+    uint b;
+    uint c;
+    extern (Windows) int function(int i, int j, int k) xxx;
 
-        a = 1;
-        b = 2;
-        c = 3;
+    a = 1;
+    b = 2;
+    c = 3;
 
-        xxx = cast(typeof(xxx))(a + b);
-        asm { int 3; }
-        xxx( 4, 5, 6 );
+    xxx = cast(typeof(xxx))(a + b);
+    throw new Exception("xxx");
+    xxx( 4, 5, 6 );
 }
 
 void test35()

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -2421,21 +2421,22 @@ bool foo150()
 
 void crash(int x)
 {
-  if (x==200) return;
-   asm { int 3; }
+    if (x==200) return;
+    assert(0);
 }
 
 void test151()
 {
-   int x;
-   bug3521(&x);
+    int x;
+    bug3521(&x);
 }
 
-void bug3521(int *a){
+void bug3521(int *a)
+{
     int c = 0;
     *a = 0;
     if ( *a || (*a != (c = 200)) )
-       crash(c);
+        crash(c);
 }
 
 /***************************************************/
@@ -4169,10 +4170,22 @@ void oddity4001()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=3809
 
-int bug3809() { asm { nop; } return 0; }
-struct BUG3809 { int xx; }
-void bug3809b() {
+int bug3809()
+{
+    static int a = 0;
+    return a;
+}
+
+struct BUG3809
+{
+    int xx;
+}
+
+void bug3809b()
+{
+    BUG3809 b = { bug3809() };
 }
 
 /***************************************************/

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -207,7 +207,10 @@ void safeexception()
 @safe
 void inlineasm()
 {
-    static assert(!__traits(compiles, { asm { int 3; } }() ));
+    version (D_InlineAsm_X86)
+        static assert(!__traits(compiles, { asm { int 3; } }() ));
+    else version (D_InlineAsm_X86_64)
+        static assert(!__traits(compiles, { asm { int 3; } }() ));
 }
 
 @safe


### PR DESCRIPTION
- runnable/ctorpowtests.d (magicVariable): Test only checks that CTFE never attempts to evaluate non-CTFEable code.  Replaced asm with global variable.
- runnable/ctorpowtests.d (containsAsm): Move asm test into D_InlineAsm_X86 version.
- runnable/test23.d (test17): Move asm test into static if AsmX86 condition, use plain assignment in else branch.
- runnable/test34.d (foo35): Function is never called during run test, replaced `int 3` with `throw new Exception`.
- runnable/test42.d (crash): Original bug report did not contain asm, actual test is for optimization bug in bug3521.  Replaced `int 3` with `assert(0)`.
- runnable/test42.d (bug3809): Original bug report did not contain asm, actual test is ensuring CTFE does not error at compile-time. Test-case was found to be incomplete, added missing line that checks the actual bug!  Replaced asm with static variable.
- runnable/testsafe.d (inlineasm): Move asm test into D_InlineAsm_X86 version condition.

Upstreamed from gdc, which doesn't support dmd-style iasm.  There are other tests in fail_compilation and compilable that have iasm, but they are not included with gdc's mirror of the dmd testsuite, or are replicated in the dejagnu testsuite using gcc-style iasm.