### PR TITLE
Build d_do_test executables with -lowmem to work around OOM errors

### DIFF
--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -42,6 +42,8 @@ if  [ "$DMD" == "gdc" ] && [ "${GDC_VERSION:-0}" == "7" ] ; then
     # bootstrap compilers in May 2019.
     # See also : https://github.com/dlang/dmd/pull/9048/files
     rm test/runnable/{testptrref,xtest46}_gc.d test/fail_compilation/mixin_gc.d || true
+    # Also remove it when building d_do_test.
+    sed -i -e 's/ -lowmem//g' test/Makefile
 fi
 
 install_d "$DMD"

--- a/test/Makefile
+++ b/test/Makefile
@@ -203,9 +203,9 @@ $(RESULTS_DIR)/d_do_test$(EXE): tools/d_do_test.d $(RESULTS_DIR)/.created
 	@echo "OS: '$(OS)'"
 	@echo "MODEL: '$(MODEL)'"
 	@echo "PIC: '$(PIC_FLAG)'"
-	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -unittest -run $< &
+	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -lowmem -unittest -run $< &
 	@pid=$!
-	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) $<
+	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -lowmem -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) $<
 	@wait $(pid)
 
 $(RESULTS_DIR)/sanitize_json$(EXE): tools/sanitize_json.d $(RESULTS_DIR)/.created


### PR DESCRIPTION
The compilation of that little file takes around 1.7 GB (probably due to `std.regex`); `-lowmem` brings that down to about 0.5 GB (with about 20% (1.5 secs on my box) runtime overhead, measured with LDC).

This should fix out-of-memory errors for the autotester, see https://github.com/dlang/dmd/pull/9446#issuecomment-473187099.