### PR TITLE
Add `-transition=in` compiler flag to help users transition away from using `in`

### DIFF
--- a/changelog/transition_in.dd
+++ b/changelog/transition_in.dd
@@ -1,0 +1,14 @@
+New compiler flag `-transition=in` to locate usages of the `in` storage class
+
+The `in` storage class has is defined as `const scope`, but it is currently implemented as `const`.  Implementing
+it as `const scope` make cause breakage and there is not yet a concrete plan for `in`.  Therefore it is higly
+recommended that it not be used, and instead explicitlly use `const` or `const scope` to reduce the risk of
+breakage if and when `in` is properly designed and implemented.
+
+To help users transition away from `in`, the `-transtion=in` compiler flag was created.  Passing `-transition=in`,
+along with `-w` or `-wi`, to any compiler invocation will cause the compiler to emit warning messages for any usage of `in`.
+
+---
+void test (in void* a) // Warning: `in` is not yet implemented.  Use `const` or `scope const` explicitly instead.
+{ }
+---

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -697,6 +697,8 @@ dmd -cov -unittest myprog.d
             "list all variables going into thread local storage"),
         Feature("vmarkdown", "vmarkdown",
             "list instances of Markdown replacements in Ddoc"),
+        Feature("in", "vin",
+            "emit deprecation message for any usage of `in`")
     ];
 
     /// Returns all available reverts

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -184,6 +184,7 @@ extern (C++) struct Param
     bool vmarkdown;         // list instances of Markdown replacements in Ddoc
 
     bool noXlinker;         // do not prepend `-Xlinker` to `-L` command-line options when invoking the linker
+    bool vin;               // emit deprecation message for any usage of `in`
 
     bool showGaggedErrors;  // print gagged errors anyway
     bool printErrorContext;  // print errors with the error context (the error line in the source file)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1261,6 +1261,26 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                     continue;
                 }
 
+                if (global.params.vin)
+                {
+                    // Only display warning message for types in the module being compiled
+                    if (sc._module is sc._module.rootModule)
+                    {
+                        if (fparam.storageClass & STC.in_)
+                        {
+                            static showSupplemental = true;
+                            warning(loc, "`in` is not yet implemented.  Use `const` or `scope const` explicitly instead.");
+                            if (showSupplemental)
+                            {
+                                warningSupplemental(loc, "`in` is currently defined as `scope const`, but it is implemented as `const`."
+                                    ~ "  Using `in` could cause code to break in the future when it is implemented, so it is recommended"
+                                    ~ " to use `const` or `const scope` explicitly until `in` is properly implemented.");
+                                showSupplemental = false;
+                            }
+                        }
+                    }
+                }
+
                 fparam.type = fparam.type.addStorageClass(fparam.storageClass);
 
                 if (fparam.storageClass & (STC.auto_ | STC.alias_ | STC.static_))

--- a/test/fail_compilation/transition_in.d
+++ b/test/fail_compilation/transition_in.d
@@ -1,0 +1,16 @@
+// PERMUTE_ARGS:
+// REQUIRED_ARGS: -w -transition=in
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/transition_in.d(14): Warning: `in` is not yet implemented.  Use `const` or `scope const` explicitly instead.
+fail_compilation/transition_in.d(14):        `in` is currently defined as `scope const`, but it is implemented as `const`.  Using `in` could cause code to break in the future when it is implemented, so it is recommended to use `const` or `const scope` explicitly until `in` is properly implemented.
+fail_compilation/transition_in.d(15): Warning: `in` is not yet implemented.  Use `const` or `scope const` explicitly instead.
+fail_compilation/transition_in.d(16): Warning: `in` is not yet implemented.  Use `const` or `scope const` explicitly instead.
+---
+*/
+
+void test(in void* x) { }
+void test1(in void* x) { }
+void test2(in void* x) { }


### PR DESCRIPTION
A "gentler" alternative to https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters