### PR TITLE
convert constants (mostly filenames and extensions) in global to strings

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1474,7 +1474,7 @@ struct ASTBase
         {
             super(ident);
             this.arg = filename;
-            srcfile = FileName(FileName.defaultExt(filename, global.mars_ext).toDString);
+            srcfile = FileName(FileName.defaultExt(filename.toDString, global.mars_ext));
         }
 
         override void accept(Visitor v)

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -63,11 +63,11 @@ private const(char)[] lookForSourceFile(const(char)[] filename)
 {
     /* Search along global.path for .di file, then .d file.
      */
-    const sdi = FileName.forceExt(filename, global.hdr_ext.toDString());
+    const sdi = FileName.forceExt(filename, global.hdr_ext);
     if (FileName.exists(sdi) == 1)
         return sdi;
     scope(exit) FileName.free(sdi.ptr);
-    const sd = FileName.forceExt(filename, global.mars_ext.toDString());
+    const sd = FileName.forceExt(filename, global.mars_ext);
     if (FileName.exists(sd) == 1)
         return sd;
     scope(exit) FileName.free(sd.ptr);
@@ -412,7 +412,7 @@ extern (C++) final class Module : Package
         const(char)[] srcfilename;
         //printf("Module::Module(filename = '%s', ident = '%s')\n", filename, ident.toChars());
         this.arg = filename;
-        srcfilename = FileName.defaultExt(filename, global.mars_ext.toDString());
+        srcfilename = FileName.defaultExt(filename, global.mars_ext);
         if (global.run_noext && global.params.run &&
             !FileName.ext(filename) &&
             FileName.exists(srcfilename) == 0 &&
@@ -421,22 +421,23 @@ extern (C++) final class Module : Package
             FileName.free(srcfilename.ptr);
             srcfilename = FileName.removeExt(filename); // just does a mem.strdup(filename)
         }
-        else if (!FileName.equalsExt(srcfilename, global.mars_ext.toDString()) &&
-                 !FileName.equalsExt(srcfilename, global.hdr_ext.toDString()) &&
+        else if (!FileName.equalsExt(srcfilename, global.mars_ext) &&
+                 !FileName.equalsExt(srcfilename, global.hdr_ext) &&
                  !FileName.equalsExt(srcfilename, "dd"))
         {
-            error("source file name '%.*s' must have .%s extension",
-                  srcfilename.length, srcfilename.ptr, global.mars_ext);
+
+            error("source file name '%.*s' must have .%.*s extension",
+                  cast(int)srcfilename.length, srcfilename.ptr,
+                  cast(int)global.mars_ext.length, global.mars_ext.ptr);
             fatal();
         }
 
         srcfile = FileName(srcfilename);
-        objfile = setOutfilename(global.params.objname.toDString, global.params.objdir.toDString, filename, global.obj_ext.toDString);
+        objfile = setOutfilename(global.params.objname, global.params.objdir, filename, global.obj_ext);
         if (doDocComment)
             setDocfile();
         if (doHdrGen)
-            hdrfile = setOutfilename(global.params.hdrname.toDString, global.params.hdrdir.toDString, arg, global.hdr_ext.toDString);
-
+            hdrfile = setOutfilename(global.params.hdrname.toDString, global.params.hdrdir.toDString, arg, global.hdr_ext);
         escapetable = new Escape();
     }
 
@@ -619,7 +620,7 @@ extern (C++) final class Module : Package
 
     void setDocfile()
     {
-        docfile = setOutfilename(global.params.docname.toDString, global.params.docdir.toDString, arg, global.doc_ext.toDString);
+        docfile = setOutfilename(global.params.docname.toDString, global.params.docdir.toDString, arg, global.doc_ext);
     }
 
     // read file, returns 'true' if succeed, 'false' otherwise.

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -97,9 +97,9 @@ void backend_init()
             exe = true;         // EXE file only optimizations
         else if (params.link && !global.params.deffile)
             exe = true;         // EXE file only optimizations
-        else if (params.exefile)           // if writing out EXE file
-        {   size_t len = strlen(params.exefile);
-            if (len >= 4 && FileName.equals(params.exefile + len - 3, "exe"))
+        else if (params.exefile.length)           // if writing out EXE file
+        {
+            if (params.exefile.length >= 4 && FileName.equals(params.exefile[$-3 .. $], "exe"))
                 exe = true;
         }
     }

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -205,9 +205,9 @@ struct Param
     Array!(const(char)*)* modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array!(const(char)*)* imppath;      // array of char*'s of where to look for import modules
     Array!(const(char)*)* fileImppath;  // array of char*'s of where to look for file import modules
-    const(char)* objdir;                // .obj/.lib file output directory
-    const(char)* objname;               // .obj file output name
-    const(char)* libname;               // .lib file output name
+    const(char)[] objdir;                // .obj/.lib file output directory
+    const(char)[] objname;               // .obj file output name
+    const(char)[] libname;               // .lib file output name
 
     bool doDocComments;                 // process embedded documentation comments
     const(char)* docdir;                // write documentation file to docdir directory
@@ -258,8 +258,8 @@ struct Param
     Array!(const(char)*) dllfiles;
     const(char)* deffile;
     const(char)* resfile;
-    const(char)* exefile;
-    const(char)* mapfile;
+    const(char)[] exefile;
+    const(char)[] mapfile;
 }
 
 alias structalign_t = uint;
