### PR TITLE
move error messages from s2ir.d to front end

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -77,6 +77,7 @@ struct Scope
     Dsymbol parent;                 /// parent to use
     LabelStatement slabel;          /// enclosing labelled statement
     SwitchStatement sw;             /// enclosing switch statement
+    Statement tryBody;              /// enclosing _body of TryCatchStatement or TryFinallyStatement
     TryFinallyStatement tf;         /// enclosing try finally statement
     ScopeGuardStatement os;            /// enclosing scope(xxx) statement
     Statement sbreak;               /// enclosing statement that supports "break"
@@ -663,6 +664,7 @@ struct Scope
         this.enclosing = sc.enclosing;
         this.parent = sc.parent;
         this.sw = sc.sw;
+        this.tryBody = sc.tryBody;
         this.tf = sc.tf;
         this.os = sc.os;
         this.tinst = sc.tinst;

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -580,8 +580,6 @@ private extern (C++) class S2irVisitor : Visitor
         if (bsw.BC == BCswitch)
             bsw.appendSucc(clabel.lblock);   // second entry in pair
         bcase.appendSucc(clabel.lblock);
-        if (blx.tryblock != bsw.Btry)
-            s.error("case cannot be in different `try` block level from `switch`");
         incUsage(irs, s.loc);
         if (s.statement)
             Statement_toIR(s.statement, irs);
@@ -594,8 +592,6 @@ private extern (C++) class S2irVisitor : Visitor
         block *bdefault = irs.getDefaultBlock();
         block_next(blx,BCgoto,bdefault);
         bcase.appendSucc(blx.curblock);
-        if (blx.tryblock != irs.getSwitchBlock().Btry)
-            s.error("default cannot be in different `try` block level from `switch`");
         incUsage(irs, s.loc);
         if (s.statement)
             Statement_toIR(s.statement, irs);

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -66,6 +66,7 @@ struct Scope
     Dsymbol *parent;            // parent to use
     LabelStatement *slabel;     // enclosing labelled statement
     SwitchStatement *sw;        // enclosing switch statement
+    Statement *tryBody;         // enclosing _body of TryCatchStatement or TryFinallyStatement
     TryFinallyStatement *tf;    // enclosing try finally statement
     ScopeGuardStatement *os;       // enclosing scope(xxx) statement
     Statement *sbreak;          // enclosing statement that supports "break"

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1568,7 +1568,8 @@ extern (C++) final class SwitchStatement : Statement
     bool isFinal;                   /// https://dlang.org/spec/statement.html#final-switch-statement
 
     DefaultStatement sdefault;      /// default:
-    TryFinallyStatement tf;         ///
+    Statement tryBody;              /// set to TryCatchStatement or TryFinallyStatement if in _body portion
+    TryFinallyStatement tf;         /// set if in the 'finally' block of a TryFinallyStatement
     GotoCaseStatements gotoCases;   /// array of unresolved GotoCaseStatement's
     CaseStatements* cases;          /// array of CaseStatement's
     int hasNoDefault;               /// !=0 if no default statement

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -439,6 +439,7 @@ public:
     bool isFinal;
 
     DefaultStatement *sdefault;
+    Statement *tryBody;            // set to TryCatchStatement or TryFinallyStatement if in _body portion
     TryFinallyStatement *tf;
     GotoCaseStatements gotoCases;  // array of unresolved GotoCaseStatement's
     CaseStatements *cases;         // array of CaseStatement's

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2481,6 +2481,7 @@ else
          */
 
         //printf("SwitchStatement::semantic(%p)\n", ss);
+        ss.tryBody = sc.tryBody;
         ss.tf = sc.tf;
         if (ss.cases)
         {
@@ -2878,6 +2879,11 @@ else
                 cs.error("`switch` and `case` are in different `finally` blocks");
                 errors = true;
             }
+            if (sc.sw.tryBody != sc.tryBody)
+            {
+                cs.error("case cannot be in different `try` block level from `switch`");
+                errors = true;
+            }
         }
         else
         {
@@ -2998,6 +3004,11 @@ else
             if (sc.sw.tf != sc.tf)
             {
                 ds.error("`switch` and `default` are in different `finally` blocks");
+                errors = true;
+            }
+            if (sc.sw.tryBody != sc.tryBody)
+            {
+                ds.error("default cannot be in different `try` block level from `switch`");
                 errors = true;
             }
             if (sc.sw.isFinal)
@@ -3851,8 +3862,11 @@ else
         enum FLAGcpp = 1;
         enum FLAGd = 2;
 
+        scope sc2 = sc.push();
+        sc2.tryBody = tcs;
         tcs._body = tcs._body.semanticScope(sc, null, null);
         assert(tcs._body);
+        sc2.pop();
 
         /* Even if body is empty, still do semantic analysis on catches
          */
@@ -3933,7 +3947,10 @@ else
     override void visit(TryFinallyStatement tfs)
     {
         //printf("TryFinallyStatement::semantic()\n");
+        auto sc2 = sc.push();
+        sc.tryBody = tfs;
         tfs._body = tfs._body.statementSemantic(sc);
+        sc2.pop();
 
         sc = sc.push();
         sc.tf = tfs;

--- a/test/fail_compilation/goto3.d
+++ b/test/fail_compilation/goto3.d
@@ -1,0 +1,37 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/goto3.d(1010): Error: case cannot be in different `try` block level from `switch`
+fail_compilation/goto3.d(1012): Error: default cannot be in different `try` block level from `switch`
+---
+ */
+
+
+void foo();
+void bar();
+
+#line 1000
+
+void test1()
+{
+    int i;
+    switch (i)
+    {
+        case 1:
+            try
+            {
+                foo();
+        case 2:
+                {   }
+        default:
+                {   }
+            }
+            finally
+            {
+                bar();
+            }
+            break;
+    }
+}
+
+


### PR DESCRIPTION
Shouldn't be detecting semantic errors in the glue code. Move it to the front end.