### PR TITLE
support VERBOSE=1 from makefiles

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -751,6 +751,9 @@ struct BuildRuleRange
 /// Sets the environment variables
 void parseEnvironment()
 {
+    if (!verbose)
+        verbose = "1" == env.getDefault("VERBOSE", null);
+
     // This block is temporary until we can remove the windows make files
     {
         const ddebug = env.get("DDEBUG", null);

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -78,13 +78,13 @@ DDEBUG=-debug -g -unittest
 DFLAGS=$(DOPT) $(DMODEL) $(DDEBUG) -wi -version=MARS -dip25
 
 # Recursive make
-DMDMAKE=$(MAKE) -fwin32.mak MAKE="$(MAKE)" HOST_DC="$(HOST_DC)" MODEL=$(MODEL) CC="$(CC)"
+DMDMAKE=$(MAKE) -fwin32.mak MAKE="$(MAKE)" HOST_DC="$(HOST_DC)" MODEL=$(MODEL) CC="$(CC)" VERBOSE=$(VERBOSE)
 
 ############################### Rule Variables ###############################
 
 PARSER_SRCS=$D/astbase.d $D/parsetimevisitor.d $D/parse.d $D/transitivevisitor.d $D/permissivevisitor.d $D/strictvisitor.d $D/utils.d
 
-RUN_BUILD=$(GEN)\build.exe --called-from-make "OS=$(OS)" "BUILD=$(BUILD)" "MODEL=$(MODEL)" "HOST_DMD=$(HOST_DMD)" "HOST_DC=$(HOST_DC)" "DDEBUG=$(DDEBUG)" "MAKE=$(MAKE)"
+RUN_BUILD=$(GEN)\build.exe --called-from-make "OS=$(OS)" "BUILD=$(BUILD)" "MODEL=$(MODEL)" "HOST_DMD=$(HOST_DMD)" "HOST_DC=$(HOST_DC)" "DDEBUG=$(DDEBUG)" "MAKE=$(MAKE)" VERBOSE=$(VERBOSE)
 
 ############################## Release Targets ###############################
 

--- a/src/win64.mak
+++ b/src/win64.mak
@@ -20,7 +20,7 @@ GEN = ..\generated
 G = $(GEN)\$(OS)\$(BUILD)\$(MODEL)
 DEPENDENCIES=vcbuild\msvc-lib.exe $G
 
-MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" BUILD=$(BUILD) MODEL=$(MODEL) HOST_DC=$(HOST_DC) GEN="$(GEN)" G="$G" LIB=vcbuild\msvc-lib
+MAKE_WIN32=$(MAKE) -f win32.mak MAKE="$(MAKE)" BUILD=$(BUILD) MODEL=$(MODEL) HOST_DC=$(HOST_DC) GEN="$(GEN)" G="$G" LIB=vcbuild\msvc-lib VERBOSE=$(VERBOSE)
 
 ################################## Targets ###################################
 


### PR DESCRIPTION
This allows makefile users to see verbose build output with `make VERBOSE=1`.

Note that the posix version of the makefiles don't need any changes because GNU make automatically promotes variables set on the command-line to environment variables. This means they will propagate down to the `build.d` process.  However, Digital Mars Make on windows does not set them as environment variables, so they must be explicitly propagated each time make is recursively called and when we call `build.d`.

> Side Note: windows makefiles are missing some variables that need to be propagated, something that we should fix in another change.

That being said, I wasn't able to edit the root makefiles `win32.mak` and `win64.mak` to propagate the `VERBOSE` variable because autotester kept giving me errors like this:
```
Error on line 3: expecting target : dependencies
```
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3867801&isPull=true
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3867802&isPull=true
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3867859&isPull=true
https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=3867868&isPull=true

It looks like the autotester is depending on those files to look a certain way.  So on windows, I could only make the `VERBOSE` flag work if you invoke make on `src/win32.mak` or `src/win64.mak` directly.