### PR TITLE
Version out assert in cppmangle

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -542,8 +542,9 @@ private final class CppMangleVisitor : Visitor
      */
     void source_name(Dsymbol s, bool haveNE = false)
     {
-        //printf("source_name(%s)\n", s.toChars());
+        version (none)
         {
+            printf("source_name(%s)\n", s.toChars());
             auto sl = this.buf.peekSlice();
             assert(sl.length == 0 || haveNE || s.namespace is null || sl != "_ZN");
         }


### PR DESCRIPTION
It won't cause any bug because it is checking for a legit error condition but should be done in a more principled way, e.g. by having systematic checks for the buffer content.