### PR TITLE
fix Issue 20126 - codegen reloads parameter from register when iasm c…

### DIFF
--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -74,6 +74,7 @@ targ_size_t paramsize(elem *e, tym_t tyf);
  */
 bool regParamInPreg(Symbol* s)
 {
+    //printf("regPAramInPreg %s\n", s.Sident.ptr);
     return (s.Sclass == SCfastpar || s.Sclass == SCshadowreg) &&
         (!(config.flags4 & CFG4optimized) || !(s.Sflags & GTregcand));
 }
@@ -1373,7 +1374,7 @@ void getlvalue(ref CodeBuilder cdb,code *pcs,elem *e,regm_t keepmsk)
                  */
                 if (regcon.params & pregm /*&& s.Spreg2 == NOREG && !(pregm & XMMREGS)*/)
                 {
-                    if (keepmsk & RMload)
+                    if (keepmsk & RMload && !anyiasm)
                     {
                         auto voffset = e.EV.Voffset;
                         if (sz <= REGSIZE)
@@ -5173,6 +5174,7 @@ void loaddata(ref CodeBuilder cdb, elem* e, regm_t* pretregs)
         // See if we can use register that parameter was passed in
         if (regcon.params &&
             regParamInPreg(e.EV.Vsym) &&
+            !anyiasm &&   // may have written to the memory for the parameter
             (regcon.params & mask(e.EV.Vsym.Spreg) && e.EV.Voffset == 0 ||
              regcon.params & mask(e.EV.Vsym.Spreg2) && e.EV.Voffset == REGSIZE) &&
             sz <= REGSIZE)                  // make sure no 'paint' to a larger size happened

--- a/test/runnable/iasm64.d
+++ b/test/runnable/iasm64.d
@@ -6809,6 +6809,29 @@ L1:     pop     RAX;
 }
 
 /****************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20126
+
+extern(C) float floop(float* r, float x)
+{
+    asm
+    {
+        mov  EAX, x;
+        mov  RCX, r;
+        xchg [RCX], EAX;
+        mov  x, EAX;
+    }
+    return x;
+}
+
+void test20126()
+{
+    float r = 1.0;
+    float x = 2.0;
+    float f = floop(&r, x);
+    assert(f == 1.0);
+}
+
+/****************************************************/
 
 int main()
 {
@@ -6885,6 +6908,7 @@ int main()
     testconst();
     test17027();
     test18553();
+    test20126();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
…hanged the backing memory