### PR TITLE
Fix Issue 19965 - [DIP1000] Template allows to escape internal pointer

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1078,6 +1078,10 @@ private bool checkReturnEscapeImpl(Scope* sc, Expression e, bool refs, bool gag)
 
         Dsymbol p = v.toParent2();
 
+        // https://issues.dlang.org/show_bug.cgi?id=19965
+        if (!refs && sc.func.vthis == v)
+            notMaybeScope(v);
+
         if ((v.storage_class & (STC.ref_ | STC.out_)) == 0)
         {
             if (p == sc.func)

--- a/test/fail_compilation/fail19965.d
+++ b/test/fail_compilation/fail19965.d
@@ -1,0 +1,37 @@
+/*
+REQUIRED_ARGS: -preview=dip1000
+TEST_OUTPUT:
+---
+fail_compilation/fail19965.d(36): Error: address of variable `f` assigned to `a` with longer lifetime
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=19965
+
+struct Buffer
+{
+    int[10] data;
+
+    int[] getData() @safe return
+    {
+        return data[];
+    }
+}
+
+struct Foo()
+{
+    Buffer buffer;
+
+    int[] toArray() @safe return
+    {
+        return buffer.getData;
+    }
+}
+
+int[] a;
+
+void main() @safe
+{
+    Foo!() f;
+    a = f.toArray;
+}


### PR DESCRIPTION
 https://issues.dlang.org/show_bug.cgi?id=19965