### PR TITLE
Remove debug logging from verbose output

### DIFF
--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -4978,8 +4978,8 @@ public:
                 AssignExp ae = ctfeEmplaceExp!AssignExp(e.loc, ale, eb);
                 ae.type = ea.type;
 
-                if (global.params.verbose)
-                    message("interpret  %s =>\n          %s", e.toChars(), ae.toChars());
+                // if (global.params.verbose)
+                //     message("interpret  %s =>\n          %s", e.toChars(), ae.toChars());
                 result = interpretRegion(ae, istate);
                 return;
             }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -8831,8 +8831,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
             Expression ce = new CallExp(ale.loc, id, arguments);
             auto res = ce.expressionSemantic(sc);
-            if (global.params.verbose)
-                message("lowered   %s =>\n          %s", exp.toChars(), res.toChars());
+            // if (global.params.verbose)
+            //     message("lowered   %s =>\n          %s", exp.toChars(), res.toChars());
             return setResult(res);
         }
         else if (auto se = exp.e1.isSliceExp())


### PR DESCRIPTION
```
Verbose output (-v flag) currently has these use cases:

1. Longer error messages such as regarding template instantiations.

   The compiler suggests adding the -v flag when the "instantiated
   from" chains are very long.

2. Dependency tracking ("import" statements).

   These have been historically used by build tools to discover which
   files a D program uses / imports (Cf. -deps).

These messages don't fit in either of these categories, and seem
unlikely to be useful to D users.

If these messages are useful to DMD developers, they can be added back
behind one of the undocumented debug flags (e.g. --x) or guarded in a
D debug block (so that they're only present in debug DMD builds).
```

CC @Vild 