### PR TITLE
Fix Issue 18719 - Doubly-called constructor against member when using forwarding constructors: Deprecation -> Error

### DIFF
--- a/changelog/error_18719.dd
+++ b/changelog/error_18719.dd
@@ -1,0 +1,47 @@
+Double initialization of immutable fields inside constructor is now obsolete
+
+Inside a constructor scope, assigning to aggregate declaration (class/struct)
+members is done by considering the first assignment as initialization and
+subsequent assignments as modifications of the initially constructed object.
+For `const`/`immutable` fields the initialization is accepted in the constructor,
+but subsequent modifications are not. Example:
+
+---
+class A
+{
+    int a;
+    immutable int b;
+    this(int a, int b)
+    {
+        this.a = a;
+        this.b = b;
+
+        this.a = 7; // OK, a is mutable
+        this.b = 9; // Error: immutable field b initialized multiple times
+    }
+}
+---
+
+However, $(BUGZILLA 18719) shows that this rule does not apply when inside
+a constructor scope there is a call to a different constructor:
+
+---
+class A
+{
+    immutable int a;
+    this()
+    {
+        this(42);
+        this.a = 5;  // second initialization of immutable field
+    }
+
+    this(int a)
+    {
+        this.a = a;
+    }
+}
+---
+
+The above code wrongfully compiled succesfully before this patch, accepting the double
+initialization of the `immutable` field `a`. Starting with this release, `this.a = 5` will emit
+an error stating that `a` is initialized multiple times.

--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -28,7 +28,6 @@ enum CSX : ushort
     return_         = 0x08,     /// seen a return statement
     any_ctor        = 0x10,     /// either this() or super() was called
     halt            = 0x20,     /// assert(0)
-    deprecate_18719 = 0x40,    // issue deprecation for Issue 18719 - delete when deprecation period is over
 }
 
 /// Individual field in the Ctor with information about its callees and location.

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -125,20 +125,8 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
                     else
                     {
                         const(char)* modStr = !var.type.isMutable() ? MODtoChars(var.type.mod) : MODtoChars(e1.type.mod);
-                        // Deprecated in 2018-04.
-                        // Change to error in 2019-04 by deleting the following
-                        // if-branch and the deprecate_18719 enum member in the
-                        // dmd.ctorflow.CSX enum.
-                        // @@@DEPRECATED_2019-01@@@.
-                        if (fi & CSX.deprecate_18719)
-                        {
-                            .deprecation(loc, "%s field `%s` was initialized in a previous constructor call", modStr, var.toChars());
-                        }
-                        else
-                        {
-                            .error(loc, "%s field `%s` initialized multiple times", modStr, var.toChars());
-                            .errorSupplemental(fieldInit.loc, "Previous initialization is here.");
-                        }
+                        .error(loc, "%s field `%s` initialized multiple times", modStr, var.toChars());
+                        .errorSupplemental(fieldInit.loc, "Previous initialization is here.");
                     }
                 }
                 else if (sc.inLoop || (fi & CSX.label))

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4592,7 +4592,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 // initialized after this call.
                 foreach (ref field; sc.ctorflow.fieldinit)
                 {
-                    field.csx |= CSX.this_ctor | CSX.deprecate_18719;
+                    field.csx |= CSX.this_ctor;
                 }
             }
 

--- a/test/fail_compilation/fail18719.d
+++ b/test/fail_compilation/fail18719.d
@@ -1,10 +1,11 @@
 // https://issues.dlang.org/show_bug.cgi?id=18719
 
-// REQUIRED_ARGS: -de
+// REQUIRED_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18719.d(29): Deprecation: immutable field `x` was initialized in a previous constructor call
+fail_compilation/fail18719.d(30): Error: immutable field `x` initialized multiple times
+       Previous initialization is here.
 ---
 */
 


### PR DESCRIPTION
Followup to https://github.com/dlang/dmd/pull/8167

cc @RazvanN7 