### PR TITLE
[SAOC] Rvalue ref attribute

### DIFF
--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -161,6 +161,8 @@ class StructDeclaration : public AggregateDeclaration
 public:
     bool zeroInit;              // !=0 if initialize with 0 fill
     bool hasIdentityAssign;     // true if has identity opAssign
+    bool hasCopyAssign;         // true if has copy opAssign
+    bool hasMoveAssign;         // true if has move opAssign
     bool hasIdentityEquals;     // true if has identity opEquals
     bool hasNoFields;           // has no fields
     FuncDeclarations postblits; // Array of postblit functions

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -167,6 +167,7 @@ public:
     FuncDeclaration *postblit;  // aggregate postblit
 
     bool hasCopyCtor;           // copy constructor
+    bool hasMoveCtor;           // move constructor
 
     FuncDeclaration *xeq;       // TypeInfo_Struct.xopEquals
     FuncDeclaration *xcmp;      // TypeInfo_Struct.xopCmp

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -837,7 +837,7 @@ struct ASTBase
 
     extern (C++) final class CtorDeclaration : FuncDeclaration
     {
-        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Type type, bool isCopyCtor = false)
+        extern (D) this(const ref Loc loc, Loc endloc, StorageClass stc, Type type, int isCopyCtor = 0)
         {
             super(loc, endloc, Id.ctor, stc, type);
         }

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3797,6 +3797,8 @@ struct ASTBase
 
     extern (C++) final class TypeReference : TypeNext
     {
+        bool isRvalueRef;
+
         extern (D) this(Type t)
         {
             super(Treference, t);

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -3929,6 +3929,7 @@ struct ASTBase
         bool isnogc;                // true: is @nogc
         bool isproperty;            // can be called without parentheses
         bool isref;                 // true: returns a reference
+        bool isrvalueref;           // true: returns a and rvalue reference
         bool isreturn;              // true: 'this' is returned by ref
         bool isscope;               // true: 'this' is scope
         LINK linkage;               // calling convention
@@ -3956,6 +3957,8 @@ struct ASTBase
 
             if (stc & STC.ref_)
                 this.isref = true;
+            if (stc & STC.rvalueref)
+                this.isrvalueref = true;
             if (stc & STC.return_)
                 this.isreturn = true;
             if (stc & STC.scope_)
@@ -3981,6 +3984,7 @@ struct ASTBase
             t.purity = purity;
             t.isproperty = isproperty;
             t.isref = isref;
+            t.isrvalueref = isrvalueref;
             t.isreturn = isreturn;
             t.isscope = isscope;
             t.iswild = iswild;
@@ -5253,16 +5257,18 @@ struct ASTBase
     {
         Type to;
         ubyte mod = cast(ubyte)~0;
+        bool rvalueRef;
 
         extern (D) this(const ref Loc loc, Expression e, Type t)
         {
             super(loc, TOK.cast_, __traits(classInstanceSize, CastExp), e);
             this.to = t;
         }
-        extern (D) this(const ref Loc loc, Expression e, ubyte mod)
+        extern (D) this(const ref Loc loc, Expression e, ubyte mod, bool rvalueRef = false)
         {
             super(loc, TOK.cast_, __traits(classInstanceSize, CastExp), e);
             this.mod = mod;
+            this.rvalueRef = rvalueRef;
         }
 
         override void accept(Visitor v)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -131,6 +131,7 @@ struct ASTBase
         local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
         returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
         rvalueref           = (1L << 53),   // @rvalue ref
+        rvaluetype          = (1L << 54),   // @rvalue type constructor
 
         safeGroup = STC.safe | STC.trusted | STC.system,
         TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
@@ -6480,6 +6481,7 @@ struct ASTBase
             SCstring(STC.disable, TOK.at, "@disable"),
             SCstring(STC.future, TOK.at, "@__future"),
             SCstring(STC.rvalueref, TOK.at, "@rvalue ref"),
+            SCstring(STC.rvaluetype, TOK.at, "@rvalue"),
             SCstring(0, TOK.reserved)
         ];
         for (int i = 0; table[i].stc; i++)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1690,6 +1690,12 @@ struct ASTBase
                             error("%s", msg);
                         Type.typeinfowild = this;
                     }
+                    if (id == Id.TypeInfo_Rvalue)
+                    {
+                        if (!inObject)
+                            error("%s", msg);
+                        Type.typeinforvalue = this;
+                    }
                     if (id == Id.TypeInfo_Vector)
                     {
                         if (!inObject)
@@ -2723,6 +2729,7 @@ struct ASTBase
         extern (C++) __gshared ClassDeclaration typeinfoinvariant;
         extern (C++) __gshared ClassDeclaration typeinfoshared;
         extern (C++) __gshared ClassDeclaration typeinfowild;
+        extern (C++) __gshared ClassDeclaration typeinforvalue;
         extern (C++) __gshared StringTable!Type stringtable;
         extern (C++) __gshared ubyte[TMAX] sizeTy = ()
             {

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -130,16 +130,17 @@ struct ASTBase
         future              = (1L << 50),   // introducing new base class function
         local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
         returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+        rvalueref           = (1L << 53),   // @rvalue ref
 
         safeGroup = STC.safe | STC.trusted | STC.system,
         TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
-        FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property |
+        FUNCATTR = (STC.ref_ | STC.rvalueref | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property |
                     safeGroup),
     }
 
     extern (C++) __gshared const(StorageClass) STCStorageClass =
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared | STC.property |
-         STC.safeGroup | STC.disable);
+         STC.safeGroup | STC.disable | STC.rvalueref);
 
     enum ENUMTY : int
     {
@@ -6470,6 +6471,7 @@ struct ASTBase
             SCstring(STC.system, TOK.at, "@system"),
             SCstring(STC.disable, TOK.at, "@disable"),
             SCstring(STC.future, TOK.at, "@__future"),
+            SCstring(STC.rvalueref, TOK.at, "@rvalue ref"),
             SCstring(0, TOK.reserved)
         ];
         for (int i = 0; table[i].stc; i++)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -132,16 +132,17 @@ struct ASTBase
         returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
         rvalueref           = (1L << 53),   // @rvalue ref
         rvaluetype          = (1L << 54),   // @rvalue type constructor
+        move                = (1L << 55),   // @move attribute
 
         safeGroup = STC.safe | STC.trusted | STC.system,
         TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
-        FUNCATTR = (STC.ref_ | STC.rvalueref | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property |
+        FUNCATTR = (STC.ref_ | STC.rvalueref | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.move |
                     safeGroup),
     }
 
     extern (C++) __gshared const(StorageClass) STCStorageClass =
         (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ | STC.deprecated_ | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest | STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared | STC.property |
-         STC.safeGroup | STC.disable | STC.rvalueref | STC.rvaluetype);
+         STC.safeGroup | STC.disable | STC.rvalueref | STC.rvaluetype | STC.move);
 
     enum ENUMTY : int
     {
@@ -6569,6 +6570,7 @@ struct ASTBase
             SCstring(STC.future, TOK.at, "@__future"),
             SCstring(STC.rvalueref, TOK.at, "@rvalue ref"),
             SCstring(STC.rvaluetype, TOK.at, "@rvalue"),
+            SCstring(STC.move, TOK.at, "@move"),
             SCstring(0, TOK.reserved)
         ];
         for (int i = 0; table[i].stc; i++)

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -736,6 +736,8 @@ dmd -cov -unittest myprog.d
             "enable the @rvalue / __rvalue type constructor"),
         Feature("nosharedaccess", "noSharedAccess",
             "disable access to shared memory objects"),
+        Feature("moveattribute", "moveAttribute",
+            "enable declaring the move constructor with the @move attribute"),
     ];
 }
 

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -730,6 +730,8 @@ dmd -cov -unittest myprog.d
             "destruct fields of partially constructed objects"),
         Feature("rvaluerefparam", "rvalueRefParam",
             "enable rvalue arguments to ref parameters"),
+        Feature("rvalueattribute", "rvalueAttribute",
+            "enable the @rvalue attribute for ref parameters and ref returns"),
         Feature("nosharedaccess", "noSharedAccess",
             "disable access to shared memory objects"),
     ];

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -732,6 +732,8 @@ dmd -cov -unittest myprog.d
             "enable rvalue arguments to ref parameters"),
         Feature("rvalueattribute", "rvalueAttribute",
             "enable the @rvalue attribute for ref parameters and ref returns"),
+        Feature("rvaluetype", "rvalueType",
+            "enable the @rvalue / __rvalue type constructor"),
         Feature("nosharedaccess", "noSharedAccess",
             "disable access to shared memory objects"),
     ];

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -962,7 +962,7 @@ private final class CppMangleVisitor : Visitor
                 this.mangleNestedFuncPrefix(tf, p);
 
                 if (auto ctor = d.isCtorDeclaration())
