### PR TITLE
[stable] Fix `extern(C++, "namespace")` following refactor

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -451,10 +451,32 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
     }
 }
 
-/***********************************************************
+/**
+ * A node to represent an `extern(C++)` namespace attribute
+ *
+ * There are two ways to declarate a symbol as member of a namespace:
+ * `Nspace` and `CPPNamespaceDeclaration`.
+ * The former creates a scope for the symbol, and inject them in the
+ * parent scope at the same time.
+ * The later, this class, has no semantic implications and is only
+ * used for mangling.
+ * Additionally, this class allows one to use reserved identifiers
+ * (D keywords) in the namespace.
+ *
+ * A `CPPNamespaceDeclaration` can be created from an `Identifier`
+ * (already resolved) or from an `Expression`, which is CTFE-ed
+ * and can be either a `TupleExp`, in which can additional
+ * `CPPNamespaceDeclaration` nodes are created, or a `StringExp`.
+ *
+ * Note that this class, like `Nspace`, matches only one identifier
+ * part of a namespace. For the namespace `"foo::bar"`,
+ * the will be a `CPPNamespaceDeclaration` with its `ident`
+ * set to `"bar"`, and its `namespace` field pointing to another
+ * `CPPNamespaceDeclaration` with its `ident` set to `"foo"`.
  */
 extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
 {
+    /// CTFE-able expression, resolving to `TupleExp` or `StringExp`
     Expression exp;
 
     extern (D) this(Identifier ident, Dsymbols* decl)
@@ -485,6 +507,10 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
             this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.namespace);
     }
 
+    /**
+     * Returns:
+     *   A copy of the parent scope, with `this` as `namespace` and C++ linkage
+     */
     override Scope* newScope(Scope* sc)
     {
         auto scx = sc.copy();

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -542,8 +542,9 @@ private final class CppMangleVisitor : Visitor
      */
     void source_name(Dsymbol s, bool haveNE = false)
     {
-        //printf("source_name(%s)\n", s.toChars());
+        version (none)
         {
+            printf("source_name(%s)\n", s.toChars());
             auto sl = this.buf.peekSlice();
             assert(sl.length == 0 || haveNE || s.namespace is null || sl != "_ZN");
         }

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1363,15 +1363,8 @@ private final class CppMangleVisitor : Visitor
      * Helper function to write a `T..._` template index.
      *
      * Params:
-     *   ident = Identifier for which substitution is attempted
-     *           (e.g. `void func(T)(T param)` => `T` from `T param`)
-     *   params = `TemplateParameters` of the enclosing symbol
-     *           (in the previous example, `func`'s template parameters)
-     *   type = Resolved type of `T`, so that `void func(T)(const T)`
-     *          gets mangled correctly
-     *
-     * Returns:
-     *   `true` if something was written to the buffer
+     *   idx   = Index of `param` in the template argument list
+     *   param = Template parameter to mangle
      */
     private void writeTemplateArgIndex(size_t idx, TemplateParameter param)
     {
@@ -1389,10 +1382,15 @@ private final class CppMangleVisitor : Visitor
      * Given an array of template parameters and an identifier,
      * returns the index of the identifier in that array.
      *
+     * Params:
+     *   ident = Identifier for which substitution is attempted
+     *           (e.g. `void func(T)(T param)` => `T` from `T param`)
+     *   params = `TemplateParameters` of the enclosing symbol
+     *           (in the previous example, `func`'s template parameters)
      *
      * Returns:
      *   The index of the identifier match in `params`,
-     *   or `params.dim` if there wasn't any match.
+     *   or `params.length` if there wasn't any match.
      */
     private static size_t templateParamIndex(
         const ref Identifier ident, TemplateParameters* params)

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -49,7 +49,7 @@ void test1()
     c.bar(4, 5, 6);
 }
 
-version (linux)
+version (Posix)
 {
     static assert(foo.mangleof == "_Z3fooiii");
     static assert(foob.mangleof == "_Z4foobiii");
@@ -85,7 +85,7 @@ void test2()
     assert(i == 8);
 }
 
-version (linux)
+version (Posix)
 {
     static assert (getD.mangleof == "_Z4getDv");
     static assert (D.bar.mangleof == "_ZN1D3barEiii");
@@ -122,7 +122,7 @@ void test3()
     assert(i == 8);
 }
 
-version (linux)
+version (Posix)
 {
     static assert (callE.mangleof == "_Z5callEP1E");
     static assert (E.bar.mangleof == "_ZN1E3barEiii");
@@ -138,7 +138,7 @@ void test4()
     foo4(null);
 }
 
-version (linux)
+version (Posix)
 {
     static assert(foo4.mangleof == "_Z4foo4Pc");
 }
@@ -164,7 +164,7 @@ void test5()
   assert(f.p == cast(void*)b);
 }
 
-version (linux)
+version (Posix)
 {
     static assert(bar5.getFoo.mangleof == "_ZN4bar56getFooEi");
     static assert (newBar.mangleof == "_Z6newBarv");
@@ -194,7 +194,7 @@ void test6()
     assert(f.d == 2.5);
 }
 
-version (linux)
+version (Posix)
 {
     static assert (foo6.mangleof == "_Z4foo6v");
 }
@@ -225,7 +225,7 @@ void test8()
     foo8(&c);
 }
 
-version (linux)
+version (Posix)
 {
     static assert(foo8.mangleof == "_Z4foo8PKc");
 }
@@ -243,7 +243,7 @@ void test9()
     foobar9(a, a);
 }
 
-version (linux)
+version (Posix)
 {
     static assert(foobar9.mangleof == "_Z7foobar9P5elem9S0_");
 }
@@ -295,7 +295,7 @@ extern (C++)
     void test10058l(void* function(void*), void* function(const (void)*), const(void)* function(void*)) { }
 }
 
