### PR TITLE
testsuite: Add TEST_OUTPUT to most verbose runnable tests

### DIFF
--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -1,3 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+false
+[] = int
+[] = string
+[0] = int
+[1] = string
+[] = string
+[] = int
+[1] = string
+[0] = int
+---
+*/
 
 extern (C) int printf(const(char*) fmt, ...);
 import core.vararg;

--- a/test/runnable/argufilem.d
+++ b/test/runnable/argufilem.d
@@ -1,4 +1,9 @@
 // EXTRA_SOURCES: imports/argufile.d
+/*
+TEST_OUTPUT:
+---
+---
+*/
 
 // NOTE: The bug only works when main.d and argufile.d are put in
 //                      separate files and compiled like 'dmd main.d argufile.d'
@@ -19,4 +24,3 @@ int main(string[] args)
 
         return 0;
 }
-

--- a/test/runnable/declaration.d
+++ b/test/runnable/declaration.d
@@ -1,3 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+S7019(16), 16
+S7019(24), 24
+S7019(32), 32
+---
+*/
 
 extern(C) int printf(const char*, ...);
 

--- a/test/runnable/foreach4.d
+++ b/test/runnable/foreach4.d
@@ -1,3 +1,8 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
 
 import core.stdc.stdio;
 import std.stdio;

--- a/test/runnable/foreach5.d
+++ b/test/runnable/foreach5.d
@@ -1,3 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+int
+double
+foobar7406(T)
+test7406()
+int
+foobar7406(T)
+int
+test7406()
+---
+*/
 
 extern(C) int printf(const char* fmt, ...);
 

--- a/test/runnable/funclit.d
+++ b/test/runnable/funclit.d
@@ -1,3 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+int delegate() pure nothrow @nogc @safe delegate() pure nothrow @nogc @safe delegate() pure nothrow @safe
+int delegate() pure nothrow @nogc @safe delegate() pure nothrow @nogc @safe delegate() pure nothrow @safe
+int
+int
+int[]
+int delegate() pure nothrow @nogc @safe function() pure nothrow @safe
+---
+*/
 import core.vararg;
 
 extern (C) int printf(const char*, ...);

--- a/test/runnable/future.d
+++ b/test/runnable/future.d
@@ -1,4 +1,8 @@
 /* PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+runnable/future.d(15): Deprecation: `@__future` base class method `future.A.msg` is being overridden by `future.B.msg`; rename the latter
+---
  */
 
 class A

--- a/test/runnable/hospital.d
+++ b/test/runnable/hospital.d
@@ -1,4 +1,10 @@
-// REQUIRED_ARGS:
+/*
+REQUIRED_ARGS:
+TEST_OUTPUT:
+---
+runnable/hospital.d(179): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 // NOTE: the shootout appears to be BSD licensed content.
 // Including this in the test suite based on that license.

--- a/test/runnable/implicit.d
+++ b/test/runnable/implicit.d
@@ -1,3 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+runnable/implicit.d(157): Deprecation: slice of static array temporary returned by `pureMaker3c()` assigned to longer lived variable `z1`
+runnable/implicit.d(158): Deprecation: slice of static array temporary returned by `pureMaker3c()` assigned to longer lived variable `z2`
+---
+*/
 
 import std.stdio;
 
@@ -187,7 +194,7 @@ void testDIP29_4()
 
 immutable int g14155;
 
-static this() { g14155 = 1; }
+shared static this() { g14155 = 1; }
 
              int*  make14155m (             int*  p) pure { return null; }
        const(int*) make14155c (       const(int*) p) pure { return &g14155; }

--- a/test/runnable/interface.d
+++ b/test/runnable/interface.d
@@ -1,3 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+runnable/interface.d(41): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interface.d(55): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 import core.stdc.stdio;
 

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -1,4 +1,11 @@
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+runnable/interface2.d(47): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interface2.d(98): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 extern(C) int printf(const char*, ...);
 

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -1,3 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+true
+g
+&Test109S(&Test109S(<recursion>))
+runnable/interpret.d(3201): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interpret.d(3203): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interpret.d(3206): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interpret.d(3209): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interpret.d(3210): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interpret.d(3216): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interpret.d(3217): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/interpret.d(3220): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+tfoo
+tfoo
+Crash!
+---
+*/
 
 import std.stdio;
 

