### PR TITLE
Fix issue 12931: Make ambiguous qualifiers illegal on the LHS of a function

### DIFF
--- a/changelog/lhs-modifier-deprecated.dd
+++ b/changelog/lhs-modifier-deprecated.dd
@@ -1,0 +1,27 @@
+Ambiguous modifiers on the left side of a function declaration are deprecated
+
+The keywords `immutable`, `const`, `shared`, `inout` could go on the left side
+of a declaration, as follows:
+---
+class Foo
+{
+    const Object makeObject();
+    shared char[] synchronizeMe();
+    // Etc...
+}
+---
+However, this could easily lead to bugs when the user
+intended the qualifier to apply to the return type, e.g.:
+---
+class Oops
+{
+    static immutable Header = [ 0x2A ];
+
+    immutable(ubyte[]) correct() { return Header; }
+    immutable ubyte[] incorrect() { return Header; }
+
+    // This is actually:
+    ubyte[] actually() immutable { return Header; }
+}
+---
+Using those keywords on the left side is now deprecated.

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3399,14 +3399,6 @@ private void visitFuncIdentWithPrefix(TypeFunction t, const Identifier ident, Te
     }
     t.inuse++;
 
-    /* Use 'storage class' (prefix) style for attributes
-     */
-    if (t.mod)
-    {
-        MODtoBuffer(buf, t.mod);
-        buf.writeByte(' ');
-    }
-
     void ignoreReturn(string str)
     {
         if (str != "return")
@@ -3451,6 +3443,13 @@ private void visitFuncIdentWithPrefix(TypeFunction t, const Identifier ident, Te
         buf.writeByte(')');
     }
     parametersToBuffer(t.parameterList, buf, hgs);
+    /* Use postfix style for attributes (prefix is deprecated)
+     */
+    if (t.mod)
+    {
+        buf.writeByte(' ');
+        MODtoBuffer(buf, t.mod);
+    }
     if (t.isreturn)
     {
         buf.writestring(" return");

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -4139,8 +4139,29 @@ final class Parser(AST) : Lexer
                     AST.Parameters* parameters = parseParameters(&varargs);
 
                     /* Parse const/immutable/shared/inout/nothrow/pure/return postfix
+                       Check if `const`/`immutable`/`inout`/`shared` prefix were used
+                       merge prefix storage classes
+
+                       @@@DEPRECATED@@@
+                       https://issues.dlang.org/show_bug.cgi?id=12931
+                       Deprecated in 2.091 - Can be removed from 2.101
                      */
-                    // merge prefix storage classes
+                    if (storageClass & STC.const_)
+                        deprecation(
+                            "Using `const` on the left hand side of a declaration is deprecated. " ~
+                            "Move `const` to the right hand side of the function.");
+                    if (storageClass & STC.immutable_)
+                        deprecation(
+                            "Using `immutable` on the left hand side of a declaration is deprecated. " ~
+                            "Move `immutable` to the right hand side of the function.");
+                    if (storageClass & STC.shared_)
+                        deprecation(
+                            "Using `shared` on the left hand side of a declaration is deprecated. " ~
+                            "Move `shared` to the right hand side of the function.");
+                    if (storageClass & STC.wild)
+                        deprecation(
+                            "Using `inout` on the left hand side of a declaration is deprecated. " ~
+                            "Move `inout` to the right hand side of the function.");
                     StorageClass stc = parsePostfix(storageClass, pudas);
 
                     AST.Type tf = new AST.TypeFunction(AST.ParameterList(parameters, varargs), t, linkage, stc);

--- a/test/compilable/extra-files/ddoc10.html
+++ b/test/compilable/extra-files/ddoc10.html
@@ -1084,7 +1084,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="S.this"></span>const pure nothrow this(long <code class="code">ticks</code>);
+            <span class="ddoc_anchor" id="S.this"></span>pure nothrow this(long <code class="code">ticks</code>) const;
 
           </code>
         </p>
@@ -1109,7 +1109,7 @@ void <code class="code">map2</code>()(int <code class="code">rs</code>);
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="S.foo"></span>const pure nothrow void <code class="code">foo</code>(long <code class="code">ticks</code>);
+            <span class="ddoc_anchor" id="S.foo"></span>pure nothrow void <code class="code">foo</code>(long <code class="code">ticks</code>) const;
 
           </code>
         </p>

--- a/test/compilable/extra-files/ddoc10869.html
+++ b/test/compilable/extra-files/ddoc10869.html
@@ -548,7 +548,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.c1Foo"></span>const void <code class="code">c1Foo</code>();
+            <span class="ddoc_anchor" id="C.c1Foo"></span>void <code class="code">c1Foo</code>() const;
 
           </code>
         </p>
@@ -573,7 +573,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.i1Foo"></span>immutable void <code class="code">i1Foo</code>();
+            <span class="ddoc_anchor" id="C.i1Foo"></span>void <code class="code">i1Foo</code>() immutable;
 
           </code>
         </p>
@@ -598,7 +598,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.c2Foo"></span>immutable void <code class="code">c2Foo</code>();
+            <span class="ddoc_anchor" id="C.c2Foo"></span>void <code class="code">c2Foo</code>() immutable;
 
           </code>
         </p>
@@ -623,7 +623,7 @@
       <div class="dlang">
         <p class="para">
           <code class="code">
-            <span class="ddoc_anchor" id="C.i2Foo"></span>immutable void <code class="code">i2Foo</code>();
+            <span class="ddoc_anchor" id="C.i2Foo"></span>void <code class="code">i2Foo</code>() immutable;
 
           </code>
         </p>

--- a/test/compilable/extra-files/header1.d
+++ b/test/compilable/extra-files/header1.d
@@ -385,7 +385,7 @@ struct S6360
 {
     @property long weeks1() const pure nothrow { return 0; }
 
-    @property const pure nothrow long weeks2() { return 0; }
+    @property pure nothrow long weeks2() const { return 0; }
 }
 
 
@@ -404,8 +404,8 @@ struct T12
     /// postfix storage class and template constructor
     this()(int args) immutable { }
 
-    /// prefix storage class (==StorageClassDeclaration) and template constructor
-    immutable this(A...)(A args){ }
+    /// postfix storage class (==StorageClassDeclaration) and template constructor
+    this(A...)(A args) immutable { }
 }
 
 
@@ -531,7 +531,7 @@ size_t magic() {
 class Foo2A {
 
     immutable(FooA) Dummy = new immutable(FooA);
-    private immutable pure nothrow @nogc @safe this() {
+    private pure nothrow @nogc @safe this() immutable {
 
     }
 

--- a/test/compilable/extra-files/header1.di
+++ b/test/compilable/extra-files/header1.di
@@ -341,8 +341,8 @@ int bar11(T)()
 }
 struct S6360
 {
-	const pure nothrow @property long weeks1();
-	const pure nothrow @property long weeks2();
+	pure nothrow @property long weeks1() const;
+	pure nothrow @property long weeks2() const;
 }
 struct S12
 {
@@ -355,10 +355,10 @@ struct S12
 }
 struct T12
 {
-	immutable this()(int args)
+	this()(int args) immutable
 	{
 	}
-	immutable this(A...)(A args)
+	this(A...)(A args) immutable
 	{
 	}
 }
@@ -492,7 +492,7 @@ size_t magic();
 class Foo2A
 {
 	immutable(FooA) Dummy = new immutable(FooA);
-	private immutable pure nothrow @nogc @safe this()
+	private pure nothrow @nogc @safe this() immutable
 	{
 	}
 }

--- a/test/compilable/extra-files/header18365.di
+++ b/test/compilable/extra-files/header18365.di
@@ -4,7 +4,7 @@ struct FullCaseEntry
 	ubyte n;
 	ubyte size;
 	ubyte entry_len;
-	auto const pure nothrow @nogc @property @trusted value() return
+	auto pure nothrow @nogc @property @trusted value() const return
 	{
 		return seq[0..entry_len];
 	}

--- a/test/compilable/extra-files/header1i.di
+++ b/test/compilable/extra-files/header1i.di
@@ -447,11 +447,11 @@ int bar11(T)()
 }
 struct S6360
 {
-	const pure nothrow @property long weeks1()
+	pure nothrow @property long weeks1() const
 	{
 		return 0;
 	}
-	const pure nothrow @property long weeks2()
+	pure nothrow @property long weeks2() const
 	{
 		return 0;
 	}
@@ -467,10 +467,10 @@ struct S12
 }
 struct T12
 {
-	immutable this()(int args)
+	this()(int args) immutable
 	{
 	}
-	immutable this(A...)(A args)
+	this(A...)(A args) immutable
 	{
 	}
 }
@@ -619,7 +619,7 @@ size_t magic()
 class Foo2A
 {
 	immutable(FooA) Dummy = new immutable(FooA);
-	private immutable pure nothrow @nogc @safe this()
+	private pure nothrow @nogc @safe this() immutable
 	{
 	}
 }

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -117,7 +117,7 @@
                                 "kind": "function",
                                 "line": 23,
                                 "name": "t",
-                                "type": "const T[0]()"
+                                "type": "T[0]() const"
                             }
                         ],
                         "name": "Baz"

