### PR TITLE
build.d: Add cxx-unittest

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -405,7 +405,7 @@ alias runCxxUnittest = memoize!(function()
         description = "Build the C++ frontend";
         msg = "(CXX) CXX-FRONTEND";
 
-        sources = srcDir.buildPath("tests", "cxxfrontend.c") ~ .sources.sources ~ .sources.root;
+        sources = srcDir.buildPath("tests", "cxxfrontend.c") ~ .sources.frontendHeaders ~ .sources.dmd ~ .sources.root;
         target = env["G"].buildPath("cxxfrontend").objName;
 
         command = [ env["CXX"], "-c", sources[0], "-o" ~ target, "-I" ~ env["D"] ] ~ flags["CXXFLAGS"];
@@ -911,7 +911,7 @@ auto sourceFiles()
 {
     struct Sources
     {
-        string[] frontend, lexer, root, glue, dmd, backend, sources;
+        string[] frontend, lexer, root, glue, dmd, backend;
         string[] frontendHeaders, backendHeaders, backendObjects;
     }
     string targetCH;
@@ -985,7 +985,6 @@ auto sourceFiles()
         "),
     };
     sources.dmd = sources.frontend ~ sources.glue ~ sources.backendHeaders;
-    sources.sources = sources.frontendHeaders ~ sources.dmd;
 
     return sources;
 }

