### PR TITLE
update dmodule to use slices rather than cstrings where possible

### DIFF
--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -406,7 +406,7 @@ body
     }
 
     auto id = Identifier.idPool(fileName.baseName.stripExtension);
-    auto m = new Module(fileName.toStringz, id, 0, 0);
+    auto m = new Module(fileName, id, 0, 0);
     if (code !is null)
         m.members = parse(m, code, diagnosticReporter);
     else

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -146,7 +146,7 @@ void obj_write_deferred(Library library)
             idbuf.data = null;
             Identifier id = Identifier.create(idstr);
 
-            Module md = Module.create(mname, id, 0, 0);
+            Module md = new Module(mname.toDString, id, 0, 0);
             md.members = new Dsymbols();
             md.members.push(s);   // its only 'member' is s
             md.doppelganger = 1;       // identify this module as doppelganger
@@ -232,7 +232,7 @@ private Symbol *callFuncsAndGates(Module m, symbols *sctors, StaticDtorDeclarati
         block *b = block_calloc();
         b.BC = BCret;
         b.Belem = ector;
-        sctor.Sfunc.Fstartline.Sfilename = m.arg;
+        sctor.Sfunc.Fstartline.Sfilename = m.arg.xarraydup.ptr;
         sctor.Sfunc.Fstartblock = b;
         writefunc(sctor);
     }
@@ -473,7 +473,7 @@ void genObjFile(Module m, bool multiobj)
             block *b = block_calloc();
             b.BC = BCret;
             b.Belem = eictor;
-            m.sictor.Sfunc.Fstartline.Sfilename = m.arg;
+            m.sictor.Sfunc.Fstartline.Sfilename = m.arg.xarraydup.ptr;
             m.sictor.Sfunc.Fstartblock = b;
             writefunc(m.sictor);
         }

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2636,7 +2636,7 @@ Modules createModules(ref Strings files, ref Strings libmodules)
          * its path and extension.
          */
         auto id = Identifier.idPool(name, cast(uint)strlen(name));
-        auto m = new Module(files[i], id, global.params.doDocComments, global.params.doHdrGeneration);
+        auto m = new Module(files[i].toDString, id, global.params.doDocComments, global.params.doHdrGeneration);
         modules.push(m);
         if (firstmodule)
         {

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -58,7 +58,7 @@ public:
     static AggregateDeclaration *moduleinfo;
 
 
-    const char *arg;    // original argument name
+    DArray<const char> arg;    // original argument name
     ModuleDeclaration *md; // if !NULL, the contents of the ModuleDeclaration declaration
     FileName srcfile;   // input source file
     FileName objfile;   // output .obj file


### PR DESCRIPTION
It looks like Module.create is part of the C++ API so can't take a slice?  Should it be marked extern(C++) ?