### PR TITLE
Fix 20449 - integer literal specification and implementation differs

### DIFF
--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -2107,18 +2107,6 @@ class Lexer
                 result = TOK.uns32Literal;
             break;
         case FLAGS.decimal | FLAGS.long_:
-            if (n & 0x8000000000000000L)
-            {
-                if (!err)
-                {
-                    error("signed integer overflow");
-                    err = true;
-                }
-                result = TOK.uns64Literal;
-            }
-            else
-                result = TOK.int64Literal;
-            break;
         case FLAGS.long_:
             if (n & 0x8000000000000000L)
                 result = TOK.uns64Literal;

--- a/test/compilable/test20449.d
+++ b/test/compilable/test20449.d
@@ -1,0 +1,5 @@
+void main()
+{
+    auto x = 9223372036854775808; // long.max + 1
+    static assert(is(typeof(x) == ulong));
+}


### PR DESCRIPTION
This is assuming we want to adjust the implementation to conform to the spec, and not the other way around.