### PR TITLE
Fix Issue 19122 - Postblits and destructors called on members of anonymous unions

### DIFF
--- a/changelog/union_members.dd
+++ b/changelog/union_members.dd
@@ -1,0 +1,8 @@
+Postblit and destructors are no longer called on members of anonymous unions.
+
+Due to a bug in dmd, members of anonymous `unions` inside `struct` declarations
+had their postblits/destructors called when an object of the containing
+`struct` type was copied/destroyed. With this release, the postblit/destructor
+is no longer called in such situations.
+
+Fixes: https://issues.dlang.org/show_bug.cgi?id=19122

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -134,8 +134,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         auto sc2 = sc.push(this);
         sc2.stc &= STC.safe | STC.trusted | STC.system;
         sc2.parent = this;
-        if (isUnionDeclaration())
-            sc2.inunion = true;
+        sc2.inunion = isUnionDeclaration();
         sc2.protection = Prot(Prot.Kind.public_);
         sc2.explicitProtection = 0;
         sc2.aligndecl = null;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -81,7 +81,7 @@ struct Scope
     Statement scontinue;            /// enclosing statement that supports "continue"
     ForeachStatement fes;           /// if nested function for ForeachStatement, this is it
     Scope* callsc;                  /// used for __FUNCTION__, __PRETTY_FUNCTION__ and __MODULE__
-    bool inunion;                   /// true if processing members of a union
+    Dsymbol inunion;                /// != null if processing members of a union
     bool nofree;                    /// true if shouldn't free it
     bool inLoop;                    /// true if inside a loop (where constructor calls aren't allowed)
     int intypeof;                   /// in typeof(exp)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1793,8 +1793,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 Dsymbol s = (*scd.decl)[i];
                 // https://issues.dlang.org/show_bug.cgi?id=19122
                 if (sc.inunion)
+                {
                     if (auto decl = s.isVarDeclaration())
                         decl.overlapped = true;
+                }
                 s.dsymbolSemantic(sc);
             }
             sc = sc.pop();

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -755,6 +755,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.semanticRun >= PASS.semanticdone)
             return;
 
+        // https://issues.dlang.org/show_bug.cgi?id=19122
+        if (sc && sc.inunion)
+            dsym.overlapped = true;
+
         Scope* scx = null;
         if (dsym._scope)
         {

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -755,10 +755,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.semanticRun >= PASS.semanticdone)
             return;
 
-        // https://issues.dlang.org/show_bug.cgi?id=19122
-        if (sc && sc.inunion)
-            dsym.overlapped = true;
-
         Scope* scx = null;
         if (dsym._scope)
         {
@@ -1795,6 +1791,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             for (size_t i = 0; i < scd.decl.dim; i++)
             {
                 Dsymbol s = (*scd.decl)[i];
+                // https://issues.dlang.org/show_bug.cgi?id=19122
+                if (sc.inunion)
+                    if (auto decl = s.isVarDeclaration())
+                        decl.overlapped = true;
                 s.dsymbolSemantic(sc);
             }
             sc = sc.pop();

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -755,6 +755,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (dsym.semanticRun >= PASS.semanticdone)
             return;
 
+        if (sc && sc.inunion && sc.inunion.isAnonDeclaration())
+            dsym.overlapped = true;
+
         Scope* scx = null;
         if (dsym._scope)
         {
@@ -1786,17 +1789,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             sc = sc.push();
             sc.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.tls | STC.gshared);
-            sc.inunion = scd.isunion;
+            sc.inunion = scd.isunion ? scd : null;
             sc.flags = 0;
             for (size_t i = 0; i < scd.decl.dim; i++)
             {
                 Dsymbol s = (*scd.decl)[i];
-                // https://issues.dlang.org/show_bug.cgi?id=19122
-                if (sc.inunion)
-                {
-                    if (auto decl = s.isVarDeclaration())
-                        decl.overlapped = true;
-                }
                 s.dsymbolSemantic(sc);
             }
             sc = sc.pop();

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -71,7 +71,7 @@ struct Scope
     Statement *scontinue;       // enclosing statement that supports "continue"
     ForeachStatement *fes;      // if nested function for ForeachStatement, this is it
     Scope *callsc;              // used for __FUNCTION__, __PRETTY_FUNCTION__ and __MODULE__
-    bool inunion;               // true if processing members of a union
+    Dsymbol *inunion;           // !=null if processing members of a union
     bool nofree;                // true if shouldn't free it
     bool inLoop;                // true if inside a loop (where constructor calls aren't allowed)
     int intypeof;               // in typeof(exp)

--- a/test/runnable/test19122.d
+++ b/test/runnable/test19122.d
@@ -1,0 +1,37 @@
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+struct HasDestructor
+{
+    ~this()
+    {
+        ++d;
+    }
+    this(this)
+    {
+        ++p;
+    }
+}
+
+struct S
+{
+    union
+    {
+        int i;
+        HasDestructor h;
+    }
+}
+
+int d, p;
+void main()
+{
+    {
+        S s;
+        s = s;
+        assert(p == 0); // Should fail.
+    }
+    assert(d == 0); // Should fail.
+}

--- a/test/runnable/test19122.d
+++ b/test/runnable/test19122.d
@@ -8,11 +8,11 @@ struct HasDestructor
 {
     ~this()
     {
-        ++d;
+        assert(0);
     }
     this(this)
     {
-        ++p;
+        assert(0);
     }
 }
 
@@ -25,13 +25,10 @@ struct S
     }
 }
 
-int d, p;
 void main()
 {
     {
         S s;
         s = s;
-        assert(p == 0); // Should fail.
     }
-    assert(d == 0); // Should fail.
 }

--- a/test/runnable/test19122.d
+++ b/test/runnable/test19122.d
@@ -25,10 +25,27 @@ struct S
     }
 }
 
+struct S2
+{
+    union
+    {
+        align(1)
+        {
+            int i;
+            HasDestructor h;
+        }
+    }
+}
+
 void main()
 {
     {
         S s;
         s = s;
+    }
+
+    {
+        S2 s2;
+        s2 = s2;
     }
 }


### PR DESCRIPTION
The problem was that the `overlapped` field of the VarDeclarations associated with anonymous union fields was set in the semantic2 pass, while the field postblit was constructed right at the end of semantic1 for struct declaration.

The patch simply checks if a var declaration is a union scope and if so, sets the overlapped field accordingly.

cc @TurkeyMan 