### PR TITLE
build.d: Add auto-tester-build

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -36,6 +36,7 @@ __gshared typeof(sourceFiles()) sources;
 /// Array of dependencies through which all other dependencies can be reached
 immutable rootDeps = [
     &dmdDefault,
+    &autoTesterBuild,
     &runDmdUnittest,
     &clean,
     &checkwhitespace,
@@ -215,6 +216,17 @@ This script is by default part of the sources and thus any change to the build s
 will trigger a full rebuild.
 
 */
+
+/// Returns: The dependency that runs the autotester build
+alias autoTesterBuild = makeDep!((builder, dep) {
+    builder
+    .name("auto-tester-build")
+    .description("Runs the autotester build")
+    .deps([dmdDefault, checkwhitespace]);
+
+    version (Posix)
+        dep.deps ~= runCxxUnittest;
+});
 
 /// Returns: the dependency that builds the lexer object file
 alias lexer = makeDep!((builder, dep) => builder
@@ -661,10 +673,6 @@ LtargetsLoop:
             case "all":
                 t = "dmd";
                 goto default;
-
-            case "auto-tester-build":
-                "TODO: auto-tester-all".writeln; // TODO
-                break;
 
             case "install":
                 "TODO: install".writeln; // TODO

--- a/src/build.d
+++ b/src/build.d
@@ -226,6 +226,13 @@ alias autoTesterBuild = makeDep!((builder, dep) {
 
     version (Posix)
         dep.deps ~= runCxxUnittest;
+
+    // unittests are currently not executed as part of `auto-tester-test` on windows
+    // because changes to `win32.mak` require additional changes on the autotester
+    // (see https://github.com/dlang/dmd/pull/7414).
+    // This requires no further actions and avoids building druntime+phobos on unittest failure
+    version (Windows)
+        dep.deps ~= runDmdUnittest;
 });
 
 /// Returns: the dependency that builds the lexer object file

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -145,7 +145,9 @@ dmd: $G/dmd $G/dmd.conf
 $(GENERATED)/build: build.d $(HOST_DMD_PATH)
 	$(HOST_DMD_RUN) -of$@ build.d
 
-auto-tester-build: dmd checkwhitespace cxx-unittest
+auto-tester-build: $(GENERATED)/build
+	$(RUN_BUILD) $@
+
 .PHONY: auto-tester-build
 
 toolchain-info: $(GENERATED)/build

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -194,7 +194,12 @@ RUN_BUILD=$(GEN)\build.exe --called-from-make "OS=$(OS)" "BUILD=$(BUILD)" "MODEL
 
 defaulttarget: $G debdmd
 
-auto-tester-build: $G dmd checkwhitespace
+# FIXME: Windows test suite uses src/dmd.exe instead of $(GENERATED)/dmd.exe
+# FIXME: DDEBUG needs to be overidden to exclude unittests from dmd.exe
+#        (They are compiled in a seperate executable for build.d's unittest target)
+auto-tester-build: $(GEN)\build.exe
+	$(RUN_BUILD) "DDEBUG=" "ENABLE_RELEASE=1" $@
+	copy $(TARGETEXE) .
 
 dmd: $G reldmd
 


### PR DESCRIPTION
~~Draft PR because this should not be merged before #10611 (or another implementation of parallel building) is merged.~~
Multiple invocations of `build.d` are mutually exclusive anyway (using a lockfile)