### PR TITLE
fix Issue 19607 - [ICE] dmd/e2ir.d(117): Invalid type mTYconst|TYstruct

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -554,7 +554,7 @@ uinteger_t resolveArrayLength(const Expression e)
     switch (e.op)
     {
         case TOK.vector:
-            return resolveArrayLength((cast(VectorExp)e).e1);
+            return (cast(VectorExp)e).dim;
 
         case TOK.null_:
             return 0;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -516,6 +516,7 @@ private:
         char[__traits(classInstanceSize, AddrExp)] addrexp;
         char[__traits(classInstanceSize, IndexExp)] indexexp;
         char[__traits(classInstanceSize, SliceExp)] sliceexp;
+        char[__traits(classInstanceSize, VectorExp)] vectorexp;
     }
 
     __AnonStruct__u u;
@@ -1600,6 +1601,7 @@ extern (C++) abstract class Expression : RootObject
         inout(DeleteExp)    isDeleteExp() { return op == TOK.delete_ ? cast(typeof(return))this : null; }
         inout(CastExp)      isCastExp() { return op == TOK.cast_ ? cast(typeof(return))this : null; }
         inout(VectorExp)    isVectorExp() { return op == TOK.vector ? cast(typeof(return))this : null; }
+        inout(VectorArrayExp) isVectorArrayExp() { return op == TOK.vectorArray ? cast(typeof(return))this : null; }
         inout(SliceExp)     isSliceExp() { return op == TOK.slice ? cast(typeof(return))this : null; }
         inout(ArrayLengthExp) isArrayLengthExp() { return op == TOK.arrayLength ? cast(typeof(return))this : null; }
         inout(ArrayExp)     isArrayExp() { return op == TOK.array ? cast(typeof(return))this : null; }
