### PR TITLE
Fix OS variable on windows in test suite

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,22 +1,22 @@
 ifeq (Windows_NT,$(OS))
     ifeq ($(findstring WOW64, $(shell uname)),WOW64)
-        OS:=win64
+        OS:=windows
         MODEL:=64
     else
-        OS:=win32
+        OS:=windows
         MODEL:=32
     endif
 endif
 ifeq (Win_32,$(OS))
-    OS:=win32
+    OS:=windows
     MODEL:=32
 endif
 ifeq (Win_32_64,$(OS))
-    OS:=win64
+    OS:=windows
     MODEL:=64
 endif
 ifeq (Win_64,$(OS))
-    OS:=win64
+    OS:=windows
     MODEL:=64
 endif
 

--- a/test/README.md
+++ b/test/README.md
@@ -252,7 +252,7 @@ The Makefile uses environment variables to store test settings and as a way to p
     REQUIRED_ARGS: arguments always passed to the compiler
     DMD:           compiler to use, ex: ../src/dmd (required)
     CC:            C++ compiler to use, ex: dmc, g++
-    OS:            win32, win64, linux, freebsd, osx, netbsd, dragonflybsd
+    OS:            windows, linux, freebsd, osx, netbsd, dragonflybsd
     RESULTS_DIR:   base directory for test results
     MODEL:         32 or 64 (required)
     AUTO_UPDATE:   set to 1 to auto-update mismatching test output

--- a/test/compilable/test19266.sh
+++ b/test/compilable/test19266.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "${OS}" == "win32" -o "${OS}" == "win64" -o "${OS}" == "win32mscoff" ]; then 
+if [ "${OS}" == "windows" ]; then
    # break out of bash to get Windows paths
    cmd //c $(echo $DMD | tr / \\) -c \\\\.\\%CD%\\compilable\\extra-files\\test19266.d -deps=nul:
 fi

--- a/test/compilable/test9680.sh
+++ b/test/compilable/test9680.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "${OS}" == "win32" -o "${OS}" == "Windows_NT" ]; then
+if [ "${OS}" == "windows" ]; then
     kinds=( main winmain dllmain )
 else
     kinds=( main )

--- a/test/runnable/paranoia.sh
+++ b/test/runnable/paranoia.sh
@@ -7,7 +7,7 @@ echo ======== Testing Double Precision ========
 $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Double -of${OUTPUT_BASE}_2${EXE}
 ${OUTPUT_BASE}_2${EXE}
 
-if [ "${OS}" == "win64" -o "${MODEL}" == "32mscoff" ]; then
+if [ "${OS}${MODEL}" == "windows64" -o "${MODEL}" == "32mscoff" ]; then
     echo ======== Testing Extended Precision ========
     $DMD -m${MODEL} ${EXTRA_FILES}/paranoia.d -version=Extended ../src/dmd/root/longdouble.d -of${OUTPUT_BASE}_3${EXE}
     ${OUTPUT_BASE}_3${EXE}

--- a/test/runnable/test18141.sh
+++ b/test/runnable/test18141.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "${OS}" == "win32" -o "${OS}" == "win64" ]; then
+if [ "${OS}" == "windows" ]; then
     expected="Windows"
 else
     expected="Posix"

--- a/test/runnable/test39.sh
+++ b/test/runnable/test39.sh
@@ -7,7 +7,7 @@ $DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -c ${EXTRA_FILES}/test39.d
 $DMD -m${MODEL} -I${TEST_DIR} -od${RESULTS_TEST_DIR} -c ${TEST_DIR}/imports/test39a.d
 libname=${OUTPUT_BASE}a${LIBEXT}
 
-if [ ${OS} == "win32" -o ${OS} == "win64" ]; then
+if [ ${OS} == "windows" ]; then
     $DMD -m${MODEL} -lib -of${libname} ${OUTPUT_BASE}a${OBJ}
 else
     ar -r ${libname} ${OUTPUT_BASE}a${OBJ}

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -38,7 +38,7 @@ void usage()
           ~ "      REQUIRED_ARGS: arguments always passed to the compiler\n"
           ~ "      DMD:           compiler to use, ex: ../src/dmd (required)\n"
           ~ "      CC:            C++ compiler to use, ex: dmc, g++\n"
