### PR TITLE
enable CSEs for XMM operands

### DIFF
--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -287,8 +287,13 @@ void note87(elem *e, uint offset, int i, int linnum)
             printf("_8087elems[%d].e = %p\n",i,_8087elems[i].e);
     }
 
-    //if (i >= stackused) *cast(char*)0=0;
+    if (i >= stackused)
+    {
+        printf("note87(e = %p.%d, i = %d, stackused = %d, line = %d)\n",e,offset,i,stackused,linnum);
+        elem_print(e);
+    }
     assert(i < stackused);
+
     while (e.Eoper == OPcomma)
         e = e.EV.E2;
     _8087elems[i].e = e;
@@ -520,8 +525,6 @@ void comsub87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             // Reload
             loaddata(cdb,e,pretregs);
     }
-
-    freenode(e);
 }
 
 
@@ -810,7 +813,11 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
     /* if retregs needs to be transferred into the 8087 */
     if (*pretregs & mST0 && retregs & (mBP | ALLREGS))
     {
-        if (sz > DOUBLESIZE) elem_print(e);
+        debug if (sz > DOUBLESIZE)
+        {
+            elem_print(e);
+            printf("retregs = %s\n", regm_str(retregs));
+        }
         assert(sz <= DOUBLESIZE);
         if (!I16)
         {
@@ -931,7 +938,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
             assert(!(*pretregs & mST0) || (retregs & mST0));
     }
     if (*pretregs & mST0)
-        note87(e,0,0);
+        note87(e,0,0,__LINE__);
 }
 
 /********************************
@@ -1059,7 +1066,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             assert((*pretregs & mST0) == 0);
             regm_t retregs = mST0;
             codelem(cdb,e1,&retregs,false);
-            note87(e1,0,0);
+            note87(e1,0,0,__LINE__);
             regm_t resregm = mPSW;
 
             if (rel_exception(e.Eoper) || config.flags4 & CFG4fastfloat)
@@ -1083,7 +1090,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 }
                 else if (NOSAHF)
                 {
-                    note87(e1,0,0);
+                    note87(e1,0,0,__LINE__);
                     load87(cdb,e2,0,&retregs,e1,-1);
                     makesure87(cdb,e1,0,1,0);
                     resregm = 0;
@@ -1110,7 +1117,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
                 }
                 else
                 {
-                    note87(e1,0,0);
+                    note87(e1,0,0,__LINE__);
                     load87(cdb,e2,0,&retregs,e1,-1);
                     makesure87(cdb,e1,0,1,0);
                     resregm = 0;
@@ -1227,7 +1234,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         {
             regm_t retregs = mST0;
             codelem(cdb,e1, &retregs, false);
-            note87(e1, 0, 0);
+            note87(e1, 0, 0,__LINE__);
             loadComplex(cdb,e2);
             makesure87(cdb, e1, 0, 2, 0);
             retregs = mST01;
@@ -1295,7 +1302,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         {
             regm_t retregs = mST0;
             codelem(cdb,e1, &retregs, false);
-            note87(e1, 0, 0);
+            note87(e1, 0, 0,__LINE__);
             codelem(cdb,e2, &retregs, false);
             makesure87(cdb, e1, 0, 1, 0);
             if (eoper == OPmin)
@@ -1380,7 +1387,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         {
             regm_t retregs = mST0;
             codelem(cdb,e1, &retregs, false);
-            note87(e1, 0, 0);
+            note87(e1, 0, 0,__LINE__);
             loadComplex(cdb,e2);
             makesure87(cdb, e1, 0, 2, 0);
             cdb.genf2(0xD9, imaginary ? 0xE0 : 0xC8 + 1); // FCHS / FXCH ST(1)
@@ -1516,7 +1523,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
     regm_t retregs1 = mST0;
     codelem(cdb,e1,&retregs1,false);
-    note87(e1,0,0);
+    note87(e1,0,0,__LINE__);
 
     if (config.flags4 & CFG4fdivcall && e.Eoper == OPdiv)
     {
@@ -1567,7 +1574,7 @@ void orth87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         freenode(e2);
     }
     if (*pretregs & mST0)
-        note87(e,0,0);
+        note87(e,0,0,__LINE__);
     //printf("orth87(-e = %p, *pretregs = %s)\n", e, regm_str(*pretregs));
 }
 
@@ -1613,8 +1620,8 @@ private void loadComplex(ref CodeBuilder cdb,elem *e)
         default:
             assert(0);
     }
-    note87(e, 0, 1);
-    note87(e, sz, 0);
+    note87(e, 0, 1,__LINE__);
+    note87(e, sz, 0,__LINE__);
 }
 
 /*************************
@@ -1702,7 +1709,7 @@ L5:
                         printf("ty = x%x\n", ty);
                         assert(0);
                 }
-                note87(e,0,0);
+                note87(e,0,0,__LINE__);
             }
             break;
 
@@ -1712,7 +1719,7 @@ L5:
             mf1 = (tybasic(e.EV.E1.Ety) == TYfloat || tybasic(e.EV.E1.Ety) == TYifloat)
                     ? MFfloat : MFdouble;
             if (op != -1 && stackused)
-                note87(eleft,eoffset,0);    // don't trash this value
+                note87(eleft,eoffset,0,__LINE__);    // don't trash this value
             if (e.EV.E1.Eoper == OPvar || e.EV.E1.Eoper == OPind)
             {
                 static if (1)
@@ -1823,7 +1830,7 @@ L5:
             assert(!I32);
 
             if (op != -1)
-                note87(eleft,eoffset,0);    // don't trash this value
+                note87(eleft,eoffset,0,__LINE__);    // don't trash this value
             retregs = ALLREGS & mLSW;
             codelem(cdb,e.EV.E1,&retregs,false);
             regwithvalue(cdb,ALLREGS & mMSW,0,&reg,0);  // 0-extend
@@ -1836,7 +1843,7 @@ L5:
         case OPs32_d:       mf1 = MFlong;   goto L6;
         L6:
             if (op != -1)
-                note87(eleft,eoffset,0);    // don't trash this value
+                note87(eleft,eoffset,0,__LINE__);    // don't trash this value
             if (e.EV.E1.Eoper == OPvar ||
                 (e.EV.E1.Eoper == OPind && e.EV.E1.Ecount == 0))
             {
@@ -1872,20 +1879,7 @@ L5:
         default:
         Ldefault:
             retregs = mST0;
-            static if (1)   /* Do this instead of codelem() to avoid the freenode(e).
-                           We also lose CSE capability  */
-            {
-                if (e.Eoper == OPconst)
-                {
-                    load87(cdb, e, 0, &retregs, null, -1);
-                }
-                else
-                    callcdxxx(cdb,e,&retregs,e.Eoper);
-            }
-            else
-            {
-                codelem(cdb,e,&retregs,false);
-            }
+            codelem(cdb,e,&retregs,2);
 
             if (op != -1)
             {
@@ -2032,7 +2026,7 @@ void eq87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             elem *e2 = e.EV.E2;
             while (e2.Eoper == OPcomma)
                 e2 = e2.EV.E2;
-            note87(e2,0,0);
+            note87(e2,0,0,__LINE__);
             getlvalue87(cdb, &cs, e.EV.E1, 0);
             makesure87(cdb,e2,0,0,1);
         }
