### PR TITLE
Fix issue 20362 - always infer scope for lambdas

### DIFF
--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -456,8 +456,14 @@ private extern(C++) final class Semantic3Visitor : Visitor
                             stc |= STC.scope_;
                         }
                     }
-                    if (funcdecl.flags & FUNCFLAG.inferScope && !(fparam.storageClass & STC.scope_))
+
+                    // infer scope for lambdas even without -preview=dip1000
+                    // See https://issues.dlang.org/show_bug.cgi?id=20362
+                    const isLambda = funcdecl.isFuncLiteralDeclaration;
+
+                    if ((funcdecl.flags & FUNCFLAG.inferScope || isLambda) && !(fparam.storageClass & STC.scope_))
                         stc |= STC.maybescope;
+
                     stc |= fparam.storageClass & (STC.in_ | STC.out_ | STC.ref_ | STC.return_ | STC.scope_ | STC.lazy_ | STC.final_ | STC.TYPECTOR | STC.nodtor);
                     v.storage_class = stc;
                     v.dsymbolSemantic(sc2);

--- a/test/compilable/issue20362.d
+++ b/test/compilable/issue20362.d
@@ -1,0 +1,8 @@
+void main() {
+    string str;
+    stringify((chars) {str ~= chars; });
+}
+
+void stringify(scope void delegate(scope const char[]) sink) {
+    sink("oops");
+}


### PR DESCRIPTION
Before, scope was only inferred if -preview=dip1000 was used, now it always is.