### PR TITLE
fix issue 1104 - CodeView: dchar shown as uint in the debugger

### DIFF
--- a/src/dmd/backend/var.d
+++ b/src/dmd/backend/var.d
@@ -652,7 +652,7 @@ __gshared ushort[TYMAX] dttab4 =
 
     TYlong    : 0x12,
     TYulong   : 0x22,
-    TYdchar   : 0x22,
+    TYdchar   : 0x7b, // UTF32
     TYllong   : 0x13,
     TYullong  : 0x23,
     TYcent    : 0x603,


### PR DESCRIPTION
This allows showing the character literal in the debugger. Mago needs a tiny patch, though (https://github.com/rainers/mago/commit/73c65723ee99da7c8d8377d2528ba5a8f4d376f1).