### PR TITLE
Revert "Refactor mangle-only `extern(C++, namespace)` into an AttribDeclaration"

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -140,7 +140,6 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         sc2.explicitProtection = 0;
         sc2.aligndecl = null;
         sc2.userAttribDecl = null;
-        sc2.namespace = null;
         return sc2;
     }
 

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1173,16 +1173,22 @@ struct ASTBase
     extern (C++) final class Nspace : ScopeDsymbol
     {
         /**
+         * Determines whether the symbol for this namespace should be included in the symbol table.
+         */
+        bool mangleOnly;
+
+        /**
          * Namespace identifier resolved during semantic.
          */
         Expression identExp;
 
-        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
+        extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
         {
             super(ident);
             this.loc = loc;
             this.members = members;
             this.identExp = identExp;
+            this.mangleOnly = mangleOnly;
         }
 
         override void accept(Visitor v)
@@ -1298,28 +1304,6 @@ struct ASTBase
         {
             super(decl);
             cppmangle = p;
-        }
-
-        override void accept(Visitor v)
-        {
-            v.visit(this);
-        }
-    }
-
-    extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
-    {
-        Expression exp;
-
-        extern (D) this(Identifier ident, Dsymbols* decl)
-        {
-            super(decl);
-            this.ident = ident;
-        }
-
-        extern (D) this(Expression exp, Dsymbols* decl)
-        {
-            super(decl);
-            this.exp = exp;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -453,66 +453,6 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
 
 /***********************************************************
  */
-extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
-{
-    Expression exp;
-
-    extern (D) this(Identifier ident, Dsymbols* decl)
-    {
-        super(decl);
-        this.ident = ident;
-    }
-
-    extern (D) this(Expression exp, Dsymbols* decl)
-    {
-        super(decl);
-        this.exp = exp;
-    }
-
-    extern (D) this(Identifier ident, Expression exp, Dsymbols* decl,
-                    CPPNamespaceDeclaration parent)
-    {
-        super(decl);
-        this.ident = ident;
-        this.exp = exp;
-        this.namespace = parent;
-    }
-
-    override Dsymbol syntaxCopy(Dsymbol s)
-    {
-        assert(!s);
-        return new CPPNamespaceDeclaration(
-            this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.namespace);
-    }
-
-    override Scope* newScope(Scope* sc)
-    {
-        auto scx = sc.copy();
-        scx.linkage = LINK.cpp;
-        scx.namespace = this;
-        return scx;
-    }
-
-    override const(char)* toChars() const
-    {
-        return toString().ptr;
-    }
-
-    extern(D) override const(char)[] toString() const
-    {
-        return "extern (C++, `namespace`)";
-    }
-
-    override void accept(Visitor v)
-    {
-        v.visit(this);
-    }
-
-    override inout(CPPNamespaceDeclaration) isCPPNamespaceDeclaration() inout { return this; }
-}
-
-/***********************************************************
- */
 extern (C++) final class ProtDeclaration : AttribDeclaration
 {
     Prot protection;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -92,17 +92,6 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class CPPNamespaceDeclaration : public AttribDeclaration
-{
-public:
-    Expression *exp;
-
-    Dsymbol *syntaxCopy(Dsymbol *s);
-    Scope *newScope(Scope *sc);
-    const char *toChars();
-    void accept(Visitor *v) { v->visit(this); }
-};
-
 class ProtDeclaration : public AttribDeclaration
 {
 public:

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -28,7 +28,6 @@ import core.stdc.string;
 import core.stdc.stdio;
 
 import dmd.arraytypes;
-import dmd.attrib;
 import dmd.declaration;
 import dmd.dsymbol;
 import dmd.dtemplate;
@@ -174,7 +173,7 @@ private final class CppMangleVisitor : Visitor
     {
         if (VarDeclaration vd = s.isVarDeclaration())
         {
-            mangle_variable(vd, vd.namespace !is null);
+            mangle_variable(vd, false);
         }
         else if (FuncDeclaration fd = s.isFuncDeclaration())
         {
@@ -310,21 +309,10 @@ private final class CppMangleVisitor : Visitor
      */
     static bool isStd(Dsymbol s)
     {
-        if (!s)
-            return false;
-
-        if (auto cnd = s.isCPPNamespaceDeclaration())
-            return isStd(cnd);
-
-        return (s.ident == Id.std &&    // the right name
+        return (s &&
+                s.ident == Id.std &&    // the right name
                 s.isNspace() &&         // g++ disallows global "std" for other than a namespace
                 !getQualifier(s));      // at global level
-    }
-
-    /// Ditto
-    static bool isStd(CPPNamespaceDeclaration s)
-    {
-        return s && s.namespace is null && s.ident == Id.std;
     }
 
     /************************
@@ -536,26 +524,15 @@ private final class CppMangleVisitor : Visitor
         //printf("source_name(%s)\n", s.toChars());
         if (TemplateInstance ti = s.isTemplateInstance())
         {
-            bool needsTa = false;
-            if (substitute(ti.tempdecl))
-                template_args(ti);
-            else if (this.writeStdSubstitution(ti, needsTa))
-            {
-                if (needsTa)
-                    template_args(ti);
-            }
-            else
+            if (!substitute(ti.tempdecl))
             {
                 append(ti.tempdecl);
-                this.writeNamespace(
-                    s.namespace, () {
-                        this.writeIdentifier(ti.tempdecl.toAlias().ident);
-                        template_args(ti);
-                    });
+                this.writeIdentifier(ti.tempdecl.toAlias().ident);
             }
+            template_args(ti);
         }
         else
-            this.writeNamespace(s.namespace, () => this.writeIdentifier(s.ident));
+            this.writeIdentifier(s.ident);
     }
 
     /********
@@ -574,15 +551,6 @@ private final class CppMangleVisitor : Visitor
                 return ti;
         }
         return s;
-    }
-
-    /// Get the namespace of a template instance
-    CPPNamespaceDeclaration getTiNamespace(TemplateInstance ti)
-    {
-        // If we receive a pre-semantic `TemplateInstance`,
-        // `namespace` is always `null`
-        return ti.tempdecl ? ti.namespace
-            : this.context.res.asType().toDsymbol(null).namespace;
     }
 
     /********
@@ -610,19 +578,19 @@ private final class CppMangleVisitor : Visitor
     }
 
     // Detect type ::std::char_traits<char>
-    bool isChar_traits_char(RootObject o)
+    static bool isChar_traits_char(RootObject o)
     {
         return isIdent_char(Id.char_traits, o);
     }
 
     // Detect type ::std::allocator<char>
-    bool isAllocator_char(RootObject o)
+    static bool isAllocator_char(RootObject o)
     {
         return isIdent_char(Id.allocator, o);
     }
 
     // Detect type ::std::ident<char>
-    bool isIdent_char(Identifier ident, RootObject o)
+    static bool isIdent_char(Identifier ident, RootObject o)
     {
         Type t = isType(o);
         if (!t || t.ty != Tstruct)
@@ -637,8 +605,7 @@ private final class CppMangleVisitor : Visitor
         if (!ti)
             return false;
         Dsymbol q = getQualifier(ti);
-        const bool inStd = isStd(q) || isStd(this.getTiNamespace(ti));
-        return inStd && ti.tiargs.dim == 1 && isChar((*ti.tiargs)[0]);
+        return isStd(q) && ti.tiargs.dim == 1 && isChar((*ti.tiargs)[0]);
     }
 
     /***
@@ -713,8 +680,6 @@ private final class CppMangleVisitor : Visitor
     bool writeStdSubstitution(TemplateInstance ti, out bool needsTa)
     {
         if (!ti)
-            return false;
-        if (!isStd(this.getTiNamespace(ti)) && !isStd(getQualifier(ti)))
             return false;
 
         if (ti.name == Id.allocator)
@@ -858,15 +823,7 @@ private final class CppMangleVisitor : Visitor
             buf.writeByte('K');
     }
 
-    /**
-     * Mangles a variable
-     *
-     * Params:
-     *   d = Variable declaration to mangle
-     *   isNested = Whether this variable is nested, e.g. a template parameter
-     *              or within a namespace
-     */
-    void mangle_variable(VarDeclaration d, bool isNested)
+    void mangle_variable(VarDeclaration d, bool is_temp_arg_ref)
     {
         // fake mangling for fields to fix https://issues.dlang.org/show_bug.cgi?id=16525
         if (!(d.storage_class & (STC.extern_ | STC.field | STC.gshared)))
@@ -882,11 +839,12 @@ private final class CppMangleVisitor : Visitor
             source_name(d);
             buf.writeByte('E');
         }
-        //char beta[6] should mangle as "beta"
-        else
+        else //char beta[6] should mangle as "beta"
         {
-            if (!isNested)
+            if (!is_temp_arg_ref)
+            {
                 buf.writestring(d.ident.toString());
+            }
             else
             {
                 buf.writestring("_Z");
@@ -949,50 +907,6 @@ private final class CppMangleVisitor : Visitor
     }
 
     /**
-     * Recursively mangles a non-scoped namespace
-     *
-     * Parameters:
-     *   ns = Namespace to mangle
-     *   dg = A delegate to write the identifier in this namespace
-     *   nested = When `false`, do not nest the name within `N..E`
-     */
-    void writeNamespace(CPPNamespaceDeclaration ns, scope void delegate() dg,
-                        bool nested = true)
-    {
-        void runDg () { if (dg !is null) dg(); }
-
-        if (ns is null)
-            return runDg();
-
-        if (isStd(ns))
-        {
-            if (!substitute(ns))
-                buf.writestring("St");
-            runDg();
-        }
-        else if (dg !is null)
-        {
-            if (nested)
-                buf.writestring("N");
-            if (!substitute(ns))
-            {
-                this.writeNamespace(ns.namespace, null);
-                this.writeIdentifier(ns.ident);
-                append(ns);
-            }
-            dg();
-            if (nested)
-                buf.writestring("E");
-        }
-        else if (!substitute(ns))
-        {
-            this.writeNamespace(ns.namespace, null);
-            this.writeIdentifier(ns.ident);
-            append(ns);
-        }
-    }
-
-    /**
      * Mangles a function template to C++
      *
      * Params:
@@ -1012,11 +926,7 @@ private final class CppMangleVisitor : Visitor
             this.context.fd = d;
             this.context.res = d;
             TypeFunction preSemantic = cast(TypeFunction)d.originalType;
-            auto nspace = ti.toParent3();
-            if (nspace && nspace.isNspace())
-                this.writeChained(ti.toParent3(), () => source_name(ti));
-            else
-                source_name(ti);
+            this.writeChained(ti.toParent3(), () => source_name(ti));
             this.mangleReturnType(preSemantic);
             this.mangleFunctionParameters(preSemantic.parameterList.parameters, tf.parameterList.varargs);
             return;
@@ -1282,7 +1192,9 @@ private final class CppMangleVisitor : Visitor
                     return;
             }
             if (!substitute(s))
+            {
                 cpp_mangle_name(s, false);
+            }
         }
         if (t.isConst())
             append(t);
@@ -1357,112 +1269,6 @@ private final class CppMangleVisitor : Visitor
          *          ::= <prefix> <data-member-prefix>
          */
         prefix_name(parent);
-    }
-
-    /**
-     * Helper function to write a `T..._` template index.
-     *
-     * Params:
-     *   ident = Identifier for which substitution is attempted
-     *           (e.g. `void func(T)(T param)` => `T` from `T param`)
-     *   params = `TemplateParameters` of the enclosing symbol
-     *           (in the previous example, `func`'s template parameters)
-     *   type = Resolved type of `T`, so that `void func(T)(const T)`
-     *          gets mangled correctly
-     *
-     * Returns:
-     *   `true` if something was written to the buffer
-     */
-    private void writeTemplateArgIndex(size_t idx, TemplateParameter param)
-    {
-        // expressions are mangled in <X..E>
-        if (param.isTemplateValueParameter())
-            buf.writeByte('X');
-        buf.writeByte('T');
-        writeSequenceFromIndex(idx);
-        buf.writeByte('_');
-        if (param.isTemplateValueParameter())
-            buf.writeByte('E');
-    }
-
-    /**
-     * Given an array of template parameters and an identifier,
-     * returns the index of the identifier in that array.
-     *
-     *
-     * Returns:
-     *   The index of the identifier match in `params`,
-     *   or `params.dim` if there wasn't any match.
-     */
-    private static size_t templateParamIndex(
-        const ref Identifier ident, TemplateParameters* params)
-    {
-        foreach (idx, param; *params)
-            if (param.ident == ident)
-                return idx;
-        return params.length;
-    }
-
-    /**
-     * Given a template instance `t`, write its qualified name
-     * without the template parameter list
-     *
-     * Params:
-     *   t = Post-parsing `TemplateInstance` pointing to the symbol
-     *       to mangle (one level deep)
-     *   dg = Delegate to execute after writing the qualified symbol
-     *
-     */
-    private void writeQualified(TemplateInstance t, scope void delegate() dg)
-    {
-        auto type = isType(this.context.res);
-        if (!type)
-        {
-            this.writeIdentifier(t.name);
-            return dg();
-        }
-        auto sym1 = type.toDsymbol(null);
-        if (!sym1)
-        {
-            this.writeIdentifier(t.name);
-            return dg();
-        }
-        // Get the template instance
-        auto sym = getQualifier(sym1);
-        auto sym2 = getQualifier(sym);
-        if (sym2)
-        {
-            if (isStd(sym2))
-            {
-                bool unused;
-                assert(sym.isTemplateInstance());
-                if (this.writeStdSubstitution(sym.isTemplateInstance(), unused))
-                    return dg();
-                // std names don't require `N..E`
-                buf.writestring("St");
-                this.writeIdentifier(t.name);
-                this.append(t);
-                return dg();
-            }
-            buf.writestring("N");
-            if (!this.substitute(sym2))
-                sym2.accept(this);
-            dg();
-        }
-        if (sym1 !is null)
-        {
-            this.writeNamespace(
-                sym1.namespace, () {
-                    this.writeIdentifier(t.name);
-                    this.append(t);
-                    dg();
-                });
-        }
-        else
-        {
-            this.writeIdentifier(t.name);
-            dg();
-        }
     }
 
 extern(C++):
@@ -1736,21 +1542,9 @@ extern(C++):
     {
         auto decl = cast(TemplateDeclaration)this.context.ti.tempdecl;
         assert(decl.parameters !is null);
-        auto idx = templateParamIndex(t.ident, decl.parameters);
         // If not found, default to the post-semantic type
-        if (idx >= decl.parameters.length)
-            return this.context.res.visitObject(this);
-
-        auto param = (*decl.parameters)[idx];
-        if (auto type = this.context.res.isType())
-            CV_qualifiers(type);
-        // Otherwise, attempt substitution (`S_` takes precedence on `T_`)
-        if (this.substitute(param))
-            return;
-
-        // If substitution failed, write `TX_` where `X` is the index
-        this.writeTemplateArgIndex(idx, param);
-        this.append(param);
+        if (!this.writeTemplateSubstitution(t.ident, decl.parameters, this.context.res.isType()))
+            this.context.res.visitObject(this);
     }
 
     /// Ditto
@@ -1760,82 +1554,57 @@ extern(C++):
         t.tempinst.accept(this);
     }
 
-    /**
-     * Mangles a `TemplateInstance`
-     *
-     * A `TemplateInstance` can be found either in the parameter,
-     * or the return value.
-     * Arguments to the template instance needs to be mangled but the template
-     * can be partially substituted, so for example the following:
-     * `Container!(T, Val) func16479_12 (alias Container, T, int Val) ()`
-     * will mangle the return value part to "T_IT0_XT1_EE"
-     */
+    /// Ditto
     override void visit(TemplateInstance t)
     {
-        // Template names are substituted, but args still need to be written
-        void writeArgs ()
-        {
-            buf.writeByte('I');
-            // When visiting the arguments, the context will be set to the
-            // resolved type
-            auto analyzed_ti = this.context.res.asType().toDsymbol(null).isInstantiated();
-            auto prev = this.context;
-            scope (exit) this.context.pop(prev);
-            foreach (idx, RootObject o; *t.tiargs)
-            {
-                this.context.res = (*analyzed_ti.tiargs)[idx];
-                o.visitObject(this);
-            }
-            if (analyzed_ti.tiargs.dim > t.tiargs.dim)
-            {
-                // If the resolved AST has more args than the parse one,
-                // we have default arguments
-                auto oparams = (cast(TemplateDeclaration)analyzed_ti.tempdecl).origParameters;
-                foreach (idx, arg; (*oparams)[t.tiargs.dim .. $])
-                {
-                    this.context.res = (*analyzed_ti.tiargs)[idx + t.tiargs.dim];
-
-                    if (auto ttp = arg.isTemplateTypeParameter())
-                        ttp.defaultType.accept(this);
-                    else if (auto tvp = arg.isTemplateValueParameter())
-                        tvp.defaultValue.accept(this);
-                    else if (auto tvp = arg.isTemplateThisParameter())
-                        tvp.defaultType.accept(this);
-                    else if (auto tvp = arg.isTemplateAliasParameter())
-                        tvp.defaultAlias.visitObject(this);
-                    else
-                        assert(0, arg.toString());
-                }
-            }
-            buf.writeByte('E');
-        }
-
-        // `name` is used, not `ident`
         assert(t.name !is null);
         assert(t.tiargs !is null);
 
-        bool needsTa;
-        auto decl = cast(TemplateDeclaration)this.context.ti.tempdecl;
-        // Attempt to substitute the template itself
-        auto idx = templateParamIndex(t.name, decl.parameters);
-        if (idx < decl.parameters.length)
+        if (this.substitute(t))
+            return;
+        auto topdecl = cast(TemplateDeclaration)this.context.ti.tempdecl;
+        // Template names are substituted, but args still need to be written
+        bool needclosing;
+        if (!this.writeTemplateSubstitution(t.name, topdecl.parameters, t.getType()))
         {
-            auto param = (*decl.parameters)[idx];
-            if (auto type = t.getType())
-                CV_qualifiers(type);
-            if (this.substitute(param))
-                return;
-            this.writeTemplateArgIndex(idx, param);
-            this.append(param);
-            writeArgs();
+            needclosing = this.writeQualified(t);
+            this.append(t);
         }
-        else if (this.writeStdSubstitution(t, needsTa))
+        buf.writeByte('I');
+        // When visiting the arguments, the context will be set to the
+        // resolved type
+        auto analyzed_ti = this.context.res.asType().toDsymbol(null).isInstantiated();
+        auto prev = this.context;
+        scope (exit) this.context.pop(prev);
+        foreach (idx, RootObject o; *t.tiargs)
         {
-            if (needsTa)
-                writeArgs();
+            this.context.res = (*analyzed_ti.tiargs)[idx];
+            o.visitObject(this);
         }
-        else if (!this.substitute(t))
-            this.writeQualified(t, &writeArgs);
+        if (analyzed_ti.tiargs.dim > t.tiargs.dim)
+        {
+            // If the resolved AST has more args than the parse one,
+            // we have default arguments
+            auto oparams = (cast(TemplateDeclaration)analyzed_ti.tempdecl).origParameters;
+            foreach (idx, arg; (*oparams)[t.tiargs.dim .. $])
+            {
+                this.context.res = (*analyzed_ti.tiargs)[idx + t.tiargs.dim];
+
+                if (auto ttp = arg.isTemplateTypeParameter())
+                    ttp.defaultType.accept(this);
+                else if (auto tvp = arg.isTemplateValueParameter())
+                    tvp.defaultValue.accept(this);
+                else if (auto tvp = arg.isTemplateThisParameter())
+                    tvp.defaultType.accept(this);
+                else if (auto tvp = arg.isTemplateAliasParameter())
+                    tvp.defaultAlias.visitObject(this);
+                else
+                    assert(0, arg.toString());
+            }
+        }
+        buf.writeByte('E');
+        if (needclosing)
+            buf.writeByte('E');
     }
 
     /// Ditto
@@ -1869,6 +1638,97 @@ extern(C++):
     void visit(Tuple t)
     {
         assert(0);
+    }
+
+    /**
+     * Helper function to go through the `TemplateParameter`s and perform
+     * a substitution, if possible.
+     *
+     * Params:
+     *   ident = Identifier for which substitution is attempted
+     *           (e.g. `void func(T)(T param)` => `T` from `T param`)
+     *   params = `TemplateParameters` of the enclosing symbol
+     *           (in the previous example, `func`'s template parameters)
+     *   type = Resolved type of `T`, so that `void func(T)(const T)`
+     *          gets mangled correctly
+     *
+     * Returns:
+     *   `true` if something was written to the buffer
+     */
+    private bool writeTemplateSubstitution(const ref Identifier ident,
+        TemplateParameters* params, Type type)
+    {
+        foreach (idx, param; *params)
+        {
+            if (param.ident == ident)
+            {
+                if (type)
+                    CV_qualifiers(type);
+                if (this.substitute(param))
+                    return true;
+                this.append(param);
+
+                // expressions are mangled in <X..E>
+                if (param.isTemplateValueParameter())
+                    buf.writeByte('X');
+                buf.writeByte('T');
+                writeSequenceFromIndex(idx);
+                buf.writeByte('_');
+                if (param.isTemplateValueParameter())
+                    buf.writeByte('E');
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Given a template instance `t`, write its qualified name
+     * without the template parameter list
+     *
+     * Params:
+     *   t = Post-parsing `TemplateInstance` pointing to the symbol
+     *       to mangle (one level deep)
+     *
+     * Returns:
+     *   `true` if the name was qualified and requires an ending `E`
+     */
+    private bool writeQualified(TemplateInstance t)
+    {
+        auto type = isType(this.context.res);
+        if (!type)
+        {
+            this.writeIdentifier(t.name);
+            return false;
+        }
+        auto sym = type.toDsymbol(null);
+        if (!sym)
+        {
+            this.writeIdentifier(t.name);
+            return false;
+        }
+        // Get the template instance
+        sym = getQualifier(sym);
+        auto sym2 = getQualifier(sym);
+        if (sym2)
+        {
+            if (isStd(sym2))
+            {
+                bool unused;
+                assert(sym.isTemplateInstance());
+                if (this.writeStdSubstitution(sym.isTemplateInstance(), unused))
+                    return false;
+                // std names don't require `N..E`
+                buf.writestring("St");
+                this.writeIdentifier(t.name);
+                return false;
+            }
+            buf.writestring("N");
+            if (!this.substitute(sym2))
+                sym2.accept(this);
+        }
+        this.writeIdentifier(t.name);
+        return sym2 !is null;
     }
 }
 
@@ -1919,9 +1779,6 @@ private extern(C++) final class ComponentVisitor : Visitor
     private Nspace namespace;
 
     /// Ditto
-    private CPPNamespaceDeclaration namespace2;
-
-    /// Ditto
     private TypePointer tpointer;
 
     /// Ditto
@@ -1943,8 +1800,6 @@ private extern(C++) final class ComponentVisitor : Visitor
         case DYNCAST.dsymbol:
             if (auto ns = (cast(Dsymbol)base).isNspace())
                 this.namespace = ns;
-            else if (auto ns = (cast(Dsymbol)base).isCPPNamespaceDeclaration())
-                this.namespace2 = ns;
             else
                 goto default;
             break;
@@ -2067,58 +1922,6 @@ private extern(C++) final class ComponentVisitor : Visitor
      */
     public override void visit(Nspace ns)
     {
-        this.result = isNamespaceEqual(this.namespace, ns)
-            || isNamespaceEqual(this.namespace2, ns);
+        this.result = this.namespace && this.namespace.equals(ns);
     }
-
-    /// Ditto
-    public override void visit(CPPNamespaceDeclaration ns)
-    {
-        this.result = isNamespaceEqual(this.namespace, ns)
-            || isNamespaceEqual(this.namespace2, ns);
-    }
-}
-
-/// Transitional functions for `CPPNamespaceDeclaration` / `Nspace`
-/// Remove when `Nspace` is removed.
-private bool isNamespaceEqual (Nspace a, Nspace b)
-{
-    if (a is null || b is null)
-        return false;
-    return a.equals(b);
-}
-
-/// Ditto
-private bool isNamespaceEqual (Nspace a, CPPNamespaceDeclaration b)
-{
-    return isNamespaceEqual(b, a);
-}
-
-/// Ditto
-private bool isNamespaceEqual (CPPNamespaceDeclaration a, Nspace b, size_t idx = 0)
-{
-    if ((a is null) != (b is null))
-        return false;
-    if (!a.ident.equals(b.ident))
-        return false;
-
-    // We need to see if there's more ident enclosing
-    if (auto pb = b.toParent().isNspace())
-        return isNamespaceEqual(a.namespace, pb);
-    else
-        return a.namespace is null;
-}
-
-/// Returns:
-///   Whether  two `CPPNamespaceDeclaration` are equals
-private bool isNamespaceEqual (CPPNamespaceDeclaration a, CPPNamespaceDeclaration b)
-{
-    if (a is null || b is null)
-        return false;
-
-    if ((a.namespace is null) != (b.namespace is null))
-        return false;
-    if (a.ident != b.ident)
-        return false;
-    return a.namespace is null ? true : isNamespaceEqual(a.namespace, b.namespace);
 }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1043,9 +1043,6 @@ private:
         while (p && !p.isModule())
         {
             mangleName(p, dont_use_back_reference);
-            // Mangle our string namespaces as well
-            for (auto ns = p.namespace; ns !is null; ns = ns.namespace)
-                mangleName(ns, dont_use_back_reference);
             p = p.toParent3();
             if (p.toParent3() && p.toParent3().isTemplateInstance())
             {

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -15,7 +15,6 @@ module dmd.dscope;
 import core.stdc.stdio;
 import core.stdc.string;
 import dmd.aggregate;
-import dmd.arraytypes;
 import dmd.attrib;
 import dmd.ctorflow;
 import dmd.dclass;
@@ -100,9 +99,6 @@ struct Scope
 
     /// alignment for struct members
     AlignDeclaration aligndecl;
-
-    /// C++ namespace this symbol is in
-    CPPNamespaceDeclaration namespace;
 
     /// linkage for external functions
     LINK linkage = LINK.d;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -228,8 +228,6 @@ extern (C++) class Dsymbol : ASTNode
 {
     Identifier ident;
     Dsymbol parent;
-    /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration namespace;
     Symbol* csym;           // symbol for code generator
     Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol
@@ -449,7 +447,16 @@ extern (C++) class Dsymbol : ASTNode
     }
 
     /// ditto
-    alias pastMixinAndNspace = pastMixin;
+    final inout(Dsymbol) pastMixinAndNspace() inout
+    {
+        //printf("Dsymbol::pastMixin() %s\n", toChars());
+        auto nspace = isNspace();
+        if (!(nspace && nspace.mangleOnly) && !isTemplateMixin() && !isForwardingAttribDeclaration())
+            return this;
+        if (!parent)
+            return null;
+        return parent.pastMixinAndNspace();
+    }
 
     /**********************************
      * `parent` field returns a lexically enclosing scope symbol this is a member of.
@@ -1180,7 +1187,6 @@ extern (C++) class Dsymbol : ASTNode
     inout(SymbolDeclaration)           isSymbolDeclaration()           inout { return null; }
     inout(AttribDeclaration)           isAttribDeclaration()           inout { return null; }
     inout(AnonDeclaration)             isAnonDeclaration()             inout { return null; }
-    inout(CPPNamespaceDeclaration)     isCPPNamespaceDeclaration()     inout { return null; }
     inout(ProtDeclaration)             isProtDeclaration()             inout { return null; }
     inout(OverloadSet)                 isOverloadSet()                 inout { return null; }
     inout(CompileDeclaration)          isCompileDeclaration()          inout { return null; }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -16,7 +16,6 @@
 #include "arraytypes.h"
 #include "visitor.h"
 
-class CPPNamespaceDeclaration;
 class Identifier;
 struct Scope;
 class DsymbolTable;
@@ -148,8 +147,6 @@ class Dsymbol : public ASTNode
 public:
     Identifier *ident;
     Dsymbol *parent;
-    /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration *namespace_;
     Symbol *csym;               // symbol for code generator
     Symbol *isym;               // import version of csym
     const utf8_t *comment;      // documentation comment for this Dsymbol

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -776,7 +776,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.error("extern symbols cannot have initializers");
 
         dsym.userAttribDecl = sc.userAttribDecl;
-        dsym.namespace = sc.namespace;
 
         AggregateDeclaration ad = dsym.isThis();
         if (ad)
@@ -2108,64 +2107,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         attribSemantic(cd);
     }
 
-    override void visit(CPPNamespaceDeclaration ns)
-    {
-        Identifier identFromSE (StringExp se)
-        {
-            const sident = se.toStringz();
-            if (!sident.length || !Identifier.isValidIdentifier(sident))
-            {
-                ns.exp.error("expected valid identifer for C++ namespace but got `%.*s`",
-                             cast(int)sident.length, sident.ptr);
-                return null;
-            }
-            else
-                return Identifier.idPool(sident);
-        }
-
-        if (ns.ident is null)
-        {
-            ns.namespace = sc.namespace;
-            sc = sc.startCTFE();
-            ns.exp = ns.exp.expressionSemantic(sc);
-            ns.exp = resolveProperties(sc, ns.exp);
-            sc = sc.endCTFE();
-            ns.exp = ns.exp.ctfeInterpret();
-            // Can be either a tuple of strings or a string itself
-            if (auto te = ns.exp.isTupleExp())
-            {
-                expandTuples(te.exps);
-                CPPNamespaceDeclaration current = ns.namespace;
-                for (size_t d = 0; d < te.exps.dim; ++d)
-                {
-                    auto exp = (*te.exps)[d];
-                    auto prev = d ? current : ns.namespace;
-                    current = (d + 1) != te.exps.dim
-                        ? new CPPNamespaceDeclaration(exp, null)
-                        : ns;
-                    current.exp = exp;
-                    current.namespace = prev;
-                    if (auto se = exp.toStringExp())
-                    {
-                        current.ident = identFromSE(se);
-                        if (current.ident is null)
-                            return; // An error happened in `identFromSE`
-                    }
-                    else
-                        ns.exp.error("`%s`: index %d is not a string constant, it is a `%s`",
-                                     ns.exp.toChars(), d, ns.exp.type.toChars());
-                }
-            }
-            else if (auto se = ns.exp.toStringExp())
-                ns.ident = identFromSE(se);
-            else
-                ns.exp.error("compile time string constant (or tuple) expected, not `%s`",
-                             ns.exp.toChars());
-        }
-        if (ns.ident)
-            attribSemantic(ns);
-    }
-
     override void visit(UserAttributeDeclaration uad)
     {
         //printf("UserAttributeDeclaration::semantic() %p\n", this);
@@ -2688,7 +2629,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         tempdecl.parent = sc.parent;
         tempdecl.protection = sc.protection;
-        tempdecl.namespace = sc.namespace;
         tempdecl.isstatic = tempdecl.toParent().isModule() || (tempdecl._scope.stc & STC.static_);
 
         if (!tempdecl.isstatic)
@@ -3080,7 +3020,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     else
                     {
                         // insert the new namespace
-                        Nspace childns = new Nspace(ns.loc, Identifier.idPool(ident), null, parentns.members);
+                        Nspace childns = new Nspace(ns.loc, Identifier.idPool(ident), null, parentns.members, ns.mangleOnly);
                         parentns.members = new Dsymbols;
                         parentns.members.push(childns);
                         parentns = childns;
@@ -3163,7 +3103,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc || funcdecl.errors)
             return;
 
-        funcdecl.namespace = sc.namespace;
         funcdecl.parent = sc.parent;
         Dsymbol parent = funcdecl.toParent();
 
@@ -4602,7 +4541,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 sd.classKind = ClassKind.cpp;
-            sd.namespace = sc.namespace;
         }
         else if (sd.symtab && !scx)
             return;
@@ -4822,7 +4760,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 cldec.classKind = ClassKind.cpp;
-            cldec.namespace = sc.namespace;
             if (sc.linkage == LINK.objc)
                 objc.setObjc(cldec);
         }
@@ -5541,7 +5478,6 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
-            idec.namespace = sc.namespace;
 
             if (sc.linkage == LINK.objc)
             {
@@ -5832,9 +5768,6 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     tempinst.hasNestedArgs(tempinst.tiargs, tempdecl.isstatic);
     if (tempinst.errors)
         goto Lerror;
-
-    // Copy the tempdecl namespace (not the scope one)
-    tempinst.namespace = tempdecl.namespace;
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -376,8 +376,6 @@ extern (C++) class FuncDeclaration : Declaration
                 return false;
         }
 
-        this.namespace = _scope.namespace;
-
         // if inferring return type, sematic3 needs to be run
         // - When the function body contains any errors, we cannot assume
         //   the inferred return type is valid.

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -32,27 +32,36 @@ private enum LOG = false;
 extern (C++) final class Nspace : ScopeDsymbol
 {
     /**
+     * Determines whether the symbol for this namespace should be included in the symbol table.
+     */
+    bool mangleOnly;
+
+    /**
      * Namespace identifier resolved during semantic.
      */
     Expression identExp;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members)
+    extern (D) this(const ref Loc loc, Identifier ident, Expression identExp, Dsymbols* members, bool mangleOnly)
     {
         super(loc, ident);
         //printf("Nspace::Nspace(ident = %s)\n", ident.toChars());
         this.members = members;
         this.identExp = identExp;
+        this.mangleOnly = mangleOnly;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
-        auto ns = new Nspace(loc, ident, identExp, null);
+        auto ns = new Nspace(loc, ident, identExp, null, mangleOnly);
         return ScopeDsymbol.syntaxCopy(ns);
     }
 
     override void addMember(Scope* sc, ScopeDsymbol sds)
     {
-        ScopeDsymbol.addMember(sc, sds);
+        if (mangleOnly)
+            parent = sds;
+        else
+            ScopeDsymbol.addMember(sc, sds);
 
         if (members)
         {
@@ -72,7 +81,7 @@ extern (C++) final class Nspace : ScopeDsymbol
             sc = sc.push(this);
             sc.linkage = LINK.cpp; // namespaces default to C++ linkage
             sc.parent = this;
-            members.foreachDsymbol(s => s.addMember(sc, this));
+            members.foreachDsymbol(s => s.addMember(sc, mangleOnly ? sds : this));
             sc.pop();
         }
     }

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -19,6 +19,7 @@
 class Nspace : public ScopeDsymbol
 {
   public:
+    bool mangleOnly;
     Expression *identExp;
     Dsymbol *syntaxCopy(Dsymbol *s);
     void addMember(Scope *sc, ScopeDsymbol *sds);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -950,10 +950,7 @@ final class Parser(AST) : Lexer
                                 a = new AST.Dsymbols();
                                 a.push(s);
                             }
-                            if (cppMangleOnly)
-                                s = new AST.CPPNamespaceDeclaration(id, a);
-                            else
-                                s = new AST.Nspace(linkLoc, id, null, a);
+                            s = new AST.Nspace(linkLoc, id, null, a, cppMangleOnly);
                         }
                         pAttrs.link = LINK.default_;
                     }
@@ -969,10 +966,7 @@ final class Parser(AST) : Lexer
                                 a = new AST.Dsymbols();
                                 a.push(s);
                             }
-                            if (cppMangleOnly)
-                                s = new AST.CPPNamespaceDeclaration(exp, a);
-                            else
-                                s = new AST.Nspace(linkLoc, null, exp, a);
+                            s = new AST.Nspace(linkLoc, null, exp, a, cppMangleOnly);
                         }
                         pAttrs.link = LINK.default_;
                     }

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -68,7 +68,6 @@ public:
     void visit(AST.AnonDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.AlignDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.CPPMangleDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
-    void visit(AST.CPPNamespaceDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.ProtDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.PragmaDeclaration s) { visit(cast(AST.AttribDeclaration)s); }
     void visit(AST.StorageClassDeclaration s) { visit(cast(AST.AttribDeclaration)s); }

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -24,7 +24,6 @@ class UserAttributeDeclaration;
 struct DocComment;
 struct AA;
 class TemplateInstance;
-class CPPNamespaceDeclaration;
 
 #include "dsymbol.h"
 
@@ -91,9 +90,6 @@ struct Scope
     size_t fieldinit_dim;
 
     AlignDeclaration *aligndecl;    // alignment for struct members
-
-    /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration *namespace_;
 
     LINK linkage;               // linkage for external functions
     CPPMANGLE cppmangle;        // C++ mangle type

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -99,7 +99,6 @@ class StorageClassDeclaration;
 class DeprecatedDeclaration;
 class LinkDeclaration;
 class CPPMangleDeclaration;
-class CPPNamespaceDeclaration;
 class ProtDeclaration;
 class AlignDeclaration;
 class AnonDeclaration;
@@ -359,7 +358,6 @@ public:
     virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
-    virtual void visit(CPPNamespaceDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(PragmaDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1,8 +1,4 @@
-/**
-TEST_OUTPUT:
----
----
-*/
+
 // Test C++ name mangling.
 // https://issues.dlang.org/show_bug.cgi?id=4059
 // https://issues.dlang.org/show_bug.cgi?id=5148

--- a/test/compilable/cppmangle3.d
+++ b/test/compilable/cppmangle3.d
@@ -1,8 +1,3 @@
-/**
-TEST_OUTPUT:
----
----
-*/
 module cppmangle3;
 
 

--- a/test/fail_compilation/cppmangle.d
+++ b/test/fail_compilation/cppmangle.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/cppmangle.d(11): Error: expected valid identifer for C++ namespace but got ``
 fail_compilation/cppmangle.d(15): Error: expected valid identifer for C++ namespace but got `0num`
-fail_compilation/cppmangle.d(19): Error: compile time string constant (or tuple) expected, not `2`
+fail_compilation/cppmangle.d(19): Error: expected string expression for namespace name, got `1 + 1`
 fail_compilation/cppmangle.d(23): Error: expected valid identifer for C++ namespace but got `invalid@namespace`
 ---
 */

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -19,10 +19,6 @@ struct S
 
 extern(C++, std)
 {
-    struct test19248_ {int a = 42;}
-}
-extern(C++, `std`)
-{
     struct test19248 {int a = 34;}
 }
 
@@ -42,8 +38,7 @@ ulong  passthrough(ulong  value);
 float  passthrough(float  value);
 double passthrough(double value);
 S      passthrough(S      value);
-test19248 passthrough(const(test19248) value);
-std.test19248_ passthrough(const(std.test19248_) value);
+std.test19248 passthrough(const(std.test19248) value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -61,8 +56,7 @@ ulong  passthrough_ptr(ulong  *value);
 float  passthrough_ptr(float  *value);
 double passthrough_ptr(double *value);
 S      passthrough_ptr(S      *value);
-test19248 passthrough_ptr(const(test19248)* value);
-std.test19248_ passthrough_ptr(const(std.test19248_)* value);
+std.test19248 passthrough_ptr(const(std.test19248)* value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -80,8 +74,7 @@ ulong  passthrough_ref(ref ulong  value);
 float  passthrough_ref(ref float  value);
 double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
-test19248 passthrough_ref(ref const(test19248) value);
-std.test19248_ passthrough_ref(ref const(std.test19248_) value);
+std.test19248 passthrough_ref(ref const(std.test19248) value);
 }
 
 template IsSigned(T)
@@ -222,8 +215,7 @@ else
     foreach(float val; values!float())   check(val);
     foreach(double val; values!double()) check(val);
     check(S());
-    check(test19248());
-    check(std.test19248_());
+    check(std.test19248());
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -6,8 +6,7 @@ struct S{
 
 namespace std
 {
-    struct test19248_ {int a;}; // Remove when `extern(C++, ns)` is gone
-    struct test19248  {int a;};
+    struct test19248 {int a;};
 };
 
 #ifdef __DMC__
@@ -37,8 +36,7 @@ unsigned long long passthrough(unsigned long long  value)     { return value; }
 float              passthrough(float               value)     { return value; }
 double             passthrough(double              value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
-std::test19248     passthrough(const std::test19248 value)    { return value; }
-std::test19248_    passthrough(const std::test19248_ value)   { return value; }
+std::test19248     passthrough(const std::test19248 value)     { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -61,7 +59,6 @@ float              passthrough_ptr(float              *value) { return *value; }
 double             passthrough_ptr(double             *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
 std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
-std::test19248_    passthrough_ptr(const std::test19248_ *value) { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -84,7 +81,6 @@ float              passthrough_ref(float              &value) { return value; }
 double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
-std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
 
 namespace ns1
 {


### PR DESCRIPTION
Reverts dlang/dmd#10021 which no longer has a purpose since its follow-on https://github.com/dlang/dmd/pull/10031 is not going to happen.