### PR TITLE
switch Identifier.generateId and callers to use dstrings instead of cstrings.  

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2869,7 +2869,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         {
             /* Assign scope local unique identifier, as same as lambdas.
              */
-            const(char)* s = "__mixin";
+            const(char)[] s = "__mixin";
 
             if (FuncDeclaration func = sc.parent.isFuncDeclaration())
             {

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3176,13 +3176,15 @@ extern (C++) final class StructLiteralExp : Expression
              *   __sl%s%d, where %s is the struct name
              */
             const size_t len = 10;
-            char[len + 1] buf = void;
-            buf[len] = 0;
-            strcpy(buf.ptr, "__sl");
-            strncat(buf.ptr, sd.ident.toChars(), len - 4 - 1);
-            assert(buf[len] == 0);
+            char[len] buf = void;
 
-            auto tmp = copyToTemp(0, buf.ptr, this);
+            const ident = sd.ident.toString;
+            const prefix = "__sl";
+            const charsToUse = ident.length > len - prefix.length ? len - prefix.length : ident.length;
+            buf[0 .. prefix.length] = prefix;
+            buf[prefix.length .. prefix.length + charsToUse] = ident[0 .. charsToUse];
+
+            auto tmp = copyToTemp(0, buf, this);
             Expression ae = new DeclarationExp(loc, tmp);
             Expression e = new CommaExp(loc, ae, new VarExp(loc, tmp));
             e = e.expressionSemantic(sc);
@@ -3641,7 +3643,7 @@ extern (C++) final class FuncExp : Expression
     {
         if (fd.ident == Id.empty)
         {
-            const(char)* s;
+            const(char)[] s;
             if (fd.fes)
                 s = "__foreachbody";
             else if (fd.tok == TOK.reserved)

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -138,16 +138,16 @@ nothrow:
 
     private extern (D) __gshared StringTable stringtable;
 
-    static Identifier generateId(const(char)* prefix)
+    extern(D) static Identifier generateId(const(char)[] prefix)
     {
         __gshared size_t i;
         return generateId(prefix, ++i);
     }
 
-    static Identifier generateId(const(char)* prefix, size_t i)
+    extern(D) static Identifier generateId(const(char)[] prefix, size_t i)
     {
         OutBuffer buf;
-        buf.writestring(prefix);
+        buf.write(prefix);
         buf.print(i);
         return idPool(buf[]);
     }

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -28,8 +28,6 @@ public:
     const char *toHChars2() const;
     DYNCAST dyncast() const;
 
-    static Identifier *generateId(const char *prefix);
-    static Identifier *generateId(const char *prefix, size_t i);
     static Identifier *idPool(const char *s, unsigned len);
 
     static inline Identifier *idPool(const char *s)

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -363,7 +363,7 @@ bool discardValue(Expression e)
  * Returns:
  *  Newly created temporary variable.
  */
-VarDeclaration copyToTemp(StorageClass stc, const char* name, Expression e)
+VarDeclaration copyToTemp(StorageClass stc, const char[] name, Expression e)
 {
     assert(name[0] == '_' && name[1] == '_');
     auto vd = new VarDeclaration(e.loc, e.type,
@@ -387,7 +387,7 @@ VarDeclaration copyToTemp(StorageClass stc, const char* name, Expression e)
  * Note:
  *  e's lvalue-ness will be handled well by STC.ref_ or STC.rvalue.
  */
-Expression extractSideEffect(Scope* sc, const char* name,
+Expression extractSideEffect(Scope* sc, const char[] name,
     ref Expression e0, Expression e, bool alwaysCopy = false)
 {
     if (!alwaysCopy && isTrivialExp(e))


### PR DESCRIPTION
Removed Identifier.generateId from C++ Api.  I noticed and fixed small fencepost error in addDtorHook (it used only 9 of the 10 chars it could have) and eliminate now unnecessary null termination.

@kinke and @ibuclaw From what I could see Identifer.generateId is never used in ldc or gdc.  Is it OK to remove it from the C++ API or should I add overloads for DStrings instead?