### PR TITLE
[REG master] Fix undefined reference to Target::isVectorOpSupported(Type*, TOK, Type*)

### DIFF
--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -363,7 +363,7 @@ struct Target
      * Returns:
      *      true if the operation is supported or type is not a vector
      */
-    extern (C++) bool isVectorOpSupported(Type type, TOK op, Type t2 = null)
+    extern (C++) bool isVectorOpSupported(Type type, ubyte op, Type t2 = null)
     {
         import dmd.tokens;
 
@@ -427,7 +427,7 @@ struct Target
         default:
             // import std.stdio : stderr, writeln;
             // stderr.writeln(op);
-            assert(0, "unhandled op " ~ Token.toString(op));
+            assert(0, "unhandled op " ~ Token.toString(cast(TOK)op));
         }
         return supported;
     }

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -241,6 +241,13 @@ void test_expression()
 
 /**********************************/
 
+void test_target()
+{
+    assert(target.isVectorOpSupported(Type::tint32, TOKpow));
+}
+
+/**********************************/
+
 int main(int argc, char **argv)
 {
     frontend_init();
@@ -248,6 +255,7 @@ int main(int argc, char **argv)
     test_visitors();
     test_semantic();
     test_expression();
+    test_target();
 
     frontend_term();
 


### PR DESCRIPTION
Introduced by #9191.