### PR TITLE
Add serializer for basic types

### DIFF
--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -189,7 +189,7 @@ extern (C++) struct CTFloat
     }
 
     @system
-    static int sprint(char* str, char fmt, real_t x)
+    static int sprint(char* str, char fmt, real_t x) nothrow
     {
         version(CRuntime_Microsoft)
         {

--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -703,7 +703,7 @@ int ld_type(longdouble_soft x)
 // consider sprintf pure
 private extern(C) int sprintf(scope char* s, scope const char* format, ...) pure @nogc nothrow;
 
-size_t ld_sprint(char* str, int fmt, longdouble_soft x) @system
+size_t ld_sprint(char* str, int fmt, longdouble_soft x) @system nothrow
 {
     // ensure dmc compatible strings for nan and inf
     switch(ld_type(x))

--- a/src/dmd/root/outbuffer.d
+++ b/src/dmd/root/outbuffer.d
@@ -15,6 +15,9 @@ module dmd.root.outbuffer;
 import core.stdc.stdarg;
 import core.stdc.stdio;
 import core.stdc.string;
+
+import dmd.root.ctfloat;
+import dmd.root.longdouble;
 import dmd.root.rmem;
 import dmd.root.rootobject;
 
@@ -274,6 +277,12 @@ struct OutBuffer
         {
             writestring(obj.toChars());
         }
+    }
+
+    extern (C++) void write(real value) nothrow
+    {
+        reserve(longdouble.sizeof * 3 + 8 + 1 + 1);
+        offset += CTFloat.sprint(cast(char*) data + offset, 'g', longdouble(value));
     }
 
     extern (C++) void fill0(size_t nbytes) pure nothrow

--- a/src/dmd/root/serializer.d
+++ b/src/dmd/root/serializer.d
@@ -1,0 +1,217 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/serializer.d, _serializer.d)
+ * Documentation:  https://dlang.org/phobos/dmd_serializer.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/serializer.d
+ */
+module dmd.root.serializer;
+
+import core.internal.traits : Unqual;
+import core.stdc.stdarg;
+
+import dmd.root.outbuffer : OutBuffer;
+import dmd.root.traits;
+
+/**
+ * Serializes the given value to a textual representation.
+ *
+ * Params:
+ *  value = the value to serialize
+ *
+ * Returns: the serialized data
+ */
+string serialize(T)(auto ref T value)
+{
+    OutBuffer buffer;
+    Serializer(&buffer).serialize(value);
+
+    return cast(string) buffer.extractSlice;
+}
+
+///
+struct Serializer
+{
+    private
+    {
+        enum Type
+        {
+            none,
+            basic,
+        }
+
+        enum indentation = 2;
+        int level = 0;
+        bool shouldIdent;
+        bool isTopLevel = true;
+        Type previousType = Type.none;
+        OutBuffer* buffer;
+    }
+
+    /// Initializes the serializer with the given buffer.
+    this(OutBuffer* buffer)
+    {
+        this.buffer = buffer;
+        append("---");
+    }
+
+    /**
+     * Serializes the given value to a textual representation.
+     *
+     * This function should be used when customizing the serialization of a type.
+     *
+     * Params:
+     *  value = the value to serialize
+     */
+    void serialize(T)(ref T value)
+    {
+        const isTopLevel = this.isTopLevel;
+        this.isTopLevel = false;
+
+        static if (isBasicType!T)
+            serializeBasicType(value, isTopLevel);
+        else
+            static assert(false, "Serializing a value of type `" ~ T.stringof ~
+                "` is not supported");
+    }
+
+private:
+
+    /**
+     * Serializes a basic type to a textual representation.
+     *
+     * Params:
+     *  value = the value to serialize
+     *  isTopLevel = indicates if this is the first value to be serialized
+     */
+    void serializeBasicType(T)(T value, bool isTopLevel)
+    if (isBasicType!T)
+    {
+        previousType = Type.basic;
+
+        if (isTopLevel)
+            append(' ');
+
+        append(value);
+    }
+
+    /**
+     * Increases the indentation level for the duration of the given block.
+     *
+     * Params:
+     *  block = the code to execute while the indentation level has been
+     *      increased
+     */
+    void indent(void delegate() block)
+    {
+        level++;
+        scope (exit) level--;
+        block();
+    }
+
+    /// Writes out the current level of indentation to the buffer.
+    void writeIndentation()
+    {
+        if (shouldIdent)
+        {
+            foreach (_ ; 0 .. level * indentation)
+                buffer.writeByte(' ');
+        }
+    }
+
+    /// Adds a newline to the buffer.
+    void newline()
+    {
+        buffer.writenl();
+        shouldIdent = true;
+    }
+
+    /**
+     * Appends the given string(s) to the buffer.
+     *
+     * Params:
+     *  strings = the string(s) to append to the buffer
+     */
+    void append(string[] strings ...)
+    {
+        writeIndentation();
+
+        foreach (str ; strings)
+            buffer.writestring(str);
+
+        shouldIdent = false;
+    }
+
+    /**
+     * Appends the given value to the buffer.
+     *
+     * Params:
+     *  value = the value to append to the buffer
+     */
+    void append(T)(T value)
+    {
+        alias U = Unqual!T;
+
+        static const(char)* printfFormatter(T)()
+        {
+            static if (is(U == byte) || is(U == ubyte))
+                return "%d";
+            else static if (is(U == char))
+                return "%c";
+            else static if (is(U == short) || is (U == int))
+                return "%d";
+            else static if (is(U == ushort) || is (U == uint))
+                return "%u";
+            else static if (is(U == long))
+                return "%lld";
+            else static if (is(U == ulong))
+                return "%llu";
+            else static if (is(U == float) || is(U == double))
+                return "%g";
+            else
+                static assert(false, "Serializing a value of type `" ~ U.stringof ~ "` is not supported");
+        }
+
+        writeIndentation();
+
+        static if (is(U == bool))
+            buffer.writestring(value ? "true" : "false");
+        else static if (is(U == char) || is(U == wchar) || is(U == dchar))
+            buffer.writeUTF8(value);
+        else static if (is(U == real))
+            buffer.write(value);
+        else
+            buffer.printf(printfFormatter!U, value);
+
+        shouldIdent = false;
+    }
+}
+
+private:
+
+/// Evaluates to `true` if `T` is a basic type, otherwise `false`.
+template isBasicType(T)
+{
+    alias U = Unqual!T;
+
+    enum isBasicType =
+        !isAggregateType!T &&
+        is(U == bool) ||
+        is(U == char) ||
+        is(U == wchar) ||
+        is(U == dchar) ||
+        is(U == byte) ||
+        is(U == ubyte) ||
+        is(U == short) ||
+        is(U == ushort) ||
+        is(U == int) ||
+        is(U == uint) ||
+        is(U == long) ||
+        is(U == ulong) ||
+        is(U == float) ||
+        is(U == double) ||
+        is(U == real);
+}

--- a/src/dmd/root/traits.d
+++ b/src/dmd/root/traits.d
@@ -1,0 +1,38 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/traits.d, _traits.d)
+ * Documentation:  https://dlang.org/phobos/dmd_traits.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/traits.d
+ */
+module dmd.root.traits;
+
+/// Evaluates to `true` if `T` is an aggregate type, otherwise `false`.
+enum isAggregateType(T) =
+    is(T == union) ||
+    is(T == class) ||
+    is(T == struct) ||
+    is(T == interface);
+
+///
+@safe unittest
+{
+    class C;
+    union U;
+    struct S;
+    interface I;
+
+    static assert( isAggregateType!C);
+    static assert( isAggregateType!U);
+    static assert( isAggregateType!S);
+    static assert( isAggregateType!I);
+    static assert(!isAggregateType!void);
+    static assert(!isAggregateType!string);
+    static assert(!isAggregateType!(int[]));
+    static assert(!isAggregateType!(C[string]));
+    static assert(!isAggregateType!(void delegate(int)));
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -328,7 +328,7 @@ LEXER_ROOT=$(addsuffix .d, $(addprefix $(ROOT)/, array ctfloat file filename out
 
 ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array ctfloat file \
 	filename man outbuffer port response rmem rootobject speller \
-	longdouble stringtable hash))
+	longdouble stringtable hash serializer))
 
 GLUE_SRCS=$(addsuffix .d, $(addprefix $D/,irstate toctype glue gluelayer todt tocsym toir dmsc \
 	tocvdebug s2ir toobj e2ir eh iasm iasmdmd iasmgcc objc_glue))

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -207,7 +207,7 @@ GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.o
 ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 	$(ROOT)/filename.d $(ROOT)/man.d $(ROOT)/outbuffer.d $(ROOT)/port.d \
 	$(ROOT)/response.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
