### PR TITLE
Revert "Compile dmd exe in build.d"

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -361,16 +361,13 @@ alias dmdExe = memoize!(function(string targetSuffix, string[] extraFlags...)
         target = env["DMD_PATH"] ~ targetSuffix;
         msg = "(DC) DMD%s %-(%s, %)".format(targetSuffix, dmdSources.map!(e => e.baseName).array);
         deps = [versionFile, sysconfDirFile, lexer, backend];
-        string[] platformArgs;
-        version (Windows)
-            platformArgs = ["-L/STACK:8388608"];
         command = [
             env["HOST_DMD_RUN"],
             "-of" ~ target,
             "-vtls",
             "-J"~env["G"],
             "-J../res",
-        ].chain(extraFlags, platformArgs, flags["DFLAGS"], sources).array;
+        ].chain(extraFlags).chain(flags["DFLAGS"], sources).array;
     }
     return new DependencyRef(dep);
 });

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -428,6 +428,12 @@ toolchain-info:
 	@echo '==== Toolchain Information ===='
 	@echo
 
+$G/dmd: $(DMD_SRCS) $(ROOT_SRCS) $G/lexer.a $G/backend.o $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
+	$(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) $(DFLAGS) $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH) $(LEXER_ROOT),$^)
+
+$G/dmd-unittest: $(DMD_SRCS) $(ROOT_SRCS) $(LEXER_SRCS) $G/backend.o $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
+	$(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) $(DFLAGS) -g -unittest -main -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
+
 unittest: $G/dmd-unittest
 	$<
 
@@ -475,6 +481,9 @@ DFLAGS=-I%@P%/../../../../../druntime/import -I%@P%/../../../../../phobos -L-L%@
 endef
 
 export DEFAULT_DMD_CONF
+
+$G/dmd.conf: $(SRC_MAKE)
+	echo "$$DEFAULT_DMD_CONF" > $@
 
 ######## VERSION
 ########################################################################

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -305,8 +305,8 @@ $(DMDFRONTENDEXE): $(GEN)\build.exe
 	$(RUN_BUILD) $@
 	copy $(DMDFRONTENDEXE) .
 
-$(TARGETEXE): $(GEN)\build.exe
-	$(RUN_BUILD) $@
+$(TARGETEXE): $(DMD_SRCS) $(ROOT_SRCS) $(LIBS) $(STRING_IMPORT_FILES)
+	$(HOST_DC) $(DSRC) -of$@ -vtls -J$G -J../res -L/STACK:8388608 $(DFLAGS) $(LFLAGS) $(DMD_SRCS) $(ROOT_SRCS) $(LIBS)
 	copy $(TARGETEXE) .
 
 ############################ Maintenance Targets #############################


### PR DESCRIPTION
Reverts dlang/dmd#10446

I don't know how build.d works, but it appears to simply grab all the .d files in the directory. This causes it to fail on my machine, as I tend to leave around other .d files, and my editor makes backup files by prepending .B to the filename.