### PR TITLE
Add druntime's rt directory to the list of directories to omit in the test/tools/sanitize_json.d

### DIFF
--- a/test/tools/sanitize_json.d
+++ b/test/tools/sanitize_json.d
@@ -175,7 +175,7 @@ void sanitizeSemantics(ref JSONValue[string] semantics)
     {
         auto semanticModule = semanticModuleNode.object();
         auto moduleName = semanticModule.getOptionalString("name");
-        if(moduleName.startsWith("std.", "core.", "etc.") || moduleName == "object")
+        if(moduleName.startsWith("std.", "core.", "etc.", "rt.") || moduleName == "object")
         {
            // remove druntime/phobos modules since they can change for each
            // platform


### PR DESCRIPTION
This PR is in support of https://github.com/dlang/druntime/pull/2634

That PR  publicly imports a couple of modules from druntime's `rt` directory into `object.d`.  It causes the test https://github.com/dlang/dmd/blob/master/test/compilable/json2.d to fail because it adds those modules to the json output, but the `sanitize_json.d` tool has not been programmed to eliminate the `rt` directory like it has for `std`, `core`, and `etc`. See https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3659831&isPull=true

This PR adds `rt` to the list of directories to omit in the `santitize_json.d` tool.

This PR is required for https://github.com/dlang/druntime/pull/2634 to pass the test suite.