### PR TITLE
Fix Issue 20507 - Debug statements affect inference...

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1240,12 +1240,12 @@ extern (C++) abstract class Expression : ASTNode
             return false;
         if (sc.intypeof == 1)
             return false;
-        if (sc.flags & SCOPE.ctfe)
+        if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
             return false;
 
         if (!f.isSafe() && !f.isTrusted())
         {
-            if (sc.flags & SCOPE.compile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafe() && !(sc.flags & SCOPE.debug_))
+            if (sc.flags & SCOPE.compile ? sc.func.isSafeBypassingInference() : sc.func.setUnsafe())
             {
                 if (!loc.isValid()) // e.g. implicitly generated dtor
                     loc = sc.func.loc;
@@ -1275,12 +1275,12 @@ extern (C++) abstract class Expression : ASTNode
             return false;
         if (sc.intypeof == 1)
             return false;
-        if (sc.flags & SCOPE.ctfe)
+        if (sc.flags & (SCOPE.ctfe | SCOPE.debug_))
             return false;
 
         if (!f.isNogc())
         {
-            if (sc.flags & SCOPE.compile ? sc.func.isNogcBypassingInference() : sc.func.setGC() && !(sc.flags & SCOPE.debug_))
+            if (sc.flags & SCOPE.compile ? sc.func.isNogcBypassingInference() : sc.func.setGC())
             {
                 if (loc.linnum == 0) // e.g. implicitly generated dtor
                     loc = sc.func.loc;

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3365,7 +3365,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 e.error("`%s` is not an expression", e.toChars());
                 return new ErrorExp();
             }
-            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe() && !(sc.flags & SCOPE.debug_))
+            else if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
                 return new ErrorExp();
@@ -3413,7 +3413,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.ptr)
         {
-            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe() && !(sc.flags & SCOPE.debug_))
+            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
             {
                 e.error("`%s.ptr` cannot be used in `@safe` code, use `&%s[0]` instead", e.toChars(), e.toChars());
                 return new ErrorExp();
@@ -3479,7 +3479,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         }
         else if (ident == Id.funcptr)
         {
-            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && sc.func.setUnsafe() && !(sc.flags & SCOPE.debug_))
+            if (!(flag & DotExpFlag.noDeref) && sc.func && !sc.intypeof && !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
             {
                 e.error("`%s.funcptr` cannot be used in `@safe` code", e.toChars());
                 return new ErrorExp();

--- a/test/compilable/debugInference.d
+++ b/test/compilable/debugInference.d
@@ -1,0 +1,55 @@
+/*
+REQUIRED_ARGS: -debug
+TEST_OUTPUT:
+---
+compilable/debugInference.d(35): Deprecation: The `delete` keyword has been deprecated.  Use `object.destroy()` (and `core.memory.GC.free()` if applicable) instead.
+---
+https://issues.dlang.org/show_bug.cgi?id=20507
+*/
+
+// Nothrow is not excluded in debug statements yet
+void main() pure  /* nothrow */ @safe @nogc
+{
+    debug foo();
+    bar!()();
+}
+
+void foo() @system
+{
+    // Just to be sure its neither @nogc, pure or nothrow
+    __gshared int counter = 0;
+
+    if (counter++)
+        throw new Exception(new immutable(char)[counter]);
+}
+
+void bar()()
+{
+    debug {
+        foo();
+
+        auto fPtr = &S.f;
+        auto f2Ptr = &f2;
+
+        S s;
+        delete s;
+
+        int* ptr = cast(int*) 0;
+        int[] slice = ptr[0 .. 4];
+        int val = ptr[1];
+
+        void[] bytes = slice;
+        bytes[] = bytes[];
+
+        scope int n;
+        int* pn = &n;
+    }
+}
+
+class S {
+    void f() @safe {}
+}
+
+ref int f2(return ref int i) {
+    return i;
+}


### PR DESCRIPTION
...of templated functions attributes.

This was caused by marking the function as @system/non-@nogc/non-nothrow BEFORE checking whether the statement is inside an debug statement / block