### PR TITLE
Fix Issue 19870 - Generated Copy Constructor disables default construction

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4184,6 +4184,20 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     return setError();
                 if (!sd.ctor)
                     sd.ctor = sd.searchCtor();
+                /* If `sd.ctor` is a generated copy constructor, this means that it
+                   is the single constructor that this struct has. In order to not
+                   disable default construction, the ctor is nullified. The side effect
+                   of this is that the generated copy constructor cannot be called
+                   explicitly, but that is ok, because when calling a constructor the
+                   default constructor should have priority over the generated copy
+                   constructor.
+                */
+                if (sd.ctor)
+                {
+                    auto ctor = sd.ctor.isCtorDeclaration();
+                    if (ctor && ctor.isCpCtor && ctor.generated)
+                        sd.ctor = null;
+                }
 
                 // First look for constructor
                 if (exp.e1.op == TOK.type && sd.ctor)

--- a/test/compilable/testCpCtor.d
+++ b/test/compilable/testCpCtor.d
@@ -1,0 +1,24 @@
+/* TEST_OUTPUT:
+---
+---
+*/
+struct T
+{
+    int i;
+    this(ref return scope inout typeof(this) src)
+        inout @safe pure nothrow @nogc
+    {
+        i = src.i;
+    }
+}
+
+struct S
+{
+    T t;
+}
+
+void main()
+{
+    T a;
+    S b = S(a);
+}


### PR DESCRIPTION
```d
struct T
{
    int i;
    this(ref return scope inout typeof(this) src)
        inout @safe pure nothrow @nogc
    {
        i = src.i;
    }
}

struct S
{
    T t;
}

auto bar(T a)
{
	S(a);
}
``` 

The compiler generates a copy constructor for S which is also a constructor, thus disabling default construction. The fix makes it so that when a struct has a single constructor that is a copy constructor and is generated, it has a lower priority than default construction.

cc @9il 