### PR TITLE
Fix asm nothrow deprecation warnings

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -469,14 +469,14 @@ int insidx(char *p,uint index)
             mov     ECX,p - [ESP]           ;
         }
     else
-        asm
+        asm nothrow
         {
             naked                           ;
             mov     EAX,index - [ESP+4]     ;
             mov     ECX,p - [ESP+4]         ;
         }
 
-    asm
+    asm nothrow
     {
         cmp     EAX,0x7F                ;
         jae     L1                      ;

--- a/src/dmd/backend/util2.d
+++ b/src/dmd/backend/util2.d
@@ -178,7 +178,7 @@ int binary(const(char)* p, const(char)*  *table,int high)
 version (X86asm)
 {
     alias len = high;        // reuse parameter storage
-    asm
+    asm nothrow
     {
 
 // First find the length of the identifier.


### PR DESCRIPTION
I don't know if these asm blocks are supposed to be nothrow or not.  I just added them to remove the deprecation warnings so feel free to verify whether or not this is the correct solution here.  Here are the warnings being addressed:
```bash
dmd\backend\cgobj.d(472): Deprecation: asm statement is assumed to throw - mark it with nothrow if it does not
dmd\backend\cgobj.d(479): Deprecation: asm statement is assumed to throw - mark it with nothrow if it does not
dmd\backend\util2.d(181): Deprecation: asm statement is assumed to throw - mark it with nothrow if it does not
```