### PR TITLE
run.d: pass DMD_MODEL to invoked tools

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -397,6 +397,7 @@ string[string] getEnvironment()
     env["RESULTS_DIR"] = resultsDir;
     env["OS"] = os;
     env["MODEL"] = model;
+    env["DMD_MODEL"] = dmdModel;
     env["BUILD"] = build;
     env["EXE"] = exeExtension;
     env["DMD"] = dmdPath;


### PR DESCRIPTION
needed by the tools to use the same compiler as run.d.