### PR TITLE
add root/bitarray.d

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -809,7 +809,7 @@ auto sourceFiles()
         lexer: fileArray(env["D"], "
             console.d entity.d errors.d filecache.d globals.d id.d identifier.d lexer.d tokens.d utf.d
         ") ~ fileArray(env["ROOT"], "
-            array.d ctfloat.d file.d filename.d hash.d outbuffer.d port.d region.d rmem.d
+            array.d bitarray.d ctfloat.d file.d filename.d hash.d outbuffer.d port.d region.d rmem.d
             rootobject.d stringtable.d
         "),
         root: fileArray(env["ROOT"], "

--- a/src/dmd/arraytypes.h
+++ b/src/dmd/arraytypes.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "root/array.h"
+#include "root/bitarray.h"
 
 typedef Array<class TemplateParameter *> TemplateParameters;
 

--- a/src/dmd/compiler.h
+++ b/src/dmd/compiler.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "root/array.h"
+#include "root/bitarray.h"
 
 // This file contains a data structure that describes a back-end compiler
 // and implements compiler-specific actions.

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1243,7 +1243,7 @@ private:
     Dsymbols* importedScopes;
     Prot.Kind* prots;            // array of Prot.Kind, one for each import
 
-    import dmd.root.array : BitArray;
+    import dmd.root.bitarray;
     BitArray accessiblePackages, privateAccessiblePackages;// whitelists of accessible (imported) packages
 
 public:

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -306,69 +306,6 @@ unittest
         assert(e == 0);
 }
 
-struct BitArray
-{
-nothrow:
-    size_t length() const pure nothrow @nogc @safe
-    {
-        return len;
-    }
-
-    void length(size_t nlen) pure nothrow
-    {
-        immutable obytes = (len + 7) / 8;
-        immutable nbytes = (nlen + 7) / 8;
-        // bt*() access memory in size_t chunks, so round up.
-        ptr = cast(size_t*)mem.xrealloc_noscan(ptr,
-            (nbytes + (size_t.sizeof - 1)) & ~(size_t.sizeof - 1));
-        if (nbytes > obytes)
-            (cast(ubyte*)ptr)[obytes .. nbytes] = 0;
-        len = nlen;
-    }
-
-    bool opIndex(size_t idx) const pure nothrow @nogc
-    {
-        import core.bitop : bt;
-
-        assert(idx < length);
-        return !!bt(ptr, idx);
-    }
-
-    void opIndexAssign(bool val, size_t idx) pure nothrow @nogc
-    {
-        import core.bitop : btc, bts;
-
-        assert(idx < length);
-        if (val)
-            bts(ptr, idx);
-        else
-            btc(ptr, idx);
-    }
-
-    @disable this(this);
-
-    ~this() pure nothrow
-    {
-        mem.xfree(ptr);
-    }
-
-private:
-    size_t len;
-    size_t *ptr;
-}
-
-unittest
-{
-    BitArray array;
-    array.length = 20;
-    assert(array[19] == 0);
-    array[10] = 1;
-    assert(array[10] == 1);
-    array[10] = 0;
-    assert(array[10] == 0);
-    assert(array.length == 20);
-}
-
 /**
  * Exposes the given root Array as a standard D array.
  * Params:

--- a/src/dmd/root/array.h
+++ b/src/dmd/root/array.h
@@ -206,21 +206,3 @@ struct Array
     }
 };
 
-struct BitArray
-{
-    BitArray()
-      : len(0)
-      , ptr(NULL)
-    {}
-
-    ~BitArray()
-    {
-        mem.xfree(ptr);
-    }
-
-    d_size_t len;
-    d_size_t *ptr;
-
-private:
-    BitArray(const BitArray&);
-};

--- a/src/dmd/root/bitarray.d
+++ b/src/dmd/root/bitarray.d
@@ -1,0 +1,82 @@
+/**
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/root/bitarray.d, root/_bitarray.d)
+ * Documentation:  https://dlang.org/phobos/dmd_root_array.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/root/bitarray.d
+ */
+
+module dmd.root.bitarray;
+
+import core.stdc.string;
+
+import dmd.root.rmem;
+
+struct BitArray
+{
+nothrow:
+    size_t length() const pure nothrow @nogc @safe
+    {
+        return len;
+    }
+
+    void length(size_t nlen) pure nothrow
+    {
+        immutable obytes = (len + 7) / 8;
+        immutable nbytes = (nlen + 7) / 8;
+        // bt*() access memory in size_t chunks, so round up.
+        ptr = cast(size_t*)mem.xrealloc_noscan(ptr,
+            (nbytes + (size_t.sizeof - 1)) & ~(size_t.sizeof - 1));
+        if (nbytes > obytes)
+            (cast(ubyte*)ptr)[obytes .. nbytes] = 0;
+        len = nlen;
+    }
+
+    bool opIndex(size_t idx) const pure nothrow @nogc
+    {
+        import core.bitop : bt;
+
+        assert(idx < length);
+        return !!bt(ptr, idx);
+    }
+
+    void opIndexAssign(bool val, size_t idx) pure nothrow @nogc
+    {
+        import core.bitop : btc, bts;
+
+        assert(idx < length);
+        if (val)
+            bts(ptr, idx);
+        else
+            btc(ptr, idx);
+    }
+
+    @disable this(this);
+
+    ~this() pure nothrow
+    {
+        mem.xfree(ptr);
+    }
+
+private:
+    size_t len;
+    size_t *ptr;
+}
+
+unittest
+{
+    BitArray array;
+    array.length = 20;
+    assert(array[19] == 0);
+    array[10] = 1;
+    assert(array[10] == 1);
+    array[10] = 0;
+    assert(array[10] == 0);
+    assert(array.length == 20);
+}
+
+

--- a/src/dmd/root/bitarray.h
+++ b/src/dmd/root/bitarray.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2011-2019 by The D Language Foundation, All Rights Reserved
+ * All Rights Reserved, written by Walter Bright
+ * http://www.digitalmars.com
+ * Distributed under the Boost Software License, Version 1.0.
+ * http://www.boost.org/LICENSE_1_0.txt
+ * https://github.com/dlang/dmd/blob/master/src/dmd/root/bitarray.h
+ */
+
+#pragma once
+
+#include "dsystem.h"
+#include "object.h"
+#include "rmem.h"
+
+struct BitArray
+{
+    BitArray()
+      : len(0)
+      , ptr(NULL)
+    {}
+
+    ~BitArray()
+    {
+        mem.xfree(ptr);
+    }
+
+    d_size_t len;
+    d_size_t *ptr;
+
+private:
+    BitArray(const BitArray&);
+};

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -331,10 +331,10 @@ FRONT_SRCS=$(addsuffix .d, $(addprefix $D/,access aggregate aliasthis apply argt
 
 LEXER_SRCS=$(addsuffix .d, $(addprefix $D/, console entity errors filecache globals id identifier lexer tokens utf ))
 
-LEXER_ROOT=$(addsuffix .d, $(addprefix $(ROOT)/, array ctfloat file filename outbuffer port rmem \
+LEXER_ROOT=$(addsuffix .d, $(addprefix $(ROOT)/, array bitarray ctfloat file filename outbuffer port rmem \
 	rootobject stringtable hash))
 
-ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array ctfloat file \
+ROOT_SRCS = $(addsuffix .d,$(addprefix $(ROOT)/,aav array bitarray ctfloat file \
 	filename man outbuffer port region response rmem rootobject speller \
 	longdouble strtold stringtable hash string))
 
@@ -386,7 +386,7 @@ SRC = $(addprefix $D/, aggregate.h aliasthis.h arraytypes.h	\
 	version.h visitor.h libomf.d scanomf.d libmscoff.d scanmscoff.d)         \
 	$(DMD_SRCS)
 
-ROOT_SRC = $(addprefix $(ROOT)/, array.h ctfloat.h dcompat.h file.h filename.h \
+ROOT_SRC = $(addprefix $(ROOT)/, array.h bitarray.h ctfloat.h dcompat.h file.h filename.h \
 	longdouble.h object.h outbuffer.h port.h \
 	rmem.h root.h)
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -152,7 +152,7 @@ FRONT_SRCS=$D/access.d $D/aggregate.d $D/aliasthis.d $D/apply.d $D/argtypes.d $D
 LEXER_SRCS=$D/console.d $D/entity.d $D/errors.d $D/filecache.d $D/globals.d $D/id.d $D/identifier.d \
 	$D/lexer.d $D/tokens.d $D/utf.d
 
-LEXER_ROOT=$(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d $(ROOT)/filename.d \
+LEXER_ROOT=$(ROOT)/array.d $(ROOT)/bitarray.d $(ROOT)/ctfloat.d $(ROOT)/file.d $(ROOT)/filename.d \
 	$(ROOT)/outbuffer.d $(ROOT)/port.d $(ROOT)/rmem.d $(ROOT)/rootobject.d \
 	$(ROOT)/stringtable.d $(ROOT)/hash.d
 
@@ -174,7 +174,7 @@ DMD_SRCS=$(FRONT_SRCS) $(GLUE_SRCS) $(BACK_HDRS)
 GLUEOBJ=
 
 # Root package
-ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
+ROOT_SRCS=$(ROOT)/aav.d $(ROOT)/array.d $(ROOT)/bitarray.d $(ROOT)/ctfloat.d $(ROOT)/file.d \
 	$(ROOT)/filename.d $(ROOT)/longdouble.d $(ROOT)/man.d $(ROOT)/outbuffer.d $(ROOT)/port.d \
 	$(ROOT)/response.d $(ROOT)/rmem.d $(ROOT)/rootobject.d $(ROOT)/region.d \
 	$(ROOT)/speller.d $(ROOT)/stringtable.d $(ROOT)/strtold.d $(ROOT)/hash.d $(ROOT)/string.d
@@ -217,10 +217,10 @@ ROOTSRCC=
 ROOTSRCD=$(ROOT)\rmem.d $(ROOT)\stringtable.d $(ROOT)\hash.d $(ROOT)\man.d $(ROOT)\port.d \
 	$(ROOT)\response.d $(ROOT)\rootobject.d $(ROOT)\speller.d $(ROOT)\aav.d \
 	$(ROOT)\ctfloat.d $(ROOT)\longdouble.d $(ROOT)\outbuffer.d $(ROOT)\filename.d \
-	$(ROOT)\file.d $(ROOT)\array.d $(ROOT)\strtold.d $(ROOT)\region.d
+	$(ROOT)\file.d $(ROOT)\array.d $(ROOT)\bitarray.d $(ROOT)\strtold.d $(ROOT)\region.d
 ROOTSRC= $(ROOT)\root.h \
 	$(ROOT)\longdouble.h $(ROOT)\outbuffer.h $(ROOT)\object.h $(ROOT)\ctfloat.h \
-	$(ROOT)\filename.h $(ROOT)\file.h $(ROOT)\array.h $(ROOT)\rmem.h $(ROOTSRCC) \
+	$(ROOT)\filename.h $(ROOT)\file.h $(ROOT)\array.h $(ROOT)\bitarray.h $(ROOT)\rmem.h $(ROOTSRCC) \
 	$(ROOTSRCD)
 # Removed garbage collector bits (look in history)
 #	$(ROOT)\gc\bits.c $(ROOT)\gc\gc.c $(ROOT)\gc\gc.h $(ROOT)\gc\mscbitops.h \


### PR DESCRIPTION
Pulls `BitArray` out of root/array.d and puts it in its own module, as it has nothing to do with `Array`. Nothing changed in it, just a cut and paste job.