-                    buf.writestring(ctor.isCpCtor ? "C2" : "C1");
+                    buf.writestring(ctor.isCpCtor || ctor.isMvCtor ? "C2" : "C1");
                 else if (d.isPrimaryDtor())
                     buf.writestring("D1");
                 else if (d.ident && d.ident == Id.assign)

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1667,7 +1667,10 @@ extern(C++):
     {
         if (substitute(t))
             return;
-        buf.writeByte('R');
+        if (t.isRvalueRef)
+            buf.writeByte('O');
+        else
+            buf.writeByte('R');         auto prev = this.context.push(this.context.res.asType().nextOf());
         CV_qualifiers(t.nextOf());
         headOfType(t.nextOf());
         if (t.nextOf().isConst())

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1670,7 +1670,7 @@ extern(C++):
         if (t.isRvalueRef)
             buf.writeByte('O');
         else
-            buf.writeByte('R');         auto prev = this.context.push(this.context.res.asType().nextOf());
+            buf.writeByte('R');
         CV_qualifiers(t.nextOf());
         headOfType(t.nextOf());
         if (t.nextOf().isConst())

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1235,7 +1235,7 @@ private:
                 if (p.storageClass & (STC.out_ | STC.ref_ | STC.rvalueref))
                 {
                     t = t.referenceTo();
-                    (cast(TypeReference)t).isRvalueRef = (p.storageClass & STC.rvalueref) != 0;
+                    (cast(TypeReference)t).isRvalueRef = (p.storageClass & STC.rvalueref) != 0 || p.type.isrvalue;
                 }
                 else if (p.storageClass & STC.lazy_)
                 {

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -351,7 +351,10 @@ public:
         if (checkImmutableShared(type))
             return;
 
-        buf.writeByte('A'); // mutable
+        if (type.isRvalueRef)
+            buf.writestring("$$Q"); // rvalue ref
+        else
+            buf.writeByte('A'); // mutable
         if (global.params.is64bit)
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
@@ -1229,9 +1232,10 @@ private:
             int mangleParameterDg(size_t n, Parameter p)
             {
                 Type t = p.type;
-                if (p.storageClass & (STC.out_ | STC.ref_))
+                if (p.storageClass & (STC.out_ | STC.ref_ | STC.rvalueref))
                 {
                     t = t.referenceTo();
+                    (cast(TypeReference)t).isRvalueRef = (p.storageClass & STC.rvalueref) != 0;
                 }
                 else if (p.storageClass & STC.lazy_)
                 {

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1588,7 +1588,7 @@ Expression ctfeCast(UnionExp* pue, const ref Loc loc, Type type, Type to, Expres
         return paint();
 
     // Allow casting away const for struct literals
-    if (e.op == TOK.structLiteral && e.type.toBasetype().castMod(0) == to.toBasetype().castMod(0))
+    if (e.op == TOK.structLiteral && e.type.toBasetype().equivalent(to.toBasetype()))
         return paint();
 
     Expression r;

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1565,6 +1565,13 @@ Expression castTo(Expression e, Scope* sc, Type t)
             const(bool) tob_isA = (tob.isintegral() || tob.isfloating());
             const(bool) t1b_isA = (t1b.isintegral() || t1b.isfloating());
 
+            if (t1b.isrvalue != tob.isrvalue && t1b.rvalueOf().equals(tob.rvalueOf()))
+            {
+                result = e.copy();
+                result.type = t;
+                return;
+            }
+
             bool hasAliasThis;
             if (AggregateDeclaration t1ad = isAggregate(t1b))
             {
@@ -2500,8 +2507,10 @@ Expression castTo(Expression e, Scope* sc, Type t)
             Type tb = t.toBasetype();
             Type typeb = e.type.toBasetype();
 
-            if (e.type.equals(t) || typeb.ty != Tarray ||
-                (tb.ty != Tarray && tb.ty != Tsarray))
+            if (e.type.equals(t)
+                || e.type.isrvalue != t.isrvalue && e.type.rvalueOf().equals(t.rvalueOf())
+                || typeb.ty != Tarray
+                || (tb.ty != Tarray && tb.ty != Tsarray))
             {
                 visit(cast(Expression)e);
                 return;

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -356,6 +356,12 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
                         error("%s", msg);
                     Type.typeinfowild = this;
                 }
+                if (id == Id.TypeInfo_Rvalue)
+                {
+                    if (!inObject)
+                        error("%s", msg);
+                    Type.typeinforvalue = this;
+                }
                 if (id == Id.TypeInfo_Vector)
                 {
                     if (!inObject)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -264,7 +264,7 @@ enum STCStorageClass =
     (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
      STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
      STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
-     STC.property | STC.safeGroup | STC.disable | STC.local | STC.rvalueref);
+     STC.property | STC.safeGroup | STC.disable | STC.local | STC.rvalueref | STC.rvaluetype);
 
 /* Accumulator for successive matches.
  */

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -249,12 +249,13 @@ enum STC : long
     future              = (1L << 50),   // introducing new base class function
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
     returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
+    rvalueref           = (1L << 53),   // @rvalue ref
 
     // Group members are mutually exclusive (there can be only one)
     safeGroup = STC.safe | STC.trusted | STC.system,
 
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
-    FUNCATTR = (STC.ref_ | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property |
+    FUNCATTR = (STC.ref_ | STC.rvalueref | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property |
                 STC.safeGroup),
 }
 
@@ -262,7 +263,7 @@ enum STCStorageClass =
     (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
      STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
      STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
-     STC.property | STC.safeGroup | STC.disable | STC.local);
+     STC.property | STC.safeGroup | STC.disable | STC.local | STC.rvalueref);
 
 /* Accumulator for successive matches.
  */

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -250,6 +250,7 @@ enum STC : long
     local               = (1L << 51),   // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
     returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
     rvalueref           = (1L << 53),   // @rvalue ref
+    rvaluetype          = (1L << 54),   // @rvalue type constructor
 
     // Group members are mutually exclusive (there can be only one)
     safeGroup = STC.safe | STC.trusted | STC.system,

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -2130,6 +2130,31 @@ extern (C++) final class TypeInfoWildDeclaration : TypeInfoDeclaration
 
 /***********************************************************
  */
+extern (C++) final class TypeInfoRvalueDeclaration : TypeInfoDeclaration
+{
+    extern (D) this(Type tinfo)
+    {
+        super(tinfo);
+        if (!Type.typeinforvalue)
+        {
+            ObjectNotFound(Id.TypeInfo_Rvalue);
+        }
+        type = Type.typeinforvalue.type;
+    }
+
+    static TypeInfoRvalueDeclaration create(Type tinfo)
+    {
+        return new TypeInfoRvalueDeclaration(tinfo);
+    }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
+}
+
+/***********************************************************
+ */
 extern (C++) final class TypeInfoVectorDeclaration : TypeInfoDeclaration
 {
     extern (D) this(Type tinfo)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -541,6 +541,11 @@ extern (C++) abstract class Declaration : Dsymbol
         return (storage_class & STC.ref_) != 0;
     }
 
+    final bool isRvalueRef() const pure nothrow @nogc @safe
+    {
+        return (storage_class & STC.rvalueref) != 0;
+    }
+
     final bool isFuture() const pure nothrow @nogc @safe
     {
         return (storage_class & STC.future) != 0;

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -251,12 +251,13 @@ enum STC : long
     returninferred      = (1L << 52),   // 'return' has been inferred and should not be part of mangling
     rvalueref           = (1L << 53),   // @rvalue ref
     rvaluetype          = (1L << 54),   // @rvalue type constructor
+    move                = (1L << 55),   // @move attribute
 
     // Group members are mutually exclusive (there can be only one)
     safeGroup = STC.safe | STC.trusted | STC.system,
 
     TYPECTOR = (STC.const_ | STC.immutable_ | STC.shared_ | STC.wild),
-    FUNCATTR = (STC.ref_ | STC.rvalueref | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property |
+    FUNCATTR = (STC.ref_ | STC.rvalueref | STC.nothrow_ | STC.nogc | STC.pure_ | STC.property | STC.move |
                 STC.safeGroup),
 }
 
@@ -264,7 +265,7 @@ enum STCStorageClass =
     (STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.const_ | STC.final_ | STC.abstract_ | STC.synchronized_ |
      STC.deprecated_ | STC.future | STC.override_ | STC.lazy_ | STC.alias_ | STC.out_ | STC.in_ | STC.manifest |
      STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
-     STC.property | STC.safeGroup | STC.disable | STC.local | STC.rvalueref | STC.rvaluetype);
+     STC.property | STC.safeGroup | STC.disable | STC.local | STC.rvalueref | STC.rvaluetype | STC.move);
 
 /* Accumulator for successive matches.
  */

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -668,6 +668,7 @@ class CtorDeclaration : public FuncDeclaration
 {
 public:
     bool isCpCtor;
+    bool isMvCtor;
     Dsymbol *syntaxCopy(Dsymbol *);
     const char *kind() const;
     const char *toChars() const;

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -64,7 +64,7 @@ struct IntRange;
 #define STCgshared      0x40000000LL
 #define STCwild         0x80000000LL    // for "wild" type constructor
 #define STC_TYPECTOR    (STCconst | STCimmutable | STCshared | STCwild)
-#define STC_FUNCATTR    (STCref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem)
+#define STC_FUNCATTR    (STCref | STCrvalueref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem)
 
 #define STCproperty      0x100000000LL
 #define STCsafe          0x200000000LL
@@ -87,6 +87,7 @@ struct IntRange;
 #define STCfuture        0x4000000000000LL // introducing new base class function
 #define STClocal         0x8000000000000LL // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
 #define STCreturninferred 0x10000000000000LL   // 'return' has been inferred and should not be part of mangling
+#define STCrvalueref      0x20000000000000LL   // @rvalue ref
 
 void ObjectNotFound(Identifier *id);
 

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -132,6 +132,7 @@ public:
     bool isIn()  const  { return (storage_class & STCin) != 0; }
     bool isOut() const  { return (storage_class & STCout) != 0; }
     bool isRef() const  { return (storage_class & STCref) != 0; }
+    bool isRvalueRef() const { return (storage_class & STCrvalueref) != 0; }
 
     bool isFuture() const { return (storage_class & STCfuture) != 0; }
 

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -88,6 +88,7 @@ struct IntRange;
 #define STClocal         0x8000000000000LL // do not forward (see dmd.dsymbol.ForwardingScopeDsymbol).
 #define STCreturninferred 0x10000000000000LL   // 'return' has been inferred and should not be part of mangling
 #define STCrvalueref      0x20000000000000LL   // @rvalue ref
+#define STCrvaluetype     0x40000000000000LL   // @rvalue type constructor
 
 void ObjectNotFound(Identifier *id);
 

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -414,6 +414,14 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
+class TypeInfoRvalueDeclaration : public TypeInfoDeclaration
+{
+public:
+    static TypeInfoRvalueDeclaration *create(Type *tinfo);
+
+    void accept(Visitor *v) { v->visit(this); }
+};
+
 class TypeInfoVectorDeclaration : public TypeInfoDeclaration
 {
 public:

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -64,7 +64,7 @@ struct IntRange;
 #define STCgshared      0x40000000LL
 #define STCwild         0x80000000LL    // for "wild" type constructor
 #define STC_TYPECTOR    (STCconst | STCimmutable | STCshared | STCwild)
-#define STC_FUNCATTR    (STCref | STCrvalueref | STCnothrow | STCnogc | STCpure | STCproperty | STCsafe | STCtrusted | STCsystem)
+#define STC_FUNCATTR    (STCref | STCrvalueref | STCnothrow | STCnogc | STCpure | STCproperty | STCmove | STCsafe | STCtrusted | STCsystem)
 
 #define STCproperty      0x100000000LL
 #define STCsafe          0x200000000LL
@@ -89,6 +89,7 @@ struct IntRange;
 #define STCreturninferred 0x10000000000000LL   // 'return' has been inferred and should not be part of mangling
 #define STCrvalueref      0x20000000000000LL   // @rvalue ref
 #define STCrvaluetype     0x40000000000000LL   // @rvalue type constructor
+#define STCmove           0x80000000000000LL   // @move attribute
 
 void ObjectNotFound(Identifier *id);
 

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -81,7 +81,7 @@ private immutable char[TMAX] mangleChar =
     //              K   // K:ref KK:rvalue ref
     //              L   // lazy
     //              M   // has this, or scope
-    //              N   // Nh:vector Ng:wild
+    //              N   // Nh:vector Ng:wild Nr:rvalue
     //              O   // shared
     Tpointer     : 'P',
     //              Q   // Type/symbol/identifier backward reference
@@ -166,6 +166,11 @@ private void MODtoDecoBuffer(OutBuffer* buf, MOD mod)
     default:
         assert(0);
     }
+}
+
+private void rvalueToDecoBuffer(OutBuffer* buf)
+{
+    buf.writestring("Nr");
 }
 
 private extern (C++) final class Mangler : Visitor
@@ -286,6 +291,8 @@ public:
      */
     void visitWithMask(Type t, ubyte modMask)
     {
+        if (t.isrvalue)
+            rvalueToDecoBuffer(buf);
         if (modMask != t.mod)
         {
             MODtoDecoBuffer(buf, t.mod);
@@ -350,6 +357,8 @@ public:
             return;
         }
         t.inuse++;
+        if (t.isrvalue)
+            rvalueToDecoBuffer(buf);
         if (modMask != t.mod)
             MODtoDecoBuffer(buf, t.mod);
 

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -78,7 +78,7 @@ private immutable char[TMAX] mangleChar =
     Taarray      : 'H',
     Tident       : 'I',
     //              J   // out
-    //              K   // ref
+    //              K   // K:ref KK:rvalue ref
     //              L   // lazy
     //              M   // has this, or scope
     //              N   // Nh:vector Ng:wild
@@ -383,7 +383,9 @@ public:
             buf.writestring("Na");
         if (ta.isnothrow)
             buf.writestring("Nb");
-        if (ta.isref)
+        if (ta.isrvalueref)
+            buf.writestring("Nr");
+        else if (ta.isref)
             buf.writestring("Nc");
         if (ta.isproperty)
             buf.writestring("Nd");
@@ -1115,6 +1117,8 @@ public:
             break;
         case STC.ref_:
             buf.writeByte('K');
+            if (p.storageClass & STC.rvalueref)
+                buf.writeByte('K');
             break;
         case STC.lazy_:
             buf.writeByte('L');

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -81,7 +81,7 @@ private immutable char[TMAX] mangleChar =
     //              K   // K:ref KK:rvalue ref
     //              L   // lazy
     //              M   // has this, or scope
-    //              N   // Nh:vector Ng:wild Nr:rvalue
+    //              N   // Nh:vector Ng:wild Nr:rvalue Nm:move
     //              O   // shared
     Tpointer     : 'P',
     //              Q   // Type/symbol/identifier backward reference
@@ -400,6 +400,8 @@ public:
             buf.writestring("Nd");
         if (ta.isnogc)
             buf.writestring("Ni");
+        if (ta.ismove)
+            buf.writestring("Nm");
 
         if (ta.isreturn && !ta.isreturninferred)
             buf.writestring("Nj");
@@ -1126,7 +1128,7 @@ public:
             break;
         case STC.ref_:
             buf.writeByte('K');
-            if (p.storageClass & STC.rvalueref)
+            if (p.storageClass & STC.rvalueref && global.params.rvalueAttribute)
                 buf.writeByte('K');
             break;
         case STC.lazy_:

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -202,6 +202,8 @@ extern (C++) class StructDeclaration : AggregateDeclaration
 {
     bool zeroInit;              // !=0 if initialize with 0 fill
     bool hasIdentityAssign;     // true if has identity opAssign
+    bool hasCopyAssign;         // true if has copy opAssign
+    bool hasMoveAssign;         // true if has move opAssign
     bool hasIdentityEquals;     // true if has identity opEquals
     bool hasNoFields;           // has no fields
     FuncDeclarations postblits; // Array of postblit functions

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -208,6 +208,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
     FuncDeclaration postblit;   // aggregate postblit
 
     bool hasCopyCtor;       // copy constructor
+    bool hasMoveCtor;       // move constructor
 
     FuncDeclaration xeq;        // TypeInfo_Struct.xopEquals
     FuncDeclaration xcmp;       // TypeInfo_Struct.xopCmp
@@ -564,7 +565,7 @@ extern (C++) class StructDeclaration : AggregateDeclaration
 
         ispod = StructPOD.yes;
 
-        if (enclosing || postblit || dtor || hasCopyCtor)
+        if (enclosing || postblit || dtor || hasCopyCtor || hasMoveCtor)
             ispod = StructPOD.no;
 
         // Recursively check all fields are POD.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4847,7 +4847,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         sd.tidtor = buildExternDDtor(sd, sc2);
         sd.postblit = buildPostBlit(sd, sc2);
         auto hasCopyCtor = buildCopyCtor(sd, sc2) != CopyCtor.none;
-        auto hasMoveCtor = buildCopyCtor(sd, sc2, true);
+        auto hasMoveCtor = buildCopyCtor(sd, sc2, true /*moveCtor*/);
         sd.hasCopyCtor = hasCopyCtor != CopyCtor.none;
         sd.hasMoveCtor = hasMoveCtor != CopyCtor.none;
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1591,7 +1591,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                             /* Remove top const for dynamic array types and pointer types
                              */
-                            if ((tt.ty == Tarray || tt.ty == Tpointer) && !tt.isMutable() && (!(fparam.storageClass & STC.ref_) || (fparam.storageClass & (STC.auto_ | STC.rvalueref)) && !farg.isLvalue()))
+                            if ((tt.ty == Tarray || tt.ty == Tpointer) && !tt.isMutable() && (!(fparam.storageClass & STC.ref_) || (fparam.storageClass & (STC.auto_ | STC.rvalueref) || prmtype.isrvalue) && !farg.isLvalue()))
                             {
                                 tt = tt.mutableOf();
                             }
@@ -1865,9 +1865,9 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                         }
                     }
 
-                    if (m > MATCH.nomatch && (fparam.storageClass & (STC.ref_ | STC.auto_ | STC.rvalueref)) == STC.ref_)
+                    if (m > MATCH.nomatch && (fparam.storageClass & (STC.ref_ | STC.auto_ | STC.rvalueref)) == STC.ref_ && !prmtype.isrvalue)
                     {
-                        if (!farg.isLvalue() || farg.isRvalueRef())
+                        if (!farg.isLvalue() || farg.type.isrvalue || farg.isRvalueRef())
                         {
                             if ((farg.op == TOK.string_ || farg.op == TOK.slice) && (prmtype.ty == Tsarray || prmtype.ty == Taarray))
                             {
@@ -1877,14 +1877,14 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                                 goto Lnomatch;
                         }
                     }
-                    if (m > MATCH.nomatch && ((fparam.storageClass & (STC.rvalueref | STC.auto_)) == STC.rvalueref))
+                    if (m > MATCH.nomatch && (fparam.storageClass & STC.rvalueref || prmtype.isrvalue) && !(fparam.storageClass & STC.auto_))
                     {
-                        if (farg.isLvalue() && !farg.isRvalueRef())
+                        if (farg.isLvalue() && farg.type.isrvalue && !farg.isRvalueRef())
                             goto Lnomatch;
                     }
                     if (m > MATCH.nomatch && (fparam.storageClass & STC.out_))
                     {
-                        if (!farg.isLvalue() || farg.isRvalueRef())
+                        if (!farg.isLvalue() || farg.type.isrvalue || farg.isRvalueRef())
                             goto Lnomatch;
                         if (!farg.type.isMutable()) // https://issues.dlang.org/show_bug.cgi?id=11916
                             goto Lnomatch;
@@ -5985,14 +5985,14 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                         Expression farg = fargs && j < fargs.dim ? (*fargs)[j] : fparam.defaultArg;
                         if (!farg)
                             goto Lnotequals;
-                        if (farg.isLvalue() && !farg.isRvalueRef())
+                        if (farg.isLvalue() && !farg.type.isrvalue && !farg.isRvalueRef())
                         {
-                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) != STC.ref_)
+                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) != STC.ref_ || fparam.type.isrvalue)
                                 goto Lnotequals; // auto ref's don't match
                         }
                         else
                         {
-                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) == STC.ref_)
+                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) == STC.ref_ && !fparam.type.isrvalue)
                                 goto Lnotequals; // auto ref's don't match
                         }
                     }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1867,7 +1867,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
 
                     if (m > MATCH.nomatch && (fparam.storageClass & (STC.ref_ | STC.auto_ | STC.rvalueref)) == STC.ref_)
                     {
-                        if (!farg.isLvalue())
+                        if (!farg.isLvalue() || farg.isRvalueRef())
                         {
                             if ((farg.op == TOK.string_ || farg.op == TOK.slice) && (prmtype.ty == Tsarray || prmtype.ty == Taarray))
                             {
@@ -1877,14 +1877,14 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
                                 goto Lnomatch;
                         }
                     }
-                    if (m > MATCH.nomatch && (fparam.storageClass & STC.rvalueref))
+                    if (m > MATCH.nomatch && ((fparam.storageClass & (STC.rvalueref | STC.auto_)) == STC.rvalueref))
                     {
                         if (farg.isLvalue() && !farg.isRvalueRef())
                             goto Lnomatch;
                     }
                     if (m > MATCH.nomatch && (fparam.storageClass & STC.out_))
                     {
-                        if (!farg.isLvalue())
+                        if (!farg.isLvalue() || farg.isRvalueRef())
                             goto Lnomatch;
                         if (!farg.type.isMutable()) // https://issues.dlang.org/show_bug.cgi?id=11916
                             goto Lnomatch;
@@ -5985,14 +5985,14 @@ extern (C++) class TemplateInstance : ScopeDsymbol
                         Expression farg = fargs && j < fargs.dim ? (*fargs)[j] : fparam.defaultArg;
                         if (!farg)
                             goto Lnotequals;
-                        if (farg.isLvalue())
+                        if (farg.isLvalue() && !farg.isRvalueRef())
                         {
-                            if (!(fparam.storageClass & STC.ref_))
+                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) != STC.ref_)
                                 goto Lnotequals; // auto ref's don't match
                         }
                         else
                         {
-                            if (fparam.storageClass & STC.ref_)
+                            if ((fparam.storageClass & (STC.ref_ | STC.rvalueref)) == STC.ref_)
                                 goto Lnotequals; // auto ref's don't match
                         }
                     }

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -3183,14 +3183,16 @@ private Type rawTypeMerge(Type t1, Type t2)
     if (t1.equals(t2))
         return t1;
     if (t1.equivalent(t2))
