### PR TITLE
[WIP] reduce size of Loc struct

### DIFF
--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -443,11 +443,11 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
         // ignore invalid files
         loc != Loc.initial &&
         // ignore mixins for now
-        !loc.filename.strstr(".d-mixin-") &&
+        !loc.filename.ptr.strstr(".d-mixin-") &&
         !global.params.mixinOut)
     {
         import dmd.filecache : FileCache;
-        auto fllines = FileCache.fileCache.addOrGetFile(loc.filename[0 .. strlen(loc.filename)]);
+        auto fllines = FileCache.fileCache.addOrGetFile(loc.filename);
 
         if (loc.linnum - 1 < fllines.lines.length)
         {

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2354,7 +2354,7 @@ class Lexer
     private void poundLine()
     {
         auto linnum = this.scanloc.linnum;
-        const(char)* filespec = null;
+        const(char)[] filespec;
         const loc = this.loc();
         Token tok;
         scan(&tok);
@@ -2380,7 +2380,7 @@ class Lexer
             case '\n':
             Lnewline:
                 this.scanloc.linnum = linnum;
-                if (filespec)
+                if (filespec.length)
                     this.scanloc.filename = filespec;
                 return;
             case '\r':
@@ -2401,12 +2401,12 @@ class Lexer
                 if (memcmp(p, "__FILE__".ptr, 8) == 0)
                 {
                     p += 8;
-                    filespec = mem.xstrdup(scanloc.filename);
+                    filespec = scanloc.filename.xarraydup;
                     continue;
                 }
                 goto Lerr;
             case '"':
-                if (filespec)
+                if (filespec.length)
                     goto Lerr;
                 stringbuffer.reset();
                 p++;
@@ -2423,7 +2423,7 @@ class Lexer
                         goto Lerr;
                     case '"':
                         stringbuffer.writeByte(0);
-                        filespec = mem.xstrdup(cast(const(char)*)stringbuffer.data);
+                        filespec = stringbuffer.peekSlice.xarraydup;
                         p++;
                         break;
                     default:


### PR DESCRIPTION
Wanted to get feedback on this approach to shrinking the size of the Loc struct in globals by storing an index into a global array of filenames.  Some other things I've thought about but aren't here are:

* using __gshared/thread safety?
* Searching for repeats when setting the filename?  
* I didn't use the Array class because it can't store slices.
* The use of a mutable global removes purity from most member functions... Is this a good tradeoff?