### PR TITLE
fix Issue 19890 - ICE: Segmentation fault with negative array size

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -765,7 +765,13 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                  * when the bottom of element type is opaque.
                  */
             }
-            else if (tbn.isintegral() || tbn.isfloating() || tbn.ty == Tpointer || tbn.ty == Tarray || tbn.ty == Tsarray || tbn.ty == Taarray || (tbn.ty == Tstruct && ((cast(TypeStruct)tbn).sym.sizeok == Sizeok.done)) || tbn.ty == Tclass)
+            else if (tbn.isTypeBasic() ||
+                     tbn.ty == Tpointer ||
+                     tbn.ty == Tarray ||
+                     tbn.ty == Tsarray ||
+                     tbn.ty == Taarray ||
+                     (tbn.ty == Tstruct && ((cast(TypeStruct)tbn).sym.sizeok == Sizeok.done)) ||
+                     tbn.ty == Tclass)
             {
                 /* Only do this for types that don't need to have semantic()
                  * run on them for the size, since they may be forward referenced.

--- a/test/fail_compilation/fail19890a.d
+++ b/test/fail_compilation/fail19890a.d
@@ -1,0 +1,7 @@
+// PERMUTE_ARGS:
+/*
+---
+fail_compilation/fail19890a.d(8): Error: `void[/^[0-9]+(LU)?$/]` size 1 * /^[0-9]+$/ exceeds 0x7fffffff size limit for static array
+---
+*/
+void[] f = cast(void[-1]) "a";

--- a/test/fail_compilation/fail19890b.d
+++ b/test/fail_compilation/fail19890b.d
@@ -1,0 +1,7 @@
+// PERMUTE_ARGS:
+/*
+---
+fail_compilation/fail19890b.d(8): Error: `void[/^[0-9]+(LU)?$/]` size 1 * /^[0-9]+$/ exceeds 0x7fffffff size limit for static array
+---
+*/
+void[] f = cast(void[-2]) "a";


### PR DESCRIPTION
Rather than `tbn.isintegral() || tbn.isfloating()`, check `tbn.isTypeBasic()` instead, so that `void` is included in the overflow check.