### PR TITLE
Dub: fix assertion failure for inline assembly

### DIFF
--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -44,7 +44,11 @@ version (NoBackend)
         void backend_term() {}
 
         // iasm
-        Statement asmSemantic(AsmStatement s, Scope* sc) { assert(0); }
+        Statement asmSemantic(AsmStatement s, Scope* sc)
+        {
+            sc.func.hasReturnExp = 8;
+            return null;
+        }
 
         // toir
         void toObjFile(Dsymbol ds, bool multiobj)   {}

--- a/test/unit/frontend.d
+++ b/test/unit/frontend.d
@@ -186,3 +186,32 @@ unittest
 
     assert(global.errors == 0);
 }
+
+@("inline assembly")
+unittest
+{
+    import std.algorithm : each;
+
+    import dmd.frontend;
+    import dmd.globals : global;
+
+    initDMD();
+    defaultImportPaths.each!addImport;
+
+    auto t = parseModule("test.d", q{
+        void foo()
+        {
+            asm
+            {
+                call foo;
+            }
+        }
+    });
+
+    assert(!t.diagnostics.hasErrors);
+    assert(!t.diagnostics.hasWarnings);
+
+    t.module_.fullSemantic();
+
+    assert(global.errors == 0);
+}


### PR DESCRIPTION
This fixes an assertion failure which is triggered when running the semantic analysis on a function containing inline assembly. The semantic analysis for inline assembly blocks, `asm`, was not implemented at all. This was most likely due to it depending on the backend.