### PR TITLE
CTFE scrubReturnValue(): fix omission

### DIFF
--- a/compiler/src/dmd/expression.d
+++ b/compiler/src/dmd/expression.d
@@ -739,6 +739,7 @@ extern (C++) abstract class Expression : ASTNode
         //printf("Expression::Expression(op = %d) this = %p\n", op, this);
         this.loc = loc;
         this.op = op;
+	assert(size < ubyte.max);
         this.size = cast(ubyte)size;
     }
 
@@ -3287,6 +3288,12 @@ extern (C++) final class StructLiteralExp : Expression
      * 'origin' pointer value of the original expression.
      */
     StructLiteralExp origin;
+
+    /** Used when moving an instance out of Region memory -
+     * this is where it is copied to.
+     * Need it because CTFE can have multiple parents to SLEs
+     */
+    StructLiteralExp copied;
 
     /// those fields need to prevent a infinite recursion when one field of struct initialized with 'this' pointer.
     StructLiteralExp inlinecopy;

--- a/compiler/src/dmd/expression.h
+++ b/compiler/src/dmd/expression.h
@@ -466,6 +466,12 @@ public:
      */
     StructLiteralExp *origin;
 
+    /** Used when moving an instance out of Region memory -
+     * this is where it is copied to.
+     * Need it because CTFE can have multiple parents to SLEs
+     */
+    StructLiteralExp *copied;
+
     // those fields need to prevent a infinite recursion when one field of struct initialized with 'this' pointer.
     StructLiteralExp *inlinecopy;
 

--- a/compiler/test/runnable/interpret.d
+++ b/compiler/test/runnable/interpret.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 true
 g
-&Test109S(&Test109S(<recursion>))
+&Test109S(&Test109S(&Test109S(<recursion>)))
 tfoo
 tfoo
 Crash!

--- a/compiler/test/runnable/xtest46.d
+++ b/compiler/test/runnable/xtest46.d
@@ -9,7 +9,7 @@ int
 !! immutable(int)[]
 int(int i, long j = 7L)
 long
-C10390(C10390(C10390(<recursion>)))
+C10390(C10390(<recursion>))
 tuple(height)
 tuple(get, get)
 tuple(clear)


### PR DESCRIPTION
Skipping this case led to a dangling reference to deleted Region allocations, i.e. memory corruption. Don't have a reasonable test case for it - spent 3 days till I found it :-(

This PR is just the fix. I plan later to do a refactoring on it to make the code saner.