### PR TITLE
fix Issue 19747 - No debug line info for code in scope(exit)

### DIFF
--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -534,7 +534,7 @@ void cv8_linnum(Srcpos srcpos, uint offset)
     __gshared uint lastlinnum;
     if (currentfuncdata.linepairnum)
     {
-        if (offset <= lastoffset || srcpos.Slinnum <= lastlinnum)
+        if (offset <= lastoffset)
             return;
     }
     lastoffset = offset;


### PR DESCRIPTION
remove gratuitous requirement of ascending source line numbers

testpdb.d now also supports registration free use of COM interfac to msdia140.dll as used by VS2017 and VS2019