@@ -5070,6 +5072,7 @@ extern (C++) final class VectorExp : UnaExp
 {
     TypeVector to;      // the target vector type before semantic()
     uint dim = ~0;      // number of elements in the vector
+    OwnedBy ownedByCtfe = OwnedBy.code;
 
     extern (D) this(const ref Loc loc, Expression e, Type t)
     {
@@ -5086,6 +5089,35 @@ extern (C++) final class VectorExp : UnaExp
     override Expression syntaxCopy()
     {
         return new VectorExp(loc, e1.syntaxCopy(), to.syntaxCopy());
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ * e1.array property for vectors.
+ *
+ * https://dlang.org/spec/simd.html#properties
+ */
+extern (C++) final class VectorArrayExp : UnaExp
+{
+    extern (D) this(const ref Loc loc, Expression e1)
+    {
+        super(loc, TOK.vectorArray, __traits(classInstanceSize, VectorArrayExp), e1);
+    }
+
+    override bool isLvalue()
+    {
+        return e1.isLvalue();
+    }
+
+    override Expression toLvalue(Scope* sc, Expression e)
+    {
+        e1 = e1.toLvalue(sc, e);
+        return this;
     }
 
     override void accept(Visitor v)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -169,6 +169,7 @@ public:
     DeleteExp* isDeleteExp();
     CastExp* isCastExp();
     VectorExp* isVectorExp();
+    VectorArrayExp* isVectorArrayExp();
     SliceExp* isSliceExp();
     ArrayLengthExp* isArrayLengthExp();
     ArrayExp* isArrayExp();
@@ -875,9 +876,18 @@ class VectorExp : public UnaExp
 public:
     TypeVector *to;             // the target vector type before semantic()
     unsigned dim;               // number of elements in the vector
+    OwnedBy ownedByCtfe;
 
     static VectorExp *create(Loc loc, Expression *e, Type *t);
     Expression *syntaxCopy();
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+class VectorArrayExp : public UnaExp
+{
+public:
+    bool isLvalue();
+    Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1363,6 +1373,7 @@ private:
         char addrexp   [sizeof(AddrExp)];
         char indexexp  [sizeof(IndexExp)];
         char sliceexp  [sizeof(SliceExp)];
+        char vectorexp [sizeof(VectorExp)];
     } u;
 #if defined(__DMC__)
     #pragma pack()

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6744,6 +6744,28 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         result = res ? new ErrorExp() : exp;
     }
 
+    override void visit(VectorArrayExp e)
+    {
+        static if (LOGSEMANTIC)
+        {
+            printf("VectorArrayExp::semantic('%s')\n", e.toChars());
+        }
+        if (!e.type)
+        {
+            unaSemantic(e, sc);
+            e.e1 = resolveProperties(sc, e.e1);
+
+            if (e.e1.op == TOK.error)
+            {
+                result = e.e1;
+                return;
+            }
+            assert(e.e1.type.ty == Tvector);
+            e.type = e.e1.type.isTypeVector().basetype;
+        }
+        result = e;
+    }
+
     override void visit(SliceExp exp)
     {
         static if (LOGSEMANTIC)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2939,6 +2939,12 @@ public:
         expToBuffer(e.e1, precedence[e.op]);
     }
 
+    override void visit(VectorArrayExp e)
+    {
+        expToBuffer(e.e1, PREC.primary);
+        buf.writestring(".array");
+    }
+
     override void visit(SliceExp e)
     {
         expToBuffer(e.e1, precedence[e.op]);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -93,6 +93,7 @@ __gshared PREC[TOK.max_] precedence =
     TOK.default_ : PREC.primary,
     TOK.overloadSet : PREC.primary,
     TOK.void_ : PREC.primary,
+    TOK.vectorArray : PREC.primary,
 
     // post
     TOK.dotTemplateInstance : PREC.primary,

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -286,6 +286,7 @@ enum TOK : ubyte
     showCtfeContext,
 
     objcClassReference,
+    vectorArray,
 
     max_,
 }
@@ -697,6 +698,7 @@ extern (C++) struct Token
         TOK.showCtfeContext : "showCtfeContext",
 
         TOK.objcClassReference: "class",
+        TOK.vectorArray: "vectorarray",
     ];
 
     static assert(() {

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -181,6 +181,7 @@ enum
         TOKshowctfecontext,
 
         TOKobjc_class_reference,
+        TOKvectorarray,
 
         TOKMAX
 };

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3164,8 +3164,8 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         {
             //e = e.castTo(sc, basetype);
             // Keep lvalue-ness
-            e = e.copy();
-            e.type = mt.basetype;
+            e = new VectorArrayExp(e.loc, e);
+            e = e.expressionSemantic(sc);
             return e;
         }
         if (ident == Id._init || ident == Id.offsetof || ident == Id.stringof || ident == Id.__xalignof)

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -74,6 +74,7 @@ public:
     void visit(ASTCodegen.DelegateExp e) { visit(cast(ASTCodegen.UnaExp)e); }
     void visit(ASTCodegen.DotTypeExp e) { visit(cast(ASTCodegen.UnaExp)e); }
     void visit(ASTCodegen.VectorExp e) { visit(cast(ASTCodegen.UnaExp)e); }
+    void visit(ASTCodegen.VectorArrayExp e) { visit(cast(ASTCodegen.UnaExp)e); }
     void visit(ASTCodegen.SliceExp e) { visit(cast(ASTCodegen.UnaExp)e); }
     void visit(ASTCodegen.ArrayLengthExp e) { visit(cast(ASTCodegen.UnaExp)e); }
     void visit(ASTCodegen.DelegatePtrExp e) { visit(cast(ASTCodegen.UnaExp)e); }
@@ -182,6 +183,11 @@ extern (C++) class SemanticTimeTransitiveVisitor : SemanticTimePermissiveVisitor
     override void visit(ASTCodegen.VectorExp e)
     {
         visitType(e.to);
+        e.e1.accept(this);
+    }
+
+    override void visit(ASTCodegen.VectorArrayExp e)
+    {
         e.e1.accept(this);
     }
 

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -228,6 +228,7 @@ class NotExp;
 class DeleteExp;
 class CastExp;
 class VectorExp;
+class VectorArrayExp;
 class SliceExp;
 class ArrayLengthExp;
 class IntervalExp;
@@ -618,6 +619,7 @@ public:
     virtual void visit(DelegateExp *e) { visit((UnaExp *)e); }
     virtual void visit(DotTypeExp *e) { visit((UnaExp *)e); }
     virtual void visit(VectorExp *e) { visit((UnaExp *)e); }
+    virtual void visit(VectorArrayExp *e) { visit((UnaExp *)e); }
     virtual void visit(SliceExp *e) { visit((UnaExp *)e); }
     virtual void visit(ArrayLengthExp *e) { visit((UnaExp *)e); }
     virtual void visit(DelegatePtrExp *e) { visit((UnaExp *)e); }

--- a/test/compilable/ctfesimd.d
+++ b/test/compilable/ctfesimd.d
@@ -1,0 +1,7 @@
+version (D_SIMD)
+{
+    import core.simd;
+
+    // https://issues.dlang.org/show_bug.cgi?id=19627
+    enum int[4] fail19627 = cast(int[4])int4(0);
+}

--- a/test/compilable/ctfesimd.d
+++ b/test/compilable/ctfesimd.d
@@ -4,4 +4,9 @@ version (D_SIMD)
 
     // https://issues.dlang.org/show_bug.cgi?id=19627
     enum int[4] fail19627 = cast(int[4])int4(0);
+
+    // https://issues.dlang.org/show_bug.cgi?id=19628
+    enum ice19628a = int4.init[0];
+    enum ice19628b = int4.init.array[0];
+    enum ice19628c = (cast(int[4])int4.init.array)[0];
 }

--- a/test/compilable/ctfesimd.d
+++ b/test/compilable/ctfesimd.d
@@ -9,11 +9,13 @@ version (D_SIMD)
     enum ice19628a = int4.init[0];
     enum ice19628b = int4.init.array[0];
     enum ice19628c = (cast(int[4])int4.init.array)[0];
+    enum ice19628d  = (cast(int[4])int4.init)[0];
 
     // https://issues.dlang.org/show_bug.cgi?id=19629
     enum fail19629a = int4(0)[0];
     enum fail19629b = int4(0).array[0];
     enum fail19629c = (cast(int[4])int4(0).array)[0];
+    enum fail19628d = (cast(int[4])int4(0))[0];
 
     // https://issues.dlang.org/show_bug.cgi?id=19630
     enum fail19630a = int4.init[1..2];
@@ -24,4 +26,64 @@ version (D_SIMD)
     enum fail19630f = (cast(int[4])int4(0).array)[1..2];
     enum fail19630g = (cast(int[4])int4.init)[1..2];
     enum fail19630h = (cast(int[4])int4(0))[1..2];
+
+    // Same tests as above, but use access via enum.
+    enum int4   V1 = int4.init;
+    enum int[4] V2 = int4.init.array;
+    enum int[4] V3 = cast(int[4])int4.init;
+    enum int[4] V4 = cast(int[4])int4.init.array;
+    enum int4   V5 = int4(0);
+    enum int[4] V6 = int4(0).array;
+    enum int[4] V7 = cast(int[4])int4(0);
+    enum int[4] V8 = cast(int[4])int4(0).array;
+
+    // CTFE index tests
+    enum I1 = V1[0];    static assert(I1 == 0);
+    enum I2 = V2[0];    static assert(I2 == 0);
+    enum I3 = V3[0];    static assert(I3 == 0);
+    enum I4 = V4[0];    static assert(I4 == 0);
+    enum I5 = V5[0];    static assert(I5 == 0);
+    enum I6 = V6[0];    static assert(I6 == 0);
+    enum I7 = V7[0];    static assert(I7 == 0);
+    enum I8 = V8[0];    static assert(I8 == 0);
+
+    // CTFE slice tests
+    enum S1 = V1[1..2]; static assert(S1 == [0]);
+    enum S2 = V2[1..2]; static assert(S2 == [0]);
+    enum S3 = V3[1..2]; static assert(S3 == [0]);
+    enum S4 = V4[1..2]; static assert(S4 == [0]);
+    enum S5 = V5[1..2]; static assert(S5 == [0]);
+    enum S6 = V6[1..2]; static assert(S6 == [0]);
+    enum S7 = V7[1..2]; static assert(S7 == [0]);
+    enum S8 = V8[1..2]; static assert(S8 == [0]);
+
+    // Same tests as above, but use access via immutable.
+    //immutable int4   v1 = int4.init;      // Cannot cast to immutable at compile time
+    immutable int[4] v2 = int4.init.array;
+    immutable int[4] v3 = cast(int[4])int4.init;
+    immutable int[4] v4 = cast(int[4])int4.init.array;
+    //immutable int4   v5 = int4(0);        // Cannot cast to immutable at compile time
+    immutable int[4] v6 = int4(0).array;
+    immutable int[4] v7 = cast(int[4])int4(0);
+    immutable int[4] v8 = cast(int[4])int4(0).array;
+
+    // CTFE index tests
+    //immutable i1 = v1[0];    static assert(i1 == 0);
+    immutable i2 = v2[0];    static assert(i2 == 0);
+    immutable i3 = v3[0];    static assert(i3 == 0);
+    immutable i4 = v4[0];    static assert(i4 == 0);
+    //immutable i5 = v5[0];    static assert(i5 == 0);
+    immutable i6 = v6[0];    static assert(i6 == 0);
+    immutable i7 = v7[0];    static assert(i7 == 0);
+    immutable i8 = v8[0];    static assert(i8 == 0);
+
+    // CTFE slice tests
+    //immutable s1 = v1[1..2]; static assert(s1 == [0]);
+    immutable s2 = v2[1..2]; static assert(s2 == [0]);
+    immutable s3 = v3[1..2]; static assert(s3 == [0]);
+    immutable s4 = v4[1..2]; static assert(s4 == [0]);
+    //immutable s5 = v5[1..2]; static assert(s5 == [0]);
+    immutable s6 = v6[1..2]; static assert(s6 == [0]);
+    immutable s7 = v7[1..2]; static assert(s7 == [0]);
+    immutable s8 = v8[1..2]; static assert(s8 == [0]);
 }

--- a/test/compilable/ctfesimd.d
+++ b/test/compilable/ctfesimd.d
@@ -9,4 +9,9 @@ version (D_SIMD)
     enum ice19628a = int4.init[0];
     enum ice19628b = int4.init.array[0];
     enum ice19628c = (cast(int[4])int4.init.array)[0];
+
+    // https://issues.dlang.org/show_bug.cgi?id=19629
+    enum fail19629a = int4(0)[0];
+    enum fail19629b = int4(0).array[0];
+    enum fail19629c = (cast(int[4])int4(0).array)[0];
 }

