### PR TITLE
Fix Issue 19754 - cast() sometimes yields lvalue, sometimes yields rvalue

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5158,6 +5158,19 @@ extern (C++) final class CastExp : UnaExp
         return to ? new CastExp(loc, e1.syntaxCopy(), to.syntaxCopy()) : new CastExp(loc, e1.syntaxCopy(), mod);
     }
 
+    override bool isLvalue()
+    {
+        //printf("e1.type = %s, to.type = %s\n", e1.type.toChars(), to.toChars());
+        return e1.isLvalue() && e1.type.mutableOf().unSharedOf().equals(to.mutableOf().unSharedOf());
+    }
+
+    override Expression toLvalue(Scope* sc, Expression e)
+    {
+        if (isLvalue())
+            return this;
+        return Expression.toLvalue(sc, e);
+    }
+
     override Expression addDtorHook(Scope* sc)
     {
         if (to.toBasetype().ty == Tvoid)        // look past the cast(void)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8515,11 +8515,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             // Try to do a decent error message with the expression
             // before it got constant folded
 
-            if (e1x.op != TOK.variable)
-                e1x = e1x.optimize(WANTvalue);
-
+            // https://issues.dlang.org/show_bug.cgi?id=19754
+            // first see if the unoptimized expression is modifiable
             if (exp.op == TOK.assign)
                 e1x = e1x.modifiableLvalue(sc, e1old);
+
+            if (e1x.op != TOK.variable)
+                e1x = e1x.optimize(WANTvalue);
 
             if (e1x.op == TOK.error)
             {

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -827,7 +827,13 @@ private extern(C++) final class Semantic3Visitor : Visitor
                         const hasCopyCtor = exp.type.ty == Tstruct && (cast(TypeStruct)exp.type).sym.hasCopyCtor;
                         // if a copy constructor is present, the return type conversion will be handled by it
                         if (!hasCopyCtor)
-                            exp = exp.implicitCastTo(sc2, tret);
+                        {
+                            if (f.isref && !MODimplicitConv(exp.type.mod, tret.mod) && !tret.isTypeSArray())
+                                error(exp.loc, "expression `%s` of type `%s` is not implicitly convertible to return type `ref %s`",
+                                      exp.toChars(), exp.type.toChars(), tret.toChars());
+                            else
+                                exp = exp.implicitCastTo(sc2, tret);
+                        }
 
                         if (f.isref)
                         {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1343,7 +1343,8 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                 if (fparam.defaultArg)
                 {
                     Expression e = fparam.defaultArg;
-                    if (fparam.storageClass & (STC.ref_ | STC.out_))
+                    auto isRefOrOut = fparam.storageClass & (STC.ref_ | STC.out_);
+                    if (isRefOrOut)
                     {
                         e = e.expressionSemantic(argsc);
                         e = resolveProperties(argsc, e);
@@ -1364,6 +1365,12 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                         e = new VarExp(e.loc, fe.fd, false);
                         e = new AddrExp(e.loc, e);
                         e = e.expressionSemantic(argsc);
+                    }
+                    if (isRefOrOut && !MODimplicitConv(e.type.mod, fparam.type.mod))
+                    {
+                        const(char)* errTxt = fparam.storageClass & STC.ref_ ? "ref" : "out";
+                        .error(e.loc, "expression `%s` of type `%s` is not implicitly convertible to type `%s %s` of parameter `%s`",
+                              e.toChars(), e.type.toChars(), errTxt, fparam.type.toChars(), fparam.toChars());
                     }
                     e = e.implicitCastTo(argsc, fparam.type);
 

--- a/test/compilable/test14929.d
+++ b/test/compilable/test14929.d
@@ -1,14 +1,3 @@
-/*
-TEST_OUTPUT:
----
-fail_compilation/ice14929.d(45): Error: `cast(Node)(*this.current).items[this.index]` is not an lvalue and cannot be modified
-fail_compilation/ice14929.d(88): Error: template instance `ice14929.HashMap!(ulong, int).HashMap.opBinaryRight!"in"` error instantiating
-fail_compilation/ice14929.d(92):        instantiated from here: `HashmapComponentStorage!int`
-fail_compilation/ice14929.d(92): Error: template instance `ice14929.isComponentStorage!(HashmapComponentStorage!int, int)` error instantiating
-fail_compilation/ice14929.d(92):        while evaluating: `static assert(isComponentStorage!(HashmapComponentStorage!int, int))`
----
-*/
-
 struct HashMap(K, V)
 {
     V* opBinaryRight(string op)(K key) const if (op == "in")

--- a/test/compilable/test19754.d
+++ b/test/compilable/test19754.d
@@ -1,0 +1,11 @@
+void main()
+{
+    shared int x;
+    (cast() x) = 5;
+
+    const int x1;
+    (cast() x1) = 5;
+
+    immutable int x2;
+    (cast() x2) = 5;
+}

--- a/test/fail_compilation/diag4596.d
+++ b/test/fail_compilation/diag4596.d
@@ -1,10 +1,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag4596.d(15): Error: `this` is not an lvalue and cannot be modified
-fail_compilation/diag4596.d(16): Error: `1 ? this : this` is not an lvalue and cannot be modified
-fail_compilation/diag4596.d(18): Error: `super` is not an lvalue and cannot be modified
-fail_compilation/diag4596.d(19): Error: `1 ? super : super` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(17): Error: `this` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(18): Error: `this` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(18): Error: `this` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(20): Error: `super` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(21): Error: `super` is not an lvalue and cannot be modified
+fail_compilation/diag4596.d(21): Error: `super` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail106.d
+++ b/test/fail_compilation/fail106.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail106.d(12): Error: cannot modify `immutable` expression `'C'`
+fail_compilation/fail106.d(12): Error: cannot modify `immutable` expression `"ABC"[2]`
 ---
 */
 

--- a/test/fail_compilation/fail17491.d
+++ b/test/fail_compilation/fail17491.d
@@ -1,13 +1,9 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17491.d(24): Error: `(S17491).init` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(25): Error: `S17491(0)` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(27): Error: cannot modify constant `S17491(0).field`
-fail_compilation/fail17491.d(28): Error: cannot modify constant `*&S17491(0).field`
-fail_compilation/fail17491.d(33): Error: `S17491(0)` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(34): Error: `S17491(0)` is not an lvalue and cannot be modified
-fail_compilation/fail17491.d(36): Error: cannot modify constant `S17491(0).field`
-fail_compilation/fail17491.d(37): Error: cannot modify constant `*&S17491(0).field`
+fail_compilation/fail17491.d(20): Error: `(S17491).init` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(21): Error: `S17491(0)` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(29): Error: `S17491(0)` is not an lvalue and cannot be modified
+fail_compilation/fail17491.d(30): Error: `S17491(0)` is not an lvalue and cannot be modified
 ---
 */
 

--- a/test/fail_compilation/fail351.d
+++ b/test/fail_compilation/fail351.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail351.d(14): Error: `cast(uint)this.num[index]` is not an lvalue and cannot be modified
+fail_compilation/fail351.d(14): Error: expression `this.num[index]` of type `immutable(uint)` is not implicitly convertible to return type `ref uint`
 ---
 */
 

--- a/test/fail_compilation/fail9891.d
+++ b/test/fail_compilation/fail9891.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9891.d(13): Error: `cast(int)i` is not an lvalue and cannot be modified
-fail_compilation/fail9891.d(18): Error: `cast(int)i` is not an lvalue and cannot be modified
+fail_compilation/fail9891.d(13): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `ref int` of parameter `n`
+fail_compilation/fail9891.d(18): Error: expression `i` of type `immutable(int)` is not implicitly convertible to type `out int` of parameter `n`
 fail_compilation/fail9891.d(23): Error: `prop()` is not an lvalue and cannot be modified
 ---
 */

--- a/test/fail_compilation/test12385.d
+++ b/test/fail_compilation/test12385.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test12385.d(29): Error: cannot modify `immutable` expression `BundledState("bla", 3).x`
+fail_compilation/test12385.d(29): Error: cannot modify `immutable` expression `unbundled.x`
 ---
 */
 


### PR DESCRIPTION
The check for modifiable lvalues was done after an optimization pass that did some const folding which was not performed in the case of `shared`. This led to accepting invalid code in the case of  casted `shared` data and confusing error messages for other qualified data which was cast to unqualified.

Later edit: I added the missing bits so that the code now behaves according to the spec; that is: `cast()` and `cast($qualifier)` returns an lvalue.