### PR TITLE
Fix DIP1000 diagnostics for `return` and add tests for both `return` and `scope`

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1231,11 +1231,6 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
             }
             if (tf.next.hasWild())
                 wildreturn = true;
-
-            if (tf.isreturn && !tf.isref && !tf.next.hasPointers())
-            {
-                tf.isreturn = false;
-            }
         }
 
         ubyte wildparams = 0;

--- a/test/fail_compilation/diag_dip1000.d
+++ b/test/fail_compilation/diag_dip1000.d
@@ -1,0 +1,53 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag_dip1000.d(19): Error: top-level function `testScope` has no `this` to which `scope` can apply
+fail_compilation/diag_dip1000.d(20): Error: top-level function `testReturn` has no `this` to which `return` can apply
+fail_compilation/diag_dip1000.d(22): Error: top-level function `testTemplateScope` has no `this` to which `scope` can apply
+fail_compilation/diag_dip1000.d(23): Error: top-level function `testTemplateReturn` has no `this` to which `return` can apply
+fail_compilation/diag_dip1000.d(27): Error: function `diag_dip1000.S.testScope` `static` member has no `this` to which `scope` can apply
+fail_compilation/diag_dip1000.d(28): Error: function `diag_dip1000.S.testReturn` `static` member has no `this` to which `return` can apply
+fail_compilation/diag_dip1000.d(30): Error: function `diag_dip1000.S.testTemplateScope()().testTemplateScope` `static` member has no `this` to which `scope` can apply
+fail_compilation/diag_dip1000.d(31): Error: function `diag_dip1000.S.testTemplateReturn()().testTemplateReturn` `static` member has no `this` to which `return` can apply
+fail_compilation/diag_dip1000.d(42): Error: function `diag_dip1000.C.testScope` `static` member has no `this` to which `scope` can apply
+fail_compilation/diag_dip1000.d(43): Error: function `diag_dip1000.C.testReturn` `static` member has no `this` to which `return` can apply
+fail_compilation/diag_dip1000.d(45): Error: function `diag_dip1000.C.testTemplateScope()().testTemplateScope` `static` member has no `this` to which `scope` can apply
+fail_compilation/diag_dip1000.d(46): Error: function `diag_dip1000.C.testTemplateReturn()().testTemplateReturn` `static` member has no `this` to which `return` can apply
+---
+*/
+
+void testScope() scope { }
+void testReturn() return { }
+
+void testTemplateScope()() scope { }
+void testTemplateReturn()() return { }
+
+struct S
+{
+    static void testScope() scope { }
+    static void testReturn() return { }
+
+    static void testTemplateScope()() scope { }
+    static void testTemplateReturn()() return { }
+
+    void testScope2() scope { }               // Should not emit an error
+    void testReturn2() return { }             // Should not emit an error
+
+    void testTemplateScope2()() scope { }     // Should not emit an error
+    void testTemplateReturn2()() return { }   // Should not emit an error
+}
+
+class C
+{
+    static void testScope() scope { }
+    static void testReturn() return { }
+
+    static void testTemplateScope()() scope { }
+    static void testTemplateReturn()() return { }
+
+    void testScope2() scope { }               // Should not emit an error
+    void testReturn2() return { }             // Should not emit an error
+
+    void testTemplateScope2()() scope { }     // Should not emit an error
+    void testTemplateReturn2()() return { }   // Should not emit an error
+}

--- a/test/fail_compilation/fail19744.d
+++ b/test/fail_compilation/fail19744.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19744.d(8): Error: Top-level function `test` has no `this` to which `return` can apply
+fail_compilation/fail19744.d(8): Error: top-level function `test` has no `this` to which `return` can apply
 ---
 */
 


### PR DESCRIPTION
I could not find a diagnostic test for when `scope` was used as a function attribute on functions without a `this` context pointer, but the code was there.

Also, `return` was not emitting a similar error for the same reason as `scope`.  I found that the compiler was actually removing the `return` attribute instead of emitting an error.

This PR fixes both.