### PR TITLE
 Fix issue 20033 - Deprecation do not trigger on `alias this`

### DIFF
--- a/changelog/deprecated_alias_this.dd
+++ b/changelog/deprecated_alias_this.dd
@@ -1,0 +1,4 @@
+`deprecated` now applies to `alias this` as well
+
+Before this release, `deprecated` on `alias this` was accepted by the parser
+but did not trigger a deprecation mesage on usage.

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -15,6 +15,7 @@ module dmd.aggregate;
 import core.stdc.stdio;
 import core.checkedint;
 
+import dmd.aliasthis;
 import dmd.arraytypes;
 import dmd.gluelayer : Symbol;
 import dmd.declaration;
@@ -108,7 +109,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     // it would be stored in TypeInfo_Class.defaultConstructor
     CtorDeclaration defaultCtor;
 
-    Dsymbol aliasthis;      // forward unresolved lookups to aliasthis
+    AliasThis aliasthis;    // forward unresolved lookups to aliasthis
     bool noDefaultCtor;     // no default construction
 
     DtorDeclarations dtors; // Array of destructors

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -13,6 +13,7 @@
 #include "dsymbol.h"
 #include "objc.h"
 
+class AliasThis;
 class Identifier;
 class Type;
 class TypeFunction;
@@ -108,7 +109,7 @@ public:
     // it would be stored in TypeInfo_Class.defaultConstructor
     CtorDeclaration *defaultCtor;
 
-    Dsymbol *aliasthis;         // forward unresolved lookups to aliasthis
+    AliasThis *aliasthis;       // forward unresolved lookups to aliasthis
     bool noDefaultCtor;         // no default construction
 
     DtorDeclarations dtors;     // Array of destructors

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -31,6 +31,8 @@ import dmd.visitor;
 extern (C++) final class AliasThis : Dsymbol
 {
     Identifier ident;
+    /// The symbol this `alias this` resolves to
+    Dsymbol sym;
 
     extern (D) this(const ref Loc loc, Identifier ident)
     {
@@ -71,7 +73,7 @@ Expression resolveAliasThis(Scope* sc, Expression e, bool gag = false)
             Type tthis = (e.op == TOK.type ? e.type : null);
             e = new DotIdExp(loc, e, ad.aliasthis.ident);
             e = e.expressionSemantic(sc);
-            if (tthis && ad.aliasthis.needThis())
+            if (tthis && ad.aliasthis.sym.needThis())
             {
                 if (e.op == TOK.variable)
                 {

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -21,9 +21,11 @@ public:
    // alias Identifier this;
     Identifier *ident;
     Dsymbol    *sym;
+    bool       isDeprecated_;
 
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;
     AliasThis *isAliasThis() { return this; }
     void accept(Visitor *v) { v->visit(this); }
+    bool isDeprecated() const { return this->isDeprecated_; }
 };

--- a/src/dmd/aliasthis.h
+++ b/src/dmd/aliasthis.h
@@ -20,6 +20,7 @@ class AliasThis : public Dsymbol
 public:
    // alias Identifier this;
     Identifier *ident;
+    Dsymbol    *sym;
 
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -377,7 +377,7 @@ struct Scope
             if (!ad || !ad.aliasthis)
                 return null;
 
-            Declaration decl = ad.aliasthis.isDeclaration();
+            Declaration decl = ad.aliasthis.sym.isDeclaration();
             if (!decl)
                 return null;
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -669,6 +669,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
 
         dsym.semanticRun = PASS.semantic;
+        dsym.isDeprecated_ = !!(sc.stc & STC.deprecated_);
 
         Dsymbol p = sc.parent.pastMixin();
         AggregateDeclaration ad = p.isAggregateDeclaration();

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -723,7 +723,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             }
         }
 
-        ad.aliasthis = s;
+        dsym.sym = s;
+        // Restore alias this
+        ad.aliasthis = dsym;
         dsym.semanticRun = PASS.semanticdone;
     }
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -290,7 +290,7 @@ extern (C++) TupleDeclaration isAliasThisTuple(Expression e)
         {
             if (auto ad = s.isAggregateDeclaration())
             {
-                s = ad.aliasthis;
+                s = ad.aliasthis ? ad.aliasthis.sym : null;
                 if (s && s.isVarDeclaration())
                 {
                     TupleDeclaration td = s.isVarDeclaration().toAlias().isTupleDeclaration();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2024,7 +2024,7 @@ extern (C++) abstract class Type : ASTNode
         if (!ad || !ad.aliasthis)
             return null;
 
-        auto s = ad.aliasthis;
+        auto s = ad.aliasthis.sym;
         if (s.isAliasDeclaration())
             s = s.toAlias();
 

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1099,11 +1099,11 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
 
                     if (ad1.fields.dim == 1 || (ad1.fields.dim == 2 && ad1.vthis))
                     {
-                        auto var = ad1.aliasthis.isVarDeclaration();
+                        auto var = ad1.aliasthis.sym.isVarDeclaration();
                         if (var && var.type == ad1.fields[0].type)
                             return;
 
-                        auto func = ad1.aliasthis.isFuncDeclaration();
+                        auto func = ad1.aliasthis.sym.isFuncDeclaration();
                         auto tf = cast(TypeFunction)(func.type);
                         if (tf.isref && ad1.fields[0].type == tf.next)
                             return;

--- a/test/fail_compilation/fail20033.d
+++ b/test/fail_compilation/fail20033.d
@@ -1,0 +1,52 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20033.d(36): Deprecation: `alias byKeyValue this` is deprecated - This was a bad idea
+fail_compilation/fail20033.d(37): Deprecation: `alias byKeyValue this` is deprecated
+fail_compilation/fail20033.d(39): Deprecation: `alias byKeyValue this` is deprecated - This was a bad idea
+fail_compilation/fail20033.d(40): Deprecation: `alias byKeyValue this` is deprecated
+---
+*/
+#line 1
+struct Test {
+    import std.typecons : Tuple;
+    alias KVT = Tuple!(string, "key", string, "value");
+
+    struct Range {
+        bool empty () { return false; }
+        KVT front() { return KVT.init; }
+        void popFront() {}
+    }
+
+    auto byKeyValue () { return Range.init; }
+
+    deprecated("This was a bad idea")
+    alias byKeyValue this;
+}
+
+struct Test2 {
+    import std.typecons : Tuple;
+    alias KVT = Tuple!(string, "key", string, "value");
+
+    struct Range {
+        bool empty () { return false; }
+        KVT front() { return KVT.init; }
+        void popFront() {}
+    }
+
+    auto byKeyValue () { return Range.init; }
+
+    deprecated alias byKeyValue this;
+}
+
+void main ()
+{
+    foreach (k, v; Test.init.byKeyValue) {} // Fine
+    foreach (k, v; Test2.init.byKeyValue) {} // Fine
+    foreach (k, v; Test.init) {} // Fails
+    foreach (k, v; Test2.init) {} // Fails
+
+    auto f1 = Test.init.front(); // Fails
+    auto f2 = Test2.init.front(); // Fails
+}


### PR DESCRIPTION
```
Before this change, `deprecated` on `alias this` was accepted by the parser
but silently ignored in semantic - as `Dsymbol` is never `deprecated`,
it is done through `Declaration` and derivatives
(`Dsymbol` does not have `storage_class`).

This fixes `alias this` to correctly trigger a deprecation message on usage.
```