-version (linux)
+version (Posix)
 {
     static assert(test10058a.mangleof == "_Z10test10058aPv");
     static assert(test10058b.mangleof == "_Z10test10058bPFvPvE");
@@ -326,7 +326,7 @@ class CallExp
     static void test11696d(Loc, Expression*, Expression*);
 }
 
-version (linux)
+version (Posix)
 {
     static assert(CallExp.test11696a.mangleof == "_ZN7CallExp10test11696aE3LocP10ExpressionS2_");
     static assert(CallExp.test11696b.mangleof == "_ZN7CallExp10test11696bE3LocP10ExpressionPS2_");
@@ -343,7 +343,7 @@ extern(C++, N13337a.N13337b.N13337c)
   void foo13337(S13337 s);
 }
 
-version (linux)
+version (Posix)
 {
     static assert(foo13337.mangleof == "_ZN7N13337a7N13337b7N13337c8foo13337ENS1_6S13337E");
 }
@@ -425,7 +425,7 @@ extern (C++, std)
     struct test18957 {}
 }
 
-version (linux)
+version (Posix)
 {
     // https://issues.dlang.org/show_bug.cgi?id=17947
     static assert(std.pair!(void*, void*).swap.mangleof == "_ZNSt4pairIPvS0_E4swapERS1_");
@@ -445,7 +445,7 @@ alias T36 = int ********** ********** ********** **********;
 
 extern (C++) void test36(T36, T36*) { }
 
-version (linux)
+version (Posix)
 {
     static assert(test36.mangleof == "_Z6test36PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPiPS12_");
 }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -425,6 +425,12 @@ extern (C++, std)
     struct test18957 {}
 }
 
