### PR TITLE
Move scp to build.d

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -73,10 +73,6 @@ DEL=del
 MD=mkdir
 # Remove directory
 RD=rmdir
-# File copy
-CP=cp
-# Copy to another directory
-SCP=$(CP)
 
 ##### User configuration switches
 
@@ -288,12 +284,8 @@ tolf: $(GEN)\build.exe
 zip: detab tolf $(GEN)\build.exe
 	$(RUN_BUILD) $@
 
-scp: detab tolf $(MAKEFILES)
-	$(SCP) $(MAKEFILES) $(SCPDIR)/src
-	$(SCP) $(SRCS) $(SCPDIR)/src
-	$(SCP) $(GLUESRC) $(SCPDIR)/src
-	$(SCP) $(BACKSRC) $(SCPDIR)/src/backend
-	$(SCP) $(ROOTSRC) $(SCPDIR)/src/root
+scp: detab tolf $(GEN)\build.exe
+	$(RUN_BUILD) $@
 
 checkwhitespace: $(GEN)\build.exe
 	$(RUN_BUILD) $@


### PR DESCRIPTION
This is the second to last target in `win32.mak` that once removed should allow us to remove most if not all source file lists in `win32.mak`.