### PR TITLE
Support markdown-style tables

### DIFF
--- a/res/default_ddoc_theme.ddoc
+++ b/res/default_ddoc_theme.ddoc
@@ -28,9 +28,13 @@ DL = <dl>$0</dl>
 DT = <dt>$0</dt>
 DD = <dd>$0</dd>
 TABLE = <table>$0</table>
+THEAD = <thead>$0</thead>
+TBODY = <tbody>$0</tbody>
 TR = <tr>$0</tr>
 TH = <th>$0</th>
 TD = <td>$0</td>
+TH_ALIGN = <th align="$1">$+</th>
+TD_ALIGN = <td align="$1">$+</td>
 OL = <ol>$0</ol>
 OL_START = <ol start="$1">$2</ol>
 UL = <ul>$0</ul>
@@ -545,11 +549,18 @@ DDOC =
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/ddoc_markdown_tables.d
+++ b/test/compilable/ddoc_markdown_tables.d
@@ -1,0 +1,47 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -preview=markdown
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+
+/*
+TEST_OUTPUT:
+----
+----
+*/
+
+/++
+# Tables
+
+| Rounding mode | rndint(4.5) | rndint(5.5) | rndint(-4.5) | Notes |
+| ------------- | ----------: | ----------: | -----------: | ----- |
+| Round to nearest | 4 | 6 | -4 | Ties round to an even number |
+| Round down | 4 | 5 | -5 | &nbsp; |
+| Round up | 5 | 6 | -4 | &nbsp; |
+| Round to zero | 4 | 5 | -4 | &nbsp; |
+
+    this|that
+    ----|----
+    cell|cell<br>sell
+
+| abc | def |
+| --- | --- |
+| bar |
+| *bar* | baz | boo |
+
+> | quote |
+> | ----- |
+> | table |
+
+* | list |
+  | ---- |
+  | table |
+
+| default | left | center | right |
+| --- | :-- | :--: | --: |
+
+Look Ma, a table without a body!
+
+| not | a | table |
+| -- |
+| wrong number of header columns |
++/
+module test.compilable.ddoc_markdown_tables;

--- a/test/compilable/ddoc_markdown_tables_verbose.d
+++ b/test/compilable/ddoc_markdown_tables_verbose.d
@@ -1,0 +1,19 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o- -preview=markdown -transition=vmarkdown
+// POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh
+
+/*
+TEST_OUTPUT:
+----
+compilable/ddoc_markdown_tables_verbose.d(19): Ddoc: formatting table '| this | that |'
+----
+*/
+
+/++
+Table:
+
+| this | that |
+| ---- | ---- |
+| cell | cell |
++/
+module test.compilable.ddoc_markdown_tables_verbose;

