### PR TITLE
Fix Issue 4544 - Better error-message when expecting string but got a character constant

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1803,7 +1803,29 @@ class Lexer
         }
         if (*p != '\'')
         {
-            error("unterminated character constant");
+            while (*p != '\'' && *p != 0x1A && *p != 0 && *p != '\n' &&
+                    *p != '\r' && *p != ';' && *p != ')' && *p != ']' && *p != '}')
+            {
+                if (*p & 0x80)
+                {
+                    const s = p;
+                    c = decodeUTF();
+                    if (c == LS || c == PS)
+                    {
+                        p = s;
+                        break;
+                    }
+                }
+                p++;
+            }
+
+            if (*p == '\'')
+            {
+                error("character constant has multiple characters");
+                p++;
+            }
+            else
+                error("unterminated character constant");
             t.unsvalue = '?';
             return tk;
         }

--- a/test/fail_compilation/fail4544.d
+++ b/test/fail_compilation/fail4544.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail4544.d(15): Error: character constant has multiple characters
+fail_compilation/fail4544.d(16): Error: `0x` isn't a valid integer literal, use `0x0` instead
+fail_compilation/fail4544.d(16): Error: no identifier for declarator `int`
+fail_compilation/fail4544.d(17): Error: unterminated character constant
+fail_compilation/fail4544.d(18): Error: character constant has multiple characters
+---
+*/
+
+int foo(char n, int m)
+{
+    int k = 5;
+    char c = 'asd';
+    int 0x = 'k';
+    foo('dasadasdaasdasdaslkdhasdlashdsalk, xxx);
+    goo('asdasdsa');
+    for (int i = 0; i < 10; i++)
+    {
+        k++;
+    }
+}


### PR DESCRIPTION
The compiler issues a poor error message when there's more than one character between single quotes. (e.g. 'aaaa')

The fix was to move the cursor until another single quote, parenthesis or semicolon is found. If no character of this type is encountered, then the cursor is moved until the EOF is encountered.