### PR TITLE
only call _d_newThrowable if -dip1008 given

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1653,7 +1653,7 @@ elem *toElem(Expression e, IRState *irs)
                 else
                 {
                     Symbol *csym = toSymbol(cd);
-                    const rtl = ne.thrownew ? RTLSYM_NEWTHROW : RTLSYM_NEWCLASS;
+                    const rtl = global.params.ehnogc && ne.thrownew ? RTLSYM_NEWTHROW : RTLSYM_NEWCLASS;
                     ex = el_bin(OPcall,TYnptr,el_var(getRtlsym(rtl)),el_ptr(csym));
                     toTraceGC(irs, ex, ne.loc);
                     ectype = null;


### PR DESCRIPTION
Followup to #9481.

Given that always calling d_newThrowable didn't break anything suggests that exceptions are not passed around that often, but DIP1008 is still not accepted (it has strange semantics to begin with IMO).