### PR TITLE
Rvalue ref arg

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -719,6 +719,8 @@ dmd -cov -unittest myprog.d
             "fix integral promotions for unary + - ~ operators"),
         Feature("dtorfields", "dtorFields",
             "destruct fields of partially constructed objects"),
+        Feature("rvaluerefparam", "rvalueRefParam",
+            "enable rvalue arguments to ref parameters"),
     ];
 }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -168,6 +168,7 @@ struct Param
     bool dtorFields;        // destruct fields of partially constructed objects
                             // https://issues.dlang.org/show_bug.cgi?id=14246
     bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
+    bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
 
     CppStdRevision cplusplus = CppStdRevision.cpp98;    // version of C++ standard to support
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -147,6 +147,7 @@ struct Param
     bool dtorFields;        // destruct fields of partially constructed objects
                             // https://issues.dlang.org/show_bug.cgi?id=14246
     bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
+    bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
     CppStdRevision cplusplus;  // version of C++ name mangling to support
     bool markdown;          // enable Markdown replacements in Ddoc
     bool vmarkdown;         // list instances of Markdown replacements in Ddoc

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4782,7 +4782,7 @@ extern (C++) final class TypeFunction : TypeNext
                             }
                         }
                         else if (!global.params.rvalueRefParam ||
-                                 p.storageClass & STC.ref_ ||
+                                 !(p.storageClass & STC.ref_) ||
                                  !arg.type.isCopyable())  // can't copy to temp for ref parameter
                         {
                             if (pMessage) *pMessage = getParamError(arg, p);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4782,7 +4782,7 @@ extern (C++) final class TypeFunction : TypeNext
                             }
                         }
                         else if (!global.params.rvalueRefParam ||
-                                 p.storageClass & STC.out_ ||
+                                 p.storageClass & STC.ref_ ||
                                  !arg.type.isCopyable())  // can't copy to temp for ref parameter
                         {
                             if (pMessage) *pMessage = getParamError(arg, p);

--- a/test/compilable/rvalueref.d
+++ b/test/compilable/rvalueref.d
@@ -1,0 +1,13 @@
+/* REQUIRED_ARGS: -preview=rvaluerefparam
+ */
+
+struct AS
+{
+    string get() @safe @nogc pure nothrow { return _s; }
+    alias get this;
+    @disable this(this);
+    string _s;
+}
+
+void popFront(ref string) { }
+static assert(!is(typeof((R r) => r.popFront)));

--- a/test/fail_compilation/ice8255.d
+++ b/test/fail_compilation/ice8255.d
@@ -1,11 +1,12 @@
 /*
+REQUIRED_ARGS: -preview=rvaluerefparam
 TEST_OUTPUT:
 ---
-fail_compilation/ice8255.d(11): Error: function `ice8255.F!(G).F.f(ref G _param_0)` is not callable using argument types `(G)`
-fail_compilation/ice8255.d(11):        cannot pass rvalue argument `G()` of type `G` to parameter `ref G _param_0`
-fail_compilation/ice8255.d(11):        while evaluating `pragma(msg, F().f(G()))`
+fail_compilation/ice8255.d(12): Error: Cannot pass argument `F().f(((G __rvalue2 = G();) , __rvalue2))` to `pragma msg` because it is `void`
 ---
 */
+
+
 struct G {}
 struct F(T) { void f(ref T) {} }
 pragma(msg, F!G().f(G.init));

--- a/test/runnable/overload.d
+++ b/test/runnable/overload.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -preview=rvaluerefparam
 // EXTRA_SOURCES: imports/ovs1528a.d imports/ovs1528b.d
 // EXTRA_SOURCES: imports/template_ovs1.d imports/template_ovs2.d imports/template_ovs3.d
 
@@ -470,7 +471,13 @@ void test9410()
 {
     S s;
     assert(foo(1, s  ) == 1); // works fine. Print: ref
-    assert(foo(1, S()) == 2); // Fails with: Error: S() is not an lvalue
+
+    /* With the rvalue to ref param change, this calls the 'ref' version
+     * because both are the same match level, but the 'ref' version is
+     * considered "more specialized", as the non-ref version undergoes
+     * a "conversion" to call the ref version.
+     */
+    assert(foo(1, S()) == 1);
 }
 
 /***************************************************/

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -325,9 +325,9 @@ int waz14(S)(ref S s) { return 2; }
 
 void test14()
 {
+    foo14(S14a(0));
+    foo14(S14b(0));
     // can not bind rvalue-sl with ref
-    static assert( __traits(compiles, foo14(S14a(0))));
-    static assert( __traits(compiles, foo14(S14b(0))));
     static assert(!__traits(compiles, hoo14(S14a(0))));
     static assert(!__traits(compiles, hoo14(S14b(0))));
     static assert(!__traits(compiles, poo14(S14a(0))));

--- a/test/runnable/structlit.d
+++ b/test/runnable/structlit.d
@@ -1,8 +1,10 @@
 /*
+REQUIRED_ARGS: -preview=rvaluerefparam
 TEST_OUTPUT:
 ---
 ---
 */
+
 import std.stdio;
 
 struct S
@@ -324,8 +326,8 @@ int waz14(S)(ref S s) { return 2; }
 void test14()
 {
     // can not bind rvalue-sl with ref
-    static assert(!__traits(compiles, foo14(S14a(0))));
-    static assert(!__traits(compiles, foo14(S14b(0))));
+    static assert( __traits(compiles, foo14(S14a(0))));
+    static assert( __traits(compiles, foo14(S14b(0))));
     static assert(!__traits(compiles, hoo14(S14a(0))));
     static assert(!__traits(compiles, hoo14(S14b(0))));
     static assert(!__traits(compiles, poo14(S14a(0))));

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -preview=rvaluerefparam
 // PERMUTE_ARGS:
 
 module breaker;
@@ -1924,13 +1925,13 @@ void h8976()()
     g8976!()();
 }
 
-static assert(! __traits(compiles, h8976!()() ) ); // causes error
-static assert(!is(typeof(          h8976!()() )));
+static assert( __traits(compiles, h8976!()() ) ); // causes error
+static assert(is(typeof(          h8976!()() )));
 
 void test8976()
 {
-    static assert(! __traits(compiles, h8976!()() ) );
-    static assert(!is(typeof(          h8976!()() )));
+    static assert( __traits(compiles, h8976!()() ) );
+    static assert(is(typeof(          h8976!()() )));
 }
 
 /****************************************/

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1925,12 +1925,12 @@ void h8976()()
     g8976!()();
 }
 
-static assert( __traits(compiles, h8976!()() ) ); // causes error
+h8976!()();
 static assert(is(typeof(          h8976!()() )));
 
 void test8976()
 {
-    static assert( __traits(compiles, h8976!()() ) );
+    h8976!()();
     static assert(is(typeof(          h8976!()() )));
 }
 

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1925,13 +1925,13 @@ void h8976()()
     g8976!()();
 }
 
