### PR TITLE
allow `scope` structs referring to themselves

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11929,7 +11929,7 @@ private bool checkAddressVar(Scope* sc, UnaExp exp, VarDeclaration v)
             const bool isRef = (v.storage_class & (STC.ref_ | STC.out_)) != 0;
             if (global.params.vsafe)
             {
-                if (exp.e1.type.hasPointers() || exp.isDelegateExp() || isRef)
+                if (exp.e1.type.hasPointers() || isRef)
                 {
                     // Taking the address of v means it cannot be set to 'scope' later
                     v.storage_class &= ~STC.maybescope;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11923,7 +11923,8 @@ private bool checkAddressVar(Scope* sc, UnaExp exp, VarDeclaration v)
             exp.error("cannot take address of `%s`", exp.e1.toChars());
             return false;
         }
-        if (sc.func && !sc.intypeof && !v.isDataseg())
+        if (sc.func && !sc.intypeof && !v.isDataseg() &&
+            exp.e1.type.hasPointers())
         {
             const(char)* p = v.isParameter() ? "parameter" : "local";
             if (global.params.vsafe)
@@ -11931,7 +11932,7 @@ private bool checkAddressVar(Scope* sc, UnaExp exp, VarDeclaration v)
                 // Taking the address of v means it cannot be set to 'scope' later
                 v.storage_class &= ~STC.maybescope;
                 v.doNotInferScope = true;
-                if (exp.e1.type.hasPointers() && v.storage_class & STC.scope_ &&
+                if (v.storage_class & STC.scope_ &&
                     !(sc.flags & SCOPE.debug_) && sc.func.setUnsafe())
                 {
                     exp.error("cannot take address of `scope` %s `%s` in `@safe` function `%s`", p, v.toChars(), sc.func.toChars());

--- a/test/fail_compilation/test20569.d
+++ b/test/fail_compilation/test20569.d
@@ -1,8 +1,9 @@
 /* REQUIRED_ARGS: -preview=dip1000
    TEST_OUTPUT:
 ---
-fail_compilation/test20569.d(19): Error: cannot take address of `scope` local `s1` in `@safe` function `main`
-fail_compilation/test20569.d(23): Error: cannot take address of `scope` local `s2` in `@safe` function `main`
+fail_compilation/test20569.d(20): Error: cannot take address of `scope` local `s1` in `@safe` function `main`
+fail_compilation/test20569.d(24): Error: cannot take address of `scope` local `s2` in `@safe` function `main`
+fail_compilation/test20569.d(28): Error: reference to local variable `x` assigned to non-scope `s3.pointer`
 ---
  */
 
@@ -21,4 +22,8 @@ void main() @safe
     int x;
     S s2 = S(&x);
     auto p2 = &s2.pointer;
+
+    S s3;
+    auto p3 = &s3.pointer;
+    s3.pointer = &x;
 }

--- a/test/runnable/testscope.d
+++ b/test/runnable/testscope.d
@@ -384,6 +384,10 @@ void test20569() @safe
     int x;
     S s2 = S(0, &x);
     int* p2 = &s2.value;
+
+    /* inferred `scope` on self-reference: */
+    S s3;
+    s3.pointer = &s3.value;
 }
 
 /********************************************/


### PR DESCRIPTION
This is a follow-up to #10773. Taking the address of the value should not prevent `scope` inference.