### PR TITLE
Fix undefined reference to Loc:Loc()

### DIFF
--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -351,7 +351,12 @@ struct Loc
         filename = NULL;
     }
 
-    Loc(const char *filename, unsigned linnum, unsigned charnum);
+    Loc(const char *filename, unsigned linnum, unsigned charnum)
+    {
+        this->linnum = linnum;
+        this->charnum = charnum;
+        this->filename = filename;
+    }
 
     const char *toChars(bool showColumns = global.params.showColumns) const;
     bool equals(const Loc& loc) const;

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -23,6 +23,7 @@
 #include "aggregate.h"
 #include "aliasthis.h"
 #include "arraytypes.h"
+#include "ast_node.h"
 #include "attrib.h"
 #include "compiler.h"
 #include "complex_t.h"
@@ -297,6 +298,15 @@ void test_parameters()
 
 /**********************************/
 
+void test_location()
+{
+    Loc loc1 = Loc("test.d", 24, 42);
+    assert(loc1.equals(Loc("test.d", 24, 42)));
+    assert(strcmp(loc1.toChars(true), "test.d(24,42)") == 0);
+}
+
+/**********************************/
+
 int main(int argc, char **argv)
 {
     frontend_init();
@@ -307,6 +317,7 @@ int main(int argc, char **argv)
     test_target();
     test_emplace();
     test_parameters();
+    test_location();
 
     frontend_term();
 


### PR DESCRIPTION
In global.d, the constructor is `extern(D)`, so provide one in the C++ headers.

Perhaps later we could do away with the constructors and just have `Loc::create()` and `Loc::initial`.