### PR TITLE
Build cxx-unittest with stricter warnings, fix headers and tests

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -1061,25 +1061,13 @@ void processEnvironmentCxx()
     const cxxKind = env["CXX_KIND"] = detectHostCxx();
 
     string[] warnings  = [
-        "-Wall", "-Werror", "-Wextra", "-Wno-attributes", "-Wno-char-subscripts", "-Wno-deprecated",
-        "-Wno-empty-body", "-Wno-format", "-Wno-missing-braces", "-Wno-missing-field-initializers",
-        "-Wno-overloaded-virtual", "-Wno-parentheses", "-Wno-reorder", "-Wno-return-type",
-        "-Wno-sign-compare", "-Wno-strict-aliasing", "-Wno-switch", "-Wno-type-limits",
-        "-Wno-unknown-pragmas", "-Wno-unused-function", "-Wno-unused-label", "-Wno-unused-parameter",
-        "-Wno-unused-value", "-Wno-unused-variable"
+        "-Wall", "-Werror", "-Wno-narrowing", "-Wwrite-strings", "-Wcast-qual", "-Wno-format",
+        "-Wmissing-format-attribute", "-Woverloaded-virtual", "-pedantic", "-Wno-long-long",
+        "-Wno-variadic-macros", "-Wno-overlength-strings",
     ];
 
-    if (cxxKind == "g++")
-        warnings ~= [
-            "-Wno-class-memaccess", "-Wno-implicit-fallthrough", "-Wno-logical-op", "-Wno-narrowing",
-            "-Wno-uninitialized", "-Wno-unused-but-set-variable"
-        ];
-
-    if (cxxKind == "clang++")
-        warnings ~= ["-Wno-logical-op-parentheses", "-Wno-unused-private-field"];
-
     auto cxxFlags = warnings ~ [
-        "-g", "-fno-exceptions", "-fno-rtti", "-fasynchronous-unwind-tables", "-DMARS=1",
+        "-g", "-fno-exceptions", "-fno-rtti", "-fno-common", "-fasynchronous-unwind-tables", "-DMARS=1",
         env["MODEL_FLAG"], env["PIC_FLAG"],
     ];
 

--- a/src/build.d
+++ b/src/build.d
@@ -409,7 +409,9 @@ alias runCxxUnittest = makeRule!((runCxxBuilder, runCxxRule) {
         .msg("(CXX) CXX-FRONTEND")
         .sources(srcDir.buildPath("tests", "cxxfrontend.c") ~ .sources.frontendHeaders ~ .sources.dmd.all ~ .sources.root)
         .target(env["G"].buildPath("cxxfrontend").objName)
-        .command([ env["CXX"], "-c", frontendRule.sources[0], "-o" ~ frontendRule.target, "-I" ~ env["D"] ] ~ flags["CXXFLAGS"])
+        // No explicit if since CXX_KIND will always be either g++ or clang++
+        .command([ env["CXX"], env["CXX_KIND"] == "g++" ? "-std=gnu++98" : "-xc++",
+                   "-c", frontendRule.sources[0], "-o" ~ frontendRule.target, "-I" ~ env["D"] ] ~ flags["CXXFLAGS"])
     );
 
     alias cxxUnittestExe = methodInit!(BuildRule, (exeBuilder, exeRule) => exeBuilder
@@ -1079,9 +1081,6 @@ void processEnvironmentCxx()
     auto cxxFlags = warnings ~ [
         "-g", "-fno-exceptions", "-fno-rtti", "-fasynchronous-unwind-tables", "-DMARS=1",
         env["MODEL_FLAG"], env["PIC_FLAG"],
-
-        // No explicit if since cxxKind will always be either g++ or clang++
-        cxxKind == "g++" ? "-std=gnu++98" : "-xc++"
     ];
 
     if (env.getNumberedBool("ENABLE_COVERAGE"))

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -372,6 +372,7 @@ public:
 
 class ExpressionDsymbol : public Dsymbol
 {
+public:
     Expression *exp;
 
     ExpressionDsymbol *isExpressionDsymbol() { return this; }

--- a/src/dmd/expression.h
+++ b/src/dmd/expression.h
@@ -1367,6 +1367,7 @@ private:
 
 class ObjcClassReferenceExp : public Expression
 {
+public:
     ClassDeclaration* classDeclaration;
 
     void accept(Visitor *v) { v->visit(this); }

--- a/src/posix.mak
+++ b/src/posix.mak
@@ -63,7 +63,7 @@ ifeq (osx,$(OS))
     export MACOSX_DEPLOYMENT_TARGET=10.9
 endif
 
-HOST_CXX=c++
+HOST_CXX?=c++
 # compatibility with old behavior
 ifneq ($(HOST_CC),)
   $(warning ===== WARNING: Please use HOST_CXX=$(HOST_CC) instead of HOST_CC=$(HOST_CC). =====)

--- a/src/tests/cxxfrontend.c
+++ b/src/tests/cxxfrontend.c
@@ -68,7 +68,7 @@ static void frontend_init()
 
     global._init();
     global.params.isLinux = true;
-    global.vendor = DString("Front-End Tester");
+    global.vendor = "Front-End Tester";
 
     Type::_init();
     Id::initialize();
@@ -107,6 +107,8 @@ void test_tokens()
 
 class TestVisitor : public Visitor
 {
+  using Visitor::visit;
+
   public:
     bool expr;
     bool package;


### PR DESCRIPTION
It wasn't possible to test clang on Linux.  That has been sorted, and the build command has been fixed so that testing with clang works.

Warnings have been synchronized to match what gdc is built with, errors that have come up as a result have been addressed.