### PR TITLE
Fix issue 19700: Obj-C wrong code overloading selectors and extern(D)

### DIFF
--- a/changelog/1_objc_class.dd
+++ b/changelog/1_objc_class.dd
@@ -20,7 +20,7 @@ Example:
 
 ---
 extern (Objective-C)
-class NSObject
+extern class NSObject // externally defined class
 {
     static NSObject alloc() @selector("alloc");
     NSObject init() @selector("init");
@@ -28,7 +28,7 @@ class NSObject
 }
 
 extern (Objective-C)
-class Foo : NSObject
+class Foo : NSObject // internally defined class
 {
     override static Foo alloc() @selector("alloc");
     override Foo init() @selector("init");

--- a/changelog/2_objc_instance_variable.dd
+++ b/changelog/2_objc_instance_variable.dd
@@ -11,7 +11,7 @@ Example:
 
 ---
 extern (Objective-C)
-class NSObject {}
+extern class NSObject {}
 
 extern (Objective-C)
 class Foo : NSObject

--- a/changelog/3_objc_super_call.dd
+++ b/changelog/3_objc_super_call.dd
@@ -7,7 +7,7 @@ Example:
 
 ---
 extern (Objective-C)
-class NSObject
+extern class NSObject
 {
     void release() @selector("release");
 }

--- a/changelog/4_deprecated_objc_interfaces.dd
+++ b/changelog/4_deprecated_objc_interfaces.dd
@@ -14,5 +14,5 @@ extern (Objective-C) interface NSObject {} // deprecated
 
 Replace with:
 ---
-extern (Objective-C) class NSObject {}
+extern (Objective-C) extern class NSObject {}
 ---

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -476,27 +476,8 @@ extern(C++) private final class Supported : Objc
 
     override void setObjc(ClassDeclaration cd)
     {
-        static bool isExtern(Dsymbols* members)
-        {
-            return members.foreachDsymbol((member) {
-                if (auto attrib = member.isAttribDeclaration)
-                {
-                    if (!isExtern(attrib.decl))
-                        return 1; // return !=0 to stop iteration
-                }
-
-                else if (auto func = member.isFuncDeclaration)
-                {
-                    if (func.fbody)
-                        return 1; // return !=0 to stop iteration
-                }
-
-                return 0;
-            }) == 0;
-        }
-
         cd.classKind = ClassKind.objc;
-        cd.objc.isExtern = isExtern(cd.members);
+        cd.objc.isExtern = (cd.storage_class & STC.extern_) > 0;
     }
 
     override void setObjc(InterfaceDeclaration id)
@@ -519,8 +500,8 @@ extern(C++) private final class Supported : Objc
 
         id.deprecation("Objective-C interfaces have been deprecated");
         deprecationSupplemental(id.loc, "Representing an Objective-C class " ~
-            "as a D interface has been deprecated. Please use the `class` "~
-            "keyword instead");
+            "as a D interface has been deprecated. Please use "~
+            "`extern (Objective-C) extern class` instead");
     }
 
     override void setSelector(FuncDeclaration fd, Scope* sc)

--- a/test/compilable/objc_class.d
+++ b/test/compilable/objc_class.d
@@ -1,16 +1,16 @@
 // EXTRA_OBJC_SOURCES
 
 extern (Objective-C)
