### PR TITLE
fix Issue 18147 - Debug information limited in size

### DIFF
--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -146,6 +146,7 @@ uint cv4_memfunctypidx(FuncDeclaration fd)
 }
 
 enum CV4_NAMELENMAX = 0x3b9f;                   // found by trial and error
+enum CV8_NAMELENMAX = 0xffff;                   // length record is 16-bit only
 
 uint cv4_Denum(EnumDeclaration e)
 {
@@ -155,33 +156,20 @@ uint cv4_Denum(EnumDeclaration e)
         : 0;
 
     // Compute the number of fields, and the length of the fieldlist record
-    uint nfields = 0;
-    uint fnamelen = 2;
+    CvFieldList mc = CvFieldList(0, 0);
     if (!property)
     {
         for (size_t i = 0; i < e.members.dim; i++)
-        {   EnumMember sf = (*e.members)[i].isEnumMember();
-            if (sf)
+        {
+            if (EnumMember sf = (*e.members)[i].isEnumMember())
             {
                 const value = sf.value().toInteger();
-                const fnamelen1 = fnamelen;
 
                 // store only member's simple name
-                fnamelen += 4 + cv4_numericbytes(cast(uint)value) + cv_stringbytes(sf.toChars());
+                uint len = 4 + cv4_numericbytes(cast(uint)value) + cv_stringbytes(sf.toChars());
 
-                if (config.fulltypes != CV8)
-                {
-                    /* Optlink dies on longer ones, so just truncate
-                     */
-                    if (fnamelen > CV4_NAMELENMAX)
-                    {   fnamelen = fnamelen1;       // back up
-                        break;                      // and skip the rest
-                    }
-                }
-                else
-                    fnamelen = cv_align(null, fnamelen - 2) + 2;
-
-                nfields++;
+                len = cv_align(null, len);
+                mc.count(len);
             }
         }
     }
@@ -218,37 +206,30 @@ uint cv4_Denum(EnumDeclaration e)
     const idx_t typidx = cv_debtyp(d);
     d.length = length_save;            // restore length
 
-    TOWORD(d.data.ptr + 2,nfields);
+    TOWORD(d.data.ptr + 2, mc.nfields);
 
     uint fieldlist = 0;
     if (!property)                      // if forward reference, then fieldlist is 0
     {
         // Generate fieldlist type record
-        debtyp_t *dt = debtyp_alloc(fnamelen);
-        TOWORD(dt.data.ptr,(config.fulltypes == CV8) ? LF_FIELDLIST_V2 : LF_FIELDLIST);
+        mc.alloc();
 
         // And fill it in
-        uint j = 2;
-        uint fieldi = 0;
         for (size_t i = 0; i < e.members.dim; i++)
-        {   EnumMember sf = (*e.members)[i].isEnumMember();
-
-            if (sf)
+        {
+            if (EnumMember sf = (*e.members)[i].isEnumMember())
             {
-                ++fieldi;
-                if (fieldi > nfields)
-                    break;                  // chop off the rest
-
+                ubyte* p = mc.writePtr();
                 dinteger_t value = sf.value().toInteger();
-                TOWORD(dt.data.ptr + j,(config.fulltypes == CV8) ? LF_ENUMERATE_V3 : LF_ENUMERATE);
+                TOWORD(p, (config.fulltypes == CV8) ? LF_ENUMERATE_V3 : LF_ENUMERATE);
                 uint attribute = 0;
-                TOWORD(dt.data.ptr + j + 2,attribute);
-                cv4_storenumeric(dt.data.ptr + j + 4,cast(uint)value);
-                j += 4 + cv4_numericbytes(cast(uint)value);
+                TOWORD(p + 2, attribute);
+                cv4_storenumeric(p + 4,cast(uint)value);
+                uint j = 4 + cv4_numericbytes(cast(uint)value);
                 // store only member's simple name
-                j += cv_namestring(dt.data.ptr + j, sf.toChars());
-                j = cv_align(dt.data.ptr + j, j - 2) + 2;
-
+                j += cv_namestring(p + j, sf.toChars());
+                j = cv_align(p + j, j);
+                mc.written(j);
                 // If enum is not a member of a class, output enum members as constants
     //          if (!isclassmember(s))
     //          {
@@ -256,8 +237,7 @@ uint cv4_Denum(EnumDeclaration e)
     //          }
             }
         }
-        assert(j == fnamelen);
-        fieldlist = cv_debtyp(dt);
+        fieldlist = mc.debtyp();
     }
 
     if (config.fulltypes == CV8)
@@ -341,31 +321,147 @@ void toDebug(EnumDeclaration ed)
     }
 }
 
-// Closure variables for Lambda cv_mem_count
-struct CvMemberCount
+/****************************
+ * Helper struct for field list records LF_FIELDLIST/LF_FIELDLIST_V2
+ *
+ * if the size exceeds the maximum length of a record, the last entry
+ * is an LF_INDEX entry with the type index pointing to the next field list record
+ *
+ * Processing is done in two phases:
+ *
+ * Phase 1: computing the size of the field list and distributing it over multiple records
+ *  - construct CvFieldList with some precalculated field count/length
+ *  - for each field, call count(length of field)
+ *
+ * Phase 2: write the actual data
+ *  - call alloc() to allocate debtyp's
+ *  - for each field,
+ *    - call writePtr() to get a pointer into the current debtyp
+ *    - fill memory with field data
+ *    - call written(length of field)
+ *  - call debtyp() to create type records and return the index of the first one
+ */
+struct CvFieldList
 {
+    // one LF_FIELDLIST record
+    static struct FLChunk
+    {
+        uint length;    // accumulated during "count" phase
+
+        debtyp_t *dt;
+        uint writepos;  // write position in dt
+    }
+
     uint nfields;
-    uint fnamelen;
+    uint writeIndex;
+    Array!FLChunk fieldLists;
+
+    const uint fieldLenMax;
+    const uint fieldIndexLen;
+
+    const bool canSplitList;
+
+    this(uint fields, uint len)
+    {
+        canSplitList = config.fulltypes == CV8; // optlink bails out with LF_INDEX
+        fieldIndexLen = canSplitList ? (config.fulltypes == CV8 ? 2 + 2 + 4 : 2 + 2) : 0;
+        fieldLenMax = (config.fulltypes == CV8 ? CV8_NAMELENMAX : CV4_NAMELENMAX) - fieldIndexLen;
+
+        assert(len < fieldLenMax);
+        nfields = fields;
+        fieldLists.push(FLChunk(2 + len));
+    }
+
+    void count(uint n)
+    {
+        if (n)
+        {
+            nfields++;
+            assert(n < fieldLenMax);
+            if (fieldLists[$-1].length + n > fieldLenMax)
+                fieldLists.push(FLChunk(2 + n));
+            else
+                fieldLists[$-1].length += n;
+        }
+    }
+
+    void alloc()
+    {
+        foreach (i, ref fld; fieldLists)
+        {
+            fld.dt = debtyp_alloc(fld.length + (i < fieldLists.length - 1 ? fieldIndexLen : 0));
+            TOWORD(fld.dt.data.ptr, config.fulltypes == CV8 ? LF_FIELDLIST_V2 : LF_FIELDLIST);
+            fld.writepos = 2;
+        }
+    }
+
+    ubyte* writePtr()
+    {
+        assert(writeIndex < fieldLists.length);
+        auto fld = &fieldLists[writeIndex];
+        if (fld.writepos >= fld.length)
+        {
+            assert(fld.writepos == fld.length);
+            if (writeIndex < fieldLists.length - 1) // if false, all further attempts must not actually write any data
+            {
+                writeIndex++;
+                fld++;
+            }
+        }
+        return fld.dt.data.ptr + fld.writepos;
+    }
+
+    void written(uint n)
+    {
+        assert(fieldLists[writeIndex].writepos + n <= fieldLists[writeIndex].length);
+        fieldLists[writeIndex].writepos += n;
+    }
+
+    idx_t debtyp()
+    {
+        idx_t typidx;
+        auto numCreate = canSplitList ? fieldLists.length : 1;
+        for(auto i = numCreate; i > 0; --i)
+        {
+            auto fld = &fieldLists[i - 1];
+            if (typidx)
+            {
+                ubyte* p = fld.dt.data.ptr + fld.writepos;
+                if (config.fulltypes == CV8)
+                {
+                    TOWORD (p, LF_INDEX_V2);
+                    TOWORD (p + 2, 0); // padding
+                    TOLONG (p + 4, typidx);
+                }
+                else
+                {
+                    TOWORD (p, LF_INDEX);
+                    TOWORD (p + 2, typidx);
+                }
+            }
+            typidx = cv_debtyp(fld.dt);
+        }
+        return typidx;
+    }
 }
 
 // Lambda function
 int cv_mem_count(Dsymbol s, void *param)
-{   CvMemberCount *pmc = cast(CvMemberCount *)param;
+{
+    CvFieldList *pmc = cast(CvFieldList *)param;
 
     int nwritten = cvMember(s, null);
-    if (nwritten)
-    {
-        pmc.fnamelen += nwritten;
-        pmc.nfields++;
-    }
+    pmc.count(nwritten);
     return 0;
 }
 
 // Lambda function
 int cv_mem_p(Dsymbol s, void *param)
 {
-    ubyte **pp = cast(ubyte **)param;
-    *pp += cvMember(s, *pp);
+    CvFieldList *pmc = cast(CvFieldList *)param;
+    ubyte *p = pmc.writePtr();
+    uint len = cvMember(s, p);
+    pmc.written(len);
     return 0;
 }
 
@@ -460,43 +556,30 @@ void toDebug(StructDeclaration sd)
         return /*typidx*/;
     }
 
-    // Compute the number of fields (nfields), and the length of the fieldlist record (fnamelen)
-    CvMemberCount mc = CvMemberCount(0, 2);
+    // Compute the number of fields and the length of the fieldlist record
+    CvFieldList mc = CvFieldList(0, 0);
     for (size_t i = 0; i < sd.members.dim; i++)
     {
         Dsymbol s = (*sd.members)[i];
         s.apply(&cv_mem_count, &mc);
     }
-    if (config.fulltypes != CV8 && mc.fnamelen > CV4_NAMELENMAX)
-    {   // Too long, fail gracefully
-        mc = CvMemberCount(0, 2);
-    }
     const uint nfields = mc.nfields;
-    const uint fnamelen = mc.fnamelen;
-
-    const int count = nfields;                  // COUNT field in LF_CLASS
 
     // Generate fieldlist type record
-    debtyp_t *dt = debtyp_alloc(fnamelen);
-    ubyte *p = dt.data.ptr;
-
-    // And fill it in
-    TOWORD(p,config.fulltypes == CV8 ? LF_FIELDLIST_V2 : LF_FIELDLIST);
-    p += 2;
+    mc.alloc();
     if (nfields)
     {
         for (size_t i = 0; i < sd.members.dim; i++)
         {
             Dsymbol s = (*sd.members)[i];
-            s.apply(&cv_mem_p, &p);
+            s.apply(&cv_mem_p, &mc);
         }
     }
 
     //dbg_printf("fnamelen = %d, p-dt.data.ptr = %d\n",fnamelen,p-dt.data.ptr);
-    assert(p - dt.data.ptr == fnamelen);
-    const idx_t fieldlist = cv_debtyp(dt);
+    const idx_t fieldlist = mc.debtyp();
 
-    TOWORD(d.data.ptr + 2,count);
+    TOWORD(d.data.ptr + 2, nfields);
     if (config.fulltypes == CV8)
     {
         TOWORD(d.data.ptr + 4,property);
@@ -618,8 +701,8 @@ void toDebug(ClassDeclaration cd)
         return /*typidx*/;
     }
 
-    // Compute the number of fields (nfields), and the length of the fieldlist record (fnamelen)
-    CvMemberCount mc = { nfields : 0, fnamelen : 2 };
+    // Compute the number of fields and the length of the fieldlist record
+    CvFieldList mc = CvFieldList(0, 0);
 
     /* Adding in the base classes causes VS 2010 debugger to refuse to display any
      * of the fields. I have not been able to determine why.
@@ -633,9 +716,8 @@ void toDebug(ClassDeclaration cd)
         for (size_t i = 0; i < cd.baseclasses.dim; i++)
         {
             const bc = (*cd.baseclasses)[i];
-            ++mc.nfields;
             const uint elementlen = 4 + cgcv.sz_idx + cv4_numericbytes(bc.offset);
-            mc.fnamelen += cv_align(null, elementlen);
+            mc.count(cv_align(null, elementlen));
         }
     }
 
@@ -644,28 +726,20 @@ void toDebug(ClassDeclaration cd)
         Dsymbol s = (*cd.members)[i];
         s.apply(&cv_mem_count, &mc);
     }
-    if (config.fulltypes != CV8 && mc.fnamelen > CV4_NAMELENMAX)
-    {   // Too long, fail gracefully
-        mc = CvMemberCount(0, 2);
-    }
     const uint nfields = mc.nfields;
-    const uint fnamelen = mc.fnamelen;
 
-    const int count = nfields;
-    TOWORD(d.data.ptr + 2,count);
+    TOWORD(d.data.ptr + 2, nfields);
 
     // Generate fieldlist type record
-    debtyp_t *dt = debtyp_alloc(fnamelen);
-    ubyte *p = dt.data.ptr;
-
-    // And fill it in
-    TOWORD(p,config.fulltypes == CV8 ? LF_FIELDLIST_V2 : LF_FIELDLIST);
-    p += 2;
+    mc.alloc();
 
     if (nfields)        // if we didn't overflow
     {
         if (addInBaseClasses)
         {
+            ubyte* base = mc.writePtr();
+            ubyte* p = base;
+
             // Add in base classes
             for (size_t i = 0; i < cd.baseclasses.dim; i++)
             {
@@ -695,20 +769,18 @@ void toDebug(ClassDeclaration cd)
                 elementlen += cv4_numericbytes(bc.offset);
                 p += cv_align(p + elementlen, elementlen);
             }
+            mc.written(cast(uint)(p - base));
         }
 
         for (size_t i = 0; i < cd.members.dim; i++)
         {
             Dsymbol s = (*cd.members)[i];
-            s.apply(&cv_mem_p, &p);
+            s.apply(&cv_mem_p, &mc);
         }
     }
 
-    //dbg_printf("fnamelen = %d, p-dt.data.ptr = %d\n",fnamelen,p-dt.data.ptr);
-    assert(p - dt.data.ptr == fnamelen);
-    const idx_t fieldlist = cv_debtyp(dt);
+    const idx_t fieldlist = mc.debtyp();
 
-    TOWORD(d.data.ptr + 2,count);
     if (config.fulltypes == CV8)
     {
         TOWORD(d.data.ptr + 4,property);


### PR DESCRIPTION
create a linked list of LF_FIELDLIST to represent large structs/enums

optlink doesn't like this version either, so CV4 records are now cut if too large, but no longer completely removed