### PR TITLE
Deprecate extern(C++, identifier)

### DIFF
--- a/changelog/extern_cpp_scoped.dd
+++ b/changelog/extern_cpp_scoped.dd
@@ -1,0 +1,32 @@
+`extern(C++, identifier)` is deprecated
+
+While interfacing with C++, there are two ways to represent namespaces:
+- `extern(C++, identifier)`
+- `extern(C++, "string")`
+
+The former suffers from three issues:
+- It introduces a scope in the code (much like an aggregate),
+  importing some C++ semantic in D and conflicting with other identifiers
+  (e.g. `extern(C++, std) { struct vector(T); }` conflicts with `int std;`)
+- It is not CTFE-able: some bindings are different depending on the platform,
+  e.g. on Clang `std::vector` is actually in the inline namespace `std::__1`
+  while on GCC it is in `std`.
+  Such a situation would require duplicating the definitions.
+- It does not accept identifiers which are D keyword:
+  `body`, `in`, `pure`, etc, cannot be binded on the D side.
+
+For this reason, users are encouraged to use `extern(C++, "namespace")` instead.
+It accepts tuples, so `extern(C++, "std", "__1")` is accepted.
+Likewise it is CTFEable, so `extern(C++, getNamespace())` works.
+
+Lastly, when the grammar could be ambiguous, users should surround the tuple with parenthesis:
+---
+private template StdNS ()
+{
+    version (CppRuntime_Clang)
+        alias StdNS = AliasSeq!(`std`, `__1`);
+    else version (CppRuntime_Gcc)
+        alias StdNS = AliasSeq!(`std`);
+}
+extern(C++, (StdNS!())) struct vector(T);
+---

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -140,6 +140,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         sc2.explicitProtection = 0;
         sc2.aligndecl = null;
         sc2.userAttribDecl = null;
