### PR TITLE
@noobject on module decalaration to prevent importing object.d

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -130,6 +130,7 @@ struct ASTBase
         future              = (1L << 50),   // introducing new base class function
         local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
         returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+        noobject            = (1L << 53),   // do not import the object module
 
         TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
         FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.safe | STC.trusted | STC.system),
@@ -6235,15 +6236,17 @@ struct ASTBase
         Identifier id;
         Identifiers *packages;
         bool isdeprecated;
+        bool isnoobject;
         Expression msg;
 
-        extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Expression msg, bool isdeprecated)
+        extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Expression msg, bool isdeprecated, bool isnoobject)
         {
             this.loc = loc;
             this.packages = packages;
             this.id = id;
             this.msg = msg;
             this.isdeprecated = isdeprecated;
+            this.isnoobject = isnoobject;
         }
 
         extern (C++) const(char)* toChars()

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -249,6 +249,7 @@ enum STC : long
     future              = (1L << 50),   // introducing new base class function
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
     returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+    noobject            = (1L << 53),   // do not import the object module
 
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
     FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.safe | STC.trusted | STC.system),

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1128,8 +1128,8 @@ extern (C++) final class Module : Package
         // If it isn't there, some compiler rewrites, like
         //    classinst == classinst -> .object.opEquals(classinst, classinst)
         // would fail inside object.d.
-        if (members.dim == 0 || (*members)[0].ident != Id.object ||
-            (*members)[0].isImport() is null)
+        if ((!md || !md.isnoobject) && (members.dim == 0 || (*members)[0].ident != Id.object ||
+            (*members)[0].isImport() is null))
         {
             auto im = new Import(Loc.initial, null, Id.object, null, 0);
             members.shift(im);
@@ -1450,15 +1450,17 @@ struct ModuleDeclaration
     Identifier id;
     Identifiers* packages;  // array of Identifier's representing packages
     bool isdeprecated;      // if it is a deprecated module
+    bool isnoobject;        // if it contians the @noobject attribute
     Expression msg;
 
-    extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Expression msg, bool isdeprecated)
+    extern (D) this(const ref Loc loc, Identifiers* packages, Identifier id, Expression msg, bool isdeprecated, bool isnoobject)
     {
         this.loc = loc;
         this.packages = packages;
         this.id = id;
         this.msg = msg;
         this.isdeprecated = isdeprecated;
+        this.isnoobject = isnoobject;
     }
 
     extern (C++) const(char)* toChars() const

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -207,6 +207,7 @@ immutable Msgtable[] msgtable =
     { "trusted" },
     { "system" },
     { "disable" },
+    { "noobject" },
 
     // For inline assembler
     { "___out", "out" },

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -156,6 +156,7 @@ struct ModuleDeclaration
     Identifier *id;
     Identifiers *packages;            // array of Identifier's representing packages
     bool isdeprecated;  // if it is a deprecated module
+    bool isnoobject;    // if it contains the @noobject attribute
     Expression *msg;
 
     const char *toChars() const;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -327,6 +327,7 @@ final class Parser(AST) : Lexer
     {
         const comment = token.blockComment;
         bool isdeprecated = false;
+        bool isnoobject = false;
         AST.Expression msg = null;
         AST.Expressions* udas = null;
         AST.Dsymbols* decldefs;
@@ -366,6 +367,8 @@ final class Parser(AST) : Lexer
                         }
                         else
                         {
+                            if (stc == AST.STC.noobject)
+                                isnoobject = true;
                             udas = AST.UserAttributeDeclaration.concat(udas, exps);
                         }
                         if (stc)
@@ -418,7 +421,7 @@ final class Parser(AST) : Lexer
                 id = token.ident;
             }
 
-            md = new AST.ModuleDeclaration(loc, a, id, msg, isdeprecated);
+            md = new AST.ModuleDeclaration(loc, a, id, msg, isdeprecated, isnoobject);
 
             if (token.value != TOK.semicolon)
                 error("`;` expected following module declaration instead of `%s`", token.toChars());
@@ -1402,6 +1405,8 @@ final class Parser(AST) : Lexer
                 stc = AST.STC.disable;
             else if (token.ident == Id.future)
                 stc = AST.STC.future;
+            else if (token.ident == Id.noobject)
+                stc = AST.STC.noobject;
             else
             {
                 // Allow identifier, template instantiation, or function call

--- a/test/fail_compilation/noobject1.d
+++ b/test/fail_compilation/noobject1.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/noobject1.d(11): Error: undefined identifier `size_t`
+---
+*/
+
+@noobject
+module _none;
+
+size_t foo();


### PR DESCRIPTION
An alternative to https://github.com/dlang/dmd/pull/10184

This PR allows modules to specify the `@noobject` attribute on their module declartion to disable importing the implicit object module, i.e.
```D
@noobject
module foo;

// the object.d module will not be imported
// because @noobject was specified on the module declaration
```

PR #10184 instead added a new command-line switch to disable importing the object module.  I created this one as an alternative because it's the source code that knows whether or not the object module should be imported. This solution is less brittle as the one compiling the module doesn't need to know whether or not the command-line switch is needed.  It also allows the compiler to compile both kinds of modules in the same invocation since each module configures itself instead of having one global configuration that must apply to every module being compiled in the same invocation.

The use case for this pointed out by @JinShil is to be able to compile modules that don't require the `object.d` module without having to create a dummy object module.  Note that I don't have a good idea of how useful this feature will be, however, I would prefer this implementation over a command-line switch if it is accepted.
