### PR TITLE
Fix issue 19881 - escaping reference to local through return scope with -dip1000 and @safe

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -553,6 +553,19 @@ ByRef:
         if (v.isDataseg())
             continue;
 
+        if (global.params.vsafe)
+        {
+            if (va && va.isScope() && va.storage_class & STC.return_ &&
+                (v.storage_class & (STC.ref_ | STC.out_)) == 0 &&
+                sc.func.setUnsafe())
+            {
+                if (!gag)
+                    error(ae.loc, "address of local variable `%s` assigned to return scope `%s`", v.toChars(), va.toChars());
+                result = true;
+                continue;
+            }
+        }
+
         Dsymbol p = v.toParent2();
 
         // If va's lifetime encloses v's, then error

--- a/test/fail_compilation/fail19881.d
+++ b/test/fail_compilation/fail19881.d
@@ -1,0 +1,15 @@
+/* REQUIRED_ARGS: -dip1000
+ * TEST_OUTPUT:
+---
+fail_compilation/fail19881.d(12): Error: address of local variable `local` assigned to return scope `input`
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=19881
+
+@safe int* test(return scope int* input) {
+    int local = 42;
+    input = &local;
+
+    return input;
+}


### PR DESCRIPTION
If my understanding of the DIP is correct, I believe this should fix https://issues.dlang.org/show_bug.cgi?id=19881.

First contribution to dmd, so any feedback most welcome.