### PR TITLE
 Remove call to write() for Microsoft platforms in tk.c 

### DIFF
--- a/src/dmd/backend/tk.c
+++ b/src/dmd/backend/tk.c
@@ -21,7 +21,6 @@
 
 #if !MEM_DEBUG
 #define MEM_NOMEMCOUNT  1
-#define MEM_NONEW       1
 #endif
 
 #include        <stdio.h>

--- a/src/dmd/backend/tk.c
+++ b/src/dmd/backend/tk.c
@@ -364,15 +364,7 @@ int mem_exception()
         switch (behavior)
         {
             case MEM_ABORTMSG:
-#if MSDOS || __OS2__ || __NT__ || _WIN32
-                /* Avoid linking in buffered I/O */
-            {   static char msg[] = "Fatal error: out of memory\r\n";
-
-                write(1,msg,sizeof(msg) - 1);
-            }
-#else
                 fprintf(stderr, "Fatal error: out of memory\n");
-#endif
                 /* FALL-THROUGH */
             case MEM_ABORT:
                 exit(EXIT_FAILURE);


### PR DESCRIPTION
Followup to #9574 #9575 #9584 #9586 #9588 #9593 #9595 

Removing some more stuff that seems to be a vestige of a bygone era.   The goal is to make the conversion of tk.c to D easier to perform and review.