### PR TITLE
root/dcompat.h: Add a convenience constructor for DArray.

### DIFF
--- a/src/dmd/root/dcompat.h
+++ b/src/dmd/root/dcompat.h
@@ -17,4 +17,7 @@ struct DArray
 {
     size_t length;
     T *ptr;
+
+    DArray(size_t length_in, T *ptr_in)
+        : length(length_in), ptr(ptr_in) { }
 };

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -67,8 +67,7 @@ static void frontend_init()
 
     global._init();
     global.params.isLinux = true;
-    global.vendor.ptr = "Front-End Tester";
-    global.vendor.length = strlen(global.vendor.ptr);
+    global.vendor = DArray<const char>(16, "Front-End Tester");
 
     Type::_init();
     Id::initialize();
@@ -212,8 +211,7 @@ void test_semantic()
         "class Error : Throwable { this(immutable(char)[]); }";
 
     FileBuffer *srcBuffer = FileBuffer::create(); // free'd in Module::parse()
-    srcBuffer->data.ptr = (unsigned char *)mem.xstrdup(buf);
-    srcBuffer->data.length = strlen(buf);
+    srcBuffer->data = DArray<unsigned char>(strlen(buf), (unsigned char *)mem.xstrdup(buf));
 
     Module *m = Module::create("object.d", Identifier::idPool("object"), 0, 0);
 


### PR DESCRIPTION
As it's getting more awkward to initialize global.params fields from C++.