### PR TITLE
Move special handling of __require and __ensure to FuncDeclaration.needsClosure.

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1567,12 +1567,6 @@ extern (C++) class VarDeclaration : Declaration
         if (!nestedrefs.contains(fdthis))
             nestedrefs.push(fdthis);
 
-        /* __require and __ensure will always get called directly,
-         * so they never make outer functions closure.
-         */
-        if (fdthis.ident == Id.require || fdthis.ident == Id.ensure)
-            return false;
-
         //printf("\tfdv = %s\n", fdv.toChars());
         //printf("\tfdthis = %s\n", fdthis.toChars());
         if (loc.isValid())

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1899,6 +1899,12 @@ extern (C++) class FuncDeclaration : Declaration
                 FuncDeclaration f = v.nestedrefs[j];
                 assert(f != this);
 
+                /* __require and __ensure will always get called directly,
+                 * so they never make outer functions closure.
+                 */
+                if (f.ident == Id.require || f.ident == Id.ensure)
+                    continue;
+
                 //printf("\t\tf = %p, %s, isVirtual=%d, isThis=%p, tookAddressOf=%d\n", f, f.toChars(), f.isVirtual(), f.isThis(), f.tookAddressOf);
 
                 /* Look to see if f escapes. We consider all parents of f within

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -491,6 +491,54 @@ void test7218()
 }
 
 /*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=7335
+
+class A7335
+{
+    int mValue = 10;
+
+    void setValue(int newValue)
+    in { }
+    out { assert(mValue == 3); }
+    do
+    {
+        mValue = newValue;
+    }
+}
+
+class B7335 : A7335
+{
+    override void setValue(int newValue)
+    in { assert(false); }
+    out { assert(mValue == 3); }
+    do
+    {
+        mValue = newValue;
+    }
+}
+
+class C7335 : A7335
+{
+    override void setValue(int newValue)
+    in { int a = newValue; }
+    out { assert(mValue == 3); }
+    body
+    {
+        mValue = newValue;
+    }
+}
+
+void test7335()
+{
+    A7335 aObject = new B7335();
+    aObject.setValue(3);
+
+    A7335 bObject = new C7335();
+    bObject.setValue(3);    // <<<<<  will crash because undefined mValue in the
+                            // A7335.setValue().out-block.
+}
+
+/*******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=7517
 
 void test7517()
@@ -1244,6 +1292,7 @@ int main()
     test6417();
     test6549();
     test7218();
+    test7335();
     test7517();
     test8073();
     test8093();


### PR DESCRIPTION
Because of the early exit in VarDeclaration.checkNestedRefence, any parameters that have nested references from a contract are never added to FuncDeclaration.closureVars, and so don't get added to the function stack frame in the code generator unless forced.

This forcing of a stack frame is done in dmd, but I'm not going to touch that.  However a non-empty closureVars array means that gdc can remove the forced frame and manual pushing of all function parameters into closureVars itself.

When digging around to see if any simplifications/removals can be made regarding AST handling of ensure/require, I stumbled across an issue that got marked as resolved, but the test case was never added to the testsuite.