### PR TITLE
[WIP] [NeedsAcceptOrRejectFromWalter] Move standard library config to dmd.conf

### DIFF
--- a/makedmdconf.d
+++ b/makedmdconf.d
@@ -1,0 +1,91 @@
+#!/usr/bin/env rdmd
+module makedmdconf;
+
+import core.stdc.stdlib : exit;
+import std.getopt, std.string;
+import std.path, std.file, std.stdio;
+import std.process;
+
+int main(string[] args)
+{
+    bool mscoff = false;
+
+    auto helpInfo = getopt(args,
+        "mscoff", &mscoff);
+    enum nonOptionArgCount = 3;
+    const wrongArgCount = (args.length != nonOptionArgCount + 1);
+    if (wrongArgCount || helpInfo.helpWanted)
+    {
+        if (wrongArgCount)
+            writefln("Error: expected %s non-option args but got %s", nonOptionArgCount, args.length - 1);
+        defaultGetoptPrinter("Usage: makedmdconf [-options] <outfile> <os> <bulid>", helpInfo.options);
+        return 1;
+    }
+
+    const outFile = args[1];
+    const os      = args[2];
+    const build   = args[3];
+
+    if (updateIfChanged(outFile, generateDmdConf(os, build, mscoff)))
+        writefln("updated '%s'", outFile);
+    else
+        writefln("already up-to-date '%s'", outFile);
+    return 0;
+}
+
+string generateDmdConf(string os, string build, bool mscoff)
+{
+    string sharedflags = "";
+    string model32flags = "";
+    string model64flags = "";
+
+    sharedflags  ~= " -I%@P%/../../../../../druntime/import";
+    sharedflags  ~= " -I%@P%/../../../../../phobos";
+    model32flags ~= " -L-L%@P%/../../../../../phobos/generated/{os}/{build}/32";
+    model64flags ~= " -L-L%@P%/../../../../../phobos/generated/{os}/{build}/64";
+
+    if (os == "windows")
+    {
+        // NOTE: I don't think I need to add user32/kernel32 because I think the
+        //       phobos library itself will cause them to be added
+        if (mscoff)
+        {
+            model32flags ~= " -defaultlib=phobos32mscoff";
+            model64flags ~= " -defaultlib=phobos64mscoff";
+        }
+        else
+        {
+            model32flags ~= " -defaultlib=phobos";
+        }
+    }
+
+    if (os == "linux" || os == "freebsd" || os == "openbsd" || os == "solaris" || os == "dragonflybsd")
+    {
+        sharedflags  ~= " -defaultlib=libphobos2.a";
+        model64flags ~= " -fPIC";
+    }
+    if (os == "linux")
+        sharedflags ~= " -L-lpthread -L-lm -L-ldl -L-lrt";
+    if (os == "osx")
+        sharedflags ~= " -L--export-dynamic";
+
+    string content = "";
+    if (model32flags.length)
+        content ~= "[Environment32]\nDFLAGS=" ~ sharedflags ~ model32flags ~ "\n";
+    if (model64flags.length)
+        content ~= "[Environment64]\nDFLAGS=" ~ sharedflags ~ model64flags ~ "\n";
+    return content.replace("{os}", os).replace("{build}", build);
+}
+
+bool updateIfChanged(const string path, const string content)
+{
+    if (path.exists)
+    {
+        if (path.readText == content)
+            return false; // up-to-date
+    }
+    else
+        mkdirRecurse(path.dirName);
+    std.file.write(path, content);
+    return true;
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -486,18 +486,12 @@ endif
 
 ######## generate a default dmd.conf
 
-define DEFAULT_DMD_CONF
-[Environment32]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/32$(if $(filter $(OS),osx),, -L--export-dynamic)
+$G/makedmdconf: ../makedmdconf.d $(HOST_DMD_PATH)
+	@echo "  (HOST_DMD_RUN)  $<  $<"
+	$(HOST_DMD_RUN) $< -of$@
 
-[Environment64]
-DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@P%/../../../../../phobos/generated/$(OS)/$(BUILD)/64$(if $(filter $(OS),osx),, -L--export-dynamic) -fPIC
-endef
-
-export DEFAULT_DMD_CONF
-
-$G/dmd.conf: $(SRC_MAKE)
-	echo "$$DEFAULT_DMD_CONF" > $@
+$G/dmd.conf: $G/makedmdconf FORCE
+	$< $@ $(OS) $(BUILD)
 
 ######## optabgen generates some source
 optabgen_output = debtab.d optab.d cdxxx.d elxxx.d fltables.d tytab.d


### PR DESCRIPTION
This is a pre-requisite working towards moving the hard-coded standard library configuration out of the compiler (https://github.com/dlang/dmd/pull/9936).

This PR moves the logic to determine linker flags for the standard library from the compiler to the tool `makedmdconf.d` which will use the logic to generate `dmd.conf`.

This moves the responsibility of configuring the standard library out of the compiler into an external tool.