### PR TITLE
Dub: Cut down frontend subpackage

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -84,8 +84,18 @@ subPackage {
     iasmdmd,\
     iasmgcc,\
     irstate,\
+    lib,\
+    libelf,\
+    libmach,\
+    libmscoff,\
+    libomf,\
+    link,\
     objc_glue,\
     s2ir,\
+    scanelf,\
+    scanmach,\
+    scanmscoff,\
+    scanomf,\
     tocsym,\
     toctype,\
     tocvdebug,\

--- a/dub.sdl
+++ b/dub.sdl
@@ -83,10 +83,12 @@ subPackage {
     iasm,\
     iasmdmd,\
     iasmgcc,\
+    irstate,\
     objc_glue,\
     s2ir,\
     tocsym,\
     toctype,\
+    tocvdebug,\
     toobj,\
     todt,\
     toir\

--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -21,8 +21,6 @@ import dmd.root.file;
 
 version (NoBackend)
 {
-    import dmd.lib : Library;
-
     struct Symbol;
     struct code;
     struct block;
@@ -33,15 +31,20 @@ version (NoBackend)
 
     extern (C++)
     {
-        // glue
-        void obj_write_deferred(Library library)        {}
-        void obj_start(const(char)* srcfile)            {}
-        void obj_end(Library library, const(char)* objfilename) {}
-        void genObjFile(Module m, bool multiobj)        {}
+        version (NoMain) {} else
+        {
+            import dmd.lib : Library;
 
-        // msc
-        void backend_init() {}
-        void backend_term() {}
+            // glue
+            void obj_write_deferred(Library library)        {}
+            void obj_start(const(char)* srcfile)            {}
+            void obj_end(Library library, const(char)* objfilename) {}
+            void genObjFile(Module m, bool multiobj)        {}
+
+            // msc
+            void backend_init() {}
+            void backend_term() {}
+        }
 
         // iasm
         Statement asmSemantic(AsmStatement s, Scope* sc)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -44,8 +44,11 @@ import dmd.id;
 import dmd.identifier;
 import dmd.inline;
 import dmd.json;
-import dmd.lib;
-import dmd.link;
+version (NoMain) {} else
+{
+    import dmd.lib;
+    import dmd.link;
+}
 import dmd.mtype;
 import dmd.objc;
 import dmd.root.array;
@@ -132,6 +135,7 @@ Where:
  * Returns:
  *   Application return code
  */
+version (NoMain) {} else
 private int tryMain(size_t argc, const(char)** argv, ref Param params)
 {
     Strings files;
@@ -2437,6 +2441,7 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
  *               and update in place
  *      numSrcFiles = number of source files
  */
+version (NoMain) {} else
 private void reconcileCommands(ref Param params, size_t numSrcFiles)
 {
     static if (TARGET.OSX)


### PR DESCRIPTION
Triggered by undefined symbol regressions with current DMD master (stable is fine) when compiling with LDC on Windows (https://github.com/ldc-developers/ldc/issues/3212).