### PR TITLE
Fix Issue 19871 - Copy constructor rejects valid code if default construction is disabled

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -447,8 +447,9 @@ private bool buildCopyCtor(StructDeclaration sd, Scope* sc)
         assert(ctorDecl);
         if (ctorDecl.isCpCtor)
         {
-            cpCtor = ctorDecl;
-            return 1;
+            if (!cpCtor)
+                cpCtor = ctorDecl;
+            return 0;
         }
 
         auto tf = ctorDecl.type.toTypeFunction();

--- a/test/fail_compilation/fail19871.d
+++ b/test/fail_compilation/fail19871.d
@@ -1,0 +1,20 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19871.d(10): Error: `struct Struct` may not define both a rvalue constructor and a copy constructor
+fail_compilation/fail19871.d(19):        rvalue constructor defined here
+fail_compilation/fail19871.d(13):        copy constructor defined here
+---
+*/
+
+struct Struct
+{
+    @disable this();
+    this(ref Struct other)
+    {
+        const Struct s = void;
+        this(s);
+    }
+
+    this(Struct) {}
+}


### PR DESCRIPTION
The initial idea was that when the compiler searches for copy constructors it should stop when it has found one, however, it should also check if the user has defined an rvalue normal constructor. The patch makes it so that the search for copy constructors does not stop when a copy constructor was found.