### PR TITLE
Revert "Fix issues 17141, 17358 - Ternary operator converts characters to integers"

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -247,7 +247,6 @@ struct ASTBase
         real_        = 8,
         imaginary    = 0x10,
         complex      = 0x20,
-        char_        = 0x40,
     }
 
     enum PKG : int
@@ -3548,17 +3547,17 @@ struct ASTBase
 
             case Tchar:
                 d = Token.toChars(TOK.char_);
-                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+                flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
             case Twchar:
                 d = Token.toChars(TOK.wchar_);
-                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+                flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
             case Tdchar:
                 d = Token.toChars(TOK.dchar_);
-                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+                flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
             default:

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2830,16 +2830,8 @@ bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expression* pe2)
 
     if (op != TOK.question || t1b.ty != t2b.ty && (t1b.isTypeBasic() && t2b.isTypeBasic()))
     {
-        if (op == TOK.question && t1b.ischar() && t2b.ischar())
-        {
-            e1 = charPromotions(e1, sc);
-            e2 = charPromotions(e2, sc);
-        }
-        else
-        {
-            e1 = integralPromotions(e1, sc);
-            e2 = integralPromotions(e2, sc);
-        }
+        e1 = integralPromotions(e1, sc);
+        e2 = integralPromotions(e2, sc);
     }
 
     t1 = e1.type;
@@ -3522,29 +3514,6 @@ Expression integralPromotions(Expression e, Scope* sc)
 
     default:
         break;
-    }
-    return e;
-}
-
-/***********************************
- * Do char promotions.
- *   char  -> dchar
- *   wchar -> dchar
- *   dchar -> dchar
- */
-Expression charPromotions(Expression e, Scope* sc)
-{
-    //printf("charPromotions %s %s\n", e.toChars(), e.type.toChars());
-    switch (e.type.toBasetype().ty)
-    {
-    case Tchar:
-    case Twchar:
-    case Tdchar:
-        e = e.castTo(sc, Type.tdchar);
-        break;
-
-    default:
-        assert(0);
     }
     return e;
 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -235,7 +235,6 @@ private enum TFlags
     real_        = 8,
     imaginary    = 0x10,
     complex      = 0x20,
-    char_        = 0x40,
 }
 
 enum ENUMTY : int
@@ -1035,11 +1034,6 @@ extern (C++) abstract class Type : ASTNode
     }
 
     bool isunsigned()
-    {
-        return false;
-    }
-
-    bool ischar()
     {
         return false;
     }
@@ -3140,17 +3134,17 @@ extern (C++) final class TypeBasic : Type
 
         case Tchar:
             d = Token.toChars(TOK.char_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned;
             break;
 
         case Twchar:
             d = Token.toChars(TOK.wchar_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned;
             break;
 
         case Tdchar:
             d = Token.toChars(TOK.dchar_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned;
             break;
 
         default:
@@ -3288,11 +3282,6 @@ extern (C++) final class TypeBasic : Type
     override bool isunsigned() const
     {
         return (flags & TFlags.unsigned) != 0;
-    }
-
-    override bool ischar() const
-    {
-        return (flags & TFlags.char_) != 0;
     }
 
     override MATCH implicitConvTo(Type to)
@@ -5811,11 +5800,6 @@ extern (C++) final class TypeEnum : Type
     override bool isunsigned()
     {
         return memType().isunsigned();
-    }
-
-    override bool ischar()
-    {
-        return memType().ischar();
     }
 
     override bool isBoolean()

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -400,7 +400,6 @@ public:
     bool iscomplex() /*const*/;
     bool isscalar() /*const*/;
     bool isunsigned() /*const*/;
-    bool ischar() /*const*/;
     MATCH implicitConvTo(Type *to);
     bool isZeroInit(const Loc &loc) /*const*/;
 
@@ -761,7 +760,6 @@ public:
     bool iscomplex();
     bool isscalar();
     bool isunsigned();
-    bool ischar();
     bool isBoolean();
     bool isString();
     bool isAssignable();

--- a/test/compilable/implicitconv.d
+++ b/test/compilable/implicitconv.d
@@ -14,10 +14,3 @@ static assert(!__traits(compiles, { const(wchar_t)[]     bar = foo; } ));
 static assert(!__traits(compiles, { immutable(wchar_t)*  bar = foo; } ));
 static assert(!__traits(compiles, { const(wchar_t)*      bar = foo; } ));
 
-// https://issues.dlang.org/show_bug.cgi?id=17141
-static assert(is(typeof(true ? char.init : char.init) == char));
-static assert(is(typeof(true ? char.init : wchar.init) == dchar));
-static assert(is(typeof(true ? char.init : dchar.init) == dchar));
-static assert(is(typeof(true ? wchar.init : wchar.init) == wchar));
-static assert(is(typeof(true ? wchar.init : dchar.init) == dchar));
-static assert(is(typeof(true ? dchar.init : dchar.init) == dchar));


### PR DESCRIPTION
Reverts dlang/dmd#9889 and does nothing else.

This is in response to https://github.com/dlang/dmd/pull/9889 which reverts and does some other things. The PRs should be separate.