### PR TITLE
add STCFlowThru constants

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -133,7 +133,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
     Scope* newScope(Scope* sc)
     {
         auto sc2 = sc.push(this);
-        sc2.stc &= STC.safeGroup;
+        sc2.stc &= STCFlowThruAggregate;
         sc2.parent = this;
         sc2.inunion = isUnionDeclaration();
         sc2.protection = Prot(Prot.Kind.public_);

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -264,6 +264,13 @@ enum STCStorageClass =
      STC.immutable_ | STC.shared_ | STC.wild | STC.nothrow_ | STC.nogc | STC.pure_ | STC.ref_ | STC.return_ | STC.tls | STC.gshared |
      STC.property | STC.safeGroup | STC.disable | STC.local);
 
+/* These storage classes "flow through" to the inner scope of a Dsymbol
+ */
+enum STCFlowThruAggregate = STC.safeGroup;    /// for an AggregateDeclaration
+enum STCFlowThruFunction = ~(STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.abstract_ | STC.deprecated_ | STC.override_ |
+                         STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property |
+                         STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system); /// for a FuncDeclaration
+
 /* Accumulator for successive matches.
  */
 struct MatchAccumulator

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -313,9 +313,7 @@ private extern(C++) final class Semantic3Visitor : Visitor
             sc2.sw = null;
             sc2.fes = funcdecl.fes;
             sc2.linkage = LINK.d;
-            sc2.stc &= ~(STC.auto_ | STC.scope_ | STC.static_ | STC.extern_ | STC.abstract_ | STC.deprecated_ | STC.override_ |
-                         STC.TYPECTOR | STC.final_ | STC.tls | STC.gshared | STC.ref_ | STC.return_ | STC.property |
-                         STC.nothrow_ | STC.pure_ | STC.safe | STC.trusted | STC.system);
+            sc2.stc &= STCFlowThruFunction;
             sc2.protection = Prot(Prot.Kind.public_);
             sc2.explicitProtection = 0;
             sc2.aligndecl = null;


### PR DESCRIPTION
It's a bit difficult to find where the "flow through" of attributes is done. This little change makes it easy by adding a couple manifest constants with greppable names.