### PR TITLE
dmd/globals.h: Fix -pedantic warnings in C++ builds

### DIFF
--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -31,7 +31,7 @@ typedef unsigned char MessageStyle;
 enum
 {
     MESSAGESTYLEdigitalmars, // file(line,column): message
-    MESSAGESTYLEgnu,         // file:line:column: message
+    MESSAGESTYLEgnu          // file:line:column: message
 };
 
 // The state of array bounds checking


### PR DESCRIPTION
Such is one of the warning flags used in gdc, so naturally the master builds are quite noisy at the moment.