### PR TITLE
Start to disable OSX-32 on the auto-tester

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -10,7 +10,12 @@ all:
 auto-tester-build: toolchain-info
 	$(QUIET)$(MAKE) -C src -f posix.mak auto-tester-build ENABLE_RELEASE=1
 
+ifneq (,$(findstring Darwin_64_32, $(PWD)))
+auto-tester-test:
+	echo "Darwin_64_32_disabled"
+else
 auto-tester-test: test
+endif
 
 buildkite-test: test
 


### PR DESCRIPTION
It would be better (and easier) to do this directly on the auto-tester, but it looks like this isn't going to happen in the forseeable future.