### PR TITLE
be more friendly to the GC

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4707,7 +4707,7 @@ struct ASTBase
         extern (D) const(char)[] toStringz() const
         {
             auto nbytes = len * sz;
-            char* s = cast(char*)mem.xmalloc(nbytes + sz);
+            char* s = cast(char*)mem.xmalloc_noscan(nbytes + sz);
             writeTo(s, true);
             return s[0 .. nbytes];
         }

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -223,6 +223,8 @@ struct Scope
         Scope* enc = enclosing;
         if (!nofree)
         {
+            if (mem.isGCEnabled)
+                this = this.init;
             enclosing = freelist;
             freelist = &this;
             flags |= SCOPE.free;

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -675,7 +675,7 @@ extern (C++) class Dsymbol : ASTNode
             length += len + 1;
         }
 
-        auto s = cast(char*)mem.xmalloc(length);
+        auto s = cast(char*)mem.xmalloc_noscan(length);
         auto q = s + length - 1;
         *q = 0;
         foreach (j; 0 .. complength)

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -464,7 +464,7 @@ string prettyPrint(Module m)
     import std.string : replace, fromStringz;
     import std.exception : assumeUnique;
 
-    auto generated = buf.extractData.fromStringz.replace("\t", "    ");
+    auto generated = buf.extractSlice.replace("\t", "    ");
     return generated.assumeUnique;
 }
 

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2651,7 +2651,7 @@ class Lexer
         if (c1.length && c1[$ - 1] != '\n')
             insertNewLine = 1;
         const retSize = c1.length + insertNewLine + newParagraphSize + c2.length;
-        auto p = cast(char*)mem.xmalloc(retSize + 1);
+        auto p = cast(char*)mem.xmalloc_noscan(retSize + 1);
         p[0 .. c1.length] = c1[];
         if (insertNewLine)
             p[c1.length] = '\n';

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -316,6 +316,8 @@ class Lexer
     /// Frees the given token by returning it to the freelist.
     private void releaseToken(Token* token) pure nothrow @nogc @safe
     {
+        if (mem.isGCEnabled)
+            *token = Token.init;
         token.next = tokenFreelist;
         tokenFreelist = token;
     }

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -2772,7 +2772,7 @@ final class Parser(AST) : Lexer
             size_t len = endPtr - begPtr;
             if (len > 0)
             {
-                docline = cast(char*)mem.xmalloc(len + 2);
+                docline = cast(char*)mem.xmalloc_noscan(len + 2);
                 memcpy(docline, begPtr, len);
                 docline[len] = '\n'; // Terminate all lines by LF
                 docline[len + 1] = '\0';
@@ -7796,7 +7796,7 @@ final class Parser(AST) : Lexer
                         const len1 = len;
                         const len2 = token.len;
                         len = len1 + len2;
-                        auto s2 = cast(char*)mem.xmalloc(len * char.sizeof);
+                        auto s2 = cast(char*)mem.xmalloc_noscan(len * char.sizeof);
                         memcpy(s2, s, len1 * char.sizeof);
                         memcpy(s2 + len1, token.ustring, len2 * char.sizeof);
                         s = s2;

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -319,7 +319,7 @@ nothrow:
         immutable obytes = (len + 7) / 8;
         immutable nbytes = (nlen + 7) / 8;
         // bt*() access memory in size_t chunks, so round up.
-        ptr = cast(size_t*)mem.xrealloc(ptr,
+        ptr = cast(size_t*)mem.xrealloc_noscan(ptr,
             (nbytes + (size_t.sizeof - 1)) & ~(size_t.sizeof - 1));
         if (nbytes > obytes)
             (cast(ubyte*)ptr)[obytes .. nbytes] = 0;

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -140,6 +140,9 @@ public:
                 allocdim = length + increment;
                 data = cast(T*)mem.xrealloc(data, allocdim * (*data).sizeof);
             }
+            if (mem.isGCEnabled)
+                if (length + nentries < allocdim)
+                    memset(data + length + nentries, 0, (allocdim - length - nentries) * data[0].sizeof);
         }
     }
 

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -56,7 +56,7 @@ public:
                 buf[u] = data[u].toString();
                 len += buf[u].length + 1; //length + ',' or null terminator
             }
-            char[] str = (cast(char*)mem.xmalloc(len))[0..len];
+            char[] str = (cast(char*)mem.xmalloc_noscan(len))[0..len];
 
             str[0] = '[';
             char* p = str.ptr + 1;

--- a/src/dmd/root/file.d
+++ b/src/dmd/root/file.d
@@ -99,7 +99,7 @@ nothrow:
                 return result;
             }
             size = cast(size_t)buf.st_size;
-            ubyte* buffer = cast(ubyte*)mem.xmalloc(size + 2);
+            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 2);
             if (!buffer)
                 goto err2;
             numread = .read(fd, buffer, size);
@@ -143,7 +143,7 @@ nothrow:
             if (h == INVALID_HANDLE_VALUE)
                 return result;
             size = GetFileSize(h, null);
-            ubyte* buffer = cast(ubyte*)mem.xmalloc(size + 2);
+            ubyte* buffer = cast(ubyte*)mem.xmalloc_noscan(size + 2);
             if (!buffer)
                 goto err2;
             if (ReadFile(h, buffer, size, &numread, null) != TRUE)

--- a/src/dmd/root/outbuffer.d
+++ b/src/dmd/root/outbuffer.d
@@ -59,6 +59,8 @@ struct OutBuffer
              */
             size = (((offset + nbytes) * 3 + 30) / 2) & ~15;
             data = cast(ubyte*)mem.xrealloc(data, size);
