### PR TITLE
replace isTrivialExp with hasSideEffect

### DIFF
--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -2636,7 +2636,7 @@ elem *toElem(Expression e, IRState *irs)
              * have any sideeffects
              */
 
-            const canSkipCompare = isTrivialExp(ie.e1) && isTrivialExp(ie.e2);
+            const canSkipCompare = !hasSideEffect(ie.e1) && !hasSideEffect(ie.e2);
             elem *e;
             if (t1.ty == Tstruct && (cast(TypeStruct)t1).sym.fields.dim == 0 && canSkipCompare)
             {

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -175,7 +175,7 @@ private Expression extractOpDollarSideEffect(Scope* sc, UnaExp ue)
     // https://issues.dlang.org/show_bug.cgi?id=12585
     // Extract the side effect part if ue.e1 is comma.
 
-    if (!isTrivialExp(e1))
+    if (hasSideEffect(e1))
     {
         /* Even if opDollar is needed, 'e1' should be evaluate only once. So
          * Rewrite:

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -3718,7 +3718,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 }
                 checkAccess(e.loc, sc, null, v);
                 Expression ve = new VarExp(e.loc, v);
-                if (!isTrivialExp(e))
+                if (hasSideEffect(e))
                 {
                     ve = new CommaExp(e.loc, e, ve);
                 }


### PR DESCRIPTION
https://github.com/dlang/dmd/pull/3672 introduces `isTrivalExp()` which has caused regressions. I believe the rationale for the function (not sharing ASTs) is botched (ASTs should never have been shared). This PR tests to see if reverting to the original `hasSideEffect()` causes anything to break.