### PR TITLE
change -stdc++ switch to -std

### DIFF
--- a/changelog/stdcpp.dd
+++ b/changelog/stdcpp.dd
@@ -4,7 +4,7 @@ $(H2 Transition to C++11 character types)
   
           With C++11 comes the advent of changed character type mangling.
           D's default behavior will be to conform to this after a one 
-          release transition period. A new switch -stdc++={c++98,c++11} is 
+          release transition period. A new switch -std={c++98,c++11} is 
           added to control the version that compatibility is set to.
           This switch sets `__traits(getTargetInfo, "cppStd")` to the value of 
           `__cplusplus` that the corresponding version of the C++ standard defines.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -562,8 +562,8 @@ dmd -cov -unittest myprog.d
             `$(UNIX Generate shared library)
              $(WINDOWS Generate DLL library)`,
         ),
-        Option("stdc++=<standard>",
-            "set c++ compatiblity with <standard>",
+        Option("std=<standard>",
+            "set compatiblity with <standard>",
             "Standards supported are:
             $(UL
                 $(LI $(I c++98) (default): Use C++98 name mangling,

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1647,11 +1647,11 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             else
                 goto Lerror;
         }
-        else if (startsWith(p + 1, "stdc++=")) // https://dlang.org/dmd.html#switch-std-c%2B%2B
+        else if (startsWith(p + 1, "std=")) // https://dlang.org/dmd.html#switch-std-c%2B%2B
         {
-            if (strcmp(p + 8, "c++98") == 0)
+            if (strcmp(p + 5, "c++98") == 0)
                 params.cplusplus = CppStdRevision.cpp98;
-            else if (strcmp(p + 8, "c++11") == 0)
+            else if (strcmp(p + 5, "c++11") == 0)
                 params.cplusplus = CppStdRevision.cpp11;
             else
                 goto Lerror;

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -stdc++=c++98
+// REQUIRED_ARGS: -std=c++98
 
 // This file is intended to contain all compilable traits-related tests in an
 // effort to keep the number of files in the `compilable` folder to a minimum.


### PR DESCRIPTION
There's no point to having `-stdc++=c++98` over just `-std=c++98`. It's redundant and not compatible with any existing practice.