-          ~ "      OS:            win32, win64, linux, freebsd, osx, netbsd, dragonflybsd\n"
+          ~ "      OS:            windows, linux, freebsd, osx, netbsd, dragonflybsd\n"
           ~ "      RESULTS_DIR:   base directory for test results\n"
           ~ "      MODEL:         32 or 64 (required)\n"
           ~ "      AUTO_UPDATE:   set to 1 to auto-update mismatching test output\n"
@@ -253,7 +253,7 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     }
 
     // win(32|64) doesn't support pic
-    if (envData.os == "win32" || envData.os == "win64")
+    if (envData.os == "windows")
     {
         auto index = std.string.indexOf(testArgs.permuteArgs, "-fPIC");
         if (index != -1)
@@ -469,7 +469,7 @@ bool collectExtraSources (in string input_dir, in string output_dir, in string[]
             {
                 command ~= ` /c /nologo `~curSrc~` /Fo`~curObj;
             }
-            else if (envData.os == "win32")
+            else if (envData.os == "windows" && envData.model == "32")
             {
                 command ~= " -c "~curSrc~" -o"~curObj;
             }
@@ -620,12 +620,14 @@ int tryMain(string[] args)
 
     if (envData.ccompiler.empty)
     {
-        switch (envData.os)
-        {
-            case "win32": envData.ccompiler = "dmc"; break;
-            case "win64": envData.ccompiler = `\"Program Files (x86)"\"Microsoft Visual Studio 10.0"\VC\bin\amd64\cl.exe`; break;
-            default:      envData.ccompiler = "c++"; break;
-        }
+        if (envData.os != "windows")
+            envData.ccompiler = "c++";
+        else if (envData.model == "32")
+            envData.ccompiler = "dmc";
+        else if (envData.model == "64")
+            envData.ccompiler = `C:\"Program Files (x86)"\"Microsoft Visual Studio 10.0"\VC\bin\amd64\cl.exe`;
+        else
+            assert(0, "unknown $OS$MODEL combination: " ~ envData.os ~ envData.model);
     }
 
     envData.usingMicrosoftCompiler = envData.ccompiler.toLower.endsWith("cl.exe");
@@ -656,7 +658,8 @@ int tryMain(string[] args)
         }
     }
 
-    if (testArgs.disabledPlatforms.any!(a => envData.os.chain(envData.model).canFind(a)))
+    const osAbbrev = (envData.os == "windows") ? "win" : envData.os;
+    if (testArgs.disabledPlatforms.any!(a => osAbbrev.chain(envData.model).canFind(a)))
         testArgs.disabled = true;
 
     //prepare cpp extra sources
@@ -665,7 +668,7 @@ int tryMain(string[] args)
         switch (envData.compiler)
         {
             case "dmd":
-                if(envData.os != "win32" && envData.os != "win64")
+                if(envData.os != "windows")
                    testArgs.requiredArgs ~= " -L-lstdc++ -L--no-demangle";
                 break;
             case "ldc":

--- a/test/tools/exported_vars.sh
+++ b/test/tools/exported_vars.sh
@@ -9,7 +9,7 @@ export EXTRA_FILES=${TEST_DIR}/extra-files # reference to the extra files direct
 
 export LC_ALL=C #otherwise objdump localizes its output
 
-if [ "$OS" == "win32" ] || [ "$OS" == "win64" ]; then
+if [ "$OS" == "windows" ]; then
     export LIBEXT=.lib
 else
     export LIBEXT=.a


### PR DESCRIPTION
It looks like windows is currently being treated differently than all the other OS's in the old dmd test-suite Makefile.  This change attempts to normalize how windows is treated, so that we don't have to add special code handling in `run.d` when we make the transition.

Currently, the DMD test-suite Makefile uses 2 variables to represent the OS and the MODEL.  However, on windows, the makefile will set OS to be either `win32` or `win64` which includes the OS and the MODEL.  This means that the bash scripts need to check for both cases to know whether or not it is on windows.  This is also in contrast to how everything else works in the dlang repositories, where they set the OS to "windows" and keep the MODEL as a separate variable set to `32` or `64`.

This change fixes the old Makefile so that the os/model are stored in 2 distinct variables like everything else so that we don't have to add special code to handle this odd corner case in our new tools written in D.