### PR TITLE
testsuite: Use 'static assert' instead of 'pragma(msg)' in compilable tests.

### DIFF
--- a/test/compilable/imports/test11563std_traits.d
+++ b/test/compilable/imports/test11563std_traits.d
@@ -16,7 +16,7 @@ template moduleName(alias T)
     }
     else
     {
-        pragma(msg, "--error--");
+        enum moduleName = "--error--";
     }
 }
 

--- a/test/compilable/imports/test17541_3.d
+++ b/test/compilable/imports/test17541_3.d
@@ -9,7 +9,7 @@ struct TT(T)
 {
     void insertabcdefg(T) // @nogc  <-- deduction problem
     {
-        pragma(msg, insertabcdefg.mangleof);
+        static assert(insertabcdefg.mangleof == "_D5three__T2TTTiZQg13insertabcdefgMFiZv");
         aaa();
     }
 }

--- a/test/compilable/test11563.d
+++ b/test/compilable/test11563.d
@@ -3,7 +3,7 @@ import imports.test11563std_traits;
 interface J : I {} // comment out to let compilation succeed
 
 struct A { }
-pragma(msg, moduleName!A);
+static assert(moduleName!A == "b");
 
 
 interface I {}

--- a/test/compilable/test12527.d
+++ b/test/compilable/test12527.d
@@ -2,9 +2,7 @@
 
 @system:
     alias Fun = void function() @safe;
-    pragma (msg, Fun.stringof);
     static assert(Fun.stringof == "void function() @safe");
     alias Del = void delegate() @safe;
-    pragma (msg, Del.stringof);
     static assert(Del.stringof == "void delegate() @safe");
 

--- a/test/compilable/test17143.d
+++ b/test/compilable/test17143.d
@@ -1,4 +1,4 @@
 import std.typecons : tuple;
 enum foo = tuple(1, 2).expand;
-pragma(msg, typeof(foo).stringof);
-pragma(msg, foo.stringof);
+static assert(typeof(foo).stringof == "(int, int)");
+static assert(foo.stringof == "tuple(1, 2)");

--- a/test/compilable/test18030.d
+++ b/test/compilable/test18030.d
@@ -3,11 +3,7 @@
 struct S(T)
 {
 	T var;
-	pragma(
-		msg,
-		"Inside S: func() is ",
-		__traits(getProtection, __traits(getMember, T, "func"))
-	);
+	static assert(__traits(getProtection, __traits(getMember, T, "func")) == "public");
 }
 
 class C

--- a/test/compilable/test19499.d
+++ b/test/compilable/test19499.d
@@ -3,4 +3,4 @@
 enum __c_long_double : double;
 enum A(T : double) = true;
 enum A(T : __c_long_double) = false;
-pragma(msg, A!double);
+static assert(A!double == true);

--- a/test/compilable/testInference.d
+++ b/test/compilable/testInference.d
@@ -655,7 +655,7 @@ void foo10296()()
 
     void bar()() { a[1] = 2; }
     bar();
-    pragma(msg, typeof(bar!()));    // nothrow @safe void()
+    static assert(typeof(bar!()).stringof == "pure nothrow @nogc @safe void()");    // nothrow @safe void()
 }
 pure void test10296()
 {

--- a/test/compilable/testparse.d
+++ b/test/compilable/testparse.d
@@ -4,7 +4,7 @@
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6719
 
-pragma(msg, __traits(compiles, mixin("(const(A))[0..0]")));
+static assert(__traits(compiles, mixin("(const(A))[0..0]")) == false);
 
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=9232

--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -296,7 +296,6 @@ static assert(is(typeof( (){ C4 g = 7; C4 h = g;})));
 alias uint DWORD;
 MY_API_FUNCTION lpStartAddress;
 extern (Windows) alias DWORD function(void*) MY_API_FUNCTION;
-pragma(msg, MY_API_FUNCTION.stringof);
 static assert(MY_API_FUNCTION.stringof == "extern (Windows) uint function(void*)");
 
 /************************************/

--- a/test/runnable/testrightthis.d
+++ b/test/runnable/testrightthis.d
@@ -578,7 +578,6 @@ class Bar11245
 {
     void func()
     {
-        pragma(msg, "====");
         float[Vec11245.f.length] newVal;
     }
 }


### PR DESCRIPTION
As tests should be quiet if it can be avoided.