### PR TITLE
[WIP] Rework -unittest flag 

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -795,8 +795,8 @@ extern (C++) final class VersionCondition : DVCondition
                 else if (findCondition(global.versionids, ident))
                 {
                     inc = Include.yes;
-                    if (ident == Id._unittest && !mod.isRoot())
-                        inc = Include.no;
+                    //if (ident == Id._unittest && !mod.isRoot())
+                        //inc = Include.no;
                 }
                 else
                 {

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -793,11 +793,7 @@ extern (C++) final class VersionCondition : DVCondition
                     definedInModule = true;
                 }
                 else if (findCondition(global.versionids, ident))
-                {
                     inc = Include.yes;
-                    //if (ident == Id._unittest && !mod.isRoot())
-                        //inc = Include.no;
-                }
                 else
                 {
                     if (!mod.versionidsNot)

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -793,7 +793,11 @@ extern (C++) final class VersionCondition : DVCondition
                     definedInModule = true;
                 }
                 else if (findCondition(global.versionids, ident))
+                {
                     inc = Include.yes;
+                    if (ident == Id._unittest && !mod.isRoot())
+                        inc = Include.no;
+                }
                 else
                 {
                     if (!mod.versionidsNot)

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7160,7 +7160,8 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     {
         Module mi = minst; // instantiated . inserted module
 
-        if (global.params.useUnitTests || global.params.debuglevel)
+        //if (global.params.useUnitTests || global.params.debuglevel)
+        if (global.params.debuglevel)
         {
             // Turn all non-root instances to speculative
             if (mi && !mi.isRoot())

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -6156,8 +6156,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
          * is behind a conditional debug declaration.
          */
         // workaround for https://issues.dlang.org/show_bug.cgi?id=11239
-        if (global.params.useUnitTests ||
-            global.params.debuglevel)
+        if (global.params.debuglevel)
         {
             // Prefer instantiations from root modules, to maximize link-ability.
             if (minst.isRoot())
@@ -7160,8 +7159,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     {
         Module mi = minst; // instantiated . inserted module
 
-        //if (global.params.useUnitTests || global.params.debuglevel)
-        if (global.params.debuglevel)
+        if (global.params.useUnitTests || global.params.debuglevel)
         {
             // Turn all non-root instances to speculative
             if (mi && !mi.isRoot())

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7117,7 +7117,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
     {
         Module mi = minst; // instantiated . inserted module
 
-        if (global.params.useUnitTests || global.params.debuglevel)
+        if (global.params.debuglevel)
         {
             // Turn all non-root instances to speculative
             if (mi && !mi.isRoot())


### PR DESCRIPTION
The idea of this PR is to decrease the compilation time when the `-unittest` switch is used. 

This has to do with the way the current algorithm that generates code for template instantiations works. The algorithm has two  branches:

-  If `-unittest` is used, then **do code generation for every template that is instantiated and used in a root module**, even if the same template is instantiated in some non-root module that is imported.

- Else (`unittests` **not** enabled) prefer instantiations from non-root modules, to minimize object code size. If a template is ever instantiated by non-root modules, **do not generate code for it**, because it will be generated when the non-root module is compiled.

 So there are 3 options in my opinion:

1. the first one is to eliminate the branching and to adopt in every case the same behaviour performed when the `-unittest` switch is used: this _might_ decrease the compile-time and will generate huge binaries because for almost every template instantiation code will be generated, but there will be a unified behaviour in the compiler
 
2. make the non-unittest behaviour the default, keep binaries small, decrease compilation time when `-unittest` is enabled but break a lot of code and force people to change the way they compile and write their code

3. make a better code generation algorithm for templates (that will use some kind of analysis to determine on which template instantiations code generation should be called and on which shouldn’t be called)
          1. this probably will lead to an increase in the binary size (not a huge one, but most likely we won’t be able to do something fine-grained because of the amount of work/time needed)
          2. and probably will break some code but not that much and will also decrease the `-unittest` compilation time

So far I've eliminated the branching from the algorithm and I've made the "if `-unittest` is used" behaviour the default one. The next step is to do some measurements regarding the compilation time and based on them to decide what should be done further. I'll update this description with the measurements when I'll have them. 

