### PR TITLE
Remove backend globals from header modules

### DIFF
--- a/src/dmd/backend/cg87.d
+++ b/src/dmd/backend/cg87.d
@@ -39,6 +39,8 @@ extern (C++):
 
 nothrow:
 
+private:
+
 int REGSIZE();
 
 private extern (D) uint mask(uint m) { return 1 << m; }
@@ -68,7 +70,7 @@ enum
     MFword          = 3
 }
 
-__gshared
+public __gshared
 {
     NDP[8] _8087elems;              // 8087 stack
     NDP ndp_zero;

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -28,6 +28,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.code;
 import dmd.backend.cgcse;
 import dmd.backend.code_x86;

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -26,6 +26,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -26,6 +26,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.code;
 import dmd.backend.code_x86;
 import dmd.backend.codebuilder;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -26,6 +26,7 @@ import core.stdc.string;
 
 import dmd.backend.cc;
 import dmd.backend.cdef;
+import dmd.backend.cg87;
 import dmd.backend.cgcse;
 import dmd.backend.code;
 import dmd.backend.code_x86;

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -636,7 +636,6 @@ void cnvt87(ref CodeBuilder cdb, elem *e , regm_t *pretregs );
 void neg87(ref CodeBuilder cdb, elem *e , regm_t *pretregs);
 void neg_complex87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdind87(ref CodeBuilder cdb,elem *e,regm_t *pretregs);
-extern __gshared { int stackused; }
 void cload87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdd_u64(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs);

--- a/src/dmd/backend/code_x86.d
+++ b/src/dmd/backend/code_x86.d
@@ -562,8 +562,6 @@ struct NDP
     __gshared int savetop;         // # of entries used in save[]
 }
 
-extern __gshared NDP[8] _8087elems;
-
 void getlvalue_msw(code *);
 void getlvalue_lsw(code *);
 void getlvalue(ref CodeBuilder cdb, code *pcs, elem *e, regm_t keepmsk);


### PR DESCRIPTION
I'm taking the encpsulation part out of #10255 and putting it in this new Pull Request.

* Make everything in `cg87.d` private by default
* Remove the `stackused` and `_8087elems` global variables from the `code.d` and `code_x86.d` backend headers.  These variables are only used internally by the backend so they don't need to be in the backend "header modules" that are imported by the frontend.