### PR TITLE
remove Tsize_t & Tptrdiff_t

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2596,9 +2596,6 @@ struct ASTBase
         }
     }
 
-    extern (C++) __gshared int Tsize_t = Tuns32;
-    extern (C++) __gshared int Tptrdiff_t = Tint32;
-
     extern (C++) abstract class Type : ASTNode
     {
         TY ty;
@@ -2799,19 +2796,10 @@ struct ASTBase
             tdstring = tdchar.immutableOf().arrayOf();
             tvalist = Target.va_listType();
 
-            if (global.params.isLP64)
-            {
-                Tsize_t = Tuns64;
-                Tptrdiff_t = Tint64;
-            }
-            else
-            {
-                Tsize_t = Tuns32;
-                Tptrdiff_t = Tint32;
-            }
+            const isLP64 = global.params.isLP64;
 
-            tsize_t = basic[Tsize_t];
-            tptrdiff_t = basic[Tptrdiff_t];
+            tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
+            tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];
             thash_t = tsize_t;
         }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -55,9 +55,6 @@ import dmd.visitor;
 enum LOGDOTEXP = 0;         // log ::dotExp()
 enum LOGDEFAULTINIT = 0;    // log ::defaultInit()
 
-extern (C++) __gshared int Tsize_t = Tuns32;
-extern (C++) __gshared int Tptrdiff_t = Tint32;
-
 enum SIZE_INVALID = (~cast(d_uns64)0);   // error return from size() functions
 
 
@@ -889,19 +886,10 @@ extern (C++) abstract class Type : ASTNode
         tdstring = tdchar.immutableOf().arrayOf();
         tvalist = target.va_listType();
 
-        if (global.params.isLP64)
-        {
-            Tsize_t = Tuns64;
-            Tptrdiff_t = Tint64;
-        }
-        else
-        {
-            Tsize_t = Tuns32;
-            Tptrdiff_t = Tint32;
-        }
+        const isLP64 = global.params.isLP64;
 
-        tsize_t = basic[Tsize_t];
-        tptrdiff_t = basic[Tptrdiff_t];
+        tsize_t    = basic[isLP64 ? Tuns64 : Tuns32];
+        tptrdiff_t = basic[isLP64 ? Tint64 : Tint32];
         thash_t = tsize_t;
     }
 

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -96,9 +96,6 @@ enum ENUMTY
 };
 typedef unsigned char TY;       // ENUMTY
 
-extern int Tsize_t;
-extern int Tptrdiff_t;
-
 #define SIZE_INVALID (~(d_uns64)0)   // error return from size() functions
 
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1358,7 +1358,7 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
                     fs.key = new VarDeclaration(loc, Type.tsize_t, idkey, null);
                     fs.key.storage_class |= STC.temp;
                 }
-                else if (fs.key.type.ty != Tsize_t)
+                else if (fs.key.type.ty != Type.tsize_t.ty)
                 {
                     tmp_length = new CastExp(loc, tmp_length, fs.key.type);
                 }


### PR DESCRIPTION
These are still available through Type.tsize_t.ty and Type.tptrdiff_t.ty

For https://github.com/dlang/dmd/pull/9913#discussion_r289627484 cc @ibuclaw @jacob-carlborg 