+extern(C++)
+{
+    allocator!int func_18957_1(allocator!(int)* v);
+    X func_18957_2(X)(X* v);
+}
+
 version (Posix)
 {
     // https://issues.dlang.org/show_bug.cgi?id=17947
@@ -437,6 +443,9 @@ version (Posix)
     static assert(std.basic_istream!(char, std.char_traits!char).fooc.mangleof == "_ZNSi4foocEv");
     static assert(std.basic_ostream!(char, std.char_traits!char).food.mangleof == "_ZNSo4foodEv");
     static assert(std.basic_iostream!(char, std.char_traits!char).fooe.mangleof == "_ZNSd4fooeEv");
+
+    static assert(func_18957_1.mangleof == `_Z12func_18957_1PSaIiE`);
+    static assert(func_18957_2!(allocator!int).mangleof == `_Z12func_18957_2ISaIiEET_PS1_`);
 }
 
 /**************************************/
@@ -1004,4 +1013,12 @@ version (Posix)
 version (Win64)
 {
     static assert(test_char_mangling.mangleof == "?test_char_mangling@@YAXD_S_U_W@Z");
+}
+
+// https://github.com/dlang/dmd/pull/10021/files#r294055424
+version (Posix)
+{
+    extern(C++, PR10021_NS) struct PR10021_Struct(T){}
+    extern(C++) void PR10021_fun(int i)(PR10021_Struct!int);
+    static assert(PR10021_fun!0.mangleof == `_Z11PR10021_funILi0EEvN10PR10021_NS14PR10021_StructIiEE`);
 }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -343,9 +343,18 @@ extern(C++, N13337a.N13337b.N13337c)
   void foo13337(S13337 s);
 }
 
+extern(C++, `N13337a`, `N13337b`, `N13337c`)
+{
+    struct S13337_2{}
+    void foo13337_2(S13337 s);
+    void foo13337_3(S13337_2 s);
+}
+
 version (Posix)
 {
     static assert(foo13337.mangleof == "_ZN7N13337a7N13337b7N13337c8foo13337ENS1_6S13337E");
+    static assert(foo13337_2.mangleof == "_ZN7N13337a7N13337b7N13337c10foo13337_2ENS1_6S13337E");
+    static assert(foo13337_3.mangleof == "_ZN7N13337a7N13337b7N13337c10foo13337_3ENS1_8S13337_2E");
 }
 
 /**************************************/
@@ -425,9 +434,55 @@ extern (C++, std)
     struct test18957 {}
 }
 
+extern (C++, `std`)
+{
+    struct pair(T1, T2)
+    {
+        void swap(ref pair other);
+    }
+
+    struct allocator(T)
+    {
+        uint fooa() const;
+        uint foob();
+    }
+
+    struct basic_string(T1, T2, T3)
+    {
+        uint fooa();
+    }
+
+    struct basic_istream(T1, T2)
+    {
+        uint fooc();
+    }
+
+    struct basic_ostream(T1, T2)
+    {
+        uint food();
+    }
+
+    struct basic_iostream(T1, T2)
+    {
+        uint fooe();
+    }
+
+    struct char_traits(T)
+    {
+        uint foof();
+    }
+
+    struct vector (T);
+
+    struct Struct18957 {}
+}
+
 extern(C++)
 {
-    allocator!int func_18957_1(allocator!(int)* v);
+    // Nspace
+    std.allocator!int func_18957_1(std.allocator!(int)* v);
+    // CPPNamespaceAttribute
+    allocator!int func_18957_2(allocator!(int)* v);
     X func_18957_2(X)(X* v);
 }
 
