### PR TITLE
Add unittests for barray and array

### DIFF
--- a/src/dmd/backend/barray.d
+++ b/src/dmd/backend/barray.d
@@ -102,6 +102,7 @@ struct Barray(T)
 unittest
 {
     Barray!int a;
+
     a.setLength(10);
     assert(a.length == 10);
     a.setLength(4);
@@ -110,4 +111,9 @@ unittest
         v = cast(int) i * 2;
     foreach (i, ref const v; a[])
         assert(v == i * 2);
+    a.remove(3);
+    assert(a.length == 3);
+    a.push(50);
+    a.remove(1);
+    assert(a[1] == 50);
 }

--- a/src/dmd/backend/barray.d
+++ b/src/dmd/backend/barray.d
@@ -102,7 +102,6 @@ struct Barray(T)
 unittest
 {
     Barray!int a;
-
     a.setLength(10);
     assert(a.length == 10);
     a.setLength(4);

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -182,7 +182,7 @@ public:
 
     size_t find(T ptr) const nothrow pure
     {
-        for (size_t i = 0; i < length; i++)
+        foreach (i; 0 .. length)
             if (data[i] is ptr)
                 return i;
         return size_t.max;
@@ -207,7 +207,7 @@ public:
     {
         auto a = new Array!T();
         a.setDim(length);
-        memcpy(a.data, data, length * (void*).sizeof);
+        memcpy(a.data, data, length * T.sizeof);
         return a;
     }
 
@@ -242,6 +242,65 @@ public:
 
     alias opDollar = length;
     alias dim = length;
+}
+
+unittest
+{
+    static struct S
+    {
+        int s = -1;
+        string toString()
+        {
+            return "S";
+        }
+    }
+    auto array = Array!S(4);
+    assert(array.toString() == "[S,S,S,S]");
+}
+
+unittest
+{
+    auto array = Array!double(4);
+    array.shift(10);
+    array.push(20);
+    array[2] = 15;
+    assert(array[0] == 10);
+    assert(array.find(10) == 0);
+    assert(array.find(20) == 5);
+    assert(!array.contains(99));
+    array.remove(1);
+    assert(array.length == 5);
+    assert(array[1] == 15);
+    assert(array.pop() == 20);
+    assert(array.length == 4);
+    array.insert(1, 30);
+    assert(array[1] == 30);
+    assert(array[2] == 15);
+}
+
+unittest
+{
+    auto arrayA = Array!int(0);
+    int[3] buf = [10, 15, 20];
+    arrayA.pushSlice(buf);
+    assert(arrayA[] == buf[]);
+    auto arrayPtr = arrayA.copy();
+    assert(arrayPtr);
+    assert((*arrayPtr)[] == arrayA[]);
+    assert(arrayPtr.tdata != arrayA.tdata);
+
+    arrayPtr.setDim(0);
+    int[2] buf2 = [100, 200];
+    arrayPtr.pushSlice(buf2);
+
+    arrayA.append(arrayPtr);
+    assert(arrayA[3..$] == buf2[]);
+    arrayA.insert(0, arrayPtr);
+    assert(arrayA[] == [100, 200, 10, 15, 20, 100, 200]);
+
+    arrayA.zero();
+    foreach(e; arrayA)
+        assert(e == 0);
 }
 
 struct BitArray
@@ -293,6 +352,18 @@ nothrow:
 private:
     size_t len;
     size_t *ptr;
+}
+
+unittest
+{
+    BitArray array;
+    array.length = 20;
+    assert(array[19] == 0);
+    array[10] = 1;
+    assert(array[10] == 1);
+    array[10] = 0;
+    assert(array[10] == 0);
+    assert(array.length == 20);
 }
 
 /**


### PR DESCRIPTION
Improve the test coverage for root/array [per request](https://forum.dlang.org/thread/qiab48$j46$1@digitalmars.com), as well as barray (by accident, I thought Barray was BitArray).
`dmd/root/array.d is 99% covered` (assert(0) if the element type has no `toString` is not covered)
`dmd/backend/barray.d is 96% covered` (out of memory assert(0) is not covered)

One bug was found with the tests, `Array.copy()` did a `memcpy` assuming element size `(void*).sizeof` instead of `T.sizeof`. Also one classic for-loop was converted to `foreach`.

If these unittests are too large I can split them up into more focussed unittests, but it would be more verbose.