### PR TITLE
[stable] DIP1008: Fix leaking exceptions for `catch(T)` without identifier

### DIFF
--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -4317,9 +4317,14 @@ void catchSemantic(Catch c, Scope* sc)
             stc |= STC.scope_;
         }
 
-        if (c.ident)
+        // DIP1008 requires destruction of the Throwable, even if the user didn't specify an identifier
+        auto ident = c.ident;
+        if (!ident && global.params.ehnogc)
+            ident = Identifier.anonymous();
+
+        if (ident)
         {
-            c.var = new VarDeclaration(c.loc, c.type, c.ident, null, stc);
+            c.var = new VarDeclaration(c.loc, c.type, ident, null, stc);
             c.var.iscatchvar = true;
             c.var.dsymbolSemantic(sc);
             sc.insert(c.var);

--- a/test/runnable/test19317.d
+++ b/test/runnable/test19317.d
@@ -22,4 +22,11 @@ void main() {
         assert(MyException.numInstances == 1);
 
     assert(MyException.numInstances == 0);
+
+    try
+        throw new MyException("oops I did it again");
+    catch(MyException)
+        assert(MyException.numInstances == 1);
+
+    assert(MyException.numInstances == 0);
 }


### PR DESCRIPTION
Detected by LLVM's address sanitizer, see https://github.com/ldc-developers/ldc/issues/3181.