### PR TITLE
saveGlobalConstant: fix region memory leak

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -375,7 +375,7 @@ public:
     {
         assert(v._init && (v.isConst() || v.isImmutable() || v.storage_class & STC.manifest) && !v.isCTFE());
         v.ctfeAdrOnStack = cast(uint)globalValues.dim;
-        globalValues.push(e);
+        globalValues.push(copyRegionExp(e));
     }
 }
 


### PR DESCRIPTION
Found a spot where Region values were leaking out of the interpreter. Unfortunately, it is not the cause of the leak I am trying to isolate. Don't have test case for it.