### PR TITLE
Fix Issue 1547 - Default parameter values should use implicit static opCall

### DIFF
--- a/test/compilable/test1547.d
+++ b/test/compilable/test1547.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=1547
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+struct A
+{
+    int b;
+    static A opCall(int k)
+    {
+        A a;
+        a.b = k;
+        return a;
+    }
+}
+
+void fun(A k = 2) {}
+
+void main()
+{
+    A a = 7;
+    fun();
+}

--- a/test/runnable/opover.d
+++ b/test/runnable/opover.d
@@ -1080,6 +1080,24 @@ class C14344
 }
 
 /**************************************/
+// https://issues.dlang.org/show_bug.cgi?id=1547
+struct A
+{
+    int b;
+    static A opCall(int k)
+    {
+        assert(0);
+    }
+    this(int) {}
+}
+
+void fun(A k = 2) {}
+
+void test1547()
+{
+    fun();
+}
+/**************************************/
 
 int main()
 {
@@ -1098,6 +1116,7 @@ int main()
     test13();
     test14();
     test15();
+    test1547();
     test4953a();
     test4953b();
     test4953c();


### PR DESCRIPTION
The `ExpInitializer` semantic function did try to wrap the initializer in a constructor call, but did not check for static opCall. I added the missing bits.

This issue is old, so I think it's fine if it goes to master.