### PR TITLE
Declare frontend structs as extern cpp

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -48,7 +48,7 @@ extern (C++) __gshared
  * A data structure that describes a back-end compiler and implements
  * compiler-specific actions.
  */
-struct Compiler
+extern (C++) struct Compiler
 {
     /**
      * Generate C main() in response to seeing D main().

--- a/src/dmd/complex.d
+++ b/src/dmd/complex.d
@@ -14,7 +14,7 @@ module dmd.complex;
 
 import dmd.root.ctfloat;
 
-struct complex_t
+extern (C++) struct complex_t
 {
     real_t re;
     real_t im;
@@ -32,49 +32,49 @@ struct complex_t
         this.im = im;
     }
 
-    complex_t opBinary(string op)(complex_t y)
+    extern (D) complex_t opBinary(string op)(complex_t y)
         if (op == "+")
     {
         return complex_t(re + y.re, im + y.im);
     }
 
-    complex_t opBinary(string op)(complex_t y)
+    extern (D) complex_t opBinary(string op)(complex_t y)
         if (op == "-")
     {
         return complex_t(re - y.re, im - y.im);
     }
 
-    complex_t opUnary(string op)()
+    extern (D) complex_t opUnary(string op)()
         if (op == "-")
     {
         return complex_t(-re, -im);
     }
 
-    complex_t opBinary(string op)(complex_t y)
+    extern (D) complex_t opBinary(string op)(complex_t y)
         if (op == "*")
     {
         return complex_t(re * y.re - im * y.im, im * y.re + re * y.im);
     }
 
-    complex_t opBinaryRight(string op)(real_t x)
+    extern (D) complex_t opBinaryRight(string op)(real_t x)
         if (op == "*")
     {
         return complex_t(x) * this;
     }
 
-    complex_t opBinary(string op)(real_t y)
+    extern (D) complex_t opBinary(string op)(real_t y)
         if (op == "*")
     {
         return this * complex_t(y);
     }
 
-    complex_t opBinary(string op)(real_t y)
+    extern (D) complex_t opBinary(string op)(real_t y)
         if (op == "/")
     {
         return this / complex_t(y);
     }
 
-    complex_t opBinary(string op)(complex_t y)
+    extern (D) complex_t opBinary(string op)(complex_t y)
         if (op == "/")
     {
         if (CTFloat.fabs(y.re) < CTFloat.fabs(y.im))
@@ -91,7 +91,7 @@ struct complex_t
         }
     }
 
-    bool opCast(T : bool)() const
+    extern (D) bool opCast(T : bool)() const
     {
         return re || im;
     }

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -41,7 +41,7 @@ enum Abstract : int
 
 /***********************************************************
  */
-struct BaseClass
+extern (C++) struct BaseClass
 {
     Type type;          // (before semantic processing)
 

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -160,7 +160,7 @@ public extern (C++) void printCtfePerformanceStats()
 /*********
  * Typesafe PIMPL idiom so we can keep CompiledCtfeFunction private.
  */
-struct CompiledCtfeFunctionPimpl
+extern (C++) struct CompiledCtfeFunctionPimpl
 {
     private CompiledCtfeFunction* pimpl;
     private alias pimpl this;

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1444,7 +1444,7 @@ extern (C++) final class Module : Package
 
 /***********************************************************
  */
-struct ModuleDeclaration
+extern (C++) struct ModuleDeclaration
 {
     Loc loc;
     Identifier id;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -484,7 +484,7 @@ extern (D) Expression doCopyOrMove(Scope *sc, Expression e, Type t = null)
  * to serve essentially as a Variant that will sit on the stack
  * during CTFE to reduce memory consumption.
  */
-struct UnionExp
+extern (C++) struct UnionExp
 {
     // yes, default constructor does nothing
     extern (D) this(Expression e)

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -106,7 +106,7 @@ enum CppStdRevision : uint
 }
 
 // Put command line switches in here
-struct Param
+extern (C++) struct Param
 {
     bool obj = true;        // write object file
     bool link = true;       // perform link
@@ -290,7 +290,7 @@ alias structalign_t = uint;
 // other values are all powers of 2
 enum STRUCTALIGN_DEFAULT = (cast(structalign_t)~0);
 
-struct Global
+extern (C++) struct Global
 {
     const(char)[] inifilename;
     string mars_ext = "d";
@@ -446,7 +446,7 @@ struct Global
      * This can be used to restore the state set by `_init` to its original
      * state.
      */
-    void deinitialize()
+    extern (D) void deinitialize()
     {
         this = this.init;
     }
@@ -492,7 +492,7 @@ struct Global
     /**
     Returns: the final defaultlibname based on the command-line parameters
     */
-    const(char)[] finalDefaultlibname() const
+    extern (D) const(char)[] finalDefaultlibname() const
     {
         return params.betterC ? null :
             params.symdebug ? params.debuglibname : params.defaultlibname;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -23,11 +23,14 @@ import dmd.tokens;
  *
  * All static fields in this struct represents a specific predefined symbol.
  */
-struct Id
+extern (C++) struct Id
 {
     static __gshared:
 
-    mixin(msgtable.generate(&identifier));
+    extern (D)
+    {
+        mixin(msgtable.generate(&identifier));
+    }
 
     /**
      * Populates the identifier pool with all predefined symbols.
@@ -46,7 +49,7 @@ struct Id
      * This can be used to restore the state set by `initialize` to its original
      * state.
      */
-    void deinitialize()
+    extern (D) void deinitialize()
     {
         mixin(msgtable.generate(&deinitializer));
     }

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -42,7 +42,7 @@ import dmd.root.outbuffer;
  * sizes since cross compiling is supported and would end up using the host
  * sizes rather than the target sizes.
  */
-struct Target
+extern (C++) struct Target
 {
     // D ABI
     uint ptrsize;             /// size of a pointer in bytes


### PR DESCRIPTION
This PR  is useful to the the C++ header [generator](https://github.com/dlang/dmd/pull/9971) to generate the dmd frontend header files that are used by `gdc`.

This is necessary because the generator takes into consideration only structs that are declared `extern (C++)`