### PR TITLE
remove unnecessary REX prefix byte from 32 bit MOV

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1928,7 +1928,10 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs)
                 assert(!(retregs & XMMREGS));
                 assert(!(forregs & XMMREGS));
                 reg = findreg(retregs & (mBP | ALLREGS));
-                genmovreg(cdb, rreg, reg);    // MOV rreg,reg
+                if (I64 && sz <= 4)
+                    genregs(cdb, 0x89, reg, rreg);  // only move 32 bits, and zero the top 32 bits
+                else
+                    genmovreg(cdb, rreg, reg);    // MOV rreg,reg
             }
         }
         cssave(e,retregs | *pretregs,opsflag);

--- a/test/runnable/test_cdcmp.d
+++ b/test/runnable/test_cdcmp.d
@@ -669,7 +669,7 @@ alias baselineCases = AliasSeq!(
     Code!(int, "<", Zero!int)([
         /* push   rbp                     */ 0x55,
         /* mov    rbp,rsp                 */ 0x48, 0x8b, 0xec,
-        /* mov    rax,rdi                 */ 0x48, 0x89, 0xf8,
+        /* mov    eax,edi                 */ 0x89, 0xf8,
         /* shr    eax,0x1f                */ 0xc1, 0xe8, 0x1f,
         /* pop    rbp                     */ 0x5d,
         /* ret                            */ 0xc3,
@@ -685,7 +685,7 @@ alias baselineCases = AliasSeq!(
     Code!(int, "<=", Zero!int)([
         /* push   rbp                     */ 0x55,
         /* mov    rbp,rsp                 */ 0x48, 0x8b, 0xec,
-        /* mov    rax,rdi                 */ 0x48, 0x89, 0xf8,
+        /* mov    eax,edi                 */ 0x89, 0xf8,
         /* add    eax,0xffffffff          */ 0x83, 0xc0, 0xff,
         /* adc    eax,0x0                 */ 0x83, 0xd0, 0x00,
         /* shr    eax,0x1f                */ 0xc1, 0xe8, 0x1f,
@@ -741,7 +741,7 @@ alias baselineCases = AliasSeq!(
     Code!(int, ">=", Zero!int)([
         /* push   rbp                     */ 0x55,
         /* mov    rbp,rsp                 */ 0x48, 0x8b, 0xec,
-        /* mov    rax,rdi                 */ 0x48, 0x89, 0xf8,
+        /* mov    eax,edi                 */ 0x89, 0xf8,
         /* add    eax,eax                 */ 0x01, 0xc0,
         /* sbb    eax,eax                 */ 0x19, 0xc0,
         /* inc    eax                     */ 0xff, 0xc0,
@@ -759,13 +759,12 @@ alias baselineCases = AliasSeq!(
     Code!(int, ">", Zero!int)([
         /* push   rbp                     */ 0x55,
         /* mov    rbp,rsp                 */ 0x48, 0x8b, 0xec,
-        /* mov    rax,rdi                 */ 0x48, 0x89, 0xf8,
+        /* mov    eax,edi                 */ 0x89, 0xf8,
         /* neg    eax                     */ 0xf7, 0xd8,
         /* sbb    eax,0x0                 */ 0x83, 0xd8, 0x00,
         /* shr    eax,0x1f                */ 0xc1, 0xe8, 0x1f,
         /* pop    rbp                     */ 0x5d,
         /* ret                            */ 0xc3,
-        /* add    BYTE PTR [rax],al       */ 0x00, 0x00,
     ]),
     Code!(int, ">", int)([
         /* push   rbp                     */ 0x55,

--- a/test/runnable/test_cdstrpar.d
+++ b/test/runnable/test_cdstrpar.d
@@ -123,7 +123,7 @@ alias baselineCases = AliasSeq!(
         /* push   rbp                     */ 0x55,
         /* mov    rbp,rsp                 */ 0x48, 0x8b, 0xec,
         /* call   9 <testee_ubyte_4+0x9>  */ 0xe8, 0x00, 0x00, 0x00, 0x00,
-        /* mov    rdi,rax                 */ 0x48, 0x89, 0xc7,
+        /* mov    edi,eax                 */ 0x89, 0xc7,
         /* call   11 <testee_ubyte_4+0x11> */ 0xe8, 0x00, 0x00, 0x00, 0x00,
         /* pop    rbp                     */ 0x5d,
         /* ret                            */ 0xc3,


### PR DESCRIPTION
Found this while working on https://github.com/dlang/dmd/pull/9281. It could be risky, so I put it in its own PR.