### PR TITLE
Makefiles: Respect DMD/DIFFABLE variables for man pages

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,10 @@
 DMD=dmd
 GENERATED=../generated
 DMD_MAN_PAGE=man/man1/dmd.1
+DIFFABLE=0
 
 build: $(GENERATED)/build
-	./$(GENERATED)/build man
+	./$(GENERATED)/build HOST_DMD="$(DMD)" DIFFABLE="$(DIFFABLE)" man
 
 preview: $(GENERATED)/docs/$(DMD_MAN_PAGE)
 	man -l $(GENERATED)/docs/$(DMD_MAN_PAGE)


### PR DESCRIPTION
Makefile invocation:
```make -C ../dmd/docs DMD=/dev/shm/dtest/work/repo/dlang.org/.generated/stable_dmd-2.088.0/dmd2/linux/bin64/dmd DIFFABLE=1 build```

Actually used dmd:
```/home/dtest/DAutoTest/work/build/bin/dmd```