### PR TITLE
Fix Issue 20151 - particular directory layout causes DMD to crash

### DIFF
--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1478,10 +1478,6 @@ public:
 
     extern (D) final void addAccessiblePackage(Package p, Prot protection)
     {
-        // https://issues.dlang.org/show_bug.cgi?id=17991
-        // An import of truly empty file/package can happen
-        if (p is null)
-            return;
         auto pary = protection.kind == Prot.Kind.private_ ? &privateAccessiblePackages : &accessiblePackages;
         if (pary.length <= p.tag)
             pary.length = p.tag + 1;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1632,6 +1632,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                     foreach (id; (*imp.packages)[1 .. imp.packages.dim]) // [b, c]
                     {
                         p = cast(Package) p.symtab.lookup(id);
+                        // https://issues.dlang.org/show_bug.cgi?id=17991
+                        // An import of truly empty file/package can happen
+                        // https://issues.dlang.org/show_bug.cgi?id=20151
+                        // Package in the path conflicts with a module name
+                        if (p is null)
+                            break;
                         scopesym.addAccessiblePackage(p, imp.protection);
                     }
                 }

--- a/test/compilable/test20151a.d
+++ b/test/compilable/test20151a.d
@@ -1,0 +1,2 @@
+module imports.test20151a;
+import imports.test20151a.b.c.c;


### PR DESCRIPTION
Similar to issue 17991 but the foreach runs more than 1 time.
Moved the workaround to where it should be;