### PR TITLE
Don't emit documentation for public import if no DDoc comment

### DIFF
--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -1057,7 +1057,8 @@ private void emitComment(Dsymbol s, OutBuffer* buf, Scope* sc)
             if (imp.prot().kind != Prot.Kind.public_ && sc.protection.kind != Prot.Kind.export_)
                 return;
 
-            emit(sc, imp, imp.comment);
+            if (imp.comment)
+                emit(sc, imp, imp.comment);
         }
 
         override void visit(Declaration d)

--- a/test/compilable/ddocunittest.d
+++ b/test/compilable/ddocunittest.d
@@ -221,6 +221,10 @@ public import core.stdc.string : copy = memcpy, compare = memcmp;
 /// This is a public renamed import
 public import str = core.stdc.string;
 
+// This is a public import without a DDoc comment.
+// It should not be emitted to the documentation file.
+public import core.stdc.stdlib;
+
 
 // ------------------------------------
 // documented unittest after conditional declarations


### PR DESCRIPTION
I believe I made a mistake in https://github.com/dlang/dmd/pull/9068

If a public import does not contain a DDoc comment, I still emitted it to the documentation file, just without the comment.  I tested other symbols, and it appears that when a DDoc comment is absent, the symbol is not emitted to the documentation file.  This PR makes the public imports work the same way.

I think this is the correct behavior, but if I'm mistaken, please let me know.

cc @thewilsonator @ZombineDev 