### PR TITLE
fix issue_8684 by bailing early in parseArguments

### DIFF
--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -8913,20 +8913,22 @@ final class Parser(AST) : Lexer
     {
         // function call
         AST.Expressions* arguments;
-        TOK endtok;
 
         arguments = new AST.Expressions();
-        endtok = token.value == TOK.leftBracket ? TOK.rightBracket : TOK.rightParentheses;
+        const endtok = token.value == TOK.leftBracket ? TOK.rightBracket : TOK.rightParentheses;
 
         nextToken();
+
         while (token.value != endtok && token.value != TOK.endOfFile)
         {
             auto arg = parseAssignExp();
             arguments.push(arg);
-            if (token.value == endtok)
+            if (token.value != TOK.comma)
                 break;
-            check(TOK.comma);
+
+            nextToken(); //comma
         }
+
         check(endtok);
 
         return arguments;

--- a/test/fail_compilation/diag8684.d
+++ b/test/fail_compilation/diag8684.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag8684.d(11): Error: found `;` when expecting `)`
+fail_compilation/diag8684.d(12): Error: semicolon expected, not `for`
+---
+*/
+
+int foo(int n, int m)
+{
+    int x = foo( 5, m;
+    for (int q=0; q<10; ++q){
+       ++q;
+    }
+    return  2;
+}

--- a/test/fail_compilation/ice11967.d
+++ b/test/fail_compilation/ice11967.d
@@ -1,18 +1,13 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice11967.d(18): Error: use `@(attributes)` instead of `[attributes]`
-fail_compilation/ice11967.d(18): Error: expression expected, not `%`
-fail_compilation/ice11967.d(18): Error: found `g` when expecting `,`
-fail_compilation/ice11967.d(19): Error: @identifier or @(ArgumentList) expected, not `@End of File`
-fail_compilation/ice11967.d(19): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
-fail_compilation/ice11967.d(19): Error: basic type expected, not `End of File`
-fail_compilation/ice11967.d(19): Error: found `End of File` when expecting `}` following compound statement
-fail_compilation/ice11967.d(19): Error: found `End of File` when expecting `,`
-fail_compilation/ice11967.d(19): Error: found `End of File` when expecting `)`
-fail_compilation/ice11967.d(19): Error: found `End of File` when expecting `,`
-fail_compilation/ice11967.d(19): Error: found `End of File` when expecting `]`
-fail_compilation/ice11967.d(19): Error: declaration expected following attribute, not end of file
+fail_compilation/ice11967.d(13): Error: use `@(attributes)` instead of `[attributes]`
+fail_compilation/ice11967.d(13): Error: expression expected, not `%`
+fail_compilation/ice11967.d(13): Error: found `g` when expecting `)`
+fail_compilation/ice11967.d(13): Error: found `{` when expecting `]`
+fail_compilation/ice11967.d(14): Error: @identifier or @(ArgumentList) expected, not `@End of File`
+fail_compilation/ice11967.d(14): Error: valid attributes are `@property`, `@safe`, `@trusted`, `@system`, `@disable`, `@nogc`
+fail_compilation/ice11967.d(14): Error: declaration expected following attribute, not end of file
 ---
 */
 [F(%g{@


### PR DESCRIPTION
This does make the error messages better for the code from the bug report: 

```
int foo(int n, int m)
{
    int x = foo( 5, m;
    for (int q=0; q<10; ++q){
       ++q;
    }
    return  2;
}
``` 

goes from a bunch of lines down to `bad.d(3): Error: found ; when expecting , or )`

Not sure if this was the best way to approach or implement a fix, so open to feedback.