### PR TITLE
cppmangle.d: target.cppMangleType should have preference over standard mangling

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1264,6 +1264,22 @@ extern(C++):
         if (t.isImmutable() || t.isShared())
             return error(t);
 
+        // Handle any target-specific basic types.
+        if (auto tm = target.cppTypeMangle(t))
+        {
+            // Only do substitutions for non-fundamental types.
+            if (!isFundamentalType(t) || t.isConst())
+            {
+                if (substitute(t))
+                    return;
+                else
+                    append(t);
+            }
+            CV_qualifiers(t);
+            buf.writestring(tm);
+            return;
+        }
+
         /* <builtin-type>:
          * v        void
          * w        wchar_t
@@ -1328,21 +1344,6 @@ extern(C++):
             case Tcomplex80:    p = 'C'; c = 'e';       break;
 
             default:
-                // Handle any target-specific basic types.
-                if (auto tm = target.cppTypeMangle(t))
-                {
-                    // Only do substitutions for non-fundamental types.
-                    if (!isFundamentalType(t) || t.isConst())
-                    {
-                        if (substitute(t))
-                            return;
-                        else
-                            append(t);
-                    }
-                    CV_qualifiers(t);
-                    buf.writestring(tm);
-                    return;
-                }
                 return error(t);
         }
         writeBasicType(t, p, c);

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -79,6 +79,7 @@ struct Target
     const char *cppTypeInfoMangle(ClassDeclaration *cd);
     const char *cppTypeMangle(Type *t);
     Type *cppParameterType(Parameter *p);
+    bool cppFundamentalType(const Type *t, bool& isFundamental);
     LINK systemLinkage();
     TypeTuple *toArgTypes(Type *t);
     bool isReturnOnStack(TypeFunction *tf, bool needsThis);


### PR DESCRIPTION
This is particularly important for getting real type mangling correct on platforms where long doubles should be mangled as 'g' (mostly Linux).