### PR TITLE
Fix Issue 809 - Should be possible to convert lazy argument to delegate

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3422,6 +3422,7 @@ extern (C++) final class SymOffExp : SymbolExp
  */
 extern (C++) final class VarExp : SymbolExp
 {
+    bool delegateWasExtracted;
     extern (D) this(const ref Loc loc, Declaration var, bool hasOverloads = true)
     {
         if (var.isVarDeclaration())
@@ -3473,7 +3474,7 @@ extern (C++) final class VarExp : SymbolExp
             error("manifest constant `%s` cannot be modified", var.toChars());
             return new ErrorExp();
         }
-        if (var.storage_class & STC.lazy_)
+        if (var.storage_class & STC.lazy_ && !delegateWasExtracted)
         {
             error("lazy variable `%s` cannot be modified", var.toChars());
             return new ErrorExp();

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -569,6 +569,7 @@ public:
 class VarExp : public SymbolExp
 {
 public:
+    bool delegateWasExtracted;
     static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = true);
     bool equals(RootObject *o);
     int checkModifiable(Scope *sc, int flag);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1297,15 +1297,13 @@ private Expression resolvePropertiesX(Scope* sc, Expression e1, Expression e2 = 
     if (e1.type && e1.op != TOK.type) // function type is not a property
     {
         /* Look for e1 being a lazy parameter; rewrite as delegate call
+         * only if the symbol wasn't already treated as a delegate
          */
-        if (e1.op == TOK.variable)
+        auto ve = e1.isVarExp();
+        if (ve && ve.var.storage_class & STC.lazy_ && !ve.delegateWasExtracted)
         {
-            VarExp ve = cast(VarExp)e1;
-            if (ve.var.storage_class & STC.lazy_)
-            {
                 Expression e = new CallExp(loc, e1);
                 return e.expressionSemantic(sc);
-            }
         }
         else if (e1.op == TOK.dotVariable)
         {
@@ -6228,6 +6226,35 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                 }
             }
         }
+        /* https://issues.dlang.org/show_bug.cgi?id=809
+         *
+         * If the address of a lazy variable is taken,
+         * the expression is rewritten so that the type
+         * of it is the delegate type. This means that
+         * the symbol is not going to represent a call
+         * to the delegate anymore, but rather, the
+         * actual symbol.
+         */
+        if (auto ve = exp.e1.isVarExp())
+        {
+            if (ve.var.storage_class & STC.lazy_)
+            {
+                exp.e1 = exp.e1.expressionSemantic(sc);
+                exp.e1 = resolveProperties(sc, exp.e1);
+                if (auto callExp = exp.e1.isCallExp())
+                {
+                    if (callExp.e1.type.toBasetype().ty == Tdelegate)
+                    {
+                        VarExp ve2 = callExp.e1.isVarExp();
+                        ve2.delegateWasExtracted = true;
+                        ve2.var.storage_class |= STC.scope_;
+                        result = ve2;
+                        return;
+                    }
+                }
+            }
+        }
+
         exp.e1 = exp.e1.toLvalue(sc, null);
         if (exp.e1.op == TOK.error)
         {

--- a/test/fail_compilation/fail809.d
+++ b/test/fail_compilation/fail809.d
@@ -1,0 +1,12 @@
+// REQUIRED_ARGS: -dip1000
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail809.d(11): Error: scope variable `dg_` may not be returned
+---
+*/
+@safe int delegate() test(lazy int dg)
+{
+    int delegate() dg_ = &dg;
+    return dg_;
+}

--- a/test/runnable/test809.d
+++ b/test/runnable/test809.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=809
+/* TEST_OUTPUT:
+---
+---
+*/
+
+void test(lazy int dg)
+{
+    int delegate() dg_ = &dg;
+    assert(dg_() == 7);
+    assert(dg == dg_());
+}
+
+void main()
+{
+    int a = 7;
+    test(a);
+}


### PR DESCRIPTION
`&dg` will extract the delegate, if `dg` is an lazy argument. I'm not sure if this needs a spec PR or not; if it does, where would it be appropriate to add it? Maybe the lazy parameters section [1]?

[1] https://dlang.org/spec/function.html#lazy-params