### PR TITLE
Replace `body` with `do` in all tests ...

### DIFF
--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -45,7 +45,7 @@ out (result)
 {
     assert(result == 0);
 }
-body
+do
 {
     float f = float.infinity;
     int i = cast(int) f;

--- a/test/compilable/imports/testcontracts.d
+++ b/test/compilable/imports/testcontracts.d
@@ -11,7 +11,7 @@ class Base3602
        assert(x > 0);
        assert(y > 0);
    }
-   body
+   do
    {
    }
 }
@@ -25,7 +25,7 @@ class Base5230
     out (res)
     {
     }
-    body
+    do
     {
         return 42;
     }

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -83,7 +83,7 @@ in {
 out(result) {
     assert(result == 18);
 }
-body {
+do {
     int x = 8;
     int inner(void* v) nothrow
     {

--- a/test/compilable/test10520.d
+++ b/test/compilable/test10520.d
@@ -7,6 +7,6 @@ void f() { }
 
 void g()()
 in { f(); } // OK <- Error: 'main.f' is not nothrow
-body { }
+do { }
 
 alias gi = g!();

--- a/test/compilable/test10981.d
+++ b/test/compilable/test10981.d
@@ -6,7 +6,7 @@ in
         void in_nested() pure
         in { assert(i); }   // OK <- NG
         out { assert(i); }  // OK <- NG
-        body {}
+        do {}
     }
 }
 out
@@ -16,9 +16,9 @@ out
         void out_nested() pure
         in { assert(i); }   // OK <- NG
         out { assert(i); }  // OK <- NG
-        body {}
+        do {}
     }
 }
-body
+do
 {
 }

--- a/test/compilable/test4375.d
+++ b/test/compilable/test4375.d
@@ -369,7 +369,7 @@ class C {
         else
             assert(63);
     }
-    body {
+    do {
         if (true)
             assert(64);
         else

--- a/test/compilable/testcontracts.d
+++ b/test/compilable/testcontracts.d
@@ -13,7 +13,7 @@ class Derived3602 : Base3602
        assert(x > 0);
        assert(y > 0);
    }
-   body
+   do
    {
    }
 }
@@ -35,31 +35,31 @@ class Foo17502
 {
     auto foo()
     out {}
-    body {}
+    do {}
 
     auto bar()
     out { assert (__result > 5); }
-    body { return 6; }
+    do { return 6; }
 
     auto bar_2()
     out (res) { assert (res > 5); }
-    body { return 6; }
+    do { return 6; }
 
     int concrete()
     out { assert(__result > 5); }
-    body { return 6; }
+    do { return 6; }
 
     int concrete_2()
     out(res) { assert (res > 5); }
-    body { return 6; }
+    do { return 6; }
 
     void void_foo()
     out {}
-    body {}
+    do {}
 
     auto void_auto()
     out {}
-    body {}
+    do {}
 }
 
 /***************************************************/
@@ -76,7 +76,7 @@ class A17502
     {
         assert(res > 5);
     }
-    body
+    do
     {
         return p;
     }
@@ -89,7 +89,7 @@ class C17502 : B17502
     {
         assert(p > 3);
     }
-    body
+    do
     {
         return p * 2;
     }
@@ -102,7 +102,7 @@ class B17502 : A17502
     {
         assert(p > 2);
     }
-    body
+    do
     {
         return p * 3;
     }
@@ -118,7 +118,7 @@ class X17502 : Y17502
     {
         assert(p > 3);
     }
-    body
+    do
     {
         return p * 2;
     }
@@ -131,7 +131,7 @@ class Y17502 : Z17502
     {
         assert(p > 2);
     }
-    body
+    do
     {
         return p * 3;
     }
@@ -148,7 +148,7 @@ class Z17502
     {
         assert(res > 5);
     }
-    body
+    do
     {
         return p;
     }
@@ -166,7 +166,7 @@ final class Foo17893(T)
     {
         maythrow();
     }
-    body
+    do
     {
     }
 }

--- a/test/runnable/extra-files/linkdebug_range.d
+++ b/test/runnable/extra-files/linkdebug_range.d
@@ -28,7 +28,7 @@ struct SortedRange(Range, alias pred = "a < b")
     {
         dbgVerifySorted();
     }
-    body
+    do
     {
     }
 

--- a/test/runnable/imports/test13a.d
+++ b/test/runnable/imports/test13a.d
@@ -17,7 +17,7 @@ template Ordinal(T) {
     public T clamp(T item, T lower, T upper)
     in {
         assert(lower <= upper);
-    } body {
+    } do {
         return max(min(item, upper), lower);
     }
 }

--- a/test/runnable/inline.d
+++ b/test/runnable/inline.d
@@ -521,7 +521,7 @@ class Foo12080
 
     public ST12080 sysTime()
     out {}
-    body
+    do
     {
         if (quux)
             return ST12080();

--- a/test/runnable/nested.d
+++ b/test/runnable/nested.d
@@ -2574,7 +2574,7 @@ class App15422(T)
     }
 
     auto test2(T val)
-    //in {} body
+    //in {} do
     {
         int closVar;
         struct Foo

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -715,7 +715,7 @@ public template TRange29(T) {
                     recursing = false;
                 }
             }
-        } body {
+        } do {
             return contains(other.lower()) || contains(other.upper()) || other.includes(this);
         }
         public bool includes(Range other)
