### PR TITLE
Use TYfgPtr instead of _tls_array fakery

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1438,24 +1438,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
             {
                 static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYBSD || TARGET_SOLARIS)
                 {
-                    // Rewrite as GS:[0000], or FS:[0000] for 64 bit
-                    if (I64)
-                    {
-                        pcs.Irm = modregrm(0, 0, 4);
-                        pcs.Isib = modregrm(0, 4, 5);  // don't use [RIP] addressing
-                        pcs.IFL1 = FLconst;
-                        pcs.IEV1.Vuns = 0;
-                        pcs.Iflags = CFfs;
-                        pcs.Irex |= REX_W;
-                    }
-                    else
-                    {
-                        pcs.Irm = modregrm(0, 0, BPRM);
-                        pcs.IFL1 = FLconst;
-                        pcs.IEV1.Vuns = 0;
-                        pcs.Iflags = CFgs;
-                    }
-                    break;
+                    assert(0);
                 }
                 else static if (TARGET_WINDOS)
                 {

--- a/src/dmd/backend/elpicpie.d
+++ b/src/dmd/backend/elpicpie.d
@@ -161,14 +161,7 @@ else static if (TARGET_LINUX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGO
             e1.Ety = TYnptr;
         }
 
-        /* Fake GS:[0000] as a load of _tls_array, and then in the back end recognize
-         * the fake and rewrite it as GS:[0000] (or FS:[0000] for I64), because there is
-         * no way to represent segment overrides in the elem nodes.
-         */
-        elem *e2 = el_calloc();
-        e2.Eoper = OPvar;
-        e2.EV.Vsym = getRtlsym(RTLSYM_TLS_ARRAY);
-        e2.Ety = e2.EV.Vsym.ty();
+        elem* e2 = el_una(OPind, TYsize, el_long(TYfgPtr, 0)); // I64: FS:[0000], I32: GS:[0000]
 
         e.Eoper = OPind;
         e.EV.E1 = el_bin(OPadd,e1.Ety,e2,e1);


### PR DESCRIPTION
now that the code generator supports FS: and GS: pointers