### PR TITLE
 Add IN_GCC path to Global._init() and fix the vendor string for GDC.

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -362,69 +362,81 @@ struct Global
 
     extern (C++) void _init()
     {
-        static if (TARGET.Windows)
+        _version = import("VERSION") ~ '\0';
+
+        version (MARS)
         {
-            obj_ext = "obj";
+            vendor = "Digital Mars D";
+            static if (TARGET.Windows)
+            {
+                obj_ext = "obj";
+            }
+            else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
+            {
+                obj_ext = "o";
+            }
+            else
+            {
+                static assert(0, "fix this");
+            }
+            static if (TARGET.Windows)
+            {
+                lib_ext = "lib";
+            }
+            else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
+            {
+                lib_ext = "a";
+            }
+            else
+            {
+                static assert(0, "fix this");
+            }
+            static if (TARGET.Windows)
+            {
+                dll_ext = "dll";
+            }
+            else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
+            {
+                dll_ext = "so";
+            }
+            else static if (TARGET.OSX)
+            {
+                dll_ext = "dylib";
+            }
+            else
+            {
+                static assert(0, "fix this");
+            }
+            static if (TARGET.Windows)
+            {
+                run_noext = false;
+            }
+            else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
+            {
+                // Allow 'script' D source files to have no extension.
+                run_noext = true;
+            }
+            else
+            {
+                static assert(0, "fix this");
+            }
+            static if (TARGET.Windows)
+            {
+                params.mscoff = params.is64bit;
+            }
+
+            // -color=auto is the default value
+            import dmd.console : Console;
+            params.color = Console.detectTerminal();
         }
-        else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
+        else version (IN_GCC)
         {
+            vendor = "GNU D";
             obj_ext = "o";
-        }
-        else
-        {
-            static assert(0, "fix this");
-        }
-        static if (TARGET.Windows)
-        {
-            lib_ext = "lib";
-        }
-        else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
-        {
             lib_ext = "a";
-        }
-        else
-        {
-            static assert(0, "fix this");
-        }
-        static if (TARGET.Windows)
-        {
-            dll_ext = "dll";
-        }
-        else static if (TARGET.Linux || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
-        {
             dll_ext = "so";
-        }
-        else static if (TARGET.OSX)
-        {
-            dll_ext = "dylib";
-        }
-        else
-        {
-            static assert(0, "fix this");
-        }
-        static if (TARGET.Windows)
-        {
-            run_noext = false;
-        }
-        else static if (TARGET.Linux || TARGET.OSX || TARGET.FreeBSD || TARGET.OpenBSD || TARGET.Solaris || TARGET.DragonFlyBSD)
-        {
-            // Allow 'script' D source files to have no extension.
             run_noext = true;
         }
-        else
-        {
-            static assert(0, "fix this");
-        }
-        static if (TARGET.Windows)
-        {
-            params.mscoff = params.is64bit;
-        }
-        _version = import("VERSION") ~ '\0';
-        vendor = "Digital Mars D";
-
-        // -color=auto is the default value
-        import dmd.console : Console;
-        params.color = Console.detectTerminal();
     }
 
     /**

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -1072,7 +1072,7 @@ private extern(D) string determineCompilerInterface()
         return "dmd";
     if (global.vendor == "LDC")
         return "ldc";
-    if (global.vendor == "GNU")
+    if (global.vendor == "GNU D")
         return "gdc";
     if (global.vendor == "SDC")
         return "sdc";


### PR DESCRIPTION
This function was omitted from the gdc mirror of dmd, and implemented instead in C++.  Since many of the fields have been switched to D strings however, it has become rather awkward to set these without some sort of macro.

So it probably makes most sense to move it into the D side of the library.

I noticed that the vendor check in `determineCompilerInterface()` has always been wrong, so fixed that up too.