--- a/test/compilable/ctfesimd.d
+++ b/test/compilable/ctfesimd.d
@@ -14,4 +14,14 @@ version (D_SIMD)
     enum fail19629a = int4(0)[0];
     enum fail19629b = int4(0).array[0];
     enum fail19629c = (cast(int[4])int4(0).array)[0];
+
+    // https://issues.dlang.org/show_bug.cgi?id=19630
+    enum fail19630a = int4.init[1..2];
+    enum fail19630b = int4.init.array[1..2];
+    enum fail19630c = (cast(int[4])int4.init.array)[1..2];
+    enum fail19630d = int4(0)[1..2];
+    enum fail19630e = int4(0).array[1..2];
+    enum fail19630f = (cast(int[4])int4(0).array)[1..2];
+    enum fail19630g = (cast(int[4])int4.init)[1..2];
+    enum fail19630h = (cast(int[4])int4(0))[1..2];
 }

--- a/test/compilable/test19224.d
+++ b/test/compilable/test19224.d
@@ -12,4 +12,7 @@ version (D_SIMD)
 
     enum x = sum(float4.init.array);
     static assert(x is float.nan);
+
+    enum y = sum(float4(1).array);
+    static assert(y == 4);
 }

--- a/test/compilable/test19224.d
+++ b/test/compilable/test19224.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=19224
+version (D_SIMD)
+{
+    float sum(const float[4] val)
+    {
+        float sum = 0;
+        foreach (x; val) sum += x;
+        return sum;
+    }
+
+    import core.simd : float4;
+
+    enum x = sum(float4.init.array);
+    static assert(x is float.nan);
+}

