### PR TITLE
Fix issue 20431 - Allow a Mixin Type to resolve to an expression

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -4230,11 +4230,13 @@ struct ASTBase
 
     extern (C++) final class TypeMixin : Type
     {
+        Loc loc;
         Expressions* exps;
 
-        extern (D) this(Expressions* exps)
+        extern (D) this(const ref Loc loc, Expressions* exps)
         {
             super(Tmixin);
+            this.loc = loc;
             this.exps = exps;
         }
 
@@ -4254,7 +4256,7 @@ struct ASTBase
                 return a;
             }
 
-            return new TypeMixin(arraySyntaxCopy(exps));
+            return new TypeMixin(loc, arraySyntaxCopy(exps));
         }
 
         override void accept(Visitor v)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5143,11 +5143,13 @@ extern (C++) final class TypeTraits : Type
  */
 extern (C++) final class TypeMixin : Type
 {
+    Loc loc;
     Expressions* exps;
 
-    extern (D) this(Expressions* exps)
+    extern (D) this(const ref Loc loc, Expressions* exps)
     {
         super(Tmixin);
+        this.loc = loc;
         this.exps = exps;
     }
 
@@ -5158,7 +5160,7 @@ extern (C++) final class TypeMixin : Type
 
     override Type syntaxCopy()
     {
-        return new TypeMixin(Expression.arraySyntaxCopy(exps));
+        return new TypeMixin(loc, Expression.arraySyntaxCopy(exps));
     }
 
     override void accept(Visitor v)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1552,7 +1552,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     p.nextToken();
                     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
-                    o = p.parseTypeOrAssignExp();
+                    o = p.parseTypeOrAssignExp(TOK.endOfFile);
                     if (p.errors ||
                         p.token.value != TOK.endOfFile)
                     {

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -566,12 +566,19 @@ Expression typeToExpression(Type t)
         return typeToExpressionHelper(t, new ScopeExp(t.loc, t.tempinst));
     }
 
+    // easy way to enable 'auto v = new int[mixin("exp")];' in 2.088+
+    static Expression visitMixin(TypeMixin t)
+    {
+        return new TypeExp(t.loc, t);
+    }
+
     switch (t.ty)
     {
         case Tsarray:   return visitSArray(cast(TypeSArray) t);
         case Taarray:   return visitAArray(cast(TypeAArray) t);
         case Tident:    return visitIdentifier(cast(TypeIdentifier) t);
         case Tinstance: return visitInstance(cast(TypeInstance) t);
+        case Tmixin:    return visitMixin(cast(TypeMixin) t);
         default:        return null;
     }
 }
@@ -883,7 +890,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
 
         // Deal with the case where we thought the index was a type, but
         // in reality it was an expression.
-        if (mtype.index.ty == Tident || mtype.index.ty == Tinstance || mtype.index.ty == Tsarray || mtype.index.ty == Ttypeof || mtype.index.ty == Treturn)
+        if (mtype.index.ty == Tident || mtype.index.ty == Tinstance || mtype.index.ty == Tsarray || mtype.index.ty == Ttypeof || mtype.index.ty == Treturn || mtype.index.ty == Tmixin)
         {
             Expression e;
             Type t;
@@ -1924,11 +1931,23 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
     Type visitMixin(TypeMixin mtype)
     {
         //printf("TypeMixin::semantic() %s\n", toChars());
-        Type t = mtype.compileTypeMixin(loc, sc);
-        if (!t)
-            return error();
-
-        return t.typeSemantic(loc, sc);
+        auto o = mtype.compileTypeMixin(loc, sc);
+        if (auto t = o.isType())
+        {
+            return t.typeSemantic(loc, sc);
+        }
+        else if (auto e = o.isExpression())
+        {
+            e = e.expressionSemantic(sc);
+            if (auto et = e.isTypeExp())
+                return et.type;
+            else
+            {
+                if (!global.errors)
+                    .error(e.loc, "`%s` does not give a valid type", o.toChars);
+            }
+        }
+        return error();
     }
 
     switch (t.ty)
@@ -1957,17 +1976,17 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
 }
 
 /******************************************
- * Compile the MixinType, returning the type AST.
+ * Compile the MixinType, returning the type or expression AST.
  *
- * Doesn't run semantic() on the returned type.
+ * Doesn't run semantic() on the returned object.
  * Params:
- *      tm = mixin to compile as a type
+ *      tm = mixin to compile as a type or expression
  *      loc = location for error messages
  *      sc = context
  * Return:
- *      null if error, else type AST as parsed
+ *      null if error, else RootObject AST as parsed
  */
