### PR TITLE
Fix Issues 20530, 20537 - resolve trait isPackage/isModule and is(package/module) quirks

### DIFF
--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -210,7 +210,16 @@ extern (C++) final class Import : Dsymbol
         if (mod && !mod.importedFrom)
             mod.importedFrom = sc ? sc._module.importedFrom : Module.rootModule;
         if (!pkg)
-            pkg = mod;
+        {
+            if (mod && mod.isPackageFile)
+            {
+                // one level depth package.d file (import pkg; ./pkg/package.d)
+                // it's necessary to use the wrapping Package already created
+                pkg = mod.pkg;
+            }
+            else
+                pkg = mod;
+        }
         //printf("-Import::load('%s'), pkg = %p\n", toChars(), pkg);
         return global.errors != errors;
     }

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -422,6 +422,7 @@ extern (C++) final class Module : Package
     bool isHdrFile;             // if it is a header (.di) file
     bool isDocFile;             // if it is a documentation input file, not D source
     bool isPackageFile;         // if it is a package.d
+    Package pkg;                // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles; // array of files whose content was imported
     int needmoduleinfo;
     int selfimports;            // 0: don't know, 1: does not, 2: does
@@ -1058,15 +1059,27 @@ extern (C++) final class Module : Package
              *
              * To avoid the conflict:
              * 1. If preceding package name insertion had occurred by Package::resolve,
-             *    later package.d loading will change Package::isPkgMod to PKG.module_ and set Package::mod.
+             *    reuse the previous wrapping 'Package' if it exists
              * 2. Otherwise, 'package.d' wrapped by 'Package' is inserted to the internal tree in here.
+             *
+             * Then change Package::isPkgMod to PKG.module_ and set Package::mod.
+             *
+             * Note that the 'wrapping Package' is the Package that contains package.d and other submodules,
+             * the one inserted to the symbol table.
              */
-            auto p = new Package(Loc.initial, ident);
+            auto ps = dst.lookup(ident);
+            Package p = ps ? ps.isPackage() : null;
+            if (p is null)
+            {
+                p = new Package(Loc.initial, ident);
+                p.tag = this.tag; // reuse the same package tag
+                p.symtab = new DsymbolTable();
+            }
+            this.tag = p.tag; // reuse the 'older' package tag
+            this.pkg = p;
             p.parent = this.parent;
             p.isPkgMod = PKG.module_;
             p.mod = this;
-            p.tag = this.tag; // reuse the same package tag
-            p.symtab = new DsymbolTable();
             s = p;
         }
         if (!dst.insert(s))
@@ -1090,16 +1103,9 @@ extern (C++) final class Module : Package
             }
             else if (Package pkg = prev.isPackage())
             {
-                if (pkg.isPkgMod == PKG.unknown && isPackageFile)
-                {
-                    /* If the previous inserted Package is not yet determined as package.d,
-                     * link it to the actual module.
-                     */
-                    pkg.isPkgMod = PKG.module_;
-                    pkg.mod = this;
-                    pkg.tag = this.tag; // reuse the same package tag
+                // 'package.d' loaded after a previous 'Package' insertion
+                if (isPackageFile)
                     amodules.push(this); // Add to global array of all modules
-                }
                 else
                     error(md ? md.loc : loc, "from file %s conflicts with package name %s", srcname, pkg.toChars());
             }

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2378,6 +2378,8 @@ Package resolveIsPackage(Dsymbol sym)
         }
         pkg = imp.pkg;
     }
+    else if (auto mod = sym.isModule())
+        pkg = mod.isPackageFile ? mod.pkg : sym.isPackage();
     else
         pkg = sym.isPackage();
     if (pkg)

--- a/src/dmd/module.h
+++ b/src/dmd/module.h
@@ -77,6 +77,7 @@ public:
     bool isHdrFile;     // if it is a header (.di) file
     bool isDocFile;     // if it is a documentation input file, not D source
     bool isPackageFile; // if it is a package.d
+    Package pkg;        // if isPackageFile is true, the Package that contains this package.d
     Strings contentImportedFiles;  // array of files whose content was imported
     int needmoduleinfo;
     int selfimports;            // 0: don't know, 1: does not, 2: does

