### PR TITLE
Translate _d_arraysetlengthT to template

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4963,6 +4963,9 @@ public:
             fd = ve.var.isFuncDeclaration();
             assert(fd);
 
+            // If `_d_HookTraceImpl` is found, resolve the underlying hook and replace `e` and `fd` with it.
+            removeHookTraceImpl(e, fd);
+
             if (fd.ident == Id.__ArrayPostblit || fd.ident == Id.__ArrayDtor)
             {
                 assert(e.arguments.dim == 1);
@@ -4995,6 +4998,25 @@ public:
                     result = evaluateDtor(istate, result);
                 if (!result)
                     result = CTFEExp.voidexp;
+                return;
+            }
+            else if (fd.ident == Id._d_arraysetlengthT)
+            {
+                // In expressionsem.d `ea.length = eb;` got lowered to `_d_arraysetlengthT(ea, eb);`.
+                // The following code will rewrite it back to `ea.length = eb` and then interpret that expression.
+                assert(e.arguments.dim == 2);
+
+                Expression ea = (*e.arguments)[0];
+                Expression eb = (*e.arguments)[1];
+
+                auto ale = new ArrayLengthExp(e.loc, ea);
+                ale.type = Type.tsize_t;
+                AssignExp ae = new AssignExp(e.loc, ale, eb);
+                ae.type = ea.type;
+
+                if (global.params.verbose)
+                    message("interpret  %s =>\n          %s", e.toChars(), ae.toChars());
+                result = interpret(ae, istate);
                 return;
             }
         }
@@ -7418,4 +7440,38 @@ private void setValue(VarDeclaration vd, Expression newval)
     }
     assert((vd.storage_class & (STC.out_ | STC.ref_)) ? isCtfeReferenceValid(newval) : isCtfeValueValid(newval));
     ctfeStack.setValue(vd, newval);
+}
+
+/**
+ * Removes `_d_HookTraceImpl` if found from `ce` and `fd`.
+ * This is needed for the CTFE interception code to be able to find hooks that are called though the hook's `*Trace`
+ * wrapper.
+ *
+ * This is done by replacing `_d_HookTraceImpl!(T, Hook, errMsg)(..., parameters)` with `Hook(parameters)`.
+ * Parameters:
+ *  ce = The CallExp that possible will be be replaced
+ *  fd = Fully resolve function declaration that `ce` would call
+ */
+private void removeHookTraceImpl(ref CallExp ce, ref FuncDeclaration fd)
+{
+    if (fd.ident != Id._d_HookTraceImpl)
+        return;
+
+    auto oldCE = ce;
+
+    // Get the Hook from the second template parameter
+    TemplateInstance templateInstance = fd.parent.isTemplateInstance;
+    RootObject hook = (*templateInstance.tiargs)[1];
+    assert(hook.dyncast() == DYNCAST.dsymbol, "Expected _d_HookTraceImpl's second template parameter to be an alias to the hook!");
+    fd = (cast(Dsymbol)hook).isFuncDeclaration;
+
+    // Remove the first three trace parameters
+    auto arguments = new Expressions();
+    arguments.reserve(ce.arguments.dim - 3);
+    arguments.pushSlice((*ce.arguments)[3 .. $]);
+
+    ce = new CallExp(ce.loc, new VarExp(ce.loc, fd, false), arguments);
+
+    if (global.params.verbose)
+        message("strip     %s =>\n          %s", oldCE.toChars(), ce.toChars());
 }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2679,23 +2679,7 @@ elem *toElem(Expression e, IRState *irs)
             // Look for array.length = n
             if (auto ale = ae.e1.isArrayLengthExp())
             {
-                // Generate:
-                //      _d_arraysetlength(e2, sizeelem, &ale.e1);
-
-                elem *p1 = toElem(ae.e2, irs);
-                elem *p3 = toElem(ale.e1, irs);
-                p3 = addressElem(p3, null);
-                Type t1 = ale.e1.type.toBasetype();
-
-                // call _d_arraysetlengthT(ti, e2, &ale.e1);
-                elem *p2 = getTypeInfo(ae.loc, t1, irs);
-                elem *ep = el_params(p3, p1, p2, null); // c function
-                int r = t1.nextOf().isZeroInit(Loc.initial) ? RTLSYM_ARRAYSETLENGTHT : RTLSYM_ARRAYSETLENGTHIT;
-
-                auto e = el_bin(OPcall, totym(ae.type), el_var(getRtlsym(r)), ep);
-                toTraceGC(irs, e, ae.loc);
-
-                return setResult(e);
+                assert(0, "This case should have been rewritten to `_d_arraysetlengthT` in the semantic phase");
             }
 
             // Look for array[]=n

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1283,8 +1283,12 @@ extern (C++) abstract class Expression : ASTNode
             {
                 if (loc.linnum == 0) // e.g. implicitly generated dtor
                     loc = sc.func.loc;
-                error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
-                    sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
+
+                // Lowered non-@nogc'd hooks will print their own error message inside of nogc.d (NOGCVisitor.visit(CallExp e)),
+                // so don't print anything to avoid double error messages.
+                if (!(f.ident == Id._d_HookTraceImpl || f.ident == Id._d_arraysetlengthT))
+                    error("`@nogc` %s `%s` cannot call non-@nogc %s `%s`",
+                        sc.func.kind(), sc.func.toPrettyChars(), f.kind(), f.toPrettyChars());
                 return true;
             }
         }

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -343,6 +343,7 @@ immutable Msgtable[] msgtable =
     { "__switch"},
     { "__switch_error"},
     { "__ArrayCast"},
