### PR TITLE
dmd/gluelayer: Mark GCC tree_node as extern(C++)

### DIFF
--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -90,7 +90,7 @@ else version (MARS)
 }
 else version (IN_GCC)
 {
-    union tree_node;
+    extern (C++) union tree_node;
 
     alias Symbol = tree_node;
     alias code = tree_node;


### PR DESCRIPTION
Improves debugging the compiler by not having to have an explicit cast from type `dmd.gluelayer.tree_node*` to `tree_node*` when inspecting gcc trees.