### PR TITLE
Cherry-pick PR 10725 to stable

### DIFF
--- a/changelog/d1-operator-deprecation.dd
+++ b/changelog/d1-operator-deprecation.dd
@@ -1,0 +1,18 @@
+D1-style operator now have a lower priority than D2-style
+
+D1 operator overloads have been deprecated in $(LINK2 https://dlang.org/changelog/2.088.0.html v2.088.0).
+They historically had priority over D2 operator overload, and that priority was kept as is even after deprecating them.
+
+One main difference between D1 and D2 operator overload is that D1's are `virtual` by default,
+while the D2 operator overloading scheme relies on template, and so cannot be virtual.
+Code relying on virtuality of operator can be trivially adapted by providing a D2-style operator
+overload that forwards to a virtual method.
+
+However, as D1 operator overloads take priority, the deprecation message will be issued even if a D2
+operator overload is present.
+This means that code relying on virtual operators would need not only to introduce the aforementioned
+D2-style overload, but also to rename their method not to match the reserved D1 names.
+This in turns forces libraries to introduce a breaking change in order to silence the deprecation.
+
+Starting from this release, D2-style operator overloads take priority over D1-style,
+making it trivial to forward the former to the later.

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -393,25 +393,6 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
             if (ad)
             {
                 Dsymbol fd = null;
-                version (all)
-                {
-                    // Old way, kept for compatibility with D1
-                    if (e.op != TOK.prePlusPlus && e.op != TOK.preMinusMinus)
-                    {
-                        auto id = opId(e);
-                        fd = search_function(ad, id);
-                        if (fd)
-                        {
-                            // @@@DEPRECATED_2.094@@@.
-                            // Deprecated in 2.088
-                            // Make an error in 2.094
-                            e.deprecation("`%s` is deprecated.  Use `opUnary(string op)() if (op == \"%s\")` instead.", id.toChars(), Token.toChars(e.op));
-                            // Rewrite +e1 as e1.add()
-                            result = build_overload(e.loc, sc, e.e1, null, fd);
-                            return;
-                        }
-                    }
-                }
                 /* Rewrite as:
                  *      e1.opUnary!(op)()
                  */
@@ -423,6 +404,22 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     result = new CallExp(e.loc, result);
                     result = result.expressionSemantic(sc);
                     return;
+                }
+                // D1-style operator overloads, deprecated
+                if (e.op != TOK.prePlusPlus && e.op != TOK.preMinusMinus)
+                {
+                    auto id = opId(e);
+                    fd = search_function(ad, id);
+                    if (fd)
+                    {
+                        // @@@DEPRECATED_2.094@@@.
+                        // Deprecated in 2.088
+                        // Make an error in 2.094
+                        e.deprecation("`%s` is deprecated.  Use `opUnary(string op)() if (op == \"%s\")` instead.", id.toChars(), Token.toChars(e.op));
+                        // Rewrite +e1 as e1.add()
+                        result = build_overload(e.loc, sc, e.e1, null, fd);
+                        return;
+                    }
                 }
                 // Didn't find it. Forward to aliasthis
                 if (ad.aliasthis && e.e1.type != e.att1)
@@ -632,40 +629,6 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
             }
             Dsymbol s = null;
             Dsymbol s_r = null;
