### PR TITLE
testsuite: Replace pragma(msg) with other tests that check same bug

### DIFF
--- a/test/compilable/compile1.d
+++ b/test/compilable/compile1.d
@@ -15,9 +15,9 @@ static assert(C1748!int.stringof == "C1748!int");
 // pragma + single semicolon DeclarationBlock
 
 version(all)
-    pragma(msg, "true");
+    pragma(inline, true);
 else
-    pragma(msg, "false");
+    pragma(inline, false);
 
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=2438
@@ -78,7 +78,7 @@ template ice8982(T)
     void bug8982(ref const int v = 7){}
 
     static if (is(typeof(bug8982) P == __parameters)) {
-        pragma(msg, ((P[0..1] g) => g[0])());
+        enum eval8982 = ((P[0..1] g) => g[0])();
     }
 }
 
@@ -296,7 +296,7 @@ void test11939()
 // https://issues.dlang.org/show_bug.cgi?id=5796
 
 template A(B) {
-    pragma(msg, "missing ;")
+    pragma(lib, "missing ;")
     enum X = 0;
 }
 
@@ -763,7 +763,7 @@ struct A12799
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=13236
 
-pragma(msg, is(typeof({ struct S { S x; } })));
+enum bug13286 = is(typeof({ struct S { S x; } }));
 
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=13280
@@ -854,14 +854,15 @@ X14166[int] makeAA14166() { return aa14166; }
 struct Tup14166(T...) { T field; alias field this; }
 Tup14166!(int, int) tup14166;
 Tup14166!(int, int) makeTup14166() { return tup14166; }
+alias TT14166(T...) = T;
 
-pragma(msg, typeof((s14166.x += 1) = 2));    // ok <- error
-pragma(msg, typeof(s14166.a.length += 2));   // ok <- error
-pragma(msg, typeof(s14166++));               // ok <- error
-pragma(msg, typeof(s14166.x ^^ 2));          // ok <- error
-pragma(msg, typeof(s14166.y ^^= 2.5));       // ok <- error
-pragma(msg, typeof(makeAA14166()[0] = 1));   // ok <- error
-pragma(msg, typeof(tup14166.field = makeTup14166()));   // ok <- error
+static assert(is(typeof((s14166.x += 1) = 2) == int));     // ok <- error
+static assert(is(typeof(s14166.a.length += 2) == size_t)); // ok <- error
+static assert(is(typeof(s14166++) == S14166));             // ok <- error
+static assert(is(typeof(s14166.x ^^ 2) == int));           // ok <- error
+static assert(is(typeof(s14166.y ^^= 2.5) == double));     // ok <- error
+static assert(is(typeof(makeAA14166()[0] = 1) == X14166)); // ok <- error
+static assert(is(typeof(tup14166.field = makeTup14166()) == TT14166!(int, int))); // ok <- error
 
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=14388

--- a/test/compilable/test15326.d
+++ b/test/compilable/test15326.d
@@ -5,19 +5,19 @@ private struct _NestedSym_
 {
     static if ((void*).sizeof == 8)
     {
-        pragma(msg, "64");
+        int pointersize = 64;
     }
     else
     {
-        pragma(msg, "32");
+        int pointersize = 32;
     }
 
     version (X86_64)
     {
-        pragma(msg, "X86_64");
+        string arch = "X86_64";
     }
     else
     {
-        pragma(msg, "Not 64");
+        string arch = "Not 64";
     }
 }

--- a/test/compilable/test16525.d
+++ b/test/compilable/test16525.d
@@ -12,8 +12,8 @@ extern(C++) struct CPP
 
 void test()
 {
-    pragma(msg, templ!(D.memvar));
-    pragma(msg, templ!(CPP.memvar));
-    // root cause, C++ member variables have no mangling
-    pragma(msg, CPP.memvar.mangleof);
+    static assert(templ!(D.memvar) == 1234);
+    static assert(templ!(CPP.memvar) == 1234);
+    // ICE: root cause, C++ member variables have no mangling
+    enum CPPmemvar = CPP.memvar.mangleof;
 }

--- a/test/compilable/test17819.d
+++ b/test/compilable/test17819.d
@@ -1,10 +1,8 @@
 static if (__traits(allMembers, __traits(parent,{}))[0]=="object") {
-	pragma(msg, "compiled in!");
 	enum test = 0;
 }
 
 static foreach (m; __traits(allMembers, __traits(parent,{}))) {
-	pragma(msg, m.stringof);
 	mixin("enum new"~m~"=`"~m~"`;");
 }
 


### PR DESCRIPTION
Following the principle that tests should be silent if they can be.

I've tested each place and verified that all alternative tests are affected by the same bug they are meant to cover.