### PR TITLE
fix Issue 19913 - ICE: Segmentation fault with mixin and enum

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -266,6 +266,10 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
 
             if (VarDeclaration v = s.isVarDeclaration())
             {
+                // https://issues.dlang.org/show_bug.cgi?id=19913
+                // v.type would be null if it is a forward referenced member.
+                if (v.type is null)
+                    v.dsymbolSemantic(sc);
                 if (v.storage_class & (STC.const_ | STC.immutable_ | STC.manifest) ||
                     v.type.isConst() || v.type.isImmutable())
                 {

--- a/test/fail_compilation/fail19913.d
+++ b/test/fail_compilation/fail19913.d
@@ -1,0 +1,13 @@
+/* PERMUTE_ARGS:
+ * TEST_OUTPUT:
+---
+fail_compilation/fail19913.d(11): Error: no property `b` for type `int`
+fail_compilation/fail19913.d(11): Error: mixin `fail19913.S.b!()` is not defined
+---
+ */
+
+struct S
+{
+    mixin a.b;
+    enum { a }
+}


### PR DESCRIPTION
Swapping the mixin and the enum gives a compiler error, so it's just a forward reference bug.