### PR TITLE
dstringify more strings in globals

### DIFF
--- a/src/dmd/dinifile.d
+++ b/src/dmd/dinifile.d
@@ -25,6 +25,7 @@ import dmd.root.filename;
 import dmd.root.outbuffer;
 import dmd.root.port;
 import dmd.root.stringtable;
+import dmd.root.rmem : xarraydup;
 import dmd.utils;
 
 version (Windows) extern (C) int putenv(const char*) nothrow;
@@ -175,7 +176,7 @@ void updateRealEnvironment(ref StringTable environment)
  *      buffer = contents of configuration file
  *      sections = section names
  */
-void parseConfFile(ref StringTable environment, const(char)* filename, const(char)[] path, const(ubyte)[] buffer, const(Strings)* sections)
+void parseConfFile(ref StringTable environment, const(char)[] filename, const(char)[] path, const(ubyte)[] buffer, const(Strings)* sections)
 {
     /********************
      * Skip spaces.
@@ -353,7 +354,7 @@ void parseConfFile(ref StringTable environment, const(char)* filename, const(cha
                 {
                     if (!writeToEnv(environment, strdup(pn)))
                     {
-                        error(Loc(filename, lineNum, 0), "Use `NAME=value` syntax, not `%s`", pn);
+                        error(Loc(filename.xarraydup.ptr, lineNum, 0), "Use `NAME=value` syntax, not `%s`", pn);
                         fatal();
                     }
                     static if (LOG)

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -523,7 +523,7 @@ extern (C++) final class Module : Package
         if (doDocComment)
             setDocfile();
         if (doHdrGen)
-            hdrfile = setOutfilename(global.params.hdrname.toDString, global.params.hdrdir.toDString, arg, global.hdr_ext);
+            hdrfile = setOutfilename(global.params.hdrname, global.params.hdrdir, arg, global.hdr_ext);
         escapetable = new Escape();
     }
 
@@ -677,8 +677,8 @@ extern (C++) final class Module : Package
         {
             .error(loc, "cannot find source code for runtime library file 'object.d'");
             errorSupplemental(loc, "dmd might not be correctly installed. Run 'dmd -man' for installation instructions.");
-            const dmdConfFile = global.inifilename ? FileName.canonicalName(global.inifilename) : null;
-            errorSupplemental(loc, "config file: %s", dmdConfFile ? dmdConfFile : "not found".ptr);
+            const dmdConfFile = global.inifilename.length ? FileName.canonicalName(global.inifilename) : "not found";
+            errorSupplemental(loc, "config file: %.*s", cast(int)dmdConfFile.length, dmdConfFile.ptr);
         }
         else
         {

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -215,12 +215,12 @@ struct Param
     Array!(const(char)*) ddocfiles;     // macro include files for Ddoc
 
     bool doHdrGeneration;               // process embedded documentation comments
-    const(char)* hdrdir;                // write 'header' file to docdir directory
-    const(char)* hdrname;               // write 'header' file to docname
+    const(char)[] hdrdir;                // write 'header' file to docdir directory
+    const(char)[] hdrname;               // write 'header' file to docname
     bool hdrStripPlainFunctions = true; // strip the bodies of plain (non-template) functions
 
     bool doJsonGeneration;              // write JSON file
-    const(char)* jsonfilename;          // write JSON file to jsonfilename
+    const(char)[] jsonfilename;          // write JSON file to jsonfilename
     JsonFieldFlags jsonFieldFlags;      // JSON field flags to include
 
     OutBuffer* mixinOut;                // write expanded mixins for debugging
@@ -233,11 +233,11 @@ struct Param
     uint versionlevel;                  // version level
     Array!(const(char)*)* versionids;   // version identifiers
 
-    const(char)* defaultlibname;        // default library for non-debug builds
-    const(char)* debuglibname;          // default library for debug builds
-    const(char)* mscrtlib;              // MS C runtime library
+    const(char)[] defaultlibname;        // default library for non-debug builds
+    const(char)[] debuglibname;          // default library for debug builds
+    const(char)[] mscrtlib;              // MS C runtime library
 
-    const(char)* moduleDepsFile;        // filename for deps output
+    const(char)[] moduleDepsFile;        // filename for deps output
     OutBuffer* moduleDeps;              // contents to be written to deps file
 
     // Hidden debug switches
@@ -256,8 +256,8 @@ struct Param
     Array!(const(char)*) linkswitches;
     Array!(const(char)*) libfiles;
     Array!(const(char)*) dllfiles;
-    const(char)* deffile;
-    const(char)* resfile;
+    const(char)[] deffile;
+    const(char)[] resfile;
     const(char)[] exefile;
     const(char)[] mapfile;
 }
@@ -270,7 +270,7 @@ enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
 
 struct Global
 {
-    const(char)* inifilename;
+    const(char)[] inifilename;
     string mars_ext = "d";
     const(char)[] obj_ext;
     const(char)[] lib_ext;
@@ -289,7 +289,7 @@ struct Global
     Array!(const(char)*)* filePath;     // Array of char*'s which form the file import lookup path
 
     string _version;
-    const(char)* vendor;    // Compiler backend name
+    const(char)[] vendor;    // Compiler backend name
 
     Param params;
     uint errors;            // number of errors reported so far

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -191,12 +191,12 @@ struct Param
     Array<const char *> ddocfiles;  // macro include files for Ddoc
 
     bool doHdrGeneration;  // process embedded documentation comments
-    const char *hdrdir;    // write 'header' file to docdir directory
-    const char *hdrname;   // write 'header' file to docname
+    DArray<const char> hdrdir;    // write 'header' file to docdir directory
+    DArray<const char> hdrname;   // write 'header' file to docname
     bool hdrStripPlainFunctions; // strip the bodies of plain (non-template) functions
 
     bool doJsonGeneration;    // write JSON file
-    const char *jsonfilename; // write JSON file to jsonfilename
+    DArray<const char> jsonfilename; // write JSON file to jsonfilename
     unsigned jsonFieldFlags;  // JSON field flags to include
 
     OutBuffer *mixinOut;                // write expanded mixins for debugging
@@ -209,11 +209,11 @@ struct Param
     unsigned versionlevel; // version level
     Array<const char *> *versionids;   // version identifiers
 
-    const char *defaultlibname; // default library for non-debug builds
-    const char *debuglibname;   // default library for debug builds
-    const char *mscrtlib;       // MS C runtime library
+    DArray<const char> defaultlibname; // default library for non-debug builds
+    DArray<const char> debuglibname;   // default library for debug builds
+    DArray<const char> mscrtlib;       // MS C runtime library
 
-    const char *moduleDepsFile; // filename for deps output
+    DArray<const char> moduleDepsFile; // filename for deps output
     OutBuffer *moduleDeps;      // contents to be written to deps file
 
     // Hidden debug switches
@@ -232,8 +232,8 @@ struct Param
     Array<const char *> linkswitches;
     Array<const char *> libfiles;
     Array<const char *> dllfiles;
-    const char *deffile;
-    const char *resfile;
+    DArray<const char> deffile;
+    DArray<const char> resfile;
     DArray<const char> exefile;
     DArray<const char> mapfile;
 };
@@ -245,7 +245,7 @@ typedef unsigned structalign_t;
 
 struct Global
 {
-    const char *inifilename;
+    DArray<const char> inifilename;
     const DArray<const char> mars_ext;
     DArray<const char> obj_ext;
     DArray<const char> lib_ext;
@@ -264,7 +264,7 @@ struct Global
     Array<const char *> *filePath;    // Array of char*'s which form the file import lookup path
 
     DArray<const char> version;     // Compiler version string
-    const char *vendor;             // Compiler backend name
+    DArray<const char> vendor;             // Compiler backend name
 
     Param params;
     unsigned errors;         // number of errors reported so far

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -294,9 +294,14 @@ void obj_end(Library library, const(char)* objfilename)
     objbuf.p = null;
 }
 
-bool obj_includelib(const(char)* name)
+bool obj_includelib(const(char)* name) nothrow
 {
     return objmod.includelib(name);
+}
+
+extern(D) bool obj_includelib(const(char)[] name) nothrow
+{
+    return name.toCStringThen!(n => obj_includelib(n.ptr));
 }
 
 void obj_startaddress(Symbol *s)
@@ -1289,7 +1294,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
  */
 private void specialFunctions(Obj objmod, FuncDeclaration fd)
 {
-    const(char)* libname = (global.params.symdebug)
+    const(char)[] libname = (global.params.symdebug)
                             ? global.params.debuglibname
                             : global.params.defaultlibname;
 
@@ -1313,7 +1318,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
             objmod.external_def("__acrtused_con");
         }
         if (libname)
-            objmod.includelib(libname);
+            obj_includelib(libname);
         s.Sclass = SCglobal;
     }
     else if (fd.isRtInit())
