### PR TITLE
add -preview=nosharedaccess flag and implementation

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -721,6 +721,8 @@ dmd -cov -unittest myprog.d
             "destruct fields of partially constructed objects"),
         Feature("rvaluerefparam", "rvalueRefParam",
             "enable rvalue arguments to ref parameters"),
+        Feature("nosharedaccess", "noSharedAccess",
+            "disable access to shared memory objects"),
     ];
 }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -4277,6 +4277,13 @@ extern (C++) abstract class BinExp : Expression
         return (r1 || r2);
     }
 
+    extern (D) final bool checkSharedAccessBin(Scope* sc)
+    {
+        const r1 = e1.checkSharedAccess(sc);
+        const r2 = e2.checkSharedAccess(sc);
+        return (r1 || r2);
+    }
+
     /*********************
      * Mark the operands as will never be dereferenced,
      * which is useful info for @safe checks.

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -157,6 +157,7 @@ struct Param
     bool useModuleInfo = true;   // generate runtime module information
     bool useTypeInfo = true;     // generate runtime type information
     bool useExceptions = true;   // support exception handling
+    bool noSharedAccess;         // read/write access to shared memory objects
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -134,6 +134,7 @@ struct Param
     bool useModuleInfo; // generate runtime module information
     bool useTypeInfo;   // generate runtime type information
     bool useExceptions; // support exception handling
+    bool noSharedAccess; // read/write access to shared memory objects
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3151,6 +3151,7 @@ else
                 rs.exp = inferType(rs.exp, fld.treq.nextOf().nextOf());
 
             rs.exp = rs.exp.expressionSemantic(sc);
+            rs.exp.checkSharedAccess(sc);
 
             // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
             if (rs.exp.op == TOK.type)

--- a/test/fail_compilation/nosharedaccess.d
+++ b/test/fail_compilation/nosharedaccess.d
@@ -1,0 +1,70 @@
+/* REQUIRED_ARGS: -preview=nosharedaccess
+ * TEST_OUTPUT:
+---
+fail_compilation/nosharedaccess.d(1010): Error: direct access to shared `j` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(1011): Error: direct access to shared `j` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(1012): Error: direct access to shared `*p` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(1013): Error: direct access to shared `a[0]` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(1014): Error: direct access to shared `s.si` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(1015): Error: direct access to shared `t` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(1015): Error: direct access to shared `t.i` is not allowed, see `core.atomic`
+---
+*/
+
+#line 1000
+
+struct S
+{
+    shared(int) si;
+    int i;
+}
+
+int test1(shared int j, shared(int)* p, shared(int)[] a, ref S s, ref shared S t)
+{
+    int i;
+    j = i;
+    i = j;
+    i = *p;
+    i = a[0];
+    i = s.si;
+    return t.i;
+}
+
+/**************************************/
+
+void byref(ref shared int);
+void byptr(shared(int)*);
+
+shared int x;
+
+void test2()
+{
+    byref(x);   // ok
+    byptr(&x);  // ok
+}
+
+/**************************************/
+
+/*
+ * TEST_OUTPUT:
+---
+fail_compilation/nosharedaccess.d(2008): Error: direct access to shared `i` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(2009): Error: direct access to shared `j` is not allowed, see `core.atomic`
+fail_compilation/nosharedaccess.d(2010): Error: direct access to shared `k` is not allowed, see `core.atomic`
+---
+ */
+
+#line 2000
+
+void func(int);
+
+shared int i;
+
+void test3(shared int k)
+{
+    shared int j = void;
+    func(i);
+    func(j);
+    func(k);
+}
+


### PR DESCRIPTION
This is a simple implementation of the idea that shared data should not be directly accessed, but should only be accessed via `core.atomic` primitives.

It's intended to replace https://github.com/dlang/dmd/pull/10142/ which I don't think is the right approach, and is incomplete.