### PR TITLE
Fix calls to `GC.addRange` and `GC.removeRange` to be const-correct in root/rmem.d

### DIFF
--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -136,13 +136,13 @@ extern (C++) struct Mem
             _isGCEnabled = false;
         }
 
-        static void addRange(const(void)* p, size_t size) nothrow @nogc
+        static void addRange(void* p, size_t size) nothrow @nogc
         {
             if (isGCEnabled)
                 GC.addRange(p, size);
         }
 
-        static void removeRange(const(void)* p) nothrow @nogc
+        static void removeRange(void* p) nothrow @nogc
         {
             if (isGCEnabled)
                 GC.removeRange(p);


### PR DESCRIPTION
In support of https://github.com/dlang/druntime/pull/2706

The interface to `GC.addRange` and `GC.removeRange` is not `const`

https://github.com/dlang/druntime/blob/a370406fae72602ab2e0fe632d7a70a71da79267/src/gc/proxy.d#L228-L231

https://github.com/dlang/druntime/blob/a370406fae72602ab2e0fe632d7a70a71da79267/src/gc/proxy.d#L238-L241

https://github.com/dlang/druntime/blob/a370406fae72602ab2e0fe632d7a70a71da79267/src/gc/impl/proto/gc.d#L27-L28

https://github.com/dlang/druntime/blob/a370406fae72602ab2e0fe632d7a70a71da79267/src/gc/impl/proto/gc.d#L202

https://github.com/dlang/druntime/blob/a370406fae72602ab2e0fe632d7a70a71da79267/src/gc/impl/proto/gc.d#L207