### PR TITLE
Fix Issue 11038 - static has no effect as a block attribute for imports

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -214,6 +214,8 @@ extern (C++) final class Import : Dsymbol
         load(sc);
         if (!mod) return; // Failed
 
+        if (sc.stc & STC.static_)
+            isstatic = true;
         mod.importAll(null);
         mod.checkImportDeprecation(loc, sc);
         if (sc.explicitProtection)

--- a/test/fail_compilation/fail11038.d
+++ b/test/fail_compilation/fail11038.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=11038
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail11038.d(16): Error: `writeln` is not defined, perhaps `import std.stdio;` is needed?
+---
+*/
+
+static
+{
+    import std.stdio;
+}
+
+void main()
+{
+    writeln("foo");  // compiles
+}


### PR DESCRIPTION
The main function of the compiler (mars.d) calls importAll on the module before doing any semantic analysis. Since for blocks such as `static{}`, the storage class is updated during semantic analysis, the imports inside static blocks are brought in the module scope which results in the present bug.

The fix is to update the isstatic field of imports when it is first used.

~~I know that this requires a deprecation cycle, but I suspect that this is not a prevalent pattern and maybe we can get away directly with an error. Let's see what the tests say.~~

Later edit; it seems that phobos has this pattern:

```d
package template MemberFunctionGenerator(alias Policy)
{
private static:
    import std.format;
    /* use of format without fully qualified name in some function */
}
```

It seems we have to go through a deprecation cycle.