### PR TITLE
Fix Issue 20581 - DIP1000 wrongly flags hidden ref temporary

### DIFF
--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1114,6 +1114,7 @@ extern (C++) class VarDeclaration : Declaration
     IntRange* range;                // if !=null, the variable is known to be within the range
 
     VarDeclarations* maybes;        // STC.maybescope variables that are assigned to this STC.maybescope variable
+    VarDeclaration refTo;           // !null if storage_class is STC.ref_; this is the variable we are referencing
 
     private bool _isAnonymous;
 

--- a/src/dmd/declaration.h
+++ b/src/dmd/declaration.h
@@ -237,6 +237,7 @@ public:
     IntRange *range;            // if !NULL, the variable is known to be within the range
 
     VarDeclarations *maybes;    // STCmaybescope variables that are assigned to this STCmaybescope variable
+    VarDeclaration *refTo;      // !null if storage_class is STCref; this is the variable we are referencing
 
 private:
     bool _isAnonymous;

--- a/test/runnable/testassert.d
+++ b/test/runnable/testassert.d
@@ -127,6 +127,40 @@ void test20375() @safe
     assert(RefCounted.instances == 0);
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=20581
+void test20581() @safe
+{
+    {
+        static auto retro(return scope int[] s) @safe
+        {
+            static struct R
+            {
+                int[] source;
+            }
+            return R(s);
+        }
+
+        int[5] a = [ 1, 2, 3, 4, 5 ];
+        // Creates ref temporary __assertTmpXXXX for source
+        // Error: address of variable a assigned to __assertOp27 with longer lifetime
+        assert(retro(a[]).source is a[]);
+    }
+    {
+        static struct Tuple(T...)
+        {
+            T content;
+            alias content this;
+        }
+
+        static Tuple!(int[]) foo() @safe
+        {
+            return typeof(return).init;
+        }
+
+        assert(foo[0] == []);
+    }
+}
+
 string getMessage(T)(lazy T expr) @trusted
 {
     try
@@ -146,4 +180,5 @@ void main()
     test9255();
     test20114();
     test20375();
+    test20581();
 }


### PR DESCRIPTION
Restrict errors for escaping by ref to `VarDeclaration`'s that actually outlive the referenced `VarDeclaration`.

The only exceptions to this rule are references to other `ref` parameters