### PR TITLE
fix Issue 19898 - ICE: in sizemask at dmd/mtype.d(2563): Assertion failure

### DIFF
--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -322,7 +322,7 @@ struct IntRange
 
     static IntRange fromType(Type type, bool isUnsigned)
     {
-        if (!type.isintegral())
+        if (!type.isintegral() || type.toBasetype().ty == Tvector)
             return widest();
 
         uinteger_t mask = type.sizemask();
@@ -444,7 +444,7 @@ struct IntRange
 
     IntRange _cast(Type type)
     {
-        if (!type.isintegral())
+        if (!type.isintegral() || type.toBasetype().ty == Tvector)
             return this;
         else if (!type.isunsigned())
             return castSigned(type.sizemask());
@@ -456,7 +456,7 @@ struct IntRange
 
     IntRange castUnsigned(Type type)
     {
-        if (!type.isintegral())
+        if (!type.isintegral() || type.toBasetype().ty == Tvector)
             return castUnsigned(ulong.max);
         else if (type.toBasetype().ty == Tdchar)
             return castDchar();

--- a/test/fail_compilation/fail19898a.d
+++ b/test/fail_compilation/fail19898a.d
@@ -1,0 +1,14 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -m64
+TEST_OUTPUT:
+---
+fail_compilation/fail19898a.d(11): Error: incompatible types for `(__key2) < (__limit3)`: both operands are of type `__vector(int[4])`
+---
+*/
+void f (__vector(int[4]) n)
+{
+    foreach (i; 0 .. n)
+        cast(void)n;
+}
+

--- a/test/fail_compilation/fail19898b.d
+++ b/test/fail_compilation/fail19898b.d
@@ -1,0 +1,21 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -m64
+TEST_OUTPUT:
+---
+fail_compilation/fail19898b.d(18): Error: cannot implicitly convert expression `m` of type `S` to `__vector(int[4])`
+fail_compilation/fail19898b.d(18): Error: incompatible types for `(__key2) != (__limit3)`: both operands are of type `__vector(int[4])`
+fail_compilation/fail19898b.d(18): Error: cannot cast expression `__key2` of type `__vector(int[4])` to `S`
+---
+*/
+struct S
+{
+    int a;
+}
+
+void f (__vector(int[4]) n, S m)
+{
+    foreach (i; m .. n)
+        cast(void)n;
+}
+


### PR DESCRIPTION
Treat __vector types the same as non-integral in IntRange code.

Error messsages are horrible, but then again, it's the same as per other non-integral types being used as a key too.