### PR TITLE
Rename backend/memh.d to backend/mem.d

### DIFF
--- a/src/dmd/backend/blockopt.d
+++ b/src/dmd/backend/blockopt.d
@@ -34,7 +34,7 @@ import dmd.backend.oper;
 import dmd.backend.dlist;
 import dmd.backend.dvec;
 import dmd.backend.el;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.type;
 import dmd.backend.global;
 import dmd.backend.goh;

--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -28,7 +28,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.oper;

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -32,7 +32,7 @@ import dmd.backend.codebuilder;
 import dmd.backend.dlist;
 import dmd.backend.dvec;
 import dmd.backend.melf;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.exh;
 import dmd.backend.global;

--- a/src/dmd/backend/cgen.d
+++ b/src/dmd/backend/cgen.d
@@ -28,7 +28,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.obj;

--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -33,7 +33,7 @@ import dmd.backend.dlist;
 import dmd.backend.dvec;
 import dmd.backend.el;
 import dmd.backend.md5;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.global;
 import dmd.backend.obj;
 import dmd.backend.oper;

--- a/src/dmd/backend/cgsched.d
+++ b/src/dmd/backend/cgsched.d
@@ -29,7 +29,7 @@ import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.dlist;
 import dmd.backend.global;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.ty;
 import dmd.backend.barray;
 

--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -27,7 +27,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.oper;

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -29,7 +29,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.exh;
 import dmd.backend.global;

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -29,7 +29,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.exh;
 import dmd.backend.global;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -32,7 +32,7 @@ import dmd.backend.codebuilder;
 import dmd.backend.dlist;
 import dmd.backend.dvec;
 import dmd.backend.melf;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.exh;
 import dmd.backend.global;

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -28,7 +28,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.global;
 import dmd.backend.oper;

--- a/src/dmd/backend/codebuilder.d
+++ b/src/dmd/backend/codebuilder.d
@@ -19,7 +19,7 @@ import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.outbuf;
 import dmd.backend.ty;
 import dmd.backend.type;

--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -27,7 +27,7 @@ import dmd.backend.cgcv;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.cv4;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.exh;
 import dmd.backend.global;

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -37,7 +37,7 @@ import dmd.backend.dlist;
 import dmd.backend.dvec;
 import dmd.backend.el;
 import dmd.backend.global;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.obj;
 import dmd.backend.outbuf;
 import dmd.backend.ty;

--- a/src/dmd/backend/dcode.d
+++ b/src/dmd/backend/dcode.d
@@ -28,7 +28,7 @@ import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.global;
-import dmd.backend.memh;
+import dmd.backend.mem;
 
 extern (C++):
 

--- a/src/dmd/backend/dt.d
+++ b/src/dmd/backend/dt.d
@@ -19,7 +19,7 @@ import core.stdc.string;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.global;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.ty;
 import dmd.backend.type;
 

--- a/src/dmd/backend/dtype.d
+++ b/src/dmd/backend/dtype.d
@@ -36,7 +36,7 @@ import dmd.backend.cc;
 import dmd.backend.dlist;
 import dmd.backend.el;
 import dmd.backend.global;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.oper;
 import dmd.backend.ty;
 import dmd.backend.type;

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -55,7 +55,7 @@ import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.dlist;
 import dmd.backend.el;
 import dmd.backend.global;

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -50,7 +50,7 @@ import dmd.backend.el;
 import dmd.backend.evalu8 : el_toldoubled;
 import dmd.backend.global;
 import dmd.backend.goh;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.rtlsym;

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -32,7 +32,7 @@ import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.aarray;
 import dmd.backend.dlist;
 import dmd.backend.el;

--- a/src/dmd/backend/filespec.d
+++ b/src/dmd/backend/filespec.d
@@ -8,7 +8,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
-import dmd.backend.memh;
+import dmd.backend.mem;
 
 extern (C++):
 

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -27,7 +27,7 @@ import dmd.backend.code;
 import dmd.backend.dlist;
 import dmd.backend.el;
 import dmd.backend.el : elem;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.type;
 //import dmd.backend.obj;
 

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -39,7 +39,7 @@ import dmd.backend.type;
 
 import dmd.backend.dlist;
 import dmd.backend.dvec;
-import dmd.backend.memh;
+import dmd.backend.mem;
 
 char symbol_isintab(Symbol *s) { return sytab[s.Sclass] & SCSS; }
 

--- a/src/dmd/backend/machobj.d
+++ b/src/dmd/backend/machobj.d
@@ -28,7 +28,7 @@ import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.aarray;
 import dmd.backend.dlist;
 import dmd.backend.el;

--- a/src/dmd/backend/mem.d
+++ b/src/dmd/backend/mem.d
@@ -6,12 +6,12 @@
  *              Copyright (C) 2000-2019 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/memh.d, backend/memh.d)
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/memh.d
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/mem.d, backend/mem.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/mem.d
  */
 
 
