### PR TITLE
account for most significant reg when loading reg variable in 2 regs

### DIFF
--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -1918,7 +1918,7 @@ int isregvar(elem *e,regm_t *pregm,uint *preg)
                 {   refparam = true;
                     reflocal = true;
                 }
-                reg = s.Sreglsw;
+                reg = e.EV.Voffset == REGSIZE ? s.Sregmsw : s.Sreglsw;
                 regm = s.Sregm;
                 //assert(tyreg(s.ty()));
 static if (0)

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -4999,7 +4999,10 @@ void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
             forregs = mask(reg);
 
             if (debugr)
-                printf("%s is fastpar and using register %s\n", e.EV.Vsym.Sident.ptr, regm_str(forregs));
+                printf("%s.%d is fastpar and using register %s\n",
+                       e.EV.Vsym.Sident.ptr,
+                       cast(int)e.EV.Voffset,
+                       regm_str(forregs));
 
             mfuncreg &= ~forregs;
             regcon.used |= forregs;


### PR DESCRIPTION
Found this while disabling struct slicing optimizations. Can't figure out a way to trip it otherwise, so no test case. The Voffset check for register selection is used elsewhere in the code generator, but was omitted here.