### PR TITLE
add links to documentation for rvalue ref implementation

### DIFF
--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -178,6 +178,10 @@ extern (C++) struct Param
                             // https://issues.dlang.org/show_bug.cgi?id=14246
     bool fieldwise;         // do struct equality testing field-wise rather than by memcmp()
     bool rvalueRefParam;    // allow rvalues to be arguments to ref parameters
+                            // http://dconf.org/2019/talks/alexandrescu.html
+                            // https://gist.github.com/andralex/e5405a5d773f07f73196c05f8339435a
+                            // https://digitalmars.com/d/archives/digitalmars/D/Binding_rvalues_to_ref_parameters_redux_325087.html
+                            // Implementation: https://github.com/dlang/dmd/pull/9817
 
     CppStdRevision cplusplus = CppStdRevision.cpp98;    // version of C++ standard to support
 


### PR DESCRIPTION
I get tired of poking around looking for it.