### PR TITLE
Mark many semantic-only final functions as extern(D)

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -637,7 +637,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     /* Append vthis field (this.tupleof[$-1]) to make this aggregate type nested.
      */
-    final void makeNested()
+    extern (D) final void makeNested()
     {
         if (enclosing) // if already nested
             return;
@@ -710,7 +710,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     /* Append vthis2 field (this.tupleof[$-1]) to add a second context pointer.
      */
-    final void makeNested2()
+    extern (D) final void makeNested2()
     {
         if (vthis2)
             return;

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -130,8 +130,6 @@ public:
     Type *getType();
     bool isDeprecated() const;         // is aggregate deprecated?
     bool isNested() const;
-    void makeNested();
-    void makeNested2();
     bool isExport() const;
     Dsymbol *searchCtor();
 
@@ -223,11 +221,7 @@ struct BaseClass
     DArray<BaseClass> baseInterfaces;   // if BaseClass is an interface, these
                                         // are a copy of the InterfaceDeclaration::interfaces
 
-    BaseClass();
-    BaseClass(Type *type);
-
     bool fillVtbl(ClassDeclaration *cd, FuncDeclarations *vtbl, int newinstance);
-    void copyBaseInterfaces(BaseClasses *);
 };
 
 struct ClassFlags

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -50,8 +50,6 @@ class ThrownExceptionExp : public Expression
 public:
     ClassReferenceExp *thrown; // the thing being tossed
     const char *toChars();
-    /// Generate an error message when this exception is not caught
-    void generateUncaughtError();
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -155,7 +155,7 @@ extern (C++) final class ThrownExceptionExp : Expression
     }
 
     // Generate an error message when this exception is not caught
-    void generateUncaughtError()
+    extern (D) void generateUncaughtError()
     {
         UnionExp ue = void;
         Expression e = resolveSlice((*thrown.value.elements)[0], &ue);

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -123,7 +123,7 @@ struct BaseClass
         return result;
     }
 
