### PR TITLE
Fix issue 20065: support empty AliasSeq tuples in compiletime array literals

### DIFF
--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1835,6 +1835,8 @@ bool isCtfeValueValid(Expression newval)
         return true; //((StructLiteralExp *)newval)->ownedByCtfe;
     if (newval.op == TOK.classReference)
         return true;
+    if (newval.op == TOK.type)
+        return true;
     if (newval.op == TOK.vector)
         return true; // vector literal
     if (newval.op == TOK.function_)

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2085,7 +2085,7 @@ public:
                 }
                 return;
             }
-            assert(result.op == TOK.structLiteral || result.op == TOK.classReference);
+            assert(result.op == TOK.structLiteral || result.op == TOK.classReference || result.op == TOK.type);
             return;
         }
         e.error("value of `this` is not known at compile time");
@@ -5071,7 +5071,8 @@ public:
                 result = CTFEExp.cantexp;
                 return;
             }
-            assert(pthis.op == TOK.structLiteral || pthis.op == TOK.classReference);
+
+            assert(pthis.op == TOK.structLiteral || pthis.op == TOK.classReference || pthis.op == TOK.type);
 
             if (fd.isVirtual() && !e.directcall)
             {

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -2029,10 +2029,19 @@ public:
         {
             printf("%s Expression::interpret() '%s' %s\n", e.loc.toChars(), Token.toChars(e.op), e.toChars());
             printf("type = %s\n", e.type.toChars());
-            e.print();
+            showCtfeExpr(e);
         }
         e.error("cannot interpret `%s` at compile time", e.toChars());
         result = CTFEExp.cantexp;
+    }
+
+    override void visit(TypeExp e)
+    {
+        debug (LOG)
+        {
+            printf("%s TypeExp.interpret() %s\n", e.loc.toChars(), e.toChars());
+        }
+        result = e;
     }
 
     override void visit(ThisExp e)

--- a/test/compilable/test20065.d
+++ b/test/compilable/test20065.d
@@ -1,0 +1,12 @@
+alias AliasSeq(T...) = T;
+
+void main()
+{
+    enum string[] array1 = [AliasSeq!("foo")];
+
+    static assert(array1 == ["foo"]);
+
+    enum string[] array2 = [AliasSeq!()];
+
+    static assert(array2 == []);
+}

--- a/test/fail_compilation/fail4206.d
+++ b/test/fail_compilation/fail4206.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail4206.d(9): Error: cannot interpret `s` at compile time
+fail_compilation/fail4206.d(9): Error: initializer must be an expression, not `s`
 ---
 */
 

--- a/test/fail_compilation/fail8262.d
+++ b/test/fail_compilation/fail8262.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail8262.d(32): Error: cannot interpret `Tuple8262!1` at compile time
+fail_compilation/fail8262.d(32): Error: initializer must be an expression, not `Tuple8262!1`
 fail_compilation/fail8262.d(27): Error: template instance `fail8262.T8262!(Tuple8262!1)` error instantiating
 fail_compilation/fail8262.d(19): Error: cannot implicitly convert expression `S(0)` of type `S` to `int`
 ---

--- a/test/fail_compilation/ice11919.d
+++ b/test/fail_compilation/ice11919.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11919.d(17): Error: cannot interpret `foo` at compile time
+fail_compilation/ice11919.d(17): Error: initializer must be an expression, not `foo`
 fail_compilation/imports/a11919.d(4): Error: template instance `a11919.doBar!(Foo).doBar.zoo!(t)` error instantiating
 fail_compilation/imports/a11919.d(11):        instantiated from here: `doBar!(Foo)`
 fail_compilation/ice11919.d(25):        instantiated from here: `doBar!(Bar)`

--- a/test/fail_compilation/ice12362.d
+++ b/test/fail_compilation/ice12362.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12362.d(12): Error: cannot interpret `foo` at compile time
+fail_compilation/ice12362.d(12): Error: initializer must be an expression, not `foo`
 ---
 */
 


### PR DESCRIPTION
Fixes:

```
import std.meta;

// Let me ask a question.
void main() {
    // This works.
    enum string[] array1 = [AliasSeq!("foo")]; 
    // So why doesn't this?
    enum string[] array2 = [AliasSeq!()];
}
```