@@ -435,7 +490,6 @@ version (Posix)
 {
     // https://issues.dlang.org/show_bug.cgi?id=17947
     static assert(std.pair!(void*, void*).swap.mangleof == "_ZNSt4pairIPvS0_E4swapERS1_");
-
     static assert(std.allocator!int.fooa.mangleof == "_ZNKSaIiE4fooaEv");
     static assert(std.allocator!int.foob.mangleof == "_ZNSaIiE4foobEv");
     static assert(std.basic_string!(char,int,uint).fooa.mangleof == "_ZNSbIcijE4fooaEv");
@@ -445,6 +499,19 @@ version (Posix)
     static assert(std.basic_iostream!(char, std.char_traits!char).fooe.mangleof == "_ZNSd4fooeEv");
 
     static assert(func_18957_1.mangleof == `_Z12func_18957_1PSaIiE`);
+    static assert(func_18957_2!(std.allocator!int).mangleof == `_Z12func_18957_2ISaIiEET_PS1_`);
+
+
+    static assert(pair!(void*, void*).swap.mangleof == "_ZNSt4pairIPvS0_E4swapERS1_");
+    static assert(allocator!int.fooa.mangleof == "_ZNKSaIiE4fooaEv");
+    static assert(allocator!int.foob.mangleof == "_ZNSaIiE4foobEv");
+    static assert(basic_string!(char,int,uint).fooa.mangleof == "_ZNSbIcijE4fooaEv");
+    static assert(basic_string!(char, char_traits!char, allocator!char).fooa.mangleof == "_ZNSs4fooaEv");
+    static assert(basic_istream!(char, char_traits!char).fooc.mangleof == "_ZNSi4foocEv");
+    static assert(basic_ostream!(char, char_traits!char).food.mangleof == "_ZNSo4foodEv");
+    static assert(basic_iostream!(char, char_traits!char).fooe.mangleof == "_ZNSd4fooeEv");
+
+    static assert(func_18957_2.mangleof == `_Z12func_18957_2PSaIiE`);
     static assert(func_18957_2!(allocator!int).mangleof == `_Z12func_18957_2ISaIiEET_PS1_`);
 }
 
@@ -465,8 +532,12 @@ version (Posix)
 extern(C++, SPACE)
 int test37(T)(){ return 0;}
 
+extern(C++, `SPACE`)
+int test37(T)(){ return 0;}
+
 version (Posix) // all non-Windows machines
 {
+    static assert(SPACE.test37!int.mangleof == "_ZN5SPACE6test37IiEEiv");
     static assert(test37!int.mangleof == "_ZN5SPACE6test37IiEEiv");
 }
 
@@ -741,15 +812,36 @@ version (Win64)
     static assert(TestOperators.opCall.mangleof          == "??RTestOperators@@QEAAHHM@Z");
 }
 
+import cppmangle2;
 extern(C++, Namespace18922)
 {
-    import cppmangle2;
-    void func18922(Struct18922) {}
+    // Nspace
+    void func18922(cppmangle2.Namespace18922.Struct18922) {}
+    // CPPNamespaceAttribute
+    void func18922_1(Struct18922) {}
+}
 
-    version (Posix)
-        static assert(func18922.mangleof == "_ZN14Namespace189229func18922ENS_11Struct18922E");
-    else version(Windows)
-        static assert(func18922.mangleof == "?func18922@Namespace18922@@YAXUStruct18922@1@@Z");
+extern(C++, `Namespace18922`)
+{
+    // Nspace
+    void func18922_2(cppmangle2.Namespace18922.Struct18922) {}
+    // CPPNamespaceAttribute
+    void func18922_3(Struct18922) {}
+}
+
+version (Posix)
+{
+    static assert(func18922.mangleof == "_ZN14Namespace189229func18922ENS_11Struct18922E");
+    static assert(func18922_1.mangleof == "_ZN14Namespace1892211func18922_1ENS_11Struct18922E");
+    static assert(func18922_2.mangleof == "_ZN14Namespace1892211func18922_2ENS_11Struct18922E");
+    static assert(func18922_3.mangleof == "_ZN14Namespace1892211func18922_3ENS_11Struct18922E");
+}
+else version(Windows)
+{
+    static assert(func18922.mangleof == "?func18922@Namespace18922@@YAXUStruct18922@1@@Z");
+    static assert(func18922_1.mangleof == "?func18922_1@Namespace18922@@YAXUStruct18922@1@@Z");
+    static assert(func18922_2.mangleof == "?func18922_2@Namespace18922@@YAXUStruct18922@1@@Z");
+    static assert(func18922_3.mangleof == "?func18922_3@Namespace18922@@YAXUStruct18922@1@@Z");
 }
 
 /**************************************/
@@ -766,9 +858,9 @@ version (Posix)
     }
     void test18957(const std::test18957& t) {}
     +/
