### PR TITLE
Remove ctfe references from re-purposed code

### DIFF
--- a/src/dmd/foreachvar.d
+++ b/src/dmd/foreachvar.d
@@ -19,7 +19,6 @@ import core.stdc.string;
 import dmd.apply;
 import dmd.arraytypes;
 import dmd.attrib;
-import dmd.ctfeexpr;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.dstruct;
@@ -68,8 +67,6 @@ void foreachVar(Expression e, void delegate(VarDeclaration) dgVar)
 
         override void visit(ErrorExp e)
         {
-            //.error(e.loc, "CTFE internal error: ErrorExp");
-            //assert(0);
         }
 
         override void visit(DeclarationExp e)


### PR DESCRIPTION
This code was lifted from the CTFE visitor by the looks of it.
It is not connected with CTFE in any way, so it should not mention it.