### PR TITLE
remove unnecessary charset parameter in dmd.root.speller functions

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -601,7 +601,7 @@ struct Scope
             return cast(void*)s;
         }
 
-        return cast(Dsymbol)speller(ident.toChars(), &scope_search_fp, idchars);
+        return cast(Dsymbol)speller(ident.toChars(), &scope_search_fp);
     }
 
     /************************************

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -774,7 +774,7 @@ extern (C++) class Dsymbol : ASTNode
 
         if (global.gag)
             return null; // don't do it for speculative compiles; too time consuming
-        return cast(Dsymbol)speller(ident.toChars(), &symbol_search_fp, idchars);
+        return cast(Dsymbol)speller(ident.toChars(), &symbol_search_fp);
     }
 
     /***************************************

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1790,7 +1790,7 @@ Lnext:
         return sv ? sv.ptrvalue : null;
     }
 
-    if (auto sub = cast(const(char)*)speller(e.ident.toChars(), &trait_search_fp, idchars))
+    if (auto sub = cast(const(char)*)speller(e.ident.toChars(), &trait_search_fp))
         e.error("unrecognized trait `%s`, did you mean `%s`?", e.ident.toChars(), sub);
     else
         e.error("unrecognized trait `%s`", e.ident.toChars());


### PR DESCRIPTION
Removing the now-useless `if (charset.length)`s made the diffs look bigger than they really are. Despite how  the changes look, the only things that changed for the function bodies were indentation and instances of charset being changed to directly reference idchars instead.