### PR TITLE
dmacro.d: fix leaky abstraction

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -487,7 +487,7 @@ extern (C++) final class Module : Package
     Identifiers* versionids;    // version identifiers
     Identifiers* versionidsNot; // forward referenced version identifiers
 
-    Macro* macrotable;          // document comment macros
+    MacroTable macrotable;      // document comment macros
     Escape* escapetable;        // document comment escapes
 
     size_t nameoffset;          // offset of module name from start of ModuleInfo

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -13,9 +13,13 @@
 #include "dsymbol.h"
 
 struct ModuleDeclaration;
-struct Macro;
 struct Escape;
 struct FileBuffer;
+
+struct MacroTable
+{
+    void* internal;  // PIMPL
+};
 
 enum PKG
 {
@@ -101,7 +105,7 @@ public:
     Strings *versionids;    // version identifiers
     Strings *versionidsNot;     // forward referenced version identifiers
 
-    Macro *macrotable;          // document comment macros
+    MacroTable macrotable;      // document comment macros
     Escape *escapetable;        // document comment escapes
 
     size_t nameoffset;          // offset of module name from start of ModuleInfo


### PR DESCRIPTION
Macro was leaking the detail that it was a linked list. The list is still there, but it's hidden from users now. Then, we can replace it with a better data structure by not touching any file other than dmacro.d.

This change winds up simplifying the interface, too. Go figure!