### PR TITLE
Fix issue 17885: use the correct expression's type when creating temporary for remove() call

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2642,7 +2642,7 @@ elem *toElem(Expression e, IRState *irs)
             elem *ea = toElem(re.e1, irs);
             elem *ekey = toElem(re.e2, irs);
 
-            ekey = addressElem(ekey, re.e1.type);
+            ekey = addressElem(ekey, re.e2.type);
             Symbol *s = aaGetSymbol(taa, "DelX", 0);
             elem *keyti = getTypeInfo(re.loc, taa.index, irs);
             elem *ep = el_params(ekey, keyti, ea, null);

--- a/test/runnable/test17885.d
+++ b/test/runnable/test17885.d
@@ -1,0 +1,11 @@
+module test17885;
+
+struct T { ulong a, b; }
+T f() { return T(); }
+
+void main()
+{
+    int[T] set = [f(): 0];
+    set.remove(f());
+    assert(f() !in set);
+}


### PR DESCRIPTION
Everybody does typos.