### PR TITLE
[dmd-cxx] Backport testsuite annotations

### DIFF
--- a/test/compilable/b6395.d
+++ b/test/compilable/b6395.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 // EXTRA_FILES: extra-files/c6395.d
 
 // 6395

--- a/test/compilable/b6395.d
+++ b/test/compilable/b6395.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -c -Icompilable/extra-files
+// EXTRA_FILES: extra-files/c6395.d
 
 // 6395
 

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -o- -X -Xf${RESULTS_DIR}/compilable/json.out
 // POST_SCRIPT: compilable/extra-files/json-postscript.sh
+// EXTRA_FILES: imports/jsonimport1.d imports/jsonimport2.d imports/jsonimport3.d imports/jsonimport4.d
 
 module json;
 

--- a/test/compilable/pull6815.d
+++ b/test/compilable/pull6815.d
@@ -1,4 +1,5 @@
 /* REQUIRED_ARGS: -inline -Icompilable/extra-files
+   EXTRA_FILES: extra-files/e6815.d
  */
 
 void b()

--- a/test/compilable/test12624.d
+++ b/test/compilable/test12624.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -lib -Icompilable/extra-files
+// EXTRA_FILES: extra-files/imp12624.d
 // https://issues.dlang.org/show_bug.cgi?id=12624
 
 struct SysTime

--- a/test/compilable/test16080.d
+++ b/test/compilable/test16080.d
@@ -1,5 +1,5 @@
 // REQUIRED_ARGS: -lib -Icompilable/imports
-// EXTRA_SOURCES: extra-files/test16080b.d
+// COMPILED_IMPORTS: extra-files/test16080b.d
 // EXTRA_FILES: imports/imp16080.d
 // https://issues.dlang.org/show_bug.cgi?id=16080
 

--- a/test/compilable/test16080.d
+++ b/test/compilable/test16080.d
@@ -1,5 +1,6 @@
 // REQUIRED_ARGS: -lib -Icompilable/imports
 // EXTRA_SOURCES: extra-files/test16080b.d
+// EXTRA_FILES: imports/imp16080.d
 // https://issues.dlang.org/show_bug.cgi?id=16080
 
 import imp16080;

--- a/test/compilable/test6395.d
+++ b/test/compilable/test6395.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -c compilable/b6395 -Icompilable/extra-files
+// EXTRA_FILES: extra-files/c6395.d
 
 // 6395
 

--- a/test/compilable/test6395.d
+++ b/test/compilable/test6395.d
@@ -1,4 +1,5 @@
-// REQUIRED_ARGS: -c compilable/b6395 -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
+// EXTRA_SOURCES: b6395.d
 // EXTRA_FILES: extra-files/c6395.d
 
 // 6395

--- a/test/compilable/test7190.d
+++ b/test/compilable/test7190.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 // EXTRA_FILES: extra-files/example7190/controllers/HomeController.d
 // EXTRA_FILES: extra-files/example7190/models/HomeModel.d
 // EXTRA_FILES: extra-files/serenity7190/core/Controller.d

--- a/test/compilable/test7190.d
+++ b/test/compilable/test7190.d
@@ -1,5 +1,9 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
+// EXTRA_FILES: extra-files/example7190/controllers/HomeController.d
+// EXTRA_FILES: extra-files/example7190/models/HomeModel.d
+// EXTRA_FILES: extra-files/serenity7190/core/Controller.d
+// EXTRA_FILES: extra-files/serenity7190/core/Model.d
 
 import example7190.controllers.HomeController;
 import example7190.models.HomeModel;

--- a/test/compilable/test9057.d
+++ b/test/compilable/test9057.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 // EXTRA_FILES: extra-files/imp9057.d extra-files/imp9057_2.d
 
 struct Bug9057(T)

