### PR TITLE
add cse.d: manage CSE memory in stack frame

### DIFF
--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -29,6 +29,7 @@ import core.stdc.string;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;
+import dmd.backend.cgcse;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
 import dmd.backend.dlist;
@@ -140,7 +141,6 @@ regm_t mfuncreg;        // Mask of registers preserved by a function
 regm_t allregs;                // ALLREGS optionally including mBP
 
 int dfoidx;                     /* which block we are in                */
-private Barray!CSE csextab;     /* CSE table (allocated for each function) */
 
 targ_size_t     funcoffset;     // offset of start of function
 targ_size_t     prolog_allocoffset;     // offset past adj of stack allocation
@@ -151,81 +151,6 @@ targ_size_t     retsize;        /* size of function return              */
 private regm_t lastretregs,last2retregs,last3retregs,last4retregs,last5retregs;
 
 }
-
-/****************************
- * Table of common subexpressions stored on the stack.
- *      csextab[]       array of info on saved CSEs
- *      CSEpe           pointer to saved elem
- *      CSEregm         mask of register that was saved (so for multi-
- *                      register variables we know which part we have)
- */
-
-enum CSEload       = 1;       // set if the CSE was ever loaded
-enum CSEsimple     = 2;       // CSE can be regenerated easily
-
-private struct CSE
-{       elem    *e;             // pointer to elem
-        code    csimple;        // if CSEsimple, this is the code to regenerate it
-        regm_t  regm;           // mask of register stored there
-        char    flags;          // flag bytes
-
-  __gshared:
-    uint slotSize;          // size of each slot in table
-    uint alignment;         // alignment for the table
-
-    /********************************
-     * Update slot size and alignment to worst case.
-     * A bit wasteful of stack space.
-     */
-    static nothrow void updateSizeAndAlign(elem* e)
-    {
-        if (I16)
-            return;
-        const sz = tysize(e.Ety);
-        if (slotSize < sz)
-            slotSize = sz;
-        const alignsize = el_alignsize(e);
-
-        static if (0)
-        printf("set slot size = %d, sz = %d, al = %d, ty = x%x, %s\n",
-            slotSize, cast(int)sz, cast(int)alignsize,
-            cast(int)tybasic(e.Ety), funcsym_p.Sident.ptr);
-
-        if (alignsize >= 16 && TARGET_STACKALIGN >= 16)
-        {
-            alignment = alignsize;
-            STACKALIGN = alignsize;
-            enforcealign = true;
-        }
-    }
-}
-
-// Returns: offset of slot i
-uint CSE_offset(int i)
-{
-    return i * CSE.slotSize;
-}
-
-// Returns: true if CSE was ever loaded
-bool CSE_loaded(int i)
-{
-    return i < csextab.length &&   // array could be shrunk for non-CSEload entries
-           (csextab[i].flags & CSEload);
-}
-
-/********************
- * The above implementation of CSE is inefficient:
- * 1. the optimization to not store CSE's that are never reloaded is based on the slot number,
- * not the CSE. This means that when a slot is shared among multiple CSEs, it is treated
- * as "reloaded" even if only one of the CSEs in that slot is reloaded.
- * 2. updateSizeAndAlign should only be run when reloading when (1) is fixed.
- * 3. all slots are aligned to worst case alignment of any slot.
- * 4. unused slots still get memory allocated to them if they aren't at the end of the
- * slot table.
- *
- * The slot number should be unique to each CSE, and allocation of actual slots should be
- * done after the code is generated, not during generation.
- */
 
 /*********************************
  * Generate code for a function.

--- a/src/dmd/backend/cgcse.d
+++ b/src/dmd/backend/cgcse.d
@@ -1,0 +1,123 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Manage the memory allocated on the runtime stack to save Common Subexpressions (CSE).
+ *
+ * Copyright:   Copyright (C) 1985-1998 by Symantec
+ *              Copyright (C) 2000-2019 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/cgcse.d, backend/cgcse.d)
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/cgcse.d
+ */
+
+module dmd.backend.cgcse;
+
+version (SCPP)
+    version = COMPILE;
+version (MARS)
+    version = COMPILE;
+
+version (COMPILE)
+{
+
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.stdc.string;
+
+import dmd.backend.cc;
+import dmd.backend.cdef;
+import dmd.backend.code;
+import dmd.backend.code_x86;
+import dmd.backend.el;
+import dmd.backend.global;
+import dmd.backend.ty;
+
+import dmd.backend.barray;
+
+extern (C++):
+nothrow:
+
+__gshared Barray!CSE csextab;     /* CSE table (allocated for each function) */
+
+/****************************
+ * Table of common subexpressions stored on the stack.
+ *      csextab[]       array of info on saved CSEs
+ *      CSEpe           pointer to saved elem
+ *      CSEregm         mask of register that was saved (so for multi-
+ *                      register variables we know which part we have)
+ */
+
+enum CSEload       = 1;       // set if the CSE was ever loaded
+enum CSEsimple     = 2;       // CSE can be regenerated easily
+
+struct CSE
+{
+    elem    *e;             // pointer to elem
+    code    csimple;        // if CSEsimple, this is the code to regenerate it
+    regm_t  regm;           // mask of register stored there
+    char    flags;          // flag bytes
+
+  __gshared:
+    uint slotSize;          // size of each slot in table
+    uint alignment;         // alignment for the table
+
+  nothrow:
+
+    /********************************
+     * Update slot size and alignment to worst case.
+     * A bit wasteful of stack space.
+     */
+    static void updateSizeAndAlign(elem* e)
+    {
+        if (I16)
+            return;
+        const sz = tysize(e.Ety);
+        if (slotSize < sz)
+            slotSize = sz;
+        const alignsize = el_alignsize(e);
+
+        static if (0)
+        printf("set slot size = %d, sz = %d, al = %d, ty = x%x, %s\n",
+            slotSize, cast(int)sz, cast(int)alignsize,
+            cast(int)tybasic(e.Ety), funcsym_p.Sident.ptr);
+
+        if (alignsize >= 16 && TARGET_STACKALIGN >= 16)
+        {
+            alignment = alignsize;
+            STACKALIGN = alignsize;
+            enforcealign = true;
+        }
+    }
+}
+
+// Returns: offset of slot i
+uint CSE_offset(int i)
+{
+    return i * CSE.slotSize;
+}
+
+// Returns: true if CSE was ever loaded
+bool CSE_loaded(int i)
+{
+    return i < csextab.length &&   // array could be shrunk for non-CSEload entries
+           (csextab[i].flags & CSEload);
+}
+
+/********************
+ * The above implementation of CSE is inefficient:
+ * 1. the optimization to not store CSE's that are never reloaded is based on the slot number,
+ * not the CSE. This means that when a slot is shared among multiple CSEs, it is treated
+ * as "reloaded" even if only one of the CSEs in that slot is reloaded.
+ * 2. updateSizeAndAlign should only be run when reloading when (1) is fixed.
+ * 3. all slots are aligned to worst case alignment of any slot.
+ * 4. unused slots still get memory allocated to them if they aren't at the end of the
+ * slot table.
+ *
+ * The slot number should be unique to each CSE, and allocation of actual slots should be
+ * done after the code is generated, not during generation.
+ */
+
+
+}

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -26,6 +26,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cgcse;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -100,9 +100,6 @@ code *code_malloc()
 
 extern __gshared con_t regcon;
 
