### PR TITLE
test: Use EXTRA_SOURCES instead of REQUIRED_ARGS for D sources

### DIFF
--- a/test/compilable/test6395.d
+++ b/test/compilable/test6395.d
@@ -1,4 +1,5 @@
-// REQUIRED_ARGS: compilable/b6395 -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
+// EXTRA_SOURCES: b6395.d
 // EXTRA_FILES: extra-files/c6395.d
 
 // https://issues.dlang.org/show_bug.cgi?id=6395

--- a/test/compilable/test9276.d
+++ b/test/compilable/test9276.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: compilable/imports/test9276parser.d
+// EXTRA_SOURCES: imports/test9276parser.d
 
 
 // This is a dummy module for compilable test

--- a/test/compilable/test9399.d
+++ b/test/compilable/test9399.d
@@ -1,4 +1,5 @@
-// REQUIRED_ARGS: -inline -Icompilable/imports compilable/imports/test9399a
+// REQUIRED_ARGS: -c -inline -Icompilable/imports
+// EXTRA_SOURCES: imports/test9399a.d
 
 import imports.test9399a;
 void fun(int a) {

--- a/test/compilable/test9436.d
+++ b/test/compilable/test9436.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: compilable/imports/test9436interp.d
+// EXTRA_SOURCES: imports/test9436interp.d
 
 // this is a dummy module for test 9436.
 

--- a/test/fail_compilation/diag4479.d
+++ b/test/fail_compilation/diag4479.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: fail_compilation/imports/fail4479.d
+// EXTRA_SOURCES: imports/fail4479.d
 /*
 TEST_OUTPUT:
 ---


### PR DESCRIPTION
This could be hacked to be handled in the testsuite, but it would be a slightly undesirable check for whether every unrecognised option is a file - both, `$option` and `$option.d`. Using EXTRA_SOURCES makes it clear what they are, and what to do with them.