### PR TITLE
fix Issue 19914/19915 - ICE: Segmentation fault using align in a templated class

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -558,7 +558,8 @@ extern (C++) final class AlignDeclaration : AttribDeclaration
     {
         assert(!s);
         return new AlignDeclaration(loc,
-            ealign.syntaxCopy(), Dsymbol.arraySyntaxCopy(decl));
+            ealign ? ealign.syntaxCopy() : null,
+            Dsymbol.arraySyntaxCopy(decl));
     }
 
     override Scope* newScope(Scope* sc)

--- a/test/compilable/aggr_alignment.d
+++ b/test/compilable/aggr_alignment.d
@@ -47,3 +47,13 @@ align(1) struct UglyStruct
 static assert(UglyStruct.i.offsetof == 4);
 static assert(UglyStruct.alignof == 1);
 static assert(UglyStruct.sizeof == 9);
+
+/***************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19914
+
+class TemplatedClass(T)
+{
+    align T field;
+}
+
+mixin TemplatedClass!(string);

--- a/test/compilable/aggr_alignment.d
+++ b/test/compilable/aggr_alignment.d
@@ -50,6 +50,7 @@ static assert(UglyStruct.sizeof == 9);
 
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=19914
+// https://issues.dlang.org/show_bug.cgi?id=19915
 
 class TemplatedClass(T)
 {
@@ -57,3 +58,4 @@ class TemplatedClass(T)
 }
 
 mixin TemplatedClass!(string);
+alias TCint = TemplatedClass!(int);

--- a/test/fail_compilation/fail19914.d
+++ b/test/fail_compilation/fail19914.d
@@ -1,0 +1,10 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19914.d(9): Error: undefined identifier `c` in module `fail19914`
+fail_compilation/fail19914.d(10): Error: mixin `fail19914.a!string` error instantiating
+---
+*/
+class a(b) { align.c d; }
+mixin a!(string);

--- a/test/fail_compilation/fail19915.d
+++ b/test/fail_compilation/fail19915.d
@@ -1,0 +1,10 @@
+// PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19915.d(9): Error: undefined identifier `c` in module `fail19915`
+fail_compilation/fail19915.d(10): Error: template instance `fail19915.a!int` error instantiating
+---
+*/
+class a (b) { align.c d; }
+alias a!(int) e;


### PR DESCRIPTION
A `null` ealign means default alignment.  Template instances and mixins do a syntaxCopy of all template members prior to instantiation, but there was no checking whether ealign was set in the AlignDeclaration override.