### PR TITLE
build.d: Upgrade D-Scanner to 0.8.0

### DIFF
--- a/src/.dscanner.ini
+++ b/src/.dscanner.ini
@@ -22,7 +22,9 @@ backwards_range_check="enabled"
 if_else_same_check="enabled"
 ; Checks for some problems with constructors
 constructor_check="enabled"
-; Checks for unused variables and function parameters
+; Checks for unused function parameters
+unused_parameter_check="disabled"
+; Checks for unused variables
 unused_variable_check="disabled"
 ; Checks for unused labels
 unused_label_check="enabled"

--- a/src/build.d
+++ b/src/build.d
@@ -468,11 +468,21 @@ alias style = makeRule!((builder, rule)
         .msg("(GIT) DScanner")
         .target(dscannerDir)
         .condition(() => !exists(dscannerDir))
-        .command([
-            // FIXME: Omitted --shallow-submodules because  it errors for libdparse
-            env["GIT"], "clone", "--depth=1", "--recurse-submodules", "--branch=v0.7.2",
-            "https://github.com/dlang-community/Dscanner", dscannerDir
-        ])
+        // .command([
+        //     // FIXME: Omitted --shallow-submodules because  it errors for libdparse
+        //     env["GIT"], "clone", "--depth=1", "--recurse-submodules", "--branch=v0.8.0",
+        //     "https://github.com/dlang-community/Dscanner", dscannerDir
+        // ])
+        .commandFunction(()
+        {
+            const git = env["GIT"];
+            run([git, "clone", "--depth=15", "--recurse-submodules", "--branch=v0.8.0",
+                "https://github.com/dlang-community/Dscanner", dscannerDir]);
+
+            // TODO: Remove this temporary fix for the invalid error messages in
+            // backend/ptrtab.d when D-Scanner upgrades DParse
+            run([git, "-C", dscannerDir.buildPath("libdparse"), "checkout", "63559db5cc6fa38c01bdda36e09638b5f20fb8e5"]);
+        })
     );
 
     alias dscanner = methodInit!(BuildRule, (dscannerBuilder, dscannerRule) {


### PR DESCRIPTION
~~Includes #10712~~

~~`.dscanner_issue372.patch` is a temporary workaround for a regression in `dparse` which raises errors in `backend/ptrntab.d`. I'll remove this file once the fix is included in D-Scanner and change the tag appropriatly.~~