### PR TITLE
Bug: Operator overloading is not rewritten

### DIFF
--- a/test/runnable/opoverloadrewrite.d
+++ b/test/runnable/opoverloadrewrite.d
@@ -1,0 +1,21 @@
+template opUnary(string op) {
+    static if (op == "+")
+        string opUnary(string name) {
+            return "hello " ~ name;
+        }
+}
+int opCmp(T1, T2)(T1 a, T2 b) {
+    return -1;
+}
+struct ArbitraryStruct {
+
+}
+void main() {
+    auto firstform = +`undefinedName`;
+    auto secondform = `undefinedName`.opUnary!("+");
+    assert(firstform == secondform);
+    ArbitraryStruct a;
+    ArbitraryStruct b;
+    assert(a < b);
+    assert(b < a);
+}


### PR DESCRIPTION
Section 20.1 of the D spec. This behavior is useful when automatically converting code from a more dynamic language (e.g. JavaScript) to readable D.