### PR TITLE
adopt more consistent and proper use of Dsymbol constructors

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -122,10 +122,8 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     final extern (D) this(const ref Loc loc, Identifier id)
     {
-        super(id);
-        this.loc = loc;
+        super(loc, id);
         protection = Prot(Prot.Kind.public_);
-        sizeok = Sizeok.none; // size not determined yet
     }
 
     /***************************************

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -34,8 +34,7 @@ extern (C++) final class AliasThis : Dsymbol
 
     extern (D) this(const ref Loc loc, Identifier ident)
     {
-        super(null);    // it's anonymous (no identifier)
-        this.loc = loc;
+        super(loc, null);    // it's anonymous (no identifier)
         this.ident = ident;
     }
 

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -45,6 +45,12 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         this.decl = decl;
     }
 
+    extern (D) this(const ref Loc loc, Identifier ident, Dsymbols* decl)
+    {
+        super(loc, ident);
+        this.decl = decl;
+    }
+
     Dsymbols* include(Scope* sc)
     {
         if (errors)
@@ -364,11 +370,11 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
 {
     LINK linkage;
 
-    extern (D) this(LINK p, Dsymbols* decl)
+    extern (D) this(LINK linkage, Dsymbols* decl)
     {
         super(decl);
-        //printf("LinkDeclaration(linkage = %d, decl = %p)\n", p, decl);
-        linkage = (p == LINK.system) ? target.systemLinkage() : p;
+        //printf("LinkDeclaration(linkage = %d, decl = %p)\n", linkage, decl);
+        this.linkage = (linkage == LINK.system) ? target.systemLinkage() : linkage;
     }
 
     static LinkDeclaration create(LINK p, Dsymbols* decl)
@@ -405,11 +411,11 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
 {
     CPPMANGLE cppmangle;
 
-    extern (D) this(CPPMANGLE p, Dsymbols* decl)
+    extern (D) this(CPPMANGLE cppmangle, Dsymbols* decl)
     {
         super(decl);
-        //printf("CPPMangleDeclaration(cppmangle = %d, decl = %p)\n", p, decl);
-        cppmangle = p;
+        //printf("CPPMangleDeclaration(cppmangle = %d, decl = %p)\n", cppmangle, decl);
+        this.cppmangle = cppmangle;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
@@ -445,14 +451,13 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
     /**
      * Params:
      *  loc = source location of attribute token
-     *  p = protection attribute data
+     *  protection = protection attribute data
      *  decl = declarations which are affected by this protection attribute
      */
-    extern (D) this(const ref Loc loc, Prot p, Dsymbols* decl)
+    extern (D) this(const ref Loc loc, Prot protection, Dsymbols* decl)
     {
-        super(decl);
-        this.loc = loc;
-        this.protection = p;
+        super(loc, null, decl);
+        this.protection = protection;
         //printf("decl = %p\n", decl);
     }
 
