### PR TITLE
Fix Issue 20074 - header file generation doesn't include attributes with CallExp

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1602,10 +1602,20 @@ public:
             buf.writeByte(' ');
         }
         TypeFunction tf = cast(TypeFunction)f.type;
-        // Don't print tf.mod, tf.trust, and tf.linkage
+
         if (!f.inferRetType && tf.next)
             typeToBuffer(tf.next, null, buf, hgs);
         parametersToBuffer(tf.parameterList, buf, hgs);
+
+        // https://issues.dlang.org/show_bug.cgi?id=20074
+        void printAttribute(string str)
+        {
+            buf.writeByte(' ');
+            buf.writestring(str);
+        }
+        tf.attributesApply(&printAttribute);
+
+
         CompoundStatement cs = f.fbody.isCompoundStatement();
         Statement s1;
         if (f.semanticRun >= PASS.semantic3done && cs)

--- a/test/compilable/extra-files/header2.d
+++ b/test/compilable/extra-files/header2.d
@@ -171,6 +171,17 @@ class LeClass
 }
 const levar = new class LeClass, LeInterface {};
 
+// https://issues.dlang.org/show_bug.cgi?id=20074
+class CC
+{
+    void fun()() @safe
+    {
+        () @trusted pure
+        {
+        } ();
+    }
+}
+
 // https://issues.dlang.org/show_bug.cgi?id=17663
 private:
 public struct Export {}

--- a/test/compilable/extra-files/header2.di
+++ b/test/compilable/extra-files/header2.di
@@ -131,6 +131,16 @@ const levar = new class LeClass, LeInterface
 {
 }
 ;
+class CC
+{
+	@safe void fun()()
+	{
+		() pure @trusted
+		{
+		}
+		();
+	}
+}
 private struct Export
 {
 }

--- a/test/compilable/extra-files/header2i.di
+++ b/test/compilable/extra-files/header2i.di
@@ -233,6 +233,16 @@ const levar = new class LeClass, LeInterface
 {
 }
 ;
+class CC
+{
+	@safe void fun()()
+	{
+		() pure @trusted
+		{
+		}
+		();
+	}
+}
 private struct Export
 {
 }

--- a/test/fail_compilation/diag13028.d
+++ b/test/fail_compilation/diag13028.d
@@ -4,9 +4,9 @@ TEST_OUTPUT:
 fail_compilation/diag13028.d(15): Error: variable `dg` cannot be read at compile time
 fail_compilation/diag13028.d(22): Error: variable `a` cannot be read at compile time
 fail_compilation/diag13028.d(28): Error: CTFE failed because of previous errors in `foo`
-fail_compilation/diag13028.d(28):        while evaluating: `static assert(foo(() => 1) == 1)`
+fail_compilation/diag13028.d(28):        while evaluating: `static assert(foo(() pure nothrow @nogc @safe => 1) == 1)`
 fail_compilation/diag13028.d(29): Error: CTFE failed because of previous errors in `bar`
-fail_compilation/diag13028.d(29):        while evaluating: `static assert(bar(delegate int() => 1) == 1)`
+fail_compilation/diag13028.d(29):        while evaluating: `static assert(bar(delegate int() pure nothrow @nogc @safe => 1) == 1)`
 ---
 */
 

--- a/test/fail_compilation/fail11125.d
+++ b/test/fail_compilation/fail11125.d
@@ -1,11 +1,11 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11125.d(26): Error: template instance `fail11125.filter!(function (int a) => a + 1)` does not match template declaration `filter(alias predfun)`
+fail_compilation/fail11125.d(26): Error: template instance `fail11125.filter!(function (int a) pure nothrow @nogc @safe => a + 1)` does not match template declaration `filter(alias predfun)`
   with `predfun = __lambda1`
   must satisfy the following constraint:
 `       is(ReturnType!predfun == bool)`
-fail_compilation/fail11125.d(27): Error: template instance `fail11125.filter!(function (int a) => a + 1)` does not match template declaration `filter(alias predfun)`
+fail_compilation/fail11125.d(27): Error: template instance `fail11125.filter!(function (int a) pure nothrow @nogc @safe => a + 1)` does not match template declaration `filter(alias predfun)`
   with `predfun = __lambda2`
   must satisfy the following constraint:
 `       is(ReturnType!predfun == bool)`

--- a/test/fail_compilation/ice10259.d
+++ b/test/fail_compilation/ice10259.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice10259.d(11): Error: circular reference to `ice10259.D.d`
-fail_compilation/ice10259.d(11):        called from here: `(*function () => x)()`
+fail_compilation/ice10259.d(11):        called from here: `(*function () pure nothrow @safe => x)()`
 ---
 */
 class D
@@ -16,7 +16,7 @@ enum x = new D;
 TEST_OUTPUT:
 ---
 fail_compilation/ice10259.d(25): Error: circular reference to `ice10259.D2.d`
-fail_compilation/ice10259.d(25):        called from here: `(*function () => x)()`
+fail_compilation/ice10259.d(25):        called from here: `(*function () pure nothrow @safe => x)()`
 ---
 */
 class D2

--- a/test/fail_compilation/ice12673.d
+++ b/test/fail_compilation/ice12673.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice12673.d(13): Error: static assert:  `__traits(compiles, ()
+fail_compilation/ice12673.d(13): Error: static assert:  `__traits(compiles, () pure nothrow @nogc @safe
 {
 __error__
 }

--- a/test/fail_compilation/ice13225.d
+++ b/test/fail_compilation/ice13225.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice13225.d(12): Error: mixin `ice13225.S.M!(function (S _param_0) => 0)` does not match template declaration `M(T)`
+fail_compilation/ice13225.d(12): Error: mixin `ice13225.S.M!(function (S _param_0) pure nothrow @nogc @safe => 0)` does not match template declaration `M(T)`
 fail_compilation/ice13225.d(16): Error: undefined identifier `undefined`
 ---
 */


### PR DESCRIPTION
I don't know why the constructor body is being outputted. Can anyone shed some light on this?