### PR TITLE
Make -dip25 the default

### DIFF
--- a/changelog/DIP25-is-default.dd
+++ b/changelog/DIP25-is-default.dd
@@ -1,0 +1,3 @@
+The -dip25 is now the default.
+
+To use the old behavior, use -transition=noDIP25.

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -127,7 +127,7 @@ struct Param
     bool stackstomp;            // add stack stomping code
     bool useUnitTests;          // generate unittest code
     bool useInline = false;     // inline expand functions
-    bool useDIP25;          // implement http://wiki.dlang.org/DIP25
+    bool useDIP25 = true;   // implement http://wiki.dlang.org/DIP25
     bool release;           // build release version
     bool preservePaths;     // true means don't strip path from source file
     Diagnostic warnings = Diagnostic.off;  // how compiler warnings are handled


### PR DESCRIPTION
Follow-up to https://github.com/dlang/dmd/pull/9154 and this PR just toggles the
default (i.e. makes `-dip25` the default).

However note that a transition phase will very likely be required as a lot of
projects still fail on Buildkite (e.g. https://github.com/dlang/dmd/pull/9154#issuecomment-450510312).