@@ -723,7 +723,7 @@ public template TRange29(T) {
             assert(other !is null);
         } out (result) {
             assert(result == (contains(other.lower()) && contains(other.upper())));
-        } body {
+        } do {
             return contains(other.lower()) && contains(other.upper());
         }
     }

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -155,7 +155,7 @@ int[] fun(int i)
     {
         assert(result[0] == 2);
     }
-    body
+    do
     {
         char result;
         int[] res = new int[10];

--- a/test/runnable/test15568.d
+++ b/test/runnable/test15568.d
@@ -11,7 +11,7 @@ class A
     {
         assert(c !is null);
     }
-    body
+    do
     {
         D[] ds2 = ds.filter!(a => c).array;
 

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -922,7 +922,7 @@ in
 {
     assert(A.length > 0);
 }
-body
+do
 {
     version (D_InlineAsm_X86)
     {
@@ -1085,7 +1085,7 @@ in
 {
     assert(A.length > 0);
 }
-body
+do
 {
     ptrdiff_t i = A.length - 1;
     real r = A[i];

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -229,7 +229,7 @@ in {
     writefln("Arguments len = %d\n", _arguments.length);
     assert(_arguments.length == 2);
 }
-body {
+do {
 
 }
 

--- a/test/runnable/test3574a.d
+++ b/test/runnable/test3574a.d
@@ -6,7 +6,7 @@ out
 {
     g = 100;
 }
-body
+do
 {
     return;
     // expected return code == 0

--- a/test/runnable/test3574b.d
+++ b/test/runnable/test3574b.d
@@ -6,7 +6,7 @@ out
 {
     g = 100;
 }
-body
+do
 {
     //return;
     // expected return code == 0

--- a/test/runnable/test3574c.d
+++ b/test/runnable/test3574c.d
@@ -6,7 +6,7 @@ void main()
 //{
 //    g = 100;
 //}
-//body
+//do
 {
     return;
     // expected return code == 0

--- a/test/runnable/test3574d.d
+++ b/test/runnable/test3574d.d
@@ -6,7 +6,7 @@ void main()
 //{
 //    g = 100;
 //}
-//body
+//do
 {
     //return;
     // expected return code == 0

--- a/test/runnable/test7932.d
+++ b/test/runnable/test7932.d
@@ -13,7 +13,7 @@ class C
                 cast(void*) this, &n, n);
         assert (N == n);
     }
-    body
+    do
     {
         int dummy;
         //printf("\n");

--- a/test/runnable/test_dip1006.d
+++ b/test/runnable/test_dip1006.d
@@ -5,7 +5,7 @@ class C
     int foo(int a)
     in { assert(a != 0); } // skipped
     out(res) { assert(res != 0); } // skipped
-    body
+    do
     {
         return a;
     }

--- a/test/runnable/test_dip1006b.d
+++ b/test/runnable/test_dip1006b.d
@@ -5,7 +5,7 @@ class C
     int foo(int a)
     in { assert(a != 0); } // skipped
     out(res) { assert(res != 0, "out"); } // triggered
-    body
+    do
     {
         return a;
     }

--- a/test/runnable/testcontracts.d
+++ b/test/runnable/testcontracts.d
@@ -318,13 +318,13 @@ void test9()
 
 /*******************************************/
 
-auto test10() body { return 3; }
-auto test11()() body { return 3; }
+auto test10() do { return 3; }
+auto test11()() do { return 3; }
 
 auto test12()
 {
-    auto test10() body { return 3; }
-    auto test11()() body { return 3; }
+    auto test10() do { return 3; }
+    auto test11()() do { return 3; }
     return 3;
 }
 
@@ -522,7 +522,7 @@ class C7335 : A7335
     override void setValue(int newValue)
     in { int a = newValue; }
     out { assert(mValue == 3); }
-    body
+    do
     {
         mValue = newValue;
     }

--- a/test/runnable/testprofile.d
+++ b/test/runnable/testprofile.d
@@ -45,7 +45,7 @@ class Foo10617
     void foo() nothrow pure @safe
     in { }
     out { }
-    body { }
+    do { }
 }
 
 // ------------------
@@ -53,12 +53,12 @@ class Foo10617
 class C10953
 {
     void func() nothrow pure @safe
-    in {} out {} body {}
+    in {} out {} do {}
 }
 class D10953 : C10953
 {
     override void func()    // inherits attributes of Foo.func
-    in {} out {} body {}
+    in {} out {} do {}
 }
 
 // ------------------

--- a/test/runnable/testreturn.d
+++ b/test/runnable/testreturn.d
@@ -96,7 +96,7 @@ out(r)
     assert(r == (f ? sx : sy));
     result13336 = r;
 }
-body
+do
 {
     mixin(fbody13336);
 }
@@ -109,7 +109,7 @@ out(r)
     assert(r == (f ? sx : sy));
     result13336 = r;
 }
-body
+do
 {
     mixin(fbody13336);
 }

--- a/test/runnable/testsafe.d
+++ b/test/runnable/testsafe.d
@@ -423,12 +423,12 @@ void classcast()
 class A6278 {
     int test()
     in { assert(0); }
-    body { return 1; }
+    do { return 1; }
 }
 class B6278 : A6278 {
     override int test()
     in { assert(0); }
-    body { return 1; }
+    do { return 1; }
 }
 
 }


### PR DESCRIPTION
... excepts those concerning `body` and its deprecation.

This avoids unnecessary `TEST_OUTPUT` sections to handle deprecation warnings when the test suite stops ignoring output of tests without such sections.