### PR TITLE
Replace RealEquals with RealIdentical

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -942,17 +942,17 @@ UnionExp Identity(TOK op, const ref Loc loc, Type type, Expression e1, Expressio
     {
         if (e1.type.isreal())
         {
-            cmp = RealEquals(e1.toReal(), e2.toReal());
+            cmp = RealIdentical(e1.toReal(), e2.toReal());
         }
         else if (e1.type.isimaginary())
         {
-            cmp = RealEquals(e1.toImaginary(), e2.toImaginary());
+            cmp = RealIdentical(e1.toImaginary(), e2.toImaginary());
         }
         else if (e1.type.iscomplex())
         {
             complex_t v1 = e1.toComplex();
             complex_t v2 = e2.toComplex();
-            cmp = RealEquals(creall(v1), creall(v2)) && RealEquals(cimagl(v1), cimagl(v1));
+            cmp = RealIdentical(creall(v1), creall(v2)) && RealIdentical(cimagl(v1), cimagl(v1));
         }
         else
         {

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1279,7 +1279,7 @@ private int ctfeRawCmp(const ref Loc loc, Expression e1, Expression e2, bool ide
         real_t r1 = e1.type.isreal() ? e1.toReal() : e1.toImaginary();
         real_t r2 = e1.type.isreal() ? e2.toReal() : e2.toImaginary();
         if (identity)
-            return !RealEquals(r1, r2);
+            return !RealIdentical(r1, r2);
         if (CTFloat.isNaN(r1) || CTFloat.isNaN(r2)) // if unordered
         {
             return 1;   // they are not equal
@@ -1295,7 +1295,7 @@ private int ctfeRawCmp(const ref Loc loc, Expression e1, Expression e2, bool ide
         auto c2 = e2.toComplex();
         if (identity)
         {
-            return !RealEquals(c1.re, c2.re) && !RealEquals(c1.im, c2.im);
+            return !RealIdentical(c1.re, c2.re) && !RealIdentical(c1.im, c2.im);
         }
         return c1 != c2;
     }
@@ -1400,14 +1400,14 @@ int ctfeIdentity(const ref Loc loc, TOK op, Expression e1, Expression e2)
         cmp = (es1.var == es2.var && es1.offset == es2.offset);
     }
     else if (e1.type.isreal())
-        cmp = RealEquals(e1.toReal(), e2.toReal());
+        cmp = RealIdentical(e1.toReal(), e2.toReal());
     else if (e1.type.isimaginary())
-        cmp = RealEquals(e1.toImaginary(), e2.toImaginary());
+        cmp = RealIdentical(e1.toImaginary(), e2.toImaginary());
     else if (e1.type.iscomplex())
     {
         complex_t v1 = e1.toComplex();
         complex_t v2 = e2.toComplex();
-        cmp = RealEquals(creall(v1), creall(v2)) && RealEquals(cimagl(v1), cimagl(v1));
+        cmp = RealIdentical(creall(v1), creall(v2)) && RealIdentical(cimagl(v1), cimagl(v1));
     }
     else
     {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -553,7 +553,7 @@ private:
  *      1 if x1 is x2
  *      else 0
  */
-int RealEquals(real_t x1, real_t x2)
+int RealIdentical(real_t x1, real_t x2)
 {
     return (CTFloat.isNaN(x1) && CTFloat.isNaN(x2)) || CTFloat.isIdentical(x1, x2);
 }
@@ -2015,7 +2015,7 @@ extern (C++) final class RealExp : Expression
             return true;
         if (auto ne = (cast(Expression)o).isRealExp())
         {
-            if (type.toHeadMutable().equals(ne.type.toHeadMutable()) && RealEquals(value, ne.value))
+            if (type.toHeadMutable().equals(ne.type.toHeadMutable()) && RealIdentical(value, ne.value))
             {
                 return true;
             }
@@ -2090,7 +2090,7 @@ extern (C++) final class ComplexExp : Expression
             return true;
         if (auto ne = (cast(Expression)o).isComplexExp())
         {
-            if (type.toHeadMutable().equals(ne.type.toHeadMutable()) && RealEquals(creall(value), creall(ne.value)) && RealEquals(cimagl(value), cimagl(ne.value)))
+            if (type.toHeadMutable().equals(ne.type.toHeadMutable()) && RealIdentical(creall(value), creall(ne.value)) && RealIdentical(cimagl(value), cimagl(ne.value)))
             {
                 return true;
             }


### PR DESCRIPTION
RealEquals was misleading

https://github.com/dlang/dmd/pull/7568#discussion_r159805780

>Calling this function Equals and then doing an Identity comparison is vastly confusing. == and is are fundamentally different operations for floating point, and we need to be careful not to conflate them.