### PR TITLE
[dmd-cxx] Backport dinterpret memory improvments

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -20,138 +20,72 @@
 #include "scope.h"
 
 /******************************
- * Private helpers for Compiler::paintAsType.
- */
-
-// Write the integer value of 'e' into a unsigned byte buffer.
-static void encodeInteger(Expression *e, unsigned char *buffer)
-{
-    dinteger_t value = e->toInteger();
-    int size = (int)e->type->size();
-
-    for (int p = 0; p < size; p++)
-    {
-        int offset = p;     // Would be (size - 1) - p; on BigEndian
-        buffer[offset] = ((value >> (p * 8)) & 0xFF);
-    }
-}
-
-// Write the bytes encoded in 'buffer' into an integer and returns
-// the value as a new IntegerExp.
-static Expression *decodeInteger(Loc loc, Type *type, unsigned char *buffer)
-{
-    dinteger_t value = 0;
-    int size = (int)type->size();
-
-    for (int p = 0; p < size; p++)
-    {
-        int offset = p;     // Would be (size - 1) - p; on BigEndian
-        value |= ((dinteger_t)buffer[offset] << (p * 8));
-    }
-
-    return new IntegerExp(loc, value, type);
-}
-
-// Write the real value of 'e' into a unsigned byte buffer.
-static void encodeReal(Expression *e, unsigned char *buffer)
-{
-    switch (e->type->ty)
-    {
-        case Tfloat32:
-        {
-            float *p = (float *)buffer;
-            *p = (float)e->toReal();
-            break;
-        }
-        case Tfloat64:
-        {
-            double *p = (double *)buffer;
-            *p = (double)e->toReal();
-            break;
-        }
-        default:
-            assert(0);
-    }
-}
-
-// Write the bytes encoded in 'buffer' into a longdouble and returns
-// the value as a new RealExp.
-static Expression *decodeReal(Loc loc, Type *type, unsigned char *buffer)
-{
-    longdouble value;
-
-    switch (type->ty)
-    {
-        case Tfloat32:
-        {
-            float *p = (float *)buffer;
-            value = ldouble(*p);
-            break;
-        }
-        case Tfloat64:
-        {
-            double *p = (double *)buffer;
-            value = ldouble(*p);
-            break;
-        }
-        default:
-            assert(0);
-    }
-
-    return new RealExp(loc, value, type);
-}
-
-/******************************
  * Encode the given expression, which is assumed to be an rvalue literal
  * as another type for use in CTFE.
  * This corresponds roughly to the idiom *(Type *)&e.
  */
 
