### PR TITLE
[RFC] Enable output transformation before `TEST_OUTPUT` check

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -219,7 +219,7 @@ $(RESULTS_DIR)/d_do_test$(EXE): tools/d_do_test.d $(RESULTS_DIR)/.created
 	@echo "PIC: '$(PIC_FLAG)'"
 	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -lowmem -unittest -run $< &
 	@pid=$!
-	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -lowmem -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) $<
+	$(DMD) -conf= $(MODEL_FLAG) $(DEBUG_FLAGS) -lowmem -i -Itools -version=NoMain -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) $<
 	@wait $(pid)
 
 $(RESULTS_DIR)/dshell_prebuilt$(OBJ): tools/dshell_prebuilt/dshell_prebuilt.d

--- a/test/compilable/jsonStdout.d
+++ b/test/compilable/jsonStdout.d
@@ -1,4 +1,36 @@
 /*
 PERMUTE_ARGS:
-REQUIRED_ARGS: -o- -v -Xf=- -Xi=compilerInfo -Xi=modules
+REQUIRED_ARGS: -o- -Xf=- -Xi=compilerInfo -Xi=modules
+TRANSFORM_OUTPUT: sanitize_json
+TEST_OUTPUT:
+----
+{
+    "compilerInfo": {
+        "__VERSION__": 0,
+        "architectures": [
+            "VALUES_REMOVED_FOR_TEST"
+        ],
+        "interface": "dmd",
+        "platforms": [
+            "VALUES_REMOVED_FOR_TEST"
+        ],
+        "predefinedVersions": [
+            "VALUES_REMOVED_FOR_TEST"
+        ],
+        "size_t": 0,
+        "supportedFeatures": {
+            "includeImports": true
+        },
+        "vendor": "VALUE_REMOVED_FOR_TEST",
+        "version": "VALUE_REMOVED_FOR_TEST"
+    },
+    "modules": [
+        {
+            "file": "VALUE_REMOVED_FOR_TEST",
+            "kind": "module",
+            "members": []
+        }
+    ]
+}
+----
 */

--- a/test/run.d
+++ b/test/run.d
@@ -61,7 +61,7 @@ enum toolsDir = testPath("tools");
 enum TestTools
 {
     unitTestRunner = TestTool("unit_test_runner", [toolsDir.buildPath("paths")]),
-    testRunner = TestTool("d_do_test"),
+    testRunner = TestTool("d_do_test", ["-I" ~ toolsDir, "-i", "-version=NoMain"]),
     jsonSanitizer = TestTool("sanitize_json"),
     dshellPrebuilt = TestTool("dshell_prebuilt", null, Yes.linksWithTests),
 }

--- a/test/tools/sanitize_json.d
+++ b/test/tools/sanitize_json.d
@@ -17,6 +17,8 @@ void usage()
 {
     writeln("Usage: santize_json [--keep-deco] <input-json> [<output-json>]");
 }
+// This module may be imported from d_do_test
+version (NoMain) {} else
 int main(string[] args)
 {
     getopt(args,
@@ -43,16 +45,23 @@ int main(string[] args)
         return 1;
     }
 
-    auto json = parseJSON(readText(inFilename));
+    auto json = readText(inFilename);
     sanitize(json);
 
-    outFile.writeln(json.toJSON(true, JSONOptions.doNotEscapeSlashes));
+    outFile.writeln(json);
     return 0;
 }
 
 string capitalize(string s)
 {
     return text(s.take(1).asCapitalized.chain(s.drop(1)));
+}
+
+void sanitize(ref string text)
+{
+    auto json = parseJSON(text);
+    sanitize(json);
+    text = json.toJSON(true, JSONOptions.doNotEscapeSlashes);
 }
 
 void sanitize(JSONValue root)


### PR DESCRIPTION
This allows tests to specify actions in `TRANSFORM_OUTPUT` which should
be applied to the output before it is compared against `TEST_OUTPUT`.
Currently only `sanitize_json` is supported which strips environment specific
informations from dmd's json output.

The current workaround is to define a custom `POST_SCRIPT ` which modifies
the output and `diff`s against a file in `extra_files`. This is inferior
to because it scatters the test over multiple files and isn't portable
to non-posix platforms.

Let me know what you think.