### PR TITLE
Have glue.d choose same defaultlib as link.d

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -454,6 +454,15 @@ struct Global
         }
         return cached;
     }
+
+    /**
+    Returns: the final defaultlibname based on the command-line parameters
+    */
+    const(char)[] finalDefaultlibname() const
+    {
+        return params.betterC ? null :
+            params.symdebug ? params.debuglibname : params.defaultlibname;
+    }
 }
 
 // Because int64_t and friends may be any integral type of the

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1294,9 +1294,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
  */
 private void specialFunctions(Obj objmod, FuncDeclaration fd)
 {
-    const(char)[] libname = (global.params.symdebug)
-                            ? global.params.debuglibname
-                            : global.params.defaultlibname;
+    const libname = global.finalDefaultlibname();
 
     Symbol* s = fd.toSymbol();  // backend symbol corresponding to fd
 

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -157,8 +157,7 @@ version (Posix)
  */
 public int runLINK()
 {
-    const phobosLibname = global.params.betterC ? null :
-        global.params.symdebug ? global.params.debuglibname : global.params.defaultlibname;
+    const phobosLibname = global.finalDefaultlibname();
 
     void setExeFile()
     {


### PR DESCRIPTION
`link.d` is currently using different logic than `glue.d` to determine the name of the default library.  `glue.d` isn't taking `-betterC` into account.