### PR TITLE
Bypass GC for compiler (without -lowmem) if built with GDC too

### DIFF
--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -206,6 +206,10 @@ else version (LDC)
     import ldc.attributes;
     enum OVERRIDE_MEMALLOC = is(typeof(ldc.attributes.weak));
 }
+else version (GNU)
+{
+    enum OVERRIDE_MEMALLOC = true;
+}
 else
 {
     enum OVERRIDE_MEMALLOC = false;


### PR DESCRIPTION
This should slightly improve runtime and significantly reduce memory requirements (something like -25%) for DMD if compiled with a GDC host compiler, by enabling the bump-pointer allocation method, as for DMD and non-ancient LDC host compilers.

The GC memory overhead was significantly reduced with druntime 2.085 (from roughly 40% to 15%), so this change is particularly useful for GDC, where druntime for gdc-9 is based on 2.076.