### PR TITLE
Issue 20376 - @disable this(ref return scope Foo rhs) enables broken binaries (out-of-bounds access)

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -840,7 +840,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
 
                         const hasCopyCtor = exp.type.ty == Tstruct && (cast(TypeStruct)exp.type).sym.hasCopyCtor;
                         // if a copy constructor is present, the return type conversion will be handled by it
-                        if (!hasCopyCtor)
+                        if (!(hasCopyCtor && exp.isLvalue()))
                             exp = exp.implicitCastTo(sc2, tret);
 
                         if (f.isref)

--- a/test/fail_compilation/fail20376.d
+++ b/test/fail_compilation/fail20376.d
@@ -1,0 +1,20 @@
+// https://issues.dlang.org/show_bug.cgi?id=20376
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20376.d(17): Error: cannot implicitly convert expression `Foo()` of type `Foo` to `ubyte`
+---
+*/
+
+struct Foo
+{
+    this(ref scope Foo);
+}
+
+ubyte fun()
+{
+    return Foo();
+}
+
+void main(){}


### PR DESCRIPTION
The conversion is handled by the copy constructor only when the return value is an lvalue and the object has a defined copy constructor.