### PR TITLE
Advance deprecation of hex string literals (Error)

### DIFF
--- a/changelog/dephexstrings.dd
+++ b/changelog/dephexstrings.dd
@@ -1,0 +1,7 @@
+HexString literals are now obsolete
+
+$(LINK2 http://dlang.org/spec/lex.html#HexString, HexString literals) are obsolete.
+
+Prior to this release, usage of hex string literals would emit a deprecation warning.  Starting with this release they will emit an error.
+
+Use $(LINK2 https://dlang.org/phobos/std_conv.html#hexString, `std.conv.hexString`) instead.

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -428,8 +428,11 @@ class Lexer
                 if (p[1] != '"')
                     goto case_ident;
                 p++;
+                auto start = p;
+                auto hexString = new OutBuffer();
                 t.value = hexStringConstant(t);
-                deprecation("Built-in hex string literals are deprecated, use `std.conv.hexString` instead.");
+                hexString.write(start, p - start);
+                error("Built-in hex string literals are obsolete, use `std.conv.hexString!%s` instead.", hexString.extractString());
                 return;
             case 'q':
                 if (p[1] == '"')

--- a/test/fail_compilation/dephexstrings.d
+++ b/test/fail_compilation/dephexstrings.d
@@ -2,7 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/dephexstrings.d(8): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+fail_compilation/dephexstrings.d(8): Error: Built-in hex string literals are obsolete, use `std.conv.hexString!"60"` instead.
 ---
 */
 enum xstr = x"60";
+

--- a/test/fail_compilation/fail136.d
+++ b/test/fail_compilation/fail136.d
@@ -1,8 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail136.d(11): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
-fail_compilation/fail136.d(11): Error: `"\xef\xbb\xbf"` has no effect
+fail_compilation/fail136.d(10): Error: Built-in hex string literals are obsolete, use `std.conv.hexString!"EF BB BF"` instead.
 ---
 */
 

--- a/test/fail_compilation/lexer1.d
+++ b/test/fail_compilation/lexer1.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/lexer1.d(30): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+fail_compilation/lexer1.d(30): Error: Built-in hex string literals are obsolete, use `std.conv.hexString!"01 02 03"w` instead.
 fail_compilation/lexer1.d(30): Error: declaration expected, not `x"01 02 03"w`
 fail_compilation/lexer1.d(31): Error: declaration expected, not `2147483649U`
 fail_compilation/lexer1.d(32): Error: declaration expected, not `0.1`

--- a/test/fail_compilation/lexer2.d
+++ b/test/fail_compilation/lexer2.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/lexer2.d(16): Error: odd number (3) of hex characters in hex string
-fail_compilation/lexer2.d(16): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+fail_compilation/lexer2.d(16): Error: Built-in hex string literals are obsolete, use `std.conv.hexString!"123"` instead.
 fail_compilation/lexer2.d(17): Error: non-hex character 'G' in hex string
-fail_compilation/lexer2.d(17): Deprecation: Built-in hex string literals are deprecated, use `std.conv.hexString` instead.
+fail_compilation/lexer2.d(17): Error: Built-in hex string literals are obsolete, use `std.conv.hexString!"123G"` instead.
 fail_compilation/lexer2.d(18): Error: heredoc rest of line should be blank
 fail_compilation/lexer2.d(20): Error: unterminated delimited string constant starting at fail_compilation/lexer2.d(20)
 fail_compilation/lexer2.d(22): Error: semicolon expected following auto declaration, not `End of File`

--- a/test/runnable/foreach4.d
+++ b/test/runnable/foreach4.d
@@ -577,7 +577,7 @@ void test18()
 
 void test19()
 {
-    string string = x"F0 9D 83 93";
+    string string = "\xF0\x9D\x83\x93";
 
     int count=0;
     dchar tmp;

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -47,7 +47,7 @@ void test7()
     string s = `hello"there'you`;
     printf("s = '%.*s'\n", s.length, s.ptr);
     assert(s == "hello\"there'you");
-    ubyte[] b = cast(ubyte[])x"8B 7D f4 0d";
+    ubyte[] b = cast(ubyte[])"\x8B\x7D\xf4\x0d";
     for (int i = 0; i < b.length; i++)
         printf("b[%d] = x%02x\n", i, b[i]);
     assert(b.length == 4);

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -743,7 +743,7 @@ void test42()
         string string1 =  "ワロスｗ";
         string string2 = r"ワロスｗ";
         string string3 =  `ワロスｗ`;
-        string string4 = x"E3 83 AF E3 83 AD E3 82 B9 EF BD 97";
+        string string4 = "\xE3\x83\xAF\xE3\x83\xAD\xE3\x82\xB9\xEF\xBD\x97";
 
         assert(string1.length==master.length);
 

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -671,7 +671,7 @@ void test30()
 
 void test31()
 {
-        string str = x"F0 9D 83 93"; // utf-8 for U+1D0D3
+        string str = "\xF0\x9D\x83\x93"; // utf-8 for U+1D0D3
 
         int count=0;
         dchar tmp;

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1315,7 +1315,7 @@ void test67()
 
 void test68()
 {
-    digestToString(cast(ubyte[16])x"c3fcd3d76192e4007dfb496cca67e13b");
+    digestToString(cast(ubyte[16])"\xc3\xfc\xd3\xd7\x61\x92\xe4\x00\x7d\xfb\x49\x6c\xca\x67\xe1\x3b");
 }
 
 void digestToString(const ubyte[16] digest)
@@ -1328,7 +1328,7 @@ void digestToString(const ubyte[16] digest)
 
 void test69()
 {
-    digestToString69(cast(ubyte[16])x"c3fcd3d76192e4007dfb496cca67e13b");
+    digestToString69(cast(ubyte[16])"\xc3\xfc\xd3\xd7\x61\x92\xe4\x00\x7d\xfb\x49\x6c\xca\x67\xe1\x3b");
 }
 
 void digestToString69(ref const ubyte[16] digest)
@@ -4093,7 +4093,7 @@ void test4539()
 
     // same as test68, 69, 70
     foo4("hello");
-    foo5(cast(ubyte[5])x"c3fcd3d761");
+    foo5(cast(ubyte[5])"\xc3\xfc\xd3\xd7\x61");
 
     //import std.conv;
     //static assert(!__traits(compiles, parse!int("10") == 10));

--- a/test/unit/lexer/diagnostic_reporter.d
+++ b/test/unit/lexer/diagnostic_reporter.d
@@ -51,7 +51,7 @@ unittest
     assert(reporter.warningCount == 1);
 }
 
-@("deprecations: hex string literal")
+@("deprecations: Invalid integer")
 unittest
 {
     static final class DeprecationsCountingDiagnosticReporter : NoopDiagnosticReporter
@@ -65,7 +65,7 @@ unittest
     }
 
     scope reporter = new DeprecationsCountingDiagnosticReporter;
-    lexUntilEndOfFile(`enum a = x"60";`, reporter);
+    lexUntilEndOfFile(`auto a = 0b;`, reporter);
 
     assert(reporter.deprecationCount == 1);
 }


### PR DESCRIPTION
Followup to https://github.com/dlang/dmd/pull/7767

Hex strings were deprecated in 2.079.  Following typical deprecation proceedings, the deprecation warning should now become an error.

Documentation update:  https://github.com/dlang/dlang.org/pull/2617