### PR TITLE
build.d: Unittests can silently fail

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -350,9 +350,7 @@ alias runDmdUnittest = makeDep!((builder, dep) {
         .description("Run the dmd unittests")
         .msg("(RUN) DMD-UNITTEST")
         .deps([dmdUnittestExe])
-        .commandFunction(() {
-            spawnProcess(dmdUnittestExe.targets[0]);
-        });
+        .command(dmdUnittestExe.targets);
 });
 
 /// Runs the C++ unittest executable


### PR DESCRIPTION
The old implementation executed the unittest executable using spawnProcess
without waiting for its execution and ignored failed unittests.

The CI are not affected since they run the unittest executable directly and only use `build.d to compile it.