### PR TITLE
Windows x64 ABI Fixes

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -176,6 +176,8 @@ public:
 
     structalign_t alignment;    // alignment applied outside of the struct
     StructPOD ispod;            // if struct is POD
+    StructPOD iscpp03pod;       // if struct is C++03 POD
+    StructPOD iscppdmcpod;      // if struct is DMC C++ POD
 
     // For 64 bit Efl function call/return ABI
     Type *arg1type;
@@ -194,6 +196,8 @@ public:
     void finalizeSize();
     bool fit(const Loc &loc, Scope *sc, Expressions *elements, Type *stype);
     bool isPOD();
+    bool isCPP03POD();
+    bool isCPPDMCPOD();
 
     StructDeclaration *isStructDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -360,7 +360,8 @@ extern (C++) final class ToClassesVisitor : Visitor
                 else
                 {
                     assert(foffset % 8 == 0 ||
-                        fEightbyteEnd - fEightbyteStart <= 1,
+                        fEightbyteEnd - fEightbyteStart <= 1 ||
+                        !global.params.isLP64,
                         "Field not aligned at eightbyte boundary but contributing to multiple eightbytes?"
                     );
                     foreach (i, fclass; classify(ftype, fsize).slice())

--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -1073,6 +1073,8 @@ enum
     STRexplicit      = 0x80000,    // if explicit template instantiation
     STRgenctor0      = 0x100000,   // need to gen X::X()
     STRnotpod        = 0x200000,   // struct is not POD
+    STRnotcpp03pod   = 0x400000,   // struct is not C++03 POD
+    STRnotcppdmcpod  = 0x800000,   // struct is not C++ POD according to DMC
 }
 
 struct struct_t

--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -802,7 +802,7 @@ void fixresult87(ref CodeBuilder cdb,elem *e,regm_t retregs,regm_t *pretregs)
     //printf("fixresult87(e = %p, retregs = %s, *pretregs = %s)\n", e,regm_str(retregs),regm_str(*pretregs));
     assert(!*pretregs || retregs);
 
-    if (*pretregs & mST01)
+    if ((*pretregs | retregs) & mST01)
     {
         fixresult_complex87(cdb, e, retregs, pretregs);
         return;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3289,7 +3289,7 @@ elem * elstruct(elem *e, goal_t goal)
         targ2 = t.Ttag.Sstruct.Sarg2type;
     }
 
-    if (ty == TYarray && sz)
+    if (ty == TYarray && sz && config.exe != EX_WIN64)
     {
         argtypes(t, targ1, targ2);
         if (!targ1)

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3294,6 +3294,7 @@ elem * elstruct(elem *e, goal_t goal)
         argtypes(t, targ1, targ2);
         if (!targ1)
             goto Ldefault;
+        tym = targ1.Tty;
         goto L1;
     }
     //if (targ1) { printf("targ1\n"); type_print(targ1); }

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3357,7 +3357,8 @@ elem * elstruct(elem *e, goal_t goal)
 
         L1:
             if (ty == TYstruct)
-            {   // This needs to match what TypeFunction::retStyle() does
+            {
+                // This needs to match what TypeFunction::retStyle() does
                 if (config.exe == EX_WIN64)
                 {
                     //if (t.Ttag.Sstruct.Sflags & STRnotpod)
@@ -3382,6 +3383,10 @@ elem * elstruct(elem *e, goal_t goal)
                         tym = TYcdouble;
                     else
                         tym = TYucent;
+                    if ((0 == tyfloating(targ1.Tty)) ^ (0 == tyfloating(targ2.Tty)))
+                    {
+                        tym |= tyfloating(targ1.Tty) ? mTYxmmgpr : mTYgprxmm;
+                    }
                 }
                 assert(tym != TYstruct);
             }
@@ -5752,6 +5757,8 @@ private elem *elToPair(elem *e)
              */
             tym_t ty0;
             tym_t ty = e.Ety;
+            if (ty & (mTYxmmgpr | mTYgprxmm))
+                break; // register allocation doesn't support it yet.
             switch (tybasic(ty))
             {
                 case TYcfloat:      ty0 = TYfloat  | (ty & ~mTYbasic); goto L1;
@@ -5778,6 +5785,8 @@ private elem *elToPair(elem *e)
              */
             tym_t ty0;
             tym_t ty = e.Ety;
+            if (ty & (mTYxmmgpr | mTYgprxmm))
+                break; // register allocation doesn't support it yet.
             switch (tybasic(ty))
             {
                 case TYcfloat:      ty0 = TYfloat  | (ty & ~mTYbasic); goto L2;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3289,7 +3289,7 @@ elem * elstruct(elem *e, goal_t goal)
         targ2 = t.Ttag.Sstruct.Sarg2type;
     }
 
-    if (ty == TYarray && sz && config.exe != EX_WIN64)
+    if (ty == TYarray && sz)
     {
         argtypes(t, targ1, targ2);
         if (!targ1)

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -23,6 +23,7 @@ import core.stdc.stdlib;
 import core.stdc.string;
 
 import dmd.backend.cc;
+import dmd.backend.code;
 import dmd.backend.cdef;
 import dmd.backend.code_x86;
 import dmd.backend.oper;
@@ -3279,14 +3280,6 @@ elem * elstruct(elem *e, goal_t goal)
 
     uint sz = (e.Eoper == OPstrpar && type_zeroSize(t, global_tyf)) ? 0 : cast(uint)type_size(t);
     //printf("\tsz = %d\n", (int)sz);
-    if (sz == 16)
-    {
-        while (ty == TYarray && t.Tdim == 1)
-        {
-            t = t.Tnext;
-            ty = tybasic(t.Tty);
-        }
-    }
 
     type *targ1 = null;
     type *targ2 = null;
@@ -3296,6 +3289,13 @@ elem * elstruct(elem *e, goal_t goal)
         targ2 = t.Ttag.Sstruct.Sarg2type;
     }
 
+    if (ty == TYarray && sz)
+    {
+        argtypes(t, targ1, targ2);
+        if (!targ1)
+            goto Ldefault;
+        goto L1;
+    }
     //if (targ1) { printf("targ1\n"); type_print(targ1); }
     //if (targ2) { printf("targ2\n"); type_print(targ2); }
     switch (cast(int)sz)
@@ -3356,7 +3356,7 @@ elem * elstruct(elem *e, goal_t goal)
             goto Ldefault;
 
         L1:
-            if (ty == TYstruct)
+            if (ty == TYstruct || ty == TYarray)
             {
                 // This needs to match what TypeFunction::retStyle() does
                 if (config.exe == EX_WIN64)
@@ -3388,6 +3388,8 @@ elem * elstruct(elem *e, goal_t goal)
                         tym |= tyfloating(targ1.Tty) ? mTYxmmgpr : mTYgprxmm;
                     }
                 }
+                else if (I32 && targ1 && targ2)
+                    tym = TYllong;
                 assert(tym != TYstruct);
             }
             assert(tym != ~0);

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3316,7 +3316,7 @@ elem * elstruct(elem *e, goal_t goal)
             {
                  goto L1;
             }
-            if (e.Eoper == OPstrpar && I64 && ty == TYstruct)
+            if (I64 && config.exe != EX_WIN64)
             {
                 goto L1;
             }
@@ -3337,7 +3337,7 @@ elem * elstruct(elem *e, goal_t goal)
         case 13:
         case 14:
         case 15:
-            if (e.Eoper == OPstrpar && I64 && ty == TYstruct && config.exe != EX_WIN64)
+            if (I64 && config.exe != EX_WIN64)
             {
                 goto L1;
             }
@@ -3396,6 +3396,25 @@ elem * elstruct(elem *e, goal_t goal)
             switch (e.Eoper)
             {
                 case OPstreq:
+                    if (sz != tysize(tym))
+                    {
+                        // we can't optimize OPstreq in this case,
+                        // there will be memory corruption in the assignment
+                        elem *e2 = e.EV.E2;
+                        if (e2.Eoper != OPvar && e2.Eoper != OPind)
+                        {
+                            // the source may come in registers. ex: returned from a function.
+                            assert(tyaggregate(e2.Ety));
+                            e2 = optelem(e2, GOALvalue);
+                            e2 = elstruct(e2, GOALvalue);
+                            e2 = exp2_copytotemp(e2); // (tmp = e2, tmp)
+                            e2.EV.E2.EV.Vsym.Sfl = FLauto;
+                            e2.Ety = e2.EV.E2.Ety = e.Ety;
+                            e2.ET = e2.EV.E2.ET = e.ET;
+                            e.EV.E2 = e2;
+                        }
+                        break;
+                    }
                     e.Eoper = OPeq;
                     e.Ety = (e.Ety & ~mTYbasic) | tym;
                     elstructwalk(e.EV.E1,tym);

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -1893,7 +1893,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs)
         *pretregs = retregs;
     else if (forregs)             // if return the result in registers
     {
-        if (forregs & (mST01 | mST0))
+        if ((forregs | retregs) & (mST01 | mST0))
         {
             fixresult87(cdb, e, retregs, pretregs);
             return;

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3996,13 +3996,8 @@ static if (0)
     }
 }
 
-    reg_t reg1 = NOREG, reg2 = NOREG;
-
-    if (config.exe == EX_WIN64) // Win64 is currently broken
-        retregs = regmask(e.Ety, tym1);
-    else
-        retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
-
+    reg_t reg1, reg2;
+    retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
     assert(retregs || !*pretregs);
 
     if (!usefuncarg)
@@ -4116,9 +4111,7 @@ static if (0)
 
     /* Special handling for functions which return complex float in XMM0 or RAX. */
 
