### PR TITLE
unit_test_runner.d: show failing command line if spawnProcess throws

### DIFF
--- a/test/tools/unit_test_runner.d
+++ b/test/tools/unit_test_runner.d
@@ -274,8 +274,14 @@ bool missingTestFiles(Range)(Range givenFiles)
 
 void execute(const string[] args ...)
 {
-    enforce(spawnProcess(args).wait() == 0,
-        "Failed to execute command: " ~ args.join(" "));
+    try
+    {
+        enforce(spawnProcess(args).wait() == 0);
+    }
+    catch(Exception e)
+    {
+        throw new Exception("Failed to execute command: " ~ args.join(" "), e);
+    }
 }
 
 bool usesOptlink()


### PR DESCRIPTION
Most common problem: the command line is not shown if the invoked executable is not available.