### PR TITLE
Replace call to runtime hook  _d_arraycast with call to template object.__ArrayCast - Take 2

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -4187,11 +4187,8 @@ elem *toElem(Expression e, IRState *irs)
                         e = el_pair(totym(ce.type), elen2, eptr);
                     }
                     else
-                    {   // Runtime check needed in case arrays don't line up
-                        if (config.exe == EX_WIN64)
-                            e = addressElem(e, t, true);
-                        elem *ep = el_params(e, el_long(TYsize_t, fsize), el_long(TYsize_t, tsize), null);
-                        e = el_bin(OPcall, totym(ce.type), el_var(getRtlsym(RTLSYM_ARRAYCAST)), ep);
+                    {
+                        assert(false, "This case should have been rewritten to `__ArrayCast` in the semantic phase");
                     }
                 }
                 goto Lret;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -342,6 +342,7 @@ immutable Msgtable[] msgtable =
     { "__equals"},
     { "__switch"},
     { "__switch_error"},
+    { "__ArrayCast"},
 
     // varargs implementation
     { "va_start" },


### PR DESCRIPTION
An attempt to finish up https://github.com/dlang/dmd/pull/8531 and set an example for a GSoC project.

~This is a WIP.  CTFE is currently running out of memory on my machine (6GB RAM) when importing `std.uni`.  I want to see how it does on the test suite.~