### PR TITLE
fix Issue 13285 - wrong codegen for destructor call of unnamed struct…

### DIFF
--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -5265,20 +5265,16 @@ void cdddtor(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         cdbx.gen1(0xC3);                      // RET
         code *c = cdbx.finish();
 
-        if (config.flags3 & CFG3pic)
+        int nalign = 0;
+        if (STACKALIGN >= 16)
         {
-            int nalign = 0;
-            if (STACKALIGN >= 16)
-            {   nalign = STACKALIGN - REGSIZE;
-                cod3_stackadj(cdb, nalign);
-            }
-            calledafunc = 1;
-            genjmp(cdb,0xE8,FLcode,cast(block *)c);   // CALL Ldtor
-            if (nalign)
-                cod3_stackadj(cdb, -nalign);
+            nalign = STACKALIGN - REGSIZE;
+            cod3_stackadj(cdb, nalign);
         }
-        else
-            genjmp(cdb,0xE8,FLcode,cast(block *)c);   // CALL Ldtor
+        calledafunc = 1;
+        genjmp(cdb,0xE8,FLcode,cast(block *)c);   // CALL Ldtor
+        if (nalign)
+            cod3_stackadj(cdb, -nalign);
 
         code *cnop = gennop(null);
 

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5146,6 +5146,21 @@ void test8199()
 }
 
 /***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=13285
+void test13285()
+{
+    static struct S
+    {
+        ~this()
+        {
+            checkAlign();
+        }
+    }
+    S s; // correct alignment of RSP when calling ~this()
+    S(); // incorrect alignment
+}
+
+/***************************************************/
 
 void test246()
 {
@@ -6463,6 +6478,7 @@ int main()
     test7997();
     test5332();
     test11472();
+    test13285();
 
     writefln("Success");
     return 0;


### PR DESCRIPTION
… instance on 64 bit environments

stack alignment is not coupled with -fPIC