### PR TITLE
Fix issue 19949 - C++ Mangling: add support for abi-tags from the Itanium ABI

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -519,6 +519,13 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
         return scx;
     }
 
+    override void setScope(Scope* sc)
+    {
+        if (semanticRun < PASS.semantic)
+            sc.userAttribDecl = null; // do not propagate UDAs until semantic
+        return AttribDeclaration.setScope(sc);
+    }
+
     override const(char)* toChars() const
     {
         return toString().ptr;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -99,6 +99,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
+    void setScope(Scope *sc);
     const char *toChars();
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -670,11 +670,18 @@ private final class CppMangleVisitor : Visitor
             TypeFunction tf = cast(TypeFunction)fd.type;
 
             Strings retTypeTags;
+            // Collect abi-tags from the returns type
+            if (!fd.inuse)
             {
+                // Avoid an infinite recursion
+                // in case this function is a parent of the return type
+                ++fd.inuse;
                 OutBuffer tmp;
                 scope CppMangleVisitor v = new CppMangleVisitor(&tmp, s.loc, &retTypeTags);
                 tf.nextOf().accept(v);
+                --fd.inuse;
             }
+            // See which tags don't appear in the parameter types, and apply them
             if (retTypeTags.dim)
             {
                 Strings paramsTags;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -246,6 +246,10 @@ extern (C++) class Dsymbol : ASTNode
     // (only use this with ddoc)
     UnitTestDeclaration ddocUnittest;
 
+    // User defined "abi-tags", part of the C++ Itanium ABI name mangling.
+    // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.abi-tag
+    Strings gnuAbiTags;
+
     final extern (D) this()
     {
         //printf("Dsymbol::Dsymbol(%p)\n", this);

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -161,6 +161,7 @@ public:
     DeprecatedDeclaration *depdecl; // customized deprecation message
     UserAttributeDeclaration *userAttribDecl;   // user defined attributes
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
+    Strings gnuAbiTags;         // Used in name mangling for C++ on the Itanium ABI
 
     static Dsymbol *create(Identifier *);
     const char *toChars();

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -432,6 +432,7 @@ immutable Msgtable[] msgtable =
     { "basic_ostream" },
     { "basic_iostream" },
     { "char_traits" },
+    { "udaGNUAbiTag", "gnuAbiTag" },
 
     // Compiler recognized UDA's
     { "udaSelector", "selector" },

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -86,6 +86,8 @@ extern (C++) final class Nspace : ScopeDsymbol
             sc = sc.push(this);
             sc.linkage = LINK.cpp; // namespaces default to C++ linkage
             sc.parent = this;
+            if (semanticRun < PASS.semantic)
+                sc.userAttribDecl = null; // do not propagate until semantic
             members.foreachDsymbol(s => s.setScope(sc));
             sc.pop();
         }

--- a/test/compilable/cppmagle_abitag.d
+++ b/test/compilable/cppmagle_abitag.d
@@ -135,3 +135,11 @@ static assert(fun1.mangleof == "_Z4fun1B1CB1Dv");
 
 void fun2();
 static assert(fun2.mangleof == "_Z4fun2B1CB1Dv");
+
+auto fun3()
+{
+    @gnuAbiTag("Nested")
+    extern(C++) struct T {}
+    return T();
+}
+static assert(fun3.mangleof == "_Z4fun3B1CB1DB6Nestedv");

--- a/test/compilable/cppmagle_abitag.d
+++ b/test/compilable/cppmagle_abitag.d
@@ -1,0 +1,137 @@
+// DISABLED: win32 win64
+
+/*
+ * Test C++ abi-tag name mangling.
+ * https://issues.dlang.org/show_bug.cgi?id=19949
+ */
+
+extern(C++):
+
+alias Tuple(A...) = A;
+enum foo_bar = gnuAbiTag("foo", "bar");
+
+// UDA
+extern (D) struct gnuAbiTag
+{
+    string tag;
+    string[] tags;
+
+    @disable this();
+
+    this(string tag, string[] tags...)
+    {
+        this.tag = tag;
+        this.tags = tags;
+    }
+}
+
+@foo_bar
+struct S
+{
+    int i;
+    this(int);
+}
+
+@foo_bar
+extern __gshared int a;
+static assert(a.mangleof == "_Z1aB3barB3foo");
+
+extern __gshared S b;
+static assert(b.mangleof == "_Z1bB3barB3foo");
+
+@foo_bar
+int f();
+static assert(f.mangleof == "_Z1fB3barB3foov");
+
+S gs(int);
+S gss(S, int);
+static assert(gs.mangleof == "_Z2gsB3barB3fooi");
+static assert(gss.mangleof == "_Z3gss1SB3barB3fooi");
+
+@foo_bar
+S fss(S, int);
+static assert(gs.mangleof == "_Z2gsB3barB3fooi");
+
+T gt(T)(int);
+T gtt(T)(T, int);
+static assert(gt!S.mangleof == "_Z2gtI1SB3barB3fooET_i");
+static assert(gtt!S.mangleof == "_Z3gttI1SB3barB3fooET_S1_i");
+
+@foo_bar
+T ft(T)(int);
+// matches Clang and GCC <= 6
+static assert(ft!S.mangleof == "_Z2ftB3barB3fooI1SB3barB3fooET_i");
+
+@foo_bar
+T ftt(T)(T, int);
+// matches Clang and GCC <= 6
+static assert(ftt!S.mangleof == "_Z3fttB3barB3fooI1SB3barB3fooET_S1_i");
+
+@gnuAbiTag("AAA") @("abc")
+extern(C++, "N")
+{
+    @gnuAbiTag("foo")
+    template K(int i)
+    {
+        @gnuAbiTag("bar")
+        struct K
+        {
+            int i;
+            this(int);
+        }
+    }
+}
+
+// make sure `gnuAbiTag("AAA")` is not inherited from namespace
+static assert(__traits(getAttributes, K!0) == Tuple!("abc", gnuAbiTag("foo"), gnuAbiTag("bar")));
+
+K!i fk(int i)(int);
+K!1 fk1(int);
+static assert(fk!0.mangleof == "_Z2fkILi0EEN1N1KB3barB3fooIXT_EEEi");
+static assert(fk1.mangleof == "_Z3fk1B3AAAB3barB3fooi");
+
+extern __gshared K!10 k10;
+static assert(k10.mangleof == "_Z3k10B3AAAB3barB3foo");
+
+// GCC >= 6 only
+@gnuAbiTag("ENN")
+enum E0 { a = 0xa, }
+E0 fe();
+E0 fei(int i)();
+static assert(fe.mangleof == "_Z2feB3ENNv");
+static assert(fei!0.mangleof == "_Z3feiILi0EE2E0B3ENNv");
+
+// Linux std::string
+// https://issues.dlang.org/show_bug.cgi?id=14956#c13
+extern(C++, "std")
+{
+    struct allocator(T);
+    struct char_traits(CharT);
+
+    @gnuAbiTag("cxx11")
+    extern(C++,  "__cxx11")
+    {
+        struct basic_string(CharT, Traits=char_traits!CharT, Allocator=allocator!CharT)
+        {
+            const char* data();
+            size_t length() const;
+        }
+    }
+    alias string_ = basic_string!char;
+}
+string_* toString(const char*);
+static assert(toString.mangleof == "_Z8toStringB5cxx11PKc");
+
+@gnuAbiTag("A", "B")
+{
+    void fun0();
+    static assert(fun0.mangleof == "_Z4fun0B1AB1Bv");
+}
+
+@gnuAbiTag("C", "D"):
+
+void fun1();
+static assert(fun1.mangleof == "_Z4fun1B1CB1Dv");
+
+void fun2();
+static assert(fun2.mangleof == "_Z4fun2B1CB1Dv");

--- a/test/fail_compilation/gnuabitag.d
+++ b/test/fail_compilation/gnuabitag.d
@@ -1,0 +1,51 @@
+// DISABLED: win32 win64
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/gnuabitag.d(35): Error: `@gnuAbiTag` at least one argument expected
+fail_compilation/gnuabitag.d(38): Error: constructor `gnuabitag.gnuAbiTag.this` cannot be used because it is annotated with `@disable`
+fail_compilation/gnuabitag.d(38): Error: `this` cannot be interpreted at compile time, because it has no available source code
+fail_compilation/gnuabitag.d(41): Error: none of the overloads of `this` are callable using argument types `(string, wstring, dstring)`, candidates are:
+fail_compilation/gnuabitag.d(26):        `gnuabitag.gnuAbiTag.this()`
+fail_compilation/gnuabitag.d(28):        `gnuabitag.gnuAbiTag.this(string tag, string[] tags...)`
+fail_compilation/gnuabitag.d(44): Error: `@gnuAbiTag()` char 0x99 not allowed in mangling
+fail_compilation/gnuabitag.d(47): Error: none of the overloads of `this` are callable using argument types `(string, int, double)`, candidates are:
+fail_compilation/gnuabitag.d(26):        `gnuabitag.gnuAbiTag.this()`
+fail_compilation/gnuabitag.d(28):        `gnuabitag.gnuAbiTag.this(string tag, string[] tags...)`
+fail_compilation/gnuabitag.d(51): Error: struct `gnuabitag.F` `@gnuAbiTag()` can only apply to C++ symbols
+fail_compilation/gnuabitag.d(38): Error: `this` cannot be interpreted at compile time, because it has no available source code
+---
+*/
+
+extern (D) struct gnuAbiTag
+{
+    string tag;
+    string[] tags;
+
+    @disable this();
+
+    this(string tag, string[] tags...)
+    {
+        this.tag = tag;
+        this.tags = tags;
+    }
+}
+
+@gnuAbiTag
+extern(C++) struct A {}
+
+@gnuAbiTag()
+extern(C++) struct B {}
+
+@gnuAbiTag("a", "b"w, "c"d)
+extern(C++) struct C {}
+
+@gnuAbiTag("a\x99")
+extern(C++) struct D {}
+
+@gnuAbiTag("a", 2, 3.3)
+extern(C++) struct E {}
+
+@gnuAbiTag("a")
+struct F {}

--- a/test/runnable/cppmangle_abitag.sh
+++ b/test/runnable/cppmangle_abitag.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Posix only
+if [[ "$OS" == "win"* ]]; then
+    exit 0
+fi
+
+DVER0=_
+DVER1=_
+
+$CC --version
+
+if $CC --version | grep -Ei "clang|llvm"; then
+    dotver=$($CC --version | grep -Eio -m1 "[0-9.]+" | head -1)
+    IFS='.' read -r -a version <<< "$dotver"
+    if $CC --version | grep -Ei "apple"; then
+        # apple clang versionning is different from open source clang
+        # 8.0 matches clang 3.9 https://en.wikipedia.org/wiki/Xcode#Latest_versions
+        if [ "${version[0]:-0}" -lt 8 ]; then
+            env
+            echo Minimum Clang version 3.9 or Apple LLVM 8.0 required
+            exit 0
+        fi
+    else
+        if [ "${version[0]:-0}" -lt 3 ] || \
+           ([ "${version[0]:-0}" -eq 3 ] && [ "${version[1]:-0}" -lt 9 ]); then
+            env
+            echo Minimum Clang version 3.9 required
+            exit 0
+        fi
+    fi
+    DVER0=clang
+else
+    IFS='.' read -r -a version <<< "$($CC -dumpversion)"
+    if [ "${version[0]:-0}" -lt 5 ]; then
+        env
+        echo Minimum GCC version 5.0 required
+        exit 0
+    fi
+    if [ "${version[0]:-0}" -ge 6 ]; then
+        DVER0=gcc6
+    fi
+    if [ "${version[0]:-0}" -ge 7 ]; then
+        DVER1=gcc7
+    fi
+fi
+
+env
+
+$CC -std=c++11 -m${MODEL} -I${EXTRA_FILES} -o${OUTPUT_BASE}.cpp${OBJ} -c ${EXTRA_FILES}${SEP}${TEST_NAME}.cpp
+$DMD -m${MODEL} -I${EXTRA_FILES} -of${OUTPUT_BASE}${EXE} -version=${DVER0} -version=${DVER1} -L-lstdc++ ${OUTPUT_BASE}.cpp${OBJ} ${EXTRA_FILES}${SEP}${TEST_NAME}.d
+
+${OUTPUT_BASE}${EXE}
+
+rm_retry ${OUTPUT_BASE}.cpp${OBJ}
+rm_retry ${OUTPUT_BASE}${EXE}

--- a/test/runnable/extra-files/cppmangle_abitag.cpp
+++ b/test/runnable/extra-files/cppmangle_abitag.cpp
@@ -1,0 +1,109 @@
+/*
+ * Test C++ abi-tag name mangling.
+ * https://issues.dlang.org/show_bug.cgi?id=19949
+ */
+
+// Requires at minimum Clang 3.9 or GCC 5
+
+#define foo_bar [[gnu::abi_tag("foo", "bar")]]
+
+struct foo_bar S
+{
+public:
+    int i;
+    S(int);
+};
+
+S::S(int i) : i(i) {}
+
+foo_bar
+int a;
+
+S b(0);
+
+foo_bar
+int f() { return 0xf; }
+
+S gs(int i) { return S(i + 0xe0); }
+S gss(S s, int i) { return S(i + s.i + 0xe0); }
+
+foo_bar
+S fss(S s, int i) { return S(i + s.i + 0xf); }
+
+template <class T>
+T gt(int i) { return T(i + 0xe0); }
+
+template <class T>
+T gtt(T t, int i) { return T(i + t.i + 0xe0); }
+
+
+template <class T>
+foo_bar /* GCC is inconsistent here, <= 6 matches clang but >= 7 is different */
+T ft(int i) { return T(i + 0xf); }
+
+template <class T>
+foo_bar /* GCC is inconsistent here, <= 6 matches clang but >= 7 is different */
+T ftt(T t, int i) { return T(i + t.i + 0xf); }
+
+#ifdef __clang__
+inline namespace [[gnu::abi_tag("AAA")]] N
+#else
+inline namespace N [[gnu::abi_tag("AAA")]]
+#endif
+{
+    template <int>
+    struct [[gnu::abi_tag("foo", "bar")]] K
+    {
+    public:
+        int i;
+        K(int i);
+    };
+}
+
+template <int j>
+K<j>::K(int i) : i(i) {}
+
+template <int j>
+K<j> fk(int i) { return K<j>(i + j + 0xf); }
+
+K<1> fk1(int i) { return K<1>(i + 1 + 0xf); }
+
+K<10> k10(0);
+
+void initVars()
+{
+    a = 10;
+    b = S(20);
+    k10 = K<10>(30);
+}
+
+// doesn't compile on Clang or GCC < 6
+#if __GNUC__ >= 6
+enum [[gnu::abi_tag("ENN")]] E0
+{ E0a = 0xa };
+
+E0 fe() { return E0a; }
+
+template<int>
+E0 fei() { return E0a; }
+#endif
+
+void instatiate()
+{
+    gt<S>(1);
+    gtt<S>(S(1), 1);
+    ft<S>(1);
+    ftt<S>(S(1), 1);
+    fk<0>(1);
+#if __GNUC__ >= 6
+    fei<0>();
+#endif
+}
+
+#ifdef __linux__
+#include <string>
+std::string* toString(const char* s)
+{
+    return new std::string(s);
+}
+#endif

--- a/test/runnable/extra-files/cppmangle_abitag.d
+++ b/test/runnable/extra-files/cppmangle_abitag.d
@@ -1,0 +1,138 @@
+/*
+ * Test C++ abi-tag name mangling.
+ * https://issues.dlang.org/show_bug.cgi?id=19949
+ */
+
+extern(C++):
+
+alias Tuple(A...) = A;
+enum foo_bar = gnuAbiTag("foo", "bar");
+
+// UDA
+extern (D) struct gnuAbiTag
+{
+    string tag;
+    string[] tags;
+
+    @disable this();
+
+    this(string tag, string[] tags...)
+    {
+        this.tag = tag;
+        this.tags = tags;
+    }
+}
+
+@foo_bar
+struct S
+{
+    int i;
+}
+
+@foo_bar
+extern __gshared int a;
+
+extern __gshared S b;
+
+@foo_bar
+int f();
+
+S gs(int);
+S gss(S, int);
+
+@foo_bar
+S fss(S, int);
+
+T gt(T)(int);
+T gtt(T)(T, int);
+
+@foo_bar
+T ft(T)(int);
+
+@foo_bar
+T ftt(T)(T, int);
+
+@gnuAbiTag("AAA") @("abc")
+extern(C++, "N")
+{
+    @gnuAbiTag("foo")
+    template K(int i)
+    {
+        @gnuAbiTag("bar")
+        struct K
+        {
+            int i;
+            this(int);
+        }
+    }
+}
+
+K!i fk(int i)(int);
+K!1 fk1(int);
+
+extern __gshared K!10 k10;
+
+@gnuAbiTag("ENN")
+enum E0 { a = 0xa, }
+E0 fe();
+E0 fei(int i)();
+
+version (linux)
+{
+    // Linux std::string
+    // https://issues.dlang.org/show_bug.cgi?id=14956#c13
+    extern(C++, "std")
+    {
+        struct allocator(T);
+        struct char_traits(CharT);
+
+        @gnuAbiTag("cxx11")
+        extern(C++,  "__cxx11")
+        {
+            struct basic_string(CharT, Traits=char_traits!CharT, Allocator=allocator!CharT)
+            {
+                const char* data();
+                size_t length() const;
+            }
+        }
+        alias string_ = basic_string!char;
+    }
+    string_* toString(const char*);
+}
+
+void initVars();
+
+void main()
+{
+    initVars();
+    assert(a == 10);
+    assert(b.i == 20);
+    assert(k10.i == 30);
+
+    assert(f() == 0xf);
+    assert(gs(1).i == 1+0xe0);
+    assert(gss(S(1), 1).i == 2+0xe0);
+    assert(fss(S(1), 1).i == 2+0xf);
+    assert(gt!S(1).i == 1+0xe0);
+    assert(gtt!S(S(1), 1).i == 2+0xe0);
+version(gcc7) {}
+else
+{
+    assert(ft!S(1).i == 1+0xf);        // GCC inconsistent
+    assert(ftt!S(S(1), 1).i == 2+0xf); // GCC inconsistent
+}
+    assert(fk!0(1).i == 1+0xf);
+    assert(fk1(1).i == 2+0xf);
+version(gcc6)
+{
+    assert(fei!0() == E0.a); // GCC only
+    assert(fe() == E0.a);    // GCC only
+}
+
+version (linux)
+{
+    auto ss = toString("test013".ptr);
+    assert(ss.data()[0..ss.length()] == "test013");
+}
+
+}


### PR DESCRIPTION
Implements "abi-tags" from the Itanium ABI specification.
https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.abi-tag.

By introducing a special compile time attribute `@__gnu_abi_tag()`.

This is crucial in order to interface `std::string` and `std::list` on linux.

See: [issue 14956 (comment 13)](https://issues.dlang.org/show_bug.cgi?id=14956#c13).