### PR TITLE
Deprecate "Fix for the non-global template issue 5710"

### DIFF
--- a/changelog/deprecate_dualcontext.dd
+++ b/changelog/deprecate_dualcontext.dd
@@ -1,0 +1,13 @@
+Deprecate local templates that receive local symbols by alias
+
+Support for local and member templates which can be instantiated with local
+symbols was added to the language in D 2.087.0, however there are a number of
+issues with the feature including:
+
+- Only DMD has code-gen support for the feature.
+- There has been no support to implement this feature in either GDC or LDC.
+- There is still no language specification that describes the feature.
+
+Because of this, there has been a dead feature introduced to the language for
+over nine releases, so now it has been deprecated, and due to be fully reverted
+in a future release.

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -364,6 +364,15 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
             funcdecl.declareThis(sc2);
 
+            // Reverts: https://issues.dlang.org/show_bug.cgi?id=5710
+            // No compiler supports this, and there was never any spec for it.
+            if (funcdecl.isThis2)
+            {
+                funcdecl.deprecation("function requires a dual-context, which is deprecated");
+                if (auto ti = sc2.parent ? sc2.parent.isInstantiated() : null)
+                    ti.printInstantiationTrace(Classification.deprecation);
+            }
+
             //printf("[%s] ad = %p vthis = %p\n", loc.toChars(), ad, vthis);
             //if (vthis) printf("\tvthis.type = %s\n", vthis.type.toChars());
 

