### PR TITLE
dmd/id: Remove tls_get_addr from frontend id table

### DIFF
--- a/src/dmd/backend/elpicpie.d
+++ b/src/dmd/backend/elpicpie.d
@@ -509,9 +509,9 @@ static if (1)
                 if (!tls_get_addr_sym)
                 {
                     /* void *___tls_get_addr(void *ptr);
-                     * Parameter ptr is passed in EAX, matching TYjfunc calling convention.
+                     * Parameter ptr is passed in RDI, matching TYnfunc calling convention.
                      */
-                    tls_get_addr_sym = symbol_name("___tls_get_addr",SCglobal,type_fake(TYjfunc));
+                    tls_get_addr_sym = symbol_name("___tls_get_addr",SCglobal,type_fake(TYnfunc));
                     symbol_keep(tls_get_addr_sym);
                 }
                 if (x == 1)

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -681,7 +681,7 @@ public:
             buf.writestring("_Dmain");
             return;
         }
-        if (fd.isWinMain() || fd.isDllMain() || fd.ident == Id.tls_get_addr)
+        if (fd.isWinMain() || fd.isDllMain())
         {
             buf.writestring(fd.ident.toString());
             return;

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -2803,7 +2803,6 @@ private bool isReservedName(const(char)[] str)
         "__EOF__",
         "__CXXLIB__",
         "__LOCAL_SIZE",
-        "___tls_get_addr",
         "__entrypoint",
     ];
     foreach (s; table)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1379,11 +1379,6 @@ private void specialFunctions(Obj objmod, FuncDeclaration fd)
             obj_includelib(libname);
         s.Sclass = SCglobal;
     }
-    else if (fd.ident == Id.tls_get_addr && fd.linkage == LINK.d)
-    {
-        // TODO: Change linkage in druntime to extern(C).
-        s.Sfunc.Fredirect = cast(char*)Id.tls_get_addr.toChars();
-    }
 }
 
 

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -336,7 +336,6 @@ immutable Msgtable[] msgtable =
     { "main" },
     { "WinMain" },
     { "DllMain" },
-    { "tls_get_addr", "___tls_get_addr" },
     { "entrypoint", "__entrypoint" },
     { "rt_init" },
     { "__cmp" },


### PR DESCRIPTION
I think I've found where the mismatch between compiler and OSX32 occurred too.  Updated dmd to call ___tls_get_addr as an `extern(C)` function, as that's what the definition is now in druntime.