### PR TITLE
Fix issues 17141, 17358 - Ternary operator converts characters to integers

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -247,6 +247,7 @@ struct ASTBase
         real_        = 8,
         imaginary    = 0x10,
         complex      = 0x20,
+        char_        = 0x40,
     }
 
     enum PKG : int
@@ -3547,17 +3548,17 @@ struct ASTBase
 
             case Tchar:
                 d = Token.toChars(TOK.char_);
-                flags |= TFlags.integral | TFlags.unsigned;
+                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
                 break;
 
             case Twchar:
                 d = Token.toChars(TOK.wchar_);
-                flags |= TFlags.integral | TFlags.unsigned;
+                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
                 break;
 
             case Tdchar:
                 d = Token.toChars(TOK.dchar_);
-                flags |= TFlags.integral | TFlags.unsigned;
+                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
                 break;
 
             default:

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2789,8 +2789,16 @@ bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expression* pe2)
 
     if (op != TOK.question || t1b.ty != t2b.ty && (t1b.isTypeBasic() && t2b.isTypeBasic()))
     {
-        e1 = integralPromotions(e1, sc);
-        e2 = integralPromotions(e2, sc);
+        if (op == TOK.question && t1b.ischar() && t2b.ischar())
+        {
+            e1 = charPromotions(e1, sc);
+            e2 = charPromotions(e2, sc);
+        }
+        else
+        {
+            e1 = integralPromotions(e1, sc);
+            e2 = integralPromotions(e2, sc);
+        }
     }
 
     Type t1 = e1.type;
@@ -3499,6 +3507,29 @@ Expression integralPromotions(Expression e, Scope* sc)
 
     default:
         break;
+    }
+    return e;
+}
+
+/***********************************
+ * Do char promotions.
+ *   char  -> dchar
+ *   wchar -> dchar
+ *   dchar -> dchar
+ */
+Expression charPromotions(Expression e, Scope* sc)
+{
+    //printf("charPromotions %s %s\n", e.toChars(), e.type.toChars());
+    switch (e.type.toBasetype().ty)
+    {
+    case Tchar:
+    case Twchar:
+    case Tdchar:
+        e = e.castTo(sc, Type.tdchar);
+        break;
+
+    default:
+        assert(0);
     }
     return e;
 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -235,6 +235,7 @@ private enum TFlags
     real_        = 8,
     imaginary    = 0x10,
     complex      = 0x20,
+    char_        = 0x40,
 }
 
 enum ENUMTY : int
@@ -1034,6 +1035,11 @@ extern (C++) abstract class Type : ASTNode
     }
 
     bool isunsigned()
+    {
+        return false;
+    }
+
+    bool ischar()
     {
         return false;
     }
@@ -3134,17 +3140,17 @@ extern (C++) final class TypeBasic : Type
 
         case Tchar:
             d = Token.toChars(TOK.char_);
-            flags |= TFlags.integral | TFlags.unsigned;
+            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
             break;
 
         case Twchar:
             d = Token.toChars(TOK.wchar_);
-            flags |= TFlags.integral | TFlags.unsigned;
+            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
             break;
 
         case Tdchar:
             d = Token.toChars(TOK.dchar_);
-            flags |= TFlags.integral | TFlags.unsigned;
+            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
             break;
 
         default:
@@ -3282,6 +3288,11 @@ extern (C++) final class TypeBasic : Type
     override bool isunsigned() const
     {
         return (flags & TFlags.unsigned) != 0;
+    }
+
+    override bool ischar() const
+    {
+        return (flags & TFlags.char_) != 0;
     }
 
     override MATCH implicitConvTo(Type to)
@@ -5800,6 +5811,11 @@ extern (C++) final class TypeEnum : Type
     override bool isunsigned()
     {
         return memType().isunsigned();
+    }
+
+    override bool ischar()
+    {
+        return memType().ischar();
     }
 
     override bool isBoolean()

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -400,6 +400,7 @@ public:
     bool iscomplex() /*const*/;
     bool isscalar() /*const*/;
     bool isunsigned() /*const*/;
+    bool ischar() /*const*/;
     MATCH implicitConvTo(Type *to);
     bool isZeroInit(const Loc &loc) /*const*/;
 
@@ -760,6 +761,7 @@ public:
     bool iscomplex();
     bool isscalar();
     bool isunsigned();
+    bool ischar();
     bool isBoolean();
     bool isString();
     bool isAssignable();

--- a/test/compilable/implicitconv.d
+++ b/test/compilable/implicitconv.d
@@ -14,3 +14,10 @@ static assert(!__traits(compiles, { const(wchar_t)[]     bar = foo; } ));
 static assert(!__traits(compiles, { immutable(wchar_t)*  bar = foo; } ));
 static assert(!__traits(compiles, { const(wchar_t)*      bar = foo; } ));
 
+// https://issues.dlang.org/show_bug.cgi?id=17141
+static assert(is(typeof(true ? char.init : char.init) == char));
+static assert(is(typeof(true ? char.init : wchar.init) == dchar));
+static assert(is(typeof(true ? char.init : dchar.init) == dchar));
+static assert(is(typeof(true ? wchar.init : wchar.init) == wchar));
+static assert(is(typeof(true ? wchar.init : dchar.init) == dchar));
+static assert(is(typeof(true ? dchar.init : dchar.init) == dchar));


### PR DESCRIPTION
If both operands of a ternary operator are char types of different sizes, then the result is always a `dchar`.

Not sure if this should target stable. 