### PR TITLE
testsuite: Add TEST_OUTPUT to most verbose compilable tests

### DIFF
--- a/test/compilable/b16382.d
+++ b/test/compilable/b16382.d
@@ -1,4 +1,10 @@
 // REQUIRED_ARGS: -c
+/*
+TEST_OUTPUT:
+---
+&this
+---
+*/
 struct S0 {
     void foo() {
         pragma(msg, &this);

--- a/test/compilable/b17111.d
+++ b/test/compilable/b17111.d
@@ -1,3 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+compilable/b17111.d(16): Deprecation: `case` variables have to be `const` or `immutable`
+compilable/b17111.d(17): Deprecation: `case` variables have to be `const` or `immutable`
+---
+*/
 alias TestType = ubyte;
 
 void test()

--- a/test/compilable/callconv.d
+++ b/test/compilable/callconv.d
@@ -1,4 +1,11 @@
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+compilable/callconv.d(21): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
+compilable/callconv.d(30): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
+---
+*/
 
 import core.stdc.stdarg;
 

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -7,10 +7,10 @@
                 "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 16,
-                "endline": 8,
+                "endline": 12,
                 "kind": "function",
-                "line": 8,
-                "name": "_staticCtor_L8_C1",
+                "line": 12,
+                "name": "_staticCtor_L12_C1",
                 "storageClass": [
                     "static"
                 ]
@@ -19,10 +19,10 @@
                 "char": 1,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 17,
-                "endline": 10,
+                "endline": 14,
                 "kind": "function",
-                "line": 10,
-                "name": "_staticDtor_L10_C1",
+                "line": 14,
+                "name": "_staticDtor_L14_C1",
                 "storageClass": [
                     "static"
                 ]
@@ -31,31 +31,31 @@
                 "char": 11,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
-                "line": 13,
+                "line": 17,
                 "name": "myInt"
             },
             {
                 "char": 7,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 14,
+                "line": 18,
                 "name": "x",
                 "originalType": "myInt"
             },
             {
                 "char": 1,
                 "kind": "template",
-                "line": 16,
+                "line": 20,
                 "members": [
                     {
                         "char": 1,
                         "kind": "struct",
-                        "line": 16,
+                        "line": 20,
                         "members": [
                             {
                                 "char": 19,
                                 "kind": "variable",
-                                "line": 16,
+                                "line": 20,
                                 "name": "t",
                                 "type": "T"
                             }
@@ -74,19 +74,19 @@
             {
                 "char": 1,
                 "kind": "template",
-                "line": 17,
+                "line": 21,
                 "members": [
                     {
                         "char": 1,
                         "kind": "class",
-                        "line": 17,
+                        "line": 21,
                         "members": [
                             {
                                 "char": 25,
                                 "deco": "VALUE_REMOVED_FOR_TEST",
                                 "init": "T",
                                 "kind": "variable",
-                                "line": 17,
+                                "line": 21,
                                 "name": "t"
                             }
                         ],
@@ -105,17 +105,17 @@
             {
                 "char": 1,
                 "kind": "template",
-                "line": 18,
+                "line": 22,
                 "members": [
                     {
                         "char": 1,
                         "kind": "interface",
-                        "line": 18,
+                        "line": 22,
                         "members": [
                             {
                                 "char": 28,
                                 "kind": "function",
-                                "line": 18,
+                                "line": 22,
                                 "name": "t",
                                 "type": "const T[0]()"
                             }
@@ -134,7 +134,7 @@
             {
                 "char": 1,
                 "kind": "template",
-                "line": 20,
+                "line": 24,
                 "members": [],
                 "name": "P",
                 "parameters": [
@@ -151,15 +151,15 @@
                     "json.Baz!(int, 2, null).Baz"
                 ],
                 "kind": "class",
-                "line": 22,
+                "line": 26,
                 "members": [
                     {
                         "char": 5,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 13,
-                        "endline": 23,
+                        "endline": 27,
                         "kind": "constructor",
-                        "line": 23,
+                        "line": 27,
                         "name": "this",
                         "originalType": "()"
                     },
@@ -167,18 +167,18 @@
                         "char": 5,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 14,
-                        "endline": 24,
+                        "endline": 28,
                         "kind": "destructor",
-                        "line": 24,
+                        "line": 28,
                         "name": "~this"
                     },
                     {
                         "char": 12,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 19,
-                        "endline": 26,
+                        "endline": 30,
                         "kind": "function",
-                        "line": 26,
+                        "line": 30,
                         "name": "foo",
                         "originalType": "()",
                         "storageClass": [
@@ -189,7 +189,7 @@
                         "char": 32,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "kind": "function",
-                        "line": 27,
+                        "line": 31,
                         "name": "baz",
                         "protection": "protected",
                         "storageClass": [
@@ -200,9 +200,9 @@
                         "char": 18,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 40,
-                        "endline": 28,
+                        "endline": 32,
                         "kind": "function",
-                        "line": 28,
+                        "line": 32,
                         "name": "t",
                         "overrides": [
                             "json.Baz!(int, 2, null).Baz.t"
@@ -222,13 +222,13 @@
                 "base": "json.Bar2",
                 "char": 1,
                 "kind": "class",
-                "line": 31,
+                "line": 35,
                 "members": [
                     {
                         "char": 17,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "kind": "variable",
-                        "line": 32,
+                        "line": 36,
                         "name": "val",
                         "offset": 0,
                         "protection": "private"
@@ -237,9 +237,9 @@
                         "char": 5,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 28,
-                        "endline": 33,
+                        "endline": 37,
                         "kind": "constructor",
-                        "line": 33,
+                        "line": 37,
                         "name": "this",
                         "originalType": "(int i)",
                         "parameters": [
@@ -253,9 +253,9 @@
                         "char": 32,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 61,
-                        "endline": 35,
+                        "endline": 39,
                         "kind": "function",
-                        "line": 35,
+                        "line": 39,
                         "name": "baz",
                         "overrides": [
                             "json.Bar2.baz"
@@ -271,13 +271,13 @@
             {
                 "char": 1,
                 "kind": "struct",
-                "line": 38,
+                "line": 42,
                 "members": [
                     {
                         "char": 10,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "kind": "variable",
-                        "line": 39,
+                        "line": 43,
                         "name": "bar2",
                         "offset": 0,
                         "originalType": "Bar2"
@@ -285,13 +285,13 @@
                     {
                         "char": 5,
                         "kind": "union",
-                        "line": 40,
+                        "line": 44,
                         "members": [
                             {
                                 "char": 19,
                                 "deco": "VALUE_REMOVED_FOR_TEST",
                                 "kind": "variable",
-                                "line": 42,
+                                "line": 46,
                                 "name": "s",
                                 "offset": 0
                             },
@@ -299,7 +299,7 @@
                                 "char": 17,
                                 "deco": "VALUE_REMOVED_FOR_TEST",
                                 "kind": "variable",
-                                "line": 43,
+                                "line": 47,
                                 "name": "i",
                                 "offset": 0
                             },
@@ -307,7 +307,7 @@
                                 "char": 16,
                                 "deco": "VALUE_REMOVED_FOR_TEST",
                                 "kind": "variable",
-                                "line": 45,
+                                "line": 49,
                                 "name": "o",
                                 "offset": 0,
                                 "originalType": "Object"
@@ -321,31 +321,31 @@
             {
                 "char": 1,
                 "kind": "template",
-                "line": 49,
+                "line": 53,
                 "members": [
                     {
                         "char": 1,
                         "kind": "struct",
-                        "line": 49,
+                        "line": 53,
                         "members": [
                             {
                                 "char": 14,
                                 "kind": "function",
-                                "line": 52,
+                                "line": 56,
                                 "name": "method1",
                                 "type": "void()"
                             },
                             {
                                 "char": 14,
                                 "kind": "function",
-                                "line": 56,
+                                "line": 60,
                                 "name": "method2",
                                 "type": "void()"
                             },
                             {
                                 "char": 10,
                                 "kind": "function",
-                                "line": 63,
+                                "line": 67,
                                 "name": "method4",
                                 "type": "void()"
                             }
@@ -366,9 +366,9 @@
                 "char": 16,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 1,
-                "endline": 72,
+                "endline": 76,
                 "kind": "function",
-                "line": 69,
+                "line": 73,
                 "name": "bar",
                 "originalType": "@trusted myInt(ref uint blah, Bar2 foo = new Bar3(7))",
                 "parameters": [
@@ -390,15 +390,15 @@
                 "char": 15,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 1,
-                "endline": 91,
+                "endline": 95,
                 "kind": "function",
-                "line": 74,
+                "line": 78,
                 "name": "outer"
             },
             {
                 "char": 8,
                 "kind": "import",
-                "line": 94,
+                "line": 98,
                 "name": "imports.jsonimport1",
                 "protection": "private",
                 "selective": [
@@ -409,7 +409,7 @@
             {
                 "char": 8,
                 "kind": "import",
-                "line": 95,
+                "line": 99,
                 "name": "imports.jsonimport2",
                 "protection": "private",
                 "renamed": {
@@ -420,7 +420,7 @@
             {
                 "char": 8,
                 "kind": "import",
-                "line": 96,
+                "line": 100,
                 "name": "imports.jsonimport3",
                 "protection": "private",
                 "renamed": {
@@ -434,26 +434,26 @@
             {
                 "char": 8,
                 "kind": "import",
-                "line": 97,
+                "line": 101,
                 "name": "imports.jsonimport4",
                 "protection": "private"
             },
             {
                 "char": 1,
                 "kind": "struct",
-                "line": 99,
+                "line": 103,
                 "members": [
                     {
                         "char": 5,
                         "kind": "template",
-                        "line": 102,
+                        "line": 106,
                         "members": [
                             {
                                 "char": 5,
                                 "endchar": 20,
-                                "endline": 102,
+                                "endline": 106,
                                 "kind": "constructor",
-                                "line": 102,
+                                "line": 106,
                                 "name": "this",
                                 "parameters": [
                                     {
@@ -478,12 +478,12 @@
             {
                 "char": 9,
                 "kind": "template",
-                "line": 106,
+                "line": 110,
                 "members": [
                     {
                         "char": 9,
                         "kind": "struct",
-                        "line": 106,
+                        "line": 110,
                         "members": [],
                         "name": "S1_9755"
                     }
@@ -500,12 +500,12 @@
             {
                 "char": 9,
                 "kind": "template",
-                "line": 107,
+                "line": 111,
                 "members": [
                     {
                         "char": 9,
                         "kind": "struct",
-                        "line": 107,
+                        "line": 111,
                         "members": [],
                         "name": "S2_9755"
                     }
@@ -522,17 +522,17 @@
             {
                 "char": 1,
                 "kind": "class",
-                "line": 109,
+                "line": 113,
                 "members": [
                     {
                         "char": 22,
                         "kind": "template",
-                        "line": 111,
+                        "line": 115,
                         "members": [
                             {
                                 "char": 22,
                                 "kind": "class",
-                                "line": 111,
+                                "line": 115,
                                 "members": [],
                                 "name": "CI_9755"
                             }
@@ -554,7 +554,7 @@
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "init": "Object()",
                 "kind": "variable",
-                "line": 115,
+                "line": 119,
                 "name": "c_10011",
                 "originalType": "Object",
                 "storageClass": [
@@ -565,54 +565,54 @@
                 "baseDeco": "i",
                 "char": 1,
                 "kind": "enum",
-                "line": 118,
+                "line": 122,
                 "members": [
                     {
                         "char": 5,
                         "kind": "enum member",
-                        "line": 120,
+                        "line": 124,
                         "name": "unspecified1",
                         "value": "0"
                     },
                     {
                         "char": 5,
                         "kind": "enum member",
-                        "line": 121,
+                        "line": 125,
                         "name": "one",
                         "value": "2"
                     },
                     {
                         "char": 5,
                         "kind": "enum member",
-                        "line": 122,
+                        "line": 126,
                         "name": "two",
                         "value": "3"
                     },
                     {
                         "char": 5,
                         "kind": "enum member",
-                        "line": 123,
+                        "line": 127,
                         "name": "FILE_NOT_FOUND",
                         "value": "101"
                     },
                     {
                         "char": 5,
                         "kind": "enum member",
-                        "line": 124,
+                        "line": 128,
                         "name": "unspecified3",
                         "value": "102"
                     },
                     {
                         "char": 5,
                         "kind": "enum member",
-                        "line": 125,
+                        "line": 129,
                         "name": "unspecified4",
                         "value": "103"
                     },
                     {
                         "char": 5,
                         "kind": "enum member",
-                        "line": 126,
+                        "line": 130,
                         "name": "four",
                         "value": "4"
                     }
@@ -623,7 +623,7 @@
                 "char": 1,
                 "constraint": "T == string",
                 "kind": "template",
-                "line": 129,
+                "line": 133,
                 "members": [],
                 "name": "IncludeConstraint",
                 "parameters": [
@@ -639,7 +639,7 @@
                 "file": "VALUE_REMOVED_FOR_TEST",
                 "init": "1",
                 "kind": "variable",
-                "line": 133,
+                "line": 137,
                 "name": "a0"
             },
             {
@@ -647,7 +647,7 @@
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "init": "1",
                 "kind": "variable",
-                "line": 133,
+                "line": 137,
                 "name": "a1"
             },
             {
@@ -655,19 +655,19 @@
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "init": "1",
                 "kind": "variable",
-                "line": 133,
+                "line": 137,
                 "name": "a2"
             },
             {
                 "char": 1,
                 "file": "VALUE_REMOVED_FOR_TEST",
                 "kind": "template",
-                "line": 136,
+                "line": 140,
                 "members": [
                     {
                         "char": 1,
                         "kind": "alias",
-                        "line": 136,
+                        "line": 140,
                         "name": "Seq",
                         "type": "T"
                     }
@@ -685,31 +685,31 @@
                 "char": 1,
                 "file": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
-                "line": 140,
+                "line": 144,
                 "name": "b0"
             },
             {},
             {
                 "char": 1,
                 "kind": "alias",
-                "line": 140,
+                "line": 144,
                 "name": "b1"
             },
             {},
             {
                 "char": 1,
                 "kind": "alias",
-                "line": 140,
+                "line": 144,
                 "name": "b2"
             },
             {
                 "char": 9,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 1,
-                "endline": 147,
+                "endline": 151,
                 "file": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 144,
+                "line": 148,
                 "name": "foo",
                 "parameters": [
                     {
@@ -726,9 +726,9 @@
                 "char": 6,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 1,
-                "endline": 152,
+                "endline": 156,
                 "kind": "function",
-                "line": 149,
+                "line": 153,
                 "name": "foo",
                 "parameters": [
                     {
@@ -745,9 +745,9 @@
                 "char": 10,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "endchar": 1,
-                "endline": 157,
+                "endline": 161,
                 "kind": "function",
-                "line": 154,
+                "line": 158,
                 "name": "foo",
                 "parameters": [
                     {
@@ -764,40 +764,40 @@
             {
                 "char": 1,
                 "kind": "struct",
-                "line": 159,
+                "line": 163,
                 "members": [
                     {
                         "char": 15,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 5,
-                        "endline": 165,
+                        "endline": 169,
                         "kind": "function",
-                        "line": 162,
+                        "line": 166,
                         "name": "foo"
                     },
                     {
                         "char": 11,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 5,
-                        "endline": 170,
+                        "endline": 174,
                         "kind": "function",
-                        "line": 167,
+                        "line": 171,
                         "name": "foo2"
                     },
                     {
                         "char": 15,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "endchar": 5,
-                        "endline": 175,
+                        "endline": 179,
                         "kind": "function",
-                        "line": 172,
+                        "line": 176,
                         "name": "foo3"
                     },
                     {
                         "char": 7,
                         "deco": "VALUE_REMOVED_FOR_TEST",
                         "kind": "variable",
-                        "line": 177,
+                        "line": 181,
                         "name": "p",
                         "offset": 0,
                         "storageClass": [
@@ -811,7 +811,7 @@
                 "char": 12,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 180,
+                "line": 184,
                 "name": "vlinkageDefault",
                 "storageClass": [
                     "extern"
@@ -821,14 +821,14 @@
                 "char": 15,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 181,
+                "line": 185,
                 "name": "vlinkageD"
             },
             {
                 "char": 15,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 182,
+                "line": 186,
                 "linkage": "c",
                 "name": "vlinakgeC"
             },
@@ -836,7 +836,7 @@
                 "char": 27,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 183,
+                "line": 187,
                 "linkage": "cpp",
                 "name": "vlinkageCpp",
                 "storageClass": [
@@ -847,7 +847,7 @@
                 "char": 21,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 184,
+                "line": 188,
                 "linkage": "windows",
                 "name": "vlinkageWindows"
             },
@@ -855,7 +855,7 @@
                 "char": 20,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 185,
+                "line": 189,
                 "linkage": "pascal",
                 "name": "vlinkagePascal"
             },
@@ -863,7 +863,7 @@
                 "char": 25,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "variable",
-                "line": 186,
+                "line": 190,
                 "linkage": "objc",
                 "name": "vlinkageObjc"
             },
@@ -871,7 +871,7 @@
                 "char": 12,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 188,
+                "line": 192,
                 "name": "flinkageDefault",
                 "storageClass": [
                     "extern"
@@ -881,14 +881,14 @@
                 "char": 15,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 189,
+                "line": 193,
                 "name": "flinkageD"
             },
             {
                 "char": 15,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 190,
+                "line": 194,
                 "linkage": "c",
                 "name": "linakgeC"
             },
@@ -896,7 +896,7 @@
                 "char": 17,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 191,
+                "line": 195,
                 "linkage": "cpp",
                 "name": "flinkageCpp"
             },
@@ -904,7 +904,7 @@
                 "char": 21,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 192,
+                "line": 196,
                 "linkage": "windows",
                 "name": "flinkageWindows"
             },
@@ -912,7 +912,7 @@
                 "char": 20,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 193,
+                "line": 197,
                 "linkage": "pascal",
                 "name": "flinkagePascal"
             },
@@ -920,14 +920,14 @@
                 "char": 25,
                 "deco": "VALUE_REMOVED_FOR_TEST",
                 "kind": "function",
-                "line": 194,
+                "line": 198,
                 "linkage": "objc",
                 "name": "flinkageObjc"
             },
             {
                 "char": 7,
                 "kind": "template",
-                "line": 196,
+                "line": 200,
                 "members": [],
                 "name": "test18211",
                 "parameters": [

--- a/test/compilable/extra-files/json2.out
+++ b/test/compilable/extra-files/json2.out
@@ -47,7 +47,7 @@
                 {
                     "char": 8,
                     "kind": "import",
-                    "line": 6,
+                    "line": 9,
                     "name": "json",
                     "protection": "private"
                 }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -1,4 +1,11 @@
 // PERMUTE_ARGS: -inline
+/*
+TEST_OUTPUT:
+---
+compilable/interpret3.d(2914): Deprecation: `case` variables have to be `const` or `immutable`
+compilable/interpret3.d(6313): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+---
+*/
 
 template compiles(int T)
 {

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -1,6 +1,10 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -dip1000 -o- -X -Xf${RESULTS_DIR}/compilable/json.out
+// REQUIRED_ARGS: -d -dip1000 -o- -X -Xf${RESULTS_DIR}/compilable/json.out
 // POST_SCRIPT: compilable/extra-files/json-postscript.sh
+/* TEST_OUTPUT:
+---
+---
+*/
 
 module json;
 

--- a/test/compilable/json2.d
+++ b/test/compilable/json2.d
@@ -1,6 +1,9 @@
 /*
 PERMUTE_ARGS:
-REQUIRED_ARGS: -o- -Xf=${RESULTS_DIR}/compilable/json2.out -Xi=compilerInfo -Xi=buildInfo -Xi=modules -Xi=semantics
+REQUIRED_ARGS: -d -o- -Xf=${RESULTS_DIR}/compilable/json2.out -Xi=compilerInfo -Xi=buildInfo -Xi=modules -Xi=semantics
 POST_SCRIPT: compilable/extra-files/json-postscript.sh
+TEST_OUTPUT:
+---
+---
 */
 import json;

--- a/test/compilable/test11471.d
+++ b/test/compilable/test11471.d
@@ -1,4 +1,10 @@
 // REQUIRED_ARGS: -profile
+/*
+TEST_OUTPUT:
+---
+compilable/test11471.d(10): Deprecation: `asm` statement is assumed to throw - mark it with `nothrow` if it does not
+---
+*/
 
 void main() nothrow
 { asm { nop; } } // Error: asm statements are assumed to throw

--- a/test/compilable/test15177.d
+++ b/test/compilable/test15177.d
@@ -1,6 +1,13 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
 // COMPILED_IMPORTS: imports/test15117a.d
+/*
+TEST_OUTPUT:
+---
+compilable/test15177.d-mixin-20(20): Deprecation: `imports.test15117a.object` is not visible from module `test15177`
+compilable/test15177.d-mixin-20(20): Deprecation: `imports.test15117a.object` is not visible from module `test15177`
+---
+*/
 
 import users = imports.test15117a;
 

--- a/test/compilable/test17419.d
+++ b/test/compilable/test17419.d
@@ -1,4 +1,9 @@
+// REQUIRED_ARGS: -d
 // https://issues.dlang.org/show_bug.cgi?id=17419
+/* TEST_OUTPUT:
+---
+---
+*/
 
 
 extern (C) int fooc();

--- a/test/compilable/test17791.d
+++ b/test/compilable/test17791.d
@@ -1,3 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+compilable/test17791.d(23): Deprecation: class `test17791.DepClass` is deprecated - A deprecated class
+---
+*/
 deprecated("A deprecated class") {
 class DepClass
 {

--- a/test/compilable/test9701.d
+++ b/test/compilable/test9701.d
@@ -1,4 +1,11 @@
 // https://issues.dlang.org/show_bug.cgi?id=9701
+/*
+TEST_OUTPUT:
+---
+compilable/test9701.d(56): Deprecation: enum member `test9701.Enum.value7` is deprecated
+compilable/test9701.d(57): Deprecation: enum member `test9701.Enum.value8` is deprecated - message
+---
+*/
 
 template AliasSeq(TList...)
 {


### PR DESCRIPTION
Same as #9231.

The majority are from `pragma(msg)`, every single one should be questioned over whether they are really necessary.

However there are also a few deprecation warnings that are brought to light.