### PR TITLE
[WIP] Translate _d_arraycatnTX to template

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -5019,6 +5019,33 @@ public:
                 result = interpret(ae, istate);
                 return;
             }
+            else if (fd.ident == Id._d_arraycatnTX)
+            {
+                assert(e.arguments.dim == 1);
+
+                Expression ea = (*e.arguments)[0];
+
+                while (true)
+                {
+                    if (auto ce = ea.isCastExp())
+                        ea = ce.e1;
+                    else
+                        break;
+                }
+                auto arr = interpret(ea, istate).isArrayLiteralExp().elements;
+
+                Expression e1 = (*arr)[0];
+                foreach (i; 1 .. arr.dim) {
+                    auto type = e1.type;
+                    e1 = new CatExp(e.loc, e1, (*arr)[i]);
+                    e1.type = type;
+                }
+
+                if (global.params.verbose)
+                    message("interpret  %s =>\n          %s", e.toChars(), e1.toChars());
+                result = interpret(e1, istate);
+                return;
+            }
         }
         else if (auto soe = ecall.isSymOffExp())
         {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1286,7 +1286,7 @@ extern (C++) abstract class Expression : ASTNode
 
                 // Lowered non-@nogc'd hooks will print their own error message inside of nogc.d (NOGCVisitor.visit(CallExp e)),
                 // so don't print anything to avoid double error messages.
-                if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT))
+                if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT || f.ident == Id._d_arraycatnTX))
                     error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
                         sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
                 return true;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -347,6 +347,9 @@ immutable Msgtable[] msgtable =
     { "_d_arraysetlengthTImpl"},
     { "_d_arraysetlengthT"},
     { "_d_arraysetlengthTTrace"},
+    { "_d_arraycatnTXImpl" },
+    { "_d_arraycatnTX" },
+    { "_d_arraycatnTXTrace" },
 
     // varargs implementation
     { "va_start" },

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -2171,7 +2171,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                     auto flag = tryParseJsonField(p + 4);
                     if (!flag)
                     {
-                        error("unknown JSON field `-Xi=%s`, expected one of " ~ jsonFieldNames, p + 4);
+                        error(cast(const(char)*)("unknown JSON field `-Xi=%s`, expected one of " ~ jsonFieldNames), p + 4);
                         continue;
                     }
                     global.params.jsonFieldFlags |= flag;

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -81,6 +81,17 @@ public:
             }
             f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
         }
+        else if (fd.ident == Id._d_arraycatnTX)
+        {
+            if (f.setGC())
+            {
+                e.error("cannot use operator `~` in `@nogc` %s `%s`",
+                    f.kind(), f.toPrettyChars());
+                err = true;
+                return;
+            }
+            f.printGCUsage(e.loc, "operator `~` may cause a GC allocation");
+        }
     }
 
     override void visit(ArrayLiteralExp e)

--- a/test/runnable/extra-files/hello-profile.d.trace.def
+++ b/test/runnable/extra-files/hello-profile.d.trace.def
@@ -1,3 +1,4 @@
 
 FUNCTIONS
 	_D5hello8showargsFAAyaZv
+	_D4core8internal5array13concatenation__T18_d_arraycatnTXImplHTAAyaHTQfTyaZ14_d_arraycatnTXFNaNbNeMxAAyaZQBp


### PR DESCRIPTION
druntime PR: https://github.com/dlang/druntime/pull/2648

These patches will lower `a ~ a` to `(S[][2] __cat2 = [arr1, arr1];) , _d_arraycatnTX(cast(S[][])__cat2)`.