### PR TITLE
Translate _d_arrayappend{T,cTX} to templates

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -5035,6 +5035,10 @@ public:
                 result = interpret(ae, istate);
                 return;
             }
+            else if (fd.ident == Id._d_arrayappendT)
+                assert(0, "CTFE cannot interpret _d_arrayappendT!");
+            else if (fd.ident == Id._d_arrayappendcTX)
+                assert(0, "CTFE cannot interpret _d_arrayappendcTX!");
         }
         else if (auto soe = ecall.isSymOffExp())
         {

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5314,7 +5314,8 @@ elem *toElem(Expression e, IRState *irs)
                 else
                 {
                     Symbol *sp = toSymbol(s);
-                    symbol_add(sp);
+                    if (sp.Ssymnum == -1)
+                        symbol_add(sp);
                     //printf("\tadding symbol '%s'\n", sp.Sident);
                     if (vd._init)
                     {

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3289,66 +3289,12 @@ elem *toElem(Expression e, IRState *irs)
 
                 case TOK.concatenateAssign:
                 {
-                    // Append array
-                    assert(tb2.ty == Tarray || tb2.ty == Tsarray);
-
-                    assert(tb1n.equals(tb2.nextOf().toBasetype()));
-
-                    e1 = el_una(OPaddr, TYnptr, e1);
-                    if (config.exe == EX_WIN64)
-                        e2 = addressElem(e2, tb2, true);
-                    else
-                        e2 = useOPstrpar(e2);
-                    elem *ep = el_params(e2, e1, getTypeInfo(ce.e1.loc, ce.e1.type, irs), null);
-                    e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYAPPENDT)), ep);
-                    toTraceGC(irs, e, ce.loc);
-                    break;
+                    assert(0, "This case should have been rewritten to `_d_arrayappendT` in the semantic phase");
                 }
 
                 case TOK.concatenateElemAssign:
                 {
-                    // Append element
-                    assert(tb1n.equals(tb2));
-
-                    elem *e2x = null;
-
-                    if (e2.Eoper != OPvar && e2.Eoper != OPconst)
-                    {
-                        // Evaluate e2 and assign result to temporary s2.
-                        // Do this because of:
-                        //    a ~= a[$-1]
-                        // because $ changes its value
-                        type* tx = Type_toCtype(tb2);
-                        Symbol *s2 = symbol_genauto(tx);
-                        e2x = elAssign(el_var(s2), e2, tb1n, tx);
-
-                        e2 = el_var(s2);
-                    }
-
-                    // Extend array with _d_arrayappendcTX(TypeInfo ti, e1, 1)
-                    e1 = el_una(OPaddr, TYnptr, e1);
-                    elem *ep = el_param(e1, getTypeInfo(ce.e1.loc, ce.e1.type, irs));
-                    ep = el_param(el_long(TYsize_t, 1), ep);
-                    e = el_bin(OPcall, TYdarray, el_var(getRtlsym(RTLSYM_ARRAYAPPENDCTX)), ep);
-                    toTraceGC(irs, e, ce.loc);
-                    Symbol *stmp = symbol_genauto(Type_toCtype(tb1));
-                    e = el_bin(OPeq, TYdarray, el_var(stmp), e);
-
-                    // Assign e2 to last element in stmp[]
-                    // *(stmp.ptr + (stmp.length - 1) * szelem) = e2
-
-                    elem *eptr = array_toPtr(tb1, el_var(stmp));
-                    elem *elength = el_una(irs.params.is64bit ? OP128_64 : OP64_32, TYsize_t, el_var(stmp));
-                    elength = el_bin(OPmin, TYsize_t, elength, el_long(TYsize_t, 1));
-                    elength = el_bin(OPmul, TYsize_t, elength, el_long(TYsize_t, ce.e2.type.size()));
-                    eptr = el_bin(OPadd, TYnptr, eptr, elength);
-                    elem *ederef = el_una(OPind, e2.Ety, eptr);
-
-                    elem *eeq = elAssign(ederef, e2, tb1n, null);
-                    e = el_combine(e2x, e);
-                    e = el_combine(e, eeq);
-                    e = el_combine(e, el_var(stmp));
-                    break;
+                    assert(0, "This case should have been rewritten to `_d_arrayappendcTX` in the semantic phase");
                 }
 
                 default:

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3529,6 +3529,18 @@ elem *toElem(Expression e, IRState *irs)
 
         override void visit(CondExp ce)
         {
+            if (auto ve = ce.econd.isVarExp)
+                if (ve.var.ident == Id.ctfe)
+                {
+                    elem *e = toElem(ce.e2, irs);
+                    if (irs.params.cov && ce.e2.loc.linnum)
+                        e = el_combine(incUsageElem(irs, ce.e2.loc), e);
+                    if (tybasic(e.Ety) == TYstruct)
+                        e.ET = Type_toCtype(ce.e2.type);
+                    elem_setLoc(e, ce.loc);
+                    result = e;
+                    return;
+                }
             elem *ec = toElem(ce.econd, irs);
 
             elem *eleft = toElem(ce.e1, irs);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1286,7 +1286,8 @@ extern (C++) abstract class Expression : ASTNode
 
                 // Lowered non-@nogc'd hooks will print their own error message inside of nogc.d (NOGCVisitor.visit(CallExp e)),
                 // so don't print anything to avoid double error messages.
-                if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT))
+                if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT
+                    || f.ident == Id._d_arrayappendT || f.ident == Id._d_arrayappendcTX))
                     error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
                 return true;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5976,6 +5976,7 @@ extern (C++) final class UshrAssignExp : BinAssignExp
  */
 extern (C++) class CatAssignExp : BinAssignExp
 {
+    bool isCTFEHookPart;
     extern (D) this(const ref Loc loc, Expression e1, Expression e2)
     {
         super(loc, TOK.concatenateAssign, __traits(classInstanceSize, CatAssignExp), e1, e2);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -9331,6 +9331,128 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if ((exp.op == TOK.concatenateElemAssign || exp.op == TOK.concatenateDcharAssign) && global.params.vsafe)
             checkAssignEscape(sc, res, false);
         result = res;
+
+        if (!exp.isCTFEHookPart &&
+            (exp.op == TOK.concatenateAssign || exp.op == TOK.concatenateElemAssign) &&
+            !(sc.flags & (SCOPE.ctfe | SCOPE.compile)))
+        {
+            // if aa ordering is triggered, `res` will be a CommaExp
+            // and `.e2` will be the rewritten original expression.
+
+            // `output` will point to the expression that the lowering will overwrite
+            Expression* output;
+            if (auto comma = res.isCommaExp())
+            {
+                output = &comma.e2;
+                // manual cast because it could be either CatAssignExp or CatElemAssignExp
+                exp = cast(CatAssignExp)comma.e2;
+            }
+            else
+            {
+                output = &result;
+                exp = cast(CatAssignExp)result;
+            }
+
+            if (exp.op == TOK.concatenateAssign)
+            {
+                Identifier hook = global.params.tracegc ? Id._d_arrayappendTTrace : Id._d_arrayappendT;
+
+                if (!verifyHookExist(exp.loc, *sc, Id._d_arrayappendTImpl, "appending array to arrays", Id.object))
+                    return setError();
+
+                // Lower to object._d_arrayappendTImpl!(typeof(e1))._d_arrayappendT{,Trace}(e1, e2)
+                Expression id = new IdentifierExp(exp.loc, Id.empty);
+                id = new DotIdExp(exp.loc, id, Id.object);
+                auto tiargs = new Objects();
+                tiargs.push(exp.e1.type);
+                id = new DotTemplateInstanceExp(exp.loc, id, Id._d_arrayappendTImpl, tiargs);
+                id = new DotIdExp(exp.loc, id, hook);
+                id = id.expressionSemantic(sc);
+
+                auto arguments = new Expressions();
+                arguments.reserve(5);
+                if (global.params.tracegc)
+                {
+                    auto funcname = (sc.callsc && sc.callsc.func) ? sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
+                    arguments.push(new StringExp(exp.loc, cast(char*)exp.loc.filename));
+                    arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
+                    arguments.push(new StringExp(exp.loc, cast(char*)funcname));
+                }
+                arguments.push(exp.e1);
+                arguments.push(exp.e2);
+
+                exp.isCTFEHookPart = true;
+                Expression ce = new CallExp(exp.loc, id, arguments).expressionSemantic(sc);
+                auto cond = new IdentifierExp(exp.loc, Id.ctfe).expressionSemantic(sc);
+                ce = new CondExp(exp.loc, cond, exp, ce);
+
+                *output = ce.expressionSemantic(sc);
+            }
+            else if (exp.op == TOK.concatenateElemAssign)
+            {
+                if (auto ve = exp.e1.isVarExp)
+                {
+                    import core.stdc.ctype : isdigit;
+                    // The name of the indices array that static foreach loops uses.
+                    // See dmd.cond.lowerNonArrayAggregate
+                    enum varName = "__res";
+                    const(char)[] id = ve.var.ident.toString;
+                    if (id.length > varName.length && id[0 .. varName.length] == varName && id[varName.length].isdigit)
+                        return;
+                }
+
+                Identifier hook = global.params.tracegc ? Id._d_arrayappendcTXTrace : Id._d_arrayappendcTX;
+                if (!verifyHookExist(exp.loc, *sc, Id._d_arrayappendcTXImpl, "appending element to arrays", Id.object))
+                    return setError();
+
+                // Lower to object._d_arrayappendcTXImpl!(typeof(e1))._d_arrayappendcTX{,Trace}(e1, 1), e1[$-1]=e2
+                Expression id = new IdentifierExp(exp.loc, Id.empty);
+                id = new DotIdExp(exp.loc, id, Id.object);
+                auto tiargs = new Objects();
+                tiargs.push(exp.e1.type);
+                id = new DotTemplateInstanceExp(exp.loc, id, Id._d_arrayappendcTXImpl, tiargs);
+                id = new DotIdExp(exp.loc, id, hook);
+                id = id.expressionSemantic(sc);
+
+                auto arguments = new Expressions();
+                arguments.reserve(5);
+                if (global.params.tracegc)
+                {
+                    auto funcname = (sc.callsc && sc.callsc.func) ? sc.callsc.func.toPrettyChars() : sc.func.toPrettyChars();
+                    arguments.push(new StringExp(exp.loc, cast(char*)exp.loc.filename));
+                    arguments.push(new IntegerExp(exp.loc, exp.loc.linnum, Type.tint32));
+                    arguments.push(new StringExp(exp.loc, cast(char*)funcname));
+                }
+                arguments.push(exp.e1);
+                arguments.push(new IntegerExp(exp.loc, 1, Type.tsize_t));
+
+                Expression ce = new CallExp(exp.loc, id, arguments);
+                ce = ce.expressionSemantic(sc);
+
+                Expression eValue;
+                Expression value = exp.e2;
+                if (!value.isVarExp && !value.isIntegerExp && !value.isStructLiteralExp && !value.isArrayLiteralExp && !value.isAssocArrayLiteralExp)
+                {
+                    value = extractSideEffect(sc, "__appendtmp", eValue, value, true);
+                    exp.e2 = value;
+                }
+
+                exp.isCTFEHookPart = true;
+                auto elem = new IndexExp(exp.loc, exp.e1, new MinExp(exp.loc, new DollarExp(exp.loc), IntegerExp.literal!1));
+                auto ae = new ConstructExp(exp.loc, elem, value);
+                ae = cast(ConstructExp)ae.expressionSemantic(sc);
+
+                auto e0 = Expression.combine(ce, ae).expressionSemantic(sc);
+                e0 = Expression.combine(e0, exp.e1).expressionSemantic(sc);
+
+                auto cond = new IdentifierExp(exp.loc, Id.ctfe).expressionSemantic(sc);
+                e0 = new CondExp(exp.loc, cond, exp, e0.expressionSemantic(sc));
+                e0 = Expression.combine(eValue, e0);
+
+                *output = e0.expressionSemantic(sc);
+            }
+        }
+
     }
 
     override void visit(AddExp exp)

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -347,6 +347,12 @@ immutable Msgtable[] msgtable =
     { "_d_arraysetlengthTImpl"},
     { "_d_arraysetlengthT"},
     { "_d_arraysetlengthTTrace"},
+    { "_d_arrayappendTImpl" },
+    { "_d_arrayappendT" },
+    { "_d_arrayappendTTrace" },
+    { "_d_arrayappendcTXImpl" },
+    { "_d_arrayappendcTX" },
+    { "_d_arrayappendcTXTrace" },
 
     // varargs implementation
     { "va_start" },

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -81,6 +81,17 @@ public:
             }
             f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
         }
