### PR TITLE
[POC] [WIP] Move constructor & move assignment op w/ and w/o rvalue ref

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -166,8 +166,8 @@ public:
     FuncDeclarations postblits; // Array of postblit functions
     FuncDeclaration *postblit;  // aggregate postblit
 
-    FuncDeclaration* moveCtor;  // aggregate move constructor
-    bool hasMoveAssign;         // true if has opMoveAssign
+    bool hasMoveAssign;         // true if has move opAssign
+    bool hasMoveCtor;           // true if has move constructor
 
     bool hasCopyCtor;           // copy constructor
 

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -166,6 +166,9 @@ public:
     FuncDeclarations postblits; // Array of postblit functions
     FuncDeclaration *postblit;  // aggregate postblit
 
+    FuncDeclaration* moveCtor;  // aggregate move constructor
+    bool hasMoveAssign;         // true if has opMoveAssign
+
     bool hasCopyCtor;           // copy constructor
 
     FuncDeclaration *xeq;       // TypeInfo_Struct.xopEquals

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -130,6 +130,7 @@ struct ASTBase
         future              = (1L << 50),   // introducing new base class function
         local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
         returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+        move                = (1L << 53),   // for annotating move constructor and move opAssign
 
         safeGroup = STC.safe | STC.trusted | STC.system,
         TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -833,11 +833,25 @@ struct ASTBase
         }
     }
 
