### PR TITLE
pass response_expand's args by ref instead of by pointer

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -154,7 +154,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             goto Largs;
         arguments[i] = argv[i];
     }
-    if (response_expand(&arguments)) // expand response files
+    if (response_expand(arguments)) // expand response files
         error(Loc.initial, "can't open response file");
     //for (size_t i = 0; i < arguments.dim; ++i) printf("arguments[%d] = '%s'\n", i, arguments[i]);
     files.reserve(arguments.dim - 1);

--- a/src/dmd/root/response.d
+++ b/src/dmd/root/response.d
@@ -47,13 +47,13 @@ import dmd.root.filename;
  *   0   success
  *   !=0   failure (argc, argv unchanged)
  */
-bool response_expand(Strings* args)
+bool response_expand(ref Strings args)
 {
     const(char)* cp;
     int recurse = 0;
     for (size_t i = 0; i < args.dim;)
     {
-        cp = (*args)[i];
+        cp = args[i];
         if (*cp != '@')
         {
             ++i;


### PR DESCRIPTION
Going after some more low-hanging fruit.