### PR TITLE
fix issue 15118 - Win32: default to using optlink.exe with the Digital Mars toolchain

### DIFF
--- a/changelog/optlink.dd
+++ b/changelog/optlink.dd
@@ -1,0 +1,6 @@
+The default linker for the Digital Mars tool chain is now optlink.exe
+
+The default linker when building with -m32 under Windows has been changed
+from link.exe to optlink.exe to avoid calling the wrong linker when both
+the Digital Mars tool chain and the Microsoft compiler tools are found in
+the PATH environment variable.

--- a/ini/windows/bin/sc.ini
+++ b/ini/windows/bin/sc.ini
@@ -13,7 +13,7 @@ LIB="%@P%\..\lib"
 
 [Environment32]
 LIB="%@P%\..\lib"
-LINKCMD=%@P%\link.exe
+LINKCMD=%@P%\optlink.exe
 
 
 [Environment64]

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -435,7 +435,7 @@ public int runLINK()
             }
             const(char)* linkcmd = getenv("LINKCMD");
             if (!linkcmd)
-                linkcmd = "link";
+                linkcmd = "optlink";
             const int status = executecmd(linkcmd, p.ptr);
             if (lnkfilename)
             {


### PR DESCRIPTION
There has been a previous attempt but that changed the default for the MS toolchain: https://github.com/dlang/dmd/pull/5147

optlink.exe has been shipped alongside link.exe since ~~2.069~~ 2.079.

More things to do on the installer side:
- write appropriate sc.ini
- remove link.exe from installation