### PR TITLE
build.d: Move install from posix.mak

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -159,12 +159,8 @@ man: $(GENERATED)/build
 
 ######################################################
 
-install: all $(DMD_MAN_PAGE)
-	$(eval bin_dir=$(if $(filter $(OS),osx), bin, bin$(MODEL)))
-	mkdir -p $(INSTALL_DIR)/$(OS)/$(bin_dir)
-	cp $G/dmd $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd
-	cp ../ini/$(OS)/$(bin_dir)/dmd.conf $(INSTALL_DIR)/$(OS)/$(bin_dir)/dmd.conf
-	cp $D/boostlicense.txt $(INSTALL_DIR)/dmd-boostlicense.txt
+install: $(GENERATED)/build $(DMD_MAN_PAGE)
+	$(RUN_BUILD) $@
 
 ######################################################
 


### PR DESCRIPTION
470c402 fixes `install-copy` omitting the configuration file (`dmd.conf` / `sc.ini`) and extends it for other OS to make it re-useable.
470c402 then renames 'install-copy'  to `install` and adds 'install-copy' as a legacy alias.

TODO (inconsistencies between windows/posix): 
- [ ] `(DMD)/src/posix.mak` omits dmd's sources, should it copy them like `win32.mak` currently does?,
- [ ] `(DMD)/posix.mak` includes docs and samples, should windows have this as well?