### PR TITLE
Support markdown-style quote blocks

### DIFF
--- a/res/default_ddoc_theme.ddoc
+++ b/res/default_ddoc_theme.ddoc
@@ -51,6 +51,7 @@ DOC_ROOT_object = $(PHOBOS_PATH)
 DOC_EXTENSION = .html
 IMAGE = <img src="$1" alt="$+" />
 IMAGE_TITLE = <img src="$1" alt="$3" title="$2" />
+BLOCKQUOTE = <blockquote>$0</blockquote>
 DEPRECATED = $0
 
 RED = <span class="color_red">$0</span>
@@ -143,6 +144,13 @@ DDOC =
       }
       ol ol ol ol {
         list-style: decimal;
+      }
+
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
       }
 
       .color_red { color: #dc322f; }

--- a/test/compilable/ddoc_markdown_quote.d
+++ b/test/compilable/ddoc_markdown_quote.d
@@ -1,0 +1,58 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -preview=markdown
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+
+/*
+TEST_OUTPUT:
+----
+----
+*/
+
+/++
+# Quote Blocks
+
+> “It seems to me that most of the ‘new’ programming languages fall into one of
+two categories: Those from academia with radical new paradigms and those from
+large corporations with a focus on RAD and the web. Maybe it’s time for a new
+language born out of practical experience implementing compilers.” -- Michael
+
+> Great, just what I need.. another D in programming. -- Segfault
+
+> To D, or not to D. -- Willeam NerdSpeare
+
+> "What I am going to tell you about is what we teach our programming students in the third or fourth year of graduate school... It is my task to convince you not to turn away because you don't understand it. You see my programming students don't understand it... That is because I don't understand it. Nobody does."
+-- Richard Deeman
+
+Here's a bit of text between quotes.
+
+> This is a quote
+> > And this is a nested quote
+
+> This is a quote with a > symbol in it
+
+> This is a quote
+with a continuation
+
+> This quote
+- is ended by this list
+
+> This quote
+### is ended by this heading
+
+> This quote is ended by a thematic break:
+____
+
+> This quote
+```
+is ended by this code
+```
+
+> ### Some things inside a quote block:
+> ___
+> ---
+> Some code
+> ---
+> - a list
+
++/
+module test.compilable.ddoc_markdown_code;

--- a/test/compilable/ddoc_markdown_quote_verbose.d
+++ b/test/compilable/ddoc_markdown_quote_verbose.d
@@ -1,0 +1,17 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -preview=markdown -transition=vmarkdown
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+
+/*
+TEST_OUTPUT:
+----
+compilable/ddoc_markdown_quote_verbose.d(17): Ddoc: starting quote block with '> Great, just what I need.. another D in programming. -- Segfault'
+----
+*/
+
+/++
+Quote Block:
+
+> Great, just what I need.. another D in programming. -- Segfault
++/
+module test.compilable.ddoc_markdown_code_verbose;

--- a/test/compilable/extra-files/ddoc1.html
+++ b/test/compilable/extra-files/ddoc1.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc10.html
+++ b/test/compilable/extra-files/ddoc10.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc10325.html
+++ b/test/compilable/extra-files/ddoc10325.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc10334.html
+++ b/test/compilable/extra-files/ddoc10334.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc10366.html
+++ b/test/compilable/extra-files/ddoc10366.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc10367.html
+++ b/test/compilable/extra-files/ddoc10367.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc10869.html
+++ b/test/compilable/extra-files/ddoc10869.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc10870.html
+++ b/test/compilable/extra-files/ddoc10870.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc11.html
+++ b/test/compilable/extra-files/ddoc11.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc11479.html
+++ b/test/compilable/extra-files/ddoc11479.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc11511.html
+++ b/test/compilable/extra-files/ddoc11511.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc11823.html
+++ b/test/compilable/extra-files/ddoc11823.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc12.html
+++ b/test/compilable/extra-files/ddoc12.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc12706.html
+++ b/test/compilable/extra-files/ddoc12706.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc12745.html
+++ b/test/compilable/extra-files/ddoc12745.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc13.html
+++ b/test/compilable/extra-files/ddoc13.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc13270.html
+++ b/test/compilable/extra-files/ddoc13270.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc13645.html
+++ b/test/compilable/extra-files/ddoc13645.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc14.html
+++ b/test/compilable/extra-files/ddoc14.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc14383.html
+++ b/test/compilable/extra-files/ddoc14383.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc14778.html
+++ b/test/compilable/extra-files/ddoc14778.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc15475.html
+++ b/test/compilable/extra-files/ddoc15475.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc17697.html
+++ b/test/compilable/extra-files/ddoc17697.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc198.html
+++ b/test/compilable/extra-files/ddoc198.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc2.html
+++ b/test/compilable/extra-files/ddoc2.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc2273.html
+++ b/test/compilable/extra-files/ddoc2273.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc3.html
+++ b/test/compilable/extra-files/ddoc3.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc4.html
+++ b/test/compilable/extra-files/ddoc4.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc4162.html
+++ b/test/compilable/extra-files/ddoc4162.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc5.html
+++ b/test/compilable/extra-files/ddoc5.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc5446.html
+++ b/test/compilable/extra-files/ddoc5446.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc6.html
+++ b/test/compilable/extra-files/ddoc6.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc648.html
+++ b/test/compilable/extra-files/ddoc648.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc6491.html
+++ b/test/compilable/extra-files/ddoc6491.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc7.html
+++ b/test/compilable/extra-files/ddoc7.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc7555.html
+++ b/test/compilable/extra-files/ddoc7555.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc7656.html
+++ b/test/compilable/extra-files/ddoc7656.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc7715.html
+++ b/test/compilable/extra-files/ddoc7715.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc7795.html
+++ b/test/compilable/extra-files/ddoc7795.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc8.html
+++ b/test/compilable/extra-files/ddoc8.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc8271.html
+++ b/test/compilable/extra-files/ddoc8271.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc8739.html
+++ b/test/compilable/extra-files/ddoc8739.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9.html
+++ b/test/compilable/extra-files/ddoc9.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9037.html
+++ b/test/compilable/extra-files/ddoc9037.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9155.html
+++ b/test/compilable/extra-files/ddoc9155.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9305.html
+++ b/test/compilable/extra-files/ddoc9305.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9369.html
+++ b/test/compilable/extra-files/ddoc9369.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9475.html
+++ b/test/compilable/extra-files/ddoc9475.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9497a.html
+++ b/test/compilable/extra-files/ddoc9497a.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9497b.html
+++ b/test/compilable/extra-files/ddoc9497b.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9497c.html
+++ b/test/compilable/extra-files/ddoc9497c.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9497d.html
+++ b/test/compilable/extra-files/ddoc9497d.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9676a.html
+++ b/test/compilable/extra-files/ddoc9676a.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9676b.html
+++ b/test/compilable/extra-files/ddoc9676b.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9727.html
+++ b/test/compilable/extra-files/ddoc9727.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9789.html
+++ b/test/compilable/extra-files/ddoc9789.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc9903.html
+++ b/test/compilable/extra-files/ddoc9903.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddocYear.html
+++ b/test/compilable/extra-files/ddocYear.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }
@@ -523,7 +530,7 @@
   <section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
