### PR TITLE
Make RootObject equals and toChars const

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -335,7 +335,7 @@ struct ASTBase
                 this.comment = Lexer.combineComments(this.comment.toDString(), comment.toDString(), true);
         }
 
-        override const(char)* toChars()
+        override const(char)* toChars() const
         {
             return ident ? ident.toChars() : "__anonymous";
         }
@@ -2768,7 +2768,7 @@ struct ASTBase
             this.ty = ty;
         }
 
-        override const(char)* toChars()
+        override const(char)* toChars() const
         {
             return "type";
         }
@@ -6295,7 +6295,7 @@ struct ASTBase
             return DYNCAST.tuple;
         }
 
-        override const(char)* toChars()
+        override const(char)* toChars() const
         {
             return objects.toChars();
         }
@@ -6323,7 +6323,7 @@ struct ASTBase
             this.isdeprecated = isdeprecated;
         }
 
-        extern (C++) const(char)* toChars()
+        extern (C++) const(char)* toChars() const
         {
             OutBuffer buf;
             if (packages && packages.dim)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6330,7 +6330,7 @@ struct ASTBase
             {
                 for (size_t i = 0; i < packages.dim; i++)
                 {
-                    Identifier pid = (*packages)[i];
+                    const Identifier pid = (*packages)[i];
                     buf.writestring(pid.toString());
                     buf.writeByte('.');
                 }

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -77,7 +77,7 @@ public:
     static LinkDeclaration *create(LINK p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    const char *toChars();
+    const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -88,7 +88,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    const char *toChars();
+    const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -99,7 +99,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
-    const char *toChars();
+    const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -546,7 +546,7 @@ extern (C++) final class DebugCondition : DVCondition
         v.visit(this);
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         return ident ? ident.toChars() : "debug".ptr;
     }
@@ -821,7 +821,7 @@ extern (C++) final class VersionCondition : DVCondition
         v.visit(this);
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         return ident ? ident.toChars() : "version".ptr;
     }
@@ -887,7 +887,7 @@ extern (C++) final class StaticIfCondition : Condition
         v.visit(this);
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         return exp ? exp.toChars() : "static if".ptr;
     }

--- a/src/dmd/ctfe.h
+++ b/src/dmd/ctfe.h
@@ -37,7 +37,7 @@ class VoidInitExp : public Expression
 public:
     VarDeclaration *var;
 
