### PR TITLE
[stable] Cherry-pick C++ mangling regression fix from master

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1670,9 +1670,9 @@ extern(C++):
         buf.writeByte('R');
         CV_qualifiers(t.nextOf());
         headOfType(t.nextOf());
-        append(t);
         if (t.nextOf().isConst())
             append(t.nextOf());
+        append(t);
     }
 
     override void visit(TypeFunction t)

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -117,9 +117,11 @@ class TestVisitor : public Visitor
     bool decl;
     bool typeinfo;
     bool idexpr;
+    bool function;
 
     TestVisitor() : expr(false), package(false), stmt(false), type(false),
-        aggr(false), attrib(false), decl(false), typeinfo(false), idexpr(false)
+        aggr(false), attrib(false), decl(false), typeinfo(false), idexpr(false),
+        function(false)
     {
     }
 
@@ -166,6 +168,11 @@ class TestVisitor : public Visitor
     void visit(TypeInfoDeclaration *)
     {
         typeinfo = true;
+    }
+
+    void visit(FuncDeclaration *)
+    {
+        function = true;
     }
 };
 
@@ -223,6 +230,15 @@ void test_visitors()
     assert(ti->tinfo == tp);
     ti->accept(&tv);
     assert(tv.typeinfo == true);
+
+    Parameters *args = new Parameters;
+    TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINKc);
+    FuncDeclaration *fd = FuncDeclaration::create(Loc (), Loc (), Identifier::idPool("test"),
+                                                  STCextern, tf);
+    assert(fd->isFuncDeclaration() == fd);
+    assert(fd->type == tf);
+    fd->accept(&tv);
+    assert(tv.function == true);
 }
 
 /**********************************/

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1215,3 +1215,18 @@ version (Posix)
         set20224!int x;
     }
 }
+
+/**************************************/
+
+version (Posix)
+{
+    extern (C++) struct Loc2 {};
+    extern (C++) class FuncDeclaration
+    {
+        static FuncDeclaration create(ref const Loc2, ref const Loc2);
+    };
+    extern (C++) FuncDeclaration FuncDeclaration_create(ref const Loc2, ref const Loc2);
+
+    static assert(FuncDeclaration_create.mangleof == `_Z22FuncDeclaration_createRK4Loc2S1_`);
+    static assert(FuncDeclaration.create.mangleof == `_ZN15FuncDeclaration6createERK4Loc2S2_`);
+}


### PR DESCRIPTION
From #10477; the regression was introduced in 2.088.1, so let's have 2.089.x fixed and not wait 2 more months for 2.090.x.