### PR TITLE
Fix issue 19325 - Deprecate body keyword

### DIFF
--- a/changelog/body-as-keyword.dd
+++ b/changelog/body-as-keyword.dd
@@ -1,0 +1,10 @@
+The keyword `body` is now deprecated
+
+The keyword `body`, used when a function / method has contract,
+has now been deprecated, and `do` should be used instead.
+Using `do` in place of `body` has been supported since 2.075.0,
+after DIP1003 was accepted.
+At the same time, `body` was made a contextual keyword,
+but kept being non-deprecated due to its prevalence.
+According to the deprecation process, `body` will be removed
+from the language in release 2.101.0 at the earliest.

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -6097,7 +6097,7 @@ struct ASTBase
         {
             assert(!!aggrfe ^ !!rangefe);
         }
-        body
+        do
         {
             this.loc = loc;
             this.aggrfe = aggrfe;

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -186,7 +186,8 @@ private struct ModuleComponentRange
  *  True if the given module should be included in the compilation.
  */
 private bool includeImportedModuleCheck(ModuleComponentRange components)
-    in { assert(includeImports); } body
+    in { assert(includeImports); }
+do
 {
     createMatchNodes();
     size_t nodeIndex = 0;

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -385,7 +385,7 @@ in
 {
     assert(diagnosticReporter !is null);
 }
-body
+do
 {
     import dmd.root.file : File, FileBuffer;
 

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -253,7 +253,7 @@ class Lexer
     {
         assert(diagnosticReporter !is null);
     }
-    body
+    do
     {
         this.diagnosticReporter = diagnosticReporter;
         scanloc = Loc(filename, 1, 1);
@@ -1185,7 +1185,7 @@ class Lexer
     {
         assert(handler !is null);
     }
-    body
+    do
     {
         const(char)* p = sequence; // cache sequence reference on stack
         scope(exit) sequence = p;

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -492,7 +492,7 @@ extern(C++) private final class Supported : Objc
     {
         assert(id.classKind == ClassKind.objc);
     }
-    body
+    do
     {
         // don't report deprecations for the metaclass to avoid duplicated
         // messages.
@@ -566,7 +566,7 @@ extern(C++) private final class Supported : Objc
         assert(fd.selector);
         assert(fd.isMember);
     }
-    body
+    do
     {
         // * final member functions are kept virtual with Objective-C linkage
         //   because the Objective-C runtime always use dynamic dispatch.
@@ -581,7 +581,7 @@ extern(C++) private final class Supported : Objc
     {
         assert(metaclass);
     }
-    body
+    do
     {
         if (cd.classKind == ClassKind.objc && fd.isStatic && !cd.objc.isMeta)
             return cd.objc.metaclass;
@@ -594,7 +594,7 @@ extern(C++) private final class Supported : Objc
     {
         assert(fd.parent.isClassDeclaration);
     }
-    body
+    do
     {
         if (cd.classKind != ClassKind.objc)
             return;
@@ -632,7 +632,7 @@ extern(C++) private final class Supported : Objc
     {
         assert(fd.selectorParameter is null);
     }
-    body
+    do
     {
         if (!fd.selector)
             return null;

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -262,7 +262,7 @@ extern(C++) final class Supported : ObjcGlue
         assert(classDeclaration !is null);
         assert(classDeclaration.classKind == ClassKind.objc);
     }
-    body
+    do
     {
         if (!classDeclaration.objc.isMeta)
             ObjcClassDeclaration(classDeclaration, false).toObjFile();
@@ -274,7 +274,7 @@ extern(C++) final class Supported : ObjcGlue
     {
         assert(fd);
     }
-    body
+    do
     {
         if (!fd.selector)
             return count;
@@ -619,7 +619,7 @@ static:
     {
         assert(classDeclaration !is null);
     }
-    body
+    do
     {
         return getClassName(ObjcClassDeclaration(classDeclaration, isMeta));
     }
@@ -715,7 +715,7 @@ static:
     {
         assert(type !is null);
     }
-    body
+    do
     {
         enum assertMessage = "imaginary types are not supported by Objective-C";
 
@@ -914,7 +914,7 @@ struct ObjcClassDeclaration
     {
         assert(classDeclaration !is null);
     }
-    body
+    do
     {
         this.classDeclaration = classDeclaration;
         this.isMeta = isMeta;
@@ -1280,7 +1280,7 @@ out(result)
 {
     assert(str.length == result.strlen);
 }
-body
+do
 {
     if (str.length == 0)
         return "".ptr;

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -840,6 +840,11 @@ final class Parser(AST) : Lexer
                      tk.value == TOK.out_ || tk.value == TOK.do_ ||
                      tk.value == TOK.identifier && tk.ident == Id._body))
                 {
+                    // @@@DEPRECATED@@@
+                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                    // Deprecated in 2.091 - Can be removed from 2.101
+                    if (tk.value == TOK.identifier && tk.ident == Id._body)
+                        deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                     a = parseDeclarations(true, pAttrs, pAttrs.comment);
                     if (a && a.dim)
                         *pLastDecl = (*a)[a.dim - 1];
@@ -4627,6 +4632,11 @@ final class Parser(AST) : Lexer
                     (tk.value == TOK.leftParentheses || tk.value == TOK.leftCurly || tk.value == TOK.in_ || tk.value == TOK.out_ ||
                      tk.value == TOK.do_ || tk.value == TOK.identifier && tk.ident == Id._body))
                 {
+                    // @@@DEPRECATED@@@
+                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                    // Deprecated in 2.091 - Can be removed from 2.101
+                    if (tk.value == TOK.identifier && tk.ident == Id._body)
+                        deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                     ts = null;
                 }
                 else
@@ -4991,7 +5001,13 @@ final class Parser(AST) : Lexer
 
         case TOK.identifier:
             if (token.ident == Id._body)
+            {
+                // @@@DEPRECATED@@@
+                // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                // Deprecated in 2.091 - Can be removed from 2.101
+                deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                 goto case TOK.do_;
+            }
             goto default;
 
         case TOK.do_:
@@ -7182,7 +7198,13 @@ final class Parser(AST) : Lexer
 
             case TOK.identifier:
                 if (t.ident == Id._body)
+                {
+                    // @@@DEPRECATED@@@
+                    // https://github.com/dlang/DIPs/blob/1f5959abe482b1f9094f6484a7d0a3ade77fc2fc/DIPs/accepted/DIP1003.md
+                    // Deprecated in 2.091 - Can be removed from 2.101
+                    deprecation("Usage of the `body` keyword is deprecated. Use `do` instead.");
                     goto case TOK.do_;
+                }
                 goto default;
 
             case TOK.if_:

--- a/src/dmd/root/man.d
+++ b/src/dmd/root/man.d
@@ -26,7 +26,7 @@ version (Windows)
     {
         assert(strncmp(url, "http://", 7) == 0 || strncmp(url, "https://", 8) == 0);
     }
-    body
+    do
     {
         ShellExecuteA(null, "open", url, null, null, SW_SHOWNORMAL);
     }
@@ -38,7 +38,7 @@ else version (OSX)
     {
         assert(strncmp(url, "http://", 7) == 0 || strncmp(url, "https://", 8) == 0);
     }
-    body
+    do
     {
         pid_t childpid;
         const(char)*[5] args;
@@ -72,7 +72,7 @@ else version (Posix)
     {
         assert(strncmp(url, "http://", 7) == 0 || strncmp(url, "https://", 8) == 0);
     }
-    body
+    do
     {
         pid_t childpid;
         const(char)*[3] args;

--- a/test/compilable/b16967.d
+++ b/test/compilable/b16967.d
@@ -1,4 +1,4 @@
-/* 
+/*
  * REQUIRED_ARGS: -c
  * TEST_OUTPUT:
 ---
@@ -27,7 +27,7 @@ out(v)
             break;
     }
 }
-body
+do
 {
     return 42;
 }

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -6440,7 +6440,7 @@ label:
             break label;        // doesn't work.
     }
 }
-body
+do
 {
     int x = 0;
 label:
@@ -7772,7 +7772,7 @@ enum KindEnum
     integer,
     arrayOf
 }
- 
+
 struct FullKind
 {
     KindEnum[] contents;

--- a/test/fail_compilation/fail17502.d
+++ b/test/fail_compilation/fail17502.d
@@ -11,9 +11,9 @@ class Foo
 {
     void foo()
     out (res) { assert(res > 5); }
-    body {}
+    do {}
 
     auto bar()
     out (res) { assert (res > 5); }
-    body { return; }
+    do { return; }
 }

--- a/test/fail_compilation/fail2350.d
+++ b/test/fail_compilation/fail2350.d
@@ -9,7 +9,7 @@ void test2350()
 in
 {
 }
-body
+do
 {
 	asm { naked; }
 }

--- a/test/fail_compilation/fail329.d
+++ b/test/fail_compilation/fail329.d
@@ -27,7 +27,7 @@ class A
         assert(x == 7);
         result++;
     }
-    body
+    do
     {
         return i;
     }
@@ -49,7 +49,7 @@ class B : A
         assert(result < 8);
         assert(x == 7);
     }
-    body
+    do
     {
         return i - 1;
     }

--- a/test/fail_compilation/fail330.d
+++ b/test/fail_compilation/fail330.d
@@ -7,4 +7,4 @@ fail_compilation/fail330.d(9): Error: variable `fail330.fun.result` cannot modif
 
 int fun()
 out(result) { result = 2; }
-body { return 1; }
+do { return 1; }

--- a/test/fail_compilation/fail6242.d
+++ b/test/fail_compilation/fail6242.d
@@ -6,4 +6,4 @@ fail_compilation/fail6242.d(9): Error: cannot implicitly override base class met
 */
 class A { void fun(int) {} }
 
-class B : A { void fun(int x) in { assert(x > 0); } body {} }
+class B : A { void fun(int x) in { assert(x > 0); } do {} }

--- a/test/fail_compilation/fail94.d
+++ b/test/fail_compilation/fail94.d
@@ -30,7 +30,7 @@ class B : A
     {
 	printf("B.clone()\n");
     }
-    body { return ia; }
+    do { return ia; }
 }
 
 void main()
@@ -59,4 +59,3 @@ void main()
 void bar(IA delegate() dg)
 {
 }
-

--- a/test/fail_compilation/fail9413.d
+++ b/test/fail_compilation/fail9413.d
@@ -40,7 +40,7 @@ in
         s = 10; // err
         a = 1;  // OK
     }
-    body
+    do
     {
         x = 10; // err
         y = 1;  // OK
@@ -68,7 +68,7 @@ out(r)
         s = 10; // err
         a = 1;  // OK
     }
-    body
+    do
     {
         x = 10; // err
         r = 10; // err
@@ -79,7 +79,7 @@ out(r)
     x = 10; // err
     r = 10; // err
 }
-body
+do
 {
     return 1;
 }

--- a/test/fail_compilation/fail9414a.d
+++ b/test/fail_compilation/fail9414a.d
@@ -42,7 +42,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             y = 1;  // OK
@@ -70,7 +70,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             r = 10; // err
@@ -81,7 +81,7 @@ class C
         x = 10; // err
         r = 10; // err
     }
-    body
+    do
     {
         return 1;
     }

--- a/test/fail_compilation/fail9414b.d
+++ b/test/fail_compilation/fail9414b.d
@@ -42,7 +42,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             y = 1;  // OK
@@ -70,7 +70,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             r = 10; // err
@@ -81,7 +81,7 @@ class C
         x = 10; // err
         r = 10; // err
     }
-    body
+    do
     {
         return 1;
     }

--- a/test/fail_compilation/fail9414c.d
+++ b/test/fail_compilation/fail9414c.d
@@ -42,7 +42,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             y = 1;  // OK
@@ -70,7 +70,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             r = 10; // err
@@ -81,7 +81,7 @@ class C
         x = 10; // err
         r = 10; // err
     }
-    body
+    do
     {
         return 1;
     }

--- a/test/fail_compilation/fail9414d.d
+++ b/test/fail_compilation/fail9414d.d
@@ -42,7 +42,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             y = 1;  // OK
@@ -70,7 +70,7 @@ class C
             s = 10; // err
             a = 1;  // OK
         }
-        body
+        do
         {
             x = 10; // err
             r = 10; // err
@@ -81,7 +81,7 @@ class C
         x = 10; // err
         r = 10; // err
     }
-    body
+    do
     {
         return 1;
     }

--- a/test/fail_compilation/fail_scope.d
+++ b/test/fail_compilation/fail_scope.d
@@ -86,7 +86,7 @@ char* fail141()
 
 int[] test1313b()
 out{}
-body
+do
 {
     int[2] a;
     return a;
@@ -94,7 +94,7 @@ body
 
 int[] test1313a()
 //out{}
-body
+do
 {
     int[2] a;
     return a;
@@ -142,4 +142,3 @@ ref foo16226(ref int bar) @safe
 {
     return bar;
 }
-

--- a/test/fail_compilation/issue19325.d
+++ b/test/fail_compilation/issue19325.d
@@ -1,0 +1,19 @@
+/* REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/issue19325.d(11): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+fail_compilation/issue19325.d(12): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+fail_compilation/issue19325.d(13): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+fail_compilation/issue19325.d(16): Deprecation: Usage of the `body` keyword is deprecated. Use `do` instead.
+---
+*/
+
+void foo () in {} body {}
+class Foo { void foo() in {} body {} }
+void bar() out {} body {
+    void fun (void* ptr)
+        in(ptr !is null)
+        body {
+            int body;
+        }
+}

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -348,7 +348,7 @@ class B12 : A12
     {
         printf("B12.clone()\n");
     }
-    body
+    do
     {
         return ia;
     }
@@ -402,7 +402,7 @@ class B13 : A13
     {
         printf("B13.clone()\n");
     }
-    body { return ia; }
+    do { return ia; }
 }
 
 void test13()

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2546,7 +2546,7 @@ class App15422(T)
     this() {}
 
     auto test1(T val)
-    in {} body      // necessary to reproduce the crash
+    in {} do      // necessary to reproduce the crash
     {
         struct Foo
         {

--- a/test/runnable/test23.d
+++ b/test/runnable/test23.d
@@ -769,7 +769,7 @@ in
 
     checkParameters();
 }
-body
+do
 {
 }
 

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -2268,7 +2268,7 @@ void test140()
 class Foo141 {
     Foo141 next;
     void start()
-    in { assert (!next); } body
+    in { assert (!next); } do
     {
         void* p = cast(void*)this;
     }
@@ -3673,7 +3673,7 @@ class A221 : B221
 {
     final override I221 sync()
     in { assert( valid ); }
-    body
+    do
     {
         return null;
     }
@@ -3683,7 +3683,7 @@ class B221 : J221
 {
     override I221 sync()
     in { assert( valid ); }
-    body
+    do
     {
         return null;
     }
@@ -6496,4 +6496,3 @@ int main()
     printf("Success\n");
     return 0;
 }
-

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -459,7 +459,7 @@ in
 out (result)
 {
 }
-body
+do
 {   int i = 5;
 
     while (i)

--- a/test/runnable/testassign.d
+++ b/test/runnable/testassign.d
@@ -446,12 +446,12 @@ void test6174c()
     static assert(!is(typeof({
         int func1a(int n)
         in{ n = 10; }
-        body { return n; }
+        do { return n; }
     })));
     static assert(!is(typeof({
         int func1b(int n)
         out(r){ r = 20; }
-        body{ return n; }
+        do{ return n; }
     })));
 
     struct DataX
@@ -461,13 +461,13 @@ void test6174c()
     static assert(!is(typeof({
         DataX func2a(DataX n)
         in{ n.x = 10; }
-        body { return n; }
+        do { return n; }
     })));
     static assert(!is(typeof({
         DataX func2b(DataX n)
         in{}
         out(r){ r.x = 20; }
-        body{ return n; }
+        do{ return n; }
     })));
 }
 
@@ -722,7 +722,7 @@ struct S9077b
 immutable(int)[] bar9140()
 out(result) {
     foreach (ref r; result) {}
-} body {
+} do {
     return null;
 }
 

--- a/test/runnable/testdstress.d
+++ b/test/runnable/testdstress.d
@@ -28,7 +28,7 @@ void test1()
                 assert(1);
         }out (result){
                 assert(result.i==1);
-        }body{
+        }do{
                 MyStruct s;
                 s.i = 1;
                 return s;
@@ -42,7 +42,7 @@ void foo2()
 in{
         assert(0);
 }
-body{
+do{
 }
 
 void test2()

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -5260,7 +5260,7 @@ public:
     {
         assert(isHage);
     }
-    body { }
+    do { }
 }
 
 class Child6859 : Parent6859


### PR DESCRIPTION
The 'do' keyword has been supported since 2.075.0,
so we can safely deprecate 'body' now.