### PR TITLE
[WIP] Lower newExp for scalar types

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1801,32 +1801,7 @@ elem *toElem(Expression e, IRState *irs)
             }
             else if (auto tp = t.isTypePointer())
             {
-                elem *ezprefix = ne.argprefix ? toElem(ne.argprefix, irs) : null;
-
-                // call _d_newitemT(ti)
-                e = getTypeInfo(ne.loc, ne.newtype, irs);
-
-                int rtl = tp.next.isZeroInit(Loc.initial) ? RTLSYM_NEWITEMT : RTLSYM_NEWITEMIT;
-                e = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),e);
-                toTraceGC(irs, e, ne.loc);
-
-                if (ne.arguments && ne.arguments.dim == 1)
-                {
-                    /* ezprefix, ts=_d_newitemT(ti), *ts=arguments[0], ts
-                     */
-                    elem *e2 = toElem((*ne.arguments)[0], irs);
-
-                    Symbol *ts = symbol_genauto(Type_toCtype(tp));
-                    elem *eeq1 = el_bin(OPeq, TYnptr, el_var(ts), e);
-
-                    elem *ederef = el_una(OPind, e2.Ety, el_var(ts));
-                    elem *eeq2 = el_bin(OPeq, e2.Ety, ederef, e2);
-
-                    e = el_combine(eeq1, eeq2);
-                    e = el_combine(e, el_var(ts));
-                    //elem_print(e);
-                }
-                e = el_combine(ezprefix, e);
+                assert(0, "Dead code. Should not be here.");
             }
             else
             {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3587,15 +3587,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
         else if (tb.isscalar())
         {
-            Identifier id;
-            if (tb.isZeroInit(exp.loc) == true)
-            {
-                id = Identifier.idPool("___d_newitemT");
-            }
-            else
-            {
-                id = Identifier.idPool("___d_newitemiT");
-            }
+            // call ___d_newitemT!(exp.newtype)()
+            auto id = Identifier.idPool("___d_newitemT");
             auto tiargs = new Objects();
             tiargs.push(exp.newtype);
             auto ti = new TemplateInstance(exp.loc, id, tiargs);
@@ -3604,17 +3597,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             auto arguments = new Expressions();
 
             newExpLowering = new CallExp(exp.loc, newExpLowering, arguments);
-            newExpLowering = newExpLowering.expressionSemantic(sc);
-
             if (!nargs)
             {
+                newExpLowering = newExpLowering.expressionSemantic(sc);
             }
             else if (nargs == 1)
             {
+                // ts = ___d_newitemT!(exp.newtype)(), *ts = arguments[0], ts
                 Expression e = (*exp.arguments)[0];
                 e = e.implicitCastTo(sc, tb);
                 newExpLowering = new ConstructExp(newExpLowering.loc, newExpLowering, e.addressOf());
-                newExpLowering.expressionSemantic(sc);
+                newExpLowering = newExpLowering.expressionSemantic(sc);
             }
             else
             {

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -342,6 +342,8 @@ immutable Msgtable[] msgtable =
     { "__equals"},
     { "__switch"},
     { "__switch_error"},
+    { "___d_newitemT" },
+    { "___d_newitemiT" },
 
     // varargs implementation
     { "va_start" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -343,7 +343,6 @@ immutable Msgtable[] msgtable =
     { "__switch"},
     { "__switch_error"},
     { "___d_newitemT" },
-    { "___d_newitemiT" },
 
     // varargs implementation
     { "va_start" },


### PR DESCRIPTION
Lower calls to `new` expression to druntime's `_d_newitemT` templated implementation that uses compile time information about the type instead of `TypeInfo`.