--- a/test/runnable/test19223.d
+++ b/test/runnable/test19223.d
@@ -17,9 +17,18 @@ version (D_SIMD)
         assert(fn(int4.init.array) == 0);
     }
 
+    // https://issues.dlang.org/show_bug.cgi?id=19607
+    void test19607()
+    {
+        int4 v1 = 1;
+        assert(fn(v1.array) == 4);
+        assert(fn(int4(2).array) == 8);
+    }
+
     void main ()
     {
         test19223();
+        test19607();
     }
 }
 else

--- a/test/runnable/test19223.d
+++ b/test/runnable/test19223.d
@@ -1,0 +1,28 @@
+version (D_SIMD)
+{
+    import core.simd;
+
+    int fn(const int[4] x)
+    {
+        int sum = 0;
+        foreach (i; x) sum += i;
+        return sum;
+    }
+
+    // https://issues.dlang.org/show_bug.cgi?id=19223
+    void test19223()
+    {
+        int4 v1 = int4.init;
+        assert(fn(v1.array) == 0);
+        assert(fn(int4.init.array) == 0);
+    }
+
+    void main ()
+    {
+        test19223();
+    }
+}
+else
+{
+    void main() { }
+}


### PR DESCRIPTION
Added new class to handle taking the array of a vector, similar DelegatePtrExp/DelegateFuncptrExp.  How this operation is done would differ between compilers anyway, and once again, dmd type painting expressions in the front-end results in garbage AST.

Back-end bit is just copy-paste guesswork, based on static array literal code.