### PR TITLE
Advance deprecation of using this and super as types: Error

### DIFF
--- a/changelog/dep_type_error.dd
+++ b/changelog/dep_type_error.dd
@@ -1,0 +1,33 @@
+Usage of `this` and `super` as types is obsolete
+
+Prior to this release, `this` and `super` could be used as both data or types depending on the context, but
+was deprecated about a year ago. Starting with this release using `this` or `super` as a type will result in a compiler error.
+
+```
+class C
+{
+    shared(this) x;    // Error: Using `this` as a type is obsolete. Use `typeof(this)` instead
+}
+
+class D : C
+{
+    shared(super) a;   // Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
+    super b;           // Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
+}
+```
+
+```
+Use typeof(super) or typeof(this) instead.
+
+class C
+{
+    shared(typeof(this)) x;
+}
+
+class D : C
+{
+    shared(typeof(super)) a;
+    typeof(super) b;
+}
+```
+

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2572,15 +2572,19 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Ds
         //printf("TypeIdentifier::resolve(sc = %p, idents = '%s')\n", sc, mt.toChars());
         if ((mt.ident.equals(Id._super) || mt.ident.equals(Id.This)) && !hasThis(sc))
         {
-            // @@@DEPRECATED_v2.086@@@.
+            // @@@DEPRECATED_v2.091@@@.
+            // Made an error in 2.086.
+            // Eligible for removal in 2.091.
             if (mt.ident.equals(Id._super))
             {
-                deprecation(mt.loc, "Using `super` as a type is deprecated. Use `typeof(super)` instead");
+                error(mt.loc, "Using `super` as a type is obsolete. Use `typeof(super)` instead");
             }
-            // @@@DEPRECATED_v2.086@@@.
+             // @@@DEPRECATED_v2.091@@@.
+            // Made an error in 2.086.
+            // Eligible for removal in 2.091.
             if (mt.ident.equals(Id.This))
             {
-                deprecation(mt.loc, "Using `this` as a type is deprecated. Use `typeof(this)` instead");
+                error(mt.loc, "Using `this` as a type is obsolete. Use `typeof(this)` instead");
             }
             if (AggregateDeclaration ad = sc.getStructClassScope())
             {

--- a/test/fail_compilation/fail18228.d
+++ b/test/fail_compilation/fail18228.d
@@ -1,10 +1,10 @@
-// REQUIRED_ARGS: -de
+// REQUIRED_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18228.d(13): Deprecation: Using `this` as a type is deprecated. Use `typeof(this)` instead
-fail_compilation/fail18228.d(14): Deprecation: Using `this` as a type is deprecated. Use `typeof(this)` instead
-fail_compilation/fail18228.d(15): Deprecation: Using `super` as a type is deprecated. Use `typeof(super)` instead
+fail_compilation/fail18228.d(13): Error: Using `this` as a type is obsolete. Use `typeof(this)` instead
+fail_compilation/fail18228.d(14): Error: Using `this` as a type is obsolete. Use `typeof(this)` instead
+fail_compilation/fail18228.d(15): Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
 ---
 */
 

--- a/test/fail_compilation/test12228.d
+++ b/test/fail_compilation/test12228.d
@@ -1,11 +1,11 @@
 /*
-REQUIRED_ARGS: -de
+REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/test12228.d(14): Deprecation: Using `this` as a type is deprecated. Use `typeof(this)` instead
+fail_compilation/test12228.d(14): Error: Using `this` as a type is obsolete. Use `typeof(this)` instead
 fail_compilation/test12228.d(19): Error: no property `x` for type `object.Object`
-fail_compilation/test12228.d(20): Deprecation: Using `super` as a type is deprecated. Use `typeof(super)` instead
-fail_compilation/test12228.d(21): Deprecation: Using `super` as a type is deprecated. Use `typeof(super)` instead
+fail_compilation/test12228.d(20): Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
+fail_compilation/test12228.d(21): Error: Using `super` as a type is obsolete. Use `typeof(super)` instead
 ---
 */
 

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -3074,7 +3074,7 @@ class C8366a : B8366
 class C8366b : B8366
 {
     bool foo(in Object o)              { return false; }
-    alias super.foo foo;
+    alias typeof(super).foo foo;
     bool foo(in Object o) immutable    { return false; }
     bool foo(in Object o) shared       { return false; }
     bool foo(in Object o) shared const { return false; }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3645,18 +3645,18 @@ class A2540
 class B2540 : A2540
 {
     int b;
-    override super.X foo() { return 1; }
+    override typeof(super).X foo() { return 1; }
 
-    alias this athis;
-    alias this.b thisb;
-    alias super.a supera;
-    alias super.foo superfoo;
-    alias this.foo thisfoo;
+    alias typeof(this) athis;
+    alias typeof(this).b thisb;
+    alias typeof(super).a supera;
+    alias typeof(super).foo superfoo;
+    alias typeof(this).foo thisfoo;
 }
 
 struct X2540
 {
-    alias this athis;
+    alias typeof(this) athis;
 }
 
 void test2540()


### PR DESCRIPTION
Deprecation introduced here: https://dlang.org/changelog/2.081.0.html#deprecate_this_super_as_types