-            version (all)
-            {
-                // the old D1 scheme
-                if (ad1 && id)
-                {
-                    s = search_function(ad1, id);
-                    if (s && id != Id.assign)
-                    {
-                        // @@@DEPRECATED_2.094@@@.
-                        // Deprecated in 2.088
-                        // Make an error in 2.094
-                        if (id == Id.postinc || id == Id.postdec)
-                            e.deprecation("`%s` is deprecated.  Use `opUnary(string op)() if (op == \"%s\")` instead.", id.toChars(), Token.toChars(e.op));
-                        else
-                            e.deprecation("`%s` is deprecated.  Use `opBinary(string op)(...) if (op == \"%s\")` instead.", id.toChars(), Token.toChars(e.op));
-                    }
-                }
-                if (ad2 && id_r)
-                {
-                    s_r = search_function(ad2, id_r);
-                    // https://issues.dlang.org/show_bug.cgi?id=12778
-                    // If both x.opBinary(y) and y.opBinaryRight(x) found,
-                    // and they are exactly same symbol, x.opBinary(y) should be preferred.
-                    if (s_r && s_r == s)
-                        s_r = null;
-                    if (s_r)
-                    {
-                        // @@@DEPRECATED_2.094@@@.
-                        // Deprecated in 2.088
-                        // Make an error in 2.094
-                        e.deprecation("`%s` is deprecated.  Use `opBinaryRight(string op)(...) if (op == \"%s\")` instead.", id_r.toChars(), Token.toChars(e.op));
-                    }
-                }
-            }
             Objects* tiargs = null;
             if (e.op == TOK.plusPlus || e.op == TOK.minusMinus)
             {
@@ -673,9 +636,9 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                 if (ad1 && search_function(ad1, Id.opUnary))
                     return;
             }
-            if (!s && !s_r && e.op != TOK.equal && e.op != TOK.notEqual && e.op != TOK.assign && e.op != TOK.plusPlus && e.op != TOK.minusMinus)
+            if (e.op != TOK.equal && e.op != TOK.notEqual && e.op != TOK.assign && e.op != TOK.plusPlus && e.op != TOK.minusMinus)
             {
-                /* Try the new D2 scheme, opBinary and opBinaryRight
+                /* Try opBinary and opBinaryRight
                  */
                 if (ad1)
                 {
@@ -705,6 +668,40 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                     id = Id.opBinary;
                     id_r = Id.opBinaryRight;
                     tiargs = opToArg(sc, e.op);
+                }
+            }
+            if (!s && !s_r)
+            {
+                // Try the D1-style operators, deprecated
+                if (ad1 && id)
+                {
+                    s = search_function(ad1, id);
+                    if (s && id != Id.assign)
+                    {
+                        // @@@DEPRECATED_2.094@@@.
+                        // Deprecated in 2.088
+                        // Make an error in 2.094
+                        if (id == Id.postinc || id == Id.postdec)
+                            e.deprecation("`%s` is deprecated.  Use `opUnary(string op)() if (op == \"%s\")` instead.", id.toChars(), Token.toChars(e.op));
+                        else
+                            e.deprecation("`%s` is deprecated.  Use `opBinary(string op)(...) if (op == \"%s\")` instead.", id.toChars(), Token.toChars(e.op));
+                    }
+                }
+                if (ad2 && id_r)
+                {
+                    s_r = search_function(ad2, id_r);
+                    // https://issues.dlang.org/show_bug.cgi?id=12778
+                    // If both x.opBinary(y) and y.opBinaryRight(x) found,
+                    // and they are exactly same symbol, x.opBinary(y) should be preferred.
+                    if (s_r && s_r == s)
+                        s_r = null;
+                    if (s_r)
+                    {
+                        // @@@DEPRECATED_2.094@@@.
+                        // Deprecated in 2.088
+                        // Make an error in 2.094
+                        e.deprecation("`%s` is deprecated.  Use `opBinaryRight(string op)(...) if (op == \"%s\")` instead.", id_r.toChars(), Token.toChars(e.op));
+                    }
                 }
             }
             if (s || s_r)
@@ -1277,45 +1274,41 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
             Expressions args2;
             AggregateDeclaration ad1 = isAggregate(e.e1.type);
             Dsymbol s = null;
