### PR TITLE
[WIP] [NeedsAcceptOrRejectFromWalter] Remove hardcoded phobos info from the compiler

### DIFF
--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -157,8 +157,6 @@ version (Posix)
  */
 public int runLINK()
 {
-    const phobosLibname = global.finalDefaultlibname();
-
     void setExeFile()
     {
         /* Generate exe file name from first obj name.
@@ -177,9 +175,6 @@ public int runLINK()
 
     version (Windows)
     {
-        if (phobosLibname)
-            global.params.libfiles.push(phobosLibname.xarraydup.ptr);
-
         if (global.params.mscoff)
         {
             OutBuffer cmdbuf;
@@ -630,53 +625,6 @@ public int runLINK()
         foreach (p; global.params.dllfiles)
         {
             argv.push(p);
-        }
-        /* D runtime libraries must go after user specified libraries
-         * passed with -l.
-         */
-        const libname = phobosLibname;
-        if (libname.length)
-        {
-            const bufsize = 2 + libname.length + 1;
-            auto buf = (cast(char*) malloc(bufsize))[0 .. bufsize];
-            buf[0 .. 2] = "-l";
-
-            char* getbuf(const(char)[] suffix)
-            {
-                buf[2 .. 2 + suffix.length] = suffix[];
-                buf[2 + suffix.length] = 0;
-                return buf.ptr;
-            }
-
-            if (libname.length > 3 + 2 && libname[0 .. 3] == "lib")
-            {
-                if (libname[$-2 .. $] == ".a")
-                {
-                    argv.push("-Xlinker");
-                    argv.push("-Bstatic");
-                    argv.push(getbuf(libname[3 .. $-2]));
-                    argv.push("-Xlinker");
-                    argv.push("-Bdynamic");
-                }
-                else if (libname[$-3 .. $] == ".so")
-                    argv.push(getbuf(libname[3 .. $-3]));
-                else
-                    argv.push(getbuf(libname));
-            }
-            else
-            {
-                argv.push(getbuf(libname));
-            }
-        }
-        //argv.push("-ldruntime");
-        argv.push("-lpthread");
-        argv.push("-lm");
-        version (linux)
-        {
-            // Changes in ld for Ubuntu 11.10 require this to appear after phobos2
-            argv.push("-lrt");
-            // Link against libdl for phobos usage of dlopen
-            argv.push("-ldl");
         }
         if (global.params.verbose)
         {

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -367,8 +367,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     // Predefined version identifiers
     addDefaultVersionIdentifiers(params);
 
-    setDefaultLibrary();
-
     // Initialization
     Type._init();
     Id.initialize();
@@ -1095,47 +1093,6 @@ const(char)[] parse_conf_arg(Strings* args)
     return conf;
 }
 
-
-/**
- * Set the default and debug libraries to link against, if not already set
- *
- * Must be called after argument parsing is done, as it won't
- * override any value.
- * Note that if `-defaultlib=` or `-debuglib=` was used,
- * we don't override that either.
- */
-private void setDefaultLibrary()
-{
-    if (global.params.defaultlibname is null)
-    {
-        static if (TARGET.Windows)
-        {
-            if (global.params.is64bit)
-                global.params.defaultlibname = "phobos64";
-            else if (global.params.mscoff)
-                global.params.defaultlibname = "phobos32mscoff";
-            else
-                global.params.defaultlibname = "phobos";
-        }
-        else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
-        {
-            global.params.defaultlibname = "libphobos2.a";
-        }
-        else static if (TARGET.OSX)
-        {
-            global.params.defaultlibname = "phobos2";
-        }
-        else
-        {
-            static assert(0, "fix this");
-        }
-    }
-    else if (!global.params.defaultlibname.length)  // if `-defaultlib=` (i.e. an empty defaultlib)
-        global.params.defaultlibname = null;
-
-    if (global.params.debuglibname is null)
-        global.params.debuglibname = global.params.defaultlibname;
-}
 
 /*************************************
  * Set the `is` target fields of `params` according


### PR DESCRIPTION
This PR is going to take some coordination between dmd/druntime/phobos and also the packaging tools.  The basic idea is to move all the hard-coded information about the standard library into `dmd.conf`.  This puts the responsibility of configuring phobos on the components who install/package dmd rather than hard-coding that configuration into DMD.

For now I've simply removed all the hard-coded information about phobos to see what breaks.  In theory, this PR should be able to be pushed as-is once the other tools are enhanced to take on the role of configuring phobos away from the compiler.