### PR TITLE
[WIP] Fix issue 20460: Stack traces involving extern(C++) can show wrong file/line

### DIFF
--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -1413,10 +1413,6 @@ static if (ELFOBJ)
                     debug_line.buf.writeByte(DW_LNS_copy);
             }
 
-            // Write DW_LNS_advance_pc to cover the function prologue
-            debug_line.buf.writeByte(DW_LNS_advance_pc);
-            debug_line.buf.writeuLEB128(cast(uint)(sd.SDbuf.size() - address));
-
             // Write DW_LNE_end_sequence
             debug_line.buf.writeByte(0);
             debug_line.buf.writeByte(1);

--- a/test/runnable/imports/stacktrace1.d
+++ b/test/runnable/imports/stacktrace1.d
@@ -1,0 +1,3 @@
+module stacktrace1;
+
+extern(C++) void func() {}

--- a/test/runnable/imports/stacktrace2.d
+++ b/test/runnable/imports/stacktrace2.d
@@ -1,0 +1,9 @@
+module stacktrace2;
+
+extern(C++) class Foo
+{
+    void bar()
+    {
+        throw new Exception("Hello");
+    }
+}

--- a/test/runnable/stack_trace.d
+++ b/test/runnable/stack_trace.d
@@ -1,0 +1,26 @@
+// REQUIRED_ARGS: -g
+// EXTRA_SOURCES: imports/stacktrace1.d imports/stacktrace2.d
+
+import stacktrace2;
+
+/*
+  Error looks like:
+  core.exception.AssertError@runnable/imports/stacktrace2.d(7): Assertion failure
+  ----------------
+  ??:? _d_assertp [0x103c21831]
+  runnable/imports/stacktrace2.d:7 _ZN3Foo3barEv [0x10d17a874]
+  runnable/stack_trace.d:19 _Dmain [0x103c14821]
+ */
+
+void main ()
+{
+    try {
+        scope o = new Foo;
+        o.bar();
+    }  catch (Exception e) {
+        import std.algorithm : canFind;
+        immutable str = e.toString();
+        assert(!str.canFind("stacktrace1.d"));
+        assert( str.canFind("stacktrace2.d:7 _ZN3Foo3barEv"));
+    }
+}


### PR DESCRIPTION
```
The comment mentions writing the 'function prologue',
but this seems to be a long-gone heritage (perhaps from DM exceptions?)
Before this change, some functions would have their 'end' address
set at the end of the next file's last function,
which in practice would mean that the last function in the module
would 'eat' the whole file, and all the stack traces would point
to the same line.
This was witnessed with extern(C++) and the _Dmain function.
```

Using the auto-tester to see if this breaks anything, as I couldn't figure out what the "function prologue" refers too. I am however sure the calculation is the source of my issues, as explained below.

Before this fix, the following debug infos would be generated on MacOSX:
```
  Address            Line   Column File   ISA Discriminator Flags
  ------------------ ------ ------ ------ --- ------------- -------------
  0x0000000100001520      6      0      3   0             0  is_stmt
  0x0000000100001528      8      0      3   0             0  is_stmt
  0x0000000100001538      9      0      3   0             0  is_stmt
  0x0000000100001543     10      0      3   0             0  is_stmt
* 0x000000010000156c     10      0      3   0             0  is_stmt end_sequence
  0x0000000100001548     32      0      4   0             0  is_stmt
  0x0000000100001557     34      0      4   0             0  is_stmt
  0x000000010000156a     35      0      4   0             0  is_stmt
* 0x000000010000156c     35      0      4   0             0  is_stmt end_sequence
  0x000000010000156c      5      0      1   0             0  is_stmt
  0x0000000100001570      7      0      1   0             0  is_stmt
  0x0000000100001575      8      0      1   0             0  is_stmt
* 0x00000001000015b3      8      0      1   0             0  is_stmt end_sequence
  0x000000010000157c      5      0      2   0             0  is_stmt
  0x000000010000159c      8      0      2   0             0  is_stmt
  0x00000001000015a0     10      0      2   0             0  is_stmt
  0x00000001000015b1     11      0      2   0             0  is_stmt
* 0x00000001000015b3     11      0      2   0             0  is_stmt end_sequence

file_names[  1]:
           name: "b.d"
      dir_index: 0
       mod_time: 0x00000000
         length: 0x00000000
file_names[  2]:
           name: "c.d"
      dir_index: 0
       mod_time: 0x00000000
         length: 0x00000000
file_names[  3]:
           name: "a.d"
      dir_index: 0
       mod_time: 0x00000000
         length: 0x00000000
file_names[  4]:
           name: "/Users/geod24/projects/dlang/install/osx/bin/../../src/druntime/import/core/internal/entrypoint.d"
      dir_index: 0
       mod_time: 0x00000000
         length: 0x00000000
```

