### PR TITLE
redo fix for issue 11856: segfault with circular template constraints

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -642,7 +642,6 @@ extern (C++) abstract class Expression : ASTNode
     ubyte parens;   // if this is a parenthesized expression
     Type type;      // !=null means that semantic() has been run
     Loc loc;        // file location
-    ubyte inuse;    // detect expressionSemantic() loops
 
     extern (D) this(const ref Loc loc, TOK op, int size)
     {

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -72,7 +72,6 @@ public:
     unsigned char parens;       // if this is a parenthesized expression
     Type *type;                 // !=NULL means that semantic() has been run
     Loc loc;                    // file location
-    unsigned char inuse;        // detect expressionSemantic() loops
 
     static void _init();
     Expression *copy();

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11094,12 +11094,6 @@ Expression binSemanticProp(BinExp e, Scope* sc)
 // entrypoint for semantic ExpressionSemanticVisitor
 extern (C++) Expression expressionSemantic(Expression e, Scope* sc)
 {
-    const inConstraint = sc ? (sc.flags & SCOPE.constraint) == SCOPE.constraint : false;
-    if (e.inuse == 2 && inConstraint)
-    {
-        e.error("circular evaluation of constraint `%s`", e.toChars());
-        return new ErrorExp();
-    }
     scope v = new ExpressionSemanticVisitor(sc);
     e.accept(v);
     return v.result;

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1533,12 +1533,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             }
             if (ex)
             {
-                const bool inConstraint = (sc2.flags & SCOPE.constraint) == SCOPE.constraint;
-                ex.inuse += inConstraint;
                 ex = ex.expressionSemantic(sc2);
                 ex = resolvePropertiesOnly(sc2, ex);
                 ex = ex.optimize(WANTvalue);
-                ex.inuse -= inConstraint;
                 if (sc2.func && sc2.func.type.ty == Tfunction)
                 {
                     const tf = cast(TypeFunction)sc2.func.type;


### PR DESCRIPTION
reverts most of PR 10205, now fixing the existing recursion check.

The existing implementation (or rather its test cases) causes out-of-memory errors when merging back to master: https://github.com/dlang/dmd/pull/10232