### PR TITLE
Fix issue 16486: Alias template function parameter resolution

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1351,6 +1351,10 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             {
                 Parameter fparam = fparameters[parami];
 
+                /* https://issues.dlang.org/show_bug.cgi?id=16486
+                 * If 'prmtype' is template alias, resolve it,
+                 * to the instance it's aliased to before proceeding.
+                 */
                 Type prmtype = fparam.type;
                 //printf("prmtype: %s\n", prmtype.toChars());
                 while (prmtype.ty == Tinstance)

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1408,18 +1408,20 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     td = s.isTemplateDeclaration();
                     /// Having found the declaration, check if it is an
                     /// alias and get the actual type.
-                    if(td && td.onemember && td.onemember.isAliasDeclaration())
+                    if (td && td.onemember && td.onemember.isAliasDeclaration())
                     {
                         AliasDeclaration ad = td.onemember.isAliasDeclaration();
                         //printf("ad: %s\n", ad.toChars());
                         Type adtype = ad.getType();
                         // Set the actual type, the type of the alias.
-                        if(adtype != prevtype) {
+                        if (adtype != prevtype) {
                             prmtype = adtype;
                             prevtype = prmtype;
                             //printf("prmtype: %s\n\n", prmtype.toChars());
                             continue;
-                        } else {
+                        }
+                        else
+                        {
                             // roll-back
                             prmtype = savetype;
                             break;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1432,22 +1432,12 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     }
 
                     // Look if any parameter doesn't match the initial parameter.
-                    bool change = false;
                     prmti = cast(TypeInstance) prmtype;
                     for(size_t i = 0; i < tempargs[0].length; ++i) {
                         if(tempargs[0][i] != prmti.tempinst.tiargs[0][i]) {
                             //printf("tempargs[i]: %s\n", tempargs[0][i].toChars());
-                            change = true;
-                            break;
-                        }
-                    }
-                    // If so, use the initial parameters.
-                    if(change) {
-                        prmti = cast(TypeInstance) prmti.copy();
-                        for(size_t i = 0; i < tempargs[0].length; ++i) {
                             prmti.tempinst.tiargs[0][i] = tempargs[0][i];
                         }
-                        prmtype = prmti;
                     }
                 }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1351,8 +1351,33 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             {
                 Parameter fparam = fparameters[parami];
 
+                Type prmtype = fparam.type;
+                //printf("prmtype: %s\n", prmtype.toChars());
+                while (prmtype.ty == Tinstance)
+                {
+                    TypeInstance prmti = cast(TypeInstance) prmtype;
+                    //printf("prmti: %s\n", prmti.toChars());
+                    if (prmti.tempinst.findTempDecl(sc, null))
+                    {
+                        if (auto td = prmti.tempinst.tempdecl.isTemplateDeclaration())
+                        {
+                            //printf("td: %s\n", td.toChars());
+                            if (td.onemember)
+                            {
+                                if (auto ad = td.onemember.isAliasDeclaration())
+                                {
+                                    Type adtype = ad.getType();
+                                    prmtype = adtype;
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+
                 // Apply function parameter storage classes to parameter types
-                Type prmtype = fparam.type.addStorageClass(fparam.storageClass);
+                prmtype = prmtype.addStorageClass(fparam.storageClass);
 
                 Expression farg;
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1379,7 +1379,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     if (!s)
                     {
                         // roll-back
-                        prmtype = savetype;
                         break;
                     }
                     /* We might have found an alias within a template when
@@ -1404,7 +1403,6 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                     }
 
 
-                    s = s.toAlias();
                     td = s.isTemplateDeclaration();
                     /// Having found the declaration, check if it is an
                     /// alias and get the actual type.
@@ -1414,7 +1412,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         //printf("ad: %s\n", ad.toChars());
                         Type adtype = ad.getType();
                         // Set the actual type, the type of the alias.
-                        if (adtype != prevtype) {
+                        if (adtype.ty == Tinstance && adtype != prevtype) {
                             prmtype = adtype;
                             prevtype = prmtype;
                             //printf("prmtype: %s\n\n", prmtype.toChars());

--- a/test/compilable/test16486.d
+++ b/test/compilable/test16486.d
@@ -1,0 +1,36 @@
+// Example 1 - Simple case
+struct TestType(T, Q) { }
+alias TestAlias(T, Q) = TestType!(T, Q);
+static void testFunction(T, Q)(TestAlias!(T, Q) arg) { }
+
+// Example 2 - Real-world case, an initial motivation
+// for the fix is Mir users to be able to do such aliasing.
+struct Slice(T) {
+}
+
+struct StairsIterator(T, string direction) {
+}
+
+alias PackedUpperTriangularMatrix(T) = Slice!(StairsIterator!(T*, "-"));
+
+auto foo(T)(PackedUpperTriangularMatrix!T m)
+{
+}
+
+// Example 3 - Multiple levels of aliasing
+struct TestType2(T) {}
+struct EnclosingType(T) {}
+alias TestAlias2(T) = TestType2!(EnclosingType!T);
+void testFunction2(T)(TestAlias2!(T) arg) {}
+
+void main()
+{
+    TestAlias!(int, float) testObj;
+    testFunction(testObj);
+
+    PackedUpperTriangularMatrix!(int) m;
+    foo(m);
+
+    TestAlias2!(int) testObj2;
+    testFunction2(testObj2);
+}

--- a/test/compilable/test16486.d
+++ b/test/compilable/test16486.d
@@ -23,14 +23,41 @@ struct EnclosingType(T) {}
 alias TestAlias2(T) = TestType2!(EnclosingType!T);
 void testFunction2(T)(TestAlias2!(T) arg) {}
 
+// Example 4 - Mismatch of root argument names and final argument names
+struct TestType3(A, B) { }
+alias TestAlias3(A, B) = TestType3!(A, B);
+alias TestAlias4(T, Q) = TestAlias3!(T, Q);
+void testFunction3(T, Q)(TestAlias4!(T, Q) arg) {}
+
+// Example 5 - More complicated mismatch of argument names
+struct TestType5(T, Q) { }
+template TestAlias5(T, Q)
+{
+    alias A = T;
+    alias TestAlias5 = TestType5!(A, Q);
+}
+alias TestAlias6(T, Q) = TestAlias5!(T, Q);
+void testFunction4(T, Q)(TestAlias6!(T, Q) arg) {}
+
 void main()
 {
+	// Example 1
     TestAlias!(int, float) testObj;
     testFunction(testObj);
 
+	// Example 2
     PackedUpperTriangularMatrix!(int) m;
     foo(m);
 
+	// Example 3
     TestAlias2!(int) testObj2;
     testFunction2(testObj2);
+	
+	// Exmaple 4
+	TestAlias4!(int, float) testObj3;
+	testFunction3(testObj3);
+	
+	// Example 5
+	TestAlias6!(int, float) testObj4;
+	testFunction4(testObj4);
 }


### PR DESCRIPTION
This is a 3-day prototype implementation of this DIP PR: https://github.com/dlang/DIPs/pull/156
More comments / info on the implementation are in this article: http://users.uoa.gr/~sdi1600105/dlang/alias.html

So, if a parameter is a template alias, we iteratively (because a template alias might be alias to another template alias) reach the actual type of the parameter before proceeding into any type-checking.

The main idea is:
```
while(paramType is ad = aliasTemplateDeclaration) {
    adtype = ad.getType();
    if(adtype is TypeInstance) {
        paramType = aliasTemplateDeclaration
    }
}
```

It fails (at least) in such cases:

```
struct TestType(T) {}
alias TestAlias(T, Q) = TestType!(T);
void testFunction(T, Q)(TestAlias!(T, Q) arg) {}

void main()
{
    TestAlias!(int, float) testObj;
    testFunction(testObj);
}
```

This basically resolves to this:
```
struct TestType(T) {}
void testFunction(T, Q)(TestType!T arg) {}
```

This code breaks and rightly so, independently of the bug. However, I'm not sure whether the initial code should break.