-	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d
+	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d $(ROOT)/serializer.d
 
 # D front end
 SRCS = $D/aggregate.h $D/aliasthis.h $D/arraytypes.h	\

--- a/test/unit/serializer/basic_types.d
+++ b/test/unit/serializer/basic_types.d
@@ -1,0 +1,123 @@
+module serializer.basic_types;
+
+import dmd.root.serializer : serialize;
+
+@("bool, true")
+unittest
+{
+    const result = serialize(true);
+    assert(result == "--- true", result);
+}
+
+@("bool, false")
+unittest
+{
+    const result = serialize(false);
+    assert(result == "--- false", result);
+}
+
+@("char")
+unittest
+{
+    const result = serialize('a');
+    assert(result == "--- a", result);
+}
+
+@("wchar")
+unittest
+{
+    const result = serialize('ö');
+    assert(result == "--- ö", result);
+}
+
+@("dchar")
+unittest
+{
+    const result = serialize('🍺');
+    assert(result == "--- 🍺", result);
+}
+
+@("byte")
+unittest
+{
+    const byte value = 3;
+    const result = serialize(value);
+
+    assert(result == "--- 3", result);
+}
+
+@("ubyte")
+unittest
+{
+    const ubyte value = 3;
+    const result = serialize(value);
+
+    assert(result == "--- 3", result);
+}
+
+@("short")
+unittest
+{
+    const short value = 3;
+    const result = serialize(value);
+
+    assert(result == "--- 3", result);
+}
+
+@("short")
+unittest
+{
+    const ushort value = 3;
+    const result = serialize(value);
+
+    assert(result == "--- 3", result);
+}
+
+@("int")
+unittest
+{
+    const result = serialize(3);
+    assert(result == "--- 3", result);
+}
+
+@("uint")
+unittest
+{
+    const result = serialize(3u);
+    assert(result == "--- 3", result);
+}
+
+@("long")
+unittest
+{
+    const result = serialize(10_000_000_000);
+    assert(result == "--- 10000000000", result);
+}
+
+@("ulong")
+unittest
+{
+    const result = serialize(10_000_000_000u);
+    assert(result == "--- 10000000000", result);
+}
+
+@("double")
+unittest
+{
+    const result = serialize(3.1);
+    assert(result == "--- 3.1", result);
+}
+
+@("float")
+unittest
+{
+    const result = serialize(3.1f);
+    assert(result == "--- 3.1", result);
+}
+
+@("real")
+unittest
+{
+    const result = serialize(3.1L);
+    assert(result == "--- 3.1", result);
+}


### PR DESCRIPTION
This is the firs step in adding a serializer to DMD which can output a textual representation of any type, manly the AST. This is useful for debugging and learning the AST. 

When everything is implemented, it's going to look something like: https://github.com/jacob-carlborg/dmd/tree/serializer.

Depends on https://github.com/dlang/dmd/pull/9408.