### PR TITLE
build.d: Fix architecture detection for the german locale on Windows

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -899,9 +899,9 @@ auto detectModel()
     else
         uname = ["uname", "-m"].execute.output;
 
-    if (uname.canFind("x86_64", "amd64", "64-bit", "64 bit"))
+    if (uname.canFind("x86_64", "amd64", "64-bit", "64-Bit", "64 bit"))
         return "64";
-    if (uname.canFind("i386", "i586", "i686", "32-bit", "32 bit"))
+    if (uname.canFind("i386", "i586", "i686", "32-bit", "32-Bit", "32 bit"))
         return "32";
 
     throw new Exception(`Cannot figure 32/64 model from "` ~ uname ~ `"`);


### PR DESCRIPTION
Tested on Windows 10 Pro, Version 1903, Build 18362.418