-Expression *Compiler::paintAsType(Expression *e, Type *type)
+Expression *Compiler::paintAsType(UnionExp *pue, Expression *e, Type *type)
 {
-    // We support up to 512-bit values.
-    unsigned char buffer[64];
+    union U
+    {
+        d_int32 int32value;
+        d_int64 int64value;
+        float float32value;
+        double float64value;
+    };
+    U u;
 
-    memset(buffer, 0, sizeof(buffer));
     assert(e->type->size() == type->size());
 
-    // Write the expression into the buffer.
     switch (e->type->ty)
     {
         case Tint32:
         case Tuns32:
+            u.int32value = (d_int32)e->toInteger();
+            break;
         case Tint64:
         case Tuns64:
-            encodeInteger(e, buffer);
+            u.int64value = (d_int64)e->toInteger();
             break;
 
         case Tfloat32:
+            u.float32value = (float)e->toReal();
+            break;
+
         case Tfloat64:
-            encodeReal(e, buffer);
+            u.float64value = (double)e->toReal();
             break;
 
         default:
             assert(0);
     }
 
-    // Interpret the buffer as a new type.
     switch (type->ty)
     {
         case Tint32:
         case Tuns32:
+            new(pue) IntegerExp(e->loc, u.int32value, type);
+            break;
+
         case Tint64:
         case Tuns64:
-            return decodeInteger(e->loc, type, buffer);
+            new(pue) IntegerExp(e->loc, u.int64value, type);
+            break;
 
         case Tfloat32:
+            new(pue) RealExp(e->loc, ldouble(u.float32value), type);
+            break;
+
         case Tfloat64:
-            return decodeReal(e->loc, type, buffer);
+            new(pue) RealExp(e->loc, ldouble(u.float64value), type);
+            break;
 
         default:
             assert(0);
     }
 
-    return NULL;    // avoid warning
+    return pue->exp();
 }
 
 /******************************

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -19,6 +19,7 @@ class Expression;
 class Module;
 class Type;
 struct Scope;
+struct UnionExp;
 
 // DMD-generated module `__entrypoint` where the C main resides
 extern Module *entrypoint;
@@ -28,7 +29,7 @@ extern Module *rootHasMain;
 struct Compiler
 {
     // CTFE support for cross-compilation.
-    static Expression *paintAsType(Expression *, Type *);
+    static Expression *paintAsType(UnionExp *, Expression *, Type *);
     // Backend
     static void loadModule(Module *);
     static void genCmain(Scope *);

--- a/src/constfold.c
+++ b/src/constfold.c
@@ -1457,8 +1457,7 @@ UnionExp Slice(Type *type, Expression *e1, Expression *lwr, Expression *upr)
             memcpy(elements->tdata(),
                    es1->elements->tdata() + ilwr,
                    (size_t)(iupr - ilwr) * sizeof((*es1->elements)[0]));
-            new(&ue) ArrayLiteralExp(e1->loc, elements);
-            ue.exp()->type = type;
+            new(&ue) ArrayLiteralExp(e1->loc, type, elements);
         }
     }
     else
@@ -1606,6 +1605,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
 
             new(&ue) StringExp(loc, s, len);
             StringExp *es = (StringExp *)ue.exp();
+            es->type = type;
             es->sz = sz;
             es->committed = 1;
         }
@@ -1614,9 +1614,8 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
             // Create an ArrayLiteralExp
             Expressions *elements = new Expressions();
             elements->push(e);
-            new(&ue) ArrayLiteralExp(e->loc, elements);
+            new(&ue) ArrayLiteralExp(e->loc, type, elements);
         }
-        ue.exp()->type = type;
         assert(ue.exp()->type);
         return ue;
     }
@@ -1627,8 +1626,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
             // Handle null ~= null
             if (t1->ty == Tarray && t2 == t1->nextOf())
             {
-                new(&ue) ArrayLiteralExp(e1->loc, e2);
-                ue.exp()->type = type;
+                new(&ue) ArrayLiteralExp(e1->loc, type, e2);
                 assert(ue.exp()->type);
                 return ue;
             }
@@ -1695,9 +1693,8 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
         {
             (*elems)[i] = ea->getElement(i);
         }
-        new(&ue) ArrayLiteralExp(e1->loc, elems);
+        new(&ue) ArrayLiteralExp(e1->loc, type, elems);
         ArrayLiteralExp *dest = (ArrayLiteralExp *)ue.exp();
-        dest->type = type;
         sliceAssignArrayLiteralFromString(dest, es, ea->elements->dim);
         assert(ue.exp()->type);
         return ue;
@@ -1715,9 +1712,8 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
         {
             (*elems)[es->len + i] = ea->getElement(i);
         }
-        new(&ue) ArrayLiteralExp(e1->loc, elems);
+        new(&ue) ArrayLiteralExp(e1->loc, type, elems);
         ArrayLiteralExp *dest = (ArrayLiteralExp *)ue.exp();
-        dest->type = type;
         sliceAssignArrayLiteralFromString(dest, es, 0);
         assert(ue.exp()->type);
         return ue;
@@ -1783,7 +1779,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
         // Concatenate the arrays
         Expressions *elems = ArrayLiteralExp::copyElements(e1, e2);
 
-        new(&ue) ArrayLiteralExp(e1->loc, elems);
+        new(&ue) ArrayLiteralExp(e1->loc, NULL, elems);
 
         e = ue.exp();
         if (type->toBasetype()->ty == Tsarray)
@@ -1809,7 +1805,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
         // Concatenate the array with null
         Expressions *elems = ArrayLiteralExp::copyElements(e);
 
-        new(&ue) ArrayLiteralExp(e->loc, elems);
+        new(&ue) ArrayLiteralExp(e->loc, NULL, elems);
 
         e = ue.exp();
         if (type->toBasetype()->ty == Tsarray)
@@ -1829,7 +1825,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
             ? ArrayLiteralExp::copyElements(e1) : new Expressions();
         elems->push(e2);
 
-        new(&ue) ArrayLiteralExp(e1->loc, elems);
+        new(&ue) ArrayLiteralExp(e1->loc, NULL, elems);
 
         e = ue.exp();
         if (type->toBasetype()->ty == Tsarray)
@@ -1846,7 +1842,7 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
     {
         Expressions *elems = ArrayLiteralExp::copyElements(e1, e2);
 
-        new(&ue) ArrayLiteralExp(e2->loc, elems);
+        new(&ue) ArrayLiteralExp(e2->loc, NULL, elems);
 
         e = ue.exp();
         if (type->toBasetype()->ty == Tsarray)
@@ -1874,9 +1870,8 @@ UnionExp Cat(Type *type, Expression *e1, Expression *e2)
         {
             Expressions *expressions = new Expressions();
             expressions->push(e);
-            new(&ue) ArrayLiteralExp(loc, expressions);
+            new(&ue) ArrayLiteralExp(loc, t, expressions);
             e = ue.exp();
-            e->type = t;
         }
         else
         {

--- a/src/ctfe.h
+++ b/src/ctfe.h
@@ -134,6 +134,7 @@ UnionExp copyLiteral(Expression *e);
 
 /// Set this literal to the given type, copying it if necessary
 Expression *paintTypeOntoLiteral(Type *type, Expression *lit);
+Expression *paintTypeOntoLiteral(UnionExp *pue, Type *type, Expression *lit);
 UnionExp paintTypeOntoLiteralCopy(Type *type, Expression *lit);
 
 /// Convert from a CTFE-internal slice, into a normal Expression
@@ -143,11 +144,11 @@ Expression *resolveSlice(Expression *e, UnionExp *pue = NULL);
 uinteger_t resolveArrayLength(Expression *e);
 
 /// Create an array literal consisting of 'elem' duplicated 'dim' times.
-ArrayLiteralExp *createBlockDuplicatedArrayLiteral(Loc loc, Type *type,
+ArrayLiteralExp *createBlockDuplicatedArrayLiteral(UnionExp *pue, Loc loc, Type *type,
         Expression *elem, size_t dim);
 
 /// Create a string literal consisting of 'value' duplicated 'dim' times.
-StringExp *createBlockDuplicatedStringLiteral(Loc loc, Type *type,
+StringExp *createBlockDuplicatedStringLiteral(UnionExp *pue, Loc loc, Type *type,
         unsigned value, size_t dim, unsigned char sz);
 
 
@@ -209,7 +210,7 @@ UnionExp pointerArithmetic(Loc loc, TOK op, Type *type,
 bool isFloatIntPaint(Type *to, Type *from);
 
 // Reinterpret float/int value 'fromVal' as a float/integer of type 'to'.
-Expression *paintFloatInt(Expression *fromVal, Type *to);
+Expression *paintFloatInt(UnionExp *pue, Expression *fromVal, Type *to);
 
 /// Return true if t is an AA
 bool isAssocArray(Type *t);
@@ -264,4 +265,4 @@ UnionExp ctfeCat(Loc loc, Type *type, Expression *e1, Expression *e2);
 Expression *ctfeIndex(Loc loc, Type *type, Expression *e1, uinteger_t indx);
 
 /// Cast 'e' of type 'type' to type 'to'.
-Expression *ctfeCast(Loc loc, Type *type, Type *to, Expression *e);
+Expression *ctfeCast(UnionExp *pue, Loc loc, Type *type, Type *to, Expression *e);

--- a/src/expression.c
+++ b/src/expression.c
@@ -1493,7 +1493,6 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                          * is now optimized. See Bugzilla 2356.
                          */
                         Type *tbn = ((TypeArray *)tb)->next;
