### PR TITLE
add OutBuffer.opSlice() to replace OutBuffer.peekSlice()

### DIFF
--- a/src/dmd/root/outbuffer.d
+++ b/src/dmd/root/outbuffer.d
@@ -407,6 +407,11 @@ struct OutBuffer
 
     extern (D) const(char)[] peekSlice() pure nothrow @nogc
     {
+        return this[];
+    }
+
+    extern (D) const(char)[] opSlice() pure nothrow @nogc
+    {
         return (cast(const char*)data)[0 .. offset];
     }
 


### PR DESCRIPTION
Should really use D notation.