### PR TITLE
Remove 8087 backend globals from frontend header modules

### DIFF
--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -39,6 +39,18 @@ extern (C++):
 
 nothrow:
 
+private struct Globals
+{
+    NDP[8] stack;              // 8087 stack
+    int stackused = 0;         // number of items on the 8087 stack
+}
+// NOTE: this could be a TLS global which would allow this variable to be used in
+//       a multi-threaded version of the backend
+__gshared Globals global87;
+__gshared NDP ndp_zero;
+
+private:
+
 int REGSIZE();
 
 private extern (D) uint mask(uint m) { return 1 << m; }
@@ -66,14 +78,6 @@ enum
     MFlong          = 1,
     MFdouble        = 2,
     MFword          = 3
-}
-
-__gshared
-{
-    NDP[8] _8087elems;              // 8087 stack
-    NDP ndp_zero;
-
-    int stackused = 0;              // number of items on the 8087 stack
 }
 
 /*********************************
@@ -226,14 +230,14 @@ void pop87(int line, const(char)* file)
     int i;
 
     if (NDPP)
-        printf("pop87(%s(%d): stackused=%d)\n", file, line, stackused);
+        printf("pop87(%s(%d): stackused=%d)\n", file, line, global87.stackused);
 
-    --stackused;
-    assert(stackused >= 0);
-    for (i = 0; i < _8087elems.length - 1; i++)
-        _8087elems[i] = _8087elems[i + 1];
+    --global87.stackused;
+    assert(global87.stackused >= 0);
+    for (i = 0; i < global87.stack.length - 1; i++)
+        global87.stack[i] = global87.stack[i + 1];
     // end of stack is nothing
-    _8087elems[_8087elems.length - 1] = ndp_zero;
+    global87.stack[$ - 1] = ndp_zero;
 }
 
 
@@ -247,26 +251,26 @@ void push87(ref CodeBuilder cdb) { push87(cdb,__LINE__,__FILE__); }
 void push87(ref CodeBuilder cdb, int line, const(char)* file)
 {
     // if we would lose the top register off of the stack
-    if (_8087elems[7].e != null)
+    if (global87.stack[7].e != null)
     {
         int i = getemptyslot();
-        NDP.save[i] = _8087elems[7];
+        NDP.save[i] = global87.stack[7];
         cdb.genf2(0xD9,0xF6);                         // FDECSTP
         genfwait(cdb);
-        ndp_fstp(cdb, i, _8087elems[7].e.Ety);       // FSTP i[BP]
-        assert(stackused == 8);
+        ndp_fstp(cdb, i, global87.stack[7].e.Ety);       // FSTP i[BP]
+        assert(global87.stackused == 8);
         if (NDPP) printf("push87() : overflow\n");
     }
     else
     {
-        if (NDPP) printf("push87(%s(%d): %d)\n", file, line, stackused);
-        stackused++;
-        assert(stackused <= 8);
+        if (NDPP) printf("push87(%s(%d): %d)\n", file, line, global87.stackused);
+        global87.stackused++;
+        assert(global87.stackused <= 8);
     }
     // Shift the stack up
     for (int i = 7; i > 0; i--)
-        _8087elems[i] = _8087elems[i - 1];
-    _8087elems[0] = ndp_zero;
+        global87.stack[i] = global87.stack[i - 1];
+    global87.stack[0] = ndp_zero;
 }
 
 /*****************************
@@ -281,25 +285,25 @@ void note87(elem *e, uint offset, int i)
 void note87(elem *e, uint offset, int i, int linnum)
 {
     if (NDPP)
-        printf("note87(e = %p.%d, i = %d, stackused = %d, line = %d)\n",e,offset,i,stackused,linnum);
+        printf("note87(e = %p.%d, i = %d, stackused = %d, line = %d)\n",e,offset,i,global87.stackused,linnum);
 
     static if (0)
     {
-        if (_8087elems[i].e)
-            printf("_8087elems[%d].e = %p\n",i,_8087elems[i].e);
+        if (global87.stack[i].e)
+            printf("global87.stack[%d].e = %p\n",i,global87.stack[i].e);
     }
 
-    debug if (i >= stackused)
+    debug if (i >= global87.stackused)
     {
-        printf("note87(e = %p.%d, i = %d, stackused = %d, line = %d)\n",e,offset,i,stackused,linnum);
+        printf("note87(e = %p.%d, i = %d, stackused = %d, line = %d)\n",e,offset,i,global87.stackused,linnum);
         elem_print(e);
     }
-    assert(i < stackused);
+    assert(i < global87.stackused);
 
     while (e.Eoper == OPcomma)
         e = e.EV.E2;
-    _8087elems[i].e = e;
-    _8087elems[i].offset = offset;
+    global87.stack[i].e = e;
+    global87.stack[i].offset = offset;
 }
 
 /****************************************************
@@ -310,9 +314,9 @@ void xchg87(int i, int j)
 {
     NDP save;
 
-    save = _8087elems[i];
-    _8087elems[i] = _8087elems[j];
-    _8087elems[j] = save;
+    save = global87.stack[i];
+    global87.stack[i] = global87.stack[j];
+    global87.stack[j] = save;
 }
 
 /****************************
@@ -335,12 +339,12 @@ private void makesure87(ref CodeBuilder cdb,elem *e,uint offset,int i,uint flag,
         e = e.EV.E2;
     assert(e && i < 4);
 L1:
-    if (_8087elems[i].e != e || _8087elems[i].offset != offset)
+    if (global87.stack[i].e != e || global87.stack[i].offset != offset)
     {
-        debug if (_8087elems[i].e)
-            printf("_8087elems[%d].e = %p, .offset = %d\n",i,_8087elems[i].e,_8087elems[i].offset);
+        debug if (global87.stack[i].e)
+            printf("global87.stack[%d].e = %p, .offset = %d\n",i,global87.stack[i].e,global87.stack[i].offset);
 
-        assert(_8087elems[i].e == null);
+        assert(global87.stack[i].e == null);
         int j;
         for (j = 0; 1; j++)
         {
@@ -371,7 +375,7 @@ L1:
         }
         NDP.save[j] = ndp_zero;                // back in 8087
     }
-    //_8087elems[i].e = null;
+    //global87.stack[i].e = null;
 }
 
 /****************************
@@ -381,15 +385,15 @@ L1:
 void save87(ref CodeBuilder cdb)
 {
     bool any = false;
-    while (_8087elems[0].e && stackused)
+    while (global87.stack[0].e && global87.stackused)
     {
         // Save it
         int i = getemptyslot();
-        if (NDPP) printf("saving %p in temporary NDP.save[%d]\n",_8087elems[0].e,i);
-        NDP.save[i] = _8087elems[0];
+        if (NDPP) printf("saving %p in temporary NDP.save[%d]\n",global87.stack[0].e,i);
+        NDP.save[i] = global87.stack[0];
 
         genfwait(cdb);
-        ndp_fstp(cdb,i,_8087elems[0].e.Ety); // FSTP i[BP]
+        ndp_fstp(cdb,i,global87.stack[0].e.Ety); // FSTP i[BP]
         pop87();
         any = true;
     }
@@ -405,29 +409,29 @@ void save87regs(ref CodeBuilder cdb, uint n)
 {
     assert(n <= 7);
     uint j = 8 - n;
-    if (stackused > j)
+    if (global87.stackused > j)
     {
         for (uint k = 8; k > j; k--)
         {
             cdb.genf2(0xD9,0xF6);     // FDECSTP
             genfwait(cdb);
-            if (k <= stackused)
+            if (k <= global87.stackused)
             {
                 int i = getemptyslot();
-                ndp_fstp(cdb, i, _8087elems[k - 1].e.Ety);   // FSTP i[BP]
-                NDP.save[i] = _8087elems[k - 1];
-                _8087elems[k - 1] = ndp_zero;
+                ndp_fstp(cdb, i, global87.stack[k - 1].e.Ety);   // FSTP i[BP]
+                NDP.save[i] = global87.stack[k - 1];
+                global87.stack[k - 1] = ndp_zero;
             }
         }
 
         for (uint k = 8; k > j; k--)
         {
-            if (k > stackused)
+            if (k > global87.stackused)
             {   cdb.genf2(0xD9,0xF7); // FINCSTP
                 genfwait(cdb);
             }
         }
-        stackused = j;
+        global87.stackused = j;
     }
 }
 
@@ -469,15 +473,15 @@ private int cse_get(elem *e, uint offset)
 
     for (i = 0; 1; i++)
     {
-        if (i == stackused)
+        if (i == global87.stackused)
         {
             i = -1;
             //printf("cse not found\n");
             //elem_print(e);
             break;
         }
-        if (_8087elems[i].e == e &&
-            _8087elems[i].offset == offset)
+        if (global87.stack[i].e == e &&
+            global87.stack[i].offset == offset)
         {   //printf("cse found %d\n",i);
             //elem_print(e);
             break;
@@ -1642,7 +1646,7 @@ void load87(ref CodeBuilder cdb,elem *e,uint eoffset,regm_t *pretregs,elem *elef
     int i;
 
     if (NDPP)
-        printf("+load87(e=%p, eoffset=%d, *pretregs=%s, eleft=%p, op=%d, stackused = %d)\n",e,eoffset,regm_str(*pretregs),eleft,op,stackused);
+        printf("+load87(e=%p, eoffset=%d, *pretregs=%s, eleft=%p, op=%d, stackused = %d)\n",e,eoffset,regm_str(*pretregs),eleft,op,global87.stackused);
 
     assert(!(NOSAHF && op == 3));
     elem_debug(e);
@@ -1720,7 +1724,7 @@ L5:
         case OPd_ld:
             mf1 = (tybasic(e.EV.E1.Ety) == TYfloat || tybasic(e.EV.E1.Ety) == TYifloat)
                     ? MFfloat : MFdouble;
-            if (op != -1 && stackused)
+            if (op != -1 && global87.stackused)
                 note87(eleft,eoffset,0);    // don't trash this value
             if (e.EV.E1.Eoper == OPvar || e.EV.E1.Eoper == OPind)
             {
@@ -1905,7 +1909,7 @@ L5:
     }
     fixresult87(cdb,e,((op == 3) ? mPSW : mST0),pretregs);
     if (NDPP)
-        printf("-load87(e=%p, eoffset=%d, *pretregs=%s, eleft=%p, op=%d, stackused = %d)\n",e,eoffset,regm_str(*pretregs),eleft,op,stackused);
+        printf("-load87(e=%p, eoffset=%d, *pretregs=%s, eleft=%p, op=%d, stackused = %d)\n",e,eoffset,regm_str(*pretregs),eleft,op,global87.stackused);
 }
 
 /********************************

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -28,6 +28,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.code;
 import dmd.backend.cgcse;
 import dmd.backend.code_x86;
@@ -218,7 +219,7 @@ tryagain:
     STACKALIGN = TARGET_STACKALIGN;
 
     regsave.reset();
-    memset(_8087elems.ptr,0,_8087elems.sizeof);
+    memset(global87.stack.ptr,0,global87.stack.sizeof);
 
     calledFinally = false;
     usednteh = 0;
@@ -243,7 +244,7 @@ tryagain:
     sfunc.Sfunc.Fflags3 |= Fnothrow;
 
     floatreg = false;
-    assert(stackused == 0);             /* nobody in 8087 stack         */
+    assert(global87.stackused == 0);             /* nobody in 8087 stack         */
 
     CSE.start();
     memset(&regcon,0,regcon.sizeof);