-    __YEAR__
+    2019
   </p>
 </div>
 

--- a/test/compilable/extra-files/ddoc_markdown_breaks.html
+++ b/test/compilable/extra-files/ddoc_markdown_breaks.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_code.html
+++ b/test/compilable/extra-files/ddoc_markdown_code.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_code_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_code_verbose.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_emphasis.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_escapes.html
+++ b/test/compilable/extra-files/ddoc_markdown_escapes.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_headings.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_links.html
+++ b/test/compilable/extra-files/ddoc_markdown_links.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_links_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_links_verbose.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_lists.html
+++ b/test/compilable/extra-files/ddoc_markdown_lists.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddoc_markdown_quote.html
+++ b/test/compilable/extra-files/ddoc_markdown_quote.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>ddoc14413</title>
+    <title>test.compilable.ddoc_markdown_code</title>
     <style type="text/css" media="screen">
       html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
       blockquote, pre, a, abbr, address, cite, code, del, dfn, em, figure,
@@ -501,55 +501,80 @@
   <body id="ddoc_main" class="ddoc dlang">
     <div class="content_wrapper">
       <article class="module">
-        <h1 class="module_name">ddoc14413</h1>
-        <section id="module_content">
-<section class="section ddoc_module_members_section">
-  <div class="ddoc_module_members">
-    <ul class="ddoc_members">
-  <li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#foo" id="foo"><code class="code">foo</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="foo"></span>void <code class="code">foo</code>();
-
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  <section class="section ddoc_sections">
+        <h1 class="module_name">test.compilable.ddoc_markdown_code</h1>
+        <section id="module_content"><section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
-    This should
-be one
-paragraph.
+    <h1>Quote Blocks</h1>
 
   </p>
 </div>
 <div class="ddoc_description">
   <h4>Discussion</h4>
   <p class="para">
