### PR TITLE
build.d: Encapsulate compiler specific flags

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -679,15 +679,17 @@ void processEnvironment()
 {
     const os = env["OS"];
 
-    auto hostDMDVersion = [env["HOST_DMD_RUN"], "--version"].execute.output;
-    if (hostDMDVersion.canFind("DMD"))
+    const hostDMDVersion = [env["HOST_DMD_RUN"], "--version"].execute.output;
+    const kindIdx = hostDMDVersion.canFind("DMD", "LDC", "GDC", "gdmd", "gdc");
+
+    enforce(kindIdx, "Invalid Host DMD found: " ~ hostDMDVersion);
+
+    if (kindIdx == 1)
         env["HOST_DMD_KIND"] = "dmd";
-    else if (hostDMDVersion.canFind("LDC"))
+    else if (kindIdx == 2)
         env["HOST_DMD_KIND"] = "ldc";
-    else if (hostDMDVersion.canFind("GDC", "gdmd", "gdc"))
-        env["HOST_DMD_KIND"] = "gdc";
     else
-        enforce(0, "Invalid Host DMD found: " ~ hostDMDVersion);
+        env["HOST_DMD_KIND"] = "gdc";
 
     env["DMD_PATH"] = env["G"].buildPath("dmd").exeName;
 

--- a/src/build.d
+++ b/src/build.d
@@ -677,16 +677,22 @@ void parseEnvironment()
 /// Checks the environment variables and flags
 void processEnvironment()
 {
+    import std.meta : AliasSeq;
+
     const os = env["OS"];
 
     const hostDMDVersion = [env["HOST_DMD_RUN"], "--version"].execute.output;
-    const kindIdx = hostDMDVersion.canFind("DMD", "LDC", "GDC", "gdmd", "gdc");
+
+    alias DMD = AliasSeq!("DMD");
+    alias LDC = AliasSeq!("LDC");
+    alias GDC = AliasSeq!("GDC", "gdmd", "gdc");
+    const kindIdx = hostDMDVersion.canFind(DMD, LDC, GDC);
 
     enforce(kindIdx, "Invalid Host DMD found: " ~ hostDMDVersion);
 
-    if (kindIdx == 1)
+    if (kindIdx <= DMD.length)
         env["HOST_DMD_KIND"] = "dmd";
-    else if (kindIdx == 2)
+    else if (kindIdx <= LDC.length + DMD.length)
         env["HOST_DMD_KIND"] = "ldc";
     else
         env["HOST_DMD_KIND"] = "gdc";


### PR DESCRIPTION
This allows build.d to build DMD with other host compilers which use slightly different flags, e.g. `-debug` (DMD), `-d-debug` (LDC) and `-fdebug` (GDC).

TODO:
- Add missing flags (if any)
- Handle gdc
-- `-fd-vtls` not always present
--  Missing `-lib` to create a static library
- Extend this function to encapsulate all flags used in build.d / supported by DMD?

This includes #10480

CC @ @wilzbach, @marler8997 