### PR TITLE
Fix Issue 20051 - ICE in func literal used in __traits(compiles)

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6299,7 +6299,7 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
     }
     if (global.gag && errors != global.errors)
     {
-        ds.type = oldtype;
+        ds.type = Type.terror;
         ds.aliassym = null;
     }
     ds.inuse = 0;

--- a/test/compilable/test20051.d
+++ b/test/compilable/test20051.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=20051
+
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+struct Templ2(Args...)
+{
+}
+
+struct WillAlsoWork(alias T : Templ!Args, Args...)
+{
+    alias A = Args[0];
+}
+
+void main()
+{
+    alias C2 = Templ2!int;
+    static assert(!__traits(compiles, {
+        alias B2 = WillAlsoWork!C2;
+        B2.A a2;
+    }));
+}


### PR DESCRIPTION
```d
struct Templ2(Args...)
{
}

struct WillAlsoWork(alias T : Templ!Args, Args...)
{
    alias A = Args[0];
}

void main()
{
    alias C2 = Templ2!int;
    static assert(!__traits(compiles, {
        alias B2 = WillAlsoWork!C2;
        B2.A a2;
    }));
}
```

When semantically analyzing the traits(compiles) code block, the compiler sees that the first statement (that contains the alias declaration) results in an error but it simply nullifies the alias and sets the type to the original, not-analyzed, type and proceeds to the inspection of the second statement. This results in a segfault because we end up with an invalid type when `B2.A` is used.

The patch propagates the error instead of setting the type to an invalid one.

IMHO a subsequent PR should be made so that in the case of traits(compiles) that receive a compound statement (that is internally lowered to a FuncExp), the compiler should analyze the statements one by one and stop once an error is encountered. Of course, the current implementation is simpler, but lacks performance if large code blocks are passed to traits(compiles) and the expected result is failure.