### PR TITLE
Rename `toParent4`/`isMember4` to `toParentDecl`/`isMemberDecl`

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -89,7 +89,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
         if (fd &&
             ((fd.isCtorDeclaration() && var.isField()) ||
              (fd.isStaticCtorDeclaration() && !var.isField())) &&
-            fd.toParent4() == var.toParent2() &&
+            fd.toParentDecl() == var.toParent2() &&
             (!e1 || e1.op == TOK.this_))
         {
             bool result = true;
@@ -104,7 +104,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
                                  var.type.needsNested());
 
                 const dim = sc.ctorflow.fieldinit.length;
-                auto ad = fd.isMember4();
+                auto ad = fd.isMemberDecl();
                 assert(ad);
                 size_t i;
                 for (i = 0; i < dim; i++) // same as findFieldIndexByName in ctfeexp.c ?

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -286,7 +286,7 @@ struct Scope
             FuncDeclaration f = func;
             if (fes)
                 f = fes.func;
-            auto ad = f.isMember4();
+            auto ad = f.isMemberDecl();
             assert(ad);
             foreach (i, v; ad.fields)
             {

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -476,7 +476,7 @@ extern (C++) class Dsymbol : ASTNode
      * `toParent3()` returns a logically enclosing scope symbol this is a member of.
      * It skips over TemplateMixin's.
      *
-     * `toParent4()` similar to `toParent2()` but always follows the template declaration scope
+     * `toParentDecl()` similar to `toParent2()` but always follows the template declaration scope
      * instead of the instantiation scope.
      *
      * Examples:
@@ -519,15 +519,15 @@ extern (C++) class Dsymbol : ASTNode
     }
 
     /// ditto
-    final inout(Dsymbol) toParent4() inout
+    final inout(Dsymbol) toParentDecl() inout
     {
         auto p = toParent();
         if (!p || !p.isTemplateInstance())
             return p;
         auto ti = p.isTemplateInstance();
         if (ti.enclosing && ti.tempdecl && !(cast(TemplateDeclaration)ti.tempdecl).isstatic)
-            return ti.tempdecl.toParent4();
-        return parent.toParent4();
+            return ti.tempdecl.toParentDecl();
+        return parent.toParentDecl();
     }
 
     final inout(TemplateInstance) isInstantiated() inout
@@ -920,11 +920,11 @@ extern (C++) class Dsymbol : ASTNode
         return p ? p.isAggregateDeclaration() : null;
     }
 
-    /// Returns an AggregateDeclaration when toParent4() is that.
-    final inout(AggregateDeclaration) isMember4() inout
+    /// Returns an AggregateDeclaration when toParentDecl() is that.
+    final inout(AggregateDeclaration) isMemberDecl() inout
     {
-        //printf("Dsymbol::isMember4() '%s'\n", toChars());
-        auto p = toParent4();
+        //printf("Dsymbol::isMemberDecl() '%s'\n", toChars());
+        auto p = toParentDecl();
         //printf("parent is %s %s\n", p.kind(), p.toChars());
         return p ? p.isAggregateDeclaration() : null;
     }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -178,7 +178,7 @@ public:
     Dsymbol *toParent();
     Dsymbol *toParent2();
     Dsymbol *toParent3();
-    Dsymbol *toParent4();
+    Dsymbol *toParentDecl();
     TemplateInstance *isInstantiated();
     TemplateInstance *isSpeculative();
     Ungag ungagSpeculative();
@@ -209,7 +209,7 @@ public:
     virtual LabelDsymbol *isLabel();            // is this a LabelDsymbol?
     AggregateDeclaration *isMember();           // is this a member of an AggregateDeclaration?
     AggregateDeclaration *isMember2();          // is this a member of an AggregateDeclaration?
