### PR TITLE
 Fix issue 17408: scope and in are considered redundant

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1342,7 +1342,7 @@ final class Parser(AST) : Lexer
     {
         static bool isIn (StorageClass stc)
         {
-            enum SC = (AST.STC.const_ | AST.STC.scope_);
+            enum SC = (AST.STC.const_);
             return !!(stc & AST.STC.in_ || ((stc & SC) == SC));
         }
 

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1340,7 +1340,13 @@ final class Parser(AST) : Lexer
      */
     private StorageClass appendStorageClass(StorageClass storageClass, StorageClass stc)
     {
-        if ((storageClass & stc) || (storageClass & AST.STC.in_ && stc & (AST.STC.const_ | AST.STC.scope_)) || (stc & AST.STC.in_ && storageClass & (AST.STC.const_ | AST.STC.scope_)))
+        static bool isIn (StorageClass stc)
+        {
+            enum SC = (AST.STC.const_ | AST.STC.scope_);
+            return !!(stc & AST.STC.in_ || ((stc & SC) == SC));
+        }
+
+        if ((storageClass & stc) || (isIn(storageClass) && isIn(stc)))
         {
             OutBuffer buf;
             AST.stcToBuffer(&buf, stc);

--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -2,6 +2,10 @@
  PERMUTE_FIXME_ARGS: -preview=dip1000
 */
 
+/// https://issues.dlang.org/show_bug.cgi?id=17408
+void f(in scope int x) {}
+void g(scope in int x) {}
+
 struct Cache
 {
     ubyte[1] v;

--- a/test/fail_compilation/fail183.d
+++ b/test/fail_compilation/fail183.d
@@ -1,11 +1,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail183.d(10): Error: redundant attribute `const`
-fail_compilation/fail183.d(10): Error: redundant attribute `scope`
-fail_compilation/fail183.d(11): Error: redundant attribute `in`
+fail_compilation/fail183.d(1): Error: redundant attribute `const`
+fail_compilation/fail183.d(2): Error: redundant attribute `in`
+fail_compilation/fail183.d(4): Error: redundant attribute `const`
+fail_compilation/fail183.d(5): Error: redundant attribute `in`
 ---
 */
 
+#line 1
 void f(in final const scope int x) {}
 void g(final const scope in int x) {}
+// Part of https://issues.dlang.org/show_bug.cgi?id=17408
+void h(in const int x) {}
+void i(const in int x) {}


### PR DESCRIPTION
This fixes the issue at hand, although I am not really sure what we should do with `in`.
As it stands should it just be deprecated or should we add `-transition=in` to make it work again ?