### PR TITLE
Fix issue 9029: make all types (including basic) match to alias template parameters with priority MATCH.convert.

### DIFF
--- a/changelog/template_alias_matches_basic_types.dd
+++ b/changelog/template_alias_matches_basic_types.dd
@@ -1,0 +1,36 @@
+Template alias parameters now match basic types as a conversion.
+
+With this release, templates with alias parameters can be instantiated with basic types,
+such as `int` or `void function()`.
+
+---
+template Example(alias A) { alias Example = A[]; }
+alias IntArray = Example!int;
+
+template MatchType(T) { enum MatchType = "type"; }
+template MatchType(alias A) { enum MatchType = "alias"; }
+
+// alias matches, but type matches take priority.
+static assert (MatchType!int == "type");
+---
+
+Templates with alias parameters already matched named types, lambdas, and even value literals. Templates with
+variadic parameters already matched basic types. This led to strange replacements for `alias` such as
+`template Template(T...) if (T.length == 1)`. Those replacements are no longer necessary.
+
+As a consequence, in some cases templates will match that did not used to. For instance, a template
+may have falsely relied on `alias` parameters being "something callable" vs. type parameters being
+"the type of something callable", such as
+
+---
+void fun(T...)(T callable) { ... }
+void fun(alias A)() { ... }
+---
+
+Such overloads may now need to explicitly check whether A is callable in the second case:
+
+---
+void fun(alias A)() if (__traits(compiles, A())) { ... }
+// shorter, but may miss cases like structs with a static opCall
+void fun(alias A)() if (!isType!A) { ... }
+---

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5697,6 +5697,13 @@ extern (C++) final class TemplateAliasParameter : TemplateParameter
                  *  template X(T) {}        // T => sa
                  */
             }
+            else if (ta)
+            {
+                /* Match any type to alias parameters, but prefer type parameter.
+                 * template X(alias a) { }  // a == ta
+                 */
+                m = MATCH.convert;
+            }
             else
                 goto Lnomatch;
         }

--- a/test/compilable/ddocunittest.d
+++ b/test/compilable/ddocunittest.d
@@ -357,6 +357,7 @@ auto redBlackTree(bool allowDuplicates, E)(E[] elems...)
 }
 /// ditto
 auto redBlackTree(alias less, E)(E[] elems...)
+if (__traits(compiles, (E a, E b) => mixin(less)))
 {
     return 3;
 }

--- a/test/compilable/extra-files/ddocunittest.html
+++ b/test/compilable/extra-files/ddocunittest.html
@@ -2028,7 +2028,7 @@
 <br>
 auto <code class="code">redBlackTree</code>(bool allowDuplicates, E)(E[] <code class="code">elems</code>...);
 <br>
-auto <code class="code">redBlackTree</code>(alias less, E)(E[] <code class="code">elems</code>...);
+auto <code class="code">redBlackTree</code>(alias less, E)(E[] <code class="code">elems</code>...) if (__traits(compiles, (E a, E b) =&gt; mixin(less)));
 
           </code>
         </p>

--- a/test/compilable/test9029.d
+++ b/test/compilable/test9029.d
@@ -1,0 +1,21 @@
+/* TEST_OUTPUT:
+---
+---
+*/
+enum NameOf(alias S) = S.stringof;
+
+static assert(NameOf!int == "int");
+
+enum BothMatch(alias S) = "alias";
+enum BothMatch(T) = "type";
+
+void foo9029() { }
+
+struct Struct { }
+
+static assert(BothMatch!int == "type");
+static assert(BothMatch!(void function()) == "type");
+static assert(BothMatch!BothMatch == "alias");
+static assert(BothMatch!Struct == "type");
+static assert(BothMatch!foo9029 == "alias");
+static assert(BothMatch!5 == "alias");


### PR DESCRIPTION
This may break code. The point of this PR is partially to determine if it does, and if so what.

This is not done by inserting basic types into the symbol table, but simply passing them through in the compiler as objects. This is the main reason I am unconfident about this PR.