### PR TITLE
build.d: check result of git describe

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -273,8 +273,13 @@ alias versionFile = memoize!(function() {
         "(TX) VERSION".writeln;
         string ver;
         if (srcDir.dirName.buildPath(".git").exists)
-            ver = ["git", "describe", "--dirty", "--always"].runCanThrow;
-        else
+        {
+            auto gitResult = ["git", "describe", "--dirty"].run;
+            if (gitResult.status == 0)
+                ver = gitResult.output.strip;
+        }
+        // version fallback
+        if (ver.length == 0)
             ver = srcDir.dirName.buildPath("VERSION").readText;
         updateIfChanged(versionFile, ver);
     };


### PR DESCRIPTION
See also: https://github.com/dlang/dmd/pull/10232#issuecomment-516530093

Though we should probably just build and call `config.d` as we have to maintain that one anyhow.