### PR TITLE
Add pr-dmd script, which uses verbose output to generate a progress bar indicating compile progress.

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -590,6 +590,7 @@ install: all $(DMD_MAN_PAGE)
 	$(eval bin_dir=$(if $(filter $(OS),osx), bin, bin$(MODEL)))
 	mkdir -p $(INSTALL_DIR)/$(OS)/$(bin_dir)
 	cp $G/dmd $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd
+	cp ./pr-dmd $(INSTALL_DIR)/$(OS)/$(bin_dir)/pr-dmd
 	cp ../ini/$(OS)/$(bin_dir)/dmd.conf $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd.conf
 	cp $D/boostlicense.txt $(INSTALL_DIR)/dmd-boostlicense.txt
 

--- a/src/pr-dmd
+++ b/src/pr-dmd
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -eo pipefail
+DMD=$(dirname "$0")/dmd
+function process {
+  declare -a MODULES
+  declare -A SEMANTIC1
+  declare -A SEMANTIC2
+  declare -A SEMANTIC3
+  declare -A CODE
+  ESCAPE="\033["
+  CLEAR="${ESCAPE}0m"
+  RED="${ESCAPE}0;31m"
+  YELLOW="${ESCAPE}1;33m"
+  GREEN="${ESCAPE}0;32m"
+  LGREEN="${ESCAPE}1;32m"
+  grep -v ^function | sed -e 's/\t/ /g' -e 's/  */ /g' |while read CMD ARG REST
+  do
+    INFO=${ARG%%!*}
+    INFO=${INFO##*.}
+    case "$CMD" in
+      parse ) MODULES+=( "$ARG" );;
+      semantic ) SEMANTIC1[$ARG]=1;;
+      semantic2 ) SEMANTIC2[$ARG]=1;;
+      semantic3 ) SEMANTIC3[$ARG]=1;;
+      code ) CODE[$ARG]=1;;
+    esac
+
+    STATUS=""
+    for MOD in "${MODULES[@]}"
+    do
+      INDICATOR=" "
+      if [[ -v "CODE[$MOD]" ]]
+      then
+        INDICATOR="$LGREEN~"
+      elif [[ -v "SEMANTIC3[$MOD]" ]]
+      then
+        INDICATOR="$GREEN-"
+      elif [[ -v "SEMANTIC2[$MOD]" ]]
+      then
+        INDICATOR="$YELLOW-"
+      elif [[ -v "SEMANTIC1[$MOD]" ]]
+      then
+        INDICATOR="$RED."
+      fi
+      STATUS="${STATUS}${INDICATOR}"
+    done
+    if [ "$STATUS" != "" ]
+    then
+      STATUS="[${STATUS}${CLEAR}] $INFO"
+    fi
+    echo -en "\033[2K\r$STATUS\r"
+  done
+}
+$DMD $@ -v |process
+echo

--- a/src/pr-dmd
+++ b/src/pr-dmd
@@ -2,54 +2,52 @@
 set -eo pipefail
 DMD=$(dirname "$0")/dmd
 function process {
+  COLUMNS=$(tput cols)
   declare -a MODULES
-  declare -A SEMANTIC1
-  declare -A SEMANTIC2
-  declare -A SEMANTIC3
-  declare -A CODE
+  declare -A INDICATOR
   ESCAPE="\033["
   CLEAR="${ESCAPE}0m"
   RED="${ESCAPE}0;31m"
   YELLOW="${ESCAPE}1;33m"
   GREEN="${ESCAPE}0;32m"
   LGREEN="${ESCAPE}1;32m"
+  ED="$(tput ed)"
   grep -v ^function | sed -e 's/\t/ /g' -e 's/  */ /g' |while read CMD ARG REST
   do
     INFO=${ARG%%!*}
     INFO=${INFO##*.}
     case "$CMD" in
       parse ) MODULES+=( "$ARG" );;
-      semantic ) SEMANTIC1[$ARG]=1;;
-      semantic2 ) SEMANTIC2[$ARG]=1;;
-      semantic3 ) SEMANTIC3[$ARG]=1;;
-      code ) CODE[$ARG]=1;;
+      semantic ) INDICATOR[$ARG]="$RED.";;
+      semantic2 ) INDICATOR[$ARG]="$YELLOW-";;
+      semantic3 ) INDICATOR[$ARG]="$GREEN-";;
+      code ) INDICATOR[$ARG]="$LGREEN~";;
     esac
 
     STATUS=""
+    PLAIN_STATUS=""
     for MOD in "${MODULES[@]}"
     do
-      INDICATOR=" "
-      if [[ -v "CODE[$MOD]" ]]
-      then
-        INDICATOR="$LGREEN~"
-      elif [[ -v "SEMANTIC3[$MOD]" ]]
-      then
-        INDICATOR="$GREEN-"
-      elif [[ -v "SEMANTIC2[$MOD]" ]]
-      then
-        INDICATOR="$YELLOW-"
-      elif [[ -v "SEMANTIC1[$MOD]" ]]
-      then
-        INDICATOR="$RED."
-      fi
-      STATUS="${STATUS}${INDICATOR}"
+      STATUS+=${INDICATOR[$MOD]:- }
+      PLAIN_STATUS+=" "
     done
     if [ "$STATUS" != "" ]
     then
       STATUS="[${STATUS}${CLEAR}] $INFO"
+      PLAIN_STATUS="[${PLAIN_STATUS}] $INFO"
     fi
-    echo -en "\033[2K\r$STATUS\r"
+    if [[ -z "$COLUMNS" ]]
+    then
+      echo -en "$ED$STATUS\r"
+    else
+      LINES=$(echo -en "${PLAIN_STATUS}" |fold -w "$COLUMNS" |wc -l)
+      echo -en "$ED$STATUS\r"
+      if [[ "$LINES" != "0" ]]
+      then
+        tput cuu $LINES
+      fi
+    fi
   done
+  echo "$ED"
 }
 $DMD $@ -v |process
-echo


### PR DESCRIPTION
This is a toy, but an amusing one. Something to look at on long compiles :)
![screenshot_20190221_092758](https://user-images.githubusercontent.com/540727/53154390-fad59000-35ba-11e9-962f-66d757c459ba.png)

Slightly annoying: while DMD does functions and templates, there's no way to tell progress on each module, meaning there's occasional pauses where nothing visually interesting happens.