### PR TITLE
Add another test that used to SEGV before #9412

### DIFF
--- a/test/fail_compilation/b19717a.d
+++ b/test/fail_compilation/b19717a.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -de
+/* TEST_OUTPUT:
+---
+fail_compilation/b19717a.d(14): Error: forward reference to template `a`
+fail_compilation/b19717a.d(14): Error: forward reference to template `a`
+fail_compilation/b19717a.d(14): Error: none of the overloads of `a` are callable using argument types `()`, candidates are:
+fail_compilation/b19717a.d(13):        `b19717a.a(int b)`
+fail_compilation/b19717a.d(14):        `b19717a.a(int b = a)`
+---
+*/
+module b19717a;
+
+auto a(int b) {}
+auto a(int b = a) {}


### PR DESCRIPTION
Caught by fuzz testing gdc, but not reproducible in master/stable.  Tracked down and referencing the fixing PR, adding test for prosperity.