### PR TITLE
fix Issue 21574 Evaluate Pure Functions With CTFE

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -261,7 +261,7 @@ MATCH implicitConvTo(Expression e, Type t)
                 e.type = Type.terror;
             }
 
-            Expression ex = e.optimize(WANTvalue);
+            Expression ex = e.optimize(WANTvalue | WANTnoctfe);
             if (ex.type.equals(t))
             {
                 result = MATCH.exact;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -641,6 +641,7 @@ enum OwnedBy : ubyte
 
 enum WANTvalue  = 0;    // default
 enum WANTexpand = 1;    // expand const/immutable variables if possible
+enum WANTnoctfe = 2;    // do not run CTFE on pure functions
 
 /***********************************************************
  * http://dlang.org/spec/expression.html#expression

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -202,8 +202,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             if (discardValue(s.exp))
                 s.exp = ErrorExp.get();
 
-            s.exp = s.exp.optimize(WANTvalue);
             s.exp = checkGC(sc, s.exp);
+            s.exp = s.exp.optimize(WANTvalue);
             if (s.exp.op == TOK.error)
                 return setError();
         }
@@ -529,8 +529,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
         ds.condition = resolveProperties(sc, ds.condition);
         if (checkNonAssignmentArrayOp(ds.condition))
             ds.condition = ErrorExp.get();
-        ds.condition = ds.condition.optimize(WANTvalue);
         ds.condition = checkGC(sc, ds.condition);
+        ds.condition = ds.condition.optimize(WANTvalue);
 
         ds.condition = ds.condition.toBoolean(sc);
 
@@ -602,8 +602,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             fs.condition = resolveProperties(sc, fs.condition);
             if (checkNonAssignmentArrayOp(fs.condition))
                 fs.condition = ErrorExp.get();
-            fs.condition = fs.condition.optimize(WANTvalue);
             fs.condition = checkGC(sc, fs.condition);
+            fs.condition = fs.condition.optimize(WANTvalue);
 
             fs.condition = fs.condition.toBoolean(sc);
         }
@@ -614,8 +614,8 @@ private extern (C++) final class StatementSemanticVisitor : Visitor
             fs.increment = resolveProperties(sc, fs.increment);
             if (checkNonAssignmentArrayOp(fs.increment))
                 fs.increment = ErrorExp.get();
-            fs.increment = fs.increment.optimize(WANTvalue);
             fs.increment = checkGC(sc, fs.increment);
+            fs.increment = fs.increment.optimize(WANTvalue);
         }
 
         sc.sbreak = fs;
@@ -2566,8 +2566,8 @@ else
         }
         if (checkNonAssignmentArrayOp(ss.condition))
             ss.condition = ErrorExp.get();
-        ss.condition = ss.condition.optimize(WANTvalue);
         ss.condition = checkGC(sc, ss.condition);
+        ss.condition = ss.condition.optimize(WANTvalue);
         if (ss.condition.op == TOK.error)
             conditionError = true;
 
@@ -3214,7 +3214,10 @@ else
                 rs.exp = valueNoDtor(rs.exp);
 
             if (e0)
+            {
+                e0 = checkGC(sc, e0);
                 e0 = e0.optimize(WANTvalue);
+            }
 
             /* Void-return function can have void typed expression
              * on return statement.
@@ -3228,6 +3231,7 @@ else
                     rs.exp = new CastExp(rs.loc, rs.exp, Type.tvoid);
                     rs.exp = rs.exp.expressionSemantic(sc);
                 }
+                rs.exp = checkGC(sc, rs.exp);
 
                 /* Replace:
                  *      return exp;
@@ -3237,8 +3241,6 @@ else
                 e0 = Expression.combine(e0, rs.exp);
                 rs.exp = null;
             }
-            if (e0)
-                e0 = checkGC(sc, e0);
         }
 
         if (rs.exp)
@@ -3624,8 +3626,8 @@ else
         {
             ss.exp = ss.exp.expressionSemantic(sc);
             ss.exp = resolveProperties(sc, ss.exp);
-            ss.exp = ss.exp.optimize(WANTvalue);
             ss.exp = checkGC(sc, ss.exp);
+            ss.exp = ss.exp.optimize(WANTvalue);
             if (ss.exp.op == TOK.error)
             {
                 if (ss._body)
@@ -3745,8 +3747,8 @@ else
         //printf("WithStatement::semantic()\n");
         ws.exp = ws.exp.expressionSemantic(sc);
         ws.exp = resolveProperties(sc, ws.exp);
-        ws.exp = ws.exp.optimize(WANTvalue);
         ws.exp = checkGC(sc, ws.exp);
+        ws.exp = ws.exp.optimize(WANTvalue);
         if (ws.exp.op == TOK.error)
             return setError();
         if (ws.exp.op == TOK.scope_)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1741,13 +1741,13 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 {
                     ex = ex.expressionSemantic(sc2);
                     ex = resolvePropertiesOnly(sc2, ex);
+                    ex = checkGC(sc2, ex);
                     ex = ex.optimize(WANTvalue);
                     if (sc2.func && sc2.func.type.ty == Tfunction)
                     {
                         const tf = cast(TypeFunction)sc2.func.type;
                         err |= tf.isnothrow && canThrow(ex, sc2.func, false);
                     }
-                    ex = checkGC(sc2, ex);
                     if (ex.op == TOK.error)
                         err = true;
                 }


### PR DESCRIPTION
This implements https://github.com/dlang/DIPs/pull/177

https://github.com/dlang/phobos/pull/7211 takes advantage of this.

For a call to a `pure` function, if the function arguments are Literals or are Expressions
that are representable by Literals after the normal semantic processing of them, and the
return type of the function can be represented by a Literal, then the function is
evaluated at compile time using CTFE.

If the call cannot be evaluated using CTFE, such as if the `pure` function contains impure
`debug` statements in the path of CTFE execution, no error is generated, the function is simply
evaluated at run time instead.

Without this change, common code patterns use templates and enums to force compile time execution, making the code more complex than necessary.