@@ -271,19 +271,20 @@ enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
 struct Global
 {
     const(char)* inifilename;
-    const(char)* mars_ext = "d";
-    const(char)* obj_ext;
-    const(char)* lib_ext;
-    const(char)* dll_ext;
-    const(char)* doc_ext = "html";      // for Ddoc generated files
-    const(char)* ddoc_ext = "ddoc";     // for Ddoc macro include files
-    const(char)* hdr_ext = "di";        // for D 'header' import files
-    const(char)* json_ext = "json";     // for JSON files
-    const(char)* map_ext = "map";       // for .map files
+    string mars_ext = "d";
+    const(char)[] obj_ext;
+    const(char)[] lib_ext;
+    const(char)[] dll_ext;
+    string doc_ext = "html";      // for Ddoc generated files
+    string ddoc_ext = "ddoc";     // for Ddoc macro include files
+    string hdr_ext = "di";        // for D 'header' import files
+    string json_ext = "json";     // for JSON files
+    string map_ext = "map";       // for .map files
     bool run_noext;                     // allow -run sources without extensions.
 
-    const(char)* copyright = "Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved";
-    const(char)* written = "written by Walter Bright";
+    string copyright = "Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved";
+    string written = "written by Walter Bright";
+
     Array!(const(char)*)* path;         // Array of char*'s which form the import lookup path
     Array!(const(char)*)* filePath;     // Array of char*'s which form the file import lookup path
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -181,9 +181,9 @@ struct Param
     Array<const char *> *modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array<const char *> *imppath;     // array of char*'s of where to look for import modules
     Array<const char *> *fileImppath; // array of char*'s of where to look for file import modules
-    const char *objdir;   // .obj/.lib file output directory
-    const char *objname;  // .obj file output name
-    const char *libname;  // .lib file output name
+    DArray<const char> objdir;   // .obj/.lib file output directory
+    DArray<const char> objname;  // .obj file output name
+    DArray<const char> libname;  // .lib file output name
 
     bool doDocComments;  // process embedded documentation comments
     const char *docdir;  // write documentation file to docdir directory
@@ -234,8 +234,8 @@ struct Param
     Array<const char *> dllfiles;
     const char *deffile;
     const char *resfile;
-    const char *exefile;
-    const char *mapfile;
+    DArray<const char> exefile;
+    DArray<const char> mapfile;
 };
 
 typedef unsigned structalign_t;
