### PR TITLE
[dmd-cxx] fix Issue 19608 - [ICE] dmd/backend/cod1.d(3826): Assertion `0' failed.

### DIFF
--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -102,6 +102,12 @@ static bool preFunctionParameters(Scope *sc, Expressions *exps)
                 arg = new ErrorExp();
                 err = true;
             }
+            else if (arg->type->toBasetype()->ty == Tfunction)
+            {
+                arg->error("cannot pass type %s as a function argument", arg->toChars());
+                arg = new ErrorExp();
+                err = true;
+            }
             else if (checkNonAssignmentArrayOp(arg))
             {
                 arg = new ErrorExp();

--- a/test/fail_compilation/test19608.d
+++ b/test/fail_compilation/test19608.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=19608
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test19608.d(15): Error: cannot pass function `*& f` as a function argument
+---
+*/
+import core.stdc.stdarg;
+
+void f(int) {}
+void g(...) {}
+void h()
+{
+    g(&f);  // OK, function address
+    g(*&f); // ICE -> Error
+}


### PR DESCRIPTION
As this accepts-invalid ICE doesn't affect just the dmd backend.