### PR TITLE
add TYimmutPtr and TYsharePtr to backend part 1

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -452,6 +452,11 @@ else
 }
     _tyalignsize[TYsptr] = LONGSIZE;
     _tyalignsize[TYcptr] = LONGSIZE;
+
+    _tysize[TYimmutPtr] = _tysize[TYnptr];
+    _tysize[TYsharePtr] = _tysize[TYnptr];
+    _tyalignsize[TYimmutPtr] = _tyalignsize[TYnptr];
+    _tyalignsize[TYsharePtr] = _tyalignsize[TYnptr];
 }
 
 /*******************************
@@ -535,5 +540,10 @@ else
     TYsize_t = TYullong;
     TYdelegate = TYcent;
     TYdarray = TYucent;
+
+    _tysize[TYimmutPtr] = _tysize[TYnptr];
+    _tysize[TYsharePtr] = _tysize[TYnptr];
+    _tyalignsize[TYimmutPtr] = _tyalignsize[TYnptr];
+    _tyalignsize[TYsharePtr] = _tyalignsize[TYnptr];
 }
 

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -2884,6 +2884,8 @@ void codelem(ref CodeBuilder cdb,elem *e,regm_t *pretregs,uint constflag)
                     case TYnptr:
                     case TYsptr:
                     case TYcptr:
+                    case TYimmutPtr:
+                    case TYsharePtr:
                         *pretregs |= IDXREGS;
                         break;
 

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -176,6 +176,8 @@ int elemisone(elem *e)
             case TYfptr:
             case TYvptr:
             case TYnptr:
+            case TYimmutPtr:
+            case TYsharePtr:
             case TYbool:
             case TYwchar_t:
             case TYdchar:
@@ -237,6 +239,8 @@ int elemisnegone(elem *e)
             case TYhptr:
             case TYfptr:
             case TYvptr:
+            case TYimmutPtr:
+            case TYsharePtr:
             case TYbool:
             case TYwchar_t:
             case TYdchar:
@@ -1168,7 +1172,9 @@ private elem * elmin(elem *e, goal_t goal)
             cnst(e1.EV.E2) && cnst(e2.EV.E2) &&
             (tyintegral(tym) ||
              tybasic(tym) == TYnptr ||
-             tybasic(tym) == TYsptr)
+             tybasic(tym) == TYsptr ||
+             tybasic(tym) == TYimmutPtr ||
+             tybasic(tym) == TYsharePtr)
            )
         {
             e.Eoper = OPadd;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -616,6 +616,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYstruct:
         case TYarray:
             return 0;
+
         case TYbool:
         case TYwchar_t:
         case TYchar16:
@@ -631,6 +632,8 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYnref:
         case TYsptr:
         case TYcptr:
+        case TYimmutPtr:
+        case TYsharePtr:
             return mAX;
 
         case TYfloat:

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -474,13 +474,18 @@ void cv_init()
         {
             dttab4[TYptr]  = 0x600;
             dttab4[TYnptr] = 0x600;
+            dttab4[TYsptr] = 0x600;
+            dttab4[TYimmutPtr] = 0x600;
+            dttab4[TYsharePtr] = 0x600;
         }
         else
         {
             dttab4[TYptr]  = 0x400;
+            dttab4[TYsptr] = 0x400;
             dttab4[TYnptr] = 0x400;
+            dttab4[TYimmutPtr] = 0x400;
+            dttab4[TYsharePtr] = 0x400;
         }
-        dttab4[TYsptr] = 0x400;
         dttab4[TYcptr] = 0x400;
         dttab4[TYfptr] = 0x500;
 

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -2203,6 +2203,8 @@ L1:
                     case TYnref:
                     case TYsptr:
                     case TYcptr:
+                    case TYimmutPtr:
+                    case TYsharePtr:
                         if (_tysize[TYnptr] == SHORTSIZE)
                             goto case_short;
                         else if (_tysize[TYnptr] == LONGSIZE)
@@ -2503,6 +2505,8 @@ version (SCPP_HTOD)
         case TYnptr:
         case TYnullptr:
         case TYnref:
+        case TYimmutPtr:
+        case TYsharePtr:
             if (_tysize[TYnptr] == SHORTSIZE)
                 goto Ushort;
             if (_tysize[TYnptr] == LONGSIZE)
@@ -2898,6 +2902,8 @@ case_tym:
         case TYnullptr:
         case TYnptr:
         case TYnref:
+        case TYimmutPtr:
+        case TYsharePtr:
             if (_tysize[TYnptr] == LONGSIZE)
                 goto L1;
             if (_tysize[TYnptr] == SHORTSIZE)

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -107,6 +107,8 @@ version (SCPP)
                 case TYfptr:
                 case TYvptr:
                 case TYnptr:
+                case TYimmutPtr:
+                case TYsharePtr:
                     b = el_tolong(e) != 0;
                     break;
                 case TYnref: // reference can't be converted to bool

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -2061,6 +2061,8 @@ private famlist * newfamlist(tym_t ty)
         case TYvptr:
         case TYnptr:
         case TYnullptr:
+        case TYimmutPtr:
+        case TYsharePtr:
             ty = TYint;
             if (I64)
                 ty = TYllong;
@@ -3375,6 +3377,8 @@ private famlist * flcmp(famlist *f1,famlist *f2)
             case TYsptr:
             case TYcptr:
             case TYnptr:        // BUG: 64 bit pointers?
+            case TYimmutPtr:
+            case TYsharePtr:
             case TYnullptr:
             case TYint:
             case TYuint:

--- a/src/dmd/backend/newman.d
+++ b/src/dmd/backend/newman.d
@@ -1030,6 +1030,8 @@ private void cpp_basic_data_type(type *t)
         case TYvptr:
         case TYmemptr:
         case TYnptr:
+        case TYimmutPtr:
+        case TYsharePtr:
             c = cast(char)('P' + cpp_cvidx(t.Tty));
             CHAR(c);
             if(I64)

--- a/src/dmd/backend/optabgen.d
+++ b/src/dmd/backend/optabgen.d
@@ -750,7 +750,7 @@ enum DS = 3;
 void dotytab()
 {
     static tym_t[] _ptr      = [ TYnptr ];
-    static tym_t[] _ptr_nflat= [ TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr ];
+    static tym_t[] _ptr_nflat= [ TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr,TYimmutPtr,TYsharePtr ];
     static tym_t[] _real     = [ TYfloat,TYdouble,TYdouble_alias,TYldouble,
                                  TYfloat4,TYdouble2,
                                  TYfloat8,TYdouble4,
@@ -917,6 +917,8 @@ void dotytab()
 {"__far *",      TYfptr,         TYfptr,    TYfptr,      4,  0x40,       0x200},
 {"__huge *",     TYhptr,         TYhptr,    TYhptr,      4,  0x40,       0x300},
 {"__handle *",   TYvptr,         TYvptr,    TYvptr,      4,  0x40,       0x200},
+{"__immutable *", TYimmutPtr,    TYimmutPtr,TYimmutPtr,  2,  0x20,       0x100},
+{"__shared *",   TYsharePtr,     TYsharePtr,TYsharePtr,  2,  0x20,       0x100},
 {"far C func",   TYffunc,        TYffunc,   TYffunc,     -1,     0x64,   0},
 {"far Pascal func", TYfpfunc,    TYfpfunc,  TYfpfunc,    -1,     0x73,   0},
 {"far std func", TYfsfunc,       TYfsfunc,  TYfsfunc,    -1,     0x64,   0},

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -138,7 +138,10 @@ enum
     TYllong8            = 0x5A, // long[8]
     TYullong8           = 0x5B, // ulong[8]
 
-    TYMAX               = 0x5C,
+    TYsharePtr          = 0x5C, // pointer to shared data
+    TYimmutPtr          = 0x5D, // pointer to immutable data
+
+    TYMAX               = 0x5E,
 }
 
 alias TYerror = TYint;


### PR DESCRIPTION
This is necessary to support immutable common subexpressions, and pointers to shared data.

I tried many approaches to this, and they all seemed to cause massive disruption of the code base. One thing I finally realized is the backend handles multiple pointer types with aplomb, thanks to its origins in dealing with such for 16 bit targets (!). So I'm trying that approach now.

The other methods were:

1. a type attribute. This kept failing because an `immutable int` is interchangeable with an `int` via copying. There was no way to attach the attribute to the pointer, not the value it points to.

2. a special operator. This complicates a great deal of code, all of which assumes only one indirection operator.

This PR is part 1, which just defines the new types and gets them installed in the tables.