### PR TITLE
mingw: use runtime from VC 12 (VS 2012) for better C99 support

### DIFF
--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -526,7 +526,7 @@ dmd -cov -unittest myprog.d
             If no Visual C installation is detected, a wrapper for the redistributable
             VC2010 dynamic runtime library and mingw based platform import libraries will
             be linked instead using the LLD linker provided by the LLVM project.
-            The detection can be skipped explicitly if $(TT msvcrt100) is specified as
+            The detection can be skipped explicitly if $(TT msvcrt120) is specified as
             $(I libname).
             If $(I libname) is empty, no C runtime library is automatically linked in.",
             TargetOS.windows,

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1047,7 +1047,7 @@ version (Windows)
             if (getVCLibDir(x64))
                 return "libcmt";
             else
-                return "msvcrt100"; // mingw replacement
+                return "msvcrt120"; // mingw replacement
         }
 
         /**


### PR DESCRIPTION
Since https://github.com/dlang/installer/pull/346, the mingw runtime can be combined with any MS C runtime from VC8 to VC12.

With https://github.com/dlang/installer/pull/436, the necessary redistributable DLLs will be part of the dmd distribution, so no additional installers necessary.