### PR TITLE
update signature of utf_decode*char 

### DIFF
--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1929,9 +1929,8 @@ Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
-                        const p = utf_decodeChar(se.peekString().ptr, e.len, u, c);
-                        if (p)
-                            e.error("%s", p);
+                        if (const s = utf_decodeChar(se.peekString(), u, c))
+                            e.error("%.*s", cast(int)s.length, s.ptr);
                         else
                             buffer.writeUTF16(c);
                     }
@@ -1943,9 +1942,8 @@ Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
-                        const p = utf_decodeChar(se.peekString().ptr, e.len, u, c);
-                        if (p)
-                            e.error("%s", p);
+                        if (const s = utf_decodeChar(se.peekString(), u, c))
+                            e.error("%.*s", cast(int)s.length, s.ptr);
                         buffer.write4(c);
                         newlen++;
                     }
@@ -1956,9 +1954,8 @@ Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
-                        const p = utf_decodeWchar(se.peekWstring().ptr, e.len, u, c);
-                        if (p)
-                            e.error("%s", p);
+                        if (const s = utf_decodeWchar(se.peekWstring(), u, c))
+                            e.error("%.*s", cast(int)s.length, s.ptr);
                         else
                             buffer.writeUTF8(c);
                     }
@@ -1970,9 +1967,8 @@ Expression castTo(Expression e, Scope* sc, Type t)
                     for (size_t u = 0; u < e.len;)
                     {
                         dchar c;
-                        const p = utf_decodeWchar(se.peekWstring().ptr, e.len, u, c);
-                        if (p)
-                            e.error("%s", p);
+                        if (const s = utf_decodeWchar(se.peekWstring(), u, c))
+                            e.error("%.*s", cast(int)s.length, s.ptr);
                         buffer.write4(c);
                         newlen++;
                     }

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -6910,7 +6910,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
     {
         // Step 1: Decode the next dchar from the string.
 
-        const(char)* errmsg = null; // Used for reporting decoding errors
+        string errmsg = null; // Used for reporting decoding errors
         dchar rawvalue; // Holds the decoded dchar
         size_t currentIndex = indx; // The index of the decoded character
 
@@ -6946,7 +6946,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
                     utf8buf[i] = cast(char)r.isIntegerExp().getInteger();
                 }
                 n = 0;
-                errmsg = utf_decodeChar(&utf8buf[0], buflen, n, rawvalue);
+                errmsg = utf_decodeChar(utf8buf[0 .. buflen], n, rawvalue);
                 break;
 
             case 2:
@@ -6971,7 +6971,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
                     utf16buf[i] = cast(ushort)r.isIntegerExp().getInteger();
                 }
                 n = 0;
-                errmsg = utf_decodeWchar(&utf16buf[0], buflen, n, rawvalue);
+                errmsg = utf_decodeWchar(utf16buf[0 .. buflen], n, rawvalue);
                 break;
 
             case 4:
@@ -7008,7 +7008,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
                     saveindx = indx;
                 }
                 auto slice = se.peekString();
-                errmsg = utf_decodeChar(slice.ptr, slice.length, indx, rawvalue);
+                errmsg = utf_decodeChar(slice, indx, rawvalue);
                 if (rvs)
                     indx = saveindx;
                 break;
@@ -7025,7 +7025,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
                     saveindx = indx;
                 }
                 const slice = se.peekWstring();
-                errmsg = utf_decodeWchar(slice.ptr, slice.length, indx, rawvalue);
+                errmsg = utf_decodeWchar(slice, indx, rawvalue);
                 if (rvs)
                     indx = saveindx;
                 break;
@@ -7044,7 +7044,7 @@ private Expression foreachApplyUtf(UnionExp* pue, InterState* istate, Expression
         }
         if (errmsg)
         {
-            deleg.error("`%s`", errmsg);
+            deleg.error("`%.*s`", cast(int)errmsg.length, errmsg.ptr);
             return CTFEExp.cantexp;
         }
 

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -607,8 +607,8 @@ public:
             {
                 dchar c;
                 auto ppos = pos;
-                auto p = utf_decodeChar(slice.ptr, slice.length, pos, c);
-                assert(p is null, p[0..strlen(p)]);
+                const s = utf_decodeChar(slice, pos, c);
+                assert(s is null, s);
                 assert(c.isValidMangling, "The mangled name '" ~ slice ~ "' " ~
                     "contains an invalid character: " ~ slice[ppos..pos]);
             }
