### PR TITLE
split type_size() into const and non-const overloads

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -259,7 +259,7 @@ type *newref(type *);
 type *topointer(type *);
 type *type_ptr(elem *, type *);
 int type_chksize(uint);
-tym_t tym_conv(type *);
+tym_t tym_conv(const type *);
 type * type_arrayroot(type *);
 void chklvalue(elem *);
 int tolvalue(elem **);

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -147,7 +147,12 @@ int type_isdependent(type *t);
 void type_hydrate(type **);
 void type_dehydrate(type **);
 
-targ_size_t type_size(type *);
+version (SCPP)
+    targ_size_t type_size(type *);
+version (HTOD)
+    targ_size_t type_size(type *);
+
+targ_size_t type_size(const type *);
 uint type_alignsize(type *);
 bool type_zeroSize(type *t, tym_t tyf);
 uint type_parameterSize(type *t, tym_t tyf);


### PR DESCRIPTION
The mutable one is only needed for DMC++.