### PR TITLE
Fix Issue 20474 - Deprecation warnings inside deprecated function template

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -1338,6 +1338,11 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         // Set up scope for parameters
         Scope* paramscope = scopeForTemplateParameters(ti,sc);
 
+        // Mark the parameter scope as deprecated if the templated
+        // function is deprecated (since paramscope.enclosing is the
+        // calling scope already)
+        paramscope.stc |= fd.storage_class & STC.deprecated_;
+
         TemplateTupleParameter tp = isVariadic();
         Tuple declaredTuple = null;
 
@@ -2187,6 +2192,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
             sc2.parent = ti;
             sc2.tinst = ti;
             sc2.minst = sc.minst;
+            sc2.stc |= fd.storage_class & STC.deprecated_;
 
             fd = doHeaderInstantiation(ti, sc2, fd, tthis, fargs);
 

--- a/test/fail_compilation/deprecations.d
+++ b/test/fail_compilation/deprecations.d
@@ -1,0 +1,65 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/deprecations.d(42): Deprecation: struct `deprecations.S` is deprecated
+fail_compilation/deprecations.d(63): Error: template instance `deprecations.otherPar!()` error instantiating
+fail_compilation/deprecations.d(54): Deprecation: struct `deprecations.S` is deprecated
+fail_compilation/deprecations.d(54): Deprecation: struct `deprecations.S` is deprecated
+fail_compilation/deprecations.d(64): Error: template instance `deprecations.otherVar!()` error instantiating
+---
+
+https://issues.dlang.org/show_bug.cgi?id=20474
+*/
+
+deprecated struct S {}
+
+deprecated void foo()(S par) if (is(S == S))
+{
+    S var;
+}
+
+deprecated template bar()  if (is(S == S))
+{
+    void bar(S par)
+    {
+        S var;
+    }
+}
+
+deprecated void foobar (T) (T par)  if (is(T == S))
+{
+    T inst;
+}
+
+template otherPar()
+{
+    deprecated void otherPar(S par)
+    {
+        S var;
+    }
+
+    void par(S par) {}
+}
+
+template otherVar()
+{
+    deprecated void otherVar(S par)
+    {
+        S var;
+    }
+
+    void var()
+    {
+        S var;
+    }
+}
+
+deprecated void main()
+{
+    foo(S.init);
+    bar(S.init);
+    foobar(S.init);
+    otherPar(S.init);
+    otherVar(S.init);
+}


### PR DESCRIPTION
The scopes used for evaluating the parameters and body were never marked as deprecated.