### PR TITLE
fix Issue 19734 - isDataseg returns true for non-static declarations

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1300,6 +1300,7 @@ extern (C++) class VarDeclaration : Declaration
             else if (storage_class & (STC.static_ | STC.extern_ | STC.tls | STC.gshared) ||
                 parent.isModule() || parent.isTemplateInstance() || parent.isNspace())
             {
+                assert(!isParameter() && !isResult());
                 isdataseg = 1; // It is in the DataSegment
             }
         }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -315,7 +315,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc2.sw = null;
             sc2.fes = funcdecl.fes;
             sc2.linkage = LINK.d;
-            sc2.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.abstract_ | STC.deprecated_ | STC.override_ | STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property | STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system);
+            sc2.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.abstract_ | STC.deprecated_ | STC.override_ |
+                         STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property |
+                         STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system);
             sc2.protection = Prot(Prot.Kind.public_);
             sc2.explicitProtection = 0;
             sc2.aligndecl = null;

--- a/test/runnable/test19734.d
+++ b/test/runnable/test19734.d
@@ -1,0 +1,36 @@
+// https://issues.dlang.org/show_bug.cgi?id=19734
+// REQUIRED_ARGS: -main
+
+class C19734
+{
+    import core.stdc.stdarg;
+
+    extern
+    {
+        // Invalid 'this' parameter because of applied 'extern' storage class.
+        void testin(typeof(this) p)
+            in(this is p)
+        {
+        }
+
+        // Undefined reference to __result.
+        int testout()
+            out(; __result == 2)
+        {
+            return 2;
+        }
+
+        // Undefined reference to var.
+        int testlocal()
+        {
+            int var;
+            return var + 2;
+        }
+
+        // Variable _argptr cannot have initializer.
+        int testvarargs(...)
+        {
+            return 0;
+        }
+    }
+}

--- a/test/runnable/test19735.d
+++ b/test/runnable/test19735.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=19735
+
+extern int test1(int par)
+{
+    int var = 42;
+    return var + par;
+}
+
+extern
+{
+    int test2(int par)
+    {
+        int var = 42;
+        return var + par;
+    }
+}
+
+void main()
+{
+    assert(test1(1) == test2(1));
+}
+


### PR DESCRIPTION
This is the quick fix to avoid ICE.  The real fix should be handled by issue 19735.