### PR TITLE
dmd.cond: Add VersionCondition.isVersionCondition

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -70,6 +70,11 @@ extern (C++) abstract class Condition : ASTNode
         return null;
     }
 
+    inout(VersionCondition) isVersionCondition() inout
+    {
+        return null;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);
@@ -804,6 +809,11 @@ extern (C++) final class VersionCondition : DVCondition
             }
         }
         return (inc == Include.yes);
+    }
+
+    override inout(VersionCondition) isVersionCondition() inout
+    {
+        return this;
     }
 
     override void accept(Visitor v)

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -65,7 +65,7 @@ extern (C++) abstract class Condition : ASTNode
 
     abstract int include(Scope* sc);
 
-    DebugCondition isDebugCondition()
+    inout(DebugCondition) isDebugCondition() inout
     {
         return null;
     }
@@ -536,7 +536,7 @@ extern (C++) final class DebugCondition : DVCondition
         return (inc == Include.yes);
     }
 
-    override DebugCondition isDebugCondition()
+    override inout(DebugCondition) isDebugCondition() inout
     {
         return this;
     }

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -40,6 +40,7 @@ public:
     virtual Condition *syntaxCopy() = 0;
     virtual int include(Scope *sc) = 0;
     virtual DebugCondition *isDebugCondition() { return NULL; }
+    virtual VersionCondition *isVersionCondition() { return NULL; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -84,6 +85,7 @@ public:
     static void addPredefinedGlobalIdent(const char *ident);
 
     int include(Scope *sc);
+    VersionCondition *isVersionCondition() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 


### PR DESCRIPTION
So a ConditionalDeclaration's condition can be identified as a VersionCondition without requiring a Visitor function.