### PR TITLE
another fix for Linux32 16 byte stack align

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3160,7 +3160,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         parameters[i].numalign = 0;
         if (alignsize > stackalign &&
             (I64 || (alignsize >= 16 &&
-                (config.exe == EX_OSX && (tyaggregate(ep.Ety) || tyvector(ep.Ety))))))
+                (config.exe & (EX_OSX | EX_LINUX) && (tyaggregate(ep.Ety) || tyvector(ep.Ety))))))
         {
             if (alignsize > STACKALIGN)
             {


### PR DESCRIPTION
I overlooked this one.