### PR TITLE
Fix Issue 20318 - Illegal instruction (core dumped)

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -6197,6 +6197,12 @@ void toTraceGC(IRState *irs, elem *e, const ref Loc loc)
         assert(e1.Eoper == OPvar);
 
         auto s = e1.EV.Vsym;
+        /* In -dip1008 code the allocation of exceptions is no longer done by the
+         * gc, but by a manual reference counting mechanism implementend in druntime.
+         * If that is the case, then there is nothing to trace.
+         */
+        if (s == getRtlsym(RTLSYM_NEWTHROW))
+            return;
         foreach (ref m; map)
         {
             if (s == getRtlsym(m[0]))

--- a/test/compilable/test20318.d
+++ b/test/compilable/test20318.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=20318
+// REQUIRED_ARGS: -dip1008 -profile=gc
+
+void main()
+{
+    throw new Exception("msg");
+}


### PR DESCRIPTION
```d
void main()
{
    throw new Exception("msg");
}
```
When an exception is thrown, typically it is allocated and managed by the garbage collector: the compiler replaces the expression with a call to a druntime hook, in this situation `_d_newclass`. If the code is compiled with `profile=gc` the hook is further replaced with a call to another hook `d_newclass_trace` that collects some stats and later calls `_d_newclass`.

If the above code is compiled with `-dip1008` the exception no longer uses the gc to be managed; it is manually managed in druntime via reference counting. So if `-dip1008` and `-profile=gc` are used together the following thing happens: (1) the exception throwing line is rewritten to a call to `_d_newthrow` in druntime which does the refcount initialization for the exception then (2) `toTraceGC` in dmd is called that replaces any allocation hooks with trace allocation hooks. Since `_d_newthrow` does not do any gc allocations and therefore does not have an associated trace function, `toTraceGC` gets confused and asserts.

The fix is to simply return from toTraceGC if the hook is not a gc allocation hook.