### PR TITLE
Fix Issue 19661 - DMD 2.084.0 SIGSEGV in std.traits.isFunction

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -882,7 +882,7 @@ Lagain:
     if (auto v = s.isVarDeclaration())
     {
         //printf("Identifier '%s' is a variable, type '%s'\n", s.toChars(), v.type.toChars());
-        if (sc.intypeof == 1)
+        if (sc.intypeof == 1 && !v.inuse)
             v.dsymbolSemantic(sc);
         if (!v.type ||                  // during variable type inference
             !v.type.deco && v.inuse)    // during variable type semantic

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -391,6 +391,8 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
                 return i;
             }
             i.exp = i.exp.ctfeInterpret();
+            if (i.exp.op == TOK.voidExpression)
+                error(i.loc, "variables cannot be initialized with an expression of type `void`. Use `void` initialization instead.");
         }
         else
         {

--- a/test/fail_compilation/imports/imp19661.d
+++ b/test/fail_compilation/imports/imp19661.d
@@ -1,0 +1,17 @@
+template isFunction(X...)
+if (X.length == 1)
+{
+    static if (is(typeof(&X[0]) U : U*) && is(U == function) ||
+               is(typeof(&X[0]) U == delegate))
+    {
+        // x is a (nested) function symbol.
+        enum isFunction = true;
+    }
+    else static if (is(X[0] T))
+    {
+        // x is a type.  Take the type of it and examine.
+        enum isFunction = is(T == function);
+    }
+    else
+        enum isFunction = false;
+}

--- a/test/fail_compilation/test19661.d
+++ b/test/fail_compilation/test19661.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test19661.d(10): Error: variables cannot be initialized with an expression of type `void`. Use `void` initialization instead.
+---
+*/
+
+module ice19661;
+
+immutable bool testModule = testFunctionMembers!();
+
+void testFunctionMembers()() {
+    import imports.imp19661 : isFunction;
+    foreach(member; __traits(allMembers, ice19661)) {
+        bool b = isFunction!(__traits(getMember, ice19661, member));
+    }
+}


### PR DESCRIPTION
```d
module test;

public immutable bool testModule = testFunctionMembers!"test";    // line 3

public void testFunctionMembers(string module_)() {
    import std.traits : isFunction;
    mixin(`import dmodule = ` ~ module_ ~ `;`);
    foreach(member; __traits(allMembers, dmodule)) {
        const bool isfunc = isFunction!(__traits(getMember, dmodule, member));
    }
}
```

Fixing the regression for this code led to outputting the error message : "Error: cannot implicitly convert expression <void> of type void to immutable(bool)" ; the line number is missing, but it refers to line 3.
I wanted to fix that also by adding the line number to the error, but noticed that this code  compiles fine:

```d
immutable bool b = void;
```

In light of this example, I modified the code so that when an ExpInitializer that is evaluated to a VoidExpression is encountered, a VoidInitializer is returned. This made the code in the original bug post compile successfully, which I believe is the right fix.