--- a/test/compilable/extra-files/ddoc1.html
+++ b/test/compilable/extra-files/ddoc1.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc10.html
+++ b/test/compilable/extra-files/ddoc10.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc10325.html
+++ b/test/compilable/extra-files/ddoc10325.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc10334.html
+++ b/test/compilable/extra-files/ddoc10334.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc10366.html
+++ b/test/compilable/extra-files/ddoc10366.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc10367.html
+++ b/test/compilable/extra-files/ddoc10367.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc10869.html
+++ b/test/compilable/extra-files/ddoc10869.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc10870.html
+++ b/test/compilable/extra-files/ddoc10870.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc11.html
+++ b/test/compilable/extra-files/ddoc11.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc11479.html
+++ b/test/compilable/extra-files/ddoc11479.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc11511.html
+++ b/test/compilable/extra-files/ddoc11511.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc11823.html
+++ b/test/compilable/extra-files/ddoc11823.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc12.html
+++ b/test/compilable/extra-files/ddoc12.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc12706.html
+++ b/test/compilable/extra-files/ddoc12706.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc12745.html
+++ b/test/compilable/extra-files/ddoc12745.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc13.html
+++ b/test/compilable/extra-files/ddoc13.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc13270.html
+++ b/test/compilable/extra-files/ddoc13270.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc13645.html
+++ b/test/compilable/extra-files/ddoc13645.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc14.html
+++ b/test/compilable/extra-files/ddoc14.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc14383.html
+++ b/test/compilable/extra-files/ddoc14383.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc14413.html
+++ b/test/compilable/extra-files/ddoc14413.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc14778.html
+++ b/test/compilable/extra-files/ddoc14778.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc15475.html
+++ b/test/compilable/extra-files/ddoc15475.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc17697.html
+++ b/test/compilable/extra-files/ddoc17697.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc198.html
+++ b/test/compilable/extra-files/ddoc198.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc2.html
+++ b/test/compilable/extra-files/ddoc2.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc2273.html
+++ b/test/compilable/extra-files/ddoc2273.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc3.html
+++ b/test/compilable/extra-files/ddoc3.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc4162.html
+++ b/test/compilable/extra-files/ddoc4162.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc5.html
+++ b/test/compilable/extra-files/ddoc5.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc5446.html
+++ b/test/compilable/extra-files/ddoc5446.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc6.html
+++ b/test/compilable/extra-files/ddoc6.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc648.html
+++ b/test/compilable/extra-files/ddoc648.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc6491.html
+++ b/test/compilable/extra-files/ddoc6491.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc7.html
+++ b/test/compilable/extra-files/ddoc7.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc7555.html
+++ b/test/compilable/extra-files/ddoc7555.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc7656.html
+++ b/test/compilable/extra-files/ddoc7656.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc7715.html
+++ b/test/compilable/extra-files/ddoc7715.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc7795.html
+++ b/test/compilable/extra-files/ddoc7795.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc8.html
+++ b/test/compilable/extra-files/ddoc8.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc8271.html
+++ b/test/compilable/extra-files/ddoc8271.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc8739.html
+++ b/test/compilable/extra-files/ddoc8739.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9.html
+++ b/test/compilable/extra-files/ddoc9.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9037.html
+++ b/test/compilable/extra-files/ddoc9037.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9155.html
+++ b/test/compilable/extra-files/ddoc9155.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9305.html
+++ b/test/compilable/extra-files/ddoc9305.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9369.html
+++ b/test/compilable/extra-files/ddoc9369.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9475.html
+++ b/test/compilable/extra-files/ddoc9475.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9497a.html
+++ b/test/compilable/extra-files/ddoc9497a.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9497b.html
+++ b/test/compilable/extra-files/ddoc9497b.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9497c.html
+++ b/test/compilable/extra-files/ddoc9497c.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9497d.html
+++ b/test/compilable/extra-files/ddoc9497d.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9676a.html
+++ b/test/compilable/extra-files/ddoc9676a.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9676b.html
+++ b/test/compilable/extra-files/ddoc9676b.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9727.html
+++ b/test/compilable/extra-files/ddoc9727.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9789.html
+++ b/test/compilable/extra-files/ddoc9789.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc9903.html
+++ b/test/compilable/extra-files/ddoc9903.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddocYear.html
+++ b/test/compilable/extra-files/ddocYear.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_breaks.html
+++ b/test/compilable/extra-files/ddoc_markdown_breaks.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_breaks_verbose.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_code.html
+++ b/test/compilable/extra-files/ddoc_markdown_code.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_code_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_code_verbose.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_emphasis.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_emphasis_verbose.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_escapes.html
+++ b/test/compilable/extra-files/ddoc_markdown_escapes.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_headings.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_headings_verbose.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_links.html
+++ b/test/compilable/extra-files/ddoc_markdown_links.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_links_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_links_verbose.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_lists.html
+++ b/test/compilable/extra-files/ddoc_markdown_lists.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_lists_verbose.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_quote.html
+++ b/test/compilable/extra-files/ddoc_markdown_quote.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_quote_verbose.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddoc_markdown_tables.html
+++ b/test/compilable/extra-files/ddoc_markdown_tables.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>ddoc4</title>
+    <title>test.compilable.ddoc_markdown_tables</title>
     <style type="text/css" media="screen">
       html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
       blockquote, pre, a, abbr, address, cite, code, del, dfn, em, figure,
@@ -508,8 +508,43 @@
   <body id="ddoc_main" class="ddoc dlang">
     <div class="content_wrapper">
       <article class="module">
