### PR TITLE
src/posix.mak: Always link against system phobos statically with gdmd

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -307,6 +307,11 @@ ifneq (gdc, $(HOST_DMD_KIND))
   override DFLAGS  += -dip25
 endif
 
+ifeq (gdc, $(HOST_DMD_KIND))
+  # Link against phobos statically
+  override DFLAGS += -q,-static-libphobos
+endif
+
 ######## DMD frontend source files
 
 FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argtypes argtypes_sysv_x64 arrayop	\


### PR DESCRIPTION
Closes #9836

@wilzbach - gdc-9 is now available in the PPA, so you could alternatively switch gdc-8 to gdc-9.