### PR TITLE
fix Issue 20514 - obj-c info incorrectly placed in __objc_const section

### DIFF
--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -582,7 +582,7 @@ static:
 
         Symbol* symbol = symbol_name("L_OBJC_LABEL_CLASS_$", SCstatic, type_allocn(TYarray, tstypes[TYchar]));
         symbol.Sdt = dtb.finish();
-        symbol.Sseg = Segments[Segments.Id.const_];
+        symbol.Sseg = Segments[Segments.Id.classlist];
         outdata(symbol);
 
         getImageInfo(); // make sure we also generate image info


### PR DESCRIPTION
see https://github.com/dlang/dmd/blob/master/docs/objective-c_abi.md#l_objc_label_class_

it looks like the original code was just a minor mistake; perhaps an auto-complete oversight with the starting c...

I emailed Jacob Carlborg and he agreed that was likely it. Without this fix, defining new classes in D doesn't fully work.