### PR TITLE
test: Add module declarations to link test imports.

### DIFF
--- a/test/runnable/imports/a11447.d
+++ b/test/runnable/imports/a11447.d
@@ -1,3 +1,4 @@
+module imports.a11447;
 struct A { }
 
 void map(alias dg)(A r) { }

--- a/test/runnable/imports/a12010.d
+++ b/test/runnable/imports/a12010.d
@@ -1,2 +1,3 @@
+module imports.a12010;
 import imports.std12010container : Array, BinaryHeap;
 BinaryHeap!(Array!int) test;

--- a/test/runnable/imports/b11447.d
+++ b/test/runnable/imports/b11447.d
@@ -1,3 +1,4 @@
+module imports.b11447;
 class A {}
 
 void map(alias dg)(int b) { }

--- a/test/runnable/imports/c11447.d
+++ b/test/runnable/imports/c11447.d
@@ -1,3 +1,4 @@
+module imports.c11447;
 template map(fun...)
 {
     auto map(Range)(Range r)

--- a/test/runnable/imports/ice15200a.d
+++ b/test/runnable/imports/ice15200a.d
@@ -1,3 +1,4 @@
+module imports.ice15200a;
 import imports.ice15200b;
 
 auto f() // not void

--- a/test/runnable/imports/inc11239.d
+++ b/test/runnable/imports/inc11239.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS:
+module imports.inc11239;
 
 int foo(T)(T x)
 {

--- a/test/runnable/imports/link11069x.d
+++ b/test/runnable/imports/link11069x.d
@@ -1,3 +1,4 @@
+module imports.link11069x;
 import imports.link11069z;
 
 import std.algorithm;

--- a/test/runnable/imports/link11069y.d
+++ b/test/runnable/imports/link11069y.d
@@ -1,3 +1,4 @@
+module imports.link11069y;
 import std.traits;
 
 void readWriteVariable(T)(ref T data)

--- a/test/runnable/imports/link11069z.d
+++ b/test/runnable/imports/link11069z.d
@@ -1,3 +1,4 @@
+module imports.link11069z;
 struct Matrix(T, uint _M)
 {
     int opCmp()(auto ref in Matrix b) const

--- a/test/runnable/imports/link12144a.d
+++ b/test/runnable/imports/link12144a.d
@@ -1,3 +1,4 @@
+module imports.link12144a;
 struct S1 { bool opEquals(T : typeof(this))(T) { return false; } }
 struct S2 { bool opEquals(T : typeof(this))(T) { return false; } }
 struct S3 { bool opEquals(T : typeof(this))(T) { return false; } }

--- a/test/runnable/imports/link13415a.d
+++ b/test/runnable/imports/link13415a.d
@@ -1,3 +1,4 @@
+module imports.link13415a;
 struct S(alias func)
 {
     void call()

--- a/test/runnable/imports/link7745b.d
+++ b/test/runnable/imports/link7745b.d
@@ -1,3 +1,4 @@
+module imports.link7745b;
 struct C { auto asdfg() {} }
 
 // extreme test of bug 4820

--- a/test/runnable/imports/link9571a.d
+++ b/test/runnable/imports/link9571a.d
@@ -1,3 +1,4 @@
+module imports.link9571a;
 struct MapResult(alias fun)
 {
     void bar() { fun(0); }

--- a/test/runnable/imports/std15017variant.d
+++ b/test/runnable/imports/std15017variant.d
@@ -1,4 +1,4 @@
-module imports.std15017;
+module imports.std15017variant;
 
 struct VariantN(size_t maxDataSize)
 {


### PR DESCRIPTION
Ultimately, the reason is that there's no automated way to compile sources separates in the dejagnu testsuite, so needed to work around conflicting module errors.  But there's no harm in having these here otherwise.