-    AggregateDeclaration *isMember4();          // is this a member of an AggregateDeclaration?
+    AggregateDeclaration *isMemberDecl();          // is this a member of an AggregateDeclaration?
     ClassDeclaration *isClassMember();          // is this a member of a ClassDeclaration?
     virtual Type *getType();                    // is this a type?
     virtual bool needThis();                    // need a 'this' pointer?

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1167,7 +1167,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 if (func.fes)
                     func = func.fes.func;
                 bool isWild = false;
-                for (FuncDeclaration fd = func; fd; fd = fd.toParent4().isFuncDeclaration())
+                for (FuncDeclaration fd = func; fd; fd = fd.toParentDecl().isFuncDeclaration())
                 {
                     if ((cast(TypeFunction)fd.type).iswild)
                     {
@@ -3899,7 +3899,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         }
 
         ctd.parent = sc.parent;
-        Dsymbol p = ctd.toParent4();
+        Dsymbol p = ctd.toParentDecl();
         AggregateDeclaration ad = p.isAggregateDeclaration();
         if (!ad)
         {
@@ -5082,23 +5082,23 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 // Use the base class's 'this' member
                 if (cldec.storage_class & STC.static_)
                     cldec.error("static class cannot inherit from nested class `%s`", cldec.baseClass.toChars());
-                if (cldec.toParent4() != cldec.baseClass.toParent4() &&
-                    (!cldec.toParent4() ||
-                     !cldec.baseClass.toParent4().getType() ||
-                     !cldec.baseClass.toParent4().getType().isBaseOf(cldec.toParent4().getType(), null)))
+                if (cldec.toParentDecl() != cldec.baseClass.toParentDecl() &&
+                    (!cldec.toParentDecl() ||
+                     !cldec.baseClass.toParentDecl().getType() ||
+                     !cldec.baseClass.toParentDecl().getType().isBaseOf(cldec.toParentDecl().getType(), null)))
                 {
-                    if (cldec.toParent4())
+                    if (cldec.toParentDecl())
                     {
                         cldec.error("is nested within `%s`, but super class `%s` is nested within `%s`",
-                            cldec.toParent4().toChars(),
+                            cldec.toParentDecl().toChars(),
                             cldec.baseClass.toChars(),
-                            cldec.baseClass.toParent4().toChars());
+                            cldec.baseClass.toParentDecl().toChars());
                     }
                     else
                     {
                         cldec.error("is not nested, but super class `%s` is nested within `%s`",
                             cldec.baseClass.toChars(),
-                            cldec.baseClass.toParent4().toChars());
+                            cldec.baseClass.toParentDecl().toChars());
                     }
                     cldec.enclosing = null;
                 }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2174,7 +2174,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             // isReturnIsolated() in functionResolve.
             scx.flags |= SCOPE.ctor;
 
-            Dsymbol parent = toParent4();
+            Dsymbol parent = toParentDecl();
             Type tret;
             AggregateDeclaration ad = parent.isAggregateDeclaration();
             if (!ad || parent.isUnionDeclaration())

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -341,7 +341,7 @@ private elem *callfunc(const ref Loc loc,
         }
     }
 
-    if (fd && fd.isMember4())
+    if (fd && fd.isMemberDecl())
     {
         assert(op == NotIntrinsic);       // members should not be intrinsics
 
@@ -1678,7 +1678,7 @@ elem *toElem(Expression e, IRState *irs)
                     //printf("cdthis = %s\n", cdthis.toChars());
                     assert(cd.isNested());
                     int offset = 0;
-                    Dsymbol cdp = cd.toParent4();     // class we're nested in
+                    Dsymbol cdp = cd.toParentDecl();     // class we're nested in
 
                     //printf("member = %p\n", member);
                     //printf("cdp = %s\n", cdp.toChars());

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -186,7 +186,7 @@ bool isNeedThisScope(Scope* sc, Declaration d)
         return false;
     //printf("d = %s, ad = %s\n", d.toChars(), ad.toChars());
 
-    for (Dsymbol s = sc.parent; s; s = s.toParent4())
+    for (Dsymbol s = sc.parent; s; s = s.toParentDecl())
     {
         //printf("\ts = %s %s, toParent2() = %p\n", s.kind(), s.toChars(), s.toParent2());
         if (AggregateDeclaration ad2 = s.isAggregateDeclaration())
@@ -200,7 +200,7 @@ bool isNeedThisScope(Scope* sc, Declaration d)
         }
         if (FuncDeclaration f = s.isFuncDeclaration())
         {
-            if (f.isMember4())
+            if (f.isMemberDecl())
                 break;
         }
     }
