### PR TITLE
Add -revert=noautoimports to begin transitioning to a pay-as-you-go opt-in langauge

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -696,6 +696,8 @@ dmd -cov -unittest myprog.d
     static immutable reverts = [
         Feature("dip25", "noDIP25", "revert DIP25 changes https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP25.md"),
         Feature("import", "bug10378", "revert to single phase name lookup", true, true),
+        Feature("noautoimports", "noautoimports",
+            "revert disabling automatic importing of modules, including object.d"),
     ];
 
     /// Returns all available previews

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1067,6 +1067,10 @@ extern (C++) final class Module : Package
         // If it isn't there, some compiler rewrites, like
         //    classinst == classinst -> .object.opEquals(classinst, classinst)
         // would fail inside object.d.
+        //
+        // TODO: After -revert=noautoimports is added to the default dmd.conf file
+        // of the host compiler and released to users, use it to disable automatically
+        // importing object.d
         if (members.dim == 0 || (*members)[0].ident != Id.object)
         {
             auto im = new Import(Loc.initial, null, Id.object, null, 0);

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -138,6 +138,7 @@ struct Param
     bool useInline = false;     // inline expand functions
     bool useDIP25;          // implement http://wiki.dlang.org/DIP25
     bool noDIP25;           // revert to pre-DIP25 behavior
+    bool noautoimports;     // don't automatically import any module, including object.d
     bool release;           // build release version
     bool preservePaths;     // true means don't strip path from source file
     DiagnosticReporting warnings = DiagnosticReporting.off;  // how compiler warnings are handled


### PR DESCRIPTION
## Abstract
This PR hopes to further transition D to a pay-as-you-go opt-in language as described by @andralex [here](https://forum.dlang.org/post/q7j4sl$17pe$1@digitalmars.com).  It adds a compiler switch to revert no longer automatically importing object.d (or any other module).  The double negative there can mess with your mind, but it seems to me to be the right way to do this.  That is, in a future PR, I will disable automatically importing object.d, and this compiler switch will revert that.

## The Plan
1.  This PR just adds the `-revert=noautoimports` compiler switch, but it does nothing for now.
2.  After this PR is merged, we need to merge https://github.com/dlang/installer/pull/390  to add this switch to the compilers' default dmd.conf and sc.ini files.  Due to this PR, adding the compiler switch to those files will not cause any "unrecognized switch" error.
3.  After the next compiler release, all users who update to the latest compiler with have that switch in their dmd.conf file.
4.  After the compiler release mentioned in 3., I will submit another PR to activate the compiler switch and disable automatically importing object.d.  Since users will already have the `-revert=noautoimports` switch in the dmd.conf and sc.ini file there will be no breaking changes.

## Background
Currently, users trying to use D in an opt-in pay-as-you-go way have to create an empty object.d file just to get a build.  This is because the compiler automatically imports object.d into every file.   Below is a minimal x86_64 Hello World program illustrating the problem.  (See it in action at https://run.dlang.io/is/khbFfl)

```D
module main;

alias string = immutable(char)[];

private extern(C) void __d_sys_exit(long arg1)
{
    asm
    {
        mov RAX, 60;
        mov RDI, arg1;
        syscall;
    }
}

private long __d_sys_write(long arg1, in void* arg2, long arg3)
{
    long result;

    asm
    {
        mov RAX, 1;
        mov RDI, arg1;
        mov RSI, arg2;
        mov RDX, arg3;
        syscall;
    }

    return result;
}

void write(string text)
{
    __d_sys_write(2, text.ptr, text.length);
}

private extern(C) void _start()
{
    main();
    __d_sys_exit(0);
}

void main()
{
    write("Hello, World!\n");
}
```

Users doing this kind of programming will compile with `dmd -conf=` to prevent automatically importing their system's default druntime and phobos.  However, without an empty object.d the compiler will emit the following error:

```
Error: cannot find source code for runtime library file 'object.d'
       dmd might not be correctly installed. Run 'dmd -man' for installation instructions.
       config file: not found
Specify path to file 'object.d' with -I switch
```
(See it in action at https://run.dlang.io/is/oRtPbo)

Adding an empty `object.d` file resolves the error. 

(At https://run.dlang.io adding an object.d file can be done by adding the `--- object.d` and `--- main.d` lines.  See https://run.dlang.io/is/khbFfl  See https://github.com/marler8997/har for more information about that syntax)

It's a bit silly to require users doing this kind of programming to create an empty object.d, and definitely not in the spirit of creating a pay-as-you-go opt-in continuum.  This PR hopes to correct that and put D on a better trajectory without causing any breaking changes.

A previous attempt at this can be found at https://github.com/dlang/dmd/pull/7825

This is basically a continuation of several other PRs that have already been merged over the past 2 years:
 * #7395 and #7768 for opt-in `ModuleInfo`
 * #7786 for opt-in `Throwable`
 * #7799 for opt-in `TypeInfo`