### PR TITLE
Move hard-coded logic to generate C main out of the compiler and into druntime

### DIFF
--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -32,8 +32,6 @@ import dmd.tokens;
 
 extern (C++) __gshared
 {
-    /// DMD-generated module `__entrypoint` where the C main resides
-    Module entrypoint = null;
     /// Module in which the D main is
     Module rootHasMain = null;
 
@@ -50,61 +48,6 @@ extern (C++) __gshared
  */
 extern (C++) struct Compiler
 {
-    /**
-     * Generate C main() in response to seeing D main().
-     *
-     * This function will generate a module called `__entrypoint`,
-     * and set the globals `entrypoint` and `rootHasMain`.
-     *
-     * This used to be in druntime, but contained a reference to _Dmain
-     * which didn't work when druntime was made into a dll and was linked
-     * to a program, such as a C++ program, that didn't have a _Dmain.
-     *
-     * Params:
-     *   sc = Scope which triggered the generation of the C main,
-     *        used to get the module where the D main is.
-     */
-    extern (C++) static void genCmain(Scope* sc)
-    {
-        if (entrypoint)
-            return;
-        /* The D code to be generated is provided as D source code in the form of a string.
-         * Note that Solaris, for unknown reasons, requires both a main() and an _main()
-         */
-        immutable cmaincode =
-        q{
-            extern(C)
-            {
-                int _d_run_main(int argc, char **argv, void* mainFunc);
-                int _Dmain(char[][] args);
-                int main(int argc, char **argv)
-                {
-                    return _d_run_main(argc, argv, &_Dmain);
-                }
-                version (Solaris) int _main(int argc, char** argv) { return main(argc, argv); }
-            }
-        };
-        Identifier id = Id.entrypoint;
-        auto m = new Module("__entrypoint.d", id, 0, 0);
-        scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
-        scope p = new Parser!ASTCodegen(m, cmaincode, false, diagnosticReporter);
-        p.scanloc = Loc.initial;
-        p.nextToken();
-        m.members = p.parseModule();
-        assert(p.token.value == TOK.endOfFile);
-        assert(!p.errors); // shouldn't have failed to parse it
-        bool v = global.params.verbose;
-        global.params.verbose = false;
-        m.importedFrom = m;
-        m.importAll(null);
-        m.dsymbolSemantic(null);
-        m.semantic2(null);
-        m.semantic3(null);
-        global.params.verbose = v;
-        entrypoint = m;
-        rootHasMain = sc._module;
-    }
-
     /******************************
      * Encode the given expression, which is assumed to be an rvalue literal
      * as another type for use in CTFE.

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -21,8 +21,6 @@ class Type;
 struct Scope;
 struct UnionExp;
 
-// DMD-generated module `__entrypoint` where the C main resides
-extern Module *entrypoint;
 // Module in which the D main is
 extern Module *rootHasMain;
 
@@ -37,6 +35,5 @@ struct Compiler
     static Expression *paintAsType(UnionExp *, Expression *, Type *);
     // Backend
     static void loadModule(Module *);
-    static void genCmain(Scope *);
     static bool onImport(Module *);
 };

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -325,21 +325,6 @@ void genObjFile(Module m, bool multiobj)
 
     //printf("Module.genobjfile(multiobj = %d) %s\n", multiobj, m.toChars());
 
-    if (m.ident == Id.entrypoint)
-    {
-        bool v = global.params.verbose;
-        global.params.verbose = false;
-
-        foreach (member; *m.members)
-        {
-            //printf("toObjFile %s %s\n", member.kind(), member.toChars());
-            toObjFile(member, multiobj);
-        }
-
-        global.params.verbose = v;
-        return;
-    }
-
     lastmname = m.srcfile.toChars();
 
     objmod.initfile(lastmname, null, m.toPrettyChars());

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -339,7 +339,7 @@ immutable Msgtable[] msgtable =
     { "main" },
     { "WinMain" },
     { "DllMain" },
-    { "entrypoint", "__entrypoint" },
+    { "CMain", "_d_cmain" },
     { "rt_init" },
     { "__cmp" },
     { "__equals"},

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -702,8 +702,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             if (params.verbose)
                 message("code      %s", m.toChars());
             genObjFile(m, false);
-            if (entrypoint && m == rootHasMain)
-                genObjFile(entrypoint, false);
         }
         if (!global.errors && firstm)
         {
@@ -720,8 +718,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
                 message("code      %s", m.toChars());
             obj_start(m.srcfile.toChars());
             genObjFile(m, params.multiobj);
-            if (entrypoint && m == rootHasMain)
-                genObjFile(entrypoint, params.multiobj);
             obj_end(library, m.objfile.toChars());
             obj_write_deferred(library);
             if (global.errors && !params.lib)

--- a/test/runnable/extra-files/minimal/object.d
+++ b/test/runnable/extra-files/minimal/object.d
@@ -1,7 +1,8 @@
 module object;
 
-private alias extern(C) int function(char[][] args) MainFunc;
-private extern (C) int _d_run_main(int argc, char** argv, MainFunc mainFunc)
+extern(C) void _Dmain();
+
+extern(C) void main()
 {
-    return mainFunc(null);
+    _Dmain();
 }


### PR DESCRIPTION
~This PR will not pass any tests until https://github.com/dlang/druntime/pull/2759 is merged.~

This PR is futher work towards making the D language and its runtime more pay-as-you-go and extensible to other emerging platforms and use cases.  It is very similar to the work already done in these PRs...

 * #7395 and #7768 for `ModuleInfo`
 * #7786 for `Throwable`
 * #7799 for `TypeInfo`
 
... and congruent with the current efforts to convert D runtime hooks to templates.

This PR moves the hard-coded logic for entry point generation (e.g. C main and the logic necessary to initialize druntime and call D main) out of the compiler and into to druntime.  Doing so removes some of the complexity in the compiler, and instead, leverages D's unique language features to achieve the same result.

With this PR, the C main to D main code path can be completely customized for any platform, compiler, compiler invocation (e.g. betterC), or other use case without requiring any changes to the compiler.  And, because it is template-based, it does not require linking in druntime.

If a user's custom runtime does not include the `_d_cmain` template definition, no C main to D main logic will be generated.  This is especially useful for some bare metal programming where a user may wish to provide their own startup code without having to adopt workarounds such as renaming their `main` function or implementing druntime stubs.

How it works:
1. The compiler detects the existence of a D main function declaration (this hasn't changed; the compiler already does this).
2. The existence of the D main function declaration triggers a check for the template `_d_cmain` which will typically exist in druntime (assuming the accompanying druntime PR is merged).
3. If the `_d_cmain` template is defined, the compiler simply appends a `mixin _d_cmain!();` statement to the module effectively injecting C main and the logic necessary to initialize druntime and call D main.
4. If the `_d_cmain` template is not defined, no code is injected, and the user is free to implement their own startup logic however they prefer

I believe this implementation will provide much more flexibility for everyone, while accomodating for emerging use cases, without the need for workarounds or compromise.

If necessary, the `_d_cmain` template could even be modified to take compile-time arguments from the compiler front-end to further extend its capabilities.

This PR is an alternative to #10181.

cc @kinke @ibuclaw @jpf91 This changes the interface in `compiler.h`, hopefully for the better.  It removes the `genCmain` function and the `entrypoint` module, delegating that logic instead to the runtime.