### PR TITLE
[dmd-cxx] Implement static foreach, aliasing traits, and fix allMembers.

### DIFF
--- a/src/attrib.h
+++ b/src/attrib.h
@@ -191,6 +191,7 @@ class StaticIfDeclaration : public ConditionalDeclaration
 public:
     ScopeDsymbol *scopesym;
     bool addisdone;
+    bool onStack;
 
     StaticIfDeclaration(Condition *condition, Dsymbols *decl, Dsymbols *elsedecl);
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -203,14 +204,16 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class StaticForeachDeclaration : public ConditionalDeclaration
+class StaticForeachDeclaration : public AttribDeclaration
 {
 public:
     StaticForeach *sfe;
     ScopeDsymbol *scopesym;
+    bool onStack;
     bool cached;
     Dsymbols *cache;
 
+    StaticForeachDeclaration(StaticForeach *sfe, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
@@ -223,14 +226,16 @@ public:
     void accept(Visitor *v) { v->visit(this); }
 };
 
-class ForwardingAttribDeclaration : AttribDeclaration
+class ForwardingAttribDeclaration : public AttribDeclaration
 {
 public:
     ForwardingScopeDsymbol *sym;
 
+    ForwardingAttribDeclaration(Dsymbols *decl);
     Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     ForwardingAttribDeclaration *isForwardingAttribDeclaration() { return this; }
+    void accept(Visitor *v) { v->visit(this); }
 };
 
 // Mixin declarations

--- a/src/cond.c
+++ b/src/cond.c
@@ -13,6 +13,7 @@
 #include "mars.h"
 #include "id.h"
 #include "init.h"
+#include "aggregate.h"
 #include "declaration.h"
 #include "identifier.h"
 #include "expression.h"
@@ -21,6 +22,7 @@
 #include "template.h"
 #include "mtype.h"
 #include "scope.h"
+#include "statement.h"
 #include "arraytypes.h"
 #include "tokens.h"
 
@@ -49,6 +51,327 @@ Condition::Condition(Loc loc)
 {
     this->loc = loc;
     inc = 0;
+}
+
+/* ============================================================ */
+
+StaticForeach::StaticForeach(Loc loc, ForeachStatement *aggrfe, ForeachRangeStatement *rangefe)
+{
+    assert(!!aggrfe ^ !!rangefe);
+    this->loc = loc;
+    this->aggrfe = aggrfe;
+    this->rangefe = rangefe;
+    this->needExpansion = false;
+}
+
+StaticForeach *StaticForeach::syntaxCopy()
+{
+    return new StaticForeach(
+        loc,
+        aggrfe ? (ForeachStatement *)aggrfe->syntaxCopy() : NULL,
+        rangefe ? (ForeachRangeStatement *)rangefe->syntaxCopy() : NULL
+    );
+}
+
+/*****************************************
+ * Turn an aggregate which is an array into an expression tuple
+ * of its elements. I.e., lower
+ *     static foreach (x; [1, 2, 3, 4]) { ... }
+ * to
+ *     static foreach (x; AliasSeq!(1, 2, 3, 4)) { ... }
+ */
+
+static void lowerArrayAggregate(StaticForeach *sfe, Scope *sc)
+{
+    Expression *aggr = sfe->aggrfe->aggr;
+    Expression *el = new ArrayLengthExp(aggr->loc, aggr);
+    sc = sc->startCTFE();
+    el = semantic(el, sc);
+    sc = sc->endCTFE();
+    el = el->optimize(WANTvalue);
+    el = el->ctfeInterpret();
+    if (el->op == TOKint64)
+    {
+        dinteger_t length = el->toInteger();
+        Expressions *es = new Expressions();
+        for (size_t i = 0; i < length; i++)
+        {
+            IntegerExp *index = new IntegerExp(sfe->loc, i, Type::tsize_t);
+            Expression *value = new IndexExp(aggr->loc, aggr, index);
+            es->push(value);
+        }
+        sfe->aggrfe->aggr = new TupleExp(aggr->loc, es);
+        sfe->aggrfe->aggr = semantic(sfe->aggrfe->aggr, sc);
+        sfe->aggrfe->aggr = sfe->aggrfe->aggr->optimize(WANTvalue);
+    }
+    else
+    {
+        sfe->aggrfe->aggr = new ErrorExp();
+    }
+}
+
+/*****************************************
+ * Wrap a statement into a function literal and call it.
+ *
+ * Params:
+ *     loc = The source location.
+ *     s  = The statement.
+ * Returns:
+ *     AST of the expression `(){ s; }()` with location loc.
+ */
+
+static Expression *wrapAndCall(Loc loc, Statement *s)
+{
+    TypeFunction *tf = new TypeFunction(new Parameters(), NULL, 0, LINKdefault, 0);
+    FuncLiteralDeclaration *fd = new FuncLiteralDeclaration(loc, loc, tf, TOKreserved, NULL);
+    fd->fbody = s;
+    FuncExp *fe = new FuncExp(loc, fd);
+    Expression *ce = new CallExp(loc, fe, new Expressions());
+    return ce;
+}
+
+/*****************************************
+ * Create a `foreach` statement from `aggrefe/rangefe` with given
+ * `foreach` variables and body `s`.
+ *
+ * Params:
+ *     loc = The source location.
+ *     parameters = The foreach variables.
+ *     s = The `foreach` body.
+ * Returns:
+ *     `foreach (parameters; aggregate) s;` or
+ *     `foreach (parameters; lower .. upper) s;`
+ *     Where aggregate/lower, upper are as for the current StaticForeach.
+ */
+
+static Statement *createForeach(StaticForeach *sfe, Loc loc, Parameters *parameters, Statement *s)
+{
+    if (sfe->aggrfe)
+    {
+        return new ForeachStatement(loc, sfe->aggrfe->op, parameters, sfe->aggrfe->aggr->syntaxCopy(), s, loc);
+    }
+    else
+    {
+        assert(sfe->rangefe && parameters->dim == 1);
+        return new ForeachRangeStatement(loc, sfe->rangefe->op, (*parameters)[0],
+                                         sfe->rangefe->lwr->syntaxCopy(),
+                                         sfe->rangefe->upr->syntaxCopy(), s, loc);
+    }
+}
+
+/*****************************************
+ * For a `static foreach` with multiple loop variables, the
+ * aggregate is lowered to an array of tuples. As D does not have
+ * built-in tuples, we need a suitable tuple type. This generates
+ * a `struct` that serves as the tuple type. This type is only
+ * used during CTFE and hence its typeinfo will not go to the
+ * object file.
+ *
+ * Params:
+ *     loc = The source location.
+ *     e = The expressions we wish to store in the tuple.
+ *     sc  = The current scope.
+ * Returns:
+ *     A struct type of the form
+ *         struct Tuple
+ *         {
+ *             typeof(AliasSeq!(e)) tuple;
+ *         }
+ */
+
+static TypeStruct *createTupleType(Loc loc, Expressions *e)
+{   // TODO: move to druntime?
+    Identifier *sid = Identifier::generateId("Tuple");
+    StructDeclaration *sdecl = new StructDeclaration(loc, sid, false);
+    sdecl->storage_class |= STCstatic;
+    sdecl->members = new Dsymbols();
+    Identifier *fid = Identifier::idPool("tuple");
+    Type *ty = new TypeTypeof(loc, new TupleExp(loc, e));
+    sdecl->members->push(new VarDeclaration(loc, ty, fid, NULL));
+    TypeStruct *r = (TypeStruct *)sdecl->type;
+    r->vtinfo = TypeInfoStructDeclaration::create(r); // prevent typeinfo from going to object file
+    return r;
+}
+
+/*****************************************
+ * Create the AST for an instantiation of a suitable tuple type.
+ *
+ * Params:
+ *     loc = The source location.
+ *     type = A Tuple type, created with createTupleType.
+ *     e = The expressions we wish to store in the tuple.
+ * Returns:
+ *     An AST for the expression `Tuple(e)`.
+ */
+
+static Expression *createTuple(Loc loc, TypeStruct *type, Expressions *e)
+{   // TODO: move to druntime?
+    return new CallExp(loc, new TypeExp(loc, type), e);
+}
+
+/*****************************************
+ * Lower any aggregate that is not an array to an array using a
+ * regular foreach loop within CTFE.  If there are multiple
+ * `static foreach` loop variables, an array of tuples is
+ * generated. In thise case, the field `needExpansion` is set to
+ * true to indicate that the static foreach loop expansion will
+ * need to expand the tuples into multiple variables.
+ *
+ * For example, `static foreach (x; range) { ... }` is lowered to:
+ *
+ *     static foreach (x; {
+ *         typeof({
+ *             foreach (x; range) return x;
+ *         }())[] __res;
+ *         foreach (x; range) __res ~= x;
+ *         return __res;
+ *     }()) { ... }
+ *
+ * Finally, call `lowerArrayAggregate` to turn the produced
+ * array into an expression tuple.
+ *
+ * Params:
+ *     sc = The current scope.
+ */
+
+static void lowerNonArrayAggregate(StaticForeach *sfe, Scope *sc)
+{
+    size_t nvars = sfe->aggrfe ? sfe->aggrfe->parameters->dim : 1;
+    Loc aloc = sfe->aggrfe ? sfe->aggrfe->aggr->loc : sfe->rangefe->lwr->loc;
+    // We need three sets of foreach loop variables because the
+    // lowering contains three foreach loops.
+    Parameters *pparams[3] = {new Parameters(), new Parameters(), new Parameters()};
+    for (size_t i = 0; i < nvars; i++)
+    {
+        for (size_t j = 0; j < 3; j++)
+        {
+            Parameters *params = pparams[j];
+            Parameter *p = sfe->aggrfe ? (*sfe->aggrfe->parameters)[i] : sfe->rangefe->prm;
+            params->push(new Parameter(p->storageClass, p->type, p->ident, NULL));
+        }
+    }
+    Expression *res[2];
+    TypeStruct *tplty = NULL;
+    if (nvars == 1) // only one `static foreach` variable, generate identifiers.
+    {
+        for (size_t i = 0; i < 2; i++)
+        {
+            res[i] = new IdentifierExp(aloc, (*pparams[i])[0]->ident);
+        }
+    }
+    else // multiple `static foreach` variables, generate tuples.
+    {
+        for (size_t i = 0; i < 2; i++)
+        {
+            Expressions *e = new Expressions();
+            for (size_t j = 0; j < pparams[0]->dim; j++)
+            {
+                Parameter *p = (*pparams[i])[j];
+                e->push(new IdentifierExp(aloc, p->ident));
+            }
+            if (!tplty)
+            {
+                tplty = createTupleType(aloc, e);
+            }
+            res[i] = createTuple(aloc, tplty, e);
+        }
+        sfe->needExpansion = true; // need to expand the tuples later
+    }
+    // generate remaining code for the new aggregate which is an
+    // array (see documentation comment).
+    if (sfe->rangefe)
+    {
+        sc = sc->startCTFE();
+        sfe->rangefe->lwr = semantic(sfe->rangefe->lwr, sc);
+        sfe->rangefe->lwr = resolveProperties(sc, sfe->rangefe->lwr);
+        sfe->rangefe->upr = semantic(sfe->rangefe->upr, sc);
+        sfe->rangefe->upr = resolveProperties(sc, sfe->rangefe->upr);
+        sc = sc->endCTFE();
+        sfe->rangefe->lwr = sfe->rangefe->lwr->optimize(WANTvalue);
+        sfe->rangefe->lwr = sfe->rangefe->lwr->ctfeInterpret();
+        sfe->rangefe->upr = sfe->rangefe->upr->optimize(WANTvalue);
+        sfe->rangefe->upr = sfe->rangefe->upr->ctfeInterpret();
+    }
+    Statements *s1 = new Statements();
+    Statements *sfebody = new Statements();
+    if (tplty) sfebody->push(new ExpStatement(sfe->loc, tplty->sym));
+    sfebody->push(new ReturnStatement(aloc, res[0]));
+    s1->push(createForeach(sfe, aloc, pparams[0], new CompoundStatement(aloc, sfebody)));
+    s1->push(new ExpStatement(aloc, new AssertExp(aloc, new IntegerExp(aloc, 0, Type::tint32))));
+    Type *ety = new TypeTypeof(aloc, wrapAndCall(aloc, new CompoundStatement(aloc, s1)));
+    Type *aty = ety->arrayOf();
+    Identifier *idres = Identifier::generateId("__res");
+    VarDeclaration *vard = new VarDeclaration(aloc, aty, idres, NULL);
+    Statements *s2 = new Statements();
+    s2->push(new ExpStatement(aloc, vard));
+    Expression *catass = new CatAssignExp(aloc, new IdentifierExp(aloc, idres), res[1]);
+    s2->push(createForeach(sfe, aloc, pparams[1], new ExpStatement(aloc, catass)));
+    s2->push(new ReturnStatement(aloc, new IdentifierExp(aloc, idres)));
+    Expression *aggr = wrapAndCall(aloc, new CompoundStatement(aloc, s2));
+    sc = sc->startCTFE();
+    aggr = semantic(aggr, sc);
+    aggr = resolveProperties(sc, aggr);
+    sc = sc->endCTFE();
+    aggr = aggr->optimize(WANTvalue);
+    aggr = aggr->ctfeInterpret();
+
+    assert(!!sfe->aggrfe ^ !!sfe->rangefe);
+    sfe->aggrfe = new ForeachStatement(sfe->loc, TOKforeach, pparams[2], aggr,
+                                  sfe->aggrfe ? sfe->aggrfe->_body : sfe->rangefe->_body,
+                                  sfe->aggrfe ? sfe->aggrfe->endloc : sfe->rangefe->endloc);
+    sfe->rangefe = NULL;
+    lowerArrayAggregate(sfe, sc); // finally, turn generated array into expression tuple
+}
+
+/*****************************************
+ * Perform `static foreach` lowerings that are necessary in order
+ * to finally expand the `static foreach` using
+ * `ddmd.statementsem.makeTupleForeach`.
+ */
+
+void staticForeachPrepare(StaticForeach *sfe, Scope *sc)
+{
+    assert(sc);
+    if (sfe->aggrfe)
+    {
+        sc = sc->startCTFE();
+        sfe->aggrfe->aggr = semantic(sfe->aggrfe->aggr, sc);
+        sc = sc->endCTFE();
+        sfe->aggrfe->aggr = sfe->aggrfe->aggr->optimize(WANTvalue);
+        Type *tab = sfe->aggrfe->aggr->type->toBasetype();
+        if (tab->ty != Ttuple)
+        {
+            sfe->aggrfe->aggr = sfe->aggrfe->aggr->ctfeInterpret();
+        }
+    }
+
+    if (sfe->aggrfe && sfe->aggrfe->aggr->type->toBasetype()->ty == Terror)
+    {
+        return;
+    }
+
+    if (!staticForeachReady(sfe))
+    {
+        if (sfe->aggrfe && sfe->aggrfe->aggr->type->toBasetype()->ty == Tarray)
+        {
+            lowerArrayAggregate(sfe, sc);
+        }
+        else
+        {
+            lowerNonArrayAggregate(sfe, sc);
+        }
+    }
+}
+
+/*****************************************
+ * Returns:
+ *     `true` iff ready to call `ddmd.statementsem.makeTupleForeach`.
+ */
+
+bool staticForeachReady(StaticForeach *sfe)
+{
+    return sfe->aggrfe && sfe->aggrfe->aggr && sfe->aggrfe->aggr->type &&
+        sfe->aggrfe->aggr->type->toBasetype()->ty == Ttuple;
 }
 
 /* ============================================================ */
@@ -324,7 +647,6 @@ StaticIfCondition::StaticIfCondition(Loc loc, Expression *exp)
     : Condition(loc)
 {
     this->exp = exp;
-    this->nest = 0;
 }
 
 Condition *StaticIfCondition::syntaxCopy()
@@ -336,13 +658,6 @@ int StaticIfCondition::include(Scope *sc, ScopeDsymbol *sds)
 {
     if (inc == 0)
     {
-        if (exp->op == TOKerror || nest > 100)
-        {
-            error(loc, (nest > 1000) ? "unresolvable circular static if expression"
-                                     : "error evaluating static if expression");
-            goto Lerror;
-        }
-
         if (!sc)
         {
             error(loc, "static if conditional cannot be at global scope");
@@ -350,14 +665,12 @@ int StaticIfCondition::include(Scope *sc, ScopeDsymbol *sds)
             return 0;
         }
 
-        ++nest;
         sc = sc->push(sc->scopesym);
         sc->sds = sds;                  // sds gets any addMember()
 
         bool errors = false;
         bool result = evalStaticCondition(sc, exp, exp, errors);
         sc->pop();
-        --nest;
 
         // Prevent repeated condition evaluation.
         // See: fail_compilation/fail7815.d

--- a/src/cond.h
+++ b/src/cond.h
@@ -53,8 +53,12 @@ public:
 
     bool needExpansion;
 
+    StaticForeach(Loc loc, ForeachStatement *aggrfe, ForeachRangeStatement *rangefe);
     StaticForeach *syntaxCopy();
 };
+
+void staticForeachPrepare(StaticForeach *sfe, Scope *sc);
+bool staticForeachReady(StaticForeach *sfe);
 
 class DVCondition : public Condition
 {
@@ -100,7 +104,6 @@ class StaticIfCondition : public Condition
 {
 public:
     Expression *exp;
-    int nest;         // limit circular dependencies
 
     StaticIfCondition(Loc loc, Expression *exp);
     Condition *syntaxCopy();

--- a/src/cppmangle.c
+++ b/src/cppmangle.c
@@ -261,7 +261,7 @@ class CppMangleVisitor : public Visitor
                     fatal();
                 }
             }
-            else if(tp->isTemplateThisParameter())
+            else if (tp->isTemplateThisParameter())
             {
                 ti->error("Internal Compiler Error: C++ `%s` template this parameter is not supported", o->toChars());
                 fatal();

--- a/src/declaration.c
+++ b/src/declaration.c
@@ -340,6 +340,9 @@ void AliasDeclaration::semantic(Scope *sc)
 void AliasDeclaration::aliasSemantic(Scope *sc)
 {
     //printf("AliasDeclaration::semantic() %s\n", toChars());
+    // TypeTraits needs to know if it's located in an AliasDeclaration
+    sc->flags |= SCOPEalias;
+
     if (aliassym)
     {
         FuncDeclaration *fd = aliassym->isFuncLiteralDeclaration();
@@ -347,7 +350,10 @@ void AliasDeclaration::aliasSemantic(Scope *sc)
         if (fd || (td && td->literal))
         {
             if (fd && fd->semanticRun >= PASSsemanticdone)
+            {
+                sc->flags &= ~SCOPEalias;
                 return;
+            }
 
             Expression *e = new FuncExp(loc, aliassym);
             e = ::semantic(e, sc);
@@ -361,11 +367,13 @@ void AliasDeclaration::aliasSemantic(Scope *sc)
                 aliassym = NULL;
                 type = Type::terror;
             }
+            sc->flags &= ~SCOPEalias;
             return;
         }
 
         if (aliassym->isTemplateInstance())
             aliassym->semantic(sc);
+        sc->flags &= ~SCOPEalias;
         return;
     }
     inuse = 1;
@@ -470,6 +478,7 @@ void AliasDeclaration::aliasSemantic(Scope *sc)
         if (!overloadInsert(sx))
             ScopeDsymbol::multiplyDefined(Loc(), sx, this);
     }
+    sc->flags &= ~SCOPEalias;
 }
 
 bool AliasDeclaration::overloadInsert(Dsymbol *s)

--- a/src/dinterpret.c
+++ b/src/dinterpret.c
@@ -4649,6 +4649,10 @@ public:
                     result = getVarExp(e->loc, istate, ((SymbolExp *)ea)->var, ctfeNeedRvalue);
                 else if (ea->op == TOKaddress)
                     result = interpret(((AddrExp *)ea)->e1, istate);
+                // https://issues.dlang.org/show_bug.cgi?id=18871
+                // https://issues.dlang.org/show_bug.cgi?id=18819
+                else if (ea->op == TOKarrayliteral)
+                    result = interpret((ArrayLiteralExp *)ea, istate);
                 else
                     assert(0);
                 if (CTFEExp::isCantExp(result))

--- a/src/dmangle.c
+++ b/src/dmangle.c
@@ -80,6 +80,7 @@ void initTypeMangle()
     mangleChar[Tslice] = "@";
     mangleChar[Treturn] = "@";
     mangleChar[Tvector] = "@";
+    mangleChar[Ttraits] = "@";
 
     mangleChar[Tnull] = "n";    // same as TypeNone
 

--- a/src/dsymbol.h
+++ b/src/dsymbol.h
@@ -376,8 +376,10 @@ public:
 
 class ForwardingScopeDsymbol : public ScopeDsymbol
 {
+public:
     ScopeDsymbol *forward;
 
+    ForwardingScopeDsymbol(ScopeDsymbol *forward);
     Dsymbol *symtabInsert(Dsymbol *s);
     Dsymbol *symtabLookup(Dsymbol *s, Identifier *id);
     void importScope(Dsymbol *s, Prot protection);

--- a/src/expression.c
+++ b/src/expression.c
@@ -2185,6 +2185,11 @@ StringExp *Expression::toStringExp()
     return NULL;
 }
 
+TupleExp *Expression::toTupleExp()
+{
+    return NULL;
+}
+
 /***************************************
  * Return !=0 if expression is an lvalue.
  */
@@ -4540,6 +4545,11 @@ bool TupleExp::equals(RootObject *o)
 Expression *TupleExp::syntaxCopy()
 {
     return new TupleExp(loc, e0 ? e0->syntaxCopy() : NULL, arraySyntaxCopy(exps));
+}
+
+TupleExp *TupleExp::toTupleExp()
+{
+    return this;
 }
 
 /******************************** FuncExp *********************************/

--- a/src/expression.h
+++ b/src/expression.h
@@ -157,6 +157,7 @@ public:
     virtual real_t toImaginary();
     virtual complex_t toComplex();
     virtual StringExp *toStringExp();
+    virtual TupleExp *toTupleExp();
     virtual bool isLvalue();
     virtual Expression *toLvalue(Scope *sc, Expression *e);
     virtual Expression *modifiableLvalue(Scope *sc, Expression *e);
@@ -397,6 +398,7 @@ public:
     TupleExp(Loc loc, Expression *e0, Expressions *exps);
     TupleExp(Loc loc, Expressions *exps);
     TupleExp(Loc loc, TupleDeclaration *tup);
+    TupleExp *toTupleExp();
     Expression *syntaxCopy();
     bool equals(RootObject *o);
 

--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -1758,15 +1758,30 @@ public:
                 else
                 {
                     // Disallow shadowing
-                    for (Scope *scx = sc->enclosing; scx && scx->func == sc->func; scx = scx->enclosing)
+                    for (Scope *scx = sc->enclosing; scx && (scx->func == sc->func || (scx->func && sc->func->fes)); scx = scx->enclosing)
                     {
                         Dsymbol *s2;
                         if (scx->scopesym && scx->scopesym->symtab &&
                             (s2 = scx->scopesym->symtab->lookup(s->ident)) != NULL &&
                             s != s2)
                         {
-                            e->error("%s %s is shadowing %s %s", s->kind(), s->ident->toChars(), s2->kind(), s2->toPrettyChars());
-                            return setError();
+                            // allow STClocal symbols to be shadowed
+                            // TODO: not reallly an optimal design
+                            Declaration *decl = s2->isDeclaration();
+                            if (!decl || !(decl->storage_class & STClocal))
+                            {
+                                if (sc->func->fes)
+                                {
+                                    e->deprecation("%s `%s` is shadowing %s `%s`. Rename the `foreach` variable.",
+                                        s->kind(), s->ident->toChars(), s2->kind(), s2->toPrettyChars());
+                                }
+                                else
+                                {
+                                    e->error("%s %s is shadowing %s %s",
+                                        s->kind(), s->ident->toChars(), s2->kind(), s2->toPrettyChars());
+                                    return setError();
+                                }
+                            }
                         }
                     }
                 }
@@ -7929,6 +7944,12 @@ public:
         bool f2 = checkNonAssignmentArrayOp(exp->e2);
         if (f1 || f2)
             return setError();
+
+        if (exp->e1->op == TOKtype || exp->e2->op == TOKtype)
+        {
+            result = exp->incompatibleTypes();
+            return;
+        }
 
         exp->type = Type::tbool;
 

--- a/src/func.c
+++ b/src/func.c
@@ -1491,8 +1491,7 @@ void FuncDeclaration::semantic3(Scope *sc)
          * e.g.
          *      class C { int x; static assert(is(typeof({ this.x = 1; }))); }
          *
-         * To properly accept it, mark these lambdas as member functions -
-         * isThis() returns true and isNested() returns false.
+         * To properly accept it, mark these lambdas as member functions.
          */
         if (FuncLiteralDeclaration *fld = isFuncLiteralDeclaration())
         {
@@ -1510,7 +1509,6 @@ void FuncDeclaration::semantic3(Scope *sc)
                     if (fld->tok != TOKfunction)
                         fld->tok = TOKdelegate;
                 }
-                assert(!isNested());
             }
         }
 

