### PR TITLE
Add the backend.d header module for internal backend symbols

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -801,7 +801,7 @@ auto sourceFiles()
             aav.d longdouble.d man.d response.d speller.d string.d strtold.d
         "),
         backend: fileArray(env["C"], "
-            bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d
+            backend.d bcomplex.d evalu8.d divcoeff.d dvec.d go.d gsroa.d glocal.d gdag.d gother.d gflow.d
             out.d
             gloop.d compress.d cgelem.d cgcs.d ee.d cod4.d cod5.d nteh.d blockopt.d mem.d cg.d cgreg.d
             dtype.d debugprint.d fp.d symbol.d elem.d dcode.d cgsched.d cg87.d cgxmm.d cgcod.d cod1.d cod2.d

--- a/src/dmd/backend/README.md
+++ b/src/dmd/backend/README.md
@@ -57,6 +57,7 @@ Exception Handling
 Miscellaneous
 -------------
 
+* **backend.d**       internal header file for the backend
 * **bcomplex.d**      our own complex number implementation
 * **md5.d**           implementation of MD5 message digest
 * **md5.di**          API for md5.d

--- a/src/dmd/backend/backend.d
+++ b/src/dmd/backend/backend.d
@@ -1,0 +1,31 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 2000-2019 by The D Language Foundation, All Rights Reserved
+ *
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/backend/backend.d, backend/backend.d)
+ */
+module dmd.backend.backend;
+
+version (SCPP)
+    version = COMPILE;
+version (MARS)
+    version = COMPILE;
+
+version (COMPILE)
+{
+
+import dmd.backend.code_x86;
+import dmd.backend.el;
+
+extern (C++):
+
+nothrow:
+
+extern __gshared { int stackused; }
+extern __gshared NDP[8] _8087elems;
+
+}

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -26,6 +26,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
+import dmd.backend.backend;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -24,6 +24,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
+import dmd.backend.backend;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;

--- a/src/dmd/backend/cod2.d
+++ b/src/dmd/backend/cod2.d
@@ -24,6 +24,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
+import dmd.backend.backend;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.code;

--- a/src/dmd/backend/cod3.d
+++ b/src/dmd/backend/cod3.d
@@ -24,6 +24,7 @@ import core.stdc.stdio;
 import core.stdc.stdlib;
 import core.stdc.string;
 
+import dmd.backend.backend;
 import dmd.backend.cc;
 import dmd.backend.cdef;
 import dmd.backend.cgcse;

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -636,7 +636,6 @@ void cnvt87(ref CodeBuilder cdb, elem *e , regm_t *pretregs );
 void neg87(ref CodeBuilder cdb, elem *e , regm_t *pretregs);
 void neg_complex87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdind87(ref CodeBuilder cdb,elem *e,regm_t *pretregs);
-extern __gshared { int stackused; }
 void cload87(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdd_u64(ref CodeBuilder cdb, elem *e, regm_t *pretregs);
 void cdd_u32(ref CodeBuilder cdb, elem *e, regm_t *pretregs);

--- a/src/dmd/backend/code_x86.d
+++ b/src/dmd/backend/code_x86.d
@@ -562,8 +562,6 @@ struct NDP
     __gshared int savetop;         // # of entries used in save[]
 }
 
-extern __gshared NDP[8] _8087elems;
-
 void getlvalue_msw(code *);
 void getlvalue_lsw(code *);
 void getlvalue(ref CodeBuilder cdb, code *pcs, elem *e, regm_t keepmsk);

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -356,7 +356,7 @@ BACK_HDRS=$C/cc.d $C/cdef.d $C/cgcv.d $C/code.d $C/cv4.d $C/dt.d $C/el.d $C/glob
 	$C/dlist.d $C/melf.d $C/varstats.di $C/dt.d
 
 BACK_SRC = \
-	$C/bcomplex.d $C/blockopt.d $C/cg.d $C/cg87.d $C/cgxmm.d \
+	$C/backend.d $C/bcomplex.d $C/blockopt.d $C/cg.d $C/cg87.d $C/cgxmm.d \
 	$C/cgcod.d $C/cgcs.d $C/dcgcv.d $C/cgelem.d $C/cgen.d $C/cgobj.d \
 	$C/compress.d $C/cgreg.d $C/var.d $C/cgcse.d \
 	$C/cgsched.d $C/cod1.d $C/cod2.d $C/cod3.d $C/cod4.d $C/cod5.d \

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -196,7 +196,7 @@ GLUESRC= \
 # D back end
 BACKSRC= \
 	$C/code_stub.h $C/platform_stub.c \
-	$C\bcomplex.d $C\blockopt.d $C\cg.d $C\cg87.d $C\cgxmm.d \
+	$C\backend.d $C\bcomplex.d $C\blockopt.d $C\cg.d $C\cg87.d $C\cgxmm.d \
 	$C\cgcod.d $C\cgcs.d $C\dcgcv.d $C\cgelem.d $C\cgen.d $C\cgobj.d \
 	$C\compress.d $C\cgreg.d $C\var.d $C\cgcse.d \
 	$C\cgsched.d $C\cod1.d $C\cod2.d $C\cod3.d $C\cod4.d $C\cod5.d \


### PR DESCRIPTION
Walter suggested that instead of importing the 4000 line `cg87` module in other backend modules, that we put the global declarations in another file named `backend.d`. 

see https://github.com/dlang/dmd/pull/10460#issuecomment-540832474

I've done that here. We may want to move more declarations from other files into this file.  However, I default to keeping changes small so I'm just starting with the `cg87.d` globals.  If anyone would like me to add more before approving then let me know.

I also wasn't sure if Walter would want to put the global definitions in the new D header module or just extern declarations and keep the definitions in cg87.d.  I went with just moving the extern declarations here as that's my best guess to what he'd want.

Ping @WalterBright 