### PR TITLE
Fix Issue 19540 - ICE when using `typeof(new class {})` as default value

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3639,6 +3639,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (!e.cd.errors && sc.intypeof && !sc.parent.inNonRoot())
         {
             ScopeDsymbol sds = sc.tinst ? cast(ScopeDsymbol)sc.tinst : sc._module;
+            if (!sds.members)
+                sds.members = new Dsymbols();
             sds.members.push(e.cd);
         }
 

--- a/test/compilable/test19540.d
+++ b/test/compilable/test19540.d
@@ -1,0 +1,2 @@
+alias inst = templ!();
+template templ(T = typeof(new class {})) {}


### PR DESCRIPTION
for template parameter