### PR TITLE
Fix Issue 19762 - ICE on invalid code

### DIFF
--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -139,7 +139,7 @@ public:
             /* Add in fields of the struct
              * (after setting ctype to avoid infinite recursion)
              */
-            if (global.params.symdebug)
+            if (global.params.symdebug && !global.errors)
             {
                 for (size_t i = 0; i < sym.fields.dim; i++)
                 {

--- a/test/fail_compilation/ice19762.d
+++ b/test/fail_compilation/ice19762.d
@@ -1,0 +1,17 @@
+// EXTRA_SOURCES:
+// PERMUTE_ARGS: -g
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice19762.d(13): Error: struct `ice19762.X` had semantic errors when compiling
+---
+*/
+
+module ice19762;
+
+struct X
+{
+	import imports.b19762 : Baz;
+	Err err;
+}

--- a/test/fail_compilation/imports/b19762.d
+++ b/test/fail_compilation/imports/b19762.d
@@ -1,0 +1,7 @@
+module imports.b19762;
+
+struct Baz {}
+struct Qux
+{
+	import imports.c19762;
+}

--- a/test/fail_compilation/imports/c19762.d
+++ b/test/fail_compilation/imports/c19762.d
@@ -1,0 +1,27 @@
+module imports.c19762;
+
+struct Foo
+{
+	import ice19762 : X;
+	X[] x;
+}
+
+Nullable!Foo foo()
+{
+	Nullable!Foo output;
+	return output;
+}
+
+struct Nullable(T)
+{
+    bool opEquals(U)(const(U) rhs) const
+    if (is(typeof(this.get == rhs)))
+    {
+        return true;
+    }
+
+    inout(T) get() inout
+    {
+        return T.init;
+    }
+}


### PR DESCRIPTION
The symbolic debug info generation should not be generated if errors occurred. 