### PR TITLE
Set correct type on IR element - Followup to #9946

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -515,6 +515,7 @@ if (!irs.params.is64bit) assert(tysize(TYnptr) == 4);
     {
         // CPP constructor returns void on Posix
         // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#return-value-ctor
+        e.Ety = TYvoid;
         e = el_combine(e, el_same(&ethis));
     }
     else if (retmethod == RET.stack)


### PR DESCRIPTION
I forgot to reset the type in #9946.