### PR TITLE
build.d: Add checkwhitespace

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -450,7 +450,9 @@ alias tools = memoize!(function()
             if(!exists(env["TOOLS_DIR"] ~ "/checkwhitespace.d"))
             {
                 writeln("(GIT) Cloning tools");
-                runCanThrow([env["GIT"], "clone", "--depth=1", env["GIT_HOME"] ~ "/tools", env["TOOLS_DIR"]]);
+                const cmd = [env["GIT"], "clone", "--depth=1", env["GIT_HOME"] ~ "/tools", env["TOOLS_DIR"]];
+                writeln(cmd);
+                runCanThrow(cmd);
             }
         };
     }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -78,7 +78,6 @@ else
 endif
 
 GIT_HOME=https://github.com/dlang
-TOOLS_DIR=../../tools
 
 INSTALL_DIR=../../install
 SYSCONFDIR=/etc
@@ -517,11 +516,8 @@ install: all $(DMD_MAN_PAGE)
 
 ######################################################
 
-checkwhitespace: $(HOST_DMD_PATH) $(TOOLS_DIR)/checkwhitespace.d
-	CC="$(HOST_CXX)" $(HOST_DMD_RUN) -run $(TOOLS_DIR)/checkwhitespace.d $(SRC) $(GLUE_SRC) $(ROOT_SRCS)
-
-$(TOOLS_DIR)/checkwhitespace.d:
-	git clone --depth=1 ${GIT_HOME}/tools $(TOOLS_DIR)
+checkwhitespace: $(GENERATED)/build
+	$(RUN_BUILD) $@
 
 ######################################################
 # DScanner

--- a/src/vcbuild/stdint.h
+++ b/src/vcbuild/stdint.h
@@ -43,9 +43,9 @@ typedef unsigned   uint_least32_t;
 typedef long long  int_least64_t;
 typedef unsigned long long   uint_least64_t;
 
-/*  7.18.1.3  Fastest minimum-width integer types 
+/*  7.18.1.3  Fastest minimum-width integer types
  *  Not actually guaranteed to be fastest for all purposes
- *  Here we use the exact-width types for 8 and 16-bit ints. 
+ *  Here we use the exact-width types for 8 and 16-bit ints.
  */
 typedef char int_fast8_t;
 typedef unsigned char uint_fast8_t;
@@ -84,7 +84,7 @@ typedef unsigned long long uintmax_t;
 #if !defined ( __cplusplus) || defined (__STDC_LIMIT_MACROS)
 
 /* 7.18.2.1  Limits of exact-width integer types */
-#define INT8_MIN (-128) 
+#define INT8_MIN (-128)
 #define INT16_MIN (-32768)
 #define INT32_MIN (-2147483647 - 1)
 #define INT64_MIN  (-9223372036854775807LL - 1)
@@ -157,7 +157,7 @@ typedef unsigned long long uintmax_t;
 
 #define SIZE_MAX UINTPTR_MAX
 
-#ifndef WCHAR_MIN  /* also in wchar.h */ 
+#ifndef WCHAR_MIN  /* also in wchar.h */
 #define WCHAR_MIN 0
 #define WCHAR_MAX 0xffff /* UINT16_MAX */
 #endif
@@ -177,14 +177,14 @@ typedef unsigned long long uintmax_t;
 /* 7.18.4.1  Macros for minimum-width integer constants
 
     Accoding to Douglas Gwyn <gwyn@arl.mil>:
-	"This spec was changed in ISO/IEC 9899:1999 TC1; in ISO/IEC
-	9899:1999 as initially published, the expansion was required
-	to be an integer constant of precisely matching type, which
-	is impossible to accomplish for the shorter types on most
-	platforms, because C99 provides no standard way to designate
-	an integer constant with width less than that of type int.
-	TC1 changed this to require just an integer constant
-	*expression* with *promoted* type."
+        "This spec was changed in ISO/IEC 9899:1999 TC1; in ISO/IEC
+        9899:1999 as initially published, the expansion was required
+        to be an integer constant of precisely matching type, which
+        is impossible to accomplish for the shorter types on most
+        platforms, because C99 provides no standard way to designate
+        an integer constant with width less than that of type int.
+        TC1 changed this to require just an integer constant
+        *expression* with *promoted* type."
 */
 
 #define INT8_C(val) ((int8_t) + (val))

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -76,7 +76,6 @@ G = $(GEN)\$(OS)\$(BUILD)\$(MODEL)
 ##### Tools
 
 GIT_HOME=https://github.com/dlang
-TOOLS_DIR=..\..\tools
 
 # D compiler (set with env variable)
 #HOST_DC=dmd
@@ -367,12 +366,8 @@ pvs:
 #	$(PVS) --cfg PVS-Studio.cfg --cl-params /I$(ROOT) /Tp $(ROOTSRCC) --source-file $(ROOTSRCC)
 #	$(PVS) --cfg PVS-Studio.cfg --cl-params /I$C /Tp $(BACKSRC) --source-file $(BACKSRC)
 
-checkwhitespace: $(TOOLS_DIR)\checkwhitespace.d
-	$(HOST_DC) -run $(TOOLS_DIR)\checkwhitespace $(SRCS) $(GLUESRC) $(ROOTSRC) $(BACKSRC)
-
-# Extra test here, wine attempts to execute git even if file already exists
-$(TOOLS_DIR)\checkwhitespace.d:
-	if not exist $(TOOLS_DIR)\checkwhitespace.d git clone --depth=1 $(GIT_HOME)/tools $(TOOLS_DIR)
+checkwhitespace: $(GEN)\build.exe
+	$(RUN_BUILD) $@
 
 ######################################################
 


### PR DESCRIPTION
Move `checkwhitespace` from win32.mak / posix.mak into build.d

~~TODO: With this patch `checkwhitespace` apparently considers some additional files which contain windows line ending and fail the check. The last commit temporarily disables this check until this issue is resolved.~~