### PR TITLE
Advance deprecation of opDot to error

### DIFF
--- a/changelog/opDot_error.dd
+++ b/changelog/opDot_error.dd
@@ -1,0 +1,51 @@
+`opDot` usage will now result in an error
+
+`opDot` was deprecated in 2.082.  It was the D1 analog to `alias this`.
+However, `alias this` covers all use cases of `opDot`, but ensures safety.
+
+---
+struct S
+{
+    int a, b;
+}
+struct T
+{
+    S s;
+
+    S* opDot()
+    {
+        return &s;
+    }
+}
+
+void main()
+{
+    T t;
+    t.a = 4;
+    assert(t.a == 4);
+    t.b = 5;
+}
+---
+
+With `alias this`:
+
+---
+struct S
+{
+    int a, b;
+}
+struct T
+{
+    S s;
+
+    alias s this;
+}
+
+void main() @safe
+{
+    T t;
+    t.a = 4;
+    assert(t.a == 4);
+    t.b = 5;
+}
+---

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3495,14 +3495,12 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
              */
             if (auto fd = search_function(sym, Id.opDot))
             {
-                /* Rewrite e.ident as:
-                 *  e.opDot().ident
-                 */
-                e = build_overload(e.loc, sc, e, null, fd);
-                // @@@DEPRECATED_2.087@@@.
-                e.deprecation("`opDot` is deprecated. Use `alias this`");
-                e = new DotIdExp(e.loc, e, ident);
-                return returnExp(e.expressionSemantic(sc));
+                // @@@DEPRECATED_2.094@@@.
+                // Deprecated in 2.082
+                // Made an error in 2.088
+                // Remove in 2.094
+                e.error("`opDot` is obsolete. Use `alias this`");
+                return returnExp(new ErrorExp());
             }
 
             /* Look for overloaded opDispatch to see if we should forward request

--- a/test/fail_compilation/deprecateopdot.d
+++ b/test/fail_compilation/deprecateopdot.d
@@ -1,10 +1,10 @@
 /*
-REQUIRED_ARGS: -de
+REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/deprecateopdot.d(27): Deprecation: `opDot` is deprecated. Use `alias this`
-fail_compilation/deprecateopdot.d(28): Deprecation: `opDot` is deprecated. Use `alias this`
-fail_compilation/deprecateopdot.d(29): Deprecation: `opDot` is deprecated. Use `alias this`
+fail_compilation/deprecateopdot.d(27): Error: `opDot` is obsolete. Use `alias this`
+fail_compilation/deprecateopdot.d(28): Error: `opDot` is obsolete. Use `alias this`
+fail_compilation/deprecateopdot.d(29): Error: `opDot` is obsolete. Use `alias this`
 ---
 */
 struct S6

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -14,14 +14,6 @@ tuple(height)
 tuple(get, get)
 tuple(clear)
 tuple(draw, draw)
-runnable/xtest46.d(149): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(151): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(152): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(154): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(181): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(183): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(184): Deprecation: `opDot` is deprecated. Use `alias this`
-runnable/xtest46.d(186): Deprecation: `opDot` is deprecated. Use `alias this`
 const(int)
 string[]
 double[]
@@ -123,70 +115,6 @@ struct S5
 
 void test5()
 {
-}
-
-/***************************************************/
-
-struct S6
-{
-    int a, b, c;
-}
-
-struct T6
-{
-    S6 s;
-    int b = 7;
-
-    S6* opDot() return
-    {
-        return &s;
-    }
-}
-
-void test6()
-{
-    T6 t;
-    t.a = 4;
-    t.b = 5;
-    t.c = 6;
-    assert(t.a == 4);
-    assert(t.b == 5);
-    assert(t.c == 6);
-    assert(t.s.b == 0);
-    assert(t.sizeof == 4*4);
-    assert(t.init.sizeof == 4*4);
-}
-
-/***************************************************/
-
-struct S7
-{
-    int a, b, c;
-}
-
-class C7
-{
-    S7 s;
-    int b = 7;
-
-    S7* opDot()
-    {
-        return &s;
-    }
-}
-
-void test7()
-{
-    C7 t = new C7();
-    t.a = 4;
-    t.b = 5;
-    t.c = 6;
-    assert(t.a == 4);
-    assert(t.b == 5);
-    assert(t.c == 6);
-    assert(t.s.b == 0);
-    assert(t.sizeof == (void*).sizeof);
-    assert(t.init is null);
 }
 
 /***************************************************/
@@ -7987,8 +7915,6 @@ int main()
     test2();
     test4();
     test5();
-    test6();
-    test7();
     test8();
     test9();
     test10();


### PR DESCRIPTION
Followup to https://github.com/dlang/dmd/pull/8406

I'm expecting this to be merged after 2.087 is released.