-class A
+extern class A
 {
     void oneTwo(int a, int b) pure @selector("one:two:");
     void test(int a, int b, int c) @selector("test:::");
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=19494
-extern (Objective-C) class NSObject
+extern (Objective-C) extern class NSObject
 {
-    extern (Objective-C) class Class {}
+    extern (Objective-C) extern class Class {}
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=19699

--- a/test/fail_compilation/deprecate_objc_interface.d
+++ b/test/fail_compilation/deprecate_objc_interface.d
@@ -4,7 +4,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/deprecate_objc_interface.d(10): Deprecation: interface `deprecate_objc_interface.NSObject` Objective-C interfaces have been deprecated
-fail_compilation/deprecate_objc_interface.d(10):        Representing an Objective-C class as a D interface has been deprecated. Please use the `class` keyword instead
+fail_compilation/deprecate_objc_interface.d(10):        Representing an Objective-C class as a D interface has been deprecated. Please use `extern (Objective-C) extern class` instead
 ---
 */
 extern (Objective-C) interface NSObject

--- a/test/fail_compilation/objc_class2.d
+++ b/test/fail_compilation/objc_class2.d
@@ -7,7 +7,7 @@ fail_compilation/objc_class2.d(12): Error: function `objc_class2.A.test` number 
 */
 
 extern (Objective-C)
-class A
+extern class A
 {
     void test(int a, int b, int c) @selector("test:"); // non-matching number of colon
 }

--- a/test/fail_compilation/objc_class3.d
+++ b/test/fail_compilation/objc_class3.d
@@ -8,7 +8,7 @@ fail_compilation/objc_class3.d(19): Error: template instance `objc_class3.A.test
 */
 
 extern (Objective-C)
-class A
+extern class A
 {
     void test(T)(T a) @selector("test:"); // selector defined for template
 }

--- a/test/runnable/objc_call.d
+++ b/test/runnable/objc_call.d
@@ -2,13 +2,13 @@
 // REQUIRED_ARGS: -L-framework -LFoundation
 
 extern (Objective-C)
-class Class
+extern class Class
 {
     NSObject alloc() @selector("alloc");
 }
 
 extern (Objective-C)
-class NSObject
+extern class NSObject
 {
     NSObject initWithUTF8String(in char* str) @selector("initWithUTF8String:");
     void release() @selector("release");

--- a/test/runnable/objc_call_static.d
+++ b/test/runnable/objc_call_static.d
@@ -2,7 +2,7 @@
 // REQUIRED_ARGS: -L-framework -LFoundation
 
 extern (Objective-C)
-class NSObject
+extern class NSObject
 {
     static NSObject alloc() @selector("alloc");
     static NSObject allocWithZone(void* zone) @selector("allocWithZone:");

--- a/test/runnable/objc_class.d
+++ b/test/runnable/objc_class.d
@@ -12,7 +12,7 @@ extern (C) int callFooInstanceMethod(int);
 extern (C) int callFooClassMethod(int);
 
 extern (Objective-C)
-class NSObject
+extern class NSObject
 {
     static NSObject alloc() @selector("alloc");
     NSObject init() @selector("init");

--- a/test/runnable/objc_external_class_19700.d
+++ b/test/runnable/objc_external_class_19700.d
@@ -1,0 +1,41 @@
+// EXTRA_OBJC_SOURCES: objc_instance_variable.m
+// REQUIRED_ARGS: -L-framework -LFoundation
+
+// Verify that a class with a method with D linkage is considered an externally
+// defined class. https://issues.dlang.org/show_bug.cgi?id=19700
+
+extern (Objective-C) extern class NSObject {}
+
+extern (Objective-C)
+extern class NSString : NSObject
+{
+    NSString init() @selector("init");
+    static NSString alloc() @selector("alloc");
+
+    const(char)* UTF8String() @selector("UTF8String");
+
+    NSString initWithBytes(
+        const(void)* bytes,
+        size_t length,
+        size_t encoding
+    ) @selector("initWithBytes:length:encoding:");
+
+    extern (D) NSString init(string s)
+    {
+        return initWithBytes(s.ptr, s.length, NSUTF8StringEncoding);
+    }
+
+    // adding C and C++ linkages for completeness
+    extern (C) void foo() {}
+    extern (C++) void bar() {}
+}
+
+enum NSUTF8StringEncoding = 4;
+
+void main()
+{
+    auto s = "hello";
+    auto str = NSString.alloc.initWithBytes(s.ptr, s.length, NSUTF8StringEncoding);
+
+    assert(str !is null);
+}

--- a/test/runnable/objc_instance_variable.d
+++ b/test/runnable/objc_instance_variable.d
@@ -1,11 +1,11 @@
 // EXTRA_OBJC_SOURCES: objc_instance_variable.m
 // REQUIRED_ARGS: -L-framework -LFoundation
 
-extern (Objective-C) class NSObject {}
+extern (Objective-C) extern class NSObject {}
 
 // Defined in `runnable/extra-files/objc_instance_variable.m`
 extern (Objective-C)
-class Foo : NSObject
+extern class Foo : NSObject
 {
     // int a = 1;
     // int b = 2;

--- a/test/runnable/objc_objc_msgSend.d
+++ b/test/runnable/objc_objc_msgSend.d
@@ -9,7 +9,7 @@ struct Struct
 }
 
 extern (Objective-C)
-class Class
+extern class Class
 {
     stret alloc_stret() @selector("alloc");
     fp2ret alloc_fp2ret() @selector("alloc");
@@ -19,7 +19,7 @@ class Class
 }
 
 extern (Objective-C)
-class stret
+extern class stret
 {
     stret init() @selector("init");
     Struct getValue() @selector("getValue");
@@ -27,7 +27,7 @@ class stret
 }
 
 extern (Objective-C)
-class fp2ret
+extern class fp2ret
 {
     fp2ret init() @selector("init");
     creal getValue() @selector("getValue");
@@ -35,7 +35,7 @@ class fp2ret
 }
 
 extern (Objective-C)
-class fpret
+extern class fpret
 {
     fpret init() @selector("init");
     real getValue() @selector("getValue");
@@ -43,7 +43,7 @@ class fpret
 }
 
 extern (Objective-C)
-class float32
+extern class float32
 {
     float32 init() @selector("init");
     float getValue() @selector("getValue");
@@ -51,7 +51,7 @@ class float32
 }
 
 extern (Objective-C)
-class double64
+extern class double64
 {
     double64 init() @selector("init");
     double getValue() @selector("getValue");

--- a/test/runnable/objc_super_call.d
+++ b/test/runnable/objc_super_call.d
@@ -2,14 +2,14 @@
 // REQUIRED_ARGS: -L-framework -LFoundation
 
 extern (Objective-C)
-class NSObject
+extern class NSObject
 {
     void release() @selector("release");
 }
 
 // Defined in `runnable/extra-files/objc_super_call.m`
 extern (Objective-C)
-class Foo : NSObject
+extern class Foo : NSObject
 {
     // returns 3
     int foo() @selector("foo");


### PR DESCRIPTION
The issue is that if an Objective-C class contains at least one method with a body it will be considered an internally defined class. This means that for a declaration for a class that is supposed to be defined externally it won't look for this class externally when linking. Basically the internally defined class has taken precedence over the externally defined class. When some of the methods don't have a body a runtime exception will occur in the Objective-C runtime when they're called.

The fix is to require `extern (Objective-C) extern` for externally defined classes. For internally defined classes, `extern (Objective-C)` is used.