### PR TITLE
Support multiple conf files with -addconf

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -169,10 +169,10 @@ auto dmdConf()
         exportDynamic = " -L--export-dynamic";
 
     auto conf = `[Environment32]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/32{exportDynamic}
+DFLAGS=-addconf=%@P%/../../../../../phobos/generated/{OS}/{BUILD}/32/defaultlib.conf
 
 [Environment64]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/{OS}/{BUILD}/64{exportDynamic} -fPIC`
+DFLAGS=-addconf=%@P%/../../../../../phobos/generated/{OS}/{BUILD}/64/defaultlib.conf`
         .replace("{exportDynamic}", exportDynamic)
         .replace("{BUILD}", env["BUILD"])
         .replace("{OS}", env["OS"]);

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -488,10 +488,10 @@ endif
 
 define DEFAULT_DMD_CONF
 [Environment32]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/32$(if $(filter $(OS),osx),, -L--export-dynamic)
+DFLAGS=-addconf=%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/32
 
 [Environment64]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/64$(if $(filter $(OS),osx),, -L--export-dynamic) -fPIC
+DFLAGS=-addconf=%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/64
 endef
 
 export DEFAULT_DMD_CONF


### PR DESCRIPTION
Alternative to: https://github.com/dlang/dmd/pull/9926
Depends on: https://github.com/dlang/phobos/pull/7052

Instead of holding the import paths/link paths in `dmd.conf` and hardcoding the library dependencies of druntime/phobos inside the compiler, I've added a new command-line option `-addconf=`.  The idea is that `dmd.conf` will now supply an `-addconf=<phobos>/defaultlib.conf` argument that then causes the conf file provided by phobos to be loaded to add it's import/link paths and library dependencies.

This decouples the compiler from the standard library by allowing it to change it's internal details without having to modify the compiler like it does today.

Also, assuming that `dmd.conf` is really only meant to hold information about the standard library, this means we could potentially remove the `-defaultlib` option and remove the hard-coded library names from dmd (in https://github.com/dlang/dmd/blob/master/src/dmd/mars.d#L1107).  This is because if you don't want the standard library, you would just use `-conf=` instead, and when you want to use your own library, you can add you're own `-conf=<mylib.conf>` or just add your own library's info directly on the command line.  Of course, if `dmd.conf` is meant to hold more than just the standard library, then this wouldn't make sense.  If that is the case, then we could move the standard library config to a separate conf file `defaultlib.conf` that lives alongside dmd and is disabled when `-defaultlib=` is set to an empty value. Some things to consider.