### PR TITLE
fix Issue 19941 - [ICE] Segmentation fault in ImplicitConvTo::visit(AddrExp*) at dmd/dcast.d(980)

### DIFF
--- a/test/compilable/test19941.d
+++ b/test/compilable/test19941.d
@@ -1,0 +1,57 @@
+// https://issues.dlang.org/show_bug.cgi?id=19941
+
+/******************************************/
+
+immutable i4 = 42;
+const v4 = new C4;
+class C4 { int f4 = i4; }
+
+const v5 = new C5;
+immutable i5 = 42;
+class C5 { int f5 = i5; }
+
+const v6 = new C6;
+class C6 { int f6 = i6; }
+immutable i6 = 42;
+
+/******************************************/
+
+immutable i10 = 42;
+__gshared v10 = new C10;
+class C10 { int f10 = i10; }
+
+__gshared v11 = new C11;
+immutable i11 = 42;
+class C11 { int f11 = i11; }
+
+__gshared v12 = new C12;
+class C12 { int f12 = i12; }
+immutable i12 = 42;
+
+/******************************************/
+
+immutable i13 = 42;
+immutable v13 = new C13;
+class C13 { int f13 = i13; }
+
+immutable v14 = new C14;
+immutable i14 = 42;
+class C14 { int f14 = i14; }
+
+immutable v15 = new C15;
+class C15 { int f15 = i15; }
+immutable i15 = 42;
+
+/******************************************/
+
+immutable i16 = 42;
+shared v16 = new C16;
+class C16 { int f16 = i16; }
+
+shared v17 = new C17;
+immutable i17 = 42;
+class C17 { int f17 = i17; }
+
+shared v18 = new C18;
+class C18 { int f18 = i18; }
+immutable i18 = 42;

--- a/test/fail_compilation/fail19941.d
+++ b/test/fail_compilation/fail19941.d
@@ -1,0 +1,62 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19941.d(8): Error: undefined identifier `dne`
+---
+*/
+auto a = new Auto;
+class Auto { int field = &dne; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19941.d(17): Error: undefined identifier `dne`
+---
+*/
+const c = new Const;
+class Const { int field = &dne; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19941.d(26): Error: undefined identifier `dne`
+---
+*/
+enum e = new Enum;
+class Enum { int field = &dne; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19941.d(35): Error: undefined identifier `dne`
+---
+*/
+__gshared g = new Gshared;
+class Gshared { int field = &dne; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19941.d(44): Error: undefined identifier `dne`
+---
+*/
+immutable i = new Immutable;
+class Immutable { int field = &dne; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19941.d(53): Error: undefined identifier `dne`
+---
+*/
+shared s = new Shared;
+class Shared { int field = &dne; }
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail19941.d(62): Error: undefined identifier `dne`
+---
+*/
+static t = new Static;
+class Static { int field = &dne; }


### PR DESCRIPTION
`new struct` gets semantic ran on all field initializers, do the same for `new class` as well, to prevent segfaulting in a place that assumes the initializer has had semantic ran on it.