### PR TITLE
fix Issue 19618 - Incorrect conversion of function returning `typeof(null)` to function returning an associative array

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -683,8 +683,16 @@ extern (C++) abstract class Type : RootObject
             }
             else if (t1n.ty == t2n.ty && t1n.implicitConvTo(t2n))
                 goto Lcovariant;
-            else if (t1n.ty == Tnull && t1n.implicitConvTo(t2n) && t1n.size() == t2n.size())
-                goto Lcovariant;
+            else if (t1n.ty == Tnull)
+            {
+                // NULL is covariant with any pointer type, but not with any
+                // dynamic arrays, associative arrays or delegates.
+                // https://issues.dlang.org/show_bug.cgi?id=8589
+                // https://issues.dlang.org/show_bug.cgi?id=19618
+                Type t2bn = t2n.toBasetype();
+                if (t2bn.ty == Tnull || t2bn.ty == Tpointer || t2bn.ty == Tclass)
+                    goto Lcovariant;
+            }
         }
         goto Lnotcovariant;
 

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -127,7 +127,7 @@ void test8589()
     {
         void f(T function() dg) { assert(!dg()); }
 
-        static assert((T.sizeof == typeof(null).sizeof) == result);
+        static assert((is(typeof(null) function() : T function())) == result);
         static assert(is(typeof( f(&retnull) )) == result);
         static assert(is(typeof( f(()=>null) )) == result);
         static if (result)
@@ -138,7 +138,7 @@ void test8589()
     }
     test!(true,  int*)();
     test!(true,  Object)();
-    test!(true,  int[int])();
+    test!(false, int[int])();
     test!(false, int[])();
     test!(false, void delegate())();
 }


### PR DESCRIPTION
As `struct {void*}` is passed and returned differently to `void*`.

Further fix to #1119 and http://d.puremagic.com/issues/show_bug.cgi?id=8589.

Alternatively, the spec could be fixed to clarify that associative arrays is just a `void*` without the struct shell, but then you'd have to also fix druntime, as the internal AA type ....

https://github.com/dlang/druntime/blob/c86e4a0e541dc63f9e9f2ee09c7efd325c0be2d5/src/rt/aaA.d#L37-L46

... as used directly in these functions ...

https://github.com/dlang/druntime/blob/c86e4a0e541dc63f9e9f2ee09c7efd325c0be2d5/src/rt/aaA.d#L613
https://github.com/dlang/druntime/blob/c86e4a0e541dc63f9e9f2ee09c7efd325c0be2d5/src/rt/aaA.d#L635
https://github.com/dlang/druntime/blob/c86e4a0e541dc63f9e9f2ee09c7efd325c0be2d5/src/rt/aaA.d#L702
https://github.com/dlang/druntime/blob/c86e4a0e541dc63f9e9f2ee09c7efd325c0be2d5/src/rt/aaA.d#L719

... is not ABI compatible with `void*`.