-        return t1.castMod(MODmerge(t1.mod, t2.mod));
+        return t1.castMod(MODmerge(t1.mod, t2.mod))
+                 .castRvalue(rvalueMerge(t1.isrvalue, t2.isrvalue));
 
     auto t1b = t1.toBasetype();
     auto t2b = t2.toBasetype();
     if (t1b.equals(t2b))
         return t1b;
     if (t1b.equivalent(t2b))
-        return t1b.castMod(MODmerge(t1b.mod, t2b.mod));
+        return t1b.castMod(MODmerge(t1b.mod, t2b.mod))
+                  .castRvalue(rvalueMerge(t1b.isrvalue, t2b.isrvalue));
 
     auto ty = cast(TY)impcnvResult[t1b.ty][t2b.ty];
     if (ty != Terror)

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1945,6 +1945,12 @@ private void escapeByRef(Expression e, EscapeByResults* er)
             else
                 er.byexp.push(e);
         }
+
+        override void visit(CastExp e)
+        {
+            if (e.rvalueRef)
+                e.e1.accept(this);
+        }
     }
 
     scope EscapeRefVisitor v = new EscapeRefVisitor(er);

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -5171,6 +5171,7 @@ extern (C++) final class CastExp : UnaExp
     Type to;                    // type to cast to
     ubyte mod = cast(ubyte)~0;  // MODxxxxx
     bool rvalueRef;             // @rvalue ref
+    bool rvalueType;            // @rvalue type modifier
 
     extern (D) this(const ref Loc loc, Expression e, Type t)
     {
@@ -5189,7 +5190,10 @@ extern (C++) final class CastExp : UnaExp
 
     override Expression syntaxCopy()
     {
-        return to ? new CastExp(loc, e1.syntaxCopy(), to.syntaxCopy()) : new CastExp(loc, e1.syntaxCopy(), mod);
+        CastExp ce = to ? new CastExp(loc, e1.syntaxCopy(), to.syntaxCopy()) : new CastExp(loc, e1.syntaxCopy(), mod);
+        ce.rvalueRef = rvalueRef;
+        ce.rvalueType = rvalueType;
+        return ce;
     }
 
     override Expression addDtorHook(Scope* sc)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3835,6 +3835,7 @@ extern (C++) final class FuncExp : Expression
             auto tfy = new TypeFunction(tfx.parameterList, tof.next,
                         tfx.linkage, STC.undefined_);
             tfy.mod = tfx.mod;
+            tfy.isrvalue = tfx.isrvalue;
             tfy.isnothrow = tfx.isnothrow;
             tfy.isnogc = tfx.isnogc;
             tfy.purity = tfx.purity;
@@ -3860,7 +3861,7 @@ extern (C++) final class FuncExp : Expression
         }
         //printf("\ttx = %s, to = %s\n", tx.toChars(), to.toChars());
 
