### PR TITLE
Fix issue 4923: Deprecate modifying immutable variable from `static this`

### DIFF
--- a/changelog/static_this_immutable_initialization.md
+++ b/changelog/static_this_immutable_initialization.md
@@ -1,0 +1,18 @@
+Initialization of `immutable` global data from `static this` is deprecated
+
+Prior to this release, the following code was possible:
+
+```
+module foo;
+immutable int bar;
+static this()
+{
+    bar = 42;
+}
+```
+
+However, module constructors (`static this`) run each time a thread is
+spawned, and `immutable` data is implicitly `shared`, which led to
+`immutable` value being overriden every time a new thread was spawned.
+The simple fix for this is to use `shared static this` over `static this`,
+as the former is only run once per process.

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8093,6 +8093,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             exp = new ConstructExp(exp.loc, exp.e1, exp.e2);
             exp.type = t;
 
+            // @@@DEPRECATED_2020-06@@@
+            // When removing, alter `checkModifiable` to return the correct value.
+            if (sc.func.isStaticCtorDeclaration() && !sc.func.isSharedStaticCtorDeclaration() &&
+                exp.e1.type.isImmutable())
+            {
+                deprecation(exp.loc, "initialization of `immutable` variable from `static this` is deprecated.");
+                deprecationSupplemental(exp.loc, "Use `shared static this` instead.");
+            }
+
             // https://issues.dlang.org/show_bug.cgi?id=13515
             // set Index::modifiable flag for complex AA element initialization
             if (auto ie1 = exp.e1.isIndexExp())

--- a/test/fail_compilation/fail4923.d
+++ b/test/fail_compilation/fail4923.d
@@ -1,0 +1,14 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/fail4923.d(4): Deprecation: initialization of `immutable` variable from `static this` is deprecated.
+fail_compilation/fail4923.d(4):        Use `shared static this` instead.
+---
+*/
+#line 1
+immutable int bar;
+static this()
+{
+    bar = 42;
+}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4659,7 +4659,7 @@ template Hoge6691()
     immutable static int[int] dict;
     immutable static int value;
 
-    static this()
+    shared static this()
     {
         dict = [1:1, 2:2];
         value = 10;


### PR DESCRIPTION
A long standing bug which turned out to be trivial to fix.
Note that the bug still applies to `shared`, however the fix here is more contentious (and less important).