### PR TITLE
Fix Issue 20108 - -dip1000 defeated by auto

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1089,6 +1089,7 @@ extern (C++) class VarDeclaration : Declaration
     bool overlapped;                // if it is a field and has overlapping
     bool overlapUnsafe;             // if it is an overlapping field and the overlaps are unsafe
     bool doNotInferScope;           // do not infer 'scope' for this variable
+    bool doNotInferReturn;          // do not infer 'return' for this variable
     ubyte isdataseg;                // private data for isDataseg 0 unset, 1 true, 2 false
     Dsymbol aliassym;               // if redone as alias to another symbol
     VarDeclaration lastVar;         // Linked list of variables for goto-skips-init detection

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -223,6 +223,7 @@ public:
     bool overlapped;            // if it is a field and has overlapping
     bool overlapUnsafe;         // if it is an overlapping field and the overlaps are unsafe
     bool doNotInferScope;       // do not infer 'scope' for this variable
+    bool doNotInferReturn;      // do not infer 'return' for this variable
     unsigned char isdataseg;    // private data for isDataseg
     Dsymbol *aliassym;          // if redone as alias to another symbol
     VarDeclaration *lastVar;    // Linked list of variables for goto-skips-init detection

--- a/test/fail_compilation/fail20108.d
+++ b/test/fail_compilation/fail20108.d
@@ -1,0 +1,19 @@
+// REQUIRED_ARGS: -dip1000
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20108.d(13): Error: scope variable `x` may not be returned
+---
+*/
+
+@safe auto test(scope int* x)
+{
+    int y = 69;
+    x = &y; //bad
+    return x;
+}
+
+void main()
+{
+    auto y = test(null);
+}


### PR DESCRIPTION
```d
@safe auto test(scope int* x)
{
    int y = 69;
    x = &y; //bad
    return x;
}

void main()
{
    auto y = test(null);
    writeln("Would you like some stack memory?");
    writeln(*y);
}
```

`return` is inferred for `scope` variables in template/auto/lambda functions. So what happens here: when the compiler analyzes `x = &y;` it sees `x` as `scope` and says "fine, x and y lifetimes are equal, it's ok", however, when it reaches the return statement it infers that `x` may be `return`, forgetting that the address of a local was assigned to it .

My patch adds a field, similar to what is done for `scope` inference, that stores the fact that if a parameter is assigned the address of a local, it cannot be inferred as `return`. Also, I would suggest changing the name of dmd.escape.inferReturn to `addReturn`, because it does not infer anything, it simply adds the `return` storage class unconditionally. 