### PR TITLE
testsuite: Explicitly list long running runnable tests first.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -116,7 +116,18 @@ DEBUG_FLAGS=$(PIC_FLAG) -g
 
 export DMD_TEST_COVERAGE=
 
-runnable_tests=$(wildcard runnable/*.d) $(wildcard runnable/*.sh)
+# List the tests that take longest to run first, so that parallel make
+# will test them sooner, because they are large, have many test
+# permutations, or typically are the last tests to finish.
+runnable_tests_long=runnable/test42.d \
+		    runnable/xtest46.d \
+		    runnable/test34.d \
+		    runnable/test23.d \
+		    runnable/hospital.d \
+		    runnable/testsignals.d \
+		    runnable/interpret.d
+
+runnable_tests=$(runnable_tests_long) $(wildcard runnable/*.d) $(wildcard runnable/*.sh)
 runnable_test_results=$(addsuffix .out,$(addprefix $(RESULTS_DIR)/,$(runnable_tests)))
 
 compilable_tests=$(wildcard compilable/*.d) $(wildcard compilable/*.sh)


### PR DESCRIPTION
As these tests - in particular runnable/xtest46.d - have a tendency to be the last tests to be done, and some take well over two minutes to run.

---

Throwing in a curveball PR here.  Tested the time on my machine with `make -j8`, this sped up the overall testsuite run-time by 60 seconds (5m40s -> 4m40s).

What I qualified as a long running test, is anything that takes over 70 seconds to finish on my machine.

---

Just had a quick look at the last few farm-4 auto-tester runs.

| PR  | Time | Link |
| ----- | ------ | ------ |
| 8688 | 5m43s | https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3483812&isPull=true |
| 9264 | 5m40s | https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3483848&isPull=true |
| 9263 | 5m40s | https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3483859&isPull=true |
| 9013 | 5m38s | https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3483835&isPull=true |
| 9270 | 4m21s | https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3483975&isPull=true |


So there is at least some substantial evidence there.