Little `*` added for emphasis.
In order to find location informations, DWARF runs a stack machine, which stops at the first match (in druntime). The output for the previous program would be:
```
./a.out
core.exception.AssertError@c.d(5): Assertion failure
----------------new debug program
file: b.d
file: c.d
file: a.d
file: /Users/geod24/projects/dlang/install/osx/bin/../../src/druntime/import/core/internal/entrypoint.d
file: b.d
file: c.d
file: a.d
file: /Users/geod24/projects/dlang/install/osx/bin/../../src/druntime/import/core/internal/entrypoint.d
program:
setAddress 0xdab520
setFile to 3
special 0 5 to 0xdab520 line 6
-- offsetting 0xdab520 to 0xdab520
special 8 2 to 0xdab528 line 8
-- offsetting 0xdab528 to 0xdab528
special 16 1 to 0xdab538 line 9
-- offsetting 0xdab538 to 0xdab538
special 11 1 to 0xdab543 line 10
-- offsetting 0xdab543 to 0xdab543
-- found for [0xdab540]:
--   file: a.d
--   line: 9
advancePC 41 to 0xdab56c
endSequence 0xdab56c
-- offsetting 0xdab56c to 0xdab56c
-- found for [0xdab569]:
--   file: a.d
--   line: 10
***********************
setAddress 0xdab520
setFile to 4
advanceLine 31 to 32
advancePC 40 to 0xdab548
copy 0xdab548
-- offsetting 0xdab548 to 0xdab548
special 15 2 to 0xdab557 line 34
-- offsetting 0xdab557 to 0xdab557
advanceLine 1 to 35
advancePC 19 to 0xdab56a
copy 0xdab56a
-- offsetting 0xdab56a to 0xdab56a
advancePC 2 to 0xdab56c
endSequence 0xdab56c
-- offsetting 0xdab56c to 0xdab56c
setAddress 0xdab56c
setFile to 1
special 0 4 to 0xdab56c line 5
-- offsetting 0xdab56c to 0xdab56c
special 4 2 to 0xdab570 line 7
-- offsetting 0xdab570 to 0xdab570
special 5 1 to 0xdab575 line 8
-- offsetting 0xdab575 to 0xdab575
advancePC 62 to 0xdab5b3
endSequence 0xdab5b3
-- offsetting 0xdab5b3 to 0xdab5b3
-- found for [0xdab598]:
--   file: b.d
--   line: 8
***********************
setAddress 0xdab56c
setFile to 2
special 16 4 to 0xdab57c line 5
-- offsetting 0xdab57c to 0xdab57c
advanceLine 3 to 8
advancePC 32 to 0xdab59c
copy 0xdab59c
-- offsetting 0xdab59c to 0xdab59c
special 4 2 to 0xdab5a0 line 10
-- offsetting 0xdab5a0 to 0xdab5a0
special 17 1 to 0xdab5b1 line 11
-- offsetting 0xdab5b1 to 0xdab5b1
advancePC 2 to 0xdab5b3
endSequence 0xdab5b3
-- offsetting 0xdab5b3 to 0xdab5b3
??:? _d_assertp [0x100db856d]
b.d:8 _ZN3Foo6foobarEv [0x100dab598]
a.d:9 _Dmain [0x100dab540]
```

Once again, `*****` emphasis mine. The program would work its way down the stack, starting with `a.d` which it correctly finds. However, when it reaches the debug info for `b.d:8`, it find the function to spawn the address range [0xdab575; 0xdab5b3], and hence contains the function `Foo.foobar` at address [0xdab598]. However we can see that the following debug info restarts at an earlier address, which is nonsensical.