### PR TITLE
prepare for VS2019: preview 2 changed the name of the file containing…

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1195,6 +1195,8 @@ version (Windows)
             if (VCToolsInstallDir is null && VCInstallDir)
             {
                 const(char)* defverFile = FileName.combine(VCInstallDir, r"Auxiliary\Build\Microsoft.VCToolsVersion.default.txt");
+                if (!FileName.exists(defverFile)) // file renamed with VS2019 Preview 2
+                    defverFile = FileName.combine(VCInstallDir, r"Auxiliary\Build\Microsoft.VCToolsVersion.v142.default.txt");
                 if (FileName.exists(defverFile))
                 {
                     // VS 2017
@@ -1553,7 +1555,7 @@ version (Windows)
             SysFreeString(bstrInstallDir);
 
             if (len > 0)
-                return path[0..len-1].idup.ptr;
+                return path[0..len].idup.ptr;
         }
         return null;
     }


### PR DESCRIPTION
… the current VC toolchain version

I also noticed that the path returned by detection via COM could miss the trailing zero.