### PR TITLE
For issue 19724, group library files explicitly listed with `-L=` in with other library-related `-L=` flags.

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -584,6 +584,7 @@ public int runLINK()
             return startsWith("-l") || startsWith("-L")
                 || flag == "-(" || flag == "-)"
                 || flag == "--start-group" || flag == "--end-group"
+                || FileName.equalsExt(flagp, "a")
             ;
         }
         /* Add libraries. The order of libraries passed is:

--- a/test/compilable/issue19724.sh
+++ b/test/compilable/issue19724.sh
@@ -45,3 +45,6 @@ ${DMD} -m${MODEL} -lib -of${D_LIB2} -I${TEST_DIR} ${D_LIBFILE2}
 # -lsecond -lfirst is wrong but for --start-group/--end-group,
 # so --start-group and --end-group must not be reordered relative to the libraries
 ${DMD} -m${MODEL} -of${APP} ${D_FILE} -I${TEST_DIR} -L-L${TEST_DIR} -L=--start-group -L-lsecond -L-lfirst -L=--end-group
+
+# analogously for libsecond.a libfirst.a
+${DMD} -m${MODEL} -of${APP} ${D_FILE} -I${TEST_DIR} -L-L${TEST_DIR} -L=--start-group -L=${TEST_DIR}/libsecond.a -L=${TEST_DIR}/libfirst.a -L=--end-group


### PR DESCRIPTION
Not just `-L-( -L-lfoo -L-lbar -L-)`, but also `-L-( -L=build/libfoo.a -L=build/libbar.a -L-)`.