### PR TITLE
access.d: remove obsolete access checks in favor of visibility checks

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -28,102 +28,6 @@ import dmd.tokens;
 
 private enum LOG = false;
 
-/****************************************
- * Return Prot access for Dsymbol smember in this declaration.
- */
-private Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
-{
-    Prot access_ret = Prot(Prot.Kind.none);
-    static if (LOG)
-    {
-        printf("+AggregateDeclaration::getAccess(this = '%s', smember = '%s')\n", ad.toChars(), smember.toChars());
-    }
-    assert(ad.isStructDeclaration() || ad.isClassDeclaration());
-    if (smember.toParent() == ad)
-    {
-        access_ret = smember.prot();
-    }
-    else if (smember.isDeclaration().isStatic())
-    {
-        access_ret = smember.prot();
-    }
-    if (ClassDeclaration cd = ad.isClassDeclaration())
-    {
-        foreach (b; *cd.baseclasses)
-        {
-            Prot access = getAccess(b.sym, smember);
-            final switch (access.kind)
-            {
-            case Prot.Kind.none:
-            case Prot.Kind.undefined:
-                break;
-            case Prot.Kind.private_:
-                access_ret = Prot(Prot.Kind.none); // private members of base class not accessible
-                break;
-            case Prot.Kind.package_:
-            case Prot.Kind.protected_:
-            case Prot.Kind.public_:
-            case Prot.Kind.export_:
-                // If access is to be tightened
-                if (Prot.Kind.public_ < access.kind)
-                    access = Prot(Prot.Kind.public_);
-                // Pick path with loosest access
-                if (access_ret.isMoreRestrictiveThan(access))
-                    access_ret = access;
-                break;
-            }
-        }
-    }
-    static if (LOG)
-    {
-        printf("-AggregateDeclaration::getAccess(this = '%s', smember = '%s') = %d\n", ad.toChars(), smember.toChars(), access_ret);
-    }
-    return access_ret;
-}
-
-/********************************************************
- * Helper function for checkAccess()
- * Returns:
- *      false   is not accessible
- *      true    is accessible
- */
-private bool isAccessible(Dsymbol smember, Dsymbol sfunc, AggregateDeclaration dthis, AggregateDeclaration cdscope)
-{
-    assert(dthis);
-    version (none)
-    {
-        printf("isAccessible for %s.%s in function %s() in scope %s\n", dthis.toChars(), smember.toChars(), sfunc ? sfunc.toChars() : "NULL", cdscope ? cdscope.toChars() : "NULL");
-    }
-    if (hasPrivateAccess(dthis, sfunc) || isFriendOf(dthis, cdscope))
-    {
-        if (smember.toParent() == dthis)
-            return true;
-        if (ClassDeclaration cdthis = dthis.isClassDeclaration())
-        {
-            foreach (b; *cdthis.baseclasses)
-            {
-                const Prot access = getAccess(b.sym, smember);
-                if (access.kind >= Prot.Kind.protected_ || isAccessible(smember, sfunc, b.sym, cdscope))
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    else
-    {
-        if (smember.toParent() != dthis)
-        {
-            if (ClassDeclaration cdthis = dthis.isClassDeclaration())
-            {
-                foreach (b; *cdthis.baseclasses)
-                    if (isAccessible(smember, sfunc, b.sym, cdscope))
-                        return true;
-            }
-        }
-    }
-    return false;
-}
 
 /*******************************
  * Do access check for member of this class, this class being the
@@ -132,92 +36,22 @@ private bool isAccessible(Dsymbol smember, Dsymbol sfunc, AggregateDeclaration d
  */
 bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymbol smember)
 {
-    FuncDeclaration f = sc.func;
-    AggregateDeclaration cdscope = sc.getStructClassScope();
     static if (LOG)
     {
         printf("AggregateDeclaration::checkAccess() for %s.%s in function %s() in scope %s\n", ad.toChars(), smember.toChars(), f ? f.toChars() : null, cdscope ? cdscope.toChars() : null);
     }
-    Dsymbol smemberparent = smember.toParent();
-    if (!smemberparent || !smemberparent.isAggregateDeclaration())
+
+    if (smember.toParent().isTemplateInstance())
     {
-        static if (LOG)
-        {
-            printf("not an aggregate member\n");
-        }
-        return false; // then it is accessible
+        return false; // for backward compatibility
     }
-    // BUG: should enable this check
-    //assert(smember.parent.isBaseOf(this, NULL));
-    bool result;
-    Prot access;
-    if (smemberparent == ad)
-    {
-        access = smember.prot();
-        result = access.kind >= Prot.Kind.public_ || hasPrivateAccess(ad, f) || isFriendOf(ad, cdscope) || (access.kind == Prot.Kind.package_ && hasPackageAccess(sc, smember)) || ad.getAccessModule() == sc._module;
-        static if (LOG)
-        {
-            printf("result1 = %d\n", result);
-        }
-    }
-    else if ((access = getAccess(ad, smember)).kind >= Prot.Kind.public_)
-    {
-        result = true;
-        static if (LOG)
-        {
-            printf("result2 = %d\n", result);
-        }
-    }
-    else if (access.kind == Prot.Kind.package_ && hasPackageAccess(sc, ad))
-    {
-        result = true;
-        static if (LOG)
-        {
-            printf("result3 = %d\n", result);
-        }
-    }
-    else
-    {
-        result = isAccessible(smember, f, ad, cdscope);
-        static if (LOG)
-        {
-            printf("result4 = %d\n", result);
-        }
-    }
-    if (!result && (!(sc.flags & SCOPE.onlysafeaccess) || sc.func.setUnsafe()))
+
+    if (!symbolIsVisible(sc, smember) && (!(sc.flags & SCOPE.onlysafeaccess) || sc.func.setUnsafe()))
     {
         ad.error(loc, "member `%s` is not accessible%s", smember.toChars(), (sc.flags & SCOPE.onlysafeaccess) ? " from `@safe` code".ptr : "".ptr);
         //printf("smember = %s %s, prot = %d, semanticRun = %d\n",
         //        smember.kind(), smember.toPrettyChars(), smember.prot(), smember.semanticRun);
         return true;
-    }
-    return false;
-}
-
-/****************************************
- * Determine if this is the same or friend of cd.
- */
-private bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
-{
-    static if (LOG)
-    {
-        printf("AggregateDeclaration::isFriendOf(this = '%s', cd = '%s')\n", ad.toChars(), cd ? cd.toChars() : "null");
-    }
-    if (ad == cd)
-        return true;
-    // Friends if both are in the same module
-    //if (toParent() == cd.toParent())
-    if (cd && ad.getAccessModule() == cd.getAccessModule())
-    {
-        static if (LOG)
-        {
-            printf("\tin same module\n");
-        }
-        return true;
-    }
-    static if (LOG)
-    {
-        printf("\tnot friend\n");
     }
     return false;
 }
@@ -321,62 +155,6 @@ private bool hasProtectedAccess(Scope *sc, Dsymbol s)
         }
     }
     return sc._module == s.getAccessModule();
