### PR TITLE
Support partial matching for absolute paths in TEST_OUTPUT 

### DIFF
--- a/test/fail_compilation/diag10327.d
+++ b/test/fail_compilation/diag10327.d
@@ -1,1 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/diag10327.d(11): Error: module `test10327` is in file 'imports/test10327.d' which cannot be read
+import path[0] = fail_compilation
+import path[1] = $p:druntime/import$
+import path[2] = $p:phobos$
+---
+*/
+
 import imports.test10327;  // package.d missing


### PR DESCRIPTION
The special sequence `$p:<tail>$` matches paths which depend on the execution environment (e.g. import paths). A path is accepted if it ends with `<tail>` and points to an existing file/directory.

For example,
```
import path[1] = $p:druntime/import$
```
matches
```
import path[1] = /some/random/path/to/druntime/import
```

EDIT:
The current syntax is derived from the existing `$n$` which matches arbitrary numbers.