### PR TITLE
Dub: fix invalid characters in mangled name

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -391,6 +391,7 @@ body
     import dmd.parse : Parser;
     import dmd.identifier : Identifier;
     import dmd.tokens : TOK;
+    import std.path : baseName, stripExtension;
     import std.string : toStringz;
     import std.typecons : tuple;
 
@@ -404,7 +405,7 @@ body
         return members;
     }
 
-    Identifier id = Identifier.idPool(fileName);
+    auto id = Identifier.idPool(fileName.baseName.stripExtension);
     auto m = new Module(fileName.toStringz, id, 0, 0);
     if (code !is null)
         m.members = parse(m, code, diagnosticReporter);

--- a/test/unit/frontend.d
+++ b/test/unit/frontend.d
@@ -67,6 +67,22 @@ unittest
     assert(visitor.created);
 }
 
+@("parseModule - invalid module name")
+unittest
+{
+    import dmd.frontend;
+
+    initDMD();
+
+    auto t = parseModule("foo/bar.d", "");
+
+    assert(!t.diagnostics.hasErrors);
+    assert(!t.diagnostics.hasWarnings);
+
+    const actual = t.module_.ident.toString;
+    assert(actual == "bar", actual);
+}
+
 @("initDMD - contract checking")
 unittest
 {


### PR DESCRIPTION
If the `dmd.frontend.parseModule` function is used and the given filename contains a path, i.e. a `/` character. Eventually when running semantic analysis the compiler will try to insert `/` characters in the mangled named because the id of the module contains the full path of the filename. This will lead to an assertion being triggered in `dmangle.d` when running an application built in debug mode, i.e. `debug` blocks are enabled.