### PR TITLE
src/expression.h: Remove StringExp::toPtr from headers

### DIFF
--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -368,7 +368,6 @@ public:
     void accept(Visitor *v) { v->visit(this); }
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;
-    char *toPtr();
 };
 
 // Tuple


### PR DESCRIPTION
This was removed by @WalterBright during the StringExp refactoring.