### PR TITLE
Fix issue 19893 - extern(C++ 'ns') should count as module scope

### DIFF
--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -81,7 +81,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             sc = sc.push(this);
             sc.linkage = LINK.cpp; // namespaces default to C++ linkage
             sc.parent = this;
-            members.foreachDsymbol(s => s.addMember(sc, this));
+            members.foreachDsymbol(s => s.addMember(sc, mangleOnly ? sds : this));
             sc.pop();
         }
     }

--- a/test/compilable/cppmangle3.d
+++ b/test/compilable/cppmangle3.d
@@ -34,5 +34,4 @@ struct Foo
 alias Alias(alias a) = a;
 alias Alias(T) = T;
 
-static assert(is(Alias!(__traits(parent, bar)) == Foo));
-
+static assert(is(Alias!(__traits(parent, Foo.bar)) == Foo));

--- a/test/compilable/cppmangle3.d
+++ b/test/compilable/cppmangle3.d
@@ -35,3 +35,21 @@ alias Alias(alias a) = a;
 alias Alias(T) = T;
 
 static assert(is(Alias!(__traits(parent, Foo.bar)) == Foo));
+
+extern(C++, "std"):
+debug = 456;
+debug = def;
+version = 456;
+version = def;
+
+extern(C++, "std")
+{
+    debug = 456;
+    debug = def;
+    version = 456;
+    version = def;
+}
+
+extern(C++, "foo")
+extern(C++, "bar")
+version = baz;


### PR DESCRIPTION
Alternative implementation to #9891 
@thewilsonator : That's why I was asking were `addMember` was called from.
CC @TurkeyMan : That might break some of your code (See the fix to cppmangle3).