--- a/src/build.d
+++ b/src/build.d
@@ -426,15 +426,6 @@ alias cxxFrontend = memoize!(function()
 /// Compiles the C++ unittest executable
 alias cxxUnittestExe = memoize!(function()
 {
-
-    const stringImportFiles = [
-        env["G"] ~ "/VERSION",
-        env["G"] ~ "/SYSCONFDIR.imp",
-        env["RES"] ~ "/default_ddoc_theme.ddoc"
-    ];
-
-    auto inputFiles = sources.dmd ~ sources.root;
-
     Dependency dep;
     with (dep)
     {
@@ -443,7 +434,7 @@ alias cxxUnittestExe = memoize!(function()
         msg = "(DMD) CXX-UNITTEST";
 
         deps = [cxxFrontend, lexer, backend];
-        sources = inputFiles ~ stringImportFiles;
+        sources = .sources.dmd ~ .sources.root;
         target = env["G"].buildPath("cxx-unittest").exeName;
 
         command = [
@@ -457,7 +448,7 @@ alias cxxUnittestExe = memoize!(function()
             "-version=NoMain",
         ].chain(
             flags["DFLAGS"],
-            inputFiles,
+            sources,
             deps.map!(d => d.target)
         ).array;
     }

--- a/src/build.d
+++ b/src/build.d
@@ -867,52 +867,26 @@ void processEnvironmentCxx()
     const cxxKind = env["CXX_KIND"] = detectHostCxx();
 
     string[] warnings  = [
-        "-Wall",
-        "-Werror",
-        "-Wextra",
-        "-Wno-attributes",
-        "-Wno-char-subscripts",
-        "-Wno-deprecated",
-        "-Wno-empty-body",
-        "-Wno-format",
-        "-Wno-missing-braces",
-        "-Wno-missing-field-initializers",
-        "-Wno-overloaded-virtual",
-        "-Wno-parentheses",
-        "-Wno-reorder",
-        "-Wno-return-type",
-        "-Wno-sign-compare",
-        "-Wno-strict-aliasing",
-        "-Wno-switch",
-        "-Wno-type-limits",
-        "-Wno-unknown-pragmas",
-        "-Wno-unused-function",
-        "-Wno-unused-label",
-        "-Wno-unused-parameter",
-        "-Wno-unused-value",
-        "-Wno-unused-variable"
+        "-Wall", "-Werror", "-Wextra", "-Wno-attributes", "-Wno-char-subscripts", "-Wno-deprecated",
+        "-Wno-empty-body", "-Wno-format", "-Wno-missing-braces", "-Wno-missing-field-initializers",
+        "-Wno-overloaded-virtual", "-Wno-parentheses", "-Wno-reorder", "-Wno-return-type",
+        "-Wno-sign-compare", "-Wno-strict-aliasing", "-Wno-switch", "-Wno-type-limits",
+        "-Wno-unknown-pragmas", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter",
+        "-Wno-unused-value", "-Wno-unused-variable"
     ];
 
     if (cxxKind == "g++")
         warnings ~= [
-            "-Wno-class-memaccess",
-            "-Wno-implicit-fallthrough",
-            "-Wno-logical-op",
-            "-Wno-narrowing",
-            "-Wno-uninitialized",
-            "-Wno-unused-but-set-variable",
+            "-Wno-class-memaccess", "-Wno-implicit-fallthrough", "-Wno-logical-op", "-Wno-narrowing",
+            "-Wno-uninitialized", "-Wno-unused-but-set-variable"
         ];
 
     if (cxxKind == "clang++")
-        warnings ~= "-Wno-logical-op-parentheses";
+        warnings ~= ["-Wno-logical-op-parentheses", "-Wno-unused-private-field"];
 
     auto cxxFlags = warnings ~ [
-        "-g",
-        "-fno-exceptions",
-        "-fno-rtti",
-        "-DMARS=1",
-        env["MODEL_FLAG"],
-        env["PIC_FLAG"],
+        "-g", "-fno-exceptions", "-fno-rtti", "-fasynchronous-unwind-tables", "-DMARS=1",
+        env["MODEL_FLAG"], env["PIC_FLAG"],
 
         // No explicit if since cxxKind will always be either g++ or clang++
         cxxKind == "g++" ? "-std=gnu++98" : "-xc++"

--- a/src/build.d
+++ b/src/build.d
@@ -784,8 +784,8 @@ auto sourceFiles()
 {
     struct Sources
     {
-        string[] frontend, lexer, root, glue, dmd, backend;
-        string[] backendHeaders, backendObjects;
+        string[] frontend, lexer, root, glue, dmd, backend, sources;
+        string[] frontendHeaders, backendHeaders, backendObjects;
     }
     string targetCH;
     string[] targetObjs;
@@ -825,6 +825,13 @@ auto sourceFiles()
             statementsem.d staticassert.d staticcond.d strictvisitor.d target.d templateparamsem.d traits.d
             transitivevisitor.d typesem.d typinf.d utils.d visitor.d
         "),
+        frontendHeaders: fileArray(env["D"], "
+            aggregate.h aliasthis.h arraytypes.h attrib.h compiler.h complex_t.h cond.h
+            ctfe.h declaration.h dsymbol.h doc.h enum.h errors.h expression.h globals.h hdrgen.h
+            identifier.h id.h import.h init.h json.h module.h mtype.h nspace.h objc.h scope.h
+            statement.h staticassert.h target.h template.h tokens.h version.h visitor.h
+            " ~ (env["OS"] == "windows" ? "" : "libomf.d scanomf.d libmscoff.d scanmscoff.d")
+        ),
         lexer: fileArray(env["D"], "
             console.d entity.d errors.d filecache.d globals.d id.d identifier.d lexer.d tokens.d utf.d
         ") ~ fileArray(env["ROOT"], "
@@ -852,6 +859,7 @@ auto sourceFiles()
         "),
     };
     sources.dmd = sources.frontend ~ sources.glue ~ sources.backendHeaders;
+    sources.sources = sources.frontendHeaders ~ sources.dmd;
 
     return sources;
 }

--- a/src/build.d
+++ b/src/build.d
@@ -951,12 +951,11 @@ void processEnvironmentCxx()
     }
 
     auto cxxFlags = warnings ~ [
+        "-g", "-g3", "-DDEBUG=1",
+        "-DUNITTEST",
         "-fno-exceptions",
         "-fno-rtti",
-        "-D__pascal=",
         "-DMARS=1",
-        "-DTARGET_" ~ env["OS"].toUpper ~ "=1",
-        "-DDM_TARGET_CPU_" ~ env["TARGET_CPU"] ~ "=1",
         env["MODEL_FLAG"],
         env["PIC_FLAG"],
         "-DDMD_VERSION=" ~ hostDmdVernum,
@@ -965,16 +964,10 @@ void processEnvironmentCxx()
         cxxKind == "g++" ? "-std=gnu++98" : "-xc++"
     ];
 
-    const pgoDir = env.getDefault("PGO_DIR", srcDir.buildPath("pgo"));
-
     const extraFlags = [
-        "ENABLE_DEBUG": ["-g", "-g3", "-DDEBUG=1", "-DUNITTEST"],
         "ENABLE_RELEASE": ["-O2"],
-        "ENABLE_PROFILING": ["-pg", "-fprofile-arcs", "-ftest-coverage"],
-        "ENABLE_PGO_GENERATE": ["-fprofile-generate=" ~ pgoDir],
-        "ENABLE_PGO_USE": ["-fprofile-use=" ~ pgoDir, "-freorder-blocks-and-partition"],
+        "ENABLE_PROFILE": ["-pg", "-fprofile-arcs"],
         "ENABLE_LTO": ["-flto"],
-        "ENABLE_UNITTEST": ["-unittest", "-cov"],
         "ENABLE_COVERAGE": ["--coverage"],
         "ENABLE_SANITIZERS": ["-fsanitize=" ~ env.getDefault("ENABLE_SANITIZERS", "")]
     ];

--- a/src/build.d
+++ b/src/build.d
@@ -408,7 +408,7 @@ alias runCxxUnittest = memoize!(function()
         sources = srcDir.buildPath("tests", "cxxfrontend.c") ~ .sources.sources ~ .sources.root;
         target = env["G"].buildPath("cxxfrontend").objName;
 
-        command = [ env["CXX"], "-c", sources[0], "-o" ~ target, "-I" ~ env["D"], "-Wuninitialized" ] ~ flags["CXXFLAGS"];
+        command = [ env["CXX"], "-c", sources[0], "-o" ~ target, "-I" ~ env["D"] ] ~ flags["CXXFLAGS"];
     }
 
     Dependency cxxUnittestExe; /// Compiles the C++ unittest executable
@@ -423,7 +423,7 @@ alias runCxxUnittest = memoize!(function()
         sources = .sources.dmd ~ .sources.root;
         target = env["G"].buildPath("cxx-unittest").exeName;
 
-        command = [ env["HOST_DMD_RUN"], "-of=" ~ target, env["MODEL_FLAG"], "-vtls", "-J" ~ env["G"], "-J" ~ env["RES"],
+        command = [ env["HOST_DMD_RUN"], "-of=" ~ target, "-vtls", "-J" ~ env["RES"],
                     "-L-lstdc++", "-version=NoMain"
         ].chain(
             flags["DFLAGS"], sources, deps.map!(d => d.target)

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -541,14 +541,8 @@ dscanner: $(DSCANNER_DIR)/dsc
 
 ######################################################
 
-$G/cxxfrontend.o: $G/%.o: tests/%.c $(SRC) $(ROOT_SRC) $(SRC_MAKE)
-	$(CXX) -c -o$@ $(CXXFLAGS) $(DMD_FLAGS) $(MMD) $<
-
-$G/cxx-unittest: $G/cxxfrontend.o $(DMD_SRCS) $(ROOT_SRCS) $G/lexer.a $G/backend.o $(STRING_IMPORT_FILES) $(HOST_DMD_PATH)
-	CC=$(HOST_CXX) $(HOST_DMD_RUN) -of$@ $(MODEL_FLAG) -vtls -J$G -J$(RES) -L-lstdc++ $(DFLAGS) -version=NoMain $(filter-out $(STRING_IMPORT_FILES) $(HOST_DMD_PATH),$^)
-
-cxx-unittest: $G/cxx-unittest
-	$<
+cxx-unittest: $(GENERATED)/build
+	$(RUN_BUILD) CXX=$(HOST_CXX) $@
 
 ######################################################
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -212,8 +212,6 @@ endif
 
 OS_UPCASE := $(shell echo $(OS) | tr '[a-z]' '[A-Z]')
 
-MMD=-MMD -MF $(basename $@).deps
-
 # Default compiler flags for all source files
 CXXFLAGS := $(WARNINGS) \
 	-fno-exceptions -fno-rtti \
@@ -290,7 +288,6 @@ endif
 endif
 
 # Unique extra flags if necessary
-DMD_FLAGS  := -I$D -Wuninitialized
 BACK_FLAGS := -I$(ROOT) -I$C -I$G -I$D -DDMDV2=1
 BACK_DFLAGS := -version=DMDV2
 ROOT_FLAGS := -I$(ROOT)
@@ -390,8 +387,6 @@ ROOT_SRC = $(addprefix $(ROOT)/, array.h bitarray.h ctfloat.h dcompat.h file.h f
 ######## Additional files
 
 SRC_MAKE = posix.mak osmodel.mak
-
-STRING_IMPORT_FILES = $G/VERSION $G/SYSCONFDIR.imp $(RES)/default_ddoc_theme.ddoc
 
 DEPS = $(patsubst %.o,%.deps,$(DMD_OBJS))
 

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -390,7 +390,7 @@ SRC_MAKE = posix.mak osmodel.mak
 
 DEPS = $(patsubst %.o,%.deps,$(DMD_OBJS))
 
-RUN_BUILD = $(GENERATED)/build HOST_DMD="$(HOST_DMD)" OS=$(OS) BUILD=$(BUILD) MODEL=$(MODEL) AUTO_BOOTSTRAP="$(AUTO_BOOTSTRAP)" --called-from-make
+RUN_BUILD = $(GENERATED)/build HOST_DMD="$(HOST_DMD)" CXX="$(HOST_CXX)" OS=$(OS) BUILD=$(BUILD) MODEL=$(MODEL) AUTO_BOOTSTRAP="$(AUTO_BOOTSTRAP)" --called-from-make
 
 ######## Begin build targets
 
@@ -537,7 +537,7 @@ dscanner: $(DSCANNER_DIR)/dsc
 ######################################################
 
 cxx-unittest: $(GENERATED)/build
-	$(RUN_BUILD) CXX=$(HOST_CXX) $@
+	$(RUN_BUILD) $@
 
 ######################################################
 


### PR DESCRIPTION
This add the `cxx-unittest` target and all required variables from `posix.mak` to `build.d`.

They are restricted to `version(Posix)` because it would require additional work to handle e.g. Cygwin on Azure)

TODO:
- [ ] Delete now obsolete CXX and CXXFLAGS detection from `posix.mak` (?)