### PR TITLE
Allow building DMD via dub + make full DMD available as dub library

### DIFF
--- a/changelog/dmd_dub.dd
+++ b/changelog/dmd_dub.dd
@@ -1,0 +1,3 @@
+Full DMD compiler is now available as dub library
+
+See the code generation example [here](https://github.com/dlang/dmd/blob/master/test/dub_package/full.d).

--- a/ci.sh
+++ b/ci.sh
@@ -108,6 +108,8 @@ test_dub_package() {
             DFLAGS="-de" dub --single --compiler="${abs_build_path}/dmd" "$file"
         done
         popd
+        # Test building DMD via dub
+        dub 2>&1 | grep "D Compiler"
         # Test rdmd build
         "${build_path}/dmd" -version=NoBackend -version=GC -version=NoMain -Jgenerated/dub -Jres -Isrc -i -run test/dub_package/frontend.d
     fi

--- a/dub.sdl
+++ b/dub.sdl
@@ -1,11 +1,10 @@
 name "dmd"
 description "The DMD compiler"
 authors "Walter Bright"
-copyright "Copyright © 1999-2018, The D Language Foundation"
+copyright "Copyright © 1999-2019, The D Language Foundation"
 license "BSL-1.0"
 
 targetType "none"
-dependency ":frontend" version="*"
 
 subPackage {
   name "root"
@@ -30,7 +29,9 @@ subPackage {
     "src/dmd/tokens.d" \
     "src/dmd/utf.d"
 
-  preGenerateCommands `
+  stringImportPaths "generated/dub"
+
+  preBuildCommands `
     "$${DUB_EXE}" \
     --arch=$${DUB_ARCH} \
     --compiler=$${DC} \
@@ -40,9 +41,7 @@ subPackage {
     /etc
    ` platform="posix"
 
-  preGenerateCommands `"%DUB_EXE%" --arch=%DUB_ARCH% --compiler="%DC%" --single "%DUB_PACKAGE_DIR%config.d" -- "%DUB_PACKAGE_DIR%generated/dub" "%DUB_PACKAGE_DIR%VERSION"` platform="windows"
-
-  stringImportPaths "generated/dub"
+  preBuildCommands `"%DUB_EXE%" --arch=%DUB_ARCH% --compiler="%DC%" --single "%DUB_PACKAGE_DIR%config.d" -- "%DUB_PACKAGE_DIR%generated/dub" "%DUB_PACKAGE_DIR%VERSION"` platform="windows"
 
   dependency "dmd:root" version="*"
 }
@@ -60,6 +59,30 @@ subPackage {
     "src/dmd/strictvisitor.d"
 
   dependency "dmd:lexer" version="*"
+}
+
+subPackage {
+  name "backend"
+  targetType "library"
+  sourcePaths "src/dmd/backend"
+  stringImportPaths "res"
+  stringImportPaths "generated/dub"
+
+  versions \
+    "GC" \
+    "MARS"
+
+  preBuildCommands `
+    "$${DUB_EXE}" \
+    --arch=$${DUB_ARCH} \
+    --compiler=$${DC} \
+    --single "$${DUB_PACKAGE_DIR}config.d" \
+    -- "$${DUB_PACKAGE_DIR}generated/dub" \
+    "$${DUB_PACKAGE_DIR}VERSION" \
+    /etc
+   ` platform="posix"
+
+  preBuildCommands `"%DUB_EXE%" --arch=%DUB_ARCH% --compiler="%DC%" --single "%DUB_PACKAGE_DIR%config.d" -- "%DUB_PACKAGE_DIR%generated/dub" "%DUB_PACKAGE_DIR%VERSION"` platform="windows"
 }
 
 subPackage {
@@ -93,4 +116,55 @@ subPackage {
   }.d"
 
   dependency "dmd:parser" version="*"
+}
+
+/* The 'full' subpackage includes frontend + backend*/
+subPackage {
+  name "full"
+
+  targetType "library"
+  sourcePaths "src/dmd"
+  stringImportPaths "res"
+  stringImportPaths "generated/dub"
+
+  versions \
+    "GC" \
+    "NoMain" \
+    "MARS"
+
+  preBuildCommands `
+    "$${DUB_EXE}" \
+    --arch=$${DUB_ARCH} \
+    --compiler=$${DC} \
+    --single "$${DUB_PACKAGE_DIR}config.d" \
+    -- "$${DUB_PACKAGE_DIR}generated/dub" \
+    "$${DUB_PACKAGE_DIR}VERSION" \
+    /etc
+   ` platform="posix"
+
+  preBuildCommands `"%DUB_EXE%" --arch=%DUB_ARCH% --compiler="%DC%" --single "%DUB_PACKAGE_DIR%config.d" -- "%DUB_PACKAGE_DIR%generated/dub" "%DUB_PACKAGE_DIR%VERSION"` platform="windows"
+}
+
+configuration "application" {
+    name "dmd"
+    targetType "executable"
+
+    sourcePaths "src/dmd"
+    excludedSourceFiles "src/dmd/backend/*"
+    excludedSourceFiles "src/examples/*"
+    excludedSourceFiles "src/vcbuild/*"
+    excludedSourceFiles "src/build.d"
+    excludedSourceFiles "src/frontend.d"
+
+    stringImportPaths "res"
+    stringImportPaths "generated/dub"
+
+    dependency "dmd:backend" version="*"
+}
+
+/* Set dmd:frontend as the default library config */
+configuration "library" {
+    targetType "none"
+    sourcePaths
+    dependency "dmd:frontend" version="*"
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,5 @@
+{
+	"fileVersion": 1,
+	"versions": {
+	}
+}

--- a/test/dub_package/full.d
+++ b/test/dub_package/full.d
@@ -1,0 +1,64 @@
+#!/usr/bin/env dub
+/+dub.sdl:
+dependency "dmd:full" path="../.."
++/
+
+void main()
+{
+    import dmd.frontend;
+
+    import std.algorithm : each, canFind;
+    import std.file : tempDir;
+    import std.path : buildPath;
+    import std.process : execute;
+
+    initDMD;
+    findImportPaths.each!addImport;
+
+    auto t = parseModule("test.d", q{
+        void foo()
+        {
+            foreach (i; 0..10) {}
+        }
+    });
+
+    assert(!t.diagnostics.hasErrors);
+    assert(!t.diagnostics.hasWarnings);
+
+    t.module_.fullSemantic;
+
+    // generate object file from module
+    auto moduleDir = tempDir;
+    auto objFile = "test.d";
+    t.module_.writeModuleAsObject(moduleDir, objFile);
+
+    // check whether codegen for 'foo' function was successful
+    auto result = execute(["objdump", "-d", moduleDir.buildPath(objFile)]);
+    assert(result.status == 0);
+    assert(result.output.canFind("<_D4test3fooFZv>:"));
+}
+
+void writeModuleAsObject(M)(M m, string moduleDir, string moduleFile)
+{
+    import dmd.gluelayer : backend_init, backend_term, genObjFile, obj_start, obj_end;
+    import dmd.inline : inlineScanModule;
+    import dmd.lib : Library;
+    import std.string : toStringz;
+
+    backend_init();
+
+    m.inlineScanModule();
+
+    auto objName = m.srcfile.toChars();
+
+    auto library = Library.factory();
+    library.setFilename(moduleDir, moduleFile);
+
+    // generate object file
+    obj_start(objName);
+    m.genObjFile(false);
+    obj_end(library, objName);
+    library.write();
+
+    backend_term();
+}


### PR DESCRIPTION
Allows to do the following:

- `dub` (in the root dir) now will build and run dmd (use `dub build` to just build `dmd`)

```
dub
Performing "debug" build using /usr/bin/dmd for x86_64.
dmd:backend ~dmd-backend: building configuration "library"...
Running pre-build commands...
Performing "$DFLAGS" build using /usr/bin/dmd for x86_64.
config ~master: building configuration "application"...
Linking...
Running ./generated/dub/config /home/seb/dlang/dmd/generated/dub /home/seb/dlang/dmd/VERSION /etc
dmd ~dmd-backend: building configuration "application"...
Linking...
Running ./dmd 
DMD v2.087.1-beta.1-300-g5b2b8a357 DEBUG
DMD64 D Compiler v2.087.1-beta.1-300-g5b2b8a357
Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved written by Walter Bright

Documentation: https://dlang.org/
Config file: /etc/dmd.conf
...
```

- allows to use the full DMD compiler as dub library (i.e. use the backend for actual codegen). This is available as the `full` subpackage (see the `full.d` example for details).

Notes:
- the change from `preGenerateCommands` to `preBuildCommands` was done to avoid executing the `config` script on every execution
- `dub.selections.json` was added to avoid needless rebuilds (dub needs this file for caching purposes)
- I couldn't find a good way to avoid the duplication of the `preBuildCommands`

CC @jacob-carlborg 