### PR TITLE
split TYfgPtr off from TYsptr

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -455,8 +455,10 @@ else
 
     _tysize[TYimmutPtr] = _tysize[TYnptr];
     _tysize[TYsharePtr] = _tysize[TYnptr];
+    _tysize[TYfgPtr] = _tysize[TYnptr];
     _tyalignsize[TYimmutPtr] = _tyalignsize[TYnptr];
     _tyalignsize[TYsharePtr] = _tyalignsize[TYnptr];
+    _tyalignsize[TYfgPtr] = _tyalignsize[TYnptr];
 }
 
 /*******************************
@@ -543,7 +545,9 @@ else
 
     _tysize[TYimmutPtr] = _tysize[TYnptr];
     _tysize[TYsharePtr] = _tysize[TYnptr];
+    _tysize[TYfgPtr] = _tysize[TYnptr];
     _tyalignsize[TYimmutPtr] = _tyalignsize[TYnptr];
     _tyalignsize[TYsharePtr] = _tyalignsize[TYnptr];
+    _tyalignsize[TYfgPtr] = _tyalignsize[TYnptr];
 }
 

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -2884,6 +2884,7 @@ void codelem(ref CodeBuilder cdb,elem *e,regm_t *pretregs,uint constflag)
                     case TYnptr:
                     case TYsptr:
                     case TYcptr:
+                    case TYfgPtr:
                     case TYimmutPtr:
                     case TYsharePtr:
                         *pretregs |= I16 ? IDXREGS : ALLREGS;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -178,6 +178,7 @@ int elemisone(elem *e)
             case TYnptr:
             case TYimmutPtr:
             case TYsharePtr:
+            case TYfgPtr:
             case TYbool:
             case TYwchar_t:
             case TYdchar:
@@ -241,6 +242,7 @@ int elemisnegone(elem *e)
             case TYvptr:
             case TYimmutPtr:
             case TYsharePtr:
+            case TYfgPtr:
             case TYbool:
             case TYwchar_t:
             case TYdchar:
@@ -1173,6 +1175,7 @@ private elem * elmin(elem *e, goal_t goal)
             (tyintegral(tym) ||
              tybasic(tym) == TYnptr ||
              tybasic(tym) == TYsptr ||
+             tybasic(tym) == TYfgPtr ||
              tybasic(tym) == TYimmutPtr ||
              tybasic(tym) == TYsharePtr)
            )
@@ -5723,7 +5726,7 @@ void postoptelem(elem *e)
             {
                 version (MARS)
                 if (e.EV.E1.Eoper == OPconst &&
-                    tybasic(e.EV.E1.Ety) == TYnptr &&   // Allow TYsptr to reference GS:[0000] etc.
+                    tybasic(e.EV.E1.Ety) == TYnptr &&   // Allow TYfgptr to reference GS:[0000] etc.
                     el_tolong(e.EV.E1) >= 0 && el_tolong(e.EV.E1) < 4096)
                 {
                     error(pos.Sfilename, pos.Slinnum, pos.Scharnum, "null dereference in function %s", funcsym_p.Sident.ptr);

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1194,10 +1194,15 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                 case TYsptr:                        /* if pointer to stack  */
                     if (config.wflags & WFssneds)   // if SS != DS
                         pcs.Iflags |= CFss;        /* then need SS: override */
-                    else if (I32)
+                    break;
+
+                case TYfgPtr:
+                    if (I32)
                         pcs.Iflags |= CFgs;
                     else if (I64)
                         pcs.Iflags |= CFfs;
+                    else
+                        assert(0);
                     break;
 
                 case TYcptr:                        /* if pointer to code   */
@@ -4284,10 +4289,15 @@ void pushParams(ref CodeBuilder cdb, elem* e, uint stackalign, tym_t tyf)
                             case TYsptr:
                                 if (config.wflags & WFssneds)
                                     seg = CFss;
-                                else if (I32)
+                                break;
+
+                            case TYfgPtr:
+                                if (I32)
                                      seg = CFgs;
                                 else if (I64)
                                      seg = CFfs;
