### PR TITLE
Remove scp target from win32.mak

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -30,7 +30,6 @@
 # install       - copy build targets to install directory
 # install-clean - delete all files in the install directory
 # zip           - create ZIP archive of source code
-# scp		- copy source files to another directory
 #
 # dmd           - release dmd (legacy target)
 # debdmd        - debug dmd
@@ -54,8 +53,6 @@ ROOT=$D\root
 INCLUDE=$(ROOT)
 # Install directory
 INSTALL=..\install
-# Where scp command copies to
-SCPDIR=..\backup
 
 # Generated files directory
 GEN = ..\generated
@@ -75,8 +72,6 @@ MD=mkdir
 RD=rmdir
 # File copy
 CP=cp
-# Copy to another directory
-SCP=$(CP)
 
 ##### User configuration switches
 
@@ -287,13 +282,6 @@ tolf: $(GEN)\build.exe
 
 zip: detab tolf $(GEN)\build.exe
 	$(RUN_BUILD) $@
-
-scp: detab tolf $(MAKEFILES)
-	$(SCP) $(MAKEFILES) $(SCPDIR)/src
-	$(SCP) $(SRCS) $(SCPDIR)/src
-	$(SCP) $(GLUESRC) $(SCPDIR)/src
-	$(SCP) $(BACKSRC) $(SCPDIR)/src/backend
-	$(SCP) $(ROOTSRC) $(SCPDIR)/src/root
 
 checkwhitespace: $(GEN)\build.exe
 	$(RUN_BUILD) $@

--- a/src/win64.mak
+++ b/src/win64.mak
@@ -39,8 +39,6 @@ install-clean : $(DEPENDENCIES)
 	$(MAKE_WIN32) $@
 zip : $(DEPENDENCIES)
 	$(MAKE_WIN32) $@
-scp : $(DEPENDENCIES)
-	$(MAKE_WIN32) $@
 dmd : $(DEPENDENCIES)
 	$(MAKE_WIN32) $@
 debdmd : $(DEPENDENCIES)


### PR DESCRIPTION
Instead of moving the `scp` target to build.d, @wilzbach indicates (https://github.com/dlang/dmd/pull/10606#pullrequestreview-321782141) it is no longer used so can be removed.

This is one of the last targets in `win32.mak` holding a reference to the source file lists in it.  Once we finish removing these last targets, we can remove the redundant source lists.