### PR TITLE
Add generic function to convert D string to C string

### DIFF
--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -305,7 +305,7 @@ static if (OVERRIDE_MEMALLOC)
 // corresponding to 2.074.0 or later.
 static if (!is(typeof(pureMalloc)))
 {
-private:
+package:
     static import core.stdc.errno;
 
     /**

--- a/src/dmd/root/string.d
+++ b/src/dmd/root/string.d
@@ -1,0 +1,61 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/array.d, root/_array.d)
+ * Documentation:  https://dlang.org/phobos/dmd_root_array.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/array.d
+ */
+module dmd.root.string;
+
+/**
+ * Converts the given string to a null terminated C string and passes it to the
+ * given callable `func`.
+ *
+ * The string is only valid during the call to `func` and will be freed after
+ * `func` returns.
+ *
+ * Params:
+ *  func = something callable to call
+ *  str = the D string to convert
+ *
+ * Returns: the return value of `func`
+ */
+auto toStringzThen(alias func)(const(char)[] str)
+{
+    import dmd.root.rmem : pureMalloc, pureFree;
+
+    if (str.length == 0)
+        return func(&""[0]);
+
+    char[1024] staticBuffer;
+    const newLength = str.length + 1;
+    char[] buffer;
+
+    if (str.length >= buffer.length)
+        buffer = (cast(char*) pureMalloc(newLength * char.sizeof))[0 .. newLength];
+    else
+        buffer = staticBuffer[0 .. newLength];
+
+    scope (exit)
+    {
+        if (&buffer[0] != &staticBuffer[0])
+            pureFree(&buffer[0]);
+    }
+
+    buffer[0 .. $ - 1] = str;
+    buffer[$ - 1] = '\0';
+
+    return func(&buffer[0]);
+}
+
+pure nothrow @nogc unittest
+{
+    import core.stdc.string : strcmp;
+
+    enum value = "foo";
+    value.toStringzThen!(str => assert(str.strcmp(value) == 0));
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -328,7 +328,7 @@ LEXER_ROOT=$(addsuffix .d, $(addprefix $(ROOT)/, array ctfloat file filename out
 
 ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array ctfloat file \
 	filename man outbuffer port response rmem rootobject speller \
-	longdouble stringtable hash))
+	longdouble stringtable hash string))
 
 GLUE_SRCS=$(addsuffix .d, $(addprefix $D/,irstate toctype glue gluelayer todt tocsym toir dmsc \
 	tocvdebug s2ir toobj e2ir eh iasm iasmdmd iasmgcc objc_glue))

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -207,7 +207,7 @@ GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.o
 ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 	$(ROOT)/filename.d $(ROOT)/man.d $(ROOT)/outbuffer.d $(ROOT)/port.d \
 	$(ROOT)/response.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
-	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d
+	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d $(ROOT)/string.d
 
 # D front end
 SRCS = $D/aggregate.h $D/aliasthis.h $D/arraytypes.h	\


### PR DESCRIPTION
Adds a new function `toStringzThen` which will convert the given D string to a null terminated C string. It passes the C string to the given callable. The C string is only valid during the call to the callable and will be freed after it returns.