@@ -688,10 +689,10 @@ tryagain:
     sfunc.Sregsaved = (functy == TYifunc) ? cast(regm_t) mBP : (mfuncreg | fregsaved);
 
     debug
-    if (stackused != 0)
-      printf("stackused = %d\n",stackused);
+    if (global87.stackused != 0)
+      printf("stackused = %d\n",global87.stackused);
 
-    assert(stackused == 0);             /* nobody in 8087 stack         */
+    assert(global87.stackused == 0);             /* nobody in 8087 stack         */
 
     /* Clean up ndp save array  */
     mem_free(NDP.save);

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -26,6 +26,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
@@ -3877,7 +3878,7 @@ static if (0)
         cdb.genadjfpu(1);
         if (*pretregs)                  // if we want the result
         {
-            //assert(stackused == 0);
+            //assert(global87.stackused == 0);
             push87(cdb);                // one item on 8087 stack
             fixresult87(cdb,e,retregs,pretregs);
             return;
@@ -3891,7 +3892,7 @@ static if (0)
         cdb.genadjfpu(2);
         if (*pretregs)                  // if we want the result
         {
-            assert(stackused == 0);
+            assert(global87.stackused == 0);
             push87(cdb);
             push87(cdb);                // two items on 8087 stack
             fixresult_complex87(cdb, e, retregs, pretregs);

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -26,6 +26,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;
@@ -1976,8 +1977,8 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
 
     /* vars to save state of 8087 */
     int stackusedold,stackusedsave;
-    NDP[_8087elems.length] _8087old;
-    NDP[_8087elems.length] _8087save;
+    NDP[global87.stack.length] _8087old;
+    NDP[global87.stack.length] _8087save;
 
     //printf("cdcond(e = %p, *pretregs = %s)\n",e,regm_str(*pretregs));
     elem *e1 = e.EV.E1;
@@ -2168,9 +2169,9 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     code *cnop2 = gennop(null);         // dummy target addresses
     logexp(cdb,e1,false,FLcode,cnop1);  // evaluate condition
     regconold = regcon;
-    stackusedold = stackused;
+    stackusedold = global87.stackused;
     stackpushold = stackpush;
-    memcpy(_8087old.ptr,_8087elems.ptr,_8087elems.sizeof);
+    memcpy(_8087old.ptr,global87.stack.ptr,global87.stack.sizeof);
     regm_t retregs = *pretregs;
     CodeBuilder cdb1;
     cdb1.ctor();
@@ -2208,11 +2209,11 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     stackpushsave = stackpush;
     stackpush = stackpushold;
 
-    stackusedsave = stackused;
-    stackused = stackusedold;
+    stackusedsave = global87.stackused;
+    global87.stackused = stackusedold;
 
-    memcpy(_8087save.ptr,_8087elems.ptr,_8087elems.sizeof);
-    memcpy(_8087elems.ptr,_8087old.ptr,_8087elems.sizeof);
+    memcpy(_8087save.ptr,global87.stack.ptr,global87.stack.sizeof);
+    memcpy(global87.stack.ptr,_8087old.ptr,global87.stack.sizeof);
 
     retregs |= psw;                     // PSW bit may have been trashed
     CodeBuilder cdb2;
@@ -2230,9 +2231,9 @@ void cdcond(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
     *pretregs = retregs | psw;
     andregcon(&regconold);
     andregcon(&regconsave);
-    assert(stackused == stackusedsave);
+    assert(global87.stackused == stackusedsave);
     assert(stackpush == stackpushsave);
-    memcpy(_8087elems.ptr,_8087save.ptr,_8087elems.sizeof);
+    memcpy(global87.stack.ptr,_8087save.ptr,global87.stack.sizeof);
     freenode(e2);
     genjmp(cdb,JMP,FLcode,cast(block *) cnop2);
     cdb.append(cnop1);

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -26,6 +26,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.cgcse;
 import dmd.backend.code;
 import dmd.backend.code_x86;
@@ -1150,11 +1151,11 @@ static if (NTEXCEPTIONS)
             gencodelem(cdb,e,&retregs,true);
         L4:
             if (retregs == mST0)
-            {   assert(stackused == 1);
+            {   assert(global87.stackused == 1);
                 pop87();                // account for return value
             }
             else if (retregs == mST01)
-            {   assert(stackused == 2);
+            {   assert(global87.stackused == 2);
                 pop87();
                 pop87();                // account for return value
             }

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -636,7 +636,6 @@ void cnvt87(ref CodeBuilder cdb, elem *e , regm_t *pretregs );
 void neg87(ref CodeBuilder cdb, elem *e , regm_t *pretregs);
 void neg_complex87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdind87(ref CodeBuilder cdb,elem *e,regm_t *pretregs);
-extern __gshared { int stackused; }
 void cload87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdd_u64(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs);

--- a/src/dmd/backend/code_x86.d
+++ b/src/dmd/backend/code_x86.d
@@ -562,8 +562,6 @@ struct NDP
     __gshared int savetop;         // # of entries used in save[]
 }
 
-extern __gshared NDP[8] _8087elems;
-
 void getlvalue_msw(code *);
 void getlvalue_lsw(code *);
 void getlvalue(ref CodeBuilder cdb, code *pcs, elem *e, regm_t keepmsk);


### PR DESCRIPTION
Removed the 8087 extern global variable declarations from the `code.d`/`code_x86.d` header modules.  The frontend does not need access to these variables.  I also put them inside a struct called `global87` which makes it easy to see that these are global variables when accessed throughout other code in the backend. And lastly I added the default `private:` specifier to `cg87.d`.

Moving the variables into the `global87` struct causes most of the turmoil, if it's too much I can leave the existing names of `_8087elems` and `stackused` rather than the new `global87.stack` and `global87.stackused`.

These changes help maintaining developers know that these global variables are only used internally by the backend meaning they don't need to look anywhere else to see if they are being modified, and also helps the developer know which variables are globals.