### PR TITLE
Fix Issue 20334 - posix.mak clean target does not remove all generated files

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -161,6 +161,10 @@ quick:
 clean:
 	@echo "Removing output directory: $(RESULTS_DIR)"
 	$(QUIET)if [ -e $(RESULTS_DIR) ]; then rm -rf $(RESULTS_DIR); fi
+	@echo "Remove coverage listing files: *.lst"
+	$(QUIET)rm -rf *.lst
+	@echo "Remove trace files: trace.def, trace.log"
+	$(QUIET)rm -rf trace.log trace.def
 
 $(RESULTS_DIR)/.created:
 	@echo Creating output directory: $(RESULTS_DIR)

--- a/test/runnable/mixin.sh
+++ b/test/runnable/mixin.sh
@@ -4,9 +4,8 @@ src_file=${EXTRA_FILES}/${TEST_NAME}.d
 expect_file=${EXTRA_FILES}/${TEST_NAME}.mixin
 tmp_file=${RESULTS_TEST_DIR}/${TEST_NAME}.mixin
 
-$DMD -c -mixin=${tmp_file} -g ${src_file}
+$DMD -o- -mixin=${tmp_file} -g ${src_file}
 tr '\\' '/' < ${tmp_file} > ${tmp_file}2
 diff -pu --strip-trailing-cr ${expect_file} ${tmp_file}2
 
 rm ${tmp_file} ${tmp_file}2
-rm ${TEST_NAME}.o

--- a/test/runnable/mixin.sh
+++ b/test/runnable/mixin.sh
@@ -9,3 +9,4 @@ tr '\\' '/' < ${tmp_file} > ${tmp_file}2
 diff -pu --strip-trailing-cr ${expect_file} ${tmp_file}2
 
 rm ${tmp_file} ${tmp_file}2
+rm ${TEST_NAME}.o

--- a/test/runnable/test_switches.sh
+++ b/test/runnable/test_switches.sh
@@ -18,7 +18,6 @@ src_file=${OUTPUT_BASE}/src.d
 clean()
 {
     rm -rf ${OUTPUT_BASE}
-    rm -rf mymod.o
 }
 
 prepare()
@@ -56,11 +55,11 @@ checkFiles()
 # as there's no common linker switch which all linkers support
 
 prepare;
-$DMD -c -of=mymod.o -od=${OUTPUT_BASE} -D -Df=${OUTPUT_BASE}/src.html -Hf=${OUTPUT_BASE}/src.di -I=${OUTPUT_BASE} -L=-v -Xf=${OUTPUT_BASE}/json.json ${src_file}
+$DMD -o- -od=${OUTPUT_BASE} -D -Df=${OUTPUT_BASE}/src.html -Hf=${OUTPUT_BASE}/src.di -I=${OUTPUT_BASE} -L=-v -Xf=${OUTPUT_BASE}/json.json ${src_file}
 checkFiles;
 
 prepare;
-$DMD -c -of=mymod.o -od=${OUTPUT_BASE} -D -Dd=${OUTPUT_BASE} -Hd=${OUTPUT_BASE} -I=${OUTPUT_BASE} -L=-v -Xf=${OUTPUT_BASE}/json.json ${src_file}
+$DMD -o- -od=${OUTPUT_BASE} -D -Dd=${OUTPUT_BASE} -Hd=${OUTPUT_BASE} -I=${OUTPUT_BASE} -L=-v -Xf=${OUTPUT_BASE}/json.json ${src_file}
 checkFiles;
 
 clean;

--- a/test/runnable/test_switches.sh
+++ b/test/runnable/test_switches.sh
@@ -18,6 +18,7 @@ src_file=${OUTPUT_BASE}/src.d
 clean()
 {
     rm -rf ${OUTPUT_BASE}
+    rm -rf mymod.o
 }
 
 prepare()


### PR DESCRIPTION
When the "runnable" test suite is run, it generates some files that are currently omitted by the existing Makefile clean target.

The fix was to extend the existing clean target with some additional remove commands. For the .o files, I added a "rm" command right in the script where they are generated.