### PR TITLE
[dmd-cxx] Backport CppStdRevision and Target::cppFundamentalType

### DIFF
--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -120,6 +120,40 @@ class CppMangleVisitor : public Visitor
                 !getQualifier(s));      // at global level
     }
 
+    /************************
+     * Determine if type is a C++ fundamental type.
+     * Params:
+     *  t = type to check
+     * Returns:
+     *  true if it is a fundamental type
+     */
+    static bool isFundamentalType(Type *t)
+    {
+        // First check the target whether some specific ABI is being followed.
+        bool isFundamental;
+        if (Target::cppFundamentalType(t, isFundamental))
+            return isFundamental;
+        if (t->ty == Tenum)
+        {
+            // Peel off enum type from special types.
+            TypeEnum *te = (TypeEnum *)t;
+            if (te->sym->isSpecial())
+                t = te->sym->getMemtype(Loc());
+        }
+
+        // Fundamental arithmetic types:
+        // 1. integral types: bool, char, int, ...
+        // 2. floating point types: float, double, real
+        // 3. void
+        // 4. null pointer: std::nullptr_t (since C++11)
+        if (t->ty == Tvoid || t->ty == Tbool)
+            return true;
+        else if (t->ty == Tnull && global.params.cplusplus >= CppStdRevisionCpp11)
+            return true;
+        else
+            return t->isTypeBasic() && (t->isintegral() || t->isreal());
+    }
+
     /******************************
      * Write the mangled representation of the template arguments.
      * Params:
@@ -741,7 +775,8 @@ public:
      */
     void writeBasicType(Type *t, char p, char c)
     {
-        if (p || t->isConst())
+        // Only do substitutions for non-fundamental types.
+        if (!isFundamentalType(t) || t->isConst())
         {
             if (substitute(t))
                 return;
@@ -835,8 +870,8 @@ public:
                 // Handle any target-specific basic types.
                 if (const char *tm = Target::cppTypeMangle(t))
                 {
-                    // Only do substitution for mangles that are longer than 1 character.
-                    if (tm[1] != 0 || t->isConst())
+                    // Only do substitutions for non-fundamental types.
+                    if (!isFundamentalType(t) || t->isConst())
                     {
                         if (substitute(t))
                             return;

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -802,6 +802,22 @@ public:
         if (t->isImmutable() || t->isShared())
             return error(t);
 
+        // Handle any target-specific basic types.
+        if (const char *tm = Target::cppTypeMangle(t))
+        {
+            // Only do substitutions for non-fundamental types.
+            if (!isFundamentalType(t) || t->isConst())
+            {
+                if (substitute(t))
+                    return;
+                else
+                    append(t);
+            }
+            CV_qualifiers(t);
+            buf->writestring(tm);
+            return;
+        }
+
         /* <builtin-type>:
          * v        void
          * w        wchar_t
@@ -867,21 +883,6 @@ public:
             case Tcomplex80:    p = 'C'; c = 'e';       break;
 
             default:
-                // Handle any target-specific basic types.
-                if (const char *tm = Target::cppTypeMangle(t))
-                {
-                    // Only do substitutions for non-fundamental types.
-                    if (!isFundamentalType(t) || t->isConst())
-                    {
-                        if (substitute(t))
-                            return;
-                        else
-                            append(t);
-                    }
-                    CV_qualifiers(t);
-                    buf->writestring(tm);
-                    return;
-                }
                 return error(t);
         }
         writeBasicType(t, p, c);

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -835,10 +835,14 @@ public:
                 // Handle any target-specific basic types.
                 if (const char *tm = Target::cppTypeMangle(t))
                 {
-                    if (substitute(t))
-                        return;
-                    else
-                        append(t);
+                    // Only do substitution for mangles that are longer than 1 character.
+                    if (tm[1] != 0 || t->isConst())
+                    {
+                        if (substitute(t))
+                            return;
+                        else
+                            append(t);
+                    }
                     CV_qualifiers(t);
                     buf->writestring(tm);
                     return;

--- a/src/globals.h
+++ b/src/globals.h
@@ -55,6 +55,12 @@ enum CPU
     native              // the machine the compiler is being run on
 };
 
+enum CppStdRevision
+{
+    CppStdRevisionCpp98 = 199711,
+    CppStdRevisionCpp11 = 201103
+};
+
 // Put command line switches in here
 struct Param
 {
@@ -114,6 +120,7 @@ struct Param
     bool check10378;    // check for issues transitioning to 10738
     bool bug10378;      // use pre-bugzilla 10378 search strategy
     bool vsafe;         // use enhanced @safe checking
+    unsigned cplusplus;     // version of C++ name mangling to support
     bool showGaggedErrors;  // print gagged errors anyway
 
     CPU cpu;                // CPU instruction set to target

--- a/src/globals.h
+++ b/src/globals.h
@@ -58,7 +58,9 @@ enum CPU
 enum CppStdRevision
 {
     CppStdRevisionCpp98 = 199711,
-    CppStdRevisionCpp11 = 201103
+    CppStdRevisionCpp11 = 201103,
+    CppStdRevisionCpp14 = 201402,
+    CppStdRevisionCpp17 = 201703
 };
 
 // Put command line switches in here

--- a/src/mars.c
+++ b/src/mars.c
@@ -230,6 +230,7 @@ int tryMain(size_t argc, const char *argv[])
     global.params.useInline = false;
     global.params.obj = true;
     global.params.useDeprecated = 2;
+    global.params.cplusplus = CppStdRevisionCpp98;
 
     global.params.linkswitches = new Strings();
     global.params.libfiles = new Strings();

--- a/src/target.c
+++ b/src/target.c
@@ -511,6 +511,19 @@ Type *Target::cppParameterType(Parameter *p)
     return t;
 }
 
+/**
+ * Checks whether type is a vendor-specific fundamental type.
+ * Params:
+ *      t = type to inspect
+ *      isFundamental = where to store result
+ * Returns:
+ *      true if isFundamental was set by function
+ */
+bool Target::cppFundamentalType(const Type *t, bool& isFundamental)
+{
+    return false;
+}
+
 /******************************
  * Return the default system linkage for the target.
  */

--- a/src/target.h
+++ b/src/target.h
@@ -71,5 +71,6 @@ struct Target
     static const char *cppTypeInfoMangle(ClassDeclaration *cd);
     static const char *cppTypeMangle(Type *t);
     static Type *cppParameterType(Parameter *p);
+    static bool cppFundamentalType(const Type *t, bool& isFundamental);
     static LINK systemLinkage();
 };

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -619,6 +619,7 @@ else
     alias c_long_double myld;
 
 extern (C++) myld testld(myld);
+extern (C++) myld testldld(myld, myld);
 
 
 void test15()
@@ -626,6 +627,10 @@ void test15()
     myld ld = 5.0;
     ld = testld(ld);
     assert(ld == 6.0);
+
+    myld ld2 = 5.0;
+    ld2 = testldld(ld2, ld2);
+    assert(ld2 == 6.0);
 }
 
 /****************************************/

--- a/test/runnable/extra-files/cppb.cpp
+++ b/test/runnable/extra-files/cppb.cpp
@@ -439,6 +439,12 @@ long double testld(long double ld)
     return ld + 1;
 }
 
+long double testldld(long double ld1, long double ld2)
+{
+    assert(ld1 == 5);
+    return ld2 + 1;
+}
+
 long testl(long lng)
 {
     assert(lng == 5);


### PR DESCRIPTION
What CppStdRevision is supported is kept internal, as there's no `__traits(getTargetInfo)`.