+        sc2.namespace = null;
         return sc2;
     }
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1173,22 +1173,16 @@ struct ASTBase
     extern (C++) final class Nspace : ScopeDsymbol
     {
         /**
-         * Determines whether the symbol for this namespace should be included in the symbol table.
-         */
-        bool mangleOnly;
-
-        /**
          * Namespace identifier resolved during semantic.
          */
         Expression identExp;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
+        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
         {
             super(ident);
             this.loc = loc;
             this.members = members;
             this.identExp = identExp;
-            this.mangleOnly = mangleOnly;
         }
 
         override void accept(Visitor v)
@@ -1304,6 +1298,28 @@ struct ASTBase
         {
             super(decl);
             cppmangle = p;
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
+    {
+        Expression exp;
+
+        extern (D) this(Identifier ident, Dsymbols* decl)
+        {
+            super(decl);
+            this.ident = ident;
+        }
+
+        extern (D) this(Expression exp, Dsymbols* decl)
+        {
+            super(decl);
+            this.exp = exp;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -453,6 +453,66 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
 
 /***********************************************************
  */
+extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
+{
+    Expression exp;
+
+    extern (D) this(Identifier ident, Dsymbols* decl)
+    {
+        super(decl);
+        this.ident = ident;
+    }
+
+    extern (D) this(Expression exp, Dsymbols* decl)
+    {
+        super(decl);
+        this.exp = exp;
+    }
+
+    extern (D) this(Identifier ident, Expression exp, Dsymbols* decl,
+                    CPPNamespaceDeclaration parent)
+    {
+        super(decl);
+        this.ident = ident;
+        this.exp = exp;
+        this.namespace = parent;
+    }
+
+    override Dsymbol syntaxCopy(Dsymbol s)
+    {
+        assert(!s);
+        return new CPPNamespaceDeclaration(
+            this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.namespace);
+    }
+
+    override Scope* newScope(Scope* sc)
+    {
+        auto scx = sc.copy();
+        scx.linkage = LINK.cpp;
+        scx.namespace = this;
+        return scx;
+    }
+
+    override const(char)* toChars() const
+    {
+        return toString().ptr;
+    }
+
+    extern(D) override const(char)[] toString() const
+    {
+        return "extern (C++, `namespace`)";
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+
+    override inout(CPPNamespaceDeclaration) isCPPNamespaceDeclaration() inout { return this; }
+}
+
+/***********************************************************
+ */
 extern (C++) final class ProtDeclaration : AttribDeclaration
 {
     Prot protection;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -92,6 +92,17 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+class CPPNamespaceDeclaration : public AttribDeclaration
+{
+public:
+    Expression *exp;
+
+    Dsymbol *syntaxCopy(Dsymbol *s);
+    Scope *newScope(Scope *sc);
+    const char *toChars();
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class ProtDeclaration : public AttribDeclaration
 {
 public:

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1043,6 +1043,9 @@ private:
         while (p && !p.isModule())
         {
             mangleName(p, dont_use_back_reference);
+            // Mangle our string namespaces as well
+            for (auto ns = p.namespace; ns !is null; ns = ns.namespace)
+                mangleName(ns, dont_use_back_reference);
             p = p.toParent3();
             if (p.toParent3() && p.toParent3().isTemplateInstance())
             {

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -15,6 +15,7 @@ module dmd.dscope;
 import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
+import dmd.arraytypes;
 import dmd.attrib;
 import dmd.ctorflow;
 import dmd.dclass;
@@ -99,6 +100,9 @@ struct Scope
 
     /// alignment for struct members
     AlignDeclaration aligndecl;
+
+    /// C++ namespace this symbol is in
+    CPPNamespaceDeclaration namespace;
 
     /// linkage for external functions
     LINK linkage = LINK.d;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -228,6 +228,8 @@ extern (C++) class Dsymbol : ASTNode
 {
     Identifier ident;
     Dsymbol parent;
+    /// C++ namespace this symbol belongs to
+    CPPNamespaceDeclaration namespace;
     Symbol* csym;           // symbol for code generator
     Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
@@ -447,16 +449,7 @@ extern (C++) class Dsymbol : ASTNode
     }
 
     /// ditto
-    final inout(Dsymbol) pastMixinAndNspace() inout
-    {
-        //printf("Dsymbol::pastMixin() %s\n", toChars());
-        auto nspace = isNspace();
-        if (!(nspace && nspace.mangleOnly) && !isTemplateMixin() && !isForwardingAttribDeclaration())
-            return this;
-        if (!parent)
-            return null;
-        return parent.pastMixinAndNspace();
-    }
+    alias pastMixinAndNspace = pastMixin;
 
     /**********************************
      * `parent` field returns a lexically enclosing scope symbol this is a member of.
@@ -1187,6 +1180,7 @@ extern (C++) class Dsymbol : ASTNode
     inout(SymbolDeclaration)           isSymbolDeclaration()           inout { return null; }
     inout(AttribDeclaration)           isAttribDeclaration()           inout { return null; }
     inout(AnonDeclaration)             isAnonDeclaration()             inout { return null; }
+    inout(CPPNamespaceDeclaration)     isCPPNamespaceDeclaration()     inout { return null; }
     inout(ProtDeclaration)             isProtDeclaration()             inout { return null; }
     inout(OverloadSet)                 isOverloadSet()                 inout { return null; }
     inout(CompileDeclaration)          isCompileDeclaration()          inout { return null; }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -16,6 +16,7 @@
 #include "arraytypes.h"
 #include "visitor.h"
 
+class CPPNamespaceDeclaration;
 class Identifier;
 struct Scope;
 class DsymbolTable;
@@ -147,6 +148,8 @@ class Dsymbol : public ASTNode
 public:
     Identifier *ident;
     Dsymbol *parent;
+    /// C++ namespace this symbol belongs to
+    CPPNamespaceDeclaration *namespace_;
     Symbol *csym;               // symbol for code generator
     Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -776,6 +776,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.error("extern symbols cannot have initializers");
 
         dsym.userAttribDecl = sc.userAttribDecl;
+        dsym.namespace = sc.namespace;
 
         AggregateDeclaration ad = dsym.isThis();
         if (ad)
@@ -2107,6 +2108,64 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         attribSemantic(cd);
     }
 
+    override void visit(CPPNamespaceDeclaration ns)
+    {
+        Identifier identFromSE (StringExp se)
+        {
+            const sident = se.toStringz();
+            if (!sident.length || !Identifier.isValidIdentifier(sident))
+            {
+                ns.exp.error("expected valid identifer for C++ namespace but got `%.*s`",
+                             cast(int)sident.length, sident.ptr);
+                return null;
+            }
+            else
+                return Identifier.idPool(sident);
+        }
+
+        if (ns.ident is null)
+        {
+            ns.namespace = sc.namespace;
+            sc = sc.startCTFE();
+            ns.exp = ns.exp.expressionSemantic(sc);
+            ns.exp = resolveProperties(sc, ns.exp);
+            sc = sc.endCTFE();
+            ns.exp = ns.exp.ctfeInterpret();
+            // Can be either a tuple of strings or a string itself
+            if (auto te = ns.exp.isTupleExp())
+            {
+                expandTuples(te.exps);
+                CPPNamespaceDeclaration current = ns.namespace;
+                for (size_t d = 0; d < te.exps.dim; ++d)
+                {
+                    auto exp = (*te.exps)[d];
+                    auto prev = d ? current : ns.namespace;
+                    current = (d + 1) != te.exps.dim
+                        ? new CPPNamespaceDeclaration(exp, null)
+                        : ns;
+                    current.exp = exp;
+                    current.namespace = prev;
+                    if (auto se = exp.toStringExp())
+                    {
+                        current.ident = identFromSE(se);
+                        if (current.ident is null)
+                            return; // An error happened in `identFromSE`
+                    }
+                    else
+                        ns.exp.error("`%s`: index %d is not a string constant, it is a `%s`",
+                                     ns.exp.toChars(), d, ns.exp.type.toChars());
+                }
+            }
+            else if (auto se = ns.exp.toStringExp())
+                ns.ident = identFromSE(se);
+            else
+                ns.exp.error("compile time string constant (or tuple) expected, not `%s`",
+                             ns.exp.toChars());
+        }
+        if (ns.ident)
+            attribSemantic(ns);
+    }
+
     override void visit(UserAttributeDeclaration uad)
     {
         //printf("UserAttributeDeclaration::semantic() %p\n", this);
@@ -2629,6 +2688,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         tempdecl.parent = sc.parent;
         tempdecl.protection = sc.protection;
+        tempdecl.namespace = sc.namespace;
         tempdecl.isstatic = tempdecl.toParent().isModule() || (tempdecl._scope.stc & STC.static_);
 
         if (!tempdecl.isstatic)
@@ -3020,7 +3080,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     else
                     {
                         // insert the new namespace
-                        Nspace childns = new Nspace(ns.loc, Identifier.idPool(ident), null, parentns.members, ns.mangleOnly);
+                        Nspace childns = new Nspace(ns.loc, Identifier.idPool(ident), null, parentns.members);
                         parentns.members = new Dsymbols;
                         parentns.members.push(childns);
                         parentns = childns;
@@ -3103,6 +3163,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc || funcdecl.errors)
             return;
 
+        funcdecl.namespace = sc.namespace;
         funcdecl.parent = sc.parent;
         Dsymbol parent = funcdecl.toParent();
 
@@ -4541,6 +4602,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 sd.classKind = ClassKind.cpp;
+            sd.namespace = sc.namespace;
         }
         else if (sd.symtab && !scx)
             return;
@@ -4760,6 +4822,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 cldec.classKind = ClassKind.cpp;
+            cldec.namespace = sc.namespace;
             if (sc.linkage == LINK.objc)
                 objc.setObjc(cldec);
         }
@@ -5478,6 +5541,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
+            idec.namespace = sc.namespace;
 
             if (sc.linkage == LINK.objc)
             {
@@ -5768,6 +5832,9 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     tempinst.hasNestedArgs(tempinst.tiargs, tempdecl.isstatic);
     if (tempinst.errors)
         goto Lerror;
+
+    // Copy the tempdecl namespace (not the scope one)
+    tempinst.namespace = tempdecl.namespace;
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3029,6 +3029,25 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
 
         bool repopulateMembers = false;
+        {
+            OutBuffer buff;
+            Nspace parent = ns;
+            void writeNameRecursive (Nspace parent, bool coma = true)
+            {
+                if (parent is null)
+                    return;
+                writeNameRecursive(parent.parent.isNspace());
+                buff.writestring(`"`);
+                buff.writestring(parent.toString());
+                buff.writestring(`"`);
+                if (coma) buff.writestring(", ");
+            }
+            writeNameRecursive(ns, false);
+            scope sl = buff.peekSlice();
+            deprecation(ns.loc, "Scoped version of `extern(C++, namespace)` is deprecated. "
+                        ~ "Use `extern(C++, %.*s)` instead.", cast(int)sl.length, sl.ptr);
+        }
+
         if (ns.identExp)
         {
             // resolve the namespace identifier

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -376,6 +376,8 @@ extern (C++) class FuncDeclaration : Declaration
                 return false;
         }
 
+        this.namespace = _scope.namespace;
+
         // if inferring return type, sematic3 needs to be run
         // - When the function body contains any errors, we cannot assume
         //   the inferred return type is valid.

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -32,36 +32,27 @@ private enum LOG = false;
 extern (C++) final class Nspace : ScopeDsymbol
 {
     /**
-     * Determines whether the symbol for this namespace should be included in the symbol table.
-     */
-    bool mangleOnly;
-
-    /**
      * Namespace identifier resolved during semantic.
      */
     Expression identExp;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
+    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
     {
         super(loc, ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());
         this.members = members;
         this.identExp = identExp;
-        this.mangleOnly = mangleOnly;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
-        auto ns = new Nspace(loc, ident, identExp, null, mangleOnly);
+        auto ns = new Nspace(loc, ident, identExp, null);
         return ScopeDsymbol.syntaxCopy(ns);
     }
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        if (mangleOnly)
-            parent = sds;
-        else
-            ScopeDsymbol.addMember(sc, sds);
+        ScopeDsymbol.addMember(sc, sds);
 
         if (members)
         {
@@ -81,7 +72,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             sc = sc.push(this);
             sc.linkage = LINK.cpp; // namespaces default to C++ linkage
             sc.parent = this;
-            members.foreachDsymbol(s => s.addMember(sc, mangleOnly ? sds : this));
+            members.foreachDsymbol(s => s.addMember(sc, this));
             sc.pop();
         }
     }

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -19,7 +19,6 @@
 class Nspace : public ScopeDsymbol
 {
   public:
-    bool mangleOnly;
     Expression *identExp;
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -950,7 +950,10 @@ final class Parser(AST) : Lexer
                                 a = new AST.Dsymbols();
                                 a.push(s);
                             }
-                            s = new AST.Nspace(linkLoc, id, null, a, cppMangleOnly);
+                            if (cppMangleOnly)
+                                s = new AST.CPPNamespaceDeclaration(id, a);
+                            else
+                                s = new AST.Nspace(linkLoc, id, null, a);
                         }
                         pAttrs.link = LINK.default_;
                     }
@@ -966,7 +969,10 @@ final class Parser(AST) : Lexer
                                 a = new AST.Dsymbols();
                                 a.push(s);
                             }
-                            s = new AST.Nspace(linkLoc, null, exp, a, cppMangleOnly);
+                            if (cppMangleOnly)
+                                s = new AST.CPPNamespaceDeclaration(exp, a);
+                            else
+                                s = new AST.Nspace(linkLoc, null, exp, a);
                         }
                         pAttrs.link = LINK.default_;
                     }

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -68,6 +68,7 @@ public:
     void visit(AST.AnonDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.AlignDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.CPPMangleDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
+    void visit(AST.CPPNamespaceDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.ProtDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.PragmaDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.StorageClassDeclaration s) { visit(cast(AST.AttribDeclaration)s); }

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -24,6 +24,7 @@ class UserAttributeDeclaration;
 struct DocComment;
 struct AA;
 class TemplateInstance;
+class CPPNamespaceDeclaration;
 
 #include "dsymbol.h"
 
@@ -90,6 +91,9 @@ struct Scope
     size_t fieldinit_dim;
 
     AlignDeclaration *aligndecl;    // alignment for struct members
+
+    /// C++ namespace this symbol belongs to
+    CPPNamespaceDeclaration *namespace_;
 
     LINK linkage;               // linkage for external functions
     CPPMANGLE cppmangle;        // C++ mangle type

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -99,6 +99,7 @@ class StorageClassDeclaration;
 class DeprecatedDeclaration;
 class LinkDeclaration;
 class CPPMangleDeclaration;
+class CPPNamespaceDeclaration;
 class ProtDeclaration;
 class AlignDeclaration;
 class AnonDeclaration;
@@ -358,6 +359,7 @@ public:
     virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(CPPNamespaceDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(PragmaDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1,4 +1,8 @@
-
+/**
+TEST_OUTPUT:
+---
+---
+*/
 // Test C++ name mangling.
 // https://issues.dlang.org/show_bug.cgi?id=4059
 // https://issues.dlang.org/show_bug.cgi?id=5148

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -337,7 +337,7 @@ version (linux)
 /**************************************/
 // https://issues.dlang.org/show_bug.cgi?id=13337
 
-extern(C++, N13337a.N13337b.N13337c)
+extern(C++, `N13337a`, `N13337b`, `N13337c`)
 {
   struct S13337{}
   void foo13337(S13337 s);
@@ -382,7 +382,7 @@ version (Posix)
 
 // Special cases of Itanium mangling
 
-extern (C++, std)
+extern (C++, `std`)
 {
     struct pair(T1, T2)
     {
@@ -428,15 +428,15 @@ extern (C++, std)
 version (linux)
 {
     // https://issues.dlang.org/show_bug.cgi?id=17947
-    static assert(std.pair!(void*, void*).swap.mangleof == "_ZNSt4pairIPvS0_E4swapERS1_");
+    static assert(pair!(void*, void*).swap.mangleof == "_ZNSt4pairIPvS0_E4swapERS1_");
 
-    static assert(std.allocator!int.fooa.mangleof == "_ZNKSaIiE4fooaEv");
-    static assert(std.allocator!int.foob.mangleof == "_ZNSaIiE4foobEv");
-    static assert(std.basic_string!(char,int,uint).fooa.mangleof == "_ZNSbIcijE4fooaEv");
-    static assert(std.basic_string!(char, std.char_traits!char, std.allocator!char).fooa.mangleof == "_ZNSs4fooaEv");
-    static assert(std.basic_istream!(char, std.char_traits!char).fooc.mangleof == "_ZNSi4foocEv");
-    static assert(std.basic_ostream!(char, std.char_traits!char).food.mangleof == "_ZNSo4foodEv");
-    static assert(std.basic_iostream!(char, std.char_traits!char).fooe.mangleof == "_ZNSd4fooeEv");
+    static assert(allocator!int.fooa.mangleof == "_ZNKSaIiE4fooaEv");
+    static assert(allocator!int.foob.mangleof == "_ZNSaIiE4foobEv");
+    static assert(basic_string!(char,int,uint).fooa.mangleof == "_ZNSbIcijE4fooaEv");
+    static assert(basic_string!(char, char_traits!char, allocator!char).fooa.mangleof == "_ZNSs4fooaEv");
+    static assert(basic_istream!(char, char_traits!char).fooc.mangleof == "_ZNSi4foocEv");
+    static assert(basic_ostream!(char, char_traits!char).food.mangleof == "_ZNSo4foodEv");
+    static assert(basic_iostream!(char, char_traits!char).fooe.mangleof == "_ZNSd4fooeEv");
 }
 
 /**************************************/
@@ -453,7 +453,7 @@ version (linux)
 /*****************************************/
 // https://issues.dlang.org/show_bug.cgi?id=17772
 
-extern(C++, SPACE)
+extern(C++, `SPACE`)
 int test37(T)(){ return 0;}
 
 version (Posix) // all non-Windows machines
@@ -732,7 +732,7 @@ version (Win64)
     static assert(TestOperators.opCall.mangleof          == "??RTestOperators@@QEAAHHM@Z");
 }
 
-extern(C++, Namespace18922)
+extern(C++, `Namespace18922`)
 {
     import cppmangle2;
     void func18922(Struct18922) {}
@@ -757,9 +757,9 @@ version (Posix)
     }
     void test18957(const std::test18957& t) {}
     +/
-    extern (C++) void test18957(ref const(std.test18957) t) {}
+    extern (C++) void test18957f(ref const(test18957) t) {}
 
-    static assert(test18957.mangleof == "_Z9test18957RKSt9test18957");
+    static assert(test18957f.mangleof == "_Z10test18957fRKSt9test18957");
 }
 
 /**************************************/
@@ -867,7 +867,7 @@ version (Posix) extern (C++)
      * (expressions always begin with a code anyway).
      */
     extern(C++) void CPPPrinter16479(const(char)*);
-    extern(C++, Namespace16479) void CPPPrinterNS16479(const(char)*);
+    extern(C++, `Namespace16479`) void CPPPrinterNS16479(const(char)*);
     void func16479_11 (alias Print) ();
     static assert(func16479_11!(CPPPrinter16479).mangleof
                   == `_Z12func16479_11IXadL_Z15CPPPrinter16479PKcEEEvv`);

--- a/test/compilable/cppmangle2.d
+++ b/test/compilable/cppmangle2.d
@@ -1,11 +1,16 @@
+/**
+TEST_OUTPUT:
+---
+---
+*/
 module cppmangle2;
 
-extern(C++, Namespace18922)
+extern(C++, `Namespace18922`)
 {
     struct Struct18922 { int i; }
 }
 
-extern(C++, std)
+extern(C++, `std`)
 {
     struct vector (T);
 }

--- a/test/compilable/cppmangle3.d
+++ b/test/compilable/cppmangle3.d
@@ -1,3 +1,8 @@
+/**
+TEST_OUTPUT:
+---
+---
+*/
 module cppmangle3;
 
 

--- a/test/fail_compilation/cppeh1.d
+++ b/test/fail_compilation/cppeh1.d
@@ -8,7 +8,7 @@ fail_compilation/cppeh1.d(26): Error: cannot catch C++ class objects in `@safe` 
 
 version (Windows) static assert(0, "This test should not run on this platform");
 
-extern (C++, std)
+extern (C++, `std`)
 {
     class exception { }
 }
@@ -23,7 +23,7 @@ void foo()
     {
         bar();
     }
-    catch (std.exception e)
+    catch (exception e)
     {
         abc();
     }

--- a/test/fail_compilation/cppeh2.d
+++ b/test/fail_compilation/cppeh2.d
@@ -8,7 +8,7 @@ fail_compilation/cppeh2.d(21): Error: cannot mix catching D and C++ exceptions i
 
 version(Windows) static assert(0, "This test should not run on this platform");
 
-extern (C++, std)
+extern (C++, `std`)
 {
     class exception { }
 }
@@ -22,7 +22,7 @@ void foo()
     {
         bar();
     }
-    catch (std.exception e)
+    catch (exception e)
     {
         abc();
     }

--- a/test/fail_compilation/cppmangle.d
+++ b/test/fail_compilation/cppmangle.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/cppmangle.d(11): Error: expected valid identifer for C++ namespace but got ``
 fail_compilation/cppmangle.d(15): Error: expected valid identifer for C++ namespace but got `0num`
-fail_compilation/cppmangle.d(19): Error: expected string expression for namespace name, got `1 + 1`
+fail_compilation/cppmangle.d(19): Error: compile time string constant (or tuple) expected, not `2`
 fail_compilation/cppmangle.d(23): Error: expected valid identifer for C++ namespace but got `invalid@namespace`
 ---
 */

--- a/test/fail_compilation/depcpp.d
+++ b/test/fail_compilation/depcpp.d
@@ -1,0 +1,17 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/depcpp.d(9): Deprecation: Scoped version of `extern(C++, namespace)` is deprecated. Use `extern(C++, "std")` instead.
+---
+*/
+
+extern (C++, std)
+{
+    struct vector (T) { T*[3] ptrs; }
+}
+
+void main ()
+{
+    std.vector!int foo;
+}

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -19,6 +19,10 @@ struct S
 
 extern(C++, std)
 {
+    struct test19248_ {int a = 42;}
+}
+extern(C++, `std`)
+{
     struct test19248 {int a = 34;}
 }
 
@@ -38,7 +42,8 @@ ulong  passthrough(ulong  value);
 float  passthrough(float  value);
 double passthrough(double value);
 S      passthrough(S      value);
-std.test19248 passthrough(const(std.test19248) value);
+test19248 passthrough(const(test19248) value);
+std.test19248_ passthrough(const(std.test19248_) value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -56,7 +61,8 @@ ulong  passthrough_ptr(ulong  *value);
 float  passthrough_ptr(float  *value);
 double passthrough_ptr(double *value);
 S      passthrough_ptr(S      *value);
-std.test19248 passthrough_ptr(const(std.test19248)* value);
+test19248 passthrough_ptr(const(test19248)* value);
+std.test19248_ passthrough_ptr(const(std.test19248_)* value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -74,7 +80,8 @@ ulong  passthrough_ref(ref ulong  value);
 float  passthrough_ref(ref float  value);
 double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
-std.test19248 passthrough_ref(ref const(std.test19248) value);
+test19248 passthrough_ref(ref const(test19248) value);
+std.test19248_ passthrough_ref(ref const(std.test19248_) value);
 }
 
 template IsSigned(T)
@@ -215,7 +222,8 @@ else
     foreach(float val; values!float())   check(val);
     foreach(double val; values!double()) check(val);
     check(S());
-    check(std.test19248());
+    check(test19248());
+    check(std.test19248_());
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -17,10 +17,6 @@ struct S
     float a = 1;
 }
 
-extern(C++, std)
-{
-    struct test19248_ {int a = 42;}
-}
 extern(C++, `std`)
 {
     struct test19248 {int a = 34;}
@@ -43,7 +39,6 @@ float  passthrough(float  value);
 double passthrough(double value);
 S      passthrough(S      value);
 test19248 passthrough(const(test19248) value);
-std.test19248_ passthrough(const(std.test19248_) value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -62,7 +57,6 @@ float  passthrough_ptr(float  *value);
 double passthrough_ptr(double *value);
 S      passthrough_ptr(S      *value);
 test19248 passthrough_ptr(const(test19248)* value);
-std.test19248_ passthrough_ptr(const(std.test19248_)* value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -81,7 +75,6 @@ float  passthrough_ref(ref float  value);
 double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
 test19248 passthrough_ref(ref const(test19248) value);
-std.test19248_ passthrough_ref(ref const(std.test19248_) value);
 }
 
 template IsSigned(T)
@@ -223,7 +216,6 @@ else
     foreach(double val; values!double()) check(val);
     check(S());
     check(test19248());
-    check(std.test19248_());
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -6,7 +6,8 @@ struct S{
 
 namespace std
 {
-    struct test19248 {int a;};
+    struct test19248_ {int a;}; // Remove when `extern(C++, ns)` is gone
+    struct test19248  {int a;};
 };
 
 #ifdef __DMC__
@@ -36,7 +37,8 @@ unsigned long long passthrough(unsigned long long  value)     { return value; }
 float              passthrough(float               value)     { return value; }
 double             passthrough(double              value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
-std::test19248     passthrough(const std::test19248 value)     { return value; }
+std::test19248     passthrough(const std::test19248 value)    { return value; }
+std::test19248_    passthrough(const std::test19248_ value)   { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -59,6 +61,7 @@ float              passthrough_ptr(float              *value) { return *value; }
 double             passthrough_ptr(double             *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
 std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
+std::test19248_    passthrough_ptr(const std::test19248_ *value) { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -81,6 +84,7 @@ float              passthrough_ref(float              &value) { return value; }
 double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
+std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
 
 namespace ns1
 {

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -6,7 +6,6 @@ struct S{
 
 namespace std
 {
-    struct test19248_ {int a;}; // Remove when `extern(C++, ns)` is gone
     struct test19248  {int a;};
 };
 
@@ -38,7 +37,6 @@ float              passthrough(float               value)     { return value; }
 double             passthrough(double              value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
 std::test19248     passthrough(const std::test19248 value)    { return value; }
-std::test19248_    passthrough(const std::test19248_ value)   { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -61,7 +59,6 @@ float              passthrough_ptr(float              *value) { return *value; }
 double             passthrough_ptr(double             *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
 std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
-std::test19248_    passthrough_ptr(const std::test19248_ *value) { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -84,7 +81,6 @@ float              passthrough_ref(float              &value) { return value; }
 double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
-std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
 
 namespace ns1
 {


### PR DESCRIPTION
Based on #10021 . Only the last commit is should actually be part of this PR.

```
This features tries to import C++ semantics into D, by giving namespaces a scope.
However, when it comes to interfacing with C++,	we only care about namespaces
in the context of mangling: they shouldn't be used for code organization.

Namespaces don't work so well for D: for example, namespaces in C++ can be spread across multiple files,
which is something D can't and won't do because it conflicts with its very core, modules.
It also	leads to issues	where identifiers used for namespaces
(which are usually outside of the programmer's control)	end up conflicting with	user code.

Instead, users should use `extern(C++, "string")`,
which makes D code follows D semantic while letting users link with a symbol in a namespace.
```