### PR TITLE
fix issue 19901 - importing export symbols causes link errors (Win32)

### DIFF
--- a/samples/win32.mak
+++ b/samples/win32.mak
@@ -3,7 +3,7 @@ DMD=..\..\windows\bin\dmd
 DFLAGS=-m$(MODEL)
 
 EXAMPLES = hello d2html dhry pi sieve wc wc2 \
-	winsamp dserver$(MODEL) mydll htmlget listener
+	winsamp dserver$(MODEL) mydll$(MODEL) htmlget listener
 
 all: $(EXAMPLES)
 	echo done
@@ -55,14 +55,19 @@ dserver32:
 	$(DMD) dclient $(DFLAGS) ole32.lib uuid.lib
 	.\dclient.exe
 
-dserver64:
+dserver64 dserver32mscoff:
 	$(DMD) dserver.d chello.d $(DFLAGS) -L/DLL dserver64.def advapi32.lib ole32.lib user32.lib
 	$(DMD) dclient $(DFLAGS) ole32.lib uuid.lib
 	.\dclient.exe
 
-mydll:
+mydll32:
 	$(DMD) $(DFLAGS) -ofmydll.dll -L/IMPLIB mydll\mydll.d mydll\dll.d mydll\mydll.def
-	$(DMD) $(DFLAGS) -ofdlltest.exe -Imydll mydll\test.d mydll.lib
+	$(DMD) $(DFLAGS) -ofdlltest.exe mydll\test.d mydll\mydll.di mydll.lib
+	.\dlltest.exe
+
+mydll64 mydll32mscoff:
+	$(DMD) $(DFLAGS) -ofmydll.dll mydll\mydll.d mydll\dll.d -L/DLL
+	$(DMD) $(DFLAGS) -ofdlltest.exe mydll\test.d mydll\mydll.di mydll.lib
 	.\dlltest.exe
 
 clean:

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -478,10 +478,6 @@ Symbol *toImport(Symbol *sym)
         else
             idlen = sprintf(id,"_imp__%s@%u",n,cast(uint)type_paramsize(sym.Stype));
     }
-    else if (sym.Stype.Tmangle == mTYman_d)
-    {
-        idlen = sprintf(id,(config.exe == EX_WIN64) ? "__imp_%s" : "_imp_%s",n);
-    }
     else
     {
         idlen = sprintf(id,(config.exe == EX_WIN64) ? "__imp_%s" : "_imp__%s",n);


### PR DESCRIPTION
build and run the mydll example also for -m64 and -m32mscoff

probably introduced by https://github.com/dlang/dmd/commit/db2976599db44f2163986ba9cb541afd7cfa8471

Does anyone know why the mydll example is not built by the autotester, contrary to all other examples?