### PR TITLE
evalu8.d: remove legacy redunancy "isnan(f) || f != 0"

### DIFF
--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -175,7 +175,7 @@ version (SCPP)
                 {   b = 0;
                     foreach (f; e.EV.Vfloat4)
                     {
-                        if (isnan(f) || f != 0) // Why not just f != 0?
+                        if (f != 0)
                         {   b = 1;
                             break;
                         }
@@ -200,7 +200,7 @@ version (SCPP)
                     b = 0;
                     foreach (f; e.EV.Vfloat8)
                     {
-                        if (isnan(f) || f != 0) // Why not just f != 0?
+                        if (f != 0)
                         {   b = 1;
                             break;
                         }
@@ -211,7 +211,7 @@ version (SCPP)
                     b = 0;
                     foreach (f; e.EV.Vdouble4)
                     {
-                        if (isnan(f) || f != 0) // Why not just f != 0?
+                        if (f != 0)
                         {   b = 1;
                             break;
                         }


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/9929#discussion_r289669477
>It's a relic from the days when it was in C and C compiler support for NaN was erratic and mostly wrong.