### PR TITLE
Fix Issue 20100 - Segfault with checkaction=context on struct comparison

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5806,12 +5806,30 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                     Expression comp = new StringExp(loc, cast(char*) compMsg.ptr);
                     comp = comp.expressionSemantic(sc);
                     (*tiargs)[0] = comp;
-                    (*tiargs)[1] = (*args)[0].type;
-                    (*tiargs)[2] = (*args)[1].type;
 
-                    // runtime args
-                    (*es)[0] = (*args)[0];
-                    (*es)[1] = (*args)[1];
+                    // structs with opEquals get rewritten to a DotVarExp:
+                    // a.opEquals(b)
+                    // https://issues.dlang.org/show_bug.cgi?id=20100
+                    if (args.length == 1)
+                    {
+                        auto dv = callExp.e1.isDotVarExp();
+                        assert(dv);
+                        (*tiargs)[1] = dv.e1.type;
+                        (*tiargs)[2] = (*args)[0].type;
+
+                        // runtime args
+                        (*es)[0] = dv.e1;
+                        (*es)[1] = (*args)[0];
+                    }
+                    else
+                    {
+                        (*tiargs)[1] = (*args)[0].type;
+                        (*tiargs)[2] = (*args)[1].type;
+
+                        // runtime args
+                        (*es)[0] = (*args)[0];
+                        (*es)[1] = (*args)[1];
+                    }
                 }
                 else
                 {

--- a/test/compilable/test20100.d
+++ b/test/compilable/test20100.d
@@ -1,0 +1,27 @@
+// REQUIRED_ARGS: -checkaction=context
+/*
+TEST_OUTPUT:
+---
+---
+*/
+struct STuple {
+	bool opEquals(STuple) { return false; }
+}
+
+class CTuple {
+}
+
+void testStruct() {
+	STuple t1;
+	assert(t1 == t1);
+}
+
+void testClass() {
+	CTuple t1 = new CTuple();
+	assert(t1 == t1);
+}
+
+void main() {
+    testStruct();
+    testClass();
+}


### PR DESCRIPTION
Currently, there's no way to `assert` on the output of runnable tests, but we can add a test to druntime afterwards (-> https://github.com/dlang/druntime/pull/2720).