### PR TITLE
Move pure `errno` wrapper to `dmd.root.errno`

### DIFF
--- a/src/dmd/root/errno.d
+++ b/src/dmd/root/errno.d
@@ -1,0 +1,73 @@
+/**
+ * Pure wrapper of `errno`.
+ *
+ * Compiler implementation of the D programming language
+ * http://dlang.org
+ *
+ * Copyright: Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * Authors:   Walter Bright, http://www.digitalmars.com
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:    $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/errno.d, root/_errno.d)
+ * Documentation:  https://dlang.org/phobos/dmd_root_errno.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/errno.d
+ */
+module dmd.root.errno;
+
+static import core.stdc.errno;
+
+/**
+ * Restores `errno` after calling `func`.
+ *
+ * Params:
+ *  func = the action to perform before `errno` is restored
+ *
+ * Returns: whatever `func` returns
+ */
+package auto restoreErrno(alias func)()
+{
+    const savedErrno = fakePureErrno;
+
+    static if (is(typeof(func) T == return))
+        alias ReturnType = T;
+
+    static if (is(ReturnType == void))
+        func();
+    else
+        auto result = func();
+
+    fakePureErrno = savedErrno;
+
+    static if (!is(ReturnType == void))
+        return result;
+}
+
+///
+unittest
+{
+    import core.stdc.errno : errno;
+
+    assert(errno == 0);
+    auto result = restoreErrno!(() => errno = 3);
+    assert(errno == 0);
+    assert(result == 3);
+}
+
+private:
+
+static if (__traits(getOverloads, core.stdc.errno, "errno").length == 1
+    && __traits(getLinkage, core.stdc.errno.errno) == "C")
+{
+    extern(C) pragma(mangle, __traits(identifier, core.stdc.errno.errno))
+    ref int fakePureErrno() pure nothrow @nogc @system;
+}
+else
+{
+    extern(C) pure nothrow @nogc @system @property
+    {
+        pragma(mangle, "getErrno")
+        int fakePureErrno();
+
+        pragma(mangle, "setErrno")
+        int fakePureErrno(int);
+    }
+}

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -327,7 +327,7 @@ LEXER_ROOT=$(addsuffix .d, $(addprefix $(ROOT)/, array ctfloat file filename out
 
 ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array ctfloat file \
 	filename man outbuffer port response rmem rootobject speller \
-	longdouble strtold stringtable hash string))
+	longdouble strtold stringtable hash string errno))
 
 GLUE_SRCS=$(addsuffix .d, $(addprefix $D/,irstate toctype glue gluelayer todt tocsym toir dmsc \
 	tocvdebug s2ir toobj e2ir eh iasm iasmdmd iasmgcc objc_glue))

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -189,7 +189,8 @@ GBACKOBJ= $G/go.obj $G/gdag.obj $G/gother.obj $G/gflow.obj $G/gloop.obj $G/var.o
 ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 	$(ROOT)/filename.d $(ROOT)/man.d $(ROOT)/outbuffer.d $(ROOT)/port.d \
 	$(ROOT)/response.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
-	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d $(ROOT)/string.d
+	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/hash.d $(ROOT)/string.d \
+	$(ROOT)/errno.d
 
 # D front end
 SRCS = $D/aggregate.h $D/aliasthis.h $D/arraytypes.h	\


### PR DESCRIPTION
This allows to use the wrapper in other modules. Also adds a new function, `restoreErrno`, that automatically restores `errno`, to make sure `errno` is always restored.

The longterm goal is to (`->` can be read as "depends on"):

Make DMD as a library easier to use -> Less global things -> More pure things -> Pure error reporting -> pure `sprintf` wrapper -> This PR, since the `sprintf` wrapper doesn't belong in `dmd.root.rmem`. 