### PR TITLE
 Move auto-update script for code-gen tests into d_do_test

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -161,6 +161,7 @@ void ensureToolsExists(const TestTool[] tools ...)
         {
             const command = [
                 hostDMD,
+                "-g",
                 "-of"~targetBin,
                 sourceFile
             ] ~ tool.extraArgs;

--- a/test/runnable/test_cdvecfill.d
+++ b/test/runnable/test_cdvecfill.d
@@ -5,101 +5,10 @@
 debug = PRINTF;
 debug (PRINTF) import core.stdc.stdio;
 
-// Run this after codegen changes:
-// env DMD=generated/linux/release/64/dmd rdmd -fPIC -version=update test/runnable/test_cdvecfill.d
-version (update)
-{
-    import std.algorithm : canFind, find, splitter, until;
-    import std.array : appender, join;
-    import std.conv : to;
-    import std.exception : enforce;
-    import std.file : readText;
-    import std.format : formattedWrite;
-    import std.meta : AliasSeq;
-    import std.path : baseName, setExtension;
-    import std.process : environment, execute, pipeProcess, wait;
-    import std.range : dropOne;
-    import std.regex : ctRegex, matchFirst, replaceFirstInto;
-    import std.stdio : File, stdout, writeln;
-    import std.string : strip;
-    import std.traits : EnumMembers;
-    import std.typecons : tuple;
-
-    enum Arch
-    {
-        baseline,
-        avx,
-        avx2,
-    }
-
-    size_t[] sizes(Arch arch)
-    {
-        final switch (arch)
-        {
-        case Arch.baseline:
-            return [16];
-        case Arch.avx:
-        case Arch.avx2:
-            return [16, 32];
-        }
-    }
-
-    enum asmRE = ctRegex!`^\s+[\da-z]+:((\s[\da-z]{2})*)(.*)$`;
-
-    void formatASM(Captures, Sink)(Captures cap, Sink sink)
-    {
-        formattedWrite(sink, "        /* %-30s */ %-(0x%s,%| %)\n", cap[3].strip, cap[1].splitter);
-    }
-
-    void main()
-    {
-        enum src = __FILE__;
-        auto dmd = environment.get("DMD", "dmd");
-        auto sink = appender!string();
-        foreach (arch; [EnumMembers!Arch])
-        {
-            auto args = [dmd, "-c", "-O", "-fPIC", "-mcpu=" ~ arch.to!string, __FILE__];
-            auto rc = execute(args);
-            enforce(rc.status == 0, rc.output);
-            formattedWrite(sink, "alias %sCases = AliasSeq!(\n", arch);
-            // Just add empty Code!(newtype, count)(null) elements when adding a new type
-            foreach (type; AliasSeq!(ubyte, byte, ushort, short, uint, int,
-                    ulong, long, float, double))
-            {
-                foreach (sz; sizes(arch))
-                {
-                    foreach (suffix; [tuple("", ""), tuple("_ptr", "*")])
-                    {
-                        args = ["objdump", "--disassemble", "--disassembler-options=intel-mnemonic",
-                            "--section=.text.testee_" ~ type.stringof ~ suffix[0] ~ "_" ~ (sz / type.sizeof)
-                                .to!string, __FILE__.baseName.setExtension(".o")];
-                        auto p = pipeProcess(args);
-                        formattedWrite(sink, "    Code!(%s%s, %s / %s.sizeof)([\n",
-                                type.stringof, suffix[1], sz, type.stringof);
-                        foreach (line; p.stdout.byLine.find!(ln => ln.matchFirst(ctRegex!">:$"))
-                                .dropOne.until!(ln => ln.canFind("...")))
-                        {
-                            replaceFirstInto!formatASM(sink, line, asmRE);
-                        }
-                        formattedWrite(sink, "    ]),\n");
-                        enforce(wait(p.pid) == 0, p.stderr.byLine.join("\n"));
-                    }
-                }
-            }
-            formattedWrite(sink, ");\n\n");
-        }
-        {
-            auto content = src.readText;
-            auto f = File(src, "w");
-            auto orng = f.lockingTextWriter;
-            immutable string start = "// dfmt off";
-            immutable string end = "// dfmt on";
-            replaceFirstInto!((_, orng) => formattedWrite(orng, start ~ "\n%s" ~ end, sink.data))(orng,
-                    content, ctRegex!(`^` ~ start ~ `[^$]*` ~ end ~ `$`, "m"));
-        }
-    }
-}
-else:
+/*
+Automatically update this file with:
+./run.d runnable/test_cdvecfill.d AUTO_UPDATE=1
+*/
 
 template testee(T, int N)
 {


### PR DESCRIPTION
Now it clearly shows that no Phobos is required to run the codegen tests.
The extraction of the assembly is a bit tricky and for now I tried to stay as close to the update scripts as possible. In the future (if we add more of these codegen tests), we might want to search for all `testee_` sections in the object file automatically.