--- a/test/compilable/imports/pkg11847/mod11847.d
+++ b/test/compilable/imports/pkg11847/mod11847.d
@@ -1,0 +1,3 @@
+module pkg11847.mod11847;
+
+int func() { return 2; }

--- a/test/compilable/imports/pkg11847/package.d
+++ b/test/compilable/imports/pkg11847/package.d
@@ -1,0 +1,3 @@
+module pkg11847;
+
+int func() { return 1; }

--- a/test/compilable/test11847.d
+++ b/test/compilable/test11847.d
@@ -1,0 +1,13 @@
+// REQUIRED_ARGS: -Icompilable/imports
+import pkg11847;
+import pkg11847.mod11847;
+
+void main() {
+	static assert(pkg11847.func() == 1);
+	static assert(pkg11847.mod11847.func() == 2);
+
+    // This correctly won't compile.
+    // Error: pkg11847.mod11847.func at imports/pkg11847/mod11847.d(3) conflicts with pkg11847.func at imports/pkg11847/package.d(3)
+    static assert(!__traits(compiles, func()));
+
+}

--- a/test/compilable/test20530.d
+++ b/test/compilable/test20530.d
@@ -1,7 +1,45 @@
 module mod;
 static assert(is(mod == module));
 static assert(is(mixin("mod") == module));
+static assert(!is(mod == package));
+static assert(!is(mixin("mod") == package));
 
 import imports.test20530a;
 static assert(is(imports == package));
 static assert(is(mixin("imports") == package));
+static assert(!is(imports == module));
+static assert(!is(mixin("imports") == module));
+
+import imports.plainpackage.plainmodule;
+import imports.pkgmodule.plainmodule;
+
+struct MyStruct;
+
+alias a = mixin("imports.plainpackage");
+alias b = mixin("imports.pkgmodule.plainmodule");
+
+static assert(is(mixin("imports.plainpackage") == package));
+static assert(is(mixin("a") == package));
+static assert(!is(mixin("imports.plainpackage.plainmodule") == package));
+static assert(!is(mixin("b") == package));
+static assert(is(mixin("imports.pkgmodule") == package));
+mixin("static assert(is(imports.pkgmodule == package));");
+
+static assert(!is(mixin("MyStruct") == package));
+
+static assert(!is(mixin("imports.plainpackage") == module));
+static assert(!is(mixin("a") == module));
+static assert(is(mixin("imports.plainpackage.plainmodule") == module));
+static assert(is(mixin("b") == module));
+static assert(is(mixin("imports.pkgmodule") == module));
+mixin("static assert(is(imports.pkgmodule == module));");
+
+static assert(!is(mixin("MyStruct") == module));
+
+static assert(!is(mixin("imports.nonexistent") == package));
+static assert(!is(mixin("imports.nonexistent") == module));
+
+// this won't work due to mixin argument .stringof expansion,
+// it will expand to mixin(package imports.pkgmodule). Issue 20519.
+//static assert(is(mixin(imports.pkgmodule) == package));
+//static assert(is(mixin(imports.pkgmodule) == module));

--- a/test/compilable/test20537.d
+++ b/test/compilable/test20537.d
@@ -1,0 +1,9 @@
+// REQUIRED_ARGS: -Icompilable/imports
+import pkg20537;
+
+static assert(is(pkg20537 == module));
+static assert(__traits(isModule, pkg20537));
+static assert(is(mixin("pkg20537") == module));
+static assert(is(pkg20537 == package));
+static assert(__traits(isPackage, pkg20537));
+static assert(is(mixin("pkg20537") == package));


### PR DESCRIPTION
…ork with string mixins

#10739  continuation.

I made two solutions to the issue of the last comment but hit another bug while trying the long alternative so I decided to put that version on another pull to fix that bug.

The short version here is changing something I wondered in the past why it was there, the typeToExpression call is unnecessary and it gave me different results a few times on compiler experiments when using mixin("ident . ident ...") vs plain code, it seems the way that TypeIdentifier is converted to DotIdExp makes the code behave different on some cases.