### PR TITLE
Track if control-flow statements have any label inside in any nesting level.

### DIFF
--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -75,6 +75,7 @@ struct Scope
     ScopeDsymbol scopesym;          /// current symbol
     FuncDeclaration func;           /// function we are in
     Dsymbol parent;                 /// parent to use
+    bool has_label;                 /// There is a label somewhere inside (in any nesting level)
     LabelStatement slabel;          /// enclosing labelled statement
     SwitchStatement sw;             /// enclosing switch statement
     Statement tryBody;              /// enclosing _body of TryCatchStatement or TryFinallyStatement
@@ -182,6 +183,10 @@ struct Scope
     extern (C++) Scope* push()
     {
         Scope* s = copy();
+        // Keep the info when we're going backwards (i.e. popping scopes)
+        // so that previous statements get it, but reset it when we push
+        // again.
+        s.has_label = false;
         //printf("Scope::push(this = %p) new = %p\n", this, s);
         assert(!(flags & SCOPE.free));
         s.scopesym = null;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -76,6 +76,9 @@ struct Scope
     FuncDeclaration func;           /// function we are in
     Dsymbol parent;                 /// parent to use
     bool has_label;                 /// There is a label somewhere inside (in any nesting level)
+    SwitchStatement has_case;       /// Used to check if we found some `case/default` somewhere
+                                    /// inside (in any nesting level). If we did, we save its
+                                    /// parent switch here.
     LabelStatement slabel;          /// enclosing labelled statement
     SwitchStatement sw;             /// enclosing switch statement
     Statement tryBody;              /// enclosing _body of TryCatchStatement or TryFinallyStatement

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -75,8 +75,8 @@ struct Scope
     ScopeDsymbol scopesym;          /// current symbol
     FuncDeclaration func;           /// function we are in
     Dsymbol parent;                 /// parent to use
-    bool has_label;                 /// There is a label somewhere inside (in any nesting level)
-    SwitchStatement has_case;       /// Used to check if we found some `case/default` somewhere
+    bool hasLabel;                  /// There is a label somewhere inside (in any nesting level)
+    SwitchStatement hasCase;        /// Used to check if we found some `case/default` somewhere
                                     /// inside (in any nesting level). If we did, we save its
                                     /// parent switch here.
     LabelStatement slabel;          /// enclosing labelled statement
@@ -189,7 +189,7 @@ struct Scope
         // Keep the info when we're going backwards (i.e. popping scopes)
         // so that previous statements get it, but reset it when we push
         // again.
-        s.has_label = false;
+        s.hasLabel = false;
         //printf("Scope::push(this = %p) new = %p\n", this, s);
         assert(!(flags & SCOPE.free));
         s.scopesym = null;

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -190,6 +190,7 @@ struct Scope
         // so that previous statements get it, but reset it when we push
         // again.
         s.hasLabel = false;
+        s.hasCase = null;
         //printf("Scope::push(this = %p) new = %p\n", this, s);
         assert(!(flags & SCOPE.free));
         s.scopesym = null;

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -64,6 +64,10 @@ struct Scope
     ScopeDsymbol *scopesym;     // current symbol
     FuncDeclaration *func;      // function we are in
     Dsymbol *parent;            // parent to use
+    bool has_label;             // There is a label somewhere inside (in any nesting level)
+    SwitchStatement *has_case;  // Used to check if we found some `case/default` somewhere
+                                // inside (in any nesting level). If we did, we save its
+                                // parent switch here.
     LabelStatement *slabel;     // enclosing labelled statement
     SwitchStatement *sw;        // enclosing switch statement
     Statement *tryBody;         // enclosing _body of TryCatchStatement or TryFinallyStatement

--- a/src/dmd/scope.h
+++ b/src/dmd/scope.h
@@ -64,8 +64,8 @@ struct Scope
     ScopeDsymbol *scopesym;     // current symbol
     FuncDeclaration *func;      // function we are in
     Dsymbol *parent;            // parent to use
-    bool has_label;             // There is a label somewhere inside (in any nesting level)
-    SwitchStatement *has_case;  // Used to check if we found some `case/default` somewhere
+    bool hasLabel;              // There is a label somewhere inside (in any nesting level)
+    SwitchStatement *hasCase;   // Used to check if we found some `case/default` somewhere
                                 // inside (in any nesting level). If we did, we save its
                                 // parent switch here.
     LabelStatement *slabel;     // enclosing labelled statement

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -130,7 +130,6 @@ extern (C++) abstract class Statement : ASTNode
 {
     const Loc loc;
     const STMT stmt;
-    bool haslabel;
 
     override final DYNCAST dyncast() const
     {
@@ -141,7 +140,6 @@ extern (C++) abstract class Statement : ASTNode
     {
         this.loc = loc;
         this.stmt = stmt;
-        this.haslabel = false;
         // If this is an in{} contract scope statement (skip for determining
         //  inlineStatus of a function body for header content)
     }
@@ -226,15 +224,6 @@ extern (C++) abstract class Statement : ASTNode
     bool hasContinue() const pure nothrow
     {
         return false;
-    }
-
-    /**
-    Returns:
-        `true` if it has an enclosed label in any nesting level
-    */
-    bool hasLabel() const pure nothrow
-    {
-        return haslabel;
     }
 
     /**********************************
@@ -1016,13 +1005,15 @@ extern (C++) final class UnrolledLoopStatement : Statement
 extern (C++) class ScopeStatement : Statement
 {
     Statement statement;
-    Loc endloc;                 // location of closing curly bracket
+    Loc endloc;                      // location of closing curly bracket
+    bool hasMultipleEntryPoints_;
 
     extern (D) this(const ref Loc loc, Statement statement, Loc endloc)
     {
         super(loc, STMT.Scope);
         this.statement = statement;
         this.endloc = endloc;
+        this.hasMultipleEntryPoints_ = false;
     }
     override Statement syntaxCopy()
     {
@@ -1045,6 +1036,15 @@ extern (C++) class ScopeStatement : Statement
     override bool hasContinue() const pure nothrow
     {
         return statement ? statement.hasContinue() : false;
+    }
+
+    /**
+    Returns:
+        `true` if it has multiple entry points.
+    */
+    bool hasMultipleEntryPoints() const pure nothrow
+    {
+        return hasMultipleEntryPoints_;
     }
 
     override void accept(Visitor v)

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -130,7 +130,7 @@ extern (C++) abstract class Statement : ASTNode
 {
     const Loc loc;
     const STMT stmt;
-    bool has_label;
+    bool haslabel;
 
     override final DYNCAST dyncast() const
     {
@@ -141,7 +141,7 @@ extern (C++) abstract class Statement : ASTNode
     {
         this.loc = loc;
         this.stmt = stmt;
-        this.has_label = false;
+        this.haslabel = false;
         // If this is an in{} contract scope statement (skip for determining
         //  inlineStatus of a function body for header content)
     }
@@ -234,7 +234,7 @@ extern (C++) abstract class Statement : ASTNode
     */
     bool hasLabel() const pure nothrow
     {
-        return has_label;
+        return haslabel;
     }
 
     /**********************************

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -130,6 +130,7 @@ extern (C++) abstract class Statement : ASTNode
 {
     const Loc loc;
     const STMT stmt;
+    bool has_label;
 
     override final DYNCAST dyncast() const
     {
@@ -140,6 +141,7 @@ extern (C++) abstract class Statement : ASTNode
     {
         this.loc = loc;
         this.stmt = stmt;
+        this.has_label = false;
         // If this is an in{} contract scope statement (skip for determining
         //  inlineStatus of a function body for header content)
     }
@@ -224,6 +226,15 @@ extern (C++) abstract class Statement : ASTNode
     bool hasContinue() const pure nothrow
     {
         return false;
+    }
+
+    /**
+    Returns:
+        `true` if it has an enclosed label in any nesting level
+    */
+    bool hasLabel() const pure nothrow
+    {
+        return has_label;
     }
 
     /**********************************

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -108,6 +108,7 @@ class Statement : public ASTNode
 public:
     Loc loc;
     STMT stmt;
+    bool has_label;
 
     virtual Statement *syntaxCopy();
 
@@ -119,6 +120,7 @@ public:
     virtual Statement *getRelatedLabeled() { return this; }
     virtual bool hasBreak() const;
     virtual bool hasContinue() const;
+    bool hasLabel() const;
     bool usesEH();
     bool comeFrom();
     bool hasCode();

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -108,7 +108,7 @@ class Statement : public ASTNode
 public:
     Loc loc;
     STMT stmt;
-    bool has_label;
+    bool haslabel;
 
     virtual Statement *syntaxCopy();
 

--- a/src/dmd/statement.h
+++ b/src/dmd/statement.h
@@ -108,7 +108,6 @@ class Statement : public ASTNode
 public:
     Loc loc;
     STMT stmt;
-    bool haslabel;
 
     virtual Statement *syntaxCopy();
 
@@ -120,7 +119,6 @@ public:
     virtual Statement *getRelatedLabeled() { return this; }
     virtual bool hasBreak() const;
     virtual bool hasContinue() const;
-    bool hasLabel() const;
     bool usesEH();
     bool comeFrom();
     bool hasCode();
@@ -255,12 +253,14 @@ class ScopeStatement : public Statement
 {
 public:
     Statement *statement;
-    Loc endloc;                 // location of closing curly bracket
+    Loc endloc;                      // location of closing curly bracket
+    bool hasMultipleEntryPoints_;
 
     Statement *syntaxCopy();
     ReturnStatement *endsWithReturnStatement();
     bool hasBreak() const;
     bool hasContinue() const;
+    bool hasMultipleEntryPoints() const;
 
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2284,7 +2284,7 @@ else
         if (has_label) {
             ifs.ifbody.has_label = true;
             scd.enclosing.has_label = true;
-            printf("If %s has label\n", ifs.condition.toChars());
+            //printf("If %s has label\n", ifs.condition.toChars());
         }
         scd.pop();
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -433,8 +433,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             }
 
             ss.statement = ss.statement.statementSemantic(sc);
-            if (sc.has_label) {
-                sc.enclosing.has_label = true;
+            if (sc.hasLabel) {
+                sc.enclosing.hasLabel = true;
             }
             if (ss.statement)
             {
@@ -2266,7 +2266,7 @@ else
 
         ifs.ifbody = ifs.ifbody.semanticNoScope(scd);
         // We found an actual label in some enclosed scope.
-        bool has_label_because_of_label = scd.has_label;
+        bool hasLabelBecauseOfLabel = scd.hasLabel;
         // We found a Case/DefaultStatement in some enclosed scope
         // whose parent `switch` is parent of this `if` too. Meaning,
         // they're both inside the same switch, and thus the `case/default`
@@ -2278,12 +2278,12 @@ else
         //      case 1: // ... whatever code;
         //          }
         //      }
-        bool has_label_because_of_case = scd.has_case && scd.sw &&
-                                         scd.has_case == scd.sw;
-        bool has_label = has_label_because_of_label || has_label_because_of_case;
-        if (has_label) {
-            ifs.ifbody.has_label = true;
-            scd.enclosing.has_label = true;
+        bool hasLabelBecauseOfCase = scd.hasCase && scd.sw &&
+                                     scd.hasCase == scd.sw;
+        bool hasLabel = hasLabelBecauseOfLabel || hasLabelBecauseOfCase;
+        if (hasLabel) {
+            ifs.ifbody.haslabel = true;
+            scd.enclosing.hasLabel = true;
             //printf("If %s has label\n", ifs.condition.toChars());
         }
         scd.pop();
@@ -2804,7 +2804,7 @@ else
 
         if (sw)
         {
-            sc.has_case = sw;
+            sc.hasCase = sw;
             cs.exp = cs.exp.implicitCastTo(sc, sw.condition.type);
             cs.exp = cs.exp.optimize(WANTvalue | WANTexpand);
 
@@ -2938,7 +2938,7 @@ else
             crs.error("case range not in `switch` statement");
             return setError();
         }
-        sc.has_case = sw;
+        sc.hasCase = sw;
         //printf("CaseRangeStatement::semantic() %s\n", toChars());
         bool errors = false;
         if (sw.isFinal)
@@ -3019,7 +3019,7 @@ else
         bool errors = false;
         if (sc.sw)
         {
-            sc.has_case = sc.sw;
+            sc.hasCase = sc.sw;
             if (sc.sw.sdefault)
             {
                 ds.error("`switch` statement already has a default");
@@ -4162,7 +4162,7 @@ else
 
     override void visit(LabelStatement ls)
     {
-        sc.has_label = true;
+        sc.hasLabel = true;
         //printf("LabelStatement::semantic()\n");
         FuncDeclaration fd = sc.parent.isFuncDeclaration();
 

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -433,6 +433,9 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             }
 
             ss.statement = ss.statement.statementSemantic(sc);
+            if (sc.has_label) {
+                sc.enclosing.has_label = true;
+            }
             if (ss.statement)
             {
                 if (ss.statement.isErrorStatement())
@@ -2262,6 +2265,10 @@ else
         CtorFlow ctorflow_root = scd.ctorflow.clone();
 
         ifs.ifbody = ifs.ifbody.semanticNoScope(scd);
+        if (scd.has_label) {
+            ifs.ifbody.has_label = true;
+            scd.enclosing.has_label = true;
+        }
         scd.pop();
 
         CtorFlow ctorflow_then = sc.ctorflow;   // move flow results
@@ -4136,6 +4143,7 @@ else
 
     override void visit(LabelStatement ls)
     {
+        sc.has_label = true;
         //printf("LabelStatement::semantic()\n");
         FuncDeclaration fd = sc.parent.isFuncDeclaration();
 

--- a/test/unit/frontend.d
+++ b/test/unit/frontend.d
@@ -254,7 +254,7 @@ unittest
 {
     import std.algorithm : each;
     import dmd.frontend;
-    import dmd.statement : IfStatement;
+    import dmd.statement : IfStatement, ScopeStatement;
     import dmd.visitor : SemanticTimeTransitiveVisitor;
 
     initDMD();
@@ -322,7 +322,8 @@ unittest
 
         override void visit(IfStatement ifs)
         {
-            auto ifbody = ifs.ifbody;
+            ScopeStatement ifbody = ifs.ifbody.isScopeStatement();
+            assert(ifbody);
             import std.conv;
             string str = to!string(ifs.condition.toChars());
             switch (str) {
@@ -331,12 +332,12 @@ unittest
                 case "5":
                 case "6":
                 case "7":
-                    assert(ifbody.hasLabel());
+                    assert(ifbody.hasMultipleEntryPoints());
                     break;
                 case "2":
                 case "4":
                 case "8":
-                    assert(ifbody.hasLabel() == false);
+                    assert(ifbody.hasMultipleEntryPoints() == false);
                     break;
                 default: break;
             }


### PR DESCRIPTION
*Why?*
To be able to query if control-flow statements have any label inside.

*Double Why?*
Because it helps LDC back-end do dead-code elimination when the condition is constant: [PR](https://github.com/ldc-developers/ldc/pull/3134).
But if the body to-be-elided has any label, we can't eliminate it because it may be accessed through the label. So, currently, we have to walk the tree again to get that info.

*How?*
If we find a label, we propagate it backwards through the scopes. Then, the statements that we care to keep that info just query the scope.
When we go forward the scopes again (i.e. push), the info is reset.

Note: This is just a draft implementation in order to see if you're positive on the addition. If yes, the prospect is to do what has been done to `if` for `while`, `for` etc. and also treat `CaseStatement` / `DefaultStatement` as label if they're not directly followed by a `SwitchStatement`.