-            version (all)
+            Objects* tiargs = null;
+            /* Try opOpAssign
+             */
+            if (ad1)
             {
-                // the old D1 scheme
-                if (ad1 && id)
+                s = search_function(ad1, Id.opOpAssign);
+                if (s && !s.isTemplateDeclaration())
                 {
-                    s = search_function(ad1, id);
-                    if (s)
-                    {
-                        // @@@DEPRECATED_2.094@@@.
-                        // Deprecated in 2.088
-                        // Make an error in 2.094
-                        scope char[] op = Token.toString(e.op).dup;
-                        op[$-1] = '\0'; // remove trailing `=`
-                        e.deprecation("`%s` is deprecated.  Use `opOpAssign(string op)(...) if (op == \"%s\")` instead.", id.toChars(), op.ptr);
-                    }
+                    e.error("`%s.opOpAssign` isn't a template", e.e1.toChars());
+                    result = new ErrorExp();
+                    return;
                 }
             }
-            Objects* tiargs = null;
-            if (!s)
+            // Set tiargs, the template argument list, which will be the operator string
+            if (s)
             {
-                /* Try the new D2 scheme, opOpAssign
-                 */
-                if (ad1)
-                {
-                    s = search_function(ad1, Id.opOpAssign);
-                    if (s && !s.isTemplateDeclaration())
-                    {
-                        e.error("`%s.opOpAssign` isn't a template", e.e1.toChars());
-                        result = new ErrorExp();
-                        return;
-                    }
-                }
-                // Set tiargs, the template argument list, which will be the operator string
+                id = Id.opOpAssign;
+                tiargs = opToArg(sc, e.op);
+            }
+
+            // Try D1-style operator overload, deprecated
+            if (!s && ad1 && id)
+            {
+                s = search_function(ad1, id);
                 if (s)
                 {
-                    id = Id.opOpAssign;
-                    tiargs = opToArg(sc, e.op);
+                    // @@@DEPRECATED_2.094@@@.
+                    // Deprecated in 2.088
+                    // Make an error in 2.094
+                    scope char[] op = Token.toString(e.op).dup;
+                    op[$-1] = '\0'; // remove trailing `=`
+                    e.deprecation("`%s` is deprecated.  Use `opOpAssign(string op)(...) if (op == \"%s\")` instead.", id.toChars(), op.ptr);
                 }
             }
