### PR TITLE
Align C++ headers with D AST layout

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -235,11 +235,16 @@ public:
 
     VarDeclarations *maybes;    // STCmaybescope variables that are assigned to this STCmaybescope variable
 
+private:
+    bool _isAnonymous;
+
+public:
     Dsymbol *syntaxCopy(Dsymbol *);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;
     AggregateDeclaration *isThis();
     bool needThis();
+    bool isAnonymous();
     bool isExport() const;
     bool isImportedSymbol() const;
     bool isDataseg();
@@ -453,8 +458,8 @@ class FuncDeclaration : public Declaration
 public:
     struct HiddenParameters
     {
-        VarDeclaration* this_;
-        VarDeclaration* selector;
+        VarDeclaration *this_;
+        VarDeclaration *selector;
     };
 
     Types *fthrows;                     // Array of Type's of exceptions (not used)
@@ -478,7 +483,9 @@ public:
     DsymbolTable *localsymtab;
     VarDeclaration *vthis;              // 'this' parameter (member and nested)
     VarDeclaration *v_arguments;        // '_arguments' parameter
-    ObjcSelector* selector;             // Objective-C method selector (member function only)
+    ObjcSelector *selector;             // Objective-C method selector (member function only)
+    VarDeclaration *selectorParameter;  // Objective-C implicit selector parameter
+
     VarDeclaration *v_argptr;           // '_argptr' variable
     VarDeclarations *parameters;        // Array of VarDeclaration's for parameters
     DsymbolTable *labtab;               // statement label symbol table

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -16,12 +16,10 @@
 class Identifier : public RootObject
 {
 private:
-    static Identifier* anonymous_;
     int value;
     DArray<const char> string;
 
 public:
-    static void initialize();
     static Identifier* anonymous();
     static Identifier* create(const char *string);
     bool equals(RootObject *o);

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -258,6 +258,9 @@ public:
     // [int, char, 100]
     Objects tdtypes;
 
+    // Modules imported by this template instance
+    Modules importedModules;
+
     Dsymbol *tempdecl;                  // referenced by foo.bar.abc
     Dsymbol *enclosing;                 // if referencing local symbols, this is the context
     Dsymbol *aliasdecl;                 // !=NULL if instance is an alias for its sole member


### PR DESCRIPTION
As usual, shocking ignorance.  Didn't look through the PR history this time, but I have no idea how identifier.h ended up the way it did... (I'm removing new additions that don't exist in the D code!)