-        <h1 class="module_name">ddoc4</h1>
-        <section id="module_content">
+        <h1 class="module_name">test.compilable.ddoc_markdown_tables</h1>
+        <section id="module_content"><section class="section ddoc_sections">
+  <div class="ddoc_summary">
+  <p class="para">
+    <h1>Tables</h1>
+
+  </p>
+</div>
+<div class="ddoc_description">
+  <h4>Discussion</h4>
+  <p class="para">
+    <table><thead><tr><th>Rounding mode</th><th align="right">rndint(4.5)</th><th align="right">rndint(5.5)</th><th align="right">rndint(-4.5)</th><th>Notes</th></tr></thead><tbody><tr><td>Round to nearest</td><td align="right">4</td><td align="right">6</td><td align="right">-4</td><td>Ties round to an even number</td></tr>
+<tr><td>Round down</td><td align="right">4</td><td align="right">5</td><td align="right">-5</td><td>&nbsp;</td></tr>
+<tr><td>Round up</td><td align="right">5</td><td align="right">6</td><td align="right">-4</td><td>&nbsp;</td></tr>
+<tr><td>Round to zero</td><td align="right">4</td><td align="right">5</td><td align="right">-4</td><td>&nbsp;</td></tr>
+</tbody></table>
+<table>    <thead><tr><th>this</th><th>that</th></tr></thead><tbody>    <tr><td>cell</td><td>cell<br>sell</td></tr>
+</tbody></table>
+<table><thead><tr><th>abc</th><th>def</th></tr></thead><tbody><tr><td>bar</td></tr>
+<tr><td><em>bar</em></td><td>baz</td></tr>
+</tbody></table>
+<blockquote><table><thead><tr><th>quote</th></tr></thead><tbody><tr><td>table</td></tr>
+</tbody></table>
+</blockquote><ul><li><table><thead><tr>
+<th>list</th></tr></thead><tbody>  <tr><td>table</td></tr>
+</tbody></table></li>
+</ul>
+<table><thead><tr><th>default</th><th align="left">left</th><th align="center">center</th><th align="right">right</th></tr></thead><tbody></tbody></table>
+Look Ma, a table without a body!
+<br><br>
+| not | a | table |
+| -- |
+| wrong number of header columns |
+  </p>
+</div>
+
+</section>
 </section>
       </article>
     </div>

--- a/test/compilable/extra-files/ddoc_markdown_tables_verbose.html
+++ b/test/compilable/extra-files/ddoc_markdown_tables_verbose.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>ddoc4</title>
+    <title>test.compilable.ddoc_markdown_tables_verbose</title>
     <style type="text/css" media="screen">
       html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p,
       blockquote, pre, a, abbr, address, cite, code, del, dfn, em, figure,
@@ -508,8 +508,16 @@
   <body id="ddoc_main" class="ddoc dlang">
     <div class="content_wrapper">
       <article class="module">
-        <h1 class="module_name">ddoc4</h1>
-        <section id="module_content">
+        <h1 class="module_name">test.compilable.ddoc_markdown_tables_verbose</h1>
+        <section id="module_content"><section class="section ddoc_sections">
+  <div class="ddoc_section">
+  <p class="para">
+    <span class="ddoc_section_h">Table:</span>
+<table><thead><tr><th>this</th><th>that</th></tr></thead><tbody><tr><td>cell</td><td>cell</td></tr></tbody></table>
+  </p>
+</div>
+
+</section>
 </section>
       </article>
     </div>

--- a/test/compilable/extra-files/ddocbackticks.html
+++ b/test/compilable/extra-files/ddocbackticks.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 

--- a/test/compilable/extra-files/ddocunittest.html
+++ b/test/compilable/extra-files/ddocunittest.html
@@ -449,11 +449,18 @@
         min-width: 50px;
       }
 
+      .ddoc th {
+        margin: 0;
+        max-width: 260px;
+        padding: 5px 10px 5px 10px;
+        vertical-align: bottom;
+      }
+
       .ddoc td {
         border: 1px solid rgba(233, 233, 233, 1);
         margin: 0;
         max-width: 260px;
-        padding: 5px 25px 5px 10px;
+        padding: 5px 10px 5px 10px;
         vertical-align: middle;
       }
 


### PR DESCRIPTION
This is my last feature PR for markdown. I could theoretically also make a PR for [auto links](https://daringfireball.net/projects/markdown/syntax#autolink) but I don't believe they get used much, and Ddoc already autodetects links that start with `http`.

*A preview screenshot:*

![screenshot](https://i.postimg.cc/tgY7ZmPV/Screen-Shot-2019-04-04-at-9-25-06-PM.png)

*Proposed documentation:*

### Tables

Data may be placed into a table. Tables consist of a single header row, a delimiter row, and zero or more data rows. Cells in each row are separated by pipe (`|`) characters. Initial and trailing `|`'s are optional. The number of cells in the delimiter row must match the number of cells in the header row:

``` d
/**
 *  | Item | Price |
 *  | ---- | ----: |
 *  | Wigs | $10 |
 *    Wheels | $13
 *  | Widgets | $200 |
 */
```

Cells in the delimiter row contain hyphens (`-`) and optional colons (`:`). A `:` to the left of the hyphens creates a left-aligned column, a `:` to the right of the hyphens creates a right-aligned column (like the example above), and `:`'s on both sides of the hyphens create a center-aligned column.