### PR TITLE
Fix Issue 19534 - Wrong error message "only one index allowed to index int"

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7383,8 +7383,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         if (isAggregate(exp.e1.type))
             exp.error("no `[]` operator overload for type `%s`", exp.e1.type.toChars());
-        else
+        else if (exp.e1.op == TOK.type && exp.e1.type.ty != Ttuple)
+            exp.error("static array of `%s` with multiple lengths not allowed", exp.e1.type.toChars());
+        else if (isIndexableNonAggregate(exp.e1.type))
             exp.error("only one index allowed to index `%s`", exp.e1.type.toChars());
+        else
+            exp.error("cannot use `[]` operator on expression of type `%s`", exp.e1.type.toChars());
+
         result = new ErrorExp();
     }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6670,6 +6670,21 @@ extern (C++) AggregateDeclaration isAggregate(Type t)
 }
 
 /***************************************************
+ * Determine if type t can be indexed or sliced given that it is not an
+ * aggregate with operator overloads.
+ * Params:
+ *      t = type to check
+ * Returns:
+ *      true if an expression of type t can be e1 in an array expression
+ */
+bool isIndexableNonAggregate(Type t)
+{
+    t = t.toBasetype();
+    return (t.ty == Tpointer || t.ty == Tsarray || t.ty == Tarray || t.ty == Taarray ||
+            t.ty == Ttuple || t.ty == Tvector);
+}
+
+/***************************************************
  * Determine if type t is copyable.
  * Params:
  *      t = type to check

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -688,8 +688,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 {
                     // If the non-aggregate expression ae.e1 is indexable or sliceable,
                     // convert it to the corresponding concrete expression.
-                    if (t1b.ty == Tpointer || t1b.ty == Tsarray || t1b.ty == Tarray || t1b.ty == Taarray ||
-                        t1b.ty == Ttuple || t1b.ty == Tvector || ae.e1.op == TOK.type)
+                    if (isIndexableNonAggregate(t1b) || ae.e1.op == TOK.type)
                     {
                         // Convert to SliceExp
                         if (maybeSlice)

--- a/test/fail_compilation/fail15.d
+++ b/test/fail_compilation/fail15.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail15.d(24): Error: only one index allowed to index `void`
+fail_compilation/fail15.d(24): Error: cannot use `[]` operator on expression of type `void`
 ---
 */
 /*

--- a/test/fail_compilation/fail_arrayexp.d
+++ b/test/fail_compilation/fail_arrayexp.d
@@ -1,0 +1,30 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail_arrayexp.d(24): Error: cannot use `[]` operator on expression of type `int`
+fail_compilation/fail_arrayexp.d(25): Error: cannot use `[]` operator on expression of type `void`
+fail_compilation/fail_arrayexp.d(26): Error: static array of `const(int)[]` with multiple lengths not allowed
+fail_compilation/fail_arrayexp.d(27): Error: only one index allowed to index `string`
+fail_compilation/fail_arrayexp.d(28): Error: no `[]` operator overload for type `U`
+fail_compilation/fail_arrayexp.d(29): Error: only one index allowed to index `(int, string)`
+---
+*/
+
+int i;
+string str;
+union U {}
+alias typeAlias = const(int)[];
+void getVoid();
+alias getTuple(T...) = T;
+
+void test19534() // https://issues.dlang.org/show_bug.cgi?id=19534
+{
+    U agg;
+#line 24
+    auto p = i[0];
+    auto q = getVoid()[0];
+    alias r = getTuple!(typeAlias[0, 1]);
+    auto s = str[0, 1, 2];
+    auto t = agg[];
+    auto u = getTuple!(int, string)[1, 2];
+}


### PR DESCRIPTION
First time fixing an issue for dmd, any tips are welcome.
Unfortunately some of the `op_over` logic had to be duplicated because with the current interface, I don't see a way `op_over` can tell why it failed to set `result`. I made a function `isIndexableNonAggregate` to avoid duplicating the long disjunction. It's a bit of a specific function to put in `mtype.d`, but I don't know a better way without reshuffling a lot.