### PR TITLE
add symbol_pointerType()

### DIFF
--- a/src/dmd/backend/global.d
+++ b/src/dmd/backend/global.d
@@ -365,6 +365,7 @@ void freesymtab(Symbol **stab, SYMIDX n1, SYMIDX n2);
 Symbol *symbol_copy(Symbol *s);
 Symbol *symbol_searchlist(symlist_t sl, const(char)* vident);
 void symbol_reset(Symbol *s);
+tym_t symbol_pointerType(const Symbol* s);
 
 // cg87.c
 void cg87_reset();

--- a/src/dmd/backend/symbol.d
+++ b/src/dmd/backend/symbol.d
@@ -2530,4 +2530,18 @@ void symbol_reset(Symbol *s)
     }
 }
 
+/****************************************
+ * Determine pointer type needed to access a Symbol,
+ * essentially what type an OPrelconst should get
+ * for that Symbol.
+ * Params:
+ *      s = pointer to Symbol
+ * Returns:
+ *      pointer type to access it
+ */
+tym_t symbol_pointerType(const Symbol* s)
+{
+    return s.Stype.Tty & mTYimmutable ? TYimmutPtr : TYnptr;
+}
+
 }


### PR DESCRIPTION
This enhances the back end to make better use of immutable pointers. By abstracting the pointer type into a new function, it can be used elsewhere and later adjusted for shared pointers.