-h8976!()();
-static assert(is(typeof(          h8976!()() )));
+static assert( __traits(compiles, h8976!()()) );
+static assert(is(typeof(          h8976!()())));
 
 void test8976()
 {
     h8976!()();
-    static assert(is(typeof(          h8976!()() )));
+    static assert(is(typeof(h8976!()())));
 }
 
 /****************************************/

--- a/test/runnable/testassign.d
+++ b/test/runnable/testassign.d
@@ -884,11 +884,10 @@ void test12211()
     foo(a += 7);
     assert(a == 3);
 
-    // array ops should make rvalue
     int[3] sa, sb;
     void bar(ref int[]) {}
-    static assert(__traits(compiles, bar(sa[]  = sb[])));
-    static assert(__traits(compiles, bar(sa[] += sb[])));
+    bar(sa[]  = sb[]);
+    bar(sa[] += sb[]);
 }
 
 /***************************************************/

--- a/test/runnable/testassign.d
+++ b/test/runnable/testassign.d
@@ -1,4 +1,5 @@
 /*
+REQUIRED_ARGS: -preview=rvaluerefparam
 TEST_OUTPUT:
 ---
 \	S1	S2a	S2b	S3a	S3b	S4a	S4b
@@ -12,6 +13,7 @@ Xf	true	true	true	true	true	true	true
 Xg	true	true	true	true	true	true	true
 ---
 */
+
 import core.stdc.stdio;
 
 template TypeTuple(T...){ alias T TypeTuple; }
@@ -885,8 +887,8 @@ void test12211()
     // array ops should make rvalue
     int[3] sa, sb;
     void bar(ref int[]) {}
