### PR TITLE
 D-Scanner: Enable check for unused variables

### DIFF
--- a/src/.dscanner.ini
+++ b/src/.dscanner.ini
@@ -25,7 +25,7 @@ constructor_check="enabled"
 ; Checks for unused function parameters
 unused_parameter_check="disabled"
 ; Checks for unused variables
-unused_variable_check="disabled"
+unused_variable_check="enabled"
 ; Checks for unused labels
 unused_label_check="enabled"
 ; Checks for duplicate attributes
@@ -118,3 +118,4 @@ trust_too_much="-dmd.root.longdouble"
 builtin_property_names_check="-dmd.backend.obj,-dmd.backend.code,-dmd.backend.cc"
 object_const_check="-dmd.dtemplate,-dmd.backend.outbuf"
 enum_array_literal_check="-dmd.backend.oper,-dmd.backend.var"
+unused_variable_check="-dmd.backend.aarray,-dmd.backend.blockopt,-dmd.backend.cg,-dmd.backend.cg87,-dmd.backend.cgelem,-dmd.backend.cgobj,-dmd.backend.cgsched,-dmd.backend.cgxmm,-dmd.backend.cod1,-dmd.backend.cod2,-dmd.backend.cod3,-dmd.backend.dcgcv,-dmd.backend.dout,-dmd.backend.dwarfdbginf,-dmd.backend.elfobj,-dmd.backend.elpicpie,-dmd.backend.gother,-dmd.backend.gsroa,-dmd.backend.machobj,-dmd.backend.mscoffobj,-dmd.backend.newman,-dmd.backend.symbol,-dmd.dinterpret,-dmd.dmangle,-dmd.dsymbolsem,-dmd.dtemplate,-dmd.dump,-dmd.e2ir,-dmd.libmscoff,-dmd.mars,-dmd.ob,-dmd.objc_glue,-dmd.root.longdouble,-dmd.semantic2,-dmd.tocvdebug"

--- a/src/dmd/backend/blockopt.d
+++ b/src/dmd/backend/blockopt.d
@@ -10,6 +10,7 @@
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/backend/blockopt.d
  */
 
+module dmd.backend.blockopt;
 
 /****************************************************************
  * Handle basic blocks.


### PR DESCRIPTION
~~Includes #10713~~

 D-Scanner revealed 107 unused variables (minus some invalid warnings caused by dlang-community/d-scanner#788)