### PR TITLE
build.d: Add Parallel scheduler

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -143,7 +143,7 @@ dmd: $G/dmd $G/dmd.conf
 .PHONY: dmd
 
 $(GENERATED)/build: build.d $(HOST_DMD_PATH)
-	$(HOST_DMD_RUN) -of$@ build.d
+	$(HOST_DMD_RUN) -g -of$@ build.d
 
 auto-tester-build: $(GENERATED)/build
 	$(RUN_BUILD) $@

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -113,7 +113,7 @@ auto-tester-build: $(GEN)\build.exe
 dmd: $G reldmd
 
 $(GEN)\build.exe: build.d $(HOST_DMD_PATH)
-	$(HOST_DC) -m$(MODEL) -of$@ build.d
+	$(HOST_DC) -m$(MODEL) -g -of$@ build.d
 
 release:
 	$(DMDMAKE) clean


### PR DESCRIPTION
This is an alternative to @MoonlightSentinel 's PR #10611 (build.d: Enable parallel builds).

This one uses D's spawn/message passing to enable full parallization of all build tasks. I've encapsulated all the complex parallel logic into a generic `Scheduler` struct.

This PR also separates out the mutable build-state from the dependency definitions, which means we can declare constructed dependencies as `immutable` now.