### PR TITLE
Refactor and test response.d

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -157,7 +157,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             goto Largs;
         arguments[i] = argv[i];
     }
-    if (response_expand(arguments)) // expand response files
+    if (!responseExpand(arguments)) // expand response files
         error(Loc.initial, "can't open response file");
     //for (size_t i = 0; i < arguments.dim; ++i) printf("arguments[%d] = '%s'\n", i, arguments[i]);
     files.reserve(arguments.dim - 1);

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -63,6 +63,14 @@ struct File
         {
             return buffer.extractData();
         }
+
+        /// ditto
+        /// Include the null-terminator at the end of the buffer in the returned array.
+        ubyte[] extractDataZ() @nogc nothrow pure
+        {
+            auto result = buffer.extractData();
+            return result.ptr[0 .. result.length + 1];
+        }
     }
 
 nothrow:

--- a/src/dmd/root/response.d
+++ b/src/dmd/root/response.d
@@ -14,200 +14,347 @@
 
 module dmd.root.response;
 
-import core.stdc.stdio;
-import core.stdc.stdlib;
-import core.stdc.string;
 import dmd.root.file;
 import dmd.root.filename;
 
+///
+alias responseExpand = responseExpandFrom!lookupInEnvironment;
+
 /*********************************
- * #include <stdlib.h>
- * int response_expand(int *pargc,char ***pargv);
- *
  * Expand any response files in command line.
  * Response files are arguments that look like:
  *   @NAME
- * The name is first searched for in the environment. If it is not
- * there, it is searched for as a file name.
+ * The names are resolved by calling the 'lookup' function passed as a template
+ * parameter. That function is expected to first check the environment and then
+ * the file system.
  * Arguments are separated by spaces, tabs, or newlines. These can be
- * imbedded within arguments by enclosing the argument in '' or "".
+ * imbedded within arguments by enclosing the argument in "".
+ * Backslashes can be used to escape a ".
+ * A line comment can be started with #.
  * Recursively expands nested response files.
  *
- * To use, put the line:
- *   response_expand(&argc,&argv);
- * as the first executable statement in main(int argc, char **argv).
- * argc and argv are adjusted to be the new command line arguments
- * after response file expansion.
+ * To use, put the arguments in a Strings object and call this on it.
  *
  * Digital Mars's MAKE program can be notified that a program can accept
  * long command lines via environment variables by preceding the rule
  * line for the program with a *.
  *
+ * Params:
+ *     lookup = alias to a function that is called to look up response file
+ *              arguments in the environment. It is expected to accept a null-
+ *              terminated string and return a mutable char[] that ends with
+ *              a null-terminator or null if the response file could not be
+ *              resolved.
+ *     args = array containing arguments as null-terminated strings
+ *
  * Returns:
- *   0   success
- *   !=0   failure (argc, argv unchanged)
+ *     true on success, false if a response file could not be expanded.
  */
