### PR TITLE
Fix C++ mangling of argument packs

### DIFF
--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -505,11 +505,13 @@ private final class CppMangleVisitor : Visitor
              * <template-arg> ::= <type>               # type or template
              *                ::= X <expression> E     # expression
              *                ::= <expr-primary>       # simple expressions
-             *                ::= I <template-arg>* E  # argument pack
+             *                ::= J <template-arg>* E  # argument pack
+             *
+             * Reference: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.template-arg
              */
             if (TemplateTupleParameter tt = tp.isTemplateTupleParameter())
             {
-                buf.writeByte('I');     // argument pack
+                buf.writeByte('J');     // argument pack
 
                 // mangle the rest of the arguments as types
                 foreach (j; i .. (*ti.tiargs).dim)

--- a/test/runnable/cpp_abi_tests.d
+++ b/test/runnable/cpp_abi_tests.d
@@ -32,6 +32,12 @@ extern(C++, `std`)
     struct test19248 {int a = 34;}
 }
 
+struct SPack(Args...)
+{
+    int i;
+}
+alias SInt = SPack!int;
+
 bool   passthrough(bool   value);
 byte   passthrough(byte   value);
 ubyte  passthrough(ubyte  value);
@@ -50,6 +56,7 @@ double passthrough(double value);
 S      passthrough(S      value);
 test19248 passthrough(const(test19248) value);
 std.test19248_ passthrough(const(std.test19248_) value);
+SInt   passthrough(SInt   value);
 
 bool   passthrough_ptr(bool   *value);
 byte   passthrough_ptr(byte   *value);
@@ -69,6 +76,7 @@ double passthrough_ptr(double *value);
 S      passthrough_ptr(S      *value);
 test19248 passthrough_ptr(const(test19248)* value);
 std.test19248_ passthrough_ptr(const(std.test19248_)* value);
+SInt   passthrough_ptr(SInt   *value);
 
 bool   passthrough_ref(ref bool   value);
 byte   passthrough_ref(ref byte   value);
@@ -88,6 +96,7 @@ double passthrough_ref(ref double value);
 S      passthrough_ref(ref S      value);
 test19248 passthrough_ref(ref const(test19248) value);
 std.test19248_ passthrough_ref(ref const(std.test19248_) value);
+SInt   passthrough_ref(ref SInt   value);
 }
 
 template IsSigned(T)
@@ -230,6 +239,7 @@ else
     check(S());
     check(test19248());
     check(std.test19248_());
+    check(SInt());
 
     assert(constFunction1(null, null) == 1);
     assert(constFunction2(null, null) == 2);

--- a/test/runnable/extra-files/cpp_abi_tests.cpp
+++ b/test/runnable/extra-files/cpp_abi_tests.cpp
@@ -26,6 +26,18 @@ struct S18784
 
 S18784::S18784(int n) : i(n) {}
 
+#ifdef __DMC__ // DMC doesn't support c++11
+template <class>
+#else
+template <class...>
+#endif
+struct SPack
+{
+    int i;
+};
+
+typedef SPack<int> SInt;
+
 bool               passthrough(bool                value)     { return value; }
 signed char        passthrough(signed char         value)     { return value; }
 unsigned char      passthrough(unsigned char       value)     { return value; }
@@ -48,6 +60,7 @@ double             passthrough(double              value)     { return value; }
 S                  passthrough(S                   value)     { return value; }
 std::test19248     passthrough(const std::test19248 value)    { return value; }
 std::test19248_    passthrough(const std::test19248_ value)   { return value; }
+SInt               passthrough(SInt value)              { return value; }
 
 bool               passthrough_ptr(bool               *value) { return *value; }
 signed char        passthrough_ptr(signed char        *value) { return *value; }
@@ -71,6 +84,7 @@ double             passthrough_ptr(double             *value) { return *value; }
 S                  passthrough_ptr(S                  *value) { return *value; }
 std::test19248     passthrough_ptr(const std::test19248 *value) { return *value; }
 std::test19248_    passthrough_ptr(const std::test19248_ *value) { return *value; }
+SInt               passthrough_ptr(SInt *value)         { return *value; }
 
 bool               passthrough_ref(bool               &value) { return value; }
 signed char        passthrough_ref(signed char        &value) { return value; }
@@ -94,6 +108,7 @@ double             passthrough_ref(double             &value) { return value; }
 S                  passthrough_ref(S                  &value) { return value; }
 std::test19248     passthrough_ref(const std::test19248 &value) { return value; }
 std::test19248_    passthrough_ref(const std::test19248_ &value) { return value; }
+SInt               passthrough_ref(SInt &value)         { return value; }
 
 namespace ns1
 {


### PR DESCRIPTION
The Itanium specification uses the letter `J` for argument packs not `I`.
[Reference](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangle.template-arg).