### PR TITLE
Fix Issue 19822 - 2.086 regression wrt. union initializers

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6563,14 +6563,14 @@ private Expression scrubReturnValue(const ref Loc loc, Expression e)
             return true;
         }
 
+        if (auto sle = e.isStructLiteralExp())
+            return isEntirelyVoid(sle.elements);
+
         if (checkArrayType && e.type.ty != Tsarray)
             return false;
 
         if (auto ale = e.isArrayLiteralExp())
             return isEntirelyVoid(ale.elements);
-
-        if (auto sle = e.isStructLiteralExp())
-            return isEntirelyVoid(sle.elements);
 
         return false;
     }

--- a/test/runnable/test19822.d
+++ b/test/runnable/test19822.d
@@ -1,0 +1,34 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+struct Quat
+{
+    static struct Vec { int x; }
+
+    union
+    {
+        Vec v;
+        struct { float x; }
+    }
+
+    static Quat identity()
+    {
+        Quat q;
+        q.x = 1.0f;
+        return q;
+    }
+}
+
+struct QuatContainerWithIncompatibleInit
+{
+    Quat q = Quat.identity;
+}
+
+void main()
+{
+    QuatContainerWithIncompatibleInit c;
+    assert(c.q.x == 1.0f); // fails
+}


### PR DESCRIPTION
The array checks should be grouped together as the initial condition was: 

```d
 if (structlit &&
    ((e.op == TOK.void_) ||
     (e.op == TOK.arrayLiteral && e.type.ty == Tsarray && isEntirelyVoid((cast(ArrayLiteralExp)e).elements)) ||
     (e.op == TOK.structLiteral && isEntirelyVoid((cast(StructLiteralExp)e).elements))))
```
