### PR TITLE
Fix segfault in trait getLocation with some symbols

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1856,7 +1856,7 @@ Lnext:
             return dimError(1);
         auto arg0 = (*e.args)[0];
         Dsymbol s = getDsymbolWithoutExpCtx(arg0);
-        if (!s)
+        if (!s || !s.loc.isValid())
         {
             e.error("can only get the location of a symbol, not `%s`", arg0.toChars());
             return new ErrorExp();

--- a/test/fail_compilation/trait_loc_err.d
+++ b/test/fail_compilation/trait_loc_err.d
@@ -1,0 +1,15 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/trait_loc_err.d(13): Error: can only get the location of a symbol, not `trait_loc_err`
+fail_compilation/trait_loc_err.d(14): Error: can only get the location of a symbol, not `std`
+---
+*/
+module trait_loc_err;
+import std.stdio;
+
+void main()
+{
+    __traits(getLocation, __traits(parent, main));
+    __traits(getLocation, __traits(parent, std.stdio));
+}


### PR DESCRIPTION
No longer crash with this
```
import std.stdio;
void main()
{
    __traits(getLocation, __traits(parent, main));
    __traits(getLocation, __traits(parent, std.stdio));
}
```