### PR TITLE
fix Issue 19636 - ICE: writing mixin to file crashes if the text contains CRLF

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -240,15 +240,17 @@ bool writeMixin(const(char)[] s, ref Loc loc)
 
     // write by line to create consistent line endings
     size_t lastpos = 0;
-    foreach (i,c; s)
+    for (size_t i = 0; i < s.length; i++)
     {
+        char c = s[i];
         // detect LF and CRLF
         if (c == '\n' || (c == '\r' && i+1 < s.length && s[i+1] == '\n'))
         {
             ob.writestring(s[lastpos .. i]);
             ob.writenl();
             global.params.mixinLines++;
-            lastpos = i + (c == '\r' ? 2 : 1);
+            i += (c == '\r' ? 1 : 0);
+            lastpos = i + 1;
         }
     }
 

--- a/test/compilable/test19636.d
+++ b/test/compilable/test19636.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -mixin=${RESULTS_DIR}/compilable/test19636.mixin
+
+const string s = "int fun(int x)\r\n{ return x; }\r\n";
+
+mixin(s);
+
+int main()
+{
+    int a = fun(1);
+    return 0;
+}


### PR DESCRIPTION
~~also avoid auto-decoding~~