### PR TITLE
Rename Dsymbol.namespace to cppnamespace

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -497,14 +497,14 @@ extern (C++) final class CPPNamespaceDeclaration : AttribDeclaration
         super(decl);
         this.ident = ident;
         this.exp = exp;
-        this.namespace = parent;
+        this.cppnamespace = parent;
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
         return new CPPNamespaceDeclaration(
-            this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.namespace);
+            this.ident, this.exp, Dsymbol.arraySyntaxCopy(this.decl), this.cppnamespace);
     }
 
     /**

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -174,7 +174,7 @@ private final class CppMangleVisitor : Visitor
     {
         if (VarDeclaration vd = s.isVarDeclaration())
         {
-            mangle_variable(vd, vd.namespace !is null);
+            mangle_variable(vd, vd.cppnamespace !is null);
         }
         else if (FuncDeclaration fd = s.isFuncDeclaration())
         {
@@ -343,7 +343,7 @@ private final class CppMangleVisitor : Visitor
     /// Ditto
     static bool isStd(CPPNamespaceDeclaration s)
     {
-        return s && s.namespace is null && s.ident == Id.std;
+        return s && s.cppnamespace is null && s.ident == Id.std;
     }
 
     /************************
@@ -564,12 +564,12 @@ private final class CppMangleVisitor : Visitor
         {
             printf("source_name(%s)\n", s.toChars());
             auto sl = this.buf.peekSlice();
-            assert(sl.length == 0 || haveNE || s.namespace is null || sl != "_ZN");
+            assert(sl.length == 0 || haveNE || s.cppnamespace is null || sl != "_ZN");
         }
         if (TemplateInstance ti = s.isTemplateInstance())
         {
             bool needsTa = false;
-            const isNested = !!ti.tempdecl.namespace || !!getQualifier(ti.tempdecl);
+            const isNested = !!ti.tempdecl.cppnamespace || !!getQualifier(ti.tempdecl);
             if (substitute(ti.tempdecl, !haveNE && isNested))
             {
                 template_args(ti);
@@ -584,7 +584,7 @@ private final class CppMangleVisitor : Visitor
             else
             {
                 this.writeNamespace(
-                    s.namespace, () {
+                    s.cppnamespace, () {
                         this.writeIdentifier(ti.tempdecl.toAlias().ident);
                         append(ti.tempdecl);
                         template_args(ti);
@@ -592,7 +592,7 @@ private final class CppMangleVisitor : Visitor
             }
         }
         else
-            this.writeNamespace(s.namespace, () => this.writeIdentifier(s.ident),
+            this.writeNamespace(s.cppnamespace, () => this.writeIdentifier(s.ident),
                                 haveNE);
     }
 
@@ -618,9 +618,9 @@ private final class CppMangleVisitor : Visitor
     CPPNamespaceDeclaration getTiNamespace(TemplateInstance ti)
     {
         // If we receive a pre-semantic `TemplateInstance`,
-        // `namespace` is always `null`
-        return ti.tempdecl ? ti.namespace
-            : this.context.res.asType().toDsymbol(null).namespace;
+        // `cppnamespace` is always `null`
+        return ti.tempdecl ? ti.cppnamespace
+            : this.context.res.asType().toDsymbol(null).cppnamespace;
     }
 
     /********
@@ -1017,7 +1017,7 @@ private final class CppMangleVisitor : Visitor
                 buf.writestring("N");
             if (!substitute(ns))
             {
-                this.writeNamespace(ns.namespace, null);
+                this.writeNamespace(ns.cppnamespace, null);
                 this.writeIdentifier(ns.ident);
                 append(ns);
             }
@@ -1027,7 +1027,7 @@ private final class CppMangleVisitor : Visitor
         }
         else if (!substitute(ns))
         {
-            this.writeNamespace(ns.namespace, null);
+            this.writeNamespace(ns.cppnamespace, null);
             this.writeIdentifier(ns.ident);
             append(ns);
         }
@@ -1488,7 +1488,7 @@ private final class CppMangleVisitor : Visitor
                 sym2.accept(this);
         }
         this.writeNamespace(
-            sym1.namespace, () {
+            sym1.cppnamespace, () {
                 this.writeIdentifier(t.name);
                 this.append(t);
                 dg();
@@ -2136,9 +2136,9 @@ private bool isNamespaceEqual (CPPNamespaceDeclaration a, Nspace b, size_t idx =
 
     // We need to see if there's more ident enclosing
     if (auto pb = b.toParent().isNspace())
-        return isNamespaceEqual(a.namespace, pb);
+        return isNamespaceEqual(a.cppnamespace, pb);
     else
-        return a.namespace is null;
+        return a.cppnamespace is null;
 }
 
 /// Returns:
@@ -2148,9 +2148,9 @@ private bool isNamespaceEqual (CPPNamespaceDeclaration a, CPPNamespaceDeclaratio
     if (a is null || b is null)
         return false;
 
-    if ((a.namespace is null) != (b.namespace is null))
+    if ((a.cppnamespace is null) != (b.cppnamespace is null))
         return false;
     if (a.ident != b.ident)
         return false;
-    return a.namespace is null ? true : isNamespaceEqual(a.namespace, b.namespace);
+    return a.cppnamespace is null ? true : isNamespaceEqual(a.cppnamespace, b.cppnamespace);
 }

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1044,7 +1044,7 @@ private:
         {
             mangleName(p, dont_use_back_reference);
             // Mangle our string namespaces as well
-            for (auto ns = p.namespace; ns !is null; ns = ns.namespace)
+            for (auto ns = p.cppnamespace; ns !is null; ns = ns.cppnamespace)
                 mangleName(ns, dont_use_back_reference);
             p = p.toParent();
             if (p.toParent() && p.toParent().isTemplateInstance())

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -229,7 +229,7 @@ extern (C++) class Dsymbol : ASTNode
     Identifier ident;
     Dsymbol parent;
     /// C++ namespace this symbol belongs to
-    CPPNamespaceDeclaration namespace;
+    CPPNamespaceDeclaration cppnamespace;
     Symbol* csym;           // symbol for code generator
     Symbol* isym;           // import version of csym
     const(char)* comment;   // documentation comment for this Dsymbol

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -788,7 +788,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             dsym.error("extern symbols cannot have initializers");
 
         dsym.userAttribDecl = sc.userAttribDecl;
-        dsym.namespace = sc.namespace;
+        dsym.cppnamespace = sc.namespace;
 
         AggregateDeclaration ad = dsym.isThis();
         if (ad)
@@ -2139,7 +2139,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         if (ns.ident is null)
         {
-            ns.namespace = sc.namespace;
+            ns.cppnamespace = sc.namespace;
             sc = sc.startCTFE();
             ns.exp = ns.exp.expressionSemantic(sc);
             ns.exp = resolveProperties(sc, ns.exp);
@@ -2149,16 +2149,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (auto te = ns.exp.isTupleExp())
             {
                 expandTuples(te.exps);
-                CPPNamespaceDeclaration current = ns.namespace;
+                CPPNamespaceDeclaration current = ns.cppnamespace;
                 for (size_t d = 0; d < te.exps.dim; ++d)
                 {
                     auto exp = (*te.exps)[d];
-                    auto prev = d ? current : ns.namespace;
+                    auto prev = d ? current : ns.cppnamespace;
                     current = (d + 1) != te.exps.dim
                         ? new CPPNamespaceDeclaration(exp, null)
                         : ns;
                     current.exp = exp;
-                    current.namespace = prev;
+                    current.cppnamespace = prev;
                     if (auto se = exp.toStringExp())
                     {
                         current.ident = identFromSE(se);
@@ -2284,7 +2284,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (sc.stc & STC.deprecated_)
             ed.isdeprecated = true;
         ed.userAttribDecl = sc.userAttribDecl;
-        ed.namespace = sc.namespace;
+        ed.cppnamespace = sc.namespace;
 
         ed.semanticRun = PASS.semantic;
 
@@ -2703,7 +2703,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         tempdecl.parent = sc.parent;
         tempdecl.protection = sc.protection;
-        tempdecl.namespace = sc.namespace;
+        tempdecl.cppnamespace = sc.namespace;
         tempdecl.isstatic = tempdecl.toParent().isModule() || (tempdecl._scope.stc & STC.static_);
 
         if (!tempdecl.isstatic)
@@ -3187,7 +3187,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (!sc || funcdecl.errors)
             return;
 
-        funcdecl.namespace = sc.namespace;
+        funcdecl.cppnamespace = sc.namespace;
         funcdecl.parent = sc.parent;
         Dsymbol parent = funcdecl.toParent();
 
@@ -4625,7 +4625,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 sd.classKind = ClassKind.cpp;
-            sd.namespace = sc.namespace;
+            sd.cppnamespace = sc.namespace;
         }
         else if (sd.symtab && !scx)
             return;
@@ -4845,7 +4845,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (sc.linkage == LINK.cpp)
                 cldec.classKind = ClassKind.cpp;
-            cldec.namespace = sc.namespace;
+            cldec.cppnamespace = sc.namespace;
             if (sc.linkage == LINK.objc)
                 objc.setObjc(cldec);
         }
@@ -5564,7 +5564,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
             if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
-            idec.namespace = sc.namespace;
+            idec.cppnamespace = sc.namespace;
 
             if (sc.linkage == LINK.objc)
             {
@@ -5857,7 +5857,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
         goto Lerror;
 
     // Copy the tempdecl namespace (not the scope one)
-    tempinst.namespace = tempdecl.namespace;
+    tempinst.cppnamespace = tempdecl.cppnamespace;
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -376,7 +376,7 @@ extern (C++) class FuncDeclaration : Declaration
                 return false;
         }
 
-        this.namespace = _scope.namespace;
+        this.cppnamespace = _scope.namespace;
 
         // if inferring return type, sematic3 needs to be run
         // - When the function body contains any errors, we cannot assume


### PR DESCRIPTION
Because `Dsymbol.namespace` is a `public` `extern (C++)` symbol, the C++ header [generator](https://github.com/dlang/dmd/pull/9971) will generate the following code

```C++
class Dsymbol : public ASTNode
{
public:
    /* ... */
    CPPNamespaceDeclaration* namespace;
    /* ... */
}
```

As you know, and see from the syntax highlight, `namespace` is a C++ keyword, so this generated code won't compile.

This PR renames **only** the **public** symbol `Dsymbol.namespace`.
Maybe it should rename all of the `namespace` occurrences?

I think, in my humble opinion, that we should avoid using other programming languages keywords as public symbols.