### PR TITLE
reduce use of extractChars()

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2082,7 +2082,8 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         const errors = global.errors;
         const len = buf.length;
-        const str = buf.extractChars()[0 .. len];
+        buf.writeByte(0);
+        const str = buf.extractSlice()[0 .. len];
         scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
         scope p = new Parser!ASTCodegen(cd.loc, sc._module, str, false, diagnosticReporter);
         p.nextToken();

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -171,7 +171,8 @@ extern (C++) abstract class Statement : ASTNode
         HdrGenState hgs;
         OutBuffer buf;
         .toCBuffer(this, &buf, &hgs);
-        return buf.extractChars();
+        buf.writeByte(0);
+        return buf.extractSlice().ptr;
     }
 
     final void error(const(char)* format, ...)
@@ -812,7 +813,8 @@ extern (C++) final class CompileStatement : Statement
 
         const errors = global.errors;
         const len = buf.length;
-        const str = buf.extractChars()[0 .. len];
+        buf.writeByte(0);
+        const str = buf.extractSlice()[0 .. len];
         scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
         scope p = new Parser!ASTCodegen(loc, sc._module, str, false, diagnosticReporter);
         p.nextToken();

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -842,7 +842,8 @@ nothrow:
                 buf.writeByte('"');
                 if (postfix)
                     buf.writeByte(postfix);
-                p = buf.extractChars();
+                buf.writeByte(0);
+                p = buf.extractSlice().ptr;
             }
             break;
         case TOK.hexadecimalString:

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1545,7 +1545,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                         break;
                     }
                     const len = buf.length;
-                    const str = buf.extractChars()[0 .. len];
+                    buf.writeByte(0);
+                    const str = buf.extractSlice()[0 .. len];
                     scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
                     scope p = new Parser!ASTCodegen(e.loc, sc._module, str, false, diagnosticReporter);
                     p.nextToken();

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1975,7 +1975,8 @@ Type compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
 
     const errors = global.errors;
     const len = buf.length;
-    const str = buf.extractChars()[0 .. len];
+    buf.writeByte(0);
+    const str = buf.extractSlice()[0 .. len];
     scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
     scope p = new Parser!ASTCodegen(loc, sc._module, str, false, diagnosticReporter);
     p.nextToken();


### PR DESCRIPTION
The management of the 0 byte should be done upstack, mainly to shame the caller into not needing it.