--- a/test/runnable/link12144.d
+++ b/test/runnable/link12144.d
@@ -1,5 +1,11 @@
 // COMPILE_SEPARATELY: -g
 // EXTRA_SOURCES: imports/link12144a.d
+/*
+TEST_OUTPUT:
+---
+runnable/imports/link12144a.d(31): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 import imports.link12144a;
 

--- a/test/runnable/link15017.d
+++ b/test/runnable/link15017.d
@@ -1,5 +1,11 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/std15017variant.d
+/*
+TEST_OUTPUT:
+---
+runnable/link15017.d(48): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 import imports.std15017variant;
 

--- a/test/runnable/link15021.d
+++ b/test/runnable/link15021.d
@@ -1,4 +1,10 @@
 // PERMUTE_ARGS: -inline -g -debug -unittest
+/*
+TEST_OUTPUT:
+---
+hit!
+---
+*/
 
 import imports.std15021conv;
 

--- a/test/runnable/link6574.d
+++ b/test/runnable/link6574.d
@@ -1,4 +1,13 @@
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+_D7imports10testmangle12detectMangleFPSQBlQBg6DetectZQq
+_D7imports10testmangle__T10DetectTmplTiZQpFNaNbNiNfZv
+true
+false
+---
+*/
 module link6574;
 
 import imports.testmangle;

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -1,5 +1,14 @@
 // PERMUTE_ARGS:
 // EXTRA_SOURCES: imports/mangle10077.d
+/*
+TEST_OUTPUT:
+---
+_D7imports10testmangle12detectMangleFPSQBlQBg6DetectZQq
+_D7imports10testmangle__T10DetectTmplTiZQpFNaNbNiNfZv
+true
+false
+---
+*/
 
 import imports.testmangle;
 

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -1,3 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+runnable/mixin1.d(906): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 module mixin1;
 

--- a/test/runnable/mixin2.d
+++ b/test/runnable/mixin2.d
@@ -1,3 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+hello
+hello
+
+
+
+hello
+hello
+---
+*/
 import std.stdio;
 
 /*********************************************/
@@ -47,7 +59,7 @@ void test4()
 
 int x5;
 
-scope class Foo5
+class Foo5
 {
         this ()
         {

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -1,4 +1,11 @@
 // REQUIRED_ARGS:
+/*
+TEST_OUTPUT:
+---
+runnable/nested.d(800): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
+null
+---
+*/
 
 import core.stdc.stdio;
 

--- a/test/runnable/newdel.d
+++ b/test/runnable/newdel.d
@@ -1,4 +1,10 @@
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+runnable/newdel.d(46): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 import core.stdc.stdio;
 import core.stdc.stdlib;
@@ -50,4 +56,3 @@ int main()
     printf("Success\n");
     return 0;
 }
-

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -1,3 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+pure nothrow @safe Object(bool b)
+pure nothrow @safe int*(bool b)
+pure nothrow @safe int[](bool b)
+---
+*/
 extern (C) int printf(const(char*) fmt, ...);
 
 alias typeof(null) null_t;

--- a/test/runnable/property2.d
+++ b/test/runnable/property2.d
@@ -1,3 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+decl: test
+stmt: test
+---
+*/
 extern (C) int printf(const char* fmt, ...);
 
 /*******************************************/

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1,5 +1,19 @@
 // PERMUTE_ARGS: -unittest -O -release -inline -fPIC -g
 // REQUIRED_ARGS: -preview=dtorfields
+/*
+TEST_OUTPUT:
+---
+runnable/sdtor.d(36): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/sdtor.d(59): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/sdtor.d(93): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/sdtor.d(117): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/sdtor.d(143): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/sdtor.d(177): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/sdtor.d(203): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/sdtor.d(276): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+S7353
+---
+*/
 
 import core.vararg;
 

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -1,3 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+runnable/structlit.d(1306): Deprecation: constructor `structlit.test11256.F11256!((gv) => true).F11256.this` all parameters have default arguments, but structs cannot have default constructors.
+runnable/structlit.d(1306): Deprecation: constructor `structlit.test11256.F11256!((gv) => true).F11256.this` all parameters have default arguments, but structs cannot have default constructors.
+runnable/structlit.d(1306): Deprecation: constructor `structlit.test11256.F11256!((gv) => true).F11256.this` all parameters have default arguments, but structs cannot have default constructors.
+---
+*/
 import std.stdio;
 
 struct S

--- a/test/runnable/template3.d
+++ b/test/runnable/template3.d
@@ -1,3 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+instantiating...
+instantiating...
+last instantiation!!!
+---
+*/
 
 import core.stdc.stdio;
 

--- a/test/runnable/template4.d
+++ b/test/runnable/template4.d
@@ -1,3 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+This actually gets evaluated!
+()
+(bool)
+(bool, short)
+(bool, short, int)
+Alias Test instantiated
+Alias Test instantiated
+---
+*/
 import std.stdio;
 import core.stdc.stdio;
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1040,7 +1040,7 @@ void test3467()
     a1 ~ a2; // line 7, Error
 }
 
