### PR TITLE
Fix issue 19891 - Confusing error messages for auto ref parameters with default values

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -956,6 +956,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                 for (size_t i = 0; i < tf.parameterList.parameters.dim; i++)
                     (*tf.parameterList.parameters)[i].defaultArg = null;
                 tf.next = null;
+                tf.incomplete = true;
 
                 // Resolve parameter types and 'auto ref's.
                 tf.fargs = fargs;
@@ -2169,6 +2170,8 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         // Shouldn't run semantic on default arguments and return type.
         for (size_t i = 0; i < tf.parameterList.parameters.dim; i++)
             (*tf.parameterList.parameters)[i].defaultArg = null;
+        tf.incomplete = true;
+
         if (fd.isCtorDeclaration())
         {
             // For constructors, emitting return type is necessary for
@@ -6212,11 +6215,9 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                     Parameter fparam = fparameters[j];
                     if (fparam.storageClass & STC.autoref)       // if "auto ref"
                     {
-                        if (!fargs)
+                        Expression farg = fargs && j < fargs.dim ? (*fargs)[j] : fparam.defaultArg;
+                        if (!farg)
                             goto Lnotequals;
-                        if (fargs.dim <= j)
-                            break;
-                        Expression farg = (*fargs)[j];
                         if (farg.isLvalue())
                         {
                             if (!(fparam.storageClass & STC.ref_))

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4154,6 +4154,7 @@ extern (C++) final class TypeFunction : TypeNext
     ubyte iswild;               // bit0: inout on params, bit1: inout on qualifier
     Expressions* fargs;         // function arguments
     int inuse;
+    bool incomplete;            // return type or default arguments removed
 
     extern (D) this(ParameterList pl, Type treturn, LINK linkage, StorageClass stc = 0)
     {

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -586,6 +586,7 @@ public:
     Expressions *fargs; // function arguments
 
     int inuse;
+    bool incomplete;
 
     static TypeFunction *create(Parameters *parameters, Type *treturn, VarArg varargs, LINK linkage, StorageClass stc = 0);
     const char *kind();

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1350,7 +1350,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                 {
                     Expression e = fparam.defaultArg;
                     const isRefOrOut = fparam.storageClass & (STC.ref_ | STC.out_);
-                    const isAuto = fparam.storageClass & STC.auto_;
+                    const isAuto = fparam.storageClass & (STC.auto_ | STC.autoref);
                     if (isRefOrOut && !isAuto)
                     {
                         e = e.expressionSemantic(argsc);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1349,8 +1349,9 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                 if (fparam.defaultArg)
                 {
                     Expression e = fparam.defaultArg;
-                    auto isRefOrOut = fparam.storageClass & (STC.ref_ | STC.out_);
-                    if (isRefOrOut)
+                    const isRefOrOut = fparam.storageClass & (STC.ref_ | STC.out_);
+                    const isAuto = fparam.storageClass & STC.auto_;
+                    if (isRefOrOut && !isAuto)
                     {
                         e = e.expressionSemantic(argsc);
                         e = resolveProperties(argsc, e);
@@ -1372,7 +1373,8 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                         e = new AddrExp(e.loc, e);
                         e = e.expressionSemantic(argsc);
                     }
-                    if (isRefOrOut && !MODimplicitConv(e.type.mod, fparam.type.mod))
+                    if (isRefOrOut && (!isAuto || e.isLvalue())
+                        && !MODimplicitConv(e.type.mod, fparam.type.mod))
                     {
                         const(char)* errTxt = fparam.storageClass & STC.ref_ ? "ref" : "out";
                         .error(e.loc, "expression `%s` of type `%s` is not implicitly convertible to type `%s %s` of parameter `%s`",
@@ -1381,7 +1383,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                     e = e.implicitCastTo(argsc, fparam.type);
 
                     // default arg must be an lvalue
-                    if (fparam.storageClass & (STC.out_ | STC.ref_))
+                    if (isRefOrOut && !isAuto)
                         e = e.toLvalue(argsc, e);
 
                     fparam.defaultArg = e;
@@ -1460,9 +1462,9 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                  */
                 if (fparam.storageClass & STC.auto_)
                 {
-                    if (mtype.fargs && i < mtype.fargs.dim && (fparam.storageClass & STC.ref_))
+                    Expression farg = mtype.fargs && i < mtype.fargs.dim ? (*mtype.fargs)[i] : fparam.defaultArg;
+                    if (farg && (fparam.storageClass & STC.ref_))
                     {
-                        Expression farg = (*mtype.fargs)[i];
                         if (farg.isLvalue())
                         {
                             // ref parameter
@@ -1470,6 +1472,14 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                         else
                             fparam.storageClass &= ~STC.ref_; // value parameter
                         fparam.storageClass &= ~STC.auto_;    // https://issues.dlang.org/show_bug.cgi?id=14656
+                        fparam.storageClass |= STC.autoref;
+                    }
+                    else if (mtype.incomplete && (fparam.storageClass & STC.ref_))
+                    {
+                        // the default argument may have been temporarily removed,
+                        // see usage of `TypeFunction.incomplete`.
+                        // https://issues.dlang.org/show_bug.cgi?id=19891
+                        fparam.storageClass &= ~STC.auto_;
                         fparam.storageClass |= STC.autoref;
                     }
                     else

--- a/test/runnable/test19891.d
+++ b/test/runnable/test19891.d
@@ -1,0 +1,13 @@
+int g;
+
+void fun(R)(auto ref int a, auto ref R r = g)
+{
+    ++r;
+}
+
+void main()
+{
+    fun(10, 2);
+    fun(10);
+    assert(g == 1);
+}

--- a/test/runnable/test19891.d
+++ b/test/runnable/test19891.d
@@ -1,6 +1,6 @@
 int g;
 
-void fun(R)(auto ref int a, auto ref R r = g)
+void fun(R)(auto ref int a, auto ref R r = g, auto ref int b = 1)
 {
     ++r;
 }


### PR DESCRIPTION
[19891](https://issues.dlang.org/show_bug.cgi?id=19891).

Should this go stable?