### PR TITLE
[dmd-cxx] Backport early return of blockExit

### DIFF
--- a/src/blockexit.c
+++ b/src/blockexit.c
@@ -496,6 +496,8 @@ int blockExit(Statement *s, FuncDeclaration *func, bool mustNotThrow)
         }
     };
 
+    if (!s)
+        return BEfallthru;
     BlockExit be(func, mustNotThrow);
     s->accept(&be);
     return be.result;


### PR DESCRIPTION
Another fix for issue 19955 specific to the C++ branch