### PR TITLE
Deprecate scope as a type constraint on class declarations

### DIFF
--- a/changelog/dep_scope_class.dd
+++ b/changelog/dep_scope_class.dd
@@ -1,0 +1,10 @@
+`scope` as a type constraint on class declarations is deprecated.
+
+`scope` as a type constraint on class declarations has been deprecated for quite some time.  However,
+starting with this release, the compiler will emit a deprecation warning if used.
+
+---
+scope class C { }  // Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+---
+
+Note that this does not apply to structs.  Deprecation of `scope` as a type constraint on structs is still awaiting a decision.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1208,6 +1208,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             {
                 dsym.error("globals, statics, fields, manifest constants, ref and out parameters cannot be `scope`");
             }
+
+            // @@@DEPRECATED@@@  https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+            // Deprecated in 2.087
+            // Remove this when the feature is removed from the language
             if (!(dsym.storage_class & STC.scope_))
             {
                 if (!(dsym.storage_class & STC.parameter) && dsym.ident != Id.withSym)
@@ -5311,6 +5315,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             cldec.deferred.semantic3(sc);
         }
         //printf("-ClassDeclaration.dsymbolSemantic(%s), type = %p, sizeok = %d, this = %p\n", toChars(), type, sizeok, this);
+
+        // @@@DEPRECATED@@@ https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Deprecated in 2.087
+        // Make an error in 2.091
+        // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
+        if (cldec.storage_class & STC.scope_)
+            deprecation(cldec.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
     }
 
     override void visit(InterfaceDeclaration idec)
@@ -5619,6 +5630,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
         assert(idec.type.ty != Tclass || (cast(TypeClass)idec.type).sym == idec);
+
+        // @@@DEPRECATED@@@https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint
+        // Deprecated in 2.087
+        // Remove in 2.091
+        // Don't forget to remove code at https://github.com/dlang/dmd/blob/b2f8274ba76358607fc3297a1e9f361480f9bcf9/src/dmd/dsymbolsem.d#L1032-L1036
+        if (idec.storage_class & STC.scope_)
+            deprecation(idec.loc, "`scope` as a type constraint is deprecated.  Use `scope` at the usage site.");
     }
 }
 

--- a/test/fail_compilation/scope_class.d
+++ b/test/fail_compilation/scope_class.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/scope_class.d(10): Error: functions cannot return `scope scope_class.C`
+fail_compilation/scope_class.d(9): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_class.d(11): Error: functions cannot return `scope scope_class.C`
 ---
 */
 

--- a/test/fail_compilation/scope_type.d
+++ b/test/fail_compilation/scope_type.d
@@ -1,0 +1,12 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/scope_type.d(10): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/scope_type.d(11): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+---
+*/
+
+scope class C { }
+scope interface I { }
+//scope struct S { }

--- a/test/fail_compilation/typeerrors.d
+++ b/test/fail_compilation/typeerrors.d
@@ -2,6 +2,7 @@
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
+fail_compilation/typeerrors.d(31): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
 fail_compilation/typeerrors.d(36): Error: tuple index 4 exceeds 4
 fail_compilation/typeerrors.d(38): Error: variable `x` cannot be read at compile time
 fail_compilation/typeerrors.d(39): Error: cannot have array of `void()`
@@ -19,7 +20,6 @@ fail_compilation/typeerrors.d(55): Error: slice `[1..5]` is out of range of [0..
 fail_compilation/typeerrors.d(56): Error: slice `[2..1]` is out of range of [0..4]
 ---
 */
-
 
 
 

--- a/test/runnable/sctor.d
+++ b/test/runnable/sctor.d
@@ -404,19 +404,6 @@ class C15258
 }
 
 /***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=15665
-
-scope class C15665 (V)
-{
-    this () {}
-}
-
-void test15665()
-{
-    scope foo = new C15665!int;
-}
-
-/***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=15869
 
 struct Set {
@@ -483,7 +470,6 @@ int main()
     test13515();
     test14450();
     test14944();
-    test15665();
     test15869();
     test19389();
 

--- a/test/runnable/sctor2.d
+++ b/test/runnable/sctor2.d
@@ -1,0 +1,19 @@
+// PERMUTE_ARGS: -w -d -dw
+
+/***************************************************/
+// 15665
+
+scope class C15665 (V)
+{
+    this () {}
+}
+
+void test15665()
+{
+    scope foo = new C15665!int;
+}
+
+void main()
+{
+    test15665();
+}


### PR DESCRIPTION
Resurrection of https://github.com/dlang/dmd/pull/8410 but only for classes and interfaces.

See https://dlang.org/deprecate.html#scope%20as%20a%20type%20constraint

PR to update the deprecations table:  https://github.com/dlang/dlang.org/pull/2644