### PR TITLE
Report code coverage for the backend

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -306,7 +306,12 @@ endif
 
 ifneq (gdc, $(HOST_DMD_KIND))
   BACK_MV = -mv=dmd.backend=$C
+# Don't enable -betterC for compiling the backend for coverage reports
+ifndef ENABLE_COVERAGE
   BACK_BETTERC = $(BACK_MV) -betterC
+else
+  BACK_BETTERC = $(BACK_MV)
+endif
   # gdmd doesn't support -dip25
   override DFLAGS  += -dip25
 endif


### PR DESCRIPTION
Some files are already there as they are compiled without `-betterC`:

https://codecov.io/gh/dlang/dmd/tree/master/src/dmd/backend