### PR TITLE
Refactoring: Make dmd.root.file.File stateless

### DIFF
--- a/src/dmd/arraytypes.h
+++ b/src/dmd/arraytypes.h
@@ -49,8 +49,6 @@ typedef Array<class AliasDeclaration *> AliasDeclarations;
 
 typedef Array<class Module *> Modules;
 
-typedef Array<struct File *> Files;
-
 typedef Array<class CaseStatement *> CaseStatements;
 
 typedef Array<class ScopeStatement *> ScopeStatements;

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -30,6 +30,7 @@ struct ASTBase
     import dmd.id;
     import dmd.errors;
     import dmd.lexer;
+    import dmd.utils : toDString;
 
     import core.stdc.string;
     import core.stdc.stdarg;
@@ -1466,15 +1467,14 @@ struct ASTBase
     {
         extern (C++) __gshared AggregateDeclaration moduleinfo;
 
-        File* srcfile;
+        const FileName srcfile;
         const(char)* arg;
 
         extern (D) this(const(char)* filename, Identifier ident, int doDocComment, int doHdrGen)
         {
             super(ident);
             this.arg = filename;
-            const(char)* srcfilename = FileName.defaultExt(filename, global.mars_ext);
-            srcfile = new File(srcfilename);
+            srcfile = FileName(FileName.defaultExt(filename, global.mars_ext).toDString);
         }
 
         override void accept(Visitor v)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -283,13 +283,8 @@ extern (C++) class Dsymbol : ASTNode
     final const(Loc) getLoc()
     {
         if (!loc.isValid()) // avoid bug 5861.
-        {
-            auto m = getModule();
-            if (m && m.srcfile)
-            {
+            if (const m = getModule())
                 return Loc(m.srcfile.toChars(), 0, 0);
-            }
-        }
         return loc;
     }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6590,7 +6590,7 @@ extern (C++) final class FileInitExp : DefaultInitExp
         //printf("FileInitExp::resolve() %s\n", toChars());
         const(char)* s;
         if (subop == TOK.fileFullPath)
-            s = FileName.toAbsolute(loc.isValid() ? loc.filename : sc._module.srcfile.name.toChars());
+            s = FileName.toAbsolute(loc.isValid() ? loc.filename : sc._module.srcfile.toChars());
         else
             s = loc.isValid() ? loc.filename : sc._module.ident.toChars();
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5592,16 +5592,17 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         }
 
         {
-            auto f = File(name);
-            if (f.read())
+            auto readResult = File.read(name);
+            if (!readResult.success)
             {
-                e.error("cannot read file `%s`", f.toChars());
+                e.error("cannot read file `%s`", name);
                 return setError();
             }
             else
             {
-                f._ref = 1;
-                se = new StringExp(e.loc, f.buffer, f.len);
+                // take ownership of buffer (probably leaking)
+                auto data = readResult.extractData();
+                se = new StringExp(e.loc, data.ptr, data.length);
             }
         }
         result = se.expressionSemantic(sc);

--- a/src/dmd/filecache.d
+++ b/src/dmd/filecache.d
@@ -15,6 +15,7 @@ module dmd.filecache;
 import dmd.root.stringtable;
 import dmd.root.array;
 import dmd.root.file;
+import dmd.root.filename;
 
 import core.stdc.stdio;
 