+            if (mem.isGCEnabled) // clear currently unused data to avoid false pointers
+                memset(data + offset + nbytes, 0xff, size - offset - nbytes);
         }
     }
 
@@ -315,6 +317,8 @@ struct OutBuffer
             }
         }
         offset += count;
+        if (mem.isGCEnabled)
+            memset(data + offset, 0xff, psize - count);
     }
 
     extern (C++) void printf(const(char)* format, ...) nothrow

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -122,10 +122,11 @@ extern (C++) struct Mem
     {
         __gshared bool _isGCEnabled = true;
 
-        static bool isGCEnabled() pure nothrow @nogc
+        // fake purity by making global variable immutable (_isGCEnabled only modified before startup)
+        enum _pIsGCEnabled = cast(immutable bool*) &_isGCEnabled;
+
+        static bool isGCEnabled() pure nothrow @nogc @safe
         {
-            // fake purity by making global variable immutable (_isGCEnabled only modified before startup)
-            enum _pIsGCEnabled = cast(immutable bool*) &_isGCEnabled;
             return *_pIsGCEnabled;
         }
 

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -99,6 +99,21 @@ extern (C++) struct Mem
         return check(pureRealloc(p, size));
     }
 
+    static void* xrealloc_noscan(void* p, size_t size) pure nothrow
+    {
+        version (GC)
+            if (isGCEnabled)
+                return GC.realloc(p, size, GC.BlkAttr.NO_SCAN);
+
+        if (!size)
+        {
+            pureFree(p);
+            return null;
+        }
+
+        return check(pureRealloc(p, size));
+    }
+
     static void* error() pure nothrow @nogc
     {
         onOutOfMemoryError();

--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -57,11 +57,29 @@ extern (C++) struct Mem
         return size ? check(pureMalloc(size)) : null;
     }
 
+    static void* xmalloc_noscan(size_t size) pure nothrow
+    {
+        version (GC)
+            if (isGCEnabled)
+                return size ? GC.malloc(size, GC.BlkAttr.NO_SCAN) : null;
+
+        return size ? check(pureMalloc(size)) : null;
+    }
+
     static void* xcalloc(size_t size, size_t n) pure nothrow
     {
         version (GC)
             if (isGCEnabled)
                 return size * n ? GC.calloc(size * n) : null;
+
+        return (size && n) ? check(pureCalloc(size, n)) : null;
+    }
+
+    static void* xcalloc_noscan(size_t size, size_t n) pure nothrow
+    {
+        version (GC)
+            if (isGCEnabled)
+                return size * n ? GC.calloc(size * n, GC.BlkAttr.NO_SCAN) : null;
 
         return (size && n) ? check(pureCalloc(size, n)) : null;
     }
@@ -315,7 +333,7 @@ extern (D) char[] xarraydup(const(char)[] s) pure nothrow
     if (!s)
         return null;
 
-    auto p = cast(char*)mem.xmalloc(s.length + 1);
+    auto p = cast(char*)mem.xmalloc_noscan(s.length + 1);
     char[] a = p[0 .. s.length];
     a[] = s[0 .. s.length];
     p[s.length] = 0;    // preserve 0 terminator semantics

--- a/src/dmd/root/stringtable.d
+++ b/src/dmd/root/stringtable.d
@@ -252,6 +252,8 @@ private:
         {
             pools = (cast(ubyte**) mem.xrealloc(pools.ptr, (pools.length + 1) * (pools[0]).sizeof))[0 .. pools.length + 1];
             pools[$-1] = cast(ubyte*) mem.xmalloc(nbytes > POOL_SIZE ? nbytes : POOL_SIZE);
+            if (mem.isGCEnabled)
+                memset(pools[$ - 1], 0xff, POOL_SIZE); // 0xff less likely to produce GC pointer
             nfill = 0;
         }
         StringValue* sv = cast(StringValue*)&pools[$ - 1][nfill];

--- a/src/dmd/root/stringtable.d
+++ b/src/dmd/root/stringtable.d
@@ -293,7 +293,7 @@ private:
         auto otab = table;
         const ndim = table.length * 2;
         countTrigger = (ndim * loadFactorNumerator) / loadFactorDenominator;
-        table = (cast(StringEntry*)mem.xcalloc(ndim, (table[0]).sizeof))[0 .. ndim];
+        table = (cast(StringEntry*)mem.xcalloc_noscan(ndim, (table[0]).sizeof))[0 .. ndim];
         foreach (const se; otab[0 .. odim])
         {
             if (!se.vptr)

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -735,7 +735,7 @@ nothrow:
      */
     void setString(const(char)* ptr, size_t length)
     {
-        auto s = cast(char*)mem.xmalloc(length + 1);
+        auto s = cast(char*)mem.xmalloc_noscan(length + 1);
         memcpy(s, ptr, length);
         s[length] = 0;
         ustring = s;

--- a/test/dub_package/frontend.d
+++ b/test/dub_package/frontend.d
@@ -38,7 +38,7 @@ void foo()
         }
     }
 }
-};
+}.toUnixLineEndings();
     assert(expected == generated, generated);
 }
 


### PR DESCRIPTION
Even though this also saves quite some memory for standard -lowmem compilation (std/regex/internal/tests -unitest 708 MB instead of 771 MB with a Win64 dmd compiler), it is more intended for long running language services using dmd as a library.
