### PR TITLE
VS: generate VERSION file into the output folder, not the intermediat…

### DIFF
--- a/.azure-pipelines/windows-visual-studio.yml
+++ b/.azure-pipelines/windows-visual-studio.yml
@@ -70,9 +70,6 @@ steps:
       cd "%DMD_DIR%\..\phobos"
       "%DM_MAKE%" -f win64.mak MODEL=32mscoff "DMD=%DMD%" "VCDIR=%VCINSTALLDIR%." "CC=%MSVC_CC%" "AR=%MSVC_AR%" "MAKE=%DM_MAKE%" || exit /B 5
 
-      REM Build DMD VERSION + string imports (not built by VisualD)
-      copy "%DMD_DIR%\VERSION" "%DMD_DIR%\generated\Windows\Release\Win32\VERSION"
-
       REM Run DMD testsuite
       cd "%DMD_DIR%\test"
       cp %DMD_DIR%\..\phobos\phobos32mscoff.lib .

--- a/src/vcbuild/dmd.vcxproj
+++ b/src/vcbuild/dmd.vcxproj
@@ -122,7 +122,7 @@
     </Link>
     <DCompile>
       <VersionIdentifiers>MARS</VersionIdentifiers>
-      <StringImportPaths>..\..\res;$(OutDir)\dmd\generated</StringImportPaths>
+      <StringImportPaths>..\..\res;$(OutDir)</StringImportPaths>
       <CRuntimeLibrary>MultiThreadedDebug</CRuntimeLibrary>
       <CompilationModel>Package</CompilationModel>
       <ImportPaths>..</ImportPaths>
@@ -146,7 +146,7 @@
     </Link>
     <DCompile>
       <VersionIdentifiers>MARS</VersionIdentifiers>
-      <StringImportPaths>..\..\res;$(OutDir)\dmd\generated</StringImportPaths>
+      <StringImportPaths>..\..\res;$(OutDir)</StringImportPaths>
       <CRuntimeLibrary>MultiThreadedDebug</CRuntimeLibrary>
       <CompilationModel>Package</CompilationModel>
       <ImportPaths>..</ImportPaths>
@@ -175,7 +175,7 @@
     </Link>
     <DCompile>
       <VersionIdentifiers>MARS</VersionIdentifiers>
-      <StringImportPaths>..\..\res;$(OutDir)\dmd\generated</StringImportPaths>
+      <StringImportPaths>..\..\res;$(OutDir)</StringImportPaths>
       <CompilationModel>Package</CompilationModel>
       <ImportPaths>..</ImportPaths>
       <Optimizer>true</Optimizer>
@@ -204,7 +204,7 @@
     </Link>
     <DCompile>
       <VersionIdentifiers>MARS</VersionIdentifiers>
-      <StringImportPaths>..\..\res;$(OutDir)\dmd\generated</StringImportPaths>
+      <StringImportPaths>..\..\res;$(OutDir)</StringImportPaths>
       <CompilationModel>Package</CompilationModel>
       <ImportPaths>..</ImportPaths>
       <Optimizer>true</Optimizer>
@@ -222,8 +222,8 @@
   <ItemGroup>
     <CustomBuild Include="..\..\VERSION">
       <Message>Creating VERSION...</Message>
-      <Command>$(_rdmdExe) ..\..\config.d $(IntDir)generated ..\..\VERSION</Command>
-      <Outputs>$(IntDir)generated\VERSION;%(Outputs)</Outputs>
+      <Command>$(_rdmdExe) ..\..\config.d $(OutDir) ..\..\VERSION</Command>
+      <Outputs>$(OutDir)VERSION;%(Outputs)</Outputs>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
…e folder

Unfortunately, https://github.com/dlang/dmd/pull/10228 wasn't good enough, the test script covered the problem by copying the VERSION file, too.