### PR TITLE
mark environment parameters in dmd.dinifile as ref instead of raw pointers

### DIFF
--- a/src/dmd/dinifile.d
+++ b/src/dmd/dinifile.d
@@ -113,7 +113,7 @@ const(char)[] findConfFile(const(char)[] argv0, const(char)[] inifile)
  * Returns:
  *      environment value corresponding to name
  */
-const(char)* readFromEnv(const(StringTable)* environment, const(char)* name)
+const(char)* readFromEnv(const ref StringTable environment, const(char)* name)
 {
     const len = strlen(name);
     const sv = environment.lookup(name, len);
@@ -125,7 +125,7 @@ const(char)* readFromEnv(const(StringTable)* environment, const(char)* name)
 /*********************************
  * Write to our copy of the environment, not the real environment
  */
-private bool writeToEnv(StringTable* environment, char* nameEqValue)
+private bool writeToEnv(ref StringTable environment, char* nameEqValue)
 {
     auto p = strchr(nameEqValue, '=');
     if (!p)
@@ -140,7 +140,7 @@ private bool writeToEnv(StringTable* environment, char* nameEqValue)
  * Params:
  *      environment = our copy of the environment
  */
-void updateRealEnvironment(StringTable* environment)
+void updateRealEnvironment(ref StringTable environment)
 {
     static int envput(const(StringValue)* sv)
     {
@@ -177,7 +177,7 @@ void updateRealEnvironment(StringTable* environment)
  *      buffer = contents of configuration file
  *      sections = section names
  */
-void parseConfFile(StringTable* environment, const(char)* filename, const(char)* path, size_t length, const(ubyte)* buffer, const(Strings)* sections)
+void parseConfFile(ref StringTable environment, const(char)* filename, const(char)* path, size_t length, const(ubyte)* buffer, const(Strings)* sections)
 {
     /********************
      * Skip spaces.

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -203,7 +203,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
      * pick up any DFLAGS settings.
      */
     sections.push("Environment");
-    parseConfFile(&environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
+    parseConfFile(environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
 
     const(char)* arch = params.is64bit ? "64" : "32"; // use default
     arch = parse_arch_arg(&arguments, arch);
@@ -211,7 +211,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     // parse architecture from DFLAGS read from [Environment] section
     {
         Strings dflags;
-        getenv_setargv(readFromEnv(&environment, "DFLAGS"), &dflags);
+        getenv_setargv(readFromEnv(environment, "DFLAGS"), &dflags);
         environment.reset(7); // erase cached environment updates
         arch = parse_arch_arg(&dflags, arch);
     }
@@ -226,9 +226,9 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     char[80] envsection = void;
     sprintf(envsection.ptr, "Environment%s", arch);
     sections.push(envsection.ptr);
-    parseConfFile(&environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
-    getenv_setargv(readFromEnv(&environment, "DFLAGS"), &arguments);
-    updateRealEnvironment(&environment);
+    parseConfFile(environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
+    getenv_setargv(readFromEnv(environment, "DFLAGS"), &arguments);
+    updateRealEnvironment(environment);
     environment.reset(1); // don't need environment cache any more
 
     if (parseCommandLine(arguments, argc, params, files))
@@ -1295,7 +1295,7 @@ extern(C) void printGlobalConfigs(FILE* stream)
         StringTable environment;
         environment._init(0);
         Strings dflags;
-        getenv_setargv(readFromEnv(&environment, "DFLAGS"), &dflags);
+        getenv_setargv(readFromEnv(environment, "DFLAGS"), &dflags);
         environment.reset(1);
         OutBuffer buf;
         foreach (flag; dflags[])


### PR DESCRIPTION
Another easy fix, I hope.