--- a/test/compilable/test20063.d
+++ b/test/compilable/test20063.d
@@ -1,3 +1,9 @@
+/* TEST_OUTPUT:
+---
+compilable/test20063.d(10): Deprecation: function `test20063.main.f!(delegate () pure nothrow @safe => new C).f` function requires a dual-context, which is deprecated
+compilable/test20063.d(19):        instantiated from here: `f!(delegate () pure nothrow @safe => new C)`
+---
+*/
 
 struct S
 {

--- a/test/compilable/test324.d
+++ b/test/compilable/test324.d
@@ -1,3 +1,17 @@
+/* TEST_OUTPUT:
+---
+compilable/test324.d(17): Deprecation: function `test324.main.doStuff!((i)
+{
+return i;
+}
+).doStuff` function requires a dual-context, which is deprecated
+compilable/test324.d(23):        instantiated from here: `doStuff!((i)
+{
+return i;
+}
+)`
+---
+*/
 struct Foo
 {
     void doStuff(alias fun)() {}

--- a/test/fail_compilation/nestedtempl1.d
+++ b/test/fail_compilation/nestedtempl1.d
@@ -1,7 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl1.d(24): Error: modify `inout` to `mutable` is not allowed inside `inout` function
+fail_compilation/nestedtempl1.d(14): Deprecation: function `nestedtempl1.main.bar!(a).bar` function requires a dual-context, which is deprecated
+fail_compilation/nestedtempl1.d(26):        instantiated from here: `bar!(a)`
+fail_compilation/nestedtempl1.d(26): Error: modify `inout` to `mutable` is not allowed inside `inout` function
 ---
 */
 

--- a/test/fail_compilation/nestedtempl2.d
+++ b/test/fail_compilation/nestedtempl2.d
@@ -1,12 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl2.d(32): Error: `this` is only defined in non-static member functions, not `test`
-fail_compilation/nestedtempl2.d(32): Error: need `this` of type `B` to call function `func`
-fail_compilation/nestedtempl2.d(33): Error: `this` is only defined in non-static member functions, not `test`
-fail_compilation/nestedtempl2.d(33): Error: need `this` of type `B` to make delegate from function `func`
+fail_compilation/nestedtempl2.d(22): Deprecation: function `nestedtempl2.B.func!(n).func` function requires a dual-context, which is deprecated
+fail_compilation/nestedtempl2.d(34):        instantiated from here: `func!(n)`
+fail_compilation/nestedtempl2.d(34): Error: `this` is only defined in non-static member functions, not `test`
+fail_compilation/nestedtempl2.d(34): Error: need `this` of type `B` to call function `func`
 fail_compilation/nestedtempl2.d(35): Error: `this` is only defined in non-static member functions, not `test`
-fail_compilation/nestedtempl2.d(35): Error: need `this` of type `B` needed to `new` nested class `N`
+fail_compilation/nestedtempl2.d(35): Error: need `this` of type `B` to make delegate from function `func`
+fail_compilation/nestedtempl2.d(37): Error: `this` is only defined in non-static member functions, not `test`
+fail_compilation/nestedtempl2.d(37): Error: need `this` of type `B` needed to `new` nested class `N`
 ---
 */
 

--- a/test/runnable/template10.d
+++ b/test/runnable/template10.d
@@ -1,4 +1,61 @@
 // PERMUTE_ARGS: -inline
+/* TEST_OUTPUT:
+---
+runnable/template10.d(89): Deprecation: function `template10.test1b.f0.f!(a).f` function requires a dual-context, which is deprecated
+runnable/template10.d(94):        instantiated from here: `f!(a)`
+runnable/template10.d(105): Deprecation: function `template10.test1c.f0.f1.v!(c).sum` function requires a dual-context, which is deprecated
+runnable/template10.d(122):        instantiated from here: `v!(c)`
+runnable/template10.d(170): Deprecation: function `template10.test3.exec!(set).exec` function requires a dual-context, which is deprecated
+runnable/template10.d(182):        instantiated from here: `exec!(set)`
+runnable/template10.d(201): Deprecation: function `template10.get4i.inner!(a).inner` function requires a dual-context, which is deprecated
+runnable/template10.d(238):        instantiated from here: `inner!(a)`
+runnable/template10.d(196): Deprecation: function `template10.test4.add!(a).add` function requires a dual-context, which is deprecated
+runnable/template10.d(245):        instantiated from here: `add!(a)`
+runnable/template10.d(211): Deprecation: function `template10.test4i!(I).test4i.add2!(b).add2` function requires a dual-context, which is deprecated
+runnable/template10.d(231):        instantiated from here: `add2!(b)`
+runnable/template10.d(251):        instantiated from here: `test4i!(I)`
+runnable/template10.d(201): Deprecation: function `template10.test4.inner!(a).inner` function requires a dual-context, which is deprecated
+runnable/template10.d(256):        instantiated from here: `inner!(a)`
+runnable/template10.d(266): Deprecation: function `template10.test5.add!(fun).add` function requires a dual-context, which is deprecated
+runnable/template10.d(282):        instantiated from here: `add!(fun)`
+runnable/template10.d(271): Deprecation: function `template10.test5.add!(fun).add.exec2!(fun, add).exec2` function requires a dual-context, which is deprecated
+runnable/template10.d(269):        instantiated from here: `exec2!(fun, add)`
+runnable/template10.d(282):        instantiated from here: `add!(fun)`
+runnable/template10.d(299): Deprecation: function `template10.test6a.makeR!(j).makeR` function requires a dual-context, which is deprecated
+runnable/template10.d(321):        instantiated from here: `makeR!(j)`
+runnable/template10.d(307): Deprecation: function `template10.test6a.inc!(k).inc` function requires a dual-context, which is deprecated
+runnable/template10.d(322):        instantiated from here: `inc!(k)`
+runnable/template10.d(333): Deprecation: function `template10.test6b.f0!(a).f0` function requires a dual-context, which is deprecated
+runnable/template10.d(358):        instantiated from here: `f0!(a)`
+runnable/template10.d(366): Deprecation: function `template10.test6c.f0.exec!(f).exec` function requires a dual-context, which is deprecated
+runnable/template10.d(385):        instantiated from here: `exec!(f)`
+runnable/template10.d(410): Deprecation: function `template10.test7.C!(c).sum` function requires a dual-context, which is deprecated
+runnable/template10.d(437):        instantiated from here: `C!(c)`
+runnable/template10.d(464): Deprecation: constructor `template10.test8.__ctor!(a).this` function requires a dual-context, which is deprecated
+runnable/template10.d(484):        instantiated from here: `__ctor!(a)`
+runnable/template10.d(468): Deprecation: function `template10.test8.add!(b).add` function requires a dual-context, which is deprecated
+runnable/template10.d(486):        instantiated from here: `add!(b)`
+runnable/template10.d(446): Deprecation: function `template10.test8.sub!(b).sub` function requires a dual-context, which is deprecated
+runnable/template10.d(487):        instantiated from here: `sub!(b)`
+runnable/template10.d(528): Deprecation: function `template10.test10.add!(fun).add` function requires a dual-context, which is deprecated
+runnable/template10.d(544):        instantiated from here: `add!(fun)`
+runnable/template10.d(533): Deprecation: function `template10.test10.add!(fun).add.exec2!(fun, add).exec2` function requires a dual-context, which is deprecated
+runnable/template10.d(531):        instantiated from here: `exec2!(fun, add)`
+runnable/template10.d(544):        instantiated from here: `add!(fun)`
+runnable/template10.d(552): Deprecation: function `template10.test11.getVal!(a).getVal` function requires a dual-context, which is deprecated
+runnable/template10.d(574):        instantiated from here: `getVal!(a)`
+runnable/template10.d(556): Deprecation: function `template10.test11.getRef!(a).getRef` function requires a dual-context, which is deprecated
+runnable/template10.d(578):        instantiated from here: `getRef!(a)`
+runnable/template10.d(588): Deprecation: function `template10.N12.sum!(n).sum` function requires a dual-context, which is deprecated
+runnable/template10.d(624):        instantiated from here: `sum!(n)`
+runnable/template10.d(593): Deprecation: function `template10.N12.inner!(n).inner` function requires a dual-context, which is deprecated
+runnable/template10.d(630):        instantiated from here: `inner!(n)`
+runnable/template10.d(692): Deprecation: function `template10.test13a.getI!(a).getI` function requires a dual-context, which is deprecated
+runnable/template10.d(719):        instantiated from here: `getI!(a)`
+runnable/template10.d(731): Deprecation: function `template10.test13b.getC.C.fun!(n).fun` function requires a dual-context, which is deprecated
+runnable/template10.d(741):        instantiated from here: `fun!(n)`
+---
+*/
 
 /********************************************/
 


### PR DESCRIPTION
Reverts dlang/dmd#9282

Breaking downstream compilers with reckless abandon is not acceptable.  While I agree with the feature, the implementation should find a better solution other than having a dual context in the form of vthis2.