### PR TITLE
Issue17125 -  Header Generation Incorrectly Formats Floating Point Number

### DIFF
--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1900,7 +1900,11 @@ public:
             if (r != value) // if exact duplication
                 CTFloat.sprint(buffer.ptr, 'a', value);
         }
+
         buf.writestring(buffer.ptr);
+        if (buffer.ptr[strlen(buffer.ptr) - 1] == '.')
+            buf.remove(buf.length() - 1, 1);
+
         if (type)
         {
             Type t = type.toBasetype();

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1900,7 +1900,6 @@ public:
             if (r != value) // if exact duplication
                 CTFloat.sprint(buffer.ptr, 'a', value);
         }
-
         buf.writestring(buffer.ptr);
         if (buffer.ptr[strlen(buffer.ptr) - 1] == '.')
             buf.remove(buf.length() - 1, 1);

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -197,9 +197,21 @@ extern (C++) struct CTFloat
         }
         else
         {
-            char[4] sfmt = "%Lg\0";
-            sfmt[2] = fmt;
-            return sprintf(str, sfmt.ptr, x);
+            if (real_t(cast(ulong)x) == x)
+            {
+                // ((1.5 -> 1 -> 1.0) == 1.5) is false
+                // ((1.0 -> 1 -> 1.0) == 1.0) is true
+                // see http://en.cppreference.com/w/cpp/io/c/fprintf
+                char[5] sfmt = "%#Lg\0";
+                sfmt[3] = fmt;
+                return sprintf(str, sfmt.ptr, x);
+            }
+            else
+            {
+                char[4] sfmt = "%Lg\0";
+                sfmt[2] = fmt;
+                return sprintf(str, sfmt.ptr, x);
+            }
         }
     }
 

--- a/src/dmd/root/ctfloat.d
+++ b/src/dmd/root/ctfloat.d
@@ -197,21 +197,9 @@ extern (C++) struct CTFloat
         }
         else
         {
-            if (real_t(cast(ulong)x) == x)
-            {
-                // ((1.5 -> 1 -> 1.0) == 1.5) is false
-                // ((1.0 -> 1 -> 1.0) == 1.0) is true
-                // see http://en.cppreference.com/w/cpp/io/c/fprintf
-                char[5] sfmt = "%#Lg\0";
-                sfmt[3] = fmt;
-                return sprintf(str, sfmt.ptr, x);
-            }
-            else
-            {
-                char[4] sfmt = "%Lg\0";
-                sfmt[2] = fmt;
-                return sprintf(str, sfmt.ptr, x);
-            }
+            char[4] sfmt = "%Lg\0";
+            sfmt[2] = fmt;
+            return sprintf(str, sfmt.ptr, x);
         }
     }
 

--- a/test/compilable/extra-files/header17125.d
+++ b/test/compilable/extra-files/header17125.d
@@ -1,0 +1,9 @@
+void func1(real value = 10.35e4L);
+void func2(real value = 520.199e3F);
+void func3(real value = 9.70e5);
+void func4(real value = 1024.5e2F);
+void func5(real value = 41250.2e1L);
+
+int main() {
+        return 0;
+}

--- a/test/compilable/extra-files/header17125.di
+++ b/test/compilable/extra-files/header17125.di
@@ -1,0 +1,6 @@
+void func1(real value = 103500L);
+void func2(real value = 520199F);
+void func3(real value = 970000);
+void func4(real value = 102450F);
+void func5(real value = 412502L);
+int main();

--- a/test/compilable/testheader17125.d
+++ b/test/compilable/testheader17125.d
@@ -1,0 +1,5 @@
+// EXTRA_SOURCES: extra-files/header17125.d
+// REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/testheader17125.di
+// POST_SCRIPT: compilable/extra-files/header-postscript.sh
+
+void main() {}


### PR DESCRIPTION
The '#' format specifier in conjunction with 'g' forces the addition of the decimal point at the end, after which the letter corresponding to the type would have been added in `floatToBuffer` of `hdrgen.d`, which resulted in incorrect headers.