### PR TITLE
Remove some more extern(C++) linkage from compiler functions

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6391,7 +6391,7 @@ struct ASTBase
     }
 
 
-    extern (C++) static const(char)* protectionToChars(Prot.Kind kind)
+    static const(char)* protectionToChars(Prot.Kind kind)
     {
         final switch (kind)
         {
@@ -6412,7 +6412,7 @@ struct ASTBase
         }
     }
 
-    extern (C++) static bool stcToBuffer(OutBuffer* buf, StorageClass stc)
+    static bool stcToBuffer(OutBuffer* buf, StorageClass stc)
     {
         bool result = false;
         if ((stc & (STC.return_ | STC.scope_)) == (STC.return_ | STC.scope_))
@@ -6436,7 +6436,7 @@ struct ASTBase
         return t.toExpression;
     }
 
-    extern (C++) static const(char)* stcToChars(ref StorageClass stc)
+    static const(char)* stcToChars(ref StorageClass stc)
     {
         struct SCstring
         {
@@ -6499,7 +6499,7 @@ struct ASTBase
         return null;
     }
 
-    extern (C++) static const(char)* linkageToChars(LINK linkage)
+    static const(char)* linkageToChars(LINK linkage)
     {
         final switch (linkage)
         {

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -39,13 +39,13 @@ private:
  * Returns:
  *  An Expression containing the return value of the call.
  */
-extern (C++) alias builtin_fp = Expression function(Loc loc, FuncDeclaration fd, Expressions* arguments);
+alias builtin_fp = Expression function(Loc loc, FuncDeclaration fd, Expressions* arguments);
 
 __gshared StringTable builtins;
 
-public extern (C++) void add_builtin(const(char)* mangle, builtin_fp fp)
+void add_builtin(const(char)[] mangle, builtin_fp fp)
 {
-    builtins.insert(mangle, strlen(mangle), cast(void*)fp);
+    builtins.insert(mangle, cast(void*)fp);
 }
 
 builtin_fp builtin_lookup(const(char)* mangle)
@@ -55,47 +55,47 @@ builtin_fp builtin_lookup(const(char)* mangle)
     return null;
 }
 
-extern (C++) Expression eval_unimp(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_unimp(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     return null;
 }
 
-extern (C++) Expression eval_sin(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_sin(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.sin(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_cos(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_cos(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.cos(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_tan(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_tan(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.tan(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_sqrt(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_sqrt(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.sqrt(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_fabs(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_fabs(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.fabs(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_ldexp(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_ldexp(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -104,77 +104,77 @@ extern (C++) Expression eval_ldexp(Loc loc, FuncDeclaration fd, Expressions* arg
     return new RealExp(loc, CTFloat.ldexp(arg0.toReal(), cast(int) arg1.toInteger()), arg0.type);
 }
 
-extern (C++) Expression eval_log(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_log(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.log(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_log2(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_log2(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.log2(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_log10(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_log10(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.log10(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_exp(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_exp(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.exp(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_expm1(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_expm1(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.expm1(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_exp2(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_exp2(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.exp2(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_round(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_round(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.round(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_floor(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_floor(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.floor(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_ceil(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_ceil(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.ceil(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_trunc(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_trunc(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new RealExp(loc, CTFloat.trunc(arg0.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_copysign(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_copysign(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -183,7 +183,7 @@ extern (C++) Expression eval_copysign(Loc loc, FuncDeclaration fd, Expressions* 
     return new RealExp(loc, CTFloat.copysign(arg0.toReal(), arg1.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_pow(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_pow(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -192,7 +192,7 @@ extern (C++) Expression eval_pow(Loc loc, FuncDeclaration fd, Expressions* argum
     return new RealExp(loc, CTFloat.pow(arg0.toReal(), arg1.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_fmin(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_fmin(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -201,7 +201,7 @@ extern (C++) Expression eval_fmin(Loc loc, FuncDeclaration fd, Expressions* argu
     return new RealExp(loc, CTFloat.fmin(arg0.toReal(), arg1.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_fmax(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_fmax(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -210,7 +210,7 @@ extern (C++) Expression eval_fmax(Loc loc, FuncDeclaration fd, Expressions* argu
     return new RealExp(loc, CTFloat.fmax(arg0.toReal(), arg1.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_fma(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_fma(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -221,21 +221,21 @@ extern (C++) Expression eval_fma(Loc loc, FuncDeclaration fd, Expressions* argum
     return new RealExp(loc, CTFloat.fma(arg0.toReal(), arg1.toReal(), arg2.toReal()), arg0.type);
 }
 
-extern (C++) Expression eval_isnan(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_isnan(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new IntegerExp(loc, CTFloat.isNaN(arg0.toReal()), Type.tbool);
 }
 
-extern (C++) Expression eval_isinfinity(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_isinfinity(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
     return new IntegerExp(loc, CTFloat.isInfinity(arg0.toReal()), Type.tbool);
 }
 
-extern (C++) Expression eval_isfinite(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_isfinite(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -243,7 +243,7 @@ extern (C++) Expression eval_isfinite(Loc loc, FuncDeclaration fd, Expressions* 
     return new IntegerExp(loc, value, Type.tbool);
 }
 
-extern (C++) Expression eval_bsf(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_bsf(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.int64);
@@ -253,7 +253,7 @@ extern (C++) Expression eval_bsf(Loc loc, FuncDeclaration fd, Expressions* argum
     return new IntegerExp(loc, core.bitop.bsf(n), Type.tint32);
 }
 
-extern (C++) Expression eval_bsr(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_bsr(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.int64);
@@ -263,7 +263,7 @@ extern (C++) Expression eval_bsr(Loc loc, FuncDeclaration fd, Expressions* argum
     return new IntegerExp(loc, core.bitop.bsr(n), Type.tint32);
 }
 
-extern (C++) Expression eval_bswap(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_bswap(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.int64);
@@ -275,7 +275,7 @@ extern (C++) Expression eval_bswap(Loc loc, FuncDeclaration fd, Expressions* arg
         return new IntegerExp(loc, core.bitop.bswap(cast(uint) n), arg0.type);
 }
 
-extern (C++) Expression eval_popcnt(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_popcnt(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.int64);
@@ -283,7 +283,7 @@ extern (C++) Expression eval_popcnt(Loc loc, FuncDeclaration fd, Expressions* ar
     return new IntegerExp(loc, core.bitop.popcnt(n), Type.tint32);
 }
 
-extern (C++) Expression eval_yl2x(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_yl2x(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);
@@ -296,7 +296,7 @@ extern (C++) Expression eval_yl2x(Loc loc, FuncDeclaration fd, Expressions* argu
     return new RealExp(loc, result, arg0.type);
 }
 
-extern (C++) Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* arguments)
+Expression eval_yl2xp1(Loc loc, FuncDeclaration fd, Expressions* arguments)
 {
     Expression arg0 = (*arguments)[0];
     assert(arg0.op == TOK.float64);

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -902,7 +902,7 @@ extern (C++) final class StaticIfCondition : Condition
  * Returns:
  *      true if found
  */
-extern (C++) bool findCondition(Identifiers* ids, Identifier ident)
+bool findCondition(Identifiers* ids, Identifier ident)
 {
     if (ids)
     {

--- a/src/dmd/cond.h
+++ b/src/dmd/cond.h
@@ -22,8 +22,6 @@ class DebugCondition;
 class ForeachStatement;
 class ForeachRangeStatement;
 
-int findCondition(Strings *ids, Identifier *ident);
-
 enum Include
 {
     INCLUDEnotComputed, /// not computed yet

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -448,9 +448,6 @@ enum BUILTIN
 
 Expression *eval_builtin(Loc loc, FuncDeclaration *fd, Expressions *arguments);
 BUILTIN isBuiltin(FuncDeclaration *fd);
-
-typedef Expression *(*builtin_fp)(Loc loc, FuncDeclaration *fd, Expressions *arguments);
-void add_builtin(const char *mangle, builtin_fp fp);
 void builtin_init();
 
 class FuncDeclaration : public Declaration

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -41,7 +41,7 @@ import dmd.visitor;
  * Returns:
  *  A delegate literal
  */
-extern (C++) Expression toDelegate(Expression e, Type t, Scope* sc)
+Expression toDelegate(Expression e, Type t, Scope* sc)
 {
     //printf("Expression::toDelegate(t = %s) %s\n", t.toChars(), e.toChars());
     Loc loc = e.loc;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -132,7 +132,7 @@ extern (C++) bool isError(const RootObject o)
 /**************************************
  * Are any of the Objects an error?
  */
-extern (C++) bool arrayObjectIsError(const Objects* args)
+bool arrayObjectIsError(const Objects* args)
 {
     foreach (const o; *args)
     {
@@ -145,7 +145,7 @@ extern (C++) bool arrayObjectIsError(const Objects* args)
 /***********************
  * Try to get arg as a type.
  */
-extern (C++) inout(Type) getType(inout RootObject o)
+inout(Type) getType(inout RootObject o)
 {
     inout t = isType(o);
     if (!t)
@@ -158,7 +158,7 @@ extern (C++) inout(Type) getType(inout RootObject o)
 
 }
 
-extern (C++) Dsymbol getDsymbol(RootObject oarg)
+Dsymbol getDsymbol(RootObject oarg)
 {
     //printf("getDsymbol()\n");
     //printf("e %p s %p t %p v %p\n", isExpression(oarg), isDsymbol(oarg), isType(oarg), isTuple(oarg));

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -278,7 +278,7 @@ extern (C++) void expandTuples(Expressions* exps)
 /****************************************
  * Expand alias this tuples.
  */
-extern (C++) TupleDeclaration isAliasThisTuple(Expression e)
+TupleDeclaration isAliasThisTuple(Expression e)
 {
     if (!e.type)
         return null;
@@ -308,7 +308,7 @@ extern (C++) TupleDeclaration isAliasThisTuple(Expression e)
     }
 }
 
-extern (C++) int expandAliasThisTuples(Expressions* exps, size_t starti = 0)
+int expandAliasThisTuples(Expressions* exps, size_t starti = 0)
 {
     if (!exps || exps.dim == 0)
         return -1;
@@ -349,7 +349,7 @@ extern (C++) int expandAliasThisTuples(Expressions* exps, size_t starti = 0)
  * Returns:
  *      template for that function, otherwise null
  */
-extern (C++) TemplateDeclaration getFuncTemplateDecl(Dsymbol s)
+TemplateDeclaration getFuncTemplateDecl(Dsymbol s)
 {
     FuncDeclaration f = s.isFuncDeclaration();
     if (f && f.parent)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -46,13 +46,7 @@ struct Symbol;          // back end symbol
 #endif
 
 void expandTuples(Expressions *exps);
-TupleDeclaration *isAliasThisTuple(Expression *e);
-int expandAliasThisTuples(Expressions *exps, size_t starti = 0);
-bool arrayExpressionSemantic(Expressions *exps, Scope *sc, bool preserveErrors = false);
-TemplateDeclaration *getFuncTemplateDecl(Dsymbol *s);
 bool isTrivialExp(Expression *e);
-
-Expression *toDelegate(Expression *e, Type* t, Scope *sc);
 bool hasSideEffect(Expression *e);
 bool canThrow(Expression *e, FuncDeclaration *func, bool mustNotThrow);
 
@@ -335,7 +329,6 @@ public:
 class SuperExp : public ThisExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -649,7 +642,6 @@ public:
 class HaltExp : public Expression
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -705,7 +697,6 @@ public:
 class BinAssignExp : public BinExp
 {
 public:
-
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *ex);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -821,7 +812,6 @@ public:
 class AddrExp : public UnaExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -839,21 +829,18 @@ public:
 class NegExp : public UnaExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class UAddExp : public UnaExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class ComExp : public UnaExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1140,91 +1127,78 @@ public:
 class AddExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class MinExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class CatExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class MulExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class DivExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class ModExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class PowExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class ShlExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class ShrExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class UshrExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class AndExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class OrExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class XorExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1238,14 +1212,12 @@ public:
 class CmpExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
 class InExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -1260,7 +1232,6 @@ public:
 class EqualExp : public BinExp
 {
 public:
-
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -328,7 +328,7 @@ Expression resolveOpDollar(Scope* sc, ArrayExp ae, IntervalExp ie, Expression* p
 /******************************
  * Perform semantic() on an array of Expressions.
  */
-extern (C++) bool arrayExpressionSemantic(Expressions* exps, Scope* sc, bool preserveErrors = false)
+bool arrayExpressionSemantic(Expressions* exps, Scope* sc, bool preserveErrors = false)
 {
     bool err = false;
     if (exps)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2749,28 +2749,12 @@ string stcToString(ref StorageClass stc)
     return null;
 }
 
-extern (C++) const(char)* stcToChars(ref StorageClass stc)
+const(char)* stcToChars(ref StorageClass stc)
 {
     const s = stcToString(stc);
     return &s[0];  // assume 0 terminated
 }
 
-
-extern (C++) void trustToBuffer(OutBuffer* buf, TRUST trust)
-{
-    buf.writestring(trustToString(trust));
-}
-
-/**
- * Returns:
- *   a human readable representation of `trust`,
- *   which is the token `trust` corresponds to
- */
-extern (C++) const(char)* trustToChars(TRUST trust)
-{
-    /// Works because we return a literal
-    return trustToString(trust).ptr;
-}
 
 /// Ditto
 extern (D) string trustToString(TRUST trust) pure nothrow
@@ -2799,7 +2783,7 @@ private void linkageToBuffer(OutBuffer* buf, LINK linkage)
     }
 }
 
-extern (C++) const(char)* linkageToChars(LINK linkage)
+const(char)* linkageToChars(LINK linkage)
 {
     /// Works because we return a literal
     return linkageToString(linkage).ptr;
@@ -2828,7 +2812,7 @@ string linkageToString(LINK linkage) pure nothrow
     }
 }
 
-extern (C++) void protectionToBuffer(OutBuffer* buf, Prot prot)
+void protectionToBuffer(OutBuffer* buf, Prot prot)
 {
     buf.writestring(protectionToString(prot.kind));
     if (prot.kind == Prot.Kind.package_ && prot.pkg)
@@ -2843,7 +2827,7 @@ extern (C++) void protectionToBuffer(OutBuffer* buf, Prot prot)
  * Returns:
  *   a human readable representation of `kind`
  */
-extern (C++) const(char)* protectionToChars(Prot.Kind kind)
+const(char)* protectionToChars(Prot.Kind kind)
 {
     // Null terminated because we return a literal
     return protectionToString(kind).ptr;
@@ -2932,7 +2916,7 @@ void arrayObjectsToBuffer(OutBuffer* buf, Objects* objects)
  *  pl = parameter list to print
  * Returns: Null-terminated string representing parameters.
  */
-extern (C++) const(char)* parametersTypeToChars(ParameterList pl)
+const(char)* parametersTypeToChars(ParameterList pl)
 {
     OutBuffer buf;
     HdrGenState hgs;

--- a/src/dmd/hdrgen.h
+++ b/src/dmd/hdrgen.h
@@ -11,18 +11,8 @@
 #pragma once
 
 #include "globals.h"
-#include "dsymbol.h"
-#include "mtype.h"
 
 class Module;
 
 void genhdrfile(Module *m);
 void moduleToBuffer(OutBuffer *buf, Module *m);
-
-const char *parametersTypeToChars(ParameterList pl);
-const char *stcToChars(StorageClass& stc);
-void trustToBuffer(OutBuffer *buf, TRUST trust);
-const char *trustToChars(TRUST trust);
-const char *linkageToChars(LINK linkage);
-void protectionToBuffer(OutBuffer *buf, Prot prot);
-const char *protectionToChars(Prot::Kind kind);

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -91,6 +91,3 @@ public:
 };
 
 Expression *initializerToExpression(Initializer *init, Type *t = NULL);
-
-Initializer *syntaxCopy(Initializer *inx);
-

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -114,15 +114,6 @@ enum MODFlags
 };
 typedef unsigned char MOD;
 
-// These tables are for implicit conversion of binary ops;
-// the indices are the type of operand one, followed by operand two.
-extern unsigned char impcnvResult[TMAX][TMAX];
-extern unsigned char impcnvType1[TMAX][TMAX];
-extern unsigned char impcnvType2[TMAX][TMAX];
-
-// If !=0, give warning on implicit conversion
-extern unsigned char impcnvWarn[TMAX][TMAX];
-
 enum VarArg
 {
     VARARGnone     = 0,  /// fixed number of arguments

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -43,9 +43,6 @@ class StaticForeach;
 // Back end
 struct code;
 
-bool inferAggregate(ForeachStatement *fes, Scope *sc, Dsymbol *&sapply);
-bool inferApplyArgTypes(ForeachStatement *fes, Scope *sc, Dsymbol *&sapply);
-
 /* How a statement exits; this is returned by blockExit()
  */
 enum BE

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -310,9 +310,4 @@ Type *isType(RootObject *o);
 Tuple *isTuple(RootObject *o);
 Parameter *isParameter(RootObject *o);
 TemplateParameter *isTemplateParameter(RootObject *o);
-bool arrayObjectIsError(const Objects *args);
 bool isError(const RootObject *const o);
-Type *getType(RootObject *o);
-Dsymbol *getDsymbol(RootObject *o);
-
-RootObject *objectSyntaxCopy(RootObject *o);


### PR DESCRIPTION
None of those present in the headers are used by at least gdc.