### PR TITLE
Fix Issue 18809 - Improve error message on nonexistent property

### DIFF
--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2159,7 +2159,7 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
                         if (const n = importHint(ident.toString()))
                             error(loc, "no property `%s` for type `%s`, perhaps `import %.*s;` is needed?", ident.toChars(), mt.toChars(), cast(int)n.length, n.ptr);
                         else
-                            error(loc, "no property `%s` for type `%s`", ident.toChars(), mt.toChars());
+                            error(loc, "no property `%s` for type `%s`", ident.toChars(), mt.toPrettyChars(true));
                     }
                 }
             }

--- a/test/fail_compilation/diag10783.d
+++ b/test/fail_compilation/diag10783.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10783.d(14): Error: no property `type` for type `Event`
+fail_compilation/diag10783.d(14): Error: no property `type` for type `diag10783.Event`
 fail_compilation/diag10783.d(14): Error: undefined identifier `En`
 ---
 */

--- a/test/fail_compilation/diag15713.d
+++ b/test/fail_compilation/diag15713.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag15713.d(19): Error: no property `widthSign` for type `Data`
+fail_compilation/diag15713.d(19): Error: no property `widthSign` for type `diag15713.WrData.Data`
 fail_compilation/diag15713.d(39): Error: template instance `diag15713.conwritefImpl!("parse-int", "width", "\x0a", Data(null))` error instantiating
 fail_compilation/diag15713.d(44):        instantiated from here: `conwritefImpl!("main", "\x0a", Data(null))`
 fail_compilation/diag15713.d(49):        instantiated from here: `fdwritef!()`

--- a/test/fail_compilation/diag8894.d
+++ b/test/fail_compilation/diag8894.d
@@ -1,10 +1,10 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag8894.d(16): Error: no property `x` for type `Foo`
-fail_compilation/diag8894.d(17): Error: no property `y` for type `Foo`
-fail_compilation/diag8894.d(18): Error: no property `x` for type `Foo`
-fail_compilation/diag8894.d(19): Error: no property `x` for type `Foo`
+fail_compilation/diag8894.d(16): Error: no property `x` for type `diag8894.Foo`
+fail_compilation/diag8894.d(17): Error: no property `y` for type `diag8894.Foo`
+fail_compilation/diag8894.d(18): Error: no property `x` for type `diag8894.Foo`
+fail_compilation/diag8894.d(19): Error: no property `x` for type `diag8894.Foo`
 ---
 */
 

--- a/test/fail_compilation/fail121.d
+++ b/test/fail_compilation/fail121.d
@@ -3,7 +3,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail121.d(23): Error: no property `typeinfo` for type `myobject`
+fail_compilation/fail121.d(23): Error: no property `typeinfo` for type `fail121.myobject`
 fail_compilation/fail121.d(23): Error: no property `typeinfo` for type `int`
 ---
 */

--- a/test/fail_compilation/fail17969.d
+++ b/test/fail_compilation/fail17969.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17969.d(9): Error: no property `sum` for type `MapResult2!((b) => b)`
+fail_compilation/fail17969.d(9): Error: no property `sum` for type `fail17969.__lambda6!(int[]).__lambda6.MapResult2!((b) => b)`
 ---
  * https://issues.dlang.org/show_bug.cgi?id=17969
  */

--- a/test/fail_compilation/fail18219.d
+++ b/test/fail_compilation/fail18219.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail18219.d(15): Error: no property `Foobar` for type `AST`, did you mean `b18219.Foobar`?
-fail_compilation/fail18219.d(16): Error: no property `Bar` for type `AST`
+fail_compilation/fail18219.d(16): Error: no property `Bar` for type `a18219.AST`
 fail_compilation/fail18219.d(17): Error: no property `fun` for type `AST`, did you mean `b18219.fun`?
 fail_compilation/fail18219.d(18): Error: no property `Foobar` for type `AST`, did you mean `b18219.Foobar`?
 ---

