### PR TITLE
GLOBAL_OFFSET_TABLE: don't emit reference unless necessary

### DIFF
--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -1519,7 +1519,7 @@ elem *el_picvar(Symbol *s)
     elem *e;
     int x;
 
-    //printf("el_picvar(s = '%s')\n", s.Sident);
+    //printf("el_picvar(s = '%s')\n", s.Sident.ptr);
     symbol_debug(s);
     type_debug(s.Stype);
     e = el_calloc();
@@ -1557,7 +1557,6 @@ elem *el_picvar(Symbol *s)
 
     if (I64)
     {
-        Obj.refGOTsym();
         switch (s.Sclass)
         {
             case SCstatic:
@@ -1572,6 +1571,7 @@ elem *el_picvar(Symbol *s)
                 x = 1;
             case_got64:
             {
+                Obj.refGOTsym();
                 int op = e.Eoper;
                 tym_t tym = e.Ety;
                 e.Ety = TYnptr;

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -122,9 +122,9 @@ enum ELF_COMDAT = TARGET_LINUX;
 /******************************************
  */
 
-__gshared Symbol *GOTsym; // global offset table reference
+private __gshared Symbol *GOTsym; // global offset table reference
 
-Symbol *Obj_getGOTsym()
+private Symbol *Obj_getGOTsym()
 {
     if (!GOTsym)
     {


### PR DESCRIPTION
This was brought up in Alexandru Militaru's talk:

    http://dconf.org/2019/talks/militaru.html

where an unnecessary reference to `_GLOBAL_OFFSET_TABLE_` was generated.