### PR TITLE
Fix Issue 20583 - no warnings printed when indexing through deprecated alias this

### DIFF
--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -551,7 +551,10 @@ Expression op_overload(Expression e, Scope* sc, TOK* pop = null)
                      */
                     ae.e1 = resolveAliasThis(sc, ae1save, true);
                     if (ae.e1)
+                    {
+                        ad.aliasthis.checkDeprecatedAliasThis(ae.e1.loc, sc);
                         continue;
+                    }
                 }
                 break;
             }

--- a/test/fail_compilation/fail20583.d
+++ b/test/fail_compilation/fail20583.d
@@ -1,0 +1,17 @@
+// https://issues.dlang.org/show_bug.cgi?id=20583
+
+// REQUIRED_ARGS: -de
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20583.d(17): Deprecation: `alias x this` is deprecated
+---
+*/
+
+struct X
+{
+    int[1] x;
+    deprecated alias x this;
+}
+
+auto y = X()[0];


### PR DESCRIPTION
The `op_overload` visit method for `ArrayExp` does not check if the alias this is deprecated. I added the missing check.