### PR TITLE
add toString overrides to classes in dmd.attrib with toChars overrides

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -396,6 +396,11 @@ extern (C++) final class LinkDeclaration : AttribDeclaration
 
     override const(char)* toChars() const
     {
+        return toString().ptr;
+    }
+
+    extern(D) override const(char)[] toString() const
+    {
         return "extern ()";
     }
 
@@ -431,6 +436,11 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
     }
 
     override const(char)* toChars() const
+    {
+        return toString().ptr;
+    }
+
+    extern(D) override const(char)[] toString() const
     {
         return "extern ()";
     }


### PR DESCRIPTION
It's important to keep toString in sync with toChars, otherwise there is little point to having both.