### PR TITLE
Fix Issue 19856 - [aApplycd2]: foreach (int) doesn't work on BigEndian targets

### DIFF
--- a/test/compilable/b16976.d
+++ b/test/compilable/b16976.d
@@ -1,16 +1,34 @@
 /* REQUIRED_ARGS: -m64
 TEST_OUTPUT:
 ---
-compilable/b16976.d(15): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
-compilable/b16976.d(16): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
-compilable/b16976.d(17): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
-compilable/b16976.d(18): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(33): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(34): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(35): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(36): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(41): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(42): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(43): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(44): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(50): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(51): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(52): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(53): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(58): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(59): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(60): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(61): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(62): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(63): Deprecation: foreach: loop index implicitly converted from `size_t` to `int`
+compilable/b16976.d(64): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
+compilable/b16976.d(65): Deprecation: foreach: loop index implicitly converted from `size_t` to `char`
 ---
 */
 void main()
 {
     int[]  dyn = [1,2,3,4,5];
     int[5] sta = [1,2,3,4,5];
+    char[]  str = ['1','2','3','4','5'];
+    char[5] chr = ['1','2','3','4','5'];
 
     foreach(int i, v; dyn) { }
     foreach_reverse(int i, v; dyn) { }
@@ -20,4 +38,29 @@ void main()
     foreach_reverse(int i, v; sta) { }
     foreach(char i, v; sta) { }
     foreach_reverse(char i, v; sta) { }
+    foreach(int i, v; str) { }
+    foreach_reverse(int i, v; str) { }
+    foreach(char i, v; str) { }
+    foreach_reverse(char i, v; str) { }
+    foreach(int i, v; chr) { }
+    foreach_reverse(int i, v; chr) { }
+    foreach(char i, v; chr) { }
+    foreach_reverse(char i, v; chr) { }
+
+    foreach(int i, dchar v; dyn) { }
+    foreach_reverse(int i, dchar v; dyn) { }
+    foreach(char i, dchar v; dyn) { }
+    foreach_reverse(char i, dchar v; dyn) { }
+    foreach(int i, dchar v; sta) { }
+    foreach_reverse(int i, dchar v; sta) { }
+    foreach(char i, dchar v; sta) { }
+    foreach_reverse(char i, dchar v; sta) { }
+    foreach(int i, dchar v; str) { }
+    foreach_reverse(int i, dchar v; str) { }
+    foreach(char i, dchar v; str) { }
+    foreach_reverse(char i, dchar v; str) { }
+    foreach(int i, dchar v; chr) { }
+    foreach_reverse(int i, dchar v; chr) { }
+    foreach(char i, dchar v; chr) { }
+    foreach_reverse(char i, dchar v; chr) { }
 }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -3387,13 +3387,13 @@ bool test3512()
     assert(q == 6);
 
     // _aApplycw2
-    foreach (int i, wchar c; s)
+    foreach (ptrdiff_t i, wchar c; s)
     {
         assert(i >= 0 && i < s.length);
     }
 
     // _aApplycd2
-    foreach (int i, dchar c; s)
+    foreach (ptrdiff_t i, dchar c; s)
     {
         assert(i >= 0 && i < s.length);
     }
@@ -3415,13 +3415,13 @@ bool test3512()
     assert(q == 13);
 
     // _aApplywc2
-    foreach (int i, char c; w)
+    foreach (ptrdiff_t i, char c; w)
     {
         assert(i >= 0 && i < w.length);
     }
 
     // _aApplywd2
-    foreach (int i, dchar c; w)
+    foreach (ptrdiff_t i, dchar c; w)
     {
         assert(i >= 0 && i < w.length);
     }
@@ -3445,19 +3445,19 @@ bool test3512()
     assert(q == 3);
 
     // _aApplydc2
-    foreach (int i, char c; d)
+    foreach (ptrdiff_t i, char c; d)
     {
         assert(i >= 0 && i < d.length);
     }
     // _aApplydw2
-    foreach (int i, wchar c; d)
+    foreach (ptrdiff_t i, wchar c; d)
     {
         assert(i >= 0 && i < d.length);
     }
 
     dchar[] dr = "squop"d.dup;
 
-    foreach (int n, char c; dr)
+    foreach (ptrdiff_t n, char c; dr)
     {
         if (n == 2)
             break;
@@ -3473,7 +3473,7 @@ bool test3512()
     {}
 
     // _aApplyRdc2
-    foreach_reverse (int n, char c; dr)
+    foreach_reverse (ptrdiff_t n, char c; dr)
     {
         if (n == 4)
             break;
@@ -3481,14 +3481,14 @@ bool test3512()
     }
 
     // _aApplyRdw2
-    foreach_reverse (int i, wchar c; dr)
+    foreach_reverse (ptrdiff_t i, wchar c; dr)
     {
         assert(i >= 0 && i < dr.length);
     }
 
     q = 0;
     wstring w2 = ['x', 'ü', 'm']; // foreach over array literals
-    foreach_reverse (int n, char c; w2)
+    foreach_reverse (ptrdiff_t n, char c; w2)
     {
         ++q;
         if (c == 'm') assert(n == 2 && q == 1);

--- a/test/fail_compilation/diag16976.d
+++ b/test/fail_compilation/diag16976.d
@@ -1,9 +1,21 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/diag16976.d(14): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(15): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(16): Error: foreach: key cannot be of non-integral type `float`
-fail_compilation/diag16976.d(17): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(28): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(29): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(30): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(31): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(32): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(33): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(34): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(35): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(36): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(37): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(38): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(39): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(40): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(41): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(42): Error: foreach: key cannot be of non-integral type `float`
+fail_compilation/diag16976.d(43): Error: foreach: key cannot be of non-integral type `float`
 ---
 */
 
@@ -11,8 +23,22 @@ void main()
 {
     int[]  dyn = [1,2,3,4,5];
     int[5] sta = [1,2,3,4,5];
+    char[]  str = ['1','2','3','4','5'];
+    char[5] chr = ['1','2','3','4','5'];
     foreach(float f, i; dyn) {}
     foreach(float f, i; sta) {}
+    foreach(float f, i; str) {}
+    foreach(float f, i; chr) {}
+    foreach(float f, dchar i; dyn) {}
+    foreach(float f, dchar i; sta) {}
+    foreach(float f, dchar i; str) {}
+    foreach(float f, dchar i; chr) {}
     foreach_reverse(float f, i; dyn) {}
     foreach_reverse(float f, i; sta) {}
+    foreach_reverse(float f, i; str) {}
+    foreach_reverse(float f, i; chr) {}
+    foreach_reverse(float f, dchar i; dyn) {}
+    foreach_reverse(float f, dchar i; sta) {}
+    foreach_reverse(float f, dchar i; str) {}
+    foreach_reverse(float f, dchar i; chr) {}
 }


### PR DESCRIPTION
Bugzilla 16976 didn't go far enough in deprecating foreach(int, T; ...).