### PR TITLE
Fix build.d when multiple dmd's in path

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -727,7 +727,7 @@ auto getHostDMDPath(string hostDmd)
     version(Posix)
         return ["which", hostDmd].execute.output;
     else version(Windows)
-        return ["where", hostDmd].execute.output;
+        return ["where", hostDmd].execute.output.lineSplitter.front;
     else
         static assert(false, "Unrecognized or unsupported OS.");
 }


### PR DESCRIPTION
The `where` command on windows returns multiple lines.  This fixes `build.d` so it only selects the first line, which is the first one found.