### PR TITLE
Issue 19563 - non-POD C++ argument not handled correctly

### DIFF
--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -183,7 +183,8 @@ Symbol *toSymbol(Dsymbol s)
             }
             else if (vd.isParameter())
             {
-                if (config.exe == EX_WIN64 && vd.type.size(Loc.initial) > _tysize[TYnptr])
+                if ((config.exe == EX_WIN64 && vd.type.size(Loc.initial) > _tysize[TYnptr]) ||
+                    (!global.params.isWindows && vd.type.isTypeStruct() && !vd.type.isTypeStruct().sym.isPOD()))
                 {
                     t = type_allocn(TYnref, Type_toCtype(vd.type));
                     t.Tcount++;

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1058,8 +1058,8 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
             if (!v.isParameter())
                 continue;
             tym_t tym = totym(v.type);
-            bool win64ref = ISWIN64REF(v);
-            if (win64ref)
+            const x64ref = ISX64REF(v);
+            if (x64ref && config.exe == EX_WIN64)
             {
                 if (v.storage_class & STC.lazy_)
                     tym = TYdelegate;
@@ -1071,7 +1071,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
             ex = el_bin(OPadd, TYnptr, el_var(sclosure), el_long(TYsize_t, v.offset));
             ex = el_una(OPind, tym, ex);
             elem *ev = el_var(toSymbol(v));
-            if (win64ref)
+            if (x64ref)
             {
                 ev.Ety = TYnref;
                 ev = el_una(OPind, tym, ev);

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -12,6 +12,12 @@ extern(C++, std)
     struct test19248 {int a = 34;}
 }
 
+struct S19563
+{
+    int i;
+    this(this) { i += 10; }
+}
+
 bool   passthrough(bool   value);
 byte   passthrough(byte   value);
 ubyte  passthrough(ubyte  value);
@@ -59,6 +65,8 @@ float  passthrough_ref(ref float  value);
 double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
 std.test19248 passthrough_ref(ref const(std.test19248) value);
+
+bool test19563(int a, int b, S19563 s);
 }
 
 template IsSigned(T)
@@ -175,6 +183,9 @@ void main()
     foreach(double val; values!double()) check(val);
     check(S());
     check(std.test19248());
+
+    S19563 s;
+    assert(test19563(0, 0, s));
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -7,6 +7,11 @@ namespace std
     struct test19248 {int a;};
 };
 
+struct S19563 {
+    int i;
+    S19563(S19563 &r) { i = r.i + 10; }
+};
+
 bool               passthrough(bool                value)     { return value; }
 signed char        passthrough(signed char         value)     { return value; }
 unsigned char      passthrough(unsigned char       value)     { return value; }
@@ -72,6 +77,11 @@ namespace ns1
     // D: `const(char*), const(char***)`
     int constFunction4(const char* const, const char* const* const* const) { return 42; }
 };
+
+bool test19563(int a, int b, S19563 s)
+{
+    return s.i == 10;
+}
 
 // Uncomment when mangling is fixed
 // typedef void(*fn0)();


### PR DESCRIPTION
According to the System V 64 bits ABI non-POD function arguments should be passed by pointer.
> Section 3.2.3 page 21:
> 2. If a C++ object is non-trivial for the purpose of calls, as specified in the
C++ ABI , it is passed by invisible reference (the object is replaced in the
parameter list by a pointer that has class INTEGER).