-    if (I64
-        && config.exe != EX_WIN64 // broken
-        && *pretregs && tybasic(e.Ety) == TYcfloat)
+    if (I64 && *pretregs && tybasic(e.Ety) == TYcfloat)
     {
         assert(reg2 == NOREG);
         // spill

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3033,8 +3033,20 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
         }
         else
         {
-            type* targ1 = t.Ttag.Sstruct.Sarg1type;
-            type* targ2 = t.Ttag.Sstruct.Sarg2type;
+            type* targ1, targ2;
+            if (tybasic(t.Tty) == TYstruct)
+            {
+                targ1 = t.Ttag.Sstruct.Sarg1type;
+                targ2 = t.Ttag.Sstruct.Sarg2type;
+            }
+            else if (tybasic(t.Tty) == TYarray)
+            {
+                if (I64)
+                    argtypes(t, targ1, targ2);
+            }
+            else
+                assert(0);
+
             if (targ1)
             {
                 t = targ1;
@@ -3127,6 +3139,108 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
         ty = ty2;
     }
     return 1;
+}
+
+/***************************************
+ * Finds replacemnt types for register passing of aggregates.
+ */
+void argtypes(type* t, ref type* arg1type, ref type* arg2type)
+{
+    if (!t) return;
+
+    tym_t ty = t.Tty;
+
+    if (!tyaggregate(ty))
+        return;
+
+    arg1type = arg2type = null;
+
+    if (tybasic(ty) == TYarray)
+    {
+        size_t sz = cast(size_t) type_size(t);
+        if (sz == 0)
+            return;
+
+        if ((I32 || config.exe == EX_WIN64) && (sz & (sz - 1)))  // power of 2
+            return;
+
+        if (config.exe == EX_WIN64 && sz > REGSIZE)
+            return;
+
+        if (sz <= 2 * REGSIZE)
+        {
+            type** argtype = &arg1type;
+            size_t argsz = sz < REGSIZE ? sz : REGSIZE;
+            foreach (v; 0 .. (sz > REGSIZE) + 1)
+            {
+                *argtype = argsz == 1 ? tstypes[TYchar]
+                         : argsz == 2 ? tstypes[TYshort]
+                         : argsz <= 4 ? tstypes[TYlong]
+                         : tstypes[TYllong];
+                argtype = &arg2type;
+                argsz = sz - REGSIZE;
+            }
+        }
+
+        if (I64 && config.exe != EX_WIN64)
+        {
+            type* tn = t.Tnext;
+            tym_t tyn = tn.Tty;
+            while (tyn == TYarray)
+            {
+                tn = tn.Tnext;
+                assert(tn);
+                tyn = tybasic(tn.Tty);
+            }
+
+            if (tybasic(tyn) == TYstruct)
+            {
+                if (type_size(tn) == sz) // array(s) of size 1
+                {
+                    arg1type = tn.Ttag.Sstruct.Sarg1type;
+                    arg2type = tn.Ttag.Sstruct.Sarg2type;
+                    return;
+                }
+
+                type* t1 = tn.Ttag.Sstruct.Sarg1type;
+                if (t1)
+                {
+                    tn = t1;
+                    tyn = tn.Tty;
+                }
+            }
+
+            if (sz == tysize(tyn))
+            {
+                if (tysimd(tyn))
+                {
+                    type* ts = type_fake(tybasic(tyn));
+                    ts.Tcount = 1;
+                    arg1type = ts;
+                    return;
+                }
+                else if (tybasic(tyn) == TYldouble || tybasic(tyn) == TYildouble)
+                {
+                    arg1type = tstypes[tybasic(tyn)];
+                    return;
+                }
+            }
+
+            if (sz <= 16)
+            {
+                if (tyfloating(tyn))
+                {
+                    arg1type = sz <= 4 ? tstypes[TYfloat] : tstypes[TYdouble];
+                    if (sz > 8)
+                        arg2type = (sz - 8) <= 4 ? tstypes[TYfloat] : tstypes[TYdouble];
+                }
+            }
+        }
+    }
+    else if (tybasic(ty) == TYstruct)
+    {
+        // TODO: Move code from `cgelem.d:elstruct()` here
+    }
 }
 
 /*******************************

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3094,6 +3094,14 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
             fpr.xmmcnt += 2;
             return 1;
         }
+
+        if (tybasic(ty) == TYcfloat
+            && fpr.numfloatregs - fpr.xmmcnt >= 1)
+        {
+            // Allocate XMM register
+            *preg1 = fpr.floatregs[fpr.xmmcnt++];
+            return 1;
+        }
     }
 
     foreach (j; 0 .. 2)
@@ -3509,12 +3517,17 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                 ++xmmcnt;
             int preg2 = parameters[i].reg2;
             reg_t mreg,lreg;
-            if (preg2 != NOREG)
+            if (preg2 != NOREG || tybasic(ep.Ety) == TYcfloat)
             {
                 assert(ep.Eoper != OPstrthis);
                 if (mask(preg2) & XMMREGS)
                     ++xmmcnt;
-                if (tyrelax(ep.Ety) == TYcent)
+                if (tybasic(ep.Ety) == TYcfloat)
+                {
+                    lreg = ST01;
+                    mreg = NOREG;
+                }
+                else if (tyrelax(ep.Ety) == TYcent)
                 {
                     lreg = mask(preg ) & mLSW ? cast(reg_t)preg  : AX;
                     mreg = mask(preg2) & mMSW ? cast(reg_t)preg2 : DX;
@@ -3524,8 +3537,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                     lreg = XMM0;
                     mreg = XMM1;
                 }
-                retregs = mask(mreg) | mask(lreg);
-
+                retregs = (mask(mreg) | mask(lreg)) & ~mask(NOREG);
                 CodeBuilder cdbsave;
                 cdbsave.ctor();
                 if (keepmsk & retregs)
@@ -3558,6 +3570,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                     retregs |= mask(preg);
                 if (preg2 != mreg)
                     retregs |= mask(preg2);
+                retregs &= ~mask(NOREG);
                 getregs(cdb,retregs);
 
                 tym_t ty1 = tybasic(ep.Ety);
@@ -3586,7 +3599,30 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                 else if (tybasic(ty1) == TYcdouble)
                     ty1 = ty2 = TYdouble;
 
-                foreach (v; 0 .. 2)
+                if (tybasic(ep.Ety) == TYcfloat)
+                {
+                    assert(I64);
+                    assert(lreg == ST01 && mreg == NOREG);
+                    // spill
+                    pop87();
+                    pop87();
+                    cdb.genfltreg(0xD9, 3, tysize(TYfloat));
+                    genfwait(cdb);
+                    cdb.genfltreg(0xD9, 3, 0);
+                    genfwait(cdb);
+                    // reload
+                    if (config.exe == EX_WIN64)
+                    {
+                        cdb.genfltreg(LOD, preg, 0);
+                        code_orrex(cdb.last(), REX_W);
+                    }
+                    else
+                    {
+                        assert(mask(preg) & XMMREGS);
+                        cdb.genxmmreg(xmmload(TYdouble), cast(reg_t) preg, 0, TYdouble);
+                    }
+                }
+                else foreach (v; 0 .. 2)
                 {
                     if (v ^ (preg != mreg))
                         genmovreg(cdb, preg, lreg, ty1);
@@ -3594,7 +3630,7 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
                         genmovreg(cdb, preg2, mreg, ty2);
                 }
 
-                retregs = mask(preg) | mask(preg2);
+                retregs = (mask(preg) | mask(preg2)) & ~mask(NOREG);
             }
             else if (ep.Eoper == OPstrthis)
             {
@@ -4071,6 +4107,35 @@ static if (0)
             }
             retregs = mask(lreg) | mask(mreg);
         }
+    }
+
+    /* Special handling for functions which return complex float in XMM0 or RAX. */
+
+    if (I64 && *pretregs && tybasic(e.Ety) == TYcfloat)
+    {
+        assert(reg2 == NOREG);
+        // spill
+        if (config.exe == EX_WIN64)
+        {
+            assert(reg1 == AX);
+            cdb.genfltreg(STO, reg1, 0);
+            code_orrex(cdb.last(), REX_W);
+        }
+        else
+        {
+            assert(reg1 == XMM0);
+            cdb.genxmmreg(xmmstore(TYdouble), reg1, 0, TYdouble);
+        }
+        // reload real
+        push87(cdb);
+        cdb.genfltreg(0xD9, 0, 0);
+        genfwait(cdb);
+        // reload imaginary
+        push87(cdb);
+        cdb.genfltreg(0xD9, 0, tysize(TYfloat));
+        genfwait(cdb);
+
+        retregs = mST01;
     }
 
     fixresult(cdb, e, retregs, pretregs);

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3996,8 +3996,13 @@ static if (0)
     }
 }
 
-    reg_t reg1, reg2;
-    retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
+    reg_t reg1 = NOREG, reg2 = NOREG;
+
+    if (config.exe == EX_WIN64) // Win64 is currently broken
+        retregs = regmask(e.Ety, tym1);
+    else
+        retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
+
     assert(retregs || !*pretregs);
 
     if (!usefuncarg)
@@ -4111,7 +4116,9 @@ static if (0)
 
     /* Special handling for functions which return complex float in XMM0 or RAX. */
 
-    if (I64 && *pretregs && tybasic(e.Ety) == TYcfloat)
+    if (I64
+        && config.exe != EX_WIN64 // broken
+        && *pretregs && tybasic(e.Ety) == TYcfloat)
     {
         assert(reg2 == NOREG);
         // spill

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -3397,18 +3397,18 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
             reg_t mreg,lreg;
             if (preg2 != NOREG)
             {
-                // BUG: still doesn't handle case of mXMM0|mAX or mAX|mXMM0
                 assert(ep.Eoper != OPstrthis);
                 if (mask(preg2) & XMMREGS)
-                {
                     ++xmmcnt;
-                    lreg = XMM0;
-                    mreg = XMM1;
-                }
-                else
+                if (tyrelax(ep.Ety) == TYcent)
                 {
                     lreg = mask(preg ) & mLSW ? cast(reg_t)preg  : AX;
                     mreg = mask(preg2) & mMSW ? cast(reg_t)preg2 : DX;
+                }
+                else
+                {
+                    lreg = XMM0;
+                    mreg = XMM1;
                 }
                 retregs = mask(mreg) | mask(lreg);
 
@@ -3846,7 +3846,9 @@ static if (0)
     }
 }
 
-    retregs = regmask(e.Ety, tym1);
+    reg_t reg1, reg2;
+    retregs = allocretregs(e.Ety, e.ET, tym1, &reg1, &reg2);
+    assert(retregs || !*pretregs);
 
     if (!usefuncarg)
     {
@@ -3923,6 +3925,37 @@ static if (0)
             // Pop unused result off 8087 stack
             cdb.gen2(0xDD, modregrm(3, 3, 0));           // FPOP
             cdb.gen2(0xDD, modregrm(3, 3, 0));           // FPOP
+        }
+    }
+
+    /* Special handling for functions that return one part
+       in XMM0 and the other part in AX
+     */
+    if (*pretregs && retregs)
+    {
+        if (reg1 == NOREG || reg2 == NOREG)
+        {}
+        else if ((0 == (mask(reg1) & XMMREGS)) ^ (0 == (mask(reg2) & XMMREGS)))
+        {
+            reg_t lreg, mreg;
+            if (mask(reg1) & XMMREGS)
+            {
+                lreg = XMM0;
+                mreg = XMM1;
+            }
+            else
+            {
+                lreg = mask(reg1) & mLSW ? reg1 : AX;
+                mreg = mask(reg2) & mMSW ? reg2 : DX;
+            }
+            for (int v = 0; v < 2; v++)
+            {
+                if (v ^ (reg2 != lreg))
+                    genmovreg(cdb,lreg,reg1);
+                else
+                    genmovreg(cdb,mreg,reg2);
+            }
+            retregs = mask(lreg) | mask(mreg);
         }
     }
 

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -2994,24 +2994,35 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
     type* t2 = null;
     tym_t ty2 = TYMAX;
 
-    tym_t tyb = tybasic(ty);
+    // SROA with mixed registers
+    if (ty & mTYxmmgpr)
+    {
+        ty = TYdouble;
+        ty2 = TYllong;
+    }
+    else if (ty & mTYgprxmm)
+    {
+        ty = TYllong;
+        ty2 = TYdouble;
+    }
 
     // Treat array of 1 the same as its element type
     // (Don't put volatile parameters in registers)
-    if (tyb == TYarray && tybasic(t.Tty) == TYarray && t.Tdim == 1 && !(t.Tty & mTYvolatile))
+    if (tybasic(ty) == TYarray && tybasic(t.Tty) == TYarray && t.Tdim == 1 && !(t.Tty & mTYvolatile))
     {
         t = t.Tnext;
-        tyb = tybasic(t.Tty);
+        ty = t.Tty;
     }
 
-    if (tyb == TYstruct && type_zeroSize(t, fpr.tyf))
+    if (tybasic(ty) == TYstruct && type_zeroSize(t, fpr.tyf))
         return 0;               // don't allocate into registers
 
     ++fpr.i;
 
