### PR TITLE
have the delegates used by dmd.root.speller take arrays instead of pointers

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -571,16 +571,15 @@ struct Scope
          * Given the failed search attempt, try to find
          * one with a close spelling.
          */
-        extern (D) void* scope_search_fp(const(char)* seed, ref int cost)
+        extern (D) void* scope_search_fp(const(char)[] seed, ref int cost)
         {
             //printf("scope_search_fp('%s')\n", seed);
             /* If not in the lexer's string table, it certainly isn't in the symbol table.
              * Doing this first is a lot faster.
              */
-            size_t len = strlen(seed);
-            if (!len)
+            if (!seed.length)
                 return null;
-            Identifier id = Identifier.lookup(seed, len);
+            Identifier id = Identifier.lookup(seed);
             if (!id)
                 return null;
             Scope* sc = &this;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -756,15 +756,14 @@ extern (C++) class Dsymbol : ASTNode
         /***************************************************
          * Search for symbol with correct spelling.
          */
-        extern (D) void* symbol_search_fp(const(char)* seed, ref int cost)
+        extern (D) void* symbol_search_fp(const(char)[] seed, ref int cost)
         {
             /* If not in the lexer's string table, it certainly isn't in the symbol table.
              * Doing this first is a lot faster.
              */
-            size_t len = strlen(seed);
-            if (!len)
+            if (!seed.length)
                 return null;
-            Identifier id = Identifier.lookup(seed, len);
+            Identifier id = Identifier.lookup(seed);
             if (!id)
                 return null;
             cost = 0;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1780,14 +1780,13 @@ Lnext:
         return r.expressionSemantic(sc);
     }
 
-    extern (D) void* trait_search_fp(const(char)* seed, ref int cost)
+    extern (D) void* trait_search_fp(const(char)[] seed, ref int cost)
     {
         //printf("trait_search_fp('%s')\n", seed);
-        size_t len = strlen(seed);
-        if (!len)
+        if (!seed.length)
             return null;
         cost = 0;
-        StringValue* sv = traitsStringTable.lookup(seed, len);
+        StringValue* sv = traitsStringTable.lookup(seed);
         return sv ? sv.ptrvalue : null;
     }
 


### PR DESCRIPTION
Say goodbye to some `strlen()`s.