--- a/test/fail_compilation/fail180.d
+++ b/test/fail_compilation/fail180.d
@@ -18,7 +18,7 @@ struct S59
     {
         x = 3;
     }
-    const void bar()
+    void bar() const
     {
         x = 4;
         this.x = 5;
@@ -33,7 +33,7 @@ class C
     {
         x = 3;
     }
-    const void bar()
+    void bar() const
     {
         x = 4;
         this.x = 5;

--- a/test/fail_compilation/fail262.d
+++ b/test/fail_compilation/fail262.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail262.d(23): Error: function `const void fail262.B.f()` does not override any function, did you mean to override `shared const void fail262.A.f()`?
+fail_compilation/fail262.d(23): Error: function `void fail262.B.f() const` does not override any function, did you mean to override `void fail262.A.f() shared const`?
 ---
 */
 
@@ -12,7 +12,7 @@ import core.stdc.stdio;
 class A
 {
     int x;
-    shared const void f()
+    void f() shared const
     {
         printf("A\n");
     }
@@ -20,7 +20,7 @@ class A
 
 class B : A
 {
-    override const void f()
+    override void f() const
     {
         //x = 2;
         printf("B\n");

--- a/test/fail_compilation/fail8631.d
+++ b/test/fail_compilation/fail8631.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail8631.d(14): Error: function `shared const int fail8631.D.foo()` does not override any function, did you mean to override `immutable int fail8631.B.foo()`?
+fail_compilation/fail8631.d(14): Error: function `int fail8631.D.foo() shared const` does not override any function, did you mean to override `int fail8631.B.foo() immutable`?
 ---
 */
 

--- a/test/fail_compilation/issue12931.d
+++ b/test/fail_compilation/issue12931.d
@@ -1,0 +1,31 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/issue12931.d(103): Deprecation: Using `const` on the left hand side of a declaration is deprecated. Move `const` to the right hand side of the function.
+fail_compilation/issue12931.d(104): Deprecation: Using `immutable` on the left hand side of a declaration is deprecated. Move `immutable` to the right hand side of the function.
+fail_compilation/issue12931.d(105): Deprecation: Using `shared` on the left hand side of a declaration is deprecated. Move `shared` to the right hand side of the function.
+fail_compilation/issue12931.d(106): Deprecation: Using `inout` on the left hand side of a declaration is deprecated. Move `inout` to the right hand side of the function.
+fail_compilation/issue12931.d(111): Deprecation: Using `const` on the left hand side of a declaration is deprecated. Move `const` to the right hand side of the function.
+fail_compilation/issue12931.d(112): Deprecation: Using `immutable` on the left hand side of a declaration is deprecated. Move `immutable` to the right hand side of the function.
+fail_compilation/issue12931.d(113): Deprecation: Using `shared` on the left hand side of a declaration is deprecated. Move `shared` to the right hand side of the function.
+fail_compilation/issue12931.d(114): Deprecation: Using `inout` on the left hand side of a declaration is deprecated. Move `inout` to the right hand side of the function.
+---
+*/
+#line 100
+
+class Foo
+{
+    const int constMeth () { assert(0); }
+    immutable int immutableMeth () { assert(0); }
+    shared int sharedMeth () { assert(0); }
+    inout int inoutMeth (inout(string) arg) { assert(0); }
+}
+
+struct Bar
+{
+    const int constMeth () { assert(0); }
+    immutable int immutableMeth () { assert(0); }
+    shared int sharedMeth () { assert(0); }
+    inout int inoutMeth (inout(string) arg) { assert(0); }
+}

--- a/test/fail_compilation/parse12967a.d
+++ b/test/fail_compilation/parse12967a.d
@@ -1,36 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parse12967a.d(14): Error: function `parse12967a.pre_i1` without `this` cannot be `immutable`
-fail_compilation/parse12967a.d(15): Error: function `parse12967a.pre_i2` without `this` cannot be `immutable`
-fail_compilation/parse12967a.d(16): Error: function `parse12967a.pre_c1` without `this` cannot be `const`
-fail_compilation/parse12967a.d(17): Error: function `parse12967a.pre_c2` without `this` cannot be `const`
-fail_compilation/parse12967a.d(18): Error: function `parse12967a.pre_w1` without `this` cannot be `inout`
-fail_compilation/parse12967a.d(19): Error: function `parse12967a.pre_w2` without `this` cannot be `inout`
-fail_compilation/parse12967a.d(20): Error: function `parse12967a.pre_s1` without `this` cannot be `shared`
-fail_compilation/parse12967a.d(21): Error: function `parse12967a.pre_s2` without `this` cannot be `shared`
----
-*/
-immutable      pre_i1() {}
-immutable void pre_i2() {}
-const          pre_c1() {}
-const     void pre_c2() {}
-inout          pre_w1() {}
-inout     void pre_w2() {}
-shared         pre_s1() {}
-shared    void pre_s2() {}
-
-/*
-TEST_OUTPUT:
----
-fail_compilation/parse12967a.d(36): Error: function `parse12967a.post_i1` without `this` cannot be `immutable`
-fail_compilation/parse12967a.d(37): Error: function `parse12967a.post_i2` without `this` cannot be `immutable`
-fail_compilation/parse12967a.d(38): Error: function `parse12967a.post_c1` without `this` cannot be `const`
-fail_compilation/parse12967a.d(39): Error: function `parse12967a.post_c2` without `this` cannot be `const`
-fail_compilation/parse12967a.d(40): Error: function `parse12967a.post_w1` without `this` cannot be `inout`
-fail_compilation/parse12967a.d(41): Error: function `parse12967a.post_w2` without `this` cannot be `inout`
-fail_compilation/parse12967a.d(42): Error: function `parse12967a.post_s1` without `this` cannot be `shared`
-fail_compilation/parse12967a.d(43): Error: function `parse12967a.post_s2` without `this` cannot be `shared`
+fail_compilation/parse12967a.d(14): Error: function `parse12967a.post_i1` without `this` cannot be `immutable`
+fail_compilation/parse12967a.d(15): Error: function `parse12967a.post_i2` without `this` cannot be `immutable`
+fail_compilation/parse12967a.d(16): Error: function `parse12967a.post_c1` without `this` cannot be `const`
+fail_compilation/parse12967a.d(17): Error: function `parse12967a.post_c2` without `this` cannot be `const`
+fail_compilation/parse12967a.d(18): Error: function `parse12967a.post_w1` without `this` cannot be `inout`
+fail_compilation/parse12967a.d(19): Error: function `parse12967a.post_w2` without `this` cannot be `inout`
+fail_compilation/parse12967a.d(20): Error: function `parse12967a.post_s1` without `this` cannot be `shared`
+fail_compilation/parse12967a.d(21): Error: function `parse12967a.post_s2` without `this` cannot be `shared`
 ---
 */
 auto post_i1() immutable {}

--- a/test/fail_compilation/parse12967b.d
+++ b/test/fail_compilation/parse12967b.d
@@ -1,31 +1,18 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/parse12967b.d(24): Error: function `parse12967b.C.pre_c` without `this` cannot be `const`
-fail_compilation/parse12967b.d(25): Error: function `parse12967b.C.pre_i` without `this` cannot be `immutable`
-fail_compilation/parse12967b.d(26): Error: function `parse12967b.C.pre_w` without `this` cannot be `inout`
-fail_compilation/parse12967b.d(27): Error: function `parse12967b.C.pre_s` without `this` cannot be `shared`
-fail_compilation/parse12967b.d(29): Error: function `parse12967b.C.post_c` without `this` cannot be `const`
-fail_compilation/parse12967b.d(30): Error: function `parse12967b.C.post_i` without `this` cannot be `immutable`
-fail_compilation/parse12967b.d(31): Error: function `parse12967b.C.post_w` without `this` cannot be `inout`
-fail_compilation/parse12967b.d(32): Error: function `parse12967b.C.post_s` without `this` cannot be `shared`
-fail_compilation/parse12967b.d(37): Error: function `parse12967b.D.pre_c` without `this` cannot be `const`
-fail_compilation/parse12967b.d(38): Error: function `parse12967b.D.pre_i` without `this` cannot be `immutable`
-fail_compilation/parse12967b.d(39): Error: function `parse12967b.D.pre_w` without `this` cannot be `inout`
-fail_compilation/parse12967b.d(40): Error: function `parse12967b.D.pre_s` without `this` cannot be `shared`
-fail_compilation/parse12967b.d(41): Error: function `parse12967b.D.post_c` without `this` cannot be `const`
-fail_compilation/parse12967b.d(42): Error: function `parse12967b.D.post_i` without `this` cannot be `immutable`
-fail_compilation/parse12967b.d(43): Error: function `parse12967b.D.post_w` without `this` cannot be `inout`
-fail_compilation/parse12967b.d(44): Error: function `parse12967b.D.post_s` without `this` cannot be `shared`
+fail_compilation/parse12967b.d(16): Error: function `parse12967b.C.post_c` without `this` cannot be `const`
+fail_compilation/parse12967b.d(17): Error: function `parse12967b.C.post_i` without `this` cannot be `immutable`
+fail_compilation/parse12967b.d(18): Error: function `parse12967b.C.post_w` without `this` cannot be `inout`
+fail_compilation/parse12967b.d(19): Error: function `parse12967b.C.post_s` without `this` cannot be `shared`
+fail_compilation/parse12967b.d(24): Error: function `parse12967b.D.post_c` without `this` cannot be `const`
+fail_compilation/parse12967b.d(25): Error: function `parse12967b.D.post_i` without `this` cannot be `immutable`
+fail_compilation/parse12967b.d(26): Error: function `parse12967b.D.post_w` without `this` cannot be `inout`
+fail_compilation/parse12967b.d(27): Error: function `parse12967b.D.post_s` without `this` cannot be `shared`
 ---
 */
 class C
 {
-    const     static      pre_c() {}
-    immutable static      pre_i() {}
-    inout     static      pre_w() {}
-    shared    static      pre_s() {}
-
     static      post_c() const     {}
     static      post_i() immutable {}
     static      post_w() inout     {}
@@ -34,10 +21,6 @@ class C
 
 class D
 {
-    const     static void pre_c() {}
-    immutable static void pre_i() {}
-    inout     static void pre_w() {}
-    shared    static void pre_s() {}
     static void post_c() const     {}
     static void post_i() immutable {}
     static void post_w() inout     {}

--- a/test/fail_compilation/parseStc.d
+++ b/test/fail_compilation/parseStc.d
@@ -34,5 +34,5 @@ fail_compilation/parseStc.d(37): Error: redundant attribute `const`
 fail_compilation/parseStc.d(38): Error: redundant attribute `const`
 ---
 */
-struct S3 { const const test3() {} }
+struct S3 { auto test3() const const {} }
 void test4(const const int x) {}

--- a/test/fail_compilation/parseStc2.d
+++ b/test/fail_compilation/parseStc2.d
@@ -5,14 +5,14 @@ fail_compilation/parseStc2.d(11): Error: conflicting attribute `const`
 fail_compilation/parseStc2.d(12): Error: conflicting attribute `@system`
 fail_compilation/parseStc2.d(13): Error: conflicting attribute `@safe`
 fail_compilation/parseStc2.d(14): Error: conflicting attribute `@trusted`
-fail_compilation/parseStc2.d(15): Error: conflicting attribute `__gshared`
+fail_compilation/parseStc2.d(15): Error: conflicting attribute `shared`
 ---
 */
-immutable const void f4() {}
+auto void f4() immutable const {}
 @safe @system void f4() {}
 @trusted @safe void f4() {}
 @system @trusted void f4() {}
-shared __gshared f4() {}
+__gshared f4() shared {}
 
 /*
 TEST_OUTPUT:

--- a/test/runnable/aliasthis.d
+++ b/test/runnable/aliasthis.d
@@ -891,7 +891,7 @@ void test6366()
         {
             str = s;
         }
-        @property const bool empty()
+        @property bool empty() const
         {
             return i == str.length;
         }

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -702,7 +702,7 @@ void test30()
 /*******************************************/
 
 template Share(T) {
-  const bool opEquals(ref const T x) { return true; }
+  bool opEquals(ref const T x) const { return true; }
 }
 
 struct List31(T) {

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1064,7 +1064,7 @@ bool approxEqual(float a, float b)
 
 struct Point {
     float x = 0, y = 0;
-    const bool opEquals(const ref Point rhs)
+    bool opEquals(const ref Point rhs) const
     {
         return approxEqual(x, rhs.x) && approxEqual(y, rhs.y);
     }
@@ -2551,7 +2551,7 @@ struct Test9386
         op[i++] = 'c';
     }
 
-    const int opCmp(ref const Test9386 t)
+    int opCmp(ref const Test9386 t) const
     {
         return op[0] - t.op[0];
     }

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -203,10 +203,10 @@ void test9()
 /*****************************************/
 
 struct Foo10 {
-  const bool opEquals(const ref Foo10 x) {
+  bool opEquals(const ref Foo10 x) const {
     return this.normalize is x.normalize;
   }
-  const Foo10 normalize() {
+  Foo10 normalize() const {
     Foo10 res;
     return res;
   }
@@ -378,12 +378,12 @@ struct Iterator18(T)
 {
    T* m_ptr;
 
-   const bool opEquals(const ref Iterator18 iter)
+   bool opEquals(const ref Iterator18 iter) const
    {
      return (m_ptr == iter.m_ptr);
    }
 
-   const int opCmp(const ref Iterator18 iter)
+   int opCmp(const ref Iterator18 iter) const
    {
      return cast(int)(m_ptr - iter.m_ptr);
    }
@@ -398,12 +398,12 @@ void test18()
 
 struct S29(T)
 {
-   const bool opEquals(const ref S29!(T) len2)
+   bool opEquals(const ref S29!(T) len2) const
    {
      return 0;
    }
 
-   const int opCmp(const ref S29!(T) len2)
+   int opCmp(const ref S29!(T) len2) const
    {
      return 0;
    }

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -446,12 +446,12 @@ class Foo31
 {
   int x;
 
-  immutable immutable(int)* geti()
+  immutable(int)* geti() immutable
   {
     return &x;
   }
 
-  const const(int)* getc()
+  const(int)* getc() const
   {
     return &x;
   }
@@ -971,7 +971,7 @@ void test56()
 
 struct S57
 {
-    const void foo(this T)(int i)
+    void foo(this T)(int i) const
     {
         showf(typeid(T).toString());
         if (i == 1)
@@ -1006,7 +1006,7 @@ class C58
         c = null;
     }
 
-    const void foo()
+    void foo() const
     {
         //c = null; // should fail
     }
@@ -1029,8 +1029,8 @@ class A59
     this() { a.length = 1; }
 
     int* ptr() { return a.ptr; }
-    const const(int)* ptr() { return a.ptr; }
-    immutable immutable(int)* ptr() { return a.ptr; }
+    const(int)* ptr() const { return a.ptr; }
+    immutable(int)* ptr() immutable { return a.ptr; }
 }
 
 void test59()

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -886,7 +886,7 @@ class A45
 
 class B45 : A45
 {
-  override const int f()
+  override int f() const
   {
     printf("B\n");
     return 2;
@@ -1142,7 +1142,7 @@ void test58()
 /***************************************************/
 
 class A59 {
-    const foo(int i)  { return i; }
+    auto foo(int i) const { return i; }
 }
 
 /***************************************************/
@@ -2040,7 +2040,7 @@ void test96()
 
 struct A97
 {
-    const bool opEquals(ref const A97) { return true; }
+    bool opEquals(ref const A97) const { return true; }
     ref A97 opUnary(string op)() if (op == "++")
     {
         return this;
@@ -3223,7 +3223,7 @@ struct S142
 {
     int v;
     this(int n) pure { v = n; }
-    const bool opCast(T:bool)() { return true; }
+    bool opCast(T:bool)() const { return true; }
 }
 
 void test142()
@@ -3783,7 +3783,7 @@ auto ref boo(int i) pure nothrow { return i; }
 
 class A152 {
     auto hoo(int i) pure  { return i; }
-    const boo(int i) nothrow { return i; }
+    auto boo(int i) nothrow { return i; }
     auto coo(int i) const { return i; }
     auto doo(int i) immutable { return i; }
     auto eoo(int i) shared { return i; }
@@ -3968,23 +3968,6 @@ void test5554()
     {
         override MC foo() { return null; }
     }
-}
-
-/***************************************************/
-// https://issues.dlang.org/show_bug.cgi?id=5962
-
-struct S156
-{
-          auto g()(){ return 1; }
-    const auto g()(){ return 2; }
-}
-
-void test156()
-{
-    auto ms = S156();
-    assert(ms.g() == 1);
-    auto cs = const(S156)();
-    assert(cs.g() == 2);
 }
 
 /***************************************************/
@@ -4304,7 +4287,7 @@ void test6335()
 
 struct S6295(int N) {
     int[N] x;
-    const nothrow pure @safe f() { return x.length; }
+    nothrow pure @safe f() const { return x.length; }
 }
 
 void test6295() {
@@ -5077,7 +5060,7 @@ struct TickDuration
 {
     template to(T) if (__traits(isIntegral,T))
     {
-        const T to()
+        T to() const
         {
             return 1;
         }
@@ -5085,13 +5068,13 @@ struct TickDuration
 
     template to(T) if (__traits(isFloating,T))
     {
-        const T to()
+        T to() const
         {
             return 0;
         }
     }
 
-    const long seconds()
+    long seconds() const
     {
         return to!(long)();
     }
@@ -5757,7 +5740,7 @@ void test7321()
 class A158
 {
     pure void foo1() { }
-    const void foo2() { }
+    void foo2() const { }
     nothrow void foo3() { }
     @safe void foo4() { }
 }
@@ -8161,7 +8144,6 @@ int main()
     test153();
     test154();
     test155();
-    test156();
     test658();
     test4258();
     test4539();


### PR DESCRIPTION
```
This has been a pain point for many D users for years,
both new and old, as can be seen from the discussions on the issue.
It is however a potentially disruptive deprecation.

Note: The test for issue 5962 in test/runnable/xtest46.d has been
removed as the issue was only present with prefix syntax.
```

~Depends on https://github.com/dlang/phobos/pull/7389 & https://github.com/dlang/phobos/pull/7391~
I'll take a look at what is affected in Buildkite before we merge this.

Still needs a spec PR, and since it's a significant change, @WalterBright / @atilaneves ' approval.