### PR TITLE
Issue 20036 - COFF: missing relocations in large object files

### DIFF
--- a/test/runnable/test20036.d
+++ b/test/runnable/test20036.d
@@ -1,0 +1,10 @@
+
+__gshared int x = 7;
+__gshared int*[70000] px = &x;
+
+void main()
+{
+	foreach(p; px)
+		assert(p && *p == 7);
+}
+


### PR DESCRIPTION
more than 65535 relocations must be encoded in the first relocation