### PR TITLE
Fix undefined reference to 'ParameterList::opIndex(unsigned long)'

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1752,18 +1752,8 @@ extern (C++) final class IntegerExp : Expression
         return new IntegerExp(loc, value, type);
     }
 
-    static IntegerExp createi(Loc loc, int value, Type type)
-    {
-        return new IntegerExp(loc, value, type);
-    }
-
     // Same as create, but doesn't allocate memory.
     static void emplace(UnionExp* pue, Loc loc, dinteger_t value, Type type)
-    {
-        emplaceExp!(IntegerExp)(pue, loc, value, type);
-    }
-
-    static void emplacei(UnionExp* pue, Loc loc, int value, Type type)
     {
         emplaceExp!(IntegerExp)(pue, loc, value, type);
     }

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -233,9 +233,7 @@ public:
     dinteger_t value;
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
-    static IntegerExp *createi(Loc loc, int value, Type *type);
     static void emplace(UnionExp *pue, Loc loc, dinteger_t value, Type *type);
-    static void emplacei(UnionExp *pue, Loc loc, int value, Type *type);
     bool equals(RootObject *o);
     dinteger_t toInteger();
     real_t toReal();

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -308,7 +308,13 @@ extern Global global;
 // we have to explicitly ask for the correct integer type to get the correct
 // mangling with dmd. The #if logic here should match the mangling of
 // Tint64 and Tuns64 in cppmangle.d.
-#if __SIZEOF_LONG__ == 8
+#if MARS && DMD_VERSION >= 2079 && DMD_VERSION <= 2081 && \
+    __APPLE__ && __SIZEOF_LONG__ == 8
+// DMD versions between 2.079 and 2.081 mapped D long to int64_t on OS X.
+typedef uint64_t dinteger_t;
+typedef int64_t sinteger_t;
+typedef uint64_t uinteger_t;
+#elif __SIZEOF_LONG__ == 8
 // Be careful not to care about sign when using dinteger_t
 // use this instead of integer_t to
 // avoid conflicts with system #include's

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -304,10 +304,11 @@ struct Global
 
 extern Global global;
 
-// Because int64_t and friends may be any integral type of the
-// correct size, we have to explicitly ask for the correct
-// integer type to get the correct mangling with dmd
-#if __LP64__
+// Because int64_t and friends may be any integral type of the correct size,
+// we have to explicitly ask for the correct integer type to get the correct
+// mangling with dmd. The #if logic here should match the mangling of
+// Tint64 and Tuns64 in cppmangle.d.
+#if __SIZEOF_LONG__ == 8
 // Be careful not to care about sign when using dinteger_t
 // use this instead of integer_t to
 // avoid conflicts with system #include's

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -550,15 +550,36 @@ enum PURE
     PUREstrong = 4      // parameters are values or immutable
 };
 
+class Parameter : public ASTNode
+{
+public:
+    StorageClass storageClass;
+    Type *type;
+    Identifier *ident;
+    Expression *defaultArg;
+    UserAttributeDeclaration *userAttribDecl;   // user defined attributes
+
+    static Parameter *create(StorageClass storageClass, Type *type, Identifier *ident,
+                             Expression *defaultArg, UserAttributeDeclaration *userAttribDecl);
+    Parameter *syntaxCopy();
+    Type *isLazyArray();
+    // kludge for template.isType()
+    DYNCAST dyncast() const { return DYNCAST_PARAMETER; }
+    void accept(Visitor *v) { v->visit(this); }
+
+    static size_t dim(Parameters *parameters);
+    static Parameter *getNth(Parameters *parameters, d_size_t nth, d_size_t *pn = NULL);
+    const char *toChars();
+    bool isCovariant(bool returnByRef, const Parameter *p) const;
+};
+
 struct ParameterList
 {
     Parameters* parameters;
     VarArg varargs;
 
     size_t length();
-    Parameter *opIndex(size_t i);
-
-    Parameter *operator[](size_t i) { return opIndex(i); }
+    Parameter *operator[](size_t i) { return Parameter::getNth(parameters, i); }
 };
 
 class TypeFunction : public TypeNext