@@ -23,7 +24,8 @@ A line-by-line representation of a $(REF File, dmd,root,file).
 */
 class FileAndLines
 {
-    File* file;
+    FileName* file;
+    FileBuffer* buffer;
     const(char[])[] lines;
 
     /**
@@ -31,15 +33,18 @@ class FileAndLines
     */
     this(const(char)[] filename)
     {
-        file = new File(filename);
+        file = new FileName(filename);
         readAndSplit();
     }
 
     // Read a file and split the file buffer linewise
     private void readAndSplit()
     {
-        file.read();
-        auto buf = file.buffer;
+        auto readResult = File.read(file.toChars());
+        // FIXME: check success
+        // take ownership of buffer
+        buffer = new FileBuffer(readResult.extractData());
+        ubyte* buf = buffer.data.ptr;
         // slice into lines
         while (*buf)
         {
@@ -63,6 +68,8 @@ class FileAndLines
         {
             file.destroy();
             file = null;
+            buffer.destroy();
+            buffer = null;
             lines.destroy();
             lines = null;
         }

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -284,7 +284,6 @@ struct Global
 
     const(char)* copyright = "Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved";
     const(char)* written = "written by Walter Bright";
-    const(char)* main_d = "__main.d";   // dummy filename for dummy main()
     Array!(const(char)*)* path;         // Array of char*'s which form the import lookup path
     Array!(const(char)*)* filePath;     // Array of char*'s which form the file import lookup path
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -259,7 +259,6 @@ struct Global
 
     const char *copyright;
     const char *written;
-    const char *main_d;         // dummy filename for dummy main()
     Array<const char *> *path;        // Array of char*'s which form the import lookup path
     Array<const char *> *filePath;    // Array of char*'s which form the file import lookup path
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -169,8 +169,7 @@ void obj_write_deferred(Library library)
         fname = namebuf.extractChars();
 
         //printf("writing '%s'\n", fname);
-        File objfile = File(fname);
-        obj_end(library, &objfile);
+        obj_end(library, fname);
     }
     obj_symbols_towrite.dim = 0;
 }
@@ -271,33 +270,25 @@ void obj_start(const(char)* srcfile)
 }
 
 
-void obj_end(Library library, File *objfile)
+void obj_end(Library library, const(char)* objfilename)
 {
-    const(char)* objfilename = objfile.name.toChars();
     objmod.term(objfilename);
     //delete objmod;
     objmod = null;
 
+    const data = objbuf.buf[0 .. objbuf.p - objbuf.buf];
     if (library)
     {
         // Transfer image to library
-        library.addObject(objfilename, objbuf.buf[0 .. objbuf.p - objbuf.buf]);
-        objbuf.buf = null;
+        library.addObject(objfilename, data);
     }
     else
     {
-        // Transfer image to file
-        objfile.setbuffer(objbuf.buf, objbuf.p - objbuf.buf);
-        objfile._ref = 1;
-
-        ensurePathToNameExists(Loc.initial, objfilename);
-
         //printf("write obj %s\n", objfilename);
-        writeFile(Loc.initial, objfile);
-
+        writeFile(Loc.initial, objfilename, data);
         free(objbuf.buf); // objbuf is a backend `Outbuffer` managed by C malloc/free
-        objbuf.buf = null;
     }
+    objbuf.buf = null;
     objbuf.pend = null;
     objbuf.p = null;
 }

--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -36,7 +36,7 @@ version (NoBackend)
         // glue
         void obj_write_deferred(Library library)        {}
         void obj_start(const(char)* srcfile)            {}
-        void obj_end(Library library, File* objfile)    {}
+        void obj_end(Library library, const(char)* objfilename) {}
         void genObjFile(Module m, bool multiobj)        {}
 
         // msc
