### PR TITLE
more uint => reg_t conversion

### DIFF
--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -856,7 +856,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
         pop87();
         cdb.genfltreg(ESC(mf,1),3,0);
         genfwait(cdb);
-        uint reg;
+        reg_t reg;
         allocreg(cdb,pretregs,&reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
         if (sz == FLOATSIZE)
         {
@@ -922,7 +922,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
             cdb.genfltreg(ESC(mf,1),3,0);
             genfwait(cdb);
             // MOVD XMM?,floatreg
-            uint reg;
+            reg_t reg;
             allocreg(cdb,pretregs,&reg,(sz == FLOATSIZE) ? TYfloat : TYdouble);
             cdb.genxmmreg(xmmload(tym),reg,0,tym);
         }
@@ -1626,7 +1626,8 @@ void load87(ref CodeBuilder cdb,elem *e,uint eoffset,regm_t *pretregs,elem *elef
 {
     code cs;
     regm_t retregs;
-    uint reg,mf1;
+    reg_t reg;
+    uint mf1;
     ubyte ldop;
     int i;
 
@@ -2963,7 +2964,7 @@ void cdd_u64(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         retregs = *pretregs;
         if (!retregs)
             retregs = ALLREGS;
-        uint reg, reg2;
+        reg_t reg, reg2;
         allocreg(cdb,&retregs,&reg,tym);
         reg  = findreglsw(retregs);
         reg2 = findregmsw(retregs);
@@ -3047,10 +3048,10 @@ void cdd_u64(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         retregs = *pretregs;
         if (!retregs)
             retregs = ALLREGS;
-        uint reg;
+        reg_t reg;
         allocreg(cdb,&retregs,&reg,tym);
         regm_t regm2 = ALLREGS & ~retregs & ~mAX;
-        uint reg2;
+        reg_t reg2;
         allocreg(cdb,&regm2,&reg2,tym);
         movregconst(cdb,reg2,0x80000000,0);
         getregs(cdb,mask(reg2) | mAX);
@@ -3124,7 +3125,7 @@ void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     retregs = *pretregs & ALLREGS;
     if (!retregs)
         retregs = ALLREGS;
-    uint reg;
+    reg_t reg;
     allocreg(cdb,&retregs,&reg,tym);
 
     cdb.genfltreg(0xC7,0,8);
@@ -3154,7 +3155,8 @@ void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
 void cnvt87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
     regm_t retregs;
-    uint mf,rf,reg;
+    uint mf,rf;
+    reg_t reg;
     int clib;
 
     //printf("cnvt87(e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
@@ -3338,7 +3340,7 @@ void cdrndtol(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     retregs = *pretregs & (ALLREGS | mBP);
     if (!retregs)
         retregs = ALLREGS;
-    uint reg;
+    reg_t reg;
     allocreg(cdb,&retregs,&reg,tym);
     genfwait(cdb);                      // FWAIT
     if (tysize(tym) > REGSIZE)

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -1899,13 +1899,13 @@ private void resetEcomsub(elem *e)
  *      returns false
  */
 
-int isregvar(elem *e,regm_t *pregm,uint *preg)
+int isregvar(elem *e,regm_t *pregm,reg_t *preg)
 {
     Symbol *s;
     uint u;
     regm_t m;
     regm_t regm;
-    uint reg;
+    reg_t reg;
 
     elem_debug(e);
     if (e.Eoper == OPvar || e.Eoper == OPrelconst)
@@ -1994,15 +1994,15 @@ Lreg:
  *      stack.
  */
 
-void allocreg(ref CodeBuilder cdb,regm_t *pretregs,uint *preg,tym_t tym)
+void allocreg(ref CodeBuilder cdb,regm_t *pretregs,reg_t *preg,tym_t tym)
 {
     allocreg(cdb, pretregs, preg, tym, __LINE__, __FILE__);
 }
 
-void allocreg(ref CodeBuilder cdb,regm_t *pretregs,uint *preg,tym_t tym
+void allocreg(ref CodeBuilder cdb,regm_t *pretregs,reg_t *preg,tym_t tym
         ,int line,const(char)* file)
 {
-        uint reg;
+        reg_t reg;
 
 static if (0)
 {
@@ -2045,7 +2045,7 @@ L1:
         //printf("L1: allregs = %s, *pretregs = %s\n", regm_str(allregs), regm_str(*pretregs));
         assert(++count < 20);           /* fail instead of hanging if blocked */
         assert(retregs);
-        uint msreg = NOREG, lsreg = NOREG;  /* no value assigned yet        */
+        reg_t msreg = NOREG, lsreg = NOREG;  /* no value assigned yet        */
 L3:
         //printf("L2: allregs = %s, *pretregs = %s\n", regm_str(allregs), regm_str(*pretregs));
         regm_t r = retregs & ~(msavereg | regcon.cse.mval | regcon.params);
@@ -2475,7 +2475,8 @@ private void comsub(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
     tym_t tym;
     regm_t regm,emask,csemask;
-    uint reg,byte_,sz;
+    reg_t reg;
+    uint byte_,sz;
 
     //printf("comsub(e = %p, *pretregs = %s)\n",e,regm_str(*pretregs));
     elem_debug(e);
@@ -2618,7 +2619,7 @@ private void comsub(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     else                                  /* reg pair is req'd            */
     if (sz <= 2 * REGSIZE)
     {
-        uint msreg,lsreg;
+        reg_t msreg,lsreg;
 
         /* see if we have both  */
         if (!((emask | csemask) & mMSW && (emask | csemask) & (mLSW | mBP)))
@@ -2925,7 +2926,7 @@ void scodelem(ref CodeBuilder cdb, elem *e,regm_t *pretregs,regm_t keepmsk,bool 
     if (constflag)
     {
         regm_t regm;
-        uint reg;
+        reg_t reg;
 
         if (isregvar(e,&regm,&reg) &&           // if e is a register variable
             (regm & *pretregs) == regm &&       // in one of the right regs

--- a/src/dmd/backend/cgen.d
+++ b/src/dmd/backend/cgen.d
@@ -303,11 +303,11 @@ void gencodelem(ref CodeBuilder cdb,elem *e,regm_t *pretregs,bool constflag)
  * If so, return !=0 and set *preg to which register it is.
  */
 
-bool reghasvalue(regm_t regm,targ_size_t value,uint *preg)
+bool reghasvalue(regm_t regm,targ_size_t value,reg_t *preg)
 {
     //printf("reghasvalue(%s, %llx)\n", regm_str(regm), cast(ulong)value);
     /* See if another register has the right value      */
-    uint r = 0;
+    reg_t r = 0;
     for (regm_t mreg = regcon.immed.mval; mreg; mreg >>= 1)
     {
         if (mreg & regm & 1 && regcon.immed.value[r] == value)
@@ -326,10 +326,10 @@ bool reghasvalue(regm_t regm,targ_size_t value,uint *preg)
  *      *preg   the register selected
  */
 
-void regwithvalue(ref CodeBuilder cdb,regm_t regm,targ_size_t value,uint *preg,regm_t flags)
+void regwithvalue(ref CodeBuilder cdb,regm_t regm,targ_size_t value,reg_t *preg,regm_t flags)
 {
     //printf("regwithvalue(value = %lld)\n", (long long)value);
-    uint reg;
+    reg_t reg;
     if (!preg)
         preg = &reg;
 

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -423,7 +423,7 @@ void genstackclean(ref CodeBuilder cdb,uint numpara,regm_t keepmsk)
 
             if (scratchm)
             {
-                uint r;
+                reg_t r;
                 allocreg(cdb, &scratchm, &r, TYint);
                 cdb.gen1(0x58 + r);           // POP r
             }
@@ -822,7 +822,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
     uint fl, f, opsave;
     elem* e1, e11, e12;
     bool e1isadd, e1free;
-    uint reg;
+    reg_t reg;
     tym_t e1ty;
     Symbol* s;
 
@@ -964,7 +964,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                         else
                         {
                             int rbase;
-                            uint r;
+                            reg_t r;
 
                             scratchm = ALLREGS & ~keepmsk;
                             allocreg(cdb, &scratchm, &r, TYint);
@@ -1080,7 +1080,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                     /* to load another register with the segment of v       */
                     if (e1ty == TYfptr)
                     {
-                        uint msreg;
+                        reg_t msreg;
 
                         idxregs |= mMSW & ALLREGS & ~keepmsk;
                         allocreg(cdb, &idxregs, &msreg, TYfptr);
@@ -1629,7 +1629,7 @@ void fltregs(ref CodeBuilder cdb, code* pcs, tym_t tym)
 
 void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
 {
-    uint scrreg;                      // scratch register
+    reg_t scrreg;                      // scratch register
     regm_t scrregm;
 
     //if (!(regm & (mBP | ALLREGS)))
@@ -1650,7 +1650,7 @@ void tstresult(ref CodeBuilder cdb, regm_t regm, tym_t tym, uint saveflag)
     }
     if (regm & XMMREGS)
     {
-        uint xreg;
+        reg_t xreg;
         regm_t xregs = XMMREGS & ~regm;
         allocreg(cdb,&xregs, &xreg, TYdouble);
         uint op = 0;
@@ -1813,7 +1813,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs)
         }
     }
 
-    uint reg,rreg;
+    reg_t reg,rreg;
     if ((retregs & forregs) == retregs)   // if already in right registers
         *pretregs = retregs;
     else if (forregs)             // if return the result in registers
@@ -3950,7 +3950,7 @@ private void movParams(ref CodeBuilder cdb, elem* e, uint stackalign, uint funca
                 do
                 {   int regsize = REGSIZE;
                     regm_t retregs = (sz == 1) ? BYTEREGS : allregs;
-                    uint reg;
+                    reg_t reg;
                     if (reghasvalue(retregs,*p,&reg))
                     {
                         cs.Iop = (cs.Iop & 1) | 0x88;
@@ -4109,7 +4109,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
             // allocated on the stack by OPstrctor.
         {
             regm_t retregs = allregs;
-            uint reg;
+            reg_t reg;
             allocreg(cdb, &retregs, &reg, TYoffset);
             genregs(cdb, 0x89, SP, reg);        // MOV reg,SP
             if (I64)
@@ -4515,7 +4515,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                 cdb.genadjesp(cast(int)sz);
                 for (int i = 0; i < 3; ++i)
                 {
-                    uint reg;
+                    reg_t reg;
                     if (reghasvalue(allregs, value, &reg))
                         cdb.gen1(0x50 + reg);           // PUSH reg
                     else
@@ -4582,7 +4582,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                         assert(0);
                 }
 
-                uint reg;
+                reg_t reg;
                 if (pushi)
                 {
                     if (I64 && regsize == 8 && value != cast(int)value)
@@ -4675,7 +4675,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
             else
             {
                 retregs = IDXREGS;                             // get an index reg
-                uint reg;
+                reg_t reg;
                 allocreg(cdb, &retregs, &reg, TYoffset);
                 genregs(cdb, 0x89, SP, reg);         // MOV reg,SP
                 pop87();
@@ -4715,7 +4715,7 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
 
 void offsetinreg(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
 {
-    uint reg;
+    reg_t reg;
     regm_t retregs = mLSW;                     // want only offset
     if (e.Ecount && e.Ecount != e.Ecomsub)
     {
@@ -4747,7 +4747,9 @@ L3:
 
 void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
 {
-    uint reg, nreg, op, sreg;
+    reg_t reg;
+    reg_t nreg;
+    uint op, sreg;
     tym_t tym;
     code cs;
     regm_t flags, forregs, regm;
@@ -4921,7 +4923,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                  * in the data segment, because they are x87 opcodes.
                  * Not so efficient. We should at least do a PXOR for 0.
                  */
-                uint r;
+                reg_t r;
                 targ_size_t unsvalue = e.EV.Vuns;
                 if (sz == 8)
                     unsvalue = cast(targ_size_t)e.EV.Vullong;
@@ -4975,7 +4977,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                      * in the data segment, because they are x87 opcodes.
                      * Not so efficient. We should at least do a PXOR for 0.
                      */
-                    uint r;
+                    reg_t r;
                     regm_t rm = ALLREGS;
                     allocreg(cdb, &rm, &r, TYint);    // allocate scratch register
                     movregconst(cdb, r, p[0], 0);

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1443,7 +1443,7 @@ void doswitch(ref CodeBuilder cdb, block *b)
             reg2 = NOREG;
         }
 
-        uint sreg = NOREG;                          // may need a scratch register
+        reg_t sreg = NOREG;                          // may need a scratch register
 
         // Put into casevals[0..ncases] so we can sort then slice
         CaseVal *casevals = cast(CaseVal *)malloc(ncases * CaseVal.sizeof);
@@ -1545,10 +1545,10 @@ static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYB
                  * LEA    R1,[R1][R2]           48 8D 04 02
                  * JMP    R1                    FF E0
                  */
-                uint r1;
+                reg_t r1;
                 regm_t scratchm = ALLREGS & ~mask(reg);
                 allocreg(cdb,&scratchm,&r1,TYint);
-                uint r2;
+                reg_t r2;
                 scratchm = ALLREGS & ~(mask(reg) | mask(r1));
                 allocreg(cdb,&scratchm,&r2,TYint);
 
@@ -1626,7 +1626,7 @@ else static if (TARGET_OSX)
              */
             // Allocate scratch register r1
             regm_t scratchm = ALLREGS & ~mask(reg);
-            uint r1;
+            reg_t r1;
             allocreg(cdb,&scratchm,&r1,TYint);
 
             cdb.genc2(CALL,0,0);                           //     CALL L1
@@ -1650,7 +1650,7 @@ else
 
                 // Allocate scratch register r1
                 regm_t scratchm = ALLREGS & ~(mask(reg) | mBX);
-                uint r1;
+                reg_t r1;
                 allocreg(cdb,&scratchm,&r1,TYint);
 
                 genmovreg(cdb,r1,BX);              // MOV R1,EBX
@@ -2134,7 +2134,7 @@ L1:
 void cod3_ptrchk(ref CodeBuilder cdb,code *pcs,regm_t keepmsk)
 {
     ubyte sib;
-    uint reg;
+    reg_t reg;
     uint flagsave;
     uint opsave;
 
@@ -2312,7 +2312,7 @@ Lcant:
 bool cse_simple(code *c, elem *e)
 {
     regm_t regm;
-    uint reg;
+    reg_t reg;
     int sz = tysize(e.Ety);
 
     if (!I16 &&                                  // don't bother with 16 bit code
@@ -2393,7 +2393,7 @@ void cdframeptr(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     regm_t retregs = *pretregs & allregs;
     if  (!retregs)
         retregs = allregs;
-    uint reg;
+    reg_t reg;
     allocreg(cdb,&retregs, &reg, TYint);
 
     code cs;
@@ -2417,7 +2417,7 @@ void cdgot(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         regm_t retregs = *pretregs & allregs;
         if  (!retregs)
             retregs = allregs;
-        uint reg;
+        reg_t reg;
         allocreg(cdb,&retregs, &reg, TYnptr);
 
         cdb.genc(CALL,0,0,0,FLgot,0);     //     CALL L1
@@ -2430,7 +2430,7 @@ void cdgot(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
         regm_t retregs = *pretregs & allregs;
         if  (!retregs)
             retregs = allregs;
-        uint reg;
+        reg_t reg;
         allocreg(cdb,&retregs, &reg, TYnptr);
 
         cdb.genc2(CALL,0,0);        //     CALL L1
@@ -5904,7 +5904,7 @@ private void pinholeopt_unittest()
 
 void simplify_code(code* c)
 {
-    uint reg;
+    reg_t reg;
     if (config.flags4 & CFG4optimized &&
         (c.Iop == 0x81 || c.Iop == 0x80) &&
         c.IFL2 == FLconst &&

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -204,8 +204,8 @@ code *genlinnum(code *,Srcpos);
 void cgen_prelinnum(code **pc,Srcpos srcpos);
 code *gennop(code *);
 void gencodelem(ref CodeBuilder cdb,elem *e,regm_t *pretregs,bool constflag);
-bool reghasvalue (regm_t regm , targ_size_t value , uint *preg );
-void regwithvalue(ref CodeBuilder cdb, regm_t regm, targ_size_t value, uint *preg, regm_t flags);
+bool reghasvalue (regm_t regm , targ_size_t value , reg_t *preg );
+void regwithvalue(ref CodeBuilder cdb, regm_t regm, targ_size_t value, reg_t *preg, regm_t flags);
 
 // cgreg.c
 void cgreg_init();
@@ -379,9 +379,9 @@ else
 reg_t findregmsw(uint regm) { return findreg(regm & mMSW); }
 reg_t findreglsw(uint regm) { return findreg(regm & (mLSW | mBP)); }
 void freenode(elem *e);
-int isregvar(elem *e, regm_t *pregm, uint *preg);
-void allocreg(ref CodeBuilder cdb, regm_t *pretregs, uint *preg, tym_t tym, int line, const(char)* file);
-void allocreg(ref CodeBuilder cdb, regm_t *pretregs, uint *preg, tym_t tym);
+int isregvar(elem *e, regm_t *pregm, reg_t *preg);
+void allocreg(ref CodeBuilder cdb, regm_t *pretregs, reg_t *preg, tym_t tym, int line, const(char)* file);
+void allocreg(ref CodeBuilder cdb, regm_t *pretregs, reg_t *preg, tym_t tym);
 regm_t lpadregs();
 void useregs (regm_t regm);
 void getregs(ref CodeBuilder cdb, regm_t r);
@@ -580,7 +580,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, regm_t* n
 /* cod4.c */
 extern __gshared
 {
-const uint[4] dblreg;
+const reg_t[4] dblreg;
 int cdcmp_flag;
 }
 


### PR DESCRIPTION
Because of the use of `uint*` pointers, I couldn't make the diff smaller in an easy way.