### PR TITLE
Update Appveyor to latest VisualD

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,12 @@ environment:
       D_COMPILER:          dmd
       D_VERSION:           2.079.1
       C_COMPILER:          MSVC
-      VISUALD_VER:         v0.45.1-rc2
+      VISUALD_VER:         v0.49.0
       LDC_VERSION:         1.8.0
 
 cache:
   - C:\projects\gnumake\make.exe
-  - C:\projects\VisualD-v0.45.1-rc2.exe
+  - C:\projects\VisualD-v0.49.0.exe
   - C:\projects\ldc2-1.8.0-windows-multilib.7z
 
 skip_commits:


### PR DESCRIPTION
From [this comment](https://github.com/dlang/dmd/pull/9592#issuecomment-482496512):

> The link fails because there is no longer a C++ file referencing the C runtime, and LDC doesn't add it to the object files. Easiest workaround would be to upgrade to the latest Visual D version 0.49 as it fixes that issue.