@@ -910,7 +910,7 @@ extern (C++) abstract class Expression : ASTNode
                 if (auto dve = this.isDotVarExp())
                 {
                     if (isNeedThisScope(sc, dve.var))
-                        for (Dsymbol s = sc.func; s; s = s.toParent4())
+                        for (Dsymbol s = sc.func; s; s = s.toParentDecl())
                     {
                         FuncDeclaration ff = s.isFuncDeclaration();
                         if (!ff)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1007,7 +1007,7 @@ Lagain:
     }
     if (TemplateDeclaration td = s.isTemplateDeclaration())
     {
-        Dsymbol p = td.toParent4();
+        Dsymbol p = td.toParentDecl();
         FuncDeclaration fdthis = hasThis(sc);
         AggregateDeclaration ad = p ? p.isAggregateDeclaration() : null;
         if (fdthis && ad && isAggregate(fdthis.vthis.type) == ad && (td._scope.stc & STC.static_) == 0)
@@ -2694,7 +2694,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e.var = fd.vthis;
         assert(e.var && e.var.parent);
 
-        s = fd.toParent4();
+        s = fd.toParentDecl();
         if (s.isTemplateDeclaration()) // allow inside template constraint
             s = s.toParent();
         assert(s);
@@ -3075,7 +3075,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (TemplateDeclaration td = ti.tempdecl.isTemplateDeclaration())
                 {
-                    Dsymbol p = td.toParent4();
+                    Dsymbol p = td.toParentDecl();
                     FuncDeclaration fdthis = hasThis(sc);
                     AggregateDeclaration ad = p ? p.isAggregateDeclaration() : null;
                     if (fdthis && ad && isAggregate(fdthis.vthis.type) == ad && (td._scope.stc & STC.static_) == 0)
@@ -3325,7 +3325,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 /* We need a 'this' pointer for the nested class.
                  * Ensure we have the right one.
                  */
-                Dsymbol s = cd.toParent4();
+                Dsymbol s = cd.toParentDecl();
 
                 //printf("cd isNested, parent = %s '%s'\n", s.kind(), s.toPrettyChars());
                 if (auto cdn = s.isClassDeclaration())
@@ -3334,7 +3334,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     {
                         // Supply an implicit 'this' and try again
                         exp.thisexp = new ThisExp(exp.loc);
-                        for (Dsymbol sp = sc.parent; 1; sp = sp.toParent4())
+                        for (Dsymbol sp = sc.parent; 1; sp = sp.toParentDecl())
                         {
                             if (!sp)
                             {
@@ -4345,7 +4345,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             if (exp.f.needThis())
             {
-                AggregateDeclaration ad = exp.f.toParent4().isAggregateDeclaration();
+                AggregateDeclaration ad = exp.f.toParentDecl().isAggregateDeclaration();
                 ue.e1 = getRightThis(exp.loc, sc, ad, ue.e1, exp.f);
                 if (ue.e1.op == TOK.error)
                 {
@@ -5915,7 +5915,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         e.type = e.type.typeSemantic(e.loc, sc);
 
         FuncDeclaration f = e.func.toAliasFunc();
-        AggregateDeclaration ad = f.toParent4().isAggregateDeclaration();
+        AggregateDeclaration ad = f.toParentDecl().isAggregateDeclaration();
         if (f.needThis())
             e.e1 = getRightThis(e.loc, sc, ad, e.e1, f);
 

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -378,7 +378,7 @@ extern (C++) class FuncDeclaration : Declaration
         if (isInstantiated() && !isVirtualMethod() &&
             ((ti = parent.isTemplateInstance()) is null || ti.isTemplateMixin() || ti.tempdecl.ident == ident))
         {
-            AggregateDeclaration ad = isMember4();
+            AggregateDeclaration ad = isMemberDecl();
             if (ad && ad.sizeok != Sizeok.done)
             {
                 /* Currently dmd cannot resolve forward references per methods,
@@ -1610,7 +1610,7 @@ extern (C++) class FuncDeclaration : Declaration
     override inout(AggregateDeclaration) isThis() inout
     {
         //printf("+FuncDeclaration::isThis() '%s'\n", toChars());
-        auto ad = (storage_class & STC.static_) ? objc.isThis(this) : isMember4();
+        auto ad = (storage_class & STC.static_) ? objc.isThis(this) : isMemberDecl();
         //printf("-FuncDeclaration::isThis() %p\n", ad);
         return ad;
     }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -551,7 +551,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 sym.endlinnum = funcdecl.endloc.linnum;
                 sc2 = sc2.push(sym);
 
-                auto ad2 = funcdecl.isMember4();
+                auto ad2 = funcdecl.isMemberDecl();
 
                 /* If this is a class constructor
                  */
@@ -1074,7 +1074,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 {
                     /* Wrap the entire function body in a synchronized statement
                      */
-                    ClassDeclaration cd = funcdecl.toParent4().isClassDeclaration();
+                    ClassDeclaration cd = funcdecl.toParentDecl().isClassDeclaration();
                     if (cd)
                     {
                         if (!global.params.is64bit && global.params.isWindows && !funcdecl.isStatic() && !sbody.usesEH() && !global.params.trace)
@@ -1272,7 +1272,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
          * structs should be benign.
          * https://issues.dlang.org/show_bug.cgi?id=14246
          */
-        AggregateDeclaration ad = ctor.isMember4();
+        AggregateDeclaration ad = ctor.isMemberDecl();
         if (ad && ad.fieldDtor && global.params.dtorFields)
         {
             /* Generate:

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3310,7 +3310,7 @@ else
 
         if (sc.ctorflow.fieldinit.length)       // if aggregate fields are being constructed
         {
-            auto ad = fd.isMember4();
+            auto ad = fd.isMemberDecl();
             assert(ad);
             foreach (i, v; ad.fields)
             {

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -92,7 +92,7 @@ uint cv4_memfunctypidx(FuncDeclaration fd)
     //printf("cv4_memfunctypidx(fd = '%s')\n", fd.toChars());
 
     type *t = Type_toCtype(fd.type);
-    if (AggregateDeclaration ad = fd.isMember4())
+    if (AggregateDeclaration ad = fd.isMemberDecl())
     {
         // It's a member function, which gets a special type record
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3870,7 +3870,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 if (mt.sym.vthis.semanticRun == PASS.init)
                     mt.sym.vthis.dsymbolSemantic(null);
 
-                if (auto cdp = mt.sym.toParent4().isClassDeclaration())
+                if (auto cdp = mt.sym.toParentDecl().isClassDeclaration())
                 {
                     auto dve = new DotVarExp(e.loc, e, mt.sym.vthis);
                     dve.type = cdp.type.addMod(e.type.mod);
@@ -3880,7 +3880,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 /* https://issues.dlang.org/show_bug.cgi?id=15839
                  * Find closest parent class through nested functions.
                  */
-                for (auto p = mt.sym.toParent4(); p; p = p.toParent4())
+                for (auto p = mt.sym.toParentDecl(); p; p = p.toParentDecl())
                 {
                     auto fd = p.isFuncDeclaration();
                     if (!fd)


### PR DESCRIPTION
This makes it clearer especially when another variant is probably in its way.