### PR TITLE
Fix the uncontrolled blitting which defeats the copy contructor

### DIFF
--- a/src/dmd/backend/cc.d
+++ b/src/dmd/backend/cc.d
@@ -1204,6 +1204,7 @@ enum
     SFLdyninit      = 0x200000,    // symbol has dynamic initializer
     SFLtmp          = 0x400000,    // symbol is a generated temporary
     SFLthunk        = 0x40000,     // symbol is temporary for thunk
+    SFLmemproxy     = 0x10000000,  // symbol used in conjunction with OPstrthis
 
     // Possible values for protection bits
     SFLprivate      = 0x60,

--- a/src/dmd/backend/cdef.d
+++ b/src/dmd/backend/cdef.d
@@ -875,7 +875,11 @@ union eve
         {
             elem* E1;           // left child for unary & binary nodes
             elem* E2;           // right child for binary nodes
-            Symbol* Edtor;      // OPctor: destructor
+            union
+            {
+                Symbol* Edtor;  // OPctor: destructor
+                Symbol* Edecl2; // VarDeclaration being constructed
+            }
         }
         struct
         {

--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -2949,7 +2949,7 @@ private extern (C++) __gshared nothrow void function (ref CodeBuilder,elem *,reg
     OPcallns:  &cdfunc,
     OPucallns: &cdfunc,
     OPstrpar:  &cderr,
-    OPstrctor: &cderr,
+    OPstrctor: &cdstrctor,
     OPstrthis: &cdstrthis,
     OPconst:   &cderr,
     OPvar:     &cderr,

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3283,8 +3283,21 @@ elem * elstruct(elem *e, goal_t goal)
     tym_t tym = ~0;
     tym_t ty = tybasic(t.Tty);
 
+    type *targ1 = null;
+    type *targ2 = null;
+
     uint sz = (e.Eoper == OPstrpar && type_zeroSize(t, global_tyf)) ? 0 : cast(uint)type_size(t);
     //printf("\tsz = %d\n", (int)sz);
+
+    // don't enregister non PODs
+    {
+        type* t2 = t;
+        while (tybasic(t2.Tty) == TYarray)
+            t2 = t2.Tnext;
+        if (tybasic(t2.Tty) == TYstruct && t2.Ttag.Sstruct.Sflags & STRnotpod)
+            goto Ldefault;
+    }
+
     if (sz == 16)
     {
         while (ty == TYarray && t.Tdim == 1)
@@ -3294,8 +3307,6 @@ elem * elstruct(elem *e, goal_t goal)
         }
     }
 
-    type *targ1 = null;
-    type *targ2 = null;
     if (ty == TYstruct)
     {   // If a struct is a wrapper for another type, prefer that other type
         targ1 = t.Ttag.Sstruct.Sarg1type;

--- a/src/dmd/backend/cgelem.d
+++ b/src/dmd/backend/cgelem.d
@@ -3269,6 +3269,12 @@ elem * elstruct(elem *e, goal_t goal)
         return optelem(e, goal);
     }
 
+    if (e.Eoper == OPstrpar && el_findstrctor(e.EV.E1))
+    {
+        assert(config.exe == EX_WIN32);
+        return e;
+    }
+
     if (!e.ET)
         return e;
     //printf("\tnumbytes = %d\n", (int)type_size(e.ET));

--- a/src/dmd/backend/cod1.d
+++ b/src/dmd/backend/cod1.d
@@ -2976,6 +2976,14 @@ private bool type_jparam2(type* t, tym_t ty)
     else if (ty == TYstruct || ty == TYarray)
     {
         type_debug(t);
+        {
+            // don't enregister non PODs
+            type* t2 = t;
+            while (tybasic(t2.Tty) == TYarray)
+                t2 = t2.Tnext;
+            if (tybasic(t2.Tty) == TYstruct && t2.Ttag.Sstruct.Sflags & STRnotpod)
+                return false;
+        }
         targ_size_t sz = type_size(t);
         return (sz <= _tysize[TYnptr]) &&
                (config.exe == EX_WIN64 || sz == 1 || sz == 2 || sz == 4 || sz == 8);

--- a/src/dmd/backend/code.d
+++ b/src/dmd/backend/code.d
@@ -458,6 +458,7 @@ void cdstrcpy(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void cdstreq(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void cdstrlen(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void cdstrthis(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
+void cdstrctor(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void cdvecfill(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void cdvecsto(ref CodeBuilder cdb, elem* e, regm_t* pretregs);
 void cdvector(ref CodeBuilder cdb, elem* e, regm_t* pretregs);

--- a/src/dmd/backend/el.d
+++ b/src/dmd/backend/el.d
@@ -237,3 +237,5 @@ void el_dehydrate(elem **);
 elem *el_var(Symbol *);
 elem *el_ptr(Symbol *);
 
+bool el_findstrctor(elem *);
+

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -3171,4 +3171,33 @@ void el_dehydrate(elem **pe)
 }
 }
 
+/***************************
+ * Find OPstrctor in the expression.
+ */
+bool el_findstrctor(elem *e)
+{
+    while (true)
+    {
+        elem_debug(e);
+        switch (e.Eoper)
+        {
+            case OPstrctor:
+                return true;
+
+            case OPcomma:
+            case OPcond:
+                break;
+
+            case OPcolon:
+            case OPcolon2:
+                if (el_findstrctor(e.EV.E1))
+                    return true;
+                break;
+
+            default:
+                return false;
+        }
+        e = e.EV.E2;
+    }
+}
 }

--- a/src/dmd/backend/elem.d
+++ b/src/dmd/backend/elem.d
@@ -2366,6 +2366,10 @@ else
             }
 
             case OPstrthis:
+                if (n1.EV.Vsym != n2.EV.Vsym)
+                    return false;
+                break;
+
             case OPframeptr:
             case OPhalt:
             case OPgot:

--- a/src/dmd/backend/elpicpie.d
+++ b/src/dmd/backend/elpicpie.d
@@ -104,6 +104,8 @@ elem * el_var(Symbol *s)
     e.EV.Vsym = s;
     type_debug(s.Stype);
     e.Ety = s.ty();
+    if (tyaggregate(s.ty()))
+        e.ET = s.Stype;
     if (s.Stype.Tty & mTYthread)
     {
         //printf("thread local %s\n", s.Sident);
@@ -469,6 +471,8 @@ private elem *el_picvar(Symbol *s)
     e.Eoper = OPvar;
     e.EV.Vsym = s;
     e.Ety = s.ty();
+    if (tyaggregate(s.ty()))
+        e.ET = s.Stype;
 
     switch (s.Sclass)
     {
@@ -630,6 +634,8 @@ private elem *el_picvar(Symbol *s)
     e.Eoper = OPvar;
     e.EV.Vsym = s;
     e.Ety = s.ty();
+    if (tyaggregate(s.ty()))
+        e.ET = s.Stype;
 
     /* For 32 bit PIC:
      *      CALL __i686.get_pc_thunk.bx@PC32
@@ -840,6 +846,8 @@ private elem *el_pievar(Symbol *s)
     e.Eoper = OPvar;
     e.EV.Vsym = s;
     e.Ety = s.ty();
+    if (tyaggregate(s.ty()))
+        e.ET = s.Stype;
 
     if (I64)
     {

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1107,6 +1107,12 @@ extern (C++) class VarDeclaration : Declaration
 
     private bool _isAnonymous;
 
+    bool ismemproxy;                // variable is a proxy for the destination.
+                                    // for ex: `a = (p = b, p)`
+                                    // `p` is a proxy for a, the result is `a = b`.
+                                    // This enables running complex initialization code of unknown memory locations,
+                                    // like function arguments.
+
     final extern (D) this(const ref Loc loc, Type type, Identifier ident, Initializer _init, StorageClass storage_class = STC.undefined_)
     {
         if (ident is Identifier.anonymous)

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -416,16 +416,6 @@ extern (C++) class StructDeclaration : AggregateDeclaration
                 break;
             }
         }
-
-        auto tt = target.toArgTypes(type);
-        size_t dim = tt ? tt.arguments.dim : 0;
-        if (dim >= 1)
-        {
-            assert(dim <= 2);
-            arg1type = (*tt.arguments)[0].type;
-            if (dim == 2)
-                arg2type = (*tt.arguments)[1].type;
-        }
     }
 
     /***************************************

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4751,6 +4751,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         if (sd.inv)
             reinforceInvariant(sd, sc2);
 
+        // recalculate isPOD
+        sd.ispod = StructPOD.fwd;
+
         Module.dprogress++;
         sd.semanticRun = PASS.semanticdone;
         //printf("-StructDeclaration::semantic(this=%p, '%s')\n", sd, sd.toChars());

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -112,11 +112,11 @@ bool ISX64REF(Declaration var)
         {
             return var.type.size(Loc.initial) > REGSIZE
                 || (var.storage_class & STC.lazy_)
-                || (var.type.isTypeStruct() && !var.type.isTypeStruct().sym.isPOD());
+                || (var.type.baseElemOf().isTypeStruct() && !var.type.baseElemOf().isTypeStruct().sym.isPOD());
         }
         else if (!global.params.isWindows)
         {
-            return !(var.storage_class & STC.lazy_) && var.type.isTypeStruct() && !var.type.isTypeStruct().sym.isPOD();
+            return !(var.storage_class & STC.lazy_) && var.type.baseElemOf().isTypeStruct() && !var.type.baseElemOf().isTypeStruct().sym.isPOD();
         }
     }
 
@@ -130,11 +130,11 @@ bool ISX64REF(IRState* irs, Expression exp)
     if (config.exe == EX_WIN64)
     {
         return exp.type.size(Loc.initial) > REGSIZE
-            || (exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD());
+            || (exp.type.baseElemOf().isTypeStruct() && !exp.type.baseElemOf().isTypeStruct().sym.isPOD());
     }
     else if (!irs.params.isWindows)
     {
-        return exp.type.isTypeStruct() && !exp.type.isTypeStruct().sym.isPOD();
+        return exp.type.baseElemOf().isTypeStruct() && !exp.type.baseElemOf().isTypeStruct().sym.isPOD();
     }
 
     return false;

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -443,6 +443,7 @@ private Expression callCpCtor(Scope* sc, Expression e, Type destinationType)
             if (sd.hasCopyCtor && destinationType)
                 tmp.type = destinationType;
             tmp.storage_class |= STC.nodtor;
+            tmp.ismemproxy = true;
             tmp.dsymbolSemantic(sc);
             Expression de = new DeclarationExp(e.loc, tmp);
             Expression ve = new VarExp(e.loc, tmp);

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -368,7 +368,6 @@ public:
     void accept(Visitor *v) { v->visit(this); }
     size_t numberOfCodeUnits(int tynto = 0) const;
     void writeTo(void* dest, bool zero, int tyto = 0) const;
-    char *toPtr();
 };
 
 // Tuple

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -701,6 +701,7 @@ private extern (C++) class S2irVisitor : Visitor
                     // Return value via hidden pointer passed as parameter
                     // Write *shidden=exp; return shidden;
                     es = el_una(OPind,e.Ety,el_var(irs.shidden));
+                    es.ET = e.ET;
                     es = elAssign(es, e, s.exp.type, null);
                 }
                 e = el_var(irs.shidden);

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -576,6 +576,20 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
         ad.determineSize(ad.loc);
 
+        if (auto sd = ad.isStructDeclaration)
+        {
+            // build argtypes
+            auto tt = target.toArgTypes(sd.type);
+            size_t dim = tt ? tt.arguments.dim : 0;
+            if (dim >= 1)
+            {
+                assert(dim <= 2);
+                sd.arg1type = (*tt.arguments)[0].type;
+                if (dim == 2)
+                    sd.arg2type = (*tt.arguments)[1].type;
+            }
+        }
+
         for (size_t i = 0; i < ad.members.dim; i++)
         {
             Dsymbol s = (*ad.members)[i];

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -166,6 +166,8 @@ Symbol *toSymbol(Dsymbol s)
                 s.Sflags |= SFLartifical;
             if (isNRVO)
                 s.Sflags |= SFLnodebug;
+            if (vd.ismemproxy)
+                s.Sflags |= SFLmemproxy;
 
             TYPE *t;
             if (vd.storage_class & (STC.out_ | STC.ref_))

--- a/test/runnable/internalpointer.d
+++ b/test/runnable/internalpointer.d
@@ -8,6 +8,8 @@ struct Container
 
     this(int) { p = &data[0]; }
     this(ref Container) { p = &data[0]; }
+    this(this) { p = &data[0]; }
+    void opAssign(ref Container) { p = &data[0]; }
 
     /** Ensure the internal pointer is correct */
     void check(int line = __LINE__, string file = __FILE__)()
@@ -21,6 +23,7 @@ struct Container
 }
 
 void func(Container c) { c.check(); } // error
+void func(Container[1] c) { c[0].check(); } // error
 
 Container get()
 {
@@ -46,6 +49,10 @@ void main()
 
     Container[1] slit = [v];
     slit[0].check(); // error
+
+    slit[0] = v;
+    slit[0].check(); // ok
+    func(slit);
 
     Container[] dlit = [v];
     dlit[0].check(); // error

--- a/test/runnable/internalpointer.d
+++ b/test/runnable/internalpointer.d
@@ -1,0 +1,60 @@
+/** Container with internal pointer
+ * bugzilla: https://issues.dlang.org/show_bug.cgi?id=20321
+ */
+struct Container
+{
+    long[3] data;
+    void* p;
+
+    this(int) { p = &data[0]; }
+    this(ref Container) { p = &data[0]; }
+
+    /** Ensure the internal pointer is correct */
+    void check(int line = __LINE__, string file = __FILE__)()
+    {
+        if (p != &data[0])
+        {
+            import core.stdc.stdio : printf;
+            printf("%s(%d): %s\n", file.ptr, line, "error".ptr);
+        }
+    }
+}
+
+void func(Container c) { c.check(); } // error
+
+Container get()
+{
+    auto a = Container(1);
+    auto b = a;
+    a.check(); // ok
+    b.check(); // ok
+    // no nrvo
+    if (1)
+        return a;
+    else
+        return b;
+}
+
+void main()
+{
+    Container v = Container(1);
+    v.check(); // ok
+
+    func(v);
+    auto r = get();
+    r.check(); // error
+
+    Container[1] slit = [v];
+    slit[0].check(); // error
+
+    Container[] dlit = [v];
+    dlit[0].check(); // error
+
+    auto b = B(v);
+    b.m.check(); // error
+}
+
+struct B
+{
+    Container m;
+}

--- a/test/runnable/internalpointer.d
+++ b/test/runnable/internalpointer.d
@@ -16,8 +16,9 @@ struct Container
     {
         if (p != &data[0])
         {
-            import core.stdc.stdio : printf;
-            printf("%s(%d): %s\n", file.ptr, line, "error".ptr);
+            //import core.stdc.stdio : printf;
+            //printf("%s(%d): %s\n", file.ptr, line, "error".ptr);
+            assert(0, "internal pointer corrupted");
         }
     }
 }


### PR DESCRIPTION
Issue [20321](https://issues.dlang.org/show_bug.cgi?id=20321).

LDC and GDC are also affected.

I chose this way of fixing it which keeps the initialization at the semantic phase then just adapts it in the codegen, but I realized that the backend creates a lot of temporaries and copies into them. There has to be some means to do elaborate copy in the backend, I'm afraid there is no workaround.

CC: @WalterBright 
CC: @kinke @ibuclaw are you going to solve this for LDC and GDC? How?