### PR TITLE
Fix Issue 20448 - Error: unknown when mutating an escaped member reference from a template function

### DIFF
--- a/test/fail_compilation/fail20448.d
+++ b/test/fail_compilation/fail20448.d
@@ -1,0 +1,23 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20448.d(16): Error: returning `p.x` escapes a reference to parameter `p`, perhaps annotate with `return`
+fail_compilation/fail20448.d(22): Error: template instance `fail20448.member!"x"` error instantiating
+---
+*/
+
+struct S
+{
+    int x, y;
+}
+
+ref int member(string mem)(S p)
+{
+    return p.x;
+}
+
+void main()
+{
+    S p;
+    p.member!"x" = 2;
+}


### PR DESCRIPTION
```d
import std.stdio : writeln;

struct S {
    int x, y;
}

ref int member(string mem)(S p) { 
    return p.x;
}

void main() {
    S p;
    p.member!"x" = 2;
}
```

`p.member!"x" = 2` could mean 2 things: `member!"x"(p) = 2` or `member!"x"(p , 2)`. The compiler tries the first rewrite but sees that it fails due to the instantiation failure (cannot escape reference to local p.x) and moves on to trying the second rewrite, thus losing the first error message; both of these rewrites are analyzed with gagged errors. When the second rewrite is semantically analyzed the AST is already in an ill-defined state, hence the unknown error.

My patch makes it so that if both rewrites do not pass semantic, then the first rewrite is put through semantic again (without ungagged errors). This seems to be the correct fix for the moment, however this experience has let me with a strong feeling that our error handling system is severely lacking. This bug could be more efficiently solved if dmd had a list of errors that can be appended during gagged analysis. This way you don't have to guess what failed if the failure had multiple potential sources.