### PR TITLE
Fix Issue 1170 - Cannot forward reference a type defined in a MixinStatement

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1159,6 +1159,11 @@ extern (C++) final class CompileDeclaration : AttribDeclaration
         return "mixin";
     }
 
+    override inout(CompileDeclaration) isCompileDeclaration() inout
+    {
+        return this;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1189,6 +1189,7 @@ extern (C++) class Dsymbol : ASTNode
     inout(AnonDeclaration)             isAnonDeclaration()             inout { return null; }
     inout(ProtDeclaration)             isProtDeclaration()             inout { return null; }
     inout(OverloadSet)                 isOverloadSet()                 inout { return null; }
+    inout(CompileDeclaration)          isCompileDeclaration()          inout { return null; }
 }
 
 /***********************************************************

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -825,7 +825,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.inuse--;
             sc2.pop();
         }
-        //printf(" semantic type = %s\n", type ? type.toChars() : "null");
+        //printf(" semantic type = %s\n", dsym.type ? dsym.type.toChars() : "null");
         if (dsym.type.ty == Terror)
             dsym.errors = true;
 

--- a/test/compilable/test1170.d
+++ b/test/compilable/test1170.d
@@ -1,0 +1,17 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=1170
+type x;
+mixin("alias int type;");
+
+// https://issues.dlang.org/show_bug.cgi?id=10739
+template DECLARE_HANDLE() {
+    struct HINTERNET { int h; }
+}
+const INTERNET_INVALID_STATUS_CALLBACK = cast(INTERNET_STATUS_CALLBACK) -1;
+mixin DECLARE_HANDLE;
+alias void function(HINTERNET) INTERNET_STATUS_CALLBACK;


### PR DESCRIPTION
```d
type x;
mixin("alias int type;");
```

This code errors because when `type` is being resolved the mixin has not yet been semantically analyzed. In order to fix this, I added a small patch that does a semantic pass of the CompileDeclarations (string mixins) in the current scope to add the potentially missing bits.

Also, this is # 24 in the top oldest dmd bugs.