### PR TITLE
do not print version in debug builds, it just complicates the testsuite

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -137,11 +137,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     Strings files;
     Strings libmodules;
     global._init();
-    debug
-    {
-        printf("DMD %.*s DEBUG\n", cast(int) global._version.length - 1, global._version.ptr);
-        fflush(stdout); // avoid interleaving with stderr output when redirecting
-    }
     // Check for malformed input
     if (argc < 1 || !argv)
     {


### PR DESCRIPTION
It seems very few people use the debug version to begin with, as it doesn't pass the test suite, see for example https://github.com/dlang/dmd/pull/10231/files#diff-ee89b0981cbb7f8ab2412e68a427d52aL589. The following changes in that PR show necessary filtering in the dmd output which is often forgotten.