### PR TITLE
Run deferred semantic in `dmd.frontend.fullSemantic`

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -336,9 +336,16 @@ void fullSemantic(Module m)
 
     m.importedFrom = m;
     m.importAll(null);
+
     m.dsymbolSemantic(null);
+    Module.dprogress = 1;
+    Module.runDeferredSemantic();
+
     m.semantic2(null);
+    Module.runDeferredSemantic2();
+
     m.semantic3(null);
+    Module.runDeferredSemantic3();
 }
 
 /**


### PR DESCRIPTION
This is what the regular compiler is doing.