### PR TITLE
[refactor] dmd.mtype: Add Type.ischaracter property, use it.

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1508,7 +1508,7 @@ UnionExp Cat(Type type, Expression e1, Expression e2)
         t = t2;
     L2:
         Type tn = e.type.toBasetype();
-        if (tn.ty == Tchar || tn.ty == Twchar || tn.ty == Tdchar)
+        if (tn.ischaracter())
         {
             // Create a StringExp
             if (t.nextOf())

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2830,7 +2830,7 @@ bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expression* pe2)
 
     if (op != TOK.question || t1b.ty != t2b.ty && (t1b.isTypeBasic() && t2b.isTypeBasic()))
     {
-        if (op == TOK.question && t1b.ischar() && t2b.ischar())
+        if (op == TOK.question && t1b.ischaracter() && t2b.ischaracter())
         {
             e1 = charPromotions(e1, sc);
             e2 = charPromotions(e2, sc);

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -3033,7 +3033,7 @@ public:
             return ae;
         }
         assert(argnum == arguments.dim - 1);
-        if (elemType.ty == Tchar || elemType.ty == Twchar || elemType.ty == Tdchar)
+        if (elemType.ischaracter())
         {
             const ch = cast(dchar)elemType.defaultInitLiteral(loc).toInteger();
             const sz = cast(ubyte)elemType.size();

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -114,8 +114,7 @@ bool expressionsToString(ref OutBuffer buf, Scope* sc, Expressions* exps)
         // char literals exp `.toStringExp` return `null` but we cant override it
         // because in most contexts we don't want the conversion to succeed.
         IntegerExp ie = e4.isIntegerExp();
-        const ty = (ie && ie.type) ? ie.type.ty : Terror;
-        if (ty == Tchar || ty == Twchar || ty == Tdchar)
+        if (ie && ie.type && ie.type.ischaracter())
         {
             auto tsa = new TypeSArray(ie.type, new IntegerExp(1));
             e4 = new ArrayLiteralExp(ex.loc, tsa, ie);
@@ -10759,8 +10758,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         {
             Type t1n = t1.nextOf().toBasetype();
             Type t2n = t2.nextOf().toBasetype();
-            if (((t1n.ty == Tchar || t1n.ty == Twchar || t1n.ty == Tdchar) &&
-                 (t2n.ty == Tchar || t2n.ty == Twchar || t2n.ty == Tdchar)) ||
+            if ((t1n.ischaracter() && t2n.ischaracter()) ||
                 (t1n.ty == Tvoid || t2n.ty == Tvoid))
             {
                 return false;

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -3594,8 +3594,7 @@ extern (C++) final class TypeSArray : TypeArray
 
     override bool isString()
     {
-        TY nty = next.toBasetype().ty;
-        return nty == Tchar || nty == Twchar || nty == Tdchar;
+        return next.toBasetype().ischaracter();
     }
 
     override bool isZeroInit(const ref Loc loc)
@@ -3764,8 +3763,7 @@ extern (C++) final class TypeDArray : TypeArray
 
     override bool isString()
     {
-        TY nty = next.toBasetype().ty;
-        return nty == Tchar || nty == Twchar || nty == Tdchar;
+        return next.toBasetype().ischaracter();
     }
 
     override bool isZeroInit(const ref Loc loc) const

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -232,7 +232,7 @@ private enum TFlags
     real_        = 8,
     imaginary    = 0x10,
     complex      = 0x20,
-    char_        = 0x40,
+    character    = 0x40,
 }
 
 enum ENUMTY : int
@@ -999,6 +999,11 @@ extern (C++) abstract class Type : ASTNode
         return false;
     }
 
+    bool ischaracter()
+    {
+        return false;
+    }
+
     // real, imaginary, or complex
     bool isfloating()
     {
@@ -1026,11 +1031,6 @@ extern (C++) abstract class Type : ASTNode
     }
 
     bool isunsigned()
-    {
-        return false;
-    }
-
-    bool ischar()
     {
         return false;
     }
@@ -3134,17 +3134,17 @@ extern (C++) final class TypeBasic : Type
 
         case Tchar:
             d = Token.toChars(TOK.char_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned | TFlags.character;
             break;
 
         case Twchar:
             d = Token.toChars(TOK.wchar_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned | TFlags.character;
             break;
 
         case Tdchar:
             d = Token.toChars(TOK.dchar_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned | TFlags.character;
             break;
 
         default:
@@ -3254,6 +3254,11 @@ extern (C++) final class TypeBasic : Type
         return (flags & TFlags.integral) != 0;
     }
 
+    override bool ischaracter()
+    {
+        return (flags & TFlags.character) != 0;
+    }
+
     override bool isfloating() const
     {
         return (flags & TFlags.floating) != 0;
@@ -3282,11 +3287,6 @@ extern (C++) final class TypeBasic : Type
     override bool isunsigned() const
     {
         return (flags & TFlags.unsigned) != 0;
-    }
-
-    override bool ischar() const
-    {
-        return (flags & TFlags.char_) != 0;
     }
 
     override MATCH implicitConvTo(Type to)
@@ -3460,6 +3460,11 @@ extern (C++) final class TypeVector : Type
     {
         //printf("TypeVector::isintegral('%s') x%x\n", toChars(), flags);
         return basetype.nextOf().isintegral();
+    }
+
+    override bool ischaracter()
+    {
+        return basetype.nextOf().ischaracter();
     }
 
     override bool isfloating()
@@ -5816,6 +5821,11 @@ extern (C++) final class TypeEnum : Type
         return memType().isintegral();
     }
 
+    override bool ischaracter()
+    {
+        return memType().ischaracter();
+    }
+
     override bool isfloating()
     {
         return memType().isfloating();
@@ -5844,11 +5854,6 @@ extern (C++) final class TypeEnum : Type
     override bool isunsigned()
     {
         return memType().isunsigned();
-    }
-
-    override bool ischar()
-    {
-        return memType().ischar();
     }
 
     override bool isBoolean()

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -246,13 +246,13 @@ public:
     char *modToChars() const;
 
     virtual bool isintegral();
+    virtual bool ischaracter();  // char, wchar, or dchar
     virtual bool isfloating();   // real, imaginary, or complex
     virtual bool isreal();
     virtual bool isimaginary();
     virtual bool iscomplex();
     virtual bool isscalar();
     virtual bool isunsigned();
-    virtual bool ischar();
     virtual bool isscope();
     virtual bool isString();
     virtual bool isAssignable();
@@ -392,13 +392,13 @@ public:
     d_uns64 size(const Loc &loc) /*const*/;
     unsigned alignsize();
     bool isintegral();
+    bool ischaracter();
     bool isfloating() /*const*/;
     bool isreal() /*const*/;
     bool isimaginary() /*const*/;
     bool iscomplex() /*const*/;
     bool isscalar() /*const*/;
     bool isunsigned() /*const*/;
-    bool ischar() /*const*/;
     MATCH implicitConvTo(Type *to);
     bool isZeroInit(const Loc &loc) /*const*/;
 
@@ -418,6 +418,7 @@ public:
     d_uns64 size(const Loc &loc);
     unsigned alignsize();
     bool isintegral();
+    bool ischaracter();
     bool isfloating();
     bool isscalar();
     bool isunsigned();
@@ -771,13 +772,13 @@ public:
     Type *memType(const Loc &loc = Loc());
     Dsymbol *toDsymbol(Scope *sc);
     bool isintegral();
+    bool ischaracter();
     bool isfloating();
     bool isreal();
     bool isimaginary();
     bool iscomplex();
     bool isscalar();
     bool isunsigned();
-    bool ischar();
     bool isBoolean();
     bool isString();
     bool isAssignable();

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1145,8 +1145,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 {
                     Type t1n = t1.nextOf().toBasetype();
                     Type t2n = t2.nextOf().toBasetype();
-                    if (((t1n.ty == Tchar || t1n.ty == Twchar || t1n.ty == Tdchar) &&
-                         (t2n.ty == Tchar || t2n.ty == Twchar || t2n.ty == Tdchar)) ||
+                    if ((t1n.ischaracter() && t2n.ischaracter()) ||
                         (t1n.ty == Tvoid || t2n.ty == Tvoid))
                     {
                         return false;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1217,9 +1217,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                      */
                     Type tv = (*fs.parameters)[1].type.toBasetype();
                     if ((tab.ty == Tarray ||
-                         (tn.ty != tv.ty &&
-                          (tn.ty == Tchar || tn.ty == Twchar || tn.ty == Tdchar) &&
-                          (tv.ty == Tchar || tv.ty == Twchar || tv.ty == Tdchar))) &&
+                         (tn.ty != tv.ty && tn.ischaracter() && tv.ischaracter())) &&
                         !Type.tsize_t.implicitConvTo(tindex))
                     {
                         fs.deprecation("foreach: loop index implicitly converted from `size_t` to `%s`",
@@ -1230,13 +1228,12 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                 /* Look for special case of parsing char types out of char type
                  * array.
                  */
-                if (tn.ty == Tchar || tn.ty == Twchar || tn.ty == Tdchar)
+                if (tn.ischaracter())
                 {
                     int i = (dim == 1) ? 0 : 1; // index of value
                     Parameter p = (*fs.parameters)[i];
                     tnv = p.type.toBasetype();
-                    if (tnv.ty != tn.ty &&
-                        (tnv.ty == Tchar || tnv.ty == Twchar || tnv.ty == Tdchar))
+                    if (tnv.ty != tn.ty && tnv.ischaracter())
                     {
                         if (p.storageClass & STC.ref_)
                         {


### PR DESCRIPTION
Pet peeve that comes up every so often, not being able to distinguish between integral and character types other than using `t.isintegral() && t.ty != Tchar && t.ty != Twchar && t.ty != Tdchar`.