### PR TITLE
Fix Issue 19234 - betterC TypeInfo error when using slice copy on Structs

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1382,9 +1382,12 @@ extern (C++) abstract class Expression : ASTNode
     {
         if (auto ts = t.baseElemOf().isTypeStruct())
         {
-            // https://issues.dlang.org/show_bug.cgi?id=11395
-            // Require TypeInfo generation for array concatenation
-            semanticTypeInfo(sc, t);
+            if (global.params.useTypeInfo)
+            {
+                // https://issues.dlang.org/show_bug.cgi?id=11395
+                // Require TypeInfo generation for array concatenation
+                semanticTypeInfo(sc, t);
+            }
 
             StructDeclaration sd = ts.sym;
             if (sd.postblit)

--- a/test/compilable/betterCarray.d
+++ b/test/compilable/betterCarray.d
@@ -15,3 +15,13 @@ int foo(int[] a, int i)
 {
     return a[i];
 }
+
+/**********************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19234
+void issue19234()
+{
+    static struct A {}
+    A[10] a;
+    A[10] b;
+    b[] = a[];
+}


### PR DESCRIPTION
Known limitation: does not work for struct with postblit or dtor.