-struct TS6806(size_t n) { pragma(msg, typeof(n)); }
+struct TS6806(uint n) { pragma(msg, typeof(n)); }
 static assert(is(TS6806!(1u) == TS6806!(1)));
 
 /**********************************/

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -1,5 +1,10 @@
-// REQUIRED_ARGS:
-// EXTRA_FILES: extra-files/test15.txt
+/*
+REQUIRED_ARGS:
+EXTRA_FILES: extra-files/test15.txt
+TEST_OUTPUT:
+---
+---
+*/
 
 import std.array;
 import core.stdc.math : cos, fabs, sin, sqrt;

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -1,3 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+runnable/test20.d(448): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 import core.vararg;
 
 extern(C) int printf(const char*, ...);
@@ -213,7 +219,7 @@ void test10()
 
 /*****************************************/
 
-scope class T11
+class T11
 {
     this(){}
     ~this(){}
@@ -1287,4 +1293,3 @@ int main()
     printf("Success\n");
     return 0;
 }
-

--- a/test/runnable/test23.d
+++ b/test/runnable/test23.d
@@ -1,4 +1,9 @@
 // REQUIRED_ARGS:
+/*
+TEST_OUTPUT:
+---
+---
+*/
 
 module test;
 

--- a/test/runnable/test34.d
+++ b/test/runnable/test34.d
@@ -1,3 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+Object
+---
+*/
 
 module test34;
 

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -1,5 +1,13 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS:
+/*
+TEST_OUTPUT:
+---
+runnable/test4.d(616): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
+runnable/test4.d(629): Deprecation: `extern(Pascal)` is deprecated. You might want to use `extern(Windows)` instead.
+runnable/test4.d(767): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 import core.exception;
 import core.stdc.math;

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -1,3 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+runnable/test8.d(283): Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
+---
+*/
 
 module testxxx8;
 

--- a/test/runnable/testappend.d
+++ b/test/runnable/testappend.d
@@ -1,4 +1,13 @@
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+runnable/testappend.d(49): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/testappend.d(50): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/testappend.d(71): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+runnable/testappend.d(72): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 import core.stdc.stdio;
 import core.stdc.math : isnan;

