### PR TITLE
fix Issue 19479 - Garbage .init in string mixins in static foreach in mixin templates

### DIFF
--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1203,6 +1203,11 @@ extern(C++) final class ForwardingAttribDeclaration: AttribDeclaration
     {
         return this;
     }
+
+    override void accept(Visitor v)
+    {
+        v.visit(this);
+    }
 }
 
 

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -215,6 +215,7 @@ public:
     Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     ForwardingAttribDeclaration *isForwardingAttribDeclaration() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 // Mixin declarations

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -605,6 +605,11 @@ private Statement toStatement(Dsymbol s)
             result = visitMembers(d.loc, d.decl);
         }
 
+        override void visit(ForwardingAttribDeclaration d)
+        {
+            result = visitMembers(d.loc, d.decl);
+        }
+
         override void visit(StaticAssert s)
         {
         }
@@ -625,8 +630,7 @@ private Statement toStatement(Dsymbol s)
         override void visit(StaticForeachDeclaration d)
         {
             assert(d.sfe && !!d.sfe.aggrfe ^ !!d.sfe.rangefe);
-            (d.sfe.aggrfe ? d.sfe.aggrfe._body : d.sfe.rangefe._body) = visitMembers(d.loc, d.decl);
-            result = new StaticForeachStatement(d.loc, d.sfe);
+            result = visitMembers(d.loc, d.include(null));
         }
 
         override void visit(CompileDeclaration d)
@@ -1476,7 +1480,7 @@ extern (C++) final class StaticForeachStatement : Statement
 
     override Statement syntaxCopy()
     {
-        return new StaticForeachStatement(loc,sfe.syntaxCopy());
+        return new StaticForeachStatement(loc, sfe.syntaxCopy());
     }
 
     override Statements* flatten(Scope* sc)
@@ -1485,7 +1489,7 @@ extern (C++) final class StaticForeachStatement : Statement
         if (sfe.ready())
         {
             import dmd.statementsem;
-            auto s = makeTupleForeach!(true,false)(sc, sfe.aggrfe,sfe.needExpansion);
+            auto s = makeTupleForeach!(true, false)(sc, sfe.aggrfe, sfe.needExpansion);
             auto result = s.flatten(sc);
             if (result)
             {

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -42,6 +42,7 @@ public:
     void visit(ASTCodegen.ArrayScopeSymbol s) { visit(cast(ASTCodegen.ScopeDsymbol)s); }
     void visit(ASTCodegen.OverDeclaration s) { visit(cast(ASTCodegen.Declaration)s); }
     void visit(ASTCodegen.SymbolDeclaration s) { visit(cast(ASTCodegen.Declaration)s); }
+    void visit(ASTCodegen.ForwardingAttribDeclaration s) { visit(cast(ASTCodegen.AttribDeclaration)s); }
     void visit(ASTCodegen.ThisDeclaration s) { visit(cast(ASTCodegen.VarDeclaration)s); }
     void visit(ASTCodegen.TypeInfoDeclaration s) { visit(cast(ASTCodegen.VarDeclaration)s); }
     void visit(ASTCodegen.TypeInfoStructDeclaration s) { visit(cast(ASTCodegen.TypeInfoDeclaration)s); }

--- a/src/dmd/visitor.h
+++ b/src/dmd/visitor.h
@@ -109,6 +109,7 @@ class StaticIfDeclaration;
 class CompileDeclaration;
 class StaticForeachDeclaration;
 class UserAttributeDeclaration;
+class ForwardingAttribDeclaration;
 
 class ScopeDsymbol;
 class TemplateDeclaration;
@@ -587,6 +588,7 @@ public:
     virtual void visit(ArrayScopeSymbol *s) { visit((ScopeDsymbol *)s); }
     virtual void visit(OverDeclaration *s) { visit((Declaration *)s); }
     virtual void visit(SymbolDeclaration *s) { visit((Declaration *)s); }
+    virtual void visit(ForwardingAttribDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ThisDeclaration *s) { visit((VarDeclaration *)s); }
     virtual void visit(TypeInfoDeclaration *s) { visit((VarDeclaration *)s); }
     virtual void visit(TypeInfoStructDeclaration *s) { visit((TypeInfoDeclaration *)s); }

--- a/test/runnable/staticforeach.d
+++ b/test/runnable/staticforeach.d
@@ -1,0 +1,45 @@
+// REQUIRED_ARGS:
+
+/**********************************/
+// https://issues.dlang.org/show_bug.cgi?id=19479
+
+mixin template genInts19479a()
+{
+    static foreach (t; 0..1)
+        int i = 5;
+}
+
+mixin template genInts19479b()
+{
+    static foreach (t; 0..2)
+        mixin("int i" ~ cast(char)('0' + t) ~ " = 5;");
+}
+
+void test19479()
+{
+    {
+        static foreach (t; 0..1)
+            int i = 5;
+        assert(i == 5);
+    }
+    {
+        mixin genInts19479a!();
+        assert(i == 5);
+    }
+    {
+        static foreach (t; 0..2)
+            mixin("int i" ~ cast(char)('0' + t) ~ " = 5;");
+        assert(i0 == 5);
+        assert(i1 == 5);
+    }
+    {
+        mixin genInts19479b!();
+        assert(i0 == 5);
+        assert(i1 == 5);
+    }
+}
+
+void main()
+{
+    test19479();
+}


### PR DESCRIPTION
The problem was that the mixin was being omitted from the codegen during the conversion from StaticForeachDeclaration to a Statement.

The first issue with `toStatement` is that it is visiting all members in the StaticForeachDeclaration's `decl`, whereas the semantically compiled list of Dsymbols is instead found in `cache`.  This is what caused the CompileDeclaration to be omitted.

The second issue with `toStatement` is that converting an already compiled StaticForeachDeclaration into a new StaticForeachStatement results in `makeTupleForeach` being called twice for the same
StaticForeach symbol.  There is no need to create a new StaticForeachStatement, simply the unrolling of all members is enough.
