### PR TITLE
[PoC] infer `scope` for `in` with DIP1000

### DIFF
--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -76,7 +76,7 @@ private immutable char[TMAX] mangleChar =
     Tfunction    : 'F', // D function
     Tsarray      : 'G',
     Taarray      : 'H',
-    Tident       : 'I',
+    //              I   // in
     //              J   // out
     //              K   // ref
     //              L   // lazy
@@ -96,6 +96,7 @@ private immutable char[TMAX] mangleChar =
     //              Z   // not variadic, end of parameters
 
     // '@' shouldn't appear anywhere in the deco'd names
+    Tident       : '@',
     Tinstance    : '@',
     Terror       : '@',
     Ttypeof      : '@',
@@ -1108,7 +1109,12 @@ public:
         switch (p.storageClass & (STC.in_ | STC.out_ | STC.ref_ | STC.lazy_))
         {
         case 0:
+            break;
         case STC.in_:
+            buf.writeByte('I');
+            break;
+        case STC.in_ | STC.ref_:
+            buf.writestring("IK");
             break;
         case STC.out_:
             buf.writeByte('J');

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -3823,6 +3823,10 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
 
                 foreach (fparam; *tp.parameterList.parameters)
                 {
+                    if (global.params.vsafe)
+                        if ((fparam.storageClass & STC.in_) && !(fparam.storageClass & STC.scope_))
+                            fparam.storageClass |= STC.scope_ | STC.scopeinferred;
+
                     // https://issues.dlang.org/show_bug.cgi?id=2579
                     // Apply function parameter storage classes to parameter types
                     fparam.type = fparam.type.addStorageClass(fparam.storageClass);

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -3830,7 +3830,7 @@ MATCH deduceType(RootObject o, Scope* sc, Type tparam, TemplateParameters* param
                     // https://issues.dlang.org/show_bug.cgi?id=2579
                     // Apply function parameter storage classes to parameter types
                     fparam.type = fparam.type.addStorageClass(fparam.storageClass);
-                    fparam.storageClass &= ~(STC.TYPECTOR | STC.in_);
+                    fparam.storageClass &= ~STC.TYPECTOR;
 
                     // https://issues.dlang.org/show_bug.cgi?id=15243
                     // Resolve parameter type if it's not related with template parameters

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -6536,7 +6536,7 @@ extern (C++) final class Parameter : ASTNode
      */
     bool isCovariant(bool returnByRef, const Parameter p) const pure nothrow @nogc @safe
     {
-        enum stc = STC.ref_ | STC.in_ | STC.out_ | STC.lazy_;
+        enum stc = STC.ref_ | STC.out_ | STC.lazy_; // STC.in_ is dealt with via scope/const
         if ((this.storageClass & stc) != (p.storageClass & stc))
             return false;
         return isCovariantScope(returnByRef, this.storageClass, p.storageClass);

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1323,7 +1323,10 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         else if (stc & STC.ref_)
             push("ref");
         else if (stc & STC.in_)
-            push("in");
+        {
+            if (global.params.vsafe)
+                stc &= ~STC.scopeinferred; // print scope
+        }
         else if (stc & STC.lazy_)
             push("lazy");
         else if (stc & STC.alias_)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1506,6 +1506,10 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                     }
                 }
 
+                if (global.params.vsafe)
+                    if ((fparam.storageClass & STC.in_) && !(fparam.storageClass & STC.scope_))
+                        fparam.storageClass |= STC.scope_ | STC.scopeinferred;
+
                 // Remove redundant storage classes for type, they are already applied
                 fparam.storageClass &= ~(STC.TYPECTOR | STC.in_);
             }

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1511,7 +1511,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
                         fparam.storageClass |= STC.scope_ | STC.scopeinferred;
 
                 // Remove redundant storage classes for type, they are already applied
-                fparam.storageClass &= ~(STC.TYPECTOR | STC.in_);
+                fparam.storageClass &= ~STC.TYPECTOR;
             }
             argsc.pop();
         }

--- a/test/compilable/test_in_scope_const.d
+++ b/test/compilable/test_in_scope_const.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -preview=dip1000
+
+@safe:
+
+void test(in char* ptr)
+{
+}
+
+void calltest()
+{
+    char[10] buf;
+    test(&buf[0]);
+}

--- a/test/fail_compilation/ice10922.d
+++ b/test/fail_compilation/ice10922.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10922.d(10): Error: function `ice10922.__lambda4(const(uint) n)` is not callable using argument types `()`
-fail_compilation/ice10922.d(10):        missing argument for parameter #1: `const(uint) n`
+fail_compilation/ice10922.d(10): Error: function `ice10922.__lambda4(in const(uint) n)` is not callable using argument types `()`
+fail_compilation/ice10922.d(10):        missing argument for parameter #1: `in const(uint) n`
 ---
 */
 

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4963,7 +4963,7 @@ void test6763()
     static assert(typeof(f6763).stringof == "void(int _param_0)");
     static assert(typeof(c6763).stringof == "void(const(int) _param_0)");
     static assert(typeof(r6763).stringof == "void(ref int _param_0)");
-    static assert(typeof(i6763).stringof == "void(const(int) _param_0)");
+    static assert(typeof(i6763).stringof == "void(in const(int) _param_0)");
     static assert(typeof(o6763).stringof == "void(out int _param_0)");
 }
 


### PR DESCRIPTION
As an alternative to https://github.com/dlang/dmd/pull/10506
Differences:
- only enabled with -preview=dip1000
- parameter storage type changed in semantics, not during parsing
- `scope` only considered inferred, so not visible in header generation
- ~~`in` emitted by __traits(getParameterStorageClasses)~~
- `in` added to mangling