### PR TITLE
Fix issue 10806: check every interface for covariance, not just the first

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3646,6 +3646,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              * functions, set the tintro.
              */
         Linterfaces:
+            bool foundVtblMatch = false;
+
             foreach (b; cd.interfaces)
             {
                 vi = funcdecl.findVtblIndex(&b.sym.vtbl, cast(int)b.sym.vtbl.dim);
@@ -3663,6 +3665,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     {
                         auto fdv = cast(FuncDeclaration)b.sym.vtbl[vi];
                         Type ti = null;
+
+                        foundVtblMatch = true;
 
                         /* Remember which functions this overrides
                          */
@@ -3696,11 +3700,17 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                                     funcdecl.error("incompatible covariant types `%s` and `%s`", funcdecl.tintro.toChars(), ti.toChars());
                                 }
                             }
-                            funcdecl.tintro = ti;
+                            else
+                            {
+                                funcdecl.tintro = ti;
+                            }
                         }
-                        goto L2;
                     }
                 }
+            }
+            if (foundVtblMatch)
+            {
+                goto L2;
             }
 
             if (!doesoverride && funcdecl.isOverride() && (funcdecl.type.nextOf() || !may_override))

--- a/test/fail_compilation/fail10806.d
+++ b/test/fail_compilation/fail10806.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail10806.d(12): Error: function `fail10806.Class.clone` incompatible covariant types `First()` and `Second()`
+---
+*/
+
+interface First { First clone(); }
+interface Second { Second clone(); void call(); }
+
+class Class : First, Second {
+  override Class clone() { return this; }
+  override void call() { }
+}
+
+void main() {
+  (cast(Second) new Class).clone().call();
+}


### PR DESCRIPTION
There's a check whether the return type of a method is covariant with the introducing interface method it overrides. However, if there are multiple interfaces declaring the same method, only the first matching interface is checked, leading to miscompilation when the method is called via the second interface (issue 10806). This pr makes dmd check every interface, erroring out in the second interface because its type is not covariant.

This is not nice (the code *should* work), but it beats silent miscompilation.
