### PR TITLE
fix issue 17289 - macos/32 With Xcode 8.3 linker, warnings of "pointer not aligned"

### DIFF
--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -1939,6 +1939,7 @@ static if (TARGET_OSX)
          */
         Symbol *sd = symboldata(Offset(DATA), TYnptr);
         sd.Sseg = DATA;
+        Obj.data_start(sd, _tysize[TYnptr], DATA);
         Offset(DATA) += Obj.reftoident(DATA, Offset(DATA), s, 0, CFoff);
         e = el_picvar(sd);
         return e;


### PR DESCRIPTION
forces alignment of pointers in DATA

I found this while debugging #9048 and I didn't want to let this go to waste, even though the platform is now legacy and tests disabled.

64-bit builds still have this problem, too, e.g. when building optabgen, but this seems to be related to debug symbols.