### PR TITLE
Add hasElaborateCopyConstructor trait

### DIFF
--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -591,6 +591,23 @@ extern (C++) class StructDeclaration : AggregateDeclaration
         return (ispod == StructPOD.yes);
     }
 
+    /***************************************
+     * Determine if `struct` has an elaborate copy constructor.
+     *
+     * A `struct` has an elaborate copy constructor if:
+     *      $(OL
+     *      $(LI has a copy constructor)
+     *      $(LI or has postblit)
+     *      )
+     *
+     * Returns:
+     *     `true` if struct has an elaborate copy constructor
+     */
+    final bool hasElaborateCopyCtor()
+    {
+        return postblit || hasCopyCtor;
+    }
+
     override final inout(StructDeclaration) isStructDeclaration() inout
     {
         return this;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -431,7 +431,7 @@ private Expression callCpCtor(Scope* sc, Expression e, Type destinationType)
     if (auto ts = e.type.baseElemOf().isTypeStruct())
     {
         StructDeclaration sd = ts.sym;
-        if (sd.postblit || sd.hasCopyCtor)
+        if (sd.hasElaborateCopyCtor())
         {
             /* Create a variable tmp, and replace the argument e with:
              *      (tmp = e),tmp

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8409,7 +8409,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         result = e;
                         return;
                     }
-                    if (sd.postblit || sd.hasCopyCtor)
+                    if (sd.hasElaborateCopyCtor())
                     {
                         /* We have a copy constructor for this
                          */

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -431,6 +431,7 @@ immutable Msgtable[] msgtable =
     { "isZeroInit" },
     { "getTargetInfo" },
     { "getLocation" },
+    { "hasElaborateCopyConstructor" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -144,6 +144,7 @@ shared static this()
         "isZeroInit",
         "getTargetInfo",
         "getLocation",
+        "hasElaborateCopyConstructor"
     ];
 
     traitsStringTable._init(names.length);
@@ -596,7 +597,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 sm => sm.isTemplateDeclaration() !is null) != 0;
         });
     }
-    if (e.ident == Id.isPOD)
+    if (e.ident == Id.isPOD ||
+        e.ident == Id.hasElaborateCopyConstructor)
     {
         if (dim != 1)
             return dimError(1);
@@ -613,7 +615,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         Type tb = t.baseElemOf();
         if (auto sd = tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null)
         {
-            return sd.isPOD() ? True() : False();
+            if (e.ident == Id.isPOD)
+            {
+                return sd.isPOD() ? True() : False();
+            }
+            else if (e.ident == Id.hasElaborateCopyConstructor)
+            {
+                return sd.hasCopyCtor ? True() : False();
+            }
         }
         return True();
     }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -597,8 +597,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 sm => sm.isTemplateDeclaration() !is null) != 0;
         });
     }
-    if (e.ident == Id.isPOD ||
-        e.ident == Id.hasElaborateCopyConstructor)
+    if (e.ident == Id.isPOD)
     {
         if (dim != 1)
             return dimError(1);
@@ -615,16 +614,30 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         Type tb = t.baseElemOf();
         if (auto sd = tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null)
         {
-            if (e.ident == Id.isPOD)
-            {
-                return sd.isPOD() ? True() : False();
-            }
-            else if (e.ident == Id.hasElaborateCopyConstructor)
-            {
-                return sd.hasCopyCtor ? True() : False();
-            }
+            return sd.isPOD() ? True() : False();
         }
         return True();
+    }
+    if (e.ident == Id.hasElaborateCopyConstructor)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        auto o = (*e.args)[0];
+        auto t = isType(o);
+        if (!t)
+        {
+            e.error("type expected as second argument of __traits `%s` instead of `%s`",
+                e.ident.toChars(), o.toChars());
+            return new ErrorExp();
+        }
+
+        Type tb = t.baseElemOf();
+        if (auto sd = tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null)
+        {
+            return sd.hasCopyCtor || sd.postblit ? True() : False();
+        }
+        return False();
     }
     if (e.ident == Id.isNested)
     {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -635,7 +635,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         Type tb = t.baseElemOf();
         if (auto sd = tb.ty == Tstruct ? (cast(TypeStruct)tb).sym : null)
         {
-            return sd.hasCopyCtor || sd.postblit ? True() : False();
+            return sd.hasElaborateCopyCtor() ? True() : False();
         }
         return False();
     }

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -101,6 +101,8 @@ struct OuterS
     {
         this (ref S rhs) {}
     }
