### PR TITLE
Revert "deheader rtlsym from global"

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -20,7 +20,6 @@ import dmd.backend.code;
 import dmd.backend.global;
 import dmd.backend.ty;
 import dmd.backend.type;
-import dmd.backend.drtlsym : rtlsym_init;
 
 extern (C++):
 

--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -483,6 +483,11 @@ uint tdb_typidx(void *buf);
 //uint tdb_typidx(ubyte *buf,uint length);
 void tdb_term();
 
+// rtlsym.c
+void rtlsym_init();
+void rtlsym_reset();
+void rtlsym_term();
+
 // compress.c
 extern(C) char *id_compress(const char *id, int idlen, size_t *plen);
 

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -32,7 +32,6 @@ import dmd.backend.obj;
 import dmd.backend.oper;
 import dmd.backend.outbuf;
 import dmd.backend.rtlsym;
-import dmd.backend.drtlsym : rtlsym_reset;
 import dmd.backend.ty;
 import dmd.backend.type;
 


### PR DESCRIPTION
Reverts dlang/dmd#9867

Please stop changing the back end. It messes up DMC++.