--- a/test/runnable/testargtypes.d
+++ b/test/runnable/testargtypes.d
@@ -1,3 +1,110 @@
+/*
+DISABLED: win32 win64 osx32 linux32 freebsd32
+TEST_OUTPUT:
+---
+S
+byte
+S
+short
+S
+int
+S
+long
+S
+ubyte
+S
+ushort
+S
+uint
+S
+ulong
+S
+ubyte
+S
+ushort
+S
+uint
+S
+float
+S
+double
+S
+real
+S
+void*
+S
+__vector(byte[16])
+S
+__vector(ubyte[16])
+S
+__vector(short[8])
+S
+__vector(ushort[8])
+S
+__vector(int[4])
+S
+__vector(uint[4])
+S
+__vector(long[2])
+S
+__vector(ulong[2])
+S
+__vector(float[4])
+S
+__vector(double[2])
+S
+short
+S
+short
+S
+int
+S
+long
+S
+int
+S
+int
+S
+long
+S
+long
+S
+long
+S
+long
+S1
+long
+long
+S2
+long
+S3
+long
+S4
+S5
+S6
+S7
+S8
+S9
+long
+int
+S9[1]
+long
+int
+S10
+long
+int
+S11
+double
+float
+RGB
+int
+int[3]
+long
+int
+S12
+int
+---
+*/
 
 void chkArgTypes(S, V...)()
 {
@@ -30,158 +137,144 @@ void chkPair(T,U,V)()
     chkArgTypes!(S, V)();
 }
 
