### PR TITLE
Fix issue 18545: When casting away const, or casting to const or immutable, don't try to generate a constructor cast.

### DIFF
--- a/changelog/const_cast_dont_construct_structs.dd
+++ b/changelog/const_cast_dont_construct_structs.dd
@@ -1,0 +1,17 @@
+Avoid calling the struct constructor from const-casts
+
+In previous versions of DMD, there was an undocumented interaction of const-cast with
+regular cast, ie. `cast()`, `cast(const)` and `cast(immutable)`, where these casts would
+be expressed as `cast(const(typeof(expr))) expr`; hence if `expr` was of type `Struct`,
+these casts could potentially call its constructor `Struct(expr)`, as per spec.
+
+The dangerous part however, was if this occurred with structs that used their first field
+as `alias this`, the implicit conversion via `alias this` would potentially satisfy an
+implicit struct constructor, leaving the other fields set to `init` and leading to apparent
+data corruption from a mere `cast()`.
+
+In other words, `cast() s` to `S(s)` to `S(s.implicitCast)`.
+
+This can no longer occur, since $(B `cast()`, `cast(const)` and `cast(immutable)` will
+no longer generate an implicit constructor call.)
+Implicit constructor calls to `S()` will only occur when one explicitly uses `cast(S)`.

--- a/test/runnable/test18545.d
+++ b/test/runnable/test18545.d
@@ -1,0 +1,65 @@
+module test18545;
+
+import std.format;
+
+enum Constness
+{
+    Mutable,
+    Const,
+    Immutable,
+}
+
+enum Cases = [Constness.Mutable, Constness.Const, Constness.Immutable];
+
+void main()
+{
+    static foreach (from; Cases)
+    {
+        static foreach (to; Cases)
+        {
+            test!(from, to)();
+        }
+    }
+}
+
+void test(Constness from, Constness to)()
+{
+    struct S {
+        int i;
+
+        @property int get() const { return 0; }
+
+        alias get this;
+    }
+
+    static if (from == Constness.Mutable)
+    {
+        alias ConstS = S;
+    }
+    else static if (from == Constness.Const)
+    {
+        alias ConstS = const(S);
+    }
+    else
+    {
+        alias ConstS = immutable(S);
+    }
+
+    ConstS s1 = S(42);
+
+    // this should reinterpret-cast, NOT call the implicit constructor with .get!
+    static if (to == Constness.Mutable)
+    {
+        auto s2 = cast() s1;
+    }
+    else static if (to == Constness.Const)
+    {
+        const s2 = cast(const) s1;
+    }
+    else static if (to == Constness.Immutable)
+    {
+        immutable s2 = cast(immutable) s1;
+    }
+
+    assert(s2.i == s1.i, format!"Bug 18545 occurred casting from %s to %s"(from, to));
+}


### PR DESCRIPTION
When casting away const, or casting to const or immutable, don't try to generate a constructor call.

This avoids issues where if a struct has an alias-this, the struct may be reconstructed using an implicit constructor call of the non-const struct with the alias-this. This may be *technically* in keeping with the spec, but it's highly unexpected and a potent source of errors.

Example:

```
struct S {
    int i;

    @property const int get() { return 0; }

    alias get this;
}

void main() {
    const(S) s1 = S(42);

    auto s2 = cast() s1;

    assert(s2.i == s1.i);
}
```

`cast() s1` is rewritten internally to `cast(S) s1`, which becomes `S(s1)`, which becomes `S(s1.get)`. Three steps of magic is too many.

The deeper reason this is so hideous is that a struct with 50 fields can be implicitly constructed by only specifying the first one. It's quite common to have a struct alias-cast to its first member, hence setting all the other fields to `init`.

With this change, `cast() s1` or `cast(const) s1` or `cast(immutable) s1` will never try to call the constructor of the target type.