### PR TITLE
Fix issue 19386 - Destructor not called when constructed inside if condition

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2207,6 +2207,14 @@ else
                 sdtor = new ScopeGuardStatement(ifs.loc, TOK.onScopeExit, sdtor);
                 ifs.ifbody = new CompoundStatement(ifs.loc, sdtor, ifs.ifbody);
                 ifs.match.storage_class |= STC.nodtor;
+
+                // the destructor is always called
+                // whether the 'ifbody' is executed or not
+                Statement sdtor2 = new DtorExpStatement(ifs.loc, ifs.match.edtor, ifs.match);
+                if (ifs.elsebody)
+                    ifs.elsebody = new CompoundStatement(ifs.loc, sdtor2, ifs.elsebody);
+                else
+                    ifs.elsebody = sdtor2;
             }
         }
         else

--- a/test/runnable/test19386.d
+++ b/test/runnable/test19386.d
@@ -1,0 +1,36 @@
+struct Thing
+{
+    this(int* i)
+    {
+        ptr = i;
+        (*ptr)++;
+    }
+
+    ~this()
+    {
+        (*ptr)--;
+    }
+
+    T opCast(T : bool)()
+    {
+        return false;
+    }
+
+    int* ptr;
+}
+
+Thing makeThing(int* p)
+{
+    return Thing(p);
+}
+
+void main()
+{
+    int i;
+    {
+        if (auto t = makeThing(&i)) // destructor not called
+        {
+        }
+    }
+    assert(i == 0);
+}


### PR DESCRIPTION
[19386](https://issues.dlang.org/show_bug.cgi?id=19386).

Example:

For the following code:
```d
if (auto t = makeThing(&i))
{
}
```
The compiler currently inserts the following:
```d
if (auto t = makeThing(&i))
{
    t.~this(); // currently inserted by the compiler
}
```
This PR adds the following:
```d
if (auto t = makeThing(&i))
{
    t.~this();
}
// added by this pull request
else
{
    t.~this();
}
```

The destructor should always be called whether the condition evaluates to `true` or `false`.