-version (Posix) version (X86_64) version = Posix_X86_64;
-
-version (Posix_X86_64)
+int main()
 {
-    int main()
+    chkIdentity!byte();
+    chkIdentity!short();
+    chkIdentity!int();
+    chkIdentity!long();
+
+    version (DigitalMars)
     {
-        chkIdentity!byte();
-        chkIdentity!short();
-        chkIdentity!int();
-        chkIdentity!long();
+        chkIdentity!ubyte();
+        chkIdentity!ushort();
+        chkIdentity!uint();
+        chkIdentity!ulong();
 
-        version (DigitalMars)
-        {
-            chkIdentity!ubyte();
-            chkIdentity!ushort();
-            chkIdentity!uint();
-            chkIdentity!ulong();
-
-            chkSingle!(char,  ubyte)();
-            chkSingle!(wchar, ushort)();
-            chkSingle!(dchar, uint)();
-        }
-        else
-        {
-            chkSingle!(ubyte,  byte)();
-            chkSingle!(ushort, short)();
-            chkSingle!(uint,   int)();
-            chkSingle!(ulong,  long)();
-
-            chkSingle!(char,  byte)();
-            chkSingle!(wchar, short)();
-            chkSingle!(dchar, int)();
-        }
-
-        chkIdentity!float();
-        chkIdentity!double();
-        chkIdentity!real();
-
-        version (DigitalMars)
-            chkIdentity!(void*)();
-        else
-            chkSingle!(void*, ptrdiff_t)();
-
-        version (DigitalMars)
-        {
-            chkIdentity!(__vector(byte[16]))();
-            chkIdentity!(__vector(ubyte[16]))();
-            chkIdentity!(__vector(short[8]))();
-            chkIdentity!(__vector(ushort[8]))();
-            chkIdentity!(__vector(int[4]))();
-            chkIdentity!(__vector(uint[4]))();
-            chkIdentity!(__vector(long[2]))();
-            chkIdentity!(__vector(ulong[2]))();
-
-            chkIdentity!(__vector(float[4]))();
-            chkIdentity!(__vector(double[2]))();
-        }
-        else
-        {
-            chkSingle!(__vector(byte[16]),  __vector(double[2]))();
-            chkSingle!(__vector(ubyte[16]), __vector(double[2]))();
-            chkSingle!(__vector(short[8]),  __vector(double[2]))();
-            chkSingle!(__vector(ushort[8]), __vector(double[2]))();
-            chkSingle!(__vector(int[4]),    __vector(double[2]))();
-            chkSingle!(__vector(uint[4]),   __vector(double[2]))();
-            chkSingle!(__vector(long[2]),   __vector(double[2]))();
-            chkSingle!(__vector(ulong[2]),  __vector(double[2]))();
-
-            chkSingle!(__vector(float[4]),  __vector(double[2]))();
-            chkSingle!(__vector(double[2]), __vector(double[2]))();
-
-            version (D_AVX)
-                chkSingle!(__vector(int[8]), __vector(double[4]))();
-        }
-
-        chkPair!(byte,  byte,  short);
-        chkPair!(ubyte, ubyte, short);
-        chkPair!(short, short, int);
-        chkPair!(int,   int,   long);
-
-        chkPair!(byte,  short, int);
-        chkPair!(short, byte,  int);
-
-        chkPair!(int,   float, long);
-        chkPair!(float, int,   long);
-        chkPair!(byte,  float, long);
-        chkPair!(float, short, long);
-
-        struct S1 { long a; long b; }
-        chkArgTypes!(S1, long, long)();
-
-        struct S2 { union { long a; double d; }}
-        chkArgTypes!(S2, long)();
-
-        struct S3 { union { double d; long a; }}
-        chkArgTypes!(S3, long)();
-
-        struct S4 { int a,b,c,d,e; }
-        chkArgTypes!(S4)();
-
-        struct S5 { align(1): char a; int b; }
-        chkArgTypes!(S5)();
-
-        struct S6 { align(1): int a; void* b; }
-        chkArgTypes!(S6)();
-
-        struct S7 { union { void* p; real r; }}
-        chkArgTypes!(S7)();
-
-        struct S8 { union { real r; void* p; }}
-        chkArgTypes!(S8)();
-
-        struct S9 { int a,b,c; }
-        chkArgTypes!(S9, long, int)();
-        chkArgTypes!(S9[1], long, int)();
-
-        struct S10 { int[3] a; }
-        chkArgTypes!(S10, long, int)();
-
-        struct S11 { float a; struct { float b; float c; } }
-        chkArgTypes!(S11, double, float)();
-
-        struct RGB { ubyte r, g, b; }
-        chkArgTypes!(RGB, int)();
-
-        chkArgTypes!(int[3], long, int)();
-
-        struct S12 { align(16) int a; }
-        version (DigitalMars)
-            chkArgTypes!(S12, int)();
-        else
-            chkArgTypes!(S12, long)();
-
-        version (DigitalMars)
-        {
-        }
-        else
-        {
-            struct S13 { short a; cfloat b; }
-            chkArgTypes!(S13, long, float)();
-
-            struct S13957 { double a; ulong b; }
-            chkArgTypes!(S13957, double, long)();
-        }
-
-        return 0;
+        chkSingle!(char,  ubyte)();
+        chkSingle!(wchar, ushort)();
+        chkSingle!(dchar, uint)();
     }
-}
-else
-{
-    int main()
+    else
     {
-        return 0;
+        chkSingle!(ubyte,  byte)();
+        chkSingle!(ushort, short)();
+        chkSingle!(uint,   int)();
+        chkSingle!(ulong,  long)();
+
+        chkSingle!(char,  byte)();
+        chkSingle!(wchar, short)();
+        chkSingle!(dchar, int)();
     }
+
+    chkIdentity!float();
+    chkIdentity!double();
+    chkIdentity!real();
+
+    version (DigitalMars)
+        chkIdentity!(void*)();
+    else
+        chkSingle!(void*, ptrdiff_t)();
+
+    version (DigitalMars)
+    {
+        chkIdentity!(__vector(byte[16]))();
+        chkIdentity!(__vector(ubyte[16]))();
+        chkIdentity!(__vector(short[8]))();
+        chkIdentity!(__vector(ushort[8]))();
+        chkIdentity!(__vector(int[4]))();
+        chkIdentity!(__vector(uint[4]))();
+        chkIdentity!(__vector(long[2]))();
+        chkIdentity!(__vector(ulong[2]))();
+
+        chkIdentity!(__vector(float[4]))();
+        chkIdentity!(__vector(double[2]))();
+    }
+    else
+    {
+        chkSingle!(__vector(byte[16]),  __vector(double[2]))();
+        chkSingle!(__vector(ubyte[16]), __vector(double[2]))();
+        chkSingle!(__vector(short[8]),  __vector(double[2]))();
+        chkSingle!(__vector(ushort[8]), __vector(double[2]))();
+        chkSingle!(__vector(int[4]),    __vector(double[2]))();
+        chkSingle!(__vector(uint[4]),   __vector(double[2]))();
+        chkSingle!(__vector(long[2]),   __vector(double[2]))();
+        chkSingle!(__vector(ulong[2]),  __vector(double[2]))();
+
+        chkSingle!(__vector(float[4]),  __vector(double[2]))();
+        chkSingle!(__vector(double[2]), __vector(double[2]))();
+
+        version (D_AVX)
+            chkSingle!(__vector(int[8]), __vector(double[4]))();
+    }
+
+    chkPair!(byte,  byte,  short);
+    chkPair!(ubyte, ubyte, short);
+    chkPair!(short, short, int);
+    chkPair!(int,   int,   long);
+
+    chkPair!(byte,  short, int);
+    chkPair!(short, byte,  int);
+
+    chkPair!(int,   float, long);
+    chkPair!(float, int,   long);
+    chkPair!(byte,  float, long);
+    chkPair!(float, short, long);
+
+    struct S1 { long a; long b; }
+    chkArgTypes!(S1, long, long)();
+
+    struct S2 { union { long a; double d; }}
+    chkArgTypes!(S2, long)();
+
+    struct S3 { union { double d; long a; }}
+    chkArgTypes!(S3, long)();
+
+    struct S4 { int a,b,c,d,e; }
+    chkArgTypes!(S4)();
+
+    struct S5 { align(1): char a; int b; }
+    chkArgTypes!(S5)();
+
+    struct S6 { align(1): int a; void* b; }
+    chkArgTypes!(S6)();
+
+    struct S7 { union { void* p; real r; }}
+    chkArgTypes!(S7)();
+
+    struct S8 { union { real r; void* p; }}
+    chkArgTypes!(S8)();
+
+    struct S9 { int a,b,c; }
+    chkArgTypes!(S9, long, int)();
+    chkArgTypes!(S9[1], long, int)();
+
+    struct S10 { int[3] a; }
+    chkArgTypes!(S10, long, int)();
+
+    struct S11 { float a; struct { float b; float c; } }
+    chkArgTypes!(S11, double, float)();
+
+    struct RGB { ubyte r, g, b; }
+    chkArgTypes!(RGB, int)();
+
+    chkArgTypes!(int[3], long, int)();
+
+    struct S12 { align(16) int a; }
+    version (DigitalMars)
+        chkArgTypes!(S12, int)();
+    else
+        chkArgTypes!(S12, long)();
+
+    version (DigitalMars) {}
+    else
+    {
+        struct S13 { short a; cfloat b; }
+        chkArgTypes!(S13, long, float)();
+
+        struct S13957 { double a; ulong b; }
+        chkArgTypes!(S13957, double, long)();
+    }
+
+    return 0;
 }

