### PR TITLE
Add `opEquals` to `Token`

### DIFF
--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -41,6 +41,8 @@ extern (C++) struct CTFloat
   @nogc:
   @safe:
 
+    alias isNaN = .isNaN;
+
     version (GNU)
         enum yl2x_supported = false;
     else
@@ -140,12 +142,6 @@ extern (C++) struct CTFloat
         return calcHash(cast(ubyte*) &a, sz);
     }
 
-    pure
-    static bool isNaN(real_t r)
-    {
-        return !(r == r);
-    }
-
     pure @trusted
     static bool isSNaN(real_t r)
     {
@@ -229,4 +225,9 @@ extern (C++) struct CTFloat
         minusone = real_t(-1);
         half = real_t(0.5);
     }
+}
+
+bool isNaN(real_t r) pure @nogc @safe
+{
+    return !(r == r);
 }

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -709,6 +709,89 @@ extern (C++) struct Token
 
 nothrow:
 
+    /**
+     * Tests the receiver and the given value for equality.
+     *
+     * Two tokens are considered equal if they both are of the same kind
+     * (`value`) and has the same contents (where applicable). The location is
+     * not part of the equality test.
+     *
+     * Params:
+     *  rhs = the other value to test for equality
+     *
+     * Returns: `true` if the values are equal
+     */
+    bool opEquals(Token rhs) const pure nothrow @nogc
+    {
+        import dmd.root.ctfloat : isNaN;
+
+        if (value != rhs.value)
+            return false;
+
+        with (TOK) switch (value)
+        {
+            case int32Literal,
+                uns32Literal,
+                int64Literal,
+                uns64Literal,
+                charLiteral,
+                wcharLiteral,
+                dcharLiteral:
+                // unsvalue is used for signed integers and characters by the lexer
+                return unsvalue == rhs.unsvalue;
+
+            case int128Literal, uns128Literal:
+                // the lexer doesn't handle these
+                assert(false, "not implemented");
+
+            case float32Literal,
+                float64Literal,
+                float80Literal,
+                imaginary32Literal,
+                imaginary64Literal,
+                imaginary80Literal:
+                    return floatvalue == rhs.floatvalue ||
+                        floatvalue.isNaN && rhs.floatvalue.isNaN;
+
+            case string_, hexadecimalString:
+                return postfix == rhs.postfix &&
+                    ustring[0 .. len] == rhs.ustring[0 .. rhs.len];
+
+            case identifier,
+                enum_,
+                struct_,
+                import_,
+                wchar_,
+                dchar_,
+                bool_,
+                char_,
+                int8,
+                uns8,
+                int16,
+                uns16,
+                int32,
+                uns32,
+                int64,
+                uns64,
+                int128,
+                uns128,
+                float32,
+                float64,
+                float80,
+                imaginary32,
+                imaginary64,
+                imaginary80,
+                complex32,
+                complex64,
+                complex80,
+                void_:
+                    return ident is rhs.ident;
+
+            default:
+                return true;
+        }
+    }
+
     shared static this()
     {
         Identifier.initTable();

--- a/test/tools/unit_test_runner.d
+++ b/test/tools/unit_test_runner.d
@@ -228,6 +228,7 @@ void writeCmdfile(string path, string runnerPath, string outputPath,
     const string[] testFiles)
 {
     auto flags = [
+        "-debug",
         "-version=NoBackend",
         "-version=GC",
         "-version=NoMain",

--- a/test/unit/lexer/token/equality.d
+++ b/test/unit/lexer/token/equality.d
@@ -1,0 +1,450 @@
+/**
+ * Tests for Token quality.
+ *
+ * Most of the tests in this module are generated based on a description.
+ */
+module lexer.token.equality;
+
+import dmd.frontend : deinitializeDMD;
+import dmd.globals : Loc;
+import dmd.tokens : TOK;
+
+import support : afterEach;
+
+@afterEach deinitializeFrontend()
+{
+    deinitializeDMD();
+}
+
+/**
+ * Contains the necessary information to generate a unit test block.
+ *
+ * The generated test will test a single token by:
+ *
+ * * Setting up two lexers
+ * * Lex the first token in both lexers
+ * * Test the two tokens for equality
+ *
+ * Example of a generate unit test block:
+ * ---
+ * @("left parentheses, (")
+ * unittest
+ * {
+ *      assert(isFirstTokenEqual("(", ")", false));
+ * }
+ * ---
+ */
+immutable struct Test
+{
+    /**
+     * The description of the unit test.
+     *
+     * This will go into the UDA attached to the `unittest` block.
+     */
+    string description_;
+
+    /**
+     * The code for the first lexer.
+     *
+     * Optional. If the code is not provided the description will be used.
+     * Useful when the description and the code is exactly the same, i.e. for
+     * keywords.
+     */
+    string code1_ = null;
+
+    /**
+     * The code for the first lexer.
+     *
+     * Optional. If the code is not provided, `code1` will be used.
+     */
+    string code2 = null;
+
+    /**
+     * An example of the token that is tested.
+     *
+     * Optional. If the example is not provided, `code1` will be used.
+     */
+    string tokenExample = null;
+
+    /**
+     * Allow failed diagnostics.
+     *
+     * If this is `false` and the lexer reports a diagnostic, an assertion is
+     * triggered.
+     */
+    bool allowFailedDiagnostics = false;
+
+    /// Returns: the code for the first lexer
+    string code1()
+    {
+        return code1_ ? code1_ : description_;
+    }
+
+    /// Returns: the description
+    string description()
+    {
+        const example = tokenExample ? tokenExample : code1;
+
+        if (example == description_)
+            return example;
+        else
+            return description_ ~ ", " ~ example;
+    }
+}
+
+/**
+ * Contains the necessary information to generate a unit test block.
+ *
+ * The generated test will test a single token for a floating point literal of
+ * various kinds. The content of the token is `NaN`.
+ *
+ * Example of a generated unit test block:
+ * ---
+ * @("32 bit floating point literal with NaN as its content")
+ * unittest
+ * {
+ *     import dmd.tokens : Token;
+ *
+ *     Token token1 = {
+ *         value: TOK.float32Literal,
+ *         floatvalue: Token.floatvalue.nan
+ *     };
+ *
+ *     auto token2 = token1;
+ *
+ *     assert(token1 == token2);
+ * }
+ * ---
+ */
+immutable struct NaNTest
+{
+    /// The description of the test.
+    string description;
+
+    /// The kind of token (`value`).
+    TOK kind;
+}
+
+enum Test hexadecimalStringLiteral = {
+    description_: "hexadecimal string literal",
+    code1_: `x"61"`,
+    // allow failed diagnostics because this is now an error. But it's still
+    // recognized by the lexer and the lexer will create a token when this error
+    // occurs.
+    allowFailedDiagnostics: true
+};
+
+/// Tests for all different kinds of tokens.
+enum tests = [
+    Test("left parentheses", "("),
+    Test("right parentheses", ")"),
+    Test("left square bracket", "["),
+    Test("right square bracket", "]"),
+    Test("left curly brace", "{"),
+    Test("right curly brace", "{"),
+    Test("colon", ":"),
+    Test("negate", "!"),
+    Test("semicolon", ";"),
+    Test("triple dot", "..."),
+    Test("end of file", "\u001A", "\0"),
+    Test("cast"),
+    Test("null"),
+    Test("assert"),
+    Test("true"),
+    Test("false"),
+    Test("throw"),
+    Test("new"),
+    Test("delete"),
+    Test("new"),
+    Test("slice", ".."),
+    Test("version"),
+    Test("module"),
+    Test("dollar", "$"),
+    Test("template"),
+    Test("typeof"),
+    Test("pragma"),
+    Test("typeid"),
+
+    Test("less than", "<"),
+    Test("greater then", ">"),
+    Test("less then or equal", "<="),
+    Test("greater then or equal", ">="),
+    Test("equal", "=="),
+    Test("not equal", "!="),
+    Test("identify", "is"),
+    Test("not identify", "!is"),
+    Test("left shift", "<<"),
+    Test("right shift", ">>"),
+    Test("left shift assign", "<<="),
+    Test("right shift assign", ">>="),
+    Test("unsigned right shift", ">>>"),
+    Test("unsigned right shift assign", ">>>="),
+    Test("concatenate assign", "~="),
+    Test("plus", "+"),
+    Test("minus", "-"),
+    Test("plus assign", "+="),
+    Test("minus assign", "-="),
+    Test("multiply", "*"),
+    Test("divide", "/"),
+    Test("modulo", "%"),
+    Test("multiply assign", "*="),
+    Test("divide assign", "/="),
+    Test("modulo assign", "%="),
+    Test("and", "&"),
+    Test("or", "|"),
+    Test("xor", "^"),
+    Test("and assign", "&="),
+    Test("or assign", "|="),
+    Test("xor assign", "^="),
+    Test("assign", "="),
+    Test("not", "!"),
+    Test("tilde", "~"),
+    Test("plus plus", "++"),
+    Test("minus minus", "--"),
+    Test("dot", "."),
+    Test("comma", ","),
+    Test("question mark", "?"),
+    Test("and and", "&&"),
+    Test("or or", "||"),
+
+    Test("32 bit integer literal", "0"),
+    Test("32 bit unsigned integer literal", "0U"),
+    Test("64 bit integer literal", "0L"),
+    Test("64 bit unsigned integer literal", "0UL"),
+    Test("32 bit floating point literal", "0.0f"),
+    Test("64 bit floating point literal", "0.0"),
+    Test("80 bit floating point literal", "0.0L"),
+    Test("32 bit imaginary floating point literal", "0.0fi"),
+    Test("64 bit imaginary floating point literal", "0.0i"),
+    Test("80 bit imaginary floating point literal", "0.0Li"),
+
+    Test("character literal", "'a'"),
+    Test("wide character literal", "'ö'"),
+    Test("double wide character literal", "'🍺'"),
+
+    Test("identifier", "foo"),
+    Test("string literal", `"foo"`),
+    hexadecimalStringLiteral,
+    Test("this"),
+    Test("super"),
+
+    Test("void"),
+    Test("byte"),
+    Test("ubyte"),
+    Test("short"),
+    Test("ushort"),
+    Test("int"),
+    Test("uint"),
+    Test("long"),
+    Test("ulong"),
+    Test("cent"),
+    Test("ucent"),
+    Test("float"),
+    Test("double"),
+    Test("real"),
+    Test("ifloat"),
+    Test("idouble"),
+    Test("ireal"),
+    Test("cfloat"),
+    Test("cdouble"),
+    Test("creal"),
+    Test("char"),
+    Test("wchar"),
+    Test("dchar"),
+    Test("bool"),
+
+    Test("struct"),
+    Test("class"),
+    Test("interface"),
+    Test("union"),
+    Test("enum"),
+    Test("import"),
+    Test("alias"),
+    Test("override"),
+    Test("delegate"),
+    Test("function"),
+    Test("mixin"),
+    Test("align"),
+    Test("extern"),
+    Test("private"),
+    Test("protected"),
+    Test("public"),
+    Test("export"),
+    Test("static"),
+    Test("final"),
+    Test("const"),
+    Test("abstract"),
+    Test("debug"),
+    Test("deprecated"),
+    Test("in"),
+    Test("out"),
+    Test("inout"),
+    Test("lazy"),
+    Test("auto"),
+    Test("package"),
+    Test("immutable"),
+
+    Test("if"),
+    Test("else"),
+    Test("while"),
+    Test("for"),
+    Test("do"),
+    Test("switch"),
+    Test("case"),
+    Test("default"),
+    Test("break"),
+    Test("continue"),
+    Test("with"),
+    Test("synchronized"),
+    Test("return"),
+    Test("goto"),
+    Test("try"),
+    Test("catch"),
+    Test("finally"),
+    Test("asm"),
+    Test("foreach"),
+    Test("foreach_reverse"),
+    Test("scope"),
+
+    Test("invariant"),
+
+    Test("unittest"),
+
+    Test("__argTypes"),
+    Test("ref"),
+    Test("macro"),
+
+    Test("__parameters"),
+    Test("__traits"),
+    Test("__overloadset"),
+    Test("pure"),
+    Test("nothrow"),
+    Test("__gshared"),
+
+    Test("__LINE__"),
+    Test("__FILE__"),
+    Test("__FILE_FULL_PATH__"),
+    Test("__MODULE__"),
+    Test("__FUNCTION__"),
+    Test("__PRETTY_FUNCTION__"),
+
+    Test("shared"),
+    Test("at sign", "@"),
+    Test("power", "^^"),
+    Test("power assign", "^^="),
+    Test("fat arrow", "=>"),
+    Test("__vector"),
+    Test("pound", "#"),
+
+    Test("32 bit integer literal with 0 prefix", "01", "1"),
+    Test("32 bit unsigned integer literal with 0 prefix", "01U", "1U"),
+    Test("64 bit integer literal with 0 prefix", "01L", "1L"),
+    Test("64 bit unsigned integer literal with 0 prefix", "01UL", "1UL"),
+    Test("32 bit floating point literal with 0 prefix", "01.0f", "1.0f"),
+    Test("64 bit floating point literal with 0 prefix", "01.0", "1.0"),
+    Test("80 bit floating point literal with 0 prefix", "01.0L", "1.0L"),
+    Test("32 bit imaginary floating point literal with 0 prefix", "01.0fi", "1.0fi"),
+    Test("64 bit imaginary floating point literal with 0 prefix", "01.0i", "1.0i"),
+    Test("80 bit imaginary floating point literal with 0 prefix", "01.0Li", "1.0Li"),
+];
+
+static foreach (test; tests)
+{
+    @(test.description)
+    unittest
+    {
+        assert(isFirstTokenEqual(test.code1, test.code2, test.allowFailedDiagnostics));
+    }
+}
+
+/// Tests for floating point literals where the content is `NaN`.
+enum nanTests = [
+    NaNTest(
+        "32 bit floating point literal with NaN as its content",
+        TOK.float32Literal
+    ),
+
+    NaNTest(
+        "64 bit floating point literal with NaN as its content",
+        TOK.float64Literal
+    ),
+
+    NaNTest(
+        "80 bit floating point literal with NaN as its content",
+        TOK.float80Literal
+    ),
+
+    NaNTest(
+        "32 bit imaginary floating point literal with NaN as its content",
+        TOK.imaginary32Literal
+    ),
+
+    NaNTest(
+        "64 bit imaginary floating point literal with NaN as its content",
+        TOK.imaginary64Literal
+    ),
+
+    NaNTest(
+        "80 bit imaginary floating point literal with NaN as its content",
+        TOK.imaginary80Literal
+    ),
+];
+
+static foreach (test; nanTests)
+{
+    @(test.description)
+    unittest
+    {
+        import dmd.tokens : Token;
+
+        Token token1 = {
+            value: test.kind,
+            floatvalue: Token.floatvalue.nan
+        };
+
+        auto token2 = token1;
+
+        assert(token1 == token2);
+    }
+}
+
+/**
+ * Returns `true` if the first token of the two code strings are equal.
+ *
+ * This will:
+ *
+ * * Setup up two lexers
+ * * Lex the first token in both lexers
+ * * Test the two tokens for equality
+ *
+ * Params:
+ *  code1 = the code for the first lexer
+ *  code2 = the code for the second lexer
+ *  allowFailedDiagnostics = if `false` and any of the lexers generates a
+ *      diagnostic, an assertion is triggered
+ */
+bool isFirstTokenEqual(string code1, string code2, bool allowFailedDiagnostics)
+{
+    import dmd.lexer : Lexer;
+    import dmd.tokens : Token;
+    import support : CollectingDiagnosticReporter;
+
+    Token lexFirstToken(string code)
+    {
+        scope reporter = new CollectingDiagnosticReporter;
+        scope lexer = new Lexer("test", code.ptr, 0, code.length, false, true, reporter);
+        lexer.nextToken();
+
+        if (!allowFailedDiagnostics)
+            assert(reporter.diagnostics.empty, '\n' ~ reporter.diagnostics.toString);
+
+        deinitializeDMD();
+
+        return lexer.token;
+    }
+
+    if (!code2)
+        code2 = code1;
+
+    return lexFirstToken(code1) == lexFirstToken(code2);
+}

--- a/test/unit/support.d
+++ b/test/unit/support.d
@@ -91,3 +91,316 @@ class NoopDiagnosticReporter : DiagnosticReporter
     override void deprecation(const ref Loc loc, const(char)* format, va_list) {}
     override void deprecationSupplemental(const ref Loc loc, const(char)* format, va_list) {}
 }
+
+/// The severity level of a diagnostic.
+enum Severity
+{
+    /// An error occurred.
+    error,
+
+    /// A warning occurred.
+    warning,
+
+    /// A deprecation occurred.
+    deprecation,
+}
+
+/// A single diagnostic message.
+struct Diagnostic
+{
+    import dmd.globals : Loc;
+
+    /// The severity of the diagnostic.
+    const Severity severity;
+
+    /// The location of where the diagnostic occurred.
+    const Loc location;
+
+    /// The message.
+    const string message;
+
+    /// The supplemental diagnostics belonging to this diagnostic.
+    private const(Diagnostic)[] _supplementalDiagnostics;
+
+    string toString() const pure
+    {
+        import std.format : format;
+        import std.string : fromStringz;
+
+        return format!"%s: %s:%s:%s: %s%s%(%s\n%)"(
+            severity,
+            location.filename.fromStringz,
+            location.linnum,
+            location.charnum,
+            message,
+            supplementalDiagnostics.length > 0 ? "\n" : "",
+            supplementalDiagnostics
+        );
+    }
+
+pure nothrow @safe:
+
+    /// Returns: the supplemental diagnostics attached to this diagnostic.
+    const(Diagnostic[]) supplementalDiagnostics() const @nogc
+    {
+        return _supplementalDiagnostics;
+    }
+
+    /**
+     * Adds a supplemental diagnostic to this diagnostic.
+     *
+     * Params:
+     *  diagnostic = the supplemental diagnostic to add
+     */
+    private void addSupplementalDiagnostic(Diagnostic diagnostic)
+    in
+    {
+        assert(diagnostic.severity == severity);
+    }
+    body
+    {
+        _supplementalDiagnostics ~= diagnostic;
+    }
+}
+
+/// Stores a set of diagnostics.
+struct DiagnosticSet
+{
+    private Diagnostic[] _diagnostics;
+
+    string toString() const pure
+    {
+        import std.format : format;
+
+        return format!"%(%s\n%)"(_diagnostics);
+    }
+
+pure nothrow @safe:
+
+    /**
+     * Adds the given diagnostic to the set of diagnostics.
+     *
+     * Params:
+     *  diagnostic = the diagnostic to add
+     */
+    DiagnosticSet opOpAssign(string op)(Diagnostic diagnostic)
+    if (op == "~")
+    {
+        _diagnostics ~= diagnostic;
+        return this;
+    }
+
+    /// ditto
+    void add(Diagnostic diagnostic)
+    {
+        _diagnostics ~= diagnostic;
+    }
+
+    /**
+     * Adds the given supplemental diagnostic to the last added diagnostic.
+     *
+     * Params:
+     *  diagnostic = the supplemental diagnostic to add
+     */
+    void addSupplemental(Diagnostic diagnostic)
+    {
+        _diagnostics[$ - 1].addSupplementalDiagnostic(diagnostic);
+    }
+
+@nogc:
+
+    /// Returns: the diagnostic at the front of the range.
+    const(Diagnostic) front() const
+    {
+        return _diagnostics[0];
+    }
+
+    /// Advances the range forward.
+    void popFront()
+    {
+        _diagnostics = _diagnostics[1 .. $];
+    }
+
+    /// Returns: `true` if no diagnostics are stored.
+    bool empty() const
+    {
+        return _diagnostics.length == 0;
+    }
+
+    /// Returns: the number of diagnostics stored.
+    size_t length() const
+    {
+        return _diagnostics.length;
+    }
+
+    /**
+     * Returns the diagnostic stored at the given index.
+     *
+     * Params:
+     *  index = the index of the diagnostic to return
+     *
+     * Returns: the diagnostic
+     */
+    const(Diagnostic) opIndex(size_t index) const
+    {
+        return _diagnostics[index];
+    }
+}
+
+/**
+ * Collects all reported diagnostics and stores them internally.
+ *
+ * Can later be retrieved for processing.
+ */
+class CollectingDiagnosticReporter : DiagnosticReporter
+{
+    import core.stdc.stdarg : va_list;
+    import std.algorithm : count;
+
+    import dmd.globals : Loc;
+    import dmd.root.outbuffer;
+
+    /// The stored diagnostics.
+    private DiagnosticSet diagnostics_;
+
+    DiagnosticSet diagnostics()
+    {
+        return diagnostics_;
+    }
+
+    override int errorCount()
+    {
+        return countDiagnostics(Severity.error);
+    }
+
+    override int warningCount()
+    {
+        return countDiagnostics(Severity.warning);
+    }
+
+    override int deprecationCount()
+    {
+        return countDiagnostics(Severity.deprecation);
+    }
+
+    override void error(const ref Loc loc, const(char)* format, va_list args)
+    {
+        appendDiagnostic(Severity.error, loc, format, args);
+    }
+
+    override void errorSupplemental(const ref Loc loc, const(char)* format,
+        va_list args)
+    {
+        appendSupplementalDiagnostic(Severity.error, loc, format, args);
+    }
+
+    override void warning(const ref Loc loc, const(char)* format, va_list args)
+    {
+        appendDiagnostic(Severity.warning, loc, format, args);
+    }
+
+    override void warningSupplemental(const ref Loc loc, const(char)* format,
+        va_list args)
+    {
+        appendSupplementalDiagnostic(Severity.warning, loc, format, args);
+    }
+
+    override void deprecation(const ref Loc loc, const(char)* format,
+        va_list args)
+    {
+        appendDiagnostic(Severity.deprecation, loc, format, args);
+    }
+
+    override void deprecationSupplemental(
+        const ref Loc loc,
+        const(char)* format,
+        va_list args
+    )
+    {
+        appendSupplementalDiagnostic(Severity.deprecation, loc, format, args);
+    }
+
+nothrow:
+
+    /**
+     * Returns the number of diagnostics stored for the given severity.
+     *
+     * Params:
+     *  severity = the severity to count
+     *
+     * Returns: the number of diagnostics
+     */
+    private int countDiagnostics(Severity severity) /*const*/
+    {
+        return cast(int) diagnostics_.count!(e => e.severity == severity);
+    }
+
+    /**
+     * Creates and appends a diagnostic.
+     *
+     * Params:
+     *  severity = the severity of the diagnostic
+     *  loc = the location of the diagnostic
+     *  format = the format string for the diagnostic message
+     *  args = the args for the diagnostic message
+     */
+    private void appendDiagnostic(
+        Severity severity,
+        const ref Loc loc,
+        const(char)* format,
+        va_list args
+    )
+    {
+        diagnostics_ ~= createDiagnostic(severity, loc, format, args);
+    }
+
+    /**
+     * Creates and appends a supplemental diagnostic.
+     *
+     * Params:
+     *  severity = the severity of the diagnostic
+     *  loc = the location of the diagnostic
+     *  format = the format string for the diagnostic message
+     *  args = the args for the diagnostic message
+     */
+    private void appendSupplementalDiagnostic(
+        Severity severity,
+        const ref Loc loc,
+        const(char)* format,
+        va_list args
+    )
+    {
+        const diagnostic = createDiagnostic(severity, loc, format, args);
+        diagnostics_.addSupplemental(diagnostic);
+    }
+
+    /**
+     * Creates a diagnostic.
+     *
+     * Params:
+     *  severity = the severity of the diagnostic
+     *  loc = the location of the diagnostic
+     *  format = the format string for the diagnostic message
+     *  args = the args for the diagnostic message
+     *
+     * Returns: the newly created diagnostic
+     */
+    private Diagnostic createDiagnostic(
+        Severity severity,
+        const ref Loc loc,
+        const(char)* format,
+        va_list args
+    ) const
+    {
+        OutBuffer buffer;
+        buffer.vprintf(format, args);
+
+        Diagnostic diagnostic = {
+            severity: Severity.error,
+            location: loc,
+            message: cast(string) buffer.extractSlice
+        };
+
+        return diagnostic;
+    }
+}


### PR DESCRIPTION
This allows to test two tokens for equality. It will include the kind of token (`value`) and the contents of the token (where applicable). The location will not be included in the equality.

Extracted from: https://github.com/dlang/dmd/pull/9963.