### PR TITLE
add bug flushing option to region.d

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3148,6 +3148,11 @@ private void expToBuffer(Expression e, PREC pr, OutBuffer* buf, HdrGenState* hgs
         if (precedence[e.op] == PREC.zero)
             printf("precedence not defined for token '%s'\n", Token.toChars(e.op));
     }
+    if (e.op == 0xFF)
+    {
+        buf.writestring("<FF>");
+        return;
+    }
     assert(precedence[e.op] != PREC.zero);
     assert(pr != PREC.zero);
     /* Despite precedence, we don't allow a<b<c expressions.


### PR DESCRIPTION
Instead of recycling the memory in region.d, this offers an option of stepping on it instead, making it much easier to track down dangling pointers. It also adds a bit to hdrgen.d so bad AST trees can be printed instead of seg faulting.

I still haven't found the memory corruption problem in dinterpret.d, but this gets me closer.