### PR TITLE
Refactor mangle-only `extern(C++, namespace)` into an AttribDeclaration

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -140,6 +140,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         sc2.explicitProtection = 0;
         sc2.aligndecl = null;
         sc2.userAttribDecl = null;
+        sc2.namespace = null;
         return sc2;
     }
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1173,22 +1173,16 @@ struct ASTBase
     extern (C++) final class Nspace : ScopeDsymbol
     {
         /**
-         * Determines whether the symbol for this namespace should be included in the symbol table.
-         */
-        bool mangleOnly;
-
-        /**
          * Namespace identifier resolved during semantic.
          */
         Expression identExp;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
+        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
         {
             super(ident);
             this.loc = loc;
             this.members = members;
             this.identExp = identExp;
-            this.mangleOnly = mangleOnly;
         }
 
         override void accept(Visitor v)
@@ -1304,6 +1298,28 @@ struct ASTBase
         {
             super(decl);
             cppmangle = p;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
+    {
+        Expression exp;
+
+        extern (D) this(Identifier ident, Dsymbols* decl)
+        {
+            super(decl);
+            this.ident = ident;
+        }
+
+        extern (D) this(Expression exp, Dsymbols* decl)
+        {
+            super(decl);
+            this.exp = exp;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -453,6 +453,66 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
 
 /***********************************************************
  */
+extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
+{
+    Expression exp;
+
+    extern (D) this(Identifier ident, Dsymbols* decl)
+    {
+        super(decl);
+        this.ident = ident;
+    }
+
+    extern (D) this(Expression exp, Dsymbols* decl)
+    {
+        super(decl);
+        this.exp = exp;
+    }
+
+    extern (D) this(Identifier ident, Expression exp, Dsymbols* decl,
+                    CPPNamespaceDeclaration parent)
+    {
+        super(decl);
+        this.ident = ident;
+        this.exp = exp;
+        this.namespace = parent;
+    }
+
+    override Dsymbol syntaxCopy(Dsymbol s)
+    {
+        assert(!s);
+        return new CPPNamespaceDeclaration(
+            this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.namespace);
+    }
+
+    override Scope* newScope(Scope* sc)
+    {
+        auto scx = sc.copy();
+        scx.linkage = LINK.cpp;
+        scx.namespace = this;
+        return scx;
+    }
+
+    override const(char)* toChars() const
+    {
+        return toString().ptr;
+    }
+
+    extern(D) override const(char)[] toString() const
+    {
+        return "extern (C++, `namespace`)";
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+
+    override inout(CPPNamespaceDeclaration) isCPPNamespaceDeclaration() inout { return this; }
+}
+
+/***********************************************************
+ */
 extern (C++) final class ProtDeclaration : AttribDeclaration
 {
     Prot protection;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -92,6 +92,17 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+class CPPNamespaceDeclaration : public AttribDeclaration
+{
+public:
+    Expression *exp;
+
+    Dsymbol *syntaxCopy(Dsymbol *s);
+    Scope *newScope(Scope *sc);
+    const char *toChars();
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class ProtDeclaration : public AttribDeclaration
 {
 public:

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1043,6 +1043,9 @@ private:
         while (p && !p.isModule())
         {
             mangleName(p, dont_use_back_reference);
+            // Mangle our string namespaces as well
+            for (auto ns = p.namespace; ns !is null; ns = ns.namespace)
+                mangleName(ns, dont_use_back_reference);
             p = p.toParent3();
             if (p.toParent3() && p.toParent3().isTemplateInstance())
             {

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -15,6 +15,7 @@ module dmd.dscope;
 import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
+import dmd.arraytypes;
 import dmd.attrib;
 import dmd.ctorflow;
 import dmd.dclass;
@@ -99,6 +100,9 @@ struct Scope
 
     /// alignment for struct members
     AlignDeclaration aligndecl;
+
+    /// C++ namespace this symbol is in
+    CPPNamespaceDeclaration namespace;
 
     /// linkage for external functions
     LINK linkage = LINK.d;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -228,6 +228,8 @@ extern (C++) class Dsymbol : ASTNode
 {
     Identifier ident;
     Dsymbol parent;
+    /// C++ namespace this symbol belongs to
+    CPPNamespaceDeclaration namespace;
     Symbol* csym;           // symbol for code generator
     Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
@@ -447,16 +449,7 @@ extern (C++) class Dsymbol : ASTNode
     }
 
     /// ditto
-    final inout(Dsymbol) pastMixinAndNspace() inout
-    {
-        //printf("Dsymbol::pastMixin() %s\n", toChars());
-        auto nspace = isNspace();
-        if (!(nspace && nspace.mangleOnly) && !isTemplateMixin() && !isForwardingAttribDeclaration())
-            return this;
-        if (!parent)
-            return null;
-        return parent.pastMixinAndNspace();
-    }
+    alias pastMixinAndNspace = pastMixin;
 
     /**********************************
      * `parent` field returns a lexically enclosing scope symbol this is a member of.
@@ -1187,6 +1180,7 @@ extern (C++) class Dsymbol : ASTNode
     inout(SymbolDeclaration)           isSymbolDeclaration()           inout { return null; }
     inout(AttribDeclaration)           isAttribDeclaration()           inout { return null; }
     inout(AnonDeclaration)             isAnonDeclaration()             inout { return null; }
+    inout(CPPNamespaceDeclaration)     isCPPNamespaceDeclaration()     inout { return null; }
     inout(ProtDeclaration)             isProtDeclaration()             inout { return null; }
     inout(OverloadSet)                 isOverloadSet()                 inout { return null; }
     inout(CompileDeclaration)          isCompileDeclaration()          inout { return null; }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -16,6 +16,7 @@
 #include "arraytypes.h"
 #include "visitor.h"
 
+class CPPNamespaceDeclaration;
 class Identifier;
 struct Scope;
 class DsymbolTable;
@@ -147,6 +148,8 @@ class Dsymbol : public ASTNode
 public:
     Identifier *ident;
     Dsymbol *parent;
+    /// C++ namespace this symbol belongs to
+    CPPNamespaceDeclaration *namespace_;
     Symbol *csym;               // symbol for code generator
     Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -776,6 +776,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.error("extern symbols cannot have initializers");
 
         dsym.userAttribDecl = sc.userAttribDecl;
+        dsym.namespace = sc.namespace;
 
         AggregateDeclaration ad = dsym.isThis();
         if (ad)
@@ -2107,6 +2108,64 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         attribSemantic(cd);
     }
 
+    override void visit(CPPNamespaceDeclaration ns)
+    {
+        Identifier identFromSE (StringExp se)
+        {
+            const sident = se.toStringz();
+            if (!sident.length || !Identifier.isValidIdentifier(sident))
+            {
+                ns.exp.error("expected valid identifer for C++ namespace but got `%.*s`",
+                             cast(int)sident.length, sident.ptr);
+                return null;
+            }
+            else
+                return Identifier.idPool(sident);
+        }
+
+        if (ns.ident is null)
+        {
+            ns.namespace = sc.namespace;
+            sc = sc.startCTFE();
+            ns.exp = ns.exp.expressionSemantic(sc);
+            ns.exp = resolveProperties(sc, ns.exp);
+            sc = sc.endCTFE();
+            ns.exp = ns.exp.ctfeInterpret();
+            // Can be either a tuple of strings or a string itself
+            if (auto te = ns.exp.isTupleExp())
+            {
+                expandTuples(te.exps);
+                CPPNamespaceDeclaration current = ns.namespace;
+                for (size_t d = 0; d < te.exps.dim; ++d)
+                {
+                    auto exp = (*te.exps)[d];
+                    auto prev = d ? current : ns.namespace;
+                    current = (d + 1) != te.exps.dim
+                        ? new CPPNamespaceDeclaration(exp, null)
+                        : ns;
+                    current.exp = exp;
+                    current.namespace = prev;
+                    if (auto se = exp.toStringExp())
+                    {
+                        current.ident = identFromSE(se);
+                        if (current.ident is null)
+                            return; // An error happened in `identFromSE`
+                    }
+                    else
+                        ns.exp.error("`%s`: index %d is not a string constant, it is a `%s`",
+                                     ns.exp.toChars(), d, ns.exp.type.toChars());
+                }
+            }
+            else if (auto se = ns.exp.toStringExp())
+                ns.ident = identFromSE(se);
+            else
+                ns.exp.error("compile time string constant (or tuple) expected, not `%s`",
+                             ns.exp.toChars());
+        }
+        if (ns.ident)
+            attribSemantic(ns);
+    }
+
     override void visit(UserAttributeDeclaration uad)
     {
         //printf("UserAttributeDeclaration::semantic() %p\n", this);
@@ -2629,6 +2688,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         tempdecl.parent = sc.parent;
         tempdecl.protection = sc.protection;
+        tempdecl.namespace = sc.namespace;
         tempdecl.isstatic = tempdecl.toParent().isModule() || (tempdecl._scope.stc & STC.static_);
 
         if (!tempdecl.isstatic)
@@ -3020,7 +3080,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     else
                     {
                         // insert the new namespace
-                        Nspace childns = new Nspace(ns.loc, Identifier.idPool(ident), null, parentns.members, ns.mangleOnly);
+                        Nspace childns = new Nspace(ns.loc, Identifier.idPool(ident), null, parentns.members);
                         parentns.members = new Dsymbols;
                         parentns.members.push(childns);
                         parentns = childns;
@@ -3103,6 +3163,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc || funcdecl.errors)
             return;
 
+        funcdecl.namespace = sc.namespace;
         funcdecl.parent = sc.parent;
         Dsymbol parent = funcdecl.toParent();
 
@@ -4541,6 +4602,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 sd.classKind = ClassKind.cpp;
+            sd.namespace = sc.namespace;
         }
         else if (sd.symtab && !scx)
             return;
@@ -4760,6 +4822,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 cldec.classKind = ClassKind.cpp;
+            cldec.namespace = sc.namespace;
             if (sc.linkage == LINK.objc)
                 objc.setObjc(cldec);
         }
@@ -5478,6 +5541,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
+            idec.namespace = sc.namespace;
 
             if (sc.linkage == LINK.objc)
             {
@@ -5768,6 +5832,9 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     tempinst.hasNestedArgs(tempinst.tiargs, tempdecl.isstatic);
     if (tempinst.errors)
         goto Lerror;
+
+    // Copy the tempdecl namespace (not the scope one)
+    tempinst.namespace = tempdecl.namespace;
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -376,6 +376,8 @@ extern (C++) class FuncDeclaration : Declaration
                 return false;
         }
 
+        this.namespace = _scope.namespace;
+
         // if inferring return type, sematic3 needs to be run
         // - When the function body contains any errors, we cannot assume
         //   the inferred return type is valid.

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -32,36 +32,27 @@ private enum LOG = false;
 extern (C++) final class Nspace : ScopeDsymbol
 {
     /**
-     * Determines whether the symbol for this namespace should be included in the symbol table.
-     */
-    bool mangleOnly;
-
-    /**
      * Namespace identifier resolved during semantic.
      */
     Expression identExp;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
+    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
     {
         super(loc, ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());
         this.members = members;
         this.identExp = identExp;
-        this.mangleOnly = mangleOnly;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
-        auto ns = new Nspace(loc, ident, identExp, null, mangleOnly);
+        auto ns = new Nspace(loc, ident, identExp, null);
         return ScopeDsymbol.syntaxCopy(ns);
     }
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        if (mangleOnly)
-            parent = sds;
-        else
-            ScopeDsymbol.addMember(sc, sds);
+        ScopeDsymbol.addMember(sc, sds);
 
         if (members)
         {
@@ -81,7 +72,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             sc = sc.push(this);
             sc.linkage = LINK.cpp; // namespaces default to C++ linkage
             sc.parent = this;
-            members.foreachDsymbol(s => s.addMember(sc, mangleOnly ? sds : this));
+            members.foreachDsymbol(s => s.addMember(sc, this));
             sc.pop();
         }
     }

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -19,7 +19,6 @@
 class Nspace : public ScopeDsymbol
 {
   public:
-    bool mangleOnly;
     Expression *identExp;
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -950,7 +950,10 @@ final class Parser(AST) : Lexer
                                 a = new AST.Dsymbols();
                                 a.push(s);
                             }
-                            s = new AST.Nspace(linkLoc, id, null, a, cppMangleOnly);
+                            if (cppMangleOnly)
+                                s = new AST.CPPNamespaceDeclaration(id, a);
+                            else
+                                s = new AST.Nspace(linkLoc, id, null, a);
                         }
                         pAttrs.link = LINK.default_;
                     }
@@ -966,7 +969,10 @@ final class Parser(AST) : Lexer
                                 a = new AST.Dsymbols();
                                 a.push(s);
                             }
-                            s = new AST.Nspace(linkLoc, null, exp, a, cppMangleOnly);
+                            if (cppMangleOnly)
+                                s = new AST.CPPNamespaceDeclaration(exp, a);
+                            else
+                                s = new AST.Nspace(linkLoc, null, exp, a);
                         }
                         pAttrs.link = LINK.default_;
                     }

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -68,6 +68,7 @@ public:
     void visit(AST.AnonDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.AlignDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.CPPMangleDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
+    void visit(AST.CPPNamespaceDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.ProtDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.PragmaDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.StorageClassDeclaration s) { visit(cast(AST.AttribDeclaration)s); }

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -24,6 +24,7 @@ class UserAttributeDeclaration;
 struct DocComment;
 struct AA;
 class TemplateInstance;
+class CPPNamespaceDeclaration;
 
 #include "dsymbol.h"
 
@@ -90,6 +91,9 @@ struct Scope
     size_t fieldinit_dim;
 
     AlignDeclaration *aligndecl;    // alignment for struct members
+
+    /// C++ namespace this symbol belongs to
+    CPPNamespaceDeclaration *namespace_;
 
     LINK linkage;               // linkage for external functions
     CPPMANGLE cppmangle;        // C++ mangle type

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -99,6 +99,7 @@ class StorageClassDeclaration;
 class DeprecatedDeclaration;
 class LinkDeclaration;
 class CPPMangleDeclaration;
+class CPPNamespaceDeclaration;
 class ProtDeclaration;
 class AlignDeclaration;
 class AnonDeclaration;
@@ -358,6 +359,7 @@ public:
     virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(CPPNamespaceDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(PragmaDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1,4 +1,8 @@
-
+/**
+TEST_OUTPUT:
+---
+---
+*/
 // Test C++ name mangling.
 // https://issues.dlang.org/show_bug.cgi?id=4059
 // https://issues.dlang.org/show_bug.cgi?id=5148

--- a/test/compilable/cppmangle3.d
+++ b/test/compilable/cppmangle3.d
@@ -1,3 +1,8 @@
+/**
+TEST_OUTPUT:
+---
+---
+*/
 module cppmangle3;
 
 

--- a/test/fail_compilation/cppmangle.d
+++ b/test/fail_compilation/cppmangle.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/cppmangle.d(11): Error: expected valid identifer for C++ namespace but got ``
 fail_compilation/cppmangle.d(15): Error: expected valid identifer for C++ namespace but got `0num`
-fail_compilation/cppmangle.d(19): Error: expected string expression for namespace name, got `1 + 1`
+fail_compilation/cppmangle.d(19): Error: compile time string constant (or tuple) expected, not `2`
 fail_compilation/cppmangle.d(23): Error: expected valid identifer for C++ namespace but got `invalid@namespace`
 ---
 */

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -19,6 +19,10 @@ struct S
 
 extern(C++, std)
 {
+    struct test19248_ {int a = 42;}
+}
+extern(C++, `std`)
+{
     struct test19248 {int a = 34;}
 }
 
@@ -38,7 +42,8 @@ ulong  passthrough(ulong  value);
 float  passthrough(float  value);
 double passthrough(double value);
 S      passthrough(S      value);
-std.test19248 passthrough(const(std.test19248) value);
+test19248 passthrough(const(test19248) value);
+std.test19248_ passthrough(const(std.test19248_) value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -56,7 +61,8 @@ ulong  passthrough_ptr(ulong  *value);
 float  passthrough_ptr(float  *value);
 double passthrough_ptr(double *value);
 S      passthrough_ptr(S      *value);
-std.test19248 passthrough_ptr(const(std.test19248)* value);
+test19248 passthrough_ptr(const(test19248)* value);
+std.test19248_ passthrough_ptr(const(std.test19248_)* value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -74,7 +80,8 @@ ulong  passthrough_ref(ref ulong  value);
 float  passthrough_ref(ref float  value);
 double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
-std.test19248 passthrough_ref(ref const(std.test19248) value);
+test19248 passthrough_ref(ref const(test19248) value);
+std.test19248_ passthrough_ref(ref const(std.test19248_) value);
 }
 
 template IsSigned(T)
@@ -215,7 +222,8 @@ else
     foreach(float val; values!float())   check(val);
     foreach(double val; values!double()) check(val);
     check(S());
-    check(std.test19248());
+    check(test19248());
+    check(std.test19248_());
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -6,7 +6,8 @@ struct S{
 
 namespace std
 {
-    struct test19248 {int a;};
+    struct test19248_ {int a;}; // Remove when `extern(C++, ns)` is gone
+    struct test19248  {int a;};
 };
 
 #ifdef __DMC__
@@ -36,7 +37,8 @@ unsigned long long passthrough(unsigned long long  value)     { return value; }
 float              passthrough(float               value)     { return value; }
 double             passthrough(double              value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
-std::test19248     passthrough(const std::test19248 value)     { return value; }
+std::test19248     passthrough(const std::test19248 value)    { return value; }
+std::test19248_    passthrough(const std::test19248_ value)   { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -59,6 +61,7 @@ float              passthrough_ptr(float              *value) { return *value; }
 double             passthrough_ptr(double             *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
 std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
+std::test19248_    passthrough_ptr(const std::test19248_ *value) { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -81,6 +84,7 @@ float              passthrough_ref(float              &value) { return value; }
 double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
+std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
 
 namespace ns1
 {


### PR DESCRIPTION
```
Originally, `extern(C++, ident)` was implemented as introducing a scope,
importing C++ semantics into D, and was made a `ScopeDsymbol`.
Introducing a scope turned out to be a behavior that was problematic,
and users of `extern(C++)` just wanted to use D semantics and have the correct mangling.

Later on, `extern(C++, "namespace")` was implemented, which removed the introduction of a scope.
However, it was implemented within the existing `Nspace`,
basically hacking around the fact that `ScopeDsymbol` introduces a scope
and injecting the symbols in the parent scope.

This commit implements a new AST node, `CPPNamespaceDeclaration`, which is an `AttributeDeclaration`.
`AttributeDeclaration` are the way storage classes (e.g. `extern(C)` and `extern(C++, class|struct)` are implemented,
as well as declarations that apply to a scope without introducing one, such as `DeprecatedDeclaration`.

Since mangling is part of the function's external interface,
CTFE on the message is run during the first semantic pass.
Since `_scope` is set earlier than `semantic` is done on the attribute,
the full `CPPNamespaceDeclaration` needs to be stored in the `Scope`,
not just the resolved `Identifiers`.

Moreover, a few tweaks are required to `cppmangle` to make it work with the new AST structure.
Once the scoped version of `extern(C++, namespace)` is deprecated, the code can be greatly simplified.
```

Over the past two weeks I tried two things:
- To fix https://github.com/dlang/dmd/pull/9912#issuecomment-497696403
- To deprecate the scoped version of `extern(C++, namespace)`

After much trial and error, I came up with the explanation mentioned above.
This will fail the CI for now as I haven't tried it on Windows yet.
I can split a few changes in separate PRs, but the bulk of it is indissociable.

CC @TurkeyMan 