-                        Type *tsa = tbn->sarrayOf(nargs - i);
 
                         Expressions *elements = new Expressions();
                         elements->setDim(nargs - i);
@@ -1511,8 +1510,7 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
                             (*elements)[u] = a;
                         }
                         // Bugzilla 14395: Convert to a static array literal, or its slice.
-                        arg = new ArrayLiteralExp(loc, elements);
-                        arg->type = tsa;
+                        arg = new ArrayLiteralExp(loc, tbn->sarrayOf(nargs - i), elements);
                         if (tb->ty == Tarray)
                         {
                             arg = new SliceExp(loc, arg, NULL, NULL);
@@ -3741,34 +3739,37 @@ unsigned StringExp::charAt(uinteger_t i) const
 
 // [ e1, e2, e3, ... ]
 
-ArrayLiteralExp::ArrayLiteralExp(Loc loc, Expressions *elements)
+ArrayLiteralExp::ArrayLiteralExp(Loc loc, Type *type, Expressions *elements)
     : Expression(loc, TOKarrayliteral, sizeof(ArrayLiteralExp))
 {
     this->basis = NULL;
+    this->type = type;
     this->elements = elements;
     this->ownedByCtfe = OWNEDcode;
 }
 
-ArrayLiteralExp::ArrayLiteralExp(Loc loc, Expression *e)
+ArrayLiteralExp::ArrayLiteralExp(Loc loc, Type *type, Expression *e)
     : Expression(loc, TOKarrayliteral, sizeof(ArrayLiteralExp))
 {
     this->basis = NULL;
+    this->type = type;
     elements = new Expressions;
     elements->push(e);
     this->ownedByCtfe = OWNEDcode;
 }
 
-ArrayLiteralExp::ArrayLiteralExp(Loc loc, Expression *basis, Expressions *elements)
+ArrayLiteralExp::ArrayLiteralExp(Loc loc, Type *type, Expression *basis, Expressions *elements)
     : Expression(loc, TOKarrayliteral, sizeof(ArrayLiteralExp))
 {
     this->basis = basis;
+    this->type = type;
     this->elements = elements;
     this->ownedByCtfe = OWNEDcode;
 }
 
 ArrayLiteralExp *ArrayLiteralExp::create(Loc loc, Expressions *elements)
 {
-    return new ArrayLiteralExp(loc, elements);
+    return new ArrayLiteralExp(loc, NULL, elements);
 }
 
 bool ArrayLiteralExp::equals(RootObject *o)
@@ -3806,6 +3807,7 @@ bool ArrayLiteralExp::equals(RootObject *o)
 Expression *ArrayLiteralExp::syntaxCopy()
 {
     return new ArrayLiteralExp(loc,
+        NULL,
         basis ? basis->syntaxCopy() : NULL,
         arraySyntaxCopy(elements));
 }
@@ -4082,8 +4084,7 @@ Expression *StructLiteralExp::getField(Type *type, unsigned offset)
                 z->setDim(length);
                 for (size_t q = 0; q < length; ++q)
                     (*z)[q] = e->copy();
-                e = new ArrayLiteralExp(loc, z);
-                e->type = type;
+                e = new ArrayLiteralExp(loc, type, z);
             }
             else
             {

--- a/src/expression.h
+++ b/src/expression.h
@@ -410,9 +410,9 @@ public:
     Expressions *elements;
     OwnedBy ownedByCtfe;
 
-    ArrayLiteralExp(Loc loc, Expressions *elements);
-    ArrayLiteralExp(Loc loc, Expression *e);
-    ArrayLiteralExp(Loc loc, Expression *basis, Expressions *elements);
+    ArrayLiteralExp(Loc loc, Type *type, Expressions *elements);
+    ArrayLiteralExp(Loc loc, Type *type, Expression *e);
+    ArrayLiteralExp(Loc loc, Type *type, Expression *basis, Expressions *elements);
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     Expression *syntaxCopy();
     bool equals(RootObject *o);

--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -6632,8 +6632,7 @@ public:
                 if (tb2->ty == Tarray || tb2->ty == Tsarray)
                 {
                     // Make e2 into [e2]
-                    exp->e2 = new ArrayLiteralExp(exp->e2->loc, exp->e2);
-                    exp->e2->type = exp->type;
+                    exp->e2 = new ArrayLiteralExp(exp->e2->loc, exp->type, exp->e2);
                 }
                 result = exp->optimize(WANTvalue);
                 return;
@@ -6669,8 +6668,7 @@ public:
                 if (tb1->ty == Tarray || tb1->ty == Tsarray)
                 {
                     // Make e1 into [e1]
-                    exp->e1 = new ArrayLiteralExp(exp->e1->loc, exp->e1);
-                    exp->e1->type = exp->type;
+                    exp->e1 = new ArrayLiteralExp(exp->e1->loc, exp->type, exp->e1);
                 }
                 result = exp->optimize(WANTvalue);
                 return;

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -267,6 +267,9 @@ Msgtable msgtable[] =
     { "_ArrayEq", NULL },
     { "_ArrayPostblit", NULL },
     { "_ArrayDtor", NULL },
+    { "dup", NULL },
+    { "_aaApply", NULL },
+    { "_aaApply2", NULL },
 
     // For pragma's
     { "Pinline", "inline" },

--- a/src/initsem.c
+++ b/src/initsem.c
@@ -612,7 +612,7 @@ public:
                 assert((*elements)[i]->op != TOKerror);
             }
 
