### PR TITLE
Remove deferred semantic analysis 2 and 3 done when using -unittest flag

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7136,7 +7136,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     {
         Module mi = minst; // instantiated . inserted module
 
-        if (global.params.useUnitTests || global.params.debuglevel)
+        if (global.params.debuglevel)
         {
             // Turn all non-root instances to speculative
             if (mi && !mi.isRoot())


### PR DESCRIPTION
There's an unnecessary semantic analysis done on templates from imported modules which leads to a compilation that takes up to 5x longer.
```d
module foo;

import std.uni;
````
**Before**
```bash
time dmd -c foo.d 

real	0m0,128s
user	0m0,121s
sys	0m0,008s

time dmd -c -unittest foo.d

real	0m0,663s
user	0m0,592s
sys	0m0,072s
```

**After:**
```bash

time dmd -c -unittest foo.d 

real	0m0,149s
user	0m0,138s
sys	0m0,012s
```




Related to: https://github.com/dlang/dmd/pull/8124