-    static assert(!__traits(compiles, bar(sa[]  = sb[])));
-    static assert(!__traits(compiles, bar(sa[] += sb[])));
+    static assert(__traits(compiles, bar(sa[]  = sb[])));
+    static assert(__traits(compiles, bar(sa[] += sb[])));
 }
 
 /***************************************************/

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1,3 +1,4 @@
+// REQUIRED_ARGS: -preview=rvaluerefparam
 // PERMUTE_ARGS: -unittest -O -release -inline -fPIC -g
 /*
 TEST_OUTPUT:
@@ -3922,7 +3923,7 @@ void test2486()
 
     int[] arr = [1,2,3];
     foo(arr);   //OK
-    static assert(!__traits(compiles, foo(arr[1..2]))); // should be NG
+    static assert(__traits(compiles, foo(arr[1..2])));
 
     struct S
     {
@@ -3933,7 +3934,7 @@ void test2486()
     s[];
     // opSlice should return rvalue
     static assert(is(typeof(&S.opSlice) == int[] function() pure nothrow @nogc @safe));
-    static assert(!__traits(compiles, foo(s[])));       // should be NG
+    static assert(__traits(compiles, foo(s[])));
 }
 
 /***************************************************/
@@ -4108,7 +4109,7 @@ void test4539()
         assert(s[4] == 0x61);
     }
 
-    static assert(!__traits(compiles, foo1("hello")));
+    static assert(__traits(compiles, foo1("hello")));
     static assert(!__traits(compiles, foo2("hello")));
     static assert(!__traits(compiles, foo3("hello")));
 
@@ -4985,7 +4986,7 @@ void test6763()
 
     f6763(0);   //With D2: Error: function main.f ((ref const const(int) _param_0)) is not callable using argument types (int)
     c6763(0);
-    r6763(n);   static assert(!__traits(compiles, r6763(0)));
+    r6763(n);   static assert(__traits(compiles, r6763(0)));
     i6763(0);
     o6763(n);   static assert(!__traits(compiles, o6763(0)));
 
@@ -7210,7 +7211,7 @@ void test11317()
     }
 
     void test(ref uint x) {}
-    static assert(!__traits(compiles, test(fun())));
+    static assert(__traits(compiles, test(fun())));
 
     assert(fun() == 0);
 }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -15,14 +15,14 @@ tuple(height)
 tuple(get, get)
 tuple(clear)
 tuple(draw, draw)
-runnable/xtest46.d(179): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(181): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(180): Deprecation: `opDot` is deprecated. Use `alias this`
 runnable/xtest46.d(182): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(184): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(211): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(213): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(183): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(185): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(212): Deprecation: `opDot` is deprecated. Use `alias this`
 runnable/xtest46.d(214): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(216): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(215): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46.d(217): Deprecation: `opDot` is deprecated. Use `alias this`
 const(int)
 string[]
 double[]

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -3923,7 +3923,7 @@ void test2486()
 
     int[] arr = [1,2,3];
     foo(arr);   //OK
-    static assert(__traits(compiles, foo(arr[1..2])));
+    foo(arr[1..2]);
 
     struct S
     {
@@ -3934,7 +3934,7 @@ void test2486()
     s[];
     // opSlice should return rvalue
     static assert(is(typeof(&S.opSlice) == int[] function() pure nothrow @nogc @safe));
-    static assert(__traits(compiles, foo(s[])));
+    foo(s[]);
 }
 
 /***************************************************/
@@ -4109,7 +4109,7 @@ void test4539()
         assert(s[4] == 0x61);
     }
 
-    static assert(__traits(compiles, foo1("hello")));
+    foo1("hello");
     static assert(!__traits(compiles, foo2("hello")));
     static assert(!__traits(compiles, foo3("hello")));
 
@@ -4986,7 +4986,7 @@ void test6763()
 
     f6763(0);   //With D2: Error: function main.f ((ref const const(int) _param_0)) is not callable using argument types (int)
     c6763(0);
-    r6763(n);   static assert(__traits(compiles, r6763(0)));
+    r6763(n);   r6763(0);
     i6763(0);
     o6763(n);   static assert(!__traits(compiles, o6763(0)));
 
@@ -7211,7 +7211,7 @@ void test11317()
     }
 
     void test(ref uint x) {}
-    static assert(__traits(compiles, test(fun())));
+    test(fun());
 
     assert(fun() == 0);
 }

--- a/test/runnable/xtest46_gc.d
+++ b/test/runnable/xtest46_gc.d
@@ -1,3 +1,3 @@
-// REQUIRED_ARGS: -lowmem -Jrunnable
+// REQUIRED_ARGS: -lowmem -Jrunnable -preview=rvaluerefparam
 
 mixin(import("xtest46.d"));


### PR DESCRIPTION
rebases #9817 
fixes some comments
replaces `static assert(__traits, compiles, foo());` with `foo();`