--- a/test/runnable/testassign.d
+++ b/test/runnable/testassign.d
@@ -1,3 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+\	S1	S2a	S2b	S3a	S3b	S4a	S4b
+-	true	true	true	true	true	true	true
+Xa	true	true	true	true	true	true	true
+Xb	true	true	true	true	true	true	true
+Xc	true	true	true	true	true	true	true
+Xd	true	true	true	true	true	true	true
+Xe	true	true	true	true	true	true	true
+Xf	true	true	true	true	true	true	true
+Xg	true	true	true	true	true	true	true
+---
+*/
 import core.stdc.stdio;
 
 template TypeTuple(T...){ alias T TypeTuple; }

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1,3 +1,45 @@
+/*
+TEST_OUTPUT:
+---
+const(immutable(char)*)
+inout(immutable(char)*)
+inout(const(char)*)
+inout(const(char))
+shared(inout(char))
+shared(inout(char))
+immutable(char)
+immutable(char)
+inout(const(char))
+inout(const(char))
+shared(const(char))
+shared(const(char))
+inout(char*****)
+inout(char****)*
+const(char*****)
+const(char****)*
+immutable(char*****)
+immutable(char****)*
+shared(char*****)
+shared(char****)*
+const(shared(char****)*)
+shared(const(char*****))
+shared(char*****)
+immutable(char*****)
+inout(shared(char****)*)
+inout(shared(char**)***)
+shared(inout(char**))
+immutable(string)
+const(char[])
+char[]
+shared(foo85)
+const(char[26])
+const(char[26])
+immutable(char[26])
+immutable(char[26])
+string
+int[3]
+---
+*/
 
 import core.stdc.stdio;
 

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -1,4 +1,10 @@
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+runnable/testdstress.d(665): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 module run.module_01;
 
