### PR TITLE
Fix Issue 930 - Templates inside templates used as mixins

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2880,6 +2880,15 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         Scope* scy = sc.push(tm);
         scy.parent = tm;
 
+        /* https://issues.dlang.org/show_bug.cgi?id=930
+         *
+         * If the template that is to be mixed in is in the scope of a template
+         * instance, we have to also declare the type aliases in the new mixin scope.
+         */
+        auto parentInstance = tempdecl.parent ? tempdecl.parent.isTemplateInstance() : null;
+        if (parentInstance)
+            parentInstance.declareParameters(scy);
+
         tm.argsym = new ScopeDsymbol();
         tm.argsym.parent = scy.parent;
         Scope* argscope = scy.push(tm.argsym);

--- a/test/compilable/test930.d
+++ b/test/compilable/test930.d
@@ -1,0 +1,28 @@
+// https://issues.dlang.org/show_bug.cgi?id=930
+
+/*
+TEST_OUTPUT:
+---
+---
+*/
+template ATemplate(T)
+{
+   template ATemplate()
+   {
+       auto foo()
+       {
+           T x = 2; // this line causes an error
+       }
+   }
+}
+
+class TheClass(alias MixIt)
+{
+    mixin MixIt!();
+}
+
+void main()
+{
+    auto val = new TheClass!(ATemplate!(int));
+    val.foo();
+}


### PR DESCRIPTION
```d
template ATemplate(T) {
   template ATemplate() {
       void foo() {
           T x = 2; // this line causes an error
           printf("Hi\n");
       }
   }
}

class TheClass(alias MixIt)
{
    mixin MixIt;
}


void main()
{
    auto val = new TheClass!(ATemplate!(int));
    val.foo();
}
```

When a template is instantiated, the template parameters are declared as aliases to the instantiation types in the scope of the template instance. In this situation, the mixin simply syntax copies the `Atemplate()` without any knowledge of its parent scope, therefore the alias for the `T` type is lost.

My patch checks for this particular case and the lost types are brought in the mixin scope.