### PR TITLE
Experimental: instead of normalizing IntegerExp after construction, error if normalization would produce a different value.

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2372,7 +2372,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
 
         assert(e.type.deco);
-        e.setInteger(e.getInteger());
+        e.checkSanity();
         result = e;
     }
 


### PR DESCRIPTION
This PR is mostly to see if this change breaks anything.