### PR TITLE
Use global.recursionLimit in a few more places

### DIFF
--- a/src/dmd/dmacro.d
+++ b/src/dmd/dmacro.d
@@ -61,10 +61,10 @@ extern (C++) struct MacroTable
         }
         // limit recursive expansion
         __gshared int nest;
-        __gshared const(int) nestLimit = 1000;
-        if (nest > nestLimit)
+        if (nest > global.recursionLimit)
         {
-            error(Loc.initial, "DDoc macro expansion limit exceeded; more than %d expansions.", nestLimit);
+            error(Loc.initial, "DDoc macro expansion limit exceeded; more than %d expansions.",
+                  global.recursionLimit);
             return;
         }
         nest++;

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1153,7 +1153,7 @@ Expression Expression_optimize(Expression e, int result, bool keepLvalue)
     size_t b;
     while (1)
     {
-        if (b++ == 500)
+        if (b++ == global.recursionLimit)
         {
             e.error("infinite loop while optimizing expression");
             fatal();

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1148,7 +1148,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
 
         bool errors = false;
 
-        if (mtype.inuse > 500)
+        if (mtype.inuse > global.recursionLimit)
         {
             mtype.inuse = 0;
             .error(loc, "recursive type");


### PR DESCRIPTION
Since recursionLimit was added to #10538, might as well use it where other places have hard-coded values.