### PR TITLE
add toString to Array, eliminate calls to strlen, add unittest

### DIFF
--- a/src/.dscanner.ini
+++ b/src/.dscanner.ini
@@ -115,5 +115,5 @@ redundant_storage_classes="enabled"
 redundant_storage_classes="-dmd.id,-dmd.toir,-dmd.tokens"
 trust_too_much="-dmd.root.longdouble"
 builtin_property_names_check="-dmd.backend.obj,-dmd.backend.code,-dmd.backend.cc"
-object_const_check="-dmd.dtemplate,-dmd.backend.outbuf,-dmd.root.rootobject"
+object_const_check="-dmd.dtemplate,-dmd.backend.outbuf,-dmd.root.rootobject,-dmd.root.array"
 final_attribute_check="-dmd.statement" ; https://github.com/dlang/dmd/pull/856


### PR DESCRIPTION
This didn't seem to actually get called running the test suite locally...
The only potential call sites I saw were the overload of toChars in Tuple (2 places)

I added a unittest to cover it.

The calls to the toString of the elements probably leak memory sometimes, but other times probably point to data needed by those objects.  Any thoughts on what could be done to reduce leakage?