### PR TITLE
remove unused addObjectToLibrary

### DIFF
--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -131,8 +131,3 @@ else version (OSX)
 }
 else
     alias cpp_size_t = size_t;
-
-extern (C++) void addObjectToLibrary(Library lib, const(char)* module_name, const(ubyte)* buf, cpp_size_t buflen)
-{
-    lib.addObject(module_name, buf[0 .. buflen]);
-}

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -121,13 +121,3 @@ class Library
   protected:
     Loc loc;                  // the filename of the library
 }
-
-version (D_LP64)
-    alias cpp_size_t = size_t;
-else version (OSX)
-{
-    import core.stdc.config : cpp_ulong;
-    alias cpp_size_t = cpp_ulong;
-}
-else
-    alias cpp_size_t = size_t;


### PR DESCRIPTION
This occurs once in the entire repo, not exposed in a header, unused by cxxfrontend tests, unused by LDC, etc. Time to kill it.