### PR TITLE
build.d: Fix host compiler detection for LDC

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -679,15 +679,17 @@ void processEnvironment()
 {
     const os = env["OS"];
 
-    auto hostDMDVersion = [env["HOST_DMD_RUN"], "--version"].execute.output;
-    if (hostDMDVersion.canFind("DMD"))
+    const hostDMDVersion = [env["HOST_DMD_RUN"], "--version"].execute.output;
+    const kindIdx = hostDMDVersion.canFind("DMD", "LDC", "GDC", "gdmd", "gdc");
+
+    enforce(kindIdx, "Invalid Host DMD found: " ~ hostDMDVersion);
+
+    if (kindIdx == 1)
         env["HOST_DMD_KIND"] = "dmd";
-    else if (hostDMDVersion.canFind("LDC"))
+    else if (kindIdx == 2)
         env["HOST_DMD_KIND"] = "ldc";
-    else if (hostDMDVersion.canFind("GDC", "gdmd", "gdc"))
-        env["HOST_DMD_KIND"] = "gdc";
     else
-        enforce(0, "Invalid Host DMD found: " ~ hostDMDVersion);
+        env["HOST_DMD_KIND"] = "gdc";
 
     env["DMD_PATH"] = env["G"].buildPath("dmd").exeName;
 

--- a/src/build.d
+++ b/src/build.d
@@ -677,16 +677,22 @@ void parseEnvironment()
 /// Checks the environment variables and flags
 void processEnvironment()
 {
+    import std.meta : AliasSeq;
+
     const os = env["OS"];
 
     const hostDMDVersion = [env["HOST_DMD_RUN"], "--version"].execute.output;
-    const kindIdx = hostDMDVersion.canFind("DMD", "LDC", "GDC", "gdmd", "gdc");
+
+    alias DMD = AliasSeq!("DMD");
+    alias LDC = AliasSeq!("LDC");
+    alias GDC = AliasSeq!("GDC", "gdmd", "gdc");
+    const kindIdx = hostDMDVersion.canFind(DMD, LDC, GDC);
 
     enforce(kindIdx, "Invalid Host DMD found: " ~ hostDMDVersion);
 
-    if (kindIdx == 1)
+    if (kindIdx <= DMD.length)
         env["HOST_DMD_KIND"] = "dmd";
-    else if (kindIdx == 2)
+    else if (kindIdx <= LDC.length + DMD.length)
         env["HOST_DMD_KIND"] = "ldc";
     else
         env["HOST_DMD_KIND"] = "gdc";


### PR DESCRIPTION
The output of ldc2 --version contains the compiler used to build it (e.g. dmd) which results in HOST_DMD_KIND being set to "dmd".

Both DMD and LDC start the output of --version with their unqualified name (tested on Windows/Ubuntu)