### PR TITLE
replace ArrayLiteralExp.getElement() with opIndex()

### DIFF
--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -795,8 +795,8 @@ UnionExp Equal(TOK op, const ref Loc loc, Type type, Expression e1, Expression e
         {
             for (size_t i = 0; i < es1.elements.dim; i++)
             {
-                auto ee1 = es1.getElement(i);
-                auto ee2 = es2.getElement(i);
+                auto ee1 = es1[i];
+                auto ee2 = es2[i];
                 ue = Equal(TOK.equal, loc, Type.tint32, ee1, ee2);
                 if (CTFEExp.isCantExp(ue.exp()))
                     return ue;
@@ -829,7 +829,7 @@ UnionExp Equal(TOK op, const ref Loc loc, Type type, Expression e1, Expression e
             for (size_t i = 0; i < dim1; i++)
             {
                 uinteger_t c = es1.charAt(i);
-                auto ee2 = es2.getElement(i);
+                auto ee2 = es2[i];
                 if (ee2.isConst() != 1)
                 {
                     cantExp(ue);
@@ -1247,7 +1247,7 @@ UnionExp Index(Type type, Expression e1, Expression e2)
         else if (e1.op == TOK.arrayLiteral)
         {
             ArrayLiteralExp ale = cast(ArrayLiteralExp)e1;
-            auto e = ale.getElement(cast(size_t)i);
+            auto e = ale[cast(size_t)i];
             e.type = type;
             e.loc = loc;
             if (hasSideEffect(e))
@@ -1271,7 +1271,7 @@ UnionExp Index(Type type, Expression e1, Expression e2)
             }
             else
             {
-                auto e = ale.getElement(cast(size_t)i);
+                auto e = ale[cast(size_t)i];
                 e.type = type;
                 e.loc = loc;
                 if (hasSideEffect(e))
@@ -1400,7 +1400,7 @@ void sliceAssignStringFromArrayLiteral(StringExp existingSE, ArrayLiteralExp new
     assert(existingSE.ownedByCtfe != OwnedBy.code);
     foreach (j; 0 .. newae.elements.dim)
     {
-        existingSE.setCodeUnit(firstIndex + j, cast(dchar)newae.getElement(j).toInteger());
+        existingSE.setCodeUnit(firstIndex + j, cast(dchar)newae[j].toInteger());
     }
 }
 
@@ -1432,7 +1432,7 @@ int sliceCmpStringWithArray(const StringExp se1, ArrayLiteralExp ae2, size_t lo1
 {
     foreach (j; 0 .. len)
     {
-        const val2 = cast(dchar)ae2.getElement(j + lo2).toInteger();
+        const val2 = cast(dchar)ae2[j + lo2].toInteger();
         const val1 = se1.getCodeUnit(j + lo1);
         const int c = val1 - val2;
         if (c)
@@ -1602,7 +1602,7 @@ UnionExp Cat(Type type, Expression e1, Expression e2)
         auto elems = new Expressions(len);
         for (size_t i = 0; i < ea.elements.dim; ++i)
         {
-            (*elems)[i] = ea.getElement(i);
+            (*elems)[i] = ea[i];
         }
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elems);
         ArrayLiteralExp dest = cast(ArrayLiteralExp)ue.exp();
@@ -1619,7 +1619,7 @@ UnionExp Cat(Type type, Expression e1, Expression e2)
         auto elems = new Expressions(len);
         for (size_t i = 0; i < ea.elements.dim; ++i)
         {
-            (*elems)[es.len + i] = ea.getElement(i);
+            (*elems)[es.len + i] = ea[i];
         }
         emplaceExp!(ArrayLiteralExp)(&ue, e1.loc, type, elems);
         ArrayLiteralExp dest = cast(ArrayLiteralExp)ue.exp();

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2755,7 +2755,7 @@ private bool isVoidArrayLiteral(Expression e, Type other)
     while (e.op == TOK.arrayLiteral && e.type.ty == Tarray && ((cast(ArrayLiteralExp)e).elements.dim == 1))
     {
         auto ale = cast(ArrayLiteralExp)e;
-        e = ale.getElement(0);
+        e = ale[0];
         if (other.ty == Tsarray || other.ty == Tarray)
             other = other.nextOf();
         else

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1024,7 +1024,7 @@ public:
         buf.print(dim);
         foreach (i; 0 .. dim)
         {
-            e.getElement(i).accept(this);
+            e[i].accept(this);
         }
     }
 

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -648,7 +648,7 @@ private bool _isZeroInit(Expression exp)
 
             foreach (i; 0 .. dim)
             {
-                if (!_isZeroInit(ale.getElement(i)))
+                if (!_isZeroInit(ale[i]))
                     return false;
             }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -425,7 +425,7 @@ private hash_t expressionHash(Expression e)
         auto ae = cast(ArrayLiteralExp)e;
         size_t hash;
         foreach (i; 0 .. ae.elements.dim)
-            hash = mixHash(hash, expressionHash(ae.getElement(i)));
+            hash = mixHash(hash, expressionHash(ae[i]));
         return hash;
     }
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -4093,7 +4093,7 @@ elem *toElem(Expression e, IRState *irs)
 
                 foreach (const i; 0 .. ve.dim)
                 {
-                    Expression elem = (cast(ArrayLiteralExp)ve.e1).getElement(i);
+                    Expression elem = ve.e1.isArrayLiteralExp()[i];
                     const complex = elem.toComplex();
                     const integer = elem.toInteger();
                     switch (elem.type.toBasetype().ty)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2813,6 +2813,11 @@ extern (C++) final class ArrayLiteralExp : Expression
 
     Expression getElement(size_t i)
     {
+        return this[i];
+    }
+
+    Expression opIndex(size_t i)
+    {
         auto el = (*elements)[i];
         return el ? el : basis;
     }
@@ -2840,7 +2845,7 @@ extern (C++) final class ArrayLiteralExp : Expression
             {
                 foreach (i; 0 .. elements.dim)
                 {
-                    auto ch = getElement(i);
+                    auto ch = this[i];
                     if (ch.op != TOK.int64)
                         return null;
                     if (sz == 1)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -412,7 +412,8 @@ public:
     static void emplace(UnionExp *pue, Loc loc, Expressions *elements);
     Expression *syntaxCopy();
     bool equals(RootObject *o);
-    Expression *getElement(d_size_t i);
+    Expression *getElement(d_size_t i); // use opIndex instead
+    Expression *opIndex(d_size_t i);
     bool isBool(bool result);
     StringExp *toStringExp();
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7033,7 +7033,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             foreach (i; 0 .. exp.dim)
             {
                 // Do not stop on first error - check all AST nodes even if error found
-                res |= checkElem((cast(ArrayLiteralExp)exp.e1).getElement(i));
+                res |= checkElem(exp.e1.isArrayLiteralExp()[i]);
             }
         }
         else if (exp.e1.type.ty == Tvoid)

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -422,7 +422,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         auto dtbarray = DtBuilder(0);
         foreach (i; 0 .. e.elements.dim)
         {
-            Expression_toDt(e.getElement(i), dtbarray);
+            Expression_toDt(e[i], dtbarray);
         }
 
         Type t = e.type.toBasetype();
@@ -522,7 +522,7 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         {
             Expression elem;
             if (auto ale = e.e1.isArrayLiteralExp())
-                elem = ale.getElement(i);
+                elem = ale[i];
             else
                 elem = e.e1;
             Expression_toDt(elem, dtb);


### PR DESCRIPTION
Array containers should be indexable like arrays.