### PR TITLE
fix Issue 20475 - Struct of static array of strings is bitwise-compar…

### DIFF
--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -423,18 +423,18 @@ bool needOpEquals(StructDeclaration sd)
             if (ts.sym.aliasthis) // https://issues.dlang.org/show_bug.cgi?id=14806
                 goto Lneed;
         }
-        if (tv.isfloating())
+        if (tvbase.isfloating())
         {
             // This is necessray for:
             //  1. comparison of +0.0 and -0.0 should be true.
             //  2. comparison of NANs should be false always.
             goto Lneed;
         }
-        if (tv.ty == Tarray)
+        if (tvbase.ty == Tarray)
             goto Lneed;
-        if (tv.ty == Taarray)
+        if (tvbase.ty == Taarray)
             goto Lneed;
-        if (tv.ty == Tclass)
+        if (tvbase.ty == Tclass)
             goto Lneed;
     }
 Ldontneed:
@@ -744,18 +744,18 @@ private bool needToHash(StructDeclaration sd)
             if (ts.sym.aliasthis) // https://issues.dlang.org/show_bug.cgi?id=14948
                 goto Lneed;
         }
-        if (tv.isfloating())
+        if (tvbase.isfloating())
         {
             /* This is necessary because comparison of +0.0 and -0.0 should be true,
              * i.e. not a bit compare.
              */
             goto Lneed;
         }
-        if (tv.ty == Tarray)
+        if (tvbase.ty == Tarray)
             goto Lneed;
-        if (tv.ty == Taarray)
+        if (tvbase.ty == Taarray)
             goto Lneed;
-        if (tv.ty == Tclass)
+        if (tvbase.ty == Tclass)
             goto Lneed;
     }
 Ldontneed:

--- a/test/runnable/opover.d
+++ b/test/runnable/opover.d
@@ -1097,8 +1097,24 @@ void test1547()
 {
     fun();
 }
-/**************************************/
 
+/**************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20475
+struct S20475
+{
+    string[2] x;
+}
+
+void test20475()
+{
+    auto s = S20475(["abc", "bcd"]);
+    auto t = S20475(["abc", ""]);
+    string u = "abcd";
+    t.x[1] = u[1..$];
+    assert(s == t);
+}
+
+/**************************************/
 int main()
 {
     test1();
@@ -1124,6 +1140,7 @@ int main()
     test4993();
     test8133();
     test8522();
+    test20475();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
…ed instead of member-wise

needOpEquals should check the type of the elements of static arrays, too.