-bool response_expand(ref Strings args) nothrow
+bool responseExpandFrom(alias lookup)(ref Strings args) nothrow
 {
     const(char)* cp;
-    int recurse = 0;
+    bool recurse = false;
+
+    // i is updated by insertArgumentsFromResponse, so no foreach
     for (size_t i = 0; i < args.dim;)
     {
         cp = args[i];
-        if (*cp != '@')
+        if (cp[0] != '@')
         {
             ++i;
             continue;
         }
         args.remove(i);
-        char* buffer;
-        char* bufend;
-        cp++;
-        if (auto p = getenv(cp))
-        {
-            buffer = strdup(p);
-            if (!buffer)
-                goto noexpand;
-            bufend = buffer + strlen(buffer);
+        auto buffer = lookup(&cp[1]);
+        if (!buffer) {
+            /* error         */
+            /* BUG: any file buffers are not free'd   */
+            return false;
         }
-        else
-        {
-            auto readResult = File.read(cp);
-            if (!readResult.success)
-                goto noexpand;
-            // take ownership of buffer (leaking)
-            auto data = readResult.extractData();
-            buffer = cast(char*)data.ptr;
-            bufend = buffer + data.length;
-        }
-        // The logic of this should match that in setargv()
-        int comment = 0;
-        for (auto p = buffer; p < bufend; p++)
-        {
-            char* d;
-            char c, lastc;
-            ubyte instring;
-            int num_slashes, non_slashes;
-            switch (*p)
-            {
-            case 26:
-                /* ^Z marks end of file      */
-                goto L2;
-            case 0xD:
-            case '\n':
-                if (comment)
-                {
-                    comment = 0;
-                }
-                goto case;
-            case 0:
-            case ' ':
-            case '\t':
-                continue;
-                // scan to start of argument
-            case '#':
-                comment = 1;
-                continue;
-            case '@':
-                if (comment)
-                {
-                    continue;
-                }
-                recurse = 1;
-                goto default;
-            default:
-                /* start of new argument   */
-                if (comment)
-                {
-                    continue;
-                }
-                args.insert(i, p);
-                ++i;
-                instring = 0;
-                c = 0;
-                num_slashes = 0;
-                for (d = p; 1; p++)
-                {
-                    lastc = c;
-                    if (p >= bufend)
-                    {
-                        *d = 0;
-                        goto L2;
-                    }
-                    c = *p;
-                    switch (c)
-                    {
-                    case '"':
-                        /*
-                         Yes this looks strange,but this is so that we are
-                         MS Compatible, tests have shown that:
-                         \\\\"foo bar"  gets passed as \\foo bar
-                         \\\\foo  gets passed as \\\\foo
-                         \\\"foo gets passed as \"foo
-                         and \"foo gets passed as "foo in VC!
-                         */
-                        non_slashes = num_slashes % 2;
-                        num_slashes = num_slashes / 2;
-                        for (; num_slashes > 0; num_slashes--)
-                        {
-                            d--;
-                            *d = '\0';
-                        }
-                        if (non_slashes)
-                        {
-                            *(d - 1) = c;
-                        }
-                        else
-                        {
-                            instring ^= 1;
-                        }
-                        break;
-                    case 26:
-                        *d = 0; // terminate argument
-                        goto L2;
-                    case 0xD:
-                        // CR
-                        c = lastc;
-                        continue;
-                        // ignore
-                    case '@':
-                        recurse = 1;
-                        goto Ladd;
-                    case ' ':
-                    case '\t':
-                        if (!instring)
-                        {
-                        case '\n':
-                        case 0:
-                            *d = 0; // terminate argument
-                            goto Lnextarg;
-                        }
-                        goto default;
-                    default:
-                    Ladd:
-                        if (c == '\\')
-                            num_slashes++;
-                        else
-                            num_slashes = 0;
-                        *d++ = c;
-                        break;
-                    }
-                }
-                break;
-            }
-        Lnextarg:
-        }
-    L2:
+
+        recurse = insertArgumentsFromResponse(buffer, args, i) || recurse;
     }
     if (recurse)
     {
         /* Recursively expand @filename   */
-        if (response_expand(args))
-            goto noexpand;
+        if (!responseExpandFrom!lookup(args))
+            /* error         */
+            /* BUG: any file buffers are not free'd   */
+            return false;
     }
-    return false; /* success         */
-noexpand:
-    /* error         */
-    /* BUG: any file buffers are not free'd   */
-    return true;
+    return true; /* success         */
+}
+
+version (unittest)
+{
+    char[] testEnvironment(const(char)* str) nothrow pure
+        {
+        import core.stdc.string: strlen;
+        switch (str[0 .. strlen(str)])
+        {
+        case "Foo":
+            return "foo @Bar #\0".dup;
+        case "Bar":
+            return "bar @Nil\0".dup;
+        case "Error":
+            return "@phony\0".dup;
+        case "Nil":
+            return "\0".dup;
+        default:
+            return null;
+        }
+    }
+}
+
+unittest
+{
+    auto args = Strings(4);
+    args[0] = "first";
+    args[1] = "@Foo";
+    args[2] = "@Bar";
+    args[3] = "last";
+
+    assert(responseExpand!testEnvironment(args));
+    assert(args.length == 5);
+    assert(args[0][0 .. 6] == "first\0");
+    assert(args[1][0 .. 4] == "foo\0");
+    assert(args[2][0 .. 4] == "bar\0");
+    assert(args[3][0 .. 4] == "bar\0");
+    assert(args[4][0 .. 5] == "last\0");
+}
+
+unittest
+{
+    auto args = Strings(2);
+    args[0] = "@phony";
+    args[1] = "dummy";
+    assert(!responseExpand!testEnvironment(args));
+}
+
+unittest
+{
+    auto args = Strings(2);
+    args[0] = "@Foo";
+    args[1] = "@Error";
+    assert(!responseExpand!testEnvironment(args));
+}
+
+/*********************************
+ * Take the contents of a response-file 'buffer', parse it and put the resulting
+ * arguments in 'args' at 'argIndex'. 'argIndex' will be updated to point just
+ * after the inserted arguments.
+ * The logic of this should match that in setargv()
+ *
+ * Params:
+ *     buffer = mutable string containing the response file
+ *     args = list of arguments
+ *     argIndex = position in 'args' where response arguments are inserted
+ *
+ * Returns:
+ *     true if another response argument was found
+ */
+bool insertArgumentsFromResponse(char[] buffer, ref Strings args, ref size_t argIndex) nothrow
+{
+    bool recurse = false;
+    bool comment = false;
+
+    for (size_t p = 0; p < buffer.length; p++)
+    {
+        //char* d;
+        size_t d = 0;
+        char c, lastc;
+        bool instring;
+        int numSlashes, nonSlashes;
+        switch (buffer[p])
+        {
+        case 26:
+            /* ^Z marks end of file      */
+            return recurse;
+        case '\r':
+        case '\n':
+            comment = false;
+            goto case;
+        case 0:
+        case ' ':
+        case '\t':
+            continue;
+            // scan to start of argument
+        case '#':
+            comment = true;
+            continue;
+        case '@':
+            if (comment)
+            {
+                continue;
+            }
+            recurse = true;
+            goto default;
+        default:
+            /* start of new argument   */
+            if (comment)
+            {
+                continue;
+            }
+            args.insert(argIndex, &buffer[p]);
+            ++argIndex;
+            instring = false;
+            c = 0;
+            numSlashes = 0;
+            for (d = p; 1; p++)
+            {
+                lastc = c;
+                if (p >= buffer.length)
+                {
+                    buffer[d] = '\0';
+                    return recurse;
+                }
+                c = buffer[p];
+                switch (c)
+                {
+                case '"':
+                    /*
+                    Yes this looks strange,but this is so that we are
+                    MS Compatible, tests have shown that:
+                    \\\\"foo bar"  gets passed as \\foo bar
+                    \\\\foo  gets passed as \\\\foo
+                    \\\"foo gets passed as \"foo
+                    and \"foo gets passed as "foo in VC!
+                    */
+                    nonSlashes = numSlashes % 2;
+                    numSlashes = numSlashes / 2;
+                    for (; numSlashes > 0; numSlashes--)
+                    {
+                        d--;
+                        buffer[d] = '\0';
+                    }
+                    if (nonSlashes)
+                    {
+                        buffer[d - 1] = c;
+                    }
+                    else
+                    {
+                        instring = !instring;
+                    }
+                    break;
+                case 26:
+                    buffer[d] = '\0'; // terminate argument
+                    return recurse;
+                case '\r':
+                    c = lastc;
+                    continue;
+                    // ignore
+                case ' ':
+                case '\t':
+                    if (!instring)
+                    {
+                    case '\n':
+                    case 0:
+                        buffer[d] = '\0'; // terminate argument
+                        goto Lnextarg;
+                    }
+                    goto default;
+                default:
+                    if (c == '\\')
+                        numSlashes++;
+                    else
+                        numSlashes = 0;
+                    buffer[d++] = c;
+                    break;
+                }
+            }
+        }
+    Lnextarg:
+    }
+    return recurse;
+}
+
+unittest
+{
+    auto args = Strings(4);
+    args[0] = "arg0";
+    args[1] = "arg1";
+    args[2] = "arg2";
+
+    char[] testData = "".dup;
+    size_t index = 1;
+    assert(insertArgumentsFromResponse(testData, args, index) == false);
+    assert(index == 1);
+
+    testData = (`\\\\"foo bar" \\\\foo \\\"foo \"foo "\"" # @comment`~'\0').dup;
+    assert(insertArgumentsFromResponse(testData, args, index) == false);
+    assert(index == 6);
+
+    assert(args[1][0 .. 9] == `\\foo bar`);
+    assert(args[2][0 .. 7] == `\\\\foo`);
+    assert(args[3][0 .. 5] == `\"foo`);
+    assert(args[4][0 .. 4] == `"foo`);
+    assert(args[5][0 .. 1] == `"`);
+
+    index = 7;
+    testData = "\t@recurse # comment\r\ntab\t\"@recurse\"\x1A after end\0".dup;
+    assert(insertArgumentsFromResponse(testData, args, index) == true);
+    assert(index == 10);
+    assert(args[7][0 .. 8] == "@recurse");
+    assert(args[8][0 .. 3] == "tab");
+    assert(args[9][0 .. 8] == "@recurse");
+}
+
+unittest
+{
+    auto args = Strings(0);
+
+    char[] testData = "\x1A".dup;
+    size_t index = 0;
+    assert(insertArgumentsFromResponse(testData, args, index) == false);
+    assert(index == 0);
+
+    testData = "@\r".dup;
+    assert(insertArgumentsFromResponse(testData, args, index) == true);
+    assert(index == 1);
+    assert(args[0][0 .. 2] == "@\0");
+
+    testData = "ä&#\0".dup;
+    assert(insertArgumentsFromResponse(testData, args, index) == false);
+    assert(index == 2);
+    assert(args[1][0 .. 5] == "ä&#\0");
+
+    testData = "one@\"word \0".dup;
+    assert(insertArgumentsFromResponse(testData, args, index) == false);
+    args[0] = "one@\"word";
+}
+
+/*********************************
+ * Try to resolve the null-terminated string cp to a null-terminated char[].
+ *
+ * The name is first searched for in the environment. If it is not
+ * there, it is searched for as a file name.
+ *
+ * Params:
+ *     cp = null-terminated string to look resolve
+ *
+ * Returns:
+ *     a mutable, manually allocated array containing the contents of the environment
+ *     variable or file, ending with a null-terminator.
+ *     The null-terminator is inside the bounds of the array.
+ *     If cp could not be resolved, null is returned.
+ */
+private char[] lookupInEnvironment(scope const(char)* cp) nothrow {
+
+    import core.stdc.stdlib: getenv;
+    import core.stdc.string: strlen;
+    import dmd.root.rmem: mem;
+
+    if (auto p = getenv(cp))
+    {
+        char* buffer = mem.xstrdup(p);
+        return buffer[0 .. strlen(buffer) + 1]; // include null-terminator
+    }
+    else
+    {
+        auto readResult = File.read(cp);
+        if (!readResult.success)
+            return null;
+        // take ownership of buffer (leaking)
+        return cast(char[]) readResult.extractDataZ();
+    }
 }


### PR DESCRIPTION
[Per request](https://forum.dlang.org/thread/qiab48$j46$1@digitalmars.com).

Sorry for the large diff, but the original code was one monster function that did everything. I separated it into three concerns:
- walking the argument list looking for response files to expand
- parsing response files
- looking up response files in the environment / on the filesystem

I added unittests so the first 2 functions are 100% covered. dmd/root/response.d as a whole is 94% covered. Further improvements:

- `core.stdc` imports are now local and selective
- wrong / outdated documentation is updated
- most `goto`s are removed
- use D arrays instead of C pointers
- don't recurse when an `@` in the middle of an argument was found

Note that most behavior remains the same, including:
- response files are allocated and then leak
- FileBuffer is assumed to have a null terminator past the array bounds. (I did add a function `extractDataZ` to at least do this in file.d itself which is less fragile than response.d assuming internals from file.d)
- null terminators are inserted into the response files since arguments are still C-strings.

This is still clumsy, so a possible future PR can add usage of D-strings for arguments as well.