### PR TITLE
hdrgen: Add space between token and expression in UnaExp override

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2804,6 +2804,7 @@ public:
     override void visit(UnaExp e)
     {
         buf.writestring(Token.toString(e.op));
+        buf.writeByte(' ');
         expToBuffer(e.e1, precedence[e.op]);
     }
 


### PR DESCRIPTION
Otherwise there's an odd error message when testing a new Expression class.