### PR TITLE
statement_toIR(): simplify conversion of case statements to goto

### DIFF
--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -468,6 +468,14 @@ private extern (C++) class S2irVisitor : Visitor
 
         const numcases = s.cases ? s.cases.dim : 0;
 
+        /* allocate a block for each case
+         */
+        if (numcases)
+            foreach (cs; *s.cases)
+            {
+                cs.extra = cast(void*)block_calloc(blx);
+            }
+
         incUsage(irs, s.loc);
         elem *econd = toElemDtor(s.condition, &mystate);
         if (s.hasVars)
@@ -487,9 +495,9 @@ private extern (C++) class S2irVisitor : Visitor
                     elem *e = el_bin(OPeqeq, TYbool, el_copytree(econd), ecase);
                     block *b = blx.curblock;
                     block_appendexp(b, e);
-                    Label *clabel = getLabel(irs, blx, cs);
+                    block* cb = cast(block*)cs.extra;
                     block_next(blx, BCiftrue, null);
-                    b.appendSucc(clabel.lblock);
+                    b.appendSucc(cb);
                     b.appendSucc(blx.curblock);
                 }
 
@@ -547,12 +555,12 @@ private extern (C++) class S2irVisitor : Visitor
     {
         Blockx *blx = irs.blx;
         block *bcase = blx.curblock;
-        Label *clabel = getLabel(irs, blx, s);
-        block_next(blx, BCgoto, clabel.lblock);
+        block* cb = cast(block*)s.extra;
+        block_next(blx, BCgoto, cb);
         block *bsw = irs.getSwitchBlock();
         if (bsw.BC == BCswitch)
-            bsw.appendSucc(clabel.lblock);   // second entry in pair
-        bcase.appendSucc(clabel.lblock);
+            bsw.appendSucc(cb);   // second entry in pair
+        bcase.appendSucc(cb);
         incUsage(irs, s.loc);
         if (s.statement)
             Statement_toIR(s.statement, irs);
@@ -588,8 +596,7 @@ private extern (C++) class S2irVisitor : Visitor
     override void visit(GotoCaseStatement s)
     {
         Blockx *blx = irs.blx;
-        Label *clabel = getLabel(irs, blx, s.cs);
-        block *bdest = clabel.lblock;
+        block *bdest = cast(block*)s.cs.extra;
         block *b = blx.curblock;
 
         // The rest is equivalent to GotoStatement

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1650,6 +1650,7 @@ extern (C++) final class CaseStatement : Statement
 
     int index;              // which case it is (since we sort this)
     VarDeclaration lastVar;
+    void* extra;            // for use by Statement_toIR()
 
     extern (D) this(const ref Loc loc, Expression exp, Statement statement)
     {

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -458,6 +458,7 @@ public:
 
     int index;          // which case it is (since we sort this)
     VarDeclaration *lastVar;
+    void* extra;            // for use by Statement_toIR()
 
     Statement *syntaxCopy();
 


### PR DESCRIPTION
Remove dependency (and memory leak) of hash table it used to use.