### PR TITLE
Macro.expand(): use ref instead of *

### DIFF
--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -457,7 +457,7 @@ extern(C++) void gendocfile(Module m)
     OutBuffer buf2;
     buf2.writestring("$(DDOC)");
     size_t end = buf2.length;
-    m.macrotable.expand(&buf2, 0, &end, null);
+    m.macrotable.expand(buf2, 0, end, null);
     version (all)
     {
         /* Remove all the escape sequences from buf2,


### PR DESCRIPTION
Pointers should not be used when a `ref` can be.