### PR TITLE
testsuite: Add another test for issue 18057

### DIFF
--- a/test/fail_compilation/fail18057b.d
+++ b/test/fail_compilation/fail18057b.d
@@ -1,0 +1,13 @@
+/**
+TEST_OUTPUT:
+---
+fail_compilation/fail18057b.d(12): Error: variable `fail18057b.Recursive.field` recursive initialization of field
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=18057
+// Recursive field initializer causes segfault.
+struct Recursive
+{
+    int field = Recursive();
+}


### PR DESCRIPTION
Bug is long fixed, but this is an interesting variant that should be covered as well.

Rather than stack overflow in `ctfeInterpret()`, this caused a null pointer dereference in `resolvePropertiesX()`.