### PR TITLE
Fix broken C++ headers and broken bootstrap builds

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1670,9 +1670,9 @@ extern(C++):
         buf.writeByte('R');
         CV_qualifiers(t.nextOf());
         headOfType(t.nextOf());
-        append(t);
         if (t.nextOf().isConst())
             append(t.nextOf());
+        append(t);
     }
 
     override void visit(TypeFunction t)

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -17,7 +17,7 @@
 #include "visitor.h"
 #include "tokens.h"
 
-#include "root/rmem.h"
+#include "root/dcompat.h"
 
 class Type;
 class TypeVector;

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -233,6 +233,7 @@ struct Param
     // Linker stuff
     Array<const char *> objfiles;
     Array<const char *> linkswitches;
+    Array<bool> linkswitchIsForCC;
     Array<const char *> libfiles;
     Array<const char *> dllfiles;
     DString deffile;

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "root/rmem.h" // for d_size_t
+#include "root/dcompat.h" // for d_size_t
 
 #include "arraytypes.h"
 #include "ast_node.h"

--- a/src/dmd/root/dcompat.h
+++ b/src/dmd/root/dcompat.h
@@ -34,3 +34,15 @@ struct DString : public DArray<const char>
     DString(size_t length, const char *ptr)
         : DArray(length, ptr) { }
 };
+
+/// Corresponding C++ type that maps to D size_t
+#if __APPLE__ && __i386__
+// size_t is 'unsigned long', which makes it mangle differently than D's 'uint'
+typedef unsigned d_size_t;
+#elif MARS && DMD_VERSION >= 2079 && DMD_VERSION <= 2081 && \
+        __APPLE__ && __SIZEOF_SIZE_T__ == 8
+// DMD versions between 2.079 and 2.081 mapped D ulong to uint64_t on OS X.
+typedef uint64_t d_size_t;
+#else
+typedef size_t d_size_t;
+#endif

