### PR TITLE
Dub: fix missing package of root modules

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -22,7 +22,9 @@ import core.stdc.limits;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
+
 import dmd.arraytypes;
+import dmd.astcodegen;
 import dmd.gluelayer;
 import dmd.builtin;
 import dmd.cond;

--- a/test/unit/frontend.d
+++ b/test/unit/frontend.d
@@ -83,6 +83,23 @@ unittest
     assert(actual == "bar", actual);
 }
 
+@("parseModule - missing package")
+unittest
+{
+    import dmd.frontend;
+
+    initDMD();
+
+    auto t = parseModule("foo/bar.d", q{
+        module foo.bar;
+    });
+
+    assert(!t.diagnostics.hasErrors);
+    assert(!t.diagnostics.hasWarnings);
+
+    assert(t.module_.parent !is null);
+}
+
 @("initDMD - contract checking")
 unittest
 {


### PR DESCRIPTION
If the source code is passed to `dmd.frontend.parseModule` the function would set up its own parser instead of calling `Module.parse`. Turns out that `Module.parse` does quite a few things, among those setting the parent, i.e. package, of the module being parsed. This caused the mangling of some types to be incorrect, which caused types to not match, which should have matched, due to the mangling being used to compare types.

The solution is to split `Module.read` into two separate functions, one that does the actual IO of reading the file and one that does the rest, including setting the source buffer. This allows to later call `Module.parse` which will set the parent for the module.