@@ -246,19 +246,20 @@ typedef unsigned structalign_t;
 struct Global
 {
     const char *inifilename;
-    const char *mars_ext;
-    const char *obj_ext;
-    const char *lib_ext;
-    const char *dll_ext;
-    const char *doc_ext;        // for Ddoc generated files
-    const char *ddoc_ext;       // for Ddoc macro include files
-    const char *hdr_ext;        // for D 'header' import files
-    const char *json_ext;       // for JSON files
-    const char *map_ext;        // for .map files
+    const DArray<const char> mars_ext;
+    DArray<const char> obj_ext;
+    DArray<const char> lib_ext;
+    DArray<const char> dll_ext;
+    const DArray<const char> doc_ext;  // for Ddoc generated files
+    const DArray<const char> ddoc_ext; // for Ddoc macro include files
+    const DArray<const char> hdr_ext;  // for D 'header' import files
+    const DArray<const char> json_ext; // for JSON files
+    const DArray<const char> map_ext;  // for .map files
     bool run_noext;             // allow -run sources without extensions.
 
-    const char *copyright;
-    const char *written;
+
+    const DArray<const char> copyright;
+    const DArray<const char> written;
     Array<const char *> *path;        // Array of char*'s which form the import lookup path
     Array<const char *> *filePath;    // Array of char*'s which form the file import lookup path
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -164,7 +164,8 @@ void obj_write_deferred(Library library)
         uint hash = 0;
         for (const(char)* p = s.toChars(); *p; p++)
             hash += *p;
-        namebuf.printf("%s_%x_%x.%s", fname, count, hash, global.obj_ext);
+        namebuf.printf("%s_%x_%x.%.*s", fname, count, hash,
+                       cast(int)global.obj_ext.length, global.obj_ext.ptr);
         FileName.free(cast(char *)fname);
         fname = namebuf.extractChars();
 

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -926,7 +926,7 @@ public:
         requiredProperty("cwd", getcwd(null, 0).toDString);
         requiredProperty("argv0", global.params.argv0);
         requiredProperty("config", global.inifilename.toDString);
-        requiredProperty("libName", global.params.libname.toDString);
+        requiredProperty("libName", global.params.libname);
 
         propertyStart("importPaths");
         arrayStart();
@@ -963,7 +963,7 @@ public:
         }
         arrayEnd();
 
-        requiredProperty("mapFile", global.params.mapfile.toDString);
+        requiredProperty("mapFile", global.params.mapfile);
         requiredProperty("resourceFile", global.params.resfile.toDString);
         requiredProperty("defFile", global.params.deffile.toDString);
 

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -78,24 +78,25 @@ class Library
      *  dir = path to file
      *  filename = name of file relative to `dir`
      */
-    final void setFilename(const(char)* dir, const(char)* filename)
+    final void setFilename(const(char)[] dir, const(char)[] filename)
     {
         static if (LOG)
         {
-            printf("LibElf::setFilename(dir = '%s', filename = '%s')\n", dir ? dir : "", filename ? filename : "");
+            printf("LibElf::setFilename(dir = '%.*s', filename = '%.*s')\n",
+                   cast(int)dir.length, dir.ptr, cast(int)filename.length, filename.ptr);
         }
-        const(char)* arg = filename;
-        if (!arg || !*arg)
+        const(char)[] arg = filename;
+        if (!arg.length)
         {
             // Generate lib file name from first obj name
-            const(char)* n = global.params.objfiles[0];
+            const(char)[] n = global.params.objfiles[0].toDString;
             n = FileName.name(n);
             arg = FileName.forceExt(n, global.lib_ext);
         }
         if (!FileName.absolute(arg))
             arg = FileName.combine(dir, arg);
 
-        loc = Loc(FileName.defaultExt(arg, global.lib_ext), 0, 0);
+        loc = Loc(FileName.defaultExt(arg, global.lib_ext).ptr, 0, 0);
     }
 
     final void write()

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -160,6 +160,22 @@ public int runLINK()
     const phobosLibname = global.params.betterC ? null :
         global.params.symdebug ? global.params.debuglibname : global.params.defaultlibname;
 
+    void setExeFile()
+    {
+        /* Generate exe file name from first obj name.
+         * No need to add it to cmdbuf because the linker will default to it.
+         */
+        const char[] n = FileName.name(global.params.objfiles[0].toDString);
+        global.params.exefile = FileName.forceExt(n, "exe");
+    }
+
+    const(char)[] getMapFilename()
+    {
+        const(char)[] fn = FileName.forceExt(global.params.exefile, "map");
+        const(char)[] path = FileName.path(global.params.exefile);
+        return path.length ? fn : FileName.combine(global.params.objdir, fn);
+    }
+
     version (Windows)
     {
         if (phobosLibname)
@@ -188,12 +204,7 @@ public int runLINK()
             }
             else
             {
-                /* Generate exe file name from first obj name.
-                 * No need to add it to cmdbuf because the linker will default to it.
-                 */
-                const(char)* n = global.params.objfiles[0];
-                n = FileName.name(n);
-                global.params.exefile = FileName.forceExt(n, "exe");
+                setExeFile();
             }
             // Make sure path to exe file exists
             ensurePathToNameExists(Loc.initial, global.params.exefile);
