### PR TITLE
 Fix Issue 19645 - Default parameters not checked for @safe

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -10677,7 +10677,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         //printf("FuncInitExp::semantic()\n");
         e.type = Type.tstring;
-        if (sc.func)
+        if (sc.func && sc.func.ident != Id.__tmpFunc)
         {
             result = e.resolveLoc(Loc.initial, sc);
             return;
@@ -10689,7 +10689,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
     {
         //printf("PrettyFuncInitExp::semantic()\n");
         e.type = Type.tstring;
-        if (sc.func)
+        if (sc.func && sc.func.ident != Id.__tmpFunc)
         {
             result = e.resolveLoc(Loc.initial, sc);
             return;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -314,6 +314,7 @@ immutable Msgtable[] msgtable =
     { "dup" },
     { "_aaApply" },
     { "_aaApply2" },
+    { "__tmpFunc"},
 
     // For pragma's
     { "Pinline", "inline" },

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1205,8 +1205,9 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
             Scope* argsc = sc.push();
             argsc.stc = 0; // don't inherit storage class
             argsc.protection = Prot(Prot.Kind.public_);
+            argsc.func = null;
             Loc tloc = Loc();
-            auto mockFunc = new FuncDeclaration(tloc, tloc, new Identifier("__tfunc"), sc.stc, new TypeFunction(ParameterList(), Type.tvoid, LINK.d, sc.stc));
+            auto mockFunc = new FuncDeclaration(tloc, tloc, Id.__tmpFunc, sc.stc, new TypeFunction(ParameterList(), Type.tvoid, LINK.d, sc.stc));
             mockFunc.parent = sc.parent;
             argsc.func = mockFunc;
 
@@ -1342,19 +1343,10 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                     }
                     else
                     {
-                        if (fparam.defaultArg.op == TOK.default_)
-                        {
-                            auto defaultExp = cast(DefaultInitExp)fparam.defaultArg;
-                            if (defaultExp.subop == TOK.functionString || defaultExp.subop == TOK.prettyFunction)
-                                argsc.func = null;
-                        }
                         e = inferType(e, fparam.type);
                         Initializer iz = new ExpInitializer(e.loc, e);
                         iz = iz.initializerSemantic(argsc, fparam.type, INITnointerpret);
                         e = iz.initializerToExpression();
-                        if (!argsc.func)
-                            argsc.func = mockFunc;
-
                     }
                     if (e.op == TOK.function_) // https://issues.dlang.org/show_bug.cgi?id=4820
                     {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1205,7 +1205,8 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
             Scope* argsc = sc.push();
             argsc.stc = 0; // don't inherit storage class
             argsc.protection = Prot(Prot.Kind.public_);
-            argsc.func = null;
+            Loc tloc = Loc();
+            argsc.func = new FuncDeclaration(tloc, tloc, new Identifier("__tfunc"), sc.stc, new TypeFunction(ParameterList(), Type.tvoid, LINK.d, sc.stc));
 
             size_t dim = tf.parameterList.length;
             for (size_t i = 0; i < dim; i++)

--- a/test/fail_compilation/b19691.d
+++ b/test/fail_compilation/b19691.d
@@ -1,8 +1,9 @@
 // REQUIRED_ARGS: -de
 /* TEST_OUTPUT:
 ---
-fail_compilation/b19691.d(13): Error: forward reference to template `this`
-fail_compilation/b19691.d(19): Deprecation: constructor `b19691.S2.this` all parameters have default arguments, but structs cannot have default constructors.
+fail_compilation/b19691.d(14): Error: forward reference to template `this`
+fail_compilation/b19691.d(20): Error: template instance `b19691.S1.__ctor!(typeof(null))` error instantiating
+fail_compilation/b19691.d(20): Deprecation: constructor `b19691.S2.this` all parameters have default arguments, but structs cannot have default constructors.
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=19691

--- a/test/fail_compilation/b19691e.d
+++ b/test/fail_compilation/b19691e.d
@@ -1,10 +1,11 @@
 // REQUIRED_ARGS: -de
 /* TEST_OUTPUT:
 ---
-fail_compilation/b19691e.d(17): Error: forward reference to template `this`
-fail_compilation/b19691e.d(17): Error: constructor `b19691e.S2.this(S1 s = "")` is not callable using argument types `(string)`
-fail_compilation/b19691e.d(17): Error: forward reference to template `this`
-fail_compilation/b19691e.d(23): Deprecation: constructor `b19691e.S2.this` all parameters have default arguments, but structs cannot have default constructors.
+fail_compilation/b19691e.d(18): Error: forward reference to template `this`
+fail_compilation/b19691e.d(18): Error: constructor `b19691e.S2.this(S1 s = "")` is not callable using argument types `(string)`
+fail_compilation/b19691e.d(18): Error: forward reference to template `this`
+fail_compilation/b19691e.d(24): Error: template instance `b19691e.S1.__ctor!string` error instantiating
+fail_compilation/b19691e.d(24): Deprecation: constructor `b19691e.S2.this` all parameters have default arguments, but structs cannot have default constructors.
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=19691

--- a/test/fail_compilation/fail19645.d
+++ b/test/fail_compilation/fail19645.d
@@ -1,0 +1,39 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19645.d(26): Error: cast from `immutable(int)*` to `int*` not allowed in safe code
+fail_compilation/fail19645.d(29): Error: Cannot call `@system` function `fail19645.non_pure` from `@safe` context
+fail_compilation/fail19645.d(32): Error: Cannot access mutable static data `b` from a `pure` context
+fail_compilation/fail19645.d(39): Error: Cannot call non-@nogc function `fail19645.m` from `@nogc` context
+---
+*/
+int non_pure()
+{
+    return 2;
+}
+
+@safe:
+
+immutable x = 42;
+
+void main()
+{
+    *f() = 7;
+    writeln(x); // 42
+    writeln(*&x); // 7
+}
+
+int* f(int* y = cast(int*) &x) { return y; }
+
+
+int f(int y = non_pure()) { return y; }
+
+shared int b;
+pure void g(int a=b){}
+pure void k()
+{
+    g();
+}
+
+int m() { return 1; }
+@nogc void g(int a = m()) {}


### PR DESCRIPTION
Default parameters are not checked for `@safe`/`pure`/`@nogc`/`nothrow`. This is mainly because dmd implemented these checks only for expressions that are in a functions' scope. Before this patch dmd created a normal scope (not function scope) for parameters to be evaluated; this led to default parameters not being checked for `@safe`/`pure`/`@nogc`/`nothrow`.

To solve the issue I created a mock-up function declaration to trick the compiler that the parameters are in a functions's scope. It would have been ideal to use the initial function declaration for this, but there is no way of obtaining it from a TypeFunction. 

`nothrow` is not handled in this PR as it is a bit different.