### PR TITLE
Fix issue 20012 - extern(C) functions inside template mixins are not mangled as C functions

### DIFF
--- a/changelog/mixin_template_mangling.dd
+++ b/changelog/mixin_template_mangling.dd
@@ -1,0 +1,74 @@
+Template mixins now mangle extern(C) declarations when mixed in at global scope
+
+This was already true for string mixins, but since template mixins introduce a new namespace they also get mangled as D symbols.
+However, users often use extern(C) inside a mixin template to automatically generate boilerplate code that should be accessible from C.
+
+-------
+// library code
+mixin template WasmEntryPoint() {
+    extern(C) export void _start() {
+        // boilerplate code
+    }
+}
+
+mixin template UseGpuInsteadOfIntegratedGraphics() {
+    extern(C) export uint NvOptimusEnablement = 0x00000001;
+    extern(C) export int AmdPowerXpressRequestHighPerformance = 1;
+}
+
+// application code
+mixin WasmEntryPoint;
+mixin UseGpuInsteadOfIntegratedGraphics;
+
+static assert(_start.mangleof == "_start");
+static assert(NvOptimusEnablement.mangleof == "NvOptimusEnablement");
+-------
+
+Previously, _start would be mangled as _D9onlineapp8__mixin46_startUkZv and users had to manually add pragma(mangle, "_start") or use a string mixin instead.
+With the new behavior this is not necessary anymore.
+extern(C++) declarations and mixed in member functions or nested functions are unaffected.
+There is a possibility this breaks code if you have an extern(C) function or variable that you use in multiple modules.
+
+-------
+import core.stdc.stdio;
+
+mixin template GenPrintCallback(string text) {
+    extern(C):
+
+    auto textLength = text.length;
+    auto textPointer = text.ptr;
+
+    void callBackOnly() {
+        printf("%.*s\n", textLength, textPointer);
+    }
+
+    mixin(`auto `, text, ` = &callBackOnly;`);
+}
+
+mixin GenPrintCallback!"foo";
+
+// in a different module:
+mixin GenPrintCallback!"bar";
+-------
+
+In this case, textLength and textPointer will be defined multiple times and give a linker error.
+callBackOnly will be defined multiple times, but because functions in templates have weak linkage that is allowed.
+It does mean that the linker will just pick one "callBackOnly" and print e.g. "foo" for both foo and bar.
+The solution is to not make variables extern(C) and make C callback functions anonymous.
+
+-------
+import core.stdc.stdio;
+
+mixin template GenPrintCallback(string text) {
+
+    auto textLength = text.length; // not below an extern(C): anymore
+    auto textPointer = text.ptr;
+
+    alias FunT = extern(C) void function();
+    enum FunT callBackOnly = () {
+        printf("%.*s\n", textLength, textPointer);
+    };
+
+    mixin(`auto `, text, ` = callBackOnly;`);
+}
+-------

--- a/changelog/mixin_template_mangling.dd
+++ b/changelog/mixin_template_mangling.dd
@@ -1,7 +1,7 @@
-Template mixins now mangle extern(C) declarations when mixed in at global scope
+`extern(C)` declarations in template mixins now mangle as C symbols when mixed in at global scope
 
-This was already true for string mixins, but since template mixins introduce a new namespace they also get mangled as D symbols.
-However, users often use extern(C) inside a mixin template to automatically generate boilerplate code that should be accessible from C.
+This was already true for string mixins, but since template mixins introduce a new scope, symbols inside them got mangled as D symbols.
+However, users often use `extern(C)` inside a mixin template to automatically generate boilerplate code that should be accessible from C.
 
 -------
 // library code
@@ -24,10 +24,11 @@ static assert(_start.mangleof == "_start");
 static assert(NvOptimusEnablement.mangleof == "NvOptimusEnablement");
 -------
 
-Previously, _start would be mangled as _D9onlineapp8__mixin46_startUkZv and users had to manually add pragma(mangle, "_start") or use a string mixin instead.
-With the new behavior this is not necessary anymore.
-extern(C++) declarations and mixed in member functions or nested functions are unaffected.
-There is a possibility this breaks code if you have an extern(C) function or variable that you use in multiple modules.
+Previously, _start would be mangled like `_D9onlineapp8__mixin46_startUkZv` and users had to manually add `pragma(mangle, "_start")` or use a string mixin instead.
+With the new behavior this is not necessary anymore for `extern(C)`, as well as `extern(Windows)` and `extern(Objective-C)`.
+`extern(C++)` remains unchanged since it already always mangles to C++, even in nested scopes.
+
+There is a possibility this breaks code if you mix in different `extern(C)` declarations with the same name in the global scope of multiple modules.
 
 -------
 import core.stdc.stdio;
@@ -51,10 +52,8 @@ mixin GenPrintCallback!"foo";
 mixin GenPrintCallback!"bar";
 -------
 
