### PR TITLE
Fix Issue 17090 - `dmd -transition=?` needs quoting => make it `-transition=help`

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -471,7 +471,7 @@ dmd -cov -unittest myprog.d
             $(DT native)$(DD use the architecture the compiler is running on)
             )`,
         ),
-        Option("mcpu=?",
+        Option("mcpu=h[elp]",
             "list all architecture options"
         ),
         Option("mixin=<filename>",
@@ -576,7 +576,7 @@ dmd -cov -unittest myprog.d
             "help with language change identified by 'id'",
             `Show additional info about language change identified by $(I id)`,
         ),
-        Option("transition=?",
+        Option("transition=h[elp]",
             "list all language changes"
         ),
         Option("unittest",

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -471,7 +471,7 @@ dmd -cov -unittest myprog.d
             $(DT native)$(DD use the architecture the compiler is running on)
             )`,
         ),
-        Option("mcpu=h[elp]",
+        Option("mcpu=[h|help|?]",
             "list all architecture options"
         ),
         Option("mixin=<filename>",
@@ -576,7 +576,7 @@ dmd -cov -unittest myprog.d
             "help with language change identified by 'id'",
             `Show additional info about language change identified by $(I id)`,
         ),
-        Option("transition=h[elp]",
+        Option("transition=[h|help|?]",
             "list all language changes"
         ),
         Option("unittest",

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1615,7 +1615,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             //      -mcpu=identifier
             if (p[5] == '=')
             {
-                if (strcmp(p + 6, "?") == 0)
+                if (isHelpOption(p + 6))
                 {
                     params.mcpuUsage = true;
                     return false;
@@ -1641,8 +1641,18 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                         goto Lerror;
                     }
                 }
+                else if (p[6] == 0)
+                {
+                    params.mcpuUsage = true;
+                    return false;
+                }
                 else
                     goto Lerror;
+            }
+            else if (p[5] == 0)
+            {
+                params.mcpuUsage = true;
+                return false;
             }
             else
                 goto Lerror;
@@ -1662,7 +1672,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
             //      -transition=number
             if (p[11] == '=')
             {
-                if (strcmp(p + 12, "?") == 0)
+                if (isHelpOption(p + 12))
                 {
                     params.transitionUsage = true;
                     return false;
@@ -1717,8 +1727,17 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                         goto Lerror;
                     }
                 }
+                else if (p[12] == 0) {
+                    params.transitionUsage = true;
+                    return false;
+                }
                 else
                     goto Lerror;
+            }
+            else if (p[11] == 0)
+            {
+                params.transitionUsage = true;
+                return false;
             }
             else
                 goto Lerror;
@@ -2375,4 +2394,17 @@ Modules createModules(ref Strings files, ref Strings libmodules)
         }
     }
     return modules;
+}
+
+/*
+Checks whether the option pointer supplied is a request
+for the help page.
+
+Returns: `true` if `p` points to `?`, `h` or `help`, otherwise `false`.
+*/
+bool isHelpOption(const(char*) p)
+{
+    return strcmp(p, "?") == 0 ||
+           strcmp(p, "h") == 0 ||
+           strcmp(p, "help") == 0;
 }

--- a/test/compilable/testdmdflags.sh
+++ b/test/compilable/testdmdflags.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+! $DMD -transitio | grep "Error: unrecognized switch '-transitio'"
+! $DMD -transition=he | grep "Error: unrecognized switch '-transition=he'"
+
+for w in "transition" "transition=" "transition=?" "transition=h" "transition=help" ; do
+    $DMD "-${w}" | grep "Language changes listed by -transition=id:"
+done
+
+! $DMD -mcp | grep "Error: unrecognized switch '-mcp'"
+! $DMD -mcpu=he | grep "Error: unrecognized switch '-mcpu=he'"
+
+for w in "mcpu" "mcpu=" "mcpu=?" "mcpu=h" "mcpu=help" ; do
+    $DMD "-${w}" | grep "CPU architectures supported by -mcpu=id:"
+done


### PR DESCRIPTION
There's still a lot more that could be done:
- create usage pages for other switches
- Trigger a message like "See -transition=help for an overview of all valid options" if an incorrect option has been provided
- ...

but this is a small start. I changed the `?` as default in the docs as its very problematic in most shells. I added a test to ensure that it will continue to be accepted though.