-            Expression *e = new ArrayLiteralExp(init->loc, elements);
+            Expression *e = new ArrayLiteralExp(init->loc, NULL, elements);
             ExpInitializer *ei = new ExpInitializer(init->loc, e);
             result = inferType(ei, sc);
             return;
@@ -857,8 +857,7 @@ public:
                             elements2->setDim(dim);
                             for (size_t j = 0; j < dim; j++)
                                 (*elements2)[j] = e;
-                            e = new ArrayLiteralExp(e->loc, elements2);
-                            e->type = tn;
+                            e = new ArrayLiteralExp(e->loc, tn, elements2);
                             (*elements)[i] = e;
                         }
                     }
@@ -877,8 +876,7 @@ public:
                 }
             }
 
-            Expression *e = new ArrayLiteralExp(init->loc, elements);
-            e->type = init->type;
+            Expression *e = new ArrayLiteralExp(init->loc, init->type, elements);
             result = e;
             return;
         }
@@ -902,8 +900,7 @@ public:
                 elements->setDim(d);
                 for (size_t i = 0; i < d; i++)
                     (*elements)[i] = e;
-                ArrayLiteralExp *ae = new ArrayLiteralExp(e->loc, elements);
-                ae->type = itype;
+                ArrayLiteralExp *ae = new ArrayLiteralExp(e->loc, itype, elements);
                 result = ae;
                 return;
             }

