### PR TITLE
[stable] Match C++ mangling for extern(C++) copy ctors

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -861,8 +861,8 @@ private final class CppMangleVisitor : Visitor
             {
                 this.mangleNestedFuncPrefix(tf, p);
 
-                if (d.isCtorDeclaration())
-                    buf.writestring("C1");
+                if (auto ctor = d.isCtorDeclaration())
+                    buf.writestring(ctor.isCpCtor ? "C2" : "C1");
                 else if (d.isPrimaryDtor())
                     buf.writestring("D1");
                 else if (d.ident && d.ident == Id.assign)

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -162,16 +162,14 @@ extern(C++)
 {
     struct SmallStruct
     {
-        this(this)
-        {
-            i += 10;
-        }
-        int i = 0;
+        int i;
+        this(int i) { this.i = i; }
+        this(ref const SmallStruct); // implemented in C++
     }
     void smallStructTest(SmallStruct p);
     void smallStructCallBack(SmallStruct p)
     {
-        assert(p.i == 10);
+        assert(p.i == 62);
     }
 }
 
@@ -198,7 +196,7 @@ void main()
     assert(constFunction3(null, null) == 3);
     assert(constFunction4(null, null) == 42);
 
-    SmallStruct ss;
+    auto ss = SmallStruct(42);
     smallStructTest(ss);
-    assert(ss.i == 0);
+    assert(ss.i == 42);
 }

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -77,20 +77,19 @@ namespace ns1
 
 struct SmallStruct
 {
-    SmallStruct()
-        : i(0) {}
-    SmallStruct(const SmallStruct& x)
-        : i(x.i + 10) {}
     int i;
+    SmallStruct(int); // implemented in D
+    SmallStruct(const SmallStruct &);
 };
+SmallStruct::SmallStruct(const SmallStruct &rhs)
+    : i(rhs.i + 10) {}
 void smallStructCallBack(SmallStruct p);
 void smallStructTest(SmallStruct p)
 {
-    assert(p.i == 10);
+    assert(p.i == 52);
 
-    SmallStruct x;
-    smallStructCallBack(x);
-    assert(x.i == 0);
+    smallStructCallBack(p);
+    assert(p.i == 52);
 }
 
 // Uncomment when mangling is fixed


### PR DESCRIPTION
The MSVC mangling was already okay, as copy ctors are mangled like regular ctors. For POSIX, it needed to be minimally adapted.