### PR TITLE
Fix compilation using LDC as the host compiler

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -61,8 +61,8 @@ enum LF_STR = "\n";
 
 extern __gshared
 {
-    uint[32] mask;                  // bit masks
-    uint[32] maskl;                 // bit masks
+    const uint[32] mask;            // bit masks
+    const uint[32] maskl;           // bit masks
 
     char* argv0;
     char* finname, foutname, foutdir;
@@ -305,8 +305,8 @@ void os_term();
 uint os_unique();
 int os_file_exists(const(char)* name);
 int os_file_mtime(const(char)* name);
-int os_file_size(int fd);
-int os_file_size(const(char)* filename);
+long os_file_size(int fd);
+long os_file_size(const(char)* filename);
 char *file_8dot3name(const(char)* filename);
 int file_write(char *name, void *buffer, uint len);
 int file_createdirs(char *name);


### PR DESCRIPTION
The problem was that the declarations did not match the type of the definitions.