### PR TITLE
runnable/test42.d: Fix bswap test for BigEndian

### DIFF
--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4915,20 +4915,35 @@ struct Test244 {
 
 int noswap245(ubyte *data)
 {
-    return
-        (data[0]<<  0) |
-        (data[1]<<  8) |
-        (data[2]<< 16) |
-        (data[3]<< 24);
+    version (LittleEndian)
+        return
+            (data[0]<<  0) |
+            (data[1]<<  8) |
+            (data[2]<< 16) |
+            (data[3]<< 24);
+    version (BigEndian)
+        return
+            (data[0]<< 24) |
+            (data[1]<< 16) |
+            (data[2]<<  8) |
+            (data[3]<<  0);
+
 }
 
 int bswap245(ubyte *data)
 {
-    return
-        (data[0]<< 24) |
-        (data[1]<< 16) |
-        (data[2]<< 8 ) |
-        (data[3]<< 0 );
+    version (LittleEndian)
+        return
+            (data[0]<< 24) |
+            (data[1]<< 16) |
+            (data[2]<<  8) |
+            (data[3]<<  0);
+    version (BigEndian)
+        return
+            (data[0]<<  0) |
+            (data[1]<<  8) |
+            (data[2]<< 16) |
+            (data[3]<< 24);
 }
 
 void test245()


### PR DESCRIPTION
dmd-cxx backport of #9683.