### PR TITLE
use opcode_t to represent CPU opcodes instead of uint

### DIFF
--- a/src/dmd/backend/code_x86.d
+++ b/src/dmd/backend/code_x86.d
@@ -20,6 +20,8 @@ import dmd.backend.codebuilder : CodeBuilder;
 import dmd.backend.el : elem;
 import dmd.backend.ty : I64;
 
+alias opcode_t = uint;          // CPU opcode
+
 /* Register definitions */
 
 enum
@@ -313,7 +315,7 @@ struct code
 
     union
     {
-        uint Iop;
+        opcode_t Iop;
         struct Svex
         {
           align(1):

--- a/src/dmd/backend/iasm.d
+++ b/src/dmd/backend/iasm.d
@@ -14,6 +14,7 @@ module dmd.backend.iasm;
 // Online documentation: https://dlang.org/phobos/dmd_backend_iasm.html
 
 import dmd.backend.cc : block;
+import dmd.backend.code_x86 : opcode_t;
 
 extern (C++):
 @nogc:
@@ -89,30 +90,30 @@ enum
 }
 
 // translates opcode into equivalent vex encoding
-uint VEX_128_W0(uint op)            { return _VEX(op)|_VEX_NOO; }
-uint VEX_128_W1(uint op)            { return _VEX(op)|_VEX_NOO|_VEX_W; }
-uint VEX_128_WIG(uint op)           { return  VEX_128_W0(op); }
-uint VEX_256_W0(uint op)            { return _VEX(op)|_VEX_NOO|_VEX_L; }
-uint VEX_256_W1(uint op)            { return _VEX(op)|_VEX_NOO|_VEX_W|_VEX_L; }
-uint VEX_256_WIG(uint op)           { return  VEX_256_W0(op); }
-uint VEX_NDS_128_W0(uint op)        { return _VEX(op)|_VEX_NDS; }
-uint VEX_NDS_128_W1(uint op)        { return _VEX(op)|_VEX_NDS|_VEX_W; }
-uint VEX_NDS_128_WIG(uint op)       { return  VEX_NDS_128_W0(op); }
-uint VEX_NDS_256_W0(uint op)        { return _VEX(op)|_VEX_NDS|_VEX_L; }
-uint VEX_NDS_256_W1(uint op)        { return _VEX(op)|_VEX_NDS|_VEX_W|_VEX_L; }
-uint VEX_NDS_256_WIG(uint op)       { return  VEX_NDS_256_W0(op); }
-uint VEX_NDD_128_W0(uint op)        { return _VEX(op)|_VEX_NDD; }
-uint VEX_NDD_128_W1(uint op)        { return _VEX(op)|_VEX_NDD|_VEX_W; }
-uint VEX_NDD_128_WIG(uint op)       { return  VEX_NDD_128_W0(op); }
-uint VEX_NDD_256_W0(uint op)        { return _VEX(op)|_VEX_NDD|_VEX_L; }
-uint VEX_NDD_256_W1(uint op)        { return _VEX(op)|_VEX_NDD|_VEX_W|_VEX_L; }
-uint VEX_NDD_256_WIG(uint op)       { return  VEX_NDD_256_W0(op); }
-uint VEX_DDS_128_W0(uint op)        { return _VEX(op)|_VEX_DDS; }
-uint VEX_DDS_128_W1(uint op)        { return _VEX(op)|_VEX_DDS|_VEX_W; }
-uint VEX_DDS_128_WIG(uint op)       { return  VEX_DDS_128_W0(op); }
-uint VEX_DDS_256_W0(uint op)        { return _VEX(op)|_VEX_DDS|_VEX_L; }
-uint VEX_DDS_256_W1(uint op)        { return _VEX(op)|_VEX_DDS|_VEX_W|_VEX_L; }
-uint VEX_DDS_256_WIG(uint op)       { return  VEX_DDS_256_W0(op); }
+uint VEX_128_W0(opcode_t op)            { return _VEX(op)|_VEX_NOO; }
+uint VEX_128_W1(opcode_t op)            { return _VEX(op)|_VEX_NOO|_VEX_W; }
+uint VEX_128_WIG(opcode_t op)           { return  VEX_128_W0(op); }
+uint VEX_256_W0(opcode_t op)            { return _VEX(op)|_VEX_NOO|_VEX_L; }
+uint VEX_256_W1(opcode_t op)            { return _VEX(op)|_VEX_NOO|_VEX_W|_VEX_L; }
+uint VEX_256_WIG(opcode_t op)           { return  VEX_256_W0(op); }
+uint VEX_NDS_128_W0(opcode_t op)        { return _VEX(op)|_VEX_NDS; }
+uint VEX_NDS_128_W1(opcode_t op)        { return _VEX(op)|_VEX_NDS|_VEX_W; }
+uint VEX_NDS_128_WIG(opcode_t op)       { return  VEX_NDS_128_W0(op); }
+uint VEX_NDS_256_W0(opcode_t op)        { return _VEX(op)|_VEX_NDS|_VEX_L; }
+uint VEX_NDS_256_W1(opcode_t op)        { return _VEX(op)|_VEX_NDS|_VEX_W|_VEX_L; }
+uint VEX_NDS_256_WIG(opcode_t op)       { return  VEX_NDS_256_W0(op); }
+uint VEX_NDD_128_W0(opcode_t op)        { return _VEX(op)|_VEX_NDD; }
+uint VEX_NDD_128_W1(opcode_t op)        { return _VEX(op)|_VEX_NDD|_VEX_W; }
+uint VEX_NDD_128_WIG(opcode_t op)       { return  VEX_NDD_128_W0(op); }
+uint VEX_NDD_256_W0(opcode_t op)        { return _VEX(op)|_VEX_NDD|_VEX_L; }
+uint VEX_NDD_256_W1(opcode_t op)        { return _VEX(op)|_VEX_NDD|_VEX_W|_VEX_L; }
+uint VEX_NDD_256_WIG(opcode_t op)       { return  VEX_NDD_256_W0(op); }
+uint VEX_DDS_128_W0(opcode_t op)        { return _VEX(op)|_VEX_DDS; }
+uint VEX_DDS_128_W1(opcode_t op)        { return _VEX(op)|_VEX_DDS|_VEX_W; }
+uint VEX_DDS_128_WIG(opcode_t op)       { return  VEX_DDS_128_W0(op); }
+uint VEX_DDS_256_W0(opcode_t op)        { return _VEX(op)|_VEX_DDS|_VEX_L; }
+uint VEX_DDS_256_W1(opcode_t op)        { return _VEX(op)|_VEX_DDS|_VEX_W|_VEX_L; }
+uint VEX_DDS_256_WIG(opcode_t op)       { return  VEX_DDS_256_W0(op); }
 
 enum _VEX_W   = 0x8000;
 /* Don't encode LIG/LZ use 128 for these.
@@ -133,9 +134,9 @@ enum
     _VEX_DDS  = VEX_DDS << 11,
 }
 
-uint _VEX(uint op) { return (0xC4 << 24) | _VEX_MM(op >> 8) | (op & 0xFF); }
+uint _VEX(opcode_t op) { return (0xC4 << 24) | _VEX_MM(op >> 8) | (op & 0xFF); }
 
-uint _VEX_MM(uint op)
+uint _VEX_MM(opcode_t op)
 {
     return
         (op & 0x00FF) == 0x000F ? (0x1 << 16 | _VEX_PP(op >>  8)) :
@@ -144,7 +145,7 @@ uint _VEX_MM(uint op)
         _VEX_ASSERT0;
 }
 
-uint _VEX_PP(uint op)
+uint _VEX_PP(opcode_t op)
 {
     return
         op == 0x00 ? 0x00 << 8 :
@@ -428,7 +429,7 @@ void asm_process_fixup( block **ppblockLabels );
 
 struct PTRNTAB4
 {
-        int opcode;
+        opcode_t opcode;
         uint usFlags;
         opflag_t usOp1;
         opflag_t usOp2;
@@ -437,7 +438,7 @@ struct PTRNTAB4
 }
 
 struct PTRNTAB3 {
-        int opcode;
+        opcode_t opcode;
         uint usFlags;
         opflag_t usOp1;
         opflag_t usOp2;
@@ -445,14 +446,14 @@ struct PTRNTAB3 {
 }
 
 struct PTRNTAB2 {
-        int opcode;
+        opcode_t opcode;
         uint usFlags;
         opflag_t usOp1;
         opflag_t usOp2;
 }
 
 struct PTRNTAB1 {
-        int opcode;
+        opcode_t opcode;
         uint usFlags;
         opflag_t usOp1;
 }
@@ -460,7 +461,7 @@ struct PTRNTAB1 {
 enum ASM_END = 0xffff;      // special opcode meaning end of PTRNTABx table
 
 struct PTRNTAB0 {
-        int opcode;
+        opcode_t opcode;
         uint usFlags;
 }
 

--- a/src/dmd/backend/ptrntab.d
+++ b/src/dmd/backend/ptrntab.d
@@ -25,6 +25,7 @@ version (SCPP) extern (C) char* strlwr(return char* s);
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.code_x86;
 import dmd.backend.iasm;
 import dmd.backend.oper;
 import dmd.backend.code;
@@ -48,7 +49,7 @@ import dmd.backend.ty;
 immutable
 {
 
-template OPTABLE0(uint op, opflag_t mod)
+template OPTABLE0(opcode_t op, opflag_t mod)
 {
     immutable PTRNTAB0[1] OPTABLE0 = [ { op, mod }, ];
 }
@@ -193,7 +194,7 @@ PTRNTAB1[2] aptb1INVLPG = /* INVLPG */ [         // 486 only instruction
 ];
 
 
-template OPTABLE_J(uint op)
+template OPTABLE_J(opcode_t op)
 {
     immutable PTRNTAB1[4] OPTABLE_J =
     [
@@ -345,7 +346,7 @@ PTRNTAB1[4] aptb1SCAS = /* SCAS */ [
         { ASM_END }
 ];
 
-template OPTABLE_SET(uint op)
+template OPTABLE_SET(opcode_t op)
 {
     immutable PTRNTAB1[2] OPTABLE_SET =
     [
@@ -422,7 +423,7 @@ PTRNTAB1[2]  aptb1CMPXCH16B = /* CMPXCH16B */ [
         { ASM_END }
 ];
 
-template OPTABLE_ARITH(uint op, uint rr, uint m)
+template OPTABLE_ARITH(opcode_t op, uint rr, uint m)
 {
     immutable PTRNTAB2[20] OPTABLE_ARITH =
     [
@@ -729,7 +730,7 @@ PTRNTAB2[4]  aptb2OUTS = /* OUTS */ [
 ];
 
 
-template OPTABLE_SHIFT(uint op)
+template OPTABLE_SHIFT(opcode_t op)
 {
     immutable PTRNTAB2[9] OPTABLE_SHIFT =
     [
@@ -796,7 +797,7 @@ PTRNTAB2[13]  aptb2XCHG = /* XCHG */ [
 ];
 
 
-template OPTABLE_CMOV(uint op)
+template OPTABLE_CMOV(opcode_t op)
 {
     immutable PTRNTAB2[4] OPTABLE_CMOV =
     [


### PR DESCRIPTION
Makes for better self-documentation, consistency, and it'll probably need to increase in size in the future.