### PR TITLE
test/compilable: Remove -transition=checkimports from tests

### DIFF
--- a/test/compilable/checkimports3.d
+++ b/test/compilable/checkimports3.d
@@ -1,5 +1,8 @@
 /*
-REQUIRED_ARGS: -transition=checkimports -de
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+---
 */
 import imports.checkimports3a;
 import imports.checkimports3b;

--- a/test/compilable/test15856.d
+++ b/test/compilable/test15856.d
@@ -1,7 +1,7 @@
-// REQUIRED_ARGS: -transition=checkimports -de
+// REQUIRED_ARGS: -de
 // PERMUTE_ARGS:
 /*
-TEST_PUTPUT:
+TEST_OUTPUT:
 ---
 ---
 */


### PR DESCRIPTION
This switch now does nothing.