### PR TITLE
Posix x64 ABI fixes 2

### DIFF
--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -359,7 +359,8 @@ extern (C++) final class ToClassesVisitor : Visitor
                 else
                 {
                     assert(foffset % 8 == 0 ||
-                        fEightbyteEnd - fEightbyteStart <= 1,
+                        fEightbyteEnd - fEightbyteStart <= 1 ||
+                        !global.params.isLP64,
                         "Field not aligned at eightbyte boundary but contributing to multiple eightbytes?"
                     );
                     foreach (i, fclass; classify(ftype, fsize).slice())

--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -777,7 +777,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
     //printf("fixresult87(e = %p, retregs = %s, *pretregs = %s)\n", e,regm_str(retregs),regm_str(*pretregs));
     assert(!*pretregs || retregs);
 
-    if (*pretregs & mST01)
+    if ((*pretregs | retregs) & mST01)
     {
         fixresult_complex87(cdb, e, retregs, pretregs);
         return;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3483,7 +3483,8 @@ elem * elstruct(elem *e, goal_t goal)
 
         L1:
             if (ty == TYstruct)
-            {   // This needs to match what TypeFunction::retStyle() does
+            {
+                // This needs to match what TypeFunction::retStyle() does
                 if (config.exe == EX_WIN64)
                 {
                     //if (t.Ttag.Sstruct.Sflags & STRnotpod)
@@ -3508,6 +3509,10 @@ elem * elstruct(elem *e, goal_t goal)
                         tym = TYcdouble;
                     else
                         tym = TYucent;
+                    if ((0 == tyfloating(targ1.Tty)) ^ (0 == tyfloating(targ2.Tty)))
+                    {
+                        tym |= tyfloating(targ1.Tty) ? mTYxmmgpr : mTYgprxmm;
+                    }
                 }
                 assert(tym != TYstruct);
             }
@@ -6040,6 +6045,8 @@ private elem *elToPair(elem *e)
              */
             tym_t ty0;
             tym_t ty = e.Ety;
+            if (ty & (mTYxmmgpr | mTYgprxmm))
+                break; // register allocation doesn't support it yet.
             switch (tybasic(ty))
             {
                 case TYcfloat:      ty0 = TYfloat  | (ty & ~mTYbasic); goto L1;
@@ -6066,6 +6073,8 @@ private elem *elToPair(elem *e)
              */
             tym_t ty0;
             tym_t ty = e.Ety;
+            if (ty & (mTYxmmgpr | mTYgprxmm))
+                break; // register allocation doesn't support it yet.
             switch (tybasic(ty))
             {
                 case TYcfloat:      ty0 = TYfloat  | (ty & ~mTYbasic); goto L2;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -28,6 +28,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.backend.cc;
+import dmd.backend.code;
 import dmd.backend.cdef;
 import dmd.backend.code_x86;
 import dmd.backend.oper;
@@ -3405,14 +3406,6 @@ elem * elstruct(elem *e, goal_t goal)
 
     uint sz = (e.Eoper == OPstrpar && type_zeroSize(t, global_tyf)) ? 0 : cast(uint)type_size(t);
     //printf("\tsz = %d\n", (int)sz);
-    if (sz == 16)
-    {
-        while (ty == TYarray && t.Tdim == 1)
-        {
-            t = t.Tnext;
-            ty = tybasic(t.Tty);
-        }
-    }
 
     type *targ1 = null;
     type *targ2 = null;
@@ -3422,6 +3415,13 @@ elem * elstruct(elem *e, goal_t goal)
         targ2 = t.Ttag.Sstruct.Sarg2type;
     }
 
+    if (ty == TYarray && sz)
+    {
+        argtypes(t, targ1, targ2);
+        if (!targ1)
+            goto Ldefault;
+        goto L1;
+    }
     //if (targ1) { printf("targ1\n"); type_print(targ1); }
     //if (targ2) { printf("targ2\n"); type_print(targ2); }
     switch (cast(int)sz)
@@ -3482,7 +3482,7 @@ elem * elstruct(elem *e, goal_t goal)
             goto Ldefault;
 
         L1:
-            if (ty == TYstruct)
+            if (ty == TYstruct || ty == TYarray)
             {
                 // This needs to match what TypeFunction::retStyle() does
                 if (config.exe == EX_WIN64)
@@ -3514,6 +3514,8 @@ elem * elstruct(elem *e, goal_t goal)
                         tym |= tyfloating(targ1.Tty) ? mTYxmmgpr : mTYgprxmm;
                     }
                 }
+                else if (I32 && targ1 && targ2)
+                    tym = TYllong;
                 assert(tym != TYstruct);
             }
             assert(tym != ~0);

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3415,7 +3415,7 @@ elem * elstruct(elem *e, goal_t goal)
         targ2 = t.Ttag.Sstruct.Sarg2type;
     }
 
-    if (ty == TYarray && sz)
+    if (ty == TYarray && sz && config.exe != EX_WIN64)
     {
         argtypes(t, targ1, targ2);
         if (!targ1)

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1898,7 +1898,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs)
         *pretregs = retregs;
     else if (forregs)             // if return the result in registers
     {
-        if (forregs & (mST01 | mST0))
+        if ((forregs | retregs) & (mST01 | mST0))
         {
             fixresult87(cdb, e, retregs, pretregs);
             return;

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -4002,8 +4002,13 @@ static if (0)
     }
 }
 
-    reg_t reg1, reg2;
-    retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
+    reg_t reg1 = NOREG, reg2 = NOREG;
+
+    if (config.exe == EX_WIN64) // Win64 is currently broken
+        retregs = regmask(e.Ety, tym1);
+    else
+        retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
+
     assert(retregs || !*pretregs);
 
     if (!usefuncarg)
@@ -4117,7 +4122,9 @@ static if (0)
 
     /* Special handling for functions which return complex float in XMM0 or RAX. */
 
-    if (I64 && *pretregs && tybasic(e.Ety) == TYcfloat)
+    if (I64
+        && config.exe != EX_WIN64 // broken
+        && *pretregs && tybasic(e.Ety) == TYcfloat)
     {
         assert(reg2 == NOREG);
         // spill

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3039,8 +3039,20 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
         }
         else
         {
-            type* targ1 = t.Ttag.Sstruct.Sarg1type;
-            type* targ2 = t.Ttag.Sstruct.Sarg2type;
+            type* targ1, targ2;
+            if (tybasic(t.Tty) == TYstruct)
+            {
+                targ1 = t.Ttag.Sstruct.Sarg1type;
+                targ2 = t.Ttag.Sstruct.Sarg2type;
+            }
+            else if (tybasic(t.Tty) == TYarray)
+            {
+                if (I64)
+                    argtypes(t, targ1, targ2);
+            }
+            else
+                assert(0);
+
             if (targ1)
             {
                 t = targ1;
@@ -3133,6 +3145,108 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
         ty = ty2;
     }
     return 1;
+}
+
+/***************************************
+ * Finds replacemnt types for register passing of aggregates.
+ */
+void argtypes(type* t, ref type* arg1type, ref type* arg2type)
+{
+    if (!t) return;
+
+    tym_t ty = t.Tty;
+
+    if (!tyaggregate(ty))
+        return;
+
+    arg1type = arg2type = null;
+
+    if (tybasic(ty) == TYarray)
+    {
+        size_t sz = cast(size_t) type_size(t);
+        if (sz == 0)
+            return;
+
+        if ((I32 || config.exe == EX_WIN64) && (sz & (sz - 1)))  // power of 2
+            return;
+
+        if (config.exe == EX_WIN64 && sz > REGSIZE)
+            return;
+
+        if (sz <= 2 * REGSIZE)
+        {
+            type** argtype = &arg1type;
+            size_t argsz = sz < REGSIZE ? sz : REGSIZE;
+            foreach (v; 0 .. (sz > REGSIZE) + 1)
+            {
+                *argtype = argsz == 1 ? tstypes[TYchar]
+                         : argsz == 2 ? tstypes[TYshort]
+                         : argsz <= 4 ? tstypes[TYlong]
+                         : tstypes[TYllong];
+                argtype = &arg2type;
+                argsz = sz - REGSIZE;
+            }
+        }
+
+        if (I64 && config.exe != EX_WIN64)
+        {
+            type* tn = t.Tnext;
+            tym_t tyn = tn.Tty;
+            while (tyn == TYarray)
+            {
+                tn = tn.Tnext;
+                assert(tn);
+                tyn = tybasic(tn.Tty);
+            }
+
+            if (tybasic(tyn) == TYstruct)
+            {
+                if (type_size(tn) == sz) // array(s) of size 1
+                {
+                    arg1type = tn.Ttag.Sstruct.Sarg1type;
+                    arg2type = tn.Ttag.Sstruct.Sarg2type;
+                    return;
+                }
+
+                type* t1 = tn.Ttag.Sstruct.Sarg1type;
+                if (t1)
+                {
+                    tn = t1;
+                    tyn = tn.Tty;
+                }
+            }
+
+            if (sz == tysize(tyn))
+            {
+                if (tysimd(tyn))
+                {
+                    type* ts = type_fake(tybasic(tyn));
+                    ts.Tcount = 1;
+                    arg1type = ts;
+                    return;
+                }
+                else if (tybasic(tyn) == TYldouble || tybasic(tyn) == TYildouble)
+                {
+                    arg1type = tstypes[tybasic(tyn)];
+                    return;
+                }
+            }
+
+            if (sz <= 16)
+            {
+                if (tyfloating(tyn))
+                {
+                    arg1type = sz <= 4 ? tstypes[TYfloat] : tstypes[TYdouble];
+                    if (sz > 8)
+                        arg2type = (sz - 8) <= 4 ? tstypes[TYfloat] : tstypes[TYdouble];
+                }
+            }
+        }
+    }
+    else if (tybasic(ty) == TYstruct)
+    {
+        // TODO: Move code from `cgelem.d:elstruct()` here
+    }
 }
 
 /*******************************

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3100,6 +3100,14 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
             fpr.xmmcnt += 2;
             return 1;
         }
+
+        if (tybasic(ty) == TYcfloat
+            && fpr.numfloatregs - fpr.xmmcnt >= 1)
+        {
+            // Allocate XMM register
+            *preg1 = fpr.floatregs[fpr.xmmcnt++];
+            return 1;
+        }
     }
 
     foreach (j; 0 .. 2)
@@ -3515,12 +3523,17 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                 ++xmmcnt;
             int preg2 = parameters[i].reg2;
             reg_t mreg,lreg;
-            if (preg2 != NOREG)
+            if (preg2 != NOREG || tybasic(ep.Ety) == TYcfloat)
             {
                 assert(ep.Eoper != OPstrthis);
                 if (mask(preg2) & XMMREGS)
                     ++xmmcnt;
-                if (tyrelax(ep.Ety) == TYcent)
+                if (tybasic(ep.Ety) == TYcfloat)
+                {
+                    lreg = ST01;
+                    mreg = NOREG;
+                }
+                else if (tyrelax(ep.Ety) == TYcent)
                 {
                     lreg = mask(preg ) & mLSW ? cast(reg_t)preg  : AX;
                     mreg = mask(preg2) & mMSW ? cast(reg_t)preg2 : DX;
@@ -3530,8 +3543,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                     lreg = XMM0;
                     mreg = XMM1;
                 }
-                retregs = mask(mreg) | mask(lreg);
-
+                retregs = (mask(mreg) | mask(lreg)) & ~mask(NOREG);
                 CodeBuilder cdbsave;
                 cdbsave.ctor();
                 if (keepmsk & retregs)
@@ -3564,6 +3576,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                     retregs |= mask(preg);
                 if (preg2 != mreg)
                     retregs |= mask(preg2);
+                retregs &= ~mask(NOREG);
                 getregs(cdb,retregs);
 
                 tym_t ty1 = tybasic(ep.Ety);
@@ -3592,7 +3605,30 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                 else if (tybasic(ty1) == TYcdouble)
                     ty1 = ty2 = TYdouble;
 
-                foreach (v; 0 .. 2)
+                if (tybasic(ep.Ety) == TYcfloat)
+                {
+                    assert(I64);
+                    assert(lreg == ST01 && mreg == NOREG);
+                    // spill
+                    pop87();
+                    pop87();
+                    cdb.genfltreg(0xD9, 3, tysize(TYfloat));
+                    genfwait(cdb);
+                    cdb.genfltreg(0xD9, 3, 0);
+                    genfwait(cdb);
+                    // reload
+                    if (config.exe == EX_WIN64)
+                    {
+                        cdb.genfltreg(LOD, preg, 0);
+                        code_orrex(cdb.last(), REX_W);
+                    }
+                    else
+                    {
+                        assert(mask(preg) & XMMREGS);
+                        cdb.genxmmreg(xmmload(TYdouble), cast(reg_t) preg, 0, TYdouble);
+                    }
+                }
+                else foreach (v; 0 .. 2)
                 {
                     if (v ^ (preg != mreg))
                         genmovreg(cdb, preg, lreg, ty1);
@@ -3600,7 +3636,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                         genmovreg(cdb, preg2, mreg, ty2);
                 }
 
-                retregs = mask(preg) | mask(preg2);
+                retregs = (mask(preg) | mask(preg2)) & ~mask(NOREG);
             }
             else if (ep.Eoper == OPstrthis)
             {
@@ -4077,6 +4113,35 @@ static if (0)
             }
             retregs = mask(lreg) | mask(mreg);
         }
+    }
+
+    /* Special handling for functions which return complex float in XMM0 or RAX. */
+
+    if (I64 && *pretregs && tybasic(e.Ety) == TYcfloat)
+    {
+        assert(reg2 == NOREG);
+        // spill
+        if (config.exe == EX_WIN64)
+        {
+            assert(reg1 == AX);
+            cdb.genfltreg(STO, reg1, 0);
+            code_orrex(cdb.last(), REX_W);
+        }
+        else
+        {
+            assert(reg1 == XMM0);
+            cdb.genxmmreg(xmmstore(TYdouble), reg1, 0, TYdouble);
+        }
+        // reload real
+        push87(cdb);
+        cdb.genfltreg(0xD9, 0, 0);
+        genfwait(cdb);
+        // reload imaginary
+        push87(cdb);
+        cdb.genfltreg(0xD9, 0, tysize(TYfloat));
+        genfwait(cdb);
+
+        retregs = mST01;
     }
 
     fixresult(cdb, e, retregs, pretregs);

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1115,8 +1115,14 @@ static if (NTEXCEPTIONS)
 
         case BCretexp:
             reg_t reg1, reg2, lreg, mreg;
-            retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), &reg1, &reg2);
-            assert(reg1 != NOREG || !retregs);
+            reg1 = reg2 = NOREG;
+            if (config.exe == EX_WIN64) // broken
+                retregs = regmask(e.Ety, funcsym_p.ty());
+            else
+            {
+                retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), &reg1, &reg2);
+                assert(reg1 != NOREG || !retregs);
+            }
 
             lreg = mreg = NOREG;
             if (reg1 == NOREG)
