### PR TITLE
Makefiles: Remove unused -debug flag from build.d compilation

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -410,7 +410,7 @@ dmd: $G/dmd $G/dmd.conf
 .PHONY: dmd
 
 $(GENERATED)/build: build.d $(HOST_DMD_PATH)
-	$(HOST_DMD_RUN) -of$@ -debug build.d
+	$(HOST_DMD_RUN) -of$@ build.d
 
 auto-tester-build: dmd checkwhitespace cxx-unittest $G/dmd_frontend
 .PHONY: auto-tester-build

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -244,7 +244,7 @@ auto-tester-build: $G dmd checkwhitespace $(DMDFRONTENDEXE)
 dmd: $G reldmd
 
 $(GEN)\build.exe: build.d $(HOST_DMD_PATH)
-	$(HOST_DC) -m$(MODEL) -of$@ -debug build.d
+	$(HOST_DC) -m$(MODEL) -of$@ build.d
 
 release:
 	$(DMDMAKE) clean


### PR DESCRIPTION
Its compiler specific and (currently) useless because the code does not
contain any debug conditions.

This allows using LDC and GDC to compile build.d.