### PR TITLE
Fix Issue 19724: wrong order of linker flags, take 2

### DIFF
--- a/test/compilable/issue19724.sh
+++ b/test/compilable/issue19724.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/env bash
+
+if [[ $OS != linux ]]; then exit 0; fi
+
+TEST_DIR=${OUTPUT_BASE}
+# create two libraries with the first depending on the second
+# so that if they're given the wrong order on the commandline,
+# linking would ordinarily fail
+D_LIBFILE1=$TEST_DIR/first.d
+D_LIBFILE2=$TEST_DIR/second.d
+D_LIB1=$TEST_DIR/libfirst.a
+D_LIB2=$TEST_DIR/libsecond.a
+# call from D
+D_FILE=$TEST_DIR/test.d
+APP=$TEST_DIR/test
+
+mkdir -p $TEST_DIR
+
+cat >$D_LIBFILE1 <<EOF
+module first;
+import second;
+
+int first(int x) { return second.second(x); }
+EOF
+
+cat >$D_LIBFILE2 <<EOF
+module second;
+
+int second(int x) { return 0; }
+EOF
+
+cat >$D_FILE <<EOF
+module test;
+
+import first;
+
+void main() {
+    first.first(0);
+}
+EOF
+
+${DMD} -m${MODEL} -lib -of${D_LIB1} -I${TEST_DIR} ${D_LIBFILE1}
+${DMD} -m${MODEL} -lib -of${D_LIB2} -I${TEST_DIR} ${D_LIBFILE2}
+
+# -lsecond -lfirst is wrong but for --start-group/--end-group,
+# so --start-group and --end-group must not be reordered relative to the libraries
+${DMD} -m${MODEL} -of${APP} ${D_FILE} -I${TEST_DIR} -L-L${TEST_DIR} -L=--start-group -L-lsecond -L-lfirst -L=--end-group


### PR DESCRIPTION
On Linux, don't reorder `-L-l` flags to be before other `-L` flags. Only reorder `-L-L`.
This keeps `-L-l` libs and linker flags that may affect the interpretation of `-l` flags such as `--start-group` ordered correctly.

(Regression since this worked correctly on 2.082.1.)

edit: Hey, can this go on stable? I'm not sure if it counts as a regression, since the behavior wasn't really specified; then again, the misbehavior is really silly.