### PR TITLE
use constructor rather than in-place setting of .op

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8000,13 +8000,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.op == TOK.assign && exp.e1.checkModifiable(sc) == 2)
         {
             //printf("[%s] change to init - %s\n", exp.loc.toChars(), exp.toChars());
-            exp.op = TOK.construct;
+            auto t = exp.type;
+            exp = new ConstructExp(exp.loc, exp.e1, exp.e2);
+            exp.type = t;
 
             // https://issues.dlang.org/show_bug.cgi?id=13515
             // set Index::modifiable flag for complex AA element initialization
-            if (exp.e1.op == TOK.index)
+            if (auto ie1 = exp.e1.isIndexExp())
             {
-                Expression e1x = (cast(IndexExp)exp.e1).markSettingAAElem();
+                Expression e1x = ie1.markSettingAAElem();
                 if (e1x.op == TOK.error)
                 {
                     result = e1x;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -965,8 +965,13 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             }
                             ExpInitializer ie = v._init.isExpInitializer();
                             assert(ie);
-                            if (ie.exp.op == TOK.construct)
-                                ie.exp.op = TOK.assign; // construction occurred in parameter processing
+                            if (auto iec = ie.exp.isConstructExp())
+                            {
+                                // construction occurred in parameter processing
+                                auto ec = new AssignExp(iec.loc, iec.e1, iec.e2);
+                                ec.type = iec.type;
+                                ie.exp = ec;
+                            }
                             a.push(new ExpStatement(Loc.initial, ie.exp));
                         }
                     }


### PR DESCRIPTION
So eventually `Expression.op` can be made `const`.