### PR TITLE
fix azure builds for master/stable (for real)

### DIFF
--- a/.azure-pipelines/lib.sh
+++ b/.azure-pipelines/lib.sh
@@ -58,9 +58,9 @@ install_grep() {
 
 clone_repos() {
     if [ -z ${SYSTEM_PULLREQUEST_TARGETBRANCH+x} ]; then
-        local REPO_BRANCH="$SYSTEM_PULLREQUEST_TARGETBRANCH"
-    else
         local REPO_BRANCH="$BUILD_SOURCEBRANCHNAME"
+    else
+        local REPO_BRANCH="$SYSTEM_PULLREQUEST_TARGETBRANCH"
     fi
     
     for proj in druntime phobos; do


### PR DESCRIPTION
unfortunately, https://github.com/dlang/dmd/pull/10278 had the wrong reversed logic, but that didn't harm pull requests because both variables contain "master".

It's a bit problematic to test the PR if it changes what happens without a PR...