### PR TITLE
No CSEs for shared types

### DIFF
--- a/src/dmd/backend/blockopt.d
+++ b/src/dmd/backend/blockopt.d
@@ -2134,7 +2134,7 @@ private int funcsideeffect_walk(elem *e)
 {
     assert(e);
     elem_debug(e);
-    if (typemask(e) & mTYvolatile)
+    if (typemask(e) & (mTYvolatile | mTYshared))
         return 1;
     int op = e.Eoper;
     switch (op)

--- a/src/dmd/backend/cgcs.d
+++ b/src/dmd/backend/cgcs.d
@@ -425,7 +425,7 @@ void ecom(elem **pe)
     /* don't CSE structures or unions or volatile stuff   */
     if (tym == TYstruct ||
         tym == TYvoid ||
-        e.Ety & mTYvolatile)
+        e.Ety & (mTYvolatile | mTYshared))
         return;
     if (tyfloating(tym) && config.inline8087)
     {
@@ -493,7 +493,7 @@ hash_t cs_comphash(const elem *e)
 {
     elem_debug(e);
     const op = e.Eoper;
-    hash_t hash = (e.Ety & (mTYbasic | mTYconst | mTYvolatile)) + (op << 8);
+    hash_t hash = (e.Ety & (mTYbasic | mTYconst | mTYvolatile | mTYshared)) + (op << 8);
     if (!OTleaf(op))
     {
         hash += cast(size_t) e.EV.E1;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -2195,7 +2195,7 @@ L2:
     int e1op = e1.Eoper;
 
   // c,e => e
-    if (OTleaf(e1op) && !OTsideff(e1op) && !(e1.Ety & mTYvolatile))
+    if (OTleaf(e1op) && !OTsideff(e1op) && !(e1.Ety & (mTYvolatile | mTYshared)))
     {
         e2.Ety = e.Ety;
         e = el_selecte2(e);
@@ -2602,7 +2602,7 @@ private elem * eloror(elem *e, goal_t goal)
         tysize(ty1) <= _tysize[TYint] &&
         !tyfloating(ty2) &&
         !tyfloating(ty1) &&
-        !(ty2 & mTYvolatile))
+        !(ty2 & (mTYvolatile | mTYshared)))
     {   /* Convert (e1 || e2) => (e1 | e2)      */
         e.Eoper = OPor;
         e.Ety = ty1;
@@ -5248,7 +5248,7 @@ beg:
     auto op = e.Eoper;
     if (OTleaf(op))                     // if not an operator node
     {
-        if (goal || OTsideff(op) || e.Ety & mTYvolatile)
+        if (goal || OTsideff(op) || e.Ety & (mTYvolatile | mTYshared))
         {
             return e;
         }
@@ -5615,7 +5615,7 @@ beg:
   else /* unary operator */
   {
         assert(!e.EV.E2 || op == OPinfo || op == OPddtor);
-        if (!goal && !OTsideff(op) && !(e.Ety & mTYvolatile))
+        if (!goal && !OTsideff(op) && !(e.Ety & (mTYvolatile | mTYshared)))
         {
             tym_t tym = e.EV.E1.Ety;
 

--- a/src/dmd/backend/debugprint.d
+++ b/src/dmd/backend/debugprint.d
@@ -145,6 +145,8 @@ void WRTYxx(tym_t t)
         printf("mTYconst|");
     if (t & mTYvolatile)
         printf("mTYvolatile|");
+    if (t & mTYshared)
+        printf("mTYshared|");
 //#if !MARS && (__linux__ || __APPLE__ || __FreeBSD__ || __OpenBSD__ || __sun)
 //    if (t & mTYtransu)
 //        printf("mTYtransu|");

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -1245,7 +1245,7 @@ int el_sideeffect(elem *e)
     const op = e.Eoper;
     assert(op < OPMAX);
     elem_debug(e);
-    return  typemask(e) & mTYvolatile ||
+    return  typemask(e) & (mTYvolatile | mTYshared) ||
             OTsideff(op) ||
             (OTunary(op) && el_sideeffect(e.EV.E1)) ||
             (OTbinary(op) && (el_sideeffect(e.EV.E1) ||

--- a/src/dmd/backend/gflow.d
+++ b/src/dmd/backend/gflow.d
@@ -725,9 +725,10 @@ private int numaeelems(elem *n)
     else
         ae = true;
 
-    if (ae && OTae(op) && !(n.Ety & mTYvolatile) &&
+    if (ae && OTae(op) && !(n.Ety & (mTYvolatile | mTYshared)) &&
         // Disallow struct AEs, because we can't handle CSEs that are structs
-        tybasic(n.Ety) != TYstruct)
+        tybasic(n.Ety) != TYstruct &&
+        tybasic(n.Ety) != TYarray)
     {
         n.Nflags |= NFLaecp;           /* remember for asgexpelems()   */
         go.exptop++;
@@ -764,7 +765,7 @@ private int numcpelems(elem *n)
             if ((op == OPeq || op == OPstreq) &&
                 n.EV.E1.Eoper == OPvar &&
                 n.EV.E2.Eoper == OPvar &&
-                !((n.EV.E1.Ety | n.EV.E2.Ety) & mTYvolatile) &&
+                !((n.EV.E1.Ety | n.EV.E2.Ety) & (mTYvolatile | mTYshared)) &&
                 n.EV.E1.EV.Vsym != n.EV.E2.EV.Vsym)
             {
                 n.Nflags |= NFLaecp;
@@ -914,7 +915,7 @@ private void defstarkill()
                         // For C/C++, casting to 'const' doesn't mean it
                         // actually is const,
                         // but immutable really doesn't change
-                        if ((n.Ety & (mTYimmutable | mTYvolatile)) == mTYimmutable &&
+                        if ((n.Ety & (mTYimmutable | mTYvolatile | mTYshared)) == mTYimmutable &&
                             n.EV.E1.Eoper == OPvar &&
                             n.EV.E1.EV.Vsym.Sflags & SFLunambig
                            )

--- a/src/dmd/backend/glocal.d
+++ b/src/dmd/backend/glocal.d
@@ -48,7 +48,7 @@ int REGSIZE();
 
 enum
 {
-    LFvolatile     = 1,       // contains volatile refs or defs
+    LFvolatile     = 1,       // contains volatile or shared refs or defs
     LFambigref     = 2,       // references ambiguous data
     LFambigdef     = 4,       // defines ambiguous data
     LFsymref       = 8,       // reference to symbol s
@@ -488,7 +488,7 @@ private void local_ins(ref Barray!loc_t lt, elem *e)
         {
             const flags = local_getflags(e.EV.E2,null);
             if (!(flags & (LFvolatile | LFinp | LFoutp)) &&
-                !(e.EV.E1.Ety & mTYvolatile))
+                !(e.EV.E1.Ety & (mTYvolatile | mTYshared)))
             {
                 // Add e to the candidate array
                 //printf("local_ins('%s'), loctop = %d\n",s.Sident.ptr,lt.length);
@@ -519,7 +519,7 @@ private int local_getflags(elem *e,Symbol *s)
     int flags = 0;
     while (1)
     {
-        if (e.Ety & mTYvolatile)
+        if (e.Ety & (mTYvolatile | mTYshared))
             flags |= LFvolatile;
         switch (e.Eoper)
         {

--- a/src/dmd/backend/gother.d
+++ b/src/dmd/backend/gother.d
@@ -407,7 +407,7 @@ private void chkrd(elem *n,list_t rdlist)
     assert(sytab[sv.Sclass] & SCRD);
     if (sv.Sflags & SFLnord)           // if already printed a warning
         return;
-    if (sv.ty() & mTYvolatile)
+    if (sv.ty() & (mTYvolatile | mTYshared))
         return;
     unambig = sv.Sflags & SFLunambig;
     foreach (l; ListRange(rdlist))
@@ -1402,8 +1402,8 @@ void rmdeadass()
             //printf("\tDEAD=%d, live=%d\n",vec_testbit(j,DEAD),vec_testbit(v.Ssymnum,b.Boutlv));
             if (!vec_testbit(j,DEAD) && vec_testbit(v.Ssymnum,b.Boutlv))
                 continue;
-            /* volatile variables are not dead              */
-            if ((v.ty() | nv.Ety) & mTYvolatile)
+            /* volatile/shared variables are not dead              */
+            if ((v.ty() | nv.Ety) & (mTYvolatile | mTYshared))
                 continue;
             debug if (debugc)
             {
@@ -1685,7 +1685,7 @@ private void accumda(elem *n,vec_t DEAD, vec_t POSS)
                         if (ti.EV.Vsym == t.EV.Vsym &&
                             ti.EV.Voffset == t.EV.Voffset &&
                             tisz == tsz &&
-                            !(t.Ety & mTYvolatile) &&
+                            !(t.Ety & (mTYvolatile | mTYshared)) &&
                             //t.EV.Vsym.Sflags & SFLunambig &&
                             vec_testbit(i,POSS))
                         {

--- a/src/dmd/backend/out.d
+++ b/src/dmd/backend/out.d
@@ -970,7 +970,7 @@ void out_regcand(symtab_t *psymtab)
         symbol_debug(s);
         //assert(sytab[s.Sclass] & SCSS);      // only stack variables
         s.Ssymnum = si;                        // Ssymnum trashed by cpp_inlineexpand
-        if (!(s.ty() & mTYvolatile) &&
+        if (!(s.ty() & (mTYvolatile | mTYshared)) &&
             !(ifunc && (s.Sclass == SCparameter || s.Sclass == SCregpar)) &&
             s.Sclass != SCstatic)
             s.Sflags |= (GTregcand | SFLunambig);      // assume register candidate
@@ -1281,7 +1281,7 @@ else
                     break;
                 }
             L3:
-                if (!(s.ty() & mTYvolatile))
+                if (!(s.ty() & (mTYvolatile | mTYshared)))
                     s.Sflags |= GTregcand | SFLunambig; // assume register candidate   */
                 break;
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2971,7 +2971,7 @@ elem *toElem(Expression e, IRState *irs)
 
             // Create a reference to e1.
             if (e1.Eoper == OPvar)
-                e1x = el_same(&e1);
+                e1x = el_copytree(e1);
             else
             {
                 /* Rewrite to:

--- a/test/compilable/sharedopt.d
+++ b/test/compilable/sharedopt.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -O
+
+void _d_critical_term()
+{
+    for (auto p = head; p; p = p.next)
+        destroyMutex(p.i);
+}
+
+shared S* head;
+
+struct S
+{
+    S* next;
+    int i;
+}
+
+void destroyMutex(int i);
+
+struct Mutex { int i; }


### PR DESCRIPTION
Shared and volatile types have a lot in common, like no common subexpressions. This adjusts the backend so shared has no CSEs.