-    const char *toChars();
+    const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -49,7 +49,7 @@ class ThrownExceptionExp : public Expression
 {
 public:
     ClassReferenceExp *thrown; // the thing being tossed
-    const char *toChars();
+    const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -60,5 +60,5 @@ public:
 class CTFEExp : public Expression
 {
 public:
-    const char *toChars();
+    const char *toChars() const;
 };

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1000,8 +1000,7 @@ extern (C++) final class OverDeclaration : Declaration
                 return true;
             if (auto fd = s.isFuncDeclaration())
             {
-                // isUnique is not callable using a const object
-                return (cast() fd).isUnique();
+                return fd.isUnique();
             }
             if (auto td = s.isTemplateDeclaration())
             {

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -980,7 +980,7 @@ extern (C++) final class OverDeclaration : Declaration
         return "overload alias"; // todo
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -1718,7 +1718,7 @@ extern (C++) class TypeInfoDeclaration : VarDeclaration
         assert(0); // should never be produced by syntax
     }
 
-    override final const(char)* toChars()
+    override final const(char)* toChars() const
     {
         //printf("TypeInfoDeclaration::toChars() tinfo = %s\n", tinfo.toChars());
         OutBuffer buf;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -980,7 +980,7 @@ extern (C++) final class OverDeclaration : Declaration
         return "overload alias"; // todo
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -1000,7 +1000,8 @@ extern (C++) final class OverDeclaration : Declaration
                 return true;
             if (auto fd = s.isFuncDeclaration())
             {
-                return fd.isUnique();
+                // isUnique is not callable using a const object
+                return (cast() fd).isUnique();
             }
             if (auto td = s.isTemplateDeclaration())
             {

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -193,7 +193,7 @@ public:
     bool hasOverloads;
 
     const char *kind() const;
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     bool overloadInsert(Dsymbol *s);
 
     Dsymbol *toAlias();
@@ -561,7 +561,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     bool functionSemantic();
     bool functionSemantic3();
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
 
     int overrides(FuncDeclaration *fd);
     int findVtblIndex(Dsymbols *vtbl, int dim, bool fix17349 = true);

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -193,7 +193,7 @@ public:
     bool hasOverloads;
 
     const char *kind() const;
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     bool overloadInsert(Dsymbol *s);
 
     Dsymbol *toAlias();
@@ -286,7 +286,7 @@ public:
 
     static TypeInfoDeclaration *create(Type *tinfo);
     Dsymbol *syntaxCopy(Dsymbol *);
-    const char *toChars();
+    const char *toChars() const;
 
     TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -561,7 +561,7 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *);
     bool functionSemantic();
     bool functionSemantic3();
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
 
     int overrides(FuncDeclaration *fd);
     int findVtblIndex(Dsymbols *vtbl, int dim, bool fix17349 = true);
@@ -658,7 +658,7 @@ public:
     bool isCpCtor;
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;
-    const char *toChars();
+    const char *toChars() const;
     bool isVirtual() const;
     bool addPreInvariant();
     bool addPostInvariant();
@@ -685,7 +685,7 @@ class DtorDeclaration : public FuncDeclaration
 public:
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;
-    const char *toChars();
+    const char *toChars() const;
     bool isVirtual() const;
     bool addPreInvariant();
     bool addPostInvariant();

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -98,6 +98,11 @@ private class Section
     size_t bodylen;
     int nooutput;
 
+    override string toString() const
+    {
+        assert(0);
+    }
+
     void write(Loc loc, DocComment* dc, Scope* sc, Dsymbols* a, OutBuffer* buf)
     {
         assert(a.dim);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -272,7 +272,7 @@ extern (C++) class Dsymbol : ASTNode
         return new Dsymbol(ident);
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         return ident ? ident.toChars() : "__anonymous";
     }
@@ -296,7 +296,7 @@ extern (C++) class Dsymbol : ASTNode
         return getLoc().toChars();
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -296,7 +296,7 @@ extern (C++) class Dsymbol : ASTNode
         return getLoc().toChars();
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -163,11 +163,11 @@ public:
     UnitTestDeclaration *ddocUnittest; // !=NULL means there's a ddoc unittest associated with this symbol (only use this with ddoc)
 
     static Dsymbol *create(Identifier *);
-    const char *toChars();
+    const char *toChars() const;
     virtual const char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc getLoc();
     const char *locToChars();
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     virtual bool isAnonymous();
     void error(const Loc &loc, const char *format, ...);
     void error(const char *format, ...);

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -167,7 +167,7 @@ public:
     virtual const char *toPrettyCharsHelper(); // helper to print fully qualified (template) arguments
     Loc getLoc();
     const char *locToChars();
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     virtual bool isAnonymous();
     void error(const Loc &loc, const char *format, ...);
     void error(const char *format, ...);

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -494,7 +494,7 @@ extern (C++) final class Tuple : RootObject
         return DYNCAST.tuple;
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         return objects.toChars();
     }
@@ -657,7 +657,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         return (onemember && onemember.isAggregateDeclaration()) ? onemember.kind() : "template";
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         if (literal)
             return Dsymbol.toChars();
@@ -669,7 +669,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         buf.writeByte('(');
         for (size_t i = 0; i < parameters.dim; i++)
         {
-            TemplateParameter tp = (*parameters)[i];
+            const TemplateParameter tp = (*parameters)[i];
             if (i)
                 buf.writestring(", ");
             .toCBuffer(tp, &buf, &hgs);
@@ -678,7 +678,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
         if (onemember)
         {
-            FuncDeclaration fd = onemember.isFuncDeclaration();
+            const FuncDeclaration fd = onemember.isFuncDeclaration();
             if (fd && fd.type)
             {
                 TypeFunction tf = cast(TypeFunction)fd.type;
@@ -5267,7 +5267,11 @@ extern (C++) class TemplateParameter : ASTNode
 
     abstract bool hasDefaultArg();
 
-    override const(char)* toChars() { return this.ident.toChars(); }
+    override const(char)* toChars()  const
+    {
+        return this.ident.toChars();
+    }
+
     override DYNCAST dyncast() const pure @nogc nothrow @safe
     {
         return DYNCAST.templateparameter;
@@ -5826,7 +5830,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
         return true;
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         OutBuffer buf;
         toCBufferInstance(this, &buf);
@@ -7455,7 +7459,7 @@ extern (C++) final class TemplateMixin : TemplateInstance
         members.foreachDsymbol( (s) { s.setFieldOffset(ad, poffset, isunion); } );
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         OutBuffer buf;
         toCBufferInstance(this, &buf);

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5267,7 +5267,7 @@ extern (C++) class TemplateParameter : ASTNode
 
     abstract bool hasDefaultArg();
 
-    override const(char)* toChars()  const
+    override const(char)* toChars() const
     {
         return this.ident.toChars();
     }

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -139,7 +139,7 @@ extern (C++) final class VersionSymbol : Dsymbol
         return ds;
     }
 
-    override const(char)* toChars() nothrow
+    override const(char)* toChars() const nothrow
     {
         if (ident)
             return ident.toChars();

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2796,8 +2796,8 @@ extern (C++) final class ArrayLiteralExp : Expression
             {
                 return false;
             }
-            Expressions* unqualElements = cast(Expressions*) elements;
-            foreach (i, e1; *unqualElements)
+
+            foreach (i, e1; *elements)
             {
                 auto e2 = (*ae.elements)[i];
                 auto e1x = e1 ? e1 : basis;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -710,7 +710,7 @@ extern (C++) abstract class Expression : ASTNode
         return DYNCAST.expression;
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         OutBuffer buf;
         HdrGenState hgs;
@@ -1679,7 +1679,7 @@ extern (C++) final class IntegerExp : Expression
         emplaceExp!(IntegerExp)(pue, loc, value, type);
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -1923,7 +1923,7 @@ extern (C++) final class RealExp : Expression
         emplaceExp!(RealExp)(pue, loc, value, type);
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -1998,7 +1998,7 @@ extern (C++) final class ComplexExp : Expression
         emplaceExp!(ComplexExp)(pue, loc, value, type);
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -2214,7 +2214,7 @@ extern (C++) final class NullExp : Expression
         this.type = type;
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (auto e = o.isExpression())
         {
@@ -2311,7 +2311,7 @@ extern (C++) final class StringExp : Expression
         emplaceExp!(StringExp)(pue, loc, string, len);
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         //printf("StringExp::equals('%s') %s\n", o.toChars(), toChars());
         if (auto e = o.isExpression())
@@ -2694,7 +2694,7 @@ extern (C++) final class TupleExp : Expression
         return new TupleExp(loc, e0 ? e0.syntaxCopy() : null, arraySyntaxCopy(exps));
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -2781,7 +2781,7 @@ extern (C++) final class ArrayLiteralExp : Expression
             arraySyntaxCopy(elements));
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -2796,11 +2796,12 @@ extern (C++) final class ArrayLiteralExp : Expression
             {
                 return false;
             }
-            foreach (i, e1; *elements)
+            Expressions* unqualElements = cast(Expressions*) elements;
+            foreach (i, e1; *unqualElements)
             {
                 Expression e2 = (*ae.elements)[i];
                 if (!e1)
-                    e1 = basis;
+                    e1 = cast(Expression) basis;
                 if (!e2)
                     e2 = ae.basis;
                 if (e1 != e2 && (!e1 || !e2 || !e1.equals(e2)))
@@ -2908,7 +2909,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
         this.values = values;
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -3009,7 +3010,7 @@ extern (C++) final class StructLiteralExp : Expression
         return new StructLiteralExp(loc, sd, cast(Expressions*)elements, stype);
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -3443,7 +3444,7 @@ extern (C++) final class VarExp : SymbolExp
         return new VarExp(loc, var, hasOverloads);
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -3576,7 +3577,7 @@ extern (C++) final class FuncExp : Expression
         assert(fd.fbody);
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;
@@ -3816,7 +3817,7 @@ extern (C++) final class FuncExp : Expression
         return m;
     }
 
-    override const(char)* toChars()
+    override const(char)* toChars() const
     {
         return fd.toChars();
     }
@@ -4407,7 +4408,7 @@ extern (C++) final class CompileExp : Expression
         return new CompileExp(loc, arraySyntaxCopy(exps));
     }
 
-    override bool equals(RootObject o)
+    override bool equals(RootObject o) const
     {
         if (this == o)
             return true;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1679,7 +1679,7 @@ extern (C++) final class IntegerExp : Expression
         emplaceExp!(IntegerExp)(pue, loc, value, type);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -1923,7 +1923,7 @@ extern (C++) final class RealExp : Expression
         emplaceExp!(RealExp)(pue, loc, value, type);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -1998,7 +1998,7 @@ extern (C++) final class ComplexExp : Expression
         emplaceExp!(ComplexExp)(pue, loc, value, type);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -2214,7 +2214,7 @@ extern (C++) final class NullExp : Expression
         this.type = type;
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (auto e = o.isExpression())
         {
@@ -2311,7 +2311,7 @@ extern (C++) final class StringExp : Expression
         emplaceExp!(StringExp)(pue, loc, string, len);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         //printf("StringExp::equals('%s') %s\n", o.toChars(), toChars());
         if (auto e = o.isExpression())
@@ -2694,7 +2694,7 @@ extern (C++) final class TupleExp : Expression
         return new TupleExp(loc, e0 ? e0.syntaxCopy() : null, arraySyntaxCopy(exps));
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -2707,7 +2707,7 @@ extern (C++) final class TupleExp : Expression
                     return false;
                 foreach (i, e1; *exps)
                 {
-                    Expression e2 = (*te.exps)[i];
+                    auto e2 = (*te.exps)[i];
                     if (!e1.equals(e2))
                         return false;
                 }
@@ -2781,11 +2781,11 @@ extern (C++) final class ArrayLiteralExp : Expression
             arraySyntaxCopy(elements));
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
-        Expression e = o.isExpression();
+        auto e = o.isExpression();
         if (!e)
             return false;
         if (auto ae = e.isArrayLiteralExp())
@@ -2799,12 +2799,11 @@ extern (C++) final class ArrayLiteralExp : Expression
             Expressions* unqualElements = cast(Expressions*) elements;
             foreach (i, e1; *unqualElements)
             {
-                Expression e2 = (*ae.elements)[i];
-                if (!e1)
-                    e1 = cast(Expression) basis;
-                if (!e2)
-                    e2 = ae.basis;
-                if (e1 != e2 && (!e1 || !e2 || !e1.equals(e2)))
+                auto e2 = (*ae.elements)[i];
+                auto e1x = e1 ? e1 : basis;
+                auto e2x = e2 ? e2 : ae.basis;
+
+                if (e1x != e2x && (!e1x || !e2x || !e1x.equals(e2x)))
                     return false;
             }
             return true;
@@ -2909,7 +2908,7 @@ extern (C++) final class AssocArrayLiteralExp : Expression
         this.values = values;
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -3010,11 +3009,11 @@ extern (C++) final class StructLiteralExp : Expression
         return new StructLiteralExp(loc, sd, cast(Expressions*)elements, stype);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
-        Expression e = o.isExpression();
+        auto e = o.isExpression();
         if (!e)
             return false;
         if (auto se = e.isStructLiteralExp())
@@ -3025,7 +3024,7 @@ extern (C++) final class StructLiteralExp : Expression
                 return false;
             foreach (i, e1; *elements)
             {
-                Expression e2 = (*se.elements)[i];
+                auto e2 = (*se.elements)[i];
                 if (e1 != e2 && (!e1 || !e2 || !e1.equals(e2)))
                     return false;
             }
@@ -3444,7 +3443,7 @@ extern (C++) final class VarExp : SymbolExp
         return new VarExp(loc, var, hasOverloads);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -3577,7 +3576,7 @@ extern (C++) final class FuncExp : Expression
         assert(fd.fbody);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -4408,7 +4407,7 @@ extern (C++) final class CompileExp : Expression
         return new CompileExp(loc, arraySyntaxCopy(exps));
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
@@ -4421,7 +4420,7 @@ extern (C++) final class CompileExp : Expression
                 return false;
             foreach (i, e1; *exps)
             {
-                Expression e2 = (*ce.exps)[i];
+                auto e2 = (*ce.exps)[i];
                 if (e1 != e2 && (!e1 || !e2 || !e1.equals(e2)))
                     return false;
             }

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -80,7 +80,7 @@ public:
     // kludge for template.isExpression()
     DYNCAST dyncast() const { return DYNCAST_EXPRESSION; }
 
-    const char *toChars();
+    const char *toChars() const;
     void error(const char *format, ...) const;
     void warning(const char *format, ...) const;
     void deprecation(const char *format, ...) const;
@@ -234,7 +234,7 @@ public:
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
     static void emplace(UnionExp *pue, Loc loc, dinteger_t value, Type *type);
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     dinteger_t toInteger();
     real_t toReal();
     real_t toImaginary();
@@ -264,7 +264,7 @@ public:
 
     static RealExp *create(Loc loc, real_t value, Type *type);
     static void emplace(UnionExp *pue, Loc loc, real_t value, Type *type);
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     dinteger_t toInteger();
     uinteger_t toUInteger();
     real_t toReal();
@@ -281,7 +281,7 @@ public:
 
     static ComplexExp *create(Loc loc, complex_t value, Type *type);
     static void emplace(UnionExp *pue, Loc loc, complex_t value, Type *type);
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     dinteger_t toInteger();
     uinteger_t toUInteger();
     real_t toReal();
@@ -344,7 +344,7 @@ class NullExp : public Expression
 public:
     unsigned char committed;    // !=0 if type is committed
 
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     bool isBool(bool result);
     StringExp *toStringExp();
     void accept(Visitor *v) { v->visit(this); }
@@ -364,7 +364,7 @@ public:
     static StringExp *create(Loc loc, void *s, size_t len);
     static void emplace(UnionExp *pue, Loc loc, char *s);
     static void emplace(UnionExp *pue, Loc loc, void *s, size_t len);
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
     bool isBool(bool result);
@@ -396,7 +396,7 @@ public:
     static TupleExp *create(Loc loc, Expressions *exps);
     TupleExp *toTupleExp();
     Expression *syntaxCopy();
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -411,7 +411,7 @@ public:
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     static void emplace(UnionExp *pue, Loc loc, Expressions *elements);
     Expression *syntaxCopy();
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     Expression *getElement(d_size_t i); // use opIndex instead
     Expression *opIndex(d_size_t i);
     bool isBool(bool result);
@@ -427,7 +427,7 @@ public:
     Expressions *values;
     OwnedBy ownedByCtfe;
 
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     Expression *syntaxCopy();
     bool isBool(bool result);
 
@@ -464,7 +464,7 @@ public:
     OwnedBy ownedByCtfe;
 
     static StructLiteralExp *create(Loc loc, StructDeclaration *sd, void *elements, Type *stype = NULL);
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     Expression *syntaxCopy();
     Expression *getField(Type *type, unsigned offset);
     int getFieldIndex(Type *type, unsigned offset);
@@ -571,7 +571,7 @@ class VarExp : public SymbolExp
 {
 public:
     static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = true);
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -601,9 +601,9 @@ public:
     TemplateDeclaration *td;
     TOK tok;
 
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     Expression *syntaxCopy();
-    const char *toChars();
+    const char *toChars() const;
     bool checkType();
     bool checkValue();
 

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -234,7 +234,7 @@ public:
 
     static IntegerExp *create(Loc loc, dinteger_t value, Type *type);
     static void emplace(UnionExp *pue, Loc loc, dinteger_t value, Type *type);
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     dinteger_t toInteger();
     real_t toReal();
     real_t toImaginary();
@@ -264,7 +264,7 @@ public:
 
     static RealExp *create(Loc loc, real_t value, Type *type);
     static void emplace(UnionExp *pue, Loc loc, real_t value, Type *type);
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     dinteger_t toInteger();
     uinteger_t toUInteger();
     real_t toReal();
@@ -281,7 +281,7 @@ public:
 
     static ComplexExp *create(Loc loc, complex_t value, Type *type);
     static void emplace(UnionExp *pue, Loc loc, complex_t value, Type *type);
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     dinteger_t toInteger();
     uinteger_t toUInteger();
     real_t toReal();
@@ -344,7 +344,7 @@ class NullExp : public Expression
 public:
     unsigned char committed;    // !=0 if type is committed
 
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     bool isBool(bool result);
     StringExp *toStringExp();
     void accept(Visitor *v) { v->visit(this); }
@@ -364,7 +364,7 @@ public:
     static StringExp *create(Loc loc, void *s, size_t len);
     static void emplace(UnionExp *pue, Loc loc, char *s);
     static void emplace(UnionExp *pue, Loc loc, void *s, size_t len);
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     StringExp *toStringExp();
     StringExp *toUTF8(Scope *sc);
     bool isBool(bool result);
@@ -396,7 +396,7 @@ public:
     static TupleExp *create(Loc loc, Expressions *exps);
     TupleExp *toTupleExp();
     Expression *syntaxCopy();
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
 
     void accept(Visitor *v) { v->visit(this); }
 };
@@ -411,7 +411,7 @@ public:
     static ArrayLiteralExp *create(Loc loc, Expressions *elements);
     static void emplace(UnionExp *pue, Loc loc, Expressions *elements);
     Expression *syntaxCopy();
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     Expression *getElement(d_size_t i); // use opIndex instead
     Expression *opIndex(d_size_t i);
     bool isBool(bool result);
@@ -427,7 +427,7 @@ public:
     Expressions *values;
     OwnedBy ownedByCtfe;
 
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     Expression *syntaxCopy();
     bool isBool(bool result);
 
@@ -464,7 +464,7 @@ public:
     OwnedBy ownedByCtfe;
 
     static StructLiteralExp *create(Loc loc, StructDeclaration *sd, void *elements, Type *stype = NULL);
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     Expression *syntaxCopy();
     Expression *getField(Type *type, unsigned offset);
     int getFieldIndex(Type *type, unsigned offset);
@@ -571,7 +571,7 @@ class VarExp : public SymbolExp
 {
 public:
     static VarExp *create(Loc loc, Declaration *var, bool hasOverloads = true);
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -601,7 +601,7 @@ public:
     TemplateDeclaration *td;
     TOK tok;
 
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     Expression *syntaxCopy();
     const char *toChars() const;
     bool checkType();

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -582,12 +582,11 @@ extern (C++) class FuncDeclaration : Declaration
             }
 
             bool b1 = fa1 !is null;
-            // isUnique is not callable using a const object
-            if (b1 && (cast() faf1).isUnique() && !fa1.hasOverloads)
+            if (b1 && faf1.isUnique() && !fa1.hasOverloads)
                 b1 = false;
 
             bool b2 = fa2 !is null;
-            if (b2 && (cast() faf2).isUnique() && !fa2.hasOverloads)
+            if (b2 && faf2.isUnique() && !fa2.hasOverloads)
                 b2 = false;
 
             if (b1 != b2)
@@ -1744,10 +1743,10 @@ extern (C++) class FuncDeclaration : Declaration
      * Returns:
      *  true if there are no overloads of this function
      */
-    final bool isUnique()
+    final bool isUnique() const
     {
         bool result = false;
-        overloadApply(this, (Dsymbol s)
+        overloadApply(cast() this, (Dsymbol s)
         {
             auto f = s.isFuncDeclaration();
             if (!f)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -558,14 +558,14 @@ extern (C++) class FuncDeclaration : Declaration
         return HiddenParameters.init;
     }
 
-    override final bool equals(RootObject o) const
+    override final bool equals(const RootObject o) const
     {
         if (this == o)
             return true;
 
         if (auto s = isDsymbol(o))
         {
-            auto fd1 = cast(FuncDeclaration) this;
+            auto fd1 = this;
             auto fd2 = s.isFuncDeclaration();
             if (!fd2)
                 return false;
@@ -582,11 +582,12 @@ extern (C++) class FuncDeclaration : Declaration
             }
 
             bool b1 = fa1 !is null;
-            if (b1 && faf1.isUnique() && !fa1.hasOverloads)
+            // isUnique is not callable using a const object
+            if (b1 && (cast() faf1).isUnique() && !fa1.hasOverloads)
                 b1 = false;
 
             bool b2 = fa2 !is null;
-            if (b2 && faf2.isUnique() && !fa2.hasOverloads)
+            if (b2 && (cast() faf2).isUnique() && !fa2.hasOverloads)
                 b2 = false;
 
             if (b1 != b2)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -558,14 +558,14 @@ extern (C++) class FuncDeclaration : Declaration
         return HiddenParameters.init;
     }
 
-    override final bool equals(RootObject o)
+    override final bool equals(RootObject o) const
     {
         if (this == o)
             return true;
 
         if (auto s = isDsymbol(o))
         {
-            auto fd1 = this;
+            auto fd1 = cast(FuncDeclaration) this;
             auto fd2 = s.isFuncDeclaration();
             if (!fd2)
                 return false;

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2632,14 +2632,12 @@ public:
 void toCBuffer(const Statement s, OutBuffer* buf, HdrGenState* hgs)
 {
     scope v = new StatementPrettyPrintVisitor(buf, hgs);
-    Statement unqualS = cast(Statement) s;
-    unqualS.accept(v);
+    (cast() s).accept(v);
 }
 
 void toCBuffer(const Type t, OutBuffer* buf, const Identifier ident, HdrGenState* hgs)
 {
-    Type unqualT = cast(Type) t;
-    typeToBuffer(unqualT, ident, buf, hgs);
+    typeToBuffer(cast() t, ident, buf, hgs);
 }
 
 void toCBuffer(Dsymbol s, OutBuffer* buf, HdrGenState* hgs)
@@ -2654,13 +2652,12 @@ void toCBufferInstance(const TemplateInstance ti, OutBuffer* buf, bool qualifyTy
     HdrGenState hgs;
     hgs.fullQual = qualifyTypes;
     scope v = new DsymbolPrettyPrintVisitor(buf, &hgs);
-    v.visit(cast(TemplateInstance) ti);
+    v.visit(cast() ti);
 }
 
 void toCBuffer(const Initializer iz, OutBuffer* buf, HdrGenState* hgs)
 {
-    Initializer unqualIz = cast(Initializer) iz;
-    initializerToBuffer(unqualIz, buf, hgs);
+    initializerToBuffer(cast() iz, buf, hgs);
 }
 
 bool stcToBuffer(OutBuffer* buf, StorageClass stc)
@@ -2891,8 +2888,7 @@ void functionToBufferWithIdent(TypeFunction tf, OutBuffer* buf, const(char)* ide
 void toCBuffer(const Expression e, OutBuffer* buf, HdrGenState* hgs)
 {
     scope v = new ExpressionPrettyPrintVisitor(buf, hgs);
-    Expression unqualE = cast(Expression) e;
-    unqualE.accept(v);
+    (cast() e).accept(v);
 }
 
 /**************************************************
@@ -2914,8 +2910,7 @@ void argExpTypesToCBuffer(OutBuffer* buf, Expressions* arguments)
 void toCBuffer(const TemplateParameter tp, OutBuffer* buf, HdrGenState* hgs)
 {
     scope v = new TemplateParameterPrettyPrintVisitor(buf, hgs);
-    TemplateParameter unqualTP = cast(TemplateParameter) tp;
-    unqualTP.accept(v);
+    (cast() tp).accept(v);
 }
 
 void arrayObjectsToBuffer(OutBuffer* buf, Objects* objects)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2629,15 +2629,17 @@ public:
     }
 }
 
-void toCBuffer(Statement s, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(const Statement s, OutBuffer* buf, HdrGenState* hgs)
 {
     scope v = new StatementPrettyPrintVisitor(buf, hgs);
-    s.accept(v);
+    Statement unqualS = cast(Statement) s;
+    unqualS.accept(v);
 }
 
-void toCBuffer(Type t, OutBuffer* buf, const Identifier ident, HdrGenState* hgs)
+void toCBuffer(const Type t, OutBuffer* buf, const Identifier ident, HdrGenState* hgs)
 {
-    typeToBuffer(t, ident, buf, hgs);
+    Type unqualT = cast(Type) t;
+    typeToBuffer(unqualT, ident, buf, hgs);
 }
 
 void toCBuffer(Dsymbol s, OutBuffer* buf, HdrGenState* hgs)
@@ -2647,17 +2649,18 @@ void toCBuffer(Dsymbol s, OutBuffer* buf, HdrGenState* hgs)
 }
 
 // used from TemplateInstance::toChars() and TemplateMixin::toChars()
-void toCBufferInstance(TemplateInstance ti, OutBuffer* buf, bool qualifyTypes = false)
+void toCBufferInstance(const TemplateInstance ti, OutBuffer* buf, bool qualifyTypes = false)
 {
     HdrGenState hgs;
     hgs.fullQual = qualifyTypes;
     scope v = new DsymbolPrettyPrintVisitor(buf, &hgs);
-    v.visit(ti);
+    v.visit(cast(TemplateInstance) ti);
 }
 
-void toCBuffer(Initializer iz, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(const Initializer iz, OutBuffer* buf, HdrGenState* hgs)
 {
-    initializerToBuffer(iz, buf, hgs);
+    Initializer unqualIz = cast(Initializer) iz;
+    initializerToBuffer(unqualIz, buf, hgs);
 }
 
 bool stcToBuffer(OutBuffer* buf, StorageClass stc)
@@ -2885,10 +2888,11 @@ void functionToBufferWithIdent(TypeFunction tf, OutBuffer* buf, const(char)* ide
     visitFuncIdentWithPostfix(tf, ident.toDString(), buf, &hgs);
 }
 
-void toCBuffer(Expression e, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(const Expression e, OutBuffer* buf, HdrGenState* hgs)
 {
     scope v = new ExpressionPrettyPrintVisitor(buf, hgs);
-    e.accept(v);
+    Expression unqualE = cast(Expression) e;
+    unqualE.accept(v);
 }
 
 /**************************************************
@@ -2907,10 +2911,11 @@ void argExpTypesToCBuffer(OutBuffer* buf, Expressions* arguments)
     }
 }
 
-void toCBuffer(TemplateParameter tp, OutBuffer* buf, HdrGenState* hgs)
+void toCBuffer(const TemplateParameter tp, OutBuffer* buf, HdrGenState* hgs)
 {
     scope v = new TemplateParameterPrettyPrintVisitor(buf, hgs);
-    tp.accept(v);
+    TemplateParameter unqualTP = cast(TemplateParameter) tp;
+    unqualTP.accept(v);
 }
 
 void arrayObjectsToBuffer(OutBuffer* buf, Objects* objects)

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -22,10 +22,10 @@ private:
 public:
     static Identifier* anonymous();
     static Identifier* create(const char *string);
-    bool equals(RootObject *o);
-    const char *toChars();
+    bool equals(RootObject *o) const;
+    const char *toChars() const;
     int getValue() const;
-    const char *toHChars2();
+    const char *toHChars2() const;
     DYNCAST dyncast() const;
 
     static Identifier *generateId(const char *prefix);

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -22,7 +22,7 @@ private:
 public:
     static Identifier* anonymous();
     static Identifier* create(const char *string);
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     const char *toChars() const;
     int getValue() const;
     const char *toHChars2() const;

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -63,7 +63,7 @@ extern (C++) class Initializer : ASTNode
         this.kind = kind;
     }
 
-    override final const(char)* toChars()
+    override final const(char)* toChars() const
     {
         OutBuffer buf;
         HdrGenState hgs;

--- a/src/dmd/init.h
+++ b/src/dmd/init.h
@@ -32,7 +32,7 @@ public:
     Loc loc;
     unsigned char kind;
 
-    const char *toChars();
+    const char *toChars() const;
 
     ErrorInitializer   *isErrorInitializer();
     VoidInitializer    *isVoidInitializer();

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -2387,6 +2387,7 @@ extern (C++) abstract class Type : ASTNode
         if (!mod)
             return this;
         Type unqualThis = cast(Type) this;
+        // `mutableOf` needs a mutable `this` only for caching
         return cast(inout(Type)) unqualThis.mutableOf();
     }
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -517,7 +517,7 @@ extern (C++) abstract class Type : ASTNode
         assert(0);
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         Type t = cast(Type)o;
         //printf("Type::equals(%s, %s)\n", toChars(), t.toChars());
@@ -6206,7 +6206,7 @@ extern (C++) final class TypeTuple : Type
         return t;
     }
 
-    override bool equals(RootObject o) const
+    override bool equals(const RootObject o) const
     {
         Type t = cast(Type)o;
         //printf("TypeTuple::equals(%s, %s)\n", toChars(), t.toChars());

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -784,7 +784,7 @@ extern (C++) abstract class Type : ASTNode
     /********************************
      * For pretty-printing a type.
      */
-    final override const(char)* toChars()
+    final override const(char)* toChars() const
     {
         OutBuffer buf;
         buf.reserve(16);
@@ -2382,11 +2382,12 @@ extern (C++) abstract class Type : ASTNode
     /**************************
      * Return type with the top level of it being mutable.
      */
-    Type toHeadMutable()
+    inout(Type) toHeadMutable() inout
     {
         if (!mod)
             return this;
-        return mutableOf();
+        Type unqualThis = cast(Type) this;
+        return cast(inout(Type)) unqualThis.mutableOf();
     }
 
     inout(ClassDeclaration) isClassHandle() inout
@@ -5754,7 +5755,7 @@ extern (C++) final class TypeStruct : Type
         return wm;
     }
 
-    override Type toHeadMutable()
+    override inout(Type) toHeadMutable() inout
     {
         return this;
     }
@@ -6068,7 +6069,7 @@ extern (C++) final class TypeClass : Type
         return wm;
     }
 
-    override Type toHeadMutable()
+    override inout(Type) toHeadMutable() inout
     {
         return this;
     }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -228,12 +228,12 @@ public:
     virtual const char *kind();
     Type *copy() const;
     virtual Type *syntaxCopy();
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     bool equivalent(Type *t);
     // kludge for template.isType()
     DYNCAST dyncast() const { return DYNCAST_TYPE; }
     int covariant(Type *t, StorageClass *pstc = NULL, bool fix17349 = true);
-    const char *toChars();
+    const char *toChars() const;
     char *toPrettyChars(bool QualifyTypes = false);
     static void _init();
 
@@ -570,7 +570,7 @@ public:
 
     static size_t dim(Parameters *parameters);
     static Parameter *getNth(Parameters *parameters, d_size_t nth, d_size_t *pn = NULL);
-    const char *toChars();
+    const char *toChars() const;
     bool isCovariant(bool returnByRef, const Parameter *p) const;
 };
 
@@ -830,7 +830,7 @@ public:
     static TypeTuple *create(Type *t1, Type *t2);
     const char *kind();
     Type *syntaxCopy();
-    bool equals(RootObject *o);
+    bool equals(RootObject *o) const;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -228,7 +228,7 @@ public:
     virtual const char *kind();
     Type *copy() const;
     virtual Type *syntaxCopy();
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     bool equivalent(Type *t);
     // kludge for template.isType()
     DYNCAST dyncast() const { return DYNCAST_TYPE; }
@@ -830,7 +830,7 @@ public:
     static TypeTuple *create(Type *t1, Type *t2);
     const char *kind();
     Type *syntaxCopy();
-    bool equals(RootObject *o) const;
+    bool equals(const RootObject *o) const;
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -249,7 +249,7 @@ unittest
     static struct S
     {
         int s = -1;
-        string toString()
+        string toString() const
         {
             return "S";
         }

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -53,15 +53,7 @@ public:
             size_t len = 2; // [ and ]
             foreach (u; 0 .. length)
             {
-                static if (is(typeof(this) == const(A), A) && is (A == Array!UnqualT, UnqualT))
-                {
-                    UnqualT* unqualData = cast(UnqualT*) data;
-                    buf[u] = unqualData[u].toString();
-                }
-                else
-                {
-                    buf[u] = data[u].toString();
-                }
+                buf[u] = data[u].toString();
                 len += buf[u].length + 1; //length + ',' or null terminator
             }
             char[] str = (cast(char*)mem.xmalloc(len))[0..len];

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -45,7 +45,7 @@ public:
             mem.xfree(data);
     }
     ///returns elements comma separated in []
-    extern(D) const(char)[] toString()
+    extern(D) const(char)[] toString() const
     {
         static if (is(typeof(T.init.toString())))
         {
@@ -53,7 +53,15 @@ public:
             size_t len = 2; // [ and ]
             foreach (u; 0 .. length)
             {
-                buf[u] = data[u].toString();
+                static if (is(typeof(this) == const(A), A) && is (A == Array!UnqualT, UnqualT))
+                {
+                    UnqualT* unqualData = cast(UnqualT*) data;
+                    buf[u] = unqualData[u].toString();
+                }
+                else
+                {
+                    buf[u] = data[u].toString();
+                }
                 len += buf[u].length + 1; //length + ',' or null terminator
             }
             char[] str = (cast(char*)mem.xmalloc(len))[0..len];
@@ -79,7 +87,7 @@ public:
         }
     }
     ///ditto
-    const(char)* toChars()
+    const(char)* toChars() const
     {
         return toString.ptr;
     }

--- a/src/dmd/root/array.h
+++ b/src/dmd/root/array.h
@@ -43,7 +43,7 @@ struct Array
             mem.xfree(data);
     }
 
-    char *toChars()
+    char *toChars() const
     {
         const char **buf = (const char **)mem.xmalloc(dim * sizeof(const char *));
         d_size_t len = 2;

--- a/src/dmd/root/object.h
+++ b/src/dmd/root/object.h
@@ -39,12 +39,12 @@ class RootObject
 public:
     RootObject() { }
 
-    virtual bool equals(RootObject *o);
+    virtual bool equals(const RootObject *o) const;
 
     /**
      * Pretty-print an Object. Useful for debugging the old-fashioned way.
      */
-    virtual const char *toChars();
+    virtual const char *toChars() const;
     /// This function is `extern(D)` and should not be called from C++,
     /// as the ABI does not match on some platforms
     virtual DString toString();

--- a/src/dmd/root/rootobject.d
+++ b/src/dmd/root/rootobject.d
@@ -42,18 +42,18 @@ extern (C++) class RootObject
     {
     }
 
-    bool equals(RootObject o)
+    bool equals(RootObject o) const
     {
         return o is this;
     }
 
-    const(char)* toChars()
+    const(char)* toChars() const
     {
         assert(0);
     }
 
     ///
-    extern(D) const(char)[] toString()
+    extern(D) const(char)[] toString() const
     {
         import core.stdc.string : strlen;
         auto p = this.toChars();

--- a/src/dmd/root/rootobject.d
+++ b/src/dmd/root/rootobject.d
@@ -42,7 +42,7 @@ extern (C++) class RootObject
     {
     }
 
-    bool equals(RootObject o) const
+    bool equals(const RootObject o) const
     {
         return o is this;
     }

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -166,7 +166,7 @@ extern (C++) abstract class Statement : ASTNode
         return b;
     }
 
-    override final const(char)* toChars()
+    override final const(char)* toChars() const
     {
         HdrGenState hgs;
         OutBuffer buf;

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -114,7 +114,7 @@ public:
 
     virtual Statement *syntaxCopy();
 
-    const char *toChars();
+    const char *toChars() const;
 
     void error(const char *format, ...);
     void warning(const char *format, ...);

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -36,7 +36,7 @@ public:
     // kludge for template.isType()
     DYNCAST dyncast() const { return DYNCAST_TUPLE; }
 
-    const char *toChars() { return objects.toChars(); }
+    const char *toChars() const { return objects.toChars(); }
 };
 
 struct TemplatePrevious
@@ -75,7 +75,7 @@ public:
     bool overloadInsert(Dsymbol *s);
     bool hasStaticCtorOrDtor();
     const char *kind() const;
-    const char *toChars();
+    const char *toChars() const;
 
     Prot prot();
 
@@ -275,7 +275,7 @@ public:
     Dsymbol *toAlias();                 // resolve real symbol
     const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    const char *toChars();
+    const char *toChars() const;
     const char* toPrettyCharsHelper();
     void printInstantiationTrace();
     Identifier *getIdent();
@@ -298,7 +298,7 @@ public:
     int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
-    const char *toChars();
+    const char *toChars() const;
 
     TemplateMixin *isTemplateMixin() { return this; }
     void accept(Visitor *v) { v->visit(this); }

--- a/src/dmd/version.h
+++ b/src/dmd/version.h
@@ -19,7 +19,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    const char *toChars();
+    const char *toChars() const;
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
@@ -32,7 +32,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *);
 
-    const char *toChars();
+    const char *toChars() const;
     void addMember(Scope *sc, ScopeDsymbol *sds);
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }


### PR DESCRIPTION
This PR  is useful to the the C++ header [generator](https://github.com/dlang/dmd/pull/9971) to generate the dmd frontend header files that are used by `gdc`.

The issue that I'm attempting to solve: D has function covariance, but C++ does not. What this means is that if I have the following D code
```D
extern (C++) class A
{
  void foo() {}
}

extern (C++) class B :  A
{
  override void foo() const {}
}
```
the generated header will look like
```C++
class A
{
  virtual void foo();
}

class B : public A
{
  void foo() const;
}
```
Note that `B` has `void foo() const`
Compiling this code with `g++ -Woverloaded-virtual` (as `gdc` does) will result in the following warning
```bash
warning: 'virtual void A::foo()' was hidden

by `void B::foo() const`
```