### PR TITLE
fix Issue 19609 - [ICE] dmd/expression.d(2790): Segmentation fault

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -20,6 +20,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.errors;
 import dmd.expression;
+import dmd.expressionsem;
 import dmd.globals;
 import dmd.identifier;
 import dmd.mtype;
@@ -213,6 +214,8 @@ extern (C++) final class Import : Dsymbol
                 if (mod.md && mod.md.isdeprecated)
                 {
                     Expression msg = mod.md.msg;
+                    if (msg)
+                        msg = semanticString(sc, msg, "deprecation message");
                     if (StringExp se = msg ? msg.toStringExp() : null)
                         mod.deprecation(loc, "is deprecated - %s", se.string);
                     else

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -28,6 +28,7 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.errors;
 import dmd.expression;
+import dmd.expressionsem;
 import dmd.globals;
 import dmd.id;
 import dmd.identifier;
@@ -965,19 +966,17 @@ extern (C++) final class Module : Package
             error("is a Ddoc file, cannot import it");
             return;
         }
-        if (md && md.msg)
-        {
-            if (StringExp se = md.msg.toStringExp())
-                md.msg = se;
-            else
-                md.msg.error("string expected, not '%s'", md.msg.toChars());
-        }
+
         /* Note that modules get their own scope, from scratch.
          * This is so regardless of where in the syntax a module
          * gets imported, it is unaffected by context.
          * Ignore prevsc.
          */
         Scope* sc = Scope.createGlobal(this); // create root scope
+
+        if (md && md.msg)
+            md.msg = semanticString(sc, md.msg, "deprecation message");
+
         // Add import of "object", even for the "object" module.
         // If it isn't there, some compiler rewrites, like
         //    classinst == classinst -> .object.opEquals(classinst, classinst)

--- a/test/compilable/imports/test19609a.d
+++ b/test/compilable/imports/test19609a.d
@@ -1,0 +1,1 @@
+deprecated([]) module imports.test19609a;

--- a/test/compilable/imports/test19609b.d
+++ b/test/compilable/imports/test19609b.d
@@ -1,0 +1,1 @@
+deprecated(['h','e','l','l','o']) module imports.test19609b;

--- a/test/compilable/imports/test19609c.d
+++ b/test/compilable/imports/test19609c.d
@@ -1,0 +1,1 @@
+deprecated(null) module imports.test19609c;

--- a/test/compilable/test12567e.d
+++ b/test/compilable/test12567e.d
@@ -2,7 +2,6 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail12567.d(8): Error: string expected, not '"a" ~ "b"'
 ---
 */
 deprecated("a" ~ "b") module fail12567;

--- a/test/compilable/test19609.d
+++ b/test/compilable/test19609.d
@@ -1,0 +1,12 @@
+// https://issues.dlang.org/show_bug.cgi?id=19609
+/*
+TEST_OUTPUT
+---
+compilable/test19609.d(10): Deprecation: module `imports.test19609a` is deprecated - 
+compilable/test19609.d(11): Deprecation: module `imports.test19609b` is deprecated - hello
+compilable/test19609.d(12): Deprecation: module `imports.test19609c` is deprecated -
+---
+*/
+import imports.test19609a;
+import imports.test19609b;
+import imports.test19609c;

--- a/test/fail_compilation/fail19609.d
+++ b/test/fail_compilation/fail19609.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=19609
+/*
+TEST_OUTPUT
+---
+fail_compilation/imports/fail19609a.d(1): Error: `string` expected for deprecation message, not `([""])` of type `string[]`
+fail_compilation/fail19609.d(16): Deprecation: module `imports.fail19609a` is deprecated
+fail_compilation/imports/fail19609a.d(1): Error: `string` expected for deprecation message, not `([""])` of type `string[]`
+fail_compilation/imports/fail19609b.d(1): Error: `string` expected for deprecation message, not `([1])` of type `int[]`
+fail_compilation/fail19609.d(17): Deprecation: module `imports.fail19609b` is deprecated
+fail_compilation/imports/fail19609b.d(1): Error: `string` expected for deprecation message, not `([1])` of type `int[]`
+fail_compilation/imports/fail19609c.d(1): Error: `string` expected for deprecation message, not `(123.4F)` of type `float`
+fail_compilation/fail19609.d(18): Deprecation: module `imports.fail19609c` is deprecated
+fail_compilation/imports/fail19609c.d(1): Error: `string` expected for deprecation message, not `(123.4F)` of type `float`
+---
+*/
+import imports.fail19609a;
+import imports.fail19609b;
+import imports.fail19609c;

--- a/test/fail_compilation/imports/fail19609a.d
+++ b/test/fail_compilation/imports/fail19609a.d
@@ -1,0 +1,1 @@
+deprecated([""]) module imports.fail19609a;

--- a/test/fail_compilation/imports/fail19609b.d
+++ b/test/fail_compilation/imports/fail19609b.d
@@ -1,0 +1,1 @@
+deprecated([1]) module imports.fail19609b;

--- a/test/fail_compilation/imports/fail19609c.d
+++ b/test/fail_compilation/imports/fail19609c.d
@@ -1,0 +1,1 @@
+deprecated(123.4f) module imports.fail19609c;


### PR DESCRIPTION
Not entirely sure that allowing anything CTFE-able as a deprecation message is wise, but still better than a segfault.