### PR TITLE
Fix Issue 20136 - opEquals not recognized for AA key

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -6037,7 +6037,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
 
             if (v && (v.isDataseg() || // fix https://issues.dlang.org/show_bug.cgi?id=8238
-                      !v.needThis()))  // fix https://issues.dlang.org/show_bug.cgi?id=17258
+                      (!v.needThis() && v.semanticRun > PASS.init)))  // fix https://issues.dlang.org/show_bug.cgi?id=17258
             {
                 // (e1, v)
                 checkAccess(exp.loc, sc, exp.e1, v);

--- a/test/compilable/test20136.d
+++ b/test/compilable/test20136.d
@@ -1,0 +1,24 @@
+// https://issues.dlang.org/show_bug.cgi?id=20136
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+class Context
+{
+    size_t[const(Key)] aa;
+    bool checkAll;
+}
+
+struct Key
+{
+    Context context;
+    int i;
+    bool opEquals(ref const Key other) const
+    {
+        if(context.checkAll && i != other.i)
+            return false;
+        return true;
+    }
+}


### PR DESCRIPTION
[1] Adds a `v.needThis` check that verifies that the variable has the `STC.field` storage set, however this field is set only after semantic has been ran on a var declaration.

This patch makes it so that check is valid only if semantic has been ran on that specific variable.

[1] https://github.com/dlang/dmd/pull/9884

