### PR TITLE
for non-ptr params, return-scope goes away

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1318,8 +1318,16 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
 
                 if (fparam.storageClass & STC.scope_ && !fparam.type.hasPointers() && fparam.type.ty != Ttuple)
                 {
+                    /*     X foo(ref return scope X) => Ref-ReturnScope
+                     * ref X foo(ref return scope X) => ReturnRef-Scope
+                     * But X has no pointers, we don't need the scope part, so:
+                     *     X foo(ref return scope X) => Ref
+                     * ref X foo(ref return scope X) => ReturnRef
+                     * Constructors are treated as if they are being returned through the hidden parameter,
+                     * which is by ref, and the ref there is ignored.
+                     */
                     fparam.storageClass &= ~STC.scope_;
-                    if (!(fparam.storageClass & STC.ref_))
+                    if (!tf.isref || (sc.flags & SCOPE.ctor))
                         fparam.storageClass &= ~STC.return_;
                 }
 

--- a/test/compilable/pr9374.d
+++ b/test/compilable/pr9374.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+// https://github.com/dlang/dmd/pull/9374
+
+struct OnlyResult
+{
+    this(return scope ref int v2);
+
+    void* data;
+}
+
+OnlyResult foo(return scope ref int v2);
+
+OnlyResult only(int y)
+{
+    if (y)
+        return OnlyResult(y);
+    return foo(y);
+}

--- a/test/fail_compilation/retscope2.d
+++ b/test/fail_compilation/retscope2.d
@@ -124,7 +124,7 @@ fail_compilation/retscope2.d(721): Error: returning `s.get1()` escapes a referen
 #line 700
 // https://issues.dlang.org/show_bug.cgi?id=17049
 
-@safe S700* get2(return ref scope S700 _this)
+@safe S700* get2(return ref S700 _this)
 {
     return &_this;
 }


### PR DESCRIPTION
Before `ref return scope p` means `ref` and `return scope`. But for `ref return scope i` it means `ref return i`. This changes the latter to be `ref i`. The reason is generic code, where the type of i or p is not known in advance. Makes for consistent behavior with generic code.