### PR TITLE
fix Issue 10100 - Identifiers with double underscores and allMembers

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1454,14 +1454,15 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
             //printf("\t[%i] %s %s\n", i, sm.kind(), sm.toChars());
             if (sm.ident)
             {
-                const idx = sm.ident.toChars();
-                if (idx[0] == '_' &&
-                    idx[1] == '_' &&
-                    sm.ident != Id.ctor &&
-                    sm.ident != Id.dtor &&
-                    sm.ident != Id.__xdtor &&
-                    sm.ident != Id.postblit &&
-                    sm.ident != Id.__xpostblit)
+                // https://issues.dlang.org/show_bug.cgi?id=10096
+                // https://issues.dlang.org/show_bug.cgi?id=10100
+                // Skip over internal members in __traits(allMembers)
+                if ((sm.isCtorDeclaration() && sm.ident != Id.ctor) ||
+                    (sm.isDtorDeclaration() && sm.ident != Id.dtor) ||
+                    (sm.isPostBlitDeclaration() && sm.ident != Id.postblit) ||
+                    sm.isInvariantDeclaration() ||
+                    sm.isUnitTestDeclaration())
+
                 {
                     return 0;
                 }

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1248,14 +1248,35 @@ struct S10096X
     invariant() {}
     invariant() {}
     unittest {}
+    unittest {}
 
     this(int) {}
     this(this) {}
     ~this() {}
+
+    string getStr() in(str) out(r; r == str) { return str; }
 }
 static assert(
     [__traits(allMembers, S10096X)] ==
-    ["str", "__ctor", "__postblit", "__dtor", "__xdtor", "__xpostblit", "opAssign"]);
+    ["str", "__ctor", "__postblit", "__dtor", "getStr", "__xdtor", "__xpostblit", "opAssign"]);
+
+class C10096X
+{
+    string str;
+
+    invariant() {}
+    invariant() {}
+    unittest {}
+    unittest {}
+
+    this(int) {}
+    ~this() {}
+
+    string getStr() in(str) out(r; r == str) { return str; }
+}
+static assert(
+    [__traits(allMembers, C10096X)] ==
+    ["str", "__ctor", "__dtor", "getStr", "__xdtor", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]);
 
 // --------
 
@@ -1552,6 +1573,21 @@ void testIsDisabled()
     static assert(!__traits(isDisabled, D1.false_));
     static assert(!__traits(isDisabled, D1));
 }
+
+/********************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=10100
+
+enum E10100
+{
+    value,
+    _value,
+    __value,
+    ___value,
+    ____value,
+}
+static assert(
+    [__traits(allMembers, E10100)] ==
+    ["value", "_value", "__value", "___value", "____value"]);
 
 /********************************************************/
 


### PR DESCRIPTION
Convert the identifier whitelist into a blacklist of all possible internal D language declarations.