@@ -840,32 +861,6 @@ public:
 };
 
 /**************************************************************/
-
-//enum InOut { None, In, Out, InOut, Lazy };
-
-class Parameter : public ASTNode
-{
-public:
-    //enum InOut inout;
-    StorageClass storageClass;
-    Type *type;
-    Identifier *ident;
-    Expression *defaultArg;
-    UserAttributeDeclaration *userAttribDecl;   // user defined attributes
-
-    static Parameter *create(StorageClass storageClass, Type *type, Identifier *ident,
-                             Expression *defaultArg, UserAttributeDeclaration *userAttribDecl);
-    Parameter *syntaxCopy();
-    Type *isLazyArray();
-    // kludge for template.isType()
-    DYNCAST dyncast() const { return DYNCAST_PARAMETER; }
-    void accept(Visitor *v) { v->visit(this); }
-
-    static size_t dim(Parameters *parameters);
-    static Parameter *getNth(Parameters *parameters, d_size_t nth, d_size_t *pn = NULL);
-    const char *toChars();
-    bool isCovariant(bool returnByRef, const Parameter *p) const;
-};
 
 bool arrayTypeCompatible(Loc loc, Type *t1, Type *t2);
 bool arrayTypeCompatibleWithoutCasting(Type *t1, Type *t2);

--- a/src/dmd/root/rmem.h
+++ b/src/dmd/root/rmem.h
@@ -16,6 +16,11 @@
      * than D's 'uint'
      */
     typedef unsigned d_size_t;
+#elif MARS && DMD_VERSION >= 2079 && DMD_VERSION <= 2081 && \
+        __APPLE__ && __SIZEOF_SIZE_T__ == 8
+    /* DMD versions between 2.079 and 2.081 mapped D ulong to uint64_t on OS X.
+     */
+    typedef uint64_t d_size_t;
 #else
     typedef size_t d_size_t;
 #endif

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -154,15 +154,19 @@ endif
 HOST_DMD_VERSION:=$(shell $(HOST_DMD_RUN) --version)
 ifneq (,$(findstring dmd,$(HOST_DMD_VERSION))$(findstring DMD,$(HOST_DMD_VERSION)))
 	HOST_DMD_KIND=dmd
+	HOST_DMD_VERNUM=$(shell echo 'pragma(msg, cast(int)__VERSION__);' | $(HOST_DMD_RUN) -o- - 2>&1)
 endif
 ifneq (,$(findstring gdc,$(HOST_DMD_VERSION))$(findstring GDC,$(HOST_DMD_VERSION)))
 	HOST_DMD_KIND=gdc
+	HOST_DMD_VERNUM=2
 endif
 ifneq (,$(findstring gdc,$(HOST_DMD_VERSION))$(findstring gdmd,$(HOST_DMD_VERSION)))
 	HOST_DMD_KIND=gdc
+	HOST_DMD_VERNUM=2
 endif
 ifneq (,$(findstring ldc,$(HOST_DMD_VERSION))$(findstring LDC,$(HOST_DMD_VERSION)))
 	HOST_DMD_KIND=ldc
+	HOST_DMD_VERNUM=2
 endif
 
 # Compiler Warnings
@@ -217,7 +221,7 @@ MMD=-MMD -MF $(basename $@).deps
 CXXFLAGS := $(WARNINGS) \
 	-fno-exceptions -fno-rtti \
 	-D__pascal= -DMARS=1 -DTARGET_$(OS_UPCASE)=1 -DDM_TARGET_CPU_$(TARGET_CPU)=1 \
-	$(MODEL_FLAG) $(PIC)
+	$(MODEL_FLAG) $(PIC) -DDMD_VERSION=$(HOST_DMD_VERNUM)
 # GCC Specific
 ifeq ($(CXX_KIND), g++)
 CXXFLAGS += \
@@ -598,7 +602,7 @@ dscanner: $(DSCANNER_DIR)/dsc
 
 ######################################################
 
