### PR TITLE
[dmd-cxx] fix Issue 20113 - Cannot find source code for runtime library file 'object.d' when the path contains '~'

### DIFF
--- a/src/iasmdmd.c
+++ b/src/iasmdmd.c
@@ -4264,7 +4264,7 @@ static OPND *asm_primary_exp()
 
     REG *regp;
 
-    switch (tok_value)
+    switch ((int)tok_value)
     {
         case TOKdollar:
             o1 = new OPND();
@@ -4566,7 +4566,7 @@ Statement* inlineAsmSemantic(InlineAsmStatement *s, Scope *sc)
     asmtok = s->tokens;
     asm_token_trans(asmtok);
 
-    switch (tok_value)
+    switch ((int)tok_value)
     {
         case ASMTKnaked:
             s->naked = true;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -110,6 +110,7 @@ endif
 # Clang Specific
 ifeq ($(CXX_KIND), clang++)
 WARNINGS += \
+	-Wno-c++11-narrowing \
 	-Wno-undefined-var-template \
 	-Wno-absolute-value \
 	-Wno-missing-braces \
@@ -133,6 +134,7 @@ BACK_WARNINGS := $(GLUE_WARNINGS) \
 # Clang Specific
 ifeq ($(CXX_KIND), clang++)
 WARNINGS += \
+	-Wno-c++11-narrowing \
 	-Wno-undefined-var-template \
 	-Wno-absolute-value
 GLUE_WARNINGS += \
@@ -165,7 +167,7 @@ endif
 # Clang Specific
 ifeq ($(CXX_KIND), clang++)
 CXXFLAGS += \
-	-xc++
+	-xc++ -std=c++11
 endif
 # Default D compiler flags for all source files
 DFLAGS := -version=MARS $(PIC)

--- a/src/root/ctfloat.c
+++ b/src/root/ctfloat.c
@@ -456,11 +456,8 @@ bool CTFloat::isNaN(real_t r)
 #else
     return __inline_isnan(r);
 #endif
-#elif __FreeBSD__ || __OpenBSD__
-    return isnan(r);
 #else
-    #undef isnan
-    return ::isnan(r);
+    return isnan(r);
 #endif
 }
 
@@ -476,11 +473,8 @@ bool CTFloat::isInfinity(real_t r)
 {
 #if __APPLE__
     return fpclassify(r) == FP_INFINITE;
-#elif __FreeBSD__ || __OpenBSD__
-    return isinf(r);
 #else
-    #undef isinf
-    return ::isinf(r);
+    return isinf(r);
 #endif
 }
 

--- a/src/root/filename.c
+++ b/src/root/filename.c
@@ -110,7 +110,8 @@ Strings *FileName::splitPath(const char *path)
                     case '~':
                     {
                         char *home = getenv("HOME");
-                        if (home)
+                        // Expand ~ only if it is prefixing the rest of the path.
+                        if (!buf.offset && p[1] == '/' && home)
                             buf.writestring(home);
                         else
                             buf.writestring("~");


### PR DESCRIPTION
Backport of #10284.