### PR TITLE
Fix Issue 20415 - ice in dwarfeh and when optimizations are enabled

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -6527,7 +6527,9 @@ extern (C++) final class CondExp : BinExp
 
                     if (v.needsScopeDtor())
                     {
-                        if (!vcond)
+                        // a temporary is created for the condition
+                        // only if it's not an integral exp
+                        if (!vcond && !ce.econd.isIntegerExp())
                         {
                             vcond = copyToTemp(STC.volatile_, "__cond", ce.econd);
                             vcond.dsymbolSemantic(sc);
@@ -6540,7 +6542,7 @@ extern (C++) final class CondExp : BinExp
                         }
 
                         //printf("\t++v = %s, v.edtor = %s\n", v.toChars(), v.edtor.toChars());
-                        Expression ve = new VarExp(vcond.loc, vcond);
+                        Expression ve = vcond ? new VarExp(vcond.loc, vcond) : ce.econd;
                         if (isThen)
                             v.edtor = new LogicalExp(v.edtor.loc, TOK.andAnd, ve, v.edtor);
                         else

--- a/test/compilable/test20415.d
+++ b/test/compilable/test20415.d
@@ -1,0 +1,14 @@
+// https://issues.dlang.org/show_bug.cgi?id=20415
+// REQUIRED_ARGS: -c -O
+
+void t()
+{
+    auto a = false ? B().p : null;
+}
+
+struct B
+{
+    void* p;
+    ~this() {}
+}
+


### PR DESCRIPTION
The assertion is triggered by a miscommunication between the frontend and the backend:

```d
void t()
{
  auto a = false ? B().p : null;
}

struct B
{
  void* p;
  ~this() {}
}
```

The frontend fails to see that the first branch in the CondExp is never taken because it assigns the false to a temporary and cannot optimize it away so it thinks that it has to call the destructor of B if that branch is taken. Later the optimizer in the backend sees that the branch is never taken and it does not generate code for it, however it still tries to insert `cond_result && temp.__dtor` for the value supposedly constructed for the first branch. That's where the assert is coming from.

I fixed this issue, by taking care of this case in the frontend: if an IntegralExp is the condition, we no longer need to assign to a temporary, therefore the frontend optimizer can do its job.