### PR TITLE
Fix the debug build due to #9291

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -50,13 +50,15 @@ void out_config_init(
         ubyte avx,              // use AVX instruction set (0, 1, 2)
         bool useModuleInfo,     // implement ModuleInfo
         bool useTypeInfo,       // implement TypeInfo
-        bool useExceptions      // implement exception handling
+        bool useExceptions,     // implement exception handling
+        const(char)* _version   // Compiler version
         )
 {
 version (MARS)
 {
     //printf("out_config_init()\n");
 
+    config._version = _version;
     if (!config.target_cpu)
     {   config.target_cpu = TARGET_PentiumPro;
         config.target_scheduler = config.target_cpu;

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -679,7 +679,7 @@ enum
 struct Config
 {
     char language;              // 'C' = C, 'D' = C++
-    char[8] _version;           // = VERSION
+    const(char)* _version;      /// Compiler version
     char[3] exetype;            // distinguish exe types so PH
                                 // files are distinct (= SUFFIX)
 

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -65,8 +65,6 @@ import dmd.backend.outbuf;
 import dmd.backend.ty;
 import dmd.backend.type;
 
-version(MARS) import dmd.globals;
-
 static if (ELFOBJ || MACHOBJ)
 {
 
@@ -1134,7 +1132,7 @@ static if (ELFOBJ)
 version (MARS)
 {
     debug_info.buf.write("Digital Mars D ");
-    debug_info.buf.writeString(global._version);     // DW_AT_producer
+    debug_info.buf.writeString(config._version);     // DW_AT_producer
     // DW_AT_language
     debug_info.buf.writeByte((config.fulltypes == CVDWARF_D) ? DW_LANG_D : DW_LANG_C89);
 }

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -43,8 +43,6 @@ import dmd.backend.outbuf;
 import dmd.backend.ty;
 import dmd.backend.type;
 
-import dmd.globals;
-
 extern (C++):
 
 static if (ELFOBJ)
@@ -1639,7 +1637,7 @@ void Obj_compiler()
     enum compileHeader = "\0Digital Mars C/C++ ";
     enum n = compileHeader.length;
     compiler[0 .. n] = compileHeader;
-    const versionArr = global._version[0 .. strlen(global._version)];
+    const versionArr = config._version[0 .. strlen(config._version)];
     assert(versionArr.length < MAX_VERSION_LENGTH);
     compiler[n .. n + versionArr.length] = versionArr;
     comment_data.write(compiler.ptr, (compiler).sizeof);

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -63,7 +63,8 @@ void out_config_init(
         ubyte avx,              // use AVX instruction set (0, 1, 2)
         bool useModuleInfo,     // implement ModuleInfo
         bool useTypeInfo,       // implement TypeInfo
-        bool useExceptions      // implement exception handling
+        bool useExceptions,     // implement exception handling
+        const(char)* _version   // Compiler version
         );
 
 void out_config_debug(
@@ -125,7 +126,8 @@ void backend_init()
         params.cpu >= CPU.avx2 ? 2 : params.cpu >= CPU.avx ? 1 : 0,
         params.useModuleInfo && Module.moduleinfo,
         params.useTypeInfo && Type.dtypeinfo,
-        params.useExceptions && ClassDeclaration.throwable
+        params.useExceptions && ClassDeclaration.throwable,
+        global._version
     );
 
     debug


### PR DESCRIPTION
The problem is that the changes in #9291 caused the frontend, which is not betterC compatible, to be compiled together with the backend (which is compiled with betterC). The fix is to make the `Global._version` field a `__gshared immutable` variable and then get access to this variable by declaring `extern` variables where the data is needed instead of importing.