### PR TITLE
prep for making Expression.op const

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4608,29 +4608,6 @@ public:
         return ret;
     }
 
-    /** Negate a relational operator, eg >= becomes <
-     */
-    static TOK reverseRelation(TOK op)
-    {
-        switch (op)
-        {
-        case TOK.greaterOrEqual:
-            return TOK.lessThan;
-
-        case TOK.greaterThan:
-            return TOK.lessOrEqual;
-
-        case TOK.lessOrEqual:
-            return TOK.greaterThan;
-
-        case TOK.lessThan:
-            return TOK.greaterOrEqual;
-
-        default:
-            assert(0);
-        }
-    }
-
     /** If this is a four pointer relation, evaluate it, else return NULL.
      *
      *  This is an expression of the form (p1 > q1 && p2 < q2) or (p1 < q1 || p2 > q2)
@@ -4759,7 +4736,27 @@ public:
             else
                 break;
         }
-        const cmpop = nott ? reverseRelation(ex.op) : ex.op;
+
+        /** Negate relational operator, eg >= becomes <
+         * Params:
+         *      op = comparison operator to negate
+         * Returns:
+         *      negate operator
+         */
+        static TOK negateRelation(TOK op) pure
+        {
+            switch (op)
+            {
+                case TOK.greaterOrEqual:  op = TOK.lessThan;       break;
+                case TOK.greaterThan:     op = TOK.lessOrEqual;    break;
+                case TOK.lessOrEqual:     op = TOK.greaterThan;    break;
+                case TOK.lessThan:        op = TOK.greaterOrEqual; break;
+                default:                  assert(0);
+            }
+            return op;
+        }
+
+        const TOK cmpop = nott ? negateRelation(ex.op) : ex.op;
         const cmp = comparePointers(cmpop, agg1, ofs1, agg2, ofs2);
         // We already know this is a valid comparison.
         assert(cmp >= 0);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2215,6 +2215,12 @@ extern (C++) class ThisExp : Expression
         //printf("ThisExp::ThisExp() loc = %d\n", loc.linnum);
     }
 
+    this(const ref Loc loc, const TOK tok)
+    {
+        super(loc, tok, __traits(classInstanceSize, ThisExp));
+        //printf("ThisExp::ThisExp() loc = %d\n", loc.linnum);
+    }
+
     override final bool isBool(bool result)
     {
         return result;
@@ -2249,8 +2255,7 @@ extern (C++) final class SuperExp : ThisExp
 {
     extern (D) this(const ref Loc loc)
     {
-        super(loc);
-        op = TOK.super_;
+        super(loc, TOK.super_);
     }
 
     override void accept(Visitor v)
@@ -5722,6 +5727,11 @@ extern (C++) class AssignExp : BinExp
         super(loc, TOK.assign, __traits(classInstanceSize, AssignExp), e1, e2);
     }
 
+    this(const ref Loc loc, TOK tok, Expression e1, Expression e2)
+    {
+        super(loc, tok, __traits(classInstanceSize, AssignExp), e1, e2);
+    }
+
     override final bool isLvalue()
     {
         // Array-op 'x[] = y[]' should make an rvalue.
@@ -5769,8 +5779,7 @@ extern (C++) final class ConstructExp : AssignExp
 {
     extern (D) this(const ref Loc loc, Expression e1, Expression e2)
     {
-        super(loc, e1, e2);
-        op = TOK.construct;
+        super(loc, TOK.construct, e1, e2);
     }
 
     // Internal use only. If `v` is a reference variable, the assinment
@@ -5780,8 +5789,7 @@ extern (C++) final class ConstructExp : AssignExp
         auto ve = new VarExp(loc, v);
         assert(v.type && ve.type);
 
-        super(loc, ve, e2);
-        op = TOK.construct;
+        super(loc, TOK.construct, ve, e2);
 
         if (v.storage_class & (STC.ref_ | STC.out_))
             memset |= MemorySet.referenceInit;
@@ -5799,8 +5807,7 @@ extern (C++) final class BlitExp : AssignExp
 {
     extern (D) this(const ref Loc loc, Expression e1, Expression e2)
     {
-        super(loc, e1, e2);
-        op = TOK.blit;
+        super(loc, TOK.blit, e1, e2);
     }
 
     // Internal use only. If `v` is a reference variable, the assinment
@@ -5810,8 +5817,7 @@ extern (C++) final class BlitExp : AssignExp
         auto ve = new VarExp(loc, v);
         assert(v.type && ve.type);
 
-        super(loc, ve, e2);
-        op = TOK.blit;
+        super(loc, TOK.blit, ve, e2);
 
         if (v.storage_class & (STC.ref_ | STC.out_))
             memset |= MemorySet.referenceInit;

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1040,23 +1040,7 @@ Expression op_overload(Expression e, Scope* sc)
                         }
                         // When reversing operands of comparison operators,
                         // need to reverse the sense of the op
-                        switch (e.op)
-                        {
-                        case TOK.lessThan:
-                            e.op = TOK.greaterThan;
-                            break;
-                        case TOK.greaterThan:
-                            e.op = TOK.lessThan;
-                            break;
-                        case TOK.lessOrEqual:
-                            e.op = TOK.greaterOrEqual;
-                            break;
-                        case TOK.greaterOrEqual:
-                            e.op = TOK.lessOrEqual;
-                            break;
-                        default:
-                            break;
-                        }
+                        e.op = reverseRelation(e.op);
                         return;
                     }
                 }
@@ -1652,23 +1636,7 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id)
             result = build_overload(e.loc, sc, e.e2, e.e1, m.lastf ? m.lastf : s_r);
             // When reversing operands of comparison operators,
             // need to reverse the sense of the op
-            switch (e.op)
-            {
-            case TOK.lessThan:
-                e.op = TOK.greaterThan;
-                break;
-            case TOK.greaterThan:
-                e.op = TOK.lessThan;
-                break;
-            case TOK.lessOrEqual:
-                e.op = TOK.greaterOrEqual;
-                break;
-            case TOK.greaterOrEqual:
-                e.op = TOK.lessOrEqual;
-                break;
-            default:
-                break;
-            }
+            e.op = reverseRelation(e.op);
         }
         return result;
     }
@@ -2089,3 +2057,26 @@ private bool matchParamsToOpApply(TypeFunction tf, Parameters* parameters, bool 
     }
     return true;
 }
+
+/**
+ * Reverse relational operator, eg >= becomes <=
+ * Note this is not negation.
+ * Params:
+ *      op = comparison operator to negate
+ * Returns:
+ *      negate operator
+ */
+private TOK reverseRelation(TOK op) pure
+{
+    switch (op)
+    {
+        case TOK.greaterOrEqual:  op = TOK.lessOrEqual;    break;
+        case TOK.greaterThan:     op = TOK.lessThan;       break;
+        case TOK.lessOrEqual:     op = TOK.greaterOrEqual; break;
+        case TOK.lessThan:        op = TOK.greaterThan;    break;
+        default:                  break;
+    }
+    return op;
+}
+
+


### PR DESCRIPTION
`op` should never be changed, and I've traced some bugs to it being changed. So it's going to become `const`.