### PR TITLE
Start removing duplication between Makefile and build.d

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -245,6 +245,8 @@ CH=
 # Makefiles
 MAKEFILES=win32.mak posix.mak osmodel.mak
 
+RUN_BUILD=$(GEN)\build.exe --called-from-make OS=$(OS) BUILD=$(BUILD) MODEL=$(MODEL) HOST_DMD=$(HOST_DMD) HOST_DC=$(HOST_DC)
+
 ############################## Release Targets ###############################
 
 defaulttarget: $G debdmd
@@ -252,6 +254,9 @@ defaulttarget: $G debdmd
 auto-tester-build: $G dmd checkwhitespace $(DMDFRONTENDEXE)
 
 dmd: $G reldmd
+
+$(GEN)\build.exe: build.d $(HOST_DMD_PATH)
+	$(HOST_DC) -of$@ -debug build.d
 
 release:
 	$(DMDMAKE) clean
@@ -294,8 +299,8 @@ LIBS=$G\backend.lib $G\lexer.lib
 $G\backend.lib: $(GBACKOBJ) $(OBJ_MSVC)
 	$(LIB) -p512 -n -c $@ $(GBACKOBJ) $(OBJ_MSVC)
 
-$G\lexer.lib: $(LEXER_SRCS) $(ROOT_SRCS) $(STRING_IMPORT_FILES) $G
-	$(HOST_DC) -of$@ -vtls -lib -J$G $(DFLAGS) $(LEXER_SRCS) $(ROOT_SRCS)
+$G\lexer.lib: $(GEN)\build.exe
+	$(RUN_BUILD) $@
 
 $G\parser.lib: $(PARSER_SRCS) $G\lexer.lib $G
 	$(HOST_DC) -of$@ -vtls -lib $(DFLAGS) $(PARSER_SRCS) $G\lexer.lib


### PR DESCRIPTION
Starting small here.  I've added rules in the makefiles `win32.mak` and `posix.mak` to build the `build.d` script, and then forward build targets to it while passing applicable variables.

The initial goal is to forward the rule to build `lexer` library target only.  This is a good initial target since it doesn't have any dependencies so it should be one of the most simple targets to transition first. This will isolate problems in `build.d` and allow support to be added for forwarding logic from the makefiles to `build.d` without mixing it with all the changes that will be needed to actually move all the make targets to `build.d`.

This approach allows us to incrementally remove logic from the makefiles and move it to the `build.d` script while still supporting both interfaces.