@@ -205,15 +216,8 @@ public int runLINK()
             }
             else if (global.params.map)
             {
-                const(char)* fn = FileName.forceExt(global.params.exefile, "map");
-                const(char)* path = FileName.path(global.params.exefile);
-                const(char)* p;
-                if (path[0] == '\0')
-                    p = FileName.combine(global.params.objdir, fn);
-                else
-                    p = fn;
                 cmdbuf.writestring("/MAP:");
-                writeFilename(&cmdbuf, p);
+                writeFilename(&cmdbuf, getMapFilename());
             }
             for (size_t i = 0; i < global.params.libfiles.dim; i++)
             {
@@ -254,15 +258,19 @@ public int runLINK()
                 cmdbuf.writeByte(' ');
                 cmdbuf.writestring(lflags);
             }
-            char* p = cmdbuf.peekChars();
-            const(char)* lnkfilename = null;
-            const size_t plen = strlen(p);
-            if (plen > 7000)
+            cmdbuf.writeByte(0); // null terminate the buffer
+            char[] p = cmdbuf.extractSlice()[0 .. $-1];
+            const(char)[] lnkfilename;
+            if (p.length > 7000)
             {
                 lnkfilename = FileName.forceExt(global.params.exefile, "lnk");
-                writeFile(Loc.initial, lnkfilename.toDString, p[0 .. plen]);
-                if (strlen(lnkfilename) < plen)
-                    sprintf(p, "@%s", lnkfilename);
+                writeFile(Loc.initial, lnkfilename, p);
+                if (lnkfilename.length < p.length)
+                {
+                    p[0] = '@';
+                    p[1 ..  lnkfilename.length +1] = lnkfilename;
+                    p[lnkfilename.length +1] = 0;
+                }
             }
             const(char)* linkcmd = getenv(global.params.is64bit ? "LINKCMD64" : "LINKCMD");
             if (!linkcmd)
@@ -270,11 +278,11 @@ public int runLINK()
             if (!linkcmd)
                 linkcmd = vsopt.linkerPath(global.params.is64bit);
 
-            const int status = executecmd(linkcmd, p);
+            const int status = executecmd(linkcmd, p.ptr);
             if (lnkfilename)
             {
-                remove(lnkfilename);
-                FileName.free(lnkfilename);
+                lnkfilename.toCStringThen!(lf => remove(lf.ptr));
+                FileName.free(lnkfilename.ptr);
             }
             return status;
         }
@@ -304,12 +312,7 @@ public int runLINK()
                 writeFilename(&cmdbuf, global.params.exefile);
             else
             {
-                /* Generate exe file name from first obj name.
-                 * No need to add it to cmdbuf because the linker will default to it.
-                 */
-                const(char)* n = global.params.objfiles[0];
-                n = FileName.name(n);
-                global.params.exefile = FileName.forceExt(n, "exe");
+                setExeFile();
             }
             // Make sure path to exe file exists
             ensurePathToNameExists(Loc.initial, global.params.exefile);
@@ -318,14 +321,7 @@ public int runLINK()
                 writeFilename(&cmdbuf, global.params.mapfile);
             else if (global.params.map)
             {
-                const(char)* fn = FileName.forceExt(global.params.exefile, "map");
-                const(char)* path = FileName.path(global.params.exefile);
-                const(char)* p;
-                if (path[0] == '\0')
-                    p = FileName.combine(global.params.objdir, fn);
-                else
-                    p = fn;
-                writeFilename(&cmdbuf, p);
+                writeFilename(&cmdbuf, getMapFilename());
             }
             else
                 cmdbuf.writestring("nul");
@@ -378,24 +374,28 @@ public int runLINK()
                 cmdbuf.writestring(global.params.linkswitches[i]);
             }
             cmdbuf.writeByte(';');
-            char* p = cmdbuf.peekChars();
-            const(char)* lnkfilename = null;
-            const size_t plen = strlen(p);
-            if (plen > 7000)
+            cmdbuf.writeByte(0); //null terminate the buffer
+            char[] p = cmdbuf.extractSlice()[0 .. $-1];
+            const(char)[] lnkfilename;
+            if (p.length > 7000)
             {
                 lnkfilename = FileName.forceExt(global.params.exefile, "lnk");
-                writeFile(Loc.initial, lnkfilename.toDString, p[0 .. plen]);
-                if (strlen(lnkfilename) < plen)
-                    sprintf(p, "@%s", lnkfilename);
+                writeFile(Loc.initial, lnkfilename, p);
+                if (lnkfilename.length < p.length)
+                {
+                    p[0] = '@';
+                    p[1 .. lnkfilename.length +1] = lnkfilename;
+                    p[lnkfilename.length +1] = 0;
+                }
             }
             const(char)* linkcmd = getenv("LINKCMD");
             if (!linkcmd)
                 linkcmd = "link";
