### PR TITLE
Avoid using the GC (when active) in toCStringThen

### DIFF
--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -305,7 +305,7 @@ static if (OVERRIDE_MEMALLOC)
 // corresponding to 2.074.0 or later.
 static if (!is(typeof(pureMalloc)))
 {
-private:
+package(dmd):
     static import core.stdc.errno;
 
     /**

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -189,24 +189,24 @@ dg  = Delegate to call afterwards
 Returns:
 The return value of `T`
 */
-auto toCStringThen(alias dg)(const(char)[] src) nothrow
+auto toCStringThen(alias dg)(const(char)[] src)
 {
     const len = src.length + 1;
     char[512] small = void;
     scope ptr = (src.length < (small.length - 1))
                     ? small[0 .. len]
-                    : (cast(char*)mem.xmalloc(len))[0 .. len];
+                    : (cast(char*)pureMalloc(len))[0 .. len];
     scope (exit)
     {
         if (&ptr[0] != &small[0])
-            mem.xfree(&ptr[0]);
+            pureFree(&ptr[0]);
     }
     ptr[0 .. src.length] = src[];
     ptr[src.length] = '\0';
     return dg(ptr);
 }
 
-unittest
+pure nothrow @nogc unittest
 {
     assert("Hello world".toCStringThen!((v) => v == "Hello world\0"));
     assert("Hello world\0".toCStringThen!((v) => v == "Hello world\0\0"));


### PR DESCRIPTION
By default `xmalloc` forwards to `malloc`. When using DMD as a library the GC is active and `xmalloc` forwards to the GC. Since the memory is always freed on return there's no reason to use the GC.