### PR TITLE
Run semantic() on Type.tvalist

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -396,7 +396,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 if (f.linkage == LINK.d || f.parameterList.length)
                 {
                     // Declare _argptr
-                    Type t = Type.tvalist;
+                    Type t = Type.tvalist.typeSemantic(funcdecl.loc, sc);
                     // Init is handled in FuncDeclaration_toObjFile
                     funcdecl.v_argptr = new VarDeclaration(funcdecl.loc, t, Id._argptr, new VoidInitializer(funcdecl.loc));
                     funcdecl.v_argptr.storage_class |= STC.temp;


### PR DESCRIPTION
rebases #5488 (reduces diff between LDC and DMD)