### PR TITLE
Clean up some messy/buggy markdown code

### DIFF
--- a/test/compilable/ddoc_markdown_links.d
+++ b/test/compilable/ddoc_markdown_links.d
@@ -5,9 +5,10 @@
 /++
 # Links
 
+[D Site]: https://dlang.org 'D lives here'
 [unused reference]: https://nowhere.com
 
-A link to [Object].
+A link to [partition].
 
 A link to [the base object][Object].
 
@@ -26,8 +27,15 @@ A slightly less simple link to [dub][].
 An image: ![D-Man](https://dlang.org/images/d3.png)
 Another image: ![D-Man again][dman-error]
 
-[D Site]: https://dlang.org 'D lives here'
 [dub]: <https://code.dlang.org>
 [dman-error]: https://dlang.org/images/dman-error.jpg
+
+$(P
+    [tour]: https://tour.dlang.org
+
+    Here's a [reference to the tour][tour] inside a macro.
+)
 +/
 module test.compilable.ddoc_markdown_links;
+
+import std.algorithm.sorting;

--- a/test/compilable/extra-files/ddoc_markdown_links.html
+++ b/test/compilable/extra-files/ddoc_markdown_links.html
@@ -512,7 +512,7 @@
 <div class="ddoc_description">
   <h4>Discussion</h4>
   <p class="para">
-    A link to <a href="https://dlang.org/phobos/object.html#.Object"><code class="code">Object</code></a>.
+    A link to <a href="https://dlang.org/phobos/std_algorithm_sorting.html#.partition"><code class="code">partition</code></a>.
 <br><br>
 A link to <a href="https://dlang.org/phobos/object.html#.Object"><code class="code">the base object</code></a>.
 <br><br>
@@ -530,8 +530,9 @@ A slightly less simple link to <a href="https://code.dlang.org">dub</a>.
 <br><br>
 An image: <img src="https://dlang.org/images/d3.png" alt="D-Man" />
 Another image: <img src="https://dlang.org/images/dman-error.jpg" alt="D-Man again" />
-
-
+<br><br>
+<p>    Here's a <a href="https://tour.dlang.org">reference to the tour</a> inside a macro.
+</p>
   </p>
 </div>
 


### PR DESCRIPTION
- Remove `ref` from a couple parameters and fix their docs
- Fix parsing reference definitions that are directly after others or within a macro