### PR TITLE
Fix issue 20488: opDispatch: copy call expression before checking for semantically valid parameters

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -535,10 +535,6 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
         }
         else
         {
-            // even opDispatch and ufcs must have valid arguments.
-            if (arrayExpressionSemantic(ce.arguments, sc))
-                return new ErrorExp();
-
             if (Expression ey = die.semanticY(sc, 1))
             {
                 if (ey.op == TOK.error)
@@ -550,6 +546,15 @@ private Expression resolveUFCS(Scope* sc, CallExp ce)
                     e = ce.syntaxCopy().expressionSemantic(sc);
                     if (!global.endGagging(errors))
                         return e;
+
+                    // even opDispatch and UFCS must have valid arguments,
+                    // so now that we've seen indication of a problem,
+                    // check them for issues.
+                    Expressions* originalArguments = Expression.arraySyntaxCopy(ce.arguments);
+
+                    if (arrayExpressionSemantic(originalArguments, sc))
+                        return new ErrorExp();
+
                     /* fall down to UFCS */
                 }
                 else

--- a/test/compilable/test20488.d
+++ b/test/compilable/test20488.d
@@ -1,0 +1,11 @@
+module test20488;
+
+// https://issues.dlang.org/show_bug.cgi?id=20488
+struct Bar {
+    void opDispatch(string s, Args...) (Args args) {
+    }
+    void fun() {
+        (bool[int]).init.length;
+        this.f((int[int]).init.length);
+    }
+}


### PR DESCRIPTION
This may avoid accidentally resolving future occurrences to the wrong type, not sure.
Fixes issue 20488.
This relates to my PR from August 18 regarding invalid opDispatch parameters being a first-line syntax error rather than a (silent) opDispatch failure: https://github.com/dlang/dmd/pull/8584 .

Somehow the `opDispatch` call ends up using the `_aaLen` from the `bool[int]` case? I don't fully understand what happens here, but we need to clone the `CallExp` anyway, so just doing it before the semantic check on the arguments is probably the way to go.