### PR TITLE
Update handling of HOST_DMD when performing builds.

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -2,7 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.079.1 # same as in dmd/src/posix.mak
+HOST_DMD_VER=2.088.0 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=4
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}

--- a/src/build.d
+++ b/src/build.d
@@ -644,7 +644,7 @@ void parseEnvironment()
     // Auto-bootstrapping of a specific host compiler
     if (env.getDefault("AUTO_BOOTSTRAP", null) == "1")
     {
-        auto hostDMDVer = "2.079.1";
+        auto hostDMDVer = env.getDefault("HOST_DMD_VER", "2.079.1");
         writefln("Using Bootstrap compiler: %s", hostDMDVer);
         auto hostDMDRoot = env["G"].buildPath("host_dmd-"~hostDMDVer);
         auto hostDMDBase = hostDMDVer~"."~os;

--- a/src/build.d
+++ b/src/build.d
@@ -644,7 +644,7 @@ void parseEnvironment()
     // Auto-bootstrapping of a specific host compiler
     if (env.getDefault("AUTO_BOOTSTRAP", null) == "1")
     {
-        auto hostDMDVer = env.getDefault("HOST_DMD_VER", "2.079.1");
+        auto hostDMDVer = env.getDefault("HOST_DMD_VER", "2.088.0");
         writefln("Using Bootstrap compiler: %s", hostDMDVer);
         auto hostDMDRoot = env["G"].buildPath("host_dmd-"~hostDMDVer);
         auto hostDMDBase = hostDMDVer~"."~os;

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -140,11 +140,11 @@ ifeq (,$(AUTO_BOOTSTRAP))
 else
   # Auto-bootstrapping, will download dmd automatically
   # Keep var below in sync with other occurrences of that variable, e.g. in circleci.sh
-  HOST_DMD_VER=2.079.1
+  HOST_DMD_VER=2.088.0
   HOST_DMD_ROOT=$(GENERATED)/host_dmd-$(HOST_DMD_VER)
-  # dmd.2.072.2.osx.zip or dmd.2.072.2.linux.tar.xz
+  # dmd.2.088.0.osx.zip or dmd.2.088.0.linux.tar.xz
   HOST_DMD_BASENAME=dmd.$(HOST_DMD_VER).$(OS)$(if $(filter $(OS),freebsd),-$(MODEL),)
-  # http://downloads.dlang.org/releases/2.x/2.072.2/dmd.2.072.2.linux.tar.xz
+  # http://downloads.dlang.org/releases/2.x/2.088.0/dmd.2.088.0.linux.tar.xz
   HOST_DMD_URL=http://downloads.dlang.org/releases/2.x/$(HOST_DMD_VER)/$(HOST_DMD_BASENAME)
   HOST_DMD=$(HOST_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))/dmd
   HOST_DMD_PATH=$(HOST_DMD)


### PR DESCRIPTION
* Honor HOST_DMD_VER passed to make when performing build.
It might be sometimes needed to pass HOST_DMD_VER manually. While posix.mak honors this variable without a problem, `build.d` still has version hardcoded. 

* Bump minimal version of DMD used for host builds.
Bump HOST_DMD from `2.079.1` to `2.088.0`.
`2.088.0` is minimal version of DMD that works on MacOS Catalina.
Without this change building from source on Catalina simply doesn't work.
