### PR TITLE
Make sure syntax highlight is applied to 'prefix' as well

### DIFF
--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -444,11 +444,17 @@ private void verrorPrint(const ref Loc loc, Color headerColor, const(char)* head
     fputs(header, stderr);
     if (con)
         con.resetColor();
-    if (p1)
-        fprintf(stderr, "%s ", p1);
-    if (p2)
-        fprintf(stderr, "%s ", p2);
     OutBuffer tmp;
+    if (p1)
+    {
+        tmp.writestring(p1);
+        tmp.writestring(" ");
+    }
+    if (p2)
+    {
+        tmp.writestring(p2);
+        tmp.writestring(" ");
+    }
     tmp.vprintf(format, ap);
 
     if (con && strchr(tmp.peekChars(), '`'))


### PR DESCRIPTION
Before this PR, the prefixes in verrorPrint would not have syntax highlight.
However, those were used by Dsymbol to pretty-print the symbol in which the error happens.
For example, for template instantiations:
'template instance Foo!(m) does not match template declaration Foo(X)'
The string `Foo!(m)` should be highlighted, but wasn't.