### PR TITLE
fix issue 16047: range error when assigning nested aa with temporary

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8614,7 +8614,15 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
                      *          ? __aatmp[__aakey].opAssign(__aaval)
                      *          : ConstructExp(__aatmp[__aakey], __aaval));
                      */
-                    IndexExp ie = cast(IndexExp)e1x;
+                    // ensure we keep the expr modifiable
+                    Expression esetting = (cast(IndexExp)e1x).markSettingAAElem();
+                    if (esetting.op == TOK.error)
+                    {
+                        result = esetting;
+                        return;
+                    }
+                    assert(esetting.op == TOK.index);
+                    IndexExp ie = cast(IndexExp) esetting;
                     Type t2 = e2x.type.toBasetype();
 
                     Expression e0 = null;

--- a/test/runnable/test16047.d
+++ b/test/runnable/test16047.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=16047
+module test16047;
+
+void main()
+{
+    Reassignable[int][int] aa;
+
+    aa[0][0] = Reassignable.init;
+    aa[s()][0] = Reassignable.init; // range violation
+}
+
+struct Reassignable
+{
+    void opAssign(Reassignable) {}
+}
+
+int s() { return 1; }


### PR DESCRIPTION
When extracting temporaries from an index expression for assignment, mark the expression as assigning.

This avoids the temporaries encountering a range error with nested associative arrays.