### PR TITLE
fix Issue 17098 - Takes hours to -O compile then fails with Internal …

### DIFF
--- a/src/dmd/backend/cgreg.d
+++ b/src/dmd/backend/cgreg.d
@@ -425,7 +425,14 @@ static if (1) // causes assert failure in std.range(4488) from std.parallelism's
     debug if (benefit > s.Sweight + retsym_cnt + 1)
         printf("s = '%s', benefit = %d, Sweight = %d, retsym_cnt = x%x\n",s.Sident.ptr,benefit,s.Sweight, retsym_cnt);
 
-    assert(benefit <= s.Sweight + retsym_cnt + 1);
+    /* This can happen upon overflow of s.Sweight, but only in extreme cases such as
+     * issues.dlang.org/show_bug.cgi?id=17098
+     * It essentially means "a whole lotta uses in nested loops", where
+     * it should go into a register anyway. So just saturate it at int.max
+     */
+    //assert(benefit <= s.Sweight + retsym_cnt + 1);
+    if (benefit > s.Sweight + retsym_cnt + 1)
+        benefit = int.max;      // saturate instead of overflow error
     return benefit;
 
 Lcant:

--- a/src/dmd/backend/gloop.d
+++ b/src/dmd/backend/gloop.d
@@ -398,12 +398,13 @@ private extern (D) void findloops(block*[] dfo, loop **ploops)
 private uint loop_weight(uint weight, int factor) pure
 {
     // Be careful not to overflow
-    if (weight < 0x10000)
+    if (weight < 0x1_0000)
         weight *= 10 * factor;
-    else if (weight < 0x100000)
+    else if (weight < 0x10_0000)
         weight *= 2 * factor;
     else
         weight += factor;
+    assert(cast(int)weight > 0);
     return weight;
 }
 


### PR DESCRIPTION
…error: backend/cgreg.c 405

The long compilation times are not fixed, there's not much to be done about that as the behavior of the optimizer is inherently quadratic. But the test case compiles now.

The test case isn't included because it takes hours to compile.