### PR TITLE
compilable/scope: Actually enable DIP1000

### DIFF
--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -1,5 +1,5 @@
 /*
- PERMUTE_FIXME_ARGS: -preview=dip1000
+REQUIRED_ARGS: -preview=dip1000
 */
 
 struct Cache
@@ -51,4 +51,3 @@ auto callWrappedOops(scope string dArgs) {
 }
 
 /************************************/
-


### PR DESCRIPTION
The test was apparently fixed in f9507956d but the ARGS statement was not.
We can use `REQUIRED_ARGS` since there's actually no required permutation.