@@ -72,7 +72,7 @@ else version (MARS)
     {
         void obj_write_deferred(Library library);
         void obj_start(const(char)* srcfile);
-        void obj_end(Library library, File* objfile);
+        void obj_end(Library library, const(char)* objfilename);
         void genObjFile(Module m, bool multiobj);
 
         void backend_init();

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -77,11 +77,7 @@ extern (C++) void genhdrfile(Module m)
     HdrGenState hgs;
     hgs.hdrgen = true;
     toCBuffer(m, &buf, &hgs);
-    // Transfer image to file
-    m.hdrfile.setbuffer(buf.data, buf.offset);
-    buf.extractData();
-    ensurePathToNameExists(Loc.initial, m.hdrfile.toChars());
-    writeFile(m.loc, m.hdrfile);
+    writeFile(m.loc, m.hdrfile.toChars(), buf.peekSlice());
 }
 
 /**

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -106,12 +106,7 @@ class Library
         OutBuffer libbuf;
         WriteLibToBuffer(&libbuf);
 
-        // Transfer image to file
-        File* libfile = File.create(loc.filename);
-        libfile.setbuffer(libbuf.data, libbuf.offset);
-        libbuf.extractData();
-        ensurePathToNameExists(Loc.initial, libfile.name.toChars());
-        writeFile(Loc.initial, libfile);
+        writeFile(Loc.initial, loc.filename, libbuf.peekSlice());
     }
 
     final void error(const(char)* format, ...)

--- a/src/dmd/libelf.d
+++ b/src/dmd/libelf.d
@@ -85,11 +85,10 @@ final class LibElf : Library
         if (!buf)
         {
             assert(module_name[0]);
-            File* file = File.create(cast(char*)module_name);
-            readFile(Loc.initial, file);
-            buf = file.buffer;
-            buflen = file.len;
-            file._ref = 1;
+            // read file and take buffer ownership
+            auto data = readFile(Loc.initial, module_name).extractData();
+            buf = data.ptr;
+            buflen = data.length;
             fromfile = 1;
         }
         if (buflen < 16)

--- a/src/dmd/libmach.d
+++ b/src/dmd/libmach.d
@@ -85,11 +85,10 @@ final class LibMach : Library
         if (!buf)
         {
             assert(module_name[0]);
-            File* file = File.create(cast(char*)module_name);
-            readFile(Loc.initial, file);
-            buf = file.buffer;
-            buflen = file.len;
-            file._ref = 1;
+            // read file and take buffer ownership
+            auto data = readFile(Loc.initial, module_name).extractData();
+            buf = data.ptr;
+            buflen = data.length;
             fromfile = 1;
         }
         int reason = 0;

--- a/src/dmd/libmscoff.d
+++ b/src/dmd/libmscoff.d
@@ -96,11 +96,10 @@ final class LibMSCoff : Library
         if (!buf)
         {
             assert(module_name[0]);
-            File* file = File.create(cast(char*)module_name);
-            readFile(Loc.initial, file);
-            buf = file.buffer;
-            buflen = file.len;
-            file._ref = 1;
+            // read file and take buffer ownership
+            auto data = readFile(Loc.initial, module_name).extractData();
+            buf = data.ptr;
+            buflen = data.length;
             fromfile = 1;
         }
         int reason = 0;

--- a/src/dmd/libomf.d
+++ b/src/dmd/libomf.d
@@ -78,11 +78,10 @@ final class LibOMF : Library
         if (!buf)
         {
             assert(module_name);
-            File* file = File.create(module_name);
-            readFile(Loc.initial, file);
-            buf = file.buffer;
-            buflen = file.len;
-            file._ref = 1;
+            // read file and take buffer ownership
+            auto data = readFile(Loc.initial, module_name).extractData();
+            buf = data.ptr;
+            buflen = data.length;
         }
         uint g_page_size;
         ubyte* pstart = cast(ubyte*)buf;

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -260,11 +260,7 @@ public int runLINK()
             if (plen > 7000)
             {
                 lnkfilename = FileName.forceExt(global.params.exefile, "lnk");
-                auto flnk = File(lnkfilename);
-                flnk.setbuffer(p, plen);
-                flnk._ref = 1;
-                if (flnk.write())
-                    error(Loc.initial, "error writing file %s", lnkfilename);
+                writeFile(Loc.initial, lnkfilename, p[0 .. plen]);
                 if (strlen(lnkfilename) < plen)
                     sprintf(p, "@%s", lnkfilename);
             }
@@ -388,11 +384,7 @@ public int runLINK()
             if (plen > 7000)
             {
                 lnkfilename = FileName.forceExt(global.params.exefile, "lnk");
-                auto flnk = File(lnkfilename);
-                flnk.setbuffer(p, plen);
-                flnk._ref = 1;
-                if (flnk.write())
-                    error(Loc.initial, "error writing file %s", lnkfilename);
+                writeFile(Loc.initial, lnkfilename, p[0 .. plen]);
                 if (strlen(lnkfilename) < plen)
                     sprintf(p, "@%s", lnkfilename);
             }
@@ -1216,10 +1208,10 @@ version (Windows)
                 if (FileName.exists(defverFile))
                 {
                     // VS 2017
-                    File f = File(defverFile);
-                    if (!f.read()) // returns true on error (!), adds sentinel 0 at end of file
+                    auto readResult = File.read(defverFile); // adds sentinel 0 at end of file
+                    if (readResult.success)
                     {
-                        auto ver = cast(char*)f.buffer;
+                        auto ver = cast(char*)readResult.buffer.data.ptr;
                         // trim version number
                         while (*ver && isspace(*ver))
                             ver++;

--- a/src/dmd/mars.h
+++ b/src/dmd/mars.h
@@ -74,6 +74,7 @@ struct OutBuffer;
 #include "globals.h"
 
 #include "root/ctfloat.h"
+#include "root/file.h"
 
 #include "complex_t.h"
 
@@ -81,15 +82,14 @@ struct OutBuffer;
 
 class Dsymbol;
 class Library;
-struct File;
 void obj_start(const char *srcfile);
-void obj_end(Library *library, File *objfile);
+void obj_end(Library *library, const char *objfilename);
 void obj_append(Dsymbol *s);
 void obj_write_deferred(Library *library);
 
 /// Utility functions used by both main and frontend.
-void readFile(Loc loc, File *f);
-void writeFile(Loc loc, File *f);
+FileBuffer readFile(Loc loc, const char *filename);
+void writeFile(Loc loc, const char *filename, const void *data, d_size_t size);
 void ensurePathToNameExists(Loc loc, const char *name);
 
 /// Little helper function for writing out deps.

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -60,10 +60,11 @@ public:
 
     const char *arg;    // original argument name
     ModuleDeclaration *md; // if !NULL, the contents of the ModuleDeclaration declaration
-    File *srcfile;      // input source file
-    File *objfile;      // output .obj file
-    File *hdrfile;      // 'header' file
-    File *docfile;      // output documentation file
+    FileName srcfile;   // input source file
+    FileName objfile;   // output .obj file
+    FileName hdrfile;   // 'header' file
+    FileName docfile;   // output documentation file
+    FileBuffer *srcBuffer; // set during load(), free'd in parse()
     unsigned errors;    // if any errors in file
     unsigned numlines;  // number of lines in source file
     bool isHdrFile;     // if it is a header (.di) file
@@ -110,7 +111,7 @@ public:
     static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
 
     const char *kind() const;
-    File *setOutfile(const char *name, const char *dir, const char *arg, const char *ext);
+    FileName setOutfilename(const char *name, const char *dir, const char *arg, const char *ext);
     void setDocfile();
     bool read(Loc loc); // read file, returns 'true' if succeed, 'false' otherwise.
     Module *parse();    // syntactic parse

--- a/src/dmd/root/file.h
+++ b/src/dmd/root/file.h
@@ -9,44 +9,33 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include "array.h"
 #include "filename.h"
 
-typedef Array<struct File *> Files;
+struct FileBuffer
+{
+    DArray<unsigned char> data;
+
+    FileBuffer(const FileBuffer &) /* = delete */;
+    ~FileBuffer() { mem.xfree(data.ptr); }
+
+    static FileBuffer *create();
+};
 
 struct File
 {
-    int ref;                    // != 0 if this is a reference to someone else's buffer
-    unsigned char *buffer;      // data for our file
-    size_t len;                 // amount of data in buffer[]
-
-    FileName name;              // name of our file
-
-    static File *create(const char *);
-    ~File();
-
-    const char *toChars() const;
-
-    /* Read file, return true if error
-     */
-
-    bool read();
-
-    /* Write file, return true if error
-     */
-
-    bool write();
-
-    /* Set buffer
-     */
-
-    void setbuffer(void *buffer, size_t len)
+    struct ReadResult
     {
-        this->buffer = (unsigned char *)buffer;
-        this->len = len;
-    }
+        bool success;
+        FileBuffer buffer;
+    };
 