@@ -2302,7 +2296,7 @@ void opass87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     }
     regm_t retregs = mST0;
     codelem(cdb,e.EV.E2,&retregs,false);     // evaluate rvalue
-    note87(e.EV.E2,0,0);
+    note87(e.EV.E2,0,0,__LINE__);
     getlvalue87(cdb,&cs,e.EV.E1,e.Eoper==OPmodass?mAX:0);
     makesure87(cdb,e.EV.E2,0,0,0);
     if (config.flags4 & CFG4fdivcall && e.Eoper == OPdivass)
@@ -2418,7 +2412,7 @@ private void opmod_complex87(ref CodeBuilder cdb, elem *e,regm_t *pretregs)
 
     regm_t retregs = mST0;
     codelem(cdb,e.EV.E2,&retregs,false);         // FLD E2
-    note87(e.EV.E2,0,0);
+    note87(e.EV.E2,0,0,__LINE__);
     getlvalue87(cdb,&cs,e.EV.E1,0);
     makesure87(cdb,e.EV.E2,0,0,0);
 
@@ -2514,7 +2508,7 @@ private void opass_complex87(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     {
         retregs = mST0;
         codelem(cdb,e.EV.E2, &retregs, false);
-        note87(e.EV.E2, 0, 0);
+        note87(e.EV.E2, 0, 0,__LINE__);
         getlvalue87(cdb,&cs, e.EV.E1, 0);
         makesure87(cdb,e.EV.E2,0,0,0);
         push87(cdb);
@@ -3369,7 +3363,7 @@ void cdscale(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
     regm_t retregs = mST0;
     codelem(cdb,e.EV.E1,&retregs,false);
-    note87(e.EV.E1,0,0);
+    note87(e.EV.E1,0,0,__LINE__);
     codelem(cdb,e.EV.E2,&retregs,false);
     makesure87(cdb,e.EV.E1,0,1,0);       // now have x,y on stack; need y,x
     switch (e.Eoper)
@@ -3723,8 +3717,8 @@ void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pret
         assert(!(*pretregs & mST01) || (retregs & mST01));
     }
     if (*pretregs & mST01)
-    {   note87(e,0,1);
-        note87(e,sz/2,0);
+    {   note87(e,0,1,__LINE__);
+        note87(e,sz/2,0,__LINE__);
     }
 }
 
@@ -3864,7 +3858,7 @@ void loadPair87(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     assert(e.Eoper == OPpair || e.Eoper == OPrpair);
     regm_t retregs = mST0;
     codelem(cdb,e.EV.E1, &retregs, false);
-    note87(e.EV.E1, 0, 0);
+    note87(e.EV.E1, 0, 0,__LINE__);
     codelem(cdb,e.EV.E2, &retregs, false);
     makesure87(cdb,e.EV.E1, 0, 1, 0);
     if (e.Eoper == OPrpair)

--- a/src/dmd/backend/cgxmm.d
+++ b/src/dmd/backend/cgxmm.d
@@ -335,6 +335,7 @@ Lp:
 
 void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 {
+    //printf("xmmconvt: %p, %s\n", e, regm_str(*pretregs));
     opcode_t op = NoOpcode;
     regm_t regs;
     tym_t ty;
@@ -364,9 +365,16 @@ void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             ty = TYfloat;
             break;
         }
+        if (e1.Ecount)
+        {
+            regs = XMMREGS;
+            op = CVTSD2SS;
+            ty = TYfloat;
+            break;
+        }
         // directly use si2ss
         regs = ALLREGS;
-        e1 = e1.EV.E1;
+        e1 = e1.EV.E1;  // fused operation
         op = CVTSI2SS;
         ty = TYfloat;
         break;
@@ -388,7 +396,12 @@ void xmmcnvt(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
         switch (e1.Eoper)
         {
         case OPf_d:
-            e1 = e1.EV.E1;
+            if (e1.Ecount)
+            {
+                op = CVTTSD2SI;
+                break;
+            }
+            e1 = e1.EV.E1;      // fused operation
             op = CVTTSS2SI;
             break;
         case OPld_d:

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -356,7 +356,7 @@ uint gensaverestore(regm_t regm,ref CodeBuilder cdbsave,ref CodeBuilder cdbresto
         if (regm & 1)
         {
             code *cs2;
-            if (i == ES)
+            if (i == ES && I16)
             {
                 stackused += REGSIZE;
                 cdbsave.gen1(0x06);                     // PUSH ES

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -2005,6 +2005,7 @@ int jmpopcode(elem *e)
     bool needsNanCheck = tyfloating(tymx) && config.inline8087 &&
         (tymx == TYldouble || tymx == TYildouble || tymx == TYcldouble ||
          tymx == TYcdouble || tymx == TYcfloat ||
+         (tyxmmreg(tymx) && config.fpxmmregs && e.Ecount != e.Ecomsub) ||
          op == OPind ||
          (OTcall(op) && (regmask(tymx, tybasic(e.EV.E1.Eoper)) & (mST0 | XMMREGS))));
     if (e.Ecount != e.Ecomsub)          // comsubs just get Z bit set
@@ -2356,25 +2357,63 @@ bool cse_simple(code *c, elem *e)
     return false;
 }
 
-void gen_testcse(ref CodeBuilder cdb, uint sz, targ_uns i)
+/**************************
+ * Store `reg` to the common subexpression save area in index `slot`.
+ * Params:
+ *      cdb = where to write code to
+ *      tym = type of value that's in `reg`
+ *      reg = register to save
+ *      slot = index into common subexpression save area
+ */
+void gen_storecse(ref CodeBuilder cdb, tym_t tym, reg_t reg, size_t slot)
 {
+    // MOV slot[BP],reg
+    if (isXMMreg(reg) && config.fpxmmregs) // watch out for ES
+    {
+        const aligned = tyvector(tym) ? STACKALIGN >= 16 : true;
+        const op = xmmstore(tym, aligned);
+        cdb.genc1(op,modregxrm(2, reg - XMM0, BPRM),FLcs,cast(targ_size_t)slot);
+        return;
+    }
+    opcode_t op = STO;              // normal mov
+    if (reg == ES)
+    {
+        reg = 0;            // the real reg number
+        op = 0x8C;          // segment reg mov
+    }
+    cdb.genc1(op,modregxrm(2, reg, BPRM),FLcs,cast(targ_uns)slot);
+    if (I64)
+        code_orrex(cdb.last(), REX_W);
+}
+
+void gen_testcse(ref CodeBuilder cdb, tym_t tym, uint sz, size_t slot)
+{
+    // CMP slot[BP],0
     cdb.genc(sz == 1 ? 0x80 : 0x81,modregrm(2,7,BPRM),
-                FLcs,i, FLconst,cast(targ_uns) 0);
+                FLcs,cast(targ_uns)slot, FLconst,cast(targ_uns) 0);
     if ((I64 || I32) && sz == 2)
         cdb.last().Iflags |= CFopsize;
     if (I64 && sz == 8)
         code_orrex(cdb.last(), REX_W);
 }
 
-void gen_loadcse(ref CodeBuilder cdb, reg_t reg, targ_uns i)
+void gen_loadcse(ref CodeBuilder cdb, tym_t tym, reg_t reg, size_t slot)
 {
-    opcode_t op = 0x8B;
+    // MOV reg,slot[BP]
+    if (isXMMreg(reg) && config.fpxmmregs)
+    {
+        const aligned = tyvector(tym) ? STACKALIGN >= 16 : true;
+        const op = xmmload(tym, aligned);
+        cdb.genc1(op,modregxrm(2, reg - XMM0, BPRM),FLcs,cast(targ_size_t)slot);
+        return;
+    }
+    opcode_t op = LOD;
     if (reg == ES)
     {
         op = 0x8E;
         reg = 0;
     }
-    cdb.genc1(op,modregxrm(2,reg,BPRM),FLcs,i);
+    cdb.genc1(op,modregxrm(2,reg,BPRM),FLcs,cast(targ_uns)slot);
     if (I64)
         code_orrex(cdb.last(), REX_W);
 }
@@ -2534,23 +2573,6 @@ void genpop(ref CodeBuilder cdb, reg_t reg)
     cdb.gen1(0x58 + (reg & 7));
     if (reg & 8)
         code_orrex(cdb.last(), REX_B);
-}
-
-/**************************
- * Generate a MOV to save a register to a stack slot
- */
-void gensavereg(ref CodeBuilder cdb, ref reg_t reg, targ_uns slot)
-{
-    // MOV i[BP],reg
-    opcode_t op = 0x89;              // normal mov
-    if (reg == ES)
-    {
-        reg = 0;            // the real reg number
-        op = 0x8C;          // segment reg mov
-    }
-    cdb.genc1(op,modregxrm(2, reg, BPRM),FLcs,slot);
-    if (I64)
-        code_orrex(cdb.last(), REX_W);
 }
 
 /**************************
@@ -3277,6 +3299,8 @@ void prolog_frameadj2(ref CodeBuilder cdb, tym_t tyf, uint xlocalsize, bool* pus
 
 void prolog_setupalloca(ref CodeBuilder cdb)
 {
+    //printf("prolog_setupalloca() offset x%x size x%x alignment x%x\n",
+        //cast(int)Alloca.offset, cast(int)Alloca.size, cast(int)Alloca.alignment);
     // Set up magic parameter for alloca()
     // MOV -REGSIZE[BP],localsize - BPoff
     cdb.genc(0xC7,modregrm(2,0,BPRM),
@@ -5075,7 +5099,7 @@ void assignaddrc(code *c)
                     c.Iop = NOP;
                     continue;
                 }
-                c.IEV1.Vpointer = sn * REGSIZE + CSoff + BPoff;
+                c.IEV1.Vpointer = CSE_offset(sn) + CSoff + BPoff;
                 c.Iflags |= CFunambig;
                 goto L2;
 

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -2731,7 +2731,7 @@ void longcmp(ref CodeBuilder cdb,elem *e,bool jcond,uint fltarg,code *targ)
 
 void cdcnvt(ref CodeBuilder cdb,elem *e, regm_t *pretregs)
 {
-    //printf("cdcnvt: *pretregs = %s\n", regm_str(*pretregs));
+    //printf("cdcnvt: %p *pretregs = %s\n", e, regm_str(*pretregs));
     //elem_print(e);
 
     static immutable ubyte[2][16] clib =

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -100,6 +100,7 @@ code *code_malloc()
 
 extern __gshared con_t regcon;
 
+uint CSE_offset(int i);
 bool CSE_loaded(int i);
 
 /************************************
@@ -395,12 +396,10 @@ void getregsNoSave(regm_t r);
 void getregs_imm(ref CodeBuilder cdb, regm_t r);
 void cse_flush(ref CodeBuilder, int);
 bool cse_simple(code *c, elem *e);
-void gen_testcse(ref CodeBuilder cdb, uint sz, targ_uns i);
-void gen_loadcse(ref CodeBuilder cdb, reg_t reg, targ_uns i);
 bool cssave (elem *e , regm_t regm , uint opsflag );
 bool evalinregister(elem *e);
 regm_t getscratch();
-void codelem(ref CodeBuilder cdb, elem *e, regm_t *pretregs, bool constflag);
+void codelem(ref CodeBuilder cdb, elem *e, regm_t *pretregs, uint constflag);
 void scodelem(ref CodeBuilder cdb, elem *e, regm_t *pretregs, regm_t keepmsk, bool constflag);
 const(char)* regm_str(regm_t rm);
 int numbitsset(regm_t);
@@ -524,7 +523,9 @@ void genregs(ref CodeBuilder cdb, opcode_t op, uint dstreg, uint srcreg);
 void gentstreg(ref CodeBuilder cdb, uint reg);
 void genpush(ref CodeBuilder cdb, reg_t reg);
 void genpop(ref CodeBuilder cdb, reg_t reg);
-void gensavereg(ref CodeBuilder cdb, ref reg_t reg, targ_uns slot);
+void gen_storecse(ref CodeBuilder cdb, tym_t tym, reg_t reg, size_t slot);
+void gen_testcse(ref CodeBuilder cdb, tym_t tym, uint sz, size_t i);
+void gen_loadcse(ref CodeBuilder cdb, tym_t tym, reg_t reg, size_t slot);
 code *genmovreg(uint to, uint from);
 void genmovreg(ref CodeBuilder cdb, uint to, uint from);
 void genmulimm(ref CodeBuilder cdb,uint r1,uint r2,targ_int imm);

--- a/src/dmd/backend/gdag.d
+++ b/src/dmd/backend/gdag.d
@@ -47,15 +47,18 @@ bool Eunambig(elem* e) { return OTassign(e.Eoper) && e.EV.E1.Eoper == OPvar; }
 
 /*************************************
  * Determine if floating point should be cse'd.
+ * Returns:
+ *      true if should be cse'd
  */
 
-int cse_float(elem *e)
+private bool cse_float(elem *e)
 {
     // Don't CSE floating stuff if generating
     // inline 8087 code, the code generator
     // can't handle it yet
     return !(tyfloating(e.Ety) && config.inline8087 &&
-           e.Eoper != OPvar && e.Eoper != OPconst);
+             e.Eoper != OPvar && e.Eoper != OPconst) ||
+           (tyxmmreg(e.Ety) && config.fpxmmregs);
 }
 
 /************************************
@@ -533,6 +536,9 @@ L1:
         // This CSE is too easy to regenerate
         else if (op == OPu16_32 && I16 && e.Ecount)
             e = delcse(pe);
+
+        else if (op == OPd_ld && e.EV.E1.Ecount > 0)
+            delcse(&e.EV.E1);
 
         // OPremquo is only worthwhile if its result is used more than once
         else if (e.EV.E1.Eoper == OPremquo &&

--- a/test/runnable/testfloat.d
+++ b/test/runnable/testfloat.d
@@ -58,10 +58,136 @@ void test241()
 
 /***************************************/
 
+void test1(float f)
+{
+    real r = f;
+    double d = f;
+}
+
+void test2(long l)
+{
+    real r = l;
+    double d = l;
+}
+
+void test3(float f)
+{
+    real r = f * f;
+    double d = f * f;
+}
+
+void test3(long l)
+{
+    real r = l * l;
+    double d = l * l;
+}
+
+/***************************************/
+
+double foo4(int i, double d)
+{
+    return ((i << 1) - d) + ((i << 1) - d);
+}
+
+void test4()
+{
+    double d = foo4(3, 4);
+    assert(d == 4);
+}
+
+/***************************************/
+
+import std.math; // trigger use of sqrt intrinsic
+
+void test5x(double p)
+{
+    bool b = p >= 0;
+    double mean = (1 - p) / p;
+    double skew = sqrt(1 - p);
+}
+
+void test5()
+{
+    test5x(2);
+}
+
+/***************************************/
+
+import std.math; // trigger use of sqrt intrinsic
+
+void dstatsEnforce(bool, string) { }
+
+ulong invNegBinomCDF(double pVal, ulong n, double p)
+{
+    dstatsEnforce(p >= 0 && p <= 1,
+        "p must be between 0, 1 for negative binomial distribution.");
+    dstatsEnforce(pVal >= 0 && pVal <= 1,
+        "P-values must be between 0, 1.");
+
+    // Normal or gamma approx, then adjust.
+    double mean = n * (1 - p) / p;
+    double var = n * (1 - p) / (p * p);
+    double skew = (2 - p) / sqrt(n * (1 - p));
+    double kk = 4.0L / (skew * skew);
+    double theta = sqrt(var / kk);
+    double offset = (kk * theta) - mean + 0.5L;
+    ulong guess;
+    return 0;
+}
+
+void test6()
+{
+    invNegBinomCDF(2.0, 3, 4.0);
+}
+
+/***************************************/
+
+float expDigamma(F)(in F x)
+{
+    return x;
+}
+
+float nextDown(float f) { return f; }
+
+void test7()
+{
+    foreach (i; 1 .. 2)
+    {
+	assert(expDigamma(float(i)) >= expDigamma(float(i).nextDown));
+    }
+}
+
+/***************************************/
+
+void foo8_1(double x)
+{
+    printf("x = %g\n", x);
+    assert(x == 0);
+}
+
+void foo8_2(double x)
+{
+    printf("x = %g\n", x);
+    assert(x != 0);
+}
+
+void test8()
+{
+    foo8_1(0.0);
+    foo8_2(1.0);
+}
+
+/***************************************/
+
 int main()
 {
     test240();
     test241();
+    test4();
+    test5();
+    test6();
+    test7();
+    test8();
 
     printf("Success\n");
     return EXIT_SUCCESS;


### PR DESCRIPTION
It's past time to get common subexpressions working for XMM registers.