### PR TITLE
Copy std.format.Mangle to test that uses it.

### DIFF
--- a/test/runnable/imports/argufile.d
+++ b/test/runnable/imports/argufile.d
@@ -36,6 +36,49 @@ void useargs(...)
 	writefln(crashage);
 }
 
+enum Mangle : char
+{
+    Tvoid     = 'v',
+    Tbool     = 'b',
+    Tbyte     = 'g',
+    Tubyte    = 'h',
+    Tshort    = 's',
+    Tushort   = 't',
+    Tint      = 'i',
+    Tuint     = 'k',
+    Tlong     = 'l',
+    Tulong    = 'm',
+    Tfloat    = 'f',
+    Tdouble   = 'd',
+    Treal     = 'e',
+
+    Tifloat   = 'o',
+    Tidouble  = 'p',
+    Tireal    = 'j',
+    Tcfloat   = 'q',
+    Tcdouble  = 'r',
+    Tcreal    = 'c',
+
+    Tchar     = 'a',
+    Twchar    = 'u',
+    Tdchar    = 'w',
+
+    Tarray    = 'A',
+    Tsarray   = 'G',
+    Taarray   = 'H',
+    Tpointer  = 'P',
+    Tfunction = 'F',
+    Tident    = 'I',
+    Tclass    = 'C',
+    Tstruct   = 'S',
+    Tenum     = 'E',
+    Ttypedef  = 'T',
+    Tdelegate = 'D',
+
+    Tconst    = 'x',
+    Timmutable = 'y',
+}
+
 
 // dustmited version of the deprecated doFormat.
 // See the full file at:
@@ -43,7 +86,6 @@ void useargs(...)
 void doFormat(void delegate(dchar) putc, TypeInfo[] arguments, va_list ap)
 {
     import core.stdc.stdlib : alloca, malloc;
-    import std.format ;
 
     size_t bufLength = 1024;
     void* argBuffer = malloc(bufLength);


### PR DESCRIPTION
Mangle has been deprecated for some time now and is supposed to be
removed, but argufile.d uses it, so this copies Mangle into it so that
it can continue to work.