### PR TITLE
add hasMonitor()

### DIFF
--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -688,7 +688,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
      */
     final bool hasMonitor()
     {
-        return classKind == ClassKind.d || classKind == ClassKind.objc;
+        return classKind == ClassKind.d;
     }
 
     override bool isAnonymous()

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -603,7 +603,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         {
             alignsize = target.ptrsize;
             structsize = target.ptrsize;      // allow room for __vptr
-            if (classKind != ClassKind.cpp)
+            if (hasMonitor())
                 structsize += target.ptrsize; // allow room for __monitor
         }
 
@@ -681,6 +681,14 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
 
         // Calculate fields[i].overlapped
         checkOverlappedFields();
+    }
+
+    /**************
+     * Returns: true if there's a __monitor field
+     */
+    final bool hasMonitor()
+    {
+        return classKind == ClassKind.d || classKind == ClassKind.objc;
     }
 
     override bool isAnonymous()

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -620,7 +620,8 @@ extern (C++) void cpp_type_info_ptr_toDt(ClassDeclaration cd, ref DtBuilder dtb)
 
     // Put in first two members, the vtbl[] and the monitor
     dtb.xoff(toVtblSymbol(ClassDeclaration.cpp_type_info_ptr), 0);
-    dtb.size(0);             // monitor
+    if (ClassDeclaration.cpp_type_info_ptr.hasMonitor())
+        dtb.size(0);             // monitor
 
     // Create symbol for C++ type info
     Symbol *s = toSymbolCppTypeInfo(cd);
@@ -954,7 +955,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.dtypeinfo, 2 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.dtypeinfo), 0);        // vtbl for TypeInfo
-        dtb.size(0);                                     // monitor
+        if (Type.dtypeinfo.hasMonitor())
+            dtb.size(0);                                  // monitor
     }
 
     override void visit(TypeInfoConstDeclaration d)
@@ -963,7 +965,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfoconst, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoconst), 0);    // vtbl for TypeInfo_Const
-        dtb.size(0);                                     // monitor
+        if (Type.typeinfoconst.hasMonitor())
+            dtb.size(0);                                  // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
         genTypeInfo(d.loc, tm, null);
@@ -976,7 +979,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfoinvariant, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoinvariant), 0);    // vtbl for TypeInfo_Invariant
-        dtb.size(0);                                         // monitor
+        if (Type.typeinfoinvariant.hasMonitor())
+            dtb.size(0);                                      // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
         genTypeInfo(d.loc, tm, null);
@@ -989,7 +993,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfoshared, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoshared), 0);   // vtbl for TypeInfo_Shared
-        dtb.size(0);                                     // monitor
+        if (Type.typeinfoshared.hasMonitor())
+            dtb.size(0);                                 // monitor
         Type tm = d.tinfo.unSharedOf();
         tm = tm.merge();
         genTypeInfo(d.loc, tm, null);
@@ -1002,7 +1007,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfowild, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfowild), 0); // vtbl for TypeInfo_Wild
-        dtb.size(0);                                 // monitor
+        if (Type.typeinfowild.hasMonitor())
+            dtb.size(0);                              // monitor
         Type tm = d.tinfo.mutableOf();
         tm = tm.merge();
         genTypeInfo(d.loc, tm, null);
@@ -1015,7 +1021,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfoenum, 7 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoenum), 0); // vtbl for TypeInfo_Enum
-        dtb.size(0);                        // monitor
+        if (Type.typeinfoenum.hasMonitor())
+            dtb.size(0);                              // monitor
 
         assert(d.tinfo.ty == Tenum);
 
@@ -1066,7 +1073,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfopointer, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfopointer), 0);  // vtbl for TypeInfo_Pointer
-        dtb.size(0);                                     // monitor
+        if (Type.typeinfopointer.hasMonitor())
+            dtb.size(0);                                  // monitor
 
         assert(d.tinfo.ty == Tpointer);
 
@@ -1082,7 +1090,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfoarray, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoarray), 0);    // vtbl for TypeInfo_Array
-        dtb.size(0);                                     // monitor
+        if (Type.typeinfoarray.hasMonitor())
+            dtb.size(0);                                  // monitor
 
         assert(d.tinfo.ty == Tarray);
 
@@ -1098,7 +1107,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfostaticarray, 4 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfostaticarray), 0);  // vtbl for TypeInfo_StaticArray
-        dtb.size(0);                                         // monitor
+        if (Type.typeinfostaticarray.hasMonitor())
+            dtb.size(0);                                      // monitor
 
         assert(d.tinfo.ty == Tsarray);
 
@@ -1116,7 +1126,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfovector, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfovector), 0);   // vtbl for TypeInfo_Vector
-        dtb.size(0);                                     // monitor
+        if (Type.typeinfovector.hasMonitor())
+            dtb.size(0);                                  // monitor
 
         assert(d.tinfo.ty == Tvector);
 
@@ -1132,7 +1143,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfoassociativearray, 4 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfoassociativearray), 0); // vtbl for TypeInfo_AssociativeArray
-        dtb.size(0);                        // monitor
+        if (Type.typeinfoassociativearray.hasMonitor())
+            dtb.size(0);                    // monitor
 
         assert(d.tinfo.ty == Taarray);
 