@@ -1137,7 +1143,8 @@ static if (NTEXCEPTIONS)
                 lreg = mask(reg1) & mLSW ? reg1 : AX;
                 mreg = mask(reg2) & mMSW ? reg2 : DX;
             }
-            retregs = (mask(lreg) | mask(mreg)) & ~mask(NOREG);
+            if (reg1 != NOREG)
+                retregs = (mask(lreg) | mask(mreg)) & ~mask(NOREG);
 
             // For the final load into the return regs, don't set regcon.used,
             // so that the optimizer can potentially use retregs for register
@@ -1219,7 +1226,8 @@ static if (NTEXCEPTIONS)
                 else
                     genmovreg(cdb, reg2, mreg);
             }
-            retregs = (mask(reg1) | mask(reg2)) & ~mask(NOREG);
+            if (reg1 != NOREG)
+                retregs = (mask(reg1) | mask(reg2)) & ~mask(NOREG);
             goto L4;
 
         case BCret:

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -493,6 +493,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs);
 void callclib(ref CodeBuilder cdb, elem *e, uint clib, regm_t *pretregs, regm_t keepmask);
 void pushParams(ref CodeBuilder cdb,elem *, uint, tym_t tyf);
 void offsetinreg(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
+void argtypes(type* t, ref type* arg1type, ref type* arg2type);
 
 /* cod2.c */
 bool movOnly(const elem *e);

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -560,6 +560,7 @@ void searchfixlist(Symbol *s) {}
 void outfixlist();
 void code_hydrate(code **pc);
 void code_dehydrate(code **pc);
+regm_t allocretregs(tym_t ty, type *t, tym_t tyf, reg_t *reg1, reg_t *reg2);
 
 extern __gshared
 {

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -188,6 +188,10 @@ enum
     mTYshared       = 0x00100000,    // shared data
     mTYnothrow      = 0x00200000,    // nothrow function
 
+    // SROA types
+    mTYxmmgpr       = 0x00400000,    // first slice in XMM register, the other in GPR
+    mTYgprxmm       = 0x00800000,    // first slice in GPR register, the other in XMM
+
     // Used only by C/C++ compiler
 //#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYBSD || TARGET_SOLARIS
     mTYnoret        = 0x01000000,    // function has no return

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -553,9 +553,13 @@ if (!irs.params.is64bit) assert(tysize(TYnptr) == 4);
     else if (retmethod == RET.stack)
     {
         if (irs.params.isOSX && eresult)
+        {
             /* ABI quirk: hidden pointer is not returned in registers
              */
+            if (tyaggregate(tyret))
+                e.ET = Type_toCtype(tret);
             e = el_combine(e, el_copytree(eresult));
+        }
         e.Ety = TYnptr;
         e = el_una(OPind, tyret, e);
     }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -968,10 +968,11 @@ private elem *setArray(Expression exp, elem *eptr, elem *edim, Type tb, elem *ev
 {
     assert(op == TOK.blit || op == TOK.assign || op == TOK.construct);
     const sz = cast(uint)tb.size();
+    Type tb2 = tb;
 
 Lagain:
     int r;
-    switch (tb.ty)
+    switch (tb2.ty)
     {
         case Tfloat80:
         case Timaginary80:
@@ -1001,11 +1002,11 @@ Lagain:
             if (!irs.params.is64bit)
                 goto default;
 
-            TypeStruct tc = cast(TypeStruct)tb;
+            TypeStruct tc = cast(TypeStruct)tb2;
             StructDeclaration sd = tc.sym;
             if (sd.numArgTypes() == 1)
             {
-                tb = sd.argType(0);
+                tb2 = sd.argType(0);
                 goto Lagain;
             }
             goto default;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -26,6 +26,7 @@
 module dmd.target;
 
 import dmd.argtypes;
+import dmd.argtypes_sysv_x64;
 import core.stdc.string : strlen;
 import dmd.cppmangle;
 import dmd.cppmanglewin;
@@ -555,6 +556,8 @@ extern (C++) struct Target
      */
     extern (C++) TypeTuple toArgTypes(Type t)
     {
+        if (global.params.is64bit && global.params.isPOSIX)
+            return .toArgTypes_sysv_x64(t);
         if (global.params.is64bit && global.params.isWindows)
             return null;
         return .toArgTypes(t);
@@ -613,6 +616,14 @@ extern (C++) struct Target
                 if (tf.linkage == LINK.cpp && needsThis)
                     return true;
             }
+        }
+        else if (global.params.is64bit && global.params.isPOSIX)
+        {
+            TypeTuple tt = .toArgTypes_sysv_x64(tn);
+            if (!tt)
+                return false; // void
+            else
+                return !tt.arguments.dim;
         }
 
     Lagain:

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -556,7 +556,7 @@ extern (C++) struct Target
      */
     extern (C++) TypeTuple toArgTypes(Type t)
     {
-        if (global.params.is64bit && global.params.isPOSIX)
+        if (global.params.is64bit && isPOSIX)
             return .toArgTypes_sysv_x64(t);
         if (global.params.is64bit && global.params.isWindows)
             return null;
@@ -617,7 +617,7 @@ extern (C++) struct Target
                     return true;
             }
         }
-        else if (global.params.is64bit && global.params.isPOSIX)
+        else if (global.params.is64bit && isPOSIX)
         {
             TypeTuple tt = .toArgTypes_sysv_x64(tn);
             if (!tt)

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -3,8 +3,7 @@
 version(Windows) {}
 else version(X86_64)
 {
-        /* uncomment to enable tests! */
-        //version = Run_X86_64_Tests;
+        version = Run_X86_64_Tests;
 }
 
 extern (C) int printf(const char*, ...);
@@ -582,6 +581,8 @@ TEST data2 = { 2, "RDI struct pointer" };
 
 T test2_asm( T, int n )( T t )
 {
+        typeof(.dump) dump = void;
+        enum m = T.sizeof < 4 ? mask(T.sizeof) : ~0LU;
         asm {
 
         mov [dump], RDI;
@@ -589,10 +590,12 @@ T test2_asm( T, int n )( T t )
         cmp EDI, 0; // TODO test RDI is a ptr to stack ? ?
         je L1;
 
-        leave; ret;
+        jmp Lret;
         }
 L1:
         data2.result[n] = true;
+Lret:
+        .dump = dump;
 }
 T test2f_asm( T, int n )( T t, int x )
 {
@@ -635,9 +638,12 @@ TEST data3 = { 3, "Check Return Register value" };
 
 void test3_run( T, int n )( )
 {
+        typeof(.dump) dump;
+
         test3_ret!T();
         mixin( gen_reg_capture!(n,`["RAX","RDX"]`)() );
 
+        //.dump = dump;
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;
@@ -669,8 +675,10 @@ TEST data4 = { 4, "Check Input Register value" };
 
 void test4_run( T, int n )( T t )
 {
+        typeof(.dump) dump = void;
         mixin( gen_reg_capture!(n,`["RDI","RSI"]`)() );
 
+        //.dump = dump;
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -674,7 +674,7 @@ void test1()
         foreach( int n, T; ALL_T )
                 test1_asm!(T,n)(12);
 
-        check( data1 );
+        assert( check( data1 ) );
 }
 
 /************************************************************************/
@@ -733,7 +733,7 @@ void test2()
                 test2f_asm!(T,n2)( T.init, 12 );
         }
 
-        check( data2 );
+        assert( check( data2 ) );
 }
 
 /************************************************************************/
@@ -774,7 +774,7 @@ void test3()
         foreach( int n, T; ALL_T )
                 test3_run!(T,n)( );
 
-        check( data3 );
+        assert( check( data3 ) );
 }
 
 // 0xFF n times
@@ -826,7 +826,7 @@ void test4()
                 foreach( i, ref e; t.tupleof )  e = i+1;
                 test4_run!(T,n)( t );
         }
-        check( data4 );
+        assert( check( data4 ) );
 }
 
 

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -482,6 +482,107 @@ immutable long[][] RegValue =
 /*  84  idi     */ null,
         ];
 
+/**
+ * The sizes of expected values.
+ *
+ * The rest is considered padding.
+ * Note: Mixed register cases have the SSE register first
+ */
+immutable long[][] RegValueSize =
+        [
+/*   0  b       */ [ 1,   ],
+/*   1  bb      */ [ 2,   ],
+/*   2  bbb     */ [ 3,   ],
+/*   3  bbbb    */ [ 4,   ],
+/*   4  bbbbb   */ [ 5,   ],
+/*   5  b6      */ [ 6,   ],
+/*   6  b7      */ [ 7,   ],
+/*   7  b8      */ [ 8,   ],
+/*   8  b9      */ [ 8, 1 ],
+/*   9  b10     */ [ 8, 2 ],
+/*  10  b11     */ [ 8, 3 ],
+/*  11  b12     */ [ 8, 4 ],
+/*  12  b13     */ [ 8, 5 ],
+/*  13  b14     */ [ 8, 6 ],
+/*  14  b15     */ [ 8, 7 ],
+/*  15  b16     */ [ 8, 8 ],
+/*  16  b17     */ null,
+/*  17  b18     */ null,
+/*  18  b19     */ null,
+/*  19  b20     */ null,
+/*  20  s       */ [ 2,   ],
+/*  21  ss      */ [ 4,   ],
+/*  22  sss     */ [ 6,   ],
+/*  23  ssss    */ [ 8,   ],
+/*  24  sssss   */ [ 8, 2 ],
+/*  25  s6      */ [ 8, 4 ],
+/*  26  s7      */ [ 8, 6 ],
+/*  27  s8      */ [ 8, 8 ],
+/*  28  s9      */ null,
+/*  29  s10     */ null,
+/*  30  i       */ [ 4,   ],
+/*  31  ii      */ [ 8,   ],
+/*  32  iii     */ [ 8, 4 ],
+/*  33  iiii    */ [ 8, 8 ],
+/*  34  iiiii   */ null,
+/*  35  l       */ [ 8,   ],
+/*  36  ll      */ [ 8, 8 ],
+/*  37  lll     */ null,
+/*  38  llll    */ null,
+/*  39  lllll   */ null,
+
+/*  40  js      */ [ 6,   ],
+/*  41  iss     */ [ 8,   ],
+/*  42  si      */ [ 8,   ],
+/*  43  ssi     */ [ 8,   ],
+/*  44  sis     */ [ 8, 2 ],
+/*  45  ls      */ [ 8, 2 ],
+/*  46  lss     */ [ 8, 4 ],
+/*  47  sl      */ [ 2, 8 ],
+/*  48  ssl     */ [ 4, 8 ],
+/*  49  sls     */ null,
+/*  50  li      */ [ 8, 4 ],
+/*  51  lii     */ [ 8, 8 ],
+/*  52  il      */ [ 4, 8 ],
+/*  53  iil     */ [ 8, 8 ],
+/*  54  ili     */ null,
+
+/*  55  fi      */ [ 8,   ],
+/*  56  fii     */ [ 8, 4 ],
+/*  57  jf      */ [ 8,   ],
+/*  58  ifi     */ [ 8, 4 ],
+
+/*  59  ifif    */ [ 8, 8 ],
+
+/*  60  f       */ [ 4,   ],
+/*  61  ff      */ [ 8,   ],
+/*  62  fff     */ [ 8, 4 ],
+/*  63  ffff    */ [ 8, 8 ],
+/*  64  fffff   */ null,
+/*  65  d       */ [ 8,   ],
+/*  66  dd      */ [ 8, 8 ],
+/*  67  ddd     */ null,
+/*  68  dddd    */ null,
+/*  69  ddddd   */ null,
+
+/*  70  df      */ [ 8, 4 ],
+/*  71  dff     */ [ 8, 8 ],
+/*  72  fd      */ [ 4, 8 ],
+/*  73  ffd     */ [ 8, 8 ],
+/*  74  fdf     */ null,
+
+/*  75  ffi     */ [ 8, 4 ],
+/*  76  ffii    */ [ 8, 8 ],
+/*  77  iff     */ [ 4, 8 ],
+/*  78  iiff    */ [ 8, 8 ],
+/*  79  iif     */ [ 4, 8 ],
+/*  80  di      */ [ 8, 4 ],
+/*  81  dii     */ [ 8, 8 ],
+/*  82  id      */ [ 8, 4 ],
+/*  83  iid     */ [ 8, 8 ],
+/*  84  idi     */ null,
+        ];
+
 /* Have to do it this way for OSX: Issue 7354 */
 __gshared long[2] dump;
 
