### PR TITLE
Fix `test/run.d` on macOS

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -397,7 +397,7 @@ string[string] getEnvironment()
         env["PIC_FLAGS"]  = pic ? "-fPIC" : "";
         env["DFLAGS"] = "-I%s/import -I%s".format(druntimePath, phobosPath)
             ~ " -L-L%s/%s".format(phobosPath, generatedSuffix);
-        bool isShared = os.among("linux", "freebsd") >= 0;
+        bool isShared = os.among("linux", "freebsd") > 0;
         if (isShared)
             env["DFLAGS"] = env["DFLAGS"] ~ " -defaultlib=libphobos2.so -L-rpath=%s/%s".format(phobosPath, generatedSuffix);
 


### PR DESCRIPTION
The issue was that the `-rpath` linker flag was used on macOS, which is not supported. This happened because the `isShared` flag was set incorrectly on macOS. The mistake was that `among` returns `0` when it fails to find the value.