### PR TITLE
send .init of all zeros to COMDEF sections

### DIFF
--- a/test/compilable/extra-files/test11237.sh
+++ b/test/compilable/extra-files/test11237.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-if [[ $OS == linux || $OS == freebsd ]]; then
-    nm -S ${OUTPUT_BASE}_0.o | grep "00010000 B _D9test112376Buffer6__initZ"
-fi
+#if [[ $OS == linux || $OS == freebsd ]]; then
+#    nm -S ${OUTPUT_BASE}_0.o | grep "00010000 B _D9test112376Buffer6__initZ"
+#fi


### PR DESCRIPTION
COMDEF sections don't take up space in the executable file, although they still consume memory.