-        MATCH m = tx.implicitConvTo(to);
+        MATCH m = tx.implicitConvTo(to.lvalueOf());
         if (m > MATCH.nomatch)
         {
             // MATCH.exact:      exact type match

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3885,6 +3885,8 @@ extern (C++) final class FuncExp : Expression
             tfy.purity = tfx.purity;
             tfy.isproperty = tfx.isproperty;
             tfy.isref = tfx.isref;
+            tfy.isrvalueref = tfx.isrvalueref;
+            tfy.ismove = tfx.ismove;
             tfy.iswild = tfx.iswild;
             tfy.deco = tfy.merge().deco;
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1938,7 +1938,7 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             }
             if (p.storageClass & STC.ref_)
             {
-                if (global.params.rvalueRefParam &&
+                if ((global.params.rvalueRefParam || p.storageClass & STC.rvalueref) &&
                     !arg.isLvalue() &&
                     targ.isCopyable())
                 {   /* allow rvalues to be passed to ref parameters by copying
@@ -6914,6 +6914,24 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         if (auto e = unaSemantic(exp, sc))
         {
             result = e;
+            return;
+        }
+
+        if (exp.rvalueRef)
+        {
+            if (exp.e1.isRvalueRef())
+            {
+                result = exp.e1;
+                return;
+            }
+            if (!exp.e1.isLvalue())
+            {
+                exp.error("cannot cast rvalue `%s` to `@rvalue ref`", exp.toChars());
+                return setError();
+            }
+            exp.to = exp.e1.type;
+            exp.type = exp.e1.type;
+            result = exp;
             return;
         }
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -4078,6 +4078,31 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             }
         }
 
+        if (exp.e1.op == TOK.identifier && (cast(IdentifierExp)exp.e1).ident == Id.__move)
+        {
+            expandTuples(exp.arguments);
+            if (exp.arguments.length != 1)
+            {
+                if (exp.arguments.length == 0)
+                    exp.error("`__move` requires an argument`");
+                else
+                    exp.error("`__move` takes only one argument`");
+                return setError();
+            }
+
+            Expression ex = (*exp.arguments)[0].expressionSemantic(sc);
+            if (ex.op == TOK.error)
+            {
+                result = ex;
+                return;
+            }
+            if (!ex.isLvalue())
+                result = ex;
+            else
+                result = moveExp(exp.loc, ex).expressionSemantic(sc);
+            return;
+        }
+
         if (Expression ex = resolveUFCS(sc, exp))
         {
             result = ex;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1032,7 +1032,7 @@ extern (C++) class FuncDeclaration : Declaration
         {
             Parameter p = tf.parameterList[u];
             Expression e;
-            if (p.storageClass & (STC.ref_ | STC.out_))
+            if (p.storageClass & (STC.ref_ | STC.out_) && !(p.storageClass & STC.rvalueref))
             {
                 e = new IdentifierExp(Loc.initial, p.ident);
                 e.type = p.type;
@@ -2084,6 +2084,8 @@ extern (C++) class FuncDeclaration : Declaration
             TypeFunction tf = type.toTypeFunction();
             if (tf.isref)
                 vresult.storage_class |= STC.ref_;
+            if (tf.isrvalueref)
+                vresult.storage_class |= STC.rvalueref;
             vresult.type = tret;
 
             vresult.dsymbolSemantic(sc);
@@ -2249,7 +2251,7 @@ extern (C++) class FuncDeclaration : Declaration
             {
                 p = p.syntaxCopy();
                 if (!(p.storageClass & STC.lazy_))
-                    p.storageClass = (p.storageClass | STC.ref_) & ~STC.out_;
+                    p.storageClass = (p.storageClass | STC.ref_) & ~(STC.out_ | STC.rvalueref);
                 p.defaultArg = null; // won't be the same with ref
                 result.push(p);
                 return 0;

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3423,23 +3423,27 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
 extern (C++) final class CtorDeclaration : FuncDeclaration
 {
     bool isCpCtor;
-    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Type type, bool isCpCtor = false)
+    bool isMvCtor;
+    extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc, Type type, int isCpCtor = 0)
     {
         super(loc, endloc, Id.ctor, stc, type);
-        this.isCpCtor = isCpCtor;
+        if (isCpCtor == 1)
+            this.isCpCtor = true;
+        else if (isCpCtor == 2)
+            this.isMvCtor = true;
         //printf("CtorDeclaration(loc = %s) %s\n", loc.toChars(), toChars());
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        auto f = new CtorDeclaration(loc, endloc, storage_class, type.syntaxCopy());
+        auto f = new CtorDeclaration(loc, endloc, storage_class, type.syntaxCopy(), isMvCtor ? 2 : isCpCtor);
         return FuncDeclaration.syntaxCopy(f);
     }
 
     override const(char)* kind() const
     {
-        return isCpCtor ? "copy constructor" : "constructor";
+        return isCpCtor ? "copy constructor" : isMvCtor ? "move constructor" : "constructor";
     }
 
     override const(char)* toChars() const

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -178,6 +178,7 @@ extern (C++) struct Param
                             // https://issues.dlang.org/show_bug.cgi?id=14246
     bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
     bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
+    bool rvalueAttribute;   // @rvalue attribute for ref parameters and ref returns
 
     CppStdRevision cplusplus = CppStdRevision.cpp98;    // version of C++ standard to support
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -179,6 +179,7 @@ extern (C++) struct Param
     bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
     bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
     bool rvalueAttribute;   // @rvalue attribute for ref parameters and ref returns
+    bool rvalueType;        // @rvalue type constructor
 
     CppStdRevision cplusplus = CppStdRevision.cpp98;    // version of C++ standard to support
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -180,6 +180,7 @@ extern (C++) struct Param
     bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
     bool rvalueAttribute;   // @rvalue attribute for ref parameters and ref returns
     bool rvalueType;        // @rvalue type constructor
+    bool moveAttribute;     // @move attribute for declaring the move constructor & opAssing
 
     CppStdRevision cplusplus = CppStdRevision.cpp98;    // version of C++ standard to support
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2728,6 +2728,7 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.disable, TOK.at, "@disable"),
         SCstring(STC.future, TOK.at, "@__future"),
         SCstring(STC.local, TOK.at, "__local"),
+        SCstring(STC.rvalueref, TOK.at, "@rvalue ref"),
         SCstring(0, TOK.reserved)
     ];
     for (int i = 0; table[i].stc; i++)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2731,6 +2731,7 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.future, TOK.at, "@__future"),
         SCstring(STC.local, TOK.at, "__local"),
         SCstring(STC.rvalueref, TOK.at, "@rvalue ref"),
+        SCstring(STC.rvaluetype, TOK.at, "@rvalue"),
         SCstring(0, TOK.reserved)
     ];
     for (int i = 0; table[i].stc; i++)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2375,6 +2375,12 @@ public:
             typeToBuffer(e.to, null, buf, hgs);
         else
         {
+            if (e.rvalueType)
+            {
+                buf.writestring("@rvalue");
+                if (e.mod && e.mod != cast(ubyte)~0)
+                    buf.writeByte(' ');
+            }
             MODtoBuffer(buf, e.mod);
         }
         buf.writeByte(')');
@@ -3199,12 +3205,17 @@ private void typeToBuffer(Type t, const Identifier ident, OutBuffer* buf, HdrGen
 private void visitWithMask(Type t, ubyte modMask, OutBuffer* buf, HdrGenState* hgs)
 {
     // Tuples and functions don't use the type constructor syntax
-    if (modMask == t.mod || t.ty == Tfunction || t.ty == Ttuple)
+    if (!t.isrvalue && modMask == t.mod || t.ty == Tfunction || t.ty == Ttuple)
     {
         typeToBufferx(t, buf, hgs);
     }
     else
     {
+        if (t.isrvalue)
+        {
+            stcToBuffer(buf, STC.rvaluetype);
+            buf.writeByte('(');
+        }
         ubyte m = t.mod & ~(t.mod & modMask);
         if (m & MODFlags.shared_)
         {
@@ -3227,6 +3238,8 @@ private void visitWithMask(Type t, ubyte modMask, OutBuffer* buf, HdrGenState* h
         if (m & MODFlags.wild)
             buf.writeByte(')');
         if (m & MODFlags.shared_)
+            buf.writeByte(')');
+        if (t.isrvalue)
             buf.writeByte(')');
     }
 }

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2369,7 +2369,9 @@ public:
     override void visit(CastExp e)
     {
         buf.writestring("cast(");
-        if (e.to)
+        if (e.rvalueRef)
+            buf.writestring("@rvalue ref");
+        else if (e.to)
             typeToBuffer(e.to, null, buf, hgs);
         else
         {
@@ -3015,6 +3017,8 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
 
     if (p.storageClass & STC.out_)
         buf.writestring("out ");
+    else if (p.storageClass & STC.rvalueref)
+        buf.writestring("@rvalue ref ");
     else if (p.storageClass & STC.ref_)
         buf.writestring("ref ");
     else if (p.storageClass & STC.in_)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -2368,6 +2368,13 @@ public:
 
     override void visit(CastExp e)
     {
+        if (e.rvalueRef && global.params.moveAttribute)
+        {
+            buf.writestring("__move(");
+            expToBuffer(e.e1, precedence[e.op], buf, hgs);
+            buf.writeByte(')');
+            return;
+        }
         buf.writestring("cast(");
         if (e.rvalueRef)
             buf.writestring("@rvalue ref");
@@ -2738,6 +2745,7 @@ string stcToString(ref StorageClass stc)
         SCstring(STC.local, TOK.at, "__local"),
         SCstring(STC.rvalueref, TOK.at, "@rvalue ref"),
         SCstring(STC.rvaluetype, TOK.at, "@rvalue"),
+        SCstring(STC.move, TOK.at, "@move"),
         SCstring(0, TOK.reserved)
     ];
     for (int i = 0; table[i].stc; i++)
@@ -3024,7 +3032,7 @@ private void parameterToBuffer(Parameter p, OutBuffer* buf, HdrGenState* hgs)
 
     if (p.storageClass & STC.out_)
         buf.writestring("out ");
-    else if (p.storageClass & STC.rvalueref)
+    else if (p.storageClass & STC.rvalueref && global.params.rvalueAttribute)
         buf.writestring("@rvalue ref ");
     else if (p.storageClass & STC.ref_)
         buf.writestring("ref ");

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -155,6 +155,7 @@ immutable Msgtable[] msgtable =
     { "TypeInfo_Invariant" },
     { "TypeInfo_Shared" },
     { "TypeInfo_Wild", "TypeInfo_Inout" },
+    { "TypeInfo_Rvalue" },
     { "elements" },
     { "_arguments_typeinfo" },
     { "_arguments" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -136,6 +136,7 @@ immutable Msgtable[] msgtable =
     { "_assert", "assert" },
     { "_unittest", "unittest" },
     { "_body", "body" },
+    { "rvalue" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -403,6 +403,7 @@ immutable Msgtable[] msgtable =
     { "isModule" },
     { "isPackage" },
     { "isRef" },
+    { "isRvalueRef" },
     { "isOut" },
     { "isLazy" },
     { "hasMember" },

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -137,6 +137,8 @@ immutable Msgtable[] msgtable =
     { "_unittest", "unittest" },
     { "_body", "body" },
     { "rvalue" },
+    { "move" },
+    { "__move" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -2145,7 +2145,7 @@ private void expandInline(Loc callLoc, FuncDeclaration fd, FuncDeclaration paren
             auto ei = new ExpInitializer(callLoc, e);
             auto tmp = Identifier.generateId("__inlineretval");
             auto vd = new VarDeclaration(callLoc, tf.next, tmp, ei);
-            vd.storage_class = STC.temp | (tf.isref ? STC.ref_ : STC.rvalue);
+            vd.storage_class = STC.temp | (tf.isref ? STC.ref_ : STC.rvalue) | (tf.isrvalueref ? STC.rvalueref : 0);
             vd.linkage = tf.linkage;
             vd.parent = parent;
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -538,7 +538,7 @@ extern (C++) abstract class Type : ASTNode
 
     final bool equivalent(Type t)
     {
-        return immutableOf().equals(t.immutableOf());
+        return immutableOf().lvalueOf().equals(t.immutableOf().lvalueOf());
     }
 
     // kludge for template.isType()

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4057,6 +4057,8 @@ extern (C++) final class TypePointer : TypeNext
  */
 extern (C++) final class TypeReference : TypeNext
 {
+    bool isRvalueRef;
+
     extern (D) this(Type t)
     {
         super(Treference, t);

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -464,6 +464,7 @@ extern (C++) abstract class Type : ASTNode
     extern (C++) __gshared ClassDeclaration typeinfoinvariant;
     extern (C++) __gshared ClassDeclaration typeinfoshared;
     extern (C++) __gshared ClassDeclaration typeinfowild;
+    extern (C++) __gshared ClassDeclaration typeinforvalue;
 
     extern (C++) __gshared TemplateDeclaration rtinfo;
 

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -4285,6 +4285,7 @@ extern (C++) final class TypeFunction : TypeNext
     bool isproperty;            // can be called without parentheses
     bool isref;                 // true: returns a reference
     bool isrvalueref;           // true: returns a and rvalue reference
+    bool ismove;                // true: is @move
     bool isreturn;              // true: 'this' is returned by ref
     bool isscope;               // true: 'this' is scope
     bool isreturninferred;      // true: 'this' is return from inference
@@ -4319,6 +4320,8 @@ extern (C++) final class TypeFunction : TypeNext
             this.isref = true;
         if (stc & STC.rvalueref)
             this.isrvalueref = true;
+        if (stc & STC.move)
+            this.ismove = true;
         if (stc & STC.return_)
             this.isreturn = true;
         if (stc & STC.returninferred)
@@ -4360,6 +4363,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isproperty = isproperty;
         t.isref = isref;
         t.isrvalueref = isrvalueref;
+        t.ismove = ismove;
         t.isreturn = isreturn;
         t.isscope = isscope;
         t.isreturninferred = isreturninferred;
@@ -4637,6 +4641,7 @@ extern (C++) final class TypeFunction : TypeNext
             tf.isproperty = t.isproperty;
             tf.isref = t.isref;
             tf.isrvalueref = t.isrvalueref;
+            tf.ismove = t.ismove;
             tf.isreturn = t.isreturn;
             tf.isscope = t.isscope;
             tf.isreturninferred = t.isreturninferred;
@@ -4703,6 +4708,7 @@ extern (C++) final class TypeFunction : TypeNext
         t.isproperty = isproperty;
         t.isref = isref;
         t.isrvalueref = isrvalueref;
+        t.ismove = ismove;
         t.isreturn = isreturn;
         t.isscope = isscope;
         t.isreturninferred = isreturninferred;
@@ -6917,6 +6923,8 @@ void attributesApply(const TypeFunction tf, void delegate(string) dg, TRUSTforma
         dg("@rvalue ref");
     else if (tf.isref)
         dg("ref");
+    if (tf.ismove)
+        dg("@move");
     if (tf.isreturn && !tf.isreturninferred)
         dg("return");
     if (tf.isscope && !tf.isscopeinferred)

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -128,6 +128,7 @@ public:
     TY ty;
     MOD mod;  // modifiers MODxxxx
     char *deco;
+    bool isrvalue;
 
     /* These are cached values that are lazily evaluated by constOf(), immutableOf(), etc.
      * They should not be referenced by anybody but mtype.c.
@@ -144,6 +145,8 @@ public:
     Type *wcto;         // MODwildconst             ? naked version of this type : wild const version
     Type *swto;         // MODshared | MODwild      ? naked version of this type : shared wild version
     Type *swcto;        // MODshared | MODwildconst ? naked version of this type : shared wild const version
+
+    Type *rvto;          // MODrvalue                ? naked version of this type : rvalue version
 
     Type *pto;          // merged pointer to this type
     Type *rto;          // reference to this type
@@ -269,6 +272,8 @@ public:
     Type *wildConstOf();
     Type *sharedWildOf();
     Type *sharedWildConstOf();
+    Type *rvalueOf();
+    Type *lvalueOf();
     void fixTo(Type *t);
     void check();
     Type *addSTC(StorageClass stc);
@@ -289,6 +294,7 @@ public:
     virtual Type *makeSharedWild();
     virtual Type *makeSharedWildConst();
     virtual Type *makeMutable();
+    virtual Type *makeRvalue();
     virtual Dsymbol *toDsymbol(Scope *sc);
     virtual Type *toBasetype();
     virtual bool isBaseOf(Type *t, int *poffset);

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -585,6 +585,7 @@ public:
     bool isnogc;        // true: is @nogc
     bool isproperty;    // can be called without parentheses
     bool isref;         // true: returns a reference
+    bool isrvalueref;   // true: returns an rvalue reference
     bool isreturn;      // true: 'this' is returned by ref
     bool isscope;       // true: 'this' is scope
     bool isreturninferred;      // true: 'this' is return from inference

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -280,6 +280,7 @@ public:
     Type *addSTC(StorageClass stc);
     Type *castMod(MOD mod);
     Type *addMod(MOD mod);
+    Type *castRvalue(bool on);
     virtual Type *addStorageClass(StorageClass stc);
     Type *pointerTo();
     Type *referenceTo();

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -214,6 +214,7 @@ public:
     static ClassDeclaration *typeinfoinvariant;
     static ClassDeclaration *typeinfoshared;
     static ClassDeclaration *typeinfowild;
+    static ClassDeclaration *typeinforvalue;
 
     static TemplateDeclaration *rtinfo;
 

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -846,7 +846,8 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
             if (e.op == TOK.assign && ad1 == ad2)
             {
                 StructDeclaration sd = ad1.isStructDeclaration();
-                if (sd && !sd.hasIdentityAssign)
+                const isRv = !e.e2.isLvalue() || e.e2.type.isrvalue || e.e2.isRvalueRef;
+                if (sd && !sd.hasIdentityAssign && (isRv ? !sd.hasMoveAssign : !sd.hasCopyAssign))
                 {
                     /* This is bitwise struct assignment. */
                     return;

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -627,6 +627,11 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
             Expression e1old = e.e1;
             if (expOptimize(e.e1, result))
                 return;
+            if (e.rvalueRef)
+            {
+                ret = e;
+                return;
+            }
             e.e1 = fromConstInitializer(result, e.e1);
             if (e.e1 == e1old && e.e1.op == TOK.arrayLiteral && e.type.toBasetype().ty == Tpointer && e.e1.type.toBasetype().ty != Tsarray)
             {

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1419,6 +1419,8 @@ final class Parser(AST) : Lexer
             }
             if (!stc && token.ident == Id.rvalue && global.params.rvalueType)
                 stc = STC.rvaluetype;
+            if (!stc && token.ident == Id.move && global.params.moveAttribute)
+                stc = STC.move;
             if (!stc)
             {
                 // Allow identifier, template instantiation, or function call

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -8392,7 +8392,7 @@ final class Parser(AST) : Lexer
                 {
                     nextToken();
                     e = parseUnaryExp();
-                    e = new AST.CastExp(loc, e, m);
+                    e = new AST.CastExp(loc, e, m, rvalueRef);
                 }
                 else
                 {

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -891,6 +891,9 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             }
                         }
 
+                        if (f.isref && tret.isrvalue && !exp.type.isrvalue && exp.isLvalue())
+                            exp.error("cannot return lvalue as `@rvalue`, perhaps you meant `cast(@rvalue)%s`", exp.toChars());
+
                         const hasCopyCtor = exp.type.ty == Tstruct && (cast(TypeStruct)exp.type).sym.hasCopyCtor;
                         // if a copy constructor is present, the return type conversion will be handled by it
                         if (!hasCopyCtor)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -581,6 +581,8 @@ private extern(C++) final class Semantic3Visitor : Visitor
                     funcdecl.nrvo_can = 0;
 
                 bool inferRef = (f.isref && (funcdecl.storage_class & STC.auto_));
+                if (inferRef)
+                    f.isrvalueref = true;
 
                 funcdecl.fbody = funcdecl.fbody.statementSemantic(sc2);
                 if (!funcdecl.fbody)
@@ -622,7 +624,10 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             continue;
                         }
                         if (inferRef && f.isref && !exp.type.constConv(f.next)) // https://issues.dlang.org/show_bug.cgi?id=13336
+                        {
                             f.isref = false;
+                            f.isrvalueref = false;
+                        }
                         i++;
                     }
                 }

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -582,7 +582,12 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                 bool inferRef = (f.isref && (funcdecl.storage_class & STC.auto_));
                 if (inferRef)
+                {
+                    // consider `@rvalue ref` as candidate
                     f.isrvalueref = true;
+                    if (f.next)
+                        f.next = f.next.rvalueOf();
+                }
 
                 funcdecl.fbody = funcdecl.fbody.statementSemantic(sc2);
                 if (!funcdecl.fbody)

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3223,7 +3223,7 @@ else
                 {
                     tf.next = rs.exp.type;
                     inferRvalueRef = inferRef;
-                    if (inferRvalueRef)
+                    if (inferRvalueRef || !inferRef)
                         tf.next = tf.next.lvalueOf();
                 }
                 else if (tret.ty != Terror && !rs.exp.type.equals(tret))

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -836,7 +836,7 @@ struct TargetCPP
         if (p.storageClass & (STC.out_ | STC.ref_ | STC.rvalueref))
         {
             t = t.referenceTo();
-            (cast(TypeReference)t).isRvalueRef = (p.storageClass & STC.rvalueref) != 0;
+            (cast(TypeReference)t).isRvalueRef = (p.storageClass & STC.rvalueref) != 0 || p.type.isrvalue;
         }
         else if (p.storageClass & STC.lazy_)
         {

--- a/src/dmd/target.d
+++ b/src/dmd/target.d
@@ -833,8 +833,11 @@ struct TargetCPP
     extern (C++) Type parameterType(Parameter p)
     {
         Type t = p.type.merge2();
-        if (p.storageClass & (STC.out_ | STC.ref_))
+        if (p.storageClass & (STC.out_ | STC.ref_ | STC.rvalueref))
+        {
             t = t.referenceTo();
+            (cast(TypeReference)t).isRvalueRef = (p.storageClass & STC.rvalueref) != 0;
+        }
         else if (p.storageClass & STC.lazy_)
         {
             // Mangle as delegate

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1011,6 +1011,20 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
         dtb.xoff(toSymbol(tm.vtinfo), 0);
     }
 
+    override void visit(TypeInfoRvalueDeclaration d)
+    {
+        //printf("TypeInfoRvalueDeclaration.toDt() %s\n", toChars());
+        verifyStructSize(Type.typeinforvalue, 3 * target.ptrsize);
+
+        dtb.xoff(toVtblSymbol(Type.typeinforvalue), 0);   // vtbl for TypeInfo_Rvalue
+        if (Type.typeinforvalue.hasMonitor())
+            dtb.size(0);                                 // monitor
+        Type tm = d.tinfo.lvalueOf();
+        tm = tm.merge();
+        genTypeInfo(d.loc, tm, null);
+        dtb.xoff(toSymbol(tm.vtinfo), 0);
+    }
+
     override void visit(TypeInfoEnumDeclaration d)
     {
         //printf("TypeInfoEnumDeclaration.toDt()\n");

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -286,6 +286,7 @@ enum TOK : ubyte
 
     objcClassReference,
     vectorArray,
+    rvalue,
 
     max_,
 }
@@ -419,6 +420,7 @@ private immutable TOK[] keywords =
     TOK.prettyFunction,
     TOK.shared_,
     TOK.immutable_,
+    TOK.rvalue,
 ];
 
 /***********************************************************
@@ -697,6 +699,7 @@ extern (C++) struct Token
 
         TOK.objcClassReference: "class",
         TOK.vectorArray: "vectorarray",
+        TOK.rvalue: "__rvalue",
     ];
 
     static assert(() {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -115,6 +115,7 @@ shared static this()
         "isModule",
         "isPackage",
         "isRef",
+        "isRvalueRef",
         "isOut",
         "isLazy",
         "isReturnOnStack",
@@ -742,7 +743,14 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         if (dim != 1)
             return dimError(1);
 
-        return isDeclX(d => d.isRef());
+        return isDeclX(d => d.isRef() && !d.isRvalueRef());
+    }
+    if (e.ident == Id.isRvalueRef)
+    {
+        if (dim != 1)
+            return dimError(1);
+
+        return isDeclX(d => d.isRvalueRef());
     }
     if (e.ident == Id.isOut)
     {

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1345,6 +1345,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
 
         if (stc & STC.out_)
             push("out");
+        else if (stc & STC.rvalueref)
+            push("@rvalue ref");
         else if (stc & STC.ref_)
             push("ref");
         else if (stc & STC.in_)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1531,15 +1531,17 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                     Expression farg = mtype.fargs && i < mtype.fargs.dim ? (*mtype.fargs)[i] : fparam.defaultArg;
                     if (farg && (fparam.storageClass & (STC.ref_ | STC.rvalueref)))
                     {
-                        if (farg.isLvalue() && !farg.isRvalueRef())
+                        if (farg.isLvalue() && !farg.type.isrvalue && !farg.isRvalueRef())
                         {
                             // ref parameter
                             fparam.storageClass &= ~STC.rvalueref;
+                            fparam.storageClass &= ~STC.rvaluetype;
+                            fparam.type = fparam.type.lvalueOf();
                         }
                         else
                         {
                             // value or rvalue ref parameter
-                            if (!(fparam.storageClass & STC.rvalueref))
+                            if (!fparam.type.isrvalue && !(fparam.storageClass & STC.rvalueref))
                                 fparam.storageClass &= ~STC.ref_;
                         }
                         fparam.storageClass &= ~STC.auto_;    // https://issues.dlang.org/show_bug.cgi?id=14656

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -197,7 +197,7 @@ private void resolveHelper(TypeQualified mt, const ref Loc loc, Scope* sc, Dsymb
     {
         /* Look for what user might have intended
          */
-        const p = mt.mutableOf().unSharedOf().toChars();
+        const p = mt.mutableOf().unSharedOf().lvalueOf().toChars();
         auto id = Identifier.idPool(p, cast(uint)strlen(p));
         if (const n = importHint(id.toString()))
             error(loc, "`%s` is not defined, perhaps `import %.*s;` ?", p, cast(int)n.length, n.ptr);

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1295,6 +1295,9 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                 if (fparam.storageClass & STC.rvalueref)
                     fparam.storageClass |= STC.ref_;
 
+                if (i == 0 && tf.ismove)
+                    fparam.storageClass |= STC.rvalueref;
+
                 fparam.type = fparam.type.addStorageClass(fparam.storageClass);
 
                 if (fparam.storageClass & (STC.auto_ | STC.alias_ | STC.static_))

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -57,7 +57,9 @@ void genTypeInfo(Loc loc, Type torig, Scope* sc)
     Type t = torig.merge2(); // do this since not all Type's are merge'd
     if (!t.vtinfo)
     {
-        if (t.isShared()) // does both 'shared' and 'shared const'
+        if (t.isrvalue) // does the rest of the modifiers as well
+            t.vtinfo = TypeInfoRvalueDeclaration.create(t);
+        else if (t.isShared()) // does both 'shared' and 'shared const'
             t.vtinfo = TypeInfoSharedDeclaration.create(t);
         else if (t.isConst())
             t.vtinfo = TypeInfoConstDeclaration.create(t);
@@ -249,7 +251,7 @@ bool isSpeculativeType(Type t)
 private bool builtinTypeInfo(Type t)
 {
     if (t.isTypeBasic() || t.ty == Tclass || t.ty == Tnull)
-        return !t.mod;
+        return !t.mod && !t.isrvalue;
     if (t.ty == Tarray)
     {
         Type next = t.nextOf();

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -58,6 +58,7 @@ public:
     void visit(ASTCodegen.TypeInfoConstDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
     void visit(ASTCodegen.TypeInfoInvariantDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
     void visit(ASTCodegen.TypeInfoSharedDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
+    void visit(ASTCodegen.TypeInfoRvalueDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
     void visit(ASTCodegen.TypeInfoWildDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
     void visit(ASTCodegen.TypeInfoVectorDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }
     void visit(ASTCodegen.FuncAliasDeclaration s) { visit(cast(ASTCodegen.FuncDeclaration)s); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -150,6 +150,7 @@ class TypeInfoTupleDeclaration;
 class TypeInfoConstDeclaration;
 class TypeInfoInvariantDeclaration;
 class TypeInfoSharedDeclaration;
+class TypeInfoRvalueDeclaration;
 class TypeInfoWildDeclaration;
 class TypeInfoVectorDeclaration;
 
@@ -606,6 +607,7 @@ public:
     virtual void visit(TypeInfoInvariantDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoSharedDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoWildDeclaration *s) { visit((TypeInfoDeclaration *)s); }
+    virtual void visit(TypeInfoRvalueDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(TypeInfoVectorDeclaration *s) { visit((TypeInfoDeclaration *)s); }
     virtual void visit(FuncAliasDeclaration *s) { visit((FuncDeclaration *)s); }
     virtual void visit(ErrorInitializer *i) { visit((Initializer *)i); }

--- a/test/compilable/movctor0.d
+++ b/test/compilable/movctor0.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+
+extern(C++) struct S
+{
+    this(@rvalue ref S);
+}
+
+version(Posix)
+    static assert(S.__ctor.mangleof == "_ZN1SC2EOS_");
+else version(Win32)
+    static assert(S.__ctor.mangleof == "??0S@@QAE@$$QAU0@@Z");
+else version(Win64)
+    static assert(S.__ctor.mangleof == "??0S@@QEAA@$$QEAU0@@Z");

--- a/test/compilable/rvalue_attrib.d
+++ b/test/compilable/rvalue_attrib.d
@@ -1,0 +1,16 @@
+// REQUIRED_ARGS: -preview=rvalueattribute
+
+static if (0) // test the parser only
+{
+@rvalue ref int func(@rvalue ref int);
+void func(in @rvalue ref int);
+
+auto f = function @rvalue ref () {};
+auto f = delegate @rvalue ref () {};
+auto f = @rvalue ref () {};
+auto f = function @rvalue ref () => 0;
+auto f = delegate @rvalue ref () => 0;
+auto f = @rvalue ref () => 0;
+
+auto c = cast(@rvalue ref) 0;
+}

--- a/test/compilable/rvalue_attrib1.d
+++ b/test/compilable/rvalue_attrib1.d
@@ -1,0 +1,11 @@
+// REQUIRED_ARGS: -preview=rvalueattribute
+
+ref int get1();
+@rvalue ref int get2();
+
+void test()
+{
+    auto a = cast(@rvalue ref) get1();
+    auto b = cast(@rvalue ref) get2();
+    auto c = cast(@rvalue ref) cast(@rvalue ref) a;
+}

--- a/test/compilable/rvalue_attrib2.d
+++ b/test/compilable/rvalue_attrib2.d
@@ -1,0 +1,8 @@
+// REQUIRED_ARGS: -preview=rvalueattribute
+
+void fun(ref int a, @rvalue ref int b)
+{
+    static assert(__traits(isRef, a));
+    static assert(__traits(isRvalueRef, b));
+    static assert(!__traits(isRef, b));
+}

--- a/test/compilable/rvalue_attrib3.d
+++ b/test/compilable/rvalue_attrib3.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -preview=rvalueattribute
+
+extern(C++) void func(@rvalue ref int);
+
+version(Posix)
+    static assert(func.mangleof == "_Z4funcOi");
+else version (Win64)
+    static assert(func.mangleof == "?func@@YAX$$QEAH@Z");
+else version (Win32)
+    static assert(func.mangleof == "?func@@YAX$$QAH@Z");

--- a/test/compilable/rvalue_type.d
+++ b/test/compilable/rvalue_type.d
@@ -1,0 +1,34 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+
+static if (0) // test the parser only
+{
+
+@rvalue const T a;
+
+@rvalue(T) a;
+const(@rvalue(shared(int))) a;
+
+__rvalue(T) a;
+
+__rvalue(int) func(@rvalue int a) {}
+@rvalue f = function @rvalue(@rvalue a) {};
+__rvalue f = delegate @rvalue(__rvalue(T)[@rvalue(T)]) {};
+
+void fun()
+{
+    foreach(@rvalue a, const b, __rvalue c; r)
+    {
+    }
+}
+
+struct S { @rvalue a = 0; }
+
+auto a = cast(const shared @rvalue)a;
+auto a = cast(__rvalue)a;
+
+auto b = is(T == @rvalue);
+auto b = is(T == __rvalue);
+
+alias T = @rvalue(int) delegate();
+
+}

--- a/test/compilable/rvalue_type1.d
+++ b/test/compilable/rvalue_type1.d
@@ -22,3 +22,5 @@ static assert(is(typeof(cast(@rvalue)0) == @rvalue(int)));
 static assert(is(typeof(cast(@rvalue const)0) == const(@rvalue(int))));
 
 ref @rvalue(int) func(ref int a) { return cast(@rvalue)a; }
+int g;
+void fun(ref @rvalue int a = 1, ref @rvalue int b = cast(@rvalue)g);

--- a/test/compilable/rvalue_type1.d
+++ b/test/compilable/rvalue_type1.d
@@ -1,0 +1,24 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+
+struct S {}
+
+static assert(is(@rvalue(S)));
+static assert(is(@rvalue(S) : S));
+static assert(is(S : @rvalue(S)));
+static assert(!is(S == @rvalue(S)));
+
+static assert(is(@rvalue(S) == @rvalue));
+static assert(!is(S == @rvalue));
+
+static assert(!is(int* : @rvalue(int)*));
+static assert(!is(S* : @rvalue(S)*));
+static assert(!is(@rvalue(S)* : S*));
+
+static assert(!is(@rvalue(int)[]));
+static assert(!is(@rvalue(char)[byte]));
+static assert(!is(char[@rvalue(char)]));
+
+static assert(is(typeof(cast(@rvalue)0) == @rvalue(int)));
+static assert(is(typeof(cast(@rvalue const)0) == const(@rvalue(int))));
+
+ref @rvalue(int) func(ref int a) { return cast(@rvalue)a; }

--- a/test/compilable/rvalue_type1.d
+++ b/test/compilable/rvalue_type1.d
@@ -4,7 +4,7 @@ struct S {}
 
 static assert(is(@rvalue(S)));
 static assert(is(@rvalue(S) : S));
-static assert(is(S : @rvalue(S)));
+static assert(!is(S : @rvalue(S)));
 static assert(!is(S == @rvalue(S)));
 
 static assert(is(@rvalue(S) == @rvalue));

--- a/test/compilable/rvalue_type2.d
+++ b/test/compilable/rvalue_type2.d
@@ -1,0 +1,10 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+
+extern(C++) void func(@rvalue ref int);
+
+version(Posix)
+    static assert(func.mangleof == "_Z4funcOi");
+else version (Win64)
+    static assert(func.mangleof == "?func@@YAX$$QEAH@Z");
+else version (Win32)
+    static assert(func.mangleof == "?func@@YAX$$QAH@Z");

--- a/test/compilable/rvalue_type3.d
+++ b/test/compilable/rvalue_type3.d
@@ -1,0 +1,31 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+
+T rvalueOf(T)();
+ref T lvalueOf(T)();
+alias X(T, U) = typeof(0 ? lvalueOf!T : lvalueOf!U);
+alias RL(T, U) = typeof(0 ? rvalueOf!T : lvalueOf!U);
+
+static assert(is(X!(@rvalue(int), int) == int));
+static assert(is(X!(@rvalue(int), @rvalue(int)) == @rvalue(int)));
+static assert(is(X!(@rvalue(int)*, int*) == int*));
+static assert(is(X!(@rvalue(const(int))*, int*) == const(int)*));
+
+struct S { ref @rvalue(int) get(); alias get this; }
+static assert(is(X!(@rvalue(S), S) == S));
+static assert(is(X!(@rvalue(S), @rvalue(const(S))) == @rvalue(const(S))));
+static assert(is(X!(@rvalue(S), int) == int));
+static assert(is(X!(@rvalue(S), @rvalue(int)) == @rvalue(int)));
+static assert(is(X!(S, @rvalue(int)) == int));
+
+alias F0 = ref @rvalue(int) function(@rvalue ref int);
+alias F1 = ref int function(ref int);
+alias F2 = ref int function(@rvalue ref int);
+static assert(is(X!(F2, F0) == F2));
+static assert(is(X!(F0, F2) == F2));
+static assert(is(X!(F2, F1) == F2));
+static assert(is(X!(F1, F2) == F2));
+
+static assert(is(X!(S, @rvalue(S)) == S));
+static assert(is(RL!(S, @rvalue(S)) == @rvalue S));
+static assert(is(X!(const(S), @rvalue(S)) == const S));
+static assert(is(RL!(const(S), @rvalue(S)) == const @rvalue S));

--- a/test/fail_compilation/movctor0.d
+++ b/test/fail_compilation/movctor0.d
@@ -1,0 +1,45 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+/*
+TEST_OUTPUT:
+---
+fail_compilation/movctor0.d(44): Error: struct `movctor0.SErr` is not copyable because it is annotated with `@disable`
+---
+*/
+
+struct S1
+{
+    this(@rvalue ref S1) {}
+    this(this) {}
+}
+
+void test1()
+{
+    S1 a;
+    S1 b = cast(@rvalue) a; // ok
+    S1 c = a; // ok
+}
+
+struct S2
+{
+    this(@rvalue ref S2) {}
+    this(ref S2) {}
+}
+
+void test2()
+{
+    S2 a;
+    S2 b = cast(@rvalue) a; // ok
+    S2 c = a; // ok
+}
+
+struct SErr
+{
+    this(@rvalue ref SErr) {}
+}
+
+void test3()
+{
+    SErr a;
+    SErr b = cast(@rvalue) a; // ok
+    SErr c = a; // error
+}

--- a/test/fail_compilation/rvalue_attrib.d
+++ b/test/fail_compilation/rvalue_attrib.d
@@ -1,0 +1,52 @@
+/*
+REQUIRED_ARGS: -preview=rvalueattribute
+TEST_OUTPUT:
+---
+fail_compilation/rvalue_attrib.d(31): Error: `@rvalue ref` for module declaration is not supported
+fail_compilation/rvalue_attrib.d(35): Error: `ref` expected after `@rvalue`, not `int`
+fail_compilation/rvalue_attrib.d(35): Error: function declaration without return type. (Note that constructors are always named `this`)
+fail_compilation/rvalue_attrib.d(35): Error: no identifier for declarator `func()`
+fail_compilation/rvalue_attrib.d(36): Error: `ref` expected after `@rvalue`, not `int`
+fail_compilation/rvalue_attrib.d(36): Error: basic type expected, not `)`
+fail_compilation/rvalue_attrib.d(38): Error: `@rvalue ref` cannot appear as postfix
+fail_compilation/rvalue_attrib.d(39): Error: `@rvalue ref` cannot appear as postfix
+fail_compilation/rvalue_attrib.d(41): Error: found `fun` when expecting function literal following `@rvalue ref`
+fail_compilation/rvalue_attrib.d(41): Error: semicolon expected following auto declaration, not `=>`
+fail_compilation/rvalue_attrib.d(41): Error: declaration expected, not `=>`
+fail_compilation/rvalue_attrib.d(42): Error: found `0` when expecting function literal following `@rvalue ref`
+fail_compilation/rvalue_attrib.d(44): Error: redundant attribute `@rvalue ref`
+fail_compilation/rvalue_attrib.d(45): Error: incompatible parameter storage classes
+fail_compilation/rvalue_attrib.d(46): Error: variadic argument cannot be `@rvalue ref`
+fail_compilation/rvalue_attrib.d(48): Error: found `)` when expecting `ref` following `@rvalue`
+fail_compilation/rvalue_attrib.d(49): Error: found `int` when expecting `)` following `cast(@rvalue ref`
+fail_compilation/rvalue_attrib.d(50): Error: found `const` when expecting `)` following `cast(@rvalue ref`
+fail_compilation/rvalue_attrib.d(50): Error: basic type expected, not `)`
+fail_compilation/rvalue_attrib.d(51): Error: basic type expected, not `@`
+fail_compilation/rvalue_attrib.d(51): Error: found `@` when expecting `)`
+fail_compilation/rvalue_attrib.d(51): Error: semicolon expected following auto declaration, not `ref`
+fail_compilation/rvalue_attrib.d(51): Error: declaration expected, not `)`
+---
+*/
+
+@rvalue ref module test;
+
+static if (0) // test the parser only
+{
+@rvalue int func();
+void func(@rvalue int);
+
+void func() @rvalue ref;
+void func(int @rvalue ref);
+
+auto a = @rvalue ref fun => 0;
+auto b = @rvalue ref 0;
+
+void func(@rvalue ref @rvalue ref int);
+void func(ref @rvalue ref int);
+void func(@rvalue ref p ...);
+
+auto c = cast(@rvalue) 0;
+auto c = cast(@rvalue ref int) 0;
+auto c = cast(@rvalue ref const) 0;
+auto c = cast(const @rvalue ref) 0;
+}

--- a/test/fail_compilation/rvalue_attrib.d
+++ b/test/fail_compilation/rvalue_attrib.d
@@ -5,7 +5,7 @@ TEST_OUTPUT:
 fail_compilation/rvalue_attrib.d(31): Error: `@rvalue ref` for module declaration is not supported
 fail_compilation/rvalue_attrib.d(35): Error: `ref` expected after `@rvalue`, not `int`
 fail_compilation/rvalue_attrib.d(35): Error: function declaration without return type. (Note that constructors are always named `this`)
-fail_compilation/rvalue_attrib.d(35): Error: no identifier for declarator `func()`
+fail_compilation/rvalue_attrib.d(35): Error: no identifier for declarator `@rvalue ref func()`
 fail_compilation/rvalue_attrib.d(36): Error: `ref` expected after `@rvalue`, not `int`
 fail_compilation/rvalue_attrib.d(36): Error: basic type expected, not `)`
 fail_compilation/rvalue_attrib.d(38): Error: `@rvalue ref` cannot appear as postfix

--- a/test/fail_compilation/rvalue_attrib1.d
+++ b/test/fail_compilation/rvalue_attrib1.d
@@ -1,0 +1,56 @@
+/*
+REQUIRED_ARGS: -preview=rvalueattribute
+TEST_OUTPUT:
+---
+fail_compilation/rvalue_attrib1.d(25): Error: `rvalue_attrib1.foo` called with argument types `(int)` matches both:
+fail_compilation/rvalue_attrib1.d(20):     `rvalue_attrib1.foo(@rvalue ref int _param_0)`
+and:
+fail_compilation/rvalue_attrib1.d(21):     `rvalue_attrib1.foo(int _param_0)`
+fail_compilation/rvalue_attrib1.d(38): Error: function `rvalue_attrib1.fb(ref int)` is not callable using argument types `(int)`
+fail_compilation/rvalue_attrib1.d(38):        cannot pass `@rvalue ref` argument `get()` of type `int` to parameter `ref int`
+fail_compilation/rvalue_attrib1.d(42): Error: function `rvalue_attrib1.fc(@rvalue ref int)` is not callable using argument types `(int)`
+fail_compilation/rvalue_attrib1.d(42):        cannot pass lvalue argument `i` of type `int` to parameter `@rvalue ref int`, perhaps you meant `cast(@rvalue ref)i`
+fail_compilation/rvalue_attrib1.d(49): Error: cannot cast rvalue `cast(@rvalue ref)1` to `@rvalue ref`
+fail_compilation/rvalue_attrib1.d(50): Error: cannot cast rvalue `cast(@rvalue ref)getv()` to `@rvalue ref`
+fail_compilation/rvalue_attrib1.d(53): Error: cannot modify constant `0`
+fail_compilation/rvalue_attrib1.d(56): Error: lvalue cannot be `@rvalue ref`, perhaps you meant `cast(@rvalue ref) l`
+---
+*/
+
+void foo(@rvalue ref int) {}
+void foo(int) {}
+
+void test()
+{
+    foo(0);
+    int i;
+    foo(i);
+}
+
+@rvalue ref int get();
+void fa(int);
+void fb(ref int);
+void fc(@rvalue ref int);
+
+void test2()
+{
+    fa(get);
+    fb(get);
+    fc(get);
+
+    int i;
+    fc(i);
+}
+
+int getv();
+
+void test3()
+{
+    auto a = cast(@rvalue ref) 1;
+    auto b = cast(@rvalue ref) getv();
+}
+
+@rvalue ref int retV() {return 0; }
+
+int l;
+@rvalue ref int retL() {return l; }

--- a/test/fail_compilation/rvalue_attrib2.d
+++ b/test/fail_compilation/rvalue_attrib2.d
@@ -1,0 +1,40 @@
+/*
+REQUIRED_ARGS: -preview=rvalueattribute
+TEST_OUTPUT:
+---
+fail_compilation/rvalue_attrib2.d(14): Error: variable `rvalue_attrib2.var0.a` only parameters can be `@rvalue ref`
+fail_compilation/rvalue_attrib2.d(20): Error: returning `cast(@rvalue ref)a` escapes a reference to local variable `a`
+fail_compilation/rvalue_attrib2.d(37): Error: returning `f0(cast(@rvalue ref)a)` escapes a reference to local variable `a`
+fail_compilation/rvalue_attrib2.d(39): Error: returning `f1(a)` escapes a reference to local variable `a`
+---
+*/
+
+void var0()
+{
+    @rvalue ref int a;
+}
+
+@rvalue ref escape0()
+{
+    int a;
+    return cast(@rvalue ref)a;
+}
+
+@rvalue ref int escape1(int i)
+{
+    static @rvalue ref f0(@rvalue ref int a)
+    {
+        return cast(@rvalue ref)a;
+    }
+
+    static @rvalue ref f1(ref int a)
+    {
+        return cast(@rvalue ref)a;
+    }
+
+    int a;
+    if (i)
+        return f0(cast(@rvalue ref)a);
+    else
+        return f1(a);
+}

--- a/test/fail_compilation/rvalue_type.d
+++ b/test/fail_compilation/rvalue_type.d
@@ -1,0 +1,29 @@
+/* REQUIRED_ARGS: -preview=rvaluetype
+TEST_OUTPUT:
+---
+fail_compilation/rvalue_type.d(18): Error: functions cannot be `@rvalue`
+fail_compilation/rvalue_type.d(19): Error: `@rvalue` cannot appear as postfix
+fail_compilation/rvalue_type.d(19): Error: function literal cannot be `@rvalue`
+fail_compilation/rvalue_type.d(20): Error: `@rvalue` cannot appear as postfix
+fail_compilation/rvalue_type.d(20): Error: function literal cannot be `@rvalue`
+fail_compilation/rvalue_type.d(24): Error: constructor cannot be `@rvalue`
+fail_compilation/rvalue_type.d(25): Error: postblit cannot be `@rvalue`
+fail_compilation/rvalue_type.d(26): Error: functions cannot be `@rvalue`
+---
+*/
+
+static if (0) // parser only
+{
+
+@rvalue int fun();
+auto a = function () @rvalue {};
+auto a = () @rvalue {};
+
+struct S
+{
+    @rvalue this() {}
+    @rvalue this(this) {}
+    @rvalue int get() {}
+}
+
+}

--- a/test/fail_compilation/rvalue_type1.d
+++ b/test/fail_compilation/rvalue_type1.d
@@ -1,14 +1,15 @@
 /* REQUIRED_ARGS: -preview=rvaluetype
 TEST_OUTPUT:
 ---
-fail_compilation/rvalue_type1.d(15): Error: enum `rvalue_type1.E` base type cannot be `__rvalue`
-fail_compilation/rvalue_type1.d(17): Error: variable `rvalue_type1.a` `@rvalue` types can only be used in `ref` function parameters or with pointer types
-fail_compilation/rvalue_type1.d(18): Error: variable `rvalue_type1.b` `@rvalue` types can only be used in `ref` function parameters or with pointer types
-fail_compilation/rvalue_type1.d(20): Error: only `ref` parameters can be `@rvalue`
+fail_compilation/rvalue_type1.d(16): Error: enum `rvalue_type1.E` base type cannot be `__rvalue`
+fail_compilation/rvalue_type1.d(18): Error: variable `rvalue_type1.a` `@rvalue` types can only be used in `ref` function parameters or with pointer types
+fail_compilation/rvalue_type1.d(19): Error: variable `rvalue_type1.b` `@rvalue` types can only be used in `ref` function parameters or with pointer types
 fail_compilation/rvalue_type1.d(21): Error: only `ref` parameters can be `@rvalue`
 fail_compilation/rvalue_type1.d(22): Error: only `ref` parameters can be `@rvalue`
-fail_compilation/rvalue_type1.d(24): Error: only `ref` parameters can be `@rvalue`
-fail_compilation/rvalue_type1.d(25): Error: functions cannot return `@rvalue` types except by `ref`
+fail_compilation/rvalue_type1.d(23): Error: only `ref` parameters can be `@rvalue`
+fail_compilation/rvalue_type1.d(25): Error: only `ref` parameters can be `@rvalue`
+fail_compilation/rvalue_type1.d(26): Error: functions cannot return `@rvalue` types except by `ref`
+fail_compilation/rvalue_type1.d(32): Error: cannot pass lvalue default argument `g` to parameter `ref @rvalue(int) a = g`
 ---
 */
 
@@ -26,3 +27,6 @@ alias T1 = @rvalue(int) delegate();
 
 ref @rvalue(int) f3(ref int a) { return a; }
 ref @rvalue(int) f4(ref int a) { return 1; }
+
+int g;
+void f5(ref @rvalue int a = g);

--- a/test/fail_compilation/rvalue_type1.d
+++ b/test/fail_compilation/rvalue_type1.d
@@ -1,0 +1,28 @@
+/* REQUIRED_ARGS: -preview=rvaluetype
+TEST_OUTPUT:
+---
+fail_compilation/rvalue_type1.d(15): Error: enum `rvalue_type1.E` base type cannot be `__rvalue`
+fail_compilation/rvalue_type1.d(17): Error: variable `rvalue_type1.a` `@rvalue` types can only be used in `ref` function parameters or with pointer types
+fail_compilation/rvalue_type1.d(18): Error: variable `rvalue_type1.b` `@rvalue` types can only be used in `ref` function parameters or with pointer types
+fail_compilation/rvalue_type1.d(20): Error: only `ref` parameters can be `@rvalue`
+fail_compilation/rvalue_type1.d(21): Error: only `ref` parameters can be `@rvalue`
+fail_compilation/rvalue_type1.d(22): Error: only `ref` parameters can be `@rvalue`
+fail_compilation/rvalue_type1.d(24): Error: only `ref` parameters can be `@rvalue`
+fail_compilation/rvalue_type1.d(25): Error: functions cannot return `@rvalue` types except by `ref`
+---
+*/
+
+enum E : @rvalue(int) { a, }
+
+@rvalue int a;
+const(@rvalue(int)) b;
+
+void f0(@rvalue int p);
+void f1(out @rvalue int p);
+void f2(lazy @rvalue int p);
+
+alias T0 = void delegate(@rvalue int);
+alias T1 = @rvalue(int) delegate();
+
+ref @rvalue(int) f3(ref int a) { return a; }
+ref @rvalue(int) f4(ref int a) { return 1; }

--- a/test/fail_compilation/rvalue_type2.d
+++ b/test/fail_compilation/rvalue_type2.d
@@ -1,0 +1,31 @@
+/* REQUIRED_ARGS: -preview=rvaluetype
+TEST_OUTPUT:
+---
+fail_compilation/rvalue_type2.d(17): Error: cannot return lvalue as `@rvalue`, perhaps you meant `cast(@rvalue)p`
+fail_compilation/rvalue_type2.d(22): Error: returning `f0(a)` escapes a reference to local variable `a`
+fail_compilation/rvalue_type2.d(23): Error: returning `f0(((@rvalue @rvalue(int) __rvalue2 = 1;) , __rvalue2))` escapes a reference to local variable `__rvalue2`
+fail_compilation/rvalue_type2.d(24): Error: returning `f1(a)` escapes a reference to local variable `a`
+fail_compilation/rvalue_type2.d(25): Error: returning `f2(a)` escapes a reference to local variable `a`
+fail_compilation/rvalue_type2.d(26): Error: returning `f2(((@rvalue @rvalue(int) __rvalue3 = 2;) , __rvalue3))` escapes a reference to local variable `__rvalue3`
+fail_compilation/rvalue_type2.d(30): Error: returning `a` escapes a reference to local variable `a`
+---
+*/
+
+ref escape()
+{
+    static ref int f0(@rvalue ref int p) { return p; }
+    static ref @rvalue(int) f1(ref int p) { return p; }
+    static ref @rvalue(int) f2(@rvalue ref int p) { return p; }
+    int a;
+    switch(a)
+    {
+    case 0: return f0(cast(@rvalue)a);
+            return f0(1);
+    case 1: return f1(a);
+    case 2: return f2(cast(@rvalue)a);
+            return f2(2);
+
+    default: break;
+    }
+    return a;
+}

--- a/test/fail_compilation/rvalue_type3.d
+++ b/test/fail_compilation/rvalue_type3.d
@@ -1,0 +1,17 @@
+/* REQUIRED_ARGS: -preview=rvaluetype
+TEST_OUTPUT:
+---
+fail_compilation/rvalue_type3.d(16): Error: `rvalue_type3.fun` called with argument types `(int)` matches both:
+fail_compilation/rvalue_type3.d(11):     `rvalue_type3.fun(ref @rvalue(int))`
+and:
+fail_compilation/rvalue_type3.d(12):     `rvalue_type3.fun(int)`
+---
+*/
+
+void fun(@rvalue ref int);
+void fun(int);
+
+void test()
+{
+    fun(0);
+}

--- a/test/runnable/movector0.d
+++ b/test/runnable/movector0.d
@@ -1,0 +1,78 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+
+void test1()
+{
+    static char[] result;
+
+    static struct A
+    {
+        this(inout ref A) inout { result ~= "Cc"; }
+        this(inout @rvalue ref A) inout { result ~= "Mc"; }
+    }
+
+    static struct S
+    {
+        A a;
+    }
+
+    static S gs;
+    static A ga;
+
+    static T getValue(T)() { return T(); }
+    static ref T getRef(T)()
+    {
+        static if (is(T == S)) return gs;
+        else return ga;
+    }
+    static ref @rvalue(T) getRvalueRef(T)()
+    {
+        static if (is(T == S))
+            return cast(@rvalue)gs;
+        else
+            return cast(@rvalue)ga;
+    }
+
+    static void test(T)()
+    {
+        result = null;
+        T a;
+        auto b = a; // Cc
+        auto c = cast(@rvalue)a; // Mc
+        assert(result == "CcMc");
+
+        result = null;
+        auto d = getValue!T(); // nrvo
+        auto f = getRvalueRef!T(); // Mc
+        auto e = getRef!T(); // Cc
+        assert(result == "McCc");
+    }
+
+    test!A();
+    test!S();
+}
+
+void test2()
+{
+    static struct S
+    {
+        static int i;
+        this(@rvalue ref S) { ++i; }
+    }
+
+    static void func(S) {}
+
+    S a = S();
+    assert(a.i == 0);
+    func(S());
+    assert(a.i == 0);
+    func(cast(@rvalue)a);
+    assert(a.i == 1);
+    S b = cast(@rvalue)a;
+    assert(a.i == 2);
+}
+
+void main()
+{
+    test1();
+    test2();
+}

--- a/test/runnable/movector1.d
+++ b/test/runnable/movector1.d
@@ -1,0 +1,71 @@
+// REQUIRED_ARGS: -preview=moveattribute
+
+void test1()
+{
+    static char[] result;
+
+    static struct A
+    {
+        this(inout ref A) inout { result ~= "Cc"; }
+        this(inout ref A) @move inout { result ~= "Mc"; }
+    }
+
+    static struct S
+    {
+        A a;
+    }
+
+    static S gs;
+    static A ga;
+
+    static T getValue(T)() { return T(); }
+    static ref T getRef(T)()
+    {
+        static if (is(T == S)) return gs;
+        else return ga;
+    }
+
+    static void test(T)()
+    {
+        result = null;
+        T a;
+        auto b = a; // Cc
+        auto c = __move(a); // Mc
+        assert(result == "CcMc", result);
+
+        result = null;
+        auto d = getValue!T(); // nrvo
+        auto e = getRef!T(); // Cc
+        auto f = __move(getRef!T()); // Mc
+        assert(result == "CcMc", result);
+    }
+
+    test!A();
+    test!S();
+}
+
+void test2()
+{
+    static struct S
+    {
+        static int i;
+        this(ref S) @move { ++i; }
+    }
+
+    static void func(S) {}
+
+    S a = S();
+    assert(a.i == 0);
+    func(S());
+    assert(a.i == 0);
+    func(__move(a));
+    assert(a.i == 1);
+    S b = __move(a);
+    assert(a.i == 2);
+}
+
+void main()
+{
+    test1();
+    test2();
+}

--- a/test/runnable/rvalue_attrib.d
+++ b/test/runnable/rvalue_attrib.d
@@ -1,0 +1,75 @@
+// REQUIRED_ARGS: -preview=rvalueattribute
+// PERMUTE_ARGS: -inline -O
+
+struct S
+{
+    int ref_;
+    int rvalueref;
+
+    void f(@rvalue ref int) { ++rvalueref; }
+    void f(ref int) { ++ref_; }
+}
+
+@rvalue ref int get(ref int a)
+{
+    return cast(@rvalue ref) a;
+}
+
+void test()
+{
+    S s;
+
+    s.f(0);
+    assert(s.rvalueref == 1);
+
+    int i;
+    s.f(i);
+    assert(s.ref_ == 1);
+
+    i = 10;
+    assert(get(i) == i);
+
+    s.f(get(i));
+    assert(s.rvalueref == 2);
+
+    s.f(cast(@rvalue ref) i);
+    assert(s.rvalueref == 3);
+}
+
+ref get2(@rvalue ref int a)
+{
+    return a;
+}
+
+void test2()
+{
+    int a;
+    assert(&a == &get2(cast(@rvalue ref)a));
+}
+
+@rvalue ref int f3(@rvalue ref int a)
+in(a == 10)
+out(r; a == 10 && r == a)
+do { return cast(@rvalue ref)a; }
+
+void test3()
+{
+    assert(f3(10) == 10);
+    int a = 10;
+    assert(&a == &f3(cast(@rvalue ref)a));
+}
+
+int tests()
+{
+    test();
+    test2();
+    test3();
+
+    return 0;
+}
+
+void main()
+{
+    tests();
+    enum _ = tests();
+}

--- a/test/runnable/rvalue_attrib4.d
+++ b/test/runnable/rvalue_attrib4.d
@@ -1,0 +1,47 @@
+/* REQUIRED_ARGS: -preview=rvalueattribute
+TEST_OUTPUT:
+---
+int function(@rvalue ref int p)
+int function(ref int p)
+int function()
+int function(ref int a) ref
+int function(ref int a) @rvalue ref
+---
+*/
+
+int fun()(auto @rvalue ref int p)
+{
+    static if (__traits(isRvalueRef, p))
+        return 1;
+    else static if (__traits(isRef, p))
+        return 2;
+    else
+        static assert(0);
+    pragma(msg, typeof(&fun).stringof);
+}
+
+void main()
+{
+    assert(fun(0) == 1);
+    int i;
+    assert(fun(i) == 2);
+    assert(fun(cast(@rvalue ref)i) == 1);
+}
+
+auto ref int fVal()
+{
+    return 1;
+    pragma(msg, typeof(&fVal).stringof);
+}
+
+auto ref int fRef(ref int a)
+{
+    return a;
+    pragma(msg, typeof(&fRef).stringof);
+}
+
+auto ref int fRvalueRef(ref int a)
+{
+    return cast(@rvalue ref) a;
+    pragma(msg, typeof(&fRvalueRef).stringof);
+}

--- a/test/runnable/rvalue_type.d
+++ b/test/runnable/rvalue_type.d
@@ -1,0 +1,80 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+// PERMUTE_ARGS: -O -inline
+
+int func(@rvalue ref int p) { return 1; }
+int func(@rvalue ref const int p) { return 11; }
+
+int func(ref int p) { return 2; }
+int func(ref const int p) { return 22; }
+
+void run1a(@rvalue ref int p)
+{
+    assert(func(p) == 1);
+    assert(func(cast(int)p) == 2);
+
+    assert(func(cast(const)p) == 11);
+    const i = cast(int)p;
+    assert(func(i) == 22);
+}
+
+int gun(@rvalue ref const int) { return 1; }
+int gun(ref int) { return 2; }
+
+void run1b(@rvalue ref int p)
+{
+    assert(gun(p) == 1);
+    assert(gun(cast(int)p) == 2);
+}
+
+void test1()
+{
+    assert(func(0) == 1);
+    int i;
+    assert(func(i) == 2);
+    assert(func(cast(@rvalue)i) == 1);
+
+    assert(func(cast(const)0) == 11);
+    const int c;
+    assert(func(c) == 22);
+    assert(func(cast(@rvalue)c) == 11);
+
+    run1a(0);
+    run1b(0);
+}
+
+struct S2
+{
+    int i;
+    this(int n) { i = n; }
+
+    this(ref S2) { ++i; }
+    ~this() { ++i; }
+}
+
+ref @rvalue(S2) func2(@rvalue ref S2 a, int i = 0)
+{
+    if (i < 20)
+        return func2(a, ++i);
+    return a;
+}
+
+void test2()
+{
+    assert(func2(S2(10)).i == 10);
+    auto s = S2(2);
+    assert(func2(cast(@rvalue)s).i == 2);
+}
+
+int tests()
+{
+    test1();
+    test2();
+
+    return 0;
+}
+
+void main()
+{
+    tests();
+    enum _ = tests();
+}

--- a/test/runnable/rvalue_type1.d
+++ b/test/runnable/rvalue_type1.d
@@ -1,0 +1,14 @@
+// REQUIRED_ARGS: -preview=rvaluetype
+
+void main()
+{
+static if (is(TypeInfo_Rvalue))
+{
+    assert(typeid(@rvalue(int)) != typeid(int));
+    assert(typeid(@rvalue(int)).toString() == "@rvalue(int)");
+    assert(typeid(@rvalue(const(int))).toString() == "@rvalue(const(int))");
+    assert(typeid(@rvalue(const(shared(int)))).toString() == "@rvalue(shared(const(int)))");
+    assert(typeid(@rvalue(immutable(int))).toString() == "@rvalue(immutable(int))");
+    assert(is(typeof(typeid(@rvalue(int))) == TypeInfo_Rvalue));
+}
+}

--- a/test/runnable/rvalue_type2.d
+++ b/test/runnable/rvalue_type2.d
@@ -1,0 +1,61 @@
+/* REQUIRED_ARGS: -preview=rvaluetype
+TEST_OUTPUT:
+---
+int function(ref @rvalue(int) p)
+int function(ref int p)
+int function()
+int function(ref int a) ref
+@rvalue(int) function(ref int a) ref
+int function(ref int a) ref
+int function(ref int a)
+---
+*/
+
+int fun()(auto @rvalue ref int p)
+{
+    static if (is(typeof(p) == @rvalue))
+        return 1;
+    else static if (__traits(isRef, p))
+        return 2;
+    else
+        static assert(0);
+    pragma(msg, typeof(&fun).stringof);
+}
+
+void main()
+{
+    assert(fun(0) == 1);
+    int i;
+    assert(fun(i) == 2);
+    assert(fun(cast(@rvalue)i) == 1);
+}
+
+auto ref int fVal()
+{
+    return 1;
+    pragma(msg, typeof(&fVal).stringof);
+}
+
+auto ref int fRef(ref int a)
+{
+    return a;
+    pragma(msg, typeof(&fRef).stringof);
+}
+
+auto ref int fRvalueRef(ref int a)
+{
+    return cast(@rvalue) a;
+    pragma(msg, typeof(&fRvalueRef).stringof);
+}
+
+auto ref int fmix0(ref int a)
+{
+    return cast(@rvalue) a; return a;
+    pragma(msg, typeof(&fmix0).stringof);
+}
+
+auto ref int fmix1(ref int a)
+{
+    return cast(@rvalue) a; return 1;
+    pragma(msg, typeof(&fmix1).stringof);
+}


### PR DESCRIPTION
This is the implementation of the `@rvalue ref` attribute for function parameter and returns.

Grammar definition: https://github.com/dlang/dlang.org/pull/2703.

**EDIT:**

Added implementation of `@rvalue` / `__rvalue` as a type constructor.

Grammar definition: https://github.com/dlang/dlang.org/pull/2704.