### PR TITLE
VS project should not build optabgen.d, frontend.d and asttypename.d …

### DIFF
--- a/src/vcbuild/dmd.vcxproj
+++ b/src/vcbuild/dmd.vcxproj
@@ -196,7 +196,7 @@
     </DCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <DCompile Include="../dmd/**/*.d" />
+    <DCompile Include="../dmd/**/*.d" Exclude="../dmd/backend/optabgen.d;../dmd/frontend.d;../dmd/asttypename.d"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="dmd_backend.vcxproj">


### PR DESCRIPTION
…into dmd itself

No idea why this doesn't fail with multiple definitions of main.

Unfortuntely https://github.com/dlang/dmd/pull/8452 has converted CRLF to LF for the vcxproj file.

Use https://github.com/dlang/dmd/pull/9218/files?w=1 to see the actual one line change.