### PR TITLE
Fix Issue 1760 - Closures - Variable unnecessarily allocated on heap

### DIFF
--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1900,6 +1900,7 @@ extern (C++) class FuncDeclaration : Declaration
         {
             VarDeclaration v = closureVars[i];
             //printf("\tv = %s\n", v.toChars());
+            bool putVarInClosure;
 
             for (size_t j = 0; j < v.nestedrefs.dim; j++)
             {
@@ -1927,6 +1928,7 @@ extern (C++) class FuncDeclaration : Declaration
                         markAsNeedingClosure((fx == f) ? fx.toParentP(this) : fx, this);
 
                         requiresClosure = true;
+                        putVarInClosure = true;
                     }
 
                     /* We also need to check if any sibling functions that
@@ -1934,7 +1936,10 @@ extern (C++) class FuncDeclaration : Declaration
                      * to check the callers of our siblings.
                      */
                     if (checkEscapingSiblings(fx, this))
+                    {
                         requiresClosure = true;
+                        putVarInClosure = true;
+                    }
 
                     /* https://issues.dlang.org/show_bug.cgi?id=12406
                      * Iterate all closureVars to mark all descendant
@@ -1942,7 +1947,13 @@ extern (C++) class FuncDeclaration : Declaration
                      */
                 }
             }
+            if (putVarInClosure)
+                continue;
+
+            closureVars.remove(i);
+            --i;
         }
+
         if (requiresClosure)
             goto Lyes;
 

--- a/test/runnable/test1760.d
+++ b/test/runnable/test1760.d
@@ -1,0 +1,25 @@
+// https://issues.dlang.org/show_bug.cgi?id=1760
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+int delegate() three()
+{
+	int a = 35;
+	int b = 60;
+	int c = 75;
+
+    int getb(){ return b; }
+    int geta(){ return a; }
+
+    *(&c - 1) = 2;       // modify b, ensuring b is on stack
+    assert(b == 2);
+    return &geta;
+}
+
+void main()
+{
+	three();
+}


### PR DESCRIPTION
This patch currently makes the example in the original bug report work, but it fails running the runnable test suite. I'm creating the PR to find out more on the generation of closures. Now here is what I could deduce from the code:

- when analyzing nested functions, if any of them reference any local variables, then the variables are put in the closureVars array of the func declaration AST node.

- during semantic3 for each variable in closureVars of a func declaration `foo` it is checked whether the variable is referenced from a nested function that may escape the scope `foo`; if that is the case for any of the variables in closureVars, then a closure must be created, however, without the patch, all the variables in closureVars make it to the closure. For example:

```d
int delegate() three(){
	int a = 35;
	int b = 60;
	int c = 75;
	
	int geta(){ return a; }
	int getb(){ return b; }

	return &geta;
}

void main(){
	three();
}
```

When semantic3 starts, both `a` and `b` are closureVars. Now each of them is checked to see if it is referenced from a function that escapes the scope of  `three` (in the function `FuncDeclaration.needsClosure`). The compiler realizes that `geta` will escape the scope of `foo` so it decides that a closure is needed and simply returns `true`. I would have expected that `b` should be removed from the closureVars list, since `getb` does not escape the scope of `three`, however, that is not the case. I tried adding the missing bits in this PR, however I am getting segfaults when running the runnable tests. I have no idea why the tests fail, but I assume that closureVars is somehow connected with the stack variables (is there a onStackVars variable that needs updating once a variable is removed from closureVars)?

Can someone with experience with this code offer some guidance?