### PR TITLE
Improve template constraint error messages

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -851,7 +851,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
     {
         import dmd.staticcond;
 
-        const msg = visualizeStaticCondition(constraint, lastConstraint, lastConstraintNegs[]);
+        const msg = visualizeStaticCondition(constraint, lastConstraint, lastConstraintNegs[], global.params.verbose);
         lastConstraint = null;
         lastConstraintNegs.setDim(0);
         return msg;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7138,6 +7138,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     const char* txt = "  whose parameters have the following constraints:";
                     const char* sep = "  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~";
                     error("%s `%s`,\n%s\n`%s\n%s%s`", msg, tmsg, txt, sep, cmsg, sep);
+                    .tip("not satisfied constraints are marked with `>`");
                 }
                 else
                     error("%s `%s`", msg, tmsg);

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -241,6 +241,7 @@ enum Classification
     gagged = Color.brightBlue,        /// for gagged errors
     warning = Color.brightYellow,     /// for warnings
     deprecation = Color.brightCyan,   /// for deprecations
+    tip = Color.brightGreen,          /// for tip messages
 }
 
 /**
@@ -397,6 +398,20 @@ extern (C++) void message(const(char)* format, ...)
     va_list ap;
     va_start(ap, format);
     vmessage(Loc.initial, format, ap);
+    va_end(ap);
+}
+
+/**
+ * Print a tip message with the prefix and highlighting.
+ * Params:
+ *      format = printf-style format specification
+ *      ...    = printf-style variadic arguments
+ */
+extern (C++) void tip(const(char)* format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vtip(format, ap);
     va_end(ap);
 }
 
@@ -608,6 +623,21 @@ extern (C++) void vmessage(const ref Loc loc, const(char)* format, va_list ap)
     fputs(tmp.peekChars(), stdout);
     fputc('\n', stdout);
     fflush(stdout);     // ensure it gets written out in case of compiler aborts
+}
+
+/**
+ * Same as $(D tip), but takes a va_list parameter.
+ * Params:
+ *      format    = printf-style format specification
+ *      ap        = printf-style variadic arguments
+ */
+extern (C++) void vtip(const(char)* format, va_list ap)
+{
+    if (!global.gag)
+    {
+        Loc loc = Loc.init;
+        verrorPrint(loc, Classification.tip, "  Tip: ", format, ap);
+    }
 }
 
 /**

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2939,6 +2939,7 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
 {
     // max num of overloads to print (-v overrides this).
     int numToDisplay = 5;
+    bool hadConstraints;
 
     overloadApply(declaration, (Dsymbol s)
     {
@@ -2965,6 +2966,7 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
                 const char* txt = "  whose parameters have the following constraints:";
                 const char* sep = "  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~";
                 .errorSupplemental(td.loc, "`%s`,\n%s\n`%s\n%s%s`", tmsg, txt, sep, cmsg, sep);
+                hadConstraints = true;
             }
             else
                 .errorSupplemental(td.loc, "`%s`", tmsg);
@@ -2983,6 +2985,10 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
             .errorSupplemental(loc, "... (%d more, -v to show) ...", num);
         return 1;   // stop iterating
     });
+
+    static if (is(Decl == TemplateDeclaration))
+        if (hadConstraints)
+            .tip("not satisfied constraints are marked with `>`");
 }
 
 /**************************************

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2939,7 +2939,7 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
 {
     // max num of overloads to print (-v overrides this).
     int numToDisplay = 5;
-    bool hadConstraints;
+    const(char)* constraintsTip;
 
     overloadApply(declaration, (Dsymbol s)
     {
@@ -2960,14 +2960,9 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
             import dmd.staticcond;
 
             const tmsg = td.toCharsNoConstraints();
-            const cmsg = td.getConstraintEvalError();
+            const cmsg = td.getConstraintEvalError(constraintsTip);
             if (cmsg)
-            {
-                const char* txt = "  whose parameters have the following constraints:";
-                const char* sep = "  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~";
-                .errorSupplemental(td.loc, "`%s`,\n%s\n`%s\n%s%s`", tmsg, txt, sep, cmsg, sep);
-                hadConstraints = true;
-            }
+                .errorSupplemental(td.loc, "`%s`\n%s", tmsg, cmsg);
             else
                 .errorSupplemental(td.loc, "`%s`", tmsg);
             nextOverload = td.overnext;
@@ -2985,10 +2980,9 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
             .errorSupplemental(loc, "... (%d more, -v to show) ...", num);
         return 1;   // stop iterating
     });
-
-    static if (is(Decl == TemplateDeclaration))
-        if (hadConstraints)
-            .tip("not satisfied constraints are marked with `>`");
+    // should be only in verbose mode
+    if (constraintsTip)
+        .tip(constraintsTip);
 }
 
 /**************************************

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2956,7 +2956,18 @@ if (is(Decl == TemplateDeclaration) || is(Decl == FuncDeclaration))
         }
         else if (auto td = s.isTemplateDeclaration())
         {
-            .errorSupplemental(td.loc, "`%s`", td.toPrettyChars());
+            import dmd.staticcond;
+
+            const tmsg = td.toCharsNoConstraints();
+            const cmsg = td.getConstraintEvalError();
+            if (cmsg)
+            {
+                const char* txt = "  whose parameters have the following constraints:";
+                const char* sep = "  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~";
+                .errorSupplemental(td.loc, "`%s`,\n%s\n`%s\n%s%s`", tmsg, txt, sep, cmsg, sep);
+            }
+            else
+                .errorSupplemental(td.loc, "`%s`", tmsg);
             nextOverload = td.overnext;
         }
 

--- a/test/fail_compilation/b6227.d
+++ b/test/fail_compilation/b6227.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
 fail_compilation/b6227.d(16): Error: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
-fail_compilation/b6227.d(16):        while evaluating: `static assert(!false)`
+fail_compilation/b6227.d(16):        while evaluating: `static assert(!(cast(X)0 != cast(Y)0))`
 fail_compilation/b6227.d(17): Error: Comparison between different enumeration types `X` and `Y`; If this behavior is intended consider using `std.conv.asOriginalType`
 fail_compilation/b6227.d(17):        while evaluating: `static assert(cast(X)0 == cast(Y)0)`
 ---

--- a/test/fail_compilation/bug9631.d
+++ b/test/fail_compilation/bug9631.d
@@ -92,9 +92,9 @@ TEST_OUTPUT:
 fail_compilation/bug9631.d(106): Error: function `bug9631.targ.ft!().ft(S _param_0)` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(106):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S _param_0`
 fail_compilation/bug9631.d(107): Error: template `bug9631.targ.ft` cannot deduce function from argument types `!()(S)`, candidates are:
-fail_compilation/bug9631.d(105):        `bug9631.targ.ft()(tem!().S)`
+fail_compilation/bug9631.d(105):        `ft()(tem!().S)`
 fail_compilation/bug9631.d(109): Error: template `bug9631.targ.ft2` cannot deduce function from argument types `!()(S, int)`, candidates are:
-fail_compilation/bug9631.d(108):        `bug9631.targ.ft2(T)(S, T)`
+fail_compilation/bug9631.d(108):        `ft2(T)(S, T)`
 ---
 */
 void targ()

