### PR TITLE
Fix issue 20437 - Transitive immutable/shared does not apply to variables captured by delegates

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5064,7 +5064,7 @@ extern (C++) final class TypeDelegate : TypeNext
         version (all)
         {
             // https://issues.dlang.org/show_bug.cgi?id=20437
-            if (!MODimplicitConv(next.mod, to.mod))
+            if (!MODimplicitConv(mod, to.mod))
                 return MATCH.nomatch;
 
             // not allowing covariant conversions because it interferes with overriding

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5063,6 +5063,10 @@ extern (C++) final class TypeDelegate : TypeNext
 
         version (all)
         {
+            // https://issues.dlang.org/show_bug.cgi?id=20437
+            if (!MODimplicitConv(next.mod, to.mod))
+                return MATCH.nomatch;
+
             // not allowing covariant conversions because it interferes with overriding
             if (to.ty == Tdelegate && this.nextOf().covariant(to.nextOf()) == 1)
             {

--- a/test/compilable/warn3882.d
+++ b/test/compilable/warn3882.d
@@ -70,7 +70,7 @@ void test12909()
 
 const struct Foo13899
 {
-    int opApply(immutable int delegate(in ref int) pure nothrow dg) pure nothrow
+    int opApply(int delegate(in ref int) pure nothrow dg) pure nothrow
     {
         return 1;
     }

--- a/test/fail_compilation/b20437.d
+++ b/test/fail_compilation/b20437.d
@@ -1,0 +1,14 @@
+/* TEST_OUTPUT:
+---
+fail_compilation/b20437.d(12): Error: cannot implicitly convert expression d of type void delegate() to immutable(void delegate())
+fail_compilation/b20437.d(13): Error: cannot implicitly convert expression d of type void delegate() to shared(void delegate())
+---
+*/
+// https://issues.dlang.org/show_bug.cgi?id=20437
+void f()
+{
+    int x;
+    void delegate() d = delegate() { x = 1; };
+    immutable(void delegate()) bad1 = d;
+    shared(void delegate()) bad2 = d;
+}

--- a/test/fail_compilation/b20437.d
+++ b/test/fail_compilation/b20437.d
@@ -1,7 +1,7 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/b20437.d(12): Error: cannot implicitly convert expression d of type void delegate() to immutable(void delegate())
-fail_compilation/b20437.d(13): Error: cannot implicitly convert expression d of type void delegate() to shared(void delegate())
+fail_compilation/b20437.d(12): Error: cannot implicitly convert expression `d` of type `void delegate()` to `immutable(void delegate())`
+fail_compilation/b20437.d(13): Error: cannot implicitly convert expression `d` of type `void delegate()` to `shared(void delegate())`
 ---
 */
 // https://issues.dlang.org/show_bug.cgi?id=20437

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -4950,7 +4950,6 @@ void test15653()
                                  float,  double,  real,
                                 ifloat, idouble, ireal,
                                 cfloat, cdouble, creal,
-                                void delegate(),
                                 int[2], X, X[2]))
     {
         foo!U(U.init);      // OK


### PR DESCRIPTION
Delegates potentially contain indirections in their environment, so implicit conversion from `T delegate()` into `{immutable,shared}(T delegate())` should not be possible.

This is my first contribution to the compiler so I’m still trying to figure things out. :) It’s also a breaking change so we should probably discuss that prior to merging. It fixes the issue as far as I can tell, but maybe it introduces more issues. :D
