### PR TITLE
test: Use EXTRA_SOURCES instead of REQUIRED_ARGS for sources

### DIFF
--- a/test/compilable/minimal.d
+++ b/test/compilable/minimal.d
@@ -1,7 +1,8 @@
 // DFLAGS:
 // PERMUTE_ARGS:
 // POST_SCRIPT: compilable/extra-files/minimal/verify_symbols.sh
-// REQUIRED_ARGS: -defaultlib= compilable/extra-files/minimal/object.d
+// REQUIRED_ARGS: -defaultlib=
+// EXTRA_SOURCES: extra-files/minimal/object.d
 
 // This test ensures an empty main with a struct and enum, built with a minimal
 // runtime, does not generate ModuleInfo or exception handling code, and does not

--- a/test/compilable/minimal2.d
+++ b/test/compilable/minimal2.d
@@ -1,5 +1,6 @@
 // DFLAGS:
-// REQUIRED_ARGS: -defaultlib= compilable/extra-files/minimal/object.d
+// REQUIRED_ARGS: -defaultlib=
+// EXTRA_SOURCES: extra-files/minimal/object.d
 
 // This test ensures that interfaces and classes can be used in a minimal
 // runtime as long as they only contain static members.

--- a/test/compilable/test17541.d
+++ b/test/compilable/test17541.d
@@ -1,4 +1,4 @@
-/* REQUIRED_ARGS: compilable/imports/test17541_2.d compilable/imports/test17541_3.d
+/* EXTRA_SOURCES: imports/test17541_2.d imports/test17541_3.d
  */
 
 // https://issues.dlang.org/show_bug.cgi?id=17541

--- a/test/fail_compilation/fail18938.d
+++ b/test/fail_compilation/fail18938.d
@@ -1,4 +1,5 @@
-// REQUIRED_ARGS: -c -Ifail_compilation/imports/ fail_compilation/imports/test18938a/cache.d fail_compilation/imports/test18938a/file.d
+// REQUIRED_ARGS: -c -Ifail_compilation/imports/
+// EXTRA_SOURCES: imports/test18938a/cache.d imports/test18938a/file.d
 /*
 TEST_OUTPUT:
 ---

--- a/test/fail_compilation/fail19911b.d
+++ b/test/fail_compilation/fail19911b.d
@@ -1,6 +1,6 @@
 /* 
 DFLAGS:
-REQUIRED_ARGS: -I=fail_compilation/extra-files/minimal/
+EXTRA_SOURCES: extra-files/minimal/object.d
 TEST_OUTPUT:
 ---
 fail_compilation/fail19911b.d(10): Error: function `fail19911b.fun` `object.TypeInfo_Tuple` could not be found, but is implicitly used in D-style variadic functions

--- a/test/fail_compilation/no_Throwable.d
+++ b/test/fail_compilation/no_Throwable.d
@@ -1,10 +1,11 @@
 /* 
 DFLAGS:
-REQUIRED_ARGS: -c -I=fail_compilation/extra-files/minimal/
+REQUIRED_ARGS: -c
+EXTRA_SOURCES: extra-files/minimal/object.d
 TEST_OUTPUT:
 ---
-fail_compilation/no_Throwable.d(13): Error: Cannot use `throw` statements because `object.Throwable` was not declared
-fail_compilation/no_Throwable.d(18): Error: Cannot use try-catch statements because `object.Throwable` was not declared
+fail_compilation/no_Throwable.d(14): Error: Cannot use `throw` statements because `object.Throwable` was not declared
+fail_compilation/no_Throwable.d(19): Error: Cannot use try-catch statements because `object.Throwable` was not declared
 ---
 */
 

--- a/test/fail_compilation/no_TypeInfo.d
+++ b/test/fail_compilation/no_TypeInfo.d
@@ -1,9 +1,10 @@
 /* 
 DFLAGS:
-REQUIRED_ARGS: -c -I=fail_compilation/extra-files/minimal/
+REQUIRED_ARGS: -c
+EXTRA_SOURCES: extra-files/minimal/object.d
 TEST_OUTPUT:
 ---
-fail_compilation/no_TypeInfo.d(13): Error: `object.TypeInfo` could not be found, but is implicitly used
+fail_compilation/no_TypeInfo.d(14): Error: `object.TypeInfo` could not be found, but is implicitly used
 ---
 */
 

--- a/test/fail_compilation/verifyhookexist.d
+++ b/test/fail_compilation/verifyhookexist.d
@@ -1,5 +1,6 @@
 /*
-REQUIRED_ARGS: -Ifail_compilation/extra-files/minimal/ -checkaction=context
+REQUIRED_ARGS: -checkaction=context
+EXTRA_SOURCES: extra-files/minimal/object.d
 PERMUTE_ARGS:
 */
 
@@ -8,12 +9,12 @@ PERMUTE_ARGS:
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/verifyhookexist.d(22): Error: `object.__ArrayCast` not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(28): Error: `object.__equals` not found. The current runtime does not support equal checks on arrays, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(29): Error: `object.__cmp` not found. The current runtime does not support comparing arrays, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(33): Error: `object._d_assert_fail` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(36): Error: `object.__switch` not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
-fail_compilation/verifyhookexist.d(41): Error: `object.__switch_error` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(23): Error: `object.__ArrayCast` not found. The current runtime does not support casting array of structs, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(29): Error: `object.__equals` not found. The current runtime does not support equal checks on arrays, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(30): Error: `object.__cmp` not found. The current runtime does not support comparing arrays, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(34): Error: `object._d_assert_fail` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(37): Error: `object.__switch` not found. The current runtime does not support switch cases on strings, or the runtime is corrupt.
+fail_compilation/verifyhookexist.d(42): Error: `object.__switch_error` not found. The current runtime does not support generating assert messages, or the runtime is corrupt.
 ---
 */
 

--- a/test/runnable/minimal.d
+++ b/test/runnable/minimal.d
@@ -1,6 +1,7 @@
 // DFLAGS:
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -defaultlib= runnable/extra-files/minimal/object.d
+// REQUIRED_ARGS: -defaultlib=
+// EXTRA_SOURCES: extra-files/minimal/object.d
 
 // This test ensures an empty main can be built and executed with a minimal runtime
 

--- a/test/runnable/minimal2.d
+++ b/test/runnable/minimal2.d
@@ -1,5 +1,6 @@
 // DFLAGS:
-// REQUIRED_ARGS: -defaultlib= runnable/extra-files/minimal/object.d
+// REQUIRED_ARGS: -defaultlib=
+// EXTRA_SOURCES: extra-files/minimal/object.d
 
 // This test ensures that interfaces and classes can be used in a minimal
 // runtime as long as they only contain shared static members.  Non-shared

--- a/test/runnable/pubprivtmpl.d
+++ b/test/runnable/pubprivtmpl.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: runnable/imports/pubprivtmpla.d
+// EXTRA_SOURCES: imports/pubprivtmpla.d
 
 module pubprivtmpl;
 


### PR DESCRIPTION
Aligns up with gdc, this way is functionally equivalence, plus it notifies the test runner that there's content required to copy across for the compilation action to succeed.