### PR TITLE
dmd.conf not needed to compile dmd, changing it shouldn't trigger a rebuild

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -148,7 +148,7 @@ auto lexer()
     Dependency dependency = {
         target: env["G"].buildPath("lexer").libName,
         sources: sources.lexer,
-        rebuildSources: buildStringFiles.map!(a => a.target).array,
+        rebuildSources: configFiles,
         name: "(DC) D_LEXER_OBJ %-(%s, %)".format(sources.lexer.map!(e => e.baseName).array),
         command: [
             env["HOST_DMD_RUN"],
@@ -278,6 +278,12 @@ auto buildStringFiles()
         commandFunction: commandFunction,
     };
     return [versionDependency, sysconfDirDependency];
+}
+
+/// Returns: a list of config files that are required by the DMD build
+auto configFiles()
+{
+    return buildStringFiles.map!(a => a.target).array;
 }
 
 /**
@@ -944,7 +950,7 @@ struct Dependency
             command[i] = c.replace("$@", target);
 
         // Support $< (shortcut for the source path)
-        if (command[$ - 1].find("$<"))
+        if (!command[$ - 1].find("$<").empty)
             command = command.remove(command.length - 1) ~ sources;
     }
 }

--- a/src/build.d
+++ b/src/build.d
@@ -148,7 +148,7 @@ auto lexer()
     Dependency dependency = {
         target: env["G"].buildPath("lexer").libName,
         sources: sources.lexer,
-        rebuildSources: configFiles,
+        rebuildSources: buildStringFiles.map!(a => a.target).array,
         name: "(DC) D_LEXER_OBJ %-(%s, %)".format(sources.lexer.map!(e => e.baseName).array),
         command: [
             env["HOST_DMD_RUN"],
@@ -278,12 +278,6 @@ auto buildStringFiles()
         commandFunction: commandFunction,
     };
     return [versionDependency, sysconfDirDependency];
-}
-
-/// Returns: a list of config files that are required by the DMD build
-auto configFiles()
-{
-    return buildStringFiles.map!(a => a.target).array ~ dmdConf.target;
 }
 
 /**

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -409,9 +409,14 @@ DEPS = $(patsubst %.o,%.deps,$(DMD_OBJS) $(BACK_OBJS) $(BACK_DOBJS))
 
 ######## Begin build targets
 
-all: $G/dmd
 
-auto-tester-build: $G/dmd checkwhitespace cxx-unittest $G/dmd_frontend
+all: dmd
+.PHONY: all
+
+dmd: $G/dmd $G/dmd.conf
+.PHONY: dmd
+
+auto-tester-build: dmd checkwhitespace cxx-unittest $G/dmd_frontend
 .PHONY: auto-tester-build
 
 toolchain-info:
@@ -437,11 +442,11 @@ $G/dmd_frontend: $(FRONT_SRCS) $D/gluelayer.d $(ROOT_SRCS) $G/lexer.a $(STRING_I
 	$(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^) -version=NoBackend
 
 ifdef ENABLE_LTO
-$G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/lexer.a $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $G/dmd.conf
-	$(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $G/dmd.conf,$^)
+$G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/lexer.a $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
+	$(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
 else
-$G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/backend.a $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $G/dmd.conf
-	$(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT) $G/dmd.conf,$^)
+$G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/backend.a $G/lexer.a $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
+	$(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT),$^)
 endif
 
 $G/dmd-unittest: $(DMD_SRCS) $(ROOT_SRCS) $(LEXER_SRCS) $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
@@ -455,10 +460,10 @@ unittest: $G/dmd-unittest
 EXAMPLES=$(addprefix $G/examples/, avg impvisitor)
 PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase parsetimevisitor transitivevisitor permissivevisitor strictvisitor utils))
 
-$G/parser.a: $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS) $G/dmd $G/dmd.conf $(SRC_MAKE)
+$G/parser.a: $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS) dmd $(SRC_MAKE)
 	$G/dmd -lib -of$@ $(MODEL_FLAG) -J$G $(DFLAGS) $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS)
 
-$G/examples/%: $(EX)/%.d $G/parser.a $G/dmd
+$G/examples/%: $(EX)/%.d $G/parser.a dmd
 	$G/dmd -of$@ $(MODEL_FLAG) $(DFLAGS) $G/parser.a $<
 
 build-examples: $(EXAMPLES)


### PR DESCRIPTION
`dmd.conf` isn't a dependency to compile dmd.

Also fixed a bug, `std.algorithm.find` always returns true even if the string is not found. the correct way is to check whether it is empty or not.

Let me know if you'd like me to split the 2 fixes into 2 different PRs.

cc @wilzbach 