### PR TITLE
fix Issue 19609 - [ICE] dmd/expression.d(2790): Segmentation fault (part 2)

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -20,7 +20,6 @@ import dmd.dsymbol;
 import dmd.dsymbolsem;
 import dmd.errors;
 import dmd.expression;
-import dmd.expressionsem;
 import dmd.globals;
 import dmd.identifier;
 import dmd.mtype;
@@ -211,17 +210,15 @@ extern (C++) final class Import : Dsymbol
             load(sc);
             if (mod) // if successfully loaded module
             {
+                mod.importAll(null);
                 if (mod.md && mod.md.isdeprecated)
                 {
                     Expression msg = mod.md.msg;
-                    if (msg)
-                        msg = semanticString(sc, msg, "deprecation message");
                     if (StringExp se = msg ? msg.toStringExp() : null)
                         mod.deprecation(loc, "is deprecated - %s", se.string);
                     else
                         mod.deprecation(loc, "is deprecated");
                 }
-                mod.importAll(null);
                 if (sc.explicitProtection)
                     protection = sc.protection;
                 if (!isstatic && !aliasId && !names.dim)

--- a/test/fail_compilation/fail19609.d
+++ b/test/fail_compilation/fail19609.d
@@ -3,16 +3,17 @@
 TEST_OUTPUT
 ---
 fail_compilation/imports/fail19609a.d(1): Error: `string` expected for deprecation message, not `([""])` of type `string[]`
-fail_compilation/fail19609.d(16): Deprecation: module `imports.fail19609a` is deprecated
-fail_compilation/imports/fail19609a.d(1): Error: `string` expected for deprecation message, not `([""])` of type `string[]`
+fail_compilation/fail19609.d(15): Deprecation: module `imports.fail19609a` is deprecated
 fail_compilation/imports/fail19609b.d(1): Error: `string` expected for deprecation message, not `([1])` of type `int[]`
-fail_compilation/fail19609.d(17): Deprecation: module `imports.fail19609b` is deprecated
-fail_compilation/imports/fail19609b.d(1): Error: `string` expected for deprecation message, not `([1])` of type `int[]`
+fail_compilation/fail19609.d(16): Deprecation: module `imports.fail19609b` is deprecated
 fail_compilation/imports/fail19609c.d(1): Error: `string` expected for deprecation message, not `(123.4F)` of type `float`
-fail_compilation/fail19609.d(18): Deprecation: module `imports.fail19609c` is deprecated
-fail_compilation/imports/fail19609c.d(1): Error: `string` expected for deprecation message, not `(123.4F)` of type `float`
+fail_compilation/fail19609.d(17): Deprecation: module `imports.fail19609c` is deprecated
+fail_compilation/imports/fail19609d.d(1): Error: undefined identifier `msg`
+fail_compilation/fail19609.d(19): Deprecation: module `imports.fail19609d` is deprecated
 ---
 */
 import imports.fail19609a;
 import imports.fail19609b;
 import imports.fail19609c;
+enum msg = "You should not be able to see me";
+import imports.fail19609d;

--- a/test/fail_compilation/imports/fail19609d.d
+++ b/test/fail_compilation/imports/fail19609d.d
@@ -1,0 +1,2 @@
+deprecated(msg) module imports.fail19609d;
+enum msg = "You won't see this either";


### PR DESCRIPTION
Fix up from previous.  Run importAll before issuing deprecation message, so that `semanticString` is only called once.