### PR TITLE
Fix race condition in bash test rm

### DIFF
--- a/test/tools/common_funcs.sh
+++ b/test/tools/common_funcs.sh
@@ -4,11 +4,11 @@
 function rm_retry {
     local attempt=1
     for true; do
-        rm $@ && break
+        rm -f $@ && break
         if [ $attempt -ge 4 ]; then
             return 1
         fi
-        attempt+=1
+        let attempt=attempt+=1
         sleep 1
     done
     return 0


### PR DESCRIPTION
Found a case where there is still a race condition when using `rm` in bash tests.

In test `runnable/test2.sh`, it removes both an executable and an object file.  On the first attempt, the obj file was removed but the exe failed with:

```
rm: cannot remove 'test_results/runnable/test2.exe': Device or resource busy
```

Then on further retries to remove the files, it failed again because now the object file was already removed:
```
rm: cannot remove 'test_results/runnable/test2.obj': No such file or directory
```

The solution is simply to use the `-f` flag when executing `rm`.  I've included the full test output below.

Also, I noticed that the attempt operation was appending `1` instead of adding it, the fix is to use `let`.

Test Output:
```
==============================
Test runnable/test2.sh failed. The logged output:
executing with args: 

executing with args: -debug

executing with args: -debug=1

executing with args: -debug=2 -debug=bar
rm: cannot remove 'test_results/runnable/test2.exe': Device or resource busy
rm: cannot remove 'test_results/runnable/test2.obj': No such file or directory
==============================
Test runnable/test2.sh failed. The xtrace output:
+ source runnable/test2.sh
++ output_file=test_results/runnable/test2.log
++ set -x
++ a[0]=
++ a[1]=-debug
++ a[2]=-debug=1
++ a[3]='-debug=2 -debug=bar'
++ for x in '"${a[@]}"'
++ echo 'executing with args: '
++ ../generated/windows/release/32/dmd.exe -m32 -unittest -oftest_results/runnable/test2.exe -oftest_results/runnable/test2.exe runnable/extra-files/test2.d
++ '[' 0 -ne 0 ']'
++ test_results/runnable/test2.exe
++ rm_retry test_results/runnable/test2.obj test_results/runnable/test2.exe
++ local attempt=1
++ for true in '"$@"'
++ rm test_results/runnable/test2.obj test_results/runnable/test2.exe
++ break
++ return 0
++ echo
++ for x in '"${a[@]}"'
++ echo 'executing with args: -debug'
++ ../generated/windows/release/32/dmd.exe -m32 -debug -unittest -oftest_results/runnable/test2.exe -oftest_results/runnable/test2.exe runnable/extra-files/test2.d
++ '[' 0 -ne 0 ']'
++ test_results/runnable/test2.exe
++ rm_retry test_results/runnable/test2.obj test_results/runnable/test2.exe
++ local attempt=1
++ for true in '"$@"'
++ rm test_results/runnable/test2.obj test_results/runnable/test2.exe
++ break
++ return 0
++ echo
++ for x in '"${a[@]}"'
++ echo 'executing with args: -debug=1'
++ ../generated/windows/release/32/dmd.exe -m32 -debug=1 -unittest -oftest_results/runnable/test2.exe -oftest_results/runnable/test2.exe runnable/extra-files/test2.d
++ '[' 0 -ne 0 ']'
++ test_results/runnable/test2.exe
++ rm_retry test_results/runnable/test2.obj test_results/runnable/test2.exe
++ local attempt=1
++ for true in '"$@"'
++ rm test_results/runnable/test2.obj test_results/runnable/test2.exe
++ break
++ return 0
++ echo
++ for x in '"${a[@]}"'
++ echo 'executing with args: -debug=2 -debug=bar'
++ ../generated/windows/release/32/dmd.exe -m32 -debug=2 -debug=bar -unittest -oftest_results/runnable/test2.exe -oftest_results/runnable/test2.exe runnable/extra-files/test2.d
++ '[' 0 -ne 0 ']'
++ test_results/runnable/test2.exe
++ rm_retry test_results/runnable/test2.obj test_results/runnable/test2.exe
++ local attempt=1
++ for true in '"$@"'
++ rm test_results/runnable/test2.obj test_results/runnable/test2.exe
++ '[' 1 -ge 4 ']'
++ attempt+=1
++ sleep 1
++ for true in '"$@"'
++ rm test_results/runnable/test2.obj test_results/runnable/test2.exe
++ '[' 11 -ge 4 ']'
++ return 1
+ finish 1
+ set +x
```
