### PR TITLE
testsuite: Use DISABLED instead of version in fail tests

### DIFF
--- a/test/fail_compilation/fail3753.d
+++ b/test/fail_compilation/fail3753.d
@@ -1,6 +1,8 @@
 /*
+DISABLED: dragonflybsd freebsd linux osx win32
+TEST_OUTPUT:
 ---
-Error: cannot mix core.std.stdlib.alloca() and exception handling in _Dmain()
+Error: cannot mix `core.std.stdlib.alloca()` and exception handling in `_Dmain()`
 ---
 */
 
@@ -26,26 +28,4 @@ void main()
     bar();
     auto a = alloca(16);
     printf("test()\n");
-    version (DigitalMars)
-    {
-        version (Win32) static assert(0);
-        version (linux)
-        {
-            static assert(0);
-        }
-        version (FreeBSD)
-        {
-            static assert(0);
-        }
-        version (DragonFlyBSD)
-        {
-            static assert(0);
-        }
-        version (OSX)
-        {
-            static assert(0);
-        }
-    }
-    else
-        static assert(0);
 }

--- a/test/fail_compilation/fail6451.d
+++ b/test/fail_compilation/fail6451.d
@@ -1,14 +1,9 @@
+/*
+DISABLED: win32 win64 linux32 osx32 freebsd32
+TEST_OUTPUT:
+---
+fail_compilation/fail6451.d(9): Error: `__va_list_tag` is not defined, perhaps `import core.stdc.stdarg;` ?
+---
+*/
 
-version(Win64)
-{
-    static assert(0);
-}
-else version(X86_64)
-{
-    void error(...){}
-}
-else
-{
-    static assert(0);
-}
-
+void error(...){}


### PR DESCRIPTION
See for example fail_compilation/fail18372.d.