### PR TITLE
Add missing TEST_OUTPUT sections to most tests in compilable

### DIFF
--- a/test/compilable/depmsg.d
+++ b/test/compilable/depmsg.d
@@ -1,6 +1,22 @@
-// REQUIRED_ARGS: -d
-// PERMUTE_ARGS: -dw
-
+/*
+REQUIRED_ARGS: -dw
+TEST_OUTPUT:
+---
+compilable/depmsg.d(39): Deprecation: struct `depmsg.main.Inner.A` is deprecated - With message!
+compilable/depmsg.d(39): Deprecation: struct `depmsg.main.Inner.A` is deprecated - With message!
+compilable/depmsg.d(40): Deprecation: class `depmsg.main.Inner.B` is deprecated - With message!
+compilable/depmsg.d(40): Deprecation: class `depmsg.main.Inner.B` is deprecated - With message!
+compilable/depmsg.d(41): Deprecation: interface `depmsg.main.Inner.C` is deprecated - With message!
+compilable/depmsg.d(41): Deprecation: interface `depmsg.main.Inner.C` is deprecated - With message!
+compilable/depmsg.d(42): Deprecation: union `depmsg.main.Inner.D` is deprecated - With message!
+compilable/depmsg.d(42): Deprecation: union `depmsg.main.Inner.D` is deprecated - With message!
+compilable/depmsg.d(43): Deprecation: enum `depmsg.main.Inner.E` is deprecated - With message!
+compilable/depmsg.d(43): Deprecation: enum `depmsg.main.Inner.E` is deprecated - With message!
+compilable/depmsg.d(45): Deprecation: alias `depmsg.main.Inner.G` is deprecated - With message!
+compilable/depmsg.d(46): Deprecation: variable `depmsg.main.Inner.H` is deprecated - With message!
+compilable/depmsg.d(47): Deprecation: class `depmsg.main.Inner.I!().I` is deprecated - With message!
+---
+*/
 void main()
 {
     class Inner

--- a/test/compilable/staticforeach.d
+++ b/test/compilable/staticforeach.d
@@ -1,5 +1,126 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
+/*
+TEST_OUTPUT:
+---
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
+S(1, 2, 3, [0, 1, 2])
+x0: 1
+x1: 2
+x2: 3
+a: [0, 1, 2]
+(int[], char[], bool[], Object[])
+[0, 0]
+x0: int
+x1: double
+x2: char
+test(0)→ 0
+test(1)→ 1
+test(2)→ 2
+test(3)→ 3
+test(4)→ 4
+test(5)→ 5
+test(6)→ 6
+test(7)→ 7
+test(8)→ 8
+test(9)→ 9
+test(10)→ -1
+test(11)→ -1
+test(12)→ -1
+test(13)→ -1
+test(14)→ -1
+1
+[1, 2, 3]
+2
+[1, 2, 3]
+3
+[1, 2, 3]
+0 1
+1 2
+2 3
+1
+3
+4
+object
+Tuple
+tuple
+main
+front
+popFront
+empty
+back
+popBack
+Iota
+iota
+map
+to
+text
+all
+any
+join
+S
+s
+Seq
+Overloads
+Parameters
+forward
+foo
+A
+B
+C
+D
+E
+Types
+Visitor
+testVisitor
+staticMap
+arrayOf
+StaticForeachLoopVariable
+StaticForeachScopeExit
+StaticForeachReverseHiding
+UnrolledForeachReverse
+StaticForeachReverse
+StaticForeachByAliasDefault
+NestedStaticForeach
+TestAliasOutsideFunctionScope
+OpApplyMultipleStaticForeach
+OpApplyMultipleStaticForeachLowered
+RangeStaticForeach
+OpApplySingleStaticForeach
+TypeStaticForeach
+AliasForeach
+EnumForeach
+TestUninterpretable
+SeqForeachConstant
+SeqForeachBreakContinue
+TestStaticForeach
+testtest
+fun
+testEmpty
+bug17660
+breakContinueBan
+MixinTemplate
+testToStatement
+bug17688
+T
+foo2
+T2
+1 2 '3'
+2 3 '4'
+0 1
+1 2
+2 3
+---
+*/
 
 module staticforeach;
 
@@ -73,7 +194,7 @@ template map(alias a){
 template to(T:string){
     string to(S)(S x)if(is(S:int)||is(S:size_t)||is(S:char)){
         static if(is(S==char)) return cast(string)[x];
-        if(x<0) return "-"~to(-x);
+        if(x<0) return "-"~to(-1 * x);
         if(x==0) return "0";
         return (x>=10?to(x/10):"")~cast(char)(x%10+'0');
     }
@@ -350,7 +471,7 @@ struct NestedStaticForeach{
     static:
     static foreach(i,name;["a"]){
         static foreach(j,name2;["d"]){
-            mixin("enum "~name~name2~"=[i,j];");
+            mixin("enum int[] "~name~name2~"=[i, j];");
         }
     }
     pragma(msg, ad);
@@ -600,12 +721,12 @@ static:
 }
 
 static foreach(i,j;[1,2,3]){
-    pragma(msg, i," ",j);
+    pragma(msg, int(i)," ",j);
 }
 
 void testtest(){
     static foreach(i,v;[1,2,3]){
-        pragma(msg, i," ",v);
+        pragma(msg, int(i)," ",v);
         static assert(i+1 == v);
     }
 }

--- a/test/compilable/test8509.d
+++ b/test/compilable/test8509.d
@@ -1,6 +1,10 @@
 module test8509;
 enum E : string { a = "hello", b = "world" }
-struct S { E opCat(S s) { return E.a; } E opCat(string s) { return E.a; } }
+struct S
+{
+    E opBinary(string s : "~")(S s) { return E.a; }
+    E opBinary(string s : "~")(string s) { return E.a; }
+}
 
 void main()
 {

--- a/test/compilable/testheader1.d
+++ b/test/compilable/testheader1.d
@@ -2,5 +2,11 @@
 // REQUIRED_ARGS: -o- -unittest -H -Hf${RESULTS_DIR}/compilable/testheader1.di -ignore
 // PERMUTE_ARGS: -d -dw
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
+/*
+TEST_OUTPUT:
+---
+Hello World
+---
+*/
 
 void main() {}

--- a/test/compilable/testheader1i.d
+++ b/test/compilable/testheader1i.d
@@ -2,5 +2,11 @@
 // REQUIRED_ARGS: -o- -H -Hf${RESULTS_DIR}/compilable/testheader1i.di -inline -ignore
 // PERMUTE_ARGS: -d -dw
 // POST_SCRIPT: compilable/extra-files/header-postscript.sh
+/*
+TEST_OUTPUT:
+---
+Hello World
+---
+*/
 
 void main() {}


### PR DESCRIPTION
These test were simply missing an appropriate section. The remaining ones need
some extensions to d_do_test.d to handle e.g. paths.

~~Currently includes #10754 to avoid some deprecations messages regarding `body`.~~