### PR TITLE
do not emit mangling for inferred 'return' attribute

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -128,6 +128,7 @@ struct ASTBase
         scopeinferred       = (1L << 49),   // 'scope' has been inferred and should not be part of mangling
         future              = (1L << 50),   // introducing new base class function
         local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
+        returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
 
         TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
         FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.safe | STC.trusted | STC.system),

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -258,6 +258,7 @@ enum STC : long
     scopeinferred       = (1L << 49),   // 'scope' has been inferred and should not be part of mangling
     future              = (1L << 50),   // introducing new base class function
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
+    returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
 
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
     FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.safe | STC.trusted | STC.system),

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -87,6 +87,7 @@ struct IntRange;
 #define STCscopeinferred 0x2000000000000LL // 'scope' has been inferred and should not be part of mangling
 #define STCfuture        0x4000000000000LL // introducing new base class function
 #define STClocal         0x8000000000000LL // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
+#define STCreturninferred 0x10000000000000LL   // 'return' has been inferred and should not be part of mangling
 
 void ObjectNotFound(Identifier *id);
 

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1066,7 +1066,8 @@ public:
         if (p.storageClass & STC.scope_ && !(p.storageClass & STC.scopeinferred))
             buf.writeByte('M');
         // 'return inout ref' is the same as 'inout ref'
-        if ((p.storageClass & (STC.return_ | STC.wild)) == STC.return_)
+        if ((p.storageClass & (STC.return_ | STC.wild)) == STC.return_ &&
+            !(p.storageClass & STC.returninferred))
             buf.writestring("Nk");
         switch (p.storageClass & (STC.in_ | STC.out_ | STC.ref_ | STC.lazy_))
         {

--- a/test/compilable/scopeinfer.d
+++ b/test/compilable/scopeinfer.d
@@ -1,0 +1,12 @@
+// PERMUTE_ARGS: -dip1000
+
+// Mangling should be the same with or without inference of `return scope`
+
+@safe:
+
+auto foo(void* p) { return 0; }
+static assert(typeof(foo).mangleof == "FNaNbNiNfPvZi");
+
+auto bar(void* p) { return p; }
+static assert(typeof(bar).mangleof == "FNaNbNiNfPvZQd");
+


### PR DESCRIPTION
The idea is to get code binaries with and without -dip1000 to play together. This is already done for `scope`.