### PR TITLE
Workaround issue 13727 only for DigitalMars CRuntime

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -994,7 +994,7 @@ auto runCanThrow(T)(T args)
     return res.output;
 }
 
-version (Win32)
+version (CRuntime_DigitalMars)
 {
     // workaround issue https://issues.dlang.org/show_bug.cgi?id=13727
     auto parallel(R)(R range, size_t workUnitSize) { return range; }


### PR DESCRIPTION
I confirmed this issue only occurs when using the DigitalMars CRuntime (thanks @wilzbach for catching this).  So we only need the workaround in that case.

Seb is usually good a catching these sorts of things.  I'm much more comfortable with a PR once he's reviewed it.