--- a/src/init.c
+++ b/src/init.c
@@ -238,7 +238,7 @@ bool hasNonConstPointers(Expression *e)
             return arrayHasNonConstPointers(ae->keys);
         return false;
     }
-    if(e->op == TOKaddress)
+    if (e->op == TOKaddress)
     {
         AddrExp *ae = (AddrExp *)e;
         if (ae->e1->op == TOKstructliteral)

--- a/src/intrange.c
+++ b/src/intrange.c
@@ -610,7 +610,7 @@ IntRange IntRange::operator/(const IntRange& rhs) const
     {
         r.imax.value--;
     }
-    else if(r.imin.value == 0)
+    else if (r.imin.value == 0)
     {
         r.imin.value++;
     }

--- a/src/json.c
+++ b/src/json.c
@@ -454,6 +454,8 @@ public:
 
     void jsonProperties(Declaration *d)
     {
+        if (d->storage_class & STClocal)
+            return;
         jsonProperties((Dsymbol *)d);
 
         propertyStorageClass("storageClass", d->storage_class);
@@ -843,6 +845,8 @@ public:
 
     void visit(VarDeclaration *d)
     {
+        if (d->storage_class & STClocal)
+            return;
         objectStart();
 
         jsonProperties(d);

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -94,6 +94,7 @@ enum ENUMTY
     Tvector,
     Tint128,
     Tuns128,
+    Ttraits,
     TMAX
 };
 typedef unsigned char TY;       // ENUMTY
@@ -656,6 +657,23 @@ public:
     Expression *dotExp(Scope *sc, Expression *e, Identifier *ident, int flag);
     bool hasPointers() /*const*/;
 
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+class TypeTraits : public Type
+{
+public:
+    Loc loc;
+    /// The expression to resolve as type or symbol.
+    TraitsExp *exp;
+    /// The symbol when exp doesn't represent a type.
+    Dsymbol *sym;
+
+    TypeTraits(const Loc &loc, TraitsExp *exp);
+    Type *syntaxCopy();
+    Type *semantic(Loc loc, Scope *sc);
+    void resolve(Loc loc, Scope *sc, Expression **pe, Type **pt, Dsymbol **ps, bool intypeid = false);
+    d_uns64 size(Loc loc);
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -120,6 +120,9 @@ public:
     FuncDeclaration *parseContracts(FuncDeclaration *f);
     void checkDanglingElse(Loc elseloc);
     void checkCstyleTypeSyntax(Loc loc, Type *t, int alt, Identifier *ident);
+    Statement *parseForeach(Loc loc, bool *isRange, bool isDecl);
+    Dsymbol *parseForeachStaticDecl(Loc loc, Dsymbol **pLastDecl);
+    Statement *parseForeachStatic(Loc loc);
     /** endPtr used for documented unittests */
     Statement *parseStatement(int flags, const utf8_t** endPtr = NULL, Loc *pEndloc = NULL);
     Initializer *parseInitializer();

--- a/src/scope.h
+++ b/src/scope.h
@@ -61,9 +61,10 @@ enum PINLINE;
 #define SCOPEctfe           0x0080  // inside a ctfe-only expression
 #define SCOPEcompile        0x0100  // inside __traits(compile)
 #define SCOPEignoresymbolvisibility 0x0200  // ignore symbol visibility (Bugzilla 15907)
-#define SCOPEfullinst       0x1000  // fully instantiate templates
 
 #define SCOPEfree           0x8000  // is on free list
+#define SCOPEfullinst       0x10000 // fully instantiate templates
+#define SCOPEalias          0x20000 // inside alias declaration
 
 struct Scope
 {

--- a/src/statement.h
+++ b/src/statement.h
@@ -232,15 +232,13 @@ public:
 
 class ForwardingStatement : public Statement
 {
+public:
     ForwardingScopeDsymbol *sym;
     Statement *statement;
 
+    ForwardingStatement(Loc loc, ForwardingScopeDsymbol *sym, Statement *s);
+    ForwardingStatement(Loc loc, Statement *s);
     Statement *syntaxCopy();
-    Statement *getRelatedLabeled();
-    bool hasBreak();
-    bool hasContinue();
-    Statement *scopeCode(Scope *sc, Statement **sentry, Statement **sexception, Statement **sfinally);
-    Statement *last();
     Statements *flatten(Scope *sc);
     ForwardingStatement *isForwardingStatement() { return this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -384,6 +382,7 @@ class StaticForeachStatement : public Statement
 public:
     StaticForeach *sfe;
 
+    StaticForeachStatement(Loc loc, StaticForeach *sfe);
     Statement *syntaxCopy();
     Statements *flatten(Scope *sc);
 

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -81,6 +81,7 @@ class TypeClass;
 class TypeTuple;
 class TypeSlice;
 class TypeNull;
+class TypeTraits;
 
 class Dsymbol;
 
@@ -107,6 +108,7 @@ class StaticIfDeclaration;
 class CompileDeclaration;
 class StaticForeachDeclaration;
 class UserAttributeDeclaration;
+class ForwardingAttribDeclaration;
 
 class ScopeDsymbol;
 class TemplateDeclaration;
@@ -373,6 +375,7 @@ public:
     virtual void visit(TypeTuple *t) { visit((Type *)t); }
     virtual void visit(TypeSlice *t) { visit((TypeNext *)t); }
     virtual void visit(TypeNull *t) { visit((Type *)t); }
+    virtual void visit(TypeTraits *t) { visit((Type *)t); }
 
     virtual void visit(Dsymbol *) { assert(0); }
 
@@ -399,6 +402,7 @@ public:
     virtual void visit(StaticForeachDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(CompileDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(UserAttributeDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(ForwardingAttribDeclaration *s) { visit((AttribDeclaration *)s); }
 
     virtual void visit(ScopeDsymbol *s) { visit((Dsymbol *)s); }
     virtual void visit(TemplateDeclaration *s) { visit((ScopeDsymbol *)s); }

--- a/test/compilable/b12001.d
+++ b/test/compilable/b12001.d
@@ -1,0 +1,9 @@
+void main()
+{
+    static assert(__traits(isSame, int, int));
+    static assert(__traits(isSame, int[][], int[][]));
+    static assert(__traits(isSame, bool*, bool*));
+
+    static assert(!__traits(isSame, bool*, bool[]));
+    static assert(!__traits(isSame, float, double));
+}

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -121,5 +121,14 @@ alias Seq(T...) = T;
 
 static foreach(int i, alias a; Seq!(a0, a1, a2))
 {
-	mixin("alias b" ~ i.stringof ~ " = a;");
+       mixin("alias b" ~ i.stringof ~ " = a;");
+}
+
+mixin template test18211(int n)
+{
+    static foreach (i; 0 .. n>10 ? 10 : n)
+    {
+        mixin("enum x" ~ cast(char)('0' + i));
+    }
+    static if (true) {}
 }

--- a/test/compilable/staticforeach.d
+++ b/test/compilable/staticforeach.d
@@ -1,5 +1,129 @@
 // REQUIRED_ARGS: -o-
 // PERMUTE_ARGS:
+// EXTRA_FILES: imports/imp12242a1.d imports/imp12242a2.d
+/*
+TEST_OUTPUT:
+---
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
+S(1, 2, 3, [0, 1, 2])
+x0: 1
+x1: 2
+x2: 3
+a: [0, 1, 2]
+(int[], char[], bool[], Object[])
+[0, 0]
+x0: int
+x1: double
+x2: char
+test(0)→ 0
+test(1)→ 1
+test(2)→ 2
+test(3)→ 3
+test(4)→ 4
+test(5)→ 5
+test(6)→ 6
+test(7)→ 7
+test(8)→ 8
+test(9)→ 9
+test(10)→ -1
+test(11)→ -1
+test(12)→ -1
+test(13)→ -1
+test(14)→ -1
+1
+[1, 2, 3]
+2
+[1, 2, 3]
+3
+[1, 2, 3]
+0 1
+1 2
+2 3
+1
+3
+4
+object
+Tuple
+tuple
+main
+front
+popFront
+empty
+back
+popBack
+Iota
+iota
+map
+to
+text
+all
+any
+join
+S
+s
+Seq
+Overloads
+Parameters
+forward
+foo
+A
+B
+C
+D
+E
+Types
+Visitor
+testVisitor
+staticMap
+arrayOf
+StaticForeachLoopVariable
+StaticForeachScopeExit
+StaticForeachReverseHiding
+UnrolledForeachReverse
+StaticForeachReverse
+StaticForeachByAliasDefault
+NestedStaticForeach
+TestAliasOutsideFunctionScope
+OpApplyMultipleStaticForeach
+OpApplyMultipleStaticForeachLowered
+RangeStaticForeach
+OpApplySingleStaticForeach
+TypeStaticForeach
+AliasForeach
+EnumForeach
+TestUninterpretable
+SeqForeachConstant
+SeqForeachBreakContinue
+TestStaticForeach
+testtest
+fun
+testEmpty
+bug17660
+breakContinueBan
+MixinTemplate
+testToStatement
+bug17688
+T
+foo2
+T2
+1 2 '3'
+2 3 '4'
+0 1
+1 2
+2 3
+---
+*/
+
+module staticforeach;
 
 struct Tuple(T...){
     T expand;
@@ -71,7 +195,7 @@ template map(alias a){
 template to(T:string){
     string to(S)(S x)if(is(S:int)||is(S:size_t)||is(S:char)){
         static if(is(S==char)) return cast(string)[x];
-        if(x<0) return "-"~to(-x);
+        if(x<0) return "-"~to(-1 * x);
         if(x==0) return "0";
         return (x>=10?to(x/10):"")~cast(char)(x%10+'0');
     }
@@ -120,6 +244,7 @@ static foreach(member;__traits(allMembers,S)){
 }
 
 // print prime numbers using overload sets as state variables.
+/+
 static assert(is(typeof(bad57)));
 static assert(!is(typeof(bad53)));
 
@@ -136,6 +261,7 @@ static foreach(x;iota(2,100)){
         static assert(iota(2,x).any!(y=>!(x%y)));
     }
 }
++/
 
 
 alias Seq(T...)=T;
@@ -346,7 +472,7 @@ struct NestedStaticForeach{
     static:
     static foreach(i,name;["a"]){
         static foreach(j,name2;["d"]){
-            mixin("enum "~name~name2~"=[i,j];");
+            mixin("enum int[] "~name~name2~"=[i, j];");
         }
     }
     pragma(msg, ad);
@@ -596,12 +722,12 @@ static:
 }
 
 static foreach(i,j;[1,2,3]){
-    pragma(msg, i," ",j);
+    pragma(msg, int(i)," ",j);
 }
 
 void testtest(){
     static foreach(i,v;[1,2,3]){
-        pragma(msg, i," ",v);
+        pragma(msg, int(i)," ",v);
         static assert(i+1 == v);
     }
 }
@@ -696,7 +822,21 @@ T foo(T v)@nogc{
     static foreach(x;0..v.n){ }
     return T.init;
 }
-T foo(T v)@nogc{
+T foo2(T v)@nogc{
     static foreach(_;0..typeof(return).n){ }
     return T.init;
 }
+
+//https://issues.dlang.org/show_bug.cgi?id=18698
+
+static foreach(m; __traits(allMembers, staticforeach))
+{
+    pragma(msg, m);
+}
+
+//https://issues.dlang.org/show_bug.cgi?id=20072
+struct T2{
+    static foreach(i;0..1)
+        struct S{}
+}
+static assert(is(__traits(parent,T2.S)==T2));

--- a/test/compilable/test11169.d
+++ b/test/compilable/test11169.d
@@ -43,3 +43,18 @@ void main()
     static assert(!__traits(compiles, { auto b = new B2(); }));
     static assert(!__traits(compiles, { auto b = new B3(); }));
 }
+
+class B : A
+{
+    // __traits(isAbstractClass) is not usable in static if condition.
+       static assert (!__traits(isAbstractClass, typeof(this)));
+
+    override void foo()
+    {
+    }
+}
+
+void main2()
+{
+    B b = new B();
+}

--- a/test/compilable/test17819.d
+++ b/test/compilable/test17819.d
@@ -1,0 +1,17 @@
+static if (__traits(allMembers, __traits(parent,{}))[0]=="object") {
+	enum test = 0;
+}
+
+static foreach (m; __traits(allMembers, __traits(parent,{}))) {
+	mixin("enum new"~m~"=`"~m~"`;");
+}
+
+static assert([__traits(allMembers, __traits(parent,{}))] == ["object", "test", "newobject", "newWorld", "newBuildStuff", "World", "BuildStuff"]);
+
+struct World {
+	mixin BuildStuff;
+}
+
+template BuildStuff() {
+	static foreach(elem; __traits(allMembers, typeof(this))) {}
+}

--- a/test/compilable/test18871.d
+++ b/test/compilable/test18871.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=18871
+// and https://issues.dlang.org/show_bug.cgi?id=18819
+
+struct Problem
+{
+    ~this() {}
+}
+struct S
+{
+    Problem[1] payload;
+}
+enum theTemplateB = {
+    static foreach (e; S.init.tupleof) {}
+    return true;
+}();

--- a/test/compilable/test7815.d
+++ b/test/compilable/test7815.d
@@ -1,0 +1,65 @@
+// REQUIRED_ARGS: -o-
+/*
+TEST_OUTPUT:
+---
+---
+*/
+
+mixin template Helpers()
+{
+    static if (is(Flags!Move))
+    {
+        Flags!Move flags;
+    }
+    else
+    {
+        pragma(msg, "X: ", __traits(derivedMembers, Flags!Move));
+    }
+}
+
+template Flags(T)
+{
+    mixin({
+        int defs = 1;
+        foreach (name; __traits(derivedMembers, Move))
+        {
+            defs++;
+        }
+        if (defs)
+        {
+            return "struct Flags { bool x; }";
+        }
+        else
+        {
+            return "";
+        }
+    }());
+}
+
+struct Move
+{
+    int a;
+    mixin Helpers!();
+}
+
+enum a7815 = Move.init.flags;
+
+/+
+This originally was an invalid case:
+When the Move struct member is analyzed:
+1. mixin Helpers!() is instantiated.
+2. In Helpers!(), static if and its condition is(Flags!Move)) evaluated.
+3. In Flags!Move, string mixin evaluates and CTFE lambda.
+4. __traits(derivedMembers, Move) tries to see the member of Move.
+   4a. mixin Helpers!() member is analyzed.
+   4b. `static if (is(Flags!Move))` in Helpers!() is evaluated
+   4c. The Flags!Move instantiation is already in progress, so it cannot be resolved.
+   4d. `static if` fails because Flags!Move cannot be determined as a type.
+5. __traits(derivedMembers, Move) returns a 1-length tuple("a").
+6. The lambda in Flags!Move returns a string "struct Flags {...}", then
+   Flags!Move is instantiated to a new struct Flags.
+7. Finally Move struct does not have flags member, then the `enum a7815`
+   definition will fail in its initializer.
+
+Now, static if will behave like a string mixin: it is invisible during its own expansion.
++/

--- a/test/compilable/test7886.d
+++ b/test/compilable/test7886.d
@@ -1,0 +1,5 @@
+// https://issues.dlang.org/show_bug.cgi?id=7886
+
+struct A {
+	static assert (__traits(derivedMembers, A).length == 0);
+}

--- a/test/fail_compilation/e7804_1.d
+++ b/test/fail_compilation/e7804_1.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e7804_1.d(10): Error: trait `farfelu` is either invalid or not supported as type
+fail_compilation/e7804_1.d(11): Error: trait `farfelu` is either invalid or not supported in alias
+---
+*/
+module e7804_1;
+
+__traits(farfelu, Aggr, "member") a;
+alias foo = __traits(farfelu, Aggr, "member");

--- a/test/fail_compilation/e7804_2.d
+++ b/test/fail_compilation/e7804_2.d
@@ -1,0 +1,19 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/e7804_2.d(17): Error: `__traits(getMember, Foo, "func")` does not give a valid type
+---
+*/
+
+module e7804_2;
+
+class Foo
+{
+     void func(){}
+}
+
+void test()
+{
+    __traits(getMember, Foo, "func") var;
+    auto a = cast(__traits(getMember, Foo, "func")) 0;
+}

--- a/test/fail_compilation/fail19182.d
+++ b/test/fail_compilation/fail19182.d
@@ -1,0 +1,18 @@
+// REQUIRED_ARGS: -c
+/*
+TEST_OUTPUT:
+---
+gigi
+fail_compilation/fail19182.d(12): Error: `pragma(msg)` is missing a terminating `;`
+---
+*/
+
+void foo()
+{
+    pragma(msg, "gigi") // Here
+    static foreach (e; [])
+    {
+        pragma(msg, "lili");
+    }
+
+}

--- a/test/fail_compilation/fail19520.d
+++ b/test/fail_compilation/fail19520.d
@@ -1,0 +1,21 @@
+/* https://issues.dlang.org/show_bug.cgi?id=19520
+TEST_OUTPUT:
+---
+fail_compilation/fail19520.d(17): Error: incompatible types for `(Empty) is (Empty)`: cannot use `is` with types
+fail_compilation/fail19520.d(17):        while evaluating: `static assert((Empty) is (Empty))`
+fail_compilation/fail19520.d(18): Error: incompatible types for `(WithSym) is (WithSym)`: cannot use `is` with types
+fail_compilation/fail19520.d(18):        while evaluating: `static assert((WithSym) is (WithSym))`
+fail_compilation/fail19520.d(19): Error: incompatible types for `(Empty) is (Empty)`: cannot use `is` with types
+fail_compilation/fail19520.d(20): Error: incompatible types for `(WithSym) is (WithSym)`: cannot use `is` with types
+---
+*/
+struct Empty { }
+struct WithSym { int i; }
+
+void test()
+{
+    static assert(Empty is Empty);
+    static assert(WithSym is WithSym);
+    assert(Empty is Empty);
+    assert(WithSym is WithSym);
+}

--- a/test/fail_compilation/fail19911b.d
+++ b/test/fail_compilation/fail19911b.d
@@ -1,6 +1,7 @@
 /* 
 DFLAGS:
-REQUIRED_ARGS: -I=fail_compilation/extra-files/minimal/
+REQUIRED_ARGS:
+EXTRA_SOURCES: extra-files/minimal/object.d
 TEST_OUTPUT:
 ---
 fail_compilation/fail19911b.d(10): Error: function `fail19911b.fun` `object.TypeInfo_Tuple` could not be found, but is implicitly used in D-style variadic functions

--- a/test/fail_compilation/fail2195.d
+++ b/test/fail_compilation/fail2195.d
@@ -1,0 +1,18 @@
+// https://issues.dlang.org/show_bug.cgi?id=2195
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail2195.d(16): Deprecation: variable `variable` is shadowing variable `fail2195.main.variable`. Rename the `foreach` variable.
+---
+*/
+
+void main()
+{
+    int[int] arr;
+    int variable;
+    foreach (i, j; arr)
+    {
+        int variable;  // shadowing is disallowed but not detected
+    }
+}

--- a/test/fail_compilation/staticforeach3.d
+++ b/test/fail_compilation/staticforeach3.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/staticforeach3.d(7): Error: variable staticforeach3.__anonymous.i conflicts with variable staticforeach3.__anonymous.i at fail_compilation/staticforeach3.d(7)
+fail_compilation/staticforeach3.d(7): Error: variable `staticforeach3.__anonymous.i` conflicts with variable `staticforeach3.__anonymous.i` at fail_compilation/staticforeach3.d(7)
 ---
 */
 static foreach(i,i;[0]){}

--- a/test/fail_compilation/test17307.d
+++ b/test/fail_compilation/test17307.d
@@ -1,0 +1,12 @@
+/* 
+TEST_OUTPUT:
+---
+fail_compilation/test17307.d(9): Error: anonymous struct can only be a part of an aggregate, not module `test17307`
+---
+ * https://issues.dlang.org/show_bug.cgi?id=17307
+ */
+
+struct { enum bitsPerWord = size_t; }
+
+void main()
+{ }

--- a/test/fail_compilation/traits_alone.d
+++ b/test/fail_compilation/traits_alone.d
@@ -1,0 +1,10 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/traits_alone.d(11): Error: found `End of File` when expecting `(`
+fail_compilation/traits_alone.d(11): Error: `__traits(identifier, args...)` expected
+fail_compilation/traits_alone.d(11): Error: no identifier for declarator `_error_`
+---
+*/
+//used to segfault
+__traits

--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -907,8 +907,20 @@ void test14851()
 
 int main()
 {
-    test1();
-    test2();
+    version(X86)
+    {
+        test1();
+        test2();
+    }
+    else version(X86_64)
+    {
+        test1();
+        test2();
+    }
+    else
+    {
+        //pragma(msg, "Test skipped because arrayop evaluation order is ill-defined.");
+    }
     test3();
     test4();
     test5();

--- a/test/runnable/constfold.d
+++ b/test/runnable/constfold.d
@@ -249,12 +249,18 @@ void test1()
 
 void test2()
 {
-    float f = float.infinity;
-    int i = cast(int) f;
-    writeln(i);
-    writeln(cast(int)float.max);
-    assert(i == cast(int)float.max);
-    assert(i == 0x80000000);
+    // This test only tests undefined, architecture-dependant behavior.
+    // E.g. the result of converting a float whose value doesn't fit into the integer
+    // leads to an undefined result.
+    version (DigitalMars)
+    {
+        float f = float.infinity;
+        int i = cast(int) f;
+        writeln(i);
+        writeln(cast(int)float.max);
+        assert(i == cast(int)float.max);
+        assert(i == 0x80000000);
+    }
 }
 
 /************************************/

--- a/test/runnable/e7804.d
+++ b/test/runnable/e7804.d
@@ -1,0 +1,179 @@
+/* REQUIRED_ARGS: -unittest
+*/
+module e7804;
+
+struct Bar {static struct B{}}
+alias BarB = __traits(getMember, Bar, "B");
+static assert(is(BarB == Bar.B));
+static assert(is(const(__traits(getMember, Bar, "B")) == const(Bar.B)));
+
+alias BarBParent = __traits(parent, BarB);
+static assert(is(BarBParent == Bar));
+
+struct Foo {alias MyInt = int;}
+alias FooInt = __traits(getMember, Foo, "MyInt");
+static immutable FooInt fi = 42;
+static assert(fi == 42);
+void declVsStatementSupport()
+{
+    __traits(getMember, Foo, "MyInt") i1 = 1;
+    const(__traits(getMember, Foo, "MyInt")) i2 = 1;
+    assert(i1 == i2);
+    __traits(getMember, Foo, "MyInt") i3 = __traits(getMember, Foo, "MyInt").max;
+    assert(i3 == int.max);
+}
+
+
+enum __traits(getMember, Foo, "MyInt") a0 = 12;
+static assert(is(typeof(a0) == int));
+static assert(a0 == 12);
+
+
+const __traits(getMember, Foo, "MyInt") a1 = 46;
+
+
+__traits(getMember, Foo, "MyInt") a2 = 78;
+
+
+const(__traits(getMember, Foo, "MyInt")) a3 = 63;
+
+
+struct WithSym {static int foo; static int bar(){return 42;}}
+alias m1 = __traits(getMember, WithSym, "foo");
+alias m2 = WithSym.foo;
+static assert(__traits(isSame, m1, m2));
+alias f1 = __traits(getMember, WithSym, "bar");
+alias f2 = WithSym.bar;
+static assert(__traits(isSame, f1, f2));
+
+
+auto ovld(const(char)[] s){return s;}
+auto ovld(int i){return i;}
+alias ovlds = __traits(getOverloads, e7804, "ovld");
+
+
+struct TmpPrm(T)
+if (is(T == int)){T t;}
+TmpPrm!(__traits(getMember, Foo, "MyInt")) tpt = TmpPrm!(__traits(getMember, Foo, "MyInt"))(42);
+
+
+@Foo @(1) class Class
+{
+    final void virtual(){}
+    int virtual(int p){return p;}
+    void test(this T)()
+    {
+        alias vf = __traits(getVirtualFunctions, Class, "virtual");
+        assert(vf.length == 2);
+        alias vm = __traits(getVirtualMethods, Class, "virtual");
+        assert(vm.length == 1);
+        assert(vm[0](42) == 42);
+        alias attribs = __traits(getAttributes, Class);
+        assert(attribs.length == 2);
+        assert(is(typeof(attribs[0]()) == Foo));
+        assert(attribs[1] == 1);
+
+        alias objectAll = __traits(allMembers, Object);
+        alias classDerived = __traits(derivedMembers, Class);
+        alias classAll = __traits(allMembers, Class);
+        enum Seq(T...) = T;
+        static assert (classAll == Seq!(classDerived, objectAll));
+    }
+}
+
+
+struct UnitTests
+{
+    static int count;
+    unittest { count++; }
+    unittest {++++count;}
+    static void test()
+    {
+        alias tests = __traits(getUnitTests, UnitTests);
+        static assert(tests.length == 2);
+        foreach(t; tests) t();
+        assert(count == 6); // not 3 because executed automatically (DRT) then manually
+    }
+}
+
+
+class One
+{
+    void foo(){}
+    void foo(int){}
+}
+
+class Two : One
+{
+    void test()
+    {
+        alias Seq(T...) = T;
+        alias p1 = Seq!(__traits(getMember, super, "foo"))[0];
+        alias p2 = __traits(getMember, super, "foo");
+        static assert(__traits(isSame, p1, p2));
+    }
+}
+
+
+class SingleSymTuple
+{
+    int foo(){return 42;}
+    void test()
+    {
+        alias f = __traits(getMember, this, "foo");
+        assert(f() == 42);
+    }
+}
+
+
+struct WithAliasThis
+{
+    auto getter(){return 42;}
+    alias getter this;
+    void test()
+    {
+        alias getterCall = __traits(getAliasThis, typeof(this));
+        assert(mixin(getterCall[0]) == 42);
+    }
+}
+
+void main()
+{
+    declVsStatementSupport();
+    assert(a1 == 46);
+    assert(a2 == 78);
+    assert(a3 == 63);
+    assert(f1() == f2());
+    Foo.MyInt fmi = cast(__traits(getMember, Foo, "MyInt")) 0;
+    auto c = __traits(getMember, Foo, "MyInt").max;
+    assert(c == int.max);
+    assert(ovlds[0]("farfelu") == "farfelu");
+    assert(ovlds[1](42) == 42);
+    (new Class).test();
+    UnitTests.test();
+    (new WithAliasThis).test();
+    (new Two).test();
+    (new SingleSymTuple).test();
+}
+
+/* https://issues.dlang.org/show_bug.cgi?id=19708 */
+struct Foo19708 {}
+struct Bar19708 {}
+template Baz19708(T) { struct Baz19708{T t;} }
+int symbol19708;
+
+@Foo19708 @Bar19708 @Baz19708 @symbol19708 int bar19708;
+
+alias TR19708 = __traits(getAttributes, bar19708);
+alias TRT = __traits(getAttributes, bar19708)[2];
+
+TR19708[0] a119708;
+TR19708[1] a219708;
+alias A3 = TRT!int;
+
+alias C19708 = TR19708[0];
+alias D19708 = TR19708[1];
+C19708 c1;
+D19708 d1;
+
+static assert(__traits(isSame, TR19708[3], symbol19708));

--- a/test/runnable/imports/template13478a.d
+++ b/test/runnable/imports/template13478a.d
@@ -3,6 +3,6 @@ module imports.template13478a;
 bool foo(T)() {
     // Make sure this is not inlined so template13478.o actually
     // needs to reference it.
-    asm { nop; }
+    pragma(inline, false);
     return false;
 }

--- a/test/runnable/staticforeach.d
+++ b/test/runnable/staticforeach.d
@@ -1,0 +1,45 @@
+// REQUIRED_ARGS:
+
+/**********************************/
+// https://issues.dlang.org/show_bug.cgi?id=19479
+
+mixin template genInts19479a()
+{
+    static foreach (t; 0..1)
+        int i = 5;
+}
+
+mixin template genInts19479b()
+{
+    static foreach (t; 0..2)
+        mixin("int i" ~ cast(char)('0' + t) ~ " = 5;");
+}
+
+void test19479()
+{
+    {
+        static foreach (t; 0..1)
+            int i = 5;
+        assert(i == 5);
+    }
+    {
+        mixin genInts19479a!();
+        assert(i == 5);
+    }
+    {
+        static foreach (t; 0..2)
+            mixin("int i" ~ cast(char)('0' + t) ~ " = 5;");
+        assert(i0 == 5);
+        assert(i1 == 5);
+    }
+    {
+        mixin genInts19479b!();
+        assert(i0 == 5);
+        assert(i1 == 5);
+    }
+}
+
+void main()
+{
+    test19479();
+}

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1674,14 +1674,13 @@ void test101()
 
 /***************************************************/
 
-version(X86)
-{
 int x103;
 
 void external(...)
 {
-    printf("external: %d\n", *cast (int *) _argptr);
-    x103 = *cast (int *) _argptr;
+    int arg = va_arg!int(_argptr);
+    printf("external: %d\n", arg);
+    x103 = arg;
 }
 
 class C103
@@ -1690,8 +1689,9 @@ class C103
     {
         void internal (...)
         {
-            printf("internal: %d\n", *cast (int *)_argptr);
-            x103 = *cast (int *) _argptr;
+            int arg = va_arg!int(_argptr);
+            printf("internal: %d\n", arg);
+            x103 = arg;
         }
 
         internal (43);
@@ -1705,14 +1705,6 @@ void test103()
     assert(x103 == 42);
     (new C103).method ();
 }
-}
-else version(X86_64)
-{
-    pragma(msg, "Not ported to x86-64 compatible varargs, yet.");
-    void test103() {}
-}
-else
-    static assert(false, "Unknown platform");
 
 /***************************************************/
 

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1247,14 +1247,35 @@ struct S10096X
     invariant() {}
     invariant() {}
     unittest {}
+    unittest {}
 
     this(int) {}
     this(this) {}
     ~this() {}
+
+    string getStr() in(str) out(r; r == str) { return str; }
 }
 static assert(
     [__traits(allMembers, S10096X)] ==
-    ["str", "__ctor", "__postblit", "__dtor", "__xdtor", "__xpostblit", "opAssign"]);
+    ["str", "__ctor", "__postblit", "__dtor", "getStr", "__xdtor", "__xpostblit", "opAssign"]);
+
+class C10096X
+{
+    string str;
+
+    invariant() {}
+    invariant() {}
+    unittest {}
+    unittest {}
+
+    this(int) {}
+    ~this() {}
+
+    string getStr() in(str) out(r; r == str) { return str;
+}
+static assert(
+    [__traits(allMembers, C10096X)] ==
+    ["str", "__ctor", "__dtor", "getStr", "__xdtor", "toString", "toHash", "opCmp", "opEquals", "Monitor", "factory"]);
 
 // --------
 
@@ -1524,6 +1545,21 @@ void async(ARGS...)(ARGS)
 }
 
 alias test17495 = async!(int, int);
+
+/********************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=10100
+
+enum E10100
+{
+    value,
+    _value,
+    __value,
+    ___value,
+    ____value,
+}
+static assert(
+    [__traits(allMembers, E10100)] ==
+    ["value", "_value", "__value", "___value", "____value"]);
 
 /********************************************************/
 


### PR DESCRIPTION
This'll be the notable addition to gdc10, as it's too late to switch to self-hosted now.

Bootstrapped and regression tested on x86_64-linux-gnu.  Though we'll wait and see how the dmd autotester responds, particularly on Windows and OSX.

ChangeLog entries below:

----

Implement DIP 1010 - (Static foreach)

Support for `static foreach` has been added.

`static foreach` is a conditional compilation construct that is to `foreach` what `static if` is to `if`.
It is a convenient way to generate declarations and statements by iteration.

```
import std.conv: to;

static foreach(i; 0 .. 10)
{

    // a `static foreach` body does not introduce a nested scope
    // (similar to `static if`).

    // The following mixin declaration is at module scope:
    mixin(`enum x` ~ to!string(i) ~ ` = i;`); // declares 10 variables x0, x1, ..., x9
}

import std.range: iota;
// all aggregate types that can be iterated with a standard `foreach`
// loop are also supported by static foreach:
static foreach(i; iota(10))
{
    // we access the declarations generated in the first `static foreach`
    pragma(msg, "x", i, ": ", mixin(`x` ~ to!string(i)));
    static assert(mixin(`x` ~ to!string(i)) == i);
}

void main()
{
    import std.conv: text;
    import std.typecons: tuple;
    import std.algorithm: map;
    import std.stdio: writeln;

    // `static foreach` has both declaration and statement forms
    // (similar to `static if`).

    static foreach(x; iota(3).map!(i => tuple(text("x", i), i)))
    {
        // generates three local variables x0, x1 and x2.
        mixin(text(`int `,x[0],` = x[1];`));

        scope(exit) // this is within the scope of `main`
        {
            writeln(mixin(x[0]));
        }
    }

    writeln(x0," ",x1," ",x2); // first runtime output
}
```

----

Aliases can be created directly from a `__trait`.

Aliases can be created directly from the traits that return symbol(s) or tuples.
This includes `getMember`, `allMembers`, `derivedMembers`, `parent`, `getOverloads`,
`getVirtualFunctions`, `getVirtualMethods`, `getUnitTests`, `getAttributes` and finally `getAliasThis`.
Previously an `AliasSeq` was necessary in order to alias their return.
Now the grammar allows to write shorter declarations:

```
struct Foo
{
    static int a;
}

alias oldWay = AliasSeq!(__traits(getMember, Foo, "a"))[0];
alias newWay = __traits(getMember, Foo, "a");
```

To permit this it was more interesting to include `__trait` in the basic types
rather than just changing the alias syntax. So additionally, wherever a type appears
a `__trait` can be used, for example in a variable declaration:

```
struct Foo { static struct Bar {} }
const(__traits(getMember, Foo, "Bar")) fooBar;
static assert(is(typeof(fooBar) == const(Foo.Bar)));
```

----

fix Issue 10100 - Identifiers with double underscores and allMembers

Convert the identifier whitelist into a blacklist of all possible
internal D language declarations.