+
             if (s)
             {
                 /* Try:

--- a/test/fail_compilation/dep_d1_ops.d
+++ b/test/fail_compilation/dep_d1_ops.d
@@ -2,49 +2,51 @@
 REQUIRED_ARGS: -de
 TEST_OUTPUT:
 ---
-fail_compilation/dep_d1_ops.d(103): Deprecation: `opAdd` is deprecated.  Use `opBinary(string op)(...) if (op == "+")` instead.
-fail_compilation/dep_d1_ops.d(104): Deprecation: `opAdd_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "+")` instead.
-fail_compilation/dep_d1_ops.d(105): Deprecation: `opSub` is deprecated.  Use `opBinary(string op)(...) if (op == "-")` instead.
-fail_compilation/dep_d1_ops.d(106): Deprecation: `opSub_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "-")` instead.
-fail_compilation/dep_d1_ops.d(107): Deprecation: `opMul` is deprecated.  Use `opBinary(string op)(...) if (op == "*")` instead.
-fail_compilation/dep_d1_ops.d(108): Deprecation: `opMul_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "*")` instead.
-fail_compilation/dep_d1_ops.d(109): Deprecation: `opDiv` is deprecated.  Use `opBinary(string op)(...) if (op == "/")` instead.
-fail_compilation/dep_d1_ops.d(110): Deprecation: `opDiv_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "/")` instead.
-fail_compilation/dep_d1_ops.d(111): Deprecation: `opMod` is deprecated.  Use `opBinary(string op)(...) if (op == "%")` instead.
-fail_compilation/dep_d1_ops.d(112): Deprecation: `opMod_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "%")` instead.
-fail_compilation/dep_d1_ops.d(114): Deprecation: `opAnd` is deprecated.  Use `opBinary(string op)(...) if (op == "&")` instead.
-fail_compilation/dep_d1_ops.d(115): Deprecation: `opOr` is deprecated.  Use `opBinary(string op)(...) if (op == "|")` instead.
-fail_compilation/dep_d1_ops.d(116): Deprecation: `opXor` is deprecated.  Use `opBinary(string op)(...) if (op == "^")` instead.
-fail_compilation/dep_d1_ops.d(118): Deprecation: `opShl` is deprecated.  Use `opBinary(string op)(...) if (op == "<<")` instead.
-fail_compilation/dep_d1_ops.d(119): Deprecation: `opShl_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "<<")` instead.
-fail_compilation/dep_d1_ops.d(120): Deprecation: `opShr` is deprecated.  Use `opBinary(string op)(...) if (op == ">>")` instead.
-fail_compilation/dep_d1_ops.d(121): Deprecation: `opShr_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == ">>")` instead.
-fail_compilation/dep_d1_ops.d(122): Deprecation: `opUShr` is deprecated.  Use `opBinary(string op)(...) if (op == ">>>")` instead.
-fail_compilation/dep_d1_ops.d(123): Deprecation: `opUShr_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == ">>>")` instead.
-fail_compilation/dep_d1_ops.d(125): Deprecation: `opCat` is deprecated.  Use `opBinary(string op)(...) if (op == "~")` instead.
-fail_compilation/dep_d1_ops.d(126): Deprecation: `opCat_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "~")` instead.
-fail_compilation/dep_d1_ops.d(128): Deprecation: `opNeg` is deprecated.  Use `opUnary(string op)() if (op == "-")` instead.
-fail_compilation/dep_d1_ops.d(129): Deprecation: `opCom` is deprecated.  Use `opUnary(string op)() if (op == "~")` instead.
-fail_compilation/dep_d1_ops.d(130): Deprecation: `opPostInc` is deprecated.  Use `opUnary(string op)() if (op == "++")` instead.
-fail_compilation/dep_d1_ops.d(131): Deprecation: `opPostDec` is deprecated.  Use `opUnary(string op)() if (op == "--")` instead.
-fail_compilation/dep_d1_ops.d(132): Deprecation: `opStar` is deprecated.  Use `opUnary(string op)() if (op == "*")` instead.
-fail_compilation/dep_d1_ops.d(134): Deprecation: `opIn` is deprecated.  Use `opBinary(string op)(...) if (op == "in")` instead.
-fail_compilation/dep_d1_ops.d(135): Deprecation: `opIn_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "in")` instead.
-fail_compilation/dep_d1_ops.d(137): Deprecation: `opAddAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "+")` instead.
-fail_compilation/dep_d1_ops.d(138): Deprecation: `opSubAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "-")` instead.
-fail_compilation/dep_d1_ops.d(139): Deprecation: `opMulAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "*")` instead.
-fail_compilation/dep_d1_ops.d(140): Deprecation: `opDivAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "/")` instead.
-fail_compilation/dep_d1_ops.d(141): Deprecation: `opModAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "%")` instead.
-fail_compilation/dep_d1_ops.d(142): Deprecation: `opAndAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "&")` instead.
-fail_compilation/dep_d1_ops.d(143): Deprecation: `opOrAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "|")` instead.
-fail_compilation/dep_d1_ops.d(144): Deprecation: `opXorAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "^")` instead.
-fail_compilation/dep_d1_ops.d(145): Deprecation: `opShlAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "<<")` instead.
-fail_compilation/dep_d1_ops.d(146): Deprecation: `opShrAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == ">>")` instead.
-fail_compilation/dep_d1_ops.d(147): Deprecation: `opUShrAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == ">>>")` instead.
-fail_compilation/dep_d1_ops.d(148): Deprecation: `opCatAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "~")` instead.
+fail_compilation/dep_d1_ops.d(105): Deprecation: `opAdd` is deprecated.  Use `opBinary(string op)(...) if (op == "+")` instead.
+fail_compilation/dep_d1_ops.d(106): Deprecation: `opAdd_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "+")` instead.
+fail_compilation/dep_d1_ops.d(107): Deprecation: `opSub` is deprecated.  Use `opBinary(string op)(...) if (op == "-")` instead.
+fail_compilation/dep_d1_ops.d(108): Deprecation: `opSub_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "-")` instead.
+fail_compilation/dep_d1_ops.d(109): Deprecation: `opMul` is deprecated.  Use `opBinary(string op)(...) if (op == "*")` instead.
+fail_compilation/dep_d1_ops.d(110): Deprecation: `opMul_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "*")` instead.
+fail_compilation/dep_d1_ops.d(111): Deprecation: `opDiv` is deprecated.  Use `opBinary(string op)(...) if (op == "/")` instead.
+fail_compilation/dep_d1_ops.d(112): Deprecation: `opDiv_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "/")` instead.
+fail_compilation/dep_d1_ops.d(113): Deprecation: `opMod` is deprecated.  Use `opBinary(string op)(...) if (op == "%")` instead.
+fail_compilation/dep_d1_ops.d(114): Deprecation: `opMod_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "%")` instead.
+fail_compilation/dep_d1_ops.d(116): Deprecation: `opAnd` is deprecated.  Use `opBinary(string op)(...) if (op == "&")` instead.
+fail_compilation/dep_d1_ops.d(117): Deprecation: `opOr` is deprecated.  Use `opBinary(string op)(...) if (op == "|")` instead.
+fail_compilation/dep_d1_ops.d(118): Deprecation: `opXor` is deprecated.  Use `opBinary(string op)(...) if (op == "^")` instead.
+fail_compilation/dep_d1_ops.d(120): Deprecation: `opShl` is deprecated.  Use `opBinary(string op)(...) if (op == "<<")` instead.
+fail_compilation/dep_d1_ops.d(121): Deprecation: `opShl_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "<<")` instead.
+fail_compilation/dep_d1_ops.d(122): Deprecation: `opShr` is deprecated.  Use `opBinary(string op)(...) if (op == ">>")` instead.
+fail_compilation/dep_d1_ops.d(123): Deprecation: `opShr_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == ">>")` instead.
+fail_compilation/dep_d1_ops.d(124): Deprecation: `opUShr` is deprecated.  Use `opBinary(string op)(...) if (op == ">>>")` instead.
+fail_compilation/dep_d1_ops.d(125): Deprecation: `opUShr_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == ">>>")` instead.
+fail_compilation/dep_d1_ops.d(127): Deprecation: `opCat` is deprecated.  Use `opBinary(string op)(...) if (op == "~")` instead.
+fail_compilation/dep_d1_ops.d(128): Deprecation: `opCat_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "~")` instead.
+fail_compilation/dep_d1_ops.d(130): Deprecation: `opNeg` is deprecated.  Use `opUnary(string op)() if (op == "-")` instead.
+fail_compilation/dep_d1_ops.d(131): Deprecation: `opCom` is deprecated.  Use `opUnary(string op)() if (op == "~")` instead.
+fail_compilation/dep_d1_ops.d(132): Deprecation: `opPostInc` is deprecated.  Use `opUnary(string op)() if (op == "++")` instead.
+fail_compilation/dep_d1_ops.d(133): Deprecation: `opPostDec` is deprecated.  Use `opUnary(string op)() if (op == "--")` instead.
+fail_compilation/dep_d1_ops.d(134): Deprecation: `opStar` is deprecated.  Use `opUnary(string op)() if (op == "*")` instead.
+fail_compilation/dep_d1_ops.d(136): Deprecation: `opIn` is deprecated.  Use `opBinary(string op)(...) if (op == "in")` instead.
+fail_compilation/dep_d1_ops.d(137): Deprecation: `opIn_r` is deprecated.  Use `opBinaryRight(string op)(...) if (op == "in")` instead.
+fail_compilation/dep_d1_ops.d(139): Deprecation: `opAddAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "+")` instead.
+fail_compilation/dep_d1_ops.d(140): Deprecation: `opSubAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "-")` instead.
+fail_compilation/dep_d1_ops.d(141): Deprecation: `opMulAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "*")` instead.
+fail_compilation/dep_d1_ops.d(142): Deprecation: `opDivAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "/")` instead.
+fail_compilation/dep_d1_ops.d(143): Deprecation: `opModAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "%")` instead.
+fail_compilation/dep_d1_ops.d(144): Deprecation: `opAndAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "&")` instead.
+fail_compilation/dep_d1_ops.d(145): Deprecation: `opOrAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "|")` instead.
+fail_compilation/dep_d1_ops.d(146): Deprecation: `opXorAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "^")` instead.
+fail_compilation/dep_d1_ops.d(147): Deprecation: `opShlAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "<<")` instead.
+fail_compilation/dep_d1_ops.d(148): Deprecation: `opShrAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == ">>")` instead.
+fail_compilation/dep_d1_ops.d(149): Deprecation: `opUShrAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == ">>>")` instead.
+fail_compilation/dep_d1_ops.d(150): Deprecation: `opCatAssign` is deprecated.  Use `opOpAssign(string op)(...) if (op == "~")` instead.
+fail_compilation/dep_d1_ops.d(158): Deprecation: `opCom` is deprecated.  Use `opUnary(string op)() if (op == "~")` instead.
 ---
 */
 
+#line 50
 struct S
 {
     int opAdd(int i) { return 0; }
@@ -146,4 +148,44 @@ void main()
     s >>= 1;
     s >>>= 1;
     s ~= 1;
+
+    scope nd = new NoDeprecation;
+    assert((42 in nd) == 0);
+    assert((nd in 42) == 0);
+    assert((nd ~ 42) == 0);
+    assert((42 ~ nd) == 0);
+
+    ~nd;
+}
+
+/// See https://github.com/dlang/dmd/pull/10716
+class NoDeprecation
+{
+    int opIn(int i) { return 0; }
+    int opIn_r(int i) { return 0; }
+    int opCat(int i) { return 0; }
+    int opCat_r(int i) { return 0; }
+
+    /// This is considered because there is no `opUnary`
+    /// However, the other overloads (`opBinary` / `opBinaryRight`)
+    /// means that other operator overloads would not be considered.
+    int opCom() { return 0; }
+
+    int opBinary(string op)(int arg)
+        if (op == "in" || op == "~")
+    {
+        static if (op == "in")
+            return this.opIn(arg);
+        else static if (op == "~")
+            return this.opCat(arg);
+    }
+
+    int opBinaryRight(string op)(int arg)
+        if (op == "in" || op == "~")
+    {
+        static if (op == "in")
+            return this.opIn_r(arg);
+        else static if (op == "~")
+            return this.opCat_r(arg);
+    }
 }


### PR DESCRIPTION
```
PR10725 fixed a usability issue in a deprecation message,
which overwhelmingly affected an industry user.
This cherry-picks it so it makes it to the next patch release.
```

Merge commit of PR10725: https://github.com/dlang/dmd/commit/97c2c62a2eab8e401b54f0fed80f1b96797676e9

```console
$ git diff e13156839 97c2c62a2eab8e401b54f0fed80f1b96797676e9 -- src/dmd/opover.d
diff --git a/src/dmd/opover.d b/src/dmd/opover.d
index 57645de6c..9acf4af09 100644
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -2,7 +2,7 @@
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
- * Copyright:   Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
+ * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/opover.d, _opover.d)
```

CC @MartinNowak : I'm uneasy about such a large merge to stable, especially since it introduces a new behavior, but this has been requested by @don-clugston-sociomantic .