### PR TITLE
fix building dmd with 2.084

### DIFF
--- a/src/dmd/scanmach.d
+++ b/src/dmd/scanmach.d
@@ -16,7 +16,7 @@ version(OSX):
 
 import core.stdc.string;
 import core.stdc.stdint;
-import core.sys.osx.mach.loader;
+import core.sys.darwin.mach.loader;
 import dmd.globals;
 import dmd.errors;
 


### PR DESCRIPTION
- deprecated core.sys.osx was removed with 2.084
  (see https://github.com/dlang/druntime/pull/2340)

See https://buildkite.com/dlang/build-release/builds/117#75f5e6c4-9f15-4a4c-bdcf-36b42c17ad5d/6-12147 for a nightly build failure.