### PR TITLE
fix Issue 19942 - [ICE] Segmentation fault in resolvePropertiesX at dmd/expressionsem.d:1112

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4163,12 +4163,19 @@ else
             }
 
             s.dsymbolSemantic(sc);
-            Module.addDeferredSemantic2(s);     // https://issues.dlang.org/show_bug.cgi?id=14666
-            sc.insert(s);
 
-            foreach (aliasdecl; s.aliasdecls)
+            // https://issues.dlang.org/show_bug.cgi?id=19942
+            // If the module that's being imported doesn't exist, don't add it to the symbol table
+            // for the current scope.
+            if (s.mod !is null)
             {
-                sc.insert(aliasdecl);
+                Module.addDeferredSemantic2(s);     // https://issues.dlang.org/show_bug.cgi?id=14666
+                sc.insert(s);
+
+                foreach (aliasdecl; s.aliasdecls)
+                {
+                    sc.insert(aliasdecl);
+                }
             }
         }
         result = imps;

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -31,3 +31,9 @@ version (linux)
     static assert(__traits(getTargetInfo, "objectFormat") == "elf");
 
 static assert(__traits(getTargetInfo, "cppStd") == 199711);
+
+/******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19942
+
+static assert(!__traits(compiles, { a.init; }));
+static assert(!__traits(compiles, { import m : a; a.init; }));


### PR DESCRIPTION
Under normal conditions, `import doesnotexist : s;` calls `fatal()` during the semantic run of the import statement.

However when gagging, this is skipped, and the selective import is added to the scope symbol table anyway, which causes problems later when attempting to resolve symbols that come from modules that don't exist.

By not adding it to the symbol table, the `undefined identifier` error path is correctly taken.