### PR TITLE
objc.d: don't pass junk bytes to lookup()

### DIFF
--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -122,6 +122,7 @@ struct ObjcSelector
         }
     Lcomplete:
         buf.writeByte('\0');
+        // the slice is not expected to include a terminating 0
         return lookup(cast(const(char)*)buf[].ptr, buf.length - 1, pcount);
     }
 


### PR DESCRIPTION
The .size gives the allocated size of the buffer, not the used size.