-    void remove();              // delete file
+    // Read the full content of a file.
+    static ReadResult read(const char *name);
+
+    // Write a file, returning `true` on success.
+    static bool write(const char *name, const void *data, d_size_t size);
+
+    // Delete a file.
+    static void remove(const char *name);
 };

--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -47,7 +47,6 @@ version (CRuntime_Glibc)
 }
 
 alias Strings = Array!(const(char)*);
-alias Files = Array!(File*);
 
 /***********************************************************
  * Encapsulate path and file names.
@@ -1046,6 +1045,12 @@ nothrow:
     const(char)[] toString() const pure nothrow @nogc @trusted
     {
         return str;
+    }
+
+    bool opCast(T)() const pure nothrow @nogc @safe
+    if (is(T == bool))
+    {
+        return str.ptr !is null;
     }
 }
 

--- a/src/dmd/root/outbuffer.d
+++ b/src/dmd/root/outbuffer.d
@@ -42,6 +42,11 @@ struct OutBuffer
         return p;
     }
 
+    extern (C++) void destroy() pure nothrow @trusted
+    {
+        mem.xfree(extractData());
+    }
+
     extern (C++) void reserve(size_t nbytes) pure nothrow
     {
         //printf("OutBuffer::reserve: size = %d, offset = %d, nbytes = %d\n", size, offset, nbytes);

--- a/src/dmd/root/outbuffer.h
+++ b/src/dmd/root/outbuffer.h
@@ -44,6 +44,7 @@ public:
         mem.xfree(data);
     }
     char *extractData();
+    void destroy();
 
     void reserve(size_t nbytes);
     void setsize(size_t size);

--- a/src/dmd/root/response.d
+++ b/src/dmd/root/response.d
@@ -72,12 +72,13 @@ bool response_expand(ref Strings args) nothrow
         }
         else
         {
-            auto f = File(cp);
-            if (f.read())
+            auto readResult = File.read(cp);
+            if (!readResult.success)
                 goto noexpand;
-            f._ref = 1;
-            buffer = cast(char*)f.buffer;
-            bufend = buffer + f.len;
+            // take ownership of buffer (leaking)
+            auto data = readResult.extractData();
+            buffer = cast(char*)data.ptr;
+            bufend = buffer + data.length;
         }
         // The logic of this should match that in setargv()
         int comment = 0;

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -54,15 +54,17 @@ const(char)* toWinPath(const(char)* src)
  *
  * Params:
  *   loc = The line number information from where the call originates
- *   f = a `dmd.root.file.File` handle to read
+ *   filename = Path to file
  */
