### PR TITLE
Fix issue 20267 - Error: `string` is used as a type - and similar “smart” error messages

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -29,6 +29,7 @@ import dmd.declaration;
 import dmd.denum;
 import dmd.dimport;
 import dmd.dmangle;
+import dmd.dmodule : Module;
 import dmd.dscope;
 import dmd.dstruct;
 import dmd.dsymbol;
@@ -1600,6 +1601,27 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                 else
                     .error(loc, "%s `%s` is used as a type", s.kind, s.toPrettyChars);
                 //assert(0);
+            }
+            else if (e.op == TOK.variable) // special case: variable is used as a type
+            {
+                Dsymbol varDecl = mtype.toDsymbol(sc);
+                const(Loc) varDeclLoc = varDecl.getLoc();
+                Module varDeclModule = varDecl.getModule();
+
+                .error(loc, "variable `%s` is used as a type", mtype.toChars());
+
+                if (varDeclModule != sc._module) // variable is imported
+                {
+                    const(Loc) varDeclModuleImportLoc = varDeclModule.getLoc();
+                    .errorSupplemental(
+                        varDeclModuleImportLoc,
+                        "variable `%s` is imported here from: `%s`",
+                        varDecl.toChars,
+                        varDeclModule.toPrettyChars,
+                    );
+                }
+
+                .errorSupplemental(varDeclLoc, "variable `%s` is declared here", varDecl.toChars);
             }
             else
                 .error(loc, "`%s` is used as a type", mtype.toChars());

--- a/test/fail_compilation/imports/test20267.d
+++ b/test/fail_compilation/imports/test20267.d
@@ -1,0 +1,3 @@
+module imports.test20267;
+
+int[1] array;

--- a/test/fail_compilation/test20267.d
+++ b/test/fail_compilation/test20267.d
@@ -1,0 +1,31 @@
+/*
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/test20267.d(20): Error: variable `string` is used as a type
+fail_compilation/test20267.d(19):        variable `string` is declared here
+fail_compilation/test20267.d(23): Error: variable `boolean` is used as a type
+fail_compilation/test20267.d(22):        variable `boolean` is declared here
+fail_compilation/test20267.d(30): Error: variable `array` is used as a type
+fail_compilation/test20267.d(28):        variable `array` is imported here from: `imports.test20267`
+fail_compilation/imports/test20267.d(3):        variable `array` is declared here
+---
+*/
+
+alias boolean = bool;
+
+void foo(string[] args)
+{
+    immutable string = "bar";
+    string[] args2 = args;
+
+    bool boolean = true;
+    boolean b = false;
+}
+
+void bar()
+{
+    import imports.test20267 : array;
+
+    array foo;
+}

--- a/test/fail_compilation/typeerrors.d
+++ b/test/fail_compilation/typeerrors.d
@@ -2,22 +2,23 @@
 PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/typeerrors.d(31): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
-fail_compilation/typeerrors.d(36): Error: tuple index 4 exceeds 4
-fail_compilation/typeerrors.d(38): Error: variable `x` cannot be read at compile time
-fail_compilation/typeerrors.d(39): Error: cannot have array of `void()`
-fail_compilation/typeerrors.d(40): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(32): Deprecation: `scope` as a type constraint is deprecated.  Use `scope` at the usage site.
+fail_compilation/typeerrors.d(37): Error: tuple index 4 exceeds 4
+fail_compilation/typeerrors.d(39): Error: variable `x` cannot be read at compile time
+fail_compilation/typeerrors.d(40): Error: cannot have array of `void()`
 fail_compilation/typeerrors.d(41): Error: cannot have array of scope `typeerrors.C`
-fail_compilation/typeerrors.d(44): Error: `int[5]` is not an expression
-fail_compilation/typeerrors.d(46): Error: `x` is used as a type
-fail_compilation/typeerrors.d(47): Error: cannot have associative array key of `void()`
-fail_compilation/typeerrors.d(48): Error: cannot have associative array key of `void`
-fail_compilation/typeerrors.d(49): Error: cannot have array of scope `typeerrors.C`
-fail_compilation/typeerrors.d(50): Error: cannot have associative array of `void`
-fail_compilation/typeerrors.d(51): Error: cannot have associative array of `void()`
-fail_compilation/typeerrors.d(53): Error: cannot have parameter of type `void`
-fail_compilation/typeerrors.d(55): Error: slice `[1..5]` is out of range of [0..4]
-fail_compilation/typeerrors.d(56): Error: slice `[2..1]` is out of range of [0..4]
+fail_compilation/typeerrors.d(42): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(45): Error: `int[5]` is not an expression
+fail_compilation/typeerrors.d(47): Error: variable `x` is used as a type
+fail_compilation/typeerrors.d(38):        variable `x` is declared here
+fail_compilation/typeerrors.d(48): Error: cannot have associative array key of `void()`
+fail_compilation/typeerrors.d(49): Error: cannot have associative array key of `void`
+fail_compilation/typeerrors.d(50): Error: cannot have array of scope `typeerrors.C`
+fail_compilation/typeerrors.d(51): Error: cannot have associative array of `void`
+fail_compilation/typeerrors.d(52): Error: cannot have associative array of `void()`
+fail_compilation/typeerrors.d(54): Error: cannot have parameter of type `void`
+fail_compilation/typeerrors.d(56): Error: slice `[1..5]` is out of range of [0..4]
+fail_compilation/typeerrors.d(57): Error: slice `[2..1]` is out of range of [0..4]
 ---
 */
 


### PR DESCRIPTION
This PR adds a special case to `visitIdentifier()` that produces a better understandable error message in case a variable is used as a type (which can happen accidentally). I couldn't really come up with any other relevant edge case that would trigger a similar confusing error message, so I went for the special case when `e.op == TOK.variable`.

For obvious reasons, this change requires tests that check for this error message to be adapted accordingly. I also added a new specialized test.