### PR TITLE
Remove astbase and strictvisitor from dmd

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1086,7 +1086,7 @@ auto sourceFiles()
         "),
         frontend: fileArray(env["D"], "
             access.d aggregate.d aliasthis.d apply.d argtypes.d argtypes_sysv_x64.d arrayop.d
-            arraytypes.d ast_node.d astbase.d astcodegen.d attrib.d blockexit.d builtin.d canthrow.d
+            arraytypes.d ast_node.d astcodegen.d attrib.d blockexit.d builtin.d canthrow.d
             cli.d clone.d compiler.d complex.d cond.d constfold.d cppmangle.d cppmanglewin.d ctfeexpr.d
             ctorflow.d dcast.d dclass.d declaration.d delegatize.d denum.d dimport.d dinifile.d
             dinterpret.d dmacro.d dmangle.d dmodule.d doc.d dscope.d dstruct.d dsymbol.d dsymbolsem.d
@@ -1095,7 +1095,7 @@ auto sourceFiles()
             libmach.d libmscoff.d libomf.d link.d mars.d mtype.d nogc.d nspace.d objc.d opover.d optimize.d
             parse.d parsetimevisitor.d permissivevisitor.d printast.d safe.d sapply.d scanelf.d scanmach.d
             scanmscoff.d scanomf.d semantic2.d semantic3.d sideeffect.d statement.d statement_rewrite_walker.d
-            statementsem.d staticassert.d staticcond.d strictvisitor.d target.d templateparamsem.d traits.d
+            statementsem.d staticassert.d staticcond.d target.d templateparamsem.d traits.d
             transitivevisitor.d typesem.d typinf.d utils.d visitor.d foreachvar.d
         "),
         backendHeaders: fileArray(env["C"], "


### PR DESCRIPTION
It looks like `astbase.d` and `strictvisitor.d` aren't being used by the `dmd` executable.  Removing them brings the dmd binary size down from 12.5 MB to 11.5 MB.

It also looks like they weren't used before, but were inadvertently added to the compilation when we moved to `build.d` (see https://github.com/dlang/dmd/pull/10446#issuecomment-566099613).