### PR TITLE
fix handling of static impure functions nested in pure functions (issues 20047 and 20050)

### DIFF
--- a/test/fail_compilation/testInference.d
+++ b/test/fail_compilation/testInference.d
@@ -183,19 +183,19 @@ void test12422() pure
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(196): Error: `pure` function `testInference.test13729a` cannot access mutable static data `g13729`
 fail_compilation/testInference.d(198): Error: `pure` function `testInference.test13729a` cannot call impure function `testInference.test13729a.foo`
 fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!().foo`
 ---
 */
 int g13729;
+
 void test13729a() pure
 {
     static void foo()   // typed as impure
     {
-        g13729++;       // disallowed
+        g13729++;
     }
-    foo();
+    foo();              // cannot call impure function
 }
 void test13729b() pure
 {

--- a/test/fail_compilation/testInference.d
+++ b/test/fail_compilation/testInference.d
@@ -184,11 +184,11 @@ void test12422() pure
 TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(196): Error: `pure` function `testInference.test13729a` cannot access mutable static data `g13729`
+fail_compilation/testInference.d(198): Error: `pure` function `testInference.test13729a` cannot call impure function `testInference.test13729a.foo`
 fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!().foo`
 ---
 */
 int g13729;
-
 void test13729a() pure
 {
     static void foo()   // typed as impure
@@ -223,4 +223,17 @@ void test17086_call ()
 {
     bool f;
     test17086(f);
+}
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/testInference.d(238): Error: `pure` function `testInference.test20047_pure_function` cannot call impure function `testInference.test20047_pure_function.bug`
+---
+*/
+void test20047_impure_function() {}
+void test20047_pure_function() pure
+{
+    static void bug() { return test20047_impure_function(); }
+    bug();
 }

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -1937,6 +1937,28 @@ void testNegConst()
 
 ////////////////////////////////////////////////////////////////////////
 
+// https://issues.dlang.org/show_bug.cgi?id=20050
+
+int test20050_g = 0;
+void test20050_impure_function_1() { ++test20050_g; }
+void function() test20050_get_impure_function() pure
+{
+    static void impure_function_2()
+    {
+        ++test20050_g;
+        test20050_impure_function_1();
+    }
+    return &impure_function_2;
+}
+void test20050()
+{
+    auto f = test20050_get_impure_function();
+    f();
+    assert(test20050_g == 2);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 int main()
 {
     testgoto();
@@ -2006,6 +2028,7 @@ int main()
     test18794();
     testfastpar();
     testNegConst();
+    test20050();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
This is mostly deleting a bunch of code. As far as I can tell, it was all based on a wrong, overly complicated model of how things should work. But it's very possible that I'm missing crucial details.