### PR TITLE
Fix issue 19905 Floating point .init should be bitwise identical to .nan

### DIFF
--- a/changelog/nan.dd
+++ b/changelog/nan.dd
@@ -1,0 +1,19 @@
+Floating point types now use a quiet nan as the .init value
+
+Prior to this release, `float.init`, `double.init` and `real.init` used a
+signalling nan. They now use a quiet nan, which is the same as the corresponding
+`.nan` value.
+
+Old behaviour:
+---
+double a = double.init, b = double.nan;
+writefln("%x",*cast(ulong*)&a); // 7ff4000000000000
+writefln("%x",*cast(ulong*)&b); // 7ff8000000000000
+---
+
+New behaviour:
+---
+double a = double.init, b = double.nan;
+writefln("%x",*cast(ulong*)&a); // 7ff8000000000000
+writefln("%x",*cast(ulong*)&b); // 7ff8000000000000
+---

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1441,28 +1441,12 @@ elem *toElem(Expression e, IRState *irs)
             {
                 case TYfloat:
                 case TYifloat:
-                    /* This assignment involves a conversion, which
-                     * unfortunately also converts SNAN to QNAN.
-                     */
                     e.EV.Vfloat = cast(float) re.value;
-                    if (CTFloat.isSNaN(re.value))
-                    {
-                        // Put SNAN back
-                        e.EV.Vuns &= 0xFFBFFFFFL;
-                    }
                     break;
 
                 case TYdouble:
                 case TYidouble:
-                    /* This assignment involves a conversion, which
-                     * unfortunately also converts SNAN to QNAN.
-                     */
                     e.EV.Vdouble = cast(double) re.value;
-                    if (CTFloat.isSNaN(re.value))
-                    {
-                        // Put SNAN back
-                        e.EV.Vullong &= 0xFFF7FFFFFFFFFFFFUL;
-                    }
                     break;
 
                 case TYldouble:

--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -83,7 +83,7 @@ struct longdouble_soft
 {
 nothrow @nogc pure:
     // DMD's x87 `real` on Windows is packed (alignof = 2 -> sizeof = 10).
-    align(2) ulong mantissa = 0xC000000000000001UL; // default to snan
+    align(2) ulong mantissa = 0xC000000000000000UL; // default to qnan
     ushort exp_sign = 0x7fff; // sign is highest bit
 
     this(ulong m, ushort es) { mantissa = m; exp_sign = es; }
@@ -165,6 +165,7 @@ nothrow @nogc pure:
         }
     }
 
+    // a qnan
     static longdouble_soft nan() { return longdouble_soft(0xC000000000000000UL, 0x7fff); }
     static longdouble_soft infinity() { return longdouble_soft(0x8000000000000000UL, 0x7fff); }
     static longdouble_soft zero() { return longdouble_soft(0, 0); }
@@ -661,7 +662,6 @@ longdouble_soft ld_mod(longdouble_soft x, longdouble_soft y)
 __gshared const
 {
     longdouble_soft ld_qnan = longdouble_soft(0xC000000000000000UL, 0x7fff);
-    longdouble_soft ld_snan = longdouble_soft(0xC000000000000001UL, 0x7fff);
     longdouble_soft ld_inf  = longdouble_soft(0x8000000000000000UL, 0x7fff);
 
     longdouble_soft ld_zero  = longdouble_soft(0, 0);

--- a/src/dmd/root/longdouble.h
+++ b/src/dmd/root/longdouble.h
@@ -237,7 +237,6 @@ inline longdouble_soft sqrt (longdouble_soft ld) { return sqrtl(ld); }
 #define LDBL_MIN_10_EXP (-4932)
 
 extern const longdouble_soft ld_qnan;
-extern const longdouble_soft ld_snan;
 extern const longdouble_soft ld_inf;
 
 extern const longdouble_soft ld_zero;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -69,7 +69,6 @@ struct Target
         real_t max;                         /// largest representable value that's not infinity
         real_t min_normal;                  /// smallest representable normalized value that's not 0
         real_t nan;                         /// NaN value
-        real_t snan;                        /// signalling NaN value
         real_t infinity;                    /// infinity value
         real_t epsilon;                     /// smallest increment to the value 1
 
@@ -85,7 +84,6 @@ struct Target
             max = T.max;
             min_normal = T.min_normal;
             nan = T.nan;
-            snan = T.init;
             infinity = T.infinity;
             epsilon = T.epsilon;
         }