@@ -451,7 +457,7 @@ void test21()
 
 /* ================================ */
 
-scope class AutoClass{
+class AutoClass{
 }
 
 void test22()
@@ -466,7 +472,7 @@ void test22()
 
 int status23;
 
-scope class C23{
+class C23{
         ~this(){
                 assert(status23==0);
                 status23--;
@@ -492,7 +498,7 @@ void test23()
 
 int status24;
 
-scope class C24{
+class C24{
         this(){
                 assert(status24==0);
                 status24+=2;

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -1,4 +1,13 @@
 // REQUIRED_ARGS: -preview=dip25
+/*
+TEST_OUTPUT:
+---
+foo1 ulong function(return ref int* delegate() return p) ref return
+foo2 int function(return ref int delegate() p) ref
+foo3 int function(return ref inout(int*) p) ref
+foo4 int function(return ref inout(int*) p) ref
+---
+*/
 
 import core.stdc.stdio;
 
@@ -245,4 +254,3 @@ void main()
     test11();
     printf("Success\n");
 }
-

--- a/test/runnable/testsignals.d
+++ b/test/runnable/testsignals.d
@@ -1,3 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+runnable/testsignals.d(56): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 import std.stdio;
 import std.signals;
 

--- a/test/runnable/testsocket.d
+++ b/test/runnable/testsocket.d
@@ -1,4 +1,10 @@
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+runnable/testsocket.d(48): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+*/
 
 import std.stdio;
 import std.socket;

--- a/test/runnable/uda.d
+++ b/test/runnable/uda.d
@@ -1,3 +1,32 @@
+/*
+TEST_OUTPUT:
+---
+tuple(3, 4, 7, (SSS))
+tuple(3, 4, 7, (SSS))
+7
+SSS
+tuple("hello")
+tuple('c')
+tuple((FFF))
+tuple(10)
+tuple(20)
+tuple(30)
+tuple((Test6))
+tuple(Test7(3, "foo"))
+tuple((Test8!"foo"))
+tuple((Test9!"foo"))
+tuple(Test10(3))
+tuple(Test11(3))
+tuple(10)
+tuple(20)
+tuple()
+tuple(40)
+B9741
+tuple((A9741))
+tuple(1)
+tuple(2)
+---
+*/
 
 import core.stdc.stdio;
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1,4 +1,44 @@
 // PERMUTE_ARGS: -unittest -O -release -inline -fPIC -g
+/*
+TEST_OUTPUT:
+---
+Boo!double
+Boo!int
+true
+int
+!! immutable(int)[]
+int(int i, long j = 7L)
+long
+C10390(C10390(<recursion>))
+tuple(height)
+tuple(get, get)
+tuple(clear)
+tuple(draw, draw)
+runnable/xtest46.d(179): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(181): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(182): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(184): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(211): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(213): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(214): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(216): Deprecation: `opDot` is deprecated. Use `alias this`
+const(int)
+string[]
+double[]
+double[]
+{}
+tuple("m")
+true
+TFunction1: extern (C) void function()
+f
+toString
+toHash
+opCmp
+opEquals
+Monitor
+factory
+---
+*/
 
 //import std.stdio;
 import core.stdc.stdio;
@@ -7387,7 +7427,7 @@ void test13476()
 // https://issues.dlang.org/show_bug.cgi?id=14038
 
 static immutable ubyte[string] wordsAA14038;
-static this()
+shared static this()
 {
     wordsAA14038["zero"] = 0;
 }


### PR DESCRIPTION
Same as #9231 and #9240.

Again, lots of `pragma(msg)` that require cleaning up.

Also, many deprecations in the output as well.  As these are runnable tests, maybe all deprecations should be fixed accordingly.