### PR TITLE
Fix Issue 19731: throw away semantic3 run after return type inference to avoid missing invariants

### DIFF
--- a/test/runnable/test19731.d
+++ b/test/runnable/test19731.d
@@ -1,0 +1,28 @@
+struct Foo
+{
+    Object obj_;
+
+    invariant (obj_ !is null);
+
+    auto obj()
+    {
+        return this.obj_;
+    }
+
+    alias type = typeof(&Foo.init.obj);
+}
+
+void main()
+{
+    import core.exception : AssertError;
+
+    Foo foo = Foo.init;
+
+    try
+    {
+        foo.obj.toString();
+    }
+    catch (AssertError)
+    {
+    }
+}


### PR DESCRIPTION
This avoids a case where forcing semantic3 via querying the return type of a struct member function led it to ignore invariants, because they were not yet determined at that point, and later on semantic3 had already run.

I don't like this solution, but I don't know enough DMD to come up with something better. At least it should be a cornercase - auto functions aren't _that_ common, hopefully.

edit: The point of this PR is mostly to run the CI pipeline to flush out possible (likely) breakage, and to softly poll for a better approach.

edit: OH GOD IT BROKE EVERYTHING