### PR TITLE
Fix Issue 20530 - is(<...> == module/package) does not work with stri…

### DIFF
--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -195,6 +195,8 @@ Dsymbol getDsymbol(RootObject oarg)
             return fe.td ? fe.td : fe.fd;
         else if (auto te = ea.isTemplateExp())
             return te.td;
+        else if (auto te = ea.isScopeExp())
+            return te.sds;
         else
             return null;
     }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5175,6 +5175,20 @@ extern (C++) final class TypeMixin : Type
         return new TypeMixin(loc, Expression.arraySyntaxCopy(exps));
     }
 
+   override Dsymbol toDsymbol(Scope* sc)
+    {
+        Type t;
+        Expression e;
+        Dsymbol s;
+        resolve(this, loc, sc, &e, &t, &s);
+        if (t)
+            s = t.toDsymbol(sc);
+        else if (e)
+            s = getDsymbol(e);
+
+        return s;
+    }
+
     override void accept(Visitor v)
     {
         v.visit(this);

--- a/test/compilable/test20530.d
+++ b/test/compilable/test20530.d
@@ -1,0 +1,7 @@
+module mod;
+static assert(is(mod == module));
+static assert(is(mixin("mod") == module));
+
+import imports.test20530a;
+static assert(is(imports == package));
+static assert(is(mixin("imports") == package));


### PR DESCRIPTION
…ng mixins

I made the fix more general (changing getDsymbol) just to try, so far no problem in dmd test suite.