+                                else
+                                     assert(0);
                                 break;
 
                             case TYcptr:

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -3318,8 +3318,10 @@ void cdstrcmp(ref CodeBuilder cdb, elem *e, regm_t *pretregs)
     switch (tybasic(ty1))
     {
         case TYnptr:
+        case TYimmutPtr:
             need_DS = false;
             break;
+
         case TYsptr:
             if (config.wflags & WFssneds)       // if sptr can't use DS segment
                 segreg = SEG_SS;
@@ -3427,8 +3429,10 @@ void cdmemcmp(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     switch (tybasic(ty1))
     {
         case TYnptr:
+        case TYimmutPtr:
             need_DS = false;
             break;
+
         case TYsptr:
             if (config.wflags & WFssneds)       // if sptr can't use DS segment
                 segreg = SEG_SS;
@@ -3537,8 +3541,10 @@ void cdstrcpy(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     switch (ty2)
     {
         case TYnptr:
+        case TYimmutPtr:
             need_DS = false;
             break;
+
         case TYsptr:
             if (config.wflags & WFssneds)       // if sptr can't use DS segment
                 segreg = SEG_SS;
@@ -3647,6 +3653,7 @@ void cdmemcpy(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     switch (tybasic(ty2))
     {
         case TYnptr:
+        case TYimmutPtr:
             need_DS = false;
             break;
 

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -634,6 +634,7 @@ regm_t regmask(tym_t tym, tym_t tyf)
         case TYcptr:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYfgPtr:
             return mAX;
 
         case TYfloat:

--- a/src/dmd/backend/cod4.d
+++ b/src/dmd/backend/cod4.d
@@ -2992,6 +2992,7 @@ void cdshtlng(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             // BUG: what about pointers to functions?
             switch (tym1)
             {
+                case TYimmutPtr:
                 case TYnptr:    segreg = SEG_DS;        break;
                 case TYcptr:    segreg = SEG_CS;        break;
                 case TYsptr:    segreg = SEG_SS;        break;

--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -477,6 +477,7 @@ void cv_init()
             dttab4[TYsptr] = 0x600;
             dttab4[TYimmutPtr] = 0x600;
             dttab4[TYsharePtr] = 0x600;
+            dttab4[TYfgPtr] = 0x600;
         }
         else
         {
@@ -485,6 +486,7 @@ void cv_init()
             dttab4[TYnptr] = 0x400;
             dttab4[TYimmutPtr] = 0x400;
             dttab4[TYsharePtr] = 0x400;
+            dttab4[TYfgPtr] = 0x400;
         }
         dttab4[TYcptr] = 0x400;
         dttab4[TYfptr] = 0x500;
@@ -1925,6 +1927,8 @@ L1:
             break;
 
         case TYnptr:
+        case TYimmutPtr:
+        case TYsharePtr:
 version (MARS)
 {
             if (t.Tkey)
@@ -1933,6 +1937,7 @@ version (MARS)
             goto Lptr;
         case TYsptr:
         case TYcptr:
+        case TYfgPtr:
         Lptr:
                         attribute |= I32 ? 10 : 0;      goto L2;
 

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -2205,6 +2205,7 @@ L1:
                     case TYcptr:
                     case TYimmutPtr:
                     case TYsharePtr:
+                    case TYfgPtr:
                         if (_tysize[TYnptr] == SHORTSIZE)
                             goto case_short;
                         else if (_tysize[TYnptr] == LONGSIZE)
@@ -2507,6 +2508,7 @@ version (SCPP_HTOD)
         case TYnref:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYfgPtr:
             if (_tysize[TYnptr] == SHORTSIZE)
                 goto Ushort;
             if (_tysize[TYnptr] == LONGSIZE)
@@ -2904,6 +2906,7 @@ case_tym:
         case TYnref:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYfgPtr:
             if (_tysize[TYnptr] == LONGSIZE)
                 goto L1;
             if (_tysize[TYnptr] == SHORTSIZE)

--- a/src/dmd/backend/elpicpie.d
+++ b/src/dmd/backend/elpicpie.d
@@ -856,7 +856,7 @@ private elem *el_pievar(Symbol *s)
                  */
                 Obj.refGOTsym();
                 tym_t tym = e.Ety;
-                e.Ety = TYsptr;         // TYsptr means FS:
+                e.Ety = TYfgPtr;
 
                 e = el_una(OPind, tym, e);
                 break;
@@ -887,7 +887,7 @@ private elem *el_pievar(Symbol *s)
                 e.Ety = TYnptr;
 
                 e = el_bin(OPadd, TYnptr, e, el_var(el_alloc_localgot()));
-                e = el_una(OPind, TYsptr, e);
+                e = el_una(OPind, TYfgPtr, e);
                 e = el_una(OPind, tym, e);
                 break;
             }
@@ -916,7 +916,7 @@ private elem *el_pieptr(Symbol *s)
     e.EV.Vsym = s;
     e.Ety = TYnptr;
 
-    elem* e0 = el_una(OPind, TYsize, el_long(TYsptr, 0)); // I64: FS:[0000], I32: GS:[0000]
+    elem* e0 = el_una(OPind, TYsize, el_long(TYfgPtr, 0)); // I64: FS:[0000], I32: GS:[0000]
 
     if (I64)
     {

--- a/src/dmd/backend/evalu8.d
+++ b/src/dmd/backend/evalu8.d
@@ -109,6 +109,7 @@ version (SCPP)
                 case TYnptr:
                 case TYimmutPtr:
                 case TYsharePtr:
+                case TYfgPtr:
                     b = el_tolong(e) != 0;
                     break;
                 case TYnref: // reference can't be converted to bool

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -2063,6 +2063,7 @@ private famlist * newfamlist(tym_t ty)
         case TYnullptr:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYfgPtr:
             ty = TYint;
             if (I64)
                 ty = TYllong;
@@ -3379,6 +3380,7 @@ private famlist * flcmp(famlist *f1,famlist *f2)
             case TYnptr:        // BUG: 64 bit pointers?
             case TYimmutPtr:
             case TYsharePtr:
+            case TYfgPtr:
             case TYnullptr:
             case TYint:
             case TYuint:

--- a/src/dmd/backend/newman.d
+++ b/src/dmd/backend/newman.d
@@ -1032,6 +1032,7 @@ private void cpp_basic_data_type(type *t)
         case TYnptr:
         case TYimmutPtr:
         case TYsharePtr:
+        case TYfgPtr:
             c = cast(char)('P' + cpp_cvidx(t.Tty));
             CHAR(c);
             if(I64)

--- a/src/dmd/backend/optabgen.d
+++ b/src/dmd/backend/optabgen.d
@@ -750,7 +750,7 @@ enum DS = 3;
 void dotytab()
 {
     static tym_t[] _ptr      = [ TYnptr ];
-    static tym_t[] _ptr_nflat= [ TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr,TYimmutPtr,TYsharePtr ];
+    static tym_t[] _ptr_nflat= [ TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr,TYimmutPtr,TYsharePtr,TYfgPtr ];
     static tym_t[] _real     = [ TYfloat,TYdouble,TYdouble_alias,TYldouble,
                                  TYfloat4,TYdouble2,
                                  TYfloat8,TYdouble4,
@@ -919,6 +919,7 @@ void dotytab()
 {"__handle *",   TYvptr,         TYvptr,    TYvptr,      4,  0x40,       0x200},
 {"__immutable *", TYimmutPtr,    TYimmutPtr,TYimmutPtr,  2,  0x20,       0x100},
 {"__shared *",   TYsharePtr,     TYsharePtr,TYsharePtr,  2,  0x20,       0x100},
+{"__fg *",       TYfgPtr,        TYfgPtr,   TYfgPtr,     2,  0x20,       0x100},
 {"far C func",   TYffunc,        TYffunc,   TYffunc,     -1,     0x64,   0},
 {"far Pascal func", TYfpfunc,    TYfpfunc,  TYfpfunc,    -1,     0x73,   0},
 {"far std func", TYfsfunc,       TYfsfunc,  TYfsfunc,    -1,     0x64,   0},

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -82,7 +82,7 @@ enum
     TYucent             = 0x3D, // 128 bit unsigned integer
 
     // Used for segmented architectures
-    TYsptr              = 0x1E, // stack segment relative pointer (I16) GS: (I32) FS: (I64)
+    TYsptr              = 0x1E, // stack segment relative pointer
     TYcptr              = 0x1F, // code segment relative pointer
     TYf16ptr            = 0x20, // special OS/2 far16 pointer
     TYfptr              = 0x21, // far pointer (has segment and offset)
@@ -140,8 +140,9 @@ enum
 
     TYsharePtr          = 0x5C, // pointer to shared data
     TYimmutPtr          = 0x5D, // pointer to immutable data
+    TYfgPtr             = 0x5E, // GS: pointer (I32) FS: pointer (I64)
 
-    TYMAX               = 0x5E,
+    TYMAX               = 0x5F,
 }
 
 alias TYerror = TYint;


### PR DESCRIPTION
Having TYsptr do double duty is not worth the confusion.