### PR TITLE
build.d: Propagate whether a dependency was built/skipped

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -431,15 +431,13 @@ alias clean = makeDep!((builder, dep) => builder
 alias toolsRepo = makeDep!((builder, dep) => builder
     .target(env["TOOLS_DIR"])
     .msg("(GIT) DLANG/TOOLS")
+    .condition(() => !exists(dep.target))
     .commandFunction(delegate() {
         auto toolsDir = env["TOOLS_DIR"];
-        if (!toolsDir.exists)
-        {
-            version(Win32)
-                // Win32-git seems to confuse C:\... as a relative path
-                toolsDir = toolsDir.relativePath(srcDir);
-            run([env["GIT"], "clone", "--depth=1", env["GIT_HOME"] ~ "/tools", toolsDir]);
-        }
+        version(Win32)
+            // Win32-git seems to confuse C:\... as a relative path
+            toolsDir = toolsDir.relativePath(srcDir);
+        run([env["GIT"], "clone", "--depth=1", env["GIT_HOME"] ~ "/tools", toolsDir]);
     })
 );
 

--- a/src/build.d
+++ b/src/build.d
@@ -134,9 +134,7 @@ Command-line parameters
     if (!args.length)
         args = ["dmd"];
 
-    auto targets = args
-        .predefinedTargets // preprocess
-        .array;
+    auto targets = predefinedTargets(args); // preprocess
 
     if (targets.length == 0)
         return showHelp;
@@ -165,7 +163,7 @@ Command-line parameters
             }
         }
         foreach (target; targets.parallel(1))
-            target();
+            target.run();
     }
 
     writeln("Success");
@@ -659,10 +657,10 @@ Params:
 Returns:
     the expanded targets
 */
-auto predefinedTargets(string[] targets)
+Dependency[] predefinedTargets(string[] targets)
 {
     import std.functional : toDelegate;
-    Appender!(void delegate()[]) newTargets;
+    Appender!(Dependency[]) newTargets;
 LtargetsLoop:
     foreach (t; targets)
     {
@@ -673,7 +671,7 @@ LtargetsLoop:
         {
             if (t == dep.name)
             {
-                newTargets.put(&dep.run);
+                newTargets.put(dep);
                 continue LtargetsLoop;
             }
         }
@@ -697,7 +695,7 @@ LtargetsLoop:
                     {
                         if (depTarget.endsWith(t, tAbsolute))
                         {
-                            newTargets.put(&dep.run);
+                            newTargets.put(dep);
                             continue LtargetsLoop;
                         }
                     }


### PR DESCRIPTION
This avoids unnecessary timestamp checks (and maybe reduces contention between multiple threads trying to check the same file).

This PR includes db20013 as it required changes to `predefinedTargets` anyway (`void delegate()` to `bool delegate()`)