### PR TITLE
[stable]  Fixup PR 10256: Properly nest substituted C++ names in N..E

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -812,7 +812,6 @@ private final class CppMangleVisitor : Visitor
                         isChar((*ti.tiargs)[0]) &&
                         isChar_traits_char((*ti.tiargs)[1]) &&
                         isAllocator_char((*ti.tiargs)[2]))
-
                     {
                         buf.writestring("Ss");
                         return;

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -236,6 +236,21 @@ private final class CppMangleVisitor : Visitor
         }
     }
 
+    /**
+     * Attempt to perform substitution on `p`
+     *
+     * If `p` already appeared in the mangling, it is stored as
+     * a 'part', and short references in the form of `SX_` can be used.
+     * Note that `p` can be anything: template declaration, struct declaration,
+     * class declaration, namespace...
+     *
+     * Params:
+     *   p = The object to attempt to substitute
+     *
+     * Returns:
+     *   Whether `p` already appeared in the mangling,
+     *   and substitution has been written to `this.buf`.
+     */
     bool substitute(RootObject p)
     {
         //printf("substitute %s\n", p ? p.toChars() : null);

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1166,5 +1166,5 @@ version (Posix)
     }
 
     extern(C++) void test20094(xvector20094!(V20094)* v);
-    static assert(test20094.mangleof == `_Z9test20094PN7ns2009412xvector20094IS0_IhEEE`);
+    static assert(test20094.mangleof == `_Z9test20094PN7ns2009412xvector20094INS0_IhEEEE`);
 }


### PR DESCRIPTION
So there was another regression in issue 20094 which I missed while working on https://github.com/dlang/dmd/pull/10256
This fixes it. Tested with our project which integrate with a modern (C++17) code base, everything passes.