### PR TITLE
Fix Issue 18617 - Need ability to check if a symbol would trigger a deprecation

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -425,8 +425,17 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         e.ident != Id.getProtection &&
         e.ident != Id.getAttributes)
     {
+        // Pretend we're in a deprecated scope so that deprecation messages
+        // aren't triggered when checking if a symbol is deprecated
+        const save = sc.stc;
+        if (e.ident == Id.isDeprecated)
+            sc.stc |= STC.deprecated_;
         if (!TemplateInstance.semanticTiargs(e.loc, sc, e.args, 1))
+        {
+            sc.stc = save;
             return new ErrorExp();
+        }
+        sc.stc = save;
     }
     size_t dim = e.args ? e.args.dim : 0;
 

--- a/test/compilable/test17791.d
+++ b/test/compilable/test17791.d
@@ -1,7 +1,7 @@
 /*
+REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-compilable/test17791.d(23): Deprecation: class `test17791.DepClass` is deprecated - A deprecated class
 ---
 */
 deprecated("A deprecated class") {
@@ -23,4 +23,6 @@ void main()
     static assert(__traits(isDeprecated, DepClass));
     // check that a class not marked deprecated is not deprecated
     static assert(!__traits(isDeprecated, NewClass));
+    // Check for expressions (18617)
+    static assert(__traits(isDeprecated, { scope foo = new DepClass; }));
 }

--- a/test/compilable/test9701.d
+++ b/test/compilable/test9701.d
@@ -2,8 +2,8 @@
 /*
 TEST_OUTPUT:
 ---
-compilable/test9701.d(56): Deprecation: enum member `test9701.Enum.value7` is deprecated
-compilable/test9701.d(57): Deprecation: enum member `test9701.Enum.value8` is deprecated - message
+compilable/test9701.d(68): Deprecation: enum member `test9701.Enum.value7` is deprecated
+compilable/test9701.d(68): Deprecation: enum member `test9701.Enum.value8` is deprecated - message
 ---
 */
 
@@ -63,3 +63,6 @@ static assert(__traits(getAttributes, value3) == AliasSeq!("uda0", uda4));
 static assert(__traits(getAttributes, value4) == AliasSeq!("uda0", uda5, uda6));
 static assert(__traits(getAttributes, value5) == AliasSeq!("uda0", "uda7", uda8));
 static assert(__traits(getAttributes, value6) == AliasSeq!("uda0", uda9, "uda10"));
+
+// Test that messages are correctly displayed
+static assert(Enum.value7 != Enum.value8);


### PR DESCRIPTION
```
... without triggering it !
__traits(isDeprecated, Symbol) currently triggers a deprecation message,
which makes it pretty useless for library writers.
Note that a pitfall is that a library would fail to get a deprecation message,
leading to a failure to remove the access to a symbol if the symbol is hard-coded.
However, the prime usage of __traits(isDeprecated) is for meta-programming,
hence it shouldn't be a problem in practice.
```

CC @timotheecour 