### PR TITLE
Implement issue 20515: add command line flag to allow selecting GNU message style for errors and warnings.

### DIFF
--- a/changelog/gnu-error-style.dd
+++ b/changelog/gnu-error-style.dd
@@ -1,0 +1,6 @@
+Can now report line numbers in GNU error style
+
+DMD now supports reporting errors and warnings in GNU error style, that is, `filename:line[:column]: message`.
+This may ease compatibility with existing IDEs.
+
+Enable this style by calling DMD with `-verror-style=gnu`.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -641,6 +641,15 @@ dmd -cov -unittest myprog.d
         Option("vcolumns",
             "print character (column) numbers in diagnostics"
         ),
+        Option("verror-style=[digitalmars|gnu]",
+            "set the style for file/line number annotations on compiler messages",
+            `Set the style for file/line number annotations on compiler messages,
+            where:
+            $(DL
+            $(DT digitalmars)$(DD 'file(line[,column]): message'. This is the default.)
+            $(DT gnu)$(DD 'file:line[:column]: message', conforming to the GNU standard used by gcc and clang.)
+            )`,
+        ),
         Option("verrors=<num>",
             "limit the number of error messages (0 means unlimited)"
         ),

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -27,6 +27,13 @@ enum
     DIAGNOSTICoff     // disable diagnostic
 };
 
+typedef unsigned char MessageStyle;
+enum
+{
+    MESSAGESTYLEdigitalmars, // file(line,column): message
+    MESSAGESTYLEgnu,         // file:line:column: message
+};
+
 // The state of array bounds checking
 typedef unsigned char CHECKENABLE;
 enum
@@ -218,6 +225,7 @@ struct Param
 
     DString moduleDepsFile;     // filename for deps output
     OutBuffer *moduleDeps;      // contents to be written to deps file
+    MessageStyle messageStyle;  // style of file/line annotations on messages
 
     // Hidden debug switches
     bool debugb;
@@ -361,7 +369,9 @@ struct Loc
         this->filename = filename;
     }
 
-    const char *toChars(bool showColumns = global.params.showColumns) const;
+    const char *toChars(
+        bool showColumns = global.params.showColumns,
+        MessageStyle messageStyle = global.params.messageStyle) const;
     bool equals(const Loc& loc) const;
 };
 

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1886,6 +1886,17 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                 return true;
             }
         }
+        else if (startsWith(p + 1, "verror-style="))
+        {
+            const style = p + 1 + "verror-style=".length;
+
+            if (strcmp(style, "digitalmars") == 0)
+                params.messageStyle = MessageStyle.digitalmars;
+            else if (strcmp(style, "gnu") == 0)
+                params.messageStyle = MessageStyle.gnu;
+            else
+                error("unknown error style '%s', must be 'digitalmars' or 'gnu'", style);
+        }
         else if (startsWith(p + 1, "mcpu")) // https://dlang.org/dmd.html#switch-mcpu
         {
             enum len = "-mcpu=".length;

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -345,7 +345,8 @@ void test_location()
 {
     Loc loc1 = Loc("test.d", 24, 42);
     assert(loc1.equals(Loc("test.d", 24, 42)));
-    assert(strcmp(loc1.toChars(true), "test.d(24,42)") == 0);
+    assert(strcmp(loc1.toChars(true, MESSAGESTYLEdigitalmars), "test.d(24,42)") == 0);
+    assert(strcmp(loc1.toChars(true, MESSAGESTYLEgnu), "test.d:24:42") == 0);
 }
 
 /**********************************/

--- a/test/fail_compilation/test20515.d
+++ b/test/fail_compilation/test20515.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -verror-style=gnu
+/*
+TEST_OUTPUT:
+---
+fail_compilation/test20515.d:16: Deprecation: function `test20515.foo` is deprecated
+fail_compilation/test20515.d:17: Error: undefined identifier `bar`
+---
+*/
+
+module test20515;
+
+deprecated void foo() { }
+
+void test()
+{
+    foo;
+    bar;
+}


### PR DESCRIPTION
This should ease interoperability with existing IDEs.

The GNU style is documented at https://www.gnu.org/prep/standards/html_node/Errors.html