### PR TITLE
have dinifile.parseConfFile take a ubyte[] instead of a ubyte*+length pair

### DIFF
--- a/src/dmd/dinifile.d
+++ b/src/dmd/dinifile.d
@@ -173,11 +173,10 @@ void updateRealEnvironment(ref StringTable environment)
  *      environment = our own cache of the program environment
  *      filename = name of the file being parsed
  *      path = what @P will expand to
- *      length = length of the configuration file buffer
  *      buffer = contents of configuration file
  *      sections = section names
  */
-void parseConfFile(ref StringTable environment, const(char)* filename, const(char)* path, size_t length, const(ubyte)* buffer, const(Strings)* sections)
+void parseConfFile(ref StringTable environment, const(char)* filename, const(char)* path, const(ubyte)[] buffer, const(Strings)* sections)
 {
     /********************
      * Skip spaces.
@@ -194,11 +193,11 @@ void parseConfFile(ref StringTable environment, const(char)* filename, const(cha
     OutBuffer buf;
     bool eof = false;
     int lineNum = 0;
-    for (size_t i = 0; i < length && !eof; i++)
+    for (size_t i = 0; i < buffer.length && !eof; i++)
     {
     Lstart:
         const linestart = i;
-        for (; i < length; i++)
+        for (; i < buffer.length; i++)
         {
             switch (buffer[i])
             {

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -203,7 +203,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
      * pick up any DFLAGS settings.
      */
     sections.push("Environment");
-    parseConfFile(environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
+    parseConfFile(environment, global.inifilename, inifilepath, inifile.buffer[0..inifile.len], &sections);
 
     const(char)* arch = params.is64bit ? "64" : "32"; // use default
     arch = parse_arch_arg(&arguments, arch);
@@ -226,7 +226,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     char[80] envsection = void;
     sprintf(envsection.ptr, "Environment%s", arch);
     sections.push(envsection.ptr);
-    parseConfFile(environment, global.inifilename, inifilepath, inifile.len, inifile.buffer, &sections);
+    parseConfFile(environment, global.inifilename, inifilepath, inifile.buffer[0..inifile.len], &sections);
     getenv_setargv(readFromEnv(environment, "DFLAGS"), &arguments);
     updateRealEnvironment(environment);
     environment.reset(1); // don't need environment cache any more


### PR DESCRIPTION
A `File.readArray()` method would make this even nicer.