--- a/test/fail_compilation/fail18892.d
+++ b/test/fail_compilation/fail18892.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18892.d(20): Error: no property `foo` for type `MT`
-fail_compilation/fail18892.d(21): Error: no property `foo` for type `MT`
+fail_compilation/fail18892.d(20): Error: no property `foo` for type `fail18892.MT`
+fail_compilation/fail18892.d(21): Error: no property `foo` for type `fail18892.MT`
 ---
 */
 

--- a/test/fail_compilation/fail18970.d
+++ b/test/fail_compilation/fail18970.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18970.d(22): Error: no property `y` for type `S`
-fail_compilation/fail18970.d(29): Error: no property `yyy` for type `S2`
+fail_compilation/fail18970.d(22): Error: no property `y` for type `fail18970.S`
+fail_compilation/fail18970.d(29): Error: no property `yyy` for type `fail18970.S2`
 ---
 */
 

--- a/test/fail_compilation/fail7861.d
+++ b/test/fail_compilation/fail7861.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail7861.d(17): Error: no property `nonexistent` for type `B`
+fail_compilation/fail7861.d(17): Error: no property `nonexistent` for type `test.B`
 ---
 */
 module test;

--- a/test/fail_compilation/ice10713.d
+++ b/test/fail_compilation/ice10713.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice10713.d(10): Error: no property `nonExistingField` for type `S`
+fail_compilation/ice10713.d(10): Error: no property `nonExistingField` for type `ice10713.S`
 ---
 */
 

--- a/test/fail_compilation/ice19755.d
+++ b/test/fail_compilation/ice19755.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/ice19755.d(11): Error: no property `x` for type `Thunk!int*`
+fail_compilation/ice19755.d(11): Error: no property `x` for type `ice19755.Thunk!int*`
 fail_compilation/ice19755.d(16): Error: template instance `ice19755.Thunk!int` error instantiating
 ---
 */

--- a/test/fail_compilation/test16188.d
+++ b/test/fail_compilation/test16188.d
@@ -1,7 +1,7 @@
 /* PERMUTE_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/test16188.d(17): Error: no property `name` for type `Where`
+fail_compilation/test16188.d(17): Error: no property `name` for type `test16188.Where`
 ---
  */
 

--- a/test/fail_compilation/test17380spec.d
+++ b/test/fail_compilation/test17380spec.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 (spec:1) fail_compilation/test17380spec.d(14): Error: cannot resolve identifier `ThisTypeDoesNotExistAndCrashesTheCompiler`
-(spec:1) fail_compilation/test17380spec.d(14): Error: no property `ThisTypeDoesNotExistAndCrashesTheCompiler` for type `Uint128`
+(spec:1) fail_compilation/test17380spec.d(14): Error: no property `ThisTypeDoesNotExistAndCrashesTheCompiler` for type `test17380spec.Uint128`
 fail_compilation/test17380spec.d(14): Error: undefined identifier `ThisTypeDoesNotExistAndCrashesTheCompiler`
 ---
  */


### PR DESCRIPTION
The current ”no property” error message does not provide information about the module where the type in question is defined, so I added this information.

The module in which a symbol is defined will be printed only for the symbols which are defined in a file and misused somewhere else. This means that for this example
```d
struct SomeStruct {}

void main() {
    auto s = SomeStruct();
    s.nonexistent = "hello";
}
``` 
the compiler will yield "Error: no property `nonexistent` for type `SomeStruct`"

while for this example
```d
import core.memory;
enum e = GC.foo;
```
the compiler will yield "Error: no property `foo` for type `core.memory.GC`"

Templates were not included in this solution since their fully qualified names may get very complicated. Moreover, I observed that sometimes the basic names of the symbols are already fully qualified (for reference: https://github.com/dlang/dmd/blob/57cd63e3095712b02b2831ced1261a053b84bd41/test/fail_compilation/test15897.d#L5 and https://github.com/dlang/dmd/blob/57cd63e3095712b02b2831ced1261a053b84bd41/test/fail_compilation/test12228.d#L6 so I added a check to avoid printing the same information twice. 