### PR TITLE
infer 'scope' for return through first parameter

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -437,10 +437,16 @@ bool checkAssignEscape(Scope* sc, Expression e, bool gag)
 
         if (v.isScope())
         {
-            if (vaIsFirstRef && v.isParameter())
+            if (vaIsFirstRef && v.isParameter() && v.storage_class & STC.return_)
             {
-                if (va.isScope() && v.storage_class & STC.return_)
+                if (va.isScope())
                     continue;
+
+                if (inferScope && !va.doNotInferScope)
+                {   //printf("inferring scope for %s\n", va.toChars());
+                    va.storage_class |= STC.scope_ | STC.scopeinferred;
+                    continue;
+                }
             }
 
             if (va && va.isScope() && va.storage_class & STC.return_ && !(v.storage_class & STC.return_) &&

--- a/test/compilable/test19097.d
+++ b/test/compilable/test19097.d
@@ -1,0 +1,17 @@
+/* REQUIRED_ARGS: -dip1000
+ */
+
+// Related to: https://github.com/dlang/dmd/pull/8504
+
+@safe:
+
+void betty()(ref int* r, return scope int* p)
+{
+    r = p; // infer `scope` for r
+}
+
+void foo(scope int* pf)
+{
+    scope int* rf;
+    betty(rf, pf);
+}


### PR DESCRIPTION
This extends https://github.com/dlang/dmd/pull/8504 to infer `scope` for the first parameter rather than just check it.