-    extern (C++) final class CtorDeclaration : FuncDeclaration
+    extern (C++) class CtorDeclaration : FuncDeclaration
     {
         extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Type type, bool isCopyCtor = false)
         {
             super(loc, endloc, Id.ctor, stc, type);
+        }
+
+        override void accept(Visitor v)
+        {
+            v.visit(this);
+        }
+    }
+
+    extern (C++) final class MoveCtorDeclaration : CtorDeclaration
+    {
+        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Type type)
+        {
+            super(loc, endloc, stc, type);
+            this.ident = Id.moveCtor;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -5278,6 +5278,7 @@ struct ASTBase
     {
         Type to;
         ubyte mod = cast(ubyte)~0;
+        bool toRvalue;
 
         extern (D) this(const ref Loc loc, Expression e, Type t)
         {

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -5172,14 +5172,18 @@ struct ASTBase
 
     extern (C++) final class PtrExp : UnaExp
     {
-        extern (D) this(const ref Loc loc, Expression e)
+        bool isRvalue;
+
+        extern (D) this(const ref Loc loc, Expression e, bool isRvalue = false)
         {
             super(loc, TOK.star, __traits(classInstanceSize, PtrExp), e);
+            this.isRvalue = isRvalue;
         }
-        extern (D) this(const ref Loc loc, Expression e, Type t)
+        extern (D) this(const ref Loc loc, Expression e, Type t, bool isRvalue = false)
         {
             super(loc, TOK.star, __traits(classInstanceSize, PtrExp), e);
             type = t;
+            this.isRvalue = isRvalue;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -250,20 +250,21 @@ enum STC : long
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
     returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
     move                = (1L << 53),   // for annotating move constructor and move opAssign
+    rvalueref           = (1L << 54),   // rvalue ref
 
     // Group members are mutually exclusive (there can be only one)
     safeGroup = STC.safe | STC.trusted | STC.system,
 
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
     FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property |
-                STC.safeGroup),
+                STC.safeGroup | STC.rvalueref),
 }
 
 enum STCStorageClass =
     (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
      STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
      STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
-     STC.property | STC.safeGroup | STC.disable | STC.local);
+     STC.property | STC.safeGroup | STC.disable | STC.local | STC.rvalueref);
 
 /* Accumulator for successive matches.
  */
@@ -539,6 +540,11 @@ extern (C++) abstract class Declaration : Dsymbol
     final bool isRef() const pure nothrow @nogc @safe
     {
         return (storage_class & STC.ref_) != 0;
+    }
+
+    final bool isRvalueRef() const pure nothrow @nogc @safe
+    {
+        return (storage_class & STC.rvalueref) != 0;
     }
 
     final bool isFuture() const pure nothrow @nogc @safe

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -249,6 +249,7 @@ enum STC : long
     future              = (1L << 50),   // introducing new base class function
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
     returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+    move                = (1L << 53),   // for annotating move constructor and move opAssign
 
     // Group members are mutually exclusive (there can be only one)
     safeGroup = STC.safe | STC.trusted | STC.system,

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -651,6 +651,7 @@ class CtorDeclaration : public FuncDeclaration
 {
 public:
     bool isCpCtor;
+    bool isMvCtor;
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;
     const char *toChars() const;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -87,6 +87,8 @@ struct IntRange;
 #define STCfuture        0x4000000000000LL // introducing new base class function
 #define STClocal         0x8000000000000LL // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
 #define STCreturninferred 0x10000000000000LL   // 'return' has been inferred and should not be part of mangling
+#define STCmove          0x20000000000000LL    // for annotating move constructor and move opAssign
+#define STCrvalueref     0x40000000000000LL    // rvalue ref
 
 void ObjectNotFound(Identifier *id);
 
@@ -131,6 +133,7 @@ public:
     bool isIn()  const  { return (storage_class & STCin) != 0; }
     bool isOut() const  { return (storage_class & STCout) != 0; }
     bool isRef() const  { return (storage_class & STCref) != 0; }
+    bool isRvalueRef() const { return (storage_class & STCrvalueref) != 0; }
 
     bool isFuture() const { return (storage_class & STCfuture) != 0; }
 

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -662,6 +662,21 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+
+class MoveCtorDeclaration : public FuncDeclaration
+{
+public:
+    Dsymbol *syntaxCopy(Dsymbol *);
+    const char *kind() const;
+    const char *toChars() const;
+    bool isVirtual() const;
+    bool addPreInvariant();
+    bool addPostInvariant();
+
+    MoveCtorDeclaration *isMoveCtorDeclaration() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class PostBlitDeclaration : public FuncDeclaration
 {
 public:

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -78,7 +78,7 @@ private immutable char[TMAX] mangleChar =
     Taarray      : 'H',
     Tident       : 'I',
     //              J   // out
-    //              K   // ref
+    //              K   // K:ref KK:rvalue ref
     //              L   // lazy
     //              M   // has this, or scope
     //              N   // Nh:vector Ng:wild
@@ -1092,6 +1092,8 @@ public:
             break;
         case STC.ref_:
             buf.writeByte('K');
+            if (p.storageClass & STC.rvalue)
+                buf.writeByte('K');
             break;
         case STC.lazy_:
             buf.writeByte('L');

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -383,7 +383,9 @@ public:
             buf.writestring("Na");
         if (ta.isnothrow)
             buf.writestring("Nb");
-        if (ta.isref)
+        if (ta.isrvalueref)
+            buf.writestring("Nm");
+        else if (ta.isref)
             buf.writestring("Nc");
         if (ta.isproperty)
             buf.writestring("Nd");
@@ -1092,7 +1094,7 @@ public:
             break;
         case STC.ref_:
             buf.writeByte('K');
-            if (p.storageClass & STC.rvalue)
+            if (p.storageClass & STC.rvalueref)
                 buf.writeByte('K');
             break;
         case STC.lazy_:

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -208,7 +208,8 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     FuncDeclaration postblit;   // aggregate postblit
 
     FuncDeclaration moveCtor;   // aggregate move constructor
-    bool hasMoveAssign;         // true if has opMoveAssign
+    bool hasMoveAssign;         // true if has move opAssign
+    bool hasMoveCtor;           // true if has move constructor
 
     bool hasCopyCtor;       // copy constructor
 

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -207,6 +207,9 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     FuncDeclarations postblits; // Array of postblit functions
     FuncDeclaration postblit;   // aggregate postblit
 
+    FuncDeclaration moveCtor;   // aggregate move constructor
+    bool hasMoveAssign;         // true if has opMoveAssign
+
     bool hasCopyCtor;       // copy constructor
 
     FuncDeclaration xeq;        // TypeInfo_Struct.xopEquals
@@ -562,7 +565,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
 
         ispod = StructPOD.yes;
 
-        if (enclosing || postblit || dtor || hasCopyCtor)
+        if (enclosing || postblit || dtor || hasCopyCtor || moveCtor)
             ispod = StructPOD.no;
 
         // Recursively check all fields are POD.

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1199,6 +1199,7 @@ extern (C++) class Dsymbol : ASTNode
     inout(OverDeclaration)             isOverDeclaration()             inout { return null; }
     inout(FuncLiteralDeclaration)      isFuncLiteralDeclaration()      inout { return null; }
     inout(CtorDeclaration)             isCtorDeclaration()             inout { return null; }
+    inout(MoveCtorDeclaration)         isMoveCtorDeclaration()         inout { return null; }
     inout(PostBlitDeclaration)         isPostBlitDeclaration()         inout { return null; }
     inout(DtorDeclaration)             isDtorDeclaration()             inout { return null; }
     inout(StaticCtorDeclaration)       isStaticCtorDeclaration()       inout { return null; }

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -36,6 +36,7 @@ class FuncAliasDeclaration;
 class OverDeclaration;
 class FuncLiteralDeclaration;
 class CtorDeclaration;
+class MoveCtorDeclaration;
 class PostBlitDeclaration;
 class DtorDeclaration;
 class StaticCtorDeclaration;
@@ -252,6 +253,7 @@ public:
     virtual OverDeclaration *isOverDeclaration() { return NULL; }
     virtual FuncLiteralDeclaration *isFuncLiteralDeclaration() { return NULL; }
     virtual CtorDeclaration *isCtorDeclaration() { return NULL; }
+    virtual MoveCtorDeclaration *isMoveCtorDeclaration() { return NULL; }
     virtual PostBlitDeclaration *isPostBlitDeclaration() { return NULL; }
     virtual DtorDeclaration *isDtorDeclaration() { return NULL; }
     virtual StaticCtorDeclaration *isStaticCtorDeclaration() { return NULL; }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4158,7 +4158,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 {
                     //printf("tf: %s\n", tf.toChars());
                     auto param = Parameter.getNth(tf.parameterList, 0);
-                    if ((param.storageClass & (STC.rvalue | STC.ref_)) == (STC.rvalue | STC.ref_) && param.type.mutableOf().unSharedOf() == sd.type.mutableOf().unSharedOf())
+                    if ((param.storageClass & STC.rvalueref) && param.type.mutableOf().unSharedOf() == sd.type.mutableOf().unSharedOf())
                     {
                         //printf("move constructor\n");
                         ctd.isMvCtor = true;

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -5983,12 +5983,12 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                             goto Lnotequals;
                         if (farg.isLvalue())
                         {
-                            if (!(fparam.storageClass & STC.ref_))
+                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) != STC.ref_)
                                 goto Lnotequals; // auto ref's don't match
                         }
                         else
                         {
-                            if (fparam.storageClass & STC.ref_)
+                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) == STC.ref_)
                                 goto Lnotequals; // auto ref's don't match
                         }
                     }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -377,8 +377,6 @@ Expression valueNoDtor(Expression e)
 {
     auto ex = lastComma(e);
 
-version(none)
-{
     if (auto ce = ex.isCallExp())
     {
         /* The struct value returned from the function is transferred
@@ -416,7 +414,6 @@ version(none)
             vtmp.storage_class |= STC.nodtor;
         }
     }
-}
     return e;
 }
 
@@ -457,6 +454,37 @@ private Expression callCpCtor(Scope* sc, Expression e, Type destinationType)
     return e;
 }
 
+/*********************************************
+ * If e is an instance of a struct, and that struct has a move constructor,
+ * rewrite e as:
+ *    (tmp = e),tmp
+ * Input:
+ *      sc = just used to specify the scope of created temporary variable
+ *      destinationType = the type of the object on which the copy constructor is called
+ */
+private Expression callMvCtor(Scope* sc, Expression e, Type destinationType)
+{
+    if (auto ts = e.type.baseElemOf().isTypeStruct())
+    {
+        StructDeclaration sd = ts.sym;
+        if (sd.hasMoveCtor)
+        {
+            /* (tmp = e),tmp */
+            auto tmp = copyToTemp(STC.rvalue, "__movetmp", e);
+            if (destinationType)
+                tmp.type = destinationType;
+            tmp.storage_class |= STC.nodtor;
+            tmp.dsymbolSemantic(sc);
+            Expression de = new DeclarationExp(e.loc, tmp);
+            Expression ve = new VarExp(e.loc, tmp);
+            de.type = Type.tvoid;
+            ve.type = e.type;
+            return Expression.combine(de, ve);
+        }
+    }
+    return valueNoDtor(e);
+}
+
 /************************************************
  * Handle the postblit call on lvalue, or the move of rvalue.
  *
@@ -477,7 +505,7 @@ extern (D) Expression doCopyOrMove(Scope *sc, Expression e, Type t = null)
     }
     else
     {
-        e = e.isLvalue() ? callCpCtor(sc, e, t) : valueNoDtor(e);
+        e = e.isLvalue() ? callCpCtor(sc, e, t) : callMvCtor(sc, e, t);
     }
     return e;
 }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -499,6 +499,25 @@ Expression toRvalueExp(const ref Loc loc, Scope* sc, Expression e)
 }
 
 /****************************************************************/
+/* Cast expression to lvalue.
+ */
+Expression toLvalueExp(const ref Loc loc, Scope* sc, Expression e)
+{
+    if (e.isLvalue())
+        return e;
+
+    e = e.expressionSemantic(sc);
+    if (e.op == TOK.error || e.type == Type.terror)
+        return e;
+
+    Type t = e.type;
+    assert(t);
+    e = new AddrExp(loc, e, t.pointerTo());
+    e = new PtrExp(loc, e, t, /* isRvalue */ false);
+    return e;
+}
+
+/****************************************************************/
 /* A type meant as a union of all the Expression types,
  * to serve essentially as a Variant that will sit on the stack
  * during CTFE to reduce memory consumption.

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5143,6 +5143,7 @@ extern (C++) final class CastExp : UnaExp
 {
     Type to;                    // type to cast to
     ubyte mod = cast(ubyte)~0;  // MODxxxxx
+    bool toRvalue;              // cast lvalue to rvalue
 
     extern (D) this(const ref Loc loc, Expression e, Type t)
     {

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -820,6 +820,8 @@ public:
 class PtrExp : public UnaExp
 {
 public:
+    bool isRvalue;
+
     int checkModifiable(Scope *sc, int flag);
     bool isLvalue();
     Expression *toLvalue(Scope *sc, Expression *e);
@@ -866,6 +868,7 @@ public:
     // Possible to cast to one type while painting to another type
     Type *to;                   // type to cast to
     unsigned char mod;          // MODxxxxx
+    bool toRvalue;              // cast lvalue to rvalue
 
     Expression *syntaxCopy();
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4074,6 +4074,19 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
+        if (exp.e1.op == TOK.identifier && (cast(IdentifierExp)exp.e1).ident == Id.__move)
+        {
+            expandTuples(exp.arguments);
+            if (exp.arguments.length > 1)
+            {
+                exp.error("`%s` takes only one argument`", Id.__move.toChars());
+                return setError();
+            }
+            result = toRvalueExp(exp.loc, sc, (*exp.arguments)[0])
+                    .expressionSemantic(sc);
+            return;
+        }
+
         if (Expression ex = resolveUFCS(sc, exp))
         {
             result = ex;
@@ -6845,6 +6858,13 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (exp.type)
         {
             result = exp;
+            return;
+        }
+
+        if (exp.toRvalue)
+        {
+            result = toRvalueExp(exp.loc, sc, exp.e1)
+                    .expressionSemantic(sc);
             return;
         }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1940,7 +1940,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
                 if ((global.params.rvalueRefParam &&
                     !arg.isLvalue() &&
                     targ.isCopyable()) ||
-                    ((p.storageClass & STC.rvalue) &&
+                    ((p.storageClass & STC.rvalueref) &&
                      !arg.isLvalue() && targ.isMovable()))
                 {   /* allow rvalues to be passed to ref parameters by copying
                      * them to a temp, then pass the temp as the argument
@@ -8503,7 +8503,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                         }
                         else
                         {
-                            if (sd.hasMoveCtor && !e2x.isCallExp())
+                            if (sd.hasMoveCtor && (!e2x.isCallExp() || e2x.isRvalueRef()))
                             {
                                 /* Rewrite as:
                                  * e1 = init, e1.moveCtor(e2);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -2076,6 +2076,8 @@ extern (C++) class FuncDeclaration : Declaration
             TypeFunction tf = type.toTypeFunction();
             if (tf.isref)
                 vresult.storage_class |= STC.ref_;
+            if (tf.isrvalueref)
+                vresult.storage_class |= STC.rvalueref;
             vresult.type = tret;
 
             vresult.dsymbolSemantic(sc);

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3410,7 +3410,7 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
 
 /***********************************************************
  */
-extern (C++) final class CtorDeclaration : FuncDeclaration
+extern (C++) class CtorDeclaration : FuncDeclaration
 {
     bool isCpCtor;
     extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Type type, bool isCpCtor = false)
@@ -3453,6 +3453,59 @@ extern (C++) final class CtorDeclaration : FuncDeclaration
     }
 
     override inout(CtorDeclaration) isCtorDeclaration() inout
+    {
+        return this;
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ */
+extern (C++) final class MoveCtorDeclaration : CtorDeclaration
+{
+    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Type type)
+    {
+        super(loc, endloc, stc, type);
+        this.ident = Id.moveCtor;
+    }
+
+    override Dsymbol syntaxCopy(Dsymbol s)
+    {
+        assert(!s);
+        auto f = new MoveCtorDeclaration(loc, endloc, storage_class, type.syntaxCopy());
+        return FuncDeclaration.syntaxCopy(f);
+    }
+
+    override const(char)* kind() const
+    {
+        return "move constructor";
+    }
+
+    override const(char)* toChars() const
+    {
+        return "__move_ctor";
+    }
+
+    override bool isVirtual() const
+    {
+        return false;
+    }
+
+    override bool addPreInvariant()
+    {
+        return false;
+    }
+
+    override bool addPostInvariant()
+    {
+        return (isThis() && vthis && global.params.useInvariants == CHECKENABLE.on);
+    }
+
+    override inout(MoveCtorDeclaration) isMoveCtorDeclaration() inout
     {
         return this;
     }

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3413,10 +3413,12 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
 extern (C++) class CtorDeclaration : FuncDeclaration
 {
     bool isCpCtor;
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Type type, bool isCpCtor = false)
+    bool isMvCtor;
+    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Type type, bool isCpCtor = false, bool isMvCtor = false)
     {
         super(loc, endloc, Id.ctor, stc, type);
         this.isCpCtor = isCpCtor;
+        this.isMvCtor = isMvCtor;
         //printf("CtorDeclaration(loc = %s) %s\n", loc.toChars(), toChars());
     }
 
@@ -3429,7 +3431,7 @@ extern (C++) class CtorDeclaration : FuncDeclaration
 
     override const(char)* kind() const
     {
-        return isCpCtor ? "copy constructor" : "constructor";
+        return isCpCtor ? "copy constructor" : isMvCtor ? "move constructor" : "constructor";
     }
 
     override const(char)* toChars() const

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3014,6 +3014,8 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
 
     if (p.storageClass & STC.out_)
         buf.writestring("out ");
+    else if (p.storageClass & STC.rvalueref)
+        buf.writestring("@rvalue ref ");
     else if (p.storageClass & STC.ref_)
         buf.writestring("ref ");
     else if (p.storageClass & STC.in_)

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -137,6 +137,8 @@ immutable Msgtable[] msgtable =
     { "_unittest", "unittest" },
     { "_body", "body" },
     { "moveCtor", "__move_ctor" },
+    { "rvalue" },
+    { "__move" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -437,6 +437,7 @@ immutable Msgtable[] msgtable =
     { "getTargetInfo" },
     { "getLocation" },
     { "getRvalue" },
+    { "isRvalueRef" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -431,6 +431,7 @@ immutable Msgtable[] msgtable =
     { "isZeroInit" },
     { "getTargetInfo" },
     { "getLocation" },
+    { "getRvalue" },
 
     // For C++ mangling
     { "allocator" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -136,6 +136,7 @@ immutable Msgtable[] msgtable =
     { "_assert", "assert" },
     { "_unittest", "unittest" },
     { "_body", "body" },
+    { "moveCtor", "__move_ctor" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },
@@ -249,6 +250,7 @@ immutable Msgtable[] msgtable =
     { "cat",     "opCat" },
     { "cat_r",   "opCat_r" },
     { "assign",  "opAssign" },
+    { "moveassign", "opMoveAssign" },
     { "addass",  "opAddAssign" },
     { "subass",  "opSubAssign" },
     { "mulass",  "opMulAssign" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -139,6 +139,7 @@ immutable Msgtable[] msgtable =
     { "moveCtor", "__move_ctor" },
     { "rvalue" },
     { "__move" },
+    { "move" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -589,6 +589,8 @@ public:
     bool isscope;       // true: 'this' is scope
     bool isreturninferred;      // true: 'this' is return from inference
     bool isscopeinferred; // true: 'this' is scope from inference
+    bool ismove;        // true: a move function
+    bool isrvalueref;   // true: returns an rvalue ref
     LINK linkage;  // calling convention
     TRUST trust;   // level of trust
     PURE purity;   // PURExxxx

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -855,8 +855,8 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 {
                     if (!e.e2.isLvalue())
                     {
-                        id = Id.moveassign;
-                        e.e2 = toLvalueExp(e.e2.loc, sc, e.e2);
+                        //id = Id.moveassign;
+                        //e.e2 = toLvalueExp(e.e2.loc, sc, e.e2);
                     }
                 }
             }

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -846,10 +846,18 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
             if (e.op == TOK.assign && ad1 == ad2)
             {
                 StructDeclaration sd = ad1.isStructDeclaration();
-                if (sd && !sd.hasIdentityAssign)
+                if (sd && !sd.hasIdentityAssign && !sd.hasMoveAssign)
                 {
                     /* This is bitwise struct assignment. */
                     return;
+                }
+                if (id == Id.assign)
+                {
+                    if (!e.e2.isLvalue())
+                    {
+                        id = Id.moveassign;
+                        e.e2 = toLvalueExp(e.e2.loc, sc, e.e2);
+                    }
                 }
             }
             Dsymbol s = null;
@@ -860,7 +868,7 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 if (ad1 && id)
                 {
                     s = search_function(ad1, id);
-                    if (s && id != Id.assign)
+                    if (s && id != Id.assign && id != Id.moveassign)
                     {
                         // @@@DEPRECATED_2.094@@@.
                         // Deprecated in 2.088

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -8251,6 +8251,7 @@ final class Parser(AST) : Lexer
                  * cast(shared), cast(shared const), cast(wild), cast(shared wild)
                  */
                 ubyte m = 0;
+                bool toRvalue;
                 while (1)
                 {
                     switch (token.value)
@@ -8283,12 +8284,28 @@ final class Parser(AST) : Lexer
                         nextToken();
                         continue;
 
+                    case TOK.identifier:
+                        if (token.ident == Id.rvalue)
+                        {
+                            toRvalue = true;
+                            nextToken();
+                            check(TOK.rightParentheses);
+                        }
+                        break;
+
                     default:
                         break;
                     }
                     break;
                 }
-                if (token.value == TOK.rightParentheses)
+                if (toRvalue)
+                {
+                    auto e1 = parseUnaryExp();
+                    auto ce = new AST.CastExp(loc, e1, 0);
+                    ce.toRvalue = true;
+                    e = ce;
+                }
+                else if (token.value == TOK.rightParentheses)
                 {
                     nextToken();
                     e = parseUnaryExp();

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1409,7 +1409,7 @@ final class Parser(AST) : Lexer
             else if (token.ident == Id.future)
                 stc = STC.future;
             else if (token.ident == Id.rvalue)
-                stc = STC.rvalue;
+                stc = STC.rvalueref;
             else
             {
                 // Allow identifier, template instantiation, or function call
@@ -2917,7 +2917,7 @@ final class Parser(AST) : Lexer
                         }
                         if (token.value == TOK.dotDotDot)
                             error("variadic parameter cannot have user-defined attributes");
-                        if (stc2 == STC.rvalue)
+                        if (stc2 == STC.rvalueref)
                         {
                             stc = stc2;
                             goto L2;
@@ -7548,7 +7548,7 @@ final class Parser(AST) : Lexer
                      * any of the above followed by (arglist)
                      * @predefined_attribute
                      */
-                    if (t.ident == Id.property || t.ident == Id.nogc || t.ident == Id.safe || t.ident == Id.trusted || t.ident == Id.system || t.ident == Id.disable)
+                    if (t.ident == Id.property || t.ident == Id.nogc || t.ident == Id.safe || t.ident == Id.trusted || t.ident == Id.system || t.ident == Id.disable || t.ident == Id.rvalue)
                         break;
                     t = peek(t);
                     if (t.value == TOK.not)

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -51,6 +51,7 @@ public:
     void visit(AST.FuncLiteralDeclaration s) { visit(cast(AST.FuncDeclaration)s); }
     void visit(AST.PostBlitDeclaration s) { visit(cast(AST.FuncDeclaration)s); }
     void visit(AST.CtorDeclaration s) { visit(cast(AST.FuncDeclaration)s); }
+    void visit(AST.MoveCtorDeclaration s) { visit(cast(AST.FuncDeclaration)s); }
     void visit(AST.DtorDeclaration s) { visit(cast(AST.FuncDeclaration)s); }
     void visit(AST.InvariantDeclaration s) { visit(cast(AST.FuncDeclaration)s); }
     void visit(AST.UnitTestDeclaration s) { visit(cast(AST.FuncDeclaration)s); }

--- a/src/dmd/strictvisitor.d
+++ b/src/dmd/strictvisitor.d
@@ -30,6 +30,7 @@ extern(C++) class StrictVisitor(AST) : ParseTimeVisitor!AST
     override void visit(AST.FuncLiteralDeclaration) { assert(0); }
     override void visit(AST.PostBlitDeclaration) { assert(0); }
     override void visit(AST.CtorDeclaration) { assert(0); }
+    override void visit(AST.MoveCtorDeclaration) { assert(0); }
     override void visit(AST.DtorDeclaration) { assert(0); }
     override void visit(AST.InvariantDeclaration) { assert(0); }
     override void visit(AST.UnitTestDeclaration) { assert(0); }

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -419,6 +419,7 @@ private immutable TOK[] keywords =
     TOK.prettyFunction,
     TOK.shared_,
     TOK.immutable_,
+
 ];
 
 /***********************************************************
@@ -697,6 +698,7 @@ extern (C++) struct Token
 
         TOK.objcClassReference: "class",
         TOK.vectorArray: "vectorarray",
+
     ];
 
     static assert(() {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -710,6 +710,13 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         return isDeclX(d => d.isRef());
     }
+    if (e.ident == Id.isRvalueRef)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        return isDeclX(d => d.isRvalueRef());
+    }
     if (e.ident == Id.isOut)
     {
         if (dim != 1)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -144,6 +144,7 @@ shared static this()
         "isZeroInit",
         "getTargetInfo",
         "getLocation",
+        "getRvalue",
     ];
 
     traitsStringTable._init(names.length);
@@ -1880,6 +1881,20 @@ Lnext:
         exps.data[2] = new IntegerExp(e.loc, s.loc.charnum,Type.tint32);
         auto tup = new TupleExp(e.loc, exps);
         return tup.expressionSemantic(sc);
+    }
+    if (e.ident == Id.getRvalue)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        auto ex = isExpression((*e.args)[0]);
+        if (!ex)
+        {
+            e.error("expression expected as argument of __traits `%s`", e.ident.toChars());
+            return new ErrorExp();
+        }
+
+        return toRvalueExp(e.loc, sc, ex).expressionSemantic(sc);
     }
 
     extern (D) const(char)* trait_search_fp(const(char)[] seed, ref int cost)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1263,7 +1263,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
 
                 if (i == 0 && tf.ismove && (fparam.storageClass & STC.ref_))
                 {
-                    fparam.storageClass |= STC.rvalue;
+                    fparam.storageClass |= STC.rvalueref;
                 }
 
                 fparam.type = fparam.type.addStorageClass(fparam.storageClass);
@@ -1491,7 +1491,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                             // ref parameter
                         }
                         else
-                            fparam.storageClass &= ~STC.ref_; // value parameter
+                            fparam.storageClass |= STC.rvalueref; // rvalue ref parameter
                         fparam.storageClass &= ~STC.auto_;    // https://issues.dlang.org/show_bug.cgi?id=14656
                         fparam.storageClass |= STC.autoref;
                     }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1261,6 +1261,11 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                     continue;
                 }
 
+                if (i == 0 && tf.ismove && (fparam.storageClass & STC.ref_))
+                {
+                    fparam.storageClass |= STC.rvalue;
+                }
+
                 fparam.type = fparam.type.addStorageClass(fparam.storageClass);
 
                 if (fparam.storageClass & (STC.auto_ | STC.alias_ | STC.static_))

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -157,6 +157,7 @@ class FuncDeclaration;
 class FuncAliasDeclaration;
 class FuncLiteralDeclaration;
 class CtorDeclaration;
+class MoveCtorDeclaration;
 class PostBlitDeclaration;
 class DtorDeclaration;
 class StaticCtorDeclaration;
@@ -342,6 +343,7 @@ public:
     virtual void visit(FuncLiteralDeclaration *s) { visit((FuncDeclaration *)s); }
     virtual void visit(PostBlitDeclaration *s) { visit((FuncDeclaration *)s); }
     virtual void visit(CtorDeclaration *s) { visit((FuncDeclaration *)s); }
+    virtual void visit(MoveCtorDeclaration *s) { visit((FuncDeclaration *)s); }
     virtual void visit(DtorDeclaration *s) { visit((FuncDeclaration *)s); }
     virtual void visit(InvariantDeclaration *s) { visit((FuncDeclaration *)s); }
     virtual void visit(UnitTestDeclaration *s) { visit((FuncDeclaration *)s); }

--- a/test/runnable/move.d
+++ b/test/runnable/move.d
@@ -35,4 +35,13 @@ void main()
     S a;
     a = get();
     assert(moveAssign == 1);
+
+    S c = cast(rvalue) a;
+    assert(moveCtor == 2);
+
+    b = __move(c);
+    assert(moveAssign == 2);
+
+    a = __traits(getRvalue, b);
+    assert(moveAssign == 3);
 }

--- a/test/runnable/move.d
+++ b/test/runnable/move.d
@@ -1,0 +1,38 @@
+import core.stdc.stdio;
+
+int moveCtor;
+int moveAssign;
+
+struct S
+{
+    long[3] a;
+
+    __move_ctor(ref S)
+    {
+        ++moveCtor;
+        printf("mc\n");
+    }
+
+    auto opMoveAssign(ref S)
+    {
+        ++moveAssign;
+        printf("m=\n");
+    }
+
+    ~this()
+    {
+        printf("~\n");
+    }
+}
+
+S get() { return S(); }
+
+void main()
+{
+    S b = get();
+    assert(moveCtor == 1);
+
+    S a;
+    a = get();
+    assert(moveAssign == 1);
+}

--- a/test/runnable/rvalue.d
+++ b/test/runnable/rvalue.d
@@ -1,0 +1,47 @@
+import core.stdc.stdio;
+
+int copyCtor;
+int dtor;
+
+struct S
+{
+    long[4] a;
+
+nothrow:
+    this(ref S)
+    {
+        ++copyCtor;
+        printf("copy constructor\n");
+    }
+
+    ~this()
+    {
+        ++dtor;
+        printf("destructor\n");
+    }
+}
+
+void testCopy()
+{
+    S a;
+    S b = a;
+}
+
+void testMove()
+{
+    S a;
+    S b = __traits(getRvalue, a);
+}
+
+void main()
+{
+    testCopy();
+    assert(copyCtor == 1);
+    assert(dtor == 2);
+
+    copyCtor = dtor = 0;
+
+    testMove();
+    assert(copyCtor == 0);
+    assert(dtor == 2);
+}


### PR DESCRIPTION
POC implementation of move semantics without rvalue ref.

Forum discussion: https://forum.dlang.org/thread/oipegxuwqmrmmzefrqcx@forum.dlang.org

Example:
```d
struct S
{
    __move_ctor(ref S) {}
    auto opMoveAssign(ref S) {}
}

S get() { return S(); }

void test()
{
    S a = get();
    a = get();    // opMoveAssign called

    //  move lvalue
    S b = cast(rvalue) a;   // move constructor called
    b = __move(a);   // __move does the same thing as cast(rvalue)
    b = __traits(getRvalue, a);   // __traits(getRvalue) is also another flavor of cast(rvalue)
}
```

You can try it out. It compiles and works as expected.

#### EDIT:
I added the rvalue ref version to the POC. In addition to the previous example you can now declare the struct `S` like the following:
```d
struct S
{
    this(ref S) @move {}     // move constructor
    opAssign(ref S) @move {} // move opAssign
}
```
or:
```d
struct S
{
    this(@rvalue ref S) {}     // move constructor
    opAssign(@rvalue ref S) {} // move opAssign
}
```

All syntaxes produce the same result.