### PR TITLE
gsroa: don't need to check for register candidate

### DIFF
--- a/src/dmd/backend/gsroa.d
+++ b/src/dmd/backend/gsroa.d
@@ -268,7 +268,7 @@ void sliceStructs(symtab_t* symtab, block* startblock)
         Symbol *s = symtab.tab[si];
         //printf("slice1: %s\n", s.Sident);
 
-        if ((s.Sflags & (GTregcand | SFLunambig)) != (GTregcand | SFLunambig))
+        if (!(s.Sflags & SFLunambig))   // if somebody took the address of s
         {
             sia[si].canSlice = false;
             continue;


### PR DESCRIPTION
Doing this as a separate PR so if it breaks something in the future, it'll be easy to identify what caused it.