### PR TITLE
Update osx-32bit.dd: fix typo Majove/Mojave

### DIFF
--- a/changelog/osx-32bit.dd
+++ b/changelog/osx-32bit.dd
@@ -4,6 +4,6 @@ With this release, the DMD compiler will no longer officially support
 building 32-bit applications for OSX. For legacy purposes, older releases
 can be used.
 
-$(B Motivation:) The latest macOS release $(I Majove) is the last version of OSX
+$(B Motivation:) The latest macOS release $(I Mojave) is the last version of OSX
 with support for running 32-bit applications. The D development team wants to
 focus its efforts and build/test infrastructure on active and important platforms.


### PR DESCRIPTION
What a handy edit button! The desert is called the [_Mojave_](https://en.wikipedia.org/wiki/Mojave_Desert), of course. (And yes, so's the release.)