### PR TITLE
testsuite: Require -m64 for __vector fail tests

### DIFF
--- a/test/fail_compilation/fail10905.d
+++ b/test/fail_compilation/fail10905.d
@@ -1,3 +1,10 @@
+/*
+REQUIRED_ARGS: -m64
+TEST_OUTPUT:
+---
+fail_compilation/fail10905.d(20): Error: incompatible types for `(this.x) == (cast(const(__vector(long[2])))cast(__vector(long[2]))1L)`: both operands are of type `const(__vector(long[2]))`
+---
+*/
 
 struct Foo
 {

--- a/test/fail_compilation/fail9301.d
+++ b/test/fail_compilation/fail9301.d
@@ -1,6 +1,10 @@
 /*
-REQUIRED_ARGS: -o-
+REQUIRED_ARGS: -m64 -o-
 PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/fail9301.d(12): Error: cannot implicitly convert expression `0` of type `int` to `__vector(void[16])`
+---
 */
 
 void main()


### PR DESCRIPTION
And add `TEST_OUTPUT`.  The use of `-m64` is required so that all platforms produce the same error.

This is done in other vector tests in the testsuite.