### PR TITLE
Fix 15984 - [REG2.071] Interface contracts retrieve garbage instead of parameters

### DIFF
--- a/changelog/interface_contracts.dd
+++ b/changelog/interface_contracts.dd
@@ -1,0 +1,25 @@
+Interface contracts retrieve arguments correctly
+
+Fixed regression $(LINK2 https://issues.dlang.org/show_bug.cgi?id=15984, 15984).
+
+As a side effect, contracts are not ABI compatible with previous releases.
+
+---
+interface I
+{
+    void fun(int i)
+    out { assert(i == 5); } // succeeds
+}
+
+class C : I
+{
+    void fun(int i)
+    do { }
+}
+
+unittest
+{
+    auto c = new C;
+    c.fun(5);
+}
+---

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -473,6 +473,9 @@ public:
     FuncDeclaration *fdrequire;         // function that does the in contract
     FuncDeclaration *fdensure;          // function that does the out contract
 
+    Expressions *fdrequireParams;       // argument list for __require
+    Expressions *fdensureParams;        // argument list for __ensure
+
     const char *mangleString;           // mangled symbol created from mangleExact()
 
     VarDeclaration *vresult;            // result variable for out contracts
@@ -612,8 +615,8 @@ public:
     bool needsClosure();
     bool hasNestedFrameRefs();
     void buildResultVar(Scope *sc, Type *tret);
-    Statement *mergeFrequire(Statement *);
-    Statement *mergeFensure(Statement *, Identifier *oid);
+    Statement *mergeFrequire(Statement *, Expressions *);
+    Statement *mergeFensure(Statement *, Identifier *oid, Expressions *);
     ParameterList getParameterList();
 
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -224,6 +224,9 @@ extern (C++) class FuncDeclaration : Declaration
     FuncDeclaration fdrequire;          /// function that does the in contract
     FuncDeclaration fdensure;           /// function that does the out contract
 
+    Expressions* fdrequireParams;       /// argument list for __require
+    Expressions* fdensureParams;        /// argument list for __ensure
+
     const(char)* mangleString;          /// mangled symbol created from mangleExact()
 
     VarDeclaration vresult;             /// result variable for out contracts
@@ -2049,7 +2052,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Merge into this function the 'in' contracts of all it overrides.
      * 'in's are OR'd together, i.e. only one of them needs to pass.
      */
-    final Statement mergeFrequire(Statement sf)
+    final Statement mergeFrequire(Statement sf, Expressions* params)
     {
         /* If a base function and its override both have an IN contract, then
          * only one of them needs to succeed. This is done by generating:
@@ -2067,22 +2070,6 @@ extern (C++) class FuncDeclaration : Declaration
          * If base.in() throws, then derived.in()'s body is executed.
          */
 
-        /* Implementing this is done by having the overriding function call
-         * nested functions (the fdrequire functions) nested inside the overridden
-         * function. This requires that the stack layout of the calling function's
-         * parameters and 'this' pointer be in the same place (as the nested
-         * function refers to them).
-         * This is easy for the parameters, as they are all on the stack in the same
-         * place by definition, since it's an overriding function. The problem is
-         * getting the 'this' pointer in the same place, since it is a local variable.
-         * We did some hacks in the code generator to make this happen:
-         *  1. always generate exception handler frame, or at least leave space for it
-         *     in the frame (Windows 32 SEH only)
-         *  2. always generate an EBP style frame
-         *  3. since 'this' is passed in a register that is subsequently copied into
-         *     a stack local, allocate that local immediately following the exception
-         *     handler block, so it is always at the same offset from EBP.
-         */
         foreach (fdv; foverrides)
         {
             /* The semantic pass on the contracts of the overridden functions must
@@ -2098,16 +2085,16 @@ extern (C++) class FuncDeclaration : Declaration
                 sc.pop();
             }
 
-            sf = fdv.mergeFrequire(sf);
+            sf = fdv.mergeFrequire(sf, params);
             if (sf && fdv.fdrequire)
             {
                 //printf("fdv.frequire: %s\n", fdv.frequire.toChars());
                 /* Make the call:
-                 *   try { __require(); }
+                 *   try { __require(params); }
                  *   catch (Throwable) { frequire; }
                  */
-                Expression eresult = null;
-                Expression e = new CallExp(loc, new VarExp(loc, fdv.fdrequire, false), eresult);
+                params = Expression.arraySyntaxCopy(params);
+                Expression e = new CallExp(loc, new VarExp(loc, fdv.fdrequire, false), params);
                 Statement s2 = new ExpStatement(loc, e);
 
                 auto c = new Catch(loc, getThrowable(), null, sf);
@@ -2207,15 +2194,41 @@ extern (C++) class FuncDeclaration : Declaration
          */
         TypeFunction f = cast(TypeFunction) type;
 
+        /* Make a copy of the parameters and make them all ref */
+        static Parameters* toRefCopy(Parameters* params)
+        {
+            auto result = new Parameters();
+
+            int toRefDg(size_t n, Parameter p)
+            {
+                p = p.syntaxCopy();
+                if (!(p.storageClass & STC.lazy_))
+                    p.storageClass = (p.storageClass | STC.ref_) & ~STC.out_;
+                p.defaultArg = null; // won't be the same with ref
+                result.push(p);
+                return 0;
+            }
+
+            Parameter._foreach(params, &toRefDg);
+            return result;
+        }
+
         if (frequire)
         {
             /*   in { ... }
              * becomes:
-             *   void __require() { ... }
-             *   __require();
+             *   void __require(ref params) { ... }
+             *   __require(params);
              */
             Loc loc = frequire.loc;
-            auto tf = new TypeFunction(ParameterList(), Type.tvoid, LINK.d);
+            fdrequireParams = new Expressions();
+            if (parameters)
+            {
+                foreach (vd; *parameters)
+                    fdrequireParams.push(new VarExp(loc, vd));
+            }
+            auto fparams = toRefCopy(f.parameterList.parameters);
+            auto tf = new TypeFunction(ParameterList(fparams), Type.tvoid, LINK.d);
             tf.isnothrow = f.isnothrow;
             tf.isnogc = f.isnogc;
             tf.purity = f.purity;
@@ -2223,27 +2236,40 @@ extern (C++) class FuncDeclaration : Declaration
             auto fd = new FuncDeclaration(loc, loc, Id.require, STC.undefined_, tf);
             fd.fbody = frequire;
             Statement s1 = new ExpStatement(loc, fd);
-            Expression e = new CallExp(loc, new VarExp(loc, fd, false), cast(Expressions*)null);
+            Expression e = new CallExp(loc, new VarExp(loc, fd, false), fdrequireParams);
             Statement s2 = new ExpStatement(loc, e);
             frequire = new CompoundStatement(loc, s1, s2);
             fdrequire = fd;
+        }
+
+        /* We need to set fdensureParams here and not in the block below to
+         * have the parameters available when calling a base class ensure(),
+         * even if this function doesn't have an out contract.
+         */
+        fdensureParams = new Expressions();
+        if (canBuildResultVar())
+            fdensureParams.push(new IdentifierExp(loc, Id.result));
+        if (parameters)
+        {
+            foreach (vd; *parameters)
+                fdensureParams.push(new VarExp(loc, vd));
         }
 
         if (fensure)
         {
             /*   out (result) { ... }
              * becomes:
-             *   void __ensure(ref tret result) { ... }
-             *   __ensure(result);
+             *   void __ensure(ref tret result, ref params) { ... }
+             *   __ensure(result, params);
              */
             Loc loc = fensure.loc;
             auto fparams = new Parameters();
-            Parameter p = null;
             if (canBuildResultVar())
             {
-                p = new Parameter(STC.ref_ | STC.const_, f.nextOf(), Id.result, null, null);
+                Parameter p = new Parameter(STC.ref_ | STC.const_, f.nextOf(), Id.result, null, null);
                 fparams.push(p);
             }
+            fparams.pushSlice((*toRefCopy(f.parameterList.parameters))[]);
             auto tf = new TypeFunction(ParameterList(fparams), Type.tvoid, LINK.d);
             tf.isnothrow = f.isnothrow;
             tf.isnogc = f.isnogc;
@@ -2255,7 +2281,7 @@ extern (C++) class FuncDeclaration : Declaration
             Expression eresult = null;
             if (canBuildResultVar())
                 eresult = new IdentifierExp(loc, Id.result);
-            Expression e = new CallExp(loc, new VarExp(loc, fd, false), eresult);
+            Expression e = new CallExp(loc, new VarExp(loc, fd, false), fdensureParams);
             Statement s2 = new ExpStatement(loc, e);
             fensure = new CompoundStatement(loc, s1, s2);
             fdensure = fd;
@@ -2266,7 +2292,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Merge into this function the 'out' contracts of all it overrides.
      * 'out's are AND'd together, i.e. all of them need to pass.
      */
-    final Statement mergeFensure(Statement sf, Identifier oid)
+    final Statement mergeFensure(Statement sf, Identifier oid, Expressions* params)
     {
         /* Same comments as for mergeFrequire(), except that we take care
          * of generating a consistent reference to the 'result' local by
@@ -2293,16 +2319,14 @@ extern (C++) class FuncDeclaration : Declaration
                 sc.pop();
             }
 
-            sf = fdv.mergeFensure(sf, oid);
+            sf = fdv.mergeFensure(sf, oid, params);
             if (fdv.fdensure)
             {
                 //printf("fdv.fensure: %s\n", fdv.fensure.toChars());
-                // Make the call: __ensure(result)
-                Expression eresult = null;
+                // Make the call: __ensure(result, params)
+                params = Expression.arraySyntaxCopy(params);
                 if (canBuildResultVar())
                 {
-                    eresult = new IdentifierExp(loc, oid);
-
                     Type t1 = fdv.type.nextOf().toBasetype();
                     Type t2 = this.type.nextOf().toBasetype();
                     if (t1.isBaseOf(t2, null))
@@ -2312,15 +2336,16 @@ extern (C++) class FuncDeclaration : Declaration
                          * https://issues.dlang.org/show_bug.cgi?id=5204
                          * https://issues.dlang.org/show_bug.cgi?id=10479
                          */
-                        auto ei = new ExpInitializer(Loc.initial, eresult);
+                        Expression* eresult = &(*params)[0];
+                        auto ei = new ExpInitializer(Loc.initial, *eresult);
                         auto v = new VarDeclaration(Loc.initial, t1, Identifier.generateId("__covres"), ei);
                         v.storage_class |= STC.temp;
                         auto de = new DeclarationExp(Loc.initial, v);
                         auto ve = new VarExp(Loc.initial, v);
-                        eresult = new CommaExp(Loc.initial, de, ve);
+                        *eresult = new CommaExp(Loc.initial, de, ve);
                     }
                 }
-                Expression e = new CallExp(loc, new VarExp(loc, fdv.fdensure, false), eresult);
+                Expression e = new CallExp(loc, new VarExp(loc, fdv.fdensure, false), params);
                 Statement s2 = new ExpStatement(loc, e);
 
                 if (sf)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -878,8 +878,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 sc2 = sc2.pop();
             }
 
-            funcdecl.frequire = funcdecl.mergeFrequire(funcdecl.frequire);
-            funcdecl.fensure = funcdecl.mergeFensure(funcdecl.fensure, Id.result);
+            funcdecl.frequire = funcdecl.mergeFrequire(funcdecl.frequire, funcdecl.fdrequireParams);
+            funcdecl.fensure = funcdecl.mergeFensure(funcdecl.fensure, Id.result, funcdecl.fdensureParams);
 
             Statement freq = funcdecl.frequire;
             Statement fens = funcdecl.fensure;

--- a/test/fail_compilation/fail9414a.d
+++ b/test/fail_compilation/fail9414a.d
@@ -1,23 +1,23 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9414a.d(47): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
-fail_compilation/fail9414a.d(34): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(47): Error: variable `fail9414a.C.foo.__require.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(34): Error: variable `fail9414a.C.foo.__require.x` cannot modify parameter `x` in contract
 fail_compilation/fail9414a.d(35): Error: variable `fail9414a.C.foo.__require.bar.y` cannot modify parameter `y` in contract
-fail_compilation/fail9414a.d(40): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(40): Error: variable `fail9414a.C.foo.__require.x` cannot modify parameter `x` in contract
 fail_compilation/fail9414a.d(41): Error: variable `fail9414a.C.foo.__require.bar.y` cannot modify parameter `y` in contract
 fail_compilation/fail9414a.d(42): Error: variable `fail9414a.C.foo.__require.bar.s` cannot modify result `s` in contract
-fail_compilation/fail9414a.d(52): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
-fail_compilation/fail9414a.d(75): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(52): Error: variable `fail9414a.C.foo.__require.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(75): Error: variable `fail9414a.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414a.d(76): Error: variable `fail9414a.C.foo.__ensure.r` cannot modify result `r` in contract
-fail_compilation/fail9414a.d(60): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(60): Error: variable `fail9414a.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414a.d(61): Error: variable `fail9414a.C.foo.__ensure.r` cannot modify result `r` in contract
 fail_compilation/fail9414a.d(62): Error: variable `fail9414a.C.foo.__ensure.baz.y` cannot modify parameter `y` in contract
-fail_compilation/fail9414a.d(67): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(67): Error: variable `fail9414a.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414a.d(68): Error: variable `fail9414a.C.foo.__ensure.r` cannot modify result `r` in contract
 fail_compilation/fail9414a.d(69): Error: variable `fail9414a.C.foo.__ensure.baz.y` cannot modify parameter `y` in contract
 fail_compilation/fail9414a.d(70): Error: variable `fail9414a.C.foo.__ensure.baz.s` cannot modify result `s` in contract
-fail_compilation/fail9414a.d(81): Error: variable `fail9414a.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414a.d(81): Error: variable `fail9414a.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414a.d(82): Error: variable `fail9414a.C.foo.__ensure.r` cannot modify result `r` in contract
 ---
 */

--- a/test/fail_compilation/fail9414b.d
+++ b/test/fail_compilation/fail9414b.d
@@ -1,23 +1,23 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail9414b.d(47): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
-fail_compilation/fail9414b.d(34): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(47): Error: variable `fail9414b.C.foo.__require.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(34): Error: variable `fail9414b.C.foo.__require.x` cannot modify parameter `x` in contract
 fail_compilation/fail9414b.d(35): Error: variable `fail9414b.C.foo.__require.bar.y` cannot modify parameter `y` in contract
-fail_compilation/fail9414b.d(40): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(40): Error: variable `fail9414b.C.foo.__require.x` cannot modify parameter `x` in contract
 fail_compilation/fail9414b.d(41): Error: variable `fail9414b.C.foo.__require.bar.y` cannot modify parameter `y` in contract
 fail_compilation/fail9414b.d(42): Error: variable `fail9414b.C.foo.__require.bar.s` cannot modify result `s` in contract
-fail_compilation/fail9414b.d(52): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
-fail_compilation/fail9414b.d(75): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(52): Error: variable `fail9414b.C.foo.__require.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(75): Error: variable `fail9414b.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414b.d(76): Error: variable `fail9414b.C.foo.__ensure.r` cannot modify result `r` in contract
-fail_compilation/fail9414b.d(60): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(60): Error: variable `fail9414b.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414b.d(61): Error: variable `fail9414b.C.foo.__ensure.r` cannot modify result `r` in contract
 fail_compilation/fail9414b.d(62): Error: variable `fail9414b.C.foo.__ensure.baz.y` cannot modify parameter `y` in contract
-fail_compilation/fail9414b.d(67): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(67): Error: variable `fail9414b.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414b.d(68): Error: variable `fail9414b.C.foo.__ensure.r` cannot modify result `r` in contract
 fail_compilation/fail9414b.d(69): Error: variable `fail9414b.C.foo.__ensure.baz.y` cannot modify parameter `y` in contract
 fail_compilation/fail9414b.d(70): Error: variable `fail9414b.C.foo.__ensure.baz.s` cannot modify result `s` in contract
-fail_compilation/fail9414b.d(81): Error: variable `fail9414b.C.foo.x` cannot modify parameter `x` in contract
+fail_compilation/fail9414b.d(81): Error: variable `fail9414b.C.foo.__ensure.x` cannot modify result `x` in contract
 fail_compilation/fail9414b.d(82): Error: variable `fail9414b.C.foo.__ensure.r` cannot modify result `r` in contract
 ---
 */

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -1080,6 +1080,79 @@ void test14779()
 }
 
 /*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=15984
+
+I15984 i15984;
+C15984 c15984;
+
+void check15984(T)(const char* s, T this_, int i)
+{
+    printf("%s this = %p, i = %d\n", s, this_, i);
+    static if (is(T == I15984)) assert(this_ is i15984);
+    else static if (is(T == C15984)) assert(this_ is c15984);
+    else static assert(0);
+    assert(i == 5);
+}
+
+interface I15984
+{
+    void f1(int i)
+    in  { check15984("I.f1.i", this, i); assert(0); }
+    out { check15984("I.f1.o", this, i); }
+
+    int[3] f2(int i)
+    in  { check15984("I.f2.i", this, i); assert(0); }
+    out { check15984("I.f2.o", this, i); }
+
+    void f3(int i)
+    in  { void nested() { check15984("I.f3.i", this, i); } nested(); assert(0); }
+    out { void nested() { check15984("I.f3.o", this, i); } nested(); }
+
+    void f4(out int i, lazy int j)
+    in  { }
+    out { }
+}
+
+class C15984 : I15984
+{
+    void f1(int i)
+    in  { check15984("C.f1.i", this, i); }
+    out { check15984("C.f1.o", this, i); }
+    do  { check15984("C.f1  ", this, i); }
+
+    int[3] f2(int i)
+    in  { check15984("C.f2.i", this, i); }
+    out { check15984("C.f2.o", this, i); }
+    do  { check15984("C.f2  ", this, i); return [0,0,0]; }
+
+    void f3(int i)
+    in  { void nested() { check15984("C.f3.i", this, i); } nested(); }
+    out { void nested() { check15984("C.f3.o", this, i); } nested(); }
+    do  { check15984("C.f3  ", this, i); }
+
+    void f4(out int i, lazy int j)
+    in  { assert(0); }
+    do  { i = 10; }
+}
+
+void test15984()
+{
+    c15984 = new C15984;
+    i15984 = c15984;
+    printf("i = %p\n", i15984);
+    printf("c = %p\n", c15984);
+    printf("====\n");
+    i15984.f1(5);
+    printf("====\n");
+    i15984.f2(5);
+    printf("====\n");
+    i15984.f3(5);
+    int i;
+    i15984.f4(i, 1);
+    assert(i == 10);
+}
+
+/*******************************************/
 
 //******************************************/
 // DIP 1009
@@ -1178,6 +1251,7 @@ int main()
     test15524();
     test15524a();
     test14779();
+    test15984();
     dip1009_1(1);
     dip1009_2(1);
     dip1009_3(1);


### PR DESCRIPTION
Copied from LDC [func.d](https://github.com/ldc-developers/ldc/blob/master/dmd/func.d) with slight modifications.

Essentially the parameters are passed explicitly to the contract functions. The major modification that I made from LDC is that I pass all the parameters by ref.
