### PR TITLE
dmd.vcxproj: add C++ header files to project, use a CustomBuild tool …

### DIFF
--- a/src/vcbuild/dmd.vcxproj
+++ b/src/vcbuild/dmd.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project InitialTargets="optabgen_target" DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -78,6 +78,9 @@
     <_DCompilerExe Condition="'$(DCompiler)' == 'LDC' and '$(Platform)'=='Win32'">$(LDCBinDir)ldmd2.exe -m32</_DCompilerExe>
     <_DCompilerExe Condition="'$(_DCompilerExe)' == ''">$(DMDBinDir)dmd.exe</_DCompilerExe>
   </PropertyGroup>
+  <PropertyGroup>
+    <CustomBuildBeforeTargets>_DMD</CustomBuildBeforeTargets>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>..\..\generated\Windows\$(Configuration)\$(PlatformName)\</OutDir>
@@ -98,19 +101,6 @@
     <OutDir>..\..\generated\Windows\$(Configuration)\$(PlatformName)\</OutDir>
     <IntDir>$(OutDir)\dmd\</IntDir>
   </PropertyGroup>
-
-  <Target Name="optabgen_target"
-          Inputs="..\dmd\backend\optabgen.d;..\dmd\backend\cc.d;..\dmd\backend\cdef.d;..\dmd\backend\oper.d;..\dmd\backend\ty.d"
-          Outputs="$(IntDir)generated\optab.d;$(IntDir)generated\debtab.d;$(IntDir)generated\cdxxx.d;$(IntDir)generated\elxxx.d;$(IntDir)generated\tytab.d;$(IntDir)generated\fltables.d">
-    <Exec Command="$(_DCompilerExe) -I.. -version=MARS -of&quot;$(IntDir)generated\optabgen.exe&quot; ..\dmd\backend\optabgen.d
-if %errorlevel% neq 0 exit /b %errorlevel%
-pushd $(IntDir)generated
-.\optabgen.exe
-if %errorlevel% neq 0 exit /b %errorlevel%
-popd
-" />
-  </Target>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -219,7 +209,23 @@ popd
     </DCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <DCompile Include="../dmd/**/*.d" Exclude="../dmd/backend/optabgen.d;../dmd/frontend.d;../dmd/asttypename.d"/>
+    <DCompile Include="../dmd/**/*.d" Exclude="../dmd/backend/optabgen.d;../dmd/frontend.d;../dmd/asttypename.d" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="../dmd/**/*.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\dmd\backend\optabgen.d">
+      <Message>Building and running $(IntDir)%(Filename).exe</Message>
+      <Command>$(_DCompilerExe) -I.. -version=MARS -of"$(IntDir)generated\%(Filename).exe" "%(FullPath)"
+if errorlevel 1 exit /B %ERRORLEVEL%
+pushd $(IntDir)generated
+"%(Filename).exe"
+if errorlevel 1 exit /B %ERRORLEVEL%
+popd</Command>
+      <Outputs>$(IntDir)generated\optab.d;$(IntDir)generated\debtab.d;$(IntDir)generated\cdxxx.d;$(IntDir)generated\elxxx.d;$(IntDir)generated\tytab.d;$(IntDir)generated\\fltables.d;%(Outputs)</Outputs>
+      <AdditionalInputs>..\dmd\backend\cc.d;..\dmd\backend\cdef.d;..\dmd\backend\oper.d;..\dmd\backend\ty.d;%(AdditionalInputs)</AdditionalInputs>
+    </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/vcbuild/dmd.vcxproj.filters
+++ b/src/vcbuild/dmd.vcxproj.filters
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="C++ Header Files">
+      <UniqueIdentifier>{35d19260-bd4e-4027-b2d0-d61e0e33faa8}</UniqueIdentifier>
+      <Extensions>h</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Generator">
+      <UniqueIdentifier>{24fae367-afdb-4167-bbb8-d63f754c8294}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="../dmd/**/*.h">
+      <Filter>C++ Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\dmd\backend\optabgen.d">
+      <Filter>Generator</Filter>
+    </CustomBuild>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
…for optabgen.d

Followup to https://github.com/dlang/dmd/pull/9592

@ZombineDev The magic for `<CustomBuildBeforeTargets>` to work is to know that the target actually executed is `_DMD`.