### PR TITLE
Temporarily discourage the use of `in` as a parameter storage class

### DIFF
--- a/changelog/discourage_in.dd
+++ b/changelog/discourage_in.dd
@@ -1,0 +1,17 @@
+`in` as parameter storage class is temporarily discouraged
+
+`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
+been properly implemented so its current implementation is equivalent to `const`.  Properly
+implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
+explicitly use `const` or `scope const` instead, until `in` is properly implemented.
+
+---
+void f(in ref T t);  // Deprecation: `in` is defined as `scope const`.  However, `in` has not
+                     // yet been properly implemented, so its current implementation is equivalent to
+                     // `const`. It is recommended to avoid using `in`, and explicitly use `scope
+                     // const` or `const` instead, until `in` is properly implemented.
+---
+
+Beginning with this release, any usage of `in` as a parameter storage class will result in a
+deprecation message.  Replace `in` with `const` or `scope const` until a future release provides a
+proper implementation of `in`.

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2901,6 +2901,14 @@ final class Parser(AST) : Lexer
                     }
                 case TOK.in_:
                     stc = AST.STC.in_;
+                    // @@@DEPRECATED_2.094@@@
+                    // Deprecated in 2.088
+                    // Remove this message after sufficient time has passed (e.g. 1 or 2 years) so `in` can be
+                    // properly implemented as `scope const` without too much risk of breakage
+                    deprecation("`in` is defined as `scope const`.  However, `in` has not yet been properly " ~
+                        "implemented, so its current implementation is equivalent to `const`. It is recommended " ~
+                        "to avoid using `in`, and explicitly use `scope const` or `const` instead, until `in` " ~
+                        "is properly implemented.");
                     goto L2;
 
                 case TOK.out_:

--- a/test/compilable/warn3882.d
+++ b/test/compilable/warn3882.d
@@ -18,7 +18,7 @@ void test3882()
 /******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=12619
 
-extern (C) @system nothrow pure void* memcpy(void* s1, in void* s2, size_t n);
+extern (C) @system nothrow pure void* memcpy(void* s1, const void* s2, size_t n);
 // -> weakly pure
 
 void test12619() pure
@@ -70,7 +70,7 @@ void test12909()
 
 const struct Foo13899
 {
-    int opApply(immutable int delegate(in ref int) pure nothrow dg) pure nothrow
+    int opApply(immutable int delegate(const ref int) pure nothrow dg) pure nothrow
     {
         return 1;
     }

--- a/test/fail_compilation/fail183.d
+++ b/test/fail_compilation/fail183.d
@@ -1,11 +1,15 @@
 /*
 TEST_OUTPUT:
 ---
+fail_compilation/fail183.d(10): Deprecation: `in` is defined as `scope const`.  However, `in` has not yet been properly implemented, so its current implementation is equivalent to `const`. It is recommended to avoid using `in`, and explicitly use `scope const` or `const` instead, until `in` is properly implemented.
+fail_compilation/fail183.d(10): Deprecation: `in` is defined as `scope const`.  However, `in` has not yet been properly implemented, so its current implementation is equivalent to `const`. It is recommended to avoid using `in`, and explicitly use `scope const` or `const` instead, until `in` is properly implemented.
 fail_compilation/fail183.d(10): Error: redundant attribute `const`
+fail_compilation/fail183.d(10): Deprecation: `in` is defined as `scope const`.  However, `in` has not yet been properly implemented, so its current implementation is equivalent to `const`. It is recommended to avoid using `in`, and explicitly use `scope const` or `const` instead, until `in` is properly implemented.
 fail_compilation/fail183.d(10): Error: redundant attribute `scope`
 fail_compilation/fail183.d(11): Error: redundant attribute `in`
 ---
 */
 
+#line 10
 void f(in final const scope int x) {}
 void g(final const scope in int x) {}

--- a/test/fail_compilation/ice11626.d
+++ b/test/fail_compilation/ice11626.d
@@ -5,4 +5,4 @@ fail_compilation/ice11626.d(8): Error: undefined identifier `Bar`
 ---
 */
 
-void foo(in ref Bar) {}
+void foo(const ref Bar) {}

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -6158,7 +6158,7 @@ static assert(!__traits(compiles, foo8220(typeof(0)))); // fail
 
 /***************************************************/
 
-void func8105(in ref int x) { }
+void func8105(const ref int x) { }
 
 void test8105()
 {


### PR DESCRIPTION
An alternative strategy to https://github.com/dlang/dmd/pull/10168

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters

