### PR TITLE
dmd/mtype: Add TypeTuple::create for tuple with types in it.

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6144,6 +6144,21 @@ extern (C++) final class TypeTuple : Type
         arguments.push(new Parameter(0, t2, null, null, null));
     }
 
+    static TypeTuple create()
+    {
+        return new TypeTuple();
+    }
+
+    static TypeTuple create(Type t1)
+    {
+        return new TypeTuple(t1);
+    }
+
+    static TypeTuple create(Type t1, Type t2)
+    {
+        return new TypeTuple(t1, t2);
+    }
+
     override const(char)* kind() const
     {
         return "tuple";

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -827,6 +827,9 @@ public:
     Parameters *arguments;      // types making up the tuple
 
     static TypeTuple *create(Parameters *arguments);
+    static TypeTuple *create();
+    static TypeTuple *create(Type *t1);
+    static TypeTuple *create(Type *t1, Type *t2);
     const char *kind();
     Type *syntaxCopy();
     bool equals(RootObject *o);


### PR DESCRIPTION
Required for implementing dmd/argtypes.d in C++.