### PR TITLE
Fix issue 20164: print deprecation if a deprecated module is imported from a local function or a mixin.

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -214,14 +214,7 @@ extern (C++) final class Import : Dsymbol
         if (!mod) return; // Failed
 
         mod.importAll(null);
-        if (mod.md && mod.md.isdeprecated && !sc.isDeprecated)
-        {
-            Expression msg = mod.md.msg;
-            if (StringExp se = msg ? msg.toStringExp() : null)
-                mod.deprecation(loc, "is deprecated - %s", se.string);
-            else
-                mod.deprecation(loc, "is deprecated");
-        }
+        mod.checkImportDeprecation(loc, sc);
         if (sc.explicitProtection)
             protection = sc.protection;
         if (!isstatic && !aliasId && !names.dim)

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1176,6 +1176,26 @@ extern (C++) final class Module : Package
         return needmoduleinfo || global.params.cov;
     }
 
+    /*******************************************
+     * Print deprecation warning if we're deprecated, when
+     * this module is imported from scope sc.
+     *
+     * Params:
+     *  sc = the scope into which we are imported
+     *  loc = the location of the import statement
+     */
+    void checkImportDeprecation(const ref Loc loc, Scope* sc)
+    {
+        if (md && md.isdeprecated && !sc.isDeprecated)
+        {
+            Expression msg = md.msg;
+            if (StringExp se = msg ? msg.toStringExp() : null)
+                deprecation(loc, "is deprecated - %s", se.string);
+            else
+                deprecation(loc, "is deprecated");
+        }
+    }
+
     override Dsymbol search(const ref Loc loc, Identifier ident, int flags = SearchLocalsOnly)
     {
         /* Since modules can be circularly referenced,

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1574,7 +1574,10 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             loadErrored = imp.load(sc);
             if (imp.mod)
+            {
                 imp.mod.importAll(null);
+                imp.mod.checkImportDeprecation(imp.loc, sc);
+            }
         }
         if (imp.mod)
         {

--- a/test/fail_compilation/fail20163.d
+++ b/test/fail_compilation/fail20163.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20163.d-mixin-10(10): Deprecation: module `imports.fail20164` is deprecated
+---
+*/
+module fail20163;
+
+mixin("import imports.fail20164;");

--- a/test/fail_compilation/fail20164.d
+++ b/test/fail_compilation/fail20164.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20164.d(12): Deprecation: module `imports.fail20164` is deprecated
+---
+*/
+module fail20164;
+
+void foo()
+{
+    import imports.fail20164;
+}

--- a/test/fail_compilation/imports/fail20164.d
+++ b/test/fail_compilation/imports/fail20164.d
@@ -1,0 +1,1 @@
+deprecated module imports.fail20164;


### PR DESCRIPTION
There's two locations where this can come up, so I moved the import deprecation checking code into a helper in dmodule. Not sure if this is the right way to go or if there's a more natural place that's always checked when a module is imported; I couldn't find one offhand.

Ping @Geod24. Hi :)