### PR TITLE
fix appveyor build: ugly escaping no longer necessary

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,8 +72,8 @@ build_script:
   # check: build druntime unittests and dmd test suite
   - cd c:\projects\druntime
   - set PATH=c:\projects\dmd2\windows\bin;%PATH%
-  - make -f win64.mak MODEL=32mscoff DMD=..\dmd\generated\Windows\Release\Win32\dmd.exe VCDIR="%VCINSTALLDIR%." "CC=\"%VCINSTALLDIR%/bin/cl.exe\"" SDKDIR=unused clean
-  - make -f win64.mak MODEL=32mscoff DMD=..\dmd\generated\Windows\Release\Win32\dmd.exe VCDIR="%VCINSTALLDIR%." "CC=\"%VCINSTALLDIR%/bin/cl.exe\"" SDKDIR=unused target unittest32mscoff
+  - make -f win64.mak MODEL=32mscoff DMD=..\dmd\generated\Windows\Release\Win32\dmd.exe VCDIR="%VCINSTALLDIR%." "CC=%VCINSTALLDIR%/bin/cl.exe" SDKDIR=unused clean
+  - make -f win64.mak MODEL=32mscoff DMD=..\dmd\generated\Windows\Release\Win32\dmd.exe VCDIR="%VCINSTALLDIR%." "CC=%VCINSTALLDIR%/bin/cl.exe" SDKDIR=unused target unittest32mscoff
   - cd c:\projects\phobos
   - make -f win64.mak MODEL=32mscoff DMD=..\dmd\generated\Windows\Release\Win32\dmd.exe VCDIR="%VCINSTALLDIR%." "CC=\"%VCINSTALLDIR%/bin/cl.exe\"" SDKDIR=unused clean
   - make -f win64.mak MODEL=32mscoff DMD=..\dmd\generated\Windows\Release\Win32\dmd.exe VCDIR="%VCINSTALLDIR%." "CC=\"%VCINSTALLDIR%/bin/cl.exe\"" SDKDIR=unused


### PR DESCRIPTION
Maybe we should wait for phobos to follow suite: https://github.com/dlang/phobos/pull/6825 ?