@@ -1002,9 +1002,8 @@ public:
             for (size_t u = 0; u < e.len;)
             {
                 dchar c;
-                const p = utf_decodeWchar(slice.ptr, slice.length, u, c);
-                if (p)
-                    e.error("%s", p);
+                if (const s = utf_decodeWchar(slice, u, c))
+                    e.error("%.*s", cast(int)s.length, s.ptr);
                 else
                     tmp.writeUTF8(c);
             }

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -2136,7 +2136,7 @@ size_t skiptoident(ref OutBuffer buf, size_t i)
     {
         dchar c;
         size_t oi = i;
-        if (utf_decodeChar(slice.ptr, slice.length, i, c))
+        if (utf_decodeChar(slice, i, c))
         {
             /* Ignore UTF errors, but still consume input
              */
@@ -2165,7 +2165,7 @@ private size_t skippastident(ref OutBuffer buf, size_t i)
     {
         dchar c;
         size_t oi = i;
-        if (utf_decodeChar(slice.ptr, slice.length, i, c))
+        if (utf_decodeChar(slice, i, c))
         {
             /* Ignore UTF errors, but still consume input
              */
@@ -2196,7 +2196,7 @@ private size_t skipPastIdentWithDots(ref OutBuffer buf, size_t i)
     {
         dchar c;
         size_t oi = i;
-        if (utf_decodeChar(slice.ptr, slice.length, i, c))
+        if (utf_decodeChar(slice, i, c))
         {
             /* Ignore UTF errors, but still consume input
              */
@@ -5339,7 +5339,7 @@ bool isIdStart(const(char)* p)
     if (c >= 0x80)
     {
         size_t i = 0;
-        if (utf_decodeChar(p, 4, i, c))
+        if (utf_decodeChar(p[0 .. 4], i, c))
             return false; // ignore errors
         if (isUniAlpha(c))
             return true;
@@ -5358,7 +5358,7 @@ bool isIdTail(const(char)* p)
     if (c >= 0x80)
     {
         size_t i = 0;
-        if (utf_decodeChar(p, 4, i, c))
+        if (utf_decodeChar(p[0 .. 4], i, c))
             return false; // ignore errors
         if (isUniAlpha(c))
             return true;
@@ -5383,7 +5383,7 @@ int utfStride(const(char)* p)
     if (c < 0x80)
         return 1;
     size_t i = 0;
-    utf_decodeChar(p, 4, i, c); // ignore errors, but still consume input
+    utf_decodeChar(p[0 .. 4], i, c); // ignore errors, but still consume input
     return cast(int)i;
 }
 

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1963,8 +1963,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 auto slice = se.peekString();
                 for (size_t i = 0; i < se.len;)
                 {
-                    auto p = slice.ptr;
-                    dchar c = p[i];
+                    dchar c = slice[i];
                     if (c < 0x80)
                     {
                         if (c.isValidMangling)
@@ -1978,9 +1977,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                             break;
                         }
                     }
-                    if (const msg = utf_decodeChar(slice.ptr, se.len, i, c))
+                    if (const msg = utf_decodeChar(slice, i, c))
                     {
-                        pd.error("%s", msg);
+                        pd.error("%.*s", cast(int)msg.length, msg.ptr);
                         break;
                     }
                     if (!isUniAlpha(c))

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -2372,9 +2372,9 @@ extern (C++) final class StringExp : Expression
         case 1:
             for (size_t u = 0; u < len;)
             {
-                if (const p = utf_decodeChar(string, len, u, c))
+                if (const s = utf_decodeChar(string[0 .. len], u, c))
                 {
-                    error("%s", p);
+                    error("%.*s", cast(int)s.length, s.ptr);
                     return 0;
                 }
                 result += utf_codeLength(encSize, c);
@@ -2384,9 +2384,9 @@ extern (C++) final class StringExp : Expression
         case 2:
             for (size_t u = 0; u < len;)
             {
-                if (const p = utf_decodeWchar(wstring, len, u, c))
+                if (const s = utf_decodeWchar(wstring[0 .. len], u, c))
                 {
-                    error("%s", p);
+                    error("%.*s", cast(int)s.length, s.ptr);
                     return 0;
                 }
                 result += utf_codeLength(encSize, c);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2849,7 +2849,6 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
         OutBuffer buffer;
         size_t newlen = 0;
-        const(char)* p;
         size_t u;
         dchar c;
 
@@ -2858,10 +2857,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         case 'd':
             for (u = 0; u < e.len;)
             {
-                p = utf_decodeChar(e.peekString().ptr, e.len, u, c);
-                if (p)
+                if (const p = utf_decodeChar(e.peekString(), u, c))
                 {
-                    e.error("%s", p);
+                    e.error("%.*s", cast(int)p.length, p.ptr);
                     return setError();
                 }
                 else
@@ -2879,10 +2877,9 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         case 'w':
             for (u = 0; u < e.len;)
             {
-                p = utf_decodeChar(e.peekString().ptr, e.len, u, c);
-                if (p)
+                if (const p = utf_decodeChar(e.peekString(), u, c))
                 {
-                    e.error("%s", p);
+                    e.error("%.*s", cast(int)p.length, p.ptr);
                     return setError();
                 }
                 else

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -277,8 +277,8 @@ nothrow:
         while (idx < str.length)
         {
             dchar dc;
-            const q = utf_decodeChar(str.ptr, str.length, idx, dc);
-            if (q ||
+            const s = utf_decodeChar(str, idx, dc);
+            if (s ||
                 !((dc >= 0x80 && isUniAlpha(dc)) || isalnum(dc) || dc == '_'))
             {
                 return false;

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2485,11 +2485,11 @@ class Lexer
         }
         size_t idx = 0;
         dchar u;
-        const msg = utf_decodeChar(s, len, idx, u);
+        const msg = utf_decodeChar(s[0 .. len], idx, u);
         p += idx - 1;
         if (msg)
         {
-            error("%s", msg);
+            error("%.*s", cast(int)msg.length, msg.ptr);
         }
         return u;
     }

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -814,7 +814,7 @@ nothrow:
                 for (size_t i = 0; i < len;)
                 {
                     dchar c;
-                    utf_decodeChar(ustring, len, i, c);
+                    utf_decodeChar(ustring[0 .. len], i, c);
                     switch (c)
                     {
                     case 0:

--- a/src/dmd/utf.d
+++ b/src/dmd/utf.d
@@ -400,21 +400,20 @@ void utf_encode(int sz, void* s, dchar c)
  * Decode a UTF-8 sequence as a single UTF-32 code point.
  * Params:
  *      s = UTF-8 sequence
- *      len = number of code units in s[]
  *      ridx = starting index in s[], updated to reflect number of code units decoded
  *      rresult = set to character decoded
  * Returns:
  *      null on success, otherwise error message string
  */
-immutable(char*) utf_decodeChar(const(char)* s, size_t len, ref size_t ridx, out dchar rresult)
+string utf_decodeChar(const(char)[] s, ref size_t ridx, out dchar rresult)
 {
     // UTF-8 decoding errors
-    static immutable char* UTF8_DECODE_OK = null; // no error
-    static immutable char* UTF8_DECODE_OUTSIDE_CODE_SPACE = "Outside Unicode code space";
-    static immutable char* UTF8_DECODE_TRUNCATED_SEQUENCE = "Truncated UTF-8 sequence";
-    static immutable char* UTF8_DECODE_OVERLONG = "Overlong UTF-8 sequence";
-    static immutable char* UTF8_DECODE_INVALID_TRAILER = "Invalid trailing code unit";
-    static immutable char* UTF8_DECODE_INVALID_CODE_POINT = "Invalid code point decoded";
+    static immutable string UTF8_DECODE_OK = null; // no error
+    static immutable string UTF8_DECODE_OUTSIDE_CODE_SPACE = "Outside Unicode code space";
+    static immutable string UTF8_DECODE_TRUNCATED_SEQUENCE = "Truncated UTF-8 sequence";
+    static immutable string UTF8_DECODE_OVERLONG = "Overlong UTF-8 sequence";
+    static immutable string UTF8_DECODE_INVALID_TRAILER = "Invalid trailing code unit";
+    static immutable string UTF8_DECODE_INVALID_CODE_POINT = "Invalid code point decoded";
 
     /* The following encodings are valid, except for the 5 and 6 byte
      * combinations:
@@ -468,7 +467,7 @@ immutable(char*) utf_decodeChar(const(char)* s, size_t len, ref size_t ridx, out
 
     assert(s !is null);
     size_t i = ridx++;
-    assert(i < len);
+
     const char u = s[i];
     // Pre-stage results for ASCII and error cases
     rresult = u;
@@ -489,7 +488,7 @@ immutable(char*) utf_decodeChar(const(char)* s, size_t len, ref size_t ridx, out
         // 5- or 6-byte sequence
         return UTF8_DECODE_OUTSIDE_CODE_SPACE;
     }
-    if (len < i + n) // source too short
+    if (s.length < i + n) // source too short
         return UTF8_DECODE_TRUNCATED_SEQUENCE;
     // Pick off 7 - n low bits from first code unit
     dchar c = u & ((1 << (7 - n)) - 1);
@@ -523,31 +522,30 @@ immutable(char*) utf_decodeChar(const(char)* s, size_t len, ref size_t ridx, out
  * Decode a UTF-16 sequence as a single UTF-32 code point.
  * Params:
  *      s = UTF-16 sequence
- *      len = number of code units in s[]
  *      ridx = starting index in s[], updated to reflect number of code units decoded
  *      rresult = set to character decoded
  * Returns:
  *      null on success, otherwise error message string
  */
-immutable(char*) utf_decodeWchar(const(wchar)* s, size_t len, ref size_t ridx, out dchar rresult)
+string utf_decodeWchar(const(wchar)[] s, ref size_t ridx, out dchar rresult)
 {
     // UTF-16 decoding errors
-    static immutable char* UTF16_DECODE_OK = null; // no error
-    static immutable char* UTF16_DECODE_TRUNCATED_SEQUENCE = "Truncated UTF-16 sequence";
-    static immutable char* UTF16_DECODE_INVALID_SURROGATE = "Invalid low surrogate";
-    static immutable char* UTF16_DECODE_UNPAIRED_SURROGATE = "Unpaired surrogate";
-    static immutable char* UTF16_DECODE_INVALID_CODE_POINT = "Invalid code point decoded";
+    static immutable string UTF16_DECODE_OK = null; // no error
+    static immutable string UTF16_DECODE_TRUNCATED_SEQUENCE = "Truncated UTF-16 sequence";
+    static immutable string UTF16_DECODE_INVALID_SURROGATE = "Invalid low surrogate";
+    static immutable string UTF16_DECODE_UNPAIRED_SURROGATE = "Unpaired surrogate";
+    static immutable string UTF16_DECODE_INVALID_CODE_POINT = "Invalid code point decoded";
 
     assert(s !is null);
     size_t i = ridx++;
-    assert(i < len);
+
     // Pre-stage results for single wchar and error cases
     dchar u = rresult = s[i];
     if (u < 0xD800) // Single wchar codepoint
         return UTF16_DECODE_OK;
     if (0xD800 <= u && u <= 0xDBFF) // Surrogate pair
     {
-        if (len <= i + 1)
+        if (s.length <= i + 1)
             return UTF16_DECODE_TRUNCATED_SEQUENCE;
         wchar u2 = s[i + 1];
         if (u2 < 0xDC00 || 0xDFFF < u)


### PR DESCRIPTION
to use slices and return strings

It wasn't obvious to me why the ptr and length in the dcast code was coming from different string expressions (1 which is a copy of another, I believe?).  I THINK they can be reduced to just passing se.peekString, but I wasn't sure so I left those basically as they were.

Since we have bounds checked slices I dropped the asserts from the implementations