### PR TITLE
Fix Issue 20367 - Postblit cannot be disabled when copy ctor is defined

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -423,7 +423,7 @@ private bool buildCopyCtor(StructDeclaration sd, Scope* sc)
         return false;
 
     bool hasPostblit;
-    if (sd.postblit)
+    if (sd.postblit && !sd.postblit.isDisabled())
         hasPostblit = true;
 
     auto ctor = sd.search(sd.loc, Id.ctor);

--- a/test/compilable/test20367.d
+++ b/test/compilable/test20367.d
@@ -1,0 +1,16 @@
+// https://issues.dlang.org/show_bug.cgi?id=20367
+
+import std.stdio;
+
+struct A
+{
+	int x;
+	this(ref return scope A rhs) {}
+	@disable this(this) {}
+}
+
+void main()
+{
+	A a;
+	A b = a; // copy constructor gets called
+}


### PR DESCRIPTION
If a struct defines both a postblit and a copy constructor and the postblit is disabled, go with the copy constructor.