### PR TITLE
fix Issue 20391 - [REG 2.089] DMD compile times increased by 40% beca…

### DIFF
--- a/src/win32.mak
+++ b/src/win32.mak
@@ -121,8 +121,8 @@ debdmd-make:
 
 reldmd: check-host-dc reldmd-make
 
-reldmd-make:
-	$(DMDMAKE) "DDEBUG=" "DOPT=-O -release -inline" $(TARGETEXE)
+reldmd-make: $(GEN)\build.exe
+	$(RUN_BUILD) "DDEBUG=" "ENABLE_RELEASE=1" $(TARGETEXE)
 
 profile:
 	$(DMDMAKE) "DDEBUG=" "DOPT=-O -release -profile" $(TARGETEXE)


### PR DESCRIPTION
…use ENABLE_RELEASE=0 in build

build release with ENABLE_RELEASE=1

The release uses target "dmd" to build dmd.exe.

The other nearby targets profile and trace probably don't work, too, but leave that for another PR.