### PR TITLE
Fix broken test case in master

### DIFF
--- a/test/fail_compilation/goto2.d
+++ b/test/fail_compilation/goto2.d
@@ -1,7 +1,6 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/goto2.d(1007): Error: cannot `goto` into `try` block
 fail_compilation/goto2.d(1024): Error: case cannot be in different `try` block level from `switch`
 fail_compilation/goto2.d(1026): Error: default cannot be in different `try` block level from `switch`
 ---
@@ -48,5 +47,3 @@ void test1()
             break;
     }
 }
-
-


### PR DESCRIPTION
This test case was added in PR 10295.
Additionally, PR 10296 was submitted, moving some of those error messages to the front end,
meaning that the 'cannot goto in try block' message, still in the glue layer,
is not deplayed anymore.