### PR TITLE
Fix issue 19639

### DIFF
--- a/test/fail_compilation/ice19639.d
+++ b/test/fail_compilation/ice19639.d
@@ -1,0 +1,9 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice19639.d(2): Error: cannot cast expression "" of type string to char[64]
+because of different sizes
+---
+*/
+enum EMPTY_STRING = "\0"[0..0];
+void main() { char[64] buf = EMPTY_STRING; }


### PR DESCRIPTION
When doing a reinterpret cast on a string literal to a static array, ensure the static array has enough capacity.

This is a minimal bandaid fix for issue 19639. It changes the behavior of a construct that has been broken at least since 2015, from giving garbage data to a compile-time error. It also fixes a segfault.