### PR TITLE
Convert lexer from Linked Linked list to Array based allocation

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -2512,15 +2512,15 @@ struct ASTBase
 
     extern (C++) class AsmStatement : Statement
     {
-        Token* tokens;
+        TokenRange tokens;
 
-        extern (D) this(const ref Loc loc, Token* tokens)
+        extern (D) this(const ref Loc loc, TokenRange tokens)
         {
             super(loc, STMT.Asm);
             this.tokens = tokens;
         }
 
-        extern (D) this(const ref Loc loc, Token* tokens, STMT stmt)
+        extern (D) this(const ref Loc loc, TokenRange tokens, STMT stmt)
         {
             super(loc, stmt);
             this.tokens = tokens;
@@ -2534,7 +2534,7 @@ struct ASTBase
 
     extern (C++) final class InlineAsmStatement : AsmStatement
     {
-        extern (D) this(const ref Loc loc, Token* tokens)
+        extern (D) this(const ref Loc loc, TokenRange tokens)
         {
             super(loc, tokens, STMT.InlineAsm);
         }
@@ -2547,7 +2547,7 @@ struct ASTBase
 
     extern (C++) final class GccAsmStatement : AsmStatement
     {
-        extern (D) this(const ref Loc loc, Token* tokens)
+        extern (D) this(const ref Loc loc, TokenRange tokens)
         {
             super(loc, tokens, STMT.GccAsm);
         }

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -989,7 +989,9 @@ extern (C++) final class Module : Package
             isHdrFile = true;
         }
         {
-            scope p = new Parser!AST(this, buf, cast(bool) docfile, diagnosticReporter);
+            //some statements need to reference the parser during semantic,
+            //so don't make it scope
+            auto p = new Parser!AST(this, buf, cast(bool) docfile, diagnosticReporter);
             p.nextToken();
             members = p.parseModule();
             md = p.md;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2091,7 +2091,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         buf.writeByte(0);
         const str = buf.extractSlice()[0 .. len];
         scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
-        scope p = new Parser!ASTCodegen(cd.loc, sc._module, str, false, diagnosticReporter);
+        auto p = new Parser!ASTCodegen(cd.loc, sc._module, str, false, diagnosticReporter);
         p.nextToken();
 
         auto d = p.parseDeclDefs(0);

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5663,7 +5663,7 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
         const len = buf.length;
         const str = buf.extractChars()[0 .. len];
         scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
-        scope p = new Parser!ASTCodegen(exp.loc, sc._module, str, false, diagnosticReporter);
+        auto p = new Parser!ASTCodegen(exp.loc, sc._module, str, false, diagnosticReporter);
         p.nextToken();
         //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -40,6 +40,7 @@ import dmd.identifier;
 import dmd.init;
 import dmd.mtype;
 import dmd.nspace;
+import dmd.lexer;
 import dmd.parse;
 import dmd.root.ctfloat;
 import dmd.root.outbuffer;
@@ -717,23 +718,23 @@ public:
     override void visit(AsmStatement s)
     {
         buf.writestring("asm { ");
-        Token* t = s.tokens;
+        TokenRange tokens = s.tokens;
         buf.level++;
-        while (t)
+        while (!tokens.empty)
         {
+            const t = tokens.front;
             buf.writestring(t.toChars());
-            if (t.next &&
-                t.value != TOK.min      &&
-                t.value != TOK.comma    && t.next.value != TOK.comma    &&
-                t.value != TOK.leftBracket && t.next.value != TOK.leftBracket &&
-                                          t.next.value != TOK.rightBracket &&
-                t.value != TOK.leftParentheses   && t.next.value != TOK.leftParentheses   &&
-                                          t.next.value != TOK.rightParentheses   &&
-                t.value != TOK.dot      && t.next.value != TOK.dot)
+            if (tokens.length >= 2 &&
+                t.value != TOK.min && t.value != TOK.comma && tokens.peekFront.value != TOK.comma &&
+                t.value != TOK.leftBracket && tokens.peekFront.value != TOK.leftBracket &&
+                tokens.peekFront.value != TOK.rightBracket && t.value != TOK.leftParentheses &&
+                tokens.peekFront.value != TOK.leftParentheses &&
+                tokens.peekFront.value != TOK.rightParentheses &&
+                t.value != TOK.dot && tokens.peekFront.value != TOK.dot)
             {
                 buf.writeByte(' ');
             }
-            t = t.next;
+            tokens.popFront();
         }
         buf.level--;
         buf.writestring("; }");

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -37,7 +37,7 @@ extern(C++) Statement asmSemantic(AsmStatement s, Scope *sc)
     FuncDeclaration fd = sc.parent.isFuncDeclaration();
     assert(fd);
 
-    if (!s.tokens)
+    if (s.tokens.empty)
         return null;
 
     // Assume assembler code takes care of setting the return value

--- a/src/dmd/iasmgcc.d
+++ b/src/dmd/iasmgcc.d
@@ -384,8 +384,7 @@ unittest
         p.check(TOK.asm_);
         p.check(TOK.leftCurly);
 
-        auto tokens = p.makeRangeFromHere();
-        tokens.popBack(); //start with an empty range
+        auto tokens = p[0 .. 0]; //start with an empty range
 
         while (1)
         {

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -210,35 +210,15 @@ unittest
  */
 private struct TokenPool
 {
-private:
-    enum PoolSize = 256; //number of tokens per pool
-    enum DefaultPoolListSize = 64; //number of pools to allocate by default
-    //Wrap a slice because Array is extern C++
-    private struct Pool
-    {
-        Token[] tokens;
-    }
-    Array!(Pool) pools;
+    private Array!Token tokens;
 
-    nothrow:
-
-    ///Token pool looks like a big array
-    public ref Token getByIndex(size_t index)
+    public ref Token getByIndex(size_t index) nothrow pure
     {
-        if (index >= PoolSize * pools.length)
+        if (index >= tokens.length)
         {
-            allocatePools(index + 1); //need space for index 0
+            tokens.setDim(index + 1);
         }
-        return pools[index / PoolSize].tokens[index % PoolSize];
-
-    }
-
-    private void allocatePools(size_t tokensNeeded)
-    {
-        const poolsNeeded = (tokensNeeded + PoolSize - 1) / PoolSize;
-        assert(poolsNeeded == pools.length + 1); //don't alloc more than 1 pool at a time
-        pools.reserve(1);
-        pools.push(Pool(new Token[PoolSize])); //will never be freed, so use GC mem
+        return tokens[index];
     }
 }
 

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -336,7 +336,7 @@ final class Parser(AST) : Lexer
         AST.Dsymbols* decldefs;
         AST.Dsymbol lastDecl = mod; // for attaching ddoc unittests to module decl
 
-        TokenRange tokens = makeRangeFromHere();
+        TokenRange tokens = this[];
         if (skipAttributes(tokens) && tokens.back.value == TOK.module_)
         {
             while (token.value != TOK.module_)
@@ -818,8 +818,7 @@ final class Parser(AST) : Lexer
                  *      storage_class identifier = initializer;
                  *      storage_class identifier(...) = initializer;
                  */
-                auto tokens = makeRangeFromHere();
-                tokens.growBack();
+                auto tokens = this[1 .. 2];
                 if (token.value == TOK.identifier && hasOptionalParensThen(tokens, TOK.assign))
                 {
                     a = parseAutoDeclarations(getStorageClass!AST(pAttrs), pAttrs.comment);
@@ -835,8 +834,7 @@ final class Parser(AST) : Lexer
 
                 /* Look for return type inference for template functions.
                  */
-                tokens = makeRangeFromHere();
-                tokens.growBack();
+                tokens = this[1 .. 2];
                 if (token.value == TOK.identifier && skipParens(tokens) && skipAttributes(tokens) &&
                     (tokens.back.value == TOK.leftParentheses || tokens.back.value == TOK.leftCurly ||
                      tokens.back.value == TOK.in_ || tokens.back.value == TOK.out_ ||
@@ -1277,8 +1275,7 @@ final class Parser(AST) : Lexer
 
             case TOK.comma:
                 nextToken();
-                auto tokens = makeRangeFromHere();
-                tokens.growBack();
+                auto tokens = this[1 .. 2];
                 if (!(token.value == TOK.identifier && hasOptionalParensThen(tokens, TOK.assign)))
                 {
                     error("identifier expected following comma");
@@ -1643,7 +1640,7 @@ final class Parser(AST) : Lexer
                     nextToken();
                     loc = token.loc; // todo
                     AST.Type spectype = null;
-                    auto tokens = makeRangeFromHere();
+                    auto tokens = this[];
                     if (isDeclaration(tokens, NeedDeclaratorId.must, TOK.reserved))
                     {
                         spectype = parseType(&tp_ident);
@@ -1662,7 +1659,7 @@ final class Parser(AST) : Lexer
                     if (token.value == TOK.colon) // : Type
                     {
                         nextToken();
-                        tokens = makeRangeFromHere();
+                        tokens = this[];
                         if (isDeclaration(tokens, NeedDeclaratorId.no, TOK.reserved))
                             spec = parseType();
                         else
@@ -1672,7 +1669,7 @@ final class Parser(AST) : Lexer
                     if (token.value == TOK.assign) // = Type
                     {
                         nextToken();
-                        tokens = makeRangeFromHere();
+                        tokens = this[];
                         if (isDeclaration(tokens, NeedDeclaratorId.no, TOK.reserved))
                             def = parseType();
                         else
@@ -1944,7 +1941,7 @@ final class Parser(AST) : Lexer
      */
     RootObject parseTypeOrAssignExp(TOK endtoken = TOK.reserved)
     {
-        auto tokens = makeRangeFromHere();
+        auto tokens = this[];
         return isDeclaration(tokens, NeedDeclaratorId.no, endtoken)
             ? parseType()           // argument is a type
             : parseAssignExp();     // argument is an expression
@@ -2464,7 +2461,7 @@ final class Parser(AST) : Lexer
          */
         AST.TemplateParameters* tpl = null;
         if (token.value == TOK.leftParentheses &&
-            peekPastParen(makeRangeFromHere()).back.value == TOK.leftParentheses)
+            peekPastParen(this[]).back.value == TOK.leftParentheses)
         {
             tpl = parseTemplateParameterList();
         }
@@ -3863,7 +3860,7 @@ final class Parser(AST) : Lexer
 
                     nextToken();
                     AST.Type t = maybeArray ? maybeArray : cast(AST.Type)tid;
-                    auto tokens = makeRangeFromHere();
+                    auto tokens = this[];
                     if (token.value == TOK.rightBracket)
                     {
                         // It's a dynamic array, and we're done:
@@ -3947,7 +3944,7 @@ final class Parser(AST) : Lexer
                 //     int[3][1] a;
                 // is (array[1] of array[3] of int)
                 nextToken();
-                auto tokens = makeRangeFromHere();
+                auto tokens = this[];
                 if (token.value == TOK.rightBracket)
                 {
                     t = new AST.TypeDArray(t); // []
@@ -4048,7 +4045,7 @@ final class Parser(AST) : Lexer
                 }
                 ts = t;
 
-                auto tokens = makeRangeFromHere();
+                auto tokens = this[];
                 /* Completely disallow C-style things like:
                  *   T (a);
                  * Improve error messages for the common bug of a missing return type
@@ -4084,7 +4081,7 @@ final class Parser(AST) : Lexer
                         // This is the old C-style post [] syntax.
                         AST.TypeNext ta;
                         nextToken();
-                        auto tokens = makeRangeFromHere();
+                        auto tokens = this[];
                         if (token.value == TOK.rightBracket)
                         {
                             // It's a dynamic array
@@ -4127,7 +4124,7 @@ final class Parser(AST) : Lexer
                 {
                     if (tpl)
                     {
-                        const tval = peekPastParen(makeRangeFromHere()).back.value;
+                        const tval = peekPastParen(this[]).back.value;
                         if (tval == TOK.leftParentheses)
                         {
                             /* Look ahead to see if this is (...)(...),
@@ -4397,8 +4394,7 @@ final class Parser(AST) : Lexer
              *  alias identifier = type;
              *  alias identifier(...) = type;
              */
-            auto tokens = makeRangeFromHere();
-            tokens.growBack();
+            auto tokens = this[1 .. 2];
             if (token.value == TOK.identifier && hasOptionalParensThen(tokens, TOK.assign))
             {
                 auto a = new AST.Dsymbols();
@@ -4435,10 +4431,9 @@ final class Parser(AST) : Lexer
                     // TypeCtors? BasicType ( Parameters ) MemberFunctionAttributes
                     bool attributesAppended;
                     const StorageClass funcStc = parseTypeCtor();
-                    auto tr1 = makeRangeFromHere();
-                    auto tr2 = makeRangeFromHere();
-                    auto tr3 = makeRangeFromHere();
-                    tr3.growBack();
+                    auto tr1 = this[];
+                    auto tr2 = this[];
+                    auto tr3 = this[1 .. 2];
 
                     if (token.value != TOK.function_ &&
                         token.value != TOK.delegate_ &&
@@ -4627,8 +4622,7 @@ final class Parser(AST) : Lexer
              *  storage_class identifier = initializer;
              *  storage_class identifier(...) = initializer;
              */
-            auto tokens = makeRangeFromHere();
-            tokens.growBack();
+            auto tokens = this[1 .. 2];
             if ((storage_class || udas) && token.value == TOK.identifier && hasOptionalParensThen(tokens, TOK.assign))
             {
                 AST.Dsymbols* a = parseAutoDeclarations(storage_class, comment);
@@ -4644,8 +4638,7 @@ final class Parser(AST) : Lexer
             /* Look for return type inference for template functions.
              */
             {
-                tokens = makeRangeFromHere();
-                tokens.growBack();
+                tokens = this[1 .. 2];
                 if ((storage_class || udas) && token.value == TOK.identifier && skipParens(tokens) &&
                     skipAttributes(tokens) &&
                     (tokens.back.value == TOK.leftParentheses || tokens.back.value == TOK.leftCurly ||
@@ -5459,7 +5452,7 @@ final class Parser(AST) : Lexer
              * If tokens can be handled as
              * old C-style declaration or D expression, prefer the latter.
              */
-            auto tokens = makeRangeFromHere();
+            auto tokens = this[];
             if (isDeclaration(tokens, NeedDeclaratorId.mustIfDstyle, TOK.reserved))
                 goto Ldeclaration;
             goto Lexp;
@@ -5658,7 +5651,7 @@ final class Parser(AST) : Lexer
             }
         case TOK.mixin_:
             {
-                auto tokens = makeRangeFromHere();
+                auto tokens = this[];
                 if (isDeclaration(tokens, NeedDeclaratorId.mustIfDstyle, TOK.reserved))
                     goto Ldeclaration;
                 if (peekNext() == TOK.leftParentheses)
@@ -5868,7 +5861,7 @@ final class Parser(AST) : Lexer
                     break;
                 }
                 const n = peekNext();
-                auto tokens = makeRangeFromHere();
+                auto tokens = this[];
                 if (storageClass != 0 && token.value == TOK.identifier &&
                     n != TOK.assign && n != TOK.identifier)
                 {
@@ -6188,8 +6181,7 @@ final class Parser(AST) : Lexer
                 AST.Expression exp;
                 AST.Statement _body;
 
-                auto tokens = makeRangeFromHere();
-                tokens.growBack();
+                auto tokens = this[1 .. 2];
                 if (skipAttributes(tokens) && tokens.back.value == TOK.class_)
                     goto Ldeclaration;
 
@@ -6301,8 +6293,7 @@ final class Parser(AST) : Lexer
                     error("`const`/`immutable`/`shared`/`inout` attributes are not allowed on `asm` blocks");
 
                 check(TOK.leftCurly);
-                TokenRange toklist = makeRangeFromHere();
-                toklist.popBack(); //make an empty range
+                TokenRange toklist = this[0 .. 0];
 
                 Identifier label = null;
                 auto statements = new AST.Statements();
@@ -6323,8 +6314,7 @@ final class Parser(AST) : Lexer
                                 nextToken();
                                 nextToken();
                                 //move the toklist forward too
-                                toklist = makeRangeFromHere();
-                                toklist.popBack();
+                                toklist = this[0 .. 0];
                                 continue;
                             }
                         }
@@ -6355,8 +6345,7 @@ final class Parser(AST) : Lexer
                         {
                             // Create AsmStatement from list of tokens we've saved
                             s = new AST.AsmStatement(token.loc, toklist);
-                            toklist = makeRangeFromHere;
-                            toklist.popBack(); //make an empty range on the semicolon
+                            toklist = this[0 .. 0]; //make an empty range on the semicolon
                             if (label)
                             {
                                 s = new AST.LabelStatement(labelloc, label, s);
@@ -6477,8 +6466,7 @@ final class Parser(AST) : Lexer
              * (e.g. prefix with "()" for empty parameter list).
              */
             braces = 1;
-            auto tokens = makeRangeFromHere();
-            for (tokens.growBack(); 1; tokens.growBack())
+            for (auto tokens = this[1 .. 2]; 1; tokens.growBack())
             {
                 switch (tokens.back.value)
                 {
@@ -6586,8 +6574,7 @@ final class Parser(AST) : Lexer
              * If it ends with a ';' ',' or '}', it is an array initializer.
              */
             brackets = 1;
-            auto tokens = makeRangeFromHere();
-            for (tokens.growBack(); 1; tokens.growBack())
+            for (auto tokens = this[1 .. 2]; 1; tokens.growBack())
             {
                 switch (tokens.back.value)
                 {
@@ -8019,7 +8006,7 @@ final class Parser(AST) : Lexer
                         error(loc, "unexpected `(` after `%s`, inside `is` expression. Try enclosing the contents of `is` with a `typeof` expression", token.toChars());
                         nextToken();
 
-                        auto tokens = peekPastParen(makeRangeFromHere());
+                        auto tokens = peekPastParen(this[]);
                         seekTo(tokens.stop -1);
                         goto Lerr;
                     }
@@ -8117,8 +8104,7 @@ final class Parser(AST) : Lexer
             {
                 if (peekNext() == TOK.leftParentheses)
                 {
-                    auto tokens = makeRangeFromHere();
-                    tokens.growBack();
+                    auto tokens = this[1 .. 2];
                     tokens = peekPastParen(tokens);
 
                     if (skipAttributes(tokens) && (tokens.back.value == TOK.goesTo ||
@@ -8135,7 +8121,7 @@ final class Parser(AST) : Lexer
             }
         case TOK.leftParentheses:
             {
-                auto tokens = peekPastParen(makeRangeFromHere());
+                auto tokens = peekPastParen(this[]);
                 if (skipAttributes(tokens) && (tokens.back.value == TOK.goesTo ||
                                                tokens.back.value == TOK.leftCurly))
                 {
@@ -8370,8 +8356,7 @@ final class Parser(AST) : Lexer
             }
         case TOK.leftParentheses:
             {
-                auto tokens = makeRangeFromHere();
-                tokens.growBack();
+                auto tokens = this[1 .. 2];
 
                 static if (CCASTSYNTAX)
                 {

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -846,7 +846,7 @@ final class Parser(AST) : Lexer
                     // @@@DEPRECATED@@@
                     // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
                     // Deprecated in 2.091 - Can be removed from 2.101
-                    if (tk.value == TOK.identifier && tk.ident == Id._body)
+                    if (tokens.back.value == TOK.identifier && tokens.back.ident == Id._body)
                         deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                     a = parseDeclarations(true, pAttrs, pAttrs.comment);
                     if (a && a.dim)
@@ -1945,7 +1945,7 @@ final class Parser(AST) : Lexer
     RootObject parseTypeOrAssignExp(TOK endtoken = TOK.reserved)
     {
         auto tokens = makeRangeFromHere();
-        return isDeclaration(tokens, NeedDeclaratorId.no, TOK.reserved)
+        return isDeclaration(tokens, NeedDeclaratorId.no, endtoken)
             ? parseType()           // argument is a type
             : parseAssignExp();     // argument is an expression
     }
@@ -4656,7 +4656,7 @@ final class Parser(AST) : Lexer
                     // @@@DEPRECATED@@@
                     // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
                     // Deprecated in 2.091 - Can be removed from 2.101
-                    if (tk.value == TOK.identifier && tk.ident == Id._body)
+                    if (tokens.back.value == TOK.identifier && tokens.back.ident == Id._body)
                         deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                     ts = null;
                 }

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -41,6 +41,7 @@ import dmd.id;
 import dmd.identifier;
 import dmd.dinterpret;
 import dmd.mtype;
+import dmd.lexer;
 import dmd.parse;
 import dmd.root.outbuffer;
 import dmd.root.rootobject;
@@ -816,7 +817,7 @@ extern (C++) final class CompileStatement : Statement
         buf.writeByte(0);
         const str = buf.extractSlice()[0 .. len];
         scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
-        scope p = new Parser!ASTCodegen(loc, sc._module, str, false, diagnosticReporter);
+        auto p = new Parser!ASTCodegen(loc, sc._module, str, false, diagnosticReporter);
         p.nextToken();
 
         auto a = new Statements();
@@ -2401,15 +2402,15 @@ extern (C++) final class LabelDsymbol : Dsymbol
  */
 extern (C++) class AsmStatement : Statement
 {
-    Token* tokens;
+    TokenRange tokens;
 
-    extern (D) this(const ref Loc loc, Token* tokens)
+    extern (D) this(const ref Loc loc, TokenRange tokens)
     {
         super(loc, STMT.Asm);
         this.tokens = tokens;
     }
 
-    extern (D) this(const ref Loc loc, Token* tokens, STMT stmt)
+    extern (D) this(const ref Loc loc, TokenRange tokens, STMT stmt)
     {
         super(loc, stmt);
         this.tokens = tokens;
@@ -2437,7 +2438,7 @@ extern (C++) final class InlineAsmStatement : AsmStatement
     bool refparam;  // true if function parameter is referenced
     bool naked;     // true if function is to be naked
 
-    extern (D) this(const ref Loc loc, Token* tokens)
+    extern (D) this(const ref Loc loc, TokenRange tokens)
     {
         super(loc, tokens, STMT.InlineAsm);
     }
@@ -2469,7 +2470,7 @@ extern (C++) final class GccAsmStatement : AsmStatement
     Identifiers* labels;        // list of goto labels
     GotoStatements* gotos;      // of the goto labels, the equivalent statements they represent
 
-    extern (D) this(const ref Loc loc, Token* tokens)
+    extern (D) this(const ref Loc loc, TokenRange tokens)
     {
         super(loc, tokens, STMT.GccAsm);
     }

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -425,7 +425,6 @@ private immutable TOK[] keywords =
  */
 extern (C++) struct Token
 {
-    Token* next;
     Loc loc;
     const(char)* ptr; // pointer to first character of this token within buffer
     TOK value;

--- a/src/dmd/tokens.h
+++ b/src/dmd/tokens.h
@@ -197,7 +197,6 @@ enum
 
 struct Token
 {
-    Token *next;
     Loc loc;
     const utf8_t *ptr;    // pointer to first character of this token within buffer
     TOK value;
@@ -223,7 +222,7 @@ struct Token
 
     void free();
 
-    Token() : next(NULL) {}
+    Token() {}
     int isKeyword();
     const char *toChars() const;
 

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1576,7 +1576,7 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                     buf.writeByte(0);
                     const str = buf.extractSlice()[0 .. len];
                     scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
-                    scope p = new Parser!ASTCodegen(e.loc, sc._module, str, false, diagnosticReporter);
+                    auto p = new Parser!ASTCodegen(e.loc, sc._module, str, false, diagnosticReporter);
                     p.nextToken();
                     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1998,7 +1998,9 @@ RootObject compileTypeMixin(TypeMixin tm, Loc loc, Scope* sc)
     buf.writeByte(0);
     const str = buf.extractSlice()[0 .. len];
     scope diagnosticReporter = new StderrDiagnosticReporter(global.params.useDeprecated);
-    scope p = new Parser!ASTCodegen(loc, sc._module, str, false, diagnosticReporter);
+    //the mixin could contain statements which refer to p during semantic
+    //so don't make it scope
+    auto p = new Parser!ASTCodegen(loc, sc._module, str, false, diagnosticReporter);
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
 


### PR DESCRIPTION
Benefits:

* Fewer allocations (1 per pool vs 1 per token)
* Better locality
* Smaller token struct size(no next pointer)
* Lots of functions that take pointers can take refs now instead
* Eliminate some tricky linked list code and replace it with clear range style code
* I think a similar design could be used for Loc objects (nodes/tokens would store a LocManager* and an index, 2 indices to have a LocRange)

Drawbacks

* Huge diff... not sure if that can be avoided, fortunately the parser is well covered by tests
* Implementation leaks info about the lexer.  Needed because ASM statements are parsed during semantic.  This could be improved if the parser was changed to operate on TokenRanges rather than call nextToken, etc.  This issue is also why Parser instances were changed from scope to auto.  Again, making the rest of the parser TokenRange aware would avoid the need for this.
* Extra variables needed in a few places because ref functions can't accept temporaries
* The choice of Pool parameters were pulled out of thin air... would probably be good to have something more principled
* a couple of API names seem bit cumbersome (makeRangeFromHere)




