### PR TITLE
build.d: Add build-examples

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -430,16 +430,10 @@ unittest: $G/dmd-unittest
 
 ######## DMD as a library examples
 
-EXAMPLES=$(addprefix $G/examples/, avg impvisitor)
 PARSER_SRCS=$(addsuffix .d, $(addprefix $D/,parse astbase parsetimevisitor transitivevisitor permissivevisitor strictvisitor utils))
 
-$G/parser.a: $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS) dmd $(SRC_MAKE)
-	$G/dmd -lib -of$@ $(MODEL_FLAG) -J$G $(DFLAGS) $(PARSER_SRCS) $(LEXER_SRCS) $(ROOT_SRCS)
-
-$G/examples/%: $(EX)/%.d $G/parser.a dmd
-	$G/dmd -of$@ $(MODEL_FLAG) $(DFLAGS) $G/parser.a $<
-
-build-examples: $(EXAMPLES)
+build-examples: $(GENERATED)/build
+	$(RUN_BUILD) $@
 
 ######## Manual cleanup
 

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -43,6 +43,7 @@
 # dmd           - release dmd (legacy target)
 # debdmd        - debug dmd
 # reldmd        - release dmd
+# build-example - Build DMD as library examples
 # detab         - replace hard tabs with spaces
 # tolf          - convert to Unix line endings
 
@@ -287,14 +288,8 @@ $G\backend.lib:  $(GEN)\build.exe
 $G\lexer.lib: $(GEN)\build.exe
 	$(RUN_BUILD) $@
 
-$G\parser.lib: $(PARSER_SRCS) $G\lexer.lib $G
-	$(HOST_DC) -of$@ -vtls -lib $(DFLAGS) $(PARSER_SRCS) $G\lexer.lib
-
-parser_test: $G\parser.lib examples\test_parser.d
-	$(HOST_DC) -of$@ -vtls $(DFLAGS) $G\parser.lib examples\test_parser.d examples\impvisitor.d
-
-example_avg: $G\libparser.lib examples\avg.d
-	$(HOST_DC) -of$@ -vtls $(DFLAGS) $G\libparser.lib examples\avg.d
+build-examples: $(GEN)\build.exe
+	$(RUN_BUILD) $@
 
 $(TARGETEXE): $(GEN)\build.exe
 	$(RUN_BUILD) $@
@@ -305,7 +300,6 @@ $(TARGETEXE): $(GEN)\build.exe
 clean:
 	$(RD) /s /q $(GEN)
 	$(DEL) $D\msgs.h $D\msgs.c
-	$(DEL) parser_test.exe example_avg.exe
 	$(DEL) $(TARGETEXE) *.map *.obj *.exe
 
 install: detab install-copy

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -291,6 +291,14 @@ $G\lexer.lib: $(GEN)\build.exe
 build-examples: $(GEN)\build.exe
 	$(RUN_BUILD) $@
 
+# Keep legacy targets?
+# Broken since December 2017, see commit 34fa7f44fe890fb6965157b9cd22892507472c43
+parser_test: build-examples
+	copy $G\examples\impvisitor.exe .\$@
+
+example_avg: build-examples
+	copy $G\examples\avg.exe .\$@
+
 $(TARGETEXE): $(GEN)\build.exe
 	$(RUN_BUILD) $@
 	copy $(TARGETEXE) .
@@ -300,6 +308,7 @@ $(TARGETEXE): $(GEN)\build.exe
 clean:
 	$(RD) /s /q $(GEN)
 	$(DEL) $D\msgs.h $D\msgs.c
+	$(DEL) parser_test.exe example_avg.exe
 	$(DEL) $(TARGETEXE) *.map *.obj *.exe
 
 install: detab install-copy


### PR DESCRIPTION
This add `build-examples` to `build.d` and furthermore allows to build the examples on Windows (which was broken since late 2017).

CC @marler8997  