### PR TITLE
ctfeInterpret: remove apparently dead code

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -77,13 +77,6 @@ public Expression ctfeInterpret(Expression e)
     if (e.type.ty == Terror)
         return new ErrorExp();
 
-    // This code is outside a function, but still needs to be compiled
-    // (there are compiler-generated temporary variables such as __dollar).
-    // However, this will only be run once and can then be discarded.
-    auto ctfeCodeGlobal = CompiledCtfeFunction(null);
-    ctfeCodeGlobal.callingloc = e.loc;
-    ctfeCodeGlobal.onExpression(e);
-
     Expression result = interpret(e, null);
 
     if (!CTFEExp.isCantExp(result))


### PR DESCRIPTION
This code was introduced by https://github.com/dlang/dmd/pull/2129 by @donc 

If it once was needed, I don't see a need any more for it, as it appears to compute a result that is just discarded. Delete it and see if anything breaks.