### PR TITLE
Define static xxxExp::emplace member function

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1709,6 +1709,17 @@ extern (C++) final class IntegerExp : Expression
         return new IntegerExp(loc, value, type);
     }
 
+    // Same as create, but doesn't allocate memory.
+    static void emplace(UnionExp* pue, Loc loc, dinteger_t value, Type type)
+    {
+        emplaceExp!(IntegerExp)(pue, loc, value, type);
+    }
+
+    static void emplacei(UnionExp* pue, Loc loc, int value, Type type)
+    {
+        emplaceExp!(IntegerExp)(pue, loc, value, type);
+    }
+
     override bool equals(RootObject o)
     {
         if (this == o)
@@ -1916,6 +1927,12 @@ extern (C++) final class RealExp : Expression
         return new RealExp(loc, value, type);
     }
 
+    // Same as create, but doesn't allocate memory.
+    static void emplace(UnionExp* pue, Loc loc, real_t value, Type type)
+    {
+        emplaceExp!(RealExp)(pue, loc, value, type);
+    }
+
     override bool equals(RootObject o)
     {
         if (this == o)
@@ -1983,6 +2000,12 @@ extern (C++) final class ComplexExp : Expression
     static ComplexExp create(Loc loc, complex_t value, Type type)
     {
         return new ComplexExp(loc, value, type);
+    }
+
+    // Same as create, but doesn't allocate memory.
+    static void emplace(UnionExp* pue, Loc loc, complex_t value, Type type)
+    {
+        emplaceExp!(ComplexExp)(pue, loc, value, type);
     }
 
     override bool equals(RootObject o)
@@ -2272,6 +2295,17 @@ extern (C++) final class StringExp : Expression
     static StringExp create(Loc loc, void* string, size_t len)
     {
         return new StringExp(loc, string, len);
+    }
+
+    // Same as create, but doesn't allocate memory.
+    static void emplace(UnionExp* pue, Loc loc, char* s)
+    {
+        emplaceExp!(StringExp)(pue, loc, s);
+    }
+
+    static void emplace(UnionExp* pue, Loc loc, void* string, size_t len)
+    {
+        emplaceExp!(StringExp)(pue, loc, string, len);
     }
 
     override bool equals(RootObject o)
@@ -2733,6 +2767,12 @@ extern (C++) final class ArrayLiteralExp : Expression
     static ArrayLiteralExp create(Loc loc, Expressions* elements)
     {
         return new ArrayLiteralExp(loc, null, elements);
+    }
+
+    // Same as create, but doesn't allocate memory.
+    static void emplace(UnionExp* pue, Loc loc, Expressions* elements)
+    {
+        emplaceExp!(ArrayLiteralExp)(pue, loc, null, elements);
     }
 
     override Expression syntaxCopy()
@@ -5081,6 +5121,12 @@ extern (C++) final class VectorExp : UnaExp
     static VectorExp create(Loc loc, Expression e, Type t)
     {
         return new VectorExp(loc, e, t);
+    }
+
+    // Same as create, but doesn't allocate memory.
+    static void emplace(UnionExp* pue, Loc loc, Expression e, Type type)
+    {
+        emplaceExp!(VectorExp)(pue, loc, e, type);
     }
 
     override Expression syntaxCopy()

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -232,6 +232,8 @@ public:
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
     static IntegerExp *createi(Loc loc, int value, Type *type);
+    static void emplace(UnionExp *pue, Loc loc, dinteger_t value, Type *type);
+    static void emplacei(UnionExp *pue, Loc loc, int value, Type *type);
     bool equals(RootObject *o);
     dinteger_t toInteger();
     real_t toReal();
@@ -260,6 +262,7 @@ public:
     real_t value;
 
     static RealExp *create(Loc loc, real_t value, Type *type);
+    static void emplace(UnionExp *pue, Loc loc, real_t value, Type *type);
     bool equals(RootObject *o);
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -276,6 +279,7 @@ public:
     complex_t value;
 
     static ComplexExp *create(Loc loc, complex_t value, Type *type);
+    static void emplace(UnionExp *pue, Loc loc, complex_t value, Type *type);
     bool equals(RootObject *o);
     dinteger_t toInteger();
     uinteger_t toUInteger();
@@ -356,6 +360,8 @@ public:
 
     static StringExp *create(Loc loc, char *s);
     static StringExp *create(Loc loc, void *s, size_t len);
+    static void emplace(UnionExp *pue, Loc loc, char *s);
+    static void emplace(UnionExp *pue, Loc loc, void *s, size_t len);
     bool equals(RootObject *o);
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
@@ -401,6 +407,7 @@ public:
     OwnedBy ownedByCtfe;
 
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
+    static void emplace(UnionExp *pue, Loc loc, Expressions *elements);
     Expression *syntaxCopy();
     bool equals(RootObject *o);
     Expression *getElement(d_size_t i);
@@ -877,6 +884,7 @@ public:
     unsigned dim;               // number of elements in the vector
 
     static VectorExp *create(Loc loc, Expression *e, Type *t);
+    static void emplace(UnionExp *pue, Loc loc, Expression *e, Type *t);
     Expression *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -77,6 +77,7 @@ static void frontend_init()
     Expression::_init();
     Objc::_init();
     target._init(global.params);
+    CTFloat::initialize();
 }
 
 /**********************************/
@@ -248,6 +249,29 @@ void test_target()
 
 /**********************************/
 
+void test_emplace()
+{
+  Loc loc;
+  UnionExp ue;
+
+  IntegerExp::emplacei(&ue, loc, 1065353216, Type::tint32);
+  Expression *e = ue.exp();
+  assert(e->op == TOKint64);
+  assert(e->toInteger() == 1065353216);
+
+  UnionExp ure;
+  Expression *re = Compiler::paintAsType(&ure, e, Type::tfloat32);
+  assert(re->op == TOKfloat64);
+  assert(re->toReal() == CTFloat::one);
+
+  UnionExp uie;
+  Expression *ie = Compiler::paintAsType(&uie, re, Type::tint32);
+  assert(ie->op == TOKint64);
+  assert(ie->toInteger() == e->toInteger());
+}
+
+/**********************************/
+
 int main(int argc, char **argv)
 {
     frontend_init();
@@ -256,6 +280,7 @@ int main(int argc, char **argv)
     test_semantic();
     test_expression();
     test_target();
+    test_emplace();
 
     frontend_term();
 


### PR DESCRIPTION
For new()'ing expressions without allocating memory.

These should be marked `@nogc`, but cannot as none of the Expression AST constructors themselves are `@nogc` either.