@@ -1330,7 +1335,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
         if (global.params.mscoff)
         {
             if (global.params.mscrtlib && global.params.mscrtlib[0])
-                objmod.includelib(global.params.mscrtlib);
+                obj_includelib(global.params.mscrtlib);
             objmod.includelib("OLDNAMES");
         }
         else if (config.exe == EX_WIN32)
@@ -1346,7 +1351,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
         {
             objmod.includelib("uuid");
             if (global.params.mscrtlib && global.params.mscrtlib[0])
-                objmod.includelib(global.params.mscrtlib);
+                obj_includelib(global.params.mscrtlib);
             objmod.includelib("OLDNAMES");
         }
         else
@@ -1354,7 +1359,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
             objmod.external_def("__acrtused");
         }
         if (libname)
-            objmod.includelib(libname);
+            obj_includelib(libname);
         s.Sclass = SCglobal;
     }
 
@@ -1365,7 +1370,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
         {
             objmod.includelib("uuid");
             if (global.params.mscrtlib && global.params.mscrtlib[0])
-                objmod.includelib(global.params.mscrtlib);
+                obj_includelib(global.params.mscrtlib);
             objmod.includelib("OLDNAMES");
         }
         else
@@ -1373,7 +1378,7 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
             objmod.external_def("__acrtused_dll");
         }
         if (libname)