@@ -464,8 +469,7 @@ extern (C++) final class ProtDeclaration : AttribDeclaration
      */
     extern (D) this(const ref Loc loc, Identifiers* pkg_identifiers, Dsymbols* decl)
     {
-        super(decl);
-        this.loc = loc;
+        super(loc, null, decl);
         this.protection.kind = Prot.Kind.package_;
         this.pkg_identifiers = pkg_identifiers;
         if (pkg_identifiers !is null && pkg_identifiers.dim > 0)
@@ -546,8 +550,7 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
 
     extern (D) this(const ref Loc loc, Expression ealign, Dsymbols* decl)
     {
-        super(decl);
-        this.loc = loc;
+        super(loc, null, decl);
         this.ealign = ealign;
     }
 
@@ -581,8 +584,7 @@ extern (C++) final class AnonDeclaration : AttribDeclaration
 
     extern (D) this(const ref Loc loc, bool isunion, Dsymbols* decl)
     {
-        super(decl);
-        this.loc = loc;
+        super(loc, null, decl);
         this.isunion = isunion;
     }
 
@@ -698,9 +700,7 @@ extern (C++) final class PragmaDeclaration : AttribDeclaration
 
     extern (D) this(const ref Loc loc, Identifier ident, Expressions* args, Dsymbols* decl)
     {
-        super(decl);
-        this.loc = loc;
-        this.ident = ident;
+        super(loc, ident, decl);
         this.args = args;
     }
 
@@ -1122,9 +1122,8 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
 
     extern (D) this(const ref Loc loc, Expressions* exps)
     {
-        super(null);
+        super(loc, null, null);
         //printf("CompileDeclaration(loc = %d)\n", loc.linnum);
-        this.loc = loc;
         this.exps = exps;
     }
 

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -285,20 +285,24 @@ extern (C++) abstract class Declaration : Dsymbol
 {
     Type type;
     Type originalType;  // before semantic analysis
-    StorageClass storage_class;
+    StorageClass storage_class = STC.undefined_;
     Prot protection;
-    LINK linkage;
+    LINK linkage = LINK.default_;
     int inuse;          // used to detect cycles
 
     // overridden symbol with pragma(mangle, "...")
     const(char)[] mangleOverride;
 
-    final extern (D) this(Identifier id)
+    final extern (D) this(Identifier ident)
     {
-        super(id);
-        storage_class = STC.undefined_;
+        super(ident);
         protection = Prot(Prot.Kind.undefined);
-        linkage = LINK.default_;
+    }
+
+    final extern (D) this(const ref Loc loc, Identifier ident)
+    {
+        super(loc, ident);
+        protection = Prot(Prot.Kind.undefined);
     }
 
     override const(char)* kind() const
@@ -562,10 +566,9 @@ extern (C++) final class TupleDeclaration : Declaration
     bool isexp;             // true: expression tuple
     TypeTuple tupletype;    // !=null if this is a type tuple
 
-    extern (D) this(const ref Loc loc, Identifier id, Objects* objects)
+    extern (D) this(const ref Loc loc, Identifier ident, Objects* objects)
     {
-        super(id);
-        this.loc = loc;
+        super(loc, ident);
         this.objects = objects;
     }
 
@@ -692,22 +695,20 @@ extern (C++) final class AliasDeclaration : Declaration
     Dsymbol overnext;   // next in overload list
     Dsymbol _import;    // !=null if unresolved internal alias for selective import
 
-    extern (D) this(const ref Loc loc, Identifier id, Type type)
+    extern (D) this(const ref Loc loc, Identifier ident, Type type)
     {
-        super(id);
+        super(loc, ident);
         //printf("AliasDeclaration(id = '%s', type = %p)\n", id.toChars(), type);
         //printf("type = '%s'\n", type.toChars());
-        this.loc = loc;
         this.type = type;
         assert(type);
     }
 
-    extern (D) this(const ref Loc loc, Identifier id, Dsymbol s)
+    extern (D) this(const ref Loc loc, Identifier ident, Dsymbol s)
     {
-        super(id);
+        super(loc, ident);
         //printf("AliasDeclaration(id = '%s', s = %p)\n", id.toChars(), s);
         assert(s != this);
-        this.loc = loc;
         this.aliassym = s;
         assert(s);
     }
@@ -1100,21 +1101,21 @@ extern (C++) class VarDeclaration : Declaration
 
     private bool _isAnonymous;
 
-    final extern (D) this(const ref Loc loc, Type type, Identifier id, Initializer _init, StorageClass storage_class = STC.undefined_)
+    final extern (D) this(const ref Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
     {
-        if (id is Identifier.anonymous)
+        if (ident is Identifier.anonymous)
         {
-            id = Identifier.generateId("__anonvar");
+            ident = Identifier.generateId("__anonvar");
             _isAnonymous = true;
         }
-        //printf("VarDeclaration('%s')\n", id.toChars());
-        assert(id);
-        super(id);
+        //printf("VarDeclaration('%s')\n", ident.toChars());
+        assert(ident);
+        super(loc, ident);
         debug
         {
             if (!type && !_init)
             {
-                //printf("VarDeclaration('%s')\n", id.toChars());
+                //printf("VarDeclaration('%s')\n", ident.toChars());
                 //*(char*)0=0;
             }
         }
@@ -1122,7 +1123,6 @@ extern (C++) class VarDeclaration : Declaration
         assert(type || _init);
         this.type = type;
         this._init = _init;
-        this.loc = loc;
         ctfeAdrOnStack = -1;
         this.storage_class = storage_class;
         sequenceNumber = ++nextSequenceNumber;
@@ -1682,8 +1682,7 @@ extern (C++) final class SymbolDeclaration : Declaration
 
     extern (D) this(const ref Loc loc, StructDeclaration dsym)
     {
-        super(dsym.ident);
-        this.loc = loc;
+        super(loc, dsym.ident);
         this.dsym = dsym;
         storage_class |= STC.const_;
     }

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -63,11 +63,10 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
     bool added;
     int inuse;
 
-    extern (D) this(const ref Loc loc, Identifier id, Type memtype)
+    extern (D) this(const ref Loc loc, Identifier ident, Type memtype)
     {
-        super(id);
+        super(loc, ident);
         //printf("EnumDeclaration() %s\n", toChars());
-        this.loc = loc;
         type = new TypeEnum(this);
         this.memtype = memtype;
         protection = Prot(Prot.Kind.undefined);

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -49,7 +49,28 @@ extern (C++) final class Import : Dsymbol
 
     extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Identifier aliasId, int isstatic)
     {
-        super(null);
+        Identifier selectIdent()
+        {
+            // select Dsymbol identifier (bracketed)
+            if (aliasId)
+            {
+                // import [aliasId] = std.stdio;
+                return aliasId;
+            }
+            else if (packages && packages.dim)
+            {
+                // import [std].stdio;
+                return (*packages)[0];
+            }
+            else
+            {
+                // import [id];
+                return id;
+            }
+        }
+
+        super(loc, selectIdent());
+
         assert(id);
         version (none)
         {
@@ -64,28 +85,11 @@ extern (C++) final class Import : Dsymbol
             }
             printf("%s)\n", id.toChars());
         }
-        this.loc = loc;
         this.packages = packages;
         this.id = id;
         this.aliasId = aliasId;
         this.isstatic = isstatic;
         this.protection = Prot.Kind.private_; // default to private
-        // Set symbol name (bracketed)
-        if (aliasId)
-        {
-            // import [cstdio] = std.stdio;
-            this.ident = aliasId;
-        }
-        else if (packages && packages.dim)
-        {
-            // import [std].stdio;
-            this.ident = (*packages)[0];
-        }
-        else
-        {
-            // import [foo];
-            this.ident = id;
-        }
     }
 
     void addAlias(Identifier name, Identifier _alias)

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -147,14 +147,13 @@ enum PKG : int
  */
 extern (C++) class Package : ScopeDsymbol
 {
-    PKG isPkgMod;
+    PKG isPkgMod = PKG.unknown;
     uint tag;        // auto incremented tag, used to mask package tree in scopes
     Module mod;     // !=null if isPkgMod == PKG.module_
 
-    final extern (D) this(Identifier ident)
+    final extern (D) this(const ref Loc loc, Identifier ident)
     {
-        super(ident);
-        this.isPkgMod = PKG.unknown;
+        super(loc, ident);
         __gshared uint packageTag;
         this.tag = packageTag++;
     }
@@ -189,7 +188,7 @@ extern (C++) class Package : ScopeDsymbol
                 Dsymbol p = dst.lookup(pid);
                 if (!p)
                 {
-                    pkg = new Package(pid);
+                    pkg = new Package(Loc.initial, pid);
                     dst.insert(pkg);
                     pkg.parent = parent;
                     pkg.symtab = new DsymbolTable();
@@ -404,9 +403,9 @@ extern (C++) final class Module : Package
     size_t nameoffset;          // offset of module name from start of ModuleInfo
     size_t namelen;             // length of module name in characters
 
-    extern (D) this(const(char)* filename, Identifier ident, int doDocComment, int doHdrGen)
+    extern (D) this(const ref Loc loc, const(char)* filename, Identifier ident, int doDocComment, int doHdrGen)
     {
-        super(ident);
+        super(loc, ident);
         const(char)* srcfilename;
         //printf("Module::Module(filename = '%s', ident = '%s')\n", filename, ident.toChars());
         this.arg = filename;
@@ -431,9 +430,14 @@ extern (C++) final class Module : Package
         escapetable = new Escape();
     }
 
+    extern (D) this(const(char)* filename, Identifier ident, int doDocComment, int doHdrGen)
+    {
+        this(Loc.initial, filename, ident, doDocComment, doHdrGen);
+    }
+
     static Module create(const(char)* filename, Identifier ident, int doDocComment, int doHdrGen)
     {
-        return new Module(filename, ident, doDocComment, doHdrGen);
+        return new Module(Loc.initial, filename, ident, doDocComment, doHdrGen);
     }
 
     static Module load(Loc loc, Identifiers* packages, Identifier ident)
@@ -497,8 +501,8 @@ extern (C++) final class Module : Package
             buf.writeByte(0);
             filename = buf.extractData().toDString();
         }
-        auto m = new Module(filename.ptr, ident, 0, 0);
-        m.loc = loc;
+        auto m = new Module(loc, filename.ptr, ident, 0, 0);
+
         /* Look for the source file
          */
         if (const result = lookForSourceFile(filename))
@@ -916,7 +920,7 @@ extern (C++) final class Module : Package
              *    later package.d loading will change Package::isPkgMod to PKG.module_ and set Package::mod.
              * 2. Otherwise, 'package.d' wrapped by 'Package' is inserted to the internal tree in here.
              */
-            auto p = new Package(ident);
+            auto p = new Package(Loc.initial, ident);
             p.parent = this.parent;
             p.isPkgMod = PKG.module_;
             p.mod = this;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -537,9 +537,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     // threaded list of previous instantiation attempts on stack
     TemplatePrevious* previous;
 
-    extern (D) this(const ref Loc loc, Identifier id, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
+    extern (D) this(const ref Loc loc, Identifier ident, TemplateParameters* parameters, Expression constraint, Dsymbols* decldefs, bool ismixin = false, bool literal = false)
     {
-        super(id);
+        super(loc, ident);
         static if (LOG)
         {
             printf("TemplateDeclaration(this = %p, id = '%s')\n", this, id.toChars());
@@ -558,7 +558,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     }
                 }
         }
-        this.loc = loc;
         this.parameters = parameters;
         this.origParameters = parameters;
         this.constraint = constraint;
@@ -5158,7 +5157,6 @@ extern (C++) class TemplateTypeParameter : TemplateParameter
     extern (D) this(const ref Loc loc, Identifier ident, Type specType, Type defaultType)
     {
         super(loc, ident);
-        this.ident = ident;
         this.specType = specType;
         this.defaultType = defaultType;
     }
@@ -5357,7 +5355,6 @@ extern (C++) final class TemplateValueParameter : TemplateParameter
         Expression specValue, Expression defaultValue)
     {
         super(loc, ident);
-        this.ident = ident;
         this.valType = valType;
         this.specValue = specValue;
         this.defaultValue = defaultValue;
@@ -5586,7 +5583,6 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
     extern (D) this(const ref Loc loc, Identifier ident, Type specType, RootObject specAlias, RootObject defaultAlias)
     {
         super(loc, ident);
-        this.ident = ident;
         this.specType = specType;
         this.specAlias = specAlias;
         this.defaultAlias = defaultAlias;
@@ -5799,7 +5795,6 @@ extern (C++) final class TemplateTupleParameter : TemplateParameter
     extern (D) this(const ref Loc loc, Identifier ident)
     {
         super(loc, ident);
-        this.ident = ident;
     }
 
     override TemplateTupleParameter isTemplateTupleParameter()
@@ -5972,12 +5967,11 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
     extern (D) this(const ref Loc loc, Identifier ident, Objects* tiargs)
     {
-        super(null);
+        super(loc, null);
         static if (LOG)
         {
             printf("TemplateInstance(this = %p, ident = '%s')\n", this, ident ? ident.toChars() : "null");
         }
-        this.loc = loc;
         this.name = ident;
         this.tiargs = tiargs;
     }
@@ -5988,12 +5982,11 @@ extern (C++) class TemplateInstance : ScopeDsymbol
      */
     extern (D) this(const ref Loc loc, TemplateDeclaration td, Objects* tiargs)
     {
-        super(null);
+        super(loc, null);
         static if (LOG)
         {
             printf("TemplateInstance(this = %p, tempdecl = '%s')\n", this, td.toChars());
         }
-        this.loc = loc;
         this.name = td.ident;
         this.tiargs = tiargs;
         this.tempdecl = td;

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -34,14 +34,13 @@ extern (C++) final class DebugSymbol : Dsymbol
 
     extern (D) this(const ref Loc loc, Identifier ident)
     {
-        super(ident);
-        this.loc = loc;
+        super(loc, ident);
     }
 
     extern (D) this(const ref Loc loc, uint level)
     {
+        super(loc, null);
         this.level = level;
-        this.loc = loc;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
@@ -123,14 +122,13 @@ extern (C++) final class VersionSymbol : Dsymbol
 
     extern (D) this(const ref Loc loc, Identifier ident)
     {
-        super(ident);
-        this.loc = loc;
+        super(loc, ident);
     }
 
     extern (D) this(const ref Loc loc, uint level)
     {
+        super(loc, null);
         this.level = level;
-        this.loc = loc;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -203,7 +203,6 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, Expression* pe0)
 
         // Create scope for '$' variable for this dimension
         auto sym = new ArrayScopeSymbol(sc, ae);
-        sym.loc = ae.loc;
         sym.parent = sc.scopesym;
         sc = sc.push(sym);
         ae.lengthVar = null; // Create it only if required
@@ -274,7 +273,6 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, Expression* p
 
     // create scope for '$'
     auto sym = new ArrayScopeSymbol(sc, ae);
-    sym.loc = ae.loc;
     sym.parent = sc.scopesym;
     sc = sc.push(sym);
 
@@ -6939,7 +6937,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             // Create scope for 'length' variable
             ScopeDsymbol sym = new ArrayScopeSymbol(sc, exp);
-            sym.loc = exp.loc;
             sym.parent = sc.scopesym;
             sc = sc.push(sym);
         }
@@ -7325,7 +7322,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             // Create scope for 'length' variable
             ScopeDsymbol sym = new ArrayScopeSymbol(sc, exp);
-            sym.loc = exp.loc;
             sym.parent = sc.scopesym;
             sc = sc.push(sym);
         }

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -307,9 +307,9 @@ extern (C++) class FuncDeclaration : Declaration
 
     uint flags;                        /// FUNCFLAG.xxxxx
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, Identifier id, StorageClass storage_class, Type type)
+    extern (D) this(const ref Loc loc, const ref Loc endloc, Identifier ident, StorageClass storage_class, Type type)
     {
-        super(id);
+        super(loc, ident);
         //printf("FuncDeclaration(id = '%s', type = %p)\n", id.toChars(), type);
         //printf("storage_class = x%x\n", storage_class);
         this.storage_class = storage_class;
@@ -320,7 +320,6 @@ extern (C++) class FuncDeclaration : Declaration
             // are already set in the 'type' in parsing phase.
             this.storage_class &= ~(STC.TYPECTOR | STC.FUNCATTR);
         }
-        this.loc = loc;
         this.endloc = endloc;
         /* The type given for "infer the return type" is a TypeFunction with
          * NULL for the return type.

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -372,9 +372,9 @@ public:
         }
     }
 
-    extern(D) void property(const(char)[] linename, const(char)[] charname, Loc* loc)
+    extern(D) void property(const(char)[] linename, const(char)[] charname, const ref Loc loc)
     {
-        if (loc)
+        if (loc.isValid())
         {
             if (auto filename = loc.filename.toDString)
             {
@@ -454,7 +454,7 @@ public:
                 property("value", em.origValue.toString());
         }
         property("comment", s.comment.toDString);
-        property("line", "char", &s.loc);
+        property("line", "char", s.loc);
     }
 
     void jsonProperties(Declaration d)
@@ -537,7 +537,7 @@ public:
         comma();
         property("kind", s.kind.toDString);
         property("comment", s.comment.toDString);
-        property("line", "char", &s.loc);
+        property("line", "char", s.loc);
         if (s.prot().kind != Prot.Kind.public_)
             property("protection", protectionToString(s.prot().kind));
         if (s.aliasId)
@@ -669,7 +669,7 @@ public:
         TypeFunction tf = cast(TypeFunction)d.type;
         if (tf && tf.ty == Tfunction)
             property("parameters", tf.parameterList.parameters);
-        property("endline", "endchar", &d.endloc);
+        property("endline", "endchar", d.endloc);
         if (d.foverrides.dim)
         {
             propertyStart("overrides");

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -43,9 +43,8 @@ extern (C++) final class Nspace : ScopeDsymbol
 
     extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
     {
-        super(ident);
+        super(loc, ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());
-        this.loc = loc;
         this.members = members;
         this.identExp = identExp;
         this.mangleOnly = mangleOnly;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -294,7 +294,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             funcdecl.localsymtab = new DsymbolTable();
 
             // Establish function scope
-            auto ss = new ScopeDsymbol();
+            auto ss = new ScopeDsymbol(funcdecl.loc, null);
             // find enclosing scope symbol, might skip symbol-less CTFE and/or FuncExp scopes
             for (auto scx = sc; ; scx = scx.enclosing)
             {
@@ -304,7 +304,6 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     break;
                 }
             }
-            ss.loc = funcdecl.loc;
             ss.endlinnum = funcdecl.endloc.linnum;
             Scope* sc2 = sc.push(ss);
             sc2.func = funcdecl;
@@ -539,18 +538,16 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 }
 
                 // scope of out contract (need for vresult.semantic)
-                auto sym = new ScopeDsymbol();
+                auto sym = new ScopeDsymbol(funcdecl.loc, null);
                 sym.parent = sc2.scopesym;
-                sym.loc = funcdecl.loc;
                 sym.endlinnum = fensure_endlin;
                 scout = sc2.push(sym);
             }
 
             if (funcdecl.fbody)
             {
-                auto sym = new ScopeDsymbol();
+                auto sym = new ScopeDsymbol(funcdecl.loc, null);
                 sym.parent = sc2.scopesym;
-                sym.loc = funcdecl.loc;
                 sym.endlinnum = funcdecl.endloc.linnum;
                 sc2 = sc2.push(sym);
 
@@ -894,9 +891,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
             {
                 /* frequire is composed of the [in] contracts
                  */
-                auto sym = new ScopeDsymbol();
+                auto sym = new ScopeDsymbol(funcdecl.loc, null);
                 sym.parent = sc2.scopesym;
-                sym.loc = funcdecl.loc;
                 sym.endlinnum = funcdecl.endloc.linnum;
                 sc2 = sc2.push(sym);
                 sc2.flags = (sc2.flags & ~SCOPE.contract) | SCOPE.require;

--- a/src/dmd/staticassert.d
+++ b/src/dmd/staticassert.d
@@ -30,8 +30,7 @@ extern (C++) final class StaticAssert : Dsymbol
 
     extern (D) this(const ref Loc loc, Expression exp, Expression msg)
     {
-        super(Id.empty);
-        this.loc = loc;
+        super(loc, Id.empty);
         this.exp = exp;
         this.msg = msg;
     }


### PR DESCRIPTION
1. The initialization of fields of Dsymbol should be done in Dsymbol's constructor
2. Name parameters to constructor the same as the fields they initialize
3. Initialization of fields with constants should be done as field initializers