### PR TITLE
de-virtualize isXxxStatement()'s

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1934,20 +1934,14 @@ struct ASTBase
             this.stmt = stmt;
         }
 
-        ExpStatement isExpStatement()
-        {
-            return null;
-        }
+        nothrow pure @nogc
+        inout(ExpStatement) isExpStatement() inout { return stmt == STMT.Exp ? cast(typeof(return))this : null; }
 
-        inout(CompoundStatement) isCompoundStatement() inout nothrow pure
-        {
-            return null;
-        }
+        nothrow pure @nogc
+        inout(CompoundStatement) isCompoundStatement() inout { return stmt == STMT.Compound ? cast(typeof(return))this : null; }
 
-        inout(ReturnStatement) isReturnStatement() inout nothrow pure
-        {
-            return null;
-        }
+        nothrow pure @nogc
+        inout(ReturnStatement) isReturnStatement() inout { return stmt == STMT.Return ? cast(typeof(return))this : null; }
 
         override void accept(Visitor v)
         {
@@ -1997,11 +1991,6 @@ struct ASTBase
         {
             super(loc, STMT.Return);
             this.exp = exp;
-        }
-
-        override inout(ReturnStatement) isReturnStatement() inout nothrow pure
-        {
-            return this;
         }
 
         override void accept(Visitor v)
@@ -2578,11 +2567,6 @@ struct ASTBase
             this.exp = new DeclarationExp(loc, declaration);
         }
 
-        override final ExpStatement isExpStatement()
-        {
-            return this;
-        }
-
         override void accept(Visitor v)
         {
             v.visit(this);
@@ -2612,11 +2596,6 @@ struct ASTBase
             statements.reserve(sts.length);
             foreach (s; sts)
                 statements.push(s);
-        }
-
-        override final inout(CompoundStatement) isCompoundStatement() inout nothrow pure
-        {
-            return this;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1614,7 +1614,7 @@ public:
         }
         else
             s1 = !cs ? f.fbody : null;
