### PR TITLE
Fix issue 20052 - SIMD 32 bytes segfault

### DIFF
--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -1003,7 +1003,14 @@ else
     }
 
     /* Determine if we need BP set up   */
-    if (config.flags & CFGalwaysframe)
+    if (enforcealign)
+    {
+        // we need BP to reset the stack before return
+        // otherwise the return address is lost
+        needframe = 1;
+
+    }
+    else if (config.flags & CFGalwaysframe)
         needframe = 1;
     else
     {

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -291,32 +291,6 @@ tryagain:
         regcon.params &= ~noparams;
     }
 
-    // See if we need to enforce a particular stack alignment
-    foreach (i; 0 .. globsym.top)
-    {
-        Symbol *s = globsym.tab[i];
-
-        switch (s.Sclass)
-        {
-            case SCregister:
-            case SCauto:
-            case SCfastpar:
-                if (s.Sfl == FLreg)
-                    break;
-
-                const sz = type_alignsize(s.Stype);
-                if (sz > STACKALIGN && (I64 || config.exe == EX_OSX))
-                {
-                    STACKALIGN = sz;
-                    enforcealign = true;
-                }
-                break;
-
-            default:
-                break;
-        }
-    }
-
     if (config.flags4 & CFG4optimized)
     {
         if (nretblocks == 0 &&                  // if no return blocks in function
@@ -374,6 +348,35 @@ tryagain:
     {
         if (CPP)
             cgcod_eh();
+    }
+
+    // See if we need to enforce a particular stack alignment
+    foreach (i; 0 .. globsym.top)
+    {
+        Symbol *s = globsym.tab[i];
+
+        if (Symbol_Sisdead(s, anyiasm))
+            continue;
+
+        switch (s.Sclass)
+        {
+            case SCregister:
+            case SCauto:
+            case SCfastpar:
+                if (s.Sfl == FLreg)
+                    break;
+
+                const sz = type_alignsize(s.Stype);
+                if (sz > STACKALIGN && (I64 || config.exe == EX_OSX))
+                {
+                    STACKALIGN = sz;
+                    enforcealign = true;
+                }
+                break;
+
+            default:
+                break;
+        }
     }
 
     stackoffsets(1);            // compute addresses of stack variables

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -4129,7 +4129,7 @@ void epilog(block *b)
         {
         L4:
             assert(hasframe);
-            if (xlocalsize)
+            if (xlocalsize || enforcealign)
             {
                 if (config.flags2 & CFG2stomp)
                 {   /*   MOV  ECX,0xBEAF

--- a/test/runnable/testxmm.d
+++ b/test/runnable/testxmm.d
@@ -1933,15 +1933,32 @@ void refIntrinsics()
 
 /*****************************************/
 
-void test6()
+void test6a()
 {
     version (D_AVX2)
     {
         // stack occasionally misaligned
         float f = 0;
         long4 v;
+        assert((cast(size_t)&v) % 32 == 0);
         v += 1;
     }
+}
+
+void test6b()
+{
+    version (D_AVX2)
+    {
+        struct S {long4 v;}
+        S s;
+        assert((cast(size_t)&s) % 32 == 0);
+    }
+}
+
+void test6()
+{
+    test6a();
+    test6b();
 }
 
 /*****************************************/
@@ -1963,6 +1980,19 @@ void test7()
         double4 r = test7r(v);
         assert(v[2] == r[2]);
         assert(v[3] == r[3]);
+    }
+}
+
+/*****************************************/
+
+
+auto test20052()
+{
+    version (D_AVX2)
+    {
+        struct S { long4 v; }
+        S s;
+        return s;
     }
 }
 
@@ -2007,6 +2037,7 @@ int main()
     test10447();
     test17344();
     test17356();
+    test20052();
 
     test6();
     test7();


### PR DESCRIPTION
issue [20052](https://issues.dlang.org/show_bug.cgi?id=20052).

When doing runtime stack alignment, the stack frame must be saved otherwise the return address will be lost.

For example:
the following function
```d
struct y { __vector(long[4]) v; }
y get()
{
    y a;
    return a;
}
```
generated the following instructions:
```asm
and    rsp,0xffffffffffffffe0
xor    eax,eax
mov    QWORD PTR [rdi],rax
mov    QWORD PTR [rdi+0x8],rax
mov    QWORD PTR [rdi+0x10],rax
mov    QWORD PTR [rdi+0x18],rax
mov    rax,rdi
ret
```

Notice there is no `RBP`. When the return procedure is reached, the `ret` instruction pops the return address from the stack which has been altered earlier by the alignment instruction, which crashes the program.

This patch does two things: **1)** make sure `BP` is stored, and a proper `leave` procedure is used whenever there is runtime stack alignent. **2)** omit runtime alignment when all symbols are dead.

