### PR TITLE
Disable `make install` for the Darwin_64_32 target on the auto-tester

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -44,11 +44,16 @@ tags: posix.mak $(ECTAGS_FILES)
 	ctags --sort=yes --links=no --excmd=number --languages=$(ECTAGS_LANGS) \
 		--langmap='C++:+.c,C++:+.h' --extra=+f --file-scope=yes --fields=afikmsSt --totals=yes posix.mak $(ECTAGS_FILES)
 
+ifneq (,$(findstring Darwin_64_32, $(PWD)))
+install:
+	echo "Darwin_64_32_disabled"
+else
 install: all
 	$(MAKE) INSTALL_DIR=$(INSTALL_DIR) -C src -f posix.mak install
 	cp -r samples $(INSTALL_DIR)
 	mkdir -p $(INSTALL_DIR)/man
 	cp -r docs/man/* $(INSTALL_DIR)/man/
+endif
 
 # Checks that all files have been committed and no temporary, untracked files exist.
 # See: https://github.com/dlang/dmd/pull/7483


### PR DESCRIPTION
OSX 32 bits builds and tests were disabled on the auto-tester but `make install` was still being run and sometimes hangs to at most an hour for obscure reasons.

Recent history of DMD master on the auto-tester Darwin_64_32 target: [link](https://auto-tester.puremagic.com/platform-history.ghtml?projectid=1&os=Darwin_64_32).
`make install` passing: [link](https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=175845&dataid=1221426).
`make install` hanging: [link](https://auto-tester.puremagic.com/show-run.ghtml?projectid=1&runid=175767&dataid=1220861).

The script that builds dmd on the auto-tester appears to be this one: [link](https://github.com/braddr/at-client/blob/8a2a2743716fcfde13d5ab0856bd4b5a0e403851/src/do_build_dmd.sh#L38-L50).