### PR TITLE
Move assert changelog entry from druntime

### DIFF
--- a/changelog/assert.dd
+++ b/changelog/assert.dd
@@ -1,0 +1,71 @@
+Context-aware assertion error messages
+
+With this release DMD supports generating context-aware assertion error messages
+when no error message has been provided by the user.
+For example, currently the following file:
+
+---
+void main()
+{
+    int a, b = 2;
+    assert(a == b);
+}
+---
+
+would yield this error when compiled and run:
+
+$(CONSOLE
+> dmd -run main.d
+core.exception.AssertError@main.d(4): Assertion failure
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? _d_assertp [0x1c4eae48]
+onlineapp.d:4 _Dmain [0x1c4ead85]
+)
+
+However, with the new experimental compiler switch `-checkaction=context` it yields:
+
+$(CONSOLE
+> dmd -checkaction=context -run main.d
+core.exception.AssertError@main.d(4): 0 != 2
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? _d_assert_msg [0x4a3f9cf0]
+??:? _Dmain [0x4a3f8fc4]
+)
+
+The new switch already supports a variety of assertion messages:
+
+---
+string dlang = "d2";
+assert(dlang != dlang); // ERROR: "dlang" == "dlang"
+
+struct S { int s; }
+assert(S(0) == S(1)); // ERROR: "S(0) !is S(1)"
+
+int a = 1, b = 2);
+assert(a > b); // ERROR: 1 <= 2
+---
+
+Also if no error message can be generated, it will now fallback to displaying
+the text of the `assert` expression. For example, for this more complicated
+assert expression:
+
+---
+void main()
+{
+    int a, b = 2;
+    assert(a && (a == b));
+}
+---
+
+Compiling and running with `-checkaction=context` will now result in:
+
+$(CONSOLE
+> dmd -checkaction=context -run main.d
+core.exception.AssertError@main.d(4): assert(a && (a == b)) failed
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? _d_assert_msg [0xb7e5fdfc]
+??:? _Dmain [0xb7e5fd40]
+)
+
+This switch for context-aware assertion error messages is still experimental
+and feedback is welcome.


### PR DESCRIPTION
It's about the compiler switch not druntime, so it should appear in the DMD changelog.

See also: https://github.com/dlang/druntime/pull/2459