### PR TITLE
Move toParentP and followInstantiationContext to public API

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -176,7 +176,7 @@ bool modifyFieldVar(Loc loc, Scope* sc, VarDeclaration var, Expression e1)
         {
             if (s)
             {
-                s = toParentP(s, var.toParent2());
+                s = s.toParentP(var.toParent2());
                 continue;
             }
         }

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -297,7 +297,7 @@ bool ensureStaticLinkTo(Dsymbol s, Dsymbol p)
             if (ad.storage_class & STC.static_)
                 break;
         }
-        s = toParentP(s, p);
+        s = s.toParentP(p);
     }
     return false;
 }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -181,7 +181,9 @@ public:
     Dsymbol *toParent2();
     Dsymbol *toParentDecl();
     Dsymbol *toParentLocal();
+    Dsymbol *toParentP(Dsymbol *p1, Dsymbol *p2 = NULL);
     TemplateInstance *isInstantiated();
+    bool followInstantiationContext(Dsymbol *p1, Dsymbol *p2 = NULL);
     TemplateInstance *isSpeculative();
     Ungag ungagSpeculative();
 

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1165,7 +1165,7 @@ extern (C++) abstract class Expression : ASTNode
              */
 
             Dsymbol vparent = v.toParent2();
-            for (Dsymbol s = sc.func; !err && s; s = toParentP(s, vparent))
+            for (Dsymbol s = sc.func; !err && s; s = s.toParentP(vparent))
             {
                 if (s == vparent)
                     break;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1039,7 +1039,7 @@ L1:
         FuncDeclaration f = hasThis(sc);
         if (f && f.isThis2)
         {
-            if (followInstantiationContext(f, ad))
+            if (f.followInstantiationContext(ad))
             {
                 e1 = new VarExp(loc, f.vthis);
                 e1 = new PtrExp(loc, e1);
@@ -1073,7 +1073,7 @@ L1:
                 /* e1 is the 'this' pointer for an inner class: tcd.
                  * Rewrite it as the 'this' pointer for the outer class.
                  */
-                auto vthis = followInstantiationContext(tcd, ad) ? tcd.vthis2 : tcd.vthis;
+                auto vthis = tcd.followInstantiationContext(ad) ? tcd.vthis2 : tcd.vthis;
                 e1 = new DotVarExp(loc, e1, vthis);
                 e1.type = vthis.type;
                 e1.type = e1.type.addMod(t.mod);
@@ -1082,7 +1082,7 @@ L1:
 
                 // Skip up over nested functions, and get the enclosing
                 // class type.
-                e1 = getThisSkipNestedFuncs(loc, sc, toParentP(tcd, ad), ad, e1, t, var);
+                e1 = getThisSkipNestedFuncs(loc, sc, tcd.toParentP(ad), ad, e1, t, var);
                 if (e1.op == TOK.error)
                     return e1;
                 goto L1;
@@ -11931,9 +11931,9 @@ Expression getThisSkipNestedFuncs(const ref Loc loc, Scope* sc, Dsymbol s, Aggre
                 if (n > 1)
                     e1 = e1.expressionSemantic(sc);
                 e1 = new PtrExp(loc, e1);
-                uint i = followInstantiationContext(f, ad);
+                uint i = f.followInstantiationContext(ad);
                 e1 = new IndexExp(loc, e1, new IntegerExp(i));
-                s = toParentP(f, ad);
+                s = f.toParentP(ad);
                 continue;
             }
         }

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -513,7 +513,7 @@ public:
                             result.type = f.vthis.type;
                         }
                         // (*__this)[i]
-                        uint i = followInstantiationContext(f, fdv);
+                        uint i = f.followInstantiationContext(fdv);
                         if (i == 1 && f == ids.fd)
                         {
                             auto ve = cast(VarExp)e.copy();
@@ -527,7 +527,7 @@ public:
                         ie.indexIsInBounds = true; // no runtime bounds checking
                         result = ie;
                         result.type = Type.tvoidptr;
-                        s = toParentP(f, fdv);
+                        s = f.toParentP(fdv);
                         ad = s.isAggregateDeclaration();
                         if (ad)
                             goto Lad;
@@ -539,11 +539,11 @@ public:
                         while (ad)
                         {
                             assert(ad.vthis);
-                            bool i = followInstantiationContext(ad, fdv);
+                            bool i = ad.followInstantiationContext(fdv);
                             auto vthis = i ? ad.vthis2 : ad.vthis;
                             result = new DotVarExp(e.loc, result, vthis);
                             result.type = vthis.type;
-                            s = toParentP(ad, fdv);
+                            s = ad.toParentP(fdv);
                             ad = s.isAggregateDeclaration();
                         }
                     }

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -266,7 +266,7 @@ elem *getEthis(const ref Loc loc, IRState *irs, Dsymbol fd, Dsymbol fdp = null, 
                 assert(thisfd.isNested() || thisfd.vthis);
 
                 // pick one context
-                ethis = fixEthis2(ethis, thisfd, followInstantiationContext(thisfd, ctxt0, ctxt1));
+                ethis = fixEthis2(ethis, thisfd, thisfd.followInstantiationContext(ctxt0, ctxt1));
             }
             else
             {
@@ -290,23 +290,23 @@ elem *getEthis(const ref Loc loc, IRState *irs, Dsymbol fd, Dsymbol fdp = null, 
                 if (!ad.isNested() || !(ad.vthis || ad.vthis2))
                     goto Lnoframe;
 
-                bool i = followInstantiationContext(ad, ctxt0, ctxt1);
+                bool i = ad.followInstantiationContext(ctxt0, ctxt1);
                 const voffset = i ? ad.vthis2.offset : ad.vthis.offset;
                 ethis = el_bin(OPadd, TYnptr, ethis, el_long(TYsize_t, voffset));
                 ethis = el_una(OPind, TYnptr, ethis);
             }
-            if (fdparent == toParentP(s, ctxt0, ctxt1))
+            if (fdparent == s.toParentP(ctxt0, ctxt1))
                 break;
 
             /* Remember that frames for functions that have no
              * nested references are skipped in the linked list
              * of frames.
              */
-            FuncDeclaration fdp2 = toParentP(s, ctxt0, ctxt1).isFuncDeclaration();
+            FuncDeclaration fdp2 = s.toParentP(ctxt0, ctxt1).isFuncDeclaration();
             if (fdp2 && fdp2.hasNestedFrameRefs())
                 ethis = el_una(OPind, TYnptr, ethis);
 
-            s = toParentP(s, ctxt0, ctxt1);
+            s = s.toParentP(ctxt0, ctxt1);
             assert(s);
         }
     }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -4209,7 +4209,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                     /* returns: true to continue, false to return */
                     if (f.isThis2)
                     {
-                        if (followInstantiationContext(f, ad))
+                        if (f.followInstantiationContext(ad))
                         {
                             e1 = new VarExp(e.loc, f.vthis);
                             e1 = new PtrExp(e1.loc, e1);
@@ -4244,7 +4244,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                         /* e1 is the 'this' pointer for an inner class: tcd.
                          * Rewrite it as the 'this' pointer for the outer class.
                          */
-                        auto vthis = followInstantiationContext(tcd, ad) ? tcd.vthis2 : tcd.vthis;
+                        auto vthis = tcd.followInstantiationContext(ad) ? tcd.vthis2 : tcd.vthis;
                         e1 = new DotVarExp(e.loc, e1, vthis);
                         e1.type = vthis.type;
                         e1.type = e1.type.addMod(t.mod);
@@ -4253,7 +4253,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
 
                         // Skip up over nested functions, and get the enclosing
                         // class type.
-                        e1 = getThisSkipNestedFuncs(e1.loc, sc, toParentP(tcd, ad), ad, e1, t, d, true);
+                        e1 = getThisSkipNestedFuncs(e1.loc, sc, tcd.toParentP(ad), ad, e1, t, d, true);
                         if (!e1)
                         {
                             e = new VarExp(e.loc, d);


### PR DESCRIPTION
I have no idea what any of this is doing, we'd be better off reverting this horrible mess.