### PR TITLE
Fix Issue 19549 - -check=in=off doesn't work

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -529,7 +529,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     if (auto s = funcdecl.fensure.isScopeStatement())
                         fensure_endlin = s.endloc.linnum;
 
-                if ((needEnsure && global.params.useOut) || fpostinv)
+                if ((needEnsure && global.params.useOut == CHECKENABLE.on) || fpostinv)
                 {
                     funcdecl.returnLabel = new LabelDsymbol(Id.returnLabel);
                 }
@@ -903,7 +903,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 sc2 = sc2.pop();
 
-                if (!global.params.useIn)
+                if (global.params.useIn == CHECKENABLE.off)
                     freq = null;
             }
             if (fens)
@@ -937,7 +937,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 sc2 = sc2.pop();
 
-                if (!global.params.useOut)
+                if (global.params.useOut == CHECKENABLE.off)
                     fens = null;
             }
             if (funcdecl.fbody && funcdecl.fbody.isErrorStatement())

--- a/test/runnable/test_dip1006.d
+++ b/test/runnable/test_dip1006.d
@@ -1,0 +1,38 @@
+// REQUIRED_ARGS: -check=in=off -check=out=off -check=invariant=off
+// PERMUTE_ARGS:
+class C
+{
+    int foo(int a)
+    in { assert(a != 0); } // skipped
+    out(res) { assert(res != 0); } // skipped
+    body
+    {
+        return a;
+    }
+
+    invariant // skipped
+    {
+        assert(false);
+    }
+
+    void bar(int a)
+    {
+        assert(a != 0); // triggered
+    }
+}
+
+void main()
+{
+    import core.exception : AssertError;
+
+    auto c = new C;
+    c.foo(0);
+
+    bool catched;
+    try
+        c.bar(0);
+    catch (AssertError e)
+        catched = true;
+    if (!catched)
+        assert(0);
+}

--- a/test/runnable/test_dip1006b.d
+++ b/test/runnable/test_dip1006b.d
@@ -1,0 +1,35 @@
+// REQUIRED_ARGS: -check=in=off -check=invariant=off
+// PERMUTE_ARGS:
+class C
+{
+    int foo(int a)
+    in { assert(a != 0); } // skipped
+    out(res) { assert(res != 0, "out"); } // triggered
+    body
+    {
+        return a;
+    }
+
+    invariant // skipped
+    {
+        assert(false);
+    }
+}
+
+void main()
+{
+    import core.exception : AssertError;
+
+    auto c = new C;
+    bool catched;
+    try
+        c.foo(0);
+    catch (AssertError e)
+    {
+        assert(e.msg == "out");
+        catched = e.msg == "out";
+    }
+
+    if (!catched)
+        assert(0);
+}


### PR DESCRIPTION
Copy over the existing tests [he said](https://github.com/dlang/dmd/pull/8972#issuecomment-440075339).

And [again he said please copy over the existing tests](https://github.com/dlang/dmd/pull/8972#issuecomment-442020270).

And [he said again there are still no tests](https://github.com/dlang/dmd/pull/8972#issuecomment-445756628).

CC @andralex @thewilsonator __PLEASE PLEASE STOP MERGING STUFF WITHOUT TESTS__.

With the fixes, the first test file yields a segfault of DMD, because this assertion no longer holds:

https://github.com/dlang/dmd/blob/a9eb1b7e1d328a1fe85b7f6c69f810d705c8a66a/src/dmd/s2ir.d#L426

 but I'm not in the mood to look into this.