-    // If struct just wraps another type
-    if (tyb == TYstruct && tybasic(t.Tty) == TYstruct)
+    // If struct or array
+    if (tyaggregate(ty))
     {
+        assert(t);
         if (config.exe == EX_WIN64)
         {
             /* Structs occupy a general purpose register, regardless of the struct
@@ -3073,7 +3084,7 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
         }
     }
 
-    for (int j = 0; j < 2; j++)
+    foreach (j; 0 .. 2)
     {
         if (fpr.regcnt < fpr.numintegerregs)
         {
@@ -3109,7 +3120,7 @@ int FuncParamRegs_alloc(ref FuncParamRegs fpr, type* t, tym_t ty, reg_t* preg1, 
         return 0;
 
      Lnext:
-        if (!t2)
+        if (tybasic(ty2) == TYMAX)
             break;
         preg = preg2;
         t = t2;
@@ -3437,7 +3448,17 @@ void cdfunc(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
 
                 tym_t ty1 = tybasic(ep.Ety);
                 tym_t ty2 = ty1;
-                if (ty1 == TYstruct)
+                if (ep.Ety & mTYgprxmm)
+                {
+                    ty1 = TYllong;
+                    ty2 = TYdouble;
+                }
+                else if (ep.Ety & mTYxmmgpr)
+                {
+                    ty1 = TYdouble;
+                    ty2 = TYllong;
+                }
+                else if (ty1 == TYstruct)
                 {
                     type* targ1 = ep.ET.Ttag.Sstruct.Sarg1type;
                     type* targ2 = ep.ET.Ttag.Sstruct.Sarg2type;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1111,7 +1111,28 @@ static if (NTEXCEPTIONS)
 }
 
         case BCretexp:
-            retregs = regmask(e.Ety, funcsym_p.ty());
+            reg_t reg1, reg2, lreg, mreg;
+            retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), &reg1, &reg2);
+            assert(reg1 != NOREG || !retregs);
+
+            lreg = mreg = NOREG;
+            if (reg1 == NOREG)
+            {}
+            else if (mask(reg1) & (mST0 | mST01))
+                lreg = reg1;
+            else if (reg2 == NOREG)
+                lreg = reg1;
+            else if (mask(reg1) & XMMREGS)
+            {
+                lreg = XMM0;
+                mreg = XMM1;
+            }
+            else
+            {
+                lreg = mask(reg1) & mLSW ? reg1 : AX;
+                mreg = mask(reg2) & mMSW ? reg2 : DX;
+            }
+            retregs = (mask(lreg) | mask(mreg)) & ~mask(NOREG);
 
             // For the final load into the return regs, don't set regcon.used,
             // so that the optimizer can potentially use retregs for register
@@ -1142,6 +1163,25 @@ static if (NTEXCEPTIONS)
             {
                 gencodelem(cdb,e,&retregs,true);
             }
+
+            if (reg1 == NOREG)
+            {
+            }
+            else if ((mask(reg1) | mask(reg2)) & (mST0 | mST01))
+            {
+                assert(reg1 == lreg && reg2 == NOREG);
+            }
+            // fix return registers
+            else if (reg2 == NOREG)
+                assert(lreg == reg1);
+            else for (int v = 0; v < 2; v++)
+            {
+                if (v ^ (reg1 != mreg))
+                    genmovreg(cdb, reg1, lreg);
+                else
+                    genmovreg(cdb, reg2, mreg);
+            }
+            retregs = (mask(reg1) | mask(reg2)) & ~mask(NOREG);
             goto L4;
 
         case BCret:
@@ -1249,6 +1289,212 @@ version (MARS)
             printf("bl.BC = %d\n",bl.BC);
             assert(0);
     }
+}
+
+/***************************
+ * Allocate registers for function return values.
+ *
+ * Params:
+ *    ty    = return type
+ *    t     = return type extended info
+ *    tyf   = function type
+ *    reg1  = output for the first part register
+ *    reg2  = output for the second part register
+ *
+ * Returns:
+ *    a bit mask of return registers.
+ *    0 if function returns on the stack or returns void.
+ */
+regm_t allocretregs(tym_t ty, type *t, tym_t tyf, reg_t *reg1, reg_t *reg2)
+{
+    tym_t ty1 = ty;
+    tym_t ty2 = TYMAX;
+
+    *reg1 = *reg2 = NOREG;
+
+    if (tybasic(ty) == TYvoid)
+        return 0;
+
+    if (ty & mTYxmmgpr)
+    {
+        ty1 = TYdouble;
+        ty2 = TYllong;
+    }
+    else if (ty & mTYgprxmm)
+    {
+        ty1 = TYllong;
+        ty2 = TYdouble;
+    }
+
+    if (tybasic(ty) == TYstruct)
+    {
+        assert(t);
+        ty1 = t.Tty;
+    }
+
+    switch (tyrelax(ty1))
+    {
+        case TYcent:
+            if (!I64 || config.exe == EX_WIN64)
+                return 0;
+            ty1 = ty2 = TYllong;
+            break;
+
+        case TYcdouble:
+            if (tybasic(tyf) == TYjfunc && I32)
+                break;
+            if (!I64 || config.exe == EX_WIN64)
+                return 0;
+            ty1 = ty2 = TYdouble;
+            break;
+
+        case TYcfloat:
+            if (tybasic(tyf) == TYjfunc && I32)
+                break;
+            if (!I64)
+                goto case TYllong;
+            if (config.exe == EX_WIN64)
+                ty1 = TYllong;
+            else
+                ty1 = TYdouble;
+            break;
+
+        case TYcldouble:
+            if (tybasic(tyf) == TYjfunc && I32)
+                break;
+            if (!I64 || config.exe == EX_WIN64)
+                return 0;
+            break;
+
+        case TYllong:
+            if (!I64)
+                ty1 = ty2 = TYlong;
+            break;
+
+        case TYarray:
+            return 0;
+
+        case TYstruct:
+            assert(t);
+            if (I64 && config.exe != EX_WIN64)
+            {
+                assert(tybasic(t.Tty) == TYstruct);
+                type *targ1 = t.Ttag.Sstruct.Sarg1type;
+                type *targ2 = t.Ttag.Sstruct.Sarg2type;
+                if (targ1)
+                    ty1 = targ1.Tty;
+                else
+                    return 0;
+                if (targ2)
+                    ty2 = targ2.Tty;
+                break;
+            }
+            else if (!(t.Ttag.Sstruct.Sflags & STRnotpod))
+            {
+                // windows only, return POD of 1, 2, 4, or 8 bytes on EAX(:EDX)
+                if (!(config.exe & (EX_WIN64 | EX_WIN32)))
+                    return 0;
+
+                uint sz = cast(uint) type_size(t);
+
+                if (sz > 8 || sz == 0)
+                    return 0;
+
+                if (sz == 8)
+                {
+                    if (config.exe == EX_WIN64)
+                        ty1 = TYllong;
+                    else
+                        ty1 = ty2 = TYlong;
+                }
+                else if (sz == 4 || sz == 2 || sz == 1)
+                    ty1 = TYlong;
+                else
+                    return 0;
+
+                break;
+            }
+            return 0;
+
+        default:
+            break;
+    }
+
+
+    static struct RetRegsAllocator
+    {
+    nothrow:
+        static reg_t[2] gp_regs = [AX, DX];
+        static reg_t[2] xmm_regs = [XMM0, XMM1];
+
+        uint cntgpr = 0,
+             cntxmm = 0;
+
+        reg_t gpr() { return gp_regs[cntgpr++]; }
+        reg_t xmm() { return xmm_regs[cntxmm++]; }
+    }
+
+    tym_t tym = ty1;
+    reg_t *reg = reg1;
+    RetRegsAllocator rralloc;
+    for (int v = 0; v < 2; ++v)
+    {
+        if (tym == TYMAX) continue;
+        switch (tysize(tym))
+        {
+        case 1:
+        case 2:
+        case 4:
+            if (tyfloating(tym))
+            {
+                if (I64)
+                    *reg = rralloc.xmm();
+                else
+                    *reg = ST0;
+            }
+            else
+                *reg = rralloc.gpr();
+            break;
+
+        case 8:
+            if (tycomplex(tym))
+            {
+                assert(tybasic(tyf) == TYjfunc && I32);
+                *reg = ST01;
+                break;
+            }
+            assert(I64 || tyfloating(tym));
+            goto case 4;
+
+        default:
+            if (tybasic(tym) == TYldouble || tybasic(tym) == TYildouble)
+            {
+                *reg = ST0;
+                break;
+            }
+            else if (tybasic(tym) == TYcldouble)
+            {
+                *reg = ST01;
+                break;
+            }
+            else if (tycomplex(tym) && tybasic(tyf) == TYjfunc && I32)
+            {
+                *reg = ST01;
+                break;
+            }
+            else if (tysimd(tym))
+            {
+                *reg = rralloc.xmm();
+                break;
+            }
+
+            debug WRTYxx(tym);
+            assert(0);
+        }
+        tym = ty2;
+        reg = reg2;
+    }
+    return (mask(*reg1) | mask(*reg2)) & ~mask(NOREG);
 }
 
 /***********************************************

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1432,7 +1432,13 @@ regm_t allocretregs(tym_t ty, type *t, tym_t tyf, reg_t *reg1, reg_t *reg2)
                     ty2 = targ2.Tty;
                 break;
             }
-            else if (!(t.Ttag.Sstruct.Sflags & STRnotpod))
+            else if ((config.exe == EX_WIN32 && config.objfmt == OBJ_OMF && tybasic(tyf) != TYjfunc &&
+                      (t.Ttag.Sstruct.Sflags & STRnotcppdmcpod)) || // DMC doesn't follow C++03 POD rules
+                     (t.Ttag.Sstruct.Sflags & STRnotcpp03pod))      // Windows follows C++03 POD rules
+            {
+                return 0; // return non POD in memory
+            }
+            else
             {
                 // windows only, return POD of 1, 2, 4, or 8 bytes on EAX(:EDX)
                 if (!(config.exe & (EX_WIN64 | EX_WIN32)))
@@ -1457,7 +1463,7 @@ regm_t allocretregs(tym_t ty, type *t, tym_t tyf, reg_t *reg1, reg_t *reg2)
 
                 break;
             }
-            return 0;
+            assert(0);
 
         default:
             break;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1118,6 +1118,8 @@ static if (NTEXCEPTIONS)
             lreg = mreg = NOREG;
             if (reg1 == NOREG)
             {}
+            else if (tybasic(e.Ety) == TYcfloat)
+                lreg = ST01;
             else if (mask(reg1) & (mST0 | mST01))
                 lreg = reg1;
             else if (reg2 == NOREG)
@@ -1172,6 +1174,39 @@ static if (NTEXCEPTIONS)
                 assert(reg1 == lreg && reg2 == NOREG);
             }
             // fix return registers
+            else if (tybasic(e.Ety) == TYcfloat)
+            {
+                assert(lreg == ST01);
+                if (I64)
+                {
+                    assert(reg2 == NOREG);
+                    // spill
+                    pop87();
+                    pop87();
+                    cdb.genfltreg(0xD9, 3, tysize(TYfloat));
+                    genfwait(cdb);
+                    cdb.genfltreg(0xD9, 3, 0);
+                    genfwait(cdb);
+                    // reload
+                    if (config.exe == EX_WIN64)
+                    {
+                        assert(reg1 == AX);
+                        cdb.genfltreg(LOD, reg1, 0);
+                        code_orrex(cdb.last(), REX_W);
+                    }
+                    else
+                    {
+                        assert(reg1 == XMM0);
+                        cdb.genxmmreg(xmmload(TYdouble), reg1, 0, TYdouble);
+                    }
+                }
+                else
+                {
+                    assert(reg1 == AX && reg2 == DX);
+                    regm_t pretregs = mask(reg1) | mask(reg2);
+                    fixresult_complex87(cdb, e, retregs, &pretregs);
+                }
+            }
             else if (reg2 == NOREG)
                 assert(lreg == reg1);
             else for (int v = 0; v < 2; v++)

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1372,7 +1372,15 @@ regm_t allocretregs(tym_t ty, type *t, tym_t tyf, reg_t *reg1, reg_t *reg2)
             break;
 
         case TYarray:
-            return 0;
+            type* targ1, targ2;
+            argtypes(t, targ1, targ2);
+            if (targ1)
+                ty1 = targ1.Tty;
+            else
+                return 0;
+            if (targ2)
+                ty2 = targ2.Tty;
+            break;
 
         case TYstruct:
             assert(t);
@@ -4058,12 +4066,14 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, out regm_
 
             // This logic is same as FuncParamRegs_alloc function at src/dmd/backend/cod1.d
             //
-            // Treat array of 1 the same as its element type
+            // Find suitable SROA based on the element type
             // (Don't put volatile parameters in registers)
-            if (tyb == TYarray && t.Tdim == 1 && !(t.Tty & mTYvolatile))
+            if (tyb == TYarray && !(t.Tty & mTYvolatile))
             {
-                t = t.Tnext;
-                tyb = tybasic(t.Tty);
+                type *targ1;
+                argtypes(t, targ1, t2);
+                if (targ1)
+                    t = targ1;
             }
 
             // If struct just wraps another type
@@ -4094,7 +4104,7 @@ void prolog_loadparams(ref CodeBuilder cdb, tym_t tyf, bool pushalloc, out regm_
                     offset += EBPtoESP;
 
                 reg_t preg = s.Spreg;
-                for (int i = 0; i < 2; ++i)     // twice, once for each possible parameter register
+                foreach (i; 0 .. 2)     // twice, once for each possible parameter register
                 {
                     shadowregm |= mask(preg);
                     opcode_t op = 0x89;                  // MOV x[EBP],preg

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1112,14 +1112,8 @@ static if (NTEXCEPTIONS)
 
         case BCretexp:
             reg_t reg1, reg2, lreg, mreg;
-            reg1 = reg2 = NOREG;
-            if (config.exe == EX_WIN64) // broken
-                retregs = regmask(e.Ety, funcsym_p.ty());
-            else
-            {
-                retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), &reg1, &reg2);
-                assert(reg1 != NOREG || !retregs);
-            }
+            retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), &reg1, &reg2);
+            assert(reg1 != NOREG || !retregs);
 
             lreg = mreg = NOREG;
             if (reg1 == NOREG)
@@ -1140,8 +1134,7 @@ static if (NTEXCEPTIONS)
                 lreg = mask(reg1) & mLSW ? reg1 : AX;
                 mreg = mask(reg2) & mMSW ? reg2 : DX;
             }
-            if (reg1 != NOREG)
-                retregs = (mask(lreg) | mask(mreg)) & ~mask(NOREG);
+            retregs = (mask(lreg) | mask(mreg)) & ~mask(NOREG);
 
             // For the final load into the return regs, don't set regcon.used,
             // so that the optimizer can potentially use retregs for register
@@ -1223,8 +1216,7 @@ static if (NTEXCEPTIONS)
                 else
                     genmovreg(cdb, reg2, mreg);
             }
-            if (reg1 != NOREG)
-                retregs = (mask(reg1) | mask(reg2)) & ~mask(NOREG);
+            retregs = (mask(reg1) | mask(reg2)) & ~mask(NOREG);
             goto L4;
 
         case BCret:

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -1112,8 +1112,14 @@ static if (NTEXCEPTIONS)
 
         case BCretexp:
             reg_t reg1, reg2, lreg, mreg;
-            retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), &reg1, &reg2);
-            assert(reg1 != NOREG || !retregs);
+            reg1 = reg2 = NOREG;
+            if (config.exe == EX_WIN64) // broken
+                retregs = regmask(e.Ety, funcsym_p.ty());
+            else
+            {
+                retregs = allocretregs(e.Ety, e.ET, funcsym_p.ty(), &reg1, &reg2);
+                assert(reg1 != NOREG || !retregs);
+            }
 
             lreg = mreg = NOREG;
             if (reg1 == NOREG)
@@ -1134,7 +1140,8 @@ static if (NTEXCEPTIONS)
                 lreg = mask(reg1) & mLSW ? reg1 : AX;
                 mreg = mask(reg2) & mMSW ? reg2 : DX;
             }
-            retregs = (mask(lreg) | mask(mreg)) & ~mask(NOREG);
+            if (reg1 != NOREG)
+                retregs = (mask(lreg) | mask(mreg)) & ~mask(NOREG);
 
             // For the final load into the return regs, don't set regcon.used,
             // so that the optimizer can potentially use retregs for register
@@ -1216,7 +1223,8 @@ static if (NTEXCEPTIONS)
                 else
                     genmovreg(cdb, reg2, mreg);
             }
-            retregs = (mask(reg1) | mask(reg2)) & ~mask(NOREG);
+            if (reg1 != NOREG)
+                retregs = (mask(reg1) | mask(reg2)) & ~mask(NOREG);
             goto L4;
 
         case BCret:

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -553,6 +553,7 @@ void searchfixlist(Symbol *s) {}
 void outfixlist();
 void code_hydrate(code **pc);
 void code_dehydrate(code **pc);
+regm_t allocretregs(tym_t ty, type *t, tym_t tyf, reg_t *reg1, reg_t *reg2);
 
 extern __gshared
 {

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -486,6 +486,7 @@ void fixresult(ref CodeBuilder cdb, elem *e, regm_t retregs, regm_t *pretregs);
 void callclib(ref CodeBuilder cdb, elem *e, uint clib, regm_t *pretregs, regm_t keepmask);
 void pushParams(ref CodeBuilder cdb,elem *, uint, tym_t tyf);
 void offsetinreg(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
+void argtypes(type* t, ref type* arg1type, ref type* arg2type);
 
 /* cod2.c */
 bool movOnly(const elem *e);

--- a/src/dmd/backend/dtype.d
+++ b/src/dmd/backend/dtype.d
@@ -637,11 +637,12 @@ type *type_enum(const(char)* name, type *tbase)
  * Params:
  *      name = name of struct (this function makes its own copy of the string)
  *      is0size = if struct has no fields (even if Sstructsize is 1)
+ *      flags = extra struct flags
  * Returns:
  *      Tcount already incremented
  */
 type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
-        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD, bool is0size)
+        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD, bool is0size, uint flags)
 {
     Symbol *s = symbol_calloc(name);
     s.Sclass = SCstruct;
@@ -652,6 +653,7 @@ type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
     s.Sstruct.Sarg1type = arg1type;
     s.Sstruct.Sarg2type = arg2type;
 
+    s.Sstruct.Sflags |= flags;
     if (!isPOD)
         s.Sstruct.Sflags |= STRnotpod;
     if (isUnion)

--- a/src/dmd/backend/ty.d
+++ b/src/dmd/backend/ty.d
@@ -187,6 +187,10 @@ enum
     mTYshared       = 0x00100000,    // shared data
     mTYnothrow      = 0x00200000,    // nothrow function
 
+    // SROA types
+    mTYxmmgpr       = 0x00400000,    // first slice in XMM register, the other in GPR
+    mTYgprxmm       = 0x00800000,    // first slice in GPR register, the other in XMM
+
     // Used only by C/C++ compiler
 //#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_DRAGONFLYBSD || TARGET_SOLARIS
     mTYnoret        = 0x01000000,    // function has no return

--- a/src/dmd/backend/type.d
+++ b/src/dmd/backend/type.d
@@ -186,5 +186,5 @@ type *type_delegate(type *tnext);
 extern (C) type *type_function(tym_t tyf, type*[] ptypes, bool variadic, type *tret);
 type *type_enum(const(char) *name, type *tbase);
 type *type_struct_class(const(char)* name, uint alignsize, uint structsize,
-        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD, bool is0size);
+        type *arg1type, type *arg2type, bool isUnion, bool isClass, bool isPOD, bool is0size, uint flags);
 

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -915,10 +915,11 @@ private elem *setArray(Expression exp, elem *eptr, elem *edim, Type tb, elem *ev
 {
     assert(op == TOK.blit || op == TOK.assign || op == TOK.construct);
     const sz = cast(uint)tb.size();
+    Type tb2 = tb;
 
 Lagain:
     int r;
-    switch (tb.ty)
+    switch (tb2.ty)
     {
         case Tfloat80:
         case Timaginary80:
@@ -948,11 +949,11 @@ Lagain:
             if (!irs.params.is64bit)
                 goto default;
 
-            TypeStruct tc = cast(TypeStruct)tb;
+            TypeStruct tc = cast(TypeStruct)tb2;
             StructDeclaration sd = tc.sym;
             if (sd.arg1type && !sd.arg2type)
             {
-                tb = sd.arg1type;
+                tb2 = sd.arg1type;
                 goto Lagain;
             }
             goto default;

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -520,9 +520,13 @@ if (!irs.params.is64bit) assert(tysize(TYnptr) == 4);
     else if (retmethod == RET.stack)
     {
         if (irs.params.isOSX && eresult)
+        {
             /* ABI quirk: hidden pointer is not returned in registers
              */
+            if (tyaggregate(tyret))
+                e.ET = Type_toCtype(tret);
             e = el_combine(e, el_copytree(eresult));
+        }
         e.Ety = TYnptr;
         e = el_una(OPind, tyret, e);
     }

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -111,6 +111,7 @@ bool ISX64REF(Declaration var)
         if (config.exe == EX_WIN64)
         {
             return var.type.size(Loc.initial) > REGSIZE
+                || (!var.type.isTypeBasic() && var.type.size() & (var.type.size() - 1))
                 || (var.storage_class & STC.lazy_)
                 || (var.type.isTypeStruct() && !var.type.isTypeStruct().sym.isPOD());
         }
@@ -130,6 +131,7 @@ bool ISX64REF(IRState* irs, Expression exp)
     if (config.exe == EX_WIN64)
     {
         return exp.type.size(Loc.initial) > REGSIZE
+            || (!exp.type.isTypeBasic() && exp.type.size() & (exp.type.size() - 1))
             || (exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD());
     }
     else if (!irs.params.isWindows)

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1647,7 +1647,7 @@ elem *toElem(Expression e, IRState *irs)
                         .type *tc = type_struct_class(tclass.sym.toChars(),
                                 tclass.sym.alignsize, tclass.sym.structsize,
                                 null, null,
-                                false, false, true, false);
+                                false, false, true, false, 0);
                         tc.Tcount--;
                         Symbol *stmp = symbol_genauto(tc);
                         ex = el_ptr(stmp);

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1083,7 +1083,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
         if (global.params.is64bit &&
             !global.params.isWindows)
         {
-            type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, null, null, false, false, true, false);
+            type *t = type_struct_class("__va_argsave_t", 16, 8 * 6 + 8 * 16 + 8 * 3, null, null, false, false, true, false, 0);
             // The backend will pick this up by name
             Symbol *sv = symbol_name("__va_argsave", SCauto, t);
             sv.Stype.Tty |= mTYvolatile;

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -13,6 +13,7 @@
 module dmd.target;
 
 import dmd.argtypes;
+import dmd.argtypes_sysv_x64;
 import core.stdc.string : strlen;
 import dmd.cppmangle;
 import dmd.cppmanglewin;
@@ -400,6 +401,8 @@ struct Target
      */
     extern (C++) TypeTuple toArgTypes(Type t)
     {
+        if (global.params.is64bit && global.params.isPOSIX)
+            return .toArgTypes_sysv_x64(t);
         if (global.params.is64bit && global.params.isWindows)
             return null;
         return .toArgTypes(t);
@@ -458,6 +461,14 @@ struct Target
                 if (tf.linkage == LINK.cpp && needsThis)
                     return true;
             }
+        }
+        else if (global.params.is64bit && global.params.isPOSIX)
+        {
+            TypeTuple tt = .toArgTypes_sysv_x64(tn);
+            if (!tt)
+                return false; // void
+            else
+                return !tt.arguments.dim;
         }
 
     Lagain:

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -470,6 +470,12 @@ struct Target
         }
         else if (global.params.is64bit && global.params.isPOSIX)
         {
+            if (tf.linkage != LINK.d && tn.isTypeStruct())
+            {
+                auto ts = cast(TypeStruct) tn;
+                if (ts.sym.hasNoFields && ts.sym.isPOD())
+                    return false;
+            }
             TypeTuple tt = .toArgTypes_sysv_x64(tn);
             if (!tt)
                 return false; // void

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -434,8 +434,14 @@ struct Target
         {
             // http://msdn.microsoft.com/en-us/library/7572ztz4.aspx
             if (tns.ty == Tcomplex32)
+                return false;
+            if (tns.iscomplex())
                 return true;
-            if (tns.isscalar())
+            if (tns.ty == Tvector)
+                return false;
+            if (tns.isfloating())
+                return false;
+            if (tns.isintegral() && sz <= 8)
                 return false;
 
             tns = tns.baseElemOf();
@@ -447,9 +453,9 @@ struct Target
                 if (!sd.isPOD() || sz > 8)
                     return true;
                 if (sd.fields.dim == 0)
-                    return true;
+                    return false;
             }
-            if (sz <= 16 && !(sz & (sz - 1)))
+            if (sz <= 8 && !(sz & (sz - 1)))
                 return false;
             return true;
         }

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -548,11 +548,7 @@ struct Target
             //printf("  3 true\n");
             return true;
         }
