### PR TITLE
Remove Dsymbol.toParent3()

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -582,7 +582,7 @@ private final class CppMangleVisitor : Visitor
      */
     static Dsymbol getInstance(Dsymbol s)
     {
-        Dsymbol p = s.toParent3();
+        Dsymbol p = s.toParent();
         if (p)
         {
             if (TemplateInstance ti = p.isTemplateInstance())
@@ -613,7 +613,7 @@ private final class CppMangleVisitor : Visitor
      */
     static Dsymbol getQualifier(Dsymbol s)
     {
-        Dsymbol p = s.toParent3();
+        Dsymbol p = s.toParent();
         return (p && !p.isModule()) ? p : null;
     }
 
@@ -645,7 +645,7 @@ private final class CppMangleVisitor : Visitor
         Dsymbol s = (cast(TypeStruct)t).toDsymbol(null);
         if (s.ident != ident)
             return false;
-        Dsymbol p = s.toParent3();
+        Dsymbol p = s.toParent();
         if (!p)
             return false;
         TemplateInstance ti = p.isTemplateInstance();
@@ -779,7 +779,7 @@ private final class CppMangleVisitor : Visitor
     void cpp_mangle_name(Dsymbol s, bool qualified)
     {
         //printf("cpp_mangle_name(%s, %d)\n", s.toChars(), qualified);
-        Dsymbol p = s.toParent3();
+        Dsymbol p = s.toParent();
         Dsymbol se = s;
         bool write_prefix = true;
         if (p && p.isTemplateInstance())
@@ -787,7 +787,7 @@ private final class CppMangleVisitor : Visitor
             se = p;
             if (find(p.isTemplateInstance().tempdecl) >= 0)
                 write_prefix = false;
-            p = p.toParent3();
+            p = p.toParent();
         }
         if (p && !p.isModule())
         {
@@ -891,7 +891,7 @@ private final class CppMangleVisitor : Visitor
             d.error("Internal Compiler Error: C++ static non-`__gshared` non-`extern` variables not supported");
             fatal();
         }
-        Dsymbol p = d.toParent3();
+        Dsymbol p = d.toParent();
         if (p && !p.isModule()) //for example: char Namespace1::beta[6] should be mangled as "_ZN10Namespace14betaE"
         {
             buf.writestring("_ZN");
@@ -934,7 +934,7 @@ private final class CppMangleVisitor : Visitor
         }
         else
         {
-            Dsymbol p = d.toParent3();
+            Dsymbol p = d.toParent();
             if (p && !p.isModule() && tf.linkage == LINK.cpp)
             {
                 this.mangleNestedFuncPrefix(tf, p);
@@ -1031,9 +1031,9 @@ private final class CppMangleVisitor : Visitor
             this.context.fd = d;
             this.context.res = d;
             TypeFunction preSemantic = cast(TypeFunction)d.originalType;
-            auto nspace = ti.toParent3();
+            auto nspace = ti.toParent();
             if (nspace && nspace.isNspace())
-                this.writeChained(ti.toParent3(), () => source_name(ti, true));
+                this.writeChained(ti.toParent(), () => source_name(ti, true));
             else
                 source_name(ti);
             this.mangleReturnType(preSemantic);
@@ -1291,7 +1291,7 @@ private final class CppMangleVisitor : Visitor
         else
         {
             Dsymbol s = t.toDsymbol(null);
-            Dsymbol p = s.toParent3();
+            Dsymbol p = s.toParent();
             if (p && p.isTemplateInstance())
             {
                  /* https://issues.dlang.org/show_bug.cgi?id=17947
@@ -1333,7 +1333,7 @@ private final class CppMangleVisitor : Visitor
 
         {
             Dsymbol s = t.toDsymbol(null);
-            Dsymbol p = s.toParent3();
+            Dsymbol p = s.toParent();
             if (p && p.isTemplateInstance())
             {
                  /* https://issues.dlang.org/show_bug.cgi?id=17947

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -575,10 +575,10 @@ private:
         buf.writeByte('?');
         mangleIdent(d);
         assert((d.storage_class & STC.field) || !d.needThis());
-        Dsymbol parent = d.toParent3();
+        Dsymbol parent = d.toParent();
         while (parent && parent.isNspace())
         {
-            parent = parent.toParent3();
+            parent = parent.toParent();
         }
         if (parent && parent.isModule()) // static member
         {
@@ -1036,9 +1036,9 @@ private:
         //                ::= $0<encoded integral number>
         //printf("mangleIdent('%s')\n", sym.toChars());
         Dsymbol p = sym;
-        if (p.toParent3() && p.toParent3().isTemplateInstance())
+        if (p.toParent() && p.toParent().isTemplateInstance())
         {
-            p = p.toParent3();
+            p = p.toParent();
         }
         while (p && !p.isModule())
         {
@@ -1046,10 +1046,10 @@ private:
             // Mangle our string namespaces as well
             for (auto ns = p.namespace; ns !is null; ns = ns.namespace)
                 mangleName(ns, dont_use_back_reference);
-            p = p.toParent3();
-            if (p.toParent3() && p.toParent3().isTemplateInstance())
+            p = p.toParent();
+            if (p.toParent() && p.toParent().isTemplateInstance())
             {
-                p = p.toParent3();
+                p = p.toParent();
             }
         }
         if (!dont_use_back_reference)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -436,7 +436,7 @@ extern (C++) class Dsymbol : ASTNode
      * `pastMixinAndNspace` does likewise, additionally skipping over Nspaces that
      * are mangleOnly.
      *
-     * See also `parent`, `toParent`, `toParent2` and `toParent3`.
+     * See also `parent`, `toParent` and `toParent2`.
      */
     final inout(Dsymbol) pastMixin() inout
     {
@@ -448,21 +448,15 @@ extern (C++) class Dsymbol : ASTNode
         return parent.pastMixin();
     }
 
-    /// ditto
-    alias pastMixinAndNspace = pastMixin;
-
     /**********************************
      * `parent` field returns a lexically enclosing scope symbol this is a member of.
      *
      * `toParent()` returns a logically enclosing scope symbol this is a member of.
-     * It skips over TemplateMixin's and Nspaces that are mangleOnly.
+     * It skips over TemplateMixin's.
      *
      * `toParent2()` returns an enclosing scope symbol this is living at runtime.
      * It skips over both TemplateInstance's and TemplateMixin's.
      * It's used when looking for the 'this' pointer of the enclosing function/class.
-     *
-     * `toParent3()` returns a logically enclosing scope symbol this is a member of.
-     * It skips over TemplateMixin's.
      *
      * `toParentDecl()` similar to `toParent2()` but always follows the template declaration scope
      * instead of the instantiation scope.
@@ -494,7 +488,7 @@ extern (C++) class Dsymbol : ASTNode
      */
     final inout(Dsymbol) toParent() inout
     {
-        return parent ? parent.pastMixinAndNspace() : null;
+        return parent ? parent.pastMixin() : null;
     }
 
     /// ditto
@@ -503,12 +497,6 @@ extern (C++) class Dsymbol : ASTNode
         if (!parent || !parent.isTemplateInstance && !parent.isForwardingAttribDeclaration())
             return parent;
         return parent.toParent2;
-    }
-
-    /// ditto
-    final inout(Dsymbol) toParent3() inout
-    {
-        return parent ? parent.pastMixin() : null;
     }
 
     /// ditto

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -177,10 +177,8 @@ public:
     Module *getModule();
     Module *getAccessModule();
     Dsymbol *pastMixin();
-    Dsymbol *pastMixinAndNspace();
     Dsymbol *toParent();
     Dsymbol *toParent2();
-    Dsymbol *toParent3();
     Dsymbol *toParentDecl();
     Dsymbol *toParentLocal();
     TemplateInstance *isInstantiated();


### PR DESCRIPTION
Since mangle-only namespaces are now an Attribute, they don't show up as parents anymore.
Hence toParent3 does the exact same thing as toParent() and can be removed.