-}
-
-/**********************************
- * Determine if smember has access to private members of this declaration.
- */
-private bool hasPrivateAccess(AggregateDeclaration ad, Dsymbol smember)
-{
-    if (smember)
-    {
-        AggregateDeclaration cd = null;
-        Dsymbol smemberparent = smember.toParent();
-        if (smemberparent)
-            cd = smemberparent.isAggregateDeclaration();
-        static if (LOG)
-        {
-            printf("AggregateDeclaration::hasPrivateAccess(class %s, member %s)\n", ad.toChars(), smember.toChars());
-        }
-        if (ad == cd) // smember is a member of this class
-        {
-            static if (LOG)
-            {
-                printf("\tyes 1\n");
-            }
-            return true; // so we get private access
-        }
-        // If both are members of the same module, grant access
-        while (1)
-        {
-            Dsymbol sp = smember.toParent();
-            if (sp.isFuncDeclaration() && smember.isFuncDeclaration())
-                smember = sp;
-            else
-                break;
-        }
-        if (!cd && ad.toParent() == smember.toParent())
-        {
-            static if (LOG)
-            {
-                printf("\tyes 2\n");
-            }
-            return true;
-        }
-        if (!cd && ad.getAccessModule() == smember.getAccessModule())
-        {
-            static if (LOG)
-            {
-                printf("\tyes 3\n");
-            }
-            return true;
-        }
-    }
-    static if (LOG)
-    {
-        printf("\tno\n");
-    }
-    return false;
 }
 
 /****************************************

--- a/test/runnable/imports/pubprivtmpla.d
+++ b/test/runnable/imports/pubprivtmpla.d
@@ -1,0 +1,8 @@
+module pubprivtmpla;
+
+struct S
+{
+   private int m = 42;
+   private int _get()() { return m; }
+   public alias get = _get!();
+}

--- a/test/runnable/pubprivtmpl.d
+++ b/test/runnable/pubprivtmpl.d
@@ -1,0 +1,20 @@
+// REQUIRED_ARGS: runnable/imports/pubprivtmpla.d
+
+module pubprivtmpl;
+
+// Idiom: public alias to private template
+// This idiom was discovered while refactoring access.d.  The idiom was not being used in any DLang repository
+// but was being used by a few projects in the D ecosystem.  It is unkown at this time if this idiom is permitted
+// by design or by accident.  This test was added to DMD to prevent regressions in those projects that utilize this
+// idiom.  See also:
+// https://issues.dlang.org/show_bug.cgi?id=4533
+// https://issues.dlang.org/show_bug.cgi?id=11173
+
+import pubprivtmpla;
+
+void main()
+{
+   auto s = S();
+   auto v = s.get();
+   assert(v == 42);
+}


### PR DESCRIPTION
Refactor followup to https://github.com/dlang/dmd/pull/9636

Thanks to @SSoulaimane 

Much of this code is no longer needed as access checks are deprecated in favor of visibility checks.  See [DIP22](https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP22.md).

There is an idiom currently in use in the D ecosystem utilizing public aliases to private templates.  I don't know at this time if that is by design or by accident.  If it is by design, and the desire is to extend the idiom to permit public aliases to any private symbol, then more of this code can be removed along with most, if not all, calls to `checkAccess`.  A test was added to this PR to prevent regressions against those that are currently utilizing public aliases to private tempates.
