### PR TITLE
Set OVERRIDE_MEMALLOC as false if building IN_GCC

### DIFF
--- a/src/dmd/root/rmem.d
+++ b/src/dmd/root/rmem.d
@@ -208,7 +208,10 @@ else version (LDC)
 }
 else version (GNU)
 {
-    enum OVERRIDE_MEMALLOC = true;
+    version (IN_GCC)
+        enum OVERRIDE_MEMALLOC = false;
+    else
+        enum OVERRIDE_MEMALLOC = true;
 }
 else
 {


### PR DESCRIPTION
The reason why I've never proposed the change in #10734 is because it doesn't work when statically linking libphobos.

(Debian/Ubuntu ships gdc with linking against a shared libphobos as the default, which permits symbol overriding).