### PR TITLE
Fix PIC_FLAGS typo in test/run.d

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -477,7 +477,7 @@ auto objName(T)(T name)
 /// Return the correct pic flags as an array of strings
 string[] getPicFlags(string[string] env)
 {
-    const picFlags = env["PIC_FLAGS"];
+    const picFlags = env["PIC_FLAG"];
     if (picFlags.length)
         return picFlags.split();
     return cast(string[])[];


### PR DESCRIPTION
Fix typo, should be `PIC_FLAG` rather than `PIC_FLAGS`.