### PR TITLE
Workaround issue 13727 (std.stdio.File not thread-safe)

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -993,3 +993,9 @@ auto runCanThrow(T)(T args)
     enforce(!res.status, res.output);
     return res.output;
 }
+
+version (Win32)
+{
+    // workaround issue https://issues.dlang.org/show_bug.cgi?id=13727
+    auto parallel(R)(R range, size_t workUnitSize) { return range; }
+}


### PR DESCRIPTION
When using the `build.d` script on win32, about half the time I get some sort of error.  I reduced `build.d` down to a small example to reproduce the error and found that this was an existing issue with thread-safety in phobos.

https://issues.dlang.org/show_bug.cgi?id=13727

Transitioning to `build.d` won't be possible on windows until this issue is fixed or we workaround it.  For now, since this issue was filed in 2014 and has yet to be fixed, I've decided to workaround it by disabling parallelism on win32.

I posted the reduced version of `build.d` to reproduce the issue on windows, and am including it here for convenience:
```D
import std.stdio, std.algorithm, std.array, std.process, std.exception, std.parallelism;
void main()
{
    auto funcs = [() {
        // std.exception.ErrnoException@std\stdio.d(997): Enforcement failed (No error)
        version (a)
            ["git", "--version"].execute;
        // std.exception.ErrnoException@std\stdio.d(563): Could not close file `HANDLE(C0)' (No error)
        else version (b)
            ["dir"].execute;
        // std.exception.ErrnoException@std\stdio.d(563): Could not close file `somefile' (Bad file descriptor)
        else version (c)
            "bar".toFile("anotherfile");
        else static assert(0, "Please specify -version=a, -version=b or -version=c");
    }, () {
        "foo".toFile("somefile");
    }];
    foreach (func; funcs.parallel(1))
        func();
}
```