### PR TITLE
Add base class for all AST nodes

### DIFF
--- a/src/dmd/ast_node.d
+++ b/src/dmd/ast_node.d
@@ -1,0 +1,27 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/ast_node.d, _ast_node.d)
+ * Documentation:  https://dlang.org/phobos/dmd_ast_node.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/ast_node.d
+ */
+module dmd.ast_node;
+
+import dmd.root.rootobject : RootObject;
+import dmd.visitor : Visitor;
+
+/// The base class of all AST nodes.
+extern (C++) abstract class ASTNode : RootObject
+{
+    /**
+     * Visits this AST node using the given visitor.
+     *
+     * Params:
+     *  v = the visitor to use when visiting this node
+     */
+    abstract void accept(Visitor v);
+}

--- a/src/dmd/ast_node.h
+++ b/src/dmd/ast_node.h
@@ -1,0 +1,20 @@
+
+/* Compiler implementation of the D programming language
+ * Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/dmd/ast_node.h
+ */
+
+#pragma once
+
+#include "root/object.h"
+
+class Visitor;
+
+class ASTNode : public RootObject
+{
+    virtual void accept(Visitor*) = 0;
+};

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -298,7 +298,12 @@ struct ASTBase
 
     alias Visitor = ParseTimeVisitor!ASTBase;
 
-    extern (C++) class Dsymbol : RootObject
+    extern (C++) abstract class ASTNode : RootObject
+    {
+        abstract void accept(Visitor v);
+    }
+
+    extern (C++) class Dsymbol : ASTNode
     {
         Loc loc;
         Identifier ident;
@@ -458,7 +463,7 @@ struct ASTBase
             return DYNCAST.dsymbol;
         }
 
-        void accept(Visitor v)
+        override void accept(Visitor v)
         {
             v.visit(this);
         }
@@ -1754,7 +1759,7 @@ struct ASTBase
         VarArg varargs = VarArg.none;
     }
 
-    extern (C++) final class Parameter : RootObject
+    extern (C++) final class Parameter : ASTNode
     {
         StorageClass storageClass;
         Type type;
@@ -1840,7 +1845,7 @@ struct ASTBase
             return new Parameter(storageClass, type ? type.syntaxCopy() : null, ident, defaultArg ? defaultArg.syntaxCopy() : null, userAttribDecl ? cast(UserAttributeDeclaration) userAttribDecl.syntaxCopy(null) : null);
         }
 
-        void accept(Visitor v)
+        override void accept(Visitor v)
         {
             v.visit(this);
         }
@@ -1860,7 +1865,7 @@ struct ASTBase
 
     }
 
-    extern (C++) abstract class Statement : RootObject
+    extern (C++) abstract class Statement : ASTNode
     {
         Loc loc;
 
@@ -1884,7 +1889,7 @@ struct ASTBase
             return null;
         }
 
-        void accept(Visitor v)
+        override void accept(Visitor v)
         {
             v.visit(this);
         }
@@ -2595,7 +2600,7 @@ struct ASTBase
     extern (C++) __gshared int Tsize_t = Tuns32;
     extern (C++) __gshared int Tptrdiff_t = Tint32;
 
-    extern (C++) abstract class Type : RootObject
+    extern (C++) abstract class Type : ASTNode
     {
         TY ty;
         MOD mod;
@@ -3418,7 +3423,7 @@ struct ASTBase
             return null;
         }
 
-        void accept(Visitor v)
+        override void accept(Visitor v)
         {
             v.visit(this);
         }
@@ -4280,7 +4285,7 @@ struct ASTBase
         }
     }
 
-    extern (C++) abstract class Expression : RootObject
+    extern (C++) abstract class Expression : ASTNode
     {
         TOK op;
         ubyte size;
@@ -4327,7 +4332,7 @@ struct ASTBase
             return DYNCAST.expression;
         }
 
-        void accept(Visitor v)
+        override void accept(Visitor v)
         {
             v.visit(this);
         }
@@ -5990,7 +5995,7 @@ struct ASTBase
         }
     }
 
-    extern (C++) abstract class Condition : RootObject
+    extern (C++) abstract class Condition : ASTNode
     {
         Loc loc;
 
@@ -5999,7 +6004,7 @@ struct ASTBase
             this.loc = loc;
         }
 
-        void accept(Visitor v)
+        override void accept(Visitor v)
         {
             v.visit(this);
         }
@@ -6095,7 +6100,7 @@ struct ASTBase
         exp,
     }
 
-    extern (C++) class Initializer : RootObject
+    extern (C++) class Initializer : ASTNode
     {
         Loc loc;
         InitKind kind;
@@ -6117,7 +6122,7 @@ struct ASTBase
             return kind == InitKind.exp ? cast(ExpInitializer)cast(void*)this : null;
         }
 
-        void accept(Visitor v)
+        override void accept(Visitor v)
         {
             v.visit(this);
         }

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -14,6 +14,7 @@ module dmd.cond;
 
 import core.stdc.string;
 import dmd.arraytypes;
+import dmd.ast_node;
 import dmd.dmodule;
 import dmd.dscope;
 import dmd.dsymbol;
