### PR TITLE
Fix Issue 19757 - crash on invalid initializer at CTFE

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2394,6 +2394,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 Expression arg = (*exp.arguments)[i];
                 arg = resolveProperties(sc, arg);
                 arg = arg.implicitCastTo(sc, Type.tsize_t);
+                if (arg.op == TOK.error)
+                    return setError();
                 arg = arg.optimize(WANTvalue);
                 if (arg.op == TOK.int64 && cast(sinteger_t)arg.toInteger() < 0)
                 {

--- a/test/fail_compilation/fail19757_m32.d
+++ b/test/fail_compilation/fail19757_m32.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -m32
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19757_m32.d(9): Error: cannot implicitly convert expression `"oops"` of type `string` to `uint`
+---
+*/
+
+auto s = new string("oops");

--- a/test/fail_compilation/fail19757_m64.d
+++ b/test/fail_compilation/fail19757_m64.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -m64
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19757_m64.d(9): Error: cannot implicitly convert expression `"oops"` of type `string` to `ulong`
+---
+*/
+
+auto s = new string("oops");


### PR DESCRIPTION
The bug in the frontend was that when the following is semantically analyzed:

```d
auto s = new string("oops");     // at module level, therefore interpreted at compile time
```

The compiler rewrites it to  `auto s = new string(__error__)`. Later on, before interpretation, the error is masked by the valid `new` expression. To fix this bug, when the string conversion to `ulong` fails, an error is returned. This way the compiler rewrites the above expression to `auto s = __error__`.