### PR TITLE
Try fixing code coverage with relative paths

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -358,7 +358,11 @@ alias dmdExe = memoize!(function(string targetSuffix, string[] extraFlags...)
             "-vtls",
             "-J"~env["G"],
             "-J../res",
-        ].chain(extraFlags, platformArgs, flags["DFLAGS"], sources).array;
+        ].chain(extraFlags, platformArgs, flags["DFLAGS"],
+            // source files need to have relative paths in order for the code coverage
+            // .lst files to be named properly for CodeCov to find them
+            sources.map!(e => e.relativePath(srcDir))
+        ).array;
     }
     return new DependencyRef(dep);
 });


### PR DESCRIPTION
Code coverage is broken since we moved building the dmd executable from the makefile to `build.d` (#10446).  After some digging I noticed that filenames of the `*.lst` files generated from running an exe with `-cov` are based on the source filenames passed to the compiler on the command-line.  The makefiles were using relative paths and `build.d` uses absolute paths, so I've switched `build.d` to use relative paths in this case to see if it fixes the issue.