### PR TITLE
fix memory leak in searchPath

### DIFF
--- a/src/dmd/root/filename.d
+++ b/src/dmd/root/filename.d
@@ -634,6 +634,11 @@ nothrow:
                 auto n = combine(p.toDString, name);
                 if (exists(n))
                     return n;
+                //combine might return name
+                if (n.ptr != name.ptr)
+                {
+                    mem.xfree(cast(void*)n.ptr);
+                }
             }
         }
         return null;


### PR DESCRIPTION
Filename.searchPath was leaking paths that don't exist.