### PR TITLE
build.d: Add toolchain-info as dependency of auto-tester-build

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -11,7 +11,7 @@ ifneq (,$(findstring Darwin_64_32, $(PWD)))
 auto-tester-build:
 	echo "Darwin_64_32_disabled"
 else
-auto-tester-build: toolchain-info
+auto-tester-build:
 	$(QUIET)$(MAKE) -C src -f posix.mak auto-tester-build ENABLE_RELEASE=1
 endif
 

--- a/src/build.d
+++ b/src/build.d
@@ -222,7 +222,7 @@ alias autoTesterBuild = makeDep!((builder, dep) {
     builder
     .name("auto-tester-build")
     .description("Run the autotester build")
-    .deps([dmdDefault, checkwhitespace]);
+    .deps([toolchainInfo, dmdDefault, checkwhitespace]);
 
     version (Posix)
         dep.deps ~= runCxxUnittest;


### PR DESCRIPTION
This avoids an additional `make` and `build.d` invocation on posi` and prints the currently used tools on windows machine as well.