+
+    S s;
 }
 
 void foo(T)()
@@ -112,19 +114,28 @@ void foo(T)()
     static assert (__traits(hasElaborateCopyConstructor, S!int));
 }
 
-struct U(T) {
+struct U(T)
+{
     this (ref U rhs) {}
 }
 
-struct SPostblit {
+struct SPostblit
+{
     this(this) {}
 }
 
+struct NoCpCtor { }
+class C19902 { }
+
 static assert(__traits(hasElaborateCopyConstructor, S));
 static assert(__traits(hasElaborateCopyConstructor, OuterS.S));
+static assert(__traits(hasElaborateCopyConstructor, OuterS));
 static assert(__traits(compiles, foo!int));
 static assert(__traits(compiles, foo!S));
 static assert(__traits(hasElaborateCopyConstructor, U!int));
 static assert(__traits(hasElaborateCopyConstructor, U!S));
+static assert(__traits(hasElaborateCopyConstructor, SPostblit));
 
-static assert(!__traits(hasElaborateCopyConstructor, SPostblit));
+static assert(!__traits(hasElaborateCopyConstructor, NoCpCtor));
+static assert(!__traits(hasElaborateCopyConstructor, C19902));
+static assert(!__traits(hasElaborateCopyConstructor, int));

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -139,3 +139,7 @@ static assert(__traits(hasElaborateCopyConstructor, SPostblit));
 static assert(!__traits(hasElaborateCopyConstructor, NoCpCtor));
 static assert(!__traits(hasElaborateCopyConstructor, C19902));
 static assert(!__traits(hasElaborateCopyConstructor, int));
+
+// Check that invalid use cases don't compile
+static assert(!__traits(compiles, __traits(hasElaborateCopyConstructor)));
+static assert(!__traits(compiles, __traits(hasElaborateCopyConstructor, S())));

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -86,3 +86,45 @@ struct Outer
 static assert(__traits(getLocation, Outer.Nested)[1] == 82);
 static assert(__traits(getLocation, Outer.method)[1] == 84);
 
+/******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19902
+// Define hasElaborateCopyConstructor trait
+
+struct S
+{
+    this (ref S rhs) {}
+}
+
+struct OuterS
+{
+    struct S
+    {
+        this (ref S rhs) {}
+    }
+}
+
+void foo(T)()
+{
+    struct S(U)
+    {
+        this (ref S rhs) {}
+    }
+    static assert (__traits(hasElaborateCopyConstructor, S!int));
+}
+
+struct U(T) {
+    this (ref U rhs) {}
+}
+
+struct SPostblit {
+    this(this) {}
+}
+
+static assert(__traits(hasElaborateCopyConstructor, S));
+static assert(__traits(hasElaborateCopyConstructor, OuterS.S));
+static assert(__traits(compiles, foo!int));
+static assert(__traits(compiles, foo!S));
+static assert(__traits(hasElaborateCopyConstructor, U!int));
+static assert(__traits(hasElaborateCopyConstructor, U!S));
+
+static assert(!__traits(hasElaborateCopyConstructor, SPostblit));


### PR DESCRIPTION
This was requested in this druntime [PR](https://github.com/dlang/druntime/pull/2709).

Exposing this behaviour straight from the compiler has two benefits:

1. First, and most important imho, it avoids the risk of missing a corner case in the library implementation
2. It significantly simplifies the library implementation

EDIT:

~~Please note that this trait returns `false` for types that have a `postblit`. Open question: should it return true?~~

After some further consideration I think that structures that define a `postblit` should also be considered to have an elaborate copy constructor. After all, this is what the library implementation do, so, imho, it would be confusing for the users for the trait to be different.