@@ -44,7 +45,7 @@ enum Include
     no,                 /// do not include the conditional code
 }
 
-extern (C++) abstract class Condition : RootObject
+extern (C++) abstract class Condition : ASTNode
 {
     Loc loc;
 
@@ -69,7 +70,7 @@ extern (C++) abstract class Condition : RootObject
         return null;
     }
 
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "ast_node.h"
 #include "globals.h"
 #include "visitor.h"
 
@@ -30,7 +31,7 @@ enum Include
     INCLUDEno           /// do not include the conditional code
 };
 
-class Condition
+class Condition : public ASTNode
 {
 public:
     Loc loc;
@@ -39,7 +40,7 @@ public:
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class StaticForeach

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -21,6 +21,7 @@ import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
 import dmd.attrib;
+import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.dclass;
 import dmd.declaration;
@@ -223,7 +224,7 @@ extern (C++) alias Dsymbol_apply_ft_t = int function(Dsymbol, void*);
 
 /***********************************************************
  */
-extern (C++) class Dsymbol : RootObject
+extern (C++) class Dsymbol : ASTNode
 {
     Identifier ident;
     Dsymbol parent;
@@ -1312,7 +1313,7 @@ extern (C++) class Dsymbol : RootObject
 
     /************
      */
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "root/port.h"
+#include "ast_node.h"
 #include "globals.h"
 #include "arraytypes.h"
 #include "visitor.h"
@@ -141,7 +142,7 @@ enum
 
 typedef int (*Dsymbol_apply_ft_t)(Dsymbol *, void *);
 
-class Dsymbol : public RootObject
+class Dsymbol : public ASTNode
 {
 public:
     Identifier *ident;
@@ -272,7 +273,7 @@ public:
     virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
     virtual ProtDeclaration *isProtDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 // Dsymbol that generates a scope

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -19,6 +19,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.aliasthis;
 import dmd.arraytypes;
+import dmd.ast_node;
 import dmd.dcast;
 import dmd.dclass;
 import dmd.declaration;
@@ -5016,7 +5017,7 @@ private bool reliesOnTemplateParameters(Expression e, TemplateParameter[] tparam
 /***********************************************************
  * https://dlang.org/spec/template.html#TemplateParameter
  */
-extern (C++) class TemplateParameter : RootObject
+extern (C++) class TemplateParameter : ASTNode
 {
     Loc loc;
     Identifier ident;
@@ -5124,7 +5125,7 @@ extern (C++) class TemplateParameter : RootObject
      */
     abstract void* dummyArg();
 
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -21,6 +21,7 @@ import dmd.aliasthis;
 import dmd.apply;
 import dmd.arrayop;
 import dmd.arraytypes;
+import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.canthrow;
 import dmd.complex;
@@ -615,7 +616,7 @@ enum WANTexpand = 1;    // expand const/immutable variables if possible
 /***********************************************************
  * http://dlang.org/spec/expression.html#expression
  */
-extern (C++) abstract class Expression : RootObject
+extern (C++) abstract class Expression : ASTNode
 {
     TOK op;         // to minimize use of dynamic_cast
     ubyte size;     // # of bytes in Expression so we can copy() it
@@ -1682,7 +1683,7 @@ extern (C++) abstract class Expression : RootObject
         inout(PrettyFuncInitExp) isPrettyFuncInitExp() { return op == TOK.prettyFunction ? cast(typeof(return))this : null; }
     }
 
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "ast_node.h"
 #include "complex_t.h"
 #include "globals.h"
 #include "arraytypes.h"
@@ -63,7 +64,7 @@ enum
     OWNEDcache      // constant value cached for CTFE
 };
 
-class Expression : public RootObject
+class Expression : public ASTNode
 {
 public:
     TOK op;                     // to minimize use of dynamic_cast
@@ -223,7 +224,7 @@ public:
     FuncInitExp* isFuncInitExp();
     PrettyFuncInitExp* isPrettyFuncInitExp();
 
-    virtual void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class IntegerExp : public Expression

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -16,6 +16,7 @@ import core.stdc.stdio;
 import core.checkedint;
 
 import dmd.arraytypes;
+import dmd.ast_node;
 import dmd.dsymbol;
 import dmd.expression;
 import dmd.globals;
@@ -50,7 +51,7 @@ enum InitKind : ubyte
 
 /***********************************************************
  */
-extern (C++) class Initializer : RootObject
+extern (C++) class Initializer : ASTNode
 {
     Loc loc;
     InitKind kind;
@@ -96,7 +97,7 @@ extern (C++) class Initializer : RootObject
         return kind == InitKind.exp ? cast(inout ExpInitializer)cast(void*)this : null;
     }
 
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "ast_node.h"
 #include "globals.h"
 #include "arraytypes.h"
 #include "visitor.h"
@@ -25,7 +26,7 @@ class ExpInitializer;
 
 enum NeedInterpret { INITnointerpret, INITinterpret };
 
-class Initializer : public RootObject
+class Initializer : public ASTNode
 {
 public:
     Loc loc;
@@ -39,7 +40,7 @@ public:
     ArrayInitializer   *isArrayInitializer();
     ExpInitializer     *isExpInitializer();
 
-    virtual void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class VoidInitializer : public Initializer

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -21,6 +21,7 @@ import core.stdc.string;
 import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.attrib;
+import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.dclass;
 import dmd.declaration;
@@ -374,7 +375,7 @@ enum VarArg
 
 /***********************************************************
  */
-extern (C++) abstract class Type : RootObject
+extern (C++) abstract class Type : ASTNode
 {
     TY ty;
     MOD mod; // modifiers MODxxxx
@@ -2671,7 +2672,7 @@ extern (C++) abstract class Type : RootObject
         inout(TypeNull)       isTypeNull()       { return ty == Tnull      ? cast(typeof(return))this : null; }
     }
 
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }
@@ -6242,7 +6243,7 @@ extern (C++) struct ParameterList
 
 /***********************************************************
  */
-extern (C++) final class Parameter : RootObject
+extern (C++) final class Parameter : ASTNode
 {
     import dmd.attrib : UserAttributeDeclaration;
 
@@ -6304,7 +6305,7 @@ extern (C++) final class Parameter : RootObject
         return DYNCAST.parameter;
     }
 
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -132,7 +132,7 @@ enum VarArg
                          ///   or https://dlang.org/spec/function.html#typesafe_variadic_functions
 };
 
-class Type : public RootObject
+class Type : public ASTNode
 {
 public:
     TY ty;
@@ -345,7 +345,7 @@ public:
     TypeSlice *isTypeSlice();
     TypeNull *isTypeNull();
 
-    virtual void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 class TypeError : public Type

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -19,6 +19,7 @@ import dmd.aggregate;
 import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astcodegen;
+import dmd.ast_node;
 import dmd.gluelayer;
 import dmd.canthrow;
 import dmd.cond;
@@ -78,7 +79,7 @@ TypeIdentifier getException()
 /***********************************************************
  * Specification: http://dlang.org/spec/statement.html
  */
-extern (C++) abstract class Statement : RootObject
+extern (C++) abstract class Statement : ASTNode
 {
     Loc loc;
 
@@ -431,7 +432,7 @@ extern (C++) abstract class Statement : RootObject
      * Params:
      *  v = visitor
      */
-    void accept(Visitor v)
+    override void accept(Visitor v)
     {
         v.visit(this);
     }

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "arraytypes.h"
+#include "ast_node.h"
 #include "dsymbol.h"
 #include "visitor.h"
 #include "tokens.h"
@@ -61,7 +62,7 @@ enum BE
     BEany = (BEfallthru | BEthrow | BEreturn | BEgoto | BEhalt)
 };
 
-class Statement : public RootObject
+class Statement : public ASTNode
 {
 public:
     Loc loc;
@@ -98,7 +99,7 @@ public:
     virtual BreakStatement *isBreakStatement() { return NULL; }
     virtual DtorExpStatement *isDtorExpStatement() { return NULL; }
     virtual ForwardingStatement *isForwardingStatement() { return NULL; }
-    virtual void accept(Visitor *v) { v->visit(this); }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 /** Any Statement that fails semantic() or has a component that is an ErrorExp or

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -311,7 +311,7 @@ endif
 ######## DMD frontend source files
 
 FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes arrayop	\
-	arraytypes astcodegen attrib builtin canthrow cli clone compiler complex cond constfold	\
+	arraytypes astcodegen ast_node attrib builtin canthrow cli clone compiler complex cond constfold	\
 	cppmangle cppmanglewin ctfeexpr ctorflow dcast dclass declaration delegatize denum dimport	\
 	dinifile dinterpret dmacro dmangle dmodule doc dscope dstruct dsymbol dsymbolsem	\
 	dtemplate dversion escape expression expressionsem func			\

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -151,7 +151,7 @@ DMDMAKE=$(MAKE) -fwin32.mak C=$C TK=$(TK) ROOT=$(ROOT) MAKE="$(MAKE)" HOST_DC="$
 
 # D front end
 FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D/arrayop.d	\
-	$D/arraytypes.d $D/astcodegen.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/cli.d $D/clone.d $D/compiler.d $D/complex.d	\
+	$D/arraytypes.d $D/astcodegen.d $D/ast_node.d $D/attrib.d $D/builtin.d $D/canthrow.d $D/cli.d $D/clone.d $D/compiler.d $D/complex.d	\
 	$D/cond.d $D/constfold.d $D/cppmangle.d $D/cppmanglewin.d $D/ctfeexpr.d $D/ctorflow.d $D/dcast.d $D/dclass.d		\
 	$D/declaration.d $D/delegatize.d $D/denum.d $D/dimport.d $D/dinifile.d $D/dinterpret.d	\
 	$D/dmacro.d $D/dmangle.d $D/dmodule.d $D/doc.d $D/dscope.d $D/dstruct.d $D/dsymbol.d $D/dsymbolsem.d		\


### PR DESCRIPTION
This is useful to be able to handle all AST nodes the same way, i.e. in an array. Common code for all AST nodes can also be placed here.