-    Paragraph 2
+    <blockquote>“It seems to me that most of the ‘new’ programming languages fall into one of
+two categories: Those from academia with radical new paradigms and those from
+large corporations with a focus on RAD and the web. Maybe it’s time for a new
+language born out of practical experience implementing compilers.” -- Michael
+</blockquote><br><br>
+<blockquote>Great, just what I need.. another D in programming. -- Segfault
+</blockquote><br><br>
+<blockquote>To D, or not to D. -- Willeam NerdSpeare
+</blockquote><br><br>
+<blockquote>"What I am going to tell you about is what we teach our programming students in the third or fourth year of graduate school... It is my task to convince you not to turn away because you don't understand it. You see my programming students don't understand it... That is because I don't understand it. Nobody does."
+-- Richard Deeman
+</blockquote><br><br>
+Here's a bit of text between quotes.
+<br><br>
+<blockquote>This is a quote
+<blockquote>And this is a nested quote
+</blockquote></blockquote><br><br>
+<blockquote>This is a quote with a &gt; symbol in it
+</blockquote><br><br>
+<blockquote>This is a quote
+with a continuation
+</blockquote><br><br>
+<blockquote>This quote
+</blockquote><ul><li>is ended by this list
+</li>
+</ul>
+<blockquote>This quote
+</blockquote><h3>is ended by this heading</h3>
+
+<blockquote>This quote is ended by a thematic break:
+</blockquote><hr />
+
+<blockquote>This quote
+</blockquote>
+<section class="code_listing">
+  <div class="code_sample">
+    <div class="dlang">
+      <ol class="code_lines">
+        <li><code class="code"><span class="keyword">is</span> ended by <span class="keyword">this</span> code
+</code></li>
+      </ol>
+    </div>
+  </div>
+</section>
+
+<blockquote><h3>Some things inside a quote block:</h3>
+<hr />
+
+<section class="code_listing">
+  <div class="code_sample">
+    <div class="dlang">
+      <ol class="code_lines">
+        <li><code class="code">Some code
+</code></li>
+      </ol>
+    </div>
+  </div>
+</section>
+<ul><li>a list</li>
+</ul></blockquote>
   </p>
 </div>
 
-</section>
-
-</div>
-
-</li>
-</ul>
-  </div>
 </section>
 </section>
       </article>

--- a/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>ddoc14413</title>
+    <title>test.compilable.ddoc_markdown_code_verbose</title>
     <style type="text/css" media="screen">
       html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
       blockquote, pre, a, abbr, address, cite, code, del, dfn, em, figure,
@@ -501,55 +501,21 @@
   <body id="ddoc_main" class="ddoc dlang">
     <div class="content_wrapper">
       <article class="module">
-        <h1 class="module_name">ddoc14413</h1>
-        <section id="module_content">
-<section class="section ddoc_module_members_section">
-  <div class="ddoc_module_members">
-    <ul class="ddoc_members">
-  <li class="ddoc_member">
-  <div class="ddoc_member_header">
-  <div class="ddoc_header_anchor">
-  <a href="#foo" id="foo"><code class="code">foo</code></a>
-</div>
-</div><div class="ddoc_decl">
-  <section class="section">
-    <div class="declaration">
-      <h4>Declaration</h4>
-      <div class="dlang">
-        <p class="para">
-          <code class="code">
-            <span class="ddoc_anchor" id="foo"></span>void <code class="code">foo</code>();
-
-          </code>
-        </p>
-      </div>
-    </div>
-  </section>
-</div>
-<div class="ddoc_decl">
-  <section class="section ddoc_sections">
+        <h1 class="module_name">test.compilable.ddoc_markdown_code_verbose</h1>
+        <section id="module_content"><section class="section ddoc_sections">
   <div class="ddoc_summary">
   <p class="para">
-    This should
-be one
-paragraph.
+    Quote Block:
 
   </p>
 </div>
 <div class="ddoc_description">
   <h4>Discussion</h4>
   <p class="para">
-    Paragraph 2
+    <blockquote>Great, just what I need.. another D in programming. -- Segfault</blockquote>
   </p>
 </div>
 
-</section>
-
-</div>
-
-</li>
-</ul>
-  </div>
 </section>
 </section>
       </article>

--- a/test/compilable/extra-files/ddocbackticks.html
+++ b/test/compilable/extra-files/ddocbackticks.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }

--- a/test/compilable/extra-files/ddocunittest.html
+++ b/test/compilable/extra-files/ddocunittest.html
@@ -50,6 +50,13 @@
         list-style: decimal;
       }
 
+      blockquote {
+        margin: 0.1em;
+        margin-left: 1em;
+        border-left: 2px solid #cccccc;
+        padding-left: 0.7em;
+      }
+
       .color_red { color: #dc322f; }
       .color_blue { color: #268bd2; }
       .color_green { color: #859901; }


### PR DESCRIPTION
*Screenshot:*

![screenshot](https://i.postimg.cc/D0bTwDvV/Screen-Shot-2019-03-23-at-9-28-39-AM.png)

*Proposed documentation:*

## Quotes

Documentation may include a section of quoted material by prefixing each line of the section with a `>`. Quotes may include headings, lists, embedded code, etc.

``` d
/**
 * > To D, or not to D. -- Willeam NerdSpeare
 */
```

Lines of text that directly follow a quoted line are considered part of the quote:

``` d
/**
 * > This line
 * and this line are both part of the quote
 *
 * This line is not part of the quote.
 */
```