### PR TITLE
Type.merge: do not keep the mangle buffer, it is copied into the string table

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2022,7 +2022,7 @@ Type merge(Type type)
 
         mangleToBuffer(type, &buf);
 
-        StringValue* sv = type.stringtable.update(buf.extractSlice());
+        StringValue* sv = type.stringtable.update(buf.peekSlice());
         if (sv.ptrvalue)
         {
             Type t = cast(Type)sv.ptrvalue;


### PR DESCRIPTION
The reserved 32-byte buffer can also contain stale pointers, but it should be garbage soon anyway.