### PR TITLE
[dmd-cxx]  recognize erroneous uses of C types 

### DIFF
--- a/src/dscope.c
+++ b/src/dscope.c
@@ -685,13 +685,13 @@ Dsymbol *Scope::search_correct(Identifier *ident)
 const char *Scope::search_correct_C(Identifier *ident)
 {
     TOK tok;
-    if (ident == Id::_NULL)
+    if (ident == Id::C_NULL)
         tok = TOKnull;
-    else if (ident == Id::_TRUE)
+    else if (ident == Id::C_TRUE)
         tok = TOKtrue;
-    else if (ident == Id::_FALSE)
+    else if (ident == Id::C_FALSE)
         tok = TOKfalse;
-    else if (ident == Id::_unsigned)
+    else if (ident == Id::C_unsigned)
         tok = TOKuns32;
     else
         return NULL;

--- a/src/dscope.c
+++ b/src/dscope.c
@@ -693,6 +693,8 @@ const char *Scope::search_correct_C(Identifier *ident)
         tok = TOKfalse;
     else if (ident == Id::C_unsigned)
         tok = TOKuns32;
+    else if (ident == Id::C_wchar_t)
+        tok = global.params.isWindows ? TOKwchar : TOKdchar;
     else
         return NULL;
     return Token::toChars(tok);

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -374,10 +374,10 @@ Msgtable msgtable[] =
     { "udaSelector", "selector" },
 
     // C names, for undefined identifier error messages
-    { "_NULL", "NULL" },
-    { "_TRUE", "TRUE" },
-    { "_FALSE", "FALSE" },
-    { "_unsigned", "unsigned" },
+    { "C_NULL", "NULL" },
+    { "C_TRUE", "TRUE" },
+    { "C_FALSE", "FALSE" },
+    { "C_unsigned", "unsigned" },
 };
 
 

--- a/src/idgen.c
+++ b/src/idgen.c
@@ -378,6 +378,7 @@ Msgtable msgtable[] =
     { "C_TRUE", "TRUE" },
     { "C_FALSE", "FALSE" },
     { "C_unsigned", "unsigned" },
+    { "C_wchar_t", "wchar_t" },
 };
 
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -901,16 +901,25 @@ void Lexer::scan(Token *t)
                 p++;
                 Token n;
                 scan(&n);
-                if (n.value == TOKidentifier && n.ident == Id::line)
+                if (n.value == TOKidentifier)
                 {
-                    poundLine();
-                    continue;
+                   if (n.ident == Id::line)
+                   {
+                       poundLine();
+                       continue;
+                   }
+                   else
+                   {
+                       const Loc locx = loc();
+                       warning(locx, "C preprocessor directive `#%s` is not supported", n.ident->toChars());
+                   }
                 }
-                else
+                else if (n.value == TOKif)
                 {
-                    t->value = TOKpound;
-                    return;
+                    error("C preprocessor directive `#if` is not supported, use `version` or `static if`");
                 }
+                t->value = TOKpound;
+                return;
             }
 
             default:

--- a/src/parse.c
+++ b/src/parse.c
@@ -3076,7 +3076,23 @@ Type *Parser::parseBasicType(bool dontLookDotIdents)
         case TOKuns16:   t = Type::tuns16; goto LabelX;
         case TOKint32:   t = Type::tint32; goto LabelX;
         case TOKuns32:   t = Type::tuns32; goto LabelX;
-        case TOKint64:   t = Type::tint64; goto LabelX;
+        case TOKint64:
+            t = Type::tint64;
+            nextToken();
+            if (token.value == TOKint64)    // if `long long`
+            {
+                error("use `long` for a 64 bit integer instead of `long long`");
+                nextToken();
+            }
+            else if (token.value == TOKfloat64) // if `long double`
+            {
+                error("use `real` instead of `long double`");
+                t = Type::tfloat80;
+                nextToken();
+
+            }
+            break;
+
         case TOKuns64:   t = Type::tuns64; goto LabelX;
         case TOKint128:  t = Type::tint128; goto LabelX;
         case TOKuns128:  t = Type::tuns128; goto LabelX;

--- a/test/fail_compilation/cerrors.d
+++ b/test/fail_compilation/cerrors.d
@@ -1,0 +1,15 @@
+/* REQUIRED_ARGS: -wi
+TEST_OUTPUT:
+---
+fail_compilation/cerrors.d(11): Error: C preprocessor directive `#if` is not supported, use `version` or `static if`
+fail_compilation/cerrors.d(11): Error: declaration expected, not `#`
+fail_compilation/cerrors.d(15): Warning: C preprocessor directive `#endif` is not supported
+fail_compilation/cerrors.d(15): Error: declaration expected, not `#`
+---
+*/
+
+#if 1
+
+void test(wchar_t u);
+
+#endif

--- a/test/fail_compilation/ctypes.d
+++ b/test/fail_compilation/ctypes.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ctypes.d(11): Error: use `real` instead of `long double`
+fail_compilation/ctypes.d(12): Error: use `long` for a 64 bit integer instead of `long long`
+---
+*/
+
+void test()
+{
+    long double r;
+    long long ll;
+}

--- a/test/fail_compilation/widechars.d
+++ b/test/fail_compilation/widechars.d
@@ -1,0 +1,10 @@
+
+/*
+DISABLED: win32 win64
+TEST_OUTPUT:
+---
+fail_compilation/widechars.d(10): Error: undefined identifier `wchar_t`, did you mean `dchar`?
+---
+*/
+
+wchar_t x;


### PR DESCRIPTION
The rename from `_NULL` -> `C_NULL` fixes build error on Cygwin hosts, where `_NULL` is a macro in `sys/reent.h`.