### PR TITLE
remove MatchAccumulator.anyf

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -280,7 +280,6 @@ struct MatchAccumulator
     MATCH last = MATCH.nomatch; // match level of lastf
     FuncDeclaration lastf;  // last matching function we found
     FuncDeclaration nextf;  // if ambiguous match, this is the "other" function
-    FuncDeclaration anyf;   // pick a func, any func, to use for error recovery
 }
 
 /***********************************************************

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -2420,7 +2420,6 @@ void functionResolve(ref MatchAccumulator m, Dsymbol dstart, Loc loc, Scope* sc,
             return 1;
         }
         //printf("fd = %s %s, fargs = %s\n", fd.toChars(), fd.type.toChars(), fargs.toChars());
-        m.anyf = fd;
         auto tf = cast(TypeFunction)fd.type;
 
         int prop = tf.isproperty ? 1 : 2;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -859,7 +859,6 @@ extern (C++) class FuncDeclaration : Declaration
             auto f = s.isFuncDeclaration();
             if (!f || f == m.lastf) // skip duplicates
                 return 0;
-            m.anyf = f;
 
             auto tf = f.type.toTypeFunction();
             //printf("tf = %s\n", tf.toChars());

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -949,9 +949,9 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 }
                 else if (m.last <= MATCH.nomatch)
                 {
-                    m.lastf = m.anyf;
                     if (tiargs)
                         goto L1;
+                    m.lastf = null;
                 }
                 if (e.op == TOK.plusPlus || e.op == TOK.minusMinus)
                 {
@@ -1034,8 +1034,9 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                         }
                         else if (m.last <= MATCH.nomatch)
                         {
-                            m.lastf = m.anyf;
+                            m.lastf = null;
                         }
+
                         if (lastf && m.lastf == lastf || !s && m.last <= MATCH.nomatch)
                         {
                             // Rewrite (e1 op e2) as e1.opfunc_r(e2)
@@ -1532,9 +1533,9 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 }
                 else if (m.last <= MATCH.nomatch)
                 {
-                    m.lastf = m.anyf;
                     if (tiargs)
                         goto L1;
+                    m.lastf = null;
                 }
                 // Rewrite (e1 op e2) as e1.opOpAssign(e2)
                 result = build_overload(e.loc, sc, e.e1, e.e2, m.lastf ? m.lastf : s);
@@ -1631,7 +1632,7 @@ private Expression compare_overload(BinExp e, Scope* sc, Identifier id, TOK* pop
         }
         else if (m.last <= MATCH.nomatch)
         {
-            m.lastf = m.anyf;
+            m.lastf = null;
         }
         Expression result;
         if (lastf && m.lastf == lastf || !s_r && m.last <= MATCH.nomatch)


### PR DESCRIPTION
`anyf` is a relic of the days when compiler error recovery was based on guessing at what the AST should look like and fixing it. Now, it's based on the "poisoning" scheme.