### PR TITLE
Tweak parallelization when building test tools

### DIFF
--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -148,7 +148,7 @@ cd "${DMD_DIR}/test"
 # REASON: LIB argument doesn't seem to work
 cp "${DMD_DIR}/../phobos/phobos64.lib" .
 
-DMD_TESTSUITE_MAKE_ARGS="-j$N" "${GNU_MAKE}" -j1 all ARGS="-O -inline -g" MODEL="$MODEL"  MODEL_FLAG="$MODEL_FLAG"
+DMD_TESTSUITE_MAKE_ARGS="-j$N" "${GNU_MAKE}" -j1 start_all_tests ARGS="-O -inline -g" MODEL="$MODEL"  MODEL_FLAG="$MODEL_FLAG"
 
 ################################################################################
 # Prepare artifacts

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -151,7 +151,7 @@ coverage()
 
     cp $build_path/dmd _${build_path}/host_dmd_cov
     make -j1 -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd_cov ENABLE_COVERAGE=1 PIC="$PIC" unittest
-    DMD_TESTSUITE_MAKE_ARGS=-j3 make -j1 -C test MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1 PIC="$PIC"
+    DMD_TESTSUITE_MAKE_ARGS=-j3 make -j1 -C test start_all_tests MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1 PIC="$PIC"
 }
 
 # Checks that all files have been committed and no temporary, untracked files exist.

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -82,4 +82,4 @@ export MODEL="64"
 export MODEL_FLAG="-m64"
 
 cd /c/projects/dmd/test
-DMD_TESTSUITE_MAKE_ARGS=-j3 ../../gnumake/make -j1 all MODEL=$MODEL ARGS="-O -inline -g" MODEL_FLAG=$MODEL_FLAG LIB="../../phobos;$LIB"
+DMD_TESTSUITE_MAKE_ARGS=-j3 ../../gnumake/make -j1 start_all_tests MODEL=$MODEL ARGS="-O -inline -g" MODEL_FLAG=$MODEL_FLAG LIB="../../phobos;$LIB"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,6 +80,6 @@ build_script:
   - cd c:\projects\dmd\test
   - set CC=c:/"Program Files (x86)"/"Microsoft Visual Studio 14.0"/VC/bin/cl.exe
   - set DMD_TESTSUITE_MAKE_ARGS=-j3
-  - ..\..\gnumake\make -j1 all MODEL=32mscoff ARGS="-O -inline -g" "OS=win32" DMD=..\generated\Windows\Release\Win32\dmd.exe LIB="../../phobos;%LIB%" RESULTS_DIR=test_m32mscoff
+  - ..\..\gnumake\make -j1 start_all_tests MODEL=32mscoff ARGS="-O -inline -g" "OS=win32" DMD=..\generated\Windows\Release\Win32\dmd.exe LIB="../../phobos;%LIB%" RESULTS_DIR=test_m32mscoff
 
 test_script: true

--- a/ci.sh
+++ b/ci.sh
@@ -86,9 +86,9 @@ test() {
 test_dmd() {
     # test fewer compiler argument permutations for PRs to reduce CI load
     if [ "$FULL_BUILD" == "true" ] && [ "$OS_NAME" == "linux"  ]; then
-        DMD_TESTSUITE_MAKE_ARGS=-j$N make -j1 -C test MODEL=$MODEL # all ARGS by default
+        DMD_TESTSUITE_MAKE_ARGS=-j$N make -j1 -C test start_all_tests MODEL=$MODEL # all ARGS by default
     else
-        DMD_TESTSUITE_MAKE_ARGS=-j$N make -j1 -C test MODEL=$MODEL ARGS="-O -inline -release"
+        DMD_TESTSUITE_MAKE_ARGS=-j$N make -j1 -C test start_all_tests MODEL=$MODEL ARGS="-O -inline -release"
     fi
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -193,7 +193,8 @@ start_fail_compilation_tests: $(RESULTS_DIR)/.created $(test_tools)
 
 run_all_tests: unit_tests run_runnable_tests run_compilable_tests run_fail_compilation_tests
 
-start_all_tests: $(RESULTS_DIR)/.created $(test_tools)
+start_all_tests: $(RESULTS_DIR)/.created
+	$(QUIET)$(MAKE) $(DMD_TESTSUITE_MAKE_ARGS) --no-print-directory $(test_tools)
 	@echo "Running all tests"
 	$(QUIET)$(MAKE) $(DMD_TESTSUITE_MAKE_ARGS) --no-print-directory run_all_tests
 
@@ -202,8 +203,10 @@ $(RESULTS_DIR)/d_do_test$(EXE): tools/d_do_test.d $(RESULTS_DIR)/.created
 	@echo "OS: '$(OS)'"
 	@echo "MODEL: '$(MODEL)'"
 	@echo "PIC: '$(PIC_FLAG)'"
-	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -unittest -run $<
+	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -unittest -run $< &
+	@pid=$!
 	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) $<
+	@wait $(pid)
 
 $(RESULTS_DIR)/sanitize_json$(EXE): tools/sanitize_json.d $(RESULTS_DIR)/.created
 	@echo "Building sanitize_json tool"


### PR DESCRIPTION
The d_do_test and sanitize_json rules can be processed in parallel. Additionally, the d_do_test executable can be built while its unittests are built & run in the background (both take around 8 seconds on my box with LDC).
These tools are prerequisites for the runnable/compilable/fail tests and are thus built before running the actual tests.
These changes save a total of about 10 seconds on my box with LDC.

The best parallelization for a full test run is achieved via `DMD_TESTSUITE_MAKE_ARGS="-j<N>" make start_all_tests`; the CI scripts have been adapted accordingly.