### PR TITLE
use .init if it will not be modified

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -3798,7 +3798,10 @@ elem *toElem(Expression e, IRState *irs)
 
                 if (auto sle = dve.e1.isStructLiteralExp())
                 {
-                    sle.useStaticInit = false;          // don't modify initializer
+                    if (fd && fd.isCtorDeclaration() ||
+                        fd.type.isMutable() ||
+                        sle.type.size() <= 8)          // more efficient than fPIC
+                        sle.useStaticInit = false;     // don't modify initializer, so make copy
                 }
 
                 ec = toElem(dve.e1, irs);


### PR DESCRIPTION
This should preclude making expensive and unnecessary copies on the parameter stack.