-            objmod.includelib(libname);
+            obj_includelib(libname);
         s.Sclass = SCglobal;
     }
     else if (fd.ident == Id.tls_get_addr && fd.linkage == LINK.d)

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -852,7 +852,7 @@ public:
     private void generateCompilerInfo()
     {
         objectStart();
-        requiredProperty("vendor", global.vendor.toDString);
+        requiredProperty("vendor", global.vendor);
         requiredProperty("version", global._version);
         property("__VERSION__", global.versionNumber());
         requiredProperty("interface", determineCompilerInterface());
@@ -925,7 +925,7 @@ public:
         objectStart();
         requiredProperty("cwd", getcwd(null, 0).toDString);
         requiredProperty("argv0", global.params.argv0);
-        requiredProperty("config", global.inifilename.toDString);
+        requiredProperty("config", global.inifilename);
         requiredProperty("libName", global.params.libname);
 
         propertyStart("importPaths");
@@ -964,8 +964,8 @@ public:
         arrayEnd();
 
         requiredProperty("mapFile", global.params.mapfile);
-        requiredProperty("resourceFile", global.params.resfile.toDString);
-        requiredProperty("defFile", global.params.deffile.toDString);
+        requiredProperty("resourceFile", global.params.resfile);
+        requiredProperty("defFile", global.params.deffile);
 
         objectEnd();
     }
@@ -1092,13 +1092,13 @@ Determines and returns the compiler interface which is one of `dmd`, `ldc`,
 */
 private extern(D) string determineCompilerInterface()
 {
-    if (!strcmp(global.vendor, "Digital Mars D"))
+    if (global.vendor == "Digital Mars D")
         return "dmd";
-    if (!strcmp(global.vendor, "LDC"))
+    if (global.vendor == "LDC")
         return "ldc";
-    if (!strcmp(global.vendor, "GNU"))
+    if (global.vendor == "GNU")
         return "gdc";
-    if (!strcmp(global.vendor, "SDC"))
+    if (global.vendor == "SDC")
         return "sdc";
     return null;
 }

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -559,7 +559,7 @@ class Lexer
                         }
                         else if (id == Id.VENDOR)
                         {
-                            t.ustring = global.vendor;
+                            t.ustring = global.vendor.xarraydup.ptr;
                             goto Lstr;
                         }
                         else if (id == Id.TIMESTAMP)

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -179,7 +179,7 @@ public int runLINK()
     version (Windows)
     {
         if (phobosLibname)
-            global.params.libfiles.push(phobosLibname);
+            global.params.libfiles.push(phobosLibname.xarraydup.ptr);
 
         if (global.params.mscoff)
         {
@@ -631,7 +631,7 @@ public int runLINK()
         /* D runtime libraries must go after user specified libraries
          * passed with -l.
          */
-        const libname = phobosLibname.toDString();
+        const libname = phobosLibname;
         if (libname.length)
         {
             const bufsize = 2 + libname.length + 1;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -772,7 +772,7 @@ struct Target
                 if (global.params.isWindows)
                 {
                     if (global.params.mscoff)
-                        return stringExp(global.params.mscrtlib ? global.params.mscrtlib.toDString : "");
+                        return stringExp(global.params.mscrtlib);
                     return stringExp("snn");
                 }
                 return stringExp("");

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -69,7 +69,8 @@ static void frontend_init()
 
     global._init();
     global.params.isLinux = true;
-    global.vendor = "Front-End Tester";
+    global.vendor.ptr = "Front-End Tester";
+    global.vendor.length = strlen(global.vendor.ptr);
 
     Type::_init();
     Id::initialize();


### PR DESCRIPTION
Replaces most (all?) of the cstrings in globals with dstrings.  The use of toCStringThen! in a couple places required me to annotate a few functions from the backend as nothrow.  It looks like they all should have been nothrow so I annotated all functions/methods in those files.