--- a/test/fail_compilation/constraints_aggr.d
+++ b/test/fail_compilation/constraints_aggr.d
@@ -1,0 +1,44 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/constraints_aggr.d(31): Error: template `imports.constraints.C.f` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(60):        `f(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       !P!T`
+fail_compilation/constraints_aggr.d(32): Error: template `imports.constraints.C.g` cannot deduce function from argument types `!()()`, candidates are:
+fail_compilation/imports/constraints.d(63):        `g(this T)()`
+  with `T = imports.constraints.C`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_aggr.d(34): Error: template instance `imports.constraints.S!int` does not match template declaration `S(T)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_aggr.d(43): Error: template instance `imports.constraints.BitFlags!(Enum)` does not match template declaration `BitFlags(E, bool unsafe = false)`
+  with `E = Enum`
+  must satisfy one of the following constraints:
+`       unsafe
+       N!E`
+---
+*/
+
+void main()
+{
+    import imports.constraints;
+
+    C c = new C;
+    c.f(0);
+    c.g();
+
+    S!int;
+
+    enum Enum
+    {
+        A = 1,
+        B = 2,
+        C = 4,
+        BC = B|C
+    }
+    BitFlags!Enum flags;
+}

--- a/test/fail_compilation/constraints_defs.d
+++ b/test/fail_compilation/constraints_defs.d
@@ -1,0 +1,55 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/constraints_defs.d(48): Error: template instance `constraints_defs.main.def!(int, 0, (a) => a)` does not match template declaration `def(T, int i = 5, alias R)()`
+  with `T = int,
+       i = 0,
+       R = __lambda1`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_defs.d(49): Error: template instance `imports.constraints.defa!int` does not match template declaration `defa(T, U = int)()`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_defs.d(50): Error: template instance `imports.constraints.defv!()` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+  with `Ts = ()`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_defs.d(51): Error: template instance `imports.constraints.defv!int` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+  with `T = int,
+       Ts = ()`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_defs.d(52): Error: template instance `imports.constraints.defv!(int, 0)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+  with `T = int,
+       i = 0,
+       Ts = ()`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_defs.d(53): Error: template instance `imports.constraints.defv!(int, 0, bool)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+  with `T = int,
+       i = 0,
+       Ts = (bool)`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_defs.d(54): Error: template instance `imports.constraints.defv!(int, 0, bool, float)` does not match template declaration `defv(T = bool, int i = 5, Ts...)()`
+  with `T = int,
+       i = 0,
+       Ts = (bool, float)`
+  must satisfy the following constraint:
+`       N!T`
+---
+*/
+
+void main()
+{
+    import imports.constraints;
+
+    def!(int, 0, a => a)();
+    defa!(int)();
+    defv!()();
+    defv!(int)();
+    defv!(int, 0)();
+    defv!(int, 0, bool)();
+    defv!(int, 0, bool, float)();
+}

--- a/test/fail_compilation/constraints_func1.d
+++ b/test/fail_compilation/constraints_func1.d
@@ -1,0 +1,92 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/constraints_func1.d(78): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(9):        `test1(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_func1.d(79): Error: template `imports.constraints.test2` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(10):        `test2(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       !P!T`
+fail_compilation/constraints_func1.d(80): Error: template `imports.constraints.test3` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(11):        `test3(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_func1.d(81): Error: template `imports.constraints.test4` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(12):        `test4(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_func1.d(82): Error: template `imports.constraints.test5` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(13):        `test5(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       N!T`
+fail_compilation/constraints_func1.d(83): Error: template `imports.constraints.test6` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(14):        `test6(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       N!T
+       !P!T`
+fail_compilation/constraints_func1.d(84): Error: template `imports.constraints.test7` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(15):        `test7(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       N!T`
+fail_compilation/constraints_func1.d(85): Error: template `imports.constraints.test8` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(16):        `test8(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_func1.d(86): Error: template `imports.constraints.test9` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(17):        `test9(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       !P!T`
+fail_compilation/constraints_func1.d(87): Error: template `imports.constraints.test10` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(18):        `test10(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       !P!T`
+fail_compilation/constraints_func1.d(88): Error: template `imports.constraints.test11` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(19):        `test11(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       !P!T`
+fail_compilation/constraints_func1.d(89): Error: template `imports.constraints.test12` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(20):        `test12(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       !P!T`
+fail_compilation/constraints_func1.d(91): Error: template `imports.constraints.test1` cannot deduce function from argument types `!()(int, int)`, candidates are:
+fail_compilation/imports/constraints.d(9):        `test1(T)(T v)`
+---
+*/
+
+void main()
+{
+    import imports.constraints;
+
+    test1(0);
+    test2(0);
+    test3(0);
+    test4(0);
+    test5(0);
+    test6(0);
+    test7(0);
+    test8(0);
+    test9(0);
+    test10(0);
+    test11(0);
+    test12(0);
+
+    test1(0, 0);
+}

--- a/test/fail_compilation/constraints_func2.d
+++ b/test/fail_compilation/constraints_func2.d
@@ -1,0 +1,107 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/constraints_func2.d(93): Error: template `imports.constraints.test13` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(23):        `test13(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       !P!T`
+fail_compilation/constraints_func2.d(94): Error: template `imports.constraints.test14` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(24):        `test14(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       !P!T
+       N!T`
+fail_compilation/constraints_func2.d(95): Error: template `imports.constraints.test15` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(25):        `test15(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       !P!T
+       !P!T`
+fail_compilation/constraints_func2.d(96): Error: template `imports.constraints.test16` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(26):        `test16(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       N!T`
+fail_compilation/constraints_func2.d(97): Error: template `imports.constraints.test17` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(27):        `test17(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_func2.d(98): Error: template `imports.constraints.test18` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(28):        `test18(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       N!T`
+fail_compilation/constraints_func2.d(99): Error: template `imports.constraints.test19` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(29):        `test19(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       !P!T
+       N!T`
+fail_compilation/constraints_func2.d(100): Error: template `imports.constraints.test20` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(30):        `test20(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_func2.d(101): Error: template `imports.constraints.test21` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(31):        `test21(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       N!T
+       N!T`
+fail_compilation/constraints_func2.d(102): Error: template `imports.constraints.test22` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(32):        `test22(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       !P!T
+       !P!T`
+fail_compilation/constraints_func2.d(103): Error: template `imports.constraints.test23` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(33):        `test23(T)(T v)`
+  with `T = int`
+  must satisfy one of the following constraints:
+`       !P!T
+       N!T
+       !P!T`
+fail_compilation/constraints_func2.d(104): Error: template `imports.constraints.test24` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(34):        `test24(R)(R r)`
+  with `R = int`
+  must satisfy the following constraint:
+`       __traits(hasMember, R, "stuff")`
+fail_compilation/constraints_func2.d(105): Error: template `imports.constraints.test25` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(35):        `test25(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_func2.d(106): Error: template `imports.constraints.test26` cannot deduce function from argument types `!(float)(int)`, candidates are:
+fail_compilation/imports/constraints.d(36):        `test26(T, U)(U u)`
+  with `T = float,
+       U = int`
+  must satisfy the following constraint:
+`       N!U`
+---
+*/
+
+void main()
+{
+    import imports.constraints;
+
+    test13(0);
+    test14(0);
+    test15(0);
+    test16(0);
+    test17(0);
+    test18(0);
+    test19(0);
+    test20(0);
+    test21(0);
+    test22(0);
+    test23(0);
+    test24(0);
+    test25(0);
+    test26!float(5);
+}

--- a/test/fail_compilation/constraints_func3.d
+++ b/test/fail_compilation/constraints_func3.d
@@ -1,0 +1,59 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/constraints_func3.d(52): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(39):        `overload(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/imports/constraints.d(40):        `overload(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       !P!T`
+fail_compilation/imports/constraints.d(41):        `overload(T)(T v1, T v2)`
+fail_compilation/imports/constraints.d(42):        `overload(T, V)(T v1, V v2)`
+fail_compilation/constraints_func3.d(53): Error: template `imports.constraints.overload` cannot deduce function from argument types `!()(int, string)`, candidates are:
+fail_compilation/imports/constraints.d(39):        `overload(T)(T v)`
+fail_compilation/imports/constraints.d(40):        `overload(T)(T v)`
+fail_compilation/imports/constraints.d(41):        `overload(T)(T v1, T v2)`
+fail_compilation/imports/constraints.d(42):        `overload(T, V)(T v1, V v2)`
+  with `T = int,
+       V = string`
+  must satisfy one of the following constraints:
+`       N!T
+       N!V`
+fail_compilation/constraints_func3.d(55): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()()`, candidates are:
+fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
+fail_compilation/constraints_func3.d(56): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
+  with `A = int,
+       T = ()`
+  must satisfy the following constraint:
+`       N!int`
+fail_compilation/constraints_func3.d(57): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int)`, candidates are:
+fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
+  with `A = int,
+       T = (int)`
+  must satisfy the following constraint:
+`       N!int`
+fail_compilation/constraints_func3.d(58): Error: template `imports.constraints.variadic` cannot deduce function from argument types `!()(int, int, int)`, candidates are:
+fail_compilation/imports/constraints.d(43):        `variadic(A, T...)(A a, T v)`
+  with `A = int,
+       T = (int, int)`
+  must satisfy the following constraint:
+`       N!int`
+---
+*/
+
+void main()
+{
+    import imports.constraints;
+
+    overload(0);
+    overload(0, "");
+
+    variadic();
+    variadic(0);
+    variadic(0, 1);
+    variadic(0, 1, 2);
+}

--- a/test/fail_compilation/constraints_tmpl.d
+++ b/test/fail_compilation/constraints_tmpl.d
@@ -1,0 +1,43 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/constraints_tmpl.d(34): Error: template instance `imports.constraints.dummy!()` does not match template declaration `dummy()()`
+  must satisfy the following constraint:
+`       false`
+fail_compilation/constraints_tmpl.d(36): Error: template instance `imports.constraints.message_nice!(int, int)` does not match template declaration `message_nice(T, U)()`
+  with `T = int,
+       U = int`
+  must satisfy the following constraint:
+`       N!U`
+fail_compilation/constraints_tmpl.d(37): Error: template instance `imports.constraints.message_ugly!int` does not match template declaration `message_ugly(T)(T v)`
+  with `T = int`
+  must satisfy the following constraint:
+`       N!T`
+fail_compilation/constraints_tmpl.d(39): Error: template instance `args!int` does not match template declaration `args(T, U)()`
+fail_compilation/constraints_tmpl.d(40): Error: template instance `imports.constraints.args!(int, float)` does not match template declaration `args(T, U)()`
+  with `T = int,
+       U = float`
+  must satisfy one of the following constraints:
+`       N!T
+       N!U`
+fail_compilation/constraints_tmpl.d(42): Error: template instance `constraints_tmpl.main.lambda!((a) => a)` does not match template declaration `lambda(alias pred)()`
+  with `pred = __lambda1`
+  must satisfy the following constraint:
+`       N!int`
+---
+*/
+
+void main()
+{
+    import imports.constraints;
+
+    dummy!();
+
+    message_nice!(int, int);
+    message_ugly!int;
+
+    args!int;
+    args!(int, float);
+
+    lambda!(a => a)();
+}

--- a/test/fail_compilation/diag13942.d
+++ b/test/fail_compilation/diag13942.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag13942.d(18): Error: template instance `isRawStaticArray!()` does not match template declaration `isRawStaticArray(T, A...)`
 fail_compilation/diag13942.d(26): Error: template `diag13942.to!double.to` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag13942.d(17):        `diag13942.to!double.to(A...)(A args) if (!isRawStaticArray!A)`
+fail_compilation/diag13942.d(17):        `to(A...)(A args)`
 ---
 */
 

--- a/test/fail_compilation/diag16977.d
+++ b/test/fail_compilation/diag16977.d
@@ -1,12 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag16977.d(22): Error: undefined identifier `undefined`, did you mean function `undefinedId`?
-fail_compilation/diag16977.d(23): Error: cannot implicitly convert expression `"\x01string"` of type `string` to `int`
-fail_compilation/diag16977.d(24): Error: template `diag16977.templ` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/diag16977.d(17):        `diag16977.templ(S)(S s) if (false)`
-fail_compilation/diag16977.d(25): Error: cannot implicitly convert expression `5` of type `int` to `string`
-fail_compilation/diag16977.d(27): Error: template instance `diag16977.test.funcTemplate!string` error instantiating
+fail_compilation/diag16977.d(25): Error: undefined identifier `undefined`, did you mean function `undefinedId`?
+fail_compilation/diag16977.d(26): Error: cannot implicitly convert expression `"\x01string"` of type `string` to `int`
+fail_compilation/diag16977.d(27): Error: template `diag16977.templ` cannot deduce function from argument types `!()(int)`, candidates are:
+fail_compilation/diag16977.d(20):        `templ(S)(S s)`
+  with `S = int`
+  must satisfy the following constraint:
+`       false`
+fail_compilation/diag16977.d(28): Error: cannot implicitly convert expression `5` of type `int` to `string`
+fail_compilation/diag16977.d(30): Error: template instance `diag16977.test.funcTemplate!string` error instantiating
 ---
 */
 

--- a/test/fail_compilation/diag8101.d
+++ b/test/fail_compilation/diag8101.d
@@ -14,16 +14,16 @@ fail_compilation/diag8101.d(39):        `diag8101.f_2(int, int, int, int)`
 fail_compilation/diag8101.d(40):        `diag8101.f_2(int, int, int, int, int)`
 fail_compilation/diag8101.d(59):        ... (1 more, -v to show) ...
 fail_compilation/diag8101.d(61): Error: template `diag8101.t_0` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag8101.d(43):        `diag8101.t_0(T1)()`
+fail_compilation/diag8101.d(43):        `t_0(T1)()`
 fail_compilation/diag8101.d(62): Error: template `diag8101.t_1` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag8101.d(45):        `diag8101.t_1(T1)()`
-fail_compilation/diag8101.d(46):        `diag8101.t_1(T1, T2)()`
+fail_compilation/diag8101.d(45):        `t_1(T1)()`
+fail_compilation/diag8101.d(46):        `t_1(T1, T2)()`
 fail_compilation/diag8101.d(63): Error: template `diag8101.t_2` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/diag8101.d(48):        `diag8101.t_2(T1)()`
-fail_compilation/diag8101.d(49):        `diag8101.t_2(T1, T2)()`
-fail_compilation/diag8101.d(50):        `diag8101.t_2(T1, T2, T3)()`
-fail_compilation/diag8101.d(51):        `diag8101.t_2(T1, T2, T3, T4)()`
-fail_compilation/diag8101.d(52):        `diag8101.t_2(T1, T2, T3, T4, T5)()`
+fail_compilation/diag8101.d(48):        `t_2(T1)()`
+fail_compilation/diag8101.d(49):        `t_2(T1, T2)()`
+fail_compilation/diag8101.d(50):        `t_2(T1, T2, T3)()`
+fail_compilation/diag8101.d(51):        `t_2(T1, T2, T3, T4)()`
+fail_compilation/diag8101.d(52):        `t_2(T1, T2, T3, T4, T5)()`
 fail_compilation/diag8101.d(63):        ... (1 more, -v to show) ...
 ---
 */

--- a/test/fail_compilation/diag8648.d
+++ b/test/fail_compilation/diag8648.d
@@ -3,13 +3,13 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag8648.d(18): Error: undefined identifier `X`
 fail_compilation/diag8648.d(29): Error: template `diag8648.foo` cannot deduce function from argument types `!()(Foo!(int, 1))`, candidates are:
-fail_compilation/diag8648.d(18):        `diag8648.foo(T, n)(X!(T, n))`
+fail_compilation/diag8648.d(18):        `foo(T, n)(X!(T, n))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
 fail_compilation/diag8648.d(31): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, 1))`, candidates are:
-fail_compilation/diag8648.d(20):        `diag8648.bar(T)(Foo!(T, a))`
+fail_compilation/diag8648.d(20):        `bar(T)(Foo!(T, a))`
 fail_compilation/diag8648.d(20): Error: undefined identifier `a`
 fail_compilation/diag8648.d(32): Error: template `diag8648.bar` cannot deduce function from argument types `!()(Foo!(int, f))`, candidates are:
-fail_compilation/diag8648.d(20):        `diag8648.bar(T)(Foo!(T, a))`
+fail_compilation/diag8648.d(20):        `bar(T)(Foo!(T, a))`
 ---
 */
 

--- a/test/fail_compilation/diag9004.d
+++ b/test/fail_compilation/diag9004.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag9004.d(21): Error: template `diag9004.bar` cannot deduce function from argument types `!()(Foo!int, int)`, candidates are:
-fail_compilation/diag9004.d(14):        `diag9004.bar(FooT)(FooT foo, FooT.T x)`
+fail_compilation/diag9004.d(14):        `bar(FooT)(FooT foo, FooT.T x)`
 ---
 */
 

--- a/test/fail_compilation/diag9880.d
+++ b/test/fail_compilation/diag9880.d
@@ -1,7 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag9880.d(9): Error: template instance `diag9880.foo!string` does not match template declaration `foo(T)(int) if (is(T == int))`
+fail_compilation/diag9880.d(12): Error: template instance `diag9880.foo!string` does not match template declaration `foo(T)(int)`
+  with `T = string`
+  must satisfy the following constraint:
+`       is(T == int)`
 ---
 */
 

--- a/test/fail_compilation/fail11125.d
+++ b/test/fail_compilation/fail11125.d
@@ -1,8 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11125.d(20): Error: template instance `fail11125.filter!(function (int a) => a + 1)` does not match template declaration `filter(alias predfun) if (is(ReturnType!predfun == bool))`
-fail_compilation/fail11125.d(21): Error: template instance `fail11125.filter!(function (int a) => a + 1)` does not match template declaration `filter(alias predfun) if (is(ReturnType!predfun == bool))`
+fail_compilation/fail11125.d(26): Error: template instance `fail11125.filter!(function (int a) => a + 1)` does not match template declaration `filter(alias predfun)`
+  with `predfun = __lambda1`
+  must satisfy the following constraint:
+`       is(ReturnType!predfun == bool)`
+fail_compilation/fail11125.d(27): Error: template instance `fail11125.filter!(function (int a) => a + 1)` does not match template declaration `filter(alias predfun)`
+  with `predfun = __lambda2`
+  must satisfy the following constraint:
+`       is(ReturnType!predfun == bool)`
 ---
 */
 

--- a/test/fail_compilation/fail12744.d
+++ b/test/fail_compilation/fail12744.d
@@ -15,10 +15,10 @@ fail_compilation/fail12744.d(40): Error: incompatible parameter storage classes 
 fail_compilation/fail12744.d(62): Error: template instance `fail12744.bar12744L!(foo12744O)` error instantiating
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `out`
 fail_compilation/fail12744.d(67): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744O)(int)`, candidates are:
-fail_compilation/fail12744.d(41):        `fail12744.bar12744A(alias f)(auto ref PTT12744!f args)`
+fail_compilation/fail12744.d(41):        `bar12744A(alias f)(auto ref PTT12744!f args)`
 fail_compilation/fail12744.d(41): Error: incompatible parameter storage classes `auto ref` and `lazy`
 fail_compilation/fail12744.d(68): Error: template `fail12744.bar12744A` cannot deduce function from argument types `!(foo12744L)(int)`, candidates are:
-fail_compilation/fail12744.d(41):        `fail12744.bar12744A(alias f)(auto ref PTT12744!f args)`
+fail_compilation/fail12744.d(41):        `bar12744A(alias f)(auto ref PTT12744!f args)`
 ---
 */
 template PTT12744(func...)

--- a/test/fail_compilation/fail14669.d
+++ b/test/fail_compilation/fail14669.d
@@ -5,7 +5,7 @@ fail_compilation/fail14669.d(11): Error: `auto` can only be used as part of `aut
 fail_compilation/fail14669.d(16): Error: template instance `fail14669.foo1!()` error instantiating
 fail_compilation/fail14669.d(12): Error: `auto` can only be used as part of `auto ref` for template function parameters
 fail_compilation/fail14669.d(17): Error: template `fail14669.foo2` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/fail14669.d(12):        `fail14669.foo2()(auto int a)`
+fail_compilation/fail14669.d(12):        `foo2()(auto int a)`
 ---
 */
 void foo1()(auto int a) {}

--- a/test/fail_compilation/fail162.d
+++ b/test/fail_compilation/fail162.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail162.d(25): Error: template `fail162.testHelper` cannot deduce function from argument types `!()(string, string)`, candidates are:
-fail_compilation/fail162.d(10):        `fail162.testHelper(A...)()`
+fail_compilation/fail162.d(10):        `testHelper(A...)()`
 fail_compilation/fail162.d(30): Error: template instance `fail162.test!("hello", "world")` error instantiating
 ---
 */

--- a/test/fail_compilation/fail236.d
+++ b/test/fail_compilation/fail236.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail236.d(14): Error: undefined identifier `x`
 fail_compilation/fail236.d(22): Error: template `fail236.Templ2` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/fail236.d(12):        `fail236.Templ2(alias a)(x)`
+fail_compilation/fail236.d(12):        `Templ2(alias a)(x)`
 ---
 */
 

--- a/test/fail_compilation/fail319.d
+++ b/test/fail_compilation/fail319.d
@@ -1,7 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail319.d(13): Error: template instance `fail319.f!(int, int)` does not match template declaration `f(T...)() if (T.length > 20)`
+fail_compilation/fail319.d(16): Error: template instance `fail319.f!(int, int)` does not match template declaration `f(T...)()`
+  with `T = (int, int)`
+  must satisfy the following constraint:
+`       T.length > 20`
 ---
 */
 

--- a/test/fail_compilation/fail8009.d
+++ b/test/fail_compilation/fail8009.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail8009.d(9): Error: template `fail8009.filter` cannot deduce function from argument types `!()(void)`, candidates are:
-fail_compilation/fail8009.d(8):        `fail8009.filter(R)(scope bool delegate(ref BAD!R) func)`
+fail_compilation/fail8009.d(8):        `filter(R)(scope bool delegate(ref BAD!R) func)`
 ---
 */
 void filter(R)(scope bool delegate(ref BAD!R) func) { }

--- a/test/fail_compilation/fail95.d
+++ b/test/fail_compilation/fail95.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail95.d(19): Error: template `fail95.A` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/fail95.d(11):        `fail95.A(alias T)(T)`
+fail_compilation/fail95.d(11):        `A(alias T)(T)`
 ---
 */
 

--- a/test/fail_compilation/ice14130.d
+++ b/test/fail_compilation/ice14130.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice14130.d(10): Error: undefined identifier `Undef`
 fail_compilation/ice14130.d(14): Error: template `ice14130.foo` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/ice14130.d(10):        `ice14130.foo(R, F = Undef)(R r, F s = 0)`
+fail_compilation/ice14130.d(10):        `foo(R, F = Undef)(R r, F s = 0)`
 ---
 */
 

--- a/test/fail_compilation/ice14907.d
+++ b/test/fail_compilation/ice14907.d
@@ -7,7 +7,7 @@ fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recur
 fail_compilation/ice14907.d(20):        while looking for match for `f!()`
 fail_compilation/ice14907.d(15): Error: template `ice14907.f(int v = f)()` recursive template expansion
 fail_compilation/ice14907.d(21): Error: template `ice14907.f` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/ice14907.d(15):        `ice14907.f(int v = f)()`
+fail_compilation/ice14907.d(15):        `f(int v = f)()`
 ---
 */
 

--- a/test/fail_compilation/ice6538.d
+++ b/test/fail_compilation/ice6538.d
@@ -8,7 +8,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice6538.d(23): Error: expression `super` is not a valid template value argument
 fail_compilation/ice6538.d(28): Error: template `ice6538.D.foo` cannot deduce function from argument types `!()()`, candidates are:
-fail_compilation/ice6538.d(23):        `ice6538.D.foo()() if (Sym!(super))`
+fail_compilation/ice6538.d(23):        `foo()()`
 ---
 */
 

--- a/test/fail_compilation/ice9284.d
+++ b/test/fail_compilation/ice9284.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice9284.d(14): Error: template `ice9284.C.__ctor` cannot deduce function from argument types `!()(int)`, candidates are:
-fail_compilation/ice9284.d(12):        `ice9284.C.__ctor()(string)`
+fail_compilation/ice9284.d(12):        `__ctor()(string)`
 fail_compilation/ice9284.d(20): Error: template instance `ice9284.C.__ctor!()` error instantiating
 ---
 */

--- a/test/fail_compilation/imports/constraints.d
+++ b/test/fail_compilation/imports/constraints.d
@@ -1,0 +1,73 @@
+module imports.constraints;
+
+// can be shared between usual and verbose output versions
+
+enum P(T) = true;
+enum N(T) = false;
+
+// constraints_func1
+void test1(T)(T v) if (N!T);
+void test2(T)(T v) if (!P!T);
+void test3(T)(T v) if (P!T && N!T);
+void test4(T)(T v) if (P!T && N!T && P!T);
+void test5(T)(T v) if (N!T || N!T);
+void test6(T)(T v) if (N!T || N!T || !P!T);
+void test7(T)(T v) if (N!T || P!T && N!T);
+void test8(T)(T v) if ((N!T || P!T) && N!T);
+void test9(T)(T v) if (!P!T && !N!T);
+void test10(T)(T v) if (!N!T && !P!T);
+void test11(T)(T v) if (!(!N!T && P!T));
+void test12(T)(T v) if (!(N!T || P!T));
+
+// constraints_func2
+void test13(T)(T v) if (P!T ? N!T : P!T);    // P!T && N!T || !P!T && P!T
+void test14(T)(T v) if (!P!T ? P!T : N!T);
+void test15(T)(T v) if (!(P!T ? P!T : N!T)); // (!P!T || !P!T) && (P!T || !N!T)
+void test16(T)(T v) if (N!T && P!T || N!T);
+void test17(T)(T v) if (N!T && P!T && (P!T || P!T));
+void test18(T)(T v) if ((N!T || P!T && N!T) && P!T);
+void test19(T)(T v) if ((N!T ? P!T : !P!T) ? P!T : N!T); // (N!T && P!T || !N!T && !P!T) && P!T || (!N!T || !P!T) && (N!T || P!T) && N!T
+void test20(T)(T v) if (N!T && (P!T && N!T || N!T));
+void test21(T)(T v) if (P!T && (N!T && P!T || N!T));
+void test22(T)(T v) if ((!P!T || !P!T && P!T) && (N!T || !P!T));
+void test23(T)(T v) if (!P!T || P!T && N!T || !P!T);
+void test24(R)(R r) if (__traits(hasMember, R, "stuff"));
+int test25(T)(T v) if (N!T);
+float test26(T, U)(U u) if (N!U);
+
+// constraints_func3
+void overload(T)(T v) if (N!T);
+void overload(T)(T v) if (!P!T);
+void overload(T)(T v1, T v2) if (N!T);
+void overload(T, V)(T v1, V v2) if (N!T || N!V);
+void variadic(A, T...)(A a, T v) if (N!int);
+
+// constraints_tmpl
+void dummy()() if (false);
+void message_nice(T, U)() if (P!T && "message 1" && N!U && "message 2");
+void message_ugly(T)(T v) if (!N!T && (T.stringof ~ " must be that") && N!T);
+void args(T, U)() if (N!T || N!U);
+void lambda(alias pred)() if (N!int);
+
+// constraints_defs
+void def(T, int i = 5, alias R)() if (N!T);
+void defa(T, U = int)() if (N!T);
+void defv(T = bool, int i = 5, Ts...)() if (N!T);
+
+// constraints_aggr
+class C
+{
+    void f(T)(T v) if (P!T && !P!T)
+    {}
+
+    void g(this T)() if (N!T)
+    {}
+}
+
+template S(T) if (N!T)
+{
+    alias S = T;
+}
+
+struct BitFlags(E, bool unsafe = false) if (unsafe || N!E)
+{}

--- a/test/fail_compilation/test19107.d
+++ b/test/fail_compilation/test19107.d
@@ -2,8 +2,12 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test19107.d(20): Error: template `test19107.all` cannot deduce function from argument types `!((c) => c)(string[])`, candidates are:
-fail_compilation/test19107.d(14):        `test19107.all(alias pred, T)(T t) if (is(typeof(I!pred(t))))`
+fail_compilation/test19107.d(24): Error: template `test19107.all` cannot deduce function from argument types `!((c) => c)(string[])`, candidates are:
+fail_compilation/test19107.d(18):        `all(alias pred, T)(T t)`
+  with `pred = __lambda2,
+       T = string[]`
+  must satisfy the following constraint:
+`       is(typeof(I!pred(t)))`
 ---
 */
 

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -1,8 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test8556.d(21): Error: template instance `test8556.Grab!(Circle!(uint[]))` does not match template declaration `Grab(Range) if (!isSliceable!Range)`
-fail_compilation/test8556.d(52): Error: template instance `test8556.grab!(Circle!(uint[]))` error instantiating
+fail_compilation/test8556.d(24): Error: template instance `test8556.Grab!(Circle!(uint[]))` does not match template declaration `Grab(Range)`
+  with `Range = Circle!(uint[])`
+  must satisfy the following constraint:
+`       !isSliceable!Range`
+fail_compilation/test8556.d(55): Error: template instance `test8556.grab!(Circle!(uint[]))` error instantiating
 ---
 */
 

--- a/test/fail_compilation/test9176.d
+++ b/test/fail_compilation/test9176.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/test9176.d(14): Error: forward reference to inferred return type of function call `get()`
-fail_compilation/test9176.d(10):        while evaluating: `static assert(!false)`
+fail_compilation/test9176.d(10):        while evaluating: `static assert(!is(typeof(foo(S()))))`
 ---
 */
 


### PR DESCRIPTION
Hello. I suppose, everyone agrees that the output on unsatisfied template constraints is very poor. This PR proposes a simple way to tell actually what's gone wrong on template matching.

Related to [issue 9626](https://issues.dlang.org/show_bug.cgi?id=9626).

### Example

This code
```D
import std.algorithm : sort;

char[] arr = ['a', 'b'];
sort(arr);
```
gives such error message:
```
./scribble.d(8): Error: template std.algorithm.sorting.sort cannot deduce function from argument types !()(char[]), candidates are:
/usr/include/dmd/phobos/std/algorithm/sorting.d(1855):        std.algorithm.sorting.sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable, Range)(Range r) if ((ss == SwapStrategy.unstable && (hasSwappableElements!Range || hasAssignableElements!Range) || ss != SwapStrategy.unstable && hasAssignableElements!Range) && isRandomAccessRange!Range && hasSlicing!Range && hasLength!Range)
```

"WHAT? Char array cannot be sorted?"

Now let's see how it will look with this PR:

```
./scribble.d(8): Error: template std.algorithm.sorting.sort cannot deduce function from argument types !()(char[]), candidates are:
/usr/include/dmd/phobos/std/algorithm/sorting.d(1855):        sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable, Range)(Range r),
  whose parameters have the following constraints:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        ss == SwapStrategy.unstable
          > hasSwappableElements!Range
            or:
          > hasAssignableElements!Range
        or:
      > ss != SwapStrategy.unstable
      - hasAssignableElements!Range
  - isRandomAccessRange!Range
  - hasSlicing!Range
  - hasLength!Range
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  Tip: not satisfied constraints are marked with >
```

The output is structured like a tree. It shares exact information about which clauses have failed. Here we can read that our `char[]`does not have swappable and/or assignable elements, which is true, because it's UTF-8 string. Not obvious though, so thinking from the user perspective, we should move the last three checks to the beginning to improve the message.

Another (artificial) example:
```D
import std.algorithm : countUntil, initializeAll;

int[] arr;
void* i;
countUntil(arr, i);
initializeAll(i);
```
Output:
```
./scribble.d(16): Error: template std.algorithm.searching.countUntil cannot deduce function from argument types !()(int[], void*), candidates are:
/usr/include/dmd/phobos/std/algorithm/searching.d(768):        countUntil(alias pred = "a == b", R, Rs...)(R haystack, Rs needles),
  whose parameters have the following constraints:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    isForwardRange!R
    Rs.length > 0
    isForwardRange!(Rs[0]) == isInputRange!(Rs[0])
  > is(typeof(startsWith!pred(haystack, needles[0])))
      - Rs.length == 1
        or:
      - is(typeof(countUntil!pred(haystack, needles[1..__dollar])))
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/dmd/phobos/std/algorithm/searching.d(856):        countUntil(alias pred = "a == b", R, N)(R haystack, N needle),
  whose parameters have the following constraints:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    isInputRange!R
  > is(typeof(binaryFun!pred(haystack.front, needle)) : bool)
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/dmd/phobos/std/algorithm/searching.d(915):        countUntil(alias pred, R)(R haystack)
  Tip: not satisfied constraints are marked with >
./scribble.d(17): Error: template std.algorithm.mutation.initializeAll cannot deduce function from argument types !()(void*), candidates are:
/usr/include/dmd/phobos/std/algorithm/mutation.d(864):        initializeAll(Range)(Range range),
  whose parameters have the following constraints:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  > isInputRange!Range
  - hasLvalueElements!Range
  - hasAssignableElements!Range
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/dmd/phobos/std/algorithm/mutation.d(913):        initializeAll(Range)(Range range),
  whose parameters have the following constraints:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  > is(Range == char[])
    or:
  > is(Range == wchar[])
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  Tip: not satisfied constraints are marked with >
```

The output is colored. It would be prettier if I didn't care about possible breakages (e.g. it needs to move signatures that don't fit to the next line).

Why my solution is cool:
* no language changes, no DIPs
* no need to rewrite existing codebases
* may be applied to `static assert` and probably, in some way, to `static if`
* can disassemble arbitrarily complex combinations of `!`, `&&`, `||`, and `?:`

The drawback is that it is shallow, it cannot say "does not implement `popFront()`", it can only point to the constraint `isInputRange!R`, though their names are mostly quite descriptive.

Old `&&` approach to make assert messages can work here to produce some readable results, for example:
```D
void stuff(T, U)()
if (isNice!T && "must be nice" && isFine!U && "must be fine")
{}
```
will print something like
```
    isNice!T
    "must be nice"
  > isFine!U
  - "must be fine"
```

I could handle this case specially and print it better, in one line (edit: and print evaluated expression), but it's too much for this PR.

### Tools

Do we have any special output for them?

IDE can simply show that message in a tooltip. Theoretically, it can parse it and highlight failed clauses (because the message contains all parts of the constraint in order from left to right). Brittle thing, we should define a special compiler flag for error formats, and form JSON.

Then we can greatly improve the error messages for humans.

## Update

Now the full tree view with the tip message is shown only in verbose mode. In the usual, it only shows failed constraints in a compact form.

A new section was added. It clarifies what type/value the passed parameters have. It prints well usual and variadic parameters, except for lambdas (`__lambda1`), enum members (`cast(Enum)0`), maybe something else.

Examples:
```
./scribble.d(67): Error: template instance `std.array.Appender!int` does not match template declaration Appender(A)
  with A = int
  must satisfy the following constraint:
       isDynamicArray!A
```
```
./scribble.d(10): Error: template std.algorithm.sorting.sort cannot deduce function from argument types !()(FilterResult!(unaryFun, int[])), candidates are:
/usr/include/dmd/phobos/std/algorithm/sorting.d(1855):        sort(alias less = "a < b", SwapStrategy ss = SwapStrategy.unstable, Range)(Range r)
  with less = "a < b",
       ss = cast(SwapStrategy)0,
       Range = FilterResult!(unaryFun, int[])
  must satisfy the following constraint:
       isRandomAccessRange!Range
```
```
/usr/include/dmd/phobos/std/range/package.d(6264):        iota(B, E)(B begin, E end)
  with B = string,
       E = string
  must satisfy one of the following constraints:
       isIntegral!(CommonType!(B, E))
       isPointer!(CommonType!(B, E))
```
(omitted other 5 iota variants)