### PR TITLE
bring SIMD to Linux 32 bit

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -98,11 +98,11 @@ static if (TARGET_WINDOS)
 }
 static if (TARGET_LINUX)
 {
+    config.fpxmmregs = true;
+    config.avx = avx;
     if (model == 64)
     {   config.exe = EX_LINUX64;
         config.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
-        config.fpxmmregs = true;
-        config.avx = avx;
     }
     else
     {
@@ -127,7 +127,6 @@ static if (TARGET_OSX)
     config.avx = avx;
     if (model == 64)
     {   config.exe = EX_OSX64;
-        config.fpxmmregs = true;
         config.ehmethod = useExceptions ? EHmethod.EH_DWARF : EHmethod.EH_NONE;
     }
     else

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1505,7 +1505,6 @@ uint totym(Type tx)
                 default:
                     assert(0);
             }
-            assert(global.params.is64bit || global.params.isOSX);
             break;
         }
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1362,7 +1362,7 @@ extern(C) void printGlobalConfigs(FILE* stream)
 
 private void setTargetCPU(ref Param params)
 {
-    if (params.is64bit || params.isOSX)
+    if (target.isXmmSupported())
     {
         switch (params.cpu)
         {

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -328,6 +328,15 @@ struct Target
         }
     }
 
+    /******************
+     * Returns:
+     *  true if xmm usage is supported
+     */
+    extern (C++) bool isXmmSupported()
+    {
+        return global.params.is64bit || global.params.isOSX;
+    }
+
     /**
      * Checks whether the target supports a vector type.
      * Params:
@@ -341,8 +350,9 @@ struct Target
      */
     extern (C++) int isVectorTypeSupported(int sz, Type type)
     {
-        if (!global.params.is64bit && !global.params.isOSX)
+        if (!isXmmSupported())
             return 1; // not supported
+
         switch (type.ty)
         {
         case Tvoid:

--- a/test/runnable/iasm.d
+++ b/test/runnable/iasm.d
@@ -4834,6 +4834,10 @@ int main()
   version (OSX)
   {
   }
+  else version (linux)
+  {
+    // stack alignment throws the tests off
+  }
   else
   {
     test5();

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -4349,9 +4349,18 @@ double foo240() {
 }
 
 void test240() {
-    double a = foo240();
-    double b = foo240();
-    double x = a*a + a*a + a*a + a*a + a*a + a*a + a*a +
+    double a = void;
+    double b = void;
+    double x = void;
+    version (D_SIMD)
+    {
+//	assert((cast(size_t)&a & 7) == 0);
+//	assert((cast(size_t)&b & 7) == 0);
+//	assert((cast(size_t)&x & 7) == 0);
+    }
+    a = foo240();
+    b = foo240();
+    x = a*a + a*a + a*a + a*a + a*a + a*a + a*a +
                a*b + a*b;
     assert(x > 0);
 }
@@ -5118,6 +5127,8 @@ else version (D_InlineAsm_X86)
     version = Check;
     version (OSX)
         enum Align = 0xC;
+//    version (linux)
+//        enum Align = 0xC;
 }
 
 void onFailure()
@@ -6188,6 +6199,7 @@ void test11472()
 
 int main()
 {
+    checkAlign();
     test1();
     test2();
     test3();


### PR DESCRIPTION
When I originally did this, Linux did not align the 32 bit stack to 16 bytes. Now it does, and so we can turn on XMM support.