### PR TITLE
Fix typo in test16096.sh: ${EXT} -> ${EXE}

### DIFF
--- a/test/runnable/test16096.sh
+++ b/test/runnable/test16096.sh
@@ -6,7 +6,7 @@ if [ "$OS" != 'osx' ] || [ "$MODEL" != '64' ]; then
 fi
 
 $DMD -I${EXTRA_FILES} -of${OUTPUT_BASE}${LIBEXT} -lib ${EXTRA_FILES}/test16096a.d
-$DMD -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXT} ${EXTRA_FILES}/test16096.d ${OUTPUT_BASE}${LIBEXT} -L-framework -LFoundation
+$DMD -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} ${EXTRA_FILES}/test16096.d ${OUTPUT_BASE}${LIBEXT} -L-framework -LFoundation
 ${OUTPUT_BASE}${EXE}
 
 rm ${OUTPUT_BASE}{${LIBEXT},${EXE}}


### PR DESCRIPTION
cc @wilzbach 