### PR TITLE
test/run.d: Allow running dshell tests separately

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -306,6 +306,10 @@ auto predefinedTargets(string[] targets)
                 newTargets.put(findFiles("compilable").map!createTestTarget);
                 break;
 
+            case "run_dshell_tests", "dshell":
+                newTargets.put(findFiles("dshell").map!createTestTarget);
+                break;
+
             case "all":
                 newTargets ~= createUnitTestTarget();
                 foreach (testDir; testDirs)


### PR DESCRIPTION
Each type of tests can be run separately with `./test/run.d compilable`, `./test/run.d runnable`, etc.   This PR adds the ability to run the `dshell` tests (tests that are similar to `.sh` tests, but written in D) separately.

cc @wilzbach @marler8997 