### PR TITLE
Add WASI and CRuntime_WASI reserved versions

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -653,6 +653,7 @@ extern (C++) final class VersionCondition : DVCondition
             case "HPPA64":
             case "SH":
             case "WebAssembly":
+            case "WASI":
             case "Alpha":
             case "Alpha_SoftFloat":
             case "Alpha_HardFloat":
@@ -666,6 +667,7 @@ extern (C++) final class VersionCondition : DVCondition
             case "CRuntime_Microsoft":
             case "CRuntime_Musl":
             case "CRuntime_UClibc":
+            case "CRuntime_WASI":
             case "CppRuntime_Clang":
             case "CppRuntime_DigitalMars":
             case "CppRuntime_Gcc":

--- a/test/fail_compilation/reserved_version.d
+++ b/test/fail_compilation/reserved_version.d
@@ -86,29 +86,31 @@ fail_compilation/reserved_version.d(185): Error: version identifier `CRuntime_Gl
 fail_compilation/reserved_version.d(186): Error: version identifier `CRuntime_Microsoft` is reserved and cannot be set
 fail_compilation/reserved_version.d(187): Error: version identifier `CRuntime_Musl` is reserved and cannot be set
 fail_compilation/reserved_version.d(188): Error: version identifier `CRuntime_UClibc` is reserved and cannot be set
-fail_compilation/reserved_version.d(189): Error: version identifier `D_Coverage` is reserved and cannot be set
-fail_compilation/reserved_version.d(190): Error: version identifier `D_Ddoc` is reserved and cannot be set
-fail_compilation/reserved_version.d(191): Error: version identifier `D_InlineAsm_X86` is reserved and cannot be set
-fail_compilation/reserved_version.d(192): Error: version identifier `D_InlineAsm_X86_64` is reserved and cannot be set
-fail_compilation/reserved_version.d(193): Error: version identifier `D_LP64` is reserved and cannot be set
-fail_compilation/reserved_version.d(194): Error: version identifier `D_X32` is reserved and cannot be set
-fail_compilation/reserved_version.d(195): Error: version identifier `D_HardFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(196): Error: version identifier `D_SoftFloat` is reserved and cannot be set
-fail_compilation/reserved_version.d(197): Error: version identifier `D_PIC` is reserved and cannot be set
-fail_compilation/reserved_version.d(198): Error: version identifier `D_SIMD` is reserved and cannot be set
-fail_compilation/reserved_version.d(199): Error: version identifier `D_Version2` is reserved and cannot be set
-fail_compilation/reserved_version.d(200): Error: version identifier `D_NoBoundsChecks` is reserved and cannot be set
-fail_compilation/reserved_version.d(203): Error: version identifier `all` is reserved and cannot be set
-fail_compilation/reserved_version.d(204): Error: version identifier `none` is reserved and cannot be set
-fail_compilation/reserved_version.d(205): Error: version identifier `AsmJS` is reserved and cannot be set
-fail_compilation/reserved_version.d(206): Error: version identifier `Emscripten` is reserved and cannot be set
-fail_compilation/reserved_version.d(207): Error: version identifier `WebAssembly` is reserved and cannot be set
-fail_compilation/reserved_version.d(208): Error: version identifier `CppRuntime_Clang` is reserved and cannot be set
-fail_compilation/reserved_version.d(209): Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
-fail_compilation/reserved_version.d(210): Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
-fail_compilation/reserved_version.d(211): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
-fail_compilation/reserved_version.d(212): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
-fail_compilation/reserved_version.d(213): Error: version identifier `D_PIE` is reserved and cannot be set
+fail_compilation/reserved_version.d(189): Error: version identifier `CRuntime_WASI` is reserved and cannot be set
+fail_compilation/reserved_version.d(190): Error: version identifier `D_Coverage` is reserved and cannot be set
+fail_compilation/reserved_version.d(191): Error: version identifier `D_Ddoc` is reserved and cannot be set
+fail_compilation/reserved_version.d(192): Error: version identifier `D_InlineAsm_X86` is reserved and cannot be set
+fail_compilation/reserved_version.d(193): Error: version identifier `D_InlineAsm_X86_64` is reserved and cannot be set
+fail_compilation/reserved_version.d(194): Error: version identifier `D_LP64` is reserved and cannot be set
+fail_compilation/reserved_version.d(195): Error: version identifier `D_X32` is reserved and cannot be set
+fail_compilation/reserved_version.d(196): Error: version identifier `D_HardFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(197): Error: version identifier `D_SoftFloat` is reserved and cannot be set
+fail_compilation/reserved_version.d(198): Error: version identifier `D_PIC` is reserved and cannot be set
+fail_compilation/reserved_version.d(199): Error: version identifier `D_SIMD` is reserved and cannot be set
+fail_compilation/reserved_version.d(200): Error: version identifier `D_Version2` is reserved and cannot be set
+fail_compilation/reserved_version.d(201): Error: version identifier `D_NoBoundsChecks` is reserved and cannot be set
+fail_compilation/reserved_version.d(204): Error: version identifier `all` is reserved and cannot be set
+fail_compilation/reserved_version.d(205): Error: version identifier `none` is reserved and cannot be set
+fail_compilation/reserved_version.d(206): Error: version identifier `AsmJS` is reserved and cannot be set
+fail_compilation/reserved_version.d(207): Error: version identifier `Emscripten` is reserved and cannot be set
+fail_compilation/reserved_version.d(208): Error: version identifier `WebAssembly` is reserved and cannot be set
+fail_compilation/reserved_version.d(209): Error: version identifier `WASI` is reserved and cannot be set
+fail_compilation/reserved_version.d(210): Error: version identifier `CppRuntime_Clang` is reserved and cannot be set
+fail_compilation/reserved_version.d(211): Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
+fail_compilation/reserved_version.d(212): Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set
+fail_compilation/reserved_version.d(213): Error: version identifier `CppRuntime_Microsoft` is reserved and cannot be set
+fail_compilation/reserved_version.d(214): Error: version identifier `CppRuntime_Sun` is reserved and cannot be set
+fail_compilation/reserved_version.d(215): Error: version identifier `D_PIE` is reserved and cannot be set
 ---
 */
 
@@ -199,6 +201,7 @@ version = CRuntime_Glibc;
 version = CRuntime_Microsoft;
 version = CRuntime_Musl;
 version = CRuntime_UClibc;
+version = CRuntime_WASI;
 version = D_Coverage;
 version = D_Ddoc;
 version = D_InlineAsm_X86;
@@ -218,6 +221,7 @@ version = none;
 version = AsmJS;
 version = Emscripten;
 version = WebAssembly;
+version = WASI;
 version = CppRuntime_Clang;
 version = CppRuntime_DigitalMars;
 version = CppRuntime_Gcc;
@@ -290,6 +294,8 @@ debug = SystemZ;
 debug = HPPA;
 debug = HPPA64;
 debug = SH;
+debug = WebAssembly;
+debug = WASI;
 debug = Alpha;
 debug = Alpha_SoftFloat;
 debug = Alpha_HardFloat;
@@ -303,6 +309,7 @@ debug = CRuntime_Glibc;
 debug = CRuntime_Microsoft;
 debug = CRuntime_Musl;
 debug = CRuntime_UClibc;
+debug = CRuntime_WASI;
 debug = CppRuntime_Clang;
 debug = CppRuntime_DigitalMars;
 debug = CppRuntime_Gcc;

--- a/test/fail_compilation/reserved_version_switch.d
+++ b/test/fail_compilation/reserved_version_switch.d
@@ -64,6 +64,8 @@
 // REQUIRED_ARGS: -version=HPPA
 // REQUIRED_ARGS: -version=HPPA64
 // REQUIRED_ARGS: -version=SH
+// REQUIRED_ARGS: -version=WebAssembly
+// REQUIRED_ARGS: -version=WASI
 // REQUIRED_ARGS: -version=Alpha
 // REQUIRED_ARGS: -version=Alpha_SoftFloat
 // REQUIRED_ARGS: -version=Alpha_HardFloat
@@ -77,6 +79,7 @@
 // REQUIRED_ARGS: -version=CRuntime_Microsoft
 // REQUIRED_ARGS: -version=CRuntime_Musl
 // REQUIRED_ARGS: -version=CRuntime_UClibc
+// REQUIRED_ARGS: -version=CRuntime_WASI
 // REQUIRED_ARGS: -version=CppRuntime_Clang
 // REQUIRED_ARGS: -version=CppRuntime_DigitalMars
 // REQUIRED_ARGS: -version=CppRuntime_Gcc
@@ -160,6 +163,8 @@
 // REQUIRED_ARGS: -debug=HPPA
 // REQUIRED_ARGS: -debug=HPPA64
 // REQUIRED_ARGS: -debug=SH
+// REQUIRED_ARGS: -debug=WebAssembly
+// REQUIRED_ARGS: -debug=WASI
 // REQUIRED_ARGS: -debug=Alpha
 // REQUIRED_ARGS: -debug=Alpha_SoftFloat
 // REQUIRED_ARGS: -debug=Alpha_HardFloat
@@ -173,6 +178,7 @@
 // REQUIRED_ARGS: -debug=CRuntime_Microsoft
 // REQUIRED_ARGS: -debug=CRuntime_Musl
 // REQUIRED_ARGS: -debug=CRuntime_UClibc
+// REQUIRED_ARGS: -debug=CRuntime_WASI
 // REQUIRED_ARGS: -debug=CppRuntime_Clang
 // REQUIRED_ARGS: -debug=CppRuntime_DigitalMars
 // REQUIRED_ARGS: -debug=CppRuntime_Gcc
@@ -261,6 +267,8 @@ Error: version identifier `SystemZ` is reserved and cannot be set
 Error: version identifier `HPPA` is reserved and cannot be set
 Error: version identifier `HPPA64` is reserved and cannot be set
 Error: version identifier `SH` is reserved and cannot be set
+Error: version identifier `WebAssembly` is reserved and cannot be set
+Error: version identifier `WASI` is reserved and cannot be set
 Error: version identifier `Alpha` is reserved and cannot be set
 Error: version identifier `Alpha_SoftFloat` is reserved and cannot be set
 Error: version identifier `Alpha_HardFloat` is reserved and cannot be set
@@ -274,6 +282,7 @@ Error: version identifier `CRuntime_Glibc` is reserved and cannot be set
 Error: version identifier `CRuntime_Microsoft` is reserved and cannot be set
 Error: version identifier `CRuntime_Musl` is reserved and cannot be set
 Error: version identifier `CRuntime_UClibc` is reserved and cannot be set
+Error: version identifier `CRuntime_WASI` is reserved and cannot be set
 Error: version identifier `CppRuntime_Clang` is reserved and cannot be set
 Error: version identifier `CppRuntime_DigitalMars` is reserved and cannot be set
 Error: version identifier `CppRuntime_Gcc` is reserved and cannot be set


### PR DESCRIPTION
As part of my work for porting DRuntime to WebAssembly (see https://gist.github.com/skoppe/7617ceba6afd67b2e20c6be4f922725d) I need these 2 versions added to the reserved list.

`CRuntime_WASI` is required because druntime depends on libc. Instead of modifying druntime the approach has been to bind to a WASI version of libc (https://github.com/CraneStation/wasi-libc), the `CRuntime_WASI` version is needed for those definitions. We cannot use WASI for that because - in time - we will want to move more code to directly depend on WASI, instead of going through libc. For that we need the WASI version as well. There are already some places where that is the case.

For more background info on WASI see https://wasi.dev/ as well as https://github.com/CraneStation/wasi-libc

NOTE: in some places the WebAssembly version/debug was missing, so I added it.