### PR TITLE
cgxmm.d: add opcode_t

### DIFF
--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -362,7 +362,7 @@ void cdeq(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
     if (tyxmmreg(tyml) && config.fpxmmregs)
     {
-        xmmeq(cdb, e, e.Eoper, e1, e2, pretregs);
+        xmmeq(cdb, e, CMP, e1, e2, pretregs);
         return;
     }
 

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -595,7 +595,7 @@ void cod5_noprol();
 /* cgxmm.c */
 bool isXMMstore(uint op);
 void orthxmm(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
-void xmmeq(ref CodeBuilder cdb, elem *e, uint op, elem *e1, elem *e2,regm_t *pretregs);
+void xmmeq(ref CodeBuilder cdb, elem *e, opcode_t op, elem *e1, elem *e2, regm_t *pretregs);
 void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs);
 void xmmopass(ref CodeBuilder cdb,elem *e, regm_t *pretregs);
 void xmmpost(ref CodeBuilder cdb, elem *e, regm_t *pretregs);

--- a/src/dmd/backend/code_x86.d
+++ b/src/dmd/backend/code_x86.d
@@ -21,6 +21,7 @@ import dmd.backend.el : elem;
 import dmd.backend.ty : I64;
 
 alias opcode_t = uint;          // CPU opcode
+enum opcode_t NoOpcode = 0xFFFF;              // not a valid opcode_t
 
 /* Register definitions */
 
@@ -413,6 +414,7 @@ enum
     SEGFS   = 0x64,
     SEGGS   = 0x65,
 
+    CMP     = 0x3B,
     CALL    = 0xE8,
     JMP     = 0xE9,    // Intra-Segment Direct
     JMPS    = 0xEB,    // JMP SHORT


### PR DESCRIPTION
And fix conflation between `OPER` and `opcode_t` in `xmmeq()`, and some wrongly typed variables.