-        ReturnStatement rs = s1 ? s1.isReturnStatement() : null;
+        ReturnStatement rs = s1 ? s1.endsWithReturnStatement() : null;
         if (rs && rs.exp)
         {
             buf.writestring(" => ");

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -220,11 +220,11 @@ public:
                 Statement s3;
                 if ((ifs = sx.isIfStatement()) !is null &&
                     ifs.ifbody &&
-                    ifs.ifbody.isReturnStatement() &&
+                    ifs.ifbody.endsWithReturnStatement() &&
                     !ifs.elsebody &&
                     i + 1 < s.statements.dim &&
                     (s3 = (*s.statements)[i + 1]) !is null &&
-                    s3.isReturnStatement()
+                    s3.endsWithReturnStatement()
                    )
                 {
                     /* Rewrite as ?:

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -207,11 +207,11 @@ public:
                 Statement s3;
                 if ((ifs = s2.isIfStatement()) !is null &&
                     ifs.ifbody &&
-                    ifs.ifbody.isReturnStatement() &&
+                    ifs.ifbody.endsWithReturnStatement() &&
                     !ifs.elsebody &&
                     i + 1 < s.statements.dim &&
                     (s3 = (*s.statements)[i + 1]) !is null &&
-                    s3.isReturnStatement()
+                    s3.endsWithReturnStatement()
                    )
                 {
                     if (ifs.prm)       // if variables are declared
@@ -272,7 +272,7 @@ public:
          *      return exp2;
          * Otherwise, we can't handle return statements nested in if's.
          */
-        if (s.elsebody && s.ifbody && s.ifbody.isReturnStatement() && s.elsebody.isReturnStatement())
+        if (s.elsebody && s.ifbody && s.ifbody.endsWithReturnStatement() && s.elsebody.endsWithReturnStatement())
         {
             s.ifbody.accept(this);
             s.elsebody.accept(this);

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -160,7 +160,7 @@ public:
         }
 
         // Now the function body can be serialized.
-        ReturnStatement rs = fld.fbody.isReturnStatement();
+        ReturnStatement rs = fld.fbody.endsWithReturnStatement();
         if (rs && rs.exp)
         {
             rs.exp.accept(this);

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -129,21 +129,23 @@ public:
     virtual Statements *flatten(Scope *sc);
     virtual Statement *last();
 
-    // Avoid dynamic_cast
-    virtual ErrorStatement *isErrorStatement() { return NULL; }
-    virtual ScopeStatement *isScopeStatement() { return NULL; }
-    virtual ExpStatement *isExpStatement() { return NULL; }
-    virtual CompoundStatement *isCompoundStatement() { return NULL; }
-    virtual ReturnStatement *isReturnStatement() { return NULL; }
-    virtual IfStatement *isIfStatement() { return NULL; }
-    virtual CaseStatement *isCaseStatement() { return NULL; }
-    virtual DefaultStatement *isDefaultStatement() { return NULL; }
-    virtual LabelStatement *isLabelStatement() { return NULL; }
-    virtual GotoDefaultStatement *isGotoDefaultStatement() { return NULL; }
-    virtual GotoCaseStatement *isGotoCaseStatement() { return NULL; }
-    virtual BreakStatement *isBreakStatement() { return NULL; }
-    virtual DtorExpStatement *isDtorExpStatement() { return NULL; }
-    virtual ForwardingStatement *isForwardingStatement() { return NULL; }
+    virtual ReturnStatement *endsWithReturnStatement() { return NULL; }
+
+    ErrorStatement       *isErrorStatement()       { return stmt == STMTerror       ? (ErrorStatement*)this       : NULL; }
+    ScopeStatement       *isScopeStatement()       { return stmt == STMTscope       ? (ScopeStatement*)this       : NULL; }
+    ExpStatement         *isExpStatement()         { return stmt == STMTexp         ? (ExpStatement*)this         : NULL; }
+    CompoundStatement    *isCompoundStatement()    { return stmt == STMTcompound    ? (CompoundStatement*)this    : NULL; }
+    ReturnStatement      *isReturnStatement()      { return stmt == STMTreturn      ? (ReturnStatement*)this      : NULL; }
+    IfStatement          *isIfStatement()          { return stmt == STMTif          ? (IfStatement*)this          : NULL; }
+    CaseStatement        *isCaseStatement()        { return stmt == STMTcase        ? (CaseStatement*)this        : NULL; }
+    DefaultStatement     *isDefaultStatement()     { return stmt == STMTdefault     ? (DefaultStatement*)this     : NULL; }
+    LabelStatement       *isLabelStatement()       { return stmt == STMTlabel       ? (LabelStatement*)this       : NULL; }
+    GotoDefaultStatement *isGotoDefaultStatement() { return stmt == STMTgotoDefault ? (GotoDefaultStatement*)this : NULL; }
+    GotoCaseStatement    *isGotoCaseStatement()    { return stmt == STMTgotoCase    ? (GotoCaseStatement*)this    : NULL; }
+    BreakStatement       *isBreakStatement()       { return stmt == STMTbreak       ? (BreakStatement*)this       : NULL; }
+    DtorExpStatement     *isDtorExpStatement()     { return stmt == STMTdtorExp     ? (DtorExpStatement*)this     : NULL; }
+    ForwardingStatement  *isForwardingStatement()  { return stmt == STMTforwarding  ? (ForwardingStatement*)this  : NULL; }
+
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -155,7 +157,6 @@ class ErrorStatement : public Statement
 public:
     Statement *syntaxCopy();
 
-    ErrorStatement *isErrorStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -177,7 +178,6 @@ public:
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
     Statements *flatten(Scope *sc);
 
-    ExpStatement *isExpStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -191,8 +191,6 @@ public:
 
     Statement *syntaxCopy();
     void accept(Visitor *v) { v->visit(this); }
-
-    DtorExpStatement *isDtorExpStatement() { return this; }
 };
 
 class CompileStatement : public Statement
@@ -213,10 +211,9 @@ public:
     static CompoundStatement *create(Loc loc, Statement *s1, Statement *s2);
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
-    ReturnStatement *isReturnStatement();
+    ReturnStatement *endsWithReturnStatement();
     Statement *last();
 
-    CompoundStatement *isCompoundStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -249,8 +246,7 @@ public:
     Loc endloc;                 // location of closing curly bracket
 
     Statement *syntaxCopy();
-    ScopeStatement *isScopeStatement() { return this; }
-    ReturnStatement *isReturnStatement();
+    ReturnStatement *endsWithReturnStatement();
     bool hasBreak() const;
     bool hasContinue() const;
 
@@ -264,7 +260,6 @@ class ForwardingStatement : public Statement
 
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
-    ForwardingStatement *isForwardingStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -373,7 +368,6 @@ public:
     Loc endloc;                 // location of closing curly bracket
 
     Statement *syntaxCopy();
-    IfStatement *isIfStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -455,7 +449,6 @@ public:
     VarDeclaration *lastVar;
 
     Statement *syntaxCopy();
-    CaseStatement *isCaseStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -480,7 +473,6 @@ public:
     VarDeclaration *lastVar;
 
     Statement *syntaxCopy();
-    DefaultStatement *isDefaultStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -491,7 +483,6 @@ public:
     SwitchStatement *sw;
 
     Statement *syntaxCopy();
-    GotoDefaultStatement *isGotoDefaultStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -503,7 +494,6 @@ public:
     CaseStatement *cs;          // case statement it resolves to
 
     Statement *syntaxCopy();
-    GotoCaseStatement *isGotoCaseStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -524,7 +514,7 @@ public:
 
     Statement *syntaxCopy();
 
-    ReturnStatement *isReturnStatement() { return this; }
+    ReturnStatement *endsWithReturnStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -535,7 +525,6 @@ public:
 
     Statement *syntaxCopy();
 
-    BreakStatement *isBreakStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -686,8 +675,6 @@ public:
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
     Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexit, Statement **sfinally);
-
-    LabelStatement *isLabelStatement() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
 };


### PR DESCRIPTION
The main difficulty was `isReturnStatement()` did more than just see if it's a ReturnStatement, so I renamed that one to `endsWithReturnStatement()` to maintain the same behavior.