### PR TITLE
Allow ref-returns of shared Variables

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3150,7 +3150,13 @@ else
                 rs.exp = inferType(rs.exp, fld.treq.nextOf().nextOf());
 
             rs.exp = rs.exp.expressionSemantic(sc);
-            rs.exp.checkSharedAccess(sc);
+            // if we are returning to a ref which does not come from auto ref
+            // it's okay to return shared, because it's returing a pointer without
+            // reading the memory itself
+            if(inferRef || !tf.isref)
+            {
+                rs.exp.checkSharedAccess(sc);
+            }
 
             // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684
             if (rs.exp.op == TOK.type)

--- a/test/compilable/shared_ref.d
+++ b/test/compilable/shared_ref.d
@@ -1,0 +1,6 @@
+// REQUIRED_ARGS: -preview=nosharedaccess
+
+ref shared(int) f(return shared ref int y)
+{
+    return y;
+}


### PR DESCRIPTION
This is okay because we are passing a pointer and not the acutal value.