### PR TITLE
Fix Issue 19754 - cast() sometimes yields lvalue, sometimes yields rvalue

### DIFF
--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -432,7 +432,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
                 return;
             }
             // Keep lvalue-ness
-            if (expOptimize(e.e1, result, true))
+            if (e.e1.op != TOK.cast_ && expOptimize(e.e1, result, true))
                 return;
             // Convert &*ex to ex
             if (e.e1.op == TOK.star)
@@ -627,6 +627,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             Expression e1old = e.e1;
             if (expOptimize(e.e1, result))
                 return;
+
             e.e1 = fromConstInitializer(result, e.e1);
             if (e.e1 == e1old && e.e1.op == TOK.arrayLiteral && e.type.toBasetype().ty == Tpointer && e.e1.type.toBasetype().ty != Tsarray)
             {

--- a/test/runnable/test19754.d
+++ b/test/runnable/test19754.d
@@ -1,0 +1,5 @@
+void main()
+{
+    const x = 0;
+    assert(&x == &(cast() x)); // fails; lowered to `assert(& x is &0)`
+}


### PR DESCRIPTION
When taking the address of a cast expression, the cast should not be constfolded because it may change an identifier/variable expression (lvalue) into a literal (rvalue).

cc @kinke 