### PR TITLE
testsuite: Open output capture file in binary mode

### DIFF
--- a/test/fail_compilation/e15876_1.d
+++ b/test/fail_compilation/e15876_1.d
@@ -1,1 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e15876_1.d(15): Error: valid scope identifiers are `exit`, `failure`, or `success`, not `x`
+fail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_1.d(16): Error: found `End of File` instead of statement
+fail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/e15876_1.d(16): Error: found `End of File` when expecting `]`
+fail_compilation/e15876_1.d(16): Error: no identifier for declarator `o[()
+{
+scope(exit) }
+]`
+---
+*/
 o[{scope(x

--- a/test/fail_compilation/e15876_2.d
+++ b/test/fail_compilation/e15876_2.d
@@ -1,1 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e15876_2.d(15): Error: identifier expected following `template`
+fail_compilation/e15876_2.d(15): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/e15876_2.d(15): Error: found `End of File` when expecting `]`
+fail_compilation/e15876_2.d(15): Error: no identifier for declarator `o[()
+{
+;
+}
+]`
+---
+*/
 o[{template

--- a/test/fail_compilation/e15876_3.d
+++ b/test/fail_compilation/e15876_3.d
@@ -1,1 +1,25 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e15876_3.d(25): Error: unexpected `(` in declarator
+fail_compilation/e15876_3.d(25): Error: basic type expected, not `=`
+fail_compilation/e15876_3.d(26): Error: found `End of File` when expecting `(`
+fail_compilation/e15876_3.d(26): Error: found `End of File` instead of statement
+fail_compilation/e15876_3.d(26): Error: expression expected, not `End of File`
+fail_compilation/e15876_3.d(26): Error: found `End of File` when expecting `;` following `for` condition
+fail_compilation/e15876_3.d(26): Error: expression expected, not `End of File`
+fail_compilation/e15876_3.d(26): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_3.d(26): Error: found `End of File` instead of statement
+fail_compilation/e15876_3.d(26): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/e15876_3.d(26): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_3.d(26): Error: no identifier for declarator `d(_error_ = ()
+{
+for (; 0; 0)
+{
+}
+}
+)`
+fail_compilation/e15876_3.d(26): Error: semicolon expected following function declaration
+---
+*/
 d(={for

--- a/test/fail_compilation/e15876_4.d
+++ b/test/fail_compilation/e15876_4.d
@@ -1,1 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e15876_4.d(23): Error: found `)` when expecting `(`
+fail_compilation/e15876_4.d(24): Error: found `End of File` when expecting `(`
+fail_compilation/e15876_4.d(24): Error: found `End of File` instead of statement
+fail_compilation/e15876_4.d(24): Error: expression expected, not `End of File`
+fail_compilation/e15876_4.d(24): Error: found `End of File` when expecting `;` following `for` condition
+fail_compilation/e15876_4.d(24): Error: expression expected, not `End of File`
+fail_compilation/e15876_4.d(24): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_4.d(24): Error: found `End of File` instead of statement
+fail_compilation/e15876_4.d(24): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/e15876_4.d(24): Error: found `End of File` when expecting `)`
+fail_compilation/e15876_4.d(24): Error: no identifier for declarator `typeof(()
+{
+for (; 0; 0)
+{
+}
+}
+)`
+---
+*/
 typeof){for

--- a/test/fail_compilation/e15876_5.d
+++ b/test/fail_compilation/e15876_5.d
@@ -1,1 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e15876_5.d(16): Error: basic type expected, not `End of File`
+fail_compilation/e15876_5.d(16): Error: semicolon expected to close `alias` declaration
+fail_compilation/e15876_5.d(16): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/e15876_5.d(16): Error: found `End of File` when expecting `]`
+fail_compilation/e15876_5.d(16): Error: no identifier for declarator `p[()
+{
+alias ;
+}
+]`
+---
+*/
 p[{alias

--- a/test/fail_compilation/fail324.d
+++ b/test/fail_compilation/fail324.d
@@ -1,7 +1,11 @@
 /*
-test_output:
+TEST_OUTPUT:
 ---
-fail_compilation/fail324.d(16): Error: template instance doStuff!((i){ return i; }) cannot use local `__lambda1` as parameter to non-global template `doStuff(alias fun)()`
+fail_compilation/fail324.d(20): Error: template instance `doStuff!((i)
+{
+return i;
+}
+)` cannot use local `__lambda1` as parameter to non-global template `doStuff(alias fun)()`
 ---
 */
 

--- a/test/fail_compilation/ice11965.d
+++ b/test/fail_compilation/ice11965.d
@@ -1,1 +1,14 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice11965.d(15): Error: no identifier for declarator `b*`
+fail_compilation/ice11965.d(15): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/ice11965.d(15): Error: found `End of File` when expecting `]`
+fail_compilation/ice11965.d(15): Error: no identifier for declarator `u[()
+{
+b* A;
+}
+]`
+---
+*/
 u[{b*A,

--- a/test/fail_compilation/ice12673.d
+++ b/test/fail_compilation/ice12673.d
@@ -1,3 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice12673.d(13): Error: static assert:  `__traits(compiles, ()
+{
+__error__
+}
+)` is false
+---
+*/
 void main()
 {
     static assert(__traits(compiles, { abcd(); }));

--- a/test/fail_compilation/ice15855.d
+++ b/test/fail_compilation/ice15855.d
@@ -1,3 +1,24 @@
 // REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice15855.d(25): Error: found `End of File` when expecting `(`
+fail_compilation/ice15855.d(25): Error: found `End of File` instead of statement
+fail_compilation/ice15855.d(25): Error: expression expected, not `End of File`
+fail_compilation/ice15855.d(25): Error: found `End of File` when expecting `;` following `for` condition
+fail_compilation/ice15855.d(25): Error: expression expected, not `End of File`
+fail_compilation/ice15855.d(25): Error: found `End of File` when expecting `)`
+fail_compilation/ice15855.d(25): Error: found `End of File` instead of statement
+fail_compilation/ice15855.d(25): Error: found `End of File` when expecting `}` following compound statement
+fail_compilation/ice15855.d(25): Error: found `End of File` when expecting `]`
+fail_compilation/ice15855.d(25): Error: no identifier for declarator `a[()
+{
+for (; 0; 0)
+{
+}
+}
+]`
+---
+*/
 
 a[{for

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -703,7 +703,7 @@ int tryMain(string[] args)
             string[] toCleanup;
 
             auto thisRunName = genTempFilename(result_path);
-            auto fThisRun = File(thisRunName, "w");
+            auto fThisRun = File(thisRunName, "wb");
             scope(exit)
             {
                 fThisRun.close();


### PR DESCRIPTION
As suggested by @rainers in #9231.

Added multiline TEST_OUTPUT tests to check that it fixes what its intended for.