### PR TITLE
Build build.d with symbols

### DIFF
--- a/src/posix.mak
+++ b/src/posix.mak
@@ -111,7 +111,7 @@ dmd: $(GENERATED)/build
 .PHONY: dmd
 
 $(GENERATED)/build: build.d $(HOST_DMD_PATH)
-	$(HOST_DMD_RUN) -of$@ build.d
+	$(HOST_DMD_RUN) -of$@ -g build.d
 
 auto-tester-build: $(GENERATED)/build
 	$(RUN_BUILD) $@

--- a/src/win32.mak
+++ b/src/win32.mak
@@ -100,7 +100,7 @@ auto-tester-build: $(GEN)\build.exe
 dmd: $G reldmd
 
 $(GEN)\build.exe: build.d $(HOST_DMD_PATH)
-	$(HOST_DC) -m$(MODEL) -of$@ build.d
+	$(HOST_DC) -m$(MODEL) -of$@ -g build.d
 
 release:
 	$(DMDMAKE) clean


### PR DESCRIPTION
Helps debug build issues when build.d crashes.