-    extern (C++) void test18957(ref const(std.test18957) t) {}
+    extern (C++) void test18957(ref const(Struct18957) t) {}
 
-    static assert(test18957.mangleof == "_Z9test18957RKSt9test18957");
+    static assert(test18957.mangleof == "_Z9test18957RKSt11Struct18957");
 }
 
 /**************************************/
@@ -877,11 +969,14 @@ version (Posix) extern (C++)
      */
     extern(C++) void CPPPrinter16479(const(char)*);
     extern(C++, Namespace16479) void CPPPrinterNS16479(const(char)*);
+    extern(C++, `Namespace16479`) void CPPPrinterNS16479_1(const(char)*);
     void func16479_11 (alias Print) ();
     static assert(func16479_11!(CPPPrinter16479).mangleof
                   == `_Z12func16479_11IXadL_Z15CPPPrinter16479PKcEEEvv`);
     static assert(func16479_11!(CPPPrinterNS16479).mangleof
                   == `_Z12func16479_11IXadL_ZN14Namespace1647917CPPPrinterNS16479EPKcEEEvv`);
+    static assert(func16479_11!(CPPPrinterNS16479_1).mangleof
+                  == `_Z12func16479_11IXadL_ZN14Namespace1647919CPPPrinterNS16479_1EPKcEEEvv`);
 
     // Functions are fine, but templates are finer
     // ---
@@ -1021,4 +1116,17 @@ version (Posix)
     extern(C++, PR10021_NS) struct PR10021_Struct(T){}
     extern(C++) void PR10021_fun(int i)(PR10021_Struct!int);
     static assert(PR10021_fun!0.mangleof == `_Z11PR10021_funILi0EEvN10PR10021_NS14PR10021_StructIiEE`);
+}
+
+// https://github.com/dlang/dmd/pull/10021#discussion_r294095749
+version (Posix)
+{
+    extern(C++, "a", "b")
+    struct PR10021_Struct2
+    {
+        void func();
+        void func2(PR10021_Struct2*);
+    }
+    static assert(PR10021_Struct2.func.mangleof == `_ZN1a1b15PR10021_Struct24funcEv`);
+    static assert(PR10021_Struct2.func2.mangleof == `_ZN1a1b15PR10021_Struct25func2EPS1_`);
 }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -363,7 +363,7 @@ void test15789()
 
 extern(C++)
 {
-    struct T
+    struct Struct7030
     {
         void foo(int) const;
         void bar(int);
@@ -373,9 +373,9 @@ extern(C++)
 
 version (Posix)
 {
-    static assert(T.foo.mangleof == "_ZNK1T3fooEi");
-    static assert(T.bar.mangleof == "_ZN1T3barEi");
-    static assert(T.boo.mangleof == "_ZN1T3booE");
+    static assert(Struct7030.foo.mangleof == "_ZNK10Struct70303fooEi");
+    static assert(Struct7030.bar.mangleof == "_ZN10Struct70303barEi");
+    static assert(Struct7030.boo.mangleof == "_ZN10Struct70303booE");
 }
 
 /****************************************/

--- a/test/compilable/cppmangle2.d
+++ b/test/compilable/cppmangle2.d
@@ -9,3 +9,13 @@ extern(C++, std)
 {
     struct vector (T);
 }
+
+extern(C++, `Namespace18922`)
+{
+    struct Struct18922 { int i; }
+}
+
+extern(C++, `std`)
+{
+    struct vector (T);
+}


### PR DESCRIPTION
The beta started after [this PR](https://github.com/dlang/dmd/pull/10021) was merged.
Unfortunately, a few issues were discovered after it was merged, hence I raised a few PRs to fix them.
After discussing with @wilzbach , it seems that the proper procedure is for me to submit those to `stable`.

The following PR were merged to master and are part of this PR:
- #10044 (First 5 commits)
- #10053 ("cppmangle: Add more tests, fix double 'N'")
- #10054 ("Version out assert in cppmangle")
