### PR TITLE
dmd.dmodule: Don't call FileName.canonicalName if global.inifilename not set.

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -614,7 +614,7 @@ extern (C++) final class Module : Package
         {
             .error(loc, "cannot find source code for runtime library file 'object.d'");
             errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-            const dmdConfFile = FileName.canonicalName(global.inifilename);
+            const dmdConfFile = global.inifilename ? FileName.canonicalName(global.inifilename) : null;
             errorSupplemental(loc, "config file: %s", dmdConfFile ? dmdConfFile : "not found".ptr);
         }
         else


### PR DESCRIPTION
Noticed that some versions of realpath() don't like being passed a null pointer, saves the effort in trying anyway.