@@ -1151,7 +1163,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfofunction, 5 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfofunction), 0); // vtbl for TypeInfo_Function
-        dtb.size(0);                                     // monitor
+        if (Type.typeinfofunction.hasMonitor())
+            dtb.size(0);                                  // monitor
 
         assert(d.tinfo.ty == Tfunction);
 
@@ -1176,7 +1189,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfodelegate, 5 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfodelegate), 0); // vtbl for TypeInfo_Delegate
-        dtb.size(0);                                     // monitor
+        if (Type.typeinfodelegate.hasMonitor())
+            dtb.size(0);                                  // monitor
 
         assert(d.tinfo.ty == Tdelegate);
 
@@ -1204,7 +1218,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             verifyStructSize(Type.typeinfostruct, 15 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfostruct), 0); // vtbl for TypeInfo_Struct
-        dtb.size(0);                        // monitor
+        if (Type.typeinfostruct.hasMonitor())
+            dtb.size(0);                                // monitor
 
         assert(d.tinfo.ty == Tstruct);
 
@@ -1377,7 +1392,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfointerface, 3 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfointerface), 0);    // vtbl for TypeInfoInterface
-        dtb.size(0);                                           // monitor
+        if (Type.typeinfointerface.hasMonitor())
+            dtb.size(0);                                  // monitor
 
         assert(d.tinfo.ty == Tclass);
 
@@ -1396,7 +1412,8 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         verifyStructSize(Type.typeinfotypelist, 4 * target.ptrsize);
 
         dtb.xoff(toVtblSymbol(Type.typeinfotypelist), 0); // vtbl for TypeInfoInterface
-        dtb.size(0);                                       // monitor
+        if (Type.typeinfotypelist.hasMonitor())
+            dtb.size(0);                                  // monitor
 
         assert(d.tinfo.ty == Ttuple);
 

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -706,7 +706,7 @@ private void membersToDt(AggregateDeclaration ad, ref DtBuilder dtb,
         {
             dtb.xoff(toVtblSymbol(concreteType), 0);  // __vptr
             offset = target.ptrsize;
-            if (cd.classKind != ClassKind.cpp)
+            if (cd.hasMonitor())
             {
                 dtb.size(0);              // __monitor
                 offset += target.ptrsize;

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1234,12 +1234,17 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
 
     auto dtb = DtBuilder(0);
 
-    if (Type.typeinfoclass)            // vtbl for TypeInfo_Class : ClassInfo
-        dtb.xoff(toVtblSymbol(Type.typeinfoclass), 0, TYnptr);
+    if (auto tic = Type.typeinfoclass)
+    {
+        dtb.xoff(toVtblSymbol(tic), 0, TYnptr); // vtbl for TypeInfo_Class : ClassInfo
+        if (tic.hasMonitor())
+            dtb.size(0);                        // monitor
+    }
     else
+    {
         dtb.size(0);                    // BUG: should be an assert()
-    if (Type.typeinfoclass.hasMonitor())
-        dtb.size(0);                    // monitor
+        dtb.size(0);                    // call hasMonitor()?
+    }
 
     // m_init[]
     assert(cd.structsize >= 8 || (cd.classKind == ClassKind.cpp && cd.structsize >= 4));
@@ -1464,12 +1469,17 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
      */
     auto dtb = DtBuilder(0);
 
-    if (Type.typeinfoclass)
-        dtb.xoff(toVtblSymbol(Type.typeinfoclass), 0, TYnptr); // vtbl for ClassInfo
+    if (auto tic = Type.typeinfoclass)
+    {
+        dtb.xoff(toVtblSymbol(tic), 0, TYnptr); // vtbl for ClassInfo
+        if (tic.hasMonitor())
+            dtb.size(0);                        // monitor
+    }
     else
+    {
         dtb.size(0);                    // BUG: should be an assert()
-    if (Type.typeinfoclass.hasMonitor())
-        dtb.size(0);                        // monitor
+        dtb.size(0);                    // call hasMonitor()?
+    }
 
     // m_init[]
     dtb.size(0);                        // size

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1238,7 +1238,8 @@ private void genClassInfoForClass(ClassDeclaration cd, Symbol* sinit)
         dtb.xoff(toVtblSymbol(Type.typeinfoclass), 0, TYnptr);
     else
         dtb.size(0);                    // BUG: should be an assert()
-    dtb.size(0);                        // monitor
+    if (Type.typeinfoclass.hasMonitor())
+        dtb.size(0);                    // monitor
 
     // m_init[]
     assert(cd.structsize >= 8 || (cd.classKind == ClassKind.cpp && cd.structsize >= 4));
@@ -1467,7 +1468,8 @@ private void genClassInfoForInterface(InterfaceDeclaration id)
         dtb.xoff(toVtblSymbol(Type.typeinfoclass), 0, TYnptr); // vtbl for ClassInfo
     else
         dtb.size(0);                    // BUG: should be an assert()
-    dtb.size(0);                        // monitor
+    if (Type.typeinfoclass.hasMonitor())
+        dtb.size(0);                        // monitor
 
     // m_init[]
     dtb.size(0);                        // size

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3853,7 +3853,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 return e;
             }
 
-            if (ident == Id.__monitor)
+            if (ident == Id.__monitor && mt.sym.hasMonitor())
             {
                 /* The handle to the monitor (call it a void*)
                  * *(cast(void**)e + 1)


### PR DESCRIPTION
Instead of hackish dependencies on whether a __monitor field exists or not, make it a trait.