### PR TITLE
Add -transition-safe to list implicit @system functions

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -711,6 +711,8 @@ dmd -cov -unittest myprog.d
             "list all variables going into thread local storage"),
         Feature("vmarkdown", "vmarkdown",
             "list instances of Markdown replacements in Ddoc"),
+        Feature("safe", "showSystem",
+            "list implicit `@system` functions which won't compile with `-preview=safedefault`"),
     ];
 
     /// Returns all available reverts

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -160,6 +160,7 @@ enum FUNCFLAG : uint
     inferScope       = 0x40,   /// infer 'scope' for parameters
     hasCatches       = 0x80,   /// function has try-catch statements
     compileTimeOnly  = 0x100,  /// is a compile time only function; no code will be generated for it
+    warnedSystem     = 0x200,  /// Was already reported as un-@safe without explicit @sytem
 }
 
 /***********************************************************
@@ -1419,6 +1420,14 @@ extern (C++) class FuncDeclaration : Declaration
         }
         else if (isSafe())
             return true;
+        else if (global.params.showSystem &&
+                 type.toTypeFunction().trust == TRUST.default_ &&
+                 !(flags & FUNCFLAG.warnedSystem))
+        {
+            flags |= FUNCFLAG.warnedSystem;
+            message(loc, "function `%s` is implicitly `@system` but not marked as `@system`", toPrettyChars());
+        }
+
         return false;
     }
 

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -187,6 +187,7 @@ extern (C++) struct Param
 
     bool markdown;          // enable Markdown replacements in Ddoc
     bool vmarkdown;         // list instances of Markdown replacements in Ddoc
+    bool showSystem;        // List implicit @system functions not marked as @system
 
     bool showGaggedErrors;  // print gagged errors anyway
     bool printErrorContext;  // print errors with the error context (the error line in the source file)

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -153,6 +153,7 @@ struct Param
     CppStdRevision cplusplus;  // version of C++ name mangling to support
     bool markdown;          // enable Markdown replacements in Ddoc
     bool vmarkdown;         // list instances of Markdown replacements in Ddoc
+    bool showSystem;        // List implicit @system functions not marked as @system
     bool showGaggedErrors;  // print gagged errors anyway
     bool printErrorContext;  // print errors with the error context (the error line in the source file)
     bool manual;            // open browser on compiler manual

--- a/test/compilable/transitionSafe.d
+++ b/test/compilable/transitionSafe.d
@@ -1,0 +1,70 @@
+// REQUIRED_ARGS: -transition=safe
+/*
+TEST_OUTPUT:
+---
+compilable/transitionSafe.d(15): function `transitionSafe.pointers` is implicitly `@system` but not marked as `@system`
+compilable/transitionSafe.d(27): function `transitionSafe.implicitUnsafe` is implicitly `@system` but not marked as `@system`
+---
+*/
+
+extern(C) void main() @safe
+{
+    call();
+}
+
+void pointers()
+{
+    int* ip = cast(int*) (void*).init;
+    char* cp = cast(char*) 2;
+    ip++;
+}
+
+void implicitSafe()
+{
+    call();
+}
+
+void implicitUnsafe()
+{
+    pointers();
+}
+
+void unions() @system
+{
+    static union U {
+        int a;
+        int* b;
+    }
+    *U.init.b = 2;
+}
+
+void call() @trusted
+{
+    pointers();
+    catchThrowable();
+    inlineAsm();
+    qualifiers();
+}
+
+void catchThrowable()()
+{
+    try {}
+    catch (Throwable) {}
+
+    int* ptr = cast(int*) 2;
+}
+
+void inlineAsm()() @system
+{
+    asm {
+        nop;
+    }
+}
+
+void qualifiers()() @trusted
+{
+    immutable int* imip;
+    int* mip = cast(int*) imip;
+    shared(int)* sip = cast(shared) mip;
+    mip = cast(int*) sip;
+}


### PR DESCRIPTION
Disclaimer: This is primarily a PoC and could probably be improved

This flag should ease the transition to `@safe` by default by highlighting all
functions that contain un-`@safe` operations and hence would stop compiling with
the new default.

Known issues:

- Flags code in DRuntime, most notably the `extern(C) int int main(int argc, char **argv)` in `entrypoint.d`
- Does not list WHY the function is `@system` (this would require to forward the expression to `setUnsafe()` )