### PR TITLE
Fix issue 19654: cannot have final methods in objc interfaces

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1623,8 +1623,8 @@ extern (C++) class FuncDeclaration : Declaration
 
         if (!isMember || !p.isClassDeclaration)
             return false;
-
-        if (p.isClassDeclaration.classKind == ClassKind.objc)
+                                                             // https://issues.dlang.org/show_bug.cgi?id=19654
+        if (p.isClassDeclaration.classKind == ClassKind.objc && !p.isInterfaceDeclaration)
             return objc.isVirtual(this);
 
         version (none)

--- a/test/compilable/objc_interface_final_19654.d
+++ b/test/compilable/objc_interface_final_19654.d
@@ -1,0 +1,7 @@
+// EXTRA_OBJC_SOURCES
+
+extern (Objective-C)
+interface Bar
+{
+    final void foo() @selector("foo") {}
+}


### PR DESCRIPTION
The following code used to work:

```d
extern (Objective-C)
interface Bar
{
    final void foo() @selector("foo") {}
}
```

This change fixes the above code so it compiles again.

FYI, the regression is in master, therefore targeting master.