### PR TITLE
Fixup #10308: Remove TOKmanifest from token.h

### DIFF
--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -900,12 +900,12 @@ nothrow:
         return p;
     }
 
-    static const(char)* toChars(TOK value)
+    static const(char)* toChars(ubyte value)
     {
         return toString(value).ptr;
     }
 
-    extern (D) static string toString(TOK value) pure nothrow @nogc @safe
+    extern (D) static string toString(ubyte value) pure nothrow @nogc @safe
     {
         return tochars[value];
     }

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -131,9 +131,9 @@ enum
         TOKalign, TOKextern, TOKprivate, TOKprotected, TOKpublic, TOKexport,
         TOKstatic, TOKfinal, TOKconst, TOKabstract,
         TOKdebug, TOKdeprecated, TOKin, TOKout, TOKinout, TOKlazy,
-        TOKauto, TOKpackage, TOKmanifest, TOKimmutable,
+        TOKauto, TOKpackage, TOKimmutable,
 
-// 183
+// 182
         // Statements
         TOKif, TOKelse, TOKwhile, TOKfor, TOKdo, TOKswitch,
         TOKcase, TOKdefault, TOKbreak, TOKcontinue, TOKwith,
@@ -142,7 +142,7 @@ enum
         TOKscope,
         TOKon_scope_exit, TOKon_scope_failure, TOKon_scope_success,
 
-// 207
+// 206
         // Contracts
         TOKinvariant,
 
@@ -154,7 +154,7 @@ enum
         TOKref,
         TOKmacro,
 
-// 212
+// 211
         TOKparameters,
         TOKtraits,
         TOKoverloadset,
@@ -175,7 +175,7 @@ enum
         TOKvector,
         TOKpound,
 
-// 231
+// 230
         TOKinterval,
         TOKvoidexp,
         TOKcantexp,

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -92,6 +92,19 @@ static void frontend_term()
 
 /**********************************/
 
+void test_tokens()
+{
+    // First valid TOK value
+    assert(TOKlparen == 1);
+    assert(strcmp(Token::toChars(TOKlparen), "(") == 0);
+
+    // Last valid TOK value
+    assert(TOKvectorarray == TOKMAX - 1);
+    assert(strcmp(Token::toChars(TOKvectorarray), "vectorarray") == 0);
+}
+
+/**********************************/
+
 class TestVisitor : public Visitor
 {
   public:
@@ -324,6 +337,7 @@ int main(int argc, char **argv)
 {
     frontend_init();
 
+    test_tokens();
     test_visitors();
     test_semantic();
     test_expression();


### PR DESCRIPTION
Original PR : #10308 
CC @kinke : Is the `TOK` change acceptable ? Otherwise I can also change `toChars` to take a `ubyte`. And thanks for reminding me of `tokens.h` existence.