### PR TITLE
Fix Issue 20375 - RefCounted does not work with checkaction-context

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5820,7 +5820,8 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             {
                 if (op.hasSideEffect)
                 {
-                    auto tmp = copyToTemp(0, "__assertOp", op);
+                    const stc = STC.exptemp | (op.isLvalue() ? STC.ref_ : STC.rvalue);
+                    auto tmp = copyToTemp(stc, "__assertOp", op);
                     tmp.dsymbolSemantic(sc);
 
                     auto decl = new DeclarationExp(op.loc, tmp);


### PR DESCRIPTION
The hidden temporary was simply blitted (without calling a constructor/postblit) but destructed at the end of the expression.This caused `RefCounted` to deallocate the payload a second time.