### PR TITLE
Make a compiler recognized UDA for mangling C++ rvalue ref parameters

### DIFF
--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -351,7 +351,10 @@ public:
         if (checkImmutableShared(type))
             return;
 
-        buf.writeByte('A'); // mutable
+        if (type.isRvalueRef)
+            buf.writestring("$$Q"); // rvalue ref
+        else
+            buf.writeByte('A'); // mutable
         if (global.params.is64bit)
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
@@ -1232,6 +1235,8 @@ private:
                 if (p.storageClass & (STC.out_ | STC.ref_))
                 {
                     t = t.referenceTo();
+                    if (p.isCPPRvalueRef)
+                        (cast(TypeReference)t).isRvalueRef = true;
                 }
                 else if (p.storageClass & STC.lazy_)
                 {

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -439,6 +439,7 @@ immutable Msgtable[] msgtable =
 
     // Compiler recognized UDA's
     { "udaSelector", "selector" },
+    { "udaRvalueRef", "rvalue_ref" },
 
     // C names, for undefined identifier error messages
     { "NULL" },

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4052,6 +4052,8 @@ extern (C++) final class TypePointer : TypeNext
  */
 extern (C++) final class TypeReference : TypeNext
 {
+    bool isRvalueRef;
+
     extern (D) this(Type t)
     {
         super(Treference, t);
@@ -6367,6 +6369,7 @@ extern (C++) final class Parameter : ASTNode
     Identifier ident;
     Expression defaultArg;
     UserAttributeDeclaration userAttribDecl; // user defined attributes
+    bool isCPPRvalueRef;
 
     extern (D) this(StorageClass storageClass, Type type, Identifier ident, Expression defaultArg, UserAttributeDeclaration userAttribDecl)
     {

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -814,7 +814,11 @@ struct TargetCPP
     {
         Type t = p.type.merge2();
         if (p.storageClass & (STC.out_ | STC.ref_))
+        {
             t = t.referenceTo();
+            if (p.isCPPRvalueRef)
+                (cast(TypeReference)t).isRvalueRef = true;
+        }
         else if (p.storageClass & STC.lazy_)
         {
             // Mangle as delegate

--- a/test/fail_compilation/uda_rvalueref0.d
+++ b/test/fail_compilation/uda_rvalueref0.d
@@ -1,0 +1,22 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/uda_rvalueref0.d(13): Error: `@rvalue_ref` can only apply to C++ function parameters
+fail_compilation/uda_rvalueref0.d(14): Error: `@rvalue_ref` can only apply to C++ function parameters
+fail_compilation/uda_rvalueref0.d(15): Error: `@rvalue_ref` can only apply to C++ function parameters
+fail_compilation/uda_rvalueref0.d(19): Error: `@rvalue_ref` can only apply to `ref` or `out` parameters
+---
+*/
+
+struct rvalue_ref {}
+
+void f(@rvalue_ref int i);
+void f(@rvalue_ref ref int i);
+void f(@rvalue_ref out int i);
+
+extern(C++)
+{
+void g(@rvalue_ref int i);
+void g(@rvalue_ref ref int i);
+void g(@rvalue_ref out int i);
+}

--- a/test/fail_compilation/uda_rvalueref1.d
+++ b/test/fail_compilation/uda_rvalueref1.d
@@ -1,0 +1,18 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/uda_rvalueref1.d(11): Error: `@rvalue_ref` cannot apply to auto ref parameters
+fail_compilation/uda_rvalueref1.d(15): Error: template instance `uda_rvalueref1.h!()` error instantiating
+---
+*/
+
+struct rvalue_ref {}
+
+extern(C++) void h()(@rvalue_ref auto ref int i);
+
+void test()
+{
+    h(1);
+    int i;
+    h(i);
+}

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -10,6 +10,8 @@ else version(Windows)
     enum __c_wchar_t : wchar;
 alias wchar_t = __c_wchar_t;
 
+struct rvalue_ref {}
+
 extern(C++) {
 
 struct S
@@ -88,6 +90,25 @@ double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
 test19248 passthrough_ref(ref const(test19248) value);
 std.test19248_ passthrough_ref(ref const(std.test19248_) value);
+
+bool   passthrough_rref(@rvalue_ref ref bool   value);
+byte   passthrough_rref(@rvalue_ref ref byte   value);
+ubyte  passthrough_rref(@rvalue_ref ref ubyte  value);
+char   passthrough_rref(@rvalue_ref ref char   value);
+wchar  passthrough_rref(@rvalue_ref ref wchar  value);
+dchar  passthrough_rref(@rvalue_ref ref dchar  value);
+wchar_t passthrough_rref(@rvalue_ref ref wchar_t value);
+short  passthrough_rref(@rvalue_ref ref short  value);
+ushort passthrough_rref(@rvalue_ref ref ushort value);
+int    passthrough_rref(@rvalue_ref ref int    value);
+uint   passthrough_rref(@rvalue_ref ref uint   value);
+long   passthrough_rref(@rvalue_ref ref long   value);
+ulong  passthrough_rref(@rvalue_ref ref ulong  value);
+float  passthrough_rref(@rvalue_ref ref float  value);
+double passthrough_rref(@rvalue_ref ref double value);
+S      passthrough_rref(@rvalue_ref ref S      value);
+test19248 passthrough_rref(@rvalue_ref ref const(test19248) value);
+std.test19248_ passthrough_rref(@rvalue_ref ref const(std.test19248_) value);
 }
 
 template IsSigned(T)
@@ -136,6 +157,8 @@ void check(T)(T value)
     check(passthrough(value), value);
     check(passthrough_ptr(&value), value);
     check(passthrough_ref(value), value);
+    version (CppRuntime_DigitalMars) {} else
+        check(passthrough_rref(value), value);
 }
 
 T[] values(T)()

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -18,6 +18,12 @@ namespace std
 #define TEST_UNICODE
 #endif
 
+#ifdef __DMC__
+// DMC doesn't support c++11
+#else
+#define TEST_RVALUE_REF
+#endif
+
 struct S18784
 {
     int i;
@@ -94,6 +100,31 @@ double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
 std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
+
+#ifdef TEST_RVALUE_REF
+bool               passthrough_rref(bool               &&value) { return value; }
+signed char        passthrough_rref(signed char        &&value) { return value; }
+unsigned char      passthrough_rref(unsigned char      &&value) { return value; }
+char               passthrough_rref(char               &&value) { return value; }
+#ifdef TEST_UNICODE
+char16_t           passthrough_rref(char16_t           &&value) { return value; }
+char32_t           passthrough_rref(char32_t           &&value) { return value; }
+#endif
+wchar_t            passthrough_rref(wchar_t            &&value) { return value; }
+short              passthrough_rref(short              &&value) { return value; }
+unsigned short     passthrough_rref(unsigned short     &&value) { return value; }
+int                passthrough_rref(int                &&value) { return value; }
+unsigned int       passthrough_rref(unsigned int       &&value) { return value; }
+long               passthrough_rref(long               &&value) { return value; }
+unsigned long      passthrough_rref(unsigned long      &&value) { return value; }
+long long          passthrough_rref(long long          &&value) { return value; }
+unsigned long long passthrough_rref(unsigned long long &&value) { return value; }
+float              passthrough_rref(float              &&value) { return value; }
+double             passthrough_rref(double             &&value) { return value; }
+S                  passthrough_rref(S                  &&value) { return value; }
+std::test19248     passthrough_rref(const std::test19248 &&value) { return value; }
+std::test19248_    passthrough_rref(const std::test19248_ &&value) { return value; }
+#endif // TEST_RVALUE_REF
 
 namespace ns1
 {


### PR DESCRIPTION
Since D doesn't support rvalue refs, at least we can have a compiler recognized UDA to get the mangling right for rvalue ref C++ functions.

Usage example:
```d
extern(C++) void func(@rvalue_ref ref int);
```
to match the C++ function:
```c++
void func(int&&) {}
```