### PR TITLE
Fix issue 20089: Handle extra case in fixresult_complex87

### DIFF
--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -3646,6 +3646,26 @@ void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pret
         cdb.genf2(0xDD,modregrm(3,3,0));        // FPOP
         pop87();
     }
+    else if (tym == TYllong)
+    {
+        assert(retregs & mST01, "this float expression is not implemented");
+        if (!(*pretregs & mCX))
+        {
+            printf("*pretregs = %d is not implemented\n", *pretregs);
+            assert(0, "moving cfloat to register other than CX is not implemented");
+        }
+        pop87();
+        cdb.genfltreg(ESC(MFfloat,1),BX,0);     // FSTP floatreg
+        genfwait(cdb);
+        getregs(cdb,mCX);
+        cdb.genfltreg(LOD, CX, 0);              // MOV ECX,floatreg
+        cdb.genc2(0xC1,(REX_W << 16) | modregrmx(3,4,CX),32); // SHL RCX,32
+
+        pop87();
+        cdb.genfltreg(ESC(MFfloat,1),BX,0);     // FSTP floatreg
+        genfwait(cdb);
+        cdb.genfltreg(LOD, CX, 0);              // MOV ECX,floatreg
+    }
     else if (tym == TYcfloat && *pretregs & (mAX|mDX) && retregs & mST01)
     {
         if (*pretregs & mPSW && !(retregs & mPSW))

--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -3648,23 +3648,17 @@ void fixresult_complex87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pret
     }
     else if (tym == TYllong)
     {
+        // passing cfloat through register for I64
         assert(retregs & mST01, "this float expression is not implemented");
-        if (!(*pretregs & mCX))
-        {
-            printf("*pretregs = %d is not implemented\n", *pretregs);
-            assert(0, "moving cfloat to register other than CX is not implemented");
-        }
         pop87();
-        cdb.genfltreg(ESC(MFfloat,1),BX,0);     // FSTP floatreg
-        genfwait(cdb);
-        getregs(cdb,mCX);
-        cdb.genfltreg(LOD, CX, 0);              // MOV ECX,floatreg
-        cdb.genc2(0xC1,(REX_W << 16) | modregrmx(3,4,CX),32); // SHL RCX,32
-
+        cdb.genfltreg(ESC(MFfloat,1),BX,4);     // FSTP floatreg
         pop87();
-        cdb.genfltreg(ESC(MFfloat,1),BX,0);     // FSTP floatreg
+        cdb.genfltreg(ESC(MFfloat,1),BX,0);     // FSTP floatreg+4
         genfwait(cdb);
-        cdb.genfltreg(LOD, CX, 0);              // MOV ECX,floatreg
+        const reg = findreg(*pretregs);
+        getregs(cdb,reg);
+        cdb.genfltreg(LOD, reg, 0);             // MOV ECX,floatreg
+        code_orrex(cdb.last(), REX_W);          // extend to RCX
     }
     else if (tym == TYcfloat && *pretregs & (mAX|mDX) && retregs & mST01)
     {

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -924,7 +924,8 @@ void cdmul(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
             config.fpxmmregs && oper != OPmod && tyxmmreg(tyml) &&
             !(*pretregs & mST0) &&
             !(ty == TYldouble || ty == TYildouble) &&  // watch out for shrinkLongDoubleConstantIfPossible()
-            !tycomplex(ty) // SIMD code is not set up to deal with complex mul/div
+            !tycomplex(ty) && // SIMD code is not set up to deal with complex mul/div
+            !(ty == TYllong)  //   or passing to function through integer register
            )
         {
             orthxmm(cdb,e,pretregs);

--- a/test/runnable/test18772.d
+++ b/test/runnable/test18772.d
@@ -88,8 +88,7 @@ void main()
 {
     test18772();
 
-    version(none) // failing
-        test!cfloat();
+    test!cfloat();
     test!cdouble();
     test!creal();
 }

--- a/test/runnable/test18772.d
+++ b/test/runnable/test18772.d
@@ -1,6 +1,10 @@
-float fun(cfloat z)
+float getreal(cfloat z)
 {
     return z.re;
+}
+float geti(cfloat z)
+{
+     return z.im;
 }
 
 void main()
@@ -8,6 +12,9 @@ void main()
     cfloat[1] A;
     float[1] B;
     int i = 0;
-    version(D_LP64) {} else // disabled because of wrong codegen: https://issues.dlang.org/show_bug.cgi?id=20089
-    double C = fun(A[i] * B[i]);
+    A[0] = 2.0f + 4i;
+    B[0] = 3.0f;
+    assert(((2.0f + 4i) * 3.0f).re == getreal(A[i] * B[i]));
+    //assert(((2.0f + 4i) * 3.0f).im == geti(A[i] * B[i]));
+    double C = getreal(A[i] * B[i]);
 }

--- a/test/runnable/test18772.d
+++ b/test/runnable/test18772.d
@@ -1,20 +1,95 @@
-float getreal(cfloat z)
+float getreal_rcx(cfloat z)
 {
     return z.re;
 }
-float geti(cfloat z)
+float getimag_rcx(cfloat z)
 {
-     return z.im;
+    return z.im;
 }
 
-void main()
+float getreal_rdx(cfloat z, int)
+{
+    return z.re;
+}
+float getimag_rdx(cfloat z, int)
+{
+    return z.im;
+}
+
+float getreal_r8(cfloat z, int, int)
+{
+    return z.re;
+}
+float getimag_r8(cfloat z, int, int)
+{
+    return z.im;
+}
+
+float getreal_r9(cfloat z, int, int, int)
+{
+    return z.re;
+}
+float getimag_r9(cfloat z, int, int, int)
+{
+    return z.im;
+}
+
+float getreal_stack(cfloat z, int, int, int, int)
+{
+    return z.re;
+}
+float getimag_stack(cfloat z, int, int, int, int)
+{
+    return z.im;
+}
+
+void test18772()
 {
     cfloat[1] A;
     float[1] B;
     int i = 0;
     A[0] = 2.0f + 4i;
     B[0] = 3.0f;
-    assert(((2.0f + 4i) * 3.0f).re == getreal(A[i] * B[i]));
-    //assert(((2.0f + 4i) * 3.0f).im == geti(A[i] * B[i]));
-    double C = getreal(A[i] * B[i]);
+    assert(6.0 == getreal_rcx(A[i] * B[i]));
+    assert(12.0 == getimag_rcx(A[i] * B[i]));
+
+    assert(6.0 == getreal_rdx(A[i] * B[i], 1));
+    assert(12.0 == getimag_rdx(A[i] * B[i], 1));
+
+    assert(6.0 == getreal_r8(A[i] * B[i], 1, 2));
+    assert(12.0 == getimag_r8(A[i] * B[i], 1, 2));
+
+    assert(6.0 == getreal_r9(A[i] * B[i], 1, 2, 3));
+    assert(12.0 == getimag_r9(A[i] * B[i], 1, 2, 3));
+
+    assert(6.0 == getreal_stack(A[i] * B[i], 1, 2, 3, 4));
+    assert(12.0 == getimag_stack(A[i] * B[i], 1, 2, 3, 4));
+}
+
+void test(T)()
+{
+    static auto getre0(T z)
+    {
+        return z.re;
+    }
+    static auto getim0(T z)
+    {
+        return z.im;
+    }
+    
+    T z = 3 + 4i;
+    auto d = z.re;
+    
+    assert(getre0(d * z) == d * 3);
+    assert(getim0(d * z) == d * 4);
+}
+
+void main()
+{
+    test18772();
+
+    version(none) // failing
+        test!cfloat();
+    test!cdouble();
+    test!creal();
 }


### PR DESCRIPTION
Fix issue 20089, FPU stack not cleaned up properly

Note that this only occurs on windows 64-bit.  It doesn't happen on windows 32 bit because it only occurs when the compiler tries to fit a cfloat into the RCX register.  With help from @rainers, we added a new `if` block to handle the case when a cfloat needs to be copied to the one of the `R*X` register.