### PR TITLE
OB: add transitivity

### DIFF
--- a/changelog/ob.md
+++ b/changelog/ob.md
@@ -208,19 +208,6 @@ They're not tracked.
 }
 ```
 
-### Memory Model Transitivity Not Checked
-
-```
-struct S { int* s; }
-
-@live void whoops()
-{
-    auto p = cast(S*)malloc(S.sizeof);
-    scope b = p;    // borrows `p`
-    scope c = p.s;  // not recognized as borrowing `p`
-}
-```
-
 ### Exceptions
 
 The analysis assumes no exceptions are thrown.

--- a/src/dmd/ob.d
+++ b/src/dmd/ob.d
@@ -1233,7 +1233,7 @@ void genKill(ref ObState obstate, ObNode* ob)
             pvs.deps.zero();
 
             EscapeByResults er;
-            escapeByValue(e, &er);
+            escapeByValue(e, &er, true);
             bool any = false;           // if any variables are assigned to v
 
             void by(VarDeclaration r)
@@ -1418,7 +1418,7 @@ void genKill(ref ObState obstate, ObNode* ob)
                         auto pt = p.type.toBasetype();
 
                         EscapeByResults er;
-                        escapeByValue(arg, &er);
+                        escapeByValue(arg, &er, true);
 
                         if (!(p.storageClass & STC.out_ && arg.isVarExp()))
                             arg.accept(this);
@@ -1463,7 +1463,7 @@ void genKill(ref ObState obstate, ObNode* ob)
                         arg.accept(this);
 
                         EscapeByResults er;
-                        escapeByValue(arg, &er);
+                        escapeByValue(arg, &er, true);
 
                         void byv(VarDeclaration v)
                         {
@@ -1872,7 +1872,7 @@ void checkObErrors(ref ObState obstate)
             pvs.deps.zero();
 
             EscapeByResults er;
-            escapeByValue(e, &er);
+            escapeByValue(e, &er, true);
 
             void by(VarDeclaration r)   // `v` = `r`
             {
@@ -2062,7 +2062,7 @@ void checkObErrors(ref ObState obstate)
                             arg.accept(this);
 
                         EscapeByResults er;
-                        escapeByValue(arg, &er);
+                        escapeByValue(arg, &er, true);
 
                         void by(VarDeclaration v)
                         {
@@ -2106,7 +2106,7 @@ void checkObErrors(ref ObState obstate)
                         arg.accept(this);
 
                         EscapeByResults er;
-                        escapeByValue(arg, &er);
+                        escapeByValue(arg, &er, true);
 
                         void byv(VarDeclaration v)
                         {
@@ -2420,7 +2420,7 @@ void checkObErrors(ref ObState obstate)
         if (ob.obtype == ObType.retexp)
         {
             EscapeByResults er;
-            escapeByValue(ob.exp, &er);
+            escapeByValue(ob.exp, &er, true);
 
             void by(VarDeclaration r)   // `r` is the rvalue
             {

--- a/test/compilable/ob1.d
+++ b/test/compilable/ob1.d
@@ -107,3 +107,43 @@ void deallocate(int* ptr, size_t length) @live
 }
 
 
+/*******************************/
+
+void zoo1(int);
+
+@live void zoo2() {
+    int* p = malloc();
+    zoo1(*p);  // does not consume p
+    free(p);
+}
+
+@live void zoo3() {
+    int** p = cast(int**)malloc();
+    free(*p); // consumes p
+}
+
+@live void zoo4() {
+    int[] a = malloc()[0 .. 1];
+    zoo1(a[0]);  // does not consume a
+    free(a.ptr); // consumes a
+}
+
+@live void zoo5() {
+    int*[] a = (cast(int**)malloc())[0 .. 1];
+    free(a[0]); // consumes a
+}
+
+struct S { int i; int* p; }
+
+@live void zoo6() {
+    S* s = cast(S*)malloc();
+    zoo1(s.i);    // does not consume s
+    free(cast(int*)s);
+}
+
+@live void zoo7() {
+    S* s = cast(S*)malloc();
+    free(s.p);    // consumes s
+}
+
+


### PR DESCRIPTION
This adds transitivity to pointer ownership tracking, i.e. can have only one owning pointer into a mutable data structure.

Turns out nearly all the work was already done by escapeByValue().