### PR TITLE
remove `HiddenParameters`, refactor `declareThis`

### DIFF
--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -454,13 +454,6 @@ void builtin_init();
 class FuncDeclaration : public Declaration
 {
 public:
-    struct HiddenParameters
-    {
-        VarDeclaration *this_;
-        bool isThis2;
-        VarDeclaration *selector;
-    };
-
     Statements *frequires;              // in contracts
     Ensures *fensures;                  // out contracts
     Statement *frequire;                // lowered in contract

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -852,7 +852,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             }
             if (isstatic)
                 fd.storage_class |= STC.static_;
-            fd.declareThis(scx, fd.isThis());
+            fd.declareThis(scx);
         }
 
         lastConstraint = constraint.syntaxCopy();

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -852,10 +852,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             }
             if (isstatic)
                 fd.storage_class |= STC.static_;
-            auto hiddenParams = fd.declareThis(scx, fd.isThis());
-            fd.vthis = hiddenParams.vthis;
-            fd.isThis2 = hiddenParams.isThis2;
-            fd.selectorParameter = hiddenParams.selectorParameter;
+            fd.declareThis(scx, fd.isThis());
         }
 
         lastConstraint = constraint.syntaxCopy();

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -456,9 +456,10 @@ extern (C++) class FuncDeclaration : Declaration
      * Hidden parameters include the `this` parameter of a class, struct or
      * nested function and the selector parameter for Objective-C methods.
      */
-    extern (D) final void declareThis(Scope* sc, AggregateDeclaration ad)
+    extern (D) final void declareThis(Scope* sc)
     {
         isThis2 = toParent2() != toParentLocal();
+        auto ad = isThis();
         if (!isThis2 && !ad && !isNested())
         {
             vthis = null;

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -362,9 +362,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
                 }
             }
 
-            // Declare 'this'
-            auto ad = funcdecl.isThis();
-            funcdecl.declareThis(sc2, ad);
+            funcdecl.declareThis(sc2);
 
             //printf("[%s] ad = %p vthis = %p\n", loc.toChars(), ad, vthis);
             //if (vthis) printf("\tvthis.type = %s\n", vthis.type.toChars());
@@ -514,7 +512,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             Statement fpreinv = null;
             if (funcdecl.addPreInvariant())
             {
-                Expression e = addInvariant(funcdecl.loc, sc, ad, funcdecl.vthis);
+                Expression e = addInvariant(funcdecl.loc, sc, funcdecl.isThis(), funcdecl.vthis);
                 if (e)
                     fpreinv = new ExpStatement(Loc.initial, e);
             }
@@ -523,7 +521,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             Statement fpostinv = null;
             if (funcdecl.addPostInvariant())
             {
-                Expression e = addInvariant(funcdecl.loc, sc, ad, funcdecl.vthis);
+                Expression e = addInvariant(funcdecl.loc, sc, funcdecl.isThis(), funcdecl.vthis);
                 if (e)
                     fpostinv = new ExpStatement(Loc.initial, e);
             }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -364,10 +364,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
             // Declare 'this'
             auto ad = funcdecl.isThis();
-            auto hiddenParams = funcdecl.declareThis(sc2, ad);
-            funcdecl.vthis = hiddenParams.vthis;
-            funcdecl.isThis2 = hiddenParams.isThis2;
-            funcdecl.selectorParameter = hiddenParams.selectorParameter;
+            funcdecl.declareThis(sc2, ad);
+
             //printf("[%s] ad = %p vthis = %p\n", loc.toChars(), ad, vthis);
             //if (vthis) printf("\tvthis.type = %s\n", vthis.type.toChars());
 


### PR DESCRIPTION
Also qualify the `void* __capture` context parameter.

@ibuclaw is that used anywhere in GDC? looks like it could be removed from the headers.