### PR TITLE
[REG 2.084.1] Fix issue 19936: `alias deprecated get this` falsely triggers deprecation on `array ~=`

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1550,7 +1550,7 @@ Expression op_overload(Expression e, Scope* sc)
             }
         L1:
             result = checkAliasThisForLhs(ad1, sc, e);
-            if (result)
+            if (result || !s) // no point in trying Rhs alias-this if there's no overload of any kind in lhs
                 return;
 
             result = checkAliasThisForRhs(isAggregate(e.e2.type), sc, e);

--- a/test/compilable/test19936.d
+++ b/test/compilable/test19936.d
@@ -1,0 +1,17 @@
+// REQUIRED_ARGS: -de
+
+struct Bla
+{
+    deprecated("bla")
+    int get() { return 5; }
+
+    alias get this;
+}
+
+void main()
+{
+    Bla[] blaArray;
+    // ~= should not try to call `.get`, because there's no indication that
+    // `blaArray` has any kind of opAppendAssign related overload in the first place.
+    blaArray ~= Bla();
+}


### PR DESCRIPTION
Don't attempt alias-this for the rhs of an opAppendAssign overload if no applicable overload was found in the lhs to begin with.