### PR TITLE
build.d: Improve dscanner target & bump version to 0.7.2

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -472,16 +472,13 @@ alias style = makeRule!((builder, rule)
         .commandFunction(()
         {
             const git = env["GIT"];
-            run([git, "clone", "https://github.com/dlang-community/Dscanner", dscannerDir]);
-            run([git, "-C", dscannerDir, "checkout", "b51ee472fe29c05cc33359ab8de52297899131fe"]);
-            run([git, "-C", dscannerDir, "submodule", "update", "--init", "--recursive"]);
+            // FIXME: Omitted --shallow-submodules because  it errors for libdparse
+            run([git, "clone", "--depth=1", "--recurse-submodules", "--branch=v0.7.2",
+                "https://github.com/dlang-community/Dscanner", dscannerDir]);
 
-            // debug build is faster, but disable 'missing import' messages (missing core from druntime)
-            const makefile = dscannerDir.buildPath("makefile");
-            const content = readText(makefile);
-            File(makefile, "w").lockingTextWriter.replaceInto(content, "dparse_verbose", "StdLoggerDisableWarning");
-
-            run([env.get("MAKE", "make"), "-C", dscannerDir, "githash", "debug"]);
+            // debug build is faster but disable trace output
+            run([env.get("MAKE", "make"), "-C", dscannerDir, "debug",
+                "DEBUG_VERSIONS=-version=StdLoggerDisableWarning"]);
         })
     );
 


### PR DESCRIPTION
Improves performance & size of the D-Scanner target:
- Combine multiple invocations of git
- Reduce history depth to the required revision
- Pass DEBUG_VERSIONS variable to make instead of patching the makefile

D-Scanner was bumped to 0.7.2 because --branch accepts tags but not individual
commits. The current version 0.8.0 cannot be used currently because of a bug
in dparse which results in error messages in backend/ptrntab.d