### PR TITLE
cgobj, cgsched: Fix indentation

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -418,8 +418,9 @@ public seg_data **SegData;
  *      reclen  =       # of bytes in record
  */
 
-void objrecord(uint rectyp,const(char)* record,uint reclen)
-{   Outbuffer *o = obj.buf;
+void objrecord(uint rectyp, const(char)* record, uint reclen)
+{
+    Outbuffer *o = obj.buf;
 
     //printf("rectyp = x%x, record[0] = x%x, reclen = x%x\n",rectyp,record[0],reclen);
     o.reserve(reclen + 4);
@@ -496,7 +497,8 @@ int insidx(char *p,uint index)
      * "library is corrupted" messages. Unverified. See Bugzilla 3601
      */
     if (index < 0x7F)
-    {   *p = cast(char)index;
+    {
+        *p = cast(char)index;
         return 1;
     }
     else if (index <= 0x7FFF)
@@ -506,7 +508,8 @@ int insidx(char *p,uint index)
         return 2;
     }
     else
-    {   too_many_symbols();
+    {
+        too_many_symbols();
         return 0;
     }
 }
@@ -926,7 +929,8 @@ static if (TERMCODE)
 
         // Update any out-of-date far segment sizes
         for (size_t i = 0; i <= seg_count; i++)
-        {   seg_data *f = SegData[i];
+        {
+            seg_data* f = SegData[i];
             if (f.isfarseg && f.origsize != f.SDoffset)
             {   obj.buf.setsize(cast(int)f.seek);
                 objsegdef(f.attr,f.SDoffset,f.lnameidx,f.classidx);
@@ -983,7 +987,8 @@ else
                 (!(srcpos_sfile(srcpos).SFflags & SFtop) || (seg_is_comdat(SegData[seg].segidx) && !obj.term));
 }
     if (cond)
-    {   // Not original source file, or a COMDAT.
+    {
+        // Not original source file, or a COMDAT.
         // Save data away and deal with it at close of compile.
         // It is done this way because presumably 99% of the lines
         // will be in the original source file, so we wish to minimize
@@ -1036,35 +1041,38 @@ else version (SCPP)
             linnum_flush();
 
         if (!obj.linrec)                        // if not allocated
-        {       obj.linrec = cast(char *) mem_calloc(LINRECMAX);
-                obj.linrec[0] = 0;              // base group / flags
-                obj.linrecheader = 1 + insidx(obj.linrec + 1,seg_is_comdat(SegData[seg].segidx) ? obj.pubnamidx : SegData[seg].segidx);
-                obj.linreci = obj.linrecheader;
-                obj.recseg = seg;
+        {
+            obj.linrec = cast(char* ) mem_calloc(LINRECMAX);
+            obj.linrec[0] = 0;              // base group / flags
+            obj.linrecheader = 1 + insidx(obj.linrec + 1,seg_is_comdat(SegData[seg].segidx) ? obj.pubnamidx : SegData[seg].segidx);
+            obj.linreci = obj.linrecheader;
+            obj.recseg = seg;
 static if (MULTISCOPE)
 {
-                if (!obj.linvec)
-                {   obj.linvec = vec_calloc(1000);
-                    obj.offvec = vec_calloc(1000);
-                }
+            if (!obj.linvec)
+            {
+                obj.linvec = vec_calloc(1000);
+                obj.offvec = vec_calloc(1000);
+            }
 }
-                if (linos2)
-                {
-                    if (!obj.linreclist)        // if first line number record
-                        obj.linreci += 8;       // leave room for header
-                    list_append(&obj.linreclist,obj.linrec);
-                }
+            if (linos2)
+            {
+                if (!obj.linreclist)        // if first line number record
+                    obj.linreci += 8;       // leave room for header
+                list_append(&obj.linreclist,obj.linrec);
+            }
 
-                // Select record type to use
-                obj.mlinnum = seg_is_comdat(SegData[seg].segidx) ? LINSYM : LINNUM;
-                if (I32 && !(config.flags & CFGeasyomf))
-                    obj.mlinnum++;
+            // Select record type to use
+            obj.mlinnum = seg_is_comdat(SegData[seg].segidx) ? LINSYM : LINNUM;
+            if (I32 && !(config.flags & CFGeasyomf))
+                obj.mlinnum++;
         }
         else if (obj.linreci > LINRECMAX - (2 + _tysize[TYint]))
-        {       objrecord(obj.mlinnum,obj.linrec,obj.linreci);  // output data
-                obj.linreci = obj.linrecheader;
-                if (seg_is_comdat(SegData[seg].segidx))        // if LINSYM record
-                    obj.linrec[0] |= 1;         // continuation bit
+        {
+            objrecord(obj.mlinnum,obj.linrec,obj.linreci);  // output data
+            obj.linreci = obj.linrecheader;
+            if (seg_is_comdat(SegData[seg].segidx))        // if LINSYM record
+                obj.linrec[0] |= 1;         // continuation bit
         }
 static if (MULTISCOPE)
 {
@@ -1095,7 +1103,8 @@ static if (MULTISCOPE)
 }
             TOWORD(obj.linrec + obj.linreci,linnum);
             if (linos2)
-            {   obj.linrec[obj.linreci + 2] = 1;        // source file index
+            {
+                obj.linrec[obj.linreci + 2] = 1;        // source file index
                 TOLONG(obj.linrec + obj.linreci + 4,cast(uint)offset);
                 obj.linrecnum++;
                 obj.linreci += 8;
@@ -1116,22 +1125,26 @@ static if (MULTISCOPE)
 private void linnum_flush()
 {
     if (obj.linreclist)
-    {   list_t list;
+    {
+        list_t list;
         size_t len;
 
         obj.linrec = cast(char *) list_ptr(obj.linreclist);
         TOWORD(obj.linrec + 6,obj.linrecnum);
         list = obj.linreclist;
         while (1)
-        {   obj.linrec = cast(char *) list_ptr(list);
+        {
+            obj.linrec = cast(char *) list_ptr(list);
 
             list = list_next(list);
             if (list)
-            {   objrecord(obj.mlinnum,obj.linrec,LINRECMAX);
+            {
+                objrecord(obj.mlinnum,obj.linrec,LINRECMAX);
                 mem_free(obj.linrec);
             }
             else
-            {   objrecord(obj.mlinnum,obj.linrec,obj.linreci);
+            {
+                objrecord(obj.mlinnum,obj.linrec,obj.linreci);
                 break;
             }
         }
@@ -1149,7 +1162,8 @@ private void linnum_flush()
         obj.linrec = null;
     }
     else if (obj.linrec)                        // if some line numbers to send
-    {   objrecord(obj.mlinnum,obj.linrec,obj.linreci);
+    {
+        objrecord(obj.mlinnum,obj.linrec,obj.linreci);
         mem_free(obj.linrec);
         obj.linrec = null;
     }
@@ -1165,7 +1179,8 @@ static if (MULTISCOPE)
  */
 
 private void linnum_term()
-{   list_t ll;
+{
+    list_t ll;
 
 version (SCPP)
     Sfile *lastfilptr = null;
@@ -1279,9 +1294,10 @@ void OmfObj_startaddress(Symbol *s)
  */
 
 void OmfObj_dosseg()
-{   static immutable char[2] dosseg = [ 0x80,0x9E ];
+{
+    static immutable char[2] dosseg = [ 0x80,0x9E ];
 
-    objrecord(COMENT,dosseg.ptr,dosseg.sizeof);
+    objrecord(COMENT, dosseg.ptr, dosseg.sizeof);
 }
 
 /*******************************
@@ -1311,7 +1327,8 @@ private void obj_comment(ubyte x, const(char)* string, size_t len)
  */
 
 bool OmfObj_includelib(const(char)* name)
-{   const(char)* p;
+{
+    const(char)* p;
     size_t len = strlen(name);
 
     p = filespecdotext(name);
@@ -1451,7 +1468,8 @@ void OmfObj_wkext(Symbol *s1,Symbol *s2)
  */
 
 void OmfObj_lzext(Symbol *s1,Symbol *s2)
-{   char[2+2+2] buffer = void;
+{
+    char[2+2+2] buffer = void;
     int i;
 
     outextdata();
@@ -1468,8 +1486,9 @@ void OmfObj_lzext(Symbol *s1,Symbol *s2)
  */
 
 void OmfObj_alias(const(char)* n1,const(char)* n2)
-{   uint len;
-    char *buffer;
+{
+    uint len;
+    char* buffer;
 
     buffer = cast(char *) alloca(strlen(n1) + strlen(n2) + 2 * ONS_OHD);
     len = obj_namestring(buffer,n1);
@@ -1537,9 +1556,9 @@ private void objheader(char *csegname)
         "\07$$TYPES\06DEBTYP\011$$SYMBOLS\06DEBSYM";
     assert(lnames[lnames.length - 2] == 'M');
 
-  // Include debug segment names if inserting type information
-  int lnamesize = config.fulltypes ? lnames.sizeof - 1 : lnames.sizeof - 1 - 32;
-  int texti = 8;                                // index of _TEXT
+    // Include debug segment names if inserting type information
+    int lnamesize = config.fulltypes ? lnames.sizeof - 1 : lnames.sizeof - 1 - 32;
+    int texti = 8;                                // index of _TEXT
 
     __gshared char[5] comment = [0,0x9D,'0','?','O']; // memory model
     __gshared char[5+1] model = "smclv";
@@ -1547,7 +1566,8 @@ private void objheader(char *csegname)
     __gshared char[7] pmdeb = [0x80,0xA1,1,'H','L','L',0];    // IBM PM debug format
 
     if (I32)
-    {   if (config.flags & CFGeasyomf)
+    {
+        if (config.flags & CFGeasyomf)
         {
             // Indicate we're in EASY OMF (hah!) format
             static immutable char[7] easy_omf = [ 0x80,0xAA,'8','0','3','8','6' ];
@@ -1555,32 +1575,34 @@ private void objheader(char *csegname)
         }
     }
 
-  // Send out a comment record showing what memory model was used
-  comment[2] = cast(char)(config.target_cpu + '0');
-  comment[3] = model[config.memmodel];
-  if (I32)
-  {     if (config.exe == EX_WIN32)
+    // Send out a comment record showing what memory model was used
+    comment[2] = cast(char)(config.target_cpu + '0');
+    comment[3] = model[config.memmodel];
+    if (I32)
+    {
+        if (config.exe == EX_WIN32)
             comment[3] = 'n';
         else if (config.exe == EX_OS2)
             comment[3] = 'f';
         else
             comment[3] = 'x';
-  }
-  objrecord(COMENT,comment.ptr,comment.sizeof);
+    }
+    objrecord(COMENT,comment.ptr,comment.sizeof);
 
     // Send out comment indicating we're using extensions to .OBJ format
     if (config.exe == EX_OS2)
-        objrecord(COMENT,pmdeb.ptr,pmdeb.sizeof);
+        objrecord(COMENT, pmdeb.ptr, pmdeb.sizeof);
     else
-        objrecord(COMENT,exten.ptr,exten.sizeof);
+        objrecord(COMENT, exten.ptr, exten.sizeof);
 
     // Change DGROUP to FLAT if we are doing flat memory model
     // (Watch out, objheader() is called twice!)
     if (config.exe & EX_flat)
     {
         if (lnames[2] != 'F')                   // do not do this twice
-        {   memcpy(lnames.ptr + 1,"\04FLAT".ptr,5);
-            memmove(lnames.ptr + 6,lnames.ptr + 8,lnames.sizeof - 8);
+        {
+            memcpy(lnames.ptr + 1, "\04FLAT".ptr, 5);
+            memmove(lnames.ptr + 6, lnames.ptr + 8, lnames.sizeof - 8);
         }
         lnamesize -= 2;
         texti -= 2;
@@ -1609,12 +1631,14 @@ private void objheader(char *csegname)
  *      mem_malloc'd code seg name
  */
 
-private char * objmodtoseg(const(char)* modname)
-{   char *csegname = null;
+private char*  objmodtoseg(const(char)* modname)
+{
+    char* csegname = null;
 
     if (LARGECODE)              // if need to add in module name
-    {   int i;
-        char *m;
+    {
+        int i;
+        char* m;
         static immutable char[6] suffix = "_TEXT";
 
         // Prepend the module name to the beginning of the _TEXT
@@ -1642,7 +1666,8 @@ private void objsegdef(int attr,targ_size_t size,int segnamidx,int classnamidx)
       //attr,size,segnamidx,classnamidx);
     sd[0] = cast(char)attr;
     if (attr & 1 || config.flags & CFGeasyomf)
-    {   TOLONG(sd.ptr + 1,cast(uint)size);          // store segment size
+    {
+        TOLONG(sd.ptr + 1, cast(uint)size);          // store segment size
         reclen = 5;
     }
     else
@@ -1660,7 +1685,8 @@ private void objsegdef(int attr,targ_size_t size,int segnamidx,int classnamidx)
     if (attr & 1)                       // if USE32
     {
         if (config.flags & CFGeasyomf)
-        {   // Translate to Pharlap format
+        {
+            // Translate to Pharlap format
             sd[0] &= ~1;                // turn off P bit
 
             // Translate A: 4.6
@@ -1682,7 +1708,8 @@ version (MARS)
 else
 {
         if (size & ~0xFFFFL)
-        {   if (size == 0x10000)        // if exactly 64Kb
+        {
+            if (size == 0x10000)        // if exactly 64Kb
                 sd[0] |= 2;             // set "B" bit
             else
                 synerr(EM_seg_gt_64k,size);     // segment exceeds 64Kb
@@ -1744,11 +1771,13 @@ else
               : SEG_ATTR(SEG_ALIGN1,SEG_C_ABS,0,USE16);
 
         if (config.exe & EX_flat)
-        {   // IBM's version of CV uses dword aligned segments
+        {
+            // IBM's version of CV uses dword aligned segments
             dsymattr = SEG_ATTR(SEG_ALIGN4,SEG_C_ABS,0,USE32);
         }
         else if (config.fulltypes == CV4)
-        {   // Always use 32 bit segments
+        {
+            // Always use 32 bit segments
             dsymattr |= USE32;
             assert(!(config.flags & CFGeasyomf));
         }
@@ -1762,12 +1791,14 @@ else
 static if (0)
 {
     // Define fixup threads, we don't use them
-    {   static immutable char[12] thread = [ 0,3,1,2,2,1,3,4,0x40,1,0x45,1 ];
+    {
+        static immutable char[12] thread = [ 0,3,1,2,2,1,3,4,0x40,1,0x45,1 ];
         objrecord(obj.mfixupp,thread.ptr,thread.sizeof);
     }
     // This comment appears to indicate that no more PUBDEFs, EXTDEFs,
     // or COMDEFs are coming.
-    {   static immutable char[3] cv = [0,0xA2,1];
+    {
+        static immutable char[3] cv = [0,0xA2,1];
         objrecord(COMENT,cv.ptr,cv.sizeof);
     }
 }
@@ -1807,7 +1838,8 @@ void OmfObj_staticctor(Symbol *s,int dtor,int seg)
         : SEG_ATTR(SEG_ALIGN2,SEG_C_PUBLIC,0,USE16);
 
     for (int i = 0; i < 5; i++)
-    {   int sz;
+    {
+        int sz;
 
         sz = (i == seg) ? 4 : 0;
 
@@ -1826,7 +1858,8 @@ void OmfObj_staticctor(Symbol *s,int dtor,int seg)
     }
 
     if (dtor)
-    {   // Leave space in XOF segment so that __fatexit() can insert a
+    {
+        // Leave space in XOF segment so that __fatexit() can insert a
         // pointer to the static destructor in XOF.
 
         // Put out LNAMES record
@@ -2051,7 +2084,8 @@ int OmfObj_readonly_comdat(Symbol *s)
 }
 
 static int generate_comdat(Symbol *s, bool is_readonly_comdat)
-{   char[IDMAX+IDOHD+1] lnames = void; // +1 to allow room for strcpy() terminating 0
+{
+    char[IDMAX+IDOHD+1] lnames = void; // +1 to allow room for strcpy() terminating 0
     char[2+2] cextdef = void;
     char *p;
     size_t lnamesize;
@@ -2105,10 +2139,12 @@ static int generate_comdat(Symbol *s, bool is_readonly_comdat)
         }
     }
     else
-    {   ubyte atyp;
+    {
+        ubyte atyp;
 
         switch (ty & mTYLINK)
-        {   case 0:
+        {
+            case 0:
             case mTYnear:       lr.pubbase = DATA;
 static if (0)
                                 atyp = 0;       // only one instance is allowed
@@ -2213,17 +2249,19 @@ int OmfObj_codeseg(const char *name,int suffix)
  *      segment for TLS segment
  */
 
-seg_data *OmfObj_tlsseg_bss() { return OmfObj_tlsseg(); }
+seg_data* OmfObj_tlsseg_bss() { return OmfObj_tlsseg(); }
 
-seg_data *OmfObj_tlsseg()
-{   //static char tlssegname[] = "\04$TLS\04$TLS";
+seg_data* OmfObj_tlsseg()
+{
+    //static char tlssegname[] = "\04$TLS\04$TLS";
     //static char tlssegname[] = "\05.tls$\03tls";
     static immutable char[25] tlssegname = "\05.tls$\03tls\04.tls\010.tls$ZZZ";
 
     assert(tlssegname[tlssegname.length - 5] == '$');
 
     if (obj.tlssegi == 0)
-    {   int segattr;
+    {
+        int segattr;
 
         objrecord(LNAMES,tlssegname.ptr,tlssegname.sizeof - 1);
 
@@ -2362,8 +2400,9 @@ else
         (s = e.EV.Vsym).ty() & mTYimport &&
         (s.Sclass == SCextern || s.Sclass == SCinline)
        )
-    {   char *name;
-        char *p;
+    {
+        char* name;
+        char* p;
         size_t len;
         char[IDMAX + IDOHD + 1] buffer = void;
 
@@ -2509,7 +2548,8 @@ else
     if (ilen > (255-2-int.sizeof*3))
         dest += 3;
     switch (type_mangle(s.Stype))
-    {   case mTYman_pas:                // if upper case
+    {
+        case mTYman_pas:                // if upper case
         case mTYman_for:
             memcpy(dest + 1,name,len);  // copy in name
             dest[1 + len] = 0;
@@ -2555,7 +2595,8 @@ else
             assert(0);
     }
     if (ilen > (255-2-int.sizeof*3))
-    {   dest -= 3;
+    {
+        dest -= 3;
         dest[0] = 0xFF;
         dest[1] = 0;
         debug
@@ -2565,7 +2606,8 @@ else
         len += 4;
     }
     else
-    {   *dest = cast(char)len;
+    {
+        *dest = cast(char)len;
         len++;
     }
     if (name2)
@@ -2578,8 +2620,9 @@ else
  * Export a function name.
  */
 
-void OmfObj_export_symbol(Symbol *s,uint argsize)
-{   char *coment;
+void OmfObj_export_symbol(Symbol* s, uint argsize)
+{
+    char* coment;
     size_t len;
 
     coment = cast(char *) alloca(4 + 1 + (IDMAX + IDOHD) + 1); // allow extra byte for mangling
@@ -2619,7 +2662,8 @@ int OmfObj_data_start(Symbol *sdata, targ_size_t datasize, int seg)
         seg = sdata.Sseg;
     targ_size_t offset = SegData[seg].SDoffset;
     if (sdata.Salignment > 0)
-    {   if (SegData[seg].SDalignment < sdata.Salignment)
+    {
+        if (SegData[seg].SDalignment < sdata.Salignment)
             SegData[seg].SDalignment = sdata.Salignment;
         alignbytes = ((offset + sdata.Salignment - 1) & ~(sdata.Salignment - 1)) - offset;
     }
@@ -2660,14 +2704,16 @@ void OmfObj_func_term(Symbol *sfunc)
 private void outpubdata()
 {
     if (obj.pubdatai)
-    {   objrecord(obj.mpubdef,obj.pubdata.ptr,obj.pubdatai);
+    {
+        objrecord(obj.mpubdef,obj.pubdata.ptr,obj.pubdatai);
         obj.pubdatai = 0;
     }
 }
 
 void OmfObj_pubdef(int seg,Symbol *s,targ_size_t offset)
-{   uint reclen,len;
-    char *p;
+{
+    uint reclen, len;
+    char* p;
     uint ti;
 
     assert(offset < 100000000);
@@ -2709,13 +2755,15 @@ void OmfObj_pubdefsize(int seg, Symbol *s, targ_size_t offset, targ_size_t symsi
 private void outextdata()
 {
     if (obj.extdatai)
-    {   objrecord(EXTDEF,obj.extdata.ptr,obj.extdatai);
+    {
+        objrecord(EXTDEF, obj.extdata.ptr, obj.extdatai);
         obj.extdatai = 0;
     }
 }
 
 int OmfObj_external_def(const(char)* name)
-{   uint len;
+{
+    uint len;
     char *e;
 
     //printf("OmfObj_external_def('%s', %d)\n",name,obj.extidx + 1);
@@ -3289,8 +3337,9 @@ void OmfObj_write_bytes(seg_data *pseg, uint nbytes, void *p)
  *      nbytes
  */
 
-uint OmfObj_bytes(int seg,targ_size_t offset,uint nbytes, void *p)
-{   uint n = nbytes;
+uint OmfObj_bytes(int seg, targ_size_t offset, uint nbytes, void* p)
+{
+    uint n = nbytes;
 
     //dbg_printf("OmfObj_bytes(seg=%d, offset=x%lx, nbytes=x%x, p=%p)\n",seg,offset,nbytes,p);
     Ledatarec *lr = cast(Ledatarec*)SegData[seg].ledata;
@@ -3304,7 +3353,8 @@ uint OmfObj_bytes(int seg,targ_size_t offset,uint nbytes, void *p)
      )
     {
         while (nbytes)
-        {   OmfObj_byte(seg,offset,*cast(char *)p);
+        {
+            OmfObj_byte(seg, offset, *cast(char*)p);
             offset++;
             p = (cast(char *)p) + 1;
             nbytes--;
@@ -3512,7 +3562,8 @@ void OmfObj_reftofarseg(int seg,targ_size_t offset,targ_size_t val,
  */
 
 void OmfObj_reftocodeseg(int seg,targ_size_t offset,targ_size_t val)
-{   uint framedatum;
+{
+    uint framedatum;
     uint lcfd;
 
     int idx = SegData[cseg].segidx;
@@ -3575,7 +3626,8 @@ static if (0)
     while (1)
     {
         switch (flags & (CFseg | CFoff))
-        {   case 0:
+        {
+            case 0:
                 // Select default
                 flags |= CFoff;
                 if (tyfunc(ty))
@@ -3631,7 +3683,8 @@ static if (0)
         case SCextern:
         case SCcomdef:
             if (s.Sxtrnnum)            // identifier is defined somewhere else
-            {   external = s.Sxtrnnum;
+            {
+                external = s.Sxtrnnum;
 
                 debug
                 if (external > obj.extidx)
@@ -3643,7 +3696,8 @@ static if (0)
                 assert(external <= obj.extidx);
             }
             else
-            {   // Don't know yet, worry about it later
+            {
+                // Don't know yet, worry about it later
              Ladd:
                 size_t byteswritten = addtofixlist(s,offset,seg,val,flags);
                 assert(byteswritten == numbytes);
@@ -3780,7 +3834,8 @@ void OmfObj_far16thunk(Symbol *s)
     assert(cod32_1[cod32_1.length - 1] == 0x3D);
 
     static ubyte[22 + 46] cod32_2 =
-    [   0x0F,0x85,0x10,0x00,0x00,0x00,  //      JNE     L1
+    [
+        0x0F,0x85,0x10,0x00,0x00,0x00,  //      JNE     L1
         0x8B,0xC4,                      //      MOV     EAX,ESP
         0x66,0x3D,0x00,0x08,            //      CMP     AX,2048
         0x0F,0x83,0x04,0x00,0x00,0x00,  //      JAE     L1

--- a/src/dmd/backend/cgsched.d
+++ b/src/dmd/backend/cgsched.d
@@ -1679,7 +1679,8 @@ else
                 if (a32)
                 {
                     if (rm == 4)
-                    {   sib = c.Isib;
+                    {
+                        sib = c.Isib;
                         if ((sib & modregrm(0,7,0)) != modregrm(0,4,0))
                             ci.a |= mask((sib >> 3) & 7);      // index register
                         if ((sib & 7) != 5)
@@ -1689,7 +1690,8 @@ else
                         ci.a |= mask(rm);
                 }
                 else
-                {   immutable ubyte[8] ea16 = [mBX|mSI,mBX|mDI,mBP|mSI,mBP|mDI,mSI,mDI,0,mBX];
+                {
+                    immutable ubyte[8] ea16 = [mBX|mSI,mBX|mDI,mBP|mSI,mBP|mDI,mSI,mDI,0,mBX];
                     ci.a |= ea16[rm];
                 }
                 goto Lmem;
@@ -1699,7 +1701,8 @@ else
                 if (a32)
                 {
                     if (rm == 4)
-                    {   sib = c.Isib;
+                    {
+                        sib = c.Isib;
                         if ((sib & modregrm(0,7,0)) != modregrm(0,4,0))
                             ci.a |= mask((sib >> 3) & 7);      // index register
                         ci.a |= mask(sib & 7);                 // base register
@@ -1708,7 +1711,8 @@ else
                         ci.a |= mask(rm);
                 }
                 else
-                {   immutable ubyte[8] ea16 = [mBX|mSI,mBX|mDI,mBP|mSI,mBP|mDI,mSI,mDI,mBP,mBX];
+                {
+                    immutable ubyte[8] ea16 = [mBX|mSI,mBX|mDI,mBP|mSI,mBP|mDI,mSI,mDI,mBP,mBX];
                     ci.a |= ea16[rm];
                 }
 
@@ -1737,20 +1741,22 @@ else
             if (irm != modregrm(0,0,5))
             {
                 switch (mod)
-                {   case 0:
-                        if ((sib & 7) != 5)     // if not disp32[index]
-                        {   c.IFL1 = FLconst;
-                            c.IEV1.Vpointer = 0;
-                            irm |= 0x80;
-                        }
-                        break;
-                    case 1:
-                        c.IEV1.Vpointer = cast(byte) c.IEV1.Vpointer;
-                        irm = modregrm(2,0,rm);
-                        break;
+                {
+                case 0:
+                    if ((sib & 7) != 5)     // if not disp32[index]
+                    {
+                        c.IFL1 = FLconst;
+                        c.IEV1.Vpointer = 0;
+                        irm |= 0x80;
+                    }
+                    break;
+                case 1:
+                    c.IEV1.Vpointer = cast(byte) c.IEV1.Vpointer;
+                    irm = modregrm(2, 0, rm);
+                    break;
 
-                    default:
-                        break;
+                default:
+                    break;
                 }
             }
         }
@@ -1759,14 +1765,15 @@ else
             if (irm != modregrm(0,0,6))
             {
                 switch (mod)
-                {   case 0:
+                {
+                    case 0:
                         c.IFL1 = FLconst;
                         c.IEV1.Vpointer = 0;
                         irm |= 0x80;
                         break;
                     case 1:
                         c.IEV1.Vpointer = cast(byte) c.IEV1.Vpointer;
-                        irm = modregrm(2,0,rm);
+                        irm = modregrm(2, 0, rm);
                         break;
 
                     default:
@@ -1801,7 +1808,8 @@ Lret:
  */
 
 private int pair_test(Cinfo *cu,Cinfo *cv)
-{   uint pcu;
+{
+    uint pcu;
     uint pcv;
     uint r1,w1;
     uint r2,w2;
@@ -1847,10 +1855,9 @@ Lnopair:
  *      !=0 if they have an AGI
  */
 
-private int pair_agi(Cinfo *c1,Cinfo *c2)
-{   uint x;
-
-    x = c1.w & c2.a;
+private int pair_agi(Cinfo *c1, Cinfo *c2)
+{
+    uint x = c1.w & c2.a;
     return x && !(x == mSP && c1.pair & c2.pair & PE);
 }
 
@@ -1864,13 +1871,12 @@ private int pair_agi(Cinfo *c1,Cinfo *c2)
  *      !=0 if they can decode simultaneously
  */
 
-private int triple_test(Cinfo *c0,Cinfo *c1,Cinfo *c2)
-{   int c2isz;
-
+private int triple_test(Cinfo *c0, Cinfo *c1, Cinfo *c2)
+{
     assert(c0);
     if (!c1)
         return 0;
-    c2isz = c2 ? c2.isz : 0;
+    int c2isz = c2 ? c2.isz : 0;
     if (c0.isz > 7 || c1.isz > 7 || c2isz > 7 ||
         c0.isz + c1.isz + c2isz > 16)
         return 0;
@@ -2205,11 +2211,9 @@ Lconflict:
             delay_clocks = 7;
     }
     else if ((w1 | r1) & (w2 | r2) & (C | S))
-    {   int reg;
-        int op;
-
-        op = c1.Iop;
-        reg = c1.Irm & modregrm(0,7,0);
+    {
+        int op = c1.Iop;
+        int reg = c1.Irm & modregrm(0,7,0);
         if (ci1.fp_op == FP.fld ||
             (op == 0xD9 && (c1.Irm & 0xF8) == 0xC0)
            )
@@ -2243,12 +2247,12 @@ nothrow:
 
     int fpustackused;           // number of slots in FPU stack that are used
 
-void initialize(int fpustackinit)          // initialize scheduler
-{
-    //printf("Schedule::initialize(fpustackinit = %d)\n", fpustackinit);
-    memset(&this,0,Schedule.sizeof);
-    fpustackused = fpustackinit;
-}
+    void initialize(int fpustackinit)          // initialize scheduler
+    {
+        //printf("Schedule::initialize(fpustackinit = %d)\n", fpustackinit);
+        memset(&this, 0, Schedule.sizeof);
+        fpustackused = fpustackinit;
+    }
 
 code **assemble(code **pc)  // reassemble scheduled instructions
 {


### PR DESCRIPTION
Just a boring collection of indentation fixes, no actual code change.
Trivially reviewed if you disable whitespace changes in the diff viewer.