### PR TITLE
Make casting to void* allowed in safe code

### DIFF
--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -118,6 +118,10 @@ bool isSafeCast(Expression e, Type tfrom, Type tto)
     auto tfromb = tfrom.toBasetype();
     auto ttob = tto.toBasetype();
 
+    // Casting to void* is always safe
+    if (ttob.ty == Tpointer && ttob.nextOf().toBasetype().ty == Tvoid)
+        return true;
+
     if (ttob.ty == Tclass && tfromb.ty == Tclass)
     {
         ClassDeclaration cdfrom = tfromb.isClassHandle();

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -24,9 +24,9 @@ void pointercast2()
     int b;
     Object c;
 
-    static assert(!__traits(compiles, cast(void*)a));
-    static assert(!__traits(compiles, cast(void*)b));
-    static assert(!__traits(compiles, cast(void*)c));
+    static assert(__traits(compiles, cast(void*)a));
+    static assert(__traits(compiles, cast(void*)b));
+    static assert(__traits(compiles, cast(void*)c));
 }
 
 @safe


### PR DESCRIPTION
This is `@safe` because you cannot do anything with `void*` in `@safe` code that corrupts memory.
It came up in: https://forum.dlang.org/thread/bhyyoojelsruhtkcprhw@forum.dlang.org

Spec PR: https://github.com/dlang/dlang.org/pull/2722
