### PR TITLE
make speller's search delegate parameter into an alias parameter

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -571,7 +571,7 @@ struct Scope
          * Given the failed search attempt, try to find
          * one with a close spelling.
          */
-        extern (D) void* scope_search_fp(const(char)[] seed, ref int cost)
+        extern (D) Dsymbol scope_search_fp(const(char)[] seed, ref int cost)
         {
             //printf("scope_search_fp('%s')\n", seed);
             /* If not in the lexer's string table, it certainly isn't in the symbol table.
@@ -598,10 +598,10 @@ struct Scope
                         return null;
                 }
             }
-            return cast(void*)s;
+            return s;
         }
 
-        return cast(Dsymbol)speller(ident.toChars(), &scope_search_fp);
+        return speller!scope_search_fp(ident.toChars());
     }
 
     /************************************

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -772,7 +772,7 @@ extern (C++) class Dsymbol : ASTNode
         /***************************************************
          * Search for symbol with correct spelling.
          */
-        extern (D) void* symbol_search_fp(const(char)[] seed, ref int cost)
+        extern (D) Dsymbol symbol_search_fp(const(char)[] seed, ref int cost)
         {
             /* If not in the lexer's string table, it certainly isn't in the symbol table.
              * Doing this first is a lot faster.
@@ -785,12 +785,12 @@ extern (C++) class Dsymbol : ASTNode
             cost = 0;
             Dsymbol s = this;
             Module.clearCache();
-            return cast(void*)s.search(Loc.initial, id, IgnoreErrors);
+            return s.search(Loc.initial, id, IgnoreErrors);
         }
 
         if (global.gag)
             return null; // don't do it for speculative compiles; too time consuming
-        return cast(Dsymbol)speller(ident.toChars(), &symbol_search_fp);
+        return speller!symbol_search_fp(ident.toChars());
     }
 
     /***************************************

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1780,17 +1780,17 @@ Lnext:
         return r.expressionSemantic(sc);
     }
 
-    extern (D) void* trait_search_fp(const(char)[] seed, ref int cost)
+    extern (D) const(char)* trait_search_fp(const(char)[] seed, ref int cost)
     {
         //printf("trait_search_fp('%s')\n", seed);
         if (!seed.length)
             return null;
         cost = 0;
         StringValue* sv = traitsStringTable.lookup(seed);
-        return sv ? sv.ptrvalue : null;
+        return sv ? cast(const(char)*)sv.ptrvalue : null;
     }
 
-    if (auto sub = cast(const(char)*)speller(e.ident.toChars(), &trait_search_fp))
+    if (auto sub = speller!trait_search_fp(e.ident.toChars()))
         e.error("unrecognized trait `%s`, did you mean `%s`?", e.ident.toChars(), sub);
     else
         e.error("unrecognized trait `%s`", e.ident.toChars());


### PR DESCRIPTION
This removes a lot of `void*`s and casts.

I'm not completely satisfied with this yet... the `typeof()`s are bothering me, and I feel like there should be some template constraints.