### PR TITLE
Fix Issue 2450 - Error using operators from named template mixin

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -7498,7 +7498,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             result = e.expressionSemantic(sc);
             return;
         }
-        if (!exp.type)
+        if (!exp.type || exp.e1.op == TOK.this_)
             exp.type = exp.e2.type;
         result = exp;
     }

--- a/test/fail_compilation/fail2450.d
+++ b/test/fail_compilation/fail2450.d
@@ -1,0 +1,22 @@
+// https://issues.dlang.org/show_bug.cgi?id=2450
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2450.d(20): Error: function expected before `()`, not `this.mixin Event!() clicked;
+` of type `void`
+---
+*/
+
+template Event()
+{
+	void opCall() { }
+	void opAddAssign(int i) { }
+}
+class Button {
+	mixin Event clicked;
+	void func()
+    {
+		clicked.opCall(); // works
+		this.clicked();   // works
+	}
+}


### PR DESCRIPTION
```d
template Event() {
	void opCall() { }
	void opAddAssign(int i) { }
}
class Button {
	mixin Event clicked;
	void func() {
		clicked.opCall(); // works
		this.clicked();   // works   => should not work, fixed by this patch

		// Error: function expected before (), not mixin Event!() clicked; of type void
		clicked();
		// Error: mixin 'Event!()' is not a variable
		clicked += 7;
	}
}
```

Operator overloading applies only for structs and classes (aggregated declarations), not for template declaration, so the expectation that a named mixin should call opCall (like in the above example) is invalid. The patch makes it so that when `this.clicked()` is rejected by the compiler. 