### PR TITLE
Revert "Fix Issue 19882 - Expected 'undefined identifier' error when …

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5026,7 +5026,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * is(targ id == tok2)
          */
 
-        //printf("IsExp::semantic(%s)\n", e.toChars());
+        //printf("IsExp::semantic(%s)\n", toChars());
         if (e.id && !(sc.flags & SCOPE.condition))
         {
             e.error("can only declare type aliases within `static if` conditionals or `static assert`s");
@@ -5223,7 +5223,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
              * is(targ == tspec)
              * is(targ : tspec)
              */
-            e.tspec = e.tspec.trySemantic(e.loc, sc);
+            e.tspec = e.tspec.typeSemantic(e.loc, sc);
             //printf("targ  = %s, %s\n", targ.toChars(), targ.deco);
             //printf("tspec = %s, %s\n", tspec.toChars(), tspec.deco);
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1540,7 +1540,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
         Type t;
         Expression e;
         Dsymbol s;
-        //printf("TypeIdentifier::semantic(%s)\n", mtype.toChars());
+        //printf("TypeIdentifier::semantic(%s)\n", toChars());
         mtype.resolve(loc, sc, &e, &t, &s);
         if (t)
         {

--- a/test/compilable/test19882.d
+++ b/test/compilable/test19882.d
@@ -1,2 +1,0 @@
-static assert (!is(undefined_id == int));
-static assert (!is(int == undefined_id));


### PR DESCRIPTION
As mentioned in bugzilla [19882](https://issues.dlang.org/show_bug.cgi?id=19882), the 'fix' (#9818) does the exact opposite of what is expected to happen. I've already been bitten, as an identifier typo in an `is` expression was silently accepted.