### PR TITLE
constructors modify immutable variables, so no CSEs for them

### DIFF
--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -317,34 +317,7 @@ bool Symbol_isAffected(const ref Symbol s)
      */
     if (s.ty() & (mTYconst | mTYimmutable))
     {
-        /* Constructors can modify immutable variables:
-            struct S
-            {
-                int v = 1;
-                this(int x) { v = x * 2; }
-            }
-            void test()
-            {
-                const S cs = S(7);  // cs.v set to 1 before constructor call
-                assert(cs.v == 14); // cs.v is 1 because of CSE
-            }
-
-           Immutables can be changed inside static constructors:
-            immutable int x;
-            shared static this()
-            {
-                x += 3;
-            }
-
-           And regular constructors:
-            struct S
-            {
-                immutable int v;
-                this(int x) { v += v; }
-            }
-
-           So until we can detect these cases, we have to eshew this optimization.
-         */
+        return false;
     }
     return true;
 }

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -356,6 +356,13 @@ extern (C++) abstract class Declaration : Dsymbol
     /*************************************
      * Check to see if declaration can be modified in this context (sc).
      * Issue error if not.
+     * Params:
+     *  loc  = location for error messages
+     *  e1   = `null` or `this` expression when this declaration is a field
+     *  sc   = context
+     *  flag = !=0 means do not issue error message for invalid modification
+     * Returns:
+     *  Modifiable.yes or Modifiable.initialization
      */
     extern (D) final Modifiable checkModify(Loc loc, Scope* sc, Expression e1, int flag)
     {


### PR DESCRIPTION
Re-enable common subexpressions for immutable variables, just disallow it if the variable has a constructor.

(Because constructors modify immutables.)