### PR TITLE
use lld/mingw if explicitly selected via -mscrtlib=msvcrt100

### DIFF
--- a/changelog/msvcrt.dd
+++ b/changelog/msvcrt.dd
@@ -1,0 +1,7 @@
+Windows: The mingw based runtime and platform import libraries can now be selected explicitly
+
+When specifying `-mscrtlib=msvcrt100` explicitly on the command line to dmd, detection
+of a Visual Studio installation is skipped and the redistributable
+VC2010 dynamic runtime library and mingw based platform import libraries will be used
+unconditionally. The LLD linker (provided by the LLVM project) will be invoked
+instead of the Microsoft linker.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -507,13 +507,18 @@ dmd -cov -unittest myprog.d
         Option("mixin=<filename>",
             "expand and save mixins to file specified by <filename>"
         ),
-        Option("mscrtlib=<name>",
+        Option("mscrtlib=<libname>",
             "MS C runtime library to reference from main/WinMain/DllMain",
             "If building MS-COFF object files with -m64 or -m32mscoff, embed a reference to
             the given C runtime library $(I libname) into the object file containing `main`,
             `DllMain` or `WinMain` for automatic linking. The default is $(TT libcmt)
             (release version with static linkage), the other usual alternatives are
             $(TT libcmtd), $(TT msvcrt) and $(TT msvcrtd).
+            If no Visual C installation is detected, a wrapper for the redistributable
+            VC2010 dynamic runtime library and mingw based platform import libraries will
+            be linked instead using the LLD linker provided by the LLVM project.
+            The detection can be skipped explicitly if $(TT msvcrt100) is specified as
+            $(I libname).
             If $(I libname) is empty, no C runtime library is automatically linked in.",
             TargetOS.windows,
         ),

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -251,7 +251,11 @@ public int runLINK()
             }
 
             VSOptions vsopt;
-            vsopt.initialize();
+            // if a runtime library (msvcrtNNN.lib) from the mingw folder is selected explicitly, do not detect VS and use lld
+            if (global.params.mscrtlib.length <= 6 ||
+                global.params.mscrtlib[0..6] != "msvcrt" || !isdigit(global.params.mscrtlib[6]))
+                vsopt.initialize();
+
             const(char)* lflags = vsopt.linkOptions(global.params.is64bit);
             if (lflags)
             {


### PR DESCRIPTION
This should also help setting up some CI tests for this toolchain.