### PR TITLE
Add a changelog entry for the -preview/-revert flags

### DIFF
--- a/changelog/preview-flags.dd
+++ b/changelog/preview-flags.dd
@@ -1,0 +1,85 @@
+`-preview` and `-revert` command line switches have been introduced
+
+Command line switches adding or subtracting features of the D language have been normally added on an ad-hoc basis.
+Over time this has grown to:
+
+$(UL
+    $(LI `-dip25`)
+    $(LI `-dip1000`)
+    $(LI `-dip1000`)
+    $(LI `-dip1008`)
+)
+
+Moreover, in parallel `-transition` has been introduced and the following DMD
+example is only a subset of the transitional features that DMD supports at the moment:
+
+$(CONSOLE
+dmd -transition=3449 -transition=10378 -transition=14246 -transition=14888 -transition=16997
+)
+
+While these transitions also have a name alias, it's still not clear for the user
+whether the transition is (a) an experimental feature or an upcoming breaking change,
+(b) a warning or help on an upcoming change, or (c) revert of a change for users
+who don't want to deal with the breaking change for now.
+
+With this release, DMD gained a `-preview` command line switch which can be used to test upcoming features or potentially breaking changes.
+For example, with this release the list of upcoming features is:
+
+$(UL
+    $(LI `-preview=dip25`: Implements $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP25.md, DIP25) (Sealed references))
+    $(LI `-preview=dip1000`: Implements $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/DIP1000.md, DIP1000) (Scoped Pointers))
+    $(LI `-preview=dip1008`: Implements $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/DIP1008.md, DIP1008) (`@nogc` Throwables))
+    $(LI `-preview=markdown`: Enables Markdown replacements in Ddoc)
+    $(LI `-preview=fixAliasThis`: Enables a potentially breaking fix for `alias this` with which DMD will first check the this scope before searching in upper scopes)
+    $(LI `-preview=intpromote`: Enables integral promotion for the unary `+`, `-` and `~` operators)
+    $(LI `-preview=dtorfields`: Enables a potentially breaking fix which enables to destruct fields of partially constructed objects)
+)
+
+Adding new features can be disruptive to existing code bases. By initially putting them behind
+a `-preview` switch users will have ample opportunity to adapt to them at their own pace.
+
+Therefore, for end users the new `-preview` interface allows a glimpse into the future.
+As always, feedback and bug reports for all `-preview` features is $(I very welcome) and encouraged,
+so that potential problems or breakages can be caught early.
+
+Whenever a `-preview` feature gets enabled by default,
+it $(I must) pass on all Continuous Integrations, pass the $(LINK2 https://buildkite.com/dlang, test suite of about 50 of the most popular D packages)
+and be without any other known major real-world issues on Bugzilla.
+
+However, as the behavior of DMD could still deviate slightly from previous versions, sometimes a `-revert` switch might be introduced by the D development team which allows an easy opt-out of a new feature for users in case they run into issues.
+As of now, DMD offers these reverts:
+
+$(UL
+    $(LI `-preview=dip25`: Reverts $(LINK2 https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP25.md, DIP25) changes)
+    $(LI `-revert=import`: Revert to single phase name lookup)
+)
+
+Transitioning to new features (or fixing an important bug) is very often not trivial which is why an additional `-transition` exists.
+The `-transition` options are $(I informational only) and intended to help gauge the problems of an upcoming change or assist debugging these changes.
+For example, DMD currently supports these transitions:
+
+$(UL
+    $(LI `-transition=field`: List all non-mutable fields which occupy an object instance)
+    $(LI `-transition=checkimports`: Emit deprecation messages about 10378 anomalies)
+    $(LI `-transition=complex`: Emit deprecation messages for all usages of complex or imaginary types)
+    $(LI `-transition=tls`: List all variables going into the thread local storage)
+    $(LI `-transition=vmarkdown`: List instances of Markdown replacements in Ddoc)
+)
+
+`-transition` command line switches might be turned into actual deprecations if the importance of a change is considered high enough (compared to the impact on real-world code),
+but they are only intended as information for developers on where they would be affected by a certain transition.
+
+As all of this information will be updated continuously with each release, all three command line switches support a help page with either `h`, `help` or `?` option listing all currently available options:
+
+$(CONSOLE
+> dmd -preview=help
+...
+> dmd -revert=help
+...
+> dmd -transition=help
+...
+)
+
+$(B IMPORTANT): All old command line switches will continue to work and won't be deprecated.
+However, they were removed from the documentation and new code is encouraged
+to use `-preview` or `-revert` where applicable.


### PR DESCRIPTION
This adds an informative changelog entry about the changes done in https://github.com/dlang/dmd/pull/9206.

It got a bit longer as I tried to be extensive and provide a reference for future users that can be found by their Google search.
Anyhow, the changelog is split-up into short and long description exactly for this reason (of supplying long changelog to only those who are interested).