### PR TITLE
Descriptive error messages for missing template hooks errors

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5718,6 +5718,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 tok == TOK.in_ ||
                 isEqualsCallExpression)
             {
+                if (!verifyHookExist(exp.loc, *sc, Id._d_assert_fail, "generating assert messages"))
+                    return setError();
+
                 auto es = new Expressions(2);
                 auto tiargs = new Objects(3);
                 Loc loc = exp.e1.loc;
@@ -6882,6 +6885,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     // be done in the implementation of `object.__ArrayCast`
                     if ((fromSize % toSize) != 0)
                     {
+                        if (!verifyHookExist(exp.loc, *sc, Id.__ArrayCast, "casting array of structs"))
+                            return setError();
+
                         // lower to `object.__ArrayCast!(TFrom, TTo)(from)`
 
                         // fully qualify as `object.__ArrayCast`
@@ -10413,6 +10419,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
             if ((t1.ty == Tarray || t1.ty == Tsarray) && (t2.ty == Tarray || t2.ty == Tsarray))
             {
+                if (!verifyHookExist(exp.loc, *sc, Id.__cmp, "comparing arrays"))
+                    return setError();
+
                 // Lower to object.__cmp(e1, e2)
                 Expression al = new IdentifierExp(exp.loc, Id.empty);
                 al = new DotIdExp(exp.loc, al, Id.object);
@@ -10654,6 +10663,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             // For e1 and e2 of struct type, lowers e1 == e2 to object.__equals(e1, e2)
             // and e1 != e2 to !(object.__equals(e1, e2)).
+
+            if (!verifyHookExist(exp.loc, *sc, Id.__equals, "equal checks on arrays"))
+                return setError();
 
             Expression __equals = new IdentifierExp(exp.loc, Id.empty);
             Identifier id = Identifier.idPool("__equals");

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11748,3 +11748,24 @@ VarDeclaration makeThis2Argument(const ref Loc loc, Scope* sc, FuncDeclaration f
     vthis2.nestedrefs.push(fd);
     return vthis2;
 }
+
+/*******************************
+ * Make sure that the runtime hook `id` exists.
+ * Params:
+ *      loc = location to use for error messages
+ *      sc = current scope
+ *      id = the hook identifier
+ *      description = what the hook does
+ *      module_ = what module the hook is located in
+ * Returns:
+ *      a `bool` indicating if the hook is present.
+ */
+bool verifyHookExist(const ref Loc loc, ref Scope sc, Identifier id, string description, Identifier module_ = Id.object)
+{
+    auto rootSymbol = sc.search(loc, Id.empty, null);
+    if (auto moduleSymbol = rootSymbol.search(loc, module_))
+        if (moduleSymbol.search(loc, id))
+          return true;
+    error(loc, "`%s.%s` not found. The current runtime does not support %.*s, or the runtime is corrupt.", module_.toChars(), id.toChars(), cast(int)description.length, description.ptr);
+    return false;
+}

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2638,6 +2638,9 @@ else
                 }
                 else
                 {
+                    if (!verifyHookExist(ss.loc, *sc, Id.__switch_error, "generating assert messages"))
+                        return setError();
+
                     Expression sl = new IdentifierExp(ss.loc, Id.empty);
                     sl = new DotIdExp(ss.loc, sl, Id.object);
                     sl = new DotIdExp(ss.loc, sl, Id.__switch_error);
@@ -2684,6 +2687,9 @@ else
 
             // We sort a copy of the array of labels because we want to do a binary search in object.__switch,
             // without modifying the order of the case blocks here in the compiler.
+
+            if (!verifyHookExist(ss.loc, *sc, Id.__switch, "switch cases on strings"))
+                return setError();
 
             size_t numcases = 0;
             if (ss.cases)

--- a/test/fail_compilation/verifyhookexist.d
+++ b/test/fail_compilation/verifyhookexist.d
@@ -1,0 +1,45 @@
+/*
+REQUIRED_ARGS: -Ifail_compilation/extra-files/minimal/ -checkaction=context
+PERMUTE_ARGS:
+*/
+
+/************************************************************/
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/verifyhookexist.d(22): Error: `object.__ArrayCast` not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(28): Error: `object.__equals` not found. The current runtime does not support equal checks on arrays, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(29): Error: `object.__cmp` not found. The current runtime does not support comparing arrays, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(33): Error: `object._d_assert_fail` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(36): Error: `object.__switch` not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(41): Error: `object.__switch_error` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+---
+*/
+
+struct MyStruct { int a, b; }
+MyStruct[] castToMyStruct(int[] arr) {
+    return cast(MyStruct[])arr;
+}
+
+void test() {
+    int[] arrA, arrB;
+
+    bool a = arrA[] == arrB[];
+    bool b = arrA < arrB;
+
+    {
+        int x = 1; int y = 1;
+        assert(x == y);
+    }
+
+    switch ("") {
+    default:
+        break;
+    }
+
+    final switch (0) {
+    case 1:
+        break;
+    }
+}


### PR DESCRIPTION
This is my warmup project for GSoC that was suggested by my mentors. This PR implemented more descriptive error messages for missing template hooks. This replaces following the none-descriptive error message: `Error: undefined identifier __equals in module object` with:
> Error: object.__equals not found. The current runtime does not support equal checks on arrays, or the runtime is corrupt.

The error message is modeled after ObjectNotFound: https://github.com/dlang/dmd/blob/8e364d300adef422a36ac39b0f09dcfaed78312a/src/dmd/declaration.d#L202

Questions:
- Does verifyHookExist use the best way of checking for an identifier inside the `object` module?
- `ObjectNotFound` have the "or corrupt" part, should this error message also have it?
- Any improvements to make the error message more clear?

---

Output from this PR with a empty object.d and -checkaction=context:
```d
struct MyStruct { int a, b; }
MyStruct[] castToMyStruct(int[] arr) {
	return cast(MyStruct[])arr;	// Error: object.__ArrayCast not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
}

extern(C) int main(int argc, char** argv) {
	int[] arrA, arrB;
	bool a = arrA[] == arrB[]; // Error: object.__equals not found. The current runtime does not support equal checks on arrays, or the runtime is corrupt.
	bool b = arrA < arrB; // Error: object.__cmp not found. The current runtime does not support comparing arrays, or the runtime is corrupt.

	{
		int x = 1; int y = 1;
		assert(x == y); // Error: object._d_assert_fail not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
	}

	switch ("a") { // Error: object.__switch not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
	default:
		break;
	}

	final switch (0) { // Error: object.__switch_error not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
	case 1:
		break;
	}

	return 0;
}

```