### PR TITLE
partially address Issue 19722 - botched implementation of semantic3Er…

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1880,6 +1880,15 @@ extern (C++) final class ErrorExp : Expression
 {
     extern (D) this()
     {
+        if (global.errors == 0 && global.gaggedErrors == 0)
+        {
+             /* Unfortunately, errors can still leak out of gagged errors,
+              * and we need to set the error count to prevent bogus code
+              * generation. At least give a message.
+              */
+             error("unknown, please file report on issues.dlang.org");
+        }
+
         super(Loc.initial, TOK.error, __traits(classInstanceSize, ErrorExp));
         type = Type.terror;
     }


### PR DESCRIPTION
…rors causes compiler assert fail

In the tangle of code in Phobos, and the tangle in the compiler, I have not been able yet to find a smallish test case. The error does result from a gagged error, so there was no message, and it would leak out and assert fail in the ungagged code. Replacing it with a generic message at least is an improvement for now.

Compiling with `-verrors=spec` makes it easier to find what the gagged error is that leaks, but tracking that back through the mass of logic has so far eluded me.