--- a/test/compilable/test9057.d
+++ b/test/compilable/test9057.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
+// EXTRA_FILES: extra-files/imp9057.d extra-files/imp9057_2.d
 
 struct Bug9057(T)
 {

--- a/test/compilable/test9276.d
+++ b/test/compilable/test9276.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: compilable/imports/test9276parser.d
+// EXTRA_SOURCES: imports/test9276parser.d
 
 
 // This is a dummy module for compilable test

--- a/test/compilable/test9399.d
+++ b/test/compilable/test9399.d
@@ -1,4 +1,5 @@
-// REQUIRED_ARGS: -c -inline -Icompilable/imports compilable/imports/test9399a
+// REQUIRED_ARGS: -c -inline -Icompilable/imports
+// EXTRA_SOURCES: imports/test9399a.d
 
 import imports.test9399a;
 void fun(int a) {

--- a/test/compilable/test9436.d
+++ b/test/compilable/test9436.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -c compilable/imports/test9436interp.d
+// EXTRA_SOURCES: imports/test9436interp.d
 
 // this is a dummy module for test 9436.
 

--- a/test/compilable/testDIP37.d
+++ b/test/compilable/testDIP37.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
 // EXTRA_FILES: extra-files/pkgDIP37/datetime/package.d
 // EXTRA_FILES: extra-files/pkgDIP37/datetime/common.d
 // EXTRA_FILES: extra-files/pkgDIP37/test17629/package.di

--- a/test/compilable/testDIP37.d
+++ b/test/compilable/testDIP37.d
@@ -1,5 +1,9 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
+// EXTRA_FILES: extra-files/pkgDIP37/datetime/package.d
+// EXTRA_FILES: extra-files/pkgDIP37/datetime/common.d
+// EXTRA_FILES: extra-files/pkgDIP37/test17629/package.di
+// EXTRA_FILES: extra-files/pkgDIP37/test17629/common.di
 
 void test1()
 {

--- a/test/compilable/testDIP37_10302.d
+++ b/test/compilable/testDIP37_10302.d
@@ -2,6 +2,7 @@
 // REQUIRED_ARGS: -c -Icompilable/extra-files
 // EXTRA_SOURCES: extra-files/pkgDIP37_10302/liba.d
 // EXTRA_SOURCES: extra-files/pkgDIP37_10302/libb.d
+// EXTRA_FILES: extra-files/pkgDIP37_10302/package.d
 
 module test;
 import pkgDIP37_10302;

--- a/test/compilable/testDIP37_10302.d
+++ b/test/compilable/testDIP37_10302.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_SOURCES: extra-files/pkgDIP37_10302/liba.d
-// EXTRA_SOURCES: extra-files/pkgDIP37_10302/libb.d
+// REQUIRED_ARGS: -Icompilable/extra-files
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10302/liba.d
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10302/libb.d
 // EXTRA_FILES: extra-files/pkgDIP37_10302/package.d
 
 module test;

--- a/test/compilable/testDIP37_10354.d
+++ b/test/compilable/testDIP37_10354.d
@@ -1,5 +1,8 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -o- -Icompilable/extra-files
+// EXTRA_FILES: extra-files/pkgDIP37_10354/mbar.d
+// EXTRA_FILES: extra-files/pkgDIP37_10354/mfoo.d
+// EXTRA_FILES: extra-files/pkgDIP37_10354/package.d
 
 module testDIP37_10354;
 import pkgDIP37_10354.mfoo;

--- a/test/fail_compilation/diag4479.d
+++ b/test/fail_compilation/diag4479.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: fail_compilation/imports/fail4479.d
+// EXTRA_SOURCES: imports/fail4479.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/runnable/imports/a11447.d
+++ b/test/runnable/imports/a11447.d
@@ -1,3 +1,4 @@
+module imports.a11447;
 struct A { }
 
 void map(alias dg)(A r) { }

--- a/test/runnable/imports/a12010.d
+++ b/test/runnable/imports/a12010.d
@@ -1,2 +1,3 @@
+module imports.a12010;
 import imports.std12010container : Array, BinaryHeap;
 BinaryHeap!(Array!int) test;

--- a/test/runnable/imports/b11447.d
+++ b/test/runnable/imports/b11447.d
@@ -1,3 +1,4 @@
+module imports.b11447;
 class A {}
 
 void map(alias dg)(int b) { }

--- a/test/runnable/imports/c11447.d
+++ b/test/runnable/imports/c11447.d
@@ -1,3 +1,4 @@
+module imports.c11447;
 template map(fun...)
 {
     auto map(Range)(Range r)

--- a/test/runnable/imports/ice15200a.d
+++ b/test/runnable/imports/ice15200a.d
@@ -1,3 +1,4 @@
+module imports.ice15200a;
 import imports.ice15200b;
 
 auto f() // not void

--- a/test/runnable/imports/inc11239.d
+++ b/test/runnable/imports/inc11239.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS:
+module imports.inc11239;
 
 int foo(T)(T x)
 {

--- a/test/runnable/imports/link11069x.d
+++ b/test/runnable/imports/link11069x.d
@@ -1,3 +1,4 @@
+module imports.link11069x;
 import imports.link11069z;
 
 import std.algorithm;

--- a/test/runnable/imports/link11069y.d
+++ b/test/runnable/imports/link11069y.d
@@ -1,3 +1,4 @@
+module imports.link11069y;
 import std.traits;
 
 void readWriteVariable(T)(ref T data)

--- a/test/runnable/imports/link11069z.d
+++ b/test/runnable/imports/link11069z.d
@@ -1,3 +1,4 @@
+module imports.link11069z;
 struct Matrix(T, uint _M)
 {
     int opCmp()(auto ref in Matrix b) const

--- a/test/runnable/imports/link12144a.d
+++ b/test/runnable/imports/link12144a.d
@@ -1,3 +1,4 @@
+module imports.link12144a;
 struct S1 { bool opEquals(T : typeof(this))(T) { return false; } }
 struct S2 { bool opEquals(T : typeof(this))(T) { return false; } }
 struct S3 { bool opEquals(T : typeof(this))(T) { return false; } }

--- a/test/runnable/imports/link13415a.d
+++ b/test/runnable/imports/link13415a.d
@@ -1,3 +1,4 @@
+module imports.link13415a;
 struct S(alias func)
 {
     void call()

--- a/test/runnable/imports/link7745b.d
+++ b/test/runnable/imports/link7745b.d
@@ -1,3 +1,4 @@
+module imports.link7745b;
 struct C { auto asdfg() {} }
 
 // extreme test of bug 4820

--- a/test/runnable/imports/link9571a.d
+++ b/test/runnable/imports/link9571a.d
@@ -1,3 +1,4 @@
+module imports.link9571a;
 struct MapResult(alias fun)
 {
     void bar() { fun(0); }

--- a/test/runnable/imports/std15017variant.d
+++ b/test/runnable/imports/std15017variant.d
@@ -1,4 +1,4 @@
-module imports.std15017;
+module imports.std15017variant;
 
 struct VariantN(size_t maxDataSize)
 {

--- a/test/runnable/link12010.d
+++ b/test/runnable/link12010.d
@@ -1,5 +1,6 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/a12010.d
+// EXTRA_FILES: imports/std12010container.d
 // REQUIRED_ARGS: -release
 // -release is necessary to avoid __assert.
 

--- a/test/runnable/test11863.d
+++ b/test/runnable/test11863.d
@@ -1,5 +1,6 @@
 // COMPILE_SEPARATELY
 // EXTRA_SOURCES: imports/std11863conv.d
+// EXTRA_FILES: imports/std11863format.d
 
 import imports.std11863conv;
 

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS:
+// EXTRA_FILES: extra-files/test15.txt
 
 import std.array;
 import core.stdc.math : cos, fabs, sin, sqrt;

--- a/test/runnable/test37.d
+++ b/test/runnable/test37.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -Jrunnable/extra-files
+// EXTRA_FILES: extra-files/foo37.txt extra-files/std14198/uni.d
 
 import std.stdio;
 

--- a/test/runnable/teststdio.d
+++ b/test/runnable/teststdio.d
@@ -1,4 +1,5 @@
 // PERMUTE_ARGS:
+// EXTRA_FILES: extra-files/teststdio.txt
 
 import std.stdio;
 import core.stdc.stdio;

--- a/test/runnable/wc3.d
+++ b/test/runnable/wc3.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
 // EXECUTE_ARGS: runnable/extra-files/alice30.txt
+// EXTRA_FILES: extra-files/alice30.txt
 
 import std.stdio;
 import std.file;


### PR DESCRIPTION
Of the dmd testsuite that's mirrored to gdc, they are now pretty much identical, save for only a handful of individually commented out tests that are too dmd-centric.