### PR TITLE
Fix Issues 19399 and 10560 - Different Conversion Rules for Same Value and Type Enum

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -367,6 +367,20 @@ MATCH implicitConvTo(Expression e, Type t)
             TY toty = t.toBasetype().ty;
             TY oldty = ty;
 
+            /* https://issues.dlang.org/show_bug.cgi?id=10560
+             *
+             * If a user has defined a type for an enum declaration,
+             * then the expression literal should be considered as of
+             * the type that the user provided. If the user has not
+             * provided a type of the enum, its members will be subject
+             * to VRP.
+             */
+            if (auto edType = e.type.isTypeEnum)
+            {
+                if (edType.sym.hasUserDefinedType && m == MATCH.nomatch)
+                    return;
+            }
+
             if (m == MATCH.nomatch && t.ty == Tenum)
                 return;
 

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -56,21 +56,23 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
     Expression defaultval;  // default initializer
     bool isdeprecated;
     bool added;
+    bool hasUserDefinedType;
     int inuse;
 
-    extern (D) this(const ref Loc loc, Identifier ident, Type memtype)
+    extern (D) this(const ref Loc loc, Identifier ident, Type memtype, bool hasUserDefinedType)
     {
         super(loc, ident);
         //printf("EnumDeclaration() %s\n", toChars());
         type = new TypeEnum(this);
         this.memtype = memtype;
+        this.hasUserDefinedType = hasUserDefinedType;
         protection = Prot(Prot.Kind.undefined);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        auto ed = new EnumDeclaration(loc, ident, memtype ? memtype.syntaxCopy() : null);
+        auto ed = new EnumDeclaration(loc, ident, memtype ? memtype.syntaxCopy() : null, hasUserDefinedType);
         return ScopeDsymbol.syntaxCopy(ed);
     }
 

--- a/src/dmd/enum.h
+++ b/src/dmd/enum.h
@@ -38,6 +38,7 @@ public:
 
     bool isdeprecated;
     bool added;
+    bool hasUserDefinedType;
     int inuse;
 
     Dsymbol *syntaxCopy(Dsymbol *s);

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3093,7 +3093,7 @@ final class Parser(AST) : Lexer
             checkCstyleTypeSyntax(typeLoc, memtype, alt, null);
         }
 
-        e = new AST.EnumDeclaration(loc, id, memtype);
+        e = new AST.EnumDeclaration(loc, id, memtype, memtype ? true : false);
         if (token.value == TOK.semicolon && id)
             nextToken();
         else if (token.value == TOK.leftCurly)

--- a/test/runnable/test19399.d
+++ b/test/runnable/test19399.d
@@ -1,0 +1,26 @@
+void boo(bool b) { assert(0); }
+void boo(int i) {}
+
+enum Boo : int
+{
+    a = 1,
+    b = 2,
+}
+
+void foo(byte v) { assert(0); }
+void foo(int v) {}
+
+enum A : int {
+    a = 127,
+    b = 128, // shh just ignore this
+}
+
+void main()
+{
+    foo(Boo.a); //prints 'bool', should print int
+    foo(Boo.b); //prints 'int' correctly
+
+    A v = A.a;
+    foo(A.a);  // byte 127
+    foo(v);    // int 127 should be byte 127
+}


### PR DESCRIPTION
Once the enum value has been analyzed and lowered to a literal expression, if the enum type cannot be implicitly converted to the desired type, VRP steps in and does the appropriate type modifications; this is problematic because it bypasses the type that the user has provided. To fix this, I added a check that disables VRP if the user provided type cannot be implicitly converted to the desired type; if no type is provided for the enum, the initial behavior is still in place (i.e. [1]).

[1] https://issues.dlang.org/show_bug.cgi?id=9999