### PR TITLE
Fix issue 20420 - some expressions are missed during by the inliner

### DIFF
--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -681,6 +681,10 @@ public:
                         vto._init = new ExpInitializer(ei.loc, doInlineAs!Expression(ei, ids));
                     }
                 }
+                if (vd.edtor)
+                {
+                    vto.edtor = doInlineAs!Expression(vd.edtor, ids);
+                }
                 auto de = cast(DeclarationExp)e.copy();
                 de.declaration = vto;
                 result = de;
@@ -715,6 +719,7 @@ public:
             //printf("NewExp.doInlineAs!%s(): %s\n", Result.stringof.ptr, e.toChars());
             auto ne = cast(NewExp)e.copy();
             ne.thisexp = doInlineAs!Expression(e.thisexp, ids);
+            ne.argprefix = doInlineAs!Expression(e.argprefix, ids);
             ne.newargs = arrayExpressionDoInline(e.newargs);
             ne.arguments = arrayExpressionDoInline(e.arguments);
             result = ne;

--- a/test/compilable/test20420.d
+++ b/test/compilable/test20420.d
@@ -1,0 +1,22 @@
+// REQUIRED_ARGS: -inline
+
+// https://issues.dlang.org/show_bug.cgi?id=20420
+
+struct S { ~this(); }
+
+class C
+{
+    this(S, int) {}
+}
+
+int i();
+
+C create()
+{
+    return new C(S(), i());
+}
+
+auto test()
+{
+    auto c = create();
+}


### PR DESCRIPTION
The destructor expression for variable declaration is not scanned, as well as the arguments prefix for the new expression.