### PR TITLE
Disable non-global template support for other compilers than DMD

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -57,6 +57,9 @@ private enum LOG = false;
 
 enum IDX_NOTFOUND = 0x12345678;
 
+version (MARS)
+    version = NonGlobalTemplate;
+
 pure nothrow @nogc
 {
 
@@ -7055,6 +7058,16 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                 Declaration d = sa.isDeclaration();
                 if ((td && td.literal) || (ti && ti.enclosing) || (d && !d.isDataseg() && !(d.storage_class & STC.manifest) && (!d.isFuncDeclaration() || d.isFuncDeclaration().isNested()) && !isTemplateMixin()))
                 {
+                    version (NonGlobalTemplate) {} else
+                    {
+                        if (!isstatic)
+                        {
+                            error("cannot use local `%s` as parameter to non-global template `%s`", sa.toChars(), tempdecl.toChars());
+                            errors = true;
+                            return nested != 0;
+                        }
+                    }
+
                     Dsymbol dparent = sa.toParent2();
                     if (!dparent)
                         goto L1;

--- a/test/compilable/nestedtempl0.d
+++ b/test/compilable/nestedtempl0.d
@@ -1,3 +1,6 @@
+version (DigitalMars)
+{
+
 class C2
 {
     class N(alias a) {}
@@ -10,4 +13,6 @@ void test2()
     static assert(__traits(isSame, __traits(parent, C2.N!a), C2));
     static assert(__traits(classInstanceSize, C2.N!0) == size_t.sizeof * 3);
     static assert(__traits(classInstanceSize, C2.N!a) == size_t.sizeof * 4);
+}
+
 }

--- a/test/compilable/nestedtempl1.d
+++ b/test/compilable/nestedtempl1.d
@@ -1,3 +1,6 @@
+version (DigitalMars)
+{
+
 class K
 {
     class B(alias a)
@@ -22,4 +25,6 @@ void main()
     auto k = new K;
     auto d = k.new K.D!a;
     auto e = k.new K.E!a;
+}
+
 }

--- a/test/compilable/test20063.d
+++ b/test/compilable/test20063.d
@@ -1,3 +1,5 @@
+version (DigitalMars)
+{
 
 struct S
 {
@@ -11,4 +13,6 @@ void main()
     class C {}
 
     S().f!(() => new C()).handleLazily;
+}
+
 }

--- a/test/compilable/test324.d
+++ b/test/compilable/test324.d
@@ -1,3 +1,6 @@
+version (DigitalMars)
+{
+
 struct Foo
 {
     void doStuff(alias fun)() {}
@@ -7,4 +10,6 @@ void main()
 {
     Foo foo;
     foo.doStuff!( (i) { return i; })();
+}
+
 }

--- a/test/fail_compilation/nestedtempl0.d
+++ b/test/fail_compilation/nestedtempl0.d
@@ -1,12 +1,16 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl0.d(18): Error: class `nestedtempl0.K.D!(1, B!(a)).D` doesn't need a frame pointer, but super class `B` needs the frame pointer of `main`
-fail_compilation/nestedtempl0.d(28): Error: template instance `nestedtempl0.K.D!(1, B!(a))` error instantiating
-fail_compilation/nestedtempl0.d(18): Error: class `nestedtempl0.main.fun.D!(b, B!(a)).D` needs the frame pointer of `fun`, but super class `B` needs the frame pointer of `main`
-fail_compilation/nestedtempl0.d(33): Error: template instance `nestedtempl0.main.fun.D!(b, B!(a))` error instantiating
+fail_compilation/nestedtempl0.d(22): Error: class `nestedtempl0.K.D!(1, B!(a)).D` doesn't need a frame pointer, but super class `B` needs the frame pointer of `main`
+fail_compilation/nestedtempl0.d(32): Error: template instance `nestedtempl0.K.D!(1, B!(a))` error instantiating
+fail_compilation/nestedtempl0.d(22): Error: class `nestedtempl0.main.fun.D!(b, B!(a)).D` needs the frame pointer of `fun`, but super class `B` needs the frame pointer of `main`
+fail_compilation/nestedtempl0.d(37): Error: template instance `nestedtempl0.main.fun.D!(b, B!(a))` error instantiating
+fail_compilation/nestedtempl0.d(51): Error: static assert:  `0` is false
 ---
 */
+
+version (DigitalMars)
+{
 
 class K
 {
@@ -33,3 +37,15 @@ void main()
         auto o = k.new K.D!(b, K.B!a);
     }
 }
+
+}
+else
+{
+    // imitate error output
+    pragma(msg, "fail_compilation/nestedtempl0.d(22): Error: class `nestedtempl0.K.D!(1, B!(a)).D` doesn't need a frame pointer, but super class `B` needs the frame pointer of `main`");
+    pragma(msg, "fail_compilation/nestedtempl0.d(32): Error: template instance `nestedtempl0.K.D!(1, B!(a))` error instantiating");
+    pragma(msg, "fail_compilation/nestedtempl0.d(22): Error: class `nestedtempl0.main.fun.D!(b, B!(a)).D` needs the frame pointer of `fun`, but super class `B` needs the frame pointer of `main`");
+    pragma(msg, "fail_compilation/nestedtempl0.d(37): Error: template instance `nestedtempl0.main.fun.D!(b, B!(a))` error instantiating");
+}
+
+void func() { static assert(0); }

--- a/test/fail_compilation/nestedtempl1.d
+++ b/test/fail_compilation/nestedtempl1.d
@@ -1,9 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl1.d(24): Error: modify `inout` to `mutable` is not allowed inside `inout` function
+fail_compilation/nestedtempl1.d(28): Error: modify `inout` to `mutable` is not allowed inside `inout` function
+fail_compilation/nestedtempl1.d(38): Error: static assert:  `0` is false
 ---
 */
+
+version (DigitalMars)
+{
 
 auto foo(ref inout(int) x)
 {
@@ -23,3 +27,12 @@ void main()
     auto o = foo(a);
     o.bar!a() = 1;      // bad!
 }
+
+}
+else
+{
+    // imitate error output
+    pragma(msg, "fail_compilation/nestedtempl1.d(28): Error: modify `inout` to `mutable` is not allowed inside `inout` function");
+}
+
+void func() { static assert(0); }

--- a/test/fail_compilation/nestedtempl2.d
+++ b/test/fail_compilation/nestedtempl2.d
@@ -1,14 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl2.d(32): Error: `this` is only defined in non-static member functions, not `test`
-fail_compilation/nestedtempl2.d(32): Error: need `this` of type `B` to call function `func`
-fail_compilation/nestedtempl2.d(33): Error: `this` is only defined in non-static member functions, not `test`
-fail_compilation/nestedtempl2.d(33): Error: need `this` of type `B` to make delegate from function `func`
-fail_compilation/nestedtempl2.d(35): Error: `this` is only defined in non-static member functions, not `test`
-fail_compilation/nestedtempl2.d(35): Error: need `this` of type `B` needed to `new` nested class `N`
+fail_compilation/nestedtempl2.d(36): Error: `this` is only defined in non-static member functions, not `test`
+fail_compilation/nestedtempl2.d(36): Error: need `this` of type `B` to call function `func`
+fail_compilation/nestedtempl2.d(37): Error: `this` is only defined in non-static member functions, not `test`
+fail_compilation/nestedtempl2.d(37): Error: need `this` of type `B` to make delegate from function `func`
+fail_compilation/nestedtempl2.d(39): Error: `this` is only defined in non-static member functions, not `test`
+fail_compilation/nestedtempl2.d(39): Error: need `this` of type `B` needed to `new` nested class `N`
+fail_compilation/nestedtempl2.d(54): Error: static assert:  `0` is false
 ---
 */
+
+version (DigitalMars)
+{
 
 class B
 {
@@ -34,3 +38,17 @@ void test()
 
     new N!(b.n)();
 }
+
+}
+else
+{
+    // imitate error output
+    pragma(msg, "fail_compilation/nestedtempl2.d(36): Error: `this` is only defined in non-static member functions, not `test`");
+    pragma(msg, "fail_compilation/nestedtempl2.d(36): Error: need `this` of type `B` to call function `func`");
+    pragma(msg, "fail_compilation/nestedtempl2.d(37): Error: `this` is only defined in non-static member functions, not `test`");
+    pragma(msg, "fail_compilation/nestedtempl2.d(37): Error: need `this` of type `B` to make delegate from function `func`");
+    pragma(msg, "fail_compilation/nestedtempl2.d(39): Error: `this` is only defined in non-static member functions, not `test`");
+    pragma(msg, "fail_compilation/nestedtempl2.d(39): Error: need `this` of type `B` needed to `new` nested class `N`");
+}
+
+void func() { static assert(0); }

--- a/test/fail_compilation/nestedtempl3.d
+++ b/test/fail_compilation/nestedtempl3.d
@@ -1,9 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl3.d(23): Error: cannot access frame pointer of `nestedtempl3.test.S!(i).S`
+fail_compilation/nestedtempl3.d(27): Error: cannot access frame pointer of `nestedtempl3.test.S!(i).S`
+fail_compilation/nestedtempl3.d(37): Error: static assert:  `0` is false
 ---
 */
+
+version (DigitalMars)
+{
 
 void test()
 {
@@ -22,3 +26,12 @@ void test()
     alias S = typeof(f0());
     auto s = S();
 }
+
+}
+else
+{
+    // imitate error output
+    pragma(msg, "fail_compilation/nestedtempl3.d(27): Error: cannot access frame pointer of `nestedtempl3.test.S!(i).S`");
+}
+
+void func() { static assert(0); }

--- a/test/runnable/template10.d
+++ b/test/runnable/template10.d
@@ -1,5 +1,8 @@
 // PERMUTE_ARGS: -inline
 
+version (DigitalMars)
+{
+
 /********************************************/
 
 void test1a()
@@ -745,4 +748,10 @@ void main()
 {
     runTests();          // runtime
     enum _ = runTests(); // ctfe
+}
+
+}
+else
+{
+    void main() {}
 }


### PR DESCRIPTION
Until GDC and LDC catch up.