### PR TITLE
Remove unused parameters from access.d

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -211,7 +211,6 @@ bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
  * Check access to package/module `p` from scope `sc`.
  *
  * Params:
- *   loc = source location for issued error message
  *   sc = scope from which to access to a fully qualified package name
  *   p = the package/module to check access for
  * Returns: true if the package is not accessible.
@@ -221,7 +220,7 @@ bool checkAccess(Loc loc, Scope* sc, Expression e, Declaration d)
  * (see https://issues.dlang.org/show_bug.cgi?id=313).
  *
  */
-bool checkAccess(Loc loc, Scope* sc, Package p)
+bool checkAccess(Scope* sc, Package p)
 {
     if (sc._module == p)
         return false;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11442,7 +11442,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         if (s)
         {
             auto p = s.isPackage();
-            if (p && checkAccess(exp.loc, sc, p))
+            if (p && checkAccess(sc, p))
             {
                 s = null;
             }


### PR DESCRIPTION
The `loc` parameter became obsolete with #9636 but was not removed.

Extracted from #10700 