### PR TITLE
fix Issue 20053 - add mixin types

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -188,6 +188,7 @@ struct ASTBase
         Tvector,
         Tint128,
         Tuns128,
+        Tmixin,
         TMAX
     }
 
@@ -235,6 +236,7 @@ struct ASTBase
     alias Tvector = ENUMTY.Tvector;
     alias Tint128 = ENUMTY.Tint128;
     alias Tuns128 = ENUMTY.Tuns128;
+    alias Tmixin = ENUMTY.Tmixin;
     alias TMAX = ENUMTY.TMAX;
 
     alias TY = ubyte;
@@ -2758,6 +2760,7 @@ struct ASTBase
                 sizeTy[Terror] = __traits(classInstanceSize, TypeError);
                 sizeTy[Tnull] = __traits(classInstanceSize, TypeNull);
                 sizeTy[Tvector] = __traits(classInstanceSize, TypeVector);
+                sizeTy[Tmixin] = __traits(classInstanceSize, TypeMixin);
                 return sizeTy;
             }();
 
@@ -4240,6 +4243,41 @@ struct ASTBase
             TypeTraits tt = new TypeTraits(loc, te);
             tt.mod = mod;
             return tt;
+        }
+    }
+
+    extern (C++) final class TypeMixin : Type
+    {
+        Expressions* exps;
+
+        extern (D) this(Expressions* exps)
+        {
+            super(Tmixin);
+            this.exps = exps;
+        }
+
+        override Type syntaxCopy()
+        {
+            static Expressions* arraySyntaxCopy(Expressions* exps)
+            {
+                Expressions* a = null;
+                if (exps)
+                {
+                    a = new Expressions(exps.dim);
+                    foreach (i, e; *exps)
+                    {
+                        (*a)[i] = e ? e.syntaxCopy() : null;
+                    }
+                }
+                return a;
+            }
+
+            return new TypeMixin(arraySyntaxCopy(exps));
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
         }
     }
 

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -103,6 +103,7 @@ private immutable char[TMAX] mangleChar =
     Treturn      : '@',
     Tvector      : '@',
     Ttraits      : '@',
+    Tmixin       : '@',
 ];
 
 unittest

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6413,6 +6413,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
             if (ta)
             {
                 //printf("type %s\n", ta.toChars());
+
                 // It might really be an Expression or an Alias
                 ta.resolve(loc, sc, &ea, &ta, &sa, (flags & 1) != 0);
                 if (ea)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1465,6 +1465,7 @@ tym_t totym(Type tx)
 
         case Tident:
         case Ttypeof:
+        case Tmixin:
             //printf("ty = %d, '%s'\n", tx.ty, tx.toChars());
             error(Loc.initial, "forward reference of `%s`", tx.toChars());
             t = TYint;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3727,6 +3727,13 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         buf.writestring("typeof(null)");
     }
 
+    void visitMixin(TypeMixin t)
+    {
+        buf.writestring("mixin(");
+        argsToBuffer(t.exps, buf, hgs, null);
+        buf.writeByte(')');
+    }
+
     switch (t.ty)
     {
         default:        return t.isTypeBasic() ?
@@ -3753,5 +3760,6 @@ private void typeToBufferx(Type t, OutBuffer* buf, HdrGenState* hgs)
         case Ttuple:     return visitTuple (cast(TypeTuple)t);
         case Tslice:     return visitSlice(cast(TypeSlice)t);
         case Tnull:      return visitNull(cast(TypeNull)t);
+        case Tmixin:     return visitMixin(cast(TypeMixin)t);
     }
 }

--- a/test/compilable/mixintype.d
+++ b/test/compilable/mixintype.d
@@ -1,0 +1,55 @@
+
+alias Int = mixin("int");
+alias Lint = mixin("Int");
+
+int test1(mixin("int")* p)
+{
+    mixin("int")[] a;
+    mixin("int[]") b;
+    mixin("int[] c;");
+    mixin("*p = c[0];");
+    *p = mixin("c[0]");
+    return *p + a[0] + b[0] + c[0];
+}
+
+/******************************************/
+
+void test2()
+{
+    auto a = __traits(allMembers, mixin(__MODULE__));
+}
+
+/*****************************************/
+
+void test3()
+{
+    char val;
+    int mod;
+    enum b = __traits(compiles, mixin("*cast(int*)&val + mod"));
+    static assert(b == true);
+}
+
+/********************************************/
+
+
+struct S
+{
+    int fielda;
+    int fieldb;
+}
+
+template Foo4(alias T)
+{
+    enum Foo4 = true;
+}
+
+void test4()
+{
+    S sa;
+    auto a = Foo4!( __traits(getMember,sa,"fielda") );
+
+    S sb;
+    enum getStuff = q{ __traits(getMember,sb,"fieldb") };
+    auto b = Foo4!(mixin(getStuff));
+}
+

--- a/test/fail_compilation/mixintype2.d
+++ b/test/fail_compilation/mixintype2.d
@@ -1,0 +1,13 @@
+
+/* TEST_OUTPUT:
+---
+fail_compilation/mixintype2.d(9): Error: alias `mixintype2.Foo.T` recursive alias declaration
+---
+*/
+
+struct Foo {
+    alias T = mixin("T2");
+}
+alias T1 = mixin("Foo.T");
+alias T2 = mixin("T1");
+void func (T2 p) {}


### PR DESCRIPTION
Currently D has these mixins:

1. declaration
2. statement
3. expression

But lacks types. This adds mixin types. I.e. adding:
```
 MixinType:
    mixin ( ArgumentList)
```
to https://dlang.org/spec/declaration.html#BasicType