### PR TITLE
Fix Issue 20220 - Use .init_array/.fini_array instead of .ctors/.dtors on !TARGET_OPENBSD

### DIFF
--- a/src/dmd/backend/melf.d
+++ b/src/dmd/backend/melf.d
@@ -122,6 +122,8 @@ struct Elf32_Ehdr
         enum SHT_REL          = 9;          /* Relocations no addends */
         enum SHT_RESTYPE      = 10;         /* Reserved section type*/
         enum SHT_DYNTAB       = 11;         /* Dynamic linker symbol table */
+        enum SHT_INIT_ARRAY   = 14;         /* Array of constructors */
+        enum SHT_FINI_ARRAY   = 15;         /* Array of destructors */
         enum SHT_GROUP        = 17;         /* Section group (COMDAT) */
         enum SHT_SYMTAB_SHNDX = 18;         /* Extended section indices */
 


### PR DESCRIPTION
Global constructors are placed in .ctors sections. lld does not convert
.ctors to .init_array (https://bugs.llvm.org/show_bug.cgi?id=31224).
The linked executable will not run constructors on most modern Linux
distributions.

GNU ld and gold convert .ctors/.dtors to .init_array/.fini_array by
default, so programs linked by them are fine.

Fix this by using .init_array/.fini_array . Linux, DragonFlyBSD, FreeBSD
and Solaris have supported .init_array for many years. The OpenBSD
support is relatively new (Aug 2016), so only use .ctors/.dtors on
OpenBSD.

-----

Most not-so-old Linux distributions configure glibc with `NO_CTORS_DTORS_SECTIONS`, so `.ctors` constructors do not run.

```c
#include <stdio.h>

static void myctor1() { puts(".ctors.1"); }
static void myctor2() { puts(".ctors.2"); }
static void myctor() { puts(".ctors"); }

static void myinit1() {puts(".init_array.1");}
static void myinit2() {puts(".init_array.2");}
static void myinit() {puts(".init_array");}

__attribute__((used,section(".ctors.1"))) static void *fpctor1[] = { myctor1 };
__attribute__((used,section(".ctors.2"))) static void *fpctor2[] = { myctor2 };
__attribute__((used,section(".ctors"))) static void *fpctor[] = { myctor };

__attribute__((used,section(".init_array.1"))) static void *fpinit1[] = { myinit1 };
__attribute__((used,section(".init_array.2"))) static void *fpinit2[] = { myinit2 };
__attribute__((used,section(".init_array"))) static void *fpinit[] = { myinit };

int main(){}
```

```sh
% cc -fuse-ld=bfd a.c -o a && ./a
.init_array.1
.init_array.2
.ctors.2
.ctors.1
.ctors
.init_array

% cc -fuse-ld=gold a.c -o a && ./a
.init_array.1
.init_array.2
.ctors.2
.ctors.1
.init_array
.ctors

# No support for converting .ctors to .init_array
% cc -fuse-ld=lld a.c -o a && ./a
.init_array.1
.init_array.2
.init_array
```

Some archaeology on the .init_array support

glibc https://sourceware.org/git/?p=glibc.git;a=commit;h=fcf70d4114db9ff7923f5dfeb3fea6e2d623e5c2 supported since 1999.

FreeBSD 2012-03-11 https://github.com/freebsd/freebsd/commit/95d1e3d11bebe5f0d75da30af98fbc94ee0e5233
It works on FreeBSD 10. It may not work on FreeBSD 9.3 but releng/9.3 reached end-of-life (https://www.freebsd.org/security/unsupported.html) on 2016-12-31

NetBSD (not supported?) 2018-12-27 https://github.com/NetBSD/src/commit/17c588ef35d9a33496f4b96ea6a68802c10e0028 "initfini array support for everyone."

OpenBSD 2016-08-23 https://github.com/openbsd/src/commit/86fa57a2792c6374b0849dd7b818a11e676e60ba "Implement support for DT_INIT_ARRAY, DT_FINI_ARRAY and DT_PREINIT_ARRAY."

Solaris: They may have supported .init_array for a long time. In https://github.com/llvm/llvm-project/blob/master/clang/lib/Driver/ToolChains/Gnu.cpp#L2728 , -fuse-init-array is unconditional on versions.
