### PR TITLE
fix building with dmd 2.086 and -m64 under Windows

### DIFF
--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -1947,10 +1947,11 @@ version (CRuntime_Microsoft)
         return cast(targ_ldouble)fmodl(cast(real)x, cast(real)y);
     }
     import core.stdc.math : isnan;
-    extern (D) private int isnan(targ_ldouble x)
-    {
-        return isnan(cast(real)x);
-    }
+    static if (!is(targ_ldouble == real))
+        extern (D) private int isnan(targ_ldouble x)
+        {
+            return isnan(cast(real)x);
+        }
     import core.stdc.math : fabsl;
     import dmd.root.longdouble : fabsl; // needed if longdouble is longdouble_soft
 }


### PR DESCRIPTION
reports:
```
..\dmd\backend\evalu8.d(120): error : `dmd.backend.evalu8.isnan` called with argument types `(real)` matches both:
  C:\l\d\dmd2.086\dmd2\windows\bin\..\..\src\druntime\import\core\stdc\math.d(500):     `core.stdc.math.isnan(real x)`
  and:
  ..\dmd\backend\evalu8.d(1950):     `dmd.backend.evalu8.isnan(real x)`
```
not sure why it passed without warning before.