### PR TITLE
avoid two possible ways to create $G/VERSION and $G/SYSCONFDIR.imp

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -512,14 +512,8 @@ $G/dmd.conf: $(SRC_MAKE)
 # However, the version check script only touches the VERSION file if it
 # actually has changed.
 
-$G/version_check: ../config.d $(HOST_DMD_PATH)
-	@echo "  (HOST_DMD_RUN)  $<  $<"
-	$(HOST_DMD_RUN) $< -of$@
-
-$G/VERSION: $G/version_check ../VERSION FORCE
-	@$< $G ../VERSION $(SYSCONFDIR)
-
-$G/SYSCONFDIR.imp: $G/VERSION
+$G/VERSION: $(GENERATED)/build ../VERSION FORCE
+	$(RUN_BUILD) -f $@
 
 FORCE: ;
 


### PR DESCRIPTION
trying to fix the semophore CI failure.

There are currently two ways to generate the VERSION and SYSCONFDIR.imp files in the generated folder: via config.d or as a dependency in the build.d script. These might both get executed in arbitrary order and maybe generate different results,