### PR TITLE
IGNOREME: just trying to figure out why autotester win32 is mangling pathnames

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -26,7 +26,7 @@ import std.algorithm, std.conv, std.datetime, std.exception, std.file, std.forma
 const thisBuildScript = __FILE_FULL_PATH__.buildNormalizedPath;
 const srcDir = thisBuildScript.dirName;
 const dmdRepo = srcDir.dirName;
-shared bool verbose; // output verbose logging
+shared bool verbose = true; // output verbose logging
 shared bool force; // always build everything (ignores timestamp checking)
 shared bool dryRun; /// dont execute targets, just print command to be executed
 
@@ -422,9 +422,6 @@ alias toolsRepo = makeDep!((builder, dep) => builder
         if (!toolsDir.exists)
         {
             writefln("cloning tools repo to '%s'...", toolsDir);
-            version(Win32)
-                // Win32-git seems to confuse C:\... as a relative path
-                toolsDir = toolsDir.relativePath(srcDir);
             run(["git", "clone", "--depth=1", env["GIT_HOME"] ~ "/tools", toolsDir]);
         }
     })


### PR DESCRIPTION
It looks like this failure occurs on some autotester Win_32 hosts but not on others.  Consistently fails on the "power" host but succeeds on the "win-farm-1" host.

The failure occurs when running git to clone the dlang tools repo.  It fails with a message indicating that it combined the current directory with the absolute path passed as the destination path for the repo, i.e.
```
Run: git clone --depth=1 https://github.com/dlang/tools C:\cygwin\home\braddr\sandbox\at-client\pull-3836022-Win_32\tools
Cloning into 'C:\cygwin\home\braddr\sandbox\at-client\pull-3836022-Win_32\tools'...
fatal: Invalid path '/home/braddr/sandbox/at-client/pull-3836022-Win_32/dmd/src/C:\cygwin\home\braddr\sandbox\at-client\pull-3836022-Win_32\tools': No such file or directory
```` 

@braddr confirms these machines are using git directly (there's no in-between script that could be mangling the arguments).  It seems the most likely culprit is cygwin.  I've emailed @braddr to ask whether these machines are using different versions of cygwin.

Ping @MoonlightSentinel 
