### PR TITLE
Fix Issue 19774 - wrong code caused by opIndex

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3292,8 +3292,15 @@ else
         }
         if (e0)
         {
-            result = new CompoundStatement(rs.loc, new ExpStatement(rs.loc, e0), rs);
-            return;
+            if (e0.op == TOK.declaration)
+            {
+                rs.exp = Expression.combine(e0, rs.exp);
+            }
+            else
+            {
+                result = new CompoundStatement(rs.loc, new ExpStatement(rs.loc, e0), rs);
+                return;
+            }
         }
         result = rs;
     }

--- a/test/runnable/test19774.d
+++ b/test/runnable/test19774.d
@@ -1,0 +1,36 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+C bar()
+{
+    return C(42);
+}
+
+C foo()
+{
+    return bar()[1];
+}
+
+struct C
+{
+    int x;
+
+    ~this()
+    {
+        x = 0;
+    }
+
+    C opIndex(int a)
+    {
+        return this;
+    }
+}
+
+void main()
+{
+    auto c = foo();
+    assert(c.x == 42); /* fails; should pass */
+}


### PR DESCRIPTION
```d
C bar()
{
    return C(42);
}

C foo()
{
    return bar()[1];
}

struct C
{
    int x;

    ~this()
    {
        x = 0;
    }

    C opIndex(int a)
    {
        return this;
    }
}

void main()
{
    auto c = foo();
    assert(c.x == 42); /* fails; should pass */
}
```
`return bar()[1]` is rewritten to :

```d
C __dop3 = bar();
return __dop3.opIndex(1)
```

Which looks correct, but the problem is that `C __dop3` is generated with a lifetime that lasts until the end of the expression. As a consequence the destructor is called before the return statement. In order to fix this I rewrote the CompoundStatement that the compiler generated to a simple return statement that has a Comma expression : return (C __dop3 = bar(); __dop3.opIndex(1));