-module dmd.backend.memh;
+module dmd.backend.mem;
 
 
 extern (C):

--- a/src/dmd/backend/mscoffobj.d
+++ b/src/dmd/backend/mscoffobj.d
@@ -29,7 +29,7 @@ import dmd.backend.dlist;
 import dmd.backend.dvec;
 import dmd.backend.el;
 import dmd.backend.md5;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.global;
 import dmd.backend.obj;
 import dmd.backend.outbuf;

--- a/src/dmd/backend/newman.d
+++ b/src/dmd/backend/newman.d
@@ -41,7 +41,7 @@ import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;
 import dmd.backend.code_x86;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.exh;
 import dmd.backend.global;

--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -26,7 +26,7 @@ import dmd.backend.code_x86;
 import dmd.backend.cv4;
 import dmd.backend.dt;
 import dmd.backend.dlist;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.el;
 import dmd.backend.exh;
 import dmd.backend.global;

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -42,7 +42,7 @@ import dmd.backend.dt;
 import dmd.backend.dvec;
 import dmd.backend.el;
 import dmd.backend.global;
-import dmd.backend.memh;
+import dmd.backend.mem;
 import dmd.backend.oper;
 import dmd.backend.ty;
 import dmd.backend.type;

--- a/src/dmd/backend/util2.d
+++ b/src/dmd/backend/util2.d
@@ -23,7 +23,7 @@ import core.stdc.stdint : uint64_t;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.global;
-import dmd.backend.memh;
+import dmd.backend.mem;
 
 extern (C++):
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -355,7 +355,7 @@ BACK_OBJS = \
 
 BACK_DOBJS = bcomplex.o evalu8.o divcoeff.o dvec.o go.o gsroa.o glocal.o gdag.o gother.o gflow.o \
 	out.o \
-	gloop.o compress.o cgelem.o cgcs.o ee.o cod4.o cod5.o nteh.o blockopt.o memh.o cg.o cgreg.o \
+	gloop.o compress.o cgelem.o cgcs.o ee.o cod4.o cod5.o nteh.o blockopt.o mem.o cg.o cgreg.o \
 	dtype.o debugprint.o fp.o symbol.o elem.o dcode.o cgsched.o cg87.o cgxmm.o cgcod.o cod1.o cod2.o \
 	cod3.o cv8.o dcgcv.o pdata.o util2.o var.o md5.o backconfig.o ph2.o drtlsym.o dwarfeh.o ptrntab.o \
 	aarray.o dvarstats.o dwarfdbginf.o elfobj.o cgen.o os.o goh.o barray.o
@@ -403,7 +403,7 @@ BACK_SRC = \
 	$C/pdata.d $C/cv8.d $C/backconfig.d $C/divcoeff.d \
 	$C/dvarstats.d $C/dvec.d \
 	$C/md5.d $C/barray.d \
-	$C/ph2.d $C/util2.d $C/dwarfeh.d $C/goh.d $C/memh.d $C/filespec.d \
+	$C/ph2.d $C/util2.d $C/dwarfeh.d $C/goh.d $C/mem.d $C/filespec.d \
 	$(TARGET_CH)
 
 TK_SRC = \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -180,7 +180,7 @@ GLUE_SRCS=$D/irstate.d $D/toctype.d $D/glue.d $D/gluelayer.d $D/todt.d $D/tocsym
 BACK_HDRS=$C/cc.d $C/cdef.d $C/cgcv.d $C/code.d $C/cv4.d $C/dt.d $C/el.d $C/global.d \
 	$C/obj.d $C/oper.d $C/outbuf.d $C/rtlsym.d $C/code_x86.d $C/iasm.d $C/codebuilder.d \
 	$C/ty.d $C/type.d $C/exh.d $C/mach.d $C/mscoff.d $C/dwarf.d $C/dwarf2.d $C/xmm.d \
-	$C/dlist.d $C/goh.d $C/memh.d $C/melf.d $C/varstats.di $C/barray.d
+	$C/dlist.d $C/goh.d $C/mem.d $C/melf.d $C/varstats.di $C/barray.d
 
 TK_HDRS=
 


### PR DESCRIPTION
The reason for this PR is to reduce the diff in https://github.com/dlang/dmd/pull/9579

There are 2 remaining .c files in the DMD repository:  `tk/mem.c` and `backend/tk.c`.  `backend/tk.c` just `#include`s `tk/mem.c`.  So, we only need one of them.

`backend/memh.d` is a translation of `tk/mem.h` to D.  See https://github.com/dlang/dmd/pull/8466

I want to translate `tk/mem.c` to D, move it to the backend directory, and delete `backend/memh.d`.  In fact I've already done that in #9575, but the diff is too big.  This will make that diff much smaller.