+    { "_d_HookTraceImpl" },
     { "_d_arraysetlengthTImpl"},
     { "_d_arraysetlengthT"},
     { "_d_arraysetlengthTTrace"},

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -343,6 +343,9 @@ immutable Msgtable[] msgtable =
     { "__switch"},
     { "__switch_error"},
     { "__ArrayCast"},
+    { "_d_arraysetlengthTImpl"},
+    { "_d_arraysetlengthT"},
+    { "_d_arraysetlengthTTrace"},
 
     // varargs implementation
     { "va_start" },

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -64,6 +64,23 @@ public:
 
     override void visit(CallExp e)
     {
+        import dmd.id : Id;
+        import core.stdc.stdio : printf;
+        if (!e.f)
+            return;
+
+        auto fd = stripHookTraceImpl(e.f);
+        if (fd.ident == Id._d_arraysetlengthT)
+        {
+            if (f.setGC())
+            {
+                e.error("setting `length` in `@nogc` %s `%s` may cause a GC allocation",
+                    f.kind(), f.toPrettyChars());
+                err = true;
+                return;
+            }
+            f.printGCUsage(e.loc, "setting `length` may cause a GC allocation");
+        }
     }
 
     override void visit(ArrayLiteralExp e)
@@ -226,4 +243,26 @@ Expression checkGC(Scope* sc, Expression e)
             return new ErrorExp();
     }
     return e;
+}
+
+/**
+ * Removes `_d_HookTraceImpl` if found from `fd`.
+ * This is needed to be able to find hooks that are called though the hook's `*Trace` wrapper.
+ * Parameters:
+ *  fd = The function declaration to remove `_d_HookTraceImpl` from
+ */
+private FuncDeclaration stripHookTraceImpl(FuncDeclaration fd)
+{
+    import dmd.id : Id;
+    import dmd.dsymbol : Dsymbol;
+    import dmd.root.rootobject : RootObject, DYNCAST;
+
+    if (fd.ident != Id._d_HookTraceImpl)
+        return fd;
+
+    // Get the Hook from the second template parameter
+    auto templateInstance = fd.parent.isTemplateInstance;
+    RootObject hook = (*templateInstance.tiargs)[1];
+    assert(hook.dyncast() == DYNCAST.dsymbol, "Expected _d_HookTraceImpl's second template parameter to be an alias to the hook!");
+    return (cast(Dsymbol)hook).isFuncDeclaration;
 }


### PR DESCRIPTION
druntime PR: https://github.com/dlang/druntime/pull/2656

The `exp.e1.type.toBasetype().nextOf().isZeroInit` check is now inside of the runtime hook.