### PR TITLE
dmd built with longdouble_soft: fix printing float.inf at compile time

### DIFF
--- a/src/dmd/root/longdouble.d
+++ b/src/dmd/root/longdouble.d
@@ -65,6 +65,12 @@ bool initFPU()
     return true;
 }
 
+version(unittest) version(CRuntime_Microsoft)
+shared static this()
+{
+    initFPU(); // otherwise not guaranteed to be run before pure unittest below
+}
+
 void ld_clearfpu()
 {
     version(AsmX86)
@@ -703,15 +709,20 @@ enum LD_TYPE_QNAN     = 4;
 
 int ld_type(longdouble_soft x)
 {
+    // see https://en.wikipedia.org/wiki/Extended_precision
     if(x.exponent == 0)
         return x.mantissa == 0 ? LD_TYPE_ZERO : LD_TYPE_OTHER; // dnormal if not zero
     if(x.exponent != 0x7fff)
-        return LD_TYPE_OTHER;
-    if(x.mantissa == 0)
-        return LD_TYPE_INFINITE;
-    if(x.mantissa & (1L << 63))
-        return LD_TYPE_QNAN;
-    return LD_TYPE_SNAN;
+        return LD_TYPE_OTHER;    // normal or denormal
+    uint  upper2  = x.mantissa >> 62;
+    ulong lower62 = x.mantissa & ((1L << 62) - 1);
+    if(upper2 == 0 && lower62 == 0)
+        return LD_TYPE_INFINITE; // pseudo-infinity
+    if(upper2 == 2 && lower62 == 0)
+        return LD_TYPE_INFINITE; // infinity
+    if(upper2 == 2 && lower62 != 0)
+        return LD_TYPE_SNAN;
+    return LD_TYPE_QNAN;         // qnan, indefinite, pseudo-nan
 }
 
 // consider sprintf pure
@@ -804,6 +815,12 @@ size_t ld_sprint(char* str, int fmt, longdouble_soft x) @system
 
     ld_sprint(buffer.ptr, 'g', longdouble_soft(1234567.89));
     assert(strcmp(buffer.ptr, "1.23457e+06") == 0);
+
+    ld_sprint(buffer.ptr, 'g', ld_inf);
+    assert(strcmp(buffer.ptr, "inf") == 0);
+
+    ld_sprint(buffer.ptr, 'g', ld_qnan);
+    assert(strcmp(buffer.ptr, "nan") == 0);
 
     longdouble_soft ldb = longdouble_soft(0.4);
     long b = cast(long)ldb;


### PR DESCRIPTION
This is not in a released compiler, but when building dmd as 64-bit binary, `pragma(msg, float.inf)` is printed as `nan` because the infinity detection only covered the "pseudo-infinity".