--- a/src/dmd/target.h
+++ b/src/dmd/target.h
@@ -50,7 +50,6 @@ struct Target
         real_t max;
         real_t min_normal;
         real_t nan;
-        real_t snan;
         real_t infinity;
         real_t epsilon;
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -4209,14 +4209,14 @@ Expression defaultInit(Type mt, const ref Loc loc)
         case Tfloat32:
         case Tfloat64:
         case Tfloat80:
-            return new RealExp(loc, target.RealProperties.snan, mt);
+            return new RealExp(loc, target.RealProperties.nan, mt);
 
         case Tcomplex32:
         case Tcomplex64:
         case Tcomplex80:
             {
                 // Can't use fvalue + I*fvalue (the im part becomes a quiet NaN).
-                const cvalue = complex_t(target.RealProperties.snan, target.RealProperties.snan);
+                const cvalue = complex_t(target.RealProperties.nan, target.RealProperties.nan);
                 return new ComplexExp(loc, cvalue, mt);
             }
 

--- a/test/runnable/nan.d
+++ b/test/runnable/nan.d
@@ -20,6 +20,52 @@ static assert(!(ed1 <= ed2));
 
 bool b;
 
+
+T byCTFE(T)()
+{
+    T x;
+    return x;
+}
+
+void printNaN(T)(T x)
+{
+    ubyte[] px = cast(ubyte[])((&x)[0..1]);
+
+    printf(T.stringof.ptr);
+    printf(".nan = 0x");
+    foreach_reverse(p; 0..T.sizeof)
+        printf("%02x", px[p]);
+    printf(" mantissa=%d\n", T.mant_dig);
+}
+
+bool bittst(ubyte[] ba, uint pos)
+{
+    uint mask = 1 << (pos % 8);
+    version(LittleEndian)
+        return (ba[pos / 8] & mask) != 0;
+    else
+        return (ba[$ - 1 - pos / 8] & mask) != 0;
+}
+
+void test2(T)()
+{
+    T a = T.init, b = T.nan;
+    //printNaN(a);
+    ubyte[] pa = cast(ubyte[])((&a)[0..1]);
+    ubyte[] pb = cast(ubyte[])((&b)[0..1]);
+    assert(pa[] == pb[]);
+
+    enum c = byCTFE!T();
+    a = c;
+    assert(pa[] == pb[]);
+
+    // the highest 2 bits of the mantissa should be set, everythng else zero
+    assert(bittst(pa, T.mant_dig - 1));
+    assert(bittst(pa, T.mant_dig - 2));
+    foreach(p; 0..T.mant_dig - 2)
+        assert(!bittst(pa, p));
+}
+
 bool test()
 {
         real r1 = real.nan;
@@ -53,5 +99,8 @@ bool test()
 
 void main()
 {
-        assert(test());
+    assert(test());
+    test2!float();
+    test2!double();
+    test2!real();
 }


### PR DESCRIPTION
See also https://github.com/dlang/dmd/pull/7568 in particular https://github.com/dlang/dmd/pull/7568#discussion_r159835497

> Walter wrote:
> They should have the same bit patterns. We tried to make .init a signalling nan, but this was a complete failure. .init and .nan should both be a quiet nan
> Because a signalling nan converts to a quiet nan when used. The problem was nobody could come up with a consistent definition of "used".