### PR TITLE
fix Issue 19785 - top level const types in function parameters should…

### DIFF
--- a/changelog/fix19785.dd
+++ b/changelog/fix19785.dd
@@ -1,0 +1,44 @@
+Function Parameter Name Mangling Changes
+
+If the parameter type can be implicitly converted to a type
+that at the top level does not have `const` or `shared` or `inout` or `immutable`
+then the converted type is mangled instead. This means
+these functions mangle to the same string:
+
+---
+void foo(immutable int i);
+void foo(const int i);
+void foo(int i);
+
+void foo(const int* p);
+void foo(const(int)* p);
+---
+
+Note that C++ compilers typically do this as well.
+
+This will break binary compatibility with existing code,
+it will need to be recompiled.
+
+It will also break code that relies on them being distinct
+functions, and the following will now fail:
+
+---
+int foo60(int i) { return 1; }
+int foo60(const int i) { return 2; }
+int foo60(immutable int i) { return 3; }
+
+void test60()
+{
+    int i;
+    const int j;
+    immutable int k;
+
+    assert(foo60(i) == 1);
+    assert(foo60(j) == 2);
+    assert(foo60(k) == 3);
+}
+---
+Although arguably such code never made sense anyway.
+
+
+https://issues.dlang.org/show_bug.cgi?id=19785

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1091,7 +1091,15 @@ public:
             }
             assert(0);
         }
-        visitWithMask(p.type, 0);
+        Type t = p.type;
+        if (t.mod == 0)    // the easy case, no modifiers
+            return mangleType(t);
+
+        /* If t can be implicitly converted to the same type sans modifiers,
+         * then don't mangle in those modifiers.
+         */
+        Type tm = t.mutableOf().unSharedOf();
+        visitWithMask(t.implicitConvTo(tm) >= MATCH.constant ? tm : t, 0);
     }
 }
 

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -456,7 +456,7 @@ int intrinsic_op(FuncDeclaration fd)
         "4math6yl2xp1FNaNbNiNfeeZe",
         "4math6yl2xp1FNaNbNiNfffZf",
 
-        "4simd10__prefetchFNaNbNiNfxPvhZv",
+        "4simd10__prefetchFNaNbNiNfPxvhZv",
         "4simd10__simd_stoFNaNbNiNfEQBgQBe3XMMNhG16vQgZQj",
         "4simd10__simd_stoFNaNbNiNfEQBgQBe3XMMdNhG16vZQh",
         "4simd10__simd_stoFNaNbNiNfEQBgQBe3XMMfNhG16vZQh",
@@ -546,7 +546,7 @@ int intrinsic_op(FuncDeclaration fd)
         "4math6yl2xp1FNaNbNiNfeeZe",
         "4math6yl2xp1FNaNbNiNfffZf",
 
-        "4simd10__prefetchFNaNbNiNfxPvhZv",
+        "4simd10__prefetchFNaNbNiNfPxvhZv",
         "4simd10__simd_stoFNaNbNiNfEQBgQBe3XMMNhG16vQgZQj",
         "4simd10__simd_stoFNaNbNiNfEQBgQBe3XMMdNhG16vZQh",
         "4simd10__simd_stoFNaNbNiNfEQBgQBe3XMMfNhG16vZQh",

--- a/test/runnable/mangle.d
+++ b/test/runnable/mangle.d
@@ -240,10 +240,9 @@ void test8847d()
 void test8847e()
 {
     enum resultHere = "6mangle"~"9test8847eFZ"~tl!"8"~"__T3fooZ"~id!("3foo","Qf");
-    enum resultBar =  "S"~resultHere~"MFNaNfNgiZ3Bar";
+    enum resultBar =  "S"~resultHere~"MFNaNfiZ3Bar";
     static if(BackRefs) {} else
       enum resultFoo = "_D"~resultHere~"MFNaNbNiNfNgiZNg"~resultBar;   // added 'Nb'
-
     // Make template function to infer 'nothrow' attributes
     auto foo()(inout int) pure @safe
     {
@@ -256,12 +255,18 @@ void test8847e()
     auto bar = foo(0);
     static assert(typeof(bar).stringof == "Bar");
     static assert(typeof(bar).mangleof == resultBar);
-    enum fooDemangled = "pure nothrow @nogc @safe inout(mangle.test8847e().foo!().foo(inout(int)).Bar) mangle.test8847e().foo!().foo(inout(int))";
+    enum fooDemangled = "pure nothrow @nogc @safe inout(mangle.test8847e().foo!().foo(int).Bar) mangle.test8847e().foo!().foo(int)";
 
     static if (BackRefs)
+    {
+      //pragma(msg, demangle(foo!().mangleof));
       static assert(demangle(foo!().mangleof) == fooDemangled);
+    }
     else
+    {
+      //pragma(msg, foo!().mangleof);
       static assert(foo!().mangleof == resultFoo);
+    }
 }
 
 // --------

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -1000,23 +1000,6 @@ void test59()
 
 /************************************/
 
-int foo60(int i) { return 1; }
-int foo60(const int i) { return 2; }
-int foo60(immutable int i) { return 3; }
-
-void test60()
-{
-    int i;
-    const int j;
-    immutable int k;
-
-    assert(foo60(i) == 1);
-    assert(foo60(j) == 2);
-    assert(foo60(k) == 3);
-}
-
-/************************************/
-
 void foo61(T)(T arg)
 {
     alias const(T) CT;
@@ -3811,7 +3794,6 @@ int main()
     test57();
     test58();
     test59();
-    test60();
     test61();
     test62();
     test63();

--- a/test/runnable/testscope2.d
+++ b/test/runnable/testscope2.d
@@ -38,8 +38,8 @@ void test3()
         // Test scope mangling
         assert(SS.foo1.mangleof == "_D10testscope22SS4foo1MFNcNjNkKDFNjZPiZm");
         assert(SS.foo2.mangleof == "_D10testscope22SS4foo2MFNcNkKDFZiZi");
-        assert(SS.foo3.mangleof == "_D10testscope22SS4foo3MFNcNkKNgPiZi");
-        assert(SS.foo4.mangleof == "_D10testscope22SS4foo4MFNcNkKNgPiZi");
+        assert(SS.foo3.mangleof == "_D10testscope22SS4foo3MFNcNkKPNgiZi");
+        assert(SS.foo4.mangleof == "_D10testscope22SS4foo4MFNcNkKPNgiZi");
 
         // Test scope pretty-printing
         assert(typeof(SS.foo1).stringof == "ref ulong(return ref int* delegate() return p) return");


### PR DESCRIPTION
… not mangle as const

If it doesn't break anything in the test suite, I'll need to add tests.