### PR TITLE
Preliminary shared work

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -721,6 +721,8 @@ dmd -cov -unittest myprog.d
             "destruct fields of partially constructed objects"),
         Feature("rvaluerefparam", "rvalueRefParam",
             "enable rvalue arguments to ref parameters"),
+        Feature("restrictiveshared", "restrictiveshared",
+            "implement a more restrictive shared", false),
     ];
 }
 

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -57,6 +57,7 @@ enum SCOPE
     ignoresymbolvisibility    = 0x0200,   /// ignore symbol visibility
                                           /// https://issues.dlang.org/show_bug.cgi?id=15907
     onlysafeaccess = 0x0400,  /// unsafe access is not allowed for @safe code
+    nosharedcheck  = 0x0800, /// allow shared acsses for the sub-expressions
     free          = 0x8000,   /// is on free list
 
     fullinst      = 0x10000,  /// fully instantiate templates
@@ -272,6 +273,19 @@ struct Scope
         return pop();
     }
 
+
+    extern (C++) Scope* startRelaxShared()
+    {
+        Scope* sc = this.push();
+        sc.flags = this.flags | SCOPE.nosharedcheck;
+        return sc;
+    }
+
+    extern (C++) Scope* endRelaxShared()
+    {
+        assert(flags & SCOPE.nosharedcheck);
+        return pop();
+    }
 
     /*******************************
      * Merge results of `ctorflow` into `this`.

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -57,7 +57,7 @@ enum SCOPE
     ignoresymbolvisibility    = 0x0200,   /// ignore symbol visibility
                                           /// https://issues.dlang.org/show_bug.cgi?id=15907
     onlysafeaccess = 0x0400,  /// unsafe access is not allowed for @safe code
-    nosharedcheck  = 0x0800, /// allow shared acsses for the sub-expressions
+    allowsharedaccess  = 0x0800, /// allow shared access for the sub-expressions
     free          = 0x8000,   /// is on free list
 
     fullinst      = 0x10000,  /// fully instantiate templates
@@ -274,16 +274,16 @@ struct Scope
     }
 
 
-    extern (C++) Scope* startRelaxShared()
+    extern (C++) Scope* startAllowSharedAccess()
     {
         Scope* sc = this.push();
-        sc.flags = this.flags | SCOPE.nosharedcheck;
+        sc.flags = this.flags | SCOPE.allowsharedaccess;
         return sc;
     }
 
-    extern (C++) Scope* endRelaxShared()
+    extern (C++) Scope* endAllowSharedAccess()
     {
-        assert(flags & SCOPE.nosharedcheck);
+        assert(flags & SCOPE.allowsharedaccess);
         return pop();
     }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -176,6 +176,7 @@ struct Param
                             // https://issues.dlang.org/show_bug.cgi?id=14246
     bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
     bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
+    bool restrictiveshared; // restrict the use of shared to casting & shared functions
 
     CppStdRevision cplusplus = CppStdRevision.cpp98;    // version of C++ standard to support
 

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -148,6 +148,7 @@ struct Param
                             // https://issues.dlang.org/show_bug.cgi?id=14246
     bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
     bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
+    bool restrictiveshared;  // restrict the use of shared to casting & shared functions
     CppStdRevision cplusplus;  // version of C++ name mangling to support
     bool markdown;          // enable Markdown replacements in Ddoc
     bool vmarkdown;         // list instances of Markdown replacements in Ddoc

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -41,6 +41,7 @@ class CPPNamespaceDeclaration;
 #define SCOPEctor           0x0001  // constructor type
 #define SCOPEcondition      0x0004  // inside static if/assert condition
 #define SCOPEdebug          0x0008  // inside debug conditional
+#define SCOPEnosharedcheck  0x0800  // allow shared access
 
 // Flags that would be inherited beyond scope nesting
 #define SCOPEnoaccesscheck  0x0002  // don't do access checks

--- a/test/compilable/test_shared.d
+++ b/test/compilable/test_shared.d
@@ -1,0 +1,22 @@
+/*
+REQUIRED_ARGS:-preview=restrictiveshared
+TEST_OUTPUT:
+---
+---
+*/
+
+
+int f1(shared int x)
+{
+    auto r = sync(&x, 22);
+    return r;
+
+}
+
+int sync(shared int *x, int y)
+{
+    auto unshared_x = cast()x;
+
+    return *unshared_x = y;
+}
+

--- a/test/fail_compilation/fail_shared.d
+++ b/test/fail_compilation/fail_shared.d
@@ -1,0 +1,24 @@
+/*
+REQUIRED_ARGS:-preview=restrictiveshared
+TEST_OUTPUT:
+---
+fail_compilation/fail_shared.d(15): Error: Trying to Access shared state `x`
+fail_compilation/fail_shared.d(16): Error: Trying to Access shared state `x`
+fail_compilation/fail_shared.d(17): Error: Trying to Access shared state `x`
+fail_compilation/fail_shared.d(22): Error: Trying to Access shared state `x`
+---
+*/
+
+
+int f1(shared int x)
+{
+    x += 7; // Error: Trying to accsess shared state x
+    x = 22; // Error: Trying to accsess shared state x
+    return x; // Error: Trying to accsess shared state x
+}
+
+int sync(shared int *x, int y)
+{
+    return x = y; // Error: Trying to accsess shared state x
+}
+


### PR DESCRIPTION
This will block read/write access to shared variables
execpt for the casting shared away operation, and when passing a shared argument to a shared parameter.  