### PR TITLE
SemaphoreCI: Remove compiler versions locking

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -36,24 +36,7 @@ source ci.sh
 # Always source a DMD instance
 ################################################################################
 
-# Later versions of LDC causes a linker error.
-if  [ "$DMD" == "ldc" ]; then
-    LDC_VERSION=1.11.0
-    DUB_VERSION=1.13.0
-
-    install_d "ldc-$LDC_VERSION"
-    source ~/dlang/ldc-$LDC_VERSION/activate
-
-    # Older versions of LDC are shipped with a version of Dub that doesn't
-    # support the `DUB_EXE` environment variable
-    curl -o dub.tar.gz -L https://github.com/dlang/dub/releases/download/v$DUB_VERSION/dub-v$DUB_VERSION-linux-x86_64.tar.gz
-    tar xf dub.tar.gz
-    # Replace default dub with newer version
-    mv dub $(which dub)
-    deactivate
-else
-    install_d "$DMD"
-fi
+install_d "$DMD"
 
 ################################################################################
 # Define commands


### PR DESCRIPTION
We only guarantee that the latest stable version can be used to bootstrap DMD.
They were locked to avoid errors with Dub. These errros have been fixed now though.