### PR TITLE
dmd.func: Remove unused fthrows field.

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -462,7 +462,6 @@ public:
         VarDeclaration *selector;
     };
 
-    Types *fthrows;                     // Array of Type's of exceptions (not used)
     Statements *frequires;              // in contracts
     Ensures *fensures;                  // out contracts
     Statement *frequire;                // lowered in contract

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -214,7 +214,6 @@ extern (C++) class FuncDeclaration : Declaration
         VarDeclaration selectorParameter;
     }
 
-    Types* fthrows;                     /// Array of Type's of exceptions (not used)
     Statements* frequires;              /// in contracts
     Ensures* fensures;                  /// out contracts
     Statement frequire;                 /// lowered in contract
@@ -341,7 +340,6 @@ extern (C++) class FuncDeclaration : Declaration
         f.frequires = frequires ? Statement.arraySyntaxCopy(frequires) : null;
         f.fensures = fensures ? Ensure.arraySyntaxCopy(fensures) : null;
         f.fbody = fbody ? fbody.syntaxCopy() : null;
-        assert(!fthrows); // deprecated
         return f;
     }
 

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4980,29 +4980,6 @@ final class Parser(AST) : Lexer
                 continue;
             }
 
-            version (none)
-            {
-                // Dumped feature
-            case TOK.throw_:
-                if (!f.fthrows)
-                    f.fthrows = new Types();
-                nextToken();
-                check(TOK.leftParentheses);
-                while (1)
-                {
-                    Type tb = parseBasicType();
-                    f.fthrows.push(tb);
-                    if (token.value == TOK.comma)
-                    {
-                        nextToken();
-                        continue;
-                    }
-                    break;
-                }
-                check(TOK.rightParentheses);
-                goto L1;
-            }
-
         case TOK.in_:
             // in { statements... }
             // in (expression)


### PR DESCRIPTION
Internally deprecated since dmd 0.50 (there's no prior history, so probably longer), marked as not used in headers since dmd 0.142.