--- a/src/dmd/root/outbuffer.d
+++ b/src/dmd/root/outbuffer.d
@@ -27,9 +27,9 @@ struct OutBuffer
 {
     private ubyte[] data;
     private size_t offset;
-    int level;
-    bool doindent;
     private bool notlinehead;
+    bool doindent;
+    int level;
 
     extern (C++) ~this() pure nothrow
     {

--- a/src/dmd/root/outbuffer.h
+++ b/src/dmd/root/outbuffer.h
@@ -10,27 +10,25 @@
 #pragma once
 
 #include "dsystem.h"
+#include "dcompat.h"
 #include "rmem.h"
 
 class RootObject;
 
 struct OutBuffer
 {
-    unsigned char *data;
-    size_t offset;
-    size_t size;
-
-    int level;
-    bool doindent;
 private:
+    DArray<unsigned char> data;
+    size_t offset;
     bool notlinehead;
 public:
+    bool doindent;
+    int level;
 
     OutBuffer()
     {
-        data = NULL;
+        data = DArray<unsigned char>();
         offset = 0;
-        size = 0;
 
         doindent = 0;
         level = 0;
@@ -38,15 +36,15 @@ public:
     }
     ~OutBuffer()
     {
-        mem.xfree(data);
+        mem.xfree(data.ptr);
     }
+    size_t length() const { return offset; }
     char *extractData();
     void destroy();
 
     void reserve(size_t nbytes);
     void setsize(size_t size);
     void reset();
-    //void write(const void *data, d_size_t nbytes);
     void writestring(const char *string);
     void prependstring(const char *string);
     void writenl();                     // write newline
@@ -57,7 +55,7 @@ public:
     void writeword(unsigned w);
     void writeUTF16(unsigned w);
     void write4(unsigned w);
-    void write(OutBuffer *buf);
+    void write(const OutBuffer *buf);
     void write(RootObject *obj);
     void fill0(size_t nbytes);
     void vprintf(const char *format, va_list args);

--- a/src/dmd/root/outbuffer.h
+++ b/src/dmd/root/outbuffer.h
@@ -19,7 +19,7 @@ struct OutBuffer
 {
 private:
     DArray<unsigned char> data;
-    size_t offset;
+    d_size_t offset;
     bool notlinehead;
 public:
     bool doindent;
@@ -38,12 +38,12 @@ public:
     {
         mem.xfree(data.ptr);
     }
-    size_t length() const { return offset; }
+    d_size_t length() const { return offset; }
     char *extractData();
     void destroy();
 
-    void reserve(size_t nbytes);
-    void setsize(size_t size);
+    void reserve(d_size_t nbytes);
+    void setsize(d_size_t size);
     void reset();
     void writestring(const char *string);
     void prependstring(const char *string);
@@ -57,14 +57,14 @@ public:
     void write4(unsigned w);
     void write(const OutBuffer *buf);
     void write(RootObject *obj);
-    void fill0(size_t nbytes);
+    void fill0(d_size_t nbytes);
     void vprintf(const char *format, va_list args);
     void printf(const char *format, ...);
     void bracket(char left, char right);
-    size_t bracket(size_t i, const char *left, size_t j, const char *right);
-    void spread(size_t offset, size_t nbytes);
-    size_t insert(size_t offset, const void *data, size_t nbytes);
-    void remove(size_t offset, size_t nbytes);
+    d_size_t bracket(d_size_t i, const char *left, d_size_t j, const char *right);
+    void spread(d_size_t offset, d_size_t nbytes);
+    d_size_t insert(d_size_t offset, const void *data, d_size_t nbytes);
+    void remove(d_size_t offset, d_size_t nbytes);
     // Append terminating null if necessary and get view of internal buffer
     char *peekChars();
     // Append terminating null if necessary and take ownership of data

--- a/src/dmd/root/rmem.h
+++ b/src/dmd/root/rmem.h
@@ -9,21 +9,7 @@
 
 #pragma once
 
-#include "dsystem.h"    // for size_t
-
-#if __APPLE__ && __i386__
-    /* size_t is 'unsigned long', which makes it mangle differently
-     * than D's 'uint'
-     */
-    typedef unsigned d_size_t;
-#elif MARS && DMD_VERSION >= 2079 && DMD_VERSION <= 2081 && \
-        __APPLE__ && __SIZEOF_SIZE_T__ == 8
-    /* DMD versions between 2.079 and 2.081 mapped D ulong to uint64_t on OS X.
-     */
-    typedef uint64_t d_size_t;
-#else
-    typedef size_t d_size_t;
-#endif
+#include "dcompat.h"    // for d_size_t
 
 struct Mem
 {

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -117,9 +117,11 @@ class TestVisitor : public Visitor
     bool decl;
     bool typeinfo;
     bool idexpr;
+    bool function;
 
     TestVisitor() : expr(false), package(false), stmt(false), type(false),
-        aggr(false), attrib(false), decl(false), typeinfo(false), idexpr(false)
+        aggr(false), attrib(false), decl(false), typeinfo(false), idexpr(false),
+        function(false)
     {
     }
 
@@ -166,6 +168,11 @@ class TestVisitor : public Visitor
     void visit(TypeInfoDeclaration *)
     {
         typeinfo = true;
+    }
+
+    void visit(FuncDeclaration *)
+    {
+        function = true;
     }
 };
 
@@ -223,6 +230,15 @@ void test_visitors()
     assert(ti->tinfo == tp);
     ti->accept(&tv);
     assert(tv.typeinfo == true);
+
+    Parameters *args = new Parameters;
+    TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINKc);
+    FuncDeclaration *fd = FuncDeclaration::create(Loc (), Loc (), Identifier::idPool("test"),
+                                                  STCextern, tf);
+    assert(fd->isFuncDeclaration() == fd);
+    assert(fd->type == tf);
+    fd->accept(&tv);
+    assert(tv.function == true);
 }
 
 /**********************************/

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -386,6 +386,25 @@ void test_array()
         assert(arrayA[i] == 0);
 }
 
+void test_outbuffer()
+{
+    OutBuffer buf;
+    mangleToBuffer(Type::tint64, &buf);
+    assert(strcmp(buf.peekChars(), "l") == 0);
+    buf.reset();
+
+    buf.reserve(16);
+    buf.writestring("hello");
+    buf.writeByte(' ');
+    buf.write(&buf);
+    buf.writenl();
+    assert(buf.length() == 13);
+
+    const char *data = buf.extractChars();
+    assert(buf.length() == 0);
+    assert(strcmp(data, "hello hello \n") == 0);
+}
+
 /**********************************/
 
 int main(int argc, char **argv)
@@ -401,6 +420,7 @@ int main(int argc, char **argv)
     test_parameters();
     test_location();
     test_array();
+    test_outbuffer();
 
     frontend_term();
 

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1215,3 +1215,18 @@ version (Posix)
         set20224!int x;
     }
 }
+
+/**************************************/
+
+version (Posix)
+{
+    extern (C++) struct Loc2 {};
+    extern (C++) class FuncDeclaration
+    {
+        static FuncDeclaration create(ref const Loc2, ref const Loc2);
+    };
+    extern (C++) FuncDeclaration FuncDeclaration_create(ref const Loc2, ref const Loc2);
+
+    static assert(FuncDeclaration_create.mangleof == `_Z22FuncDeclaration_createRK4Loc2S1_`);
+    static assert(FuncDeclaration.create.mangleof == `_ZN15FuncDeclaration6createERK4Loc2S2_`);
+}


### PR DESCRIPTION
~To prevent bootstrap regressions from being silently introduced, the compiler used to build cxx-frontend has been switched from the host dmd to the target dmd.~

Edit: Removed this as is just a bit too involved, and doesn't play well with current auto-tester order (adds a dependency on druntime that isn't built yet).

All that's left are relevant fixes and testsuite code.