### PR TITLE
Fix issue 14696 - Fix a remaining case where the destructor is still called on a cold branch

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6495,8 +6495,11 @@ extern (C++) final class CondExp : BinExp
                     if (v._init)
                     {
                         if (auto ei = v._init.isExpInitializer())
-                            ei.exp.accept(this);
+                            walkPostorder(ei.exp, this);
                     }
+
+                    if (v.edtor)
+                        walkPostorder(v.edtor, this);
 
                     if (v.needsScopeDtor())
                     {

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -4369,6 +4369,8 @@ void test14696(int len = 2)
     check({ foo(len == 2 ? makeS(1).get(len != 2 ? makeS(2).get() : null) : null); }, "makeS(1).get(1).foo.dtor(1).");
     check({ foo(len != 2 ? makeS(1).get(len == 2 ? makeS(2).get() : null) : null); }, "foo.");
     check({ foo(len != 2 ? makeS(1).get(len != 2 ? makeS(2).get() : null) : null); }, "foo.");
+    check({ foo(len == 2 ? makeS(makeS(2).n - 1).get() : null); }, "makeS(2).makeS(1).get(1).foo.dtor(1).dtor(2).");
+    check({ foo(len != 2 ? makeS(makeS(2).n - 1).get() : null); }, "foo.");
 }
 
 /**********************************/


### PR DESCRIPTION
Temporary variables should not be destroyed when the branch that initializes them is not taken.