### PR TITLE
Fix issue 19699: Obj-C segfault - in objc_glue.getClassName

### DIFF
--- a/docs/objective-c_abi.md
+++ b/docs/objective-c_abi.md
@@ -509,7 +509,7 @@ class.
 Pointer to the base class. This is stored as a reference to the
 `_OBJC_CLASS_$_<class_name>` symbol, where `<class_name>` is the name of the
 base class. Or a reference to the `_OBJC_METACLASS_$_<class_name>`, if this is a
-metaclass.
+metaclass. If this class is a root class this will be `null`.
 
 #### `cache`
 

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -259,6 +259,7 @@ extern(C++) final class Supported : ObjcGlue
     override void toObjFile(ClassDeclaration classDeclaration) const
     in
     {
+        assert(classDeclaration !is null);
         assert(classDeclaration.classKind == ClassKind.objc);
     }
     body
@@ -614,6 +615,11 @@ static:
 
     /// ditto
     Symbol* getClassName(ClassDeclaration classDeclaration, bool isMeta = false)
+    in
+    {
+        assert(classDeclaration !is null);
+    }
+    body
     {
         return getClassName(ObjcClassDeclaration(classDeclaration, isMeta));
     }
@@ -946,11 +952,11 @@ private:
      */
     void toDt(ref DtBuilder dtb)
     {
-        auto baseClassSymbol = Symbols.getClassName(classDeclaration.baseClass,
-            isMeta);
+        auto baseClassSymbol = classDeclaration.baseClass ?
+            Symbols.getClassName(classDeclaration.baseClass, isMeta) : null;
 
         dtb.xoff(getMetaclass(), 0); // pointer to metaclass
-        dtb.xoff(baseClassSymbol, 0); // pointer to base class
+        dtb.xoffOrNull(baseClassSymbol); // pointer to base class
         dtb.xoff(Symbols.getEmptyCache(), 0);
         dtb.xoff(Symbols.getEmptyVTable(), 0);
         dtb.xoff(getClassRo(), 0);

--- a/test/compilable/objc_class.d
+++ b/test/compilable/objc_class.d
@@ -12,3 +12,10 @@ extern (Objective-C) class NSObject
 {
     extern (Objective-C) class Class {}
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=19699
+// Declaring a root class with a method with a body
+extern(Objective-C) class Test
+{
+   void foo() {}
+}


### PR DESCRIPTION
The problem occurs when declaring an Objective-C root class and it contains a method with a body.