### PR TITLE
add .isreturninferred to TypeFunction

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -389,7 +389,7 @@ public:
         if (ta.isnogc)
             buf.writestring("Ni");
 
-        if (ta.isreturn)
+        if (ta.isreturn && !ta.isreturninferred)
             buf.writestring("Nj");
         else if (ta.isscope && !ta.isscopeinferred)
             buf.writestring("Nl");
@@ -1065,6 +1065,7 @@ public:
     {
         if (p.storageClass & STC.scope_ && !(p.storageClass & STC.scopeinferred))
             buf.writeByte('M');
+
         // 'return inout ref' is the same as 'inout ref'
         if ((p.storageClass & (STC.return_ | STC.wild)) == STC.return_ &&
             !(p.storageClass & STC.returninferred))

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3290,6 +3290,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             TypeFunction tfx = funcdecl.type.toTypeFunction();
             tfo.mod = tfx.mod;
             tfo.isscope = tfx.isscope;
+            tfo.isreturninferred = tfx.isreturninferred;
             tfo.isscopeinferred = tfx.isscopeinferred;
             tfo.isref = tfx.isref;
             tfo.isnothrow = tfx.isnothrow;

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1075,7 +1075,9 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
                  * Because dg.ptr points to x, this is returning dt.ptr+offset
                  */
                 if (global.params.vsafe)
+                {
                     sc.func.storage_class |= STC.return_ | STC.returninferred;
+                }
             }
 
         }
@@ -1157,6 +1159,7 @@ private void inferReturn(FuncDeclaration fd, VarDeclaration v)
         {
             //printf("'this' too %p %s\n", tf, sc.func.toChars());
             tf.isreturn = true;
+            tf.isreturninferred = true;
         }
     }
     else

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4137,6 +4137,7 @@ extern (C++) final class TypeFunction : TypeNext
     bool isref;                 // true: returns a reference
     bool isreturn;              // true: 'this' is returned by ref
     bool isscope;               // true: 'this' is scope
+    bool isreturninferred;      // true: 'this' is return from inference
     bool isscopeinferred;       // true: 'this' is scope from inference
     LINK linkage;               // calling convention
     TRUST trust;                // level of trust
@@ -4167,6 +4168,8 @@ extern (C++) final class TypeFunction : TypeNext
             this.isref = true;
         if (stc & STC.return_)
             this.isreturn = true;
+        if (stc & STC.returninferred)
+            this.isreturninferred = true;
         if (stc & STC.scope_)
             this.isscope = true;
         if (stc & STC.scopeinferred)
@@ -4204,6 +4207,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isref = isref;
         t.isreturn = isreturn;
         t.isscope = isscope;
+        t.isreturninferred = isreturninferred;
         t.isscopeinferred = isscopeinferred;
         t.iswild = iswild;
         t.trust = trust;
@@ -4468,6 +4472,7 @@ extern (C++) final class TypeFunction : TypeNext
             tf.isref = t.isref;
             tf.isreturn = t.isreturn;
             tf.isscope = t.isscope;
+            tf.isreturninferred = t.isreturninferred;
             tf.isscopeinferred = t.isscopeinferred;
             tf.trust = t.trust;
             tf.iswild = t.iswild;
@@ -4531,6 +4536,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isref = isref;
         t.isreturn = isreturn;
         t.isscope = isscope;
+        t.isreturninferred = isreturninferred;
         t.isscopeinferred = isscopeinferred;
         t.iswild = 0;
         t.trust = trust;
@@ -6634,7 +6640,7 @@ int attributesApply(TypeFunction tf, void* param, int function(void*, string) fp
     if (res)
         return res;
 
-    if (tf.isreturn)
+    if (tf.isreturn && !tf.isreturninferred)
         res = fp(param, "return");
     if (res)
         return res;

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -574,6 +574,7 @@ public:
     bool isref;         // true: returns a reference
     bool isreturn;      // true: 'this' is returned by ref
     bool isscope;       // true: 'this' is scope
+    bool isreturninferred;      // true: 'this' is return from inference
     bool isscopeinferred; // true: 'this' is scope from inference
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1133,6 +1133,8 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
             tf.isref = true;
         if (sc.stc & STC.return_)
             tf.isreturn = true;
+        if (sc.stc & STC.returninferred)
+            tf.isreturninferred = true;
         if (sc.stc & STC.scope_)
             tf.isscope = true;
         if (sc.stc & STC.scopeinferred)
@@ -1275,7 +1277,8 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                     }
                     else
                     {
-                        fparam.storageClass |= STC.scope_;        // 'return' implies 'scope'
+                        if (!(fparam.storageClass & STC.scope_))
+                            fparam.storageClass |= STC.scope_ | STC.scopeinferred; // 'return' implies 'scope'
                         if (tf.isref)
                         {
                         }

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -506,9 +506,9 @@ void foo16() @nogc nothrow
 TEST_OUTPUT:
 ---
 fail_compilation/retscope.d(1701): Error: cannot implicitly convert expression `& func` of type `int* function(int* p)` to `int* function(scope int* p)`
-fail_compilation/retscope.d(1702): Error: cannot implicitly convert expression `& func` of type `int* function(int* p)` to `int* function(return scope int* p)`
+fail_compilation/retscope.d(1702): Error: cannot implicitly convert expression `& func` of type `int* function(int* p)` to `int* function(return int* p)`
 fail_compilation/retscope.d(1703): Error: cannot implicitly convert expression `& func` of type `int* function(int* p)` to `int* function(return scope int* p)`
-fail_compilation/retscope.d(1711): Error: cannot implicitly convert expression `& funcr` of type `int* function(return scope int* p)` to `int* function(scope int* p)`
+fail_compilation/retscope.d(1711): Error: cannot implicitly convert expression `& funcr` of type `int* function(return int* p)` to `int* function(scope int* p)`
 fail_compilation/retscope.d(1716): Error: cannot implicitly convert expression `& funcrs` of type `int* function(return scope int* p)` to `int* function(scope int* p)`
 ---
 */


### PR DESCRIPTION
This should help make name mangling compatible between -dip1000 and not -dip1000 compilations.