### PR TITLE
fix Issue 20072 - [2.087.0] Mixin templates: no property `somevar` for type `some.Type`, did you mean `some.Type.__anonymous.somevar`?

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -441,7 +441,7 @@ extern (C++) class Dsymbol : ASTNode
     final inout(Dsymbol) pastMixin() inout
     {
         //printf("Dsymbol::pastMixin() %s\n", toChars());
-        if (!isTemplateMixin() && !isForwardingAttribDeclaration())
+        if (!isTemplateMixin() && !isForwardingAttribDeclaration() && !isForwardingScopeDsymbol())
             return this;
         if (!parent)
             return null;
@@ -500,7 +500,7 @@ extern (C++) class Dsymbol : ASTNode
     /// ditto
     final inout(Dsymbol) toParent2() inout
     {
-        if (!parent || !parent.isTemplateInstance && !parent.isForwardingAttribDeclaration())
+        if (!parent || !parent.isTemplateInstance && !parent.isForwardingAttribDeclaration() && !parent.isForwardingScopeDsymbol())
             return parent;
         return parent.toParent2;
     }

--- a/test/compilable/staticforeach.d
+++ b/test/compilable/staticforeach.d
@@ -711,3 +711,10 @@ static foreach(m; __traits(allMembers, staticforeach))
 {
     pragma(msg, m);
 }
+
+//https://issues.dlang.org/show_bug.cgi?id=20072
+struct T2{
+    static foreach(i;0..1)
+        struct S{}
+}
+static assert(is(__traits(parent,T2.S)==T2));


### PR DESCRIPTION
I'm not sure if it is even possible that a `ForwardingAttribDeclaration` is stored in some declaration's parent field, but I'm leaving it in for now, to avoid creating a regression.