### PR TITLE
fix Issue 19897 - dinterpret.d:6439: Internal Compiler Error: null field

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6378,9 +6378,16 @@ public:
         result = (*se.elements)[i];
         if (!result)
         {
-            e.error("Internal Compiler Error: null field `%s`", v.toChars());
-            result = CTFEExp.cantexp;
-            return;
+            // https://issues.dlang.org/show_bug.cgi?id=19897
+            // Zero-length fields don't have an initializer.
+            if (v.type.size() == 0)
+                result = voidInitLiteral(e.type, v).copy();
+            else
+            {
+                e.error("Internal Compiler Error: null field `%s`", v.toChars());
+                result = CTFEExp.cantexp;
+                return;
+            }
         }
         if (auto vie = result.isVoidInitExp())
         {

--- a/test/fail_compilation/fail19897.d
+++ b/test/fail_compilation/fail19897.d
@@ -1,0 +1,13 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT
+---
+fail_compilation/fail19897.d(10): Error: cannot implicitly convert expression `[]` of type `const(char[0])` to `const(char)`
+---
+*/
+struct S
+{
+    char[0] x;
+}
+const a = S('a');
+const char c = a.x;


### PR DESCRIPTION
Empty initializers in struct literal expressions are scrubbed, so a null field is valid for only for them.