-uint CSE_offset(int i);
-bool CSE_loaded(int i);
-
 /************************************
  * Register save state.
  */

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -339,7 +339,7 @@ BACK_DOBJS = bcomplex.o evalu8.o divcoeff.o dvec.o go.o gsroa.o glocal.o gdag.o 
 	gloop.o compress.o cgelem.o cgcs.o ee.o cod4.o cod5.o nteh.o blockopt.o mem.o cg.o cgreg.o \
 	dtype.o debugprint.o fp.o symbol.o elem.o dcode.o cgsched.o cg87.o cgxmm.o cgcod.o cod1.o cod2.o \
 	cod3.o cv8.o dcgcv.o pdata.o util2.o var.o md5.o backconfig.o ph2.o drtlsym.o dwarfeh.o ptrntab.o \
-	aarray.o dvarstats.o dwarfdbginf.o elfobj.o cgen.o os.o goh.o barray.o
+	aarray.o dvarstats.o dwarfdbginf.o elfobj.o cgen.o os.o goh.o barray.o cgcse.o
 
 G_OBJS  = $(addprefix $G/, $(BACK_OBJS))
 G_DOBJS = $(addprefix $G/, $(BACK_DOBJS))
@@ -367,7 +367,7 @@ BACK_SRC = \
 	$C/optabgen.d \
 	$C/bcomplex.d $C/blockopt.d $C/cg.d $C/cg87.d $C/cgxmm.d \
 	$C/cgcod.d $C/cgcs.d $C/dcgcv.d $C/cgelem.d $C/cgen.d $C/cgobj.d \
