### PR TITLE
Fix Issue 19441 - alias this causes partial assignment

### DIFF
--- a/test/fail_compilation/fail19441.d
+++ b/test/fail_compilation/fail19441.d
@@ -1,0 +1,49 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19441.d(44): Deprecation: Cannot use `alias this` to partially initialize variable `wrap[0]` of type `Wrap10595`. Use `wrap[0].i`
+---
+*/
+
+struct S10595
+{
+    bool b = true;
+
+    bool test()
+    {
+        if (!b)  // note: must be a check, not 'return b;'
+            return false;
+
+        return true;
+    }
+}
+
+struct Wrap10595
+{
+    int i;
+    alias i this;
+    S10595 s;
+}
+
+void main()
+{
+    {
+        Wrap10595[int] wrap;
+
+        wrap[0] = Wrap10595();
+        wrap[0].i = 0;
+
+        assert(wrap[0].s.test());  // ok
+    }
+
+    {
+        Wrap10595[int] wrap;
+
+        wrap[0] = Wrap10595();
+        wrap[0] = 0;  // note: using 'alias this' to assign
+
+        assert(wrap[0].s.test());  // failure
+    }
+}
+

--- a/test/runnable/test19441.d
+++ b/test/runnable/test19441.d
@@ -1,0 +1,28 @@
+/* TEST_OUTPUT:
+---
+---
+*/
+
+struct S1
+{
+    int a;
+    long b;
+    alias a this;
+}
+
+struct S2
+{
+    S1 v;
+    alias v this;
+}
+
+void main()
+{
+    auto x = S2(S1(1, 12345678));
+    assert(x.a == 1 &&  x.b == 12345678); // prints: 1 12345678
+    S1 y;
+    y = x;
+    assert(y.a == 1 && y.b == 12345678);
+    y = x.v;
+    assert(y.a == 1 && y.b == 12345678);
+}

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -1072,7 +1072,6 @@ void test10595()
         Wrap10595[int] wrap;
 
         wrap[0] = Wrap10595();
-        wrap[0] = 0;  // note: using 'alias this' to assign
 
         assert(wrap[0].s.test());  // failure
     }


### PR DESCRIPTION
Alias this is never employed on assignment because this leads to partial assignment. 