### PR TITLE
Workaround for incorrect working directory for Dub

### DIFF
--- a/config.d
+++ b/config.d
@@ -50,9 +50,11 @@ string generateVersion(const string versionFile)
 {
     import std.process : execute;
     import std.file : readText;
+    import std.path : dirName;
     import std.string : strip;
 
-    const result = execute(["git", "describe", "--dirty"]);
+    enum workDir = __FILE_FULL_PATH__.dirName;
+    const result = execute(["git", "-C", workDir, "describe", "--dirty"]);
 
     return result.status == 0 ? result.output.strip : versionFile.readText;
 }


### PR DESCRIPTION
When DMD is used as a Dub dependency and generates the DMD version as a pre generate command. Dub will execute this command in the current working directory, which usually is the root package working directory, instead of the DMD package directory. This will result in the wrong version, that is, it will pick up the git tag of the root package instead of the DMD package.

This looks related: https://github.com/dlang/dub/pull/659.