### PR TITLE
Fix Issue 19954 - ICE: Casting AliasSeq to array and passing to a function

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6652,6 +6652,14 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return setError();
         }
 
+        // https://issues.dlang.org/show_bug.cgi?id=19954
+        if (exp.e1.type.ty == Ttuple)
+        {
+            TupleExp te = exp.e1.isTupleExp();
+            if (te.exps.dim == 1)
+                exp.e1 = (*te.exps)[0];
+        }
+
         // only allow S(x) rewrite if cast specified S explicitly.
         // See https://issues.dlang.org/show_bug.cgi?id=18545
         const bool allowImplicitConstruction = exp.to !is null;
@@ -6757,38 +6765,42 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
 
-            if(t1b.ty == Tarray && exp.e1.op != TOK.string_ && exp.e1.op != TOK.arrayLiteral)
+            if(t1b.ty == Tarray && exp.e1.op != TOK.arrayLiteral && (sc.flags & SCOPE.ctfe) == 0)
             {
                 auto tFrom = t1b.nextOf();
                 auto tTo = tob.nextOf();
 
-                const uint fromSize = cast(uint)tFrom.size();
-                const uint toSize = cast(uint)tTo.size();
-
-                // If array element sizes do not match, we must adjust the dimensions
-                if (fromSize != toSize)
+                // https://issues.dlang.org/show_bug.cgi?id=19954
+                if (exp.e1.op != TOK.string_ || tTo.ty == Tarray)
                 {
-                    // A runtime check is needed in case arrays don't line up.  That check should
-                    // be done in the implementation of `object.__ArrayCast`
-                    if (toSize == 0 || (fromSize % toSize) != 0)
+                    const uint fromSize = cast(uint)tFrom.size();
+                    const uint toSize = cast(uint)tTo.size();
+
+                    // If array element sizes do not match, we must adjust the dimensions
+                    if (fromSize != toSize)
                     {
-                        // lower to `object.__ArrayCast!(TFrom, TTo)(from)`
+                        // A runtime check is needed in case arrays don't line up.  That check should
+                        // be done in the implementation of `object.__ArrayCast`
+                        if (toSize == 0 || (fromSize % toSize) != 0)
+                        {
+                            // lower to `object.__ArrayCast!(TFrom, TTo)(from)`
 
-                        // fully qualify as `object.__ArrayCast`
-                        Expression id = new IdentifierExp(exp.loc, Id.empty);
-                        auto dotid = new DotIdExp(exp.loc, id, Id.object);
+                            // fully qualify as `object.__ArrayCast`
+                            Expression id = new IdentifierExp(exp.loc, Id.empty);
+                            auto dotid = new DotIdExp(exp.loc, id, Id.object);
 
-                        auto tiargs = new Objects();
-                        tiargs.push(tFrom);
-                        tiargs.push(tTo);
-                        auto dt = new DotTemplateInstanceExp(exp.loc, dotid, Id.__ArrayCast, tiargs);
+                            auto tiargs = new Objects();
+                            tiargs.push(tFrom);
+                            tiargs.push(tTo);
+                            auto dt = new DotTemplateInstanceExp(exp.loc, dotid, Id.__ArrayCast, tiargs);
 
-                        auto arguments = new Expressions();
-                        arguments.push(exp.e1);
-                        Expression ce = new CallExp(exp.loc, dt, arguments);
+                            auto arguments = new Expressions();
+                            arguments.push(exp.e1);
+                            Expression ce = new CallExp(exp.loc, dt, arguments);
 
-                        result = expressionSemantic(ce, sc);
-                        return;
+                            result = expressionSemantic(ce, sc);
+                            return;
+                        }
                     }
                 }
             }

--- a/test/compilable/test19954.d
+++ b/test/compilable/test19954.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=19954
+
+template AliasSeq(TList...)
+{
+    alias AliasSeq = TList;
+}
+
+void fun(string[]){}
+
+void main()
+{
+    fun(cast(string[])AliasSeq!"");
+    auto a = cast(char[][])"";
+}


### PR DESCRIPTION
Best viewed without whitespace changes.