### PR TITLE
Fix Issue 19688 - [ICE] Default function argument concatenation crashes DMD

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6023,6 +6023,13 @@ extern (C++) final class CatExp : BinExp
         super(loc, TOK.concatenate, __traits(classInstanceSize, CatExp), e1, e2);
     }
 
+    override Expression resolveLoc(const ref Loc loc, Scope* sc)
+    {
+        e1 = e1.resolveLoc(loc, sc);
+        e2 = e2.resolveLoc(loc, sc);
+        return this;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/test/runnable/test19688.d
+++ b/test/runnable/test19688.d
@@ -1,0 +1,13 @@
+/* TEST_OUTUT:
+---
+---
+*/
+void test(string s = __FUNCTION__ ~ __MODULE__ ~ __FUNCTION__)
+{
+    assert(s == "test19688.maintest19688test19688.main");
+}
+
+void main()
+{
+    test();
+}


### PR DESCRIPTION
`__FUNCTION__` and `__PRETTY_FUNCTION__`, unlike the other special attributes (`__LINE__`, `__MODULE__` etc.), cannot be resolved at parse time when they are used as default function arguments because they need to be evaluated to the function in where the call takes place. The problem here is that when default arguments are evaluated in `functionParameters` [1], resolveLoc is called on a CatExp AST node which does not implement an override for resolveLoc, so it defaults to the one in Expression, which does .... nothing. In order to fix this, I overloaded the function and recursively called resolveLoc on the expressions of the CatExp. 

[1] https://github.com/dlang/dmd/blob/master/src/dmd/expressionsem.d#L1739 