### PR TITLE
Revert "Move more targets to build.d"

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -5,12 +5,6 @@ DMD builder
 Usage:
   ./build.d dmd
 
-detab, tolf, install targets - require the D Language Tools (detab.exe, tolf.exe)
-  https://github.com/dlang/tools.
-
-zip target - requires Info-ZIP or equivalent (zip32.exe)
-  http://www.info-zip.org/Zip.html#Downloads
-
 TODO:
 - add all posix.mak Makefile targets
 - support 32-bit builds
@@ -42,8 +36,6 @@ immutable rootDeps = [
     &clean,
     &checkwhitespace,
     &runCxxUnittest,
-    &detab,
-    &tolf,
     &zip,
     &html,
 ];
@@ -417,6 +409,7 @@ alias checkwhitespace = makeDep!((builder, dep) => builder
     .deps([toolsRepo])
     .commandFunction(delegate() {
         const cmdPrefix = [env["HOST_DMD_RUN"], "-run", env["TOOLS_DIR"].buildPath("checkwhitespace.d")];
+        const allSources = srcDir.dirEntries("*.{d,h,di}", SpanMode.depth).map!(e => e.name).array;
         writefln("Checking whitespace on %s files...", allSources.length);
         auto chunkLength = allSources.length;
         version (Win32)
@@ -428,20 +421,6 @@ alias checkwhitespace = makeDep!((builder, dep) => builder
             run(nextCommand);
         }
     })
-);
-
-alias detab = makeDep!((builder, dep) => builder
-    .name("detab")
-    .description("replace hard tabs with spaces")
-    .command([env["DETAB"]] ~ allSources)
-    .msg(dep.command.join(" "))
-);
-
-alias tolf = makeDep!((builder, dep) => builder
-    .name("tolf")
-    .description("convert to Unix line endings")
-    .command([env["TOLF"]] ~ allSources)
-    .msg(dep.command.join(" "))
 );
 
 alias zip = makeDep!((builder, dep) => builder
@@ -775,8 +754,6 @@ void processEnvironment()
         env["HOST_DMD_KIND"] = "gdc";
 
     env["DMD_PATH"] = env["G"].buildPath("dmd").exeName;
-    env.getDefault("DETAB", "detab");
-    env.getDefault("TOLF", "tolf");
     version (Windows)
         env.getDefault("ZIP", "zip32");
     else
@@ -905,9 +882,6 @@ string detectHostCxx()
 ////////////////////////////////////////////////////////////////////////////////
 // D source files
 ////////////////////////////////////////////////////////////////////////////////
-
-/// Returns: all source files in the repository
-alias allSources = memoize!(() => srcDir.dirEntries("*.{d,h,di}", SpanMode.depth).map!(e => e.name).array);
 
 /// Returns: all source files for the compiler
 auto sourceFiles()

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -15,6 +15,12 @@
 # win32.mak (this file) - requires Digital Mars Make ($DM_HOME\dm\bin\make.exe)
 #   http://www.digitalmars.com/ctg/make.html
 #
+# detab, tolf, install targets - require the D Language Tools (detab.exe, tolf.exe)
+#   https://github.com/dlang/tools.
+#
+# zip target - requires Info-ZIP or equivalent (zip32.exe)
+#   http://www.info-zip.org/Zip.html#Downloads
+#
 # Configuration:
 #
 # The easiest and recommended way to configure this makefile is to add
@@ -37,6 +43,8 @@
 # dmd           - release dmd (legacy target)
 # debdmd        - debug dmd
 # reldmd        - release dmd
+# detab         - replace hard tabs with spaces
+# tolf          - convert to Unix line endings
 
 ############################### Configuration ################################
 
@@ -81,6 +89,10 @@ MD=mkdir
 RD=rmdir
 # File copy
 CP=cp
+# De-tabify
+DETAB=detab
+# Convert line endings to Unix
+TOLF=tolf
 # Copy to another directory
 SCP=$(CP)
 # PVS-Studio command line executable
@@ -314,11 +326,11 @@ install-clean:
 	$(DEL) /s/q $(INSTALL)\*
 	$(RD) /s/q $(INSTALL)
 
-detab: $(GEN)\build.exe
-	$(RUN_BUILD) $@
+detab:
+	$(DETAB) $(SRCS) $(GLUESRC) $(ROOTSRC) $(BACKSRC)
 
-tolf: $(GEN)\build.exe
-	$(RUN_BUILD) $@
+tolf:
+	$(TOLF) $(SRCS) $(GLUESRC) $(ROOTSRC) $(BACKSRC) $(MAKEFILES)
 
 zip: detab tolf $(GEN)\build.exe
 	$(RUN_BUILD) $@


### PR DESCRIPTION
Reverts dlang/dmd#10549

Sorry, but there's ABSOLUTELY no reason to maintain these targets. If Walter is super insistent that he can't use git nor can call them directly, we can leave them in his win32.mak, but let's please not clog the new build script with more legacy stuff than necessary!