### PR TITLE
Fix issue 19679, add test

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3088,6 +3088,19 @@ private bool checkEscapingSiblings(FuncDeclaration f, FuncDeclaration outerFunc,
             bAnyClosures = true;
         }
 
+        for (auto parent = g.parent; parent && parent !is outerFunc; parent = parent.parent)
+        {
+            // A parent of the sibling had its address taken.
+            // Assume escaping of parent affects its children, so needs propagating.
+            // see https://issues.dlang.org/show_bug.cgi?id=19679
+            FuncDeclaration parentFunc = parent.isFuncDeclaration;
+            if (parentFunc && parentFunc.tookAddressOf)
+            {
+                markAsNeedingClosure(parentFunc, outerFunc);
+                bAnyClosures = true;
+            }
+        }
+
         PrevSibling* prev = cast(PrevSibling*)p;
         while (1)
         {

--- a/test/runnable/test19679.d
+++ b/test/runnable/test19679.d
@@ -1,0 +1,21 @@
+void delegate() foo()
+{
+    size_t value = 0;
+
+    void check()
+    {
+        assert(value == 0);
+    }
+
+    void nest1()
+    {
+        void nest2() { check(); }
+        nest2();
+    }
+    return &nest1;
+}
+
+void main()
+{
+    foo()();
+}


### PR DESCRIPTION
Fix issue 19679.

if the address of the parent of a sibling caller was taken, consider the caller escaped via that reference.

Issue: https://issues.dlang.org/show_bug.cgi?id=19679

Thanks @ibuclaw for coming up with the solution.

Golf repro:

    void main() {
      (){ int value = 0; void check() { assert(value == 0); } return () => (() => check())(); }()();
    }