-        else if ((global.params.isLinux || global.params.isOSX ||
-                  global.params.isFreeBSD || global.params.isSolaris ||
-                  global.params.isDragonFlyBSD) &&
-                 tf.linkage == LINK.c &&
-                 tns.iscomplex())
+        else if (tf.linkage != LINK.d && tns.iscomplex())
         {
             if (tns.ty == Tcomplex32)
                 return false;     // in EDX:EAX, not ST1:ST0

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -432,7 +432,7 @@ struct Target
 
         if (global.params.isWindows && global.params.is64bit)
         {
-            // http://msdn.microsoft.com/en-us/library/7572ztz4.aspx
+            // https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=vs-2019#return-values
             if (tns.ty == Tcomplex32)
                 return false;
             if (tns.iscomplex())

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -565,7 +565,7 @@ Classsym *fake_classsym(Identifier id)
 {
     auto t = type_struct_class(id.toChars(),8,0,
         null,null,
-        false, false, true, false);
+        false, false, true, false, 0);
 
     t.Ttag.Sstruct.Sflags = STRglobal;
     t.Tflags |= TFsizeunknown | TFforward;

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -160,9 +160,12 @@ public:
         //printf("TypeStruct::toCtype() '%s'\n", t.sym.toChars());
         if (t.mod == 0)
         {
+            import dmd.backend.cc : STRnotcpp03pod, STRnotcpp03pod;
+
             // Create a new backend type
             StructDeclaration sym = t.sym;
-            t.ctype = type_struct_class(sym.toPrettyChars(true), sym.alignsize, sym.structsize, sym.arg1type ? Type_toCtype(sym.arg1type) : null, sym.arg2type ? Type_toCtype(sym.arg2type) : null, sym.isUnionDeclaration() !is null, false, sym.isPOD() != 0, sym.hasNoFields);
+            uint flags = (sym.isCPP03POD() ? 0 : STRnotcpp03pod) | (sym.isCPPDMCPOD() ? 0 : STRnotcpp03pod);
+            t.ctype = type_struct_class(sym.toPrettyChars(true), sym.alignsize, sym.structsize, sym.arg1type ? Type_toCtype(sym.arg1type) : null, sym.arg2type ? Type_toCtype(sym.arg2type) : null, sym.isUnionDeclaration() !is null, false, sym.isPOD() != 0, sym.hasNoFields, flags);
             /* Add in fields of the struct
              * (after setting ctype to avoid infinite recursion)
              */
@@ -247,7 +250,7 @@ public:
         if (t.mod == 0)
         {
             //printf("TypeClass::toCtype() %s\n", toChars());
-            type* tc = type_struct_class(t.sym.toPrettyChars(true), t.sym.alignsize, t.sym.structsize, null, null, false, true, true, false);
+            type* tc = type_struct_class(t.sym.toPrettyChars(true), t.sym.alignsize, t.sym.structsize, null, null, false, true, true, false, 0);
             t.ctype = type_pointer(tc);
             /* Add in fields of the class
              * (after setting ctype to avoid infinite recursion)

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -994,7 +994,7 @@ void buildClosure(FuncDeclaration fd, IRState *irs)
         strcat(strcat(closname, name1), name2);
 
         /* Build type for closure */
-        type *Closstru = type_struct_class(closname, target.ptrsize, 0, null, null, false, false, true, false);
+        type *Closstru = type_struct_class(closname, target.ptrsize, 0, null, null, false, false, true, false, 0);
         free(closname);
         auto chaintype = getParentClosureType(irs.sthis, fd);
         symbol_struct_addField(Closstru.Ttag, "__chain", chaintype, 0);
@@ -1146,7 +1146,7 @@ void buildCapture(FuncDeclaration fd)
         strcat(strcat(capturename, name1), name2);
 
         /* Build type for struct */
-        type *capturestru = type_struct_class(capturename, target.ptrsize, 0, null, null, false, false, true, false);
+        type *capturestru = type_struct_class(capturename, target.ptrsize, 0, null, null, false, false, true, false, 0);
         free(capturename);
 
         foreach (v; fd.closureVars)

--- a/test/runnable/cabi1.d
+++ b/test/runnable/cabi1.d
@@ -20,11 +20,6 @@ extern (C) Foo5 ctest5();
 extern (C) Foo6 ctest6();
 extern (C) S7 ctest10();
 
-version(Windows)
-    version = Windows_or_32bit;
-else version(X86)
-    version = Windows_or_32bit;
-
 
 void test1()
 {
@@ -44,13 +39,10 @@ void test1()
     assert(f5.i == 0x12345678);
     assert(f5.j == 0x21436587);
 
-version(Windows_or_32bit)
-{
     Foo6 f6 = ctest6();
     assert(f6.i == 0x12345678);
     assert(f6.j == 0x21463587);
     assert(f6.k == 0x24163857);
-}
 
     S7 s7 = ctest10();
     assert(s7.a == 2.5);
@@ -104,8 +96,6 @@ extern (C) S11 ctest11(ubyte x, S11, ubyte y);
 
 void test11()
 {
-  version (X86)
-  {
   S11 t;
   assert(S11.sizeof == 3);
   t.a = 2;
@@ -115,7 +105,6 @@ void test11()
   assert(s.a == 2);
   assert(s.b == 3);
   assert(s.c == 4);
-  }
 }
 
 /******************************************/
@@ -126,8 +115,6 @@ extern (C) S12 ctest12(ubyte x, S12, ubyte y);
 
 void test12()
 {
-  version (X86)
-  {
   S12 t;
   printf("D sz = %d\n", cast(int)S12.sizeof);
 //  assert(S12.sizeof == 5);
@@ -138,7 +125,6 @@ void test12()
   assert(s.a == 2);
   assert(s.b == 3);
   assert(s.c == 4);
-  }
 }
 
 /******************************************/
@@ -149,8 +135,6 @@ extern (C) S13 ctest13(ubyte x, S13, ubyte y);
 
 void test13()
 {
-  version (X86)
-  {
   S13 t;
   assert(S13.sizeof == 6);
   t.a = 2;
@@ -160,7 +144,6 @@ void test13()
   assert(s.a == 2);
   assert(s.b == 3);
   assert(s.c == 4);
-  }
 }
 
 /******************************************/
@@ -171,8 +154,6 @@ extern (C) S14 ctest14(ubyte x, S14, ubyte y);
 
 void test14()
 {
-  version (X86)
-  {
   S14 t;
   assert(S14.sizeof == 7);
   t.a = 2;
@@ -182,7 +163,6 @@ void test14()
   assert(s.a == 2);
   assert(s.b == 3);
   assert(s.c == 4);
-  }
 }
 
 /******************************************/
@@ -193,8 +173,6 @@ extern (C) S15 ctest15(ubyte x, S15, ubyte y);
 
 void test15()
 {
-  version (X86)
-  {
   S15 t;
   assert(S15.sizeof == 9);
   t.a = 2;
@@ -204,7 +182,6 @@ void test15()
   assert(s.a == 2);
   assert(s.b == 3);
   assert(s.c == 4);
-  }
 }
 
 /******************************************/
@@ -222,8 +199,6 @@ extern (C) S16 ctest16(ubyte x, S16, ubyte y);
 
 void test16()
 {
-  version (X86) // misaligned field
-  {
   S16 t;
   assert(S16.sizeof == 10);
   assert(S16.alignof == 1);
@@ -234,7 +209,6 @@ void test16()
   assert(s.a == "hello");
   assert(s.b == 3);
   assert(s.c == 0x11223344);
-  }
 }
 
 /******************************************/
@@ -244,13 +218,7 @@ int main()
     test1();
     test2();
     test3();
-version (Win64)
-{
-}
-else
-{
     test4();
-}
     test11();
     test12();
     test13();

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -50,6 +50,9 @@ struct S
     float a = 1;
 }
 
+struct S3 { byte a, b, c; }
+struct S4 { byte a, b, c, d; }
+struct S5 { byte a, b, c, d, e; }
 struct S8 { int a; float b; }
 struct S16 { int a, b; float c, d; }
 
@@ -94,6 +97,9 @@ version(D_AVX2) float8 passthrough(float8 value);
 S      passthrough(S      value);
 test19248 passthrough(const(test19248) value);
 std.test19248_ passthrough(const(std.test19248_) value);
+S3     passthrough(S3     value);
+S4     passthrough(S4     value);
+S5     passthrough(S5     value);
 S8     passthrough(S8     value);
 S16    passthrough(S16    value);
 
@@ -120,6 +126,9 @@ version(D_AVX2) float8 passthrough_ptr(float8 *value);
 S      passthrough_ptr(S      *value);
 test19248 passthrough_ptr(const(test19248)* value);
 std.test19248_ passthrough_ptr(const(std.test19248_)* value);
+S3     passthrough_ptr(S3     *value);
+S4     passthrough_ptr(S4     *value);
+S5     passthrough_ptr(S5     *value);
 S8     passthrough_ptr(S8     *value);
 S16    passthrough_ptr(S16    *value);
 
@@ -146,6 +155,9 @@ version(D_AVX2) float8 passthrough_ref(ref float8 value);
 S      passthrough_ref(ref S      value);
 test19248 passthrough_ref(ref const(test19248) value);
 std.test19248_ passthrough_ref(ref const(std.test19248_) value);
+S3     passthrough_ref(ref S3     value);
+S4     passthrough_ref(ref S4     value);
+S5     passthrough_ref(ref S5     value);
 S8     passthrough_ref(ref S8     value);
 S16    passthrough_ref(ref S16    value);
 }
@@ -325,6 +337,9 @@ version(D_AVX2) foreach(float8 val; values!float8()) check(val);
     check(S());
     check(test19248());
     check(std.test19248_());
+    check(S3(1, 2, 3));
+    check(S4(1, 2, 3, 4));
+    check(S5(1, 2, 3, 4, 5));
     check(S8(1, 2));
     check(S16(1, 2, 3, 4));
 

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -90,7 +90,8 @@ struct S032
 }
 
 struct S0 { }
-S0 passthrough(S0, ref int);
+S0 passthrough(S0, int, int, int, int, int, int, S0, int);
+S0 passthrough2(S0, int, int, int, int, int, int, S0 s, int i) { assert(i == 10); return s; }
 
 bool   passthrough(bool   value);
 byte   passthrough(byte   value);
@@ -383,10 +384,5 @@ version(D_AVX2) foreach(float8 val; values!float8()) check(val);
     assert(ss.i == 42);
     assert(S18784(1).i == 1);
 
-version(Windows) // fails on Posix
-{
-    int i = 10;
-    passthrough(S0(), i);
-    assert(i == 11);
-}
+    passthrough(S0(), 1, 2, 3, 4, 5, 6, S0(), 10);
 }

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -71,6 +71,24 @@ extern(C++, `std`)
     struct test19248 {int a = 34;}
 }
 
