### PR TITLE
Partially revert PR/10540

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3177,15 +3177,16 @@ extern (C++) final class StructLiteralExp : Expression
              *   __sl%s%d, where %s is the struct name
              */
             const size_t len = 10;
-            char[len] buf = void;
+            char[len + 1] buf = void;
 
             const ident = sd.ident.toString;
             const prefix = "__sl";
             const charsToUse = ident.length > len - prefix.length ? len - prefix.length : ident.length;
             buf[0 .. prefix.length] = prefix;
             buf[prefix.length .. prefix.length + charsToUse] = ident[0 .. charsToUse];
+            buf[len] = 0;
 
-            auto tmp = copyToTemp(0, buf, this);
+            auto tmp = copyToTemp(0, buf.ptr, this);
             Expression ae = new DeclarationExp(loc, tmp);
             Expression e = new CommaExp(loc, ae, new VarExp(loc, tmp));
             e = e.expressionSemantic(sc);

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -138,10 +138,10 @@ nothrow:
 
     private extern (D) __gshared StringTable!Identifier stringtable;
 
-    extern(D) static Identifier generateId(const(char)[] prefix)
+    static Identifier generateId(const(char)* prefix)
     {
         __gshared size_t i;
-        return generateId(prefix, ++i);
+        return generateId(prefix.toDString(), ++i);
     }
 
     extern(D) static Identifier generateId(const(char)[] prefix, size_t i)

--- a/src/dmd/identifier.h
+++ b/src/dmd/identifier.h
@@ -28,6 +28,7 @@ public:
     const char *toHChars2() const;
     DYNCAST dyncast() const;
 
+    static Identifier *generateId(const char *prefix);
     static Identifier *idPool(const char *s, unsigned len);
 
     static inline Identifier *idPool(const char *s)

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -363,7 +363,7 @@ bool discardValue(Expression e)
  * Returns:
  *  Newly created temporary variable.
  */
-VarDeclaration copyToTemp(StorageClass stc, const char[] name, Expression e)
+VarDeclaration copyToTemp(StorageClass stc, const char* name, Expression e)
 {
     assert(name[0] == '_' && name[1] == '_');
     auto vd = new VarDeclaration(e.loc, e.type,
@@ -387,7 +387,7 @@ VarDeclaration copyToTemp(StorageClass stc, const char[] name, Expression e)
  * Note:
  *  e's lvalue-ness will be handled well by STC.ref_ or STC.rvalue.
  */
-Expression extractSideEffect(Scope* sc, const char[] name,
+Expression extractSideEffect(Scope* sc, const char* name,
     ref Expression e0, Expression e, bool alwaysCopy = false)
 {
     if (!alwaysCopy && isTrivialExp(e))

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -180,7 +180,7 @@ void test_visitors()
 {
     TestVisitor tv;
     Loc loc;
-    Identifier *ident = Identifier::idPool("test");
+    Identifier *ident = Identifier::generateId("test");
 
     IntegerExp *ie = IntegerExp::create(loc, 42, Type::tint32);
     ie->accept(&tv);
@@ -233,8 +233,7 @@ void test_visitors()
 
     Parameters *args = new Parameters;
     TypeFunction *tf = TypeFunction::create(args, Type::tvoid, VARARGnone, LINKc);
-    FuncDeclaration *fd = FuncDeclaration::create(Loc (), Loc (), Identifier::idPool("test"),
-                                                  STCextern, tf);
+    FuncDeclaration *fd = FuncDeclaration::create(Loc (), Loc (), ident, STCextern, tf);
     assert(fd->isFuncDeclaration() == fd);
     assert(fd->type == tf);
     fd->accept(&tv);


### PR DESCRIPTION
Identifier::generateId is used by gdc.

Grep for `Identifier.generateId("__enum")` in dmd source code for why.