### PR TITLE
Issue6592 - di header file created even if errors occur

### DIFF
--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -695,7 +695,7 @@ extern (C++) final class Module : Package
             }
             else
                 fprintf(stderr, "Specify path to file '%s' with -I switch\n", srcfile.toChars());
-            fatal();
+            // fatal();
         }
         return false;
     }

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -507,25 +507,6 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     if (global.errors)
         fatal();
 
-    if (params.doHdrGeneration)
-    {
-        /* Generate 'header' import files.
-         * Since 'header' import files must be independent of command
-         * line switches and what else is imported, they are generated
-         * before any semantic analysis.
-         */
-        foreach (m; modules)
-        {
-            if (m.isHdrFile)
-                continue;
-            if (params.verbose)
-                message("import    %s", m.toChars());
-            genhdrfile(m);
-        }
-    }
-    if (global.errors)
-        fatal();
-
     // load all unconditional imports for better symbol resolving
     foreach (m; modules)
     {
@@ -737,6 +718,27 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
             }
         }
     }
+
+    if (global.errors)
+        fatal();
+
+    if (params.doHdrGeneration)
+    {
+        /* Generate 'header' import files.
+         * Since 'header' import files must be be generated only if
+         * there are no erros occurring in any compilation stage,
+         * they will be generated at the end
+         */
+        foreach (m; modules)
+        {
+            if (m.isHdrFile)
+                continue;
+            if (params.verbose)
+                message("import    %s", m.toChars());
+            genhdrfile(m);
+        }
+    }
+    
     if (global.errors || global.warnings)
         fatal();
     return status;

--- a/test/fail_compilation/extra-files/fail6592.d
+++ b/test/fail_compilation/extra-files/fail6592.d
@@ -1,0 +1,3 @@
+module test;
+
+import std.foo;

--- a/test/fail_compilation/fail6592.sh
+++ b/test/fail_compilation/fail6592.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+! $DMD -c ${EXTRA_FILES}/fail6592.d -H -Hf${RESULTS_DIR}/fail_compilation/fail6592.di 2> /dev/null
+
+if [ -f ${RESULTS_DIR}/fail_compilation/fail6592.di ]; then exit 1; fi
+
+exit 0


### PR DESCRIPTION
Moved header file generation at the end to make sure the header file is generate only if no errors occur during compilation.