### PR TITLE
fix Issue 19912: No implicit import of object module when an object declaration exists.

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1004,7 +1004,8 @@ extern (C++) final class Module : Package
         // If it isn't there, some compiler rewrites, like
         //    classinst == classinst -> .object.opEquals(classinst, classinst)
         // would fail inside object.d.
-        if (members.dim == 0 || (*members)[0].ident != Id.object)
+        if (members.dim == 0 || (*members)[0].ident != Id.object ||
+            (*members)[0].isImport() is null)
         {
             auto im = new Import(Loc.initial, null, Id.object, null, 0);
             members.shift(im);

--- a/test/compilable/test19912.d
+++ b/test/compilable/test19912.d
@@ -1,0 +1,3 @@
+// PERMUTE_ARGS:
+import object;
+void fun(string) { }

--- a/test/fail_compilation/fail19912a.d
+++ b/test/fail_compilation/fail19912a.d
@@ -1,0 +1,9 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19912a.d(8): Error: struct `fail19912a.object` conflicts with import `fail19912a.object` at fail_compilation/fail19912a.d
+---
+*/
+struct object { }
+void fun(string) { }

--- a/test/fail_compilation/fail19912b.d
+++ b/test/fail_compilation/fail19912b.d
@@ -1,0 +1,9 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19912b.d(8): Error: class `fail19912b.object` conflicts with import `fail19912b.object` at fail_compilation/fail19912b.d
+---
+*/
+class object { }
+void fun(string) { }

--- a/test/fail_compilation/fail19912c.d
+++ b/test/fail_compilation/fail19912c.d
@@ -1,0 +1,9 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19912c.d(8): Error: alias `fail19912c.object` conflicts with import `fail19912c.object` at fail_compilation/fail19912c.d
+---
+*/
+alias object = int;
+void fun(string) { }

--- a/test/fail_compilation/fail19912d.d
+++ b/test/fail_compilation/fail19912d.d
@@ -1,0 +1,9 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19912d.d(8): Error: enum `fail19912d.object` conflicts with import `fail19912d.object` at fail_compilation/fail19912d.d
+---
+*/
+enum object { }
+void fun(string) { }

--- a/test/fail_compilation/fail19912e.d
+++ b/test/fail_compilation/fail19912e.d
@@ -1,0 +1,9 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19912e.d(8): Error: function `fail19912e.object` conflicts with import `fail19912e.object` at fail_compilation/fail19912e.d
+---
+*/
+void object() { }
+void fun(string) { }


### PR DESCRIPTION
Check the first member is really an import, not only that its identity is `object`.