### PR TITLE
Issue 20253 - bad debug line info for function without epilog (COFF)

### DIFF
--- a/src/dmd/backend/cgcod.d
+++ b/src/dmd/backend/cgcod.d
@@ -631,7 +631,8 @@ tryagain:
                start of the last instruction
              */
             /* Instead, try offset to cleanup code  */
-            objmod.linnum(sfunc.Sfunc.Fendline,sfunc.Sseg,funcoffset + retoffset);
+            if (retoffset < sfunc.Ssize)
+                objmod.linnum(sfunc.Sfunc.Fendline,sfunc.Sseg,funcoffset + retoffset);
 
         static if (TARGET_WINDOS && MARS)
         {

--- a/src/dmd/backend/cv8.d
+++ b/src/dmd/backend/cv8.d
@@ -367,7 +367,7 @@ void cv8_func_term(Symbol *sfunc)
     //printf("cv8_func_term(%s)\n", sfunc.Sident);
 
     assert(currentfuncdata.sfunc == sfunc);
-    currentfuncdata.section_length = cast(uint)(retoffset + retsize);
+    currentfuncdata.section_length = cast(uint)sfunc.Ssize;
 
     funcdata.write(&currentfuncdata, currentfuncdata.sizeof);
 


### PR DESCRIPTION
fix size of function by using the actual emitted code offset, not guessing from epilog data
do not emit line number for closing brace if the epilog was omitted