### PR TITLE
[dmd-cxx] test42.d: Add cases for 128 bit reals in testreal_to_ulong()

### DIFF
--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -5628,7 +5628,11 @@ void testreal_to_ulong()
     real adjust = 1.0L/real.epsilon;
     u = r2ulong(adjust);
     //writefln("%s %s", adjust, u);
-    static if(real.mant_dig == 64)
+    static if(real.mant_dig == 113)
+        assert(u == 18446744073709551615UL);
+    else static if(real.mant_dig == 106)
+        assert(u == 18446744073709551615UL);
+    else static if(real.mant_dig == 64)
         assert(u == 9223372036854775808UL);
     else static if(real.mant_dig == 53)
         assert(u == 4503599627370496UL);


### PR DESCRIPTION
Fixes a test failure on ppc/ppc64 and aarch64 platforms.