### PR TITLE
build.d: Use alternative host model detection for Windows

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -895,7 +895,17 @@ auto detectModel()
     if (detectOS == "solaris")
         uname = ["isainfo", "-n"].execute.output;
     else if (detectOS == "windows")
-        uname = ["wmic", "OS", "get", "OSArchitecture"].execute.output;
+    {
+        version (D_LP64)
+            return "64"; // host must be 64-bit if this compiles
+        else version (Windows)
+        {
+            import core.sys.windows.winbase;
+            int is64;
+            if (IsWow64Process(GetCurrentProcess(), &is64))
+                return is64 ? "64" : "32";
+        }
+    }
     else
         uname = ["uname", "-m"].execute.output;
 


### PR DESCRIPTION
WMIC output seems to vary based on the host locale, and we don't want to patch the output detection to include all different localizations which are hard to test.