### PR TITLE
workaround Issue 19974 - changed naked asm parameter offsets

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -460,11 +460,24 @@ version (X86ASM)
 {
 int insidx(char *p,uint index)
 {
+    // https://issues.dlang.org/show_bug.cgi?id=19974
+    static if (__VERSION__ >= 2086)
+        asm
+        {
+            naked                           ;
+            mov     EAX,index - [ESP]       ;
+            mov     ECX,p - [ESP]           ;
+        }
+    else
+        asm
+        {
+            naked                           ;
+            mov     EAX,index - [ESP+4]     ;
+            mov     ECX,p - [ESP+4]         ;
+        }
+
     asm
     {
-        naked                           ;
-        mov     EAX,index - [ESP+4]     ;
-        mov     ECX,p - [ESP+4]         ;
         cmp     EAX,0x7F                ;
         jae     L1                      ;
         mov     [ECX],AL                ;


### PR DESCRIPTION
- fixes building dmd for Win32 with 2.086 host compiler
  (nightly and upcoming 2.087.0-beta.1)