@@ -590,6 +691,7 @@ T test2_asm( T, int n )( T t )
 
         mov [dump], RDI;
         mov [dump+8], RSP;
+        and EDI, m; // remove padding noise
         cmp EDI, 0; // TODO test RDI is a ptr to stack ? ?
         je L1;
 
@@ -650,6 +752,7 @@ void test3_run( T, int n )( )
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;
+        foreach ( i; 0..len ) dump[i] &= mask(RegValueSize[n][i]); // zero out padding
         if( dump[0..len] == RegValue[n] )
                 data3.result[n] = true;
 }
@@ -671,6 +774,14 @@ void test3()
         check( data3 );
 }
 
+// 0xFF n times
+ulong mask(ulong n)
+{
+        if ( n == ulong.sizeof )   // may wrap
+                return ~0UL;
+        return 2^^( n*8 ) - 1;
+}
+
 /************************************************************************/
 // test4
 
@@ -685,6 +796,7 @@ void test4_run( T, int n )( T t )
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;
+        foreach ( i; 0..len ) dump[i] &= mask(RegValueSize[n][i]); // zero out padding
         if( dump[0..len] == RegValue[n] )
                 data4.result[n] = true;
 }

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -131,8 +131,7 @@ alias tuple!(   b,bb,bbb,bbbb,bbbbb,
                 js,iss,si,ssi, sis,
                 ls,lss,sl,ssl, sls,
                 li,lii,il,iil, ili,
-                fi,fii,jf,iif, ifi,
-                ffi,ffii,iff,iiff,ifif, // INT_END
+                fi,fii,jf,ifi,ifif,                   // INT_END
 
                 // SSE registers only
                 f,ff,fff,ffff,fffff,
@@ -141,12 +140,13 @@ alias tuple!(   b,bb,bbb,bbbb,bbbbb,
                 df,dff,fd,ffd, fdf,     // SSE_END
 
                 // Int and SSE
+                ffi,ffii,iff,iiff,iif,
                 di,  dii,id, iid, idi,  // MIX_END
                 // ---
             ) ALL_T;
 
-enum INT_END = 65;
-enum SSE_END = 80;
+enum INT_END = 60;
+enum SSE_END = 75;
 enum MIX_END = ALL_T.length;
 
                 // x87
@@ -169,13 +169,13 @@ string[] ALL_S=[
                 "js","iss","si","ssi", "sis",
                 "ls","lss","sl","ssl", "sls",
                 "li","lii","il","iil", "ili",
-                "fi","fii","jf","iif", "ifi",
-                "ffi","ffii","iff","iiff","ifif",
+                "fi","fii","jf", "ifi","ifif",
                 // ---
                 "f","ff","fff","ffff","fffff",
                 "d","dd","ddd","dddd","ddddd",
                 "df","dff","fd","ffd", "dfd",
                 // ---
+                "ffi","ffii","iff","iiff","iif",
                 "di","dii","id","iid","idi",
                ];
 
@@ -352,6 +352,7 @@ struct TEST
  */
 immutable int[MIX_END] expected =
         [
+        // INT regs only
         1,1,1,1,1, // b
         1,1,1,1,1, // b6
         1,1,1,1,1, // b11
@@ -365,7 +366,6 @@ immutable int[MIX_END] expected =
         1,1,1,1,0, // sl
         1,1,1,1,0, // il
         1,1,1,1,1, // int and float
-        1,1,1,1,1, // int and float
 
         // SSE regs only
         1,1,1,1,0, // f
@@ -373,6 +373,7 @@ immutable int[MIX_END] expected =
         1,1,1,1,0, // float and double
 
         // SSE + INT regs
+        1,1,1,1,1, // int and float
         1,1,1,1,0, // int and double
         ];
 
@@ -382,6 +383,8 @@ immutable int[MIX_END] expected =
  *
  * null means do not test
  * ( because value is passed on the stack ).
+ *
+ * Note: Mixed register cases have the SSE register first
  */
 
 immutable long[][] RegValue =
@@ -446,32 +449,32 @@ immutable long[][] RegValue =
 /*  55  fi      */ [ 0x000000023f800000,                    ],
 /*  56  fii     */ [ 0x000000023f800000, 0x0000000000000003 ],
 /*  57  jf      */ [ 0x4000000000000001,                    ],
-/*  58  iif     */ [ 0x0000000200000001, 0x0000000040400000 ],
-/*  59  ifi     */ [ 0x4000000000000001, 0x0000000000000003 ],
+/*  58  ifi     */ [ 0x4000000000000001, 0x0000000000000003 ],
 
-/*  60  ffi     */ [ 0x0000000000000003, 0x400000003f800000 ],
-/*  61  ffii    */ [ 0x0000000400000003, 0x400000003f800000 ],
-/*  62  iff     */ [ 0x4000000000000001, 0x0000000040400000 ],
-/*  63  iiff    */ [ 0x0000000200000001, 0x4080000040400000 ],
-/*  64  ifif    */ [ 0x4000000000000001, 0x4080000000000003 ],
+/*  59  ifif    */ [ 0x4000000000000001, 0x4080000000000003 ],
 
-/*  65  f       */ [ 0x000000003f800000,                    ],
-/*  66  ff      */ [ 0x400000003f800000,                    ],
-/*  67  fff     */ [ 0x400000003f800000, 0x0000000040400000 ],
-/*  68  ffff    */ [ 0x400000003f800000, 0x4080000040400000 ],
-/*  69  fffff   */ null,
-/*  70  d       */ [ 0x3ff0000000000000,                    ],
-/*  71  dd      */ [ 0x3ff0000000000000, 0x4000000000000000 ],
-/*  72  ddd     */ null,
-/*  73  dddd    */ null,
-/*  74  ddddd   */ null,
+/*  60  f       */ [ 0x000000003f800000,                    ],
+/*  61  ff      */ [ 0x400000003f800000,                    ],
+/*  62  fff     */ [ 0x400000003f800000, 0x0000000040400000 ],
+/*  63  ffff    */ [ 0x400000003f800000, 0x4080000040400000 ],
+/*  64  fffff   */ null,
+/*  65  d       */ [ 0x3ff0000000000000,                    ],
+/*  66  dd      */ [ 0x3ff0000000000000, 0x4000000000000000 ],
+/*  67  ddd     */ null,
+/*  68  dddd    */ null,
+/*  69  ddddd   */ null,
 
-/*  75  df      */ [ 0x3ff0000000000000, 0x0000000040000000 ],
-/*  76  dff     */ [ 0x3ff0000000000000, 0x4040000040000000 ],
-/*  77  fd      */ [ 0x000000003f800000, 0x4000000000000000 ],
-/*  78  ffd     */ [ 0x400000003f800000, 0x4008000000000000 ],
-/*  79  fdf     */ null,
+/*  70  df      */ [ 0x3ff0000000000000, 0x0000000040000000 ],
+/*  71  dff     */ [ 0x3ff0000000000000, 0x4040000040000000 ],
+/*  72  fd      */ [ 0x000000003f800000, 0x4000000000000000 ],
+/*  73  ffd     */ [ 0x400000003f800000, 0x4008000000000000 ],
+/*  74  fdf     */ null,
 
+/*  75  ffi     */ [ 0x400000003f800000, 0x0000000000000003 ],
+/*  76  ffii    */ [ 0x400000003f800000, 0x0000000400000003 ],
+/*  77  iff     */ [ 0x0000000040400000, 0x4000000000000001 ],
+/*  78  iiff    */ [ 0x4080000040400000, 0x0000000200000001 ],
+/*  79  iif     */ [ 0x0000000040400000, 0x0000000200000001 ],
 /*  80  di      */ [ 0x3ff0000000000000, 0x0000000000000002 ],
 /*  81  dii     */ [ 0x3ff0000000000000, 0x0000000300000002 ],
 /*  82  id      */ [ 0x4000000000000000, 0x0000000000000001 ],

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -745,6 +745,9 @@ void test3_run( T, int n )( )
 {
         typeof(.dump) dump;
 
+        if (RegValue[n] == null)
+                return;
+
         test3_ret!T();
         mixin( gen_reg_capture!(n,`["RAX","RDX"]`)() );
 
@@ -791,6 +794,9 @@ void test4_run( T, int n )( T t )
 {
         typeof(.dump) dump = void;
         mixin( gen_reg_capture!(n,`["RDI","RSI"]`)() );
+
+        if (RegValue[n] == null)
+                return;
 
         //.dump = dump;
         //dbg!(T,n)( );

--- a/test/runnable/testargtypes.d
+++ b/test/runnable/testargtypes.d
@@ -43,69 +43,35 @@ int main()
     chkIdentity!int();
     chkIdentity!long();
 
-    version (DigitalMars)
-    {
-        chkIdentity!ubyte();
-        chkIdentity!ushort();
-        chkIdentity!uint();
-        chkIdentity!ulong();
+    chkSingle!(ubyte,  byte)();
+    chkSingle!(ushort, short)();
+    chkSingle!(uint,   int)();
+    chkSingle!(ulong,  long)();
 
-        chkSingle!(char,  ubyte)();
-        chkSingle!(wchar, ushort)();
-        chkSingle!(dchar, uint)();
-    }
-    else
-    {
-        chkSingle!(ubyte,  byte)();
-        chkSingle!(ushort, short)();
-        chkSingle!(uint,   int)();
-        chkSingle!(ulong,  long)();
-
-        chkSingle!(char,  byte)();
-        chkSingle!(wchar, short)();
-        chkSingle!(dchar, int)();
-    }
+    chkSingle!(char,  byte)();
+    chkSingle!(wchar, short)();
+    chkSingle!(dchar, int)();
 
     chkIdentity!float();
     chkIdentity!double();
     chkIdentity!real();
 
-    version (DigitalMars)
-        chkIdentity!(void*)();
-    else
-        chkSingle!(void*, ptrdiff_t)();
+    chkSingle!(void*, ptrdiff_t)();
 
-    version (DigitalMars)
-    {
-        chkIdentity!(__vector(byte[16]))();
-        chkIdentity!(__vector(ubyte[16]))();
-        chkIdentity!(__vector(short[8]))();
-        chkIdentity!(__vector(ushort[8]))();
-        chkIdentity!(__vector(int[4]))();
-        chkIdentity!(__vector(uint[4]))();
-        chkIdentity!(__vector(long[2]))();
-        chkIdentity!(__vector(ulong[2]))();
+    chkSingle!(__vector(byte[16]),  __vector(double[2]))();
+    chkSingle!(__vector(ubyte[16]), __vector(double[2]))();
+    chkSingle!(__vector(short[8]),  __vector(double[2]))();
+    chkSingle!(__vector(ushort[8]), __vector(double[2]))();
+    chkSingle!(__vector(int[4]),    __vector(double[2]))();
+    chkSingle!(__vector(uint[4]),   __vector(double[2]))();
+    chkSingle!(__vector(long[2]),   __vector(double[2]))();
+    chkSingle!(__vector(ulong[2]),  __vector(double[2]))();
 
-        chkIdentity!(__vector(float[4]))();
-        chkIdentity!(__vector(double[2]))();
-    }
-    else
-    {
-        chkSingle!(__vector(byte[16]),  __vector(double[2]))();
-        chkSingle!(__vector(ubyte[16]), __vector(double[2]))();
-        chkSingle!(__vector(short[8]),  __vector(double[2]))();
-        chkSingle!(__vector(ushort[8]), __vector(double[2]))();
-        chkSingle!(__vector(int[4]),    __vector(double[2]))();
-        chkSingle!(__vector(uint[4]),   __vector(double[2]))();
-        chkSingle!(__vector(long[2]),   __vector(double[2]))();
-        chkSingle!(__vector(ulong[2]),  __vector(double[2]))();
+    chkSingle!(__vector(float[4]),  __vector(double[2]))();
+    chkSingle!(__vector(double[2]), __vector(double[2]))();
 
-        chkSingle!(__vector(float[4]),  __vector(double[2]))();
-        chkSingle!(__vector(double[2]), __vector(double[2]))();
-
-        version (D_AVX)
-            chkSingle!(__vector(int[8]), __vector(double[4]))();
-    }
+    version (D_AVX)
+        chkSingle!(__vector(int[8]), __vector(double[4]))();
 
     chkPair!(byte,  byte,  short);
     chkPair!(ubyte, ubyte, short);
@@ -160,20 +126,13 @@ int main()
     chkArgTypes!(int[3], long, int)();
 
     struct S12 { align(16) int a; }
-    version (DigitalMars)
-        chkArgTypes!(S12, int)();
-    else
-        chkArgTypes!(S12, long)();
+    chkArgTypes!(S12, long)();
 
-    version (DigitalMars) {}
-    else
-    {
-        struct S13 { short a; cfloat b; }
-        chkArgTypes!(S13, long, float)();
+    struct S13 { short a; cfloat b; }
+    chkArgTypes!(S13, long, float)();
 
-        struct S13957 { double a; ulong b; }
-        chkArgTypes!(S13957, double, long)();
-    }
+    struct S13957 { double a; ulong b; }
+    chkArgTypes!(S13957, double, long)();
 
     return 0;
 }


### PR DESCRIPTION
Corrects DMD's nonadherence to the C ABI in Posix x64.
Fixes issues [13957](https://issues.dlang.org/show_bug.cgi?id=13957) and [5570](https://issues.dlang.org/show_bug.cgi?id=5570).

This is a reboot of #9013 with less boilerplate. It solves all cases of structs containing integral and/or floats, but doesn't touch 80bit real and SIMD vectors, these are planned to be followups in separate PRs.

Windows x64 is planned next.