-extern (C++) void readFile(Loc loc, File* f)
+extern (C++) FileBuffer readFile(Loc loc, const(char)* filename)
 {
-    if (f.read())
+    auto result = File.read(filename);
+    if (!result.success)
     {
-        error(loc, "Error reading file '%s'", f.name.toChars());
+        error(loc, "Error reading file '%s'", filename);
         fatal();
     }
+    return FileBuffer(result.extractData());
 }
 
 
@@ -71,15 +73,23 @@ extern (C++) void readFile(Loc loc, File* f)
  *
  * Params:
  *   loc = The line number information from where the call originates
- *   f = a `dmd.root.file.File` handle to write
+ *   filename = Path to file
+ *   data = Full content of the file to be written
  */
-extern (C++) void writeFile(Loc loc, File* f)
+extern (D) void writeFile(Loc loc, const(char)* filename, const void[] data)
 {
-    if (f.write())
+    ensurePathToNameExists(Loc.initial, filename);
+    if (!File.write(filename, data))
     {
-        error(loc, "Error writing file '%s'", f.name.toChars());
+        error(loc, "Error writing file '%s'", filename);
         fatal();
     }
+}
+
+/// Ditto
+extern (C++) void writeFile(Loc loc, const(char)* filename, const(void)* data, size_t size)
+{
+    writeFile(loc, filename, data[0 .. size]);
 }
 
 

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -212,12 +212,15 @@ void test_semantic()
         "class Throwable { }\n"
         "class Error : Throwable { this(immutable(char)[]); }";
 
+    FileBuffer *srcBuffer = FileBuffer::create(); // free'd in Module::parse()
+    srcBuffer->data.ptr = (unsigned char *)mem.xstrdup(buf);
+    srcBuffer->data.length = strlen(buf);
+
     Module *m = Module::create("object.d", Identifier::idPool("object"), 0, 0);
 
     unsigned errors = global.startGagging();
 
-    m->srcfile->setbuffer((void*)buf, strlen(buf));
-    m->srcfile->ref = 1;
+    m->srcBuffer = srcBuffer;
     m->parse();
     m->importedFrom = m;
     m->importAll(NULL);


### PR DESCRIPTION
[I had to look into this, as we get an [ICE with `-lowmem` on Linux/i386](https://github.com/ldc-developers/ldc2.snap/issues/80), a segfault originating from a `File` dtor.]