### PR TITLE
Fix test case - escaping reference to stack struct

### DIFF
--- a/test/runnable/template10.d
+++ b/test/runnable/template10.d
@@ -176,7 +176,7 @@ void test4i(T)(T i)
 
 auto get4i(int a)
 {
-    return S4(5).inner!a(6);
+    return new S4(5).inner!a(6);
 }
 
 void test4()


### PR DESCRIPTION
This was failing at #9956.
DIP 1000 could have caught it. Another case which is similar is issue [19812](https://issues.dlang.org/show_bug.cgi?id=19812).