### PR TITLE
Fix Issue 19809 - override block affects passing lambda as argument

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3337,7 +3337,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             funcdecl.error("`%s` functions cannot be `abstract`", sfunc);
         }
 
-        if (funcdecl.isOverride() && !funcdecl.isVirtual())
+        if (funcdecl.isOverride() && !funcdecl.isVirtual() && !funcdecl.isFuncLiteralDeclaration())
         {
             Prot.Kind kind = funcdecl.prot().kind;
             if ((kind == Prot.Kind.private_ || kind == Prot.Kind.package_) && funcdecl.isMember())

--- a/test/compilable/test19809.d
+++ b/test/compilable/test19809.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+mixin template Impl(M...)
+{
+    int opCmp(Object o) { return 0; }
+}
+
+class C
+{
+    override
+    {
+        int function(int) fp = ((int x) => x);
+        mixin Impl!("x", "y", ((int x) => x));
+    }
+}


### PR DESCRIPTION
Anonymous functions should be `exempt` from `override` keyword.