### PR TITLE
Fix issue 19542:  Forward reference segfault with string namespace C++ syntax

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -5897,6 +5897,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
 
     // Copy the tempdecl namespace (not the scope one)
     tempinst.cppnamespace = tempdecl.cppnamespace;
+    if (tempinst.cppnamespace)
+        tempinst.cppnamespace.dsymbolSemantic(sc);
 
     /* See if there is an existing TemplateInstantiation that already
      * implements the typeargs. If so, just refer to that one instead.

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1237,3 +1237,10 @@ version (Posix)
     static assert(FuncDeclaration_create.mangleof == `_Z22FuncDeclaration_createRK4Loc2S1_`);
     static assert(FuncDeclaration.create.mangleof == `_ZN15FuncDeclaration6createERK4Loc2S2_`);
 }
+
+enum Enum19542 = func19542!(int).mangleof;
+
+extern(C++, `bar`)
+{
+    void func19542(T)();
+}


### PR DESCRIPTION
This segfaulted for some constructs, such as `pragma(msg)` and `enum`,
but not others, such as `static assert`, hence why the value isn't checked.