### PR TITLE
fix issue 20212 - invalid debug info with enum type in library

### DIFF
--- a/src/dmd/backend/dcgcv.d
+++ b/src/dmd/backend/dcgcv.d
@@ -1742,9 +1742,6 @@ private uint cv4_fwdenum(type* t)
 {
     Symbol* s = t.Ttag;
 
-    if (s.Stypidx)                 // if reference already generated
-        return s.Stypidx;          // use already existing reference
-
     // write a forward reference enum record that is enough for the linker to
     // fold with original definition from EnumDeclaration
     uint bty = dttab4[tybasic(t.Tnext.Tty)];


### PR DESCRIPTION
reusing an old type index does not work because it might be in a different object file. Let cv_debtyp() sort out duplicates instead.

Regression is on master only (no enum type debug info emitted before). A test as in the report seems excessive, there is a test in runnable/testpdb.d that emission still works.