### PR TITLE
encapsulate CSE

### DIFF
--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -5098,12 +5098,12 @@ void assignaddrc(code *c)
 
             case FLcs:
                 sn = c.IEV1.Vuns;
-                if (!CSE_loaded(sn))            // if never loaded
+                if (!CSE.loaded(sn))            // if never loaded
                 {
                     c.Iop = NOP;
                     continue;
                 }
-                c.IEV1.Vpointer = CSE_offset(sn) + CSoff + BPoff;
+                c.IEV1.Vpointer = CSE.offset(sn) + CSoff + BPoff;
                 c.Iflags |= CFunambig;
                 goto L2;
 


### PR DESCRIPTION
This is not perfect, but it's what I mean by encapsulation:

1. global data was encapsulated and made private
2. allocation of data structures was encapsulated and made private
3. the details of the data structure, such as it being an array, are now encapsulated and made private
4. the mechanics of loops were separated from what the loop was trying to do (could go further with this and use algorithms)
5. the slot number is now semantically separated from being an array index
6. the code should be a lot easier to follow now
7. no more foreach_reverse

If I did this right, the deficiencies of the CSE storage methods (outlined at the end of cgcse.d) can be addressed without changing any file other than cgcse.d.