-Type compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
+RootObject compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
 {
     OutBuffer buf;
     if (expressionsToString(buf, sc, tm.exps))
@@ -1982,7 +2001,7 @@ Type compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 
-    Type t = p.parseType();
+    auto o = p.parseTypeOrAssignExp(TOK.endOfFile);
     if (p.errors)
     {
         assert(global.errors != errors); // should have caught all these cases
@@ -1993,7 +2012,11 @@ Type compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
         .error(loc, "incomplete mixin type `%s`", str.ptr);
         return null;
     }
-    return t;
+
+    Type t = o.isType();
+    Expression e = t ? t.typeToExpression() : o.isExpression();
+
+    return (!e && t) ? t : e;
 }
 
 
@@ -3039,16 +3062,19 @@ void resolve(Type mt, const ref Loc loc, Scope* sc, Expression* pe, Type* pt, Ds
 
     void visitMixin(TypeMixin mt)
     {
-        auto ta = mt.compileTypeMixin(loc, sc);
-        if (ta)
+        auto o = mt.compileTypeMixin(loc, sc);
+
+        if (auto t = o.isType())
         {
-            auto tt = ta.isTypeTraits();
-            if (tt && tt.exp)
-            {
-                *pe = tt.exp;
-            }
+            resolve(t, loc, sc, pe, pt, ps, intypeid);
+        }
+        else if (auto e = o.isExpression())
+        {
+            e = e.expressionSemantic(sc);
+            if (auto et = e.isTypeExp())
+                return returnType(et.type);
             else
-                resolve(ta, loc, sc, pe, pt, ps, intypeid);
+                returnExp(e);
         }
         else
             returnError();

--- a/test/compilable/mixintype2.d
+++ b/test/compilable/mixintype2.d
@@ -1,0 +1,36 @@
+
+alias fun = mixin("(){}");
+
+void test1()
+{
+    int x = 1;
+    static immutable c = 2;
+
+    fun();
+    foo!(mixin("int"))();
+    foo!(mixin("long*"))();
+    foo!(mixin("ST!(int, S.T)"))();
+    foo!(mixin(ST!(int, S.T)))();
+
+    int[mixin("string")] a1;
+    int[mixin("5")] a2;
+    int[mixin("c")] a3;
+    int[] v1 = new int[mixin("3")];
+    auto v2 = new int[mixin("x")];
+
+    mixin(q{__traits(getMember, S, "T")}) ftv;
+
+    alias T = int*;
+    static assert(__traits(compiles, mixin("int")));
+    static assert(__traits(compiles, mixin(q{int[mixin("string")]})));
+    static assert(__traits(compiles, mixin(q{int[mixin("2")]})));
+    static assert(__traits(compiles, mixin(T)));
+    static assert(__traits(compiles, mixin("int*")));
+    static assert(__traits(compiles, mixin(typeof(0))));
+}
+
+struct S { alias T = float*; }
+
+struct ST(X,Y) {}
+
+void foo(alias t)() {}


### PR DESCRIPTION
It also fix the parsing of mixin(basic type) in __traits(compiles) and using a mixin as an index in array declarations. See the test case.

A side effect is that the next code works now:

`alias fun = mixin("(){}");`