### PR TITLE
test: Update generic tests that use x86 asm to work across all compilers

### DIFF
--- a/test/runnable/imports/template13478a.d
+++ b/test/runnable/imports/template13478a.d
@@ -3,6 +3,6 @@ module imports.template13478a;
 bool foo(T)() {
     // Make sure this is not inlined so template13478.o actually
     // needs to reference it.
-    asm { nop; }
+    pragma(inline, false);
     return false;
 }

--- a/test/runnable/minimal2.d
+++ b/test/runnable/minimal2.d
@@ -30,7 +30,8 @@ void poorMansAssert(bool condition)
 {
     if (!condition)
     {
-        asm {hlt;}
+        static char* hlt;
+        *hlt = 0;
     }
 }
 


### PR DESCRIPTION
I don't know why there's a `version(LDC)` in gdc's fork of the D2 testsuite, including it anyway so it doesn't show up in the diff.

@kinke - does this test match your downstream?