### PR TITLE
add bzeroBytes symbol to share struct inits

### DIFF
--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -604,16 +604,40 @@ Symbol *toVtblSymbol(ClassDeclaration cd)
 
 Symbol *toInitializer(AggregateDeclaration ad)
 {
+    //printf("toInitializer() %s\n", ad.toChars());
     if (!ad.sinit)
     {
-        auto stag = fake_classsym(Id.ClassInfo);
-        auto s = toSymbolX(ad, "__init", SCextern, stag.Stype, "Z");
-        s.Sfl = FLextern;
-        s.Sflags |= SFLnodebug;
+        static structalign_t alignOf(Type t)
+        {
+            const explicitAlignment = t.alignment();
+            return explicitAlignment == STRUCTALIGN_DEFAULT ? t.alignsize() : explicitAlignment;
+        }
+
         auto sd = ad.isStructDeclaration();
-        if (sd)
-            s.Salignment = sd.alignment;
-        ad.sinit = s;
+        if (sd &&
+            alignOf(sd.type) <= 16 &&
+            sd.type.size() <= 128 &&
+            sd.zeroInit &&
+            config.objfmt != OBJ_MACH && // same reason as in toobj.d toObjFile()
+            !(config.objfmt == OBJ_MSCOFF && !global.params.is64bit)) // -m32mscoff relocations are wrong
+        {
+            auto bzsave = bzeroSymbol;
+            ad.sinit = getBzeroSymbol();
+
+            // Ensure emitted only once per object file
+            if (bzsave && bzeroSymbol != bzsave)
+                assert(0);
+        }
+        else
+        {
+            auto stag = fake_classsym(Id.ClassInfo);
+            auto s = toSymbolX(ad, "__init", SCextern, stag.Stype, "Z");
+            s.Sfl = FLextern;
+            s.Sflags |= SFLnodebug;
+            if (sd)
+                s.Salignment = sd.alignment;
+            ad.sinit = s;
+        }
     }
     return ad.sinit;
 }


### PR DESCRIPTION
This takes advantage of:

1. structs with initializers that are all zeros
2. struct initializers are immutable

to have them share memory. In this case, they share it with a COMDEF named `__bzeroBytes`. This should substantially reduce memory consumption for applications with lots of small structs.

Unfortunately, the separate TypeInfos are still generated.