### PR TITLE
[stable] Enforce re-semantic for ThisExp.syntaxCopy() result

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4439,12 +4439,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
              * was already performed on it, create a syntax copy and
              * redo the first semantic step.
              */
-            auto err = global.startGagging();
-            auto fd_temp = fd.syntaxCopy(null);
+            auto fd_temp = fd.syntaxCopy(null).isFuncDeclaration();
+            fd_temp.storage_class &= ~STC.auto_; // type has already been inferred
             if (auto cd = ad.isClassDeclaration())
                 cd.vtbl.remove(fd.vtblIndex);
             fd_temp.dsymbolSemantic(sc);
-            global.endGagging(err);
             (*ad.members)[i] = fd_temp;
         }
     }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2214,6 +2214,15 @@ extern (C++) class ThisExp : Expression
         //printf("ThisExp::ThisExp() loc = %d\n", loc.linnum);
     }
 
+    override Expression syntaxCopy()
+    {
+        auto r = cast(ThisExp) super.syntaxCopy();
+        // require new semantic (possibly new `var` etc.)
+        r.type = null;
+        r.var = null;
+        return r;
+    }
+
     override final bool isBool(bool result)
     {
         return result;

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -317,6 +317,7 @@ public:
     Dsymbol *s;
     bool hasOverloads;
 
+    Expression *syntaxCopy();
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     void accept(Visitor *v) { v->visit(this); }


### PR DESCRIPTION
`expressionSemantic()` for a ThisExp doesn't just set its type (and do nothing if it's already set), but may also set the `ThisExp.var` VarDeclaration. This crucial step was previously skipped after syntaxCopying an already analyzed ThisExp, as a later `expressionSemantic()` for that copy was a no-op and `var` still pointed to the original one, while that variable may have been syntaxCopied too.

See the comments in #9467; this is covered by an existing test which happens to pass with DMD (but failed with LDC).