-$G/cxxfrontend.o: $G/%.o: tests/%.c $(SRC) $(ROOT_SRC)
+$G/cxxfrontend.o: $G/%.o: tests/%.c $(SRC) $(ROOT_SRC) $(SRC_MAKE)
 	$(CXX) -c -o$@ $(CXXFLAGS) $(DMD_FLAGS) $(MMD) $<
 
 $G/cxx-unittest: $G/cxxfrontend.o $(DMD_SRCS) $(ROOT_SRCS) $G/lexer.a $(G_OBJS) $(G_DOBJS) $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -253,23 +253,38 @@ void test_target()
 
 void test_emplace()
 {
-  Loc loc;
-  UnionExp ue;
+    Loc loc;
+    UnionExp ue;
 
-  IntegerExp::emplacei(&ue, loc, 1065353216, Type::tint32);
-  Expression *e = ue.exp();
-  assert(e->op == TOKint64);
-  assert(e->toInteger() == 1065353216);
+    IntegerExp::emplacei(&ue, loc, 1065353216, Type::tint32);
+    Expression *e = ue.exp();
+    assert(e->op == TOKint64);
+    assert(e->toInteger() == 1065353216);
 
-  UnionExp ure;
-  Expression *re = Compiler::paintAsType(&ure, e, Type::tfloat32);
-  assert(re->op == TOKfloat64);
-  assert(re->toReal() == CTFloat::one);
+    UnionExp ure;
+    Expression *re = Compiler::paintAsType(&ure, e, Type::tfloat32);
+    assert(re->op == TOKfloat64);
+    assert(re->toReal() == CTFloat::one);
 
-  UnionExp uie;
-  Expression *ie = Compiler::paintAsType(&uie, re, Type::tint32);
-  assert(ie->op == TOKint64);
-  assert(ie->toInteger() == e->toInteger());
+    UnionExp uie;
+    Expression *ie = Compiler::paintAsType(&uie, re, Type::tint32);
+    assert(ie->op == TOKint64);
+    assert(ie->toInteger() == e->toInteger());
+}
+
+/**********************************/
+
+void test_parameters()
+{
+    Parameters *args = new Parameters;
+    args->push(Parameter::create(STCundefined, Type::tint32, NULL, NULL, NULL));
+    args->push(Parameter::create(STCundefined, Type::tint64, NULL, NULL, NULL));
+
+    TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINKc);
+
+    assert(tf->parameterList.length() == 2);
+    assert(tf->parameterList[0]->type == Type::tint32);
+    assert(tf->parameterList[1]->type == Type::tint64);
 }
 
 /**********************************/
@@ -283,6 +298,7 @@ int main(int argc, char **argv)
     test_expression();
     test_target();
     test_emplace();
+    test_parameters();
 
     frontend_term();
 

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -162,7 +162,7 @@ void test_visitors()
     Loc loc;
     Identifier *ident = Identifier::idPool("test");
 
-    IntegerExp *ie = IntegerExp::createi(loc, 42, Type::tint32);
+    IntegerExp *ie = IntegerExp::create(loc, 42, Type::tint32);
     ie->accept(&tv);
     assert(tv.expr == true);
 
@@ -235,7 +235,7 @@ void test_semantic()
 void test_expression()
 {
     Loc loc;
-    IntegerExp *ie = IntegerExp::createi(loc, 42, Type::tint32);
+    IntegerExp *ie = IntegerExp::create(loc, 42, Type::tint32);
     Expression *e = ie->ctfeInterpret();
 
     assert(e);
@@ -256,7 +256,7 @@ void test_emplace()
     Loc loc;
     UnionExp ue;
 
-    IntegerExp::emplacei(&ue, loc, 1065353216, Type::tint32);
+    IntegerExp::emplace(&ue, loc, 1065353216, Type::tint32);
     Expression *e = ue.exp();
     assert(e->op == TOKint64);
     assert(e->toInteger() == 1065353216);


### PR DESCRIPTION
At some point, the C++ mangler started mangling opIndex as operator[], breaking the bootstrap of the compiler.