### PR TITLE
StringExp.peekSlice(): rename to peekString()

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1120,7 +1120,7 @@ private final class CppMangleVisitor : Visitor
                 switch (whichOp)
                 {
                 case CppOperator.Unary:
-                    switch (str.peekSlice())
+                    switch (str.peekString())
                     {
                     case "*":   symName = "de"; goto continue_template;
                     case "++":  symName = "pp"; goto continue_template;
@@ -1132,7 +1132,7 @@ private final class CppMangleVisitor : Visitor
                     }
                     break;
                 case CppOperator.Binary:
-                    switch (str.peekSlice())
+                    switch (str.peekString())
                     {
                     case ">>":  symName = "rs"; goto continue_template;
                     case "<<":  symName = "ls"; goto continue_template;
@@ -1148,7 +1148,7 @@ private final class CppMangleVisitor : Visitor
                     }
                     break;
                 case CppOperator.OpAssign:
-                    switch (str.peekSlice())
+                    switch (str.peekString())
                     {
                     case "*":   symName = "mL"; goto continue_template;
                     case "+":   symName = "pL"; goto continue_template;

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -705,7 +705,7 @@ private:
             switch (whichOp)
             {
             case CppOperator.Unary:
-                switch (str.peekSlice())
+                switch (str.peekString())
                 {
                     case "*":   symName = "?D";     goto continue_template;
                     case "++":  symName = "?E";     goto continue_template;
@@ -716,7 +716,7 @@ private:
                     default:    return false;
                 }
             case CppOperator.Binary:
-                switch (str.peekSlice())
+                switch (str.peekString())
                 {
                     case ">>":  symName = "?5";     goto continue_template;
                     case "<<":  symName = "?6";     goto continue_template;
@@ -731,7 +731,7 @@ private:
                     default:    return false;
                     }
             case CppOperator.OpAssign:
-                switch (str.peekSlice())
+                switch (str.peekString())
                 {
                     case "*":   symName = "?X";     goto continue_template;
                     case "+":   symName = "?Y";     goto continue_template;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2622,7 +2622,7 @@ extern (C++) final class StringExp : Expression
         return s[0 .. nbytes];
     }
 
-    extern (D) const(char)[] peekSlice() const
+    extern (D) const(char)[] peekString() const
     {
         assert(sz == 1);
         return this.string[0 .. len];

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -122,7 +122,7 @@ bool expressionsToString(ref OutBuffer buf, Scope* sc, Expressions* exps)
         }
 
         if (StringExp se = e4.toStringExp())
-            buf.writestring(se.toUTF8(sc).peekSlice());
+            buf.writestring(se.toUTF8(sc).peekString());
         else
             buf.writestring(e4.toString());
     }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -905,7 +905,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             e.error("string must be chars");
             return new ErrorExp();
         }
-        auto id = Identifier.idPool(se.peekSlice());
+        auto id = Identifier.idPool(se.peekString());
 
         /* Prefer dsymbol, because it might need some runtime contexts.
          */


### PR DESCRIPTION
First step in getting control of all the accesses to StringExp's internals.