+        else if (fd.ident == Id._d_arrayappendT || fd.ident == Id._d_arrayappendcTX)
+        {
+            if (f.setGC())
+            {
+                e.error("cannot use operator `~=` in `@nogc` %s `%s`",
+                    f.kind(), f.toPrettyChars());
+                err = true;
+                return;
+            }
+            f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
+        }
     }
 
     override void visit(ArrayLiteralExp e)
@@ -206,14 +217,15 @@ public:
 
     override void visit(CatAssignExp e)
     {
+        /* CatAssignExp will exist in `__traits(compiles, ...)` and in the `.e1` branch of a `__ctfe ? :` CondExp.
+         * The other branch will be `_d_arrayappendcTX(e1, 1), e1[$-1]=e2` which will generate the warning about
+         * GC usage. See visit(CallExp).
+         */
         if (f.setGC())
         {
-            e.error("cannot use operator `~=` in `@nogc` %s `%s`",
-                f.kind(), f.toPrettyChars());
             err = true;
             return;
         }
-        f.printGCUsage(e.loc, "operator `~=` may cause a GC allocation");
     }
 
     override void visit(CatExp e)


### PR DESCRIPTION
druntime PR needed for this: https://github.com/dlang/druntime/pull/2632

- This lowers `Cat{,Elem}AssignExp}` to the templates `object._d_arrayappend{T,cTX}`.
- CTFE support is restored by rewriting `CallExp`, that will run the new hooks, back to `Cat{,Elem}AssignExp`.


