### PR TITLE
[Minor] Fix unittest related to barray.d

### DIFF
--- a/src/dmd/backend/barray.d
+++ b/src/dmd/backend/barray.d
@@ -107,7 +107,7 @@ unittest
     a.setLength(4);
     assert(a.length == 4);
     foreach (i, ref v; a[])
-        v = i * 2;
+        v = cast(int) i * 2;
     foreach (i, ref const v; a[])
         assert(v == i * 2);
     a.dtor();


### PR DESCRIPTION
variable i is of size_t which converts to ulong, but v is of type int, so cast is required
Error: cannot implicitly convert expression i * 2LU of type ulong to int  (barray.d:110)