### PR TITLE
Fix issue 20413 - Itanium mangling bug with template substitution in the std namespace

### DIFF
--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -486,6 +486,11 @@ extern(C++)
     X func_18957_2(X)(X* v);
 }
 
+extern (C++)
+{
+    void func_20413(pair!(int, float), pair!(float, int));
+}
+
 version (Posix)
 {
     // https://issues.dlang.org/show_bug.cgi?id=17947
@@ -513,6 +518,8 @@ version (Posix)
 
     static assert(func_18957_2.mangleof == `_Z12func_18957_2PSaIiE`);
     static assert(func_18957_2!(allocator!int).mangleof == `_Z12func_18957_2ISaIiEET_PS1_`);
+
+    static assert(func_20413.mangleof == `_Z10func_20413St4pairIifES_IfiE`);
 }
 
 /**************************************/


### PR DESCRIPTION
Issue [20413](https://issues.dlang.org/show_bug.cgi?id=20413)

N..E is not needed in when substituting template instances of "std" members.

The Itanium spec isn't too clear about this one but this is the way of GCC and Clang implementations.
