### PR TITLE
Remove constant folding of powers in the compiler.

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -10181,40 +10181,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
             return;
         }
 
-        // For built-in numeric types, there are several cases.
-        // TODO: backend support, especially for  e1 ^^ 2.
-
         // First, attempt to fold the expression.
         e = exp.optimize(WANTvalue);
         if (e.op != TOK.pow)
         {
-            e = e.expressionSemantic(sc);
-            result = e;
-            return;
-        }
-
-        // Determine if we're raising to an integer power.
-        sinteger_t intpow = 0;
-        if (exp.e2.op == TOK.int64 && (cast(sinteger_t)exp.e2.toInteger() == 2 || cast(sinteger_t)exp.e2.toInteger() == 3))
-            intpow = exp.e2.toInteger();
-        else if (exp.e2.op == TOK.float64 && (exp.e2.toReal() == real_t(cast(sinteger_t)exp.e2.toReal())))
-            intpow = cast(sinteger_t)exp.e2.toReal();
-
-        // Deal with x^^2, x^^3 immediately, since they are of practical importance.
-        if (intpow == 2 || intpow == 3)
-        {
-            // Replace x^^2 with (tmp = x, tmp*tmp)
-            // Replace x^^3 with (tmp = x, tmp*tmp*tmp)
-            auto tmp = copyToTemp(0, "__powtmp", exp.e1);
-            Expression de = new DeclarationExp(exp.loc, tmp);
-            Expression ve = new VarExp(exp.loc, tmp);
-
-            /* Note that we're reusing ve. This should be ok.
-             */
-            Expression me = new MulExp(exp.loc, ve, ve);
-            if (intpow == 3)
-                me = new MulExp(exp.loc, me, ve);
-            e = new CommaExp(exp.loc, de, me);
             e = e.expressionSemantic(sc);
             result = e;
             return;

--- a/test/runnable/ctorpowtests.d
+++ b/test/runnable/ctorpowtests.d
@@ -77,13 +77,16 @@ static assert( 2 ^^ 3 ^^ 2 == 2 ^^ 9);
 static assert( 2.0 ^^ -3 ^^ 2 == 2.0 ^^ -9);
 
 // 1 ^^ n is always 1, even if n is negative
-static assert( 1 ^^ -5 == 1);
+static assert( 1 ^^ -5.0 == 1);
 
-// -1 ^^ n gets transformed into  n & 1 ? -1 : 1
-// even if n is negative
-static assert( (-1) ^^ -5 == -1);
-static assert( (-1) ^^ -4 == 1);
-static assert( (-1) ^^ 0 == 1);
+// -1.0 ^^ n is either 1 or -1 if n is integral.
+static assert( (-1.0) ^^ -5 == -1);
+static assert( (-1.0) ^^ -4 == 1);
+static assert( (-1.0) ^^ 0 == 1);
+// -1.0 ^^ n is otherwise always NaN.
+static assert( (-1.0) ^^ -5.5 is double.nan);
+static assert( (-1.0) ^^ -4.4 is double.nan);
+static assert( (-1.0) ^^ -0.1 is double.nan);
 
 // n ^^ 0 is always 1
 static assert( (-5) ^^ 0 == 1);

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -4175,10 +4175,10 @@ void test1962()
 /***************************************************/
 // https://issues.dlang.org/show_bug.cgi?id=6228
 
-
 void test6228()
 {
-    const(int)* ptr;
+    int val;
+    const(int)* ptr = &val;
     const(int)  temp;
     auto x = (*ptr) ^^ temp;
 }


### PR DESCRIPTION
Instead, all the work is handed over to CTFE running std.math.pow().

Tests have been fixed up where there was a difference between what the compiler did, and what runtime does.

As author of these pattern match/rewrites, the original rationale for adding them was because of an allergy to phobos creep in the compiler.  Nowadays I'm not so fussed any more, the phobos implementations are now CTFE-able (I _think_ this wasn't originally the case many years ago) which make it more than capable of handling these cases by itself.