### PR TITLE
copyRegionExp: handle dotVariable as a unary expression

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6935,6 +6935,7 @@ private Expression copyRegionExp(Expression e)
         case TOK.address:
         case TOK.delegate_:
         case TOK.vector:
+        case TOK.dotVariable:
         {
             UnaExp ue = cast(UnaExp)e;
             ue.e1 = copyRegionExp(ue.e1);
@@ -6971,7 +6972,7 @@ private Expression copyRegionExp(Expression e)
             return e;
 
         default:
-            printf("e: %d, %s\n", e.op, e.toChars());
+            printf("e: %s, %s\n", Token.toChars(e.op), e.toChars());
             assert(0);
     }
 

--- a/test/compilable/test20181.d
+++ b/test/compilable/test20181.d
@@ -1,0 +1,11 @@
+module test20181;
+
+struct InversionList
+{
+    ubyte[] byCodepoint() { return null; }
+}
+
+void main()
+{
+    static foreach (ch; InversionList().byCodepoint) { }
+}


### PR DESCRIPTION
Quickly thrown together reproduction:

edit: removed old reproduction. Shorter:
```
struct InversionList
{
    ubyte[] byCodepoint() { return null; }
}
void main()
{
    static foreach (ch; InversionList().byCodepoint) { }
}
```

@WalterBright : is this fix correct?