### PR TITLE
[Proposal] De-couple standard library from compiler

### DIFF
--- a/test/runnable/altdefaultlib.sh
+++ b/test/runnable/altdefaultlib.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+mkdir -p $OUTPUT_BASE
+export DFLAGS=$(echo $DFLAGS | sed -E 's/-defaultlib=[^ ]*/-defaultlib=/')
+set +u
+BOUND_PIC_FLAG="$PIC_FLAG"
+set -u
+$DMD -m$MODEL -shared $BOUND_PIC_FLAG -of$OUTPUT_BASE/libdefaultlib$SOEXT -defaultlib= $EXTRA_FILES${SEP}defaultlib.d
+
+echo 'pragma(lib, "defaultlib");' > $OUTPUT_BASE/_defaultlibconf.d
+
+extra_args=""
+if [ "$OS" == "linux" ] || [ "$OS" == "freebsd" ]; then
+    extra_args+=" -L-rpath=$(realpath $OUTPUT_BASE)"
+fi
+export DFLAGS=$(echo $DFLAGS | sed -E 's/-defaultlib=[^ ]*//')
+$DMD -m$MODEL -conf= $BOUND_PIC_FLAG -of$OUTPUT_BASE/use$EXE $EXTRA_FILES${SEP}usedefaultlib.d -L-L$OUTPUT_BASE  -I=$TEST_DIR/extra-files $extra_args
+
+$OUTPUT_BASE/use$EXE

--- a/test/runnable/extra-files/defaultlib.d
+++ b/test/runnable/extra-files/defaultlib.d
@@ -1,0 +1,13 @@
+module defaultlib;
+
+int defaultlibFunc() { return 42; }
+
+extern (C) void _d_dso_registry() { }
+version (FreeBSD)
+{
+    extern (C) void __dmd_personality_v0() { }
+}
+version (Windows)
+{
+    extern (Windows) int _DllMainCRTStartup(void*,uint,void*) { return 0; }
+}

--- a/test/runnable/extra-files/usedefaultlib.d
+++ b/test/runnable/extra-files/usedefaultlib.d
@@ -1,0 +1,7 @@
+import defaultlib;
+
+extern (C) int main(int argc, char **argv)
+{
+    const result = defaultlibFunc();
+    return 0;
+}


### PR DESCRIPTION
Rather than hardcoding the standard library and its dependencies into the compiler (see `dmd/link.d`), this change allows the default library to provide this information to the compiler.  The idea is to allow the standard library to provide a `D` source file named `_defaultlibconf.d` alongside its libraries to pass the standard library and it's dependencies to the compiler using `pragma(lib,...)`.  Currently, this file for phobos would look something like this:

```D
// _defaultlibconf.d
version (Windows)
{
    version (X86_64)
        pragma(lib, "phobos64");
    else
        pragma(lib, "phobos");
    pragma(lib, "kernel32.lib")
    pragma(lib, "user32.lib")
}
else
{
    pragma(lib, "phobos2");
    pragma(lib, "pthread");
    pragma(lib, "m");
    pragma(lib, "rt");
    pragma(lib, "dl");
}
```

Setting `-defaultlib=` disables checking for `_defaultlibconf.d`.  This search occurs before falling back to the hard-coded values which makes it backwards compatible.  The implementation leverages existing features, namely, compiling D files and `pragma(lib)`, which allows us to add support by adding 15 lines of code to a single location in `mars.d`.

cc @andralex @atilaneves @wilzbach @JinShil @thewilsonator 