### PR TITLE
Fix issue 13582: Don't print deprecation when importing a deprecated module from another deprecated module.

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -214,7 +214,7 @@ extern (C++) final class Import : Dsymbol
         if (!mod) return; // Failed
 
         mod.importAll(null);
-        if (mod.md && mod.md.isdeprecated)
+        if (mod.md && mod.md.isdeprecated && !sc.isDeprecated)
         {
             Expression msg = mod.md.msg;
             if (StringExp se = msg ? msg.toStringExp() : null)

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -725,6 +725,10 @@ struct Scope
             if (sc2.stc & STC.deprecated_)
                 return true;
         }
+        if (_module.md && _module.md.isdeprecated)
+        {
+            return true;
+        }
         return false;
     }
 }

--- a/test/compilable/imports/test13582.d
+++ b/test/compilable/imports/test13582.d
@@ -1,0 +1,1 @@
+deprecated module imports.test13582;

--- a/test/compilable/test13582a.d
+++ b/test/compilable/test13582a.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -de
+deprecated module test13582a;
+
+import imports.test13582;
+
+void main() { }

--- a/test/compilable/test13582b.d
+++ b/test/compilable/test13582b.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -de
+module test13582b;
+
+deprecated void foo()
+{
+    import imports.test13582;
+}
+
+deprecated struct S
+{
+    import imports.test13582;
+}
+
+void main() { }


### PR DESCRIPTION
There was a previous PR: https://github.com/dlang/dmd/pull/4048 but it got closed unmerged.
This PR only addresses a subset, but it's a subset that was personally annoying me and the fix is cheap, so there you go.