### PR TITLE
Remove global token freelist

### DIFF
--- a/src/dmd/iasmgcc.d
+++ b/src/dmd/iasmgcc.d
@@ -291,7 +291,7 @@ public Statement gccAsmSemantic(GccAsmStatement s, Scope *sc)
 
     for (Token *token = s.tokens; token; token = token.next)
     {
-        *ptoklist = Token.alloc();
+        *ptoklist = p.allocateToken();
         memcpy(*ptoklist, token, Token.sizeof);
         ptoklist = &(*ptoklist).next;
         *ptoklist = null;
@@ -390,7 +390,7 @@ unittest
         {
             if (p.token.value == TOK.rightCurly || p.token.value == TOK.endOfFile)
                 break;
-            *ptoklist = Token.alloc();
+            *ptoklist = p.allocateToken();
             memcpy(*ptoklist, &p.token, Token.sizeof);
             ptoklist = &(*ptoklist).next;
             *ptoklist = null;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -6323,7 +6323,7 @@ final class Parser(AST) : Lexer
                         goto Lerror;
 
                     default:
-                        *ptoklist = Token.alloc();
+                        *ptoklist = allocateToken();
                         memcpy(*ptoklist, &token, Token.sizeof);
                         ptoklist = &(*ptoklist).next;
                         *ptoklist = null;

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -715,26 +715,6 @@ extern (C++) struct Token
         }
     }
 
-    extern (D) private __gshared Token* freelist = null;
-
-    extern (D) static Token* alloc()
-    {
-        if (Token.freelist)
-        {
-            Token* t = freelist;
-            freelist = t.next;
-            t.next = null;
-            return t;
-        }
-        return new Token();
-    }
-
-    void free()
-    {
-        next = freelist;
-        freelist = &this;
-    }
-
     int isKeyword() const
     {
         foreach (kw; keywords)


### PR DESCRIPTION
This is accomplished by moving the freelist to an instance variable of the lexer. This will also make it possible to add more `pure` annotations to the lexer.