-	$C/compress.d $C/cgreg.d $C/var.d \
+	$C/compress.d $C/cgreg.d $C/var.d $C/cgcse.d \
 	$C/cgsched.d $C/cod1.d $C/cod2.d $C/cod3.d $C/cod4.d $C/cod5.d \
 	$C/dcode.d $C/symbol.d $C/debugprint.d $C/dt.d $C/ee.d $C/elem.d \
 	$C/evalu8.d $C/fp.d $C/go.d $C/gflow.d $C/gdag.d \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -179,7 +179,7 @@ GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.o
 	$G/drtlsym.obj $G/cgelem.obj $G/cgen.obj $G/cgreg.obj $G/out.obj \
 	$G/blockopt.obj $G/cgobj.obj $G/cg.obj $G/dcgcv.obj $G/dtype.obj \
 	$G/debugprint.obj $G/dcode.obj $G/cg87.obj $G/cgxmm.obj $G/cgsched.obj $G/ee.obj $G/symbol.obj \
-	$G/cgcod.obj $G/cod1.obj $G/cod2.obj $G/cod3.obj $G/cod4.obj $G/cod5.obj \
+	$G/cgcod.obj $G/cod1.obj $G/cod2.obj $G/cod3.obj $G/cod4.obj $G/cod5.obj $G/cgcse.obj \
 	$G/bcomplex.obj $G/ptrntab.obj $G/md5.obj $G/barray.obj $G/goh.obj \
 	$G/mscoffobj.obj $G/pdata.obj $G/cv8.obj $G/backconfig.obj \
 	$G/divcoeff.obj $G/dwarfdbginf.obj $G/compress.obj $G/dvarstats.obj \
@@ -210,7 +210,7 @@ BACKSRC= $C\optabgen.d \
 	$C/code_stub.h $C/platform_stub.c \
 	$C\bcomplex.d $C\blockopt.d $C\cg.d $C\cg87.d $C\cgxmm.d \
 	$C\cgcod.d $C\cgcs.d $C\dcgcv.d $C\cgelem.d $C\cgen.d $C\cgobj.d \
-	$C\compress.d $C\cgreg.d $C\var.d \
+	$C\compress.d $C\cgreg.d $C\var.d $C\cgcse.d \
 	$C\cgsched.d $C\cod1.d $C\cod2.d $C\cod3.d $C\cod4.d $C\cod5.d \
 	$C\dcode.d $C\symbol.d $C\debugprint.d $C\ee.d $C\elem.d \
 	$C\evalu8.d $C\fp.d $C\go.d $C\gflow.d $C\gdag.d \
@@ -438,6 +438,9 @@ $G/cgcod.obj : $G\cdxxx.d $C\cgcod.d
 
 $G/cgcs.obj : $C\cgcs.d
 	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\cgcs
+
+$G/cgcse.obj : $C\cgcse.d
+	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\cgcse
 
 $G/dcgcv.obj : $C\dcgcv.d
 	$(HOST_DC) -c -of$@ $(DFLAGS) -betterC -mv=dmd.backend=$C $C\dcgcv


### PR DESCRIPTION
The distributed nature of https://github.com/dlang/dmd/pull/9905 suggests that managing CSEs can be encapsulated into its own module. This is a start.