-In this case, textLength and textPointer will be defined multiple times and give a linker error.
-callBackOnly will be defined multiple times, but because functions in templates have weak linkage that is allowed.
-It does mean that the linker will just pick one "callBackOnly" and print e.g. "foo" for both foo and bar.
-The solution is to not make variables extern(C) and make C callback functions anonymous.
+In this case textLength, textPointer and callBackOnly will be defined multiple times, so the linker either picks one or raises and error.
+The solution is to not make variables `extern(C)` and make C callback functions anonymous:
 
 -------
 import core.stdc.stdio;

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -544,9 +544,26 @@ public:
         }
     }
 
+    /************************************************************
+     * Try to obtain an externally mangled identifier from a declaration.
+     * If the declaration is at global scope or mixed in at global scope,
+     * the user might want to call it externally, so an externally mangled
+     * name is returned. Member functions or nested functions can't be called
+     * externally in C, so in that case null is returned. C++ does support
+     * namespaces, so extern(C++) always gives a C++ mangled name.
+     *
+     * See also: https://issues.dlang.org/show_bug.cgi?id=20012
+     *
+     * Params:
+     *     d = declaration to mangle
+     *
+     * Returns:
+     *     an externally mangled name or null if the declaration cannot be called externally
+     */
     extern (D) static const(char)[] externallyMangledIdentifier(Declaration d)
     {
-        if (!d.parent || d.parent.isModule() || d.linkage == LINK.cpp) // if at global scope
+        const par = d.toParent(); //toParent() skips over mixin templates
+        if (!par || par.isModule() || d.linkage == LINK.cpp)
         {
             final switch (d.linkage)
             {

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -827,6 +827,18 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
     {
         if (p.isTemplateInstance())
         {
+            // functions without D or C++ name mangling mixed in at global scope
+            // shouldn't have multiple definitions
+            if (p.isTemplateMixin() && (fd.linkage == LINK.c || fd.linkage == LINK.windows ||
+                fd.linkage == LINK.pascal || fd.linkage == LINK.objc))
+            {
+                const q = p.toParent();
+                if (q && q.isModule())
+                {
+                    s.Sclass = SCglobal;
+                    break;
+                }
+            }
             s.Sclass = SCcomdat;
             break;
         }

--- a/test/compilable/mixinTemplateMangling.d
+++ b/test/compilable/mixinTemplateMangling.d
@@ -1,0 +1,35 @@
+// https://issues.dlang.org/show_bug.cgi?id=20012
+
+mixin template mixinFoo() {
+
+    extern(C) void cFoo() {}
+
+    extern(C) int cVar;
+    extern(D) int dVar;
+
+    void dFoo() {}
+
+    mixin(`mixin mixinBar;`); // test nesting and interaction with string mixins
+}
+
+mixin mixinFoo;
+
+mixin template mixinBar() {
+    extern(C) void cBar() {}
+    void dBar() {}
+}
+
+static assert(cFoo.mangleof == "cFoo");
+static assert(dFoo.mangleof == "_D21mixinTemplateMangling8__mixin54dFooFZv");
+static assert(cVar.mangleof == "cVar");
+static assert(dVar.mangleof == "_D21mixinTemplateMangling8__mixin54dVari");
+static assert(cBar.mangleof == "cBar");
+static assert(dBar.mangleof == "_D21mixinTemplateMangling8__mixin5Qj4dBarFZv");
+
+struct S {
+    mixin mixinFoo;
+    static assert(cFoo.mangleof == "_D21mixinTemplateMangling1S8__mixin14cFooMUZv");
+    static assert(cBar.mangleof == "_D21mixinTemplateMangling1S8__mixin18__mixin54cBarMUZv");
+    static assert(dBar.mangleof == "_D21mixinTemplateMangling1S8__mixin18__mixin54dBarMFZv");
+    static assert(dFoo.mangleof == "_D21mixinTemplateMangling1S8__mixin14dFooMFZv");
+}


### PR DESCRIPTION
See also the [newsgroup discussion](https://forum.dlang.org/thread/mailman.10402.1563944613.29801.digitalmars-d@puremagic.com?page=1).

The only change is that instead of checking the `parent` field directly, `toParent` is called, which skips over mixin templates. Member functions and nested `extern(C)` functions are unaffected.

This should only break code where *all* of the following applies:
1 you have a C-ABI callback-only function
2 but it's not anonymous
3 and it's in a mixin template
4 which is mixed in at global scope
5 and its name clashes with other extern(C) functions / you want to mix it in multiple times

Walter has not given his okay on this yet, because:
> Template mixins are meant to be included multiple times. That's why the scope is part of the mangled name.

So I scanned all git repositories in the dub repository to look for mixin templates. 
[Full results here](https://gist.github.com/dkorpel/df2c2f567588bb8ee59e293146e52723), but in summary there are 13/1584 packages that have `exern()` inside `template mixin`.
- 5 of them have the `pragma(mangle)` hack to get the proposed behavior
- 7 are unaffected (use it only for function pointer types, non-global functions)
- 1 use of it breaks ([mir-pybind](https://github.com/ShigekiKarita/mir-pybind/blob/0b8e805af78a95ecb80303efc9e6b58282799479/source/mir/pybind/package.d#L25))

That's right, with the new behavior 1 package breaks while in at least 10 found / reported cases (5 aforementioned packages using pragma mangle, DPlug, Excel-D issue 962, 12575, 20012) it would be what users want. 

I hope that's convincing enough.