--- a/src/mtype.c
+++ b/src/mtype.c
@@ -4340,8 +4340,7 @@ Expression *TypeSArray::defaultInitLiteral(Loc loc)
     elements->setDim(d);
     for (size_t i = 0; i < d; i++)
         (*elements)[i] = NULL;
-    ArrayLiteralExp *ae = new ArrayLiteralExp(Loc(), elementinit, elements);
-    ae->type = this;
+    ArrayLiteralExp *ae = new ArrayLiteralExp(Loc(), this, elementinit, elements);
     return ae;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -7020,7 +7020,7 @@ Expression *Parser::parsePrimaryExp()
             if (keys)
                 e = new AssocArrayLiteralExp(loc, keys, values);
             else
-                e = new ArrayLiteralExp(loc, values);
+                e = new ArrayLiteralExp(loc, NULL, values);
             break;
         }
 

--- a/src/traits.c
+++ b/src/traits.c
@@ -479,8 +479,7 @@ Expression *pointerBitmap(TraitsExp *e)
     for (d_uns64 i = 0; i < cntdata; i++)
         exps->push(new IntegerExp(e->loc, data[(size_t)i], Type::tsize_t));
 
-    ArrayLiteralExp* ale = new ArrayLiteralExp(e->loc, exps);
-    ale->type = Type::tsize_t->sarrayOf(cntdata + 1);
+    ArrayLiteralExp* ale = new ArrayLiteralExp(e->loc, Type::tsize_t->sarrayOf(cntdata + 1), exps);
     return ale;
 }
 


### PR DESCRIPTION
Last time I did this there was a huge memory reduction in many contrived CTFE tests.

The smaller the memory footprint the better, especially as there's no GC in the C++ version.

Bootstrapped and regression tested on x86_64-linux-gnu.