### PR TITLE
Fix Issue 19095 - deprecate array length mismatch in global static arrays

### DIFF
--- a/changelog/deprecate_array_length_mismatch.dd
+++ b/changelog/deprecate_array_length_mismatch.dd
@@ -1,0 +1,10 @@
+Deprecate array length mismatch in global static arrays.
+
+Example
+---
+// Old
+int[2] ARR = [5]; // [5, 0]
+
+// New
+int[2] ARR = [5]; // Deprecation: mismatched array lengths. array initializer has 1 elements, but array length is 2
+---

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -342,6 +342,13 @@ extern(C++) Initializer initializerSemantic(Initializer init, Scope* sc, Type t,
         if (t.ty == Tsarray)
         {
             uinteger_t edim = (cast(TypeSArray)t).dim.toInteger();
+            // Deprecated in 2019-11.
+            // Change to error in 2020-11.
+            // @@@DEPRECATED_2019-11@@@.
+            if (!i.isAssociativeArray() && i.dim != edim)
+            {
+                deprecation(i.loc, "mismatched array lengths. array initializer has %u elements, but array length is %llu", i.dim, edim);
+            }
             if (i.dim > edim)
             {
                 error(i.loc, "array initializer has %u elements, but array length is %llu", i.dim, edim);

--- a/test/fail_compilation/fail19095.d
+++ b/test/fail_compilation/fail19095.d
@@ -1,0 +1,16 @@
+/* REQUIRED_ARGS: -de
+ * PERMUTE_ARGS:
+ * TEST_OUTPUT:
+---
+fail_compilation/fail19095.d(13): Deprecation: mismatched array lengths. array initializer has 1 elements, but array length is 2
+fail_compilation/fail19095.d(14): Deprecation: mismatched array lengths. array initializer has 1 elements, but array length is 2
+fail_compilation/fail19095.d(15): Deprecation: mismatched array lengths. array initializer has 1 elements, but array length is 2
+---
+ */
+
+// https://issues.dlang.org/show_bug.cgi?id=19095
+
+int[2] ARR = [1];
+static int[2] static_arr = [1];
+__gshared int[2] gshared_arr = [1];
+int[3] asoc_arr = [1:2];

--- a/test/fail_compilation/ice15002.d
+++ b/test/fail_compilation/ice15002.d
@@ -1,8 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice15002.d(10): Error: array index 5 is out of bounds `x[0 .. 3]`
-fail_compilation/ice15002.d(10): Error: array index 5 is out of bounds `x[0 .. 3]`
+fail_compilation/ice15002.d(10): Deprecation: mismatched array lengths. array initializer has 0 elements, but array length is 3
+fail_compilation/ice15002.d(11): Error: array index 5 is out of bounds `x[0 .. 3]`
+fail_compilation/ice15002.d(11): Error: array index 5 is out of bounds `x[0 .. 3]`
 ---
 */
 

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -792,7 +792,7 @@ struct S44
   int i;
 }
 
-static S44[12] S44s = [];
+static S44[12] S44s;
 
 void test44()
 {

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -570,7 +570,7 @@ void test17()
 
 /* ================================ */
 
-private const uint[256] crc_table = [
+private const uint[6] crc_table = [
     0x00000000u, 0x77073096u, 0xee0e612cu, 0x990951bau, 0x076dc419u,
     0x2d02ef8du
   ];

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -1048,7 +1048,7 @@ void test50()
 
 void test51()
 {
-    static immutable int[2] array = [ 42 ];
+    static immutable int[2] array = [ 42, 0 ];
     enum e = array[1];
     static immutable int[1] array2 = [ 0: 42 ];
     enum e2 = array2[0];


### PR DESCRIPTION
Adoption of: https://github.com/dlang/dmd/pull/8503