### PR TITLE
posix.mak: Don't invoke build.d twice to build dmd

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -106,7 +106,8 @@ RUN_BUILD = $(GENERATED)/build HOST_DMD="$(HOST_DMD)" CXX="$(HOST_CXX)" OS=$(OS)
 all: dmd
 .PHONY: all
 
-dmd: $G/dmd $G/dmd.conf
+dmd: $(GENERATED)/build
+	$(RUN_BUILD) $@
 .PHONY: dmd
 
 $(GENERATED)/build: build.d $(HOST_DMD_PATH)


### PR DESCRIPTION
Both instances run sequentially anyway (=> lockfile) and determining the targets
to built from the supplied file paths is unnecessary work.