### PR TITLE
dmd.dmodule: fix memory leak in lookForSourceFile

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -509,8 +509,8 @@ extern (C++) final class Module : Package
          */
         if (const result = lookForSourceFile(filename))
         {
-            scope(exit) FileName.free(result.ptr);
             m.srcfile = new File(result);
+            FileName.free(result.ptr);
         }
 
         if (!m.read(loc))

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -66,9 +66,11 @@ private const(char)[] lookForSourceFile(const(char)[] filename)
     const sdi = FileName.forceExt(filename, global.hdr_ext.toDString());
     if (FileName.exists(sdi) == 1)
         return sdi;
+    scope(exit) FileName.free(sdi.ptr);
     const sd = FileName.forceExt(filename, global.mars_ext.toDString());
     if (FileName.exists(sd) == 1)
         return sd;
+    scope(exit) FileName.free(sd.ptr);
     if (FileName.exists(filename) == 2)
     {
         /* The filename exists and it's a directory.
@@ -506,7 +508,10 @@ extern (C++) final class Module : Package
         /* Look for the source file
          */
         if (const result = lookForSourceFile(filename))
+        {
+            scope(exit) FileName.free(result.ptr);
             m.srcfile = new File(result);
+        }
 
         if (!m.read(loc))
             return null;


### PR DESCRIPTION
`lookForSourceFile` calls `forceExt`, but did not always call `free` as [`forceExt` suggests](https://github.com/dlang/dmd/blob/e09e97e0b8468bc1ce238bcb8de95f80a5beb430/src/dmd/root/filename.d#L551-L565).