### PR TITLE
Fix Issue 20149 - [DIP1000] temp returned from constructor call not checked for scope problems

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1699,6 +1699,14 @@ private void escapeByRef(Expression e, EscapeByResults* er)
                 if (e.e1.op == TOK.dotVariable && t1.ty == Tfunction)
                 {
                     DotVarExp dve = cast(DotVarExp)e.e1;
+
+                    // https://issues.dlang.org/show_bug.cgi?id=20149#c10
+                    if (dve.var.isCtorDeclaration())
+                    {
+                        er.byexp.push(e);
+                        return;
+                    }
+
                     if (dve.var.storage_class & STC.return_ || tf.isreturn)
                     {
                         if (dve.var.storage_class & STC.scope_ || tf.isscope)

--- a/test/fail_compilation/test20149.d
+++ b/test/fail_compilation/test20149.d
@@ -1,0 +1,34 @@
+/* REQUIRED_ARGS: -preview=dip1000
+ * TEST_OUTPUT:
+---
+fail_compilation/test20149.d(28): Error: escaping reference to stack allocated value returned by `S('\xff').this(1)`
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=20149#c10
+
+@safe:
+
+struct S
+{
+    this(int){ }
+
+    char[] opSlice() return
+    {
+      return buf[];
+    }
+
+    char[4] buf;
+}
+
+S bar();
+
+char[] fun()
+{
+    return S(1)[];
+}
+
+void main()
+{
+    auto x = fun();
+}


### PR DESCRIPTION
This addresses the problem @WalterBright identified at https://issues.dlang.org/show_bug.cgi?id=20149#c10, but unfortunately, it does not resolve the original issue.

However, I may have a solution for the original issue too, but I need this to be merged first.