### PR TITLE
[stable] Fix repainting of compile-time reals for targets with 64-bit reals

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -139,6 +139,9 @@ struct Compiler
         case Tfloat64:
             u.float64value = cast(double) e.toReal();
             break;
+        case Tfloat80:
+            assert(e.type.size() == 8); // 64-bit target `real`
+            goto case Tfloat64;
         default:
             assert(0, "Unsupported source type");
         }
@@ -165,6 +168,10 @@ struct Compiler
             r = u.float64value;
             emplaceExp!(RealExp)(pue, e.loc, r, type);
             break;
+
+        case Tfloat80:
+            assert(type.size() == 8); // 64-bit target `real`
+            goto case Tfloat64;
 
         default:
             assert(0, "Unsupported target type");


### PR DESCRIPTION
By converting the `real_t` to a `double` and repainting that value.
E.g., this fixes druntime's `hash` test for those targets (where the compiler would previously assert with enabled assertions); `core.internal.hash.hashOf!(real)` reinterprets a 64-bit (target) `real` as `ulong`, and that code path is taken at CTFE too.