### PR TITLE
Followup 19774

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3373,7 +3373,7 @@ else
         }
         if (e0)
         {
-            if (e0.op == TOK.declaration)
+            if (e0.op == TOK.declaration || e0.op == TOK.comma)
             {
                 rs.exp = Expression.combine(e0, rs.exp);
             }

--- a/test/runnable/test19774.d
+++ b/test/runnable/test19774.d
@@ -14,6 +14,11 @@ C foo()
     return bar()[1];
 }
 
+C gun()
+{
+    return bar()[$];
+}
+
 struct C
 {
     int x;
@@ -21,6 +26,11 @@ struct C
     ~this()
     {
         x = 0;
+    }
+
+    int opDollar()
+    {
+        return 1;
     }
 
     C opIndex(int a)
@@ -33,4 +43,6 @@ void main()
 {
     auto c = foo();
     assert(c.x == 42); /* fails; should pass */
+    auto d = gun();
+    assert(d.x == 42);
 }


### PR DESCRIPTION
The fix in #9696 does not take into account situations where multiple declarations are needed for the return statement (that is the case of opDollar: a temporary for the function call + a temporary for opDollar). This patch fixes that.