### PR TITLE
Don't crash when compiling for 16-bit platforms

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4427,13 +4427,13 @@ struct ASTBase
                 break;
 
             case Tpointer:
+                if (Target.ptrsize == 8)
+                    goto case Tuns64;
                 if (Target.ptrsize == 4)
-                    value = cast(d_uns32)value;
-                else if (Target.ptrsize == 8)
-                    value = cast(d_uns64)value;
-                else
-                    assert(0);
-                break;
+                    goto case Tuns32;
+                if (Target.ptrsize == 2)
+                    goto case Tuns16;
+                assert(0);
 
             default:
                 break;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1887,13 +1887,13 @@ extern (C++) final class IntegerExp : Expression
             break;
 
         case Tpointer:
+            if (target.ptrsize == 8)
+                goto case Tuns64;
             if (target.ptrsize == 4)
-                result = cast(d_uns32)value;
-            else if (target.ptrsize == 8)
-                result = cast(d_uns64)value;
-            else
-                assert(0);
-            break;
+                goto case Tuns32;
+            if (target.ptrsize == 2)
+                goto case Tuns16;
+            assert(0);
 
         default:
             break;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1823,19 +1823,17 @@ public:
                 break;
             case Tuns8:
                 buf.writestring("cast(ubyte)");
-                goto L3;
+                goto case Tuns32;
             case Tuns16:
                 buf.writestring("cast(ushort)");
-                goto L3;
+                goto case Tuns32;
             case Tuns32:
-            L3:
                 buf.printf("%uu", cast(uint)v);
                 break;
             case Tint64:
                 buf.printf("%lldL", v);
                 break;
             case Tuns64:
-            L4:
                 buf.printf("%lluLU", v);
                 break;
             case Tbool:
@@ -1845,12 +1843,10 @@ public:
                 buf.writestring("cast(");
                 buf.writestring(t.toChars());
                 buf.writeByte(')');
-                if (target.ptrsize == 4)
-                    goto L3;
-                else if (target.ptrsize == 8)
-                    goto L4;
+                if (target.ptrsize == 8)
+                    goto case Tuns64;
                 else
-                    assert(0);
+                    goto case Tuns32;
             default:
                 /* This can happen if errors, such as
                  * the type is painted on like in fromConstInitializer().
@@ -3122,11 +3118,13 @@ private void sizeToBuffer(Expression e, OutBuffer* buf, HdrGenState* hgs)
         const dinteger_t uval = ex.op == TOK.int64 ? ex.toInteger() : cast(dinteger_t)-1;
         if (cast(sinteger_t)uval >= 0)
         {
-            dinteger_t sizemax;
-            if (target.ptrsize == 4)
-                sizemax = 0xFFFFFFFFU;
-            else if (target.ptrsize == 8)
+            dinteger_t sizemax = void;
+            if (target.ptrsize == 8)
                 sizemax = 0xFFFFFFFFFFFFFFFFUL;
+            else if (target.ptrsize == 4)
+                sizemax = 0xFFFFFFFFU;
+            else if (target.ptrsize == 2)
+                sizemax = 0xFFFFU;
             else
                 assert(0);
             if (uval <= sizemax && uval <= 0x7FFFFFFFFFFFFFFFUL)


### PR DESCRIPTION
There's only three places where the front-end needs to be mindful of size of size_t.

If there's a need to support more exotic targets, IntegerExp.normalize and sizeToBuffer could be computed as:
```
if (target.ptrsize == 8)  // Check should be same size as host dinteger_t
    result = value;
else
    result = value & (1UL << (target.ptrsize * 8) - 1);
```
