### PR TITLE
Fix Issue 519 - Invariant not called from autogenerated class/struct constructor/destructor

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -970,6 +970,12 @@ DtorDeclaration buildDtor(AggregateDeclaration ad, Scope* sc)
     switch (ad.dtors.dim)
     {
     case 0:
+        /* If running invariant, need a destructor to hang it on,
+         * but only do for root modules, as ones in the library may not
+         * have been compiled with useInvariants
+         */
+        if (global.params.useInvariants && ad.inv && sc._module.isRoot())
+            goto default;
         break;
 
     case 1:

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4611,6 +4611,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
          */
         sd.aggNew = cast(NewDeclaration)sd.search(Loc.initial, Id.classNew);
         sd.aggDelete = cast(DeleteDeclaration)sd.search(Loc.initial, Id.classDelete);
+        sd.inv = buildInv(sd, sc2);
+        if (sd.inv)
+            reinforceInvariant(sd, sc2);
 
         // Look for the constructor
         sd.ctor = sd.searchCtor();
@@ -4629,10 +4632,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sd.xcmp = buildXopCmp(sd, sc2);
             sd.xhash = buildXtoHash(sd, sc2);
         }
-
-        sd.inv = buildInv(sd, sc2);
-        if (sd.inv)
-            reinforceInvariant(sd, sc2);
 
         Module.dprogress++;
         sd.semanticRun = PASS.semanticdone;
@@ -5207,6 +5206,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         // Can be in base class
         cldec.aggNew = cast(NewDeclaration)cldec.search(Loc.initial, Id.classNew);
         cldec.aggDelete = cast(DeleteDeclaration)cldec.search(Loc.initial, Id.classDelete);
+        cldec.inv = buildInv(cldec, sc2);
+        if (cldec.inv)
+            reinforceInvariant(cldec, sc2);
 
         // Look for the constructor
         cldec.ctor = cldec.searchCtor();
@@ -5279,10 +5281,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (!(f.storage_class & STC.disable))
                 cldec.error(f.loc, "identity assignment operator overload is illegal");
         }
-
-        cldec.inv = buildInv(cldec, sc2);
-        if (cldec.inv)
-            reinforceInvariant(cldec, sc2);
 
         Module.dprogress++;
         cldec.semanticRun = PASS.semanticdone;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -5814,6 +5814,18 @@ private elem *toElemStructLit(StructLiteralExp sle, IRState *irs, TOK op, Symbol
         e = el_combine(e, e2);
     }
 
+    if (global.params.useInvariants && sle.sd.inv)
+    {
+        /* Should only call invariant if this is not a default initialization of the struct.
+         */
+        if (!sle.isDefaultStructInitializerExp)
+        {
+            FuncDeclaration inv = sle.sd.inv;
+            elem *einv = callfunc(sle.loc, irs, 1, inv.type.nextOf(), el_ptr(stmp), sle.sd.type.pointerTo(), inv, inv.type, null, null);
+            e = el_combine(e, einv);
+        }
+    }
+
     elem *ev = el_var(stmp);
     ev.ET = Type_toCtype(sle.sd.type);
     e = el_combine(e, ev);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3074,6 +3074,7 @@ extern (C++) final class StructLiteralExp : Expression
     int stageflags;
 
     bool useStaticInit;     /// if this is true, use the StructDeclaration's init symbol
+    bool isDefaultStructInitializerExp;
     OwnedBy ownedByCtfe = OwnedBy.code;
 
     extern (D) this(const ref Loc loc, StructDeclaration sd, Expressions* elements, Type stype = null)
@@ -3083,6 +3084,8 @@ extern (C++) final class StructLiteralExp : Expression
         if (!elements)
             elements = new Expressions();
         this.elements = elements;
+        if (elements.dim == 0)
+            isDefaultStructInitializerExp = true;
         this.stype = stype;
         this.origin = this;
         //printf("StructLiteralExp::StructLiteralExp(%s)\n", toChars());

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -464,6 +464,7 @@ public:
     int stageflags;
 
     bool useStaticInit;         // if this is true, use the StructDeclaration's init symbol
+    bool isDefaultStructInitializerExp;
     OwnedBy ownedByCtfe;
 
     static StructLiteralExp *create(Loc loc, StructDeclaration *sd, void *elements, Type *stype = NULL);

--- a/test/runnable/test19731.d
+++ b/test/runnable/test19731.d
@@ -45,6 +45,8 @@ void main()
         }
         catch(AssertError)
         {
+            foo.obj_ = new Object();
+            foo2.obj_ = new Object();
             return;
         }
         assert(0);

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -815,10 +815,12 @@ class Parent40{
 
         invariant()
         {
-                assert(!checked40);
+            if(!checked40)
+            {
                 checked40=true;
                 // even number
                 assert((x&1u)==0);
+            }
         }
 }
 

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -25,6 +25,85 @@ int testinvariant()
     return 0;
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=519
+class C519
+{
+    invariant
+    {
+        printf("C519.invariant\n");
+        ++x;
+    }
+    __gshared int x;
+}
+
+struct S519
+{
+    invariant()
+    {
+        printf("S519.invariant\n");
+        ++x;
+    }
+    __gshared int x;
+}
+
+struct S519c
+{
+    invariant()
+    {
+        printf("S519c.invariant\n");
+        ++x;
+    }
+    __gshared int x;
+    int y;
+}
+
+void test519()
+{
+    //printf("test1\n");
+    {
+        auto foo = new C519();
+        assert(C519.x == 0);
+        printf("lifetime of foo\n");
+        destroy(foo);
+        assert(C519.x == 1);
+    }
+    {
+        scope auto foo = new C519();
+        assert(C519.x == 1);
+        printf("lifetime of foo\n");
+    }
+    assert(C519.x == 2);
+
+    //printf("test2\n");
+    {
+        auto foo = new S519();
+        printf("%d\n", S519.x);
+        assert(S519.x == 0);
+        printf("lifetime of foo\n");
+        destroy(*foo);
+        assert(S519.x == 1);
+    }
+    {
+        auto foo = S519();
+        assert(S519.x == 1);
+        printf("lifetime of foo\n");
+    }
+    assert(S519.x == 2);
+
+    //printf("test3\n");
+    {
+        auto foo = new S519c(1);
+        assert(S519c.x == 1);
+        printf("lifetime of foo\n");
+    }
+    {
+        auto foo = S519c(1);
+        assert(S519c.x == 2);
+        printf("lifetime of foo\n");
+    }
+    assert(S519c.x == 3);
+}
+
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6453
 
@@ -182,6 +261,7 @@ void test13147()
 void main()
 {
     testinvariant();
+    test519();
     test6453();
     test13113();
     test13147();


### PR DESCRIPTION
Rebase of https://github.com/dlang/dmd/pull/7536 . I added a few modifications:

   - in the original pull request, when the call to the invariant was introduced for StructLiteralExp the case where a default struct constructor was used had to be excluded; this was done by checking the length of the array of arguments that was passed to the struct literal (in e2ir.d), however by that point the default struct initializer was already lowered to a StructLiteral call with default values as arguments for the fields of the struct; the tests did not catch this bug because only structs with 0 members were used with default struct constructors.

  - I modified a test (runnable/test19731.d) because before this patch the invariant was not called when an object had to be destroyed, while after it is called before destruction. A deprecation cannot be issued; this is silent change of code behavior.

cc @ibuclaw @WalterBright  