-    extern (C++) void copyBaseInterfaces(BaseClasses* vtblInterfaces)
+    extern (D) void copyBaseInterfaces(BaseClasses* vtblInterfaces)
     {
         //printf("+copyBaseInterfaces(), %s\n", sym.toChars());
         //    if (baseInterfaces.length)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1375,7 +1375,7 @@ extern (C++) class VarDeclaration : Declaration
      * If a variable has a scope destructor call, return call for it.
      * Otherwise, return NULL.
      */
-    final Expression callScopeDtor(Scope* sc)
+    extern (D) final Expression callScopeDtor(Scope* sc)
     {
         //printf("VarDeclaration::callScopeDtor() %s\n", toChars());
 
@@ -1478,7 +1478,7 @@ extern (C++) class VarDeclaration : Declaration
      * If variable has a constant expression initializer, get it.
      * Otherwise, return null.
      */
-    final Expression getConstInitializer(bool needFullType = true)
+    extern (D) final Expression getConstInitializer(bool needFullType = true)
     {
         assert(type && _init);
 
@@ -1507,7 +1507,7 @@ extern (C++) class VarDeclaration : Declaration
     /*******************************************
      * Helper function for the expansion of manifest constant.
      */
-    final Expression expandInitializer(Loc loc)
+    extern (D) final Expression expandInitializer(Loc loc)
     {
         assert((storage_class & STC.manifest) && _init);
 

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -257,9 +257,6 @@ public:
     bool canTakeAddressOf();
     bool needsScopeDtor();
     bool enclosesLifetimeOf(VarDeclaration *v) const;
-    Expression *callScopeDtor(Scope *sc);
-    Expression *getConstInitializer(bool needFullType = true);
-    Expression *expandInitializer(Loc loc);
     void checkCtorConstInit();
     Dsymbol *toAlias();
     // Eliminate need for dynamic_cast
@@ -563,17 +560,12 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     bool functionSemantic();
     bool functionSemantic3();
-    // called from semantic3
-    HiddenParameters declareThis(Scope *sc, AggregateDeclaration *ad);
     bool equals(RootObject *o);
 
     int overrides(FuncDeclaration *fd);
     int findVtblIndex(Dsymbols *vtbl, int dim, bool fix17349 = true);
     BaseClass *overrideInterface();
     bool overloadInsert(Dsymbol *s);
-    FuncDeclaration *overloadExactMatch(Type *t);
-    FuncDeclaration *overloadModMatch(const Loc &loc, Type *tthis, bool &hasOverloads);
-    TemplateDeclaration *findTemplateDeclRoot();
     bool inUnittest();
     MATCH leastAsSpecialized(FuncDeclaration *g);
     LabelDsymbol *searchLabel(Identifier *ident);
@@ -592,19 +584,13 @@ public:
     bool isAbstract();
     PURE isPure();
     PURE isPureBypassingInference();
-    bool setImpure();
     bool isSafe();
     bool isSafeBypassingInference();
     bool isTrusted();
-    bool setUnsafe();
 
     bool isNogc();
     bool isNogcBypassingInference();
-    bool setGC();
 
-    void printGCUsage(const Loc &loc, const char *warn);
-    bool isolateReturn();
-    bool parametersIntersect(Type *t);
     virtual bool isNested() const;
     AggregateDeclaration *isThis();
     bool needThis();
@@ -617,9 +603,6 @@ public:
     bool isUnique();
     bool needsClosure();
     bool hasNestedFrameRefs();
-    void buildResultVar(Scope *sc, Type *tret);
-    Statement *mergeFrequire(Statement *, Expressions *);
-    Statement *mergeFensure(Statement *, Identifier *oid, Expressions *);
     ParameterList getParameterList();
 
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -92,7 +92,7 @@ extern (C++) final class Import : Dsymbol
         this.protection = Prot.Kind.private_; // default to private
     }
 
-    void addAlias(Identifier name, Identifier _alias)
+    extern (D) void addAlias(Identifier name, Identifier _alias)
     {
         if (isstatic)
             error("cannot have an import bind list");

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -603,12 +603,6 @@ extern (C++) final class Module : Package
      *      global.params.preservePaths     get output path from arg
      *      srcfile Input file - output file name must not match input file
      */
-    FileName setOutfilename(const(char)* name, const(char)* dir, const(char)* arg, const(char)* ext)
-    {
-        return setOutfilename(name.toDString(), dir.toDString(), arg.toDString(), ext.toDString());
-    }
-
-    /// Ditto
     extern(D) FileName setOutfilename(const(char)[] name, const(char)[] dir, const(char)[] arg, const(char)[] ext)
     {
         const(char)[] docfilename;
@@ -649,7 +643,7 @@ extern (C++) final class Module : Package
         return FileName(docfilename);
     }
 
-    void setDocfile()
+    extern (D) void setDocfile()
     {
         docfile = setOutfilename(global.params.docname.toDString, global.params.docdir.toDString, arg, global.doc_ext);
     }
@@ -1251,19 +1245,19 @@ extern (C++) final class Module : Package
     /*******************************************
      * Can't run semantic on s now, try again later.
      */
-    static void addDeferredSemantic(Dsymbol s)
+    extern (D) static void addDeferredSemantic(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic('%s')\n", s.toChars());
         deferred.push(s);
     }
 
-    static void addDeferredSemantic2(Dsymbol s)
+    extern (D) static void addDeferredSemantic2(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic2('%s')\n", s.toChars());
         deferred2.push(s);
     }
 
-    static void addDeferredSemantic3(Dsymbol s)
+    extern (D) static void addDeferredSemantic3(Dsymbol s)
     {
         //printf("Module::addDeferredSemantic3('%s')\n", s.toChars());
         deferred3.push(s);
@@ -1356,7 +1350,7 @@ extern (C++) final class Module : Package
         a.setDim(0);
     }
 
-    static void clearCache()
+    extern (D) static void clearCache()
     {
         for (size_t i = 0; i < amodules.dim; i++)
         {

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -495,7 +495,7 @@ struct Scope
         return s;
     }
 
-    extern (C++) Dsymbol search_correct(Identifier ident)
+    extern (D) Dsymbol search_correct(Identifier ident)
     {
         if (global.gag)
             return null; // don't do it for speculative compiles; too time consuming
@@ -567,7 +567,7 @@ struct Scope
         return Token.toChars(tok);
     }
 
-    extern (C++) Dsymbol insert(Dsymbol s)
+    extern (D) Dsymbol insert(Dsymbol s)
     {
         if (VarDeclaration vd = s.isVarDeclaration())
         {
@@ -639,7 +639,7 @@ struct Scope
      * where it was declared. So mark the Scope as not
      * to be free'd.
      */
-    extern (C++) void setNoFree()
+    extern (D) void setNoFree()
     {
         //int i = 0;
         //printf("Scope::setNoFree(this = %p)\n", this);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -743,7 +743,7 @@ extern (C++) class Dsymbol : ASTNode
         return null;
     }
 
-    final Dsymbol search_correct(Identifier ident)
+    extern (D) final Dsymbol search_correct(Identifier ident)
     {
         /***************************************************
          * Search for symbol with correct spelling.
@@ -785,7 +785,7 @@ extern (C++) class Dsymbol : ASTNode
      * Returns:
      *      symbol found, NULL if not
      */
-    final Dsymbol searchX(const ref Loc loc, Scope* sc, RootObject id, int flags)
+    extern (D) final Dsymbol searchX(const ref Loc loc, Scope* sc, RootObject id, int flags)
     {
         //printf("Dsymbol::searchX(this=%p,%s, ident='%s')\n", this, toChars(), ident.toChars());
         Dsymbol s = toAlias();
@@ -1347,7 +1347,7 @@ public:
         return null;
     }
 
-    final OverloadSet mergeOverloadSet(Identifier ident, OverloadSet os, Dsymbol s)
+    extern (D) private OverloadSet mergeOverloadSet(Identifier ident, OverloadSet os, Dsymbol s)
     {
         if (!os)
         {
@@ -1420,7 +1420,7 @@ public:
         }
     }
 
-    final void addAccessiblePackage(Package p, Prot protection)
+    extern (D) final void addAccessiblePackage(Package p, Prot protection)
     {
         // https://issues.dlang.org/show_bug.cgi?id=17991
         // An import of truly empty file/package can happen

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -198,8 +198,6 @@ public:
     virtual void setScope(Scope *sc);
     virtual void importAll(Scope *sc);
     virtual Dsymbol *search(const Loc &loc, Identifier *ident, int flags = IgnoreNone);
-    Dsymbol *search_correct(Identifier *id);
-    Dsymbol *searchX(const Loc &loc, Scope *sc, RootObject *id);
     virtual bool overloadInsert(Dsymbol *s);
     virtual d_uns64 size(const Loc &loc);
     virtual bool isforwardRef();
@@ -301,9 +299,7 @@ private:
 public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    OverloadSet *mergeOverloadSet(Identifier *ident, OverloadSet *os, Dsymbol *s);
     virtual void importScope(Dsymbol *s, Prot protection);
-    void addAccessiblePackage(Package *p, Prot protection);
     virtual bool isPackageAccessible(Package *p, Prot protection, int flags = 0);
     bool isforwardRef();
     static void multiplyDefined(const Loc &loc, Dsymbol *s1, Dsymbol *s2);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1830,7 +1830,7 @@ extern (C++) final class IntegerExp : Expression
         this.value = normalize(type.toBasetype().ty, value);
     }
 
-    static dinteger_t normalize(TY ty, dinteger_t value)
+    extern (D) static dinteger_t normalize(TY ty, dinteger_t value)
     {
         /* 'Normalize' the value of the integer to be in range of the type
          */
@@ -2397,7 +2397,7 @@ extern (C++) final class StringExp : Expression
         {
             if (auto se = e.isStringExp())
             {
-                return comparex(se) == 0;
+                return compare(se) == 0;
             }
         }
         return false;
@@ -2577,7 +2577,7 @@ extern (C++) final class StringExp : Expression
         return this;
     }
 
-    int comparex(const StringExp se2) const nothrow pure @nogc
+    int compare(const StringExp se2) const nothrow pure @nogc
     {
         //printf("StringExp::compare()\n");
         // Used to sort case statement expressions so we can do an efficient lookup
@@ -5680,7 +5680,7 @@ extern (C++) final class IndexExp : BinExp
         return Expression.modifiableLvalue(sc, e);
     }
 
-    Expression markSettingAAElem()
+    extern (D) Expression markSettingAAElem()
     {
         if (e1.type.toBasetype().ty == Taarray)
         {

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -244,7 +244,6 @@ public:
     void accept(Visitor *v) { v->visit(this); }
     dinteger_t getInteger() { return value; }
     void setInteger(dinteger_t value);
-    void normalize();
     template<int v>
     static IntegerExp literal();
 };
@@ -368,7 +367,6 @@ public:
     bool equals(RootObject *o);
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
-    int compare(RootObject *obj);
     bool isBool(bool result);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -1009,8 +1007,6 @@ public:
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
     Expression *modifiableLvalue(Scope *sc, Expression *e);
-
-    Expression *markSettingAAElem();
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -469,7 +469,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Hidden parameters include the `this` parameter of a class, struct or
      * nested function and the selector parameter for Objective-C methods.
      */
-    final HiddenParameters declareThis(Scope* sc, AggregateDeclaration ad)
+    extern (D) final HiddenParameters declareThis(Scope* sc, AggregateDeclaration ad)
     {
         if (toParent2() != toParentLocal())
         {
@@ -804,7 +804,7 @@ extern (C++) class FuncDeclaration : Declaration
     /********************************************
      * Find function in overload list that exactly matches t.
      */
-    final FuncDeclaration overloadExactMatch(Type t)
+    extern (D) final FuncDeclaration overloadExactMatch(Type t)
     {
         FuncDeclaration fd;
         overloadApply(this, (Dsymbol s)
@@ -855,7 +855,7 @@ extern (C++) class FuncDeclaration : Declaration
      * 4. If there's no candidates, it's "no match" and returns null with error report.
      *      e.g. If 'tthis' is const but there's no const methods.
      */
-    final FuncDeclaration overloadModMatch(const ref Loc loc, Type tthis, ref bool hasOverloads)
+    extern (D) final FuncDeclaration overloadModMatch(const ref Loc loc, Type tthis, ref bool hasOverloads)
     {
         //printf("FuncDeclaration::overloadModMatch('%s')\n", toChars());
         MatchAccumulator m;
@@ -945,7 +945,7 @@ extern (C++) class FuncDeclaration : Declaration
     /********************************************
      * find function template root in overload list
      */
-    final TemplateDeclaration findTemplateDeclRoot()
+    extern (D) final TemplateDeclaration findTemplateDeclRoot()
     {
         FuncDeclaration f = this;
         while (f && f.overnext)
@@ -1363,7 +1363,7 @@ extern (C++) class FuncDeclaration : Declaration
      * so mark it as impure.
      * If there's a purity error, return true.
      */
-    final bool setImpure()
+    extern (D) final bool setImpure()
     {
         if (flags & FUNCFLAG.purityInprocess)
         {
@@ -1400,7 +1400,7 @@ extern (C++) class FuncDeclaration : Declaration
      * so mark it as unsafe.
      * If there's a safe error, return true.
      */
-    final bool setUnsafe()
+    extern (D) final bool setUnsafe()
     {
         if (flags & FUNCFLAG.safetyInprocess)
         {
@@ -1433,7 +1433,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Returns:
      *      true if function is marked as @nogc, meaning a user error occurred
      */
-    final bool setGC()
+    extern (D) final bool setGC()
     {
         //printf("setGC() %s\n", toChars());
         if (flags & FUNCFLAG.nogcInprocess && semanticRun < PASS.semantic3 && _scope)
@@ -1454,7 +1454,7 @@ extern (C++) class FuncDeclaration : Declaration
         return false;
     }
 
-    final void printGCUsage(const ref Loc loc, const(char)* warn)
+    extern (D) final void printGCUsage(const ref Loc loc, const(char)* warn)
     {
         if (!global.params.vgc)
             return;
@@ -1473,7 +1473,7 @@ extern (C++) class FuncDeclaration : Declaration
      *   true if the function return value is isolated from
      *   any inputs to the function
      */
-    final bool isReturnIsolated()
+    extern (D) final bool isReturnIsolated()
     {
         TypeFunction tf = type.toTypeFunction();
         assert(tf.next);
@@ -1494,7 +1494,7 @@ extern (C++) class FuncDeclaration : Declaration
      *   true if `t` is isolated from
      *   any inputs to the function
      */
-    final bool isTypeIsolated(Type t)
+    extern (D) final bool isTypeIsolated(Type t)
     {
         //printf("isTypeIsolated(t: %s)\n", t.toChars());
 
@@ -2052,7 +2052,7 @@ extern (C++) class FuncDeclaration : Declaration
     /****************************************************
      * Declare result variable lazily.
      */
-    final void buildResultVar(Scope* sc, Type tret)
+    extern (D) final void buildResultVar(Scope* sc, Type tret)
     {
         if (!vresult)
         {
@@ -2091,7 +2091,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Merge into this function the 'in' contracts of all it overrides.
      * 'in's are OR'd together, i.e. only one of them needs to pass.
      */
-    final Statement mergeFrequire(Statement sf, Expressions* params)
+    extern (D) final Statement mergeFrequire(Statement sf, Expressions* params)
     {
         /* If a base function and its override both have an IN contract, then
          * only one of them needs to succeed. This is done by generating:
@@ -2330,7 +2330,7 @@ extern (C++) class FuncDeclaration : Declaration
      * Merge into this function the 'out' contracts of all it overrides.
      * 'out's are AND'd together, i.e. all of them need to pass.
      */
-    final Statement mergeFensure(Statement sf, Identifier oid, Expressions* params)
+    extern (D) final Statement mergeFensure(Statement sf, Identifier oid, Expressions* params)
     {
         /* Same comments as for mergeFrequire(), except that we take care
          * of generating a consistent reference to the 'result' local by

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -23,7 +23,6 @@ public:
     static Identifier* anonymous();
     static Identifier* create(const char *string);
     bool equals(RootObject *o);
-    int compare(RootObject *o);
     const char *toChars();
     int getValue() const;
     const char *toHChars2();

--- a/src/dmd/import.h
+++ b/src/dmd/import.h
@@ -38,7 +38,6 @@ public:
 
     AliasDeclarations aliasdecls; // corresponding AliasDeclarations for alias=name pairs
 
-    void addAlias(Identifier *name, Identifier *alias);
     const char *kind() const;
     Prot prot();
     Dsymbol *syntaxCopy(Dsymbol *s);    // copy only syntax trees

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -147,7 +147,7 @@ extern (C++) final class StructInitializer : Initializer
         super(loc, InitKind.struct_);
     }
 
-    void addInit(Identifier field, Initializer value)
+    extern (D) void addInit(Identifier field, Initializer value)
     {
         //printf("StructInitializer::addInit(field = %p, value = %p)\n", field, value);
         this.field.push(field);
@@ -175,7 +175,7 @@ extern (C++) final class ArrayInitializer : Initializer
         super(loc, InitKind.array);
     }
 
-    void addInit(Expression index, Initializer value)
+    extern (D) void addInit(Expression index, Initializer value)
     {
         this.index.push(index);
         this.value.push(value);

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -63,8 +63,6 @@ public:
     Identifiers field;  // of Identifier *'s
     Initializers value; // parallel array of Initializer *'s
 
-    void addInit(Identifier *field, Initializer *value);
-
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -77,7 +75,6 @@ public:
     Type *type;         // type that array will be used to initialize
     bool sem;           // true if semantic() is run
 
-    void addInit(Expression *index, Initializer *value);
     bool isAssociativeArray() const;
     Expression *toAssocArrayLiteral();
 

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -111,8 +111,6 @@ public:
     static Module *load(Loc loc, Identifiers *packages, Identifier *ident);
 
     const char *kind() const;
-    FileName setOutfilename(const char *name, const char *dir, const char *arg, const char *ext);
-    void setDocfile();
     bool read(const Loc &loc); // read file, returns 'true' if succeed, 'false' otherwise.
     Module *parse();    // syntactic parse
     void importAll(Scope *sc);
@@ -121,13 +119,9 @@ public:
     bool isPackageAccessible(Package *p, Prot protection, int flags = 0);
     Dsymbol *symtabInsert(Dsymbol *s);
     void deleteObjFile();
-    static void addDeferredSemantic(Dsymbol *s);
-    static void addDeferredSemantic2(Dsymbol *s);
-    static void addDeferredSemantic3(Dsymbol *s);
     static void runDeferredSemantic();
     static void runDeferredSemantic2();
     static void runDeferredSemantic3();
-    static void clearCache();
     int imports(Module *m);
 
     bool isRoot() { return this->importedFrom == this; }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5610,7 +5610,7 @@ extern (C++) final class TypeStruct : Type
         return false;
     }
 
-    MATCH implicitConvToWithoutAliasThis(Type to)
+    extern (D) MATCH implicitConvToWithoutAliasThis(Type to)
     {
         MATCH m;
 
@@ -5668,7 +5668,7 @@ extern (C++) final class TypeStruct : Type
         return m;
     }
 
-    MATCH implicitConvToThroughAliasThis(Type to)
+    extern (D) MATCH implicitConvToThroughAliasThis(Type to)
     {
         MATCH m;
         if (!(ty == to.ty && sym == (cast(TypeStruct)to).sym) && sym.aliasthis && !(att & AliasThisRec.tracing))
@@ -5947,7 +5947,7 @@ extern (C++) final class TypeClass : Type
         return false;
     }
 
-    MATCH implicitConvToWithoutAliasThis(Type to)
+    extern (D) MATCH implicitConvToWithoutAliasThis(Type to)
     {
         MATCH m = constConv(to);
         if (m > MATCH.nomatch)
@@ -5970,7 +5970,7 @@ extern (C++) final class TypeClass : Type
         return MATCH.nomatch;
     }
 
-    MATCH implicitConvToThroughAliasThis(Type to)
+    extern (D) MATCH implicitConvToThroughAliasThis(Type to)
     {
         MATCH m;
         if (sym.aliasthis && !(att & AliasThisRec.tracing))

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -752,8 +752,6 @@ public:
     bool needsNested();
     bool hasPointers();
     bool hasVoidInitPointers();
-    MATCH implicitConvToWithoutAliasThis(Type *to);
-    MATCH implicitConvToThroughAliasThis(Type *to);
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
     unsigned char deduceWild(Type *t, bool isRef);
@@ -810,8 +808,6 @@ public:
     Dsymbol *toDsymbol(Scope *sc);
     ClassDeclaration *isClassHandle();
     bool isBaseOf(Type *t, int *poffset);
-    MATCH implicitConvToWithoutAliasThis(Type *to);
-    MATCH implicitConvToThroughAliasThis(Type *to);
     MATCH implicitConvTo(Type *to);
     MATCH constConv(Type *to);
     unsigned char deduceWild(Type *t, bool isRef);

--- a/src/dmd/root/array.h
+++ b/src/dmd/root/array.h
@@ -139,29 +139,6 @@ struct Array
         memset(data,0,dim * sizeof(data[0]));
     }
 
-    void sort()
-    {
-        struct ArraySort
-        {
-            static int
-    #if _WIN32
-              __cdecl
-    #endif
-            Array_sort_compare(const void *x, const void *y)
-            {
-                RootObject *ox = *(RootObject **)const_cast<void *>(x);
-                RootObject *oy = *(RootObject **)const_cast<void *>(y);
-
-                return ox->compare(oy);
-            }
-        };
-
-        if (dim)
-        {
-            qsort(data, dim, sizeof(RootObject *), &ArraySort::Array_sort_compare);
-        }
-    }
-
     TYPE *tdata()
     {
         return data;

--- a/src/dmd/root/object.h
+++ b/src/dmd/root/object.h
@@ -42,12 +42,6 @@ public:
     virtual bool equals(RootObject *o);
 
     /**
-     * Return <0, ==0, or >0 if this is less than, equal to, or greater than obj.
-     * Useful for sorting Objects.
-     */
-    virtual int compare(RootObject *obj);
-
-    /**
      * Pretty-print an Object. Useful for debugging the old-fashioned way.
      */
     virtual const char *toChars();

--- a/src/dmd/root/rootobject.d
+++ b/src/dmd/root/rootobject.d
@@ -47,11 +47,6 @@ extern (C++) class RootObject
         return o is this;
     }
 
-    int compare(RootObject)
-    {
-        assert(0);
-    }
-
     const(char)* toChars()
     {
         assert(0);

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -125,20 +125,12 @@ struct Scope
     Scope *startCTFE();
     Scope *endCTFE();
 
-    void mergeCallSuper(Loc loc, unsigned cs);
-
-    unsigned *saveFieldInit();
-    void mergeFieldInit(Loc loc, unsigned *cses);
-
     Module *instantiatingModule();
 
     Dsymbol *search(const Loc &loc, Identifier *ident, Dsymbol **pscopesym, int flags = IgnoreNone);
-    Dsymbol *search_correct(Identifier *ident);
-    Dsymbol *insert(Dsymbol *s);
 
     ClassDeclaration *getClassScope();
     AggregateDeclaration *getStructClassScope();
-    void setNoFree();
 
     structalign_t alignment();
 

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -410,7 +410,6 @@ public:
     VarDeclaration *lastVar;
 
     Statement *syntaxCopy();
-    int compare(RootObject *obj);
     CaseStatement *isCaseStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2722,7 +2722,7 @@ else
 
                     auto se1 = ox.exp.isStringExp();
                     auto se2 = oy.exp.isStringExp();
-                    return (se1 && se2) ? se1.comparex(se2) : 0;
+                    return (se1 && se2) ? se1.compare(se2) : 0;
                 }
 
                 // Sort cases for efficient lookup

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -330,7 +330,7 @@ struct Target
      * Returns:
      *  true if xmm usage is supported
      */
-    extern (C++) bool isXmmSupported()
+    extern (D) bool isXmmSupported()
     {
         return global.params.is64bit || global.params.isOSX;
     }

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -292,7 +292,6 @@ public:
     const char* toPrettyCharsHelper();
     void printInstantiationTrace();
     Identifier *getIdent();
-    int compare(RootObject *o);
     hash_t toHash();
 
     bool needsCodegen();


### PR DESCRIPTION
And there were also a few that were declared in the headers, but no longer defined anywhere, or no longer work (in the case of `Array::sort`, which the use of will always call `assert(0)` in `ox->compare(oy)`).