### PR TITLE
fix Issue 19551 - corrupt ELF library when using pragma(crt_constructor)

### DIFF
--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -1959,9 +1959,12 @@ private int elf_addsegment2(IDXSEC shtidx, IDXSYM symidx, IDXSEC relidx)
     }
     assert(seg_count < seg_max);
     if (!SegData[seg])
-    {   SegData[seg] = cast(seg_data *)mem_calloc((seg_data).sizeof);
+    {
+        SegData[seg] = cast(seg_data *)mem_calloc(seg_data.sizeof);
         //printf("test2: SegData[%d] = %p\n", seg, SegData[seg]);
     }
+    else
+        memset(SegData[seg], 0, seg_data.sizeof);
 
     seg_data *pseg = SegData[seg];
     pseg.SDseg = seg;

--- a/test/runnable/extra-files/lib18456b.d
+++ b/test/runnable/extra-files/lib18456b.d
@@ -1,0 +1,12 @@
+module manual;
+
+class ManualGC {
+    void enable()
+    {
+    }
+
+    void disable()
+    {
+    }
+
+}

--- a/test/runnable/test18456.sh
+++ b/test/runnable/test18456.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/lib18456.d
+# source file order is important
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/lib18456b.d ${EXTRA_FILES}/lib18456.d
 $DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/test18456.d ${OUTPUT_BASE}${LIBEXT}
 ${OUTPUT_BASE}${EXE}
 


### PR DESCRIPTION
seg_data reused without being reset, this could cause arbitrary cross-talk. In this case, SDassocseg caused data to be written into an unrelated segment