### PR TITLE
Use standard Ddoc LINK2 since markdown isn't enabled yet for dlang.org

### DIFF
--- a/changelog/ddoc_markdown.dd
+++ b/changelog/ddoc_markdown.dd
@@ -1,5 +1,5 @@
-Add Markdown-inspired features to Ddoc.
+Add Markdown-inspired features to Ddoc
 
-With the `-preview=markdown` flag to dmd, Ddoc now supports [Markdown](https://daringfireball.net/projects/markdown/syntax) features like headings, emphasized text, links and more. The full list of features is described in [the Ddoc documentation page](https://dlang.org/spec/ddoc.html#highlighting).
+With the `-preview=markdown` flag to dmd, Ddoc now supports $(LINK2 https://daringfireball.net/projects/markdown/syntax, Markdown) features like headings, emphasized text, links and more. The full list of features is described in $(LINK2 https://dlang.org/spec/ddoc.html#highlighting, the Ddoc documentation page).
 
 Use the `-transition=vmarkdown` flag together with the `-preview=markdown` flag to log all instances of Markdown features as they're processed in your documentation.


### PR DESCRIPTION
I planned to enable `preview=markdown` for dlang.org before this landed but other things got in the way. Sorry @wilzbach and @Basile-z!