### PR TITLE
testsuite: Prepare for stricter TEST_OUTPUT tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -156,6 +156,8 @@ The following is a list of all available settings:
                          Some
                          Output
                          ---
+                         note: if not given, it is assumed that the compilation will be silent.
+                         default: (none)
 
     POST_SCRIPT:         name of script to execute after test run
                          note: arguments to the script may be included after the name.


### PR DESCRIPTION
As a means of making sure that a test regression like #9134 doesn't slip through again, this change prepares the test runner to make it mandatory for all tests to provide `TEST_OUTPUT` if any messages are outputted during compilation.

Currently this does nothing, but will follow up by fixing each test directory one PR at a time, removing them from the condition in `testCombination`.