+// Non C++03 POD structs
+struct S030
+{
+    int i;
+    private int j;
+}
+
+struct S031
+{
+    private int i, j;
+}
+
+struct S032
+{
+    int i;
+    this(int);
+}
+
 struct S0 { }
 S0 passthrough(S0, ref int);
 
@@ -102,6 +120,9 @@ S4     passthrough(S4     value);
 S5     passthrough(S5     value);
 S8     passthrough(S8     value);
 S16    passthrough(S16    value);
+S030   passthrough(S030   value);
+S031   passthrough(S031   value);
+S032   passthrough(S032   value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -131,6 +152,9 @@ S4     passthrough_ptr(S4     *value);
 S5     passthrough_ptr(S5     *value);
 S8     passthrough_ptr(S8     *value);
 S16    passthrough_ptr(S16    *value);
+S030   passthrough_ptr(S030   *value);
+S031   passthrough_ptr(S031   *value);
+S032   passthrough_ptr(S032   *value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -160,6 +184,9 @@ S4     passthrough_ref(ref S4     value);
 S5     passthrough_ref(ref S5     value);
 S8     passthrough_ref(ref S8     value);
 S16    passthrough_ref(ref S16    value);
+S030   passthrough_ref(ref S030   value);
+S031   passthrough_ref(ref S031   value);
+S032   passthrough_ref(ref S032   value);
 }
 
 template IsSigned(T)
@@ -342,6 +369,9 @@ version(D_AVX2) foreach(float8 val; values!float8()) check(val);
     check(S5(1, 2, 3, 4, 5));
     check(S8(1, 2));
     check(S16(1, 2, 3, 4));
+    check(S030(1, 2));
+    check(S031(1, 2));
+    check(S032(1));
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -1,8 +1,16 @@
 // EXTRA_CPP_SOURCES: cpp_abi_tests.cpp
 // CXXFLAGS(linux freebsd osx netbsd dragonflybsd): -std=c++11
+// CXXFLAGS(win64): /arch:AVX2
+// PERMUTE_ARGS: -mcpu=native
 
 // N.B MSVC doesn't have a C++11 switch, but it defaults to the latest fully-supported standard
 // N.B MSVC 2013 doesn't support char16_t/char32_t
+
+import core.simd;
+import core.stdc.config : c_long_double;
+
+version (Posix) version (X86_64)
+    version = Posix_x86_64;
 
 version(Posix)
     enum __c_wchar_t : dchar;
@@ -10,12 +18,40 @@ else version(Windows)
     enum __c_wchar_t : wchar;
 alias wchar_t = __c_wchar_t;
 
+version (Windows)
+{
+    // MSVC doesn't have native complex types
+    mixin template ComplexProperties(E)
+    {
+        static typeof(this) nan() @property { return typeof(this)(E.nan.re, E.nan.im); }
+        static typeof(this) min_normal() @property { return typeof(this)(E.min_normal.re, E.min_normal.im); }
+        static typeof(this) max() @property { return typeof(this)(E.max.re, E.max.im); }
+    }
+    struct cfloat_t  { float re, im; mixin ComplexProperties!float; }
+    struct cdouble_t { double re, im; mixin ComplexProperties!double; }
+    struct creal_t   { c_long_double re, im; mixin ComplexProperties!c_long_double; }
+
+    T to(T : cfloat_t)(cfloat i)   { return T(i.re, i.im); }
+    T to(T : cdouble_t)(cdouble i) { return T(i.re, i.im); }
+    T to(T : creal_t)(creal i)     { return T(i.re, i.im); }
+}
+else
+{
+    alias cfloat_t = cfloat;
+    alias cdouble_t = cdouble;
+    alias creal_t = creal;
+    T to(T)(T i) { return i; }
+}
+
 extern(C++) {
 
 struct S
 {
     float a = 1;
 }
+
+struct S8 { int a; float b; }
+struct S16 { int a, b; float c, d; }
 
 struct S18784
 {
@@ -32,6 +68,9 @@ extern(C++, `std`)
     struct test19248 {int a = 34;}
 }
 
+struct S0 { }
+S0 passthrough(S0, ref int);
+
 bool   passthrough(bool   value);
 byte   passthrough(byte   value);
 ubyte  passthrough(ubyte  value);
@@ -47,9 +86,16 @@ long   passthrough(long   value);
 ulong  passthrough(ulong  value);
 float  passthrough(float  value);
 double passthrough(double value);
+cfloat_t passthrough(cfloat_t value);
+cdouble_t passthrough(cdouble_t value);
+creal_t passthrough(creal_t value);
+version(D_SIMD) float4 passthrough(float4 value);
+version(D_AVX2) float8 passthrough(float8 value);
 S      passthrough(S      value);
 test19248 passthrough(const(test19248) value);
 std.test19248_ passthrough(const(std.test19248_) value);
+S8     passthrough(S8     value);
+S16    passthrough(S16    value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -66,9 +112,16 @@ long   passthrough_ptr(long   *value);
 ulong  passthrough_ptr(ulong  *value);
 float  passthrough_ptr(float  *value);
 double passthrough_ptr(double *value);
+cfloat_t passthrough_ptr(cfloat_t *value);
+cdouble_t passthrough_ptr(cdouble_t *value);
+creal_t passthrough_ptr(creal_t *value);
+version(D_SIMD) float4 passthrough_ptr(float4 *value);
+version(D_AVX2) float8 passthrough_ptr(float8 *value);
 S      passthrough_ptr(S      *value);
 test19248 passthrough_ptr(const(test19248)* value);
 std.test19248_ passthrough_ptr(const(std.test19248_)* value);
+S8     passthrough_ptr(S8     *value);
+S16    passthrough_ptr(S16    *value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -85,9 +138,16 @@ long   passthrough_ref(ref long   value);
 ulong  passthrough_ref(ref ulong  value);
 float  passthrough_ref(ref float  value);
 double passthrough_ref(ref double value);
+cfloat_t passthrough_ref(ref cfloat_t value);
+cdouble_t passthrough_ref(ref cdouble_t value);
+creal_t passthrough_ref(ref creal_t value);
+version(D_SIMD) float4 passthrough_ref(ref float4 value);
+version(D_AVX2) float8 passthrough_ref(ref float8 value);
 S      passthrough_ref(ref S      value);
 test19248 passthrough_ref(ref const(test19248) value);
 std.test19248_ passthrough_ref(ref const(std.test19248_) value);
+S8     passthrough_ref(ref S8     value);
+S16    passthrough_ref(ref S16    value);
 }
 
 template IsSigned(T)
@@ -116,6 +176,11 @@ template IsFloatingPoint(T)
     enum IsFloatingPoint = is(T==float) || is(T==double) || is(T==real);
 }
 
+template IsComplex(T)
+{
+    enum IsComplex = is(T==cfloat_t) || is(T==cdouble_t) || is(T==creal_t);
+}
+
 template IsBoolean(T)
 {
     enum IsBoolean = is(T==bool);
@@ -128,7 +193,18 @@ template IsSomeChar(T)
 
 void check(T)(T actual, T expected)
 {
+    static if (is(T == creal_t) && creal_t.sizeof > 20)
+    {
+        // this is a trick to zero out the padding
+        actual = actual;
+        expected = expected;
+    }
     assert(actual is expected);
+}
+
+void check(T : __vector(V[N]), V, size_t N)(T actual, T expected)
+{
+    assert(actual.array == expected.array);
 }
 
 void check(T)(T value)
@@ -154,14 +230,22 @@ T[] values(T)()
     }
     else
     {
-        values ~= T(0);
-        values ~= T(1);
+        static if (IsComplex!T)
+        {
+            values ~= to!T(0+0i);
+            values ~= to!T(1+1i);
+        }
+        else
+        {
+            values ~= T(0);
+            values ~= T(1);
+        }
         static if(IsIntegral!T)
         {
             static if(IsSigned!T) values ~= T.min;
             values ~= T.max;
         }
-        else static if(IsFloatingPoint!T)
+        else static if(IsFloatingPoint!T || IsComplex!T)
         {
             values ~= T.nan;
             values ~= T.min_normal;
@@ -227,9 +311,22 @@ else
     foreach(ulong val; values!ulong())   check(val);
     foreach(float val; values!float())   check(val);
     foreach(double val; values!double()) check(val);
+    foreach(cfloat_t val; values!cfloat_t()) check(val);
+    foreach(cdouble_t val; values!cdouble_t()) check(val);
+version (Posix_x86_64) {} else // still fails on POSIX x86_64
+{
+    foreach(creal_t val; values!creal_t()) check(val);
+}
+version(none) // Enable when the mangling is fixed
+{
+version(D_SIMD) foreach(float4 val; values!float4()) check(val);
+version(D_AVX2) foreach(float8 val; values!float8()) check(val);
+}
     check(S());
     check(test19248());
     check(std.test19248_());
+    check(S8(1, 2));
+    check(S16(1, 2, 3, 4));
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);
@@ -240,4 +337,11 @@ else
     smallStructTest(ss);
     assert(ss.i == 42);
     assert(S18784(1).i == 1);
+
+version(Windows) // fails on Posix
+{
+    int i = 10;
+    passthrough(S0(), i);
+    assert(i == 11);
+}
 }

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -1,8 +1,42 @@
 #include <assert.h>
+#include <complex.h>
+
+#if !defined (__SSE__) && (defined (_M_X64) || (defined (_M_IX86_FP) && _M_IX86_FP >= 1))
+#define __SSE__ 1
+#endif
+
+#ifdef __SSE__
+#include <immintrin.h>
+#endif
+
+#ifdef _WIN32
+struct cfloat_t  { float re, im; };
+struct cdouble_t { double re, im; };
+struct creal_t   { long double re, im; };
+#else
+typedef _Complex float cfloat_t;
+typedef _Complex double cdouble_t;
+typedef _Complex long double creal_t;
+#endif
+
+#ifdef __SSE__
+typedef __m128 float4_t;
+#else
+struct float4_t { float v[4]; };
+#endif
+
+#ifdef __AVX2__
+typedef __m256 float8_t;
+#else
+struct float8_t { float v[8]; };
+#endif
 
 struct S{
     float a;
 };
+
+struct S8 { int a; float b; };
+struct S16 { int a, b; float c, d; };
 
 namespace std
 {
@@ -26,6 +60,9 @@ struct S18784
 
 S18784::S18784(int n) : i(n) {}
 
+struct S0 { };
+S0 passthrough(S0 s, int &i) { ++i; return s; }
+
 bool               passthrough(bool                value)     { return value; }
 signed char        passthrough(signed char         value)     { return value; }
 unsigned char      passthrough(unsigned char       value)     { return value; }
@@ -45,9 +82,16 @@ long long          passthrough(long long           value)     { return value; }
 unsigned long long passthrough(unsigned long long  value)     { return value; }
 float              passthrough(float               value)     { return value; }
 double             passthrough(double              value)     { return value; }
+cfloat_t           passthrough(cfloat_t            value)     { return value; }
+cdouble_t          passthrough(cdouble_t           value)     { return value; }
+creal_t            passthrough(creal_t             value)     { return value; }
+float4_t           passthrough(float4_t            value)     { return value; }
+float8_t           passthrough(float8_t            value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
 std::test19248     passthrough(const std::test19248 value)    { return value; }
 std::test19248_    passthrough(const std::test19248_ value)   { return value; }
+S8                 passthrough(S8                  value)     { return value; }
+S16                passthrough(S16                 value)     { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -68,9 +112,16 @@ long long          passthrough_ptr(long long          *value) { return *value; }
 unsigned long long passthrough_ptr(unsigned long long *value) { return *value; }
 float              passthrough_ptr(float              *value) { return *value; }
 double             passthrough_ptr(double             *value) { return *value; }
+cfloat_t           passthrough_ptr(cfloat_t           *value) { return *value; }
+cdouble_t          passthrough_ptr(cdouble_t          *value) { return *value; }
+creal_t            passthrough_ptr(creal_t            *value) { return *value; }
+float4_t           passthrough_ptr(float4_t           *value) { return *value; }
+float8_t           passthrough_ptr(float8_t           *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
 std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
 std::test19248_    passthrough_ptr(const std::test19248_ *value) { return *value; }
+S8                 passthrough_ptr(S8                 *value) { return *value; }
+S16                passthrough_ptr(S16                *value) { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -91,9 +142,16 @@ long long          passthrough_ref(long long          &value) { return value; }
 unsigned long long passthrough_ref(unsigned long long &value) { return value; }
 float              passthrough_ref(float              &value) { return value; }
 double             passthrough_ref(double             &value) { return value; }
+cfloat_t           passthrough_ref(cfloat_t           &value) { return value; }
+cdouble_t          passthrough_ref(cdouble_t          &value) { return value; }
+creal_t            passthrough_ref(creal_t            &value) { return value; }
+float4_t           passthrough_ref(float4_t           &value) { return value; }
+float8_t           passthrough_ref(float8_t           &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
 std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
+S8                 passthrough_ref(S8                 &value) { return value; }
+S16                passthrough_ref(S16                &value) { return value; }
 
 namespace ns1
 {

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -63,6 +63,27 @@ struct S18784
 
 S18784::S18784(int n) : i(n) {}
 
+struct S030
+{
+    int i;
+private:
+    int j;
+};
+
+struct S031
+{
+private:
+    int i, j;
+};
+
+struct S032
+{
+    int i;
+    S032(int);
+};
+
+S032::S032(int i) : i(i) {}
+
 struct S0 { };
 S0 passthrough(S0 s, int &i) { ++i; return s; }
 
@@ -98,6 +119,9 @@ S4                 passthrough(S4                  value)     { return value; }
 S5                 passthrough(S5                  value)     { return value; }
 S8                 passthrough(S8                  value)     { return value; }
 S16                passthrough(S16                 value)     { return value; }
+S030               passthrough(S030                value)     { return value; }
+S031               passthrough(S031                value)     { return value; }
+S032               passthrough(S032                value)     { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -131,6 +155,9 @@ S4                 passthrough_ptr(S4                 *value) { return *value; }
 S5                 passthrough_ptr(S5                 *value) { return *value; }
 S8                 passthrough_ptr(S8                 *value) { return *value; }
 S16                passthrough_ptr(S16                *value) { return *value; }
+S030               passthrough_ptr(S030               *value) { return *value; }
+S031               passthrough_ptr(S031               *value) { return *value; }
+S032               passthrough_ptr(S032               *value) { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -164,6 +191,9 @@ S4                 passthrough_ref(S4                 &value) { return value; }
 S5                 passthrough_ref(S5                 &value) { return value; }
 S8                 passthrough_ref(S8                 &value) { return value; }
 S16                passthrough_ref(S16                &value) { return value; }
+S030               passthrough_ref(S030               &value) { return value; }
+S031               passthrough_ref(S031               &value) { return value; }
+S032               passthrough_ref(S032               &value) { return value; }
 
 namespace ns1
 {

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -35,6 +35,9 @@ struct S{
     float a;
 };
 
+struct S3 { signed char a, b, c; };
+struct S4 { signed char a, b, c, d; };
+struct S5 { signed char a, b, c, d, e; };
 struct S8 { int a; float b; };
 struct S16 { int a, b; float c, d; };
 
@@ -90,6 +93,9 @@ float8_t           passthrough(float8_t            value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
 std::test19248     passthrough(const std::test19248 value)    { return value; }
 std::test19248_    passthrough(const std::test19248_ value)   { return value; }
+S3                 passthrough(S3                  value)     { return value; }
+S4                 passthrough(S4                  value)     { return value; }
+S5                 passthrough(S5                  value)     { return value; }
 S8                 passthrough(S8                  value)     { return value; }
 S16                passthrough(S16                 value)     { return value; }
 
@@ -120,6 +126,9 @@ float8_t           passthrough_ptr(float8_t           *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
 std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
 std::test19248_    passthrough_ptr(const std::test19248_ *value) { return *value; }
+S3                 passthrough_ptr(S3                 *value) { return *value; }
+S4                 passthrough_ptr(S4                 *value) { return *value; }
+S5                 passthrough_ptr(S5                 *value) { return *value; }
 S8                 passthrough_ptr(S8                 *value) { return *value; }
 S16                passthrough_ptr(S16                *value) { return *value; }
 
@@ -150,6 +159,9 @@ float8_t           passthrough_ref(float8_t           &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
 std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
+S3                 passthrough_ref(S3                 &value) { return value; }
+S4                 passthrough_ref(S4                 &value) { return value; }
+S5                 passthrough_ref(S5                 &value) { return value; }
 S8                 passthrough_ref(S8                 &value) { return value; }
 S16                passthrough_ref(S16                &value) { return value; }
 

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -85,7 +85,18 @@ struct S032
 S032::S032(int i) : i(i) {}
 
 struct S0 { };
-S0 passthrough(S0 s, int &i) { ++i; return s; }
+S0 passthrough2(S0, int, int, int, int, int, int, S0 s, int i);
+S0 passthrough(S0, int, int, int, int, int, int, S0 s, int i)
+{
+#if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ < 8)
+    // GCC pre 8 had a different ABI for zero sized parameters.
+    // DMD supports the clang ABI which GCC adopted since 8.0.
+    return S0();
+#else
+    assert(i == 10);
+    return passthrough2(s, 1, 2, 3, 4, 5, 6, s, i);
+#endif
+}
 
 bool               passthrough(bool                value)     { return value; }
 signed char        passthrough(signed char         value)     { return value; }

--- a/test/runnable/test15862.d
+++ b/test/runnable/test15862.d
@@ -44,6 +44,7 @@ void main()
         auto a1 = an();
         auto a2 = an();
 
+        version(Win64) {} else // returns on stack in windows 64
         if (a1 !is a2) assert(0);
 
         auto o1 = on();

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -3,8 +3,7 @@
 version(Windows) {}
 else version(X86_64)
 {
-        /* uncomment to enable tests! */
-        //version = Run_X86_64_Tests;
+        version = Run_X86_64_Tests;
 }
 
 extern (C) int printf(const char*, ...);
@@ -582,6 +581,8 @@ TEST data2 = { 2, "RDI struct pointer" };
 
 T test2_asm( T, int n )( T t )
 {
+        typeof(.dump) dump = void;
+        enum m = T.sizeof < 4 ? mask(T.sizeof) : ~0LU;
         asm {
 
         mov [dump], RDI;
@@ -589,10 +590,12 @@ T test2_asm( T, int n )( T t )
         cmp EDI, 0; // TODO test RDI is a ptr to stack ? ?
         je L1;
 
-        leave; ret;
+        jmp Lret;
         }
 L1:
         data2.result[n] = true;
+Lret:
+        .dump = dump;
 }
 T test2f_asm( T, int n )( T t, int x )
 {
@@ -635,9 +638,12 @@ TEST data3 = { 3, "Check Return Register value" };
 
 void test3_run( T, int n )( )
 {
+        typeof(.dump) dump;
+
         test3_ret!T();
         mixin( gen_reg_capture!(n,`["RAX","RDX"]`)() );
 
+        //.dump = dump;
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;
@@ -669,8 +675,10 @@ TEST data4 = { 4, "Check Input Register value" };
 
 void test4_run( T, int n )( T t )
 {
+        typeof(.dump) dump = void;
         mixin( gen_reg_capture!(n,`["RDI","RSI"]`)() );
 
+        //.dump = dump;
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -674,7 +674,7 @@ void test1()
         foreach( int n, T; ALL_T )
                 test1_asm!(T,n)(12);
 
-        check( data1 );
+        assert( check( data1 ) );
 }
 
 /************************************************************************/
@@ -733,7 +733,7 @@ void test2()
                 test2f_asm!(T,n2)( T.init, 12 );
         }
 
-        check( data2 );
+        assert( check( data2 ) );
 }
 
 /************************************************************************/
@@ -774,7 +774,7 @@ void test3()
         foreach( int n, T; ALL_T )
                 test3_run!(T,n)( );
 
-        check( data3 );
+        assert( check( data3 ) );
 }
 
 // 0xFF n times
@@ -826,7 +826,7 @@ void test4()
                 foreach( i, ref e; t.tupleof )  e = i+1;
                 test4_run!(T,n)( t );
         }
-        check( data4 );
+        assert( check( data4 ) );
 }
 
 

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -482,6 +482,107 @@ immutable long[][] RegValue =
 /*  84  idi     */ null,
         ];
 
+/**
+ * The sizes of expected values.
+ *
+ * The rest is considered padding.
+ * Note: Mixed register cases have the SSE register first
+ */
+immutable long[][] RegValueSize =
+        [
+/*   0  b       */ [ 1,   ],
+/*   1  bb      */ [ 2,   ],
+/*   2  bbb     */ [ 3,   ],
+/*   3  bbbb    */ [ 4,   ],
+/*   4  bbbbb   */ [ 5,   ],
+/*   5  b6      */ [ 6,   ],
+/*   6  b7      */ [ 7,   ],
+/*   7  b8      */ [ 8,   ],
+/*   8  b9      */ [ 8, 1 ],
+/*   9  b10     */ [ 8, 2 ],
+/*  10  b11     */ [ 8, 3 ],
+/*  11  b12     */ [ 8, 4 ],
+/*  12  b13     */ [ 8, 5 ],
+/*  13  b14     */ [ 8, 6 ],
+/*  14  b15     */ [ 8, 7 ],
+/*  15  b16     */ [ 8, 8 ],
+/*  16  b17     */ null,
+/*  17  b18     */ null,
+/*  18  b19     */ null,
+/*  19  b20     */ null,
+/*  20  s       */ [ 2,   ],
+/*  21  ss      */ [ 4,   ],
+/*  22  sss     */ [ 6,   ],
+/*  23  ssss    */ [ 8,   ],
+/*  24  sssss   */ [ 8, 2 ],
+/*  25  s6      */ [ 8, 4 ],
+/*  26  s7      */ [ 8, 6 ],
+/*  27  s8      */ [ 8, 8 ],
+/*  28  s9      */ null,
+/*  29  s10     */ null,
+/*  30  i       */ [ 4,   ],
+/*  31  ii      */ [ 8,   ],
+/*  32  iii     */ [ 8, 4 ],
+/*  33  iiii    */ [ 8, 8 ],
+/*  34  iiiii   */ null,
+/*  35  l       */ [ 8,   ],
+/*  36  ll      */ [ 8, 8 ],
+/*  37  lll     */ null,
+/*  38  llll    */ null,
+/*  39  lllll   */ null,
+
+/*  40  js      */ [ 6,   ],
+/*  41  iss     */ [ 8,   ],
+/*  42  si      */ [ 8,   ],
+/*  43  ssi     */ [ 8,   ],
+/*  44  sis     */ [ 8, 2 ],
+/*  45  ls      */ [ 8, 2 ],
+/*  46  lss     */ [ 8, 4 ],
+/*  47  sl      */ [ 2, 8 ],
+/*  48  ssl     */ [ 4, 8 ],
+/*  49  sls     */ null,
+/*  50  li      */ [ 8, 4 ],
+/*  51  lii     */ [ 8, 8 ],
+/*  52  il      */ [ 4, 8 ],
+/*  53  iil     */ [ 8, 8 ],
+/*  54  ili     */ null,
+
+/*  55  fi      */ [ 8,   ],
+/*  56  fii     */ [ 8, 4 ],
+/*  57  jf      */ [ 8,   ],
+/*  58  ifi     */ [ 8, 4 ],
+
+/*  59  ifif    */ [ 8, 8 ],
+
+/*  60  f       */ [ 4,   ],
+/*  61  ff      */ [ 8,   ],
+/*  62  fff     */ [ 8, 4 ],
+/*  63  ffff    */ [ 8, 8 ],
+/*  64  fffff   */ null,
+/*  65  d       */ [ 8,   ],
+/*  66  dd      */ [ 8, 8 ],
+/*  67  ddd     */ null,
+/*  68  dddd    */ null,
+/*  69  ddddd   */ null,
+
+/*  70  df      */ [ 8, 4 ],
+/*  71  dff     */ [ 8, 8 ],
+/*  72  fd      */ [ 4, 8 ],
+/*  73  ffd     */ [ 8, 8 ],
+/*  74  fdf     */ null,
+
+/*  75  ffi     */ [ 8, 4 ],
+/*  76  ffii    */ [ 8, 8 ],
+/*  77  iff     */ [ 4, 8 ],
+/*  78  iiff    */ [ 8, 8 ],
+/*  79  iif     */ [ 4, 8 ],
+/*  80  di      */ [ 8, 4 ],
+/*  81  dii     */ [ 8, 8 ],
+/*  82  id      */ [ 8, 4 ],
+/*  83  iid     */ [ 8, 8 ],
+/*  84  idi     */ null,
+        ];
+
 /* Have to do it this way for OSX: Issue 7354 */
 __gshared long[2] dump;
 
@@ -590,6 +691,7 @@ T test2_asm( T, int n )( T t )
 
         mov [dump], RDI;
         mov [dump+8], RSP;
+        and EDI, m; // remove padding noise
         cmp EDI, 0; // TODO test RDI is a ptr to stack ? ?
         je L1;
 
@@ -650,6 +752,7 @@ void test3_run( T, int n )( )
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;
+        foreach ( i; 0..len ) dump[i] &= mask(RegValueSize[n][i]); // zero out padding
         if( dump[0..len] == RegValue[n] )
                 data3.result[n] = true;
 }
@@ -671,6 +774,14 @@ void test3()
         check( data3 );
 }
 
+// 0xFF n times
+ulong mask(ulong n)
+{
+        if ( n == ulong.sizeof )   // may wrap
+                return ~0UL;
+        return 2^^( n*8 ) - 1;
+}
+
 /************************************************************************/
 // test4
 
@@ -685,6 +796,7 @@ void test4_run( T, int n )( T t )
         //dbg!(T,n)( );
 
         enum len = RegValue[n].length;
+        foreach ( i; 0..len ) dump[i] &= mask(RegValueSize[n][i]); // zero out padding
         if( dump[0..len] == RegValue[n] )
                 data4.result[n] = true;
 }

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -131,8 +131,7 @@ alias tuple!(   b,bb,bbb,bbbb,bbbbb,
                 js,iss,si,ssi, sis,
                 ls,lss,sl,ssl, sls,
                 li,lii,il,iil, ili,
-                fi,fii,jf,iif, ifi,
-                ffi,ffii,iff,iiff,ifif, // INT_END
+                fi,fii,jf,ifi,ifif,                   // INT_END
 
                 // SSE registers only
                 f,ff,fff,ffff,fffff,
@@ -141,12 +140,13 @@ alias tuple!(   b,bb,bbb,bbbb,bbbbb,
                 df,dff,fd,ffd, fdf,     // SSE_END
 
                 // Int and SSE
+                ffi,ffii,iff,iiff,iif,
                 di,  dii,id, iid, idi,  // MIX_END
                 // ---
             ) ALL_T;
 
-enum INT_END = 65;
-enum SSE_END = 80;
+enum INT_END = 60;
+enum SSE_END = 75;
 enum MIX_END = ALL_T.length;
 
                 // x87
@@ -169,13 +169,13 @@ string[] ALL_S=[
                 "js","iss","si","ssi", "sis",
                 "ls","lss","sl","ssl", "sls",
                 "li","lii","il","iil", "ili",
-                "fi","fii","jf","iif", "ifi",
-                "ffi","ffii","iff","iiff","ifif",
+                "fi","fii","jf", "ifi","ifif",
                 // ---
                 "f","ff","fff","ffff","fffff",
                 "d","dd","ddd","dddd","ddddd",
                 "df","dff","fd","ffd", "dfd",
                 // ---
+                "ffi","ffii","iff","iiff","iif",
                 "di","dii","id","iid","idi",
                ];
 
@@ -352,6 +352,7 @@ struct TEST
  */
 immutable int[MIX_END] expected =
         [
+        // INT regs only
         1,1,1,1,1, // b
         1,1,1,1,1, // b6
         1,1,1,1,1, // b11
@@ -365,7 +366,6 @@ immutable int[MIX_END] expected =
         1,1,1,1,0, // sl
         1,1,1,1,0, // il
         1,1,1,1,1, // int and float
-        1,1,1,1,1, // int and float
 
         // SSE regs only
         1,1,1,1,0, // f
@@ -373,6 +373,7 @@ immutable int[MIX_END] expected =
         1,1,1,1,0, // float and double
 
         // SSE + INT regs
+        1,1,1,1,1, // int and float
         1,1,1,1,0, // int and double
         ];
 
@@ -382,6 +383,8 @@ immutable int[MIX_END] expected =
  *
  * null means do not test
  * ( because value is passed on the stack ).
+ *
+ * Note: Mixed register cases have the SSE register first
  */
 
 immutable long[][] RegValue =
@@ -446,32 +449,32 @@ immutable long[][] RegValue =
 /*  55  fi      */ [ 0x000000023f800000,                    ],
 /*  56  fii     */ [ 0x000000023f800000, 0x0000000000000003 ],
 /*  57  jf      */ [ 0x4000000000000001,                    ],
-/*  58  iif     */ [ 0x0000000200000001, 0x0000000040400000 ],
-/*  59  ifi     */ [ 0x4000000000000001, 0x0000000000000003 ],
+/*  58  ifi     */ [ 0x4000000000000001, 0x0000000000000003 ],
 
-/*  60  ffi     */ [ 0x0000000000000003, 0x400000003f800000 ],
-/*  61  ffii    */ [ 0x0000000400000003, 0x400000003f800000 ],
-/*  62  iff     */ [ 0x4000000000000001, 0x0000000040400000 ],
-/*  63  iiff    */ [ 0x0000000200000001, 0x4080000040400000 ],
-/*  64  ifif    */ [ 0x4000000000000001, 0x4080000000000003 ],
+/*  59  ifif    */ [ 0x4000000000000001, 0x4080000000000003 ],
 
-/*  65  f       */ [ 0x000000003f800000,                    ],
-/*  66  ff      */ [ 0x400000003f800000,                    ],
-/*  67  fff     */ [ 0x400000003f800000, 0x0000000040400000 ],
-/*  68  ffff    */ [ 0x400000003f800000, 0x4080000040400000 ],
-/*  69  fffff   */ null,
-/*  70  d       */ [ 0x3ff0000000000000,                    ],
-/*  71  dd      */ [ 0x3ff0000000000000, 0x4000000000000000 ],
-/*  72  ddd     */ null,
-/*  73  dddd    */ null,
-/*  74  ddddd   */ null,
+/*  60  f       */ [ 0x000000003f800000,                    ],
+/*  61  ff      */ [ 0x400000003f800000,                    ],
+/*  62  fff     */ [ 0x400000003f800000, 0x0000000040400000 ],
+/*  63  ffff    */ [ 0x400000003f800000, 0x4080000040400000 ],
+/*  64  fffff   */ null,
+/*  65  d       */ [ 0x3ff0000000000000,                    ],
+/*  66  dd      */ [ 0x3ff0000000000000, 0x4000000000000000 ],
+/*  67  ddd     */ null,
+/*  68  dddd    */ null,
+/*  69  ddddd   */ null,
 
-/*  75  df      */ [ 0x3ff0000000000000, 0x0000000040000000 ],
-/*  76  dff     */ [ 0x3ff0000000000000, 0x4040000040000000 ],
-/*  77  fd      */ [ 0x000000003f800000, 0x4000000000000000 ],
-/*  78  ffd     */ [ 0x400000003f800000, 0x4008000000000000 ],
-/*  79  fdf     */ null,
+/*  70  df      */ [ 0x3ff0000000000000, 0x0000000040000000 ],
+/*  71  dff     */ [ 0x3ff0000000000000, 0x4040000040000000 ],
+/*  72  fd      */ [ 0x000000003f800000, 0x4000000000000000 ],
+/*  73  ffd     */ [ 0x400000003f800000, 0x4008000000000000 ],
+/*  74  fdf     */ null,
 
+/*  75  ffi     */ [ 0x400000003f800000, 0x0000000000000003 ],
+/*  76  ffii    */ [ 0x400000003f800000, 0x0000000400000003 ],
+/*  77  iff     */ [ 0x0000000040400000, 0x4000000000000001 ],
+/*  78  iiff    */ [ 0x4080000040400000, 0x0000000200000001 ],
+/*  79  iif     */ [ 0x0000000040400000, 0x0000000200000001 ],
 /*  80  di      */ [ 0x3ff0000000000000, 0x0000000000000002 ],
 /*  81  dii     */ [ 0x3ff0000000000000, 0x0000000300000002 ],
 /*  82  id      */ [ 0x4000000000000000, 0x0000000000000001 ],

--- a/test/runnable/testabi.d
+++ b/test/runnable/testabi.d
@@ -745,6 +745,9 @@ void test3_run( T, int n )( )
 {
         typeof(.dump) dump;
 
+        if (RegValue[n] == null)
+                return;
+
         test3_ret!T();
         mixin( gen_reg_capture!(n,`["RAX","RDX"]`)() );
 
@@ -791,6 +794,9 @@ void test4_run( T, int n )( T t )
 {
         typeof(.dump) dump = void;
         mixin( gen_reg_capture!(n,`["RDI","RSI"]`)() );
+
+        if (RegValue[n] == null)
+                return;
 
         //.dump = dump;
         //dbg!(T,n)( );

--- a/test/runnable/testargtypes.d
+++ b/test/runnable/testargtypes.d
@@ -43,69 +43,35 @@ int main()
     chkIdentity!int();
     chkIdentity!long();
 
-    version (DigitalMars)
-    {
-        chkIdentity!ubyte();
-        chkIdentity!ushort();
-        chkIdentity!uint();
-        chkIdentity!ulong();
+    chkSingle!(ubyte,  byte)();
+    chkSingle!(ushort, short)();
+    chkSingle!(uint,   int)();
+    chkSingle!(ulong,  long)();
 
-        chkSingle!(char,  ubyte)();
-        chkSingle!(wchar, ushort)();
-        chkSingle!(dchar, uint)();
-    }
-    else
-    {
-        chkSingle!(ubyte,  byte)();
-        chkSingle!(ushort, short)();
-        chkSingle!(uint,   int)();
-        chkSingle!(ulong,  long)();
-
-        chkSingle!(char,  byte)();
-        chkSingle!(wchar, short)();
-        chkSingle!(dchar, int)();
-    }
+    chkSingle!(char,  byte)();
+    chkSingle!(wchar, short)();
+    chkSingle!(dchar, int)();
 
     chkIdentity!float();
     chkIdentity!double();
     chkIdentity!real();
 
-    version (DigitalMars)
-        chkIdentity!(void*)();
-    else
-        chkSingle!(void*, ptrdiff_t)();
+    chkSingle!(void*, ptrdiff_t)();
 
-    version (DigitalMars)
-    {
-        chkIdentity!(__vector(byte[16]))();
-        chkIdentity!(__vector(ubyte[16]))();
-        chkIdentity!(__vector(short[8]))();
-        chkIdentity!(__vector(ushort[8]))();
-        chkIdentity!(__vector(int[4]))();
-        chkIdentity!(__vector(uint[4]))();
-        chkIdentity!(__vector(long[2]))();
-        chkIdentity!(__vector(ulong[2]))();
+    chkSingle!(__vector(byte[16]),  __vector(double[2]))();
+    chkSingle!(__vector(ubyte[16]), __vector(double[2]))();
+    chkSingle!(__vector(short[8]),  __vector(double[2]))();
+    chkSingle!(__vector(ushort[8]), __vector(double[2]))();
+    chkSingle!(__vector(int[4]),    __vector(double[2]))();
+    chkSingle!(__vector(uint[4]),   __vector(double[2]))();
+    chkSingle!(__vector(long[2]),   __vector(double[2]))();
+    chkSingle!(__vector(ulong[2]),  __vector(double[2]))();
 
-        chkIdentity!(__vector(float[4]))();
-        chkIdentity!(__vector(double[2]))();
-    }
-    else
-    {
-        chkSingle!(__vector(byte[16]),  __vector(double[2]))();
-        chkSingle!(__vector(ubyte[16]), __vector(double[2]))();
-        chkSingle!(__vector(short[8]),  __vector(double[2]))();
-        chkSingle!(__vector(ushort[8]), __vector(double[2]))();
-        chkSingle!(__vector(int[4]),    __vector(double[2]))();
-        chkSingle!(__vector(uint[4]),   __vector(double[2]))();
-        chkSingle!(__vector(long[2]),   __vector(double[2]))();
-        chkSingle!(__vector(ulong[2]),  __vector(double[2]))();
+    chkSingle!(__vector(float[4]),  __vector(double[2]))();
+    chkSingle!(__vector(double[2]), __vector(double[2]))();
 
-        chkSingle!(__vector(float[4]),  __vector(double[2]))();
-        chkSingle!(__vector(double[2]), __vector(double[2]))();
-
-        version (D_AVX)
-            chkSingle!(__vector(int[8]), __vector(double[4]))();
-    }
+    version (D_AVX)
+        chkSingle!(__vector(int[8]), __vector(double[4]))();
 
     chkPair!(byte,  byte,  short);
     chkPair!(ubyte, ubyte, short);
@@ -160,20 +126,13 @@ int main()
     chkArgTypes!(int[3], long, int)();
 
     struct S12 { align(16) int a; }
-    version (DigitalMars)
-        chkArgTypes!(S12, int)();
-    else
-        chkArgTypes!(S12, long)();
+    chkArgTypes!(S12, long)();
 
-    version (DigitalMars) {}
-    else
-    {
-        struct S13 { short a; cfloat b; }
-        chkArgTypes!(S13, long, float)();
+    struct S13 { short a; cfloat b; }
+    chkArgTypes!(S13, long, float)();
 
-        struct S13957 { double a; ulong b; }
-        chkArgTypes!(S13957, double, long)();
-    }
+    struct S13957 { double a; ulong b; }
+    chkArgTypes!(S13957, double, long)();
 
     return 0;
 }


### PR DESCRIPTION
Fixes DMD's C++ calling conventions on windows x64.
Closes issue [12343](https://issues.dlang.org/show_bug.cgi?id=12343).

This PR is based on #10200.


Requires https://github.com/dlang/phobos/pull/7132 for phobos tests to pass.