### PR TITLE
update Loc.filename to use a dstring instead of a cstring

### DIFF
--- a/src/dmd/dinifile.d
+++ b/src/dmd/dinifile.d
@@ -354,7 +354,8 @@ void parseConfFile(ref StringTable environment, const(char)* filename, const(cha
                 {
                     if (!writeToEnv(environment, strdup(pn)))
                     {
-                        error(Loc(filename, lineNum, 0), "Use `NAME=value` syntax, not `%s`", pn);
+                        import dmd.utils : toDString;
+                        error(Loc(filename.toDString, lineNum, 0), "Use `NAME=value` syntax, not `%s`", pn);
                         fatal();
                     }
                     static if (LOG)

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -423,7 +423,7 @@ extern(C++) void gendocfile(Module m)
     if (m.isDocFile)
     {
         const ploc = m.md ? &m.md.loc : &m.loc;
-        const loc = Loc(ploc.filename ? ploc.filename : srcfilename.ptr,
+        const loc = Loc(ploc.filename ? ploc.filename : srcfilename,
                         ploc.linnum,
                         ploc.charnum);
 

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -287,7 +287,7 @@ extern (C++) class Dsymbol : ASTNode
             auto m = getModule();
             if (m && m.srcfile)
             {
-                return Loc(m.srcfile.toChars(), 0, 0);
+                return Loc(m.srcfile.toString(), 0, 0);
             }
         }
         return loc;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2087,12 +2087,11 @@ elem *toElem(Expression e, IRState *irs)
                  * to a #line directive.
                  */
                 elem *ea;
-                if (ae.loc.filename && (ae.msg || strcmp(ae.loc.filename, mname) != 0))
+                if (ae.loc.filename && (ae.msg || strcmp(ae.loc.filename.ptr, mname) != 0))
                 {
-                    const(char)* id = ae.loc.filename;
-                    size_t len = strlen(id);
-                    Symbol *si = toStringSymbol(id, len, 1);
-                    elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
+                    const(char)[] id = ae.loc.filename;
+                    Symbol *si = toStringSymbol(id.ptr, id.length, 1);
+                    elem *efilename = el_pair(TYdarray, el_long(TYsize_t, id.length), el_ptr(si));
                     if (config.exe == EX_WIN64)
                         efilename = addressElem(efilename, Type.tstring, true);
 
@@ -6051,10 +6050,9 @@ Symbol *toStringSymbol(StringExp se)
 
 private elem *filelinefunction(IRState *irs, const ref Loc loc)
 {
-    const(char)* id = loc.filename;
-    size_t len = strlen(id);
-    Symbol *si = toStringSymbol(id, len, 1);
-    elem *efilename = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
+    const(char)[] id = loc.filename;
+    Symbol *si = toStringSymbol(id.ptr, id.length, 1);
+    elem *efilename = el_pair(TYdarray, el_long(TYsize_t, id.length), el_ptr(si));
     if (config.exe == EX_WIN64)
         efilename = addressElem(efilename, Type.tstring, true);
 
@@ -6067,7 +6065,7 @@ private elem *filelinefunction(IRState *irs, const ref Loc loc)
         s = fd.toPrettyChars();
     }
 
-    len = strlen(s);
+    const len = strlen(s);
     si = toStringSymbol(s, len, 1);
     elem *efunction = el_pair(TYdarray, el_long(TYsize_t, len), el_ptr(si));
     if (config.exe == EX_WIN64)
@@ -6197,7 +6195,7 @@ elem *callCAssert(IRState *irs, const ref Loc loc, Expression exp, Expression em
 {
     //printf("callCAssert.toElem() %s\n", e.toChars());
     Module m = cast(Module)irs.blx._module;
-    const(char)* mname = m.srcfile.toChars();
+    const(char)[] mname = m.srcfile.toString();
 
     //printf("filename = '%s'\n", loc.filename);
     //printf("module = '%s'\n", mname);
@@ -6206,11 +6204,9 @@ elem *callCAssert(IRState *irs, const ref Loc loc, Expression exp, Expression em
      * to a #line directive.
      */
     elem *efilename;
-    if (loc.filename && strcmp(loc.filename, mname) != 0)
+    if (loc.filename == mname)
     {
-        const(char)* id = loc.filename;
-        size_t len = strlen(id);
-        Symbol *si = toStringSymbol(id, len, 1);
+        Symbol *si = toStringSymbol(loc.filename.ptr, loc.filename.length, 1);
         efilename = el_ptr(si);
     }
     else

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -278,7 +278,8 @@ extern (D) void error(Loc loc, const(char)* format, ...)
  */
 extern (C++) void error(const(char)* filename, uint linnum, uint charnum, const(char)* format, ...)
 {
-    const loc = Loc(filename, linnum, charnum);
+    import dmd.utils : toDString;
+    const loc = Loc(filename.toDString, linnum, charnum);
     va_list ap;
     va_start(ap, format);
     verror(loc, format, ap);
@@ -443,11 +444,11 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
         // ignore invalid files
         loc != Loc.initial &&
         // ignore mixins for now
-        !loc.filename.strstr(".d-mixin-") &&
+        !loc.filename.ptr.strstr(".d-mixin-") &&
         !global.params.mixinOut)
     {
         import dmd.filecache : FileCache;
-        auto fllines = FileCache.fileCache.addOrGetFile(loc.filename[0 .. strlen(loc.filename)]);
+        auto fllines = FileCache.fileCache.addOrGetFile(loc.filename);
 
         if (loc.linnum - 1 < fllines.lines.length)
         {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6579,9 +6579,9 @@ extern (C++) final class FileInitExp : DefaultInitExp
         //printf("FileInitExp::resolve() %s\n", toChars());
         const(char)* s;
         if (subop == TOK.fileFullPath)
-            s = FileName.toAbsolute(loc.isValid() ? loc.filename : sc._module.srcfile.name.toChars());
+            s = FileName.toAbsolute(loc.isValid() ? loc.filename.ptr : sc._module.srcfile.name.toChars());
         else
-            s = loc.isValid() ? loc.filename : sc._module.ident.toChars();
+            s = loc.isValid() ? loc.filename.ptr : sc._module.ident.toChars();
 
         Expression e = new StringExp(loc, cast(char*)s);
         e = e.expressionSemantic(sc);

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -478,14 +478,14 @@ alias d_uns64 = uint64_t;
 // file location
 struct Loc
 {
-    const(char)* filename; // either absolute or relative to cwd
+    const(char)[] filename; // either absolute or relative to cwd
     uint linnum;
     uint charnum;
 
     static immutable Loc initial;       /// use for default initialization of const ref Loc's
 
 nothrow:
-    extern (D) this(const(char)* filename, uint linnum, uint charnum) pure
+    extern (D) this(const(char)[] filename, uint linnum, uint charnum) pure
     {
         this.linnum = linnum;
         this.charnum = charnum;
@@ -534,12 +534,9 @@ nothrow:
      */
     extern (D) bool opEquals(ref const(Loc) loc) const @trusted pure nothrow @nogc
     {
-        import core.stdc.string : strcmp;
-
         return charnum == loc.charnum &&
                linnum == loc.linnum &&
-               (filename == loc.filename ||
-                (filename && loc.filename && strcmp(filename, loc.filename) == 0));
+               filename == loc.filename;
     }
 
     extern (D) size_t toHash() const @trusted pure nothrow
@@ -548,7 +545,7 @@ nothrow:
 
         auto hash = hashOf(linnum);
         hash = hashOf(charnum, hash);
-        hash = hashOf(filename.toDString, hash);
+        hash = hashOf(filename, hash);
         return hash;
     }
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -332,7 +332,7 @@ typedef uint64_t                d_uns64;
 // file location
 struct Loc
 {
-    const char *filename; // either absolute or relative to cwd
+    DArray<const char> filename; // either absolute or relative to cwd
     unsigned linnum;
     unsigned charnum;
 
@@ -340,7 +340,8 @@ struct Loc
     {
         linnum = 0;
         charnum = 0;
-        filename = NULL;
+        filename.length = 0;
+        filename.ptr = 0;
     }
 
     Loc(const char *filename, unsigned linnum, unsigned charnum);

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -1955,7 +1955,7 @@ L2:
 
     if (global.params.symdebug)
     {
-        cdb.genlinnum(Srcpos.create(loc.filename, loc.linnum, loc.charnum));
+        cdb.genlinnum(Srcpos.create(loc.filename.ptr, loc.linnum, loc.charnum));
     }
 
     cdb.append(pc);
@@ -3304,7 +3304,7 @@ code *asm_da_parse(OP *pop)
                 error(asmstate.loc, "label `%s` not found", asmstate.tok.ident.toChars());
 
             if (global.params.symdebug)
-                cdb.genlinnum(Srcpos.create(asmstate.loc.filename, asmstate.loc.linnum, asmstate.loc.charnum));
+                cdb.genlinnum(Srcpos.create(asmstate.loc.filename.ptr, asmstate.loc.linnum, asmstate.loc.charnum));
             cdb.genasm(cast(_LabelDsymbol*)label);
         }
         else
@@ -3518,7 +3518,7 @@ code *asm_db_parse(OP *pop)
     CodeBuilder cdb;
     cdb.ctor();
     if (global.params.symdebug)
-        cdb.genlinnum(Srcpos.create(asmstate.loc.filename, asmstate.loc.linnum, asmstate.loc.charnum));
+        cdb.genlinnum(Srcpos.create(asmstate.loc.filename.ptr, asmstate.loc.linnum, asmstate.loc.charnum));
     cdb.genasm(cast(char*)bytes, cast(uint)usBytes);
     code *c = cdb.finish();
     mem.xfree(bytes);

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -376,7 +376,7 @@ public:
     {
         if (loc.isValid())
         {
-            if (auto filename = loc.filename.toDString)
+            if (auto filename = loc.filename)
             {
                 if (filename != this.filename)
                 {

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -249,8 +249,9 @@ class Lexer
     }
     body
     {
+        import dmd.utils : toDString;
         this.diagnosticReporter = diagnosticReporter;
-        scanloc = Loc(filename, 1, 1);
+        scanloc = Loc(filename.toDString, 1, 1);
         //printf("Lexer::Lexer(%p,%d)\n",base,length);
         //printf("lexer.filename = %s\n", filename);
         token = Token.init;
@@ -2353,6 +2354,7 @@ class Lexer
      */
     private void poundLine()
     {
+        import dmd.utils : toDString;
         auto linnum = this.scanloc.linnum;
         const(char)* filespec = null;
         const loc = this.loc();
@@ -2381,7 +2383,7 @@ class Lexer
             Lnewline:
                 this.scanloc.linnum = linnum;
                 if (filespec)
-                    this.scanloc.filename = filespec;
+                    this.scanloc.filename = filespec.toDString;
                 return;
             case '\r':
                 p++;
@@ -2401,7 +2403,7 @@ class Lexer
                 if (memcmp(p, "__FILE__".ptr, 8) == 0)
                 {
                     p += 8;
-                    filespec = mem.xstrdup(scanloc.filename);
+                    filespec = mem.xstrdup(scanloc.filename.ptr);
                     continue;
                 }
                 goto Lerr;

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -95,19 +95,19 @@ class Library
         if (!FileName.absolute(arg))
             arg = FileName.combine(dir, arg);
 
-        loc = Loc(FileName.defaultExt(arg, global.lib_ext), 0, 0);
+        loc = Loc(FileName.defaultExt(arg, global.lib_ext).toDString, 0, 0);
     }
 
     final void write()
     {
         if (global.params.verbose)
-            message("library   %s", loc.filename);
+            message("library   %s", loc.filename.ptr);
 
         OutBuffer libbuf;
         WriteLibToBuffer(&libbuf);
 
         // Transfer image to file
-        File* libfile = File.create(loc.filename);
+        File* libfile = new File(loc.filename);
         libfile.setbuffer(libbuf.data, libbuf.offset);
         libbuf.extractData();
         ensurePathToNameExists(Loc.initial, libfile.name.toChars());

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -77,7 +77,7 @@ extern (D) elem *incUsageElem(IRState *irs, const ref Loc loc)
 
     Module m = cast(Module)irs.blx._module;
     if (!m.cov || !linnum ||
-        loc.filename != m.srcfile.toChars())
+        loc.filename != m.srcfile.toString())
         return null;
 
     //printf("cov = %p, covb = %p, linnum = %u\n", m.cov, m.covb, p, linnum);


### PR DESCRIPTION
It looks like Loc.opEquals can be removed as it's now just the compiler default.  Am I missing something, or should I just delete it?