### PR TITLE
dmd.declaration: Add VarDeclaration.create to C++ API

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1131,6 +1131,11 @@ extern (C++) class VarDeclaration : Declaration
         sequenceNumber = ++nextSequenceNumber;
     }
 
+    static VarDeclaration create(const ref Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
+    {
+        return new VarDeclaration(loc, type, ident, _init, storage_class);
+    }
+
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         //printf("VarDeclaration::syntaxCopy(%s)\n", toChars());

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -240,6 +240,7 @@ private:
     bool _isAnonymous;
 
 public:
+    static VarDeclaration *create(Loc loc, Type *t, Identifier *id, Initializer *init, StorageClass storage_class = STCundefined);
     Dsymbol *syntaxCopy(Dsymbol *);
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;


### PR DESCRIPTION
Main use-case is for inserting fields into the auto-generated struct va_list type (where the underlying type is a struct).