### PR TITLE
syntaxCopy: copy comments, too

### DIFF
--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -45,7 +45,9 @@ extern (C++) final class AliasThis : Dsymbol
     override Dsymbol syntaxCopy(Dsymbol s)
     {
         assert(!s);
-        return new AliasThis(loc, ident);
+        auto at = new AliasThis(loc, ident);
+        at.comment = comment;
+        return at;
     }
 
     override const(char)* kind() const

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -726,6 +726,7 @@ extern (C++) final class AliasDeclaration : Declaration
         //printf("AliasDeclaration::syntaxCopy()\n");
         assert(!s);
         AliasDeclaration sa = type ? new AliasDeclaration(loc, ident, type.syntaxCopy()) : new AliasDeclaration(loc, ident, aliassym.syntaxCopy(null));
+        sa.comment = comment;
         sa.storage_class = storage_class;
         return sa;
     }
@@ -1143,6 +1144,7 @@ extern (C++) class VarDeclaration : Declaration
         //printf("VarDeclaration::syntaxCopy(%s)\n", toChars());
         assert(!s);
         auto v = new VarDeclaration(loc, type ? type.syntaxCopy() : null, ident, _init ? _init.syntaxCopy() : null, storage_class);
+        v.comment = comment;
         return v;
     }
 

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -117,6 +117,7 @@ extern (C++) final class Import : Dsymbol
     {
         assert(!s);
         auto si = new Import(loc, packages, id, aliasId, isstatic);
+        si.comment = comment;
         for (size_t i = 0; i < names.dim; i++)
         {
             si.addAlias(names[i], aliases[i]);

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1265,6 +1265,7 @@ public:
     {
         //printf("ScopeDsymbol::syntaxCopy('%s')\n", toChars());
         ScopeDsymbol sds = s ? cast(ScopeDsymbol)s : new ScopeDsymbol(ident);
+        sds.comment = comment;
         sds.members = arraySyntaxCopy(members);
         sds.endlinnum = endlinnum;
         return sds;

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -47,6 +47,7 @@ extern (C++) final class DebugSymbol : Dsymbol
     {
         assert(!s);
         auto ds = new DebugSymbol(loc, ident);
+        ds.comment = comment;
         ds.level = level;
         return ds;
     }
@@ -136,6 +137,7 @@ extern (C++) final class VersionSymbol : Dsymbol
         assert(!s);
         auto ds = ident ? new VersionSymbol(loc, ident)
                         : new VersionSymbol(loc, level);
+        ds.comment = comment;
         return ds;
     }
 


### PR DESCRIPTION
useful when when using dmd as a library when:
- making a copy of the parsed module for analysis .
- showing documentation when analyzing a template instance