### PR TITLE
dsymbol.h: Fix warnings about unused parameters

### DIFF
--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -217,7 +217,7 @@ public:
     virtual bool hasPointers();
     virtual bool hasStaticCtorOrDtor();
     virtual void addLocalClass(ClassDeclarations *) { }
-    virtual void addObjcSymbols(ClassDeclarations *classes, ClassDeclarations *categories) { }
+    virtual void addObjcSymbols(ClassDeclarations *, ClassDeclarations *) { }
     virtual void checkCtorConstInit() { }
 
     virtual void addComment(const utf8_t *comment);


### PR DESCRIPTION
And another one caught when building with `--enable-werror`