### PR TITLE
Remove building dmd_frontend executable

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -34,7 +34,6 @@ immutable rootDeps = [
     &dmdDefault,
     &runDmdUnittest,
     &clean,
-    &dmdFrontend,
     &checkwhitespace,
 ];
 
@@ -324,31 +323,6 @@ alias sysconfDirFile = memoize!(function()
         {
             updateIfChanged(target, env["SYSCONFDIR"]);
         };
-    }
-    return new DependencyRef(dep);
-});
-
-alias dmdFrontend = memoize!(function()
-{
-    Dependency dep;
-    with (dep)
-    {
-        name = "dmd_frontend";
-        sources = .sources.frontend.chain([env["D"].buildPath("gluelayer.d")], .sources.root, [lexer.target]).array;
-        target = env["G"].buildPath("dmd_frontend");
-        deps = [versionFile, sysconfDirFile, lexer];
-        msg = "(DC) DMD-FRONTEND %-(%s, %)".format(.sources.frontend.map!(e => e.baseName).array);
-        string[] platformArgs;
-        version (Windows)
-            platformArgs = ["-L/STACK:8388608"];
-        command = [
-            env["HOST_DMD_RUN"],
-            "-of" ~ target,
-            "-version=NoBackend",
-            "-vtls",
-            "-J"~env["G"],
-            "-J../res",
-        ].chain(flags["DFLAGS"], platformArgs, sources).array;
     }
     return new DependencyRef(dep);
 });

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -409,7 +409,7 @@ dmd: $G/dmd $G/dmd.conf
 $(GENERATED)/build: build.d $(HOST_DMD_PATH)
 	$(HOST_DMD_RUN) -of$@ build.d
 
-auto-tester-build: dmd checkwhitespace cxx-unittest $G/dmd_frontend
+auto-tester-build: dmd checkwhitespace cxx-unittest
 .PHONY: auto-tester-build
 
 toolchain-info:

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -236,7 +236,7 @@ RUN_BUILD=$(GEN)\build.exe --called-from-make "OS=$(OS)" "BUILD=$(BUILD)" "MODEL
 
 defaulttarget: $G debdmd
 
-auto-tester-build: $G dmd checkwhitespace $(DMDFRONTENDEXE)
+auto-tester-build: $G dmd checkwhitespace
 
 dmd: $G reldmd
 
@@ -296,12 +296,6 @@ parser_test: $G\parser.lib examples\test_parser.d
 example_avg: $G\libparser.lib examples\avg.d
 	$(HOST_DC) -of$@ -vtls $(DFLAGS) $G\libparser.lib examples\avg.d
 
-DMDFRONTENDEXE = $G\dmd_frontend.exe
-
-$(DMDFRONTENDEXE): $(GEN)\build.exe
-	$(RUN_BUILD) $@
-	copy $(DMDFRONTENDEXE) .
-
 $(TARGETEXE): $(GEN)\build.exe
 	$(RUN_BUILD) $@
 	copy $(TARGETEXE) .
@@ -312,7 +306,7 @@ clean:
 	$(RD) /s /q $(GEN)
 	$(DEL) $D\msgs.h $D\msgs.c
 	$(DEL) parser_test.exe example_avg.exe
-	$(DEL) $(TARGETEXE) $(DMDFRONTENDEXE) *.map *.obj *.exe
+	$(DEL) $(TARGETEXE) *.map *.obj *.exe
 
 install: detab install-copy
 


### PR DESCRIPTION
@wilzbach raised a concern that the `dmd_frontend` executable is not being used by anyone and should probably be removed.