### PR TITLE
Fix for issue 19656

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -977,7 +977,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
         else if (tbase.ty == Tclass && !(cast(TypeClass)tbase).sym.isInterfaceDeclaration())
         {
             ClassDeclaration cd = (cast(TypeClass)tbase).sym;
-	    if (cd._scope && cd.semanticRun < PASS.semanticdone)
+            if (cd._scope && cd.semanticRun < PASS.semanticdone)
                 cd.dsymbolSemantic(null);
 
             if (!ClassDeclaration.object)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -977,7 +977,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
         else if (tbase.ty == Tclass && !(cast(TypeClass)tbase).sym.isInterfaceDeclaration())
         {
             ClassDeclaration cd = (cast(TypeClass)tbase).sym;
-            if (cd.semanticRun < PASS.semanticdone)
+	    if (cd._scope && cd.semanticRun < PASS.semanticdone)
                 cd.dsymbolSemantic(null);
 
             if (!ClassDeclaration.object)

--- a/test/compilable/test19656.d
+++ b/test/compilable/test19656.d
@@ -1,0 +1,9 @@
+import test19656a;
+import test19656c: Thud;
+class Foo {
+  Foo[Foo] _map;
+  void func (Thud ) { }
+  void thunk () { }
+}
+
+

--- a/test/compilable/test19656a.d
+++ b/test/compilable/test19656a.d
@@ -1,0 +1,2 @@
+import test19656;
+class Corge: Foo {}

--- a/test/compilable/test19656b.d
+++ b/test/compilable/test19656b.d
@@ -1,0 +1,8 @@
+import test19656;
+class Bar {}
+class Qux(T): Foo {
+  override void thunk() { }
+}
+class Fred {
+  Qux!Bar _q;
+}

--- a/test/compilable/test19656c.d
+++ b/test/compilable/test19656c.d
@@ -1,0 +1,2 @@
+import test19656b;
+class Thud {}


### PR DESCRIPTION
When DMD encounters an associative array with a class type (say Foo) specified as key, the compiler immediately wants to analyze the Foo class. And in some cases (circular module references), it may so happen that DMD may already be in the process of analyzing Foo. In such a scenario, the second call to visit(ClassDeclaration ) method malfunctions and marks Foo with PASS.semanticdone without actually completing analysis of the class.

Since this method marks a ongoing call with setting _scope to null, this situation can be avoided by testing cldec._scope for Foo before calling the dsymbolSemantic method. This makes sure that if semantic analysis for Foo is already running, it would not be run again.