### PR TITLE
[dmd-cxx] fix Issue 19618 - Associative arrays are not covariant with typeof(null)

### DIFF
--- a/src/mtype.c
+++ b/src/mtype.c
@@ -5331,9 +5331,16 @@ int Type::covariant(Type *t, StorageClass *pstc, bool fix17349)
     }
     else if (t1n->ty == t2n->ty && t1n->implicitConvTo(t2n))
         goto Lcovariant;
-    else if (t1n->ty == Tnull && t1n->implicitConvTo(t2n) &&
-             t1n->size() == t2n->size())
-        goto Lcovariant;
+    else if (t1n->ty == Tnull)
+    {
+        // NULL is covariant with any pointer type, but not with any
+        // dynamic arrays, associative arrays or delegates.
+        // https://issues.dlang.org/show_bug.cgi?id=8589
+        // https://issues.dlang.org/show_bug.cgi?id=19618
+        Type *t2bn = t2n->toBasetype();
+        if (t2bn->ty == Tnull || t2bn->ty == Tpointer || t2bn->ty == Tclass)
+            goto Lcovariant;
+    }
   }
     goto Lnotcovariant;
 

--- a/test/runnable/nulltype.d
+++ b/test/runnable/nulltype.d
@@ -127,7 +127,7 @@ void test8589()
     {
         void f(T function() dg) { assert(!dg()); }
 
-        static assert((T.sizeof == typeof(null).sizeof) == result);
+        static assert((is(typeof(null) function() : T function())) == result);
         static assert(is(typeof( f(&retnull) )) == result);
         static assert(is(typeof( f(()=>null) )) == result);
         static if (result)
@@ -138,7 +138,7 @@ void test8589()
     }
     test!(true,  int*)();
     test!(true,  Object)();
-    test!(true,  int[int])();
+    test!(false, int[int])();
     test!(false, int[])();
     test!(false, void delegate())();
 }


### PR DESCRIPTION
As associative arrays are value types (`struct {void*}`), which are
passed and returned differently to the void pointer typeof(null).