### PR TITLE
swap several uses of Identifier.toChars to Identifier.toString

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6249,11 +6249,11 @@ struct ASTBase
                 for (size_t i = 0; i < packages.dim; i++)
                 {
                     Identifier pid = (*packages)[i];
-                    buf.writestring(pid.toChars());
+                    buf.writestring(pid.toString());
                     buf.writeByte('.');
                 }
             }
-            buf.writestring(id.toChars());
+            buf.writestring(id.toString());
             return buf.extractString();
         }
     }

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -824,7 +824,7 @@ private final class CppMangleVisitor : Visitor
         {
             if (!is_temp_arg_ref)
             {
-                buf.writestring(d.ident.toChars());
+                buf.writestring(d.ident.toString());
             }
             else
             {

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -683,7 +683,7 @@ public:
         }
         if (fd.isWinMain() || fd.isDllMain() || fd.ident == Id.tls_get_addr)
         {
-            buf.writestring(fd.ident.toChars());
+            buf.writestring(fd.ident.toString());
             return;
         }
         visit(cast(Declaration)fd);

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -1224,7 +1224,7 @@ private void toDocBuffer(Dsymbol s, OutBuffer* buf, Scope* sc)
                     .toCBuffer(origType, buf, d.ident, &hgs);
             }
             else
-                buf.writestring(d.ident.toChars());
+                buf.writestring(d.ident.toString());
             if (d.isVarDeclaration() && td)
             {
                 buf.writeByte('(');

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1706,7 +1706,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     ob.printf("%s.", pid.toChars());
                 }
             }
-            ob.writestring(imp.id.toChars());
+            ob.writestring(imp.id.toString());
             ob.writestring(" (");
             if (imp.mod)
                 escapePath(ob, imp.mod.srcfile.toChars());
@@ -1981,7 +1981,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 /* Print unrecognized pragmas
                  */
                 OutBuffer buf;
-                buf.writestring(pd.ident.toChars());
+                buf.writestring(pd.ident.toString());
                 if (pd.args)
                 {
                     for (size_t i = 0; i < pd.args.dim; i++)

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -649,7 +649,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         OutBuffer buf;
         HdrGenState hgs;
 
-        buf.writestring(ident.toChars());
+        buf.writestring(ident.toString());
         buf.writeByte('(');
         for (size_t i = 0; i < parameters.dim; i++)
         {


### PR DESCRIPTION
OutBuffer can handle char arrays, and `Identifier`s can provide them. Let's cut out some `strlen()`s.