-            const int status = executecmd(linkcmd, p);
+            const int status = executecmd(linkcmd, p.ptr);
             if (lnkfilename)
             {
-                remove(lnkfilename);
-                FileName.free(lnkfilename);
+                lnkfilename.toCStringThen!(lf => remove(lf.ptr));
+                FileName.free(lnkfilename.ptr);
             }
             return status;
         }
@@ -441,7 +441,7 @@ public int runLINK()
         argv.push("-o");
         if (global.params.exefile)
         {
-            argv.push(global.params.exefile);
+            argv.push(global.params.exefile.xarraydup.ptr);
         }
         else if (global.params.run)
         {
@@ -458,8 +458,8 @@ public int runLINK()
                 }
                 else
                     close(fd);
-                global.params.exefile = mem.xstrdup(name.ptr);
-                argv.push(global.params.exefile);
+                global.params.exefile = name.arraydup;
+                argv.push(global.params.exefile.xarraydup.ptr);
             }
             else
             {
@@ -486,14 +486,14 @@ public int runLINK()
             if (const e = FileName.ext(n))
             {
                 if (global.params.dll)
-                    ex = FileName.forceExt(ex, global.dll_ext.toDString());
+                    ex = FileName.forceExt(ex, global.dll_ext);
                 else
                     ex = FileName.removeExt(n);
             }
             else
                 ex = "a.out"; // no extension, so give up
             argv.push(ex.ptr);
-            global.params.exefile = ex.ptr;
+            global.params.exefile = ex;
         }
         // Make sure path to exe file exists
         ensurePathToNameExists(Loc.initial, global.params.exefile);
@@ -524,7 +524,7 @@ public int runLINK()
             argv.push("-Xlinker");
             argv.push("-no_compact_unwind");
         }
-        if (global.params.map || global.params.mapfile)
+        if (global.params.map || global.params.mapfile.length)
         {
             argv.push("-Xlinker");
             version (OSX)
@@ -535,19 +535,14 @@ public int runLINK()
             {
                 argv.push("-Map");
             }
-            if (!global.params.mapfile)
+            if (!global.params.mapfile.length)
             {
-                const(char)* fn = FileName.forceExt(global.params.exefile, "map");
-                const(char)* path = FileName.path(global.params.exefile);
-                const(char)* p;
-                if (path[0] == '\0')
-                    p = FileName.combine(global.params.objdir, fn);
-                else
-                    p = fn;
-                global.params.mapfile = cast(char*)p;
+                const(char)[] fn = FileName.forceExt(global.params.exefile, "map");
+                const(char)[] path = FileName.path(global.params.exefile);
+                global.params.mapfile = path.length ? fn : FileName.combine(global.params.objdir, fn);
             }
             argv.push("-Xlinker");
-            argv.push(global.params.mapfile);
+            argv.push(global.params.mapfile.xarraydup.ptr);
         }
         if (0 && global.params.exefile)
         {
@@ -878,7 +873,7 @@ public int runProgram()
     }
     // Build argv[]
     Strings argv;
-    argv.push(global.params.exefile);
+    argv.push(global.params.exefile.xarraydup.ptr);
     for (size_t i = 0; i < global.params.runargs.dim; ++i)
     {
         const(char)* a = global.params.runargs[i];
@@ -897,13 +892,13 @@ public int runProgram()
     argv.push(null);
     version (Windows)
     {
-        const(char)* ex = FileName.name(global.params.exefile);
+        const(char)[] ex = FileName.name(global.params.exefile);
         if (ex == global.params.exefile)
             ex = FileName.combine(".", ex);
         else
             ex = global.params.exefile;
         // spawnlp returns intptr_t in some systems, not int
-        return spawnv(0, ex, argv.tdata());
+        return spawnv(0, ex.xarraydup.ptr, argv.tdata());
     }
     else version (Posix)
     {


### PR DESCRIPTION
Reduce .toDString noise lots of places.