### PR TITLE
Try turning of "all comdat"

### DIFF
--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -257,10 +257,6 @@ static if (0)
 else static if (TARGET_OSX)
 {
 }
-else
-{
-    config.flags4 |= CFG4allcomdat;
-}
     if (trace)
         config.flags |= CFGtrace;       // turn on profiler
     if (nofloat)

--- a/src/dmd/backend/backconfig.d
+++ b/src/dmd/backend/backconfig.d
@@ -257,6 +257,11 @@ static if (0)
 else static if (TARGET_OSX)
 {
 }
+else
+{
+    version(Windows)
+        config.flags4 |= CFG4allcomdat;
+}
     if (trace)
         config.flags |= CFGtrace;       // turn on profiler
     if (nofloat)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -831,7 +831,6 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             break;
         }
     }
-    s.Sclass = SCcomdat;
 
     /* Vector operations should be comdat's
      */

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -831,6 +831,7 @@ void FuncDeclaration_toObjFile(FuncDeclaration fd, bool multiobj)
             break;
         }
     }
+    s.Sclass = SCcomdat;
 
     /* Vector operations should be comdat's
      */


### PR DESCRIPTION
As mentioned in a [comment](https://github.com/dlang/dmd/pull/10236#issuecomment-519575095) on #10236, DMD only emits weak symbols for functions, whether they are `SCglobal` or `SCcomdat`. 
Apparently, this is something explicitly coded in as long ago as [dmd 2.026](https://github.com/dlang/dmd/commit/00337ef8d8c4c1c08da68f95963e2fe1658a49ec#diff-6b33787dce20fb00d997456ba0b7654dR100). Does anyone know why? LDC doesn't have this, and I'm not aware of any linking issues with strong function symbols there.

While it's not a problem for D functions because of name mangling, it can be annoying for C functions. Any extern(C) function defined in D can be overriden by a function of the same name in a C library that you link, and when there are multiple extern(C) functions of the same name in D it will just pick a random one.
