### PR TITLE
Make several symbols related to library formats private

### DIFF
--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -41,7 +41,7 @@ else
     static assert(0, "unsupported system");
 }
 
-enum LOG = false;
+private enum LOG = false;
 
 class Library
 {

--- a/src/dmd/libelf.d
+++ b/src/dmd/libelf.d
@@ -37,6 +37,14 @@ import dmd.root.stringtable;
 
 import dmd.scanelf;
 
+// Entry point (only public symbol in this module).
+public extern (C++) Library LibElf_factory()
+{
+    return new LibElf();
+}
+
+private: // for the remainder of this module
+
 enum LOG = false;
 
 struct ElfObjSymbol
@@ -473,11 +481,6 @@ private:
         }
         assert(libbuf.offset == moffset);
     }
-}
-
-extern (C++) Library LibElf_factory()
-{
-    return new LibElf();
 }
 
 /*****************************************************************************/

--- a/src/dmd/libmach.d
+++ b/src/dmd/libmach.d
@@ -37,6 +37,14 @@ import dmd.root.stringtable;
 
 import dmd.scanmach;
 
+// Entry point (only public symbol in this module).
+public extern (C++) Library LibMach_factory()
+{
+    return new LibMach();
+}
+
+private: // for the remainder of this module
+
 enum LOG = false;
 
 struct MachObjSymbol
@@ -444,11 +452,6 @@ private:
         }
         assert(libbuf.offset == moffset);
     }
-}
-
-extern (C++) Library LibMach_factory()
-{
-    return new LibMach();
 }
 
 /*****************************************************************************/

--- a/src/dmd/libmscoff.d
+++ b/src/dmd/libmscoff.d
@@ -36,6 +36,14 @@ import dmd.root.stringtable;
 
 import dmd.scanmscoff;
 
+// Entry point (only public symbol in this module).
+public extern (C++) Library LibMSCoff_factory()
+{
+    return new LibMSCoff();
+}
+
+private: // for the remainder of this module
+
 enum LOG = false;
 
 alias stat_t = struct_stat;
@@ -583,11 +591,6 @@ private:
         }
         assert(libbuf.offset == moffset);
     }
-}
-
-extern (C++) Library LibMSCoff_factory()
-{
-    return new LibMSCoff();
 }
 
 /*****************************************************************************/

--- a/src/dmd/libomf.d
+++ b/src/dmd/libomf.d
@@ -30,6 +30,14 @@ import dmd.root.stringtable;
 
 import dmd.scanomf;
 
+// Entry point (only public symbol in this module).
+extern (C++) Library LibOMF_factory()
+{
+    return new LibOMF();
+}
+
+private: // for the remainder of this module
+
 enum LOG = false;
 
 struct OmfObjSymbol
@@ -481,11 +489,6 @@ private:
     }
 }
 
-extern (C++) Library LibOMF_factory()
-{
-    return new LibOMF();
-}
-
 /*****************************************************************************/
 /*****************************************************************************/
 struct OmfObjModule
@@ -515,7 +518,7 @@ enum BUCKETSIZE = (BUCKETPAGE - HASHMOD - 1);
  * Returns:
  *      false   failure
  */
-private bool EnterDict(ubyte* bucketsP, ushort ndicpages, ubyte* entry, uint entrylen)
+bool EnterDict(ubyte* bucketsP, ushort ndicpages, ubyte* entry, uint entrylen)
 {
     ushort uStartIndex;
     ushort uStep;

--- a/src/dmd/scanmach.d
+++ b/src/dmd/scanmach.d
@@ -20,7 +20,7 @@ import core.sys.darwin.mach.loader;
 import dmd.globals;
 import dmd.errors;
 
-enum LOG = false;
+private enum LOG = false;
 
 /*****************************************
  * Reads an object module from base[] and passes the names
@@ -232,6 +232,8 @@ void scanMachObjModule(void delegate(const(char)[] name, int pickAny) pAddSymbol
         }
     }
 }
+
+private: // for the remainder of this module
 
 enum CPU_TYPE_I386 = 7;
 enum CPU_TYPE_X86_64 = CPU_TYPE_I386 | 0x1000000;

--- a/src/dmd/scanmscoff.d
+++ b/src/dmd/scanmscoff.d
@@ -17,7 +17,7 @@ version(Windows):
 import core.stdc.string, core.stdc.stdlib, core.sys.windows.winnt;
 import dmd.globals, dmd.errors;
 
-enum LOG = false;
+private enum LOG = false;
 
 /*****************************************
  * Reads an object module from base[] and passes the names
@@ -175,6 +175,8 @@ void scanMSCoffObjModule(void delegate(const(char)[] name, int pickAny) pAddSymb
         pAddSymbol(p[0 .. strlen(p)], 1);
     }
 }
+
+private: // for the remainder of this module
 
 align(1)
 struct BIGOBJ_HEADER


### PR DESCRIPTION
This is investigating how many of the symbols in lib-related code could be encapsulated as private, vs. repackaged per https://github.com/dlang/dmd/pull/9844/. I only built on Linux so I expect errors specific to Windows/Mac.