### PR TITLE
Add `__traits(getTargetInfo, "allKeys")`

### DIFF
--- a/changelog/targetinfoallkeys.dd
+++ b/changelog/targetinfoallkeys.dd
@@ -1,0 +1,12 @@
+Add `__traits(getTargetInfo, "allKeys")` to query the set of targetInfo data available from the backend.
+
+This evaluates to a tuple of strings containing all keys accepted by the implementation for the current target
+and set of flags.
+
+---
+static assert([ __traits(getTargetInfo, "allKeys") ] == [ "cppRuntimeLibrary", ... ]); // not a true list
+---
+
+`getTargetInfo` keys are implementation defined, allowing relevant data for exotic targets or configurations.
+A reliable subset of which are always available, and are mentioned in the spec.
+

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -13,6 +13,7 @@
 module dmd.target;
 
 import dmd.argtypes;
+import dmd.arraytypes;
 import core.stdc.string : strlen;
 import dmd.cppmangle;
 import dmd.cppmanglewin;
@@ -767,6 +768,14 @@ struct Target
 
         switch (name.toDString) with (TargetInfoKeys)
         {
+            case "allKeys":
+            {
+                Expressions* exps = new Expressions();
+                foreach (k; __traits(allMembers, TargetInfoKeys))
+                    exps.push(new StringExp(loc, cast(char*)k.ptr));
+
+                return new TupleExp(loc, exps);
+            }
             case objectFormat.stringof:
                 if (global.params.isWindows)
                     return stringExp(global.params.mscoff ? "coff" : "omf");

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -14,6 +14,7 @@ class C19152
     }
 }
 
+static assert(is(typeof(__traits(getTargetInfo, "allKeys")[0]) == string));
 static assert(is(typeof(__traits(getTargetInfo, "cppRuntimeLibrary")) == string));
 version (CppRuntime_Microsoft)
 {


### PR DESCRIPTION
Supersedes #8763

I'm now actually getting around to adding more `getTargetInfo` keys specific to LDC, so this is useful to have. The only difference between this and #8763 is that this is not its own trait. This _will_ be added to LDC, so I hope upstream accepts it.

cc @TurkeyMan 