### PR TITLE
Turn deprecation on struct ctor with all defaults to error

### DIFF
--- a/changelog/static_this_immutable_initialization.dd
+++ b/changelog/static_this_immutable_initialization.dd
@@ -2,14 +2,14 @@ Initialization of `immutable` global data from `static this` is deprecated
 
 Prior to this release, the following code was possible:
 
-```
+---
 module foo;
 immutable int bar;
 static this()
 {
     bar = 42;
 }
-```
+---
 
 However, module constructors (`static this`) run each time a thread is
 spawned, and `immutable` data is implicitly `shared`, which led to

--- a/changelog/struct_ctor_default_params.dd
+++ b/changelog/struct_ctor_default_params.dd
@@ -1,0 +1,10 @@
+Struct constructors with all-default parameter will now error
+
+Since 2.070.0, the following code has been giving deprecations:
+---
+struct Oops
+{
+    this (int universe = 42) {}
+}
+---
+It will now error out.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3996,13 +3996,13 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     // if the first parameter has a default argument, then the rest does as well
                     if (ctd.storage_class & STC.disable)
                     {
-                        ctd.deprecation("is marked `@disable`, so it cannot have default "~
-                                    "arguments for all parameters.");
-                        deprecationSupplemental(ctd.loc, "Use `@disable this();` if you want to disable default initialization.");
+                        ctd.error("is marked `@disable`, so it cannot have default "~
+                                  "arguments for all parameters.");
+                        errorSupplemental(ctd.loc, "Use `@disable this();` if you want to disable default initialization.");
                     }
                     else
-                        ctd.deprecation("all parameters have default arguments, "~
-                                    "but structs cannot have default constructors.");
+                        ctd.error("all parameters have default arguments, "~
+                                  "but structs cannot have default constructors.");
                 }
                 else if ((dim == 1 || (dim > 1 && tf.parameterList[1].defaultArg)))
                 {

--- a/test/fail_compilation/b19691.d
+++ b/test/fail_compilation/b19691.d
@@ -1,8 +1,7 @@
 // REQUIRED_ARGS: -de
 /* TEST_OUTPUT:
 ---
-fail_compilation/b19691.d(13): Error: forward reference to template `this`
-fail_compilation/b19691.d(19): Deprecation: constructor `b19691.S2.this` all parameters have default arguments, but structs cannot have default constructors.
+fail_compilation/b19691.d(12): Error: forward reference to template `this`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=19691
@@ -10,11 +9,11 @@ module b19691;
 
 struct S1 {
     this(T...)(T) {
-        S2("");
+        S2(42, "");
     }
 }
 
 struct S2 {
-    this(string) {}
-    this(S1 s = null) {}
+    this(int a, string) {}
+    this(int a, S1 s = null) {}
 }

--- a/test/fail_compilation/b19691e.d
+++ b/test/fail_compilation/b19691e.d
@@ -1,10 +1,9 @@
 // REQUIRED_ARGS: -de
 /* TEST_OUTPUT:
 ---
-fail_compilation/b19691e.d(17): Error: forward reference to template `this`
-fail_compilation/b19691e.d(17): Error: constructor `b19691e.S2.this(S1 s = "")` is not callable using argument types `(string)`
-fail_compilation/b19691e.d(17): Error: forward reference to template `this`
-fail_compilation/b19691e.d(23): Deprecation: constructor `b19691e.S2.this` all parameters have default arguments, but structs cannot have default constructors.
+fail_compilation/b19691e.d(16): Error: forward reference to template `this`
+fail_compilation/b19691e.d(16): Error: constructor `b19691e.S2.this(int a, S1 s = "")` is not callable using argument types `(int, string)`
+fail_compilation/b19691e.d(16): Error: forward reference to template `this`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=19691
@@ -14,11 +13,11 @@ struct S1
 {
     this(T)(T)
     {
-        S2("");
+        S2(42, "");
     }
 }
 
 struct S2
 {
-    this(S1 s = ""){}
+    this(int a, S1 s = ""){}
 }

--- a/test/fail_compilation/diag3438.d
+++ b/test/fail_compilation/diag3438.d
@@ -2,11 +2,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag3438.d(16): Deprecation: constructor `diag3438.F1.this` all parameters have default arguments, but structs cannot have default constructors.
-fail_compilation/diag3438.d(17): Deprecation: constructor `diag3438.F2.this` all parameters have default arguments, but structs cannot have default constructors.
-fail_compilation/diag3438.d(20): Deprecation: constructor `diag3438.F5.this` is marked `@disable`, so it cannot have default arguments for all parameters.
+fail_compilation/diag3438.d(16): Error: constructor `diag3438.F1.this` all parameters have default arguments, but structs cannot have default constructors.
+fail_compilation/diag3438.d(17): Error: constructor `diag3438.F2.this` all parameters have default arguments, but structs cannot have default constructors.
+fail_compilation/diag3438.d(20): Error: constructor `diag3438.F5.this` is marked `@disable`, so it cannot have default arguments for all parameters.
 fail_compilation/diag3438.d(20):        Use `@disable this();` if you want to disable default initialization.
-fail_compilation/diag3438.d(21): Deprecation: constructor `diag3438.F6.this` is marked `@disable`, so it cannot have default arguments for all parameters.
+fail_compilation/diag3438.d(21): Error: constructor `diag3438.F6.this` is marked `@disable`, so it cannot have default arguments for all parameters.
 fail_compilation/diag3438.d(21):        Use `@disable this();` if you want to disable default initialization.
 ---
 */

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -1,9 +1,6 @@
 /*
 TEST_OUTPUT:
 ---
-runnable/structlit.d(1306): Deprecation: constructor `structlit.test11256.F11256!((gv) => true).F11256.this` all parameters have default arguments, but structs cannot have default constructors.
-runnable/structlit.d(1306): Deprecation: constructor `structlit.test11256.F11256!((gv) => true).F11256.this` all parameters have default arguments, but structs cannot have default constructors.
-runnable/structlit.d(1306): Deprecation: constructor `structlit.test11256.F11256!((gv) => true).F11256.this` all parameters have default arguments, but structs cannot have default constructors.
 ---
 */
 import std.stdio;
@@ -1303,7 +1300,7 @@ struct Z11256c(Ranges...)
 
 struct F11256(alias pred)
 {
-    this(int[] = null) { }
+    this(int[]) { }
 }
 
 Z!Ranges z11256(alias Z, Ranges...)(Ranges ranges)
@@ -1313,9 +1310,9 @@ Z!Ranges z11256(alias Z, Ranges...)(Ranges ranges)
 
 void test11256()
 {
-    z11256!Z11256a(S11256.init, F11256!(gv => true)());
-    z11256!Z11256b(S11256.init, F11256!(gv => true)());
-    z11256!Z11256c(S11256.init, F11256!(gv => true)());
+    z11256!Z11256a(S11256.init, F11256!(gv => true)(null));
+    z11256!Z11256b(S11256.init, F11256!(gv => true)(null));
+    z11256!Z11256c(S11256.init, F11256!(gv => true)(null));
 }
 
 /********************************************/


### PR DESCRIPTION
It has been deprecated since 2.070.0

CC @AndrejMitrovic 