### PR TITLE
Fix Issue 15110 - pragma(inline, true) should always *attempt* to inline regardless of the -inline compiler flag

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3603,7 +3603,7 @@ elem *toElem(Expression e, IRState *irs)
             assert(txb.ty == tyb.ty);
 
             // https://issues.dlang.org/show_bug.cgi?id=14730
-            if (irs.params.useInline && v.offset == 0)
+            if (v.offset == 0)
             {
                 FuncDeclaration fd = v.parent.isFuncDeclaration();
                 if (fd && fd.semanticRun < PASS.obj)

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1683,13 +1683,13 @@ private bool canInline(FuncDeclaration fd, bool hasthis, bool hdrscan, bool stat
         break;
     }
 
-    final switch (fd.inlining)
+    if (fd.inlining == PINLINE.never)
     {
-    case PINLINE.default_:
-        break;
-    case PINLINE.always:
-        break;
-    case PINLINE.never:
+        return false;
+    }
+
+    if (fd.inlining == PINLINE.default_ && !global.params.useInline)
+    {
         return false;
     }
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -620,15 +620,13 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
         fatal();
 
     // Scan for functions to inline
-    if (params.useInline)
+    foreach (m; modules)
     {
-        foreach (m; modules)
-        {
-            if (params.verbose)
-                message("inline scan %s", m.toChars());
-            inlineScanModule(m);
-        }
+        if (params.verbose)
+            message("inline scan %s", m.toChars());
+        inlineScanModule(m);
     }
+
     // Do not attempt to generate output files if errors or warnings occurred
     if (global.errors || global.warnings)
         fatal();


### PR DESCRIPTION
Currently the compiler does not attempt to do any inlining whatsoever regardless of any `pragma(inline, true)` annotations.  It will only attempt to inline functions if the compiler is invoked with the `-inline` flag.

This PR changes the behavior of `pragma(inline, true)` so the compiler always *attempts* to inline a function annotated with `pragma(inline, true) regardless of whether or not the compiler is invoked with the `-inline` flag. All other behaviors remain the same.