### PR TITLE
add validation of printf format and arguments

### DIFF
--- a/changelog/chkprintf.md
+++ b/changelog/chkprintf.md
@@ -1,0 +1,50 @@
+# Validate printf arguments against format specifiers
+
+Follows the C99 specification 7.19.6.1 for printf.
+
+Takes a generous, rather than strict, view of compatiblity.
+For example, an unsigned value can be formatted with a signed specifier.
+
+Diagnosed incompatibilities are:
+
+1. incompatible sizes which will cause argument misalignment
+2. deferencing arguments that are not pointers
+3. insufficient number of arguments
+4. struct arguments
+5. array and slice arguments
+6. non-pointer arguments to `s` specifier
+7. non-standard formats
+8. undefined behavior per C99
+
+Per the C Standard, extra arguments are ignored.
+
+No attempt is made to fix the arguments or the format string.
+
+In order to use non-Standard printf formats, an easy workaround is:
+
+```
+printf("%k\n", value);  // error: non-Standard format k
+```
+```
+const format = "%k\n";
+printf(format, value):  // no error
+```
+
+Most of the errors detected are portability issues. For instance,
+
+```
+string s;
+printf("%.*s\n", s.length, s.ptr);
+printf("%d\n", s.sizeof);
+long i;
+printf("%ld\n", i);
+```
+should be replaced with:
+```
+string s;
+printf("%.*s\n", cast(int) s.length, s.ptr);
+printf("%zd\n", s.sizeof);
+long i;
+printf("%lld\n", i);
+```
+

--- a/samples/dclient.d
+++ b/samples/dclient.d
@@ -107,7 +107,7 @@ int dll_regserver(const (char) *dllname, int flag)
     if (SUCCEEDED(CoInitialize(null)))
     {
         hMod=LoadLibraryA(dllname);
-        printf("hMod = %d\n", hMod);
+        printf("hMod = %p\n", hMod);
 
         if (hMod)
         {

--- a/samples/dhry.d
+++ b/samples/dhry.d
@@ -579,7 +579,7 @@ void main()
     printf ("        should be:   %d\n", 2);
     printf ("  Int_Comp:          %d\n", Ptr_Glob.variant.var_1.Int_Comp);
     printf ("        should be:   %d\n", 17);
-    printf ("  Str_Comp:          %.*s\n", Ptr_Glob.variant.var_1.Str_Comp.length,
+    printf ("  Str_Comp:          %.*s\n", cast(int) Ptr_Glob.variant.var_1.Str_Comp.length,
                                            Ptr_Glob.variant.var_1.Str_Comp.ptr);
     printf ("        should be:   DHRYSTONE PROGRAM, SOME STRING\n");
     printf ("Next_Ptr_Glob.\n");
@@ -591,7 +591,7 @@ void main()
     printf ("        should be:   %d\n", 1);
     printf ("  Int_Comp:          %d\n", Next_Ptr_Glob.variant.var_1.Int_Comp);
     printf ("        should be:   %d\n", 18);
-    printf ("  Str_Comp:          %.*s\n", Next_Ptr_Glob.variant.var_1.Str_Comp.length,
+    printf ("  Str_Comp:          %.*s\n", cast(int) Next_Ptr_Glob.variant.var_1.Str_Comp.length,
                                            Next_Ptr_Glob.variant.var_1.Str_Comp.ptr);
     printf ("        should be:   DHRYSTONE PROGRAM, SOME STRING\n");
     printf ("Int_1_Loc:           %d\n", Int_1_Loc);
@@ -602,9 +602,9 @@ void main()
     printf ("        should be:   %d\n", 7);
     printf ("Enum_Loc:            %d\n", Enum_Loc);
     printf ("        should be:   %d\n", 1);
-    printf ("Str_1_Loc:           %.*s\n", Str_1_Loc.length, Str_1_Loc.ptr);
+    printf ("Str_1_Loc:           %.*s\n", cast(int) Str_1_Loc.length, Str_1_Loc.ptr);
     printf ("        should be:   DHRYSTONE PROGRAM, 1'ST STRING\n");
-    printf ("Str_2_Loc:           %.*s\n", Str_2_Loc.length, Str_2_Loc.ptr);
+    printf ("Str_2_Loc:           %.*s\n", cast(int) Str_2_Loc.length, Str_2_Loc.ptr);
     printf ("        should be:   DHRYSTONE PROGRAM, 2'ND STRING\n");
     printf ("\n");
 
@@ -634,7 +634,7 @@ void main()
 
         fprintf(Ap, "\n");
         fprintf(Ap, "Dhrystone Benchmark, Version 2.1 (Language: D)\n");
-        fprintf(Ap, "%.*s\n", Reg_Define.ptr);
+        fprintf(Ap, "%*s\n", Reg_Define.ptr);
         fprintf(Ap, "Microseconds for one loop: %7.1lf\n", Microseconds);
         fprintf(Ap, "Dhrystones per second: %10.1lf\n", Dhrystones_Per_Second);
         fprintf(Ap, "VAX MIPS rating: %10.3lf\n", Vax_Mips);

--- a/src/build.d
+++ b/src/build.d
@@ -1173,7 +1173,7 @@ auto sourceFiles()
             parse.d parsetimevisitor.d permissivevisitor.d printast.d safe.d sapply.d scanelf.d scanmach.d
             scanmscoff.d scanomf.d semantic2.d semantic3.d sideeffect.d statement.d statement_rewrite_walker.d
             statementsem.d staticassert.d staticcond.d target.d templateparamsem.d traits.d
-            transitivevisitor.d typesem.d typinf.d utils.d visitor.d foreachvar.d
+            transitivevisitor.d typesem.d typinf.d utils.d visitor.d foreachvar.d chkprintf.d
         "),
         backendHeaders: fileArray(env["C"], "
             cc.d cdef.d cgcv.d code.d cv4.d dt.d el.d global.d

--- a/src/dmd/backend/cgsched.d
+++ b/src/dmd/backend/cgsched.d
@@ -118,7 +118,7 @@ struct Cinfo
             printf("push,");
         if (ci.flags & ~(CIFL.arraybounds|CIFL.nostage|CIFL.push|CIFL.ea))
             printf("bad flag,");
-        printf("\n\tr %lx w %lx a %lx reg %x uops %x sibmodrm %x spadjust %ld\n",
+        printf("\n\tr %x w %x a %x reg %x uops %x sibmodrm %x spadjust %d\n",
                 cast(int)r,cast(int)w,cast(int)a,reg,uops,sibmodrm,cast(int)spadjust);
         if (ci.fp_op)
         {

--- a/src/dmd/backend/debugprint.d
+++ b/src/dmd/backend/debugprint.d
@@ -259,7 +259,7 @@ void WReqn(elem *e)
                     if (e.EV.Voffset.sizeof == 8)
                         printf(".x%llx", cast(ulong)e.EV.Voffset);
                     else
-                        printf(".%ld",cast(int)e.EV.Voffset);
+                        printf(".%d",cast(int)e.EV.Voffset);
                 }
                 break;
             case OPasm:

--- a/src/dmd/backend/dtype.d
+++ b/src/dmd/backend/dtype.d
@@ -1255,7 +1255,7 @@ void type_print(const type *t)
             break;
 
         case TYarray:
-            printf(" Tdim=%ld", cast(int)t.Tdim);
+            printf(" Tdim=%lld", cast(long)t.Tdim);
             break;
 
         case TYident:

--- a/src/dmd/chkprintf.d
+++ b/src/dmd/chkprintf.d
@@ -1,0 +1,698 @@
+/**
+ * Check the arguments to `printf` against the `format` string.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/chkprintf.d, _chkprintf.d)
+ * Documentation:  https://dlang.org/phobos/dmd_chkprintf.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/chkprintf.d
+ */
+
+module dmd.chkprintf;
+
+import core.stdc.stdio : printf;
+
+import dmd.errors;
+import dmd.expression;
+import dmd.globals;
+import dmd.mtype;
+import dmd.target;
+
+/******************************************
+ * Check that arguments to a printf format string are compatible
+ * with that string. Issue errors for incompatibilities.
+ *
+ * Follows the C99 specification for printf.
+ *
+ * Takes a generous, rather than strict, view of compatiblity.
+ * For example, an unsigned value can be formatted with a signed specifier.
+ *
+ * Diagnosed incompatibilities are:
+ *
+ * 1. incompatible sizes which will cause argument misalignment
+ * 2. deferencing arguments that are not pointers
+ * 3. insufficient number of arguments
+ * 4. struct arguments
+ * 5. array and slice arguments
+ * 6. non-pointer arguments to `s` specifier
+ * 7. non-standard formats
+ * 8. undefined behavior per C99
+ *
+ * Per the C Standard, extra arguments are ignored.
+ *
+ * No attempt is made to fix the arguments or the format string.
+ *
+ * Returns:
+ *      `true` if errors occurred
+ * References:
+ * C99 7.19.6.1
+ * http://www.cplusplus.com/reference/cstdio/printf/
+ */
+
+bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expression[] args)
+{
+    //printf("checkPrintFormat('%.*s')\n", cast(int)format.length, format.ptr);
+    size_t n = 0;
+    for (size_t i = 0; i < format.length;)
+    {
+        if (format[i] != '%')
+        {
+            ++i;
+            continue;
+        }
+        bool widthStar;
+        bool precisionStar;
+        size_t j = i;
+        const fmt = parseFormatSpecifier(format, j, widthStar, precisionStar);
+        const slice = format[i .. j];
+        i = j;
+
+        if (fmt == Format.percent)
+            continue;                   // "%%", no arguments
+
+        Expression getNextArg()
+        {
+            if (n == args.length)
+            {
+                deprecation(loc, "more format specifiers than %d arguments", cast(int)n);
+                return null;
+            }
+            return args[n++];
+        }
+
+        void errorMsg(const char* prefix, const char[] specifier, Expression arg, const char* texpect, Type tactual)
+        {
+            deprecation(arg.loc, "%sargument `%s` for format specification `\"%.*s\"` must be `%s`, not `%s`",
+                  prefix ? prefix : "", arg.toChars(), cast(int)slice.length, slice.ptr, texpect, tactual.toChars());
+        }
+
+        if (widthStar)
+        {
+            auto e = getNextArg();
+            if (!e)
+                return true;
+            auto t = e.type.toBasetype();
+            if (t.ty != Tint32 && t.ty != Tuns32)
+                errorMsg("width ", slice, e, "int", t);
+        }
+
+        if (precisionStar)
+        {
+            auto e = getNextArg();
+            if (!e)
+                return true;
+            auto t = e.type.toBasetype();
+            if (t.ty != Tint32 && t.ty != Tuns32)
+                errorMsg("precision ", slice, e, "int", t);
+        }
+
+        auto e = getNextArg();
+        if (!e)
+            return true;
+        auto t = e.type.toBasetype();
+        auto tnext = t.nextOf();
+        const c_longsize = target.c.longsize;
+        const is64bit = global.params.is64bit;
+
+        final switch (fmt)
+        {
+            case Format.d:      // int
+                if (t.ty != Tint32 && t.ty != Tuns32)
+                    errorMsg(null, slice, e, "int", t);
+                break;
+
+            case Format.ld:     // long int
+                if (!(t.isintegral() && t.size() == c_longsize))
+                    errorMsg(null, slice, e, (c_longsize == 4 ? "int" : "long"), t);
+                break;
+
+            case Format.lld:    // long long int
+                if (t.ty != Tint64 && t.ty != Tuns64)
+                    errorMsg(null, slice, e, "long", t);
+                break;
+
+            case Format.jd:     // intmax_t
+                if (t.ty != Tint64 && t.ty != Tuns64)
+                    errorMsg(null, slice, e, "core.stdc.stdint.intmax_t", t);
+                break;
+
+            case Format.zd:     // size_t
+                if (!(t.isintegral() && t.size() == (is64bit ? 8 : 4)))
+                    errorMsg(null, slice, e, "size_t", t);
+                break;
+
+            case Format.td:     // ptrdiff_t
+                if (!(t.isintegral() && t.size() == (is64bit ? 8 : 4)))
+                    errorMsg(null, slice, e, "ptrdiff_t", t);
+                break;
+
+            case Format.g:      // double
+                if (t.ty != Tfloat64 && t.ty != Timaginary64)
+                    errorMsg(null, slice, e, "double", t);
+                break;
+
+            case Format.Lg:     // long double
+                if (t.ty != Tfloat80 && t.ty != Timaginary80)
+                    errorMsg(null, slice, e, "real", t);
+                break;
+
+            case Format.p:      // pointer
+                if (t.ty != Tpointer && t.ty != Tnull && t.ty != Tclass && t.ty != Tdelegate && t.ty != Taarray)
+                    errorMsg(null, slice, e, "void*", t);
+                break;
+
+            case Format.n:      // pointer to int
+                if (!(t.ty == Tpointer && tnext.ty == Tint32))
+                    errorMsg(null, slice, e, "int*", t);
+                break;
+
+            case Format.ln:     // pointer to long int
+                if (!(t.ty == Tpointer && tnext.isintegral() && tnext.size() == c_longsize))
+                    errorMsg(null, slice, e, (c_longsize == 4 ? "int*" : "long*"), t);
+                break;
+
+            case Format.lln:    // pointer to long long int
+                if (!(t.ty == Tpointer && tnext.ty == Tint64))
+                    errorMsg(null, slice, e, "long*", t);
+                break;
+
+            case Format.hn:     // pointer to short
+                if (!(t.ty == Tpointer && tnext.ty == Tint16))
+                    errorMsg(null, slice, e, "short*", t);
+                break;
+
+            case Format.hhn:    // pointer to signed char
+                if (!(t.ty == Tpointer && tnext.ty == Tint16))
+                    errorMsg(null, slice, e, "byte*", t);
+                break;
+
+            case Format.jn:     // pointer to intmax_t
+                if (!(t.ty == Tpointer && tnext.ty == Tint64))
+                    errorMsg(null, slice, e, "core.stdc.stdint.intmax_t*", t);
+                break;
+
+            case Format.zn:     // pointer to size_t
+                if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tuns64 : Tuns32)))
+                    errorMsg(null, slice, e, "size_t*", t);
+                break;
+            case Format.tn:     // pointer to ptrdiff_t
+                if (!(t.ty == Tpointer && tnext.ty == (is64bit ? Tint64 : Tint32)))
+                    errorMsg(null, slice, e, "ptrdiff_t*", t);
+                break;
+
+            case Format.c:      // char
+                if (t.ty != Tint32 && t.ty != Tuns32)
+                    errorMsg(null, slice, e, "char", t);
+                break;
+
+            case Format.lc:     // wint_t
+                if (t.ty != Tint32 && t.ty != Tuns32)
+                    errorMsg(null, slice, e, "wchar_t", t);
+                break;
+
+            case Format.s:      // pointer to char string
+                if (!(t.ty == Tpointer && (tnext.ty == Tchar || tnext.ty == Tint8 || tnext.ty == Tuns8)))
+                    errorMsg(null, slice, e, "char*", t);
+                break;
+
+            case Format.ls:     // pointer to wchar_t string
+                const twchar_t = global.params.isWindows ? Twchar : Tdchar;
+                if (!(t.ty == Tpointer && tnext.ty == twchar_t))
+                    errorMsg(null, slice, e, "wchar_t*", t);
+                break;
+
+            case Format.error:
+                deprecation(loc, "format specifier `\"%.*s\"` is invalid", cast(int)slice.length, slice.ptr);
+                break;
+
+            case Format.percent:
+                assert(0);
+        }
+    }
+    return false;
+}
+
+private:
+
+/* Different kinds of formatting specifications, variations we don't
+   care about are merged. (Like we don't care about the difference between
+   a, A, g, G, etc.)
+ */
+enum Format
+{
+    d,          // int
+    ld,         // long int
+    lld,        // long long int
+    jd,         // intmax_t
+    zd,         // size_t
+    td,         // ptrdiff_t
+    g,          // double
+    Lg,         // long double
+    p,          // pointer
+    n,          // pointer to int
+    ln,         // pointer to long int
+    lln,        // pointer to long long int
+    hn,         // pointer to short
+    hhn,        // pointer to signed char
+    jn,         // pointer to intmax_t
+    zn,         // pointer to size_t
+    tn,         // pointer to ptrdiff_t
+    c,          // char
+    lc,         // wint_t
+    s,          // pointer to char string
+    ls,         // pointer to wchar_t string
+    percent,    // %% (i.e. no argument)
+    error,      // invalid format specification
+}
+
+
+/**************************************
+ * Parse the *format specifier* which is of the form:
+ *
+ * `%[flags][field width][.precision][length modifier]specifier`
+ *
+ * Params:
+ *      format = format string
+ *      idx = index of `%` of start of format specifier,
+ *          which gets updated to index past the end of it,
+ *          even if Format.error is returned
+ *      widthStar = set if * for width
+ *      precisionStar = set if * for precision
+ * Returns:
+ *      Format
+ */
+pure nothrow @safe
+Format parseFormatSpecifier(scope const char[] format, ref size_t idx,
+        out bool widthStar, out bool precisionStar)
+{
+    auto i = idx;
+    assert(format[i] == '%');
+    const length = format.length;
+    bool hash;
+    bool zero;
+    bool flags;
+    bool width;
+    bool precision;
+
+    Format error()
+    {
+        idx = i;
+        return Format.error;
+    }
+
+    ++i;
+    if (i == length)
+        return error();
+
+    if (format[i] == '%')
+    {
+        idx = i + 1;
+        return Format.percent;
+    }
+
+    /* Read the `flags`
+     */
+    while (1)
+    {
+        const c = format[i];
+        if (c == '-' ||
+            c == '+' ||
+            c == ' ')
+        {
+            flags = true;
+        }
+        else if (c == '#')
+        {
+            hash = true;
+        }
+        else if (c == '0')
+        {
+            zero = true;
+        }
+        else
+            break;
+        ++i;
+        if (i == length)
+            return error();
+    }
+
+    /* Read the `field width`
+     */
+    {
+        const c = format[i];
+        if (c == '*')
+        {
+            width = true;
+            widthStar = true;
+            ++i;
+            if (i == length)
+                return error();
+        }
+        else if ('1' <= c && c <= '9')
+        {
+            width = true;
+            ++i;
+            if (i == length)
+                return error();
+            while ('0' <= format[i] && format[i] <= '9')
+            {
+               ++i;
+               if (i == length)
+                    return error();
+            }
+        }
+    }
+
+    /* Read the `precision`
+     */
+    if (format[i] == '.')
+    {
+        precision = true;
+        ++i;
+        if (i == length)
+            return error();
+        const c = format[i];
+        if (c == '*')
+        {
+            precisionStar = true;
+            ++i;
+            if (i == length)
+                return error();
+        }
+        else if ('0' <= c && c <= '9')
+        {
+            ++i;
+            if (i == length)
+                return error();
+            while ('0' <= format[i] && format[i] <= '9')
+            {
+               ++i;
+               if (i == length)
+                    return error();
+            }
+        }
+    }
+
+    /* Read the `length modifier`
+     */
+    const lm = format[i];
+    bool lm1;        // if jztL
+    bool lm2;        // if `hh` or `ll`
+    if (lm == 'j' ||
+        lm == 'z' ||
+        lm == 't' ||
+        lm == 'L')
+    {
+        ++i;
+        if (i == length)
+            return error();
+        lm1 = true;
+    }
+    else if (lm == 'h' || lm == 'l')
+    {
+        ++i;
+        if (i == length)
+            return error();
+        lm2 = lm == format[i];
+        if (lm2)
+        {
+            ++i;
+            if (i == length)
+                return error();
+        }
+    }
+
+    /* Read the `specifier`
+     */
+    Format specifier;
+    const sc = format[i];
+    ++i;
+    switch (sc)
+    {
+        case 'd':
+        case 'i':
+        case 'u':
+            if (hash)
+                return error();
+            goto case 'o';
+
+        case 'o':
+        case 'x':
+        case 'X':
+            specifier = lm == 'l' && lm2 ? Format.lld :
+                        lm == 'l'        ? Format.ld  :
+                        lm == 'j'        ? Format.jd  :
+                        lm == 'z'        ? Format.zd  :
+                        lm == 't'        ? Format.td  :
+                                           Format.d;
+            break;
+
+        case 'f':
+        case 'F':
+        case 'e':
+        case 'E':
+        case 'g':
+        case 'G':
+        case 'a':
+        case 'A':
+            if (lm == 'L')
+                specifier = Format.Lg;
+            else if (lm1 ||lm2 || lm == 'h')
+                return error();
+            else
+                specifier = Format.g;
+            break;
+
+        case 'c':
+            if (hash || zero ||
+                lm1 || lm2 || lm == 'h')
+                return error();
+            specifier = lm == 'l' ? Format.lc : Format.c;
+            break;
+
+        case 's':
+            if (hash || zero ||
+                lm1 || lm2 || lm == 'h')
+                return error();
+            specifier = lm == 'l' ? Format.ls : Format.s;
+            break;
+
+        case 'p':
+            if (lm1 || lm == 'h' || lm == 'l')
+                return error();
+            specifier = Format.p;
+            break;
+
+        case 'n':
+            if (flags || hash || zero ||
+                width || precision ||
+                lm == 'L')
+            {
+                return error();
+            }
+            specifier = lm == 'l' && lm2 ? Format.lln :
+                        lm == 'l'        ? Format.ln  :
+                        lm == 'h' && lm2 ? Format.hhn :
+                        lm == 'h'        ? Format.hn  :
+                        lm == 'j'        ? Format.jn  :
+                        lm == 'z'        ? Format.zn  :
+                        lm == 't'        ? Format.tn  :
+                                           Format.n;
+            break;
+
+        default:
+            return error();
+    }
+
+    idx = i;
+    return specifier;  // success
+}
+
+unittest
+{
+    //printf("parseFormatSpecifier()\n");
+
+    size_t idx;
+    bool widthStar;
+    bool precisionStar;
+
+    // one for each Format
+    idx = 0;
+    assert(parseFormatSpecifier("%d", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 2);
+    assert(!widthStar && !precisionStar);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%ld", idx, widthStar, precisionStar) == Format.ld);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%lld", idx, widthStar, precisionStar) == Format.lld);
+    assert(idx == 4);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%jd", idx, widthStar, precisionStar) == Format.jd);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%zd", idx, widthStar, precisionStar) == Format.zd);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%td", idx, widthStar, precisionStar) == Format.td);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%g", idx, widthStar, precisionStar) == Format.g);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%Lg", idx, widthStar, precisionStar) == Format.Lg);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%p", idx, widthStar, precisionStar) == Format.p);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%n", idx, widthStar, precisionStar) == Format.n);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%ln", idx, widthStar, precisionStar) == Format.ln);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%lln", idx, widthStar, precisionStar) == Format.lln);
+    assert(idx == 4);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%hn", idx, widthStar, precisionStar) == Format.hn);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%hhn", idx, widthStar, precisionStar) == Format.hhn);
+    assert(idx == 4);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%jn", idx, widthStar, precisionStar) == Format.jn);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%zn", idx, widthStar, precisionStar) == Format.zn);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%tn", idx, widthStar, precisionStar) == Format.tn);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%c", idx, widthStar, precisionStar) == Format.c);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%lc", idx, widthStar, precisionStar) == Format.lc);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%s", idx, widthStar, precisionStar) == Format.s);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%ls", idx, widthStar, precisionStar) == Format.ls);
+    assert(idx == 3);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%%", idx, widthStar, precisionStar) == Format.percent);
+    assert(idx == 2);
+
+    // Synonyms
+    idx = 0;
+    assert(parseFormatSpecifier("%i", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%u", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%o", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%x", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%X", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%f", idx, widthStar, precisionStar) == Format.g);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%F", idx, widthStar, precisionStar) == Format.g);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%G", idx, widthStar, precisionStar) == Format.g);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%a", idx, widthStar, precisionStar) == Format.g);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%A", idx, widthStar, precisionStar) == Format.g);
+    assert(idx == 2);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%lg", idx, widthStar, precisionStar) == Format.g);
+    assert(idx == 3);
+
+    // width, precision
+    idx = 0;
+    assert(parseFormatSpecifier("%*d", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 3);
+    assert(widthStar && !precisionStar);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%.*d", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 4);
+    assert(!widthStar && precisionStar);
+
+    idx = 0;
+    assert(parseFormatSpecifier("%*.*d", idx, widthStar, precisionStar) == Format.d);
+    assert(idx == 5);
+    assert(widthStar && precisionStar);
+
+    // Too short formats
+    {
+        foreach (s; ["%", "%-", "%+", "% ", "%#", "%0", "%*", "%1", "%19", "%.", "%.*", "%.1", "%.12",
+                     "%j", "%z", "%t", "%l", "%h", "%ll", "%hh", "%K"])
+        {
+            idx = 0;
+            assert(parseFormatSpecifier(s, idx, widthStar, precisionStar) == Format.error);
+            assert(idx == s.length);
+        }
+    }
+
+    // Undefined format combinations
+    {
+        foreach (s; ["%#d", "%llg", "%jg", "%zg", "%tg", "%hg", "%hhg",
+                     "%#c", "%0c", "%jc", "%zc", "%tc", "%Lc", "%hc", "%hhc", "%llc",
+                     "%#s", "%0s", "%js", "%zs", "%ts", "%Ls", "%hs", "%hhs", "%lls",
+                     "%jp", "%zp", "%tp", "%Lp", "%hp", "%lp", "%hhp", "%llp",
+                     "%-n", "%+n", "% n", "%#n", "%0n", "%*n", "%1n", "%19n", "%.n", "%.*n", "%.1n", "%.12n", "%Ln"])
+        {
+            idx = 0;
+            assert(parseFormatSpecifier(s, idx, widthStar, precisionStar) == Format.error);
+            assert(idx == s.length);
+        }
+    }
+}

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -22,6 +22,7 @@ import dmd.arraytypes;
 import dmd.attrib;
 import dmd.astcodegen;
 import dmd.canthrow;
+import dmd.chkprintf;
 import dmd.ctorflow;
 import dmd.dscope;
 import dmd.dsymbol;
@@ -2147,6 +2148,17 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
             arg = arg.optimize(WANTvalue);
         }
         (*arguments)[i] = arg;
+    }
+
+    /* If calling C printf(), check the format string against the arguments
+     */
+    if (tf.linkage == LINK.c && nparams >= 1 && fd && fd.ident == Id.printf)
+    {
+        if (auto se = (*arguments)[0].isStringExp())
+        {
+            if (checkPrintfFormat(se.loc, se.peekString(), (*arguments)[1 .. nargs]))
+                err = true;
+        }
     }
 
     /* Remaining problems:

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -133,6 +133,7 @@ immutable Msgtable[] msgtable =
     { "_assert", "assert" },
     { "_unittest", "unittest" },
     { "_body", "body" },
+    { "printf" },
 
     { "TypeInfo" },
     { "TypeInfo_Class" },

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -187,7 +187,7 @@ extern (C) int foosize6();
 void test6()
 {
     S6 f = foo6();
-    printf("%d %d\n", foosize6(), S6.sizeof);
+    printf("%d %d\n", foosize6(), cast(int)S6.sizeof);
     assert(foosize6() == S6.sizeof);
     assert(f.i == 42);
     printf("f.d = %g\n", f.d);
@@ -211,7 +211,7 @@ struct S
 
 void test7()
 {
-    printf("%d %d\n", foo7(), S.sizeof);
+    printf("%d %d\n", foo7(), cast(int)S.sizeof);
     assert(foo7() == S.sizeof);
 }
 

--- a/test/compilable/fail137.d
+++ b/test/compilable/fail137.d
@@ -21,6 +21,6 @@ template IndexOf( T, TList... )
 void main()
 {
     TypeTuple!(int, long) T;
-    printf( "%u\n", IndexOf!(long, T) );
+    printf( "%u\n", cast(uint)IndexOf!(long, T) );
 }
 

--- a/test/fail_compilation/chkprintf.d
+++ b/test/fail_compilation/chkprintf.d
@@ -1,0 +1,49 @@
+/*
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/chkprintf.d(101): Deprecation: width argument `0L` for format specification `"%*.*d"` must be `int`, not `long`
+fail_compilation/chkprintf.d(101): Deprecation: precision argument `1L` for format specification `"%*.*d"` must be `int`, not `long`
+fail_compilation/chkprintf.d(101): Deprecation: argument `2L` for format specification `"%*.*d"` must be `int`, not `long`
+fail_compilation/chkprintf.d(103): Deprecation: argument `4` for format specification `"%lld"` must be `long`, not `int`
+fail_compilation/chkprintf.d(104): Deprecation: argument `5` for format specification `"%jd"` must be `core.stdc.stdint.intmax_t`, not `int`
+fail_compilation/chkprintf.d(105): Deprecation: argument `6.00000` for format specification `"%zd"` must be `size_t`, not `double`
+fail_compilation/chkprintf.d(106): Deprecation: argument `7.00000` for format specification `"%td"` must be `ptrdiff_t`, not `double`
+fail_compilation/chkprintf.d(107): Deprecation: argument `8.00000L` for format specification `"%g"` must be `double`, not `real`
+fail_compilation/chkprintf.d(108): Deprecation: argument `9.00000` for format specification `"%Lg"` must be `real`, not `double`
+fail_compilation/chkprintf.d(109): Deprecation: argument `10` for format specification `"%p"` must be `void*`, not `int`
+fail_compilation/chkprintf.d(110): Deprecation: argument `& u` for format specification `"%n"` must be `int*`, not `uint*`
+fail_compilation/chkprintf.d(112): Deprecation: argument `& u` for format specification `"%lln"` must be `long*`, not `int*`
+fail_compilation/chkprintf.d(113): Deprecation: argument `& u` for format specification `"%hn"` must be `short*`, not `int*`
+fail_compilation/chkprintf.d(114): Deprecation: argument `& u` for format specification `"%hhn"` must be `byte*`, not `int*`
+fail_compilation/chkprintf.d(115): Deprecation: argument `16L` for format specification `"%c"` must be `char`, not `long`
+fail_compilation/chkprintf.d(116): Deprecation: argument `17L` for format specification `"%c"` must be `char`, not `long`
+fail_compilation/chkprintf.d(117): Deprecation: argument `& u` for format specification `"%s"` must be `char*`, not `int*`
+fail_compilation/chkprintf.d(118): Deprecation: argument `& u` for format specification `"%ls"` must be `wchar_t*`, not `int*`
+---
+*/
+
+
+import core.stdc.stdio;
+
+#line 100
+
+void test1() {  printf("%*.*d\n", 0L, 1L, 2L); }
+//void test3() {  printf("%ld\n", 3.0); }
+void test4() {  printf("%lld\n", 4); }
+void test5() {  printf("%jd\n", 5); }
+void test6() {  printf("%zd\n", 6.0); }
+void test7() {  printf("%td\n", 7.0); }
+void test8() {  printf("%g\n", 8.0L); }
+void test9() {  printf("%Lg\n", 9.0); }
+void test10() {  printf("%p\n", 10); }
+void test11() { uint u; printf("%n\n", &u); }
+//void test12() { ushort u; printf("%ln\n", &u); }
+void test13() { int u; printf("%lln\n", &u); }
+void test14() { int u; printf("%hn\n", &u); }
+void test15() { int u; printf("%hhn\n", &u); }
+void test16() { printf("%c\n", 16L); }
+void test17() { printf("%c\n", 17L); }
+void test18() { int u; printf("%s\n", &u); }
+void test19() { int u; printf("%ls\n", &u); }
+

--- a/test/fail_compilation/test8556.d
+++ b/test/fail_compilation/test8556.d
@@ -37,7 +37,7 @@ struct Circle(Range)
     {
         //pragma(msg, typeof(opSlice)); // prints "fwdref err" with B, but doesn't with A
 
-        printf("%d %d\n", i, j);
+        printf("%d %d\n", cast(int)i, cast(int)j);
         assert(j >= i);
 
         // 1. grabExactly curcular refers this opSlice.

--- a/test/runnable/bench1.d
+++ b/test/runnable/bench1.d
@@ -18,7 +18,7 @@ extern(C) int atoi(const char *);
             s ~= "hello\n";
         for (loop = 0; loop < count; loop ++)
             s ~= "h";
-        printf ("%d\n", s.length);
+        printf ("%zd\n", s.length);
         //printf("%.*s\n", s[0..100]);
         assert(s.length == count * (6 + 1));
         s.length = 3;

--- a/test/runnable/bitops.d
+++ b/test/runnable/bitops.d
@@ -16,35 +16,35 @@ else
 
     array[0] = 2;
     array[1] = 0x100;
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
 
     x = btc(array.ptr, bitToUse);
-    printf("btc(array, %d) = %d\n", bitToUse, x);
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("btc(array, %zd) = %d\n", bitToUse, x);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
     assert(x == 0);
     assert(array[0] == 0x2 && array[1] == 0x108);
 
     x = btc(array.ptr, bitToUse);
-    printf("btc(array, %d) = %d\n", bitToUse, x);
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("btc(array, %zd) = %d\n", bitToUse, x);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
     assert(x != 0);
     assert(array[0] == 2 && array[1] == 0x100);
 
     x = bts(array.ptr, bitToUse);
-    printf("bts(array, %d) = %d\n", bitToUse, x);
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("bts(array, %zd) = %d\n", bitToUse, x);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
     assert(x == 0);
     assert(array[0] == 2 && array[1] == 0x108);
 
     x = btr(array.ptr, bitToUse);
-    printf("btr(array, %d) = %d\n", bitToUse, x);
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("btr(array, %zd) = %d\n", bitToUse, x);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
     assert(x != 0);
     assert(array[0] == 2 && array[1] == 0x100);
 
     x = bt(array.ptr, 1);
     printf("bt(array, 1) = %d\n", x);
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
     assert(x != 0);
     assert(array[0] == 2 && array[1] == 0x100);
 }
@@ -103,19 +103,19 @@ void test5()
     array[1] = 0x100;
 
     printf("btc(array, 35) = %d\n", btc(array.ptr, 35));
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
 
     printf("btc(array, 35) = %d\n", btc(array.ptr, 35));
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
 
     printf("bts(array, 35) = %d\n", bts(array.ptr, 35));
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
 
     printf("btr(array, 35) = %d\n", btr(array.ptr, 35));
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
 
     printf("bt(array, 1) = %d\n", bt(array.ptr, 1));
-    printf("array = [0]:x%x, [1]:x%x\n", array[0], array[1]);
+    printf("array = [0]:x%zx, [1]:x%zx\n", array[0], array[1]);
 }
 
 

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -157,7 +157,7 @@ extern (C) int foosize6();
 void test6()
 {
     S6 f = foo6();
-    printf("%d %d\n", foosize6(), S6.sizeof);
+    printf("%d %zd\n", foosize6(), S6.sizeof);
     assert(foosize6() == S6.sizeof);
 version (X86)
 {
@@ -181,7 +181,7 @@ struct S
 
 void test7()
 {
-    printf("%d %d\n", foo7(), S.sizeof);
+    printf("%d %zd\n", foo7(), S.sizeof);
     assert(foo7() == S.sizeof);
 }
 

--- a/test/runnable/dhry.d
+++ b/test/runnable/dhry.d
@@ -567,7 +567,7 @@ void main ()
   printf ("        should be:   %d\n", 2);
   printf ("  Int_Comp:          %d\n", Ptr_Glob.variant.var_1.Int_Comp);
   printf ("        should be:   %d\n", 17);
-  printf ("  Str_Comp:          %.*s\n", Ptr_Glob.variant.var_1.Str_Comp.length, Ptr_Glob.variant.var_1.Str_Comp.ptr);
+  printf ("  Str_Comp:          %.*s\n", cast(int)Ptr_Glob.variant.var_1.Str_Comp.length, Ptr_Glob.variant.var_1.Str_Comp.ptr);
   printf ("        should be:   DHRYSTONE PROGRAM, SOME STRING\n");
   printf ("Next_Ptr_Glob.\n");
   printf ("  Ptr_Comp:          %d\n", cast(int) Next_Ptr_Glob.Ptr_Comp);
@@ -578,7 +578,7 @@ void main ()
   printf ("        should be:   %d\n", 1);
   printf ("  Int_Comp:          %d\n", Next_Ptr_Glob.variant.var_1.Int_Comp);
   printf ("        should be:   %d\n", 18);
-  printf ("  Str_Comp:          %.*s\n", Next_Ptr_Glob.variant.var_1.Str_Comp.length, Next_Ptr_Glob.variant.var_1.Str_Comp.ptr);
+  printf ("  Str_Comp:          %.*s\n", cast(int)Next_Ptr_Glob.variant.var_1.Str_Comp.length, Next_Ptr_Glob.variant.var_1.Str_Comp.ptr);
   printf ("        should be:   DHRYSTONE PROGRAM, SOME STRING\n");
   printf ("Int_1_Loc:           %d\n", Int_1_Loc);
   printf ("        should be:   %d\n", 5);
@@ -588,9 +588,9 @@ void main ()
   printf ("        should be:   %d\n", 7);
   printf ("Enum_Loc:            %d\n", Enum_Loc);
   printf ("        should be:   %d\n", 1);
-  printf ("Str_1_Loc:           %.*s\n", Str_1_Loc.length, Str_1_Loc.ptr);
+  printf ("Str_1_Loc:           %.*s\n", cast(int)Str_1_Loc.length, Str_1_Loc.ptr);
   printf ("        should be:   DHRYSTONE PROGRAM, 1'ST STRING\n");
-  printf ("Str_2_Loc:           %.*s\n", Str_2_Loc.length, Str_2_Loc.ptr);
+  printf ("Str_2_Loc:           %.*s\n", cast(int)Str_2_Loc.length, Str_2_Loc.ptr);
   printf ("        should be:   DHRYSTONE PROGRAM, 2'ND STRING\n");
   printf ("\n");
 

--- a/test/runnable/eh.d
+++ b/test/runnable/eh.d
@@ -104,7 +104,7 @@ printf("catch, i = %d\n", i);
         }
     }
 
-    printf("iterations %d totals: %ld, %ld\n", cIterations, total_x, total_nox);
+    printf("iterations %d totals: %lld, %lld\n", cIterations, total_x, total_nox);
 }
 
 int fn2_nox()
@@ -170,7 +170,7 @@ void test4()
     catch(Exception e)
     {
         auto es = e.toString();
-                printf("%.*s\n", es.length, es.ptr);
+                printf("%.*s\n", cast(int)es.length, es.ptr);
         b++;
     }
     finally
@@ -213,7 +213,7 @@ void test4()
     {
         d++;
         string es = e.toString;
-        printf("%.*s\n", es.length, es.ptr);
+        printf("%.*s\n", cast(int)es.length, es.ptr);
     }
 
     assert(a == 2);
@@ -255,7 +255,7 @@ void test4()
     {
         q3++;
                 string es = e.toString;
-        printf("%.*s\n", es.length, es.ptr);
+        printf("%.*s\n", cast(int)es.length, es.ptr);
     }
 
     assert(q0 == 1);
@@ -287,7 +287,7 @@ void test5()
             result ~= cast(char)('a' + i);
         }
     }
-    printf("--- %.*s", result.length, result.ptr);
+    printf("--- %.*s", cast(int)result.length, result.ptr);
     if (result != "tctbta")
         assert(0);
 }

--- a/test/runnable/extra-files/test2.d
+++ b/test/runnable/extra-files/test2.d
@@ -159,7 +159,7 @@ void test7()
     OutBuffer7 ob = new OutBuffer7;
 
     ob.data = new char[10];
-    printf("ob.data.length = %d\n", ob.data.length);
+    printf("ob.data.length = %zd\n", ob.data.length);
     assert(ob.data.length == 10);
     for (i = 0; i < 10; i++)
 	assert(ob.data[i] == char.init);
@@ -173,7 +173,7 @@ printf("test7.2()\n");
 
     ob.offset = 3;
     ob.write("foo", 3);
-    printf("ob.data.length = %d\n", ob.data.length);
+    printf("ob.data.length = %zd\n", ob.data.length);
     printf("ob.data[] = '%.*s'\n", cast(int)ob.data.length, ob.data.ptr);
     for (i = 0; i < 10; i++)
     {	if (i < 3 || i >= 6)

--- a/test/runnable/foreach.d
+++ b/test/runnable/foreach.d
@@ -211,7 +211,7 @@ void test7()
     a["bar"] = 4;
     foreach (string s, uint v; a)
     {
-        printf("a[%.*s] = %d\n", s.length, s.ptr, v);
+        printf("a[%.*s] = %d\n", cast(int)s.length, s.ptr, v);
         if (s == "bar")
             assert(v == 4);
         else if (s == "foo")

--- a/test/runnable/foreach4.d
+++ b/test/runnable/foreach4.d
@@ -368,7 +368,7 @@ void test12()
     j = 0;
     foreach (size_t i, dchar d; "hello")
     {
-        printf("i = %d, d = x%x\n", i, d);
+        printf("i = %zd, d = x%x\n", i, d);
         if (j == 0) assert(d == 'h');
         if (j == 1) assert(d == 'e');
         if (j == 2) assert(d == 'l');
@@ -402,7 +402,7 @@ void test13()
     j = 0;
     foreach (size_t i, wchar d; "hello")
     {
-        printf("i = %d, d = x%x\n", i, d);
+        printf("i = %zd, d = x%x\n", i, d);
         if (j == 0) assert(d == 'h');
         if (j == 1) assert(d == 'e');
         if (j == 2) assert(d == 'l');
@@ -436,7 +436,7 @@ void test14()
     j = 0;
     foreach (size_t i, char d; cast(wstring)"hello")
     {
-        printf("i = %d, d = x%x\n", i, d);
+        printf("i = %zd, d = x%x\n", i, d);
         if (j == 0) assert(d == 'h');
         if (j == 1) assert(d == 'e');
         if (j == 2) assert(d == 'l');
@@ -470,7 +470,7 @@ void test15()
     j = 0;
     foreach (size_t i, dchar d; cast(wstring)"hello")
     {
-        printf("i = %d, d = x%x\n", i, d);
+        printf("i = %zd, d = x%x\n", i, d);
         if (j == 0) assert(d == 'h');
         if (j == 1) assert(d == 'e');
         if (j == 2) assert(d == 'l');
@@ -504,7 +504,7 @@ void test16()
     j = 0;
     foreach (size_t i, char d; cast(dstring)"hello")
     {
-        printf("i = %d, d = x%x\n", i, d);
+        printf("i = %zd, d = x%x\n", i, d);
         if (j == 0) assert(d == 'h');
         if (j == 1) assert(d == 'e');
         if (j == 2) assert(d == 'l');
@@ -538,7 +538,7 @@ void test17()
     j = 0;
     foreach (size_t i, wchar d; cast(dstring)"hello")
     {
-        printf("i = %d, d = x%x\n", i, d);
+        printf("i = %zd, d = x%x\n", i, d);
         if (j == 0) assert(d == 'h');
         if (j == 1) assert(d == 'e');
         if (j == 2) assert(d == 'l');
@@ -620,7 +620,7 @@ void test20()
 
 void foo21(string[] args)
 {
-    printf("args.length = %d\n", args.length);
+    printf("args.length = %zd\n", args.length);
     assert(args.length == 3);
     foreach (i, arg; args)
     {

--- a/test/runnable/hello-profile.d
+++ b/test/runnable/hello-profile.d
@@ -15,9 +15,9 @@ extern(C)
 void showargs(string[] args)
 {
     printf("hello world\n");
-    printf("args.length = %d\n", args.length);
+    printf("args.length = %zd\n", args.length);
     for (int i = 0; i < args.length; i++)
-        printf("args[%d] = '%.*s'\n", i, args[i].length, args[i].ptr);
+        printf("args[%d] = '%.*s'\n", i, cast(int)args[i].length, args[i].ptr);
 }
 
 int main(string[] args)

--- a/test/runnable/hello.d
+++ b/test/runnable/hello.d
@@ -5,8 +5,8 @@ extern(C) int printf(const char*, ...);
 int main(char[][] args)
 {
     printf("hello world\n");
-    printf("args.length = %d\n", args.length);
+    printf("args.length = %zd\n", args.length);
     for (int i = 0; i < args.length; i++)
-        printf("args[%d] = '%.*s'\n", i, args[i].length, args[i].ptr);
+        printf("args[%d] = '%.*s'\n", i, cast(int)args[i].length, args[i].ptr);
     return 0;
 }

--- a/test/runnable/imports/test39a.d
+++ b/test/runnable/imports/test39a.d
@@ -6,7 +6,7 @@ class Test (T)
 {
         final void show (in T[] msg)
         {
-                printf ("%.*s\n", msg.length, msg.ptr);
+                printf ("%.*s\n", cast(int)msg.length, msg.ptr);
         }
 }
 

--- a/test/runnable/imports/test40a.d
+++ b/test/runnable/imports/test40a.d
@@ -8,7 +8,7 @@ template Mix()
     {
 	auto context = new Context;
         auto ts = context.toString;
-	printf("context: %.*s %p\n", ts.length, ts.ptr, context);
+	printf("context: %.*s %p\n", cast(int)ts.length, ts.ptr, context);
 	context.func!(typeof(this))();
 	printf("returning from opCall\n");
     }
@@ -23,8 +23,8 @@ class Bar
 
 void someFunc(string z)
 {
-    printf("str length: %d\n", z.length);
-    printf("str: '%.*s'\n", z.length, z.ptr);
+    printf("str length: %zd\n", z.length);
+    printf("str: '%.*s'\n", cast(int)z.length, z.ptr);
 }
 
 

--- a/test/runnable/interface2.d
+++ b/test/runnable/interface2.d
@@ -34,7 +34,7 @@ void test1()
     printf("f = %p\n", f);
     assert(cast(void*)b !is cast(void*)f);
 
-    printf("f.class = '%.*s'\n", f.classinfo.name.length, f.classinfo.name.ptr);
+    printf("f.class = '%.*s'\n", cast(int)f.classinfo.name.length, f.classinfo.name.ptr);
     assert(f.classinfo.name == "interface2.Foo");
 
     f.bar();
@@ -669,11 +669,11 @@ void test19()
     assert(cast(void*)c + (3*(void*).sizeof) == cast(void*)ifoo);
 
     string s = ifoo.classinfo.name;
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     assert(s == "interface2.IFoo19");
 
     s = (cast(Object)ifoo).toString;
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     assert(s == "interface2.Child19");
 }
 

--- a/test/runnable/interpret.d
+++ b/test/runnable/interpret.d
@@ -1814,7 +1814,7 @@ string foo90(string a, string b)
 void test90()
 {
     static const string xxx = foo90("A", "xxx");
-    printf("%.*s\n", xxx.length, xxx.ptr);
+    printf("%.*s\n", cast(int)xxx.length, xxx.ptr);
     assert(xxx == "A");
 }
 

--- a/test/runnable/mars1.d
+++ b/test/runnable/mars1.d
@@ -177,7 +177,7 @@ struct Foo4
 
 void testsizes()
 {
-    printf("%d\n", Foo1.sizeof);
+    printf("%zd\n", Foo1.sizeof);
     assert(Foo1.a.offsetof == 0);
     assert(Foo1.b.offsetof == 4);
     assert(Foo1.c.offsetof == 5);
@@ -279,12 +279,12 @@ void testulldiv()
     {
         ulong q = vectors[i][0] / vectors[i][1];
         if (q != vectors[i][2])
-            printf("[%d] %lld / %lld = %lld, should be %lld\n",
-                vectors[i][0], vectors[i][1], q, vectors[i][2]);
+            printf("[%zd] %lld / %lld = %lld, should be %lld\n",
+                i, vectors[i][0], vectors[i][1], q, vectors[i][2]);
 
         ulong r = vectors[i][0] % vectors[i][1];
         if (r != vectors[i][3])
-            printf("[%d] %lld %% %lld = %lld, should be %lld\n",
+            printf("[%zd] %lld %% %lld = %lld, should be %lld\n",
                 i, vectors[i][0], vectors[i][1], r, vectors[i][3]);
     }
 }
@@ -442,13 +442,13 @@ void test12095(int k)
 
 bool test3918a( float t, real u )
 {
-        printf("%f\n", u );
+        printf("%Lf\n", u );
         return t && u;
 }
 
 bool test3918b( real t, float u )
 {
-        printf("%f\n", t );
+        printf("%Lf\n", t );
         return t && u;
 }
 

--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -831,7 +831,7 @@ struct Foo36
 void test36()
 {
    Foo36 f;
-   printf("f.sizeof = %d\n", f.sizeof);
+   printf("f.sizeof = %zd\n", f.sizeof);
    assert(f.sizeof == 12);
 
    f.a = 1;

--- a/test/runnable/opover.d
+++ b/test/runnable/opover.d
@@ -776,7 +776,7 @@ class A13
  A13 opShl(string x)
  {
     printf("A::opShl(char[])\n");
-    printf("%.*s", x.length, x.ptr);
+    printf("%.*s", cast(int)x.length, x.ptr);
     return this;
  }
 }

--- a/test/runnable/opover2.d
+++ b/test/runnable/opover2.d
@@ -21,7 +21,7 @@ class A
 {
     string opUnary(string s)()
     {
-        printf("A.opUnary!(%.*s)\n", s.length, s.ptr);
+        printf("A.opUnary!(%.*s)\n", cast(int)s.length, s.ptr);
         return s;
     }
 }
@@ -50,7 +50,7 @@ class A2
     T opCast(T)()
     {
         auto s = T.stringof;
-        printf("A.opCast!(%.*s)\n", s.length, s.ptr);
+        printf("A.opCast!(%.*s)\n", cast(int)s.length, s.ptr);
         return T.init;
     }
 }
@@ -73,20 +73,20 @@ struct A3
 {
     int opBinary(string s)(int i)
     {
-        printf("A.opBinary!(%.*s)\n", s.length, s.ptr);
+        printf("A.opBinary!(%.*s)\n", cast(int)s.length, s.ptr);
         return 0;
     }
 
     int opBinaryRight(string s)(int i) if (s == "/" || s == "*")
     {
-        printf("A.opBinaryRight!(%.*s)\n", s.length, s.ptr);
+        printf("A.opBinaryRight!(%.*s)\n", cast(int)s.length, s.ptr);
         return 0;
     }
 
     T opCast(T)()
     {
         auto s = T.stringof;
-        printf("A.opCast!(%.*s)\n", s.length, s.ptr);
+        printf("A.opCast!(%.*s)\n", cast(int)s.length, s.ptr);
         return T.init;
     }
 }
@@ -108,14 +108,14 @@ struct A4
 {
     int opUnary(string s)()
     {
-        printf("A.opUnary!(%.*s)\n", s.length, s.ptr);
+        printf("A.opUnary!(%.*s)\n", cast(int)s.length, s.ptr);
         return 0;
     }
 
     T opCast(T)()
     {
         auto s = T.stringof;
-        printf("A.opCast!(%.*s)\n", s.length, s.ptr);
+        printf("A.opCast!(%.*s)\n", cast(int)s.length, s.ptr);
         return T.init;
     }
 }
@@ -145,14 +145,14 @@ class A5
 
     int opUnary(string s)()
     {
-        printf("A.opUnary!(%.*s)\n", s.length, s.ptr);
+        printf("A.opUnary!(%.*s)\n", cast(int)s.length, s.ptr);
         return 0;
     }
 
     T opCast(T)()
     {
         auto s = T.stringof;
-        printf("A.opCast!(%.*s)\n", s.length, s.ptr);
+        printf("A.opCast!(%.*s)\n", cast(int)s.length, s.ptr);
         return T.init;
     }
 }
@@ -296,31 +296,31 @@ struct A8
 {
     int opUnary(string s)()
     {
-        printf("A.opUnary!(%.*s)\n", s.length, s.ptr);
+        printf("A.opUnary!(%.*s)\n", cast(int)s.length, s.ptr);
         return 0;
     }
 
     int opIndexUnary(string s, T)(T i)
     {
-        printf("A.opIndexUnary!(%.*s)(%d)\n", s.length, s.ptr, i);
+        printf("A.opIndexUnary!(%.*s)(%d)\n", cast(int)s.length, s.ptr, i);
         return 0;
     }
 
     int opIndexUnary(string s, T)(T i, T j)
     {
-        printf("A.opIndexUnary!(%.*s)(%d, %d)\n", s.length, s.ptr, i, j);
+        printf("A.opIndexUnary!(%.*s)(%d, %d)\n", cast(int)s.length, s.ptr, i, j);
         return 0;
     }
 
     int opSliceUnary(string s)()
     {
-        printf("A.opSliceUnary!(%.*s)()\n", s.length, s.ptr);
+        printf("A.opSliceUnary!(%.*s)()\n", cast(int)s.length, s.ptr);
         return 0;
     }
 
     int opSliceUnary(string s, T)(T i, T j)
     {
-        printf("A.opSliceUnary!(%.*s)(%d, %d)\n", s.length, s.ptr, i, j);
+        printf("A.opSliceUnary!(%.*s)(%d, %d)\n", cast(int)s.length, s.ptr, i, j);
         return 0;
     }
 }
@@ -344,31 +344,31 @@ struct A9
 {
     int opOpAssign(string s)(int i)
     {
-        printf("A.opOpAssign!(%.*s)\n", s.length, s.ptr);
+        printf("A.opOpAssign!(%.*s)\n", cast(int)s.length, s.ptr);
         return 0;
     }
 
     int opIndexOpAssign(string s, T)(int v, T i)
     {
-        printf("A.opIndexOpAssign!(%.*s)(%d, %d)\n", s.length, s.ptr, v, i);
+        printf("A.opIndexOpAssign!(%.*s)(%d, %d)\n", cast(int)s.length, s.ptr, v, i);
         return 0;
     }
 
     int opIndexOpAssign(string s, T)(int v, T i, T j)
     {
-        printf("A.opIndexOpAssign!(%.*s)(%d, %d, %d)\n", s.length, s.ptr, v, i, j);
+        printf("A.opIndexOpAssign!(%.*s)(%d, %d, %d)\n", cast(int)s.length, s.ptr, v, i, j);
         return 0;
     }
 
     int opSliceOpAssign(string s)(int v)
     {
-        printf("A.opSliceOpAssign!(%.*s)(%d)\n", s.length, s.ptr, v);
+        printf("A.opSliceOpAssign!(%.*s)(%d)\n", cast(int)s.length, s.ptr, v);
         return 0;
     }
 
     int opSliceOpAssign(string s, T)(int v, T i, T j)
     {
-        printf("A.opSliceOpAssign!(%.*s)(%d, %d, %d)\n", s.length, s.ptr, v, i, j);
+        printf("A.opSliceOpAssign!(%.*s)(%d, %d, %d)\n", cast(int)s.length, s.ptr, v, i, j);
         return 0;
     }
 }

--- a/test/runnable/printargs.d
+++ b/test/runnable/printargs.d
@@ -8,7 +8,7 @@ int main(char[][] args)
     int i;
 
     for (i = 0; i < args.length; i++)
-        printf("args[%d] = '%.*s'\n", i, args[i].length, args[i].ptr);
+        printf("args[%d] = '%.*s'\n", i, cast(int)args[i].length, args[i].ptr);
 
     assert(args[1] == "A");
     assert(args[2] == "B");

--- a/test/runnable/sdtor.d
+++ b/test/runnable/sdtor.d
@@ -1335,7 +1335,7 @@ void test52()
     A52 b = a.copy();
     printf("a: %p, b: %p\n", &a, &b);
   }
-    printf("s = '%.*s'\n", s52.length, s52.ptr);
+    printf("s = '%.*s'\n", cast(int)s52.length, s52.ptr);
     assert(s52 == "cabb");
 }
 
@@ -1836,18 +1836,18 @@ struct S6499
     this(string s)
     {
         m = s;
-        printf("Constructor - %.*s\n", m.length, m.ptr);
+        printf("Constructor - %.*s\n", cast(int)m.length, m.ptr);
         if (m == "foo") { ++sdtor; assert(sdtor == 1); }
         if (m == "bar") { ++sdtor; assert(sdtor == 2); }
     }
     this(this)
     {
-        printf("Postblit    - %.*s\n", m.length, m.ptr);
+        printf("Postblit    - %.*s\n", cast(int)m.length, m.ptr);
         assert(0);
     }
     ~this()
     {
-        printf("Destructor  - %.*s\n", m.length, m.ptr);
+        printf("Destructor  - %.*s\n", cast(int)m.length, m.ptr);
         if (m == "bar") { assert(sdtor == 2); --sdtor; }
         if (m == "foo") { assert(sdtor == 1); --sdtor; }
     }
@@ -2532,21 +2532,21 @@ struct Test9386
     this(string name)
     {
         this.name = name;
-        printf("Created %.*s...\n", name.length, name.ptr);
+        printf("Created %.*s...\n", cast(int)name.length, name.ptr);
         assert(i + 1 < op.length);
         op[i++] = 'a';
     }
 
     this(this)
     {
-        printf("Copied %.*s...\n", name.length, name.ptr);
+        printf("Copied %.*s...\n", cast(int)name.length, name.ptr);
         assert(i + 1 < op.length);
         op[i++] = 'b';
     }
 
     ~this()
     {
-        printf("Deleted %.*s\n", name.length, name.ptr);
+        printf("Deleted %.*s\n", cast(int)name.length, name.ptr);
         assert(i + 1 < op.length);
         op[i++] = 'c';
     }
@@ -2576,7 +2576,7 @@ void test9386()
         printf("----\n");
         foreach (Test9386 test; tests)
         {
-            printf("\tForeach %.*s\n", test.name.length, test.name.ptr);
+            printf("\tForeach %.*s\n", cast(int)test.name.length, test.name.ptr);
             Test9386.op[Test9386.i++] = 'x';
         }
 
@@ -2587,7 +2587,7 @@ void test9386()
         printf("----\n");
         foreach (ref Test9386 test; tests)
         {
-            printf("\tForeach %.*s\n", test.name.length, test.name.ptr);
+            printf("\tForeach %.*s\n", cast(int)test.name.length, test.name.ptr);
             Test9386.op[Test9386.i++] = 'x';
         }
         assert(Test9386.sop == "xxxx");
@@ -2609,8 +2609,8 @@ void test9386()
         printf("----\n");
         foreach (Test9386 k, Test9386 v; tests)
         {
-            printf("\tForeach %.*s : %.*s\n", k.name.length, k.name.ptr,
-                                              v.name.length, v.name.ptr);
+            printf("\tForeach %.*s : %.*s\n", cast(int)k.name.length, k.name.ptr,
+                                              cast(int)v.name.length, v.name.ptr);
             Test9386.op[Test9386.i++] = 'x';
         }
 
@@ -2621,8 +2621,8 @@ void test9386()
         printf("----\n");
         foreach (Test9386 k, ref Test9386 v; tests)
         {
-            printf("\tForeach %.*s : %.*s\n", k.name.length, k.name.ptr,
-                                              v.name.length, v.name.ptr);
+            printf("\tForeach %.*s : %.*s\n", cast(int)k.name.length, k.name.ptr,
+                                              cast(int)v.name.length, v.name.ptr);
             Test9386.op[Test9386.i++] = 'x';
         }
         assert(Test9386.sop == "bxcbxcbxcbxc");
@@ -2681,7 +2681,7 @@ struct Data
 
     ~this()
     {
-        printf("%d\n", _store._count);
+        printf("%zd\n", _store._count);
         --_store._count;
     }
 }
@@ -2730,13 +2730,13 @@ void test9907()
 
         void opAssign(SX rhs)
         {
-            printf("%08X(%d) from Rvalue %08X(%d)\n", &this.i, this.i, &rhs.i, rhs.i);
+            printf("%08zX(%d) from Rvalue %08zX(%d)\n", cast(size_t)&this.i, this.i, cast(size_t)&rhs.i, rhs.i);
             ++assign;
         }
 
         void opAssign(ref SX rhs)
         {
-            printf("%08X(%d) from Lvalue %08X(%d)\n", &this.i, this.i, &rhs.i, rhs.i);
+            printf("%08zX(%d) from Lvalue %08zX(%d)\n", cast(size_t)&this.i, this.i, cast(size_t)&rhs.i, rhs.i);
             assert(0);
         }
 
@@ -2744,7 +2744,7 @@ void test9907()
         {
             ~this()
             {
-                printf("destroying %08X(%d)\n", &this.i, this.i);
+                printf("destroying %08zX(%d)\n", cast(size_t)&this.i, this.i);
                 ++dtor;
             }
         }

--- a/test/runnable/stress.d
+++ b/test/runnable/stress.d
@@ -82,10 +82,10 @@ void MDCHAR()
         str[idx] = str[idx] ~ "TEST LINE\n";
     }
 
-    if(str.length != ITERS) printf("Length Error: %d\n",str.length);
-    if(str[0].length != 10) printf("Length Error: %d\n",str[0].length);
-    if(str[ITERS-1].sizeof != (typ[]).sizeof) printf("Size Error: %d\n",str[ITERS-1].sizeof);
-    if(str[ITERS-1][0].sizeof != (typ).sizeof) printf("Size Error: %d\n",str[ITERS-1][0].sizeof);
+    if(str.length != ITERS) printf("Length Error: %zd\n",str.length);
+    if(str[0].length != 10) printf("Length Error: %zd\n",str[0].length);
+    if(str[ITERS-1].sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",str[ITERS-1].sizeof);
+    if(str[ITERS-1][0].sizeof != (typ).sizeof) printf("Size Error: %zd\n",str[ITERS-1][0].sizeof);
 
     foreach(s; str) {
         size_t lstart;
@@ -130,8 +130,8 @@ void CHAR()
         str = str ~ "TEST LINE\n";
     }
 
-    if(str.length != (ITERS * 10)) printf("Length Error: %d\n",str.length);
-    if(str.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",str.sizeof);
+    if(str.length != (ITERS * 10)) printf("Length Error: %zd\n",str.length);
+    if(str.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",str.sizeof);
 
     size_t lstart;
     foreach(size_t idx, char c; str) {
@@ -155,8 +155,8 @@ void WCHAR()
         str = str ~ toUTF16(cast(char[])"TEST LINE\n");
     }
 
-    if(str.length != (ITERS * 10)) printf("Length Error: %d\n",str.length);
-    if(str.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",str.sizeof);
+    if(str.length != (ITERS * 10)) printf("Length Error: %zd\n",str.length);
+    if(str.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",str.sizeof);
 
     size_t lstart;
     foreach(size_t idx, char c; str) {
@@ -180,8 +180,8 @@ void DCHAR()
         str = str ~ toUTF32(cast(char[])"TEST LINE\n");
     }
 
-    if(str.length != (ITERS * 10)) printf("Length Error: %d\n",str.length);
-    if(str.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",str.sizeof);
+    if(str.length != (ITERS * 10)) printf("Length Error: %zd\n",str.length);
+    if(str.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",str.sizeof);
 
     size_t lstart;
     foreach(size_t idx, char c; str) {
@@ -205,8 +205,8 @@ void BYTE()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
             printf("a Data Error: %d\n",a[idx]);
@@ -217,8 +217,8 @@ void BYTE()
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
             printf("b Data Error: %d\n",b[idx]);
@@ -229,8 +229,8 @@ void BYTE()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
             printf("c Data Error: %d\n",c[idx]);
@@ -249,8 +249,8 @@ void UBYTE()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
             printf("a Data Error: %d\n",a[idx]);
@@ -261,8 +261,8 @@ void UBYTE()
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
             printf("b Data Error: %d\n",b[idx]);
@@ -274,8 +274,8 @@ void UBYTE()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
             printf("c Data Error: %d\n",c[idx]);
@@ -294,8 +294,8 @@ void SHORT()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
             printf("a Data Error: %d\n",a[idx]);
@@ -305,8 +305,8 @@ void SHORT()
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
             printf("b Data Error: %d\n",b[idx]);
@@ -318,8 +318,8 @@ void SHORT()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
             printf("c Data Error: %d\n",c[idx]);
@@ -338,8 +338,8 @@ void USHORT()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
             printf("a Data Error: %d\n",a[idx]);
@@ -349,8 +349,8 @@ void USHORT()
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
             printf("b Data Error: %d\n",b[idx]);
@@ -362,8 +362,8 @@ void USHORT()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
             printf("c Data Error: %d\n",c[idx]);
@@ -382,8 +382,8 @@ void INT()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
             printf("a Data Error: %d\n",a[idx]);
@@ -394,8 +394,8 @@ void INT()
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
             printf("b Data Error: %d\n",b[idx]);
@@ -407,8 +407,8 @@ void INT()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
             printf("c Data Error: %d\n",c[idx]);
@@ -427,8 +427,8 @@ void UINT()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
             printf("a Data Error: %d\n",a[idx]);
@@ -439,8 +439,8 @@ void UINT()
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
             printf("b Data Error: %d\n",b[idx]);
@@ -452,8 +452,8 @@ void UINT()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
             printf("c Data Error: %d\n",c[idx]);
@@ -472,22 +472,22 @@ void LONG()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
-            printf("a Data Error: %d\n",a[idx]);
+            printf("a Data Error: %lld\n",a[idx]);
             break;
         }
     }
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
-            printf("b Data Error: %d\n",b[idx]);
+            printf("b Data Error: %lld\n",b[idx]);
             break;
         }
     }
@@ -496,11 +496,11 @@ void LONG()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
-            printf("c Data Error: %d\n",c[idx]);
+            printf("c Data Error: %lld\n",c[idx]);
             break;
         }
     }
@@ -516,22 +516,22 @@ void ULONG()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
-            printf("a Data Error: %d\n",a[idx]);
+            printf("a Data Error: %lld\n",a[idx]);
             break;
         }
     }
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
-            printf("b Data Error: %d\n",b[idx]);
+            printf("b Data Error: %lld\n",b[idx]);
             break;
         }
     }
@@ -540,11 +540,11 @@ void ULONG()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
-            printf("c Data Error: %d\n",c[idx]);
+            printf("c Data Error: %lld\n",c[idx]);
             break;
         }
     }
@@ -560,22 +560,22 @@ void FLOAT()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
-            printf("a Data Error: %d\n",a[idx]);
+            printf("a Data Error: %g\n",a[idx]);
             break;
         }
     }
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
-            printf("b Data Error: %d\n",b[idx]);
+            printf("b Data Error: %g\n",b[idx]);
             break;
         }
     }
@@ -584,11 +584,11 @@ void FLOAT()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
-            printf("c Data Error: %d\n",c[idx]);
+            printf("c Data Error: %g\n",c[idx]);
             break;
         }
     }
@@ -604,22 +604,22 @@ void DOUBLE()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
-            printf("a Data Error: %d\n",a[idx]);
+            printf("a Data Error: %g\n",a[idx]);
             break;
         }
     }
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
-            printf("b Data Error: %d\n",b[idx]);
+            printf("b Data Error: %g\n",b[idx]);
             break;
         }
     }
@@ -628,11 +628,11 @@ void DOUBLE()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
-            printf("c Data Error: %d\n",c[idx]);
+            printf("c Data Error: %g\n",c[idx]);
             break;
         }
     }
@@ -648,22 +648,22 @@ void REAL()
         a ~= idx;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx] != idx) {
-            printf("a Data Error: %d\n",a[idx]);
+            printf("a Data Error: %Lg\n",a[idx]);
             break;
         }
     }
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx] != idx) {
-            printf("b Data Error: %d\n",b[idx]);
+            printf("b Data Error: %Lg\n",b[idx]);
             break;
         }
     }
@@ -672,11 +672,11 @@ void REAL()
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx] != idx) {
-            printf("c Data Error: %d\n",c[idx]);
+            printf("c Data Error: %Lg\n",c[idx]);
             break;
         }
     }
@@ -693,8 +693,8 @@ void CLASS()
         a ~= tc;
     }
 
-    if(a.length != ITERS) printf("Length Error: %d\n",a.length);
-    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",a.sizeof);
+    if(a.length != ITERS) printf("Length Error: %zd\n",a.length);
+    if(a.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",a.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(a[idx].i != idx) {
             printf("a Data Error: %d\n",a[idx].i);
@@ -704,8 +704,8 @@ void CLASS()
 
     typ[] b = a[];
 
-    if(b.length != ITERS) printf("Length Error: %d\n",b.length);
-    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",b.sizeof);
+    if(b.length != ITERS) printf("Length Error: %zd\n",b.length);
+    if(b.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",b.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(b[idx].i != idx) {
             printf("b Data Error: %d\n",b[idx].i);
@@ -716,8 +716,8 @@ void CLASS()
     typ[] c;
     c = a[0..ITERS/2] ~ b[ITERS/2..$];
 
-    if(c.length != ITERS) printf("Length Error: %d\n",c.length);
-    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %d\n",c.sizeof);
+    if(c.length != ITERS) printf("Length Error: %zd\n",c.length);
+    if(c.sizeof != (typ[]).sizeof) printf("Size Error: %zd\n",c.sizeof);
     for(int idx = 0; idx < ITERS; idx++) {
         if(c[idx].i != idx) {
             printf("c Data Error: %d\n",c[idx].i);

--- a/test/runnable/template1.d
+++ b/test/runnable/template1.d
@@ -771,7 +771,7 @@ void test30()
     assert(i == 3);
 
     copystr.copy(s, "Here it comes");
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     assert(s == "Here it comes");
 }
 
@@ -1367,7 +1367,7 @@ void test56()
 {
   alias CT56!(int) Ct;
   Ct.C c= new Ct.C();
-  printf("%.*s\n", c.arrArr[0].length, c.arrArr[0].ptr);
+  printf("%.*s\n", cast(int)c.arrArr[0].length, c.arrArr[0].ptr);
   assert(c.arrArr[0] == "foo");
 }
 
@@ -1449,15 +1449,15 @@ void test60()
         B60!(int, long).Thing   thing1;
         B60!(int).Thing         thing2;
 
-        printf("thing1.sizeof: %u\n", thing1.sizeof);
-        printf("thing2.sizeof: %u\n", thing2.sizeof);
+        printf("thing1.sizeof: %zu\n", thing1.sizeof);
+        printf("thing2.sizeof: %zu\n", thing2.sizeof);
 
         assert(thing1.sizeof == long.alignof + long.sizeof);
         assert(thing2.sizeof == 8);
 
         C60!(int /*,A60*/ )     container1;
 
-        printf("container1.sizeof: %u\n", container1.sizeof);
+        printf("container1.sizeof: %zu\n", container1.sizeof);
         assert(container1.sizeof == (void*).sizeof);
 }
 
@@ -1604,7 +1604,7 @@ template Foo67(alias T)
 {
     void Foo67()
     {
-        printf("T = '%.*s'\n", T.length, T.ptr);
+        printf("T = '%.*s'\n", cast(int)T.length, T.ptr);
         assert(T == "hello");
     }
 }
@@ -1637,7 +1637,7 @@ void test68()
 
 size_t printx(string s)
 {
-    printf("s = '%.*s'\n", s.length, s.ptr);
+    printf("s = '%.*s'\n", cast(int)s.length, s.ptr);
     return s.length;
 }
 
@@ -1735,8 +1735,8 @@ void test72()
     static ulong[5] a = [0,1,2,3,4];
     static uint[5] b = [0,1,2,3,4];
     char[] r;
-    r = foo72!(ulong[5])(a); printf("%.*s\n", r.length, r.ptr);
-    r = foo72!(uint[5])(b);  printf("%.*s\n", r.length, r.ptr);
+    r = foo72!(ulong[5])(a); printf("%.*s\n", cast(int)r.length, r.ptr);
+    r = foo72!(uint[5])(b);  printf("%.*s\n", cast(int)r.length, r.ptr);
 }
 
 

--- a/test/runnable/test11.d
+++ b/test/runnable/test11.d
@@ -681,7 +681,7 @@ void test35()
  try {
   alias Foo35!( Bar35 ) filter;
  } catch (Exception e) {
-  printf( "Exception %.*s", e.msg.length, e.msg.ptr );
+  printf( "Exception %.*s", cast(int)e.msg.length, e.msg.ptr );
  } finally {
   printf( "Done0." );
  }
@@ -885,7 +885,7 @@ void test45()
     char[5] foo;
 
     foo[] = "hello";
-    printf("'%.*s'\n", foo.length, foo.ptr);
+    printf("'%.*s'\n", cast(int)foo.length, foo.ptr);
     func45(cast(string)foo);
 }
 
@@ -1189,7 +1189,7 @@ void test63()
 {
      A63 f = new A63();
      auto s = f.getcwd();
-     printf("%.*s\n", s.length, s.ptr);
+     printf("%.*s\n", cast(int)s.length, s.ptr);
 }
 
 

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -365,32 +365,32 @@ union U6
 
 void test14()
 {
-   printf("%d %d %d\n", U1.a.offsetof, U1.b.offsetof, U1.sizeof);
+   printf("%zd %zd %zd\n", U1.a.offsetof, U1.b.offsetof, U1.sizeof);
    assert(U1.a.offsetof == 0);
    assert(U1.b.offsetof == 0);
    assert(U1.sizeof == 4);
 
-   printf("%d %d %d\n", U2.a.offsetof, U2.b.offsetof, U2.sizeof);
+   printf("%zd %zd %zd\n", U2.a.offsetof, U2.b.offsetof, U2.sizeof);
    assert(U2.a.offsetof == 0);
    assert(U2.b.offsetof == 0);
    assert(U2.sizeof == 8);
 
-   printf("%d %d %d\n", U3.a.offsetof, U3.b.offsetof, U3.sizeof);
+   printf("%zd %zd %zd\n", U3.a.offsetof, U3.b.offsetof, U3.sizeof);
    assert(U3.a.offsetof == 0);
    assert(U3.b.offsetof == 0);
    assert(U3.sizeof == 8);
 
-   printf("%d %d %d\n", U4.a.offsetof, U4.b.offsetof, U4.sizeof);
+   printf("%zd %zd %zd\n", U4.a.offsetof, U4.b.offsetof, U4.sizeof);
    assert(U4.a.offsetof == 0);
    assert(U4.b.offsetof == 0);
    assert(U4.sizeof == 4);
 
-   printf("%d %d %d\n", U5.a.offsetof, U5.b.offsetof, U5.sizeof);
+   printf("%zd %zd %zd\n", U5.a.offsetof, U5.b.offsetof, U5.sizeof);
    assert(U5.a.offsetof == 0);
    assert(U5.b.offsetof == 0);
    assert(U5.sizeof == 8);
 
-   printf("%d %d %d\n", U6.a.offsetof, U6.b.offsetof, U6.sizeof);
+   printf("%zd %zd %zd\n", U6.a.offsetof, U6.b.offsetof, U6.sizeof);
    assert(U6.a.offsetof == 0);
    assert(U6.b.offsetof == 0);
    assert(U6.sizeof == 8);
@@ -670,9 +670,9 @@ void test31()
 
     printf("%s\n", foo.ptr);
     auto s = typeid(typeof(foo.ptr)).toString();
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     s = typeid(char*).toString();
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     assert(typeid(typeof(foo.ptr)) == typeid(immutable(char)*));
 }
 
@@ -688,7 +688,7 @@ class Qwert32
 
     void foo()
     {
-        printf("yuiop = %d, asdfg = %d\n", Qwert32.yuiop.offsetof, Qwert32.asdfg.offsetof);
+        printf("yuiop = %zd, asdfg = %zd\n", Qwert32.yuiop.offsetof, Qwert32.asdfg.offsetof);
         version(D_LP64)
         {
             assert(Qwert32.yuiop.offsetof == 16);
@@ -777,7 +777,7 @@ void test36()
 {
     A36 a = new A36;
 
-    printf("A36.sizeof = %d\n", a.classinfo.initializer.length);
+    printf("A36.sizeof = %zd\n", a.classinfo.initializer.length);
     printf("%d\n", a.s);
     printf("%d\n", a.a);
     printf("%d\n", a.b);
@@ -818,7 +818,7 @@ class Foo38
 {
     static void display_name()
     {
-        printf("%.*s\n", Object.classinfo.name.length, Object.classinfo.name.ptr);
+        printf("%.*s\n", cast(int)Object.classinfo.name.length, Object.classinfo.name.ptr);
         assert(Object.classinfo.name == "object.Object");
         assert(super.classinfo.name == "object.Object");
         assert(this.classinfo.name == "test12.Foo38");
@@ -969,7 +969,7 @@ void test45()
 
     foreach (Shell s; a)
     {
-        printf("%.*s\n", s.str.length, s.str.ptr);
+        printf("%.*s\n", cast(int)s.str.length, s.str.ptr);
     }
 
     assert(a[0].str == "betty");
@@ -1152,7 +1152,7 @@ void test55()
 
 void writefln(string s)
 {
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
 }
 
 void test58()

--- a/test/runnable/test15.d
+++ b/test/runnable/test15.d
@@ -50,7 +50,7 @@ void test6()
 void test7()
 {
     string s = `hello"there'you`;
-    printf("s = '%.*s'\n", s.length, s.ptr);
+    printf("s = '%.*s'\n", cast(int)s.length, s.ptr);
     assert(s == "hello\"there'you");
     ubyte[] b = cast(ubyte[])"\x8B\x7D\xf4\x0d";
     for (int i = 0; i < b.length; i++)
@@ -227,7 +227,7 @@ void test16()
     uint c = 200000;
     while (c--)
         a ~= 'x';
-    //printf("a = '%.*s'\n", a.length, a.ptr);
+    //printf("a = '%.*s'\n", cast(int)a.length, a.ptr);
 }
 
 
@@ -375,7 +375,7 @@ void test26()
 
     foreach(string instr; instructions)
     {
-        printf("%.*s\n", instr.length, instr.ptr);
+        printf("%.*s\n", cast(int)instr.length, instr.ptr);
     }
 }
 
@@ -406,7 +406,7 @@ void test27()
 
 void foo28(ClassInfo ci)
 {
-    printf("%.*s\n", ci.name.length, ci.name.ptr);
+    printf("%.*s\n", cast(int)ci.name.length, ci.name.ptr);
 
     static int i;
     switch (i++)
@@ -790,7 +790,7 @@ class C44
 void test44()
 {
   C44 c= new C44();
-  printf("%.*s\n", c.arrArr[0].length, c.arrArr[0].ptr);
+  printf("%.*s\n", cast(int)c.arrArr[0].length, c.arrArr[0].ptr);
   assert(c.arrArr[0] == "foo");
 }
 
@@ -819,11 +819,11 @@ union A46
 void test46()
 {
     A46 a;
-    printf("%d\n", cast(byte*)&a.c - cast(byte*)&a);
-    printf("%d\n", cast(byte*)&a.s - cast(byte*)&a);
-    printf("%d\n", cast(byte*)&a.l - cast(byte*)&a);
-    printf("%d\n", cast(byte*)&a.a - cast(byte*)&a);
-    printf("%d\n", cast(byte*)&a.f - cast(byte*)&a);
+    printf("%td\n", cast(byte*)&a.c - cast(byte*)&a);
+    printf("%td\n", cast(byte*)&a.s - cast(byte*)&a);
+    printf("%td\n", cast(byte*)&a.l - cast(byte*)&a);
+    printf("%td\n", cast(byte*)&a.a - cast(byte*)&a);
+    printf("%td\n", cast(byte*)&a.f - cast(byte*)&a);
 
     assert(cast(byte*)&a.c == cast(byte*)&a);
     assert(cast(byte*)&a.s == cast(byte*)&a);
@@ -1128,7 +1128,7 @@ void test61()
     int i = 123;
     StdString g = new StdString();
     string s = g.toString("%s", i);
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     assert(s == "123");
 }
 

--- a/test/runnable/test17.d
+++ b/test/runnable/test17.d
@@ -5,7 +5,7 @@ extern(C) int printf(const char*, ...);
 
 void ulog(string s)
 {
-    printf("%.*s\n",s.length, s.ptr);
+    printf("%.*s\n",cast(int)s.length, s.ptr);
     fflush(stdout);
 }
 

--- a/test/runnable/test19.d
+++ b/test/runnable/test19.d
@@ -161,7 +161,7 @@ void test7()
     OutBuffer7 ob = new OutBuffer7;
 
     ob.data = new char[10];
-    printf("ob.data.length = %d\n", ob.data.length);
+    printf("ob.data.length = %zd\n", ob.data.length);
     assert(ob.data.length == 10);
     for (i = 0; i < 10; i++)
         assert(ob.data[i] == char.init);
@@ -169,14 +169,14 @@ void test7()
 printf("test7.1()\n");
     ob.data[] = '-';
 printf("test7.2()\n");
-    printf("ob.data[] = '%.*s'\n", ob.data.length, ob.data.ptr);
+    printf("ob.data[] = '%.*s'\n", cast(int)ob.data.length, ob.data.ptr);
     for (i = 0; i < 10; i++)
         assert(ob.data[i] == '-');
 
     ob.offset = 3;
     ob.write("foo", 3);
-    printf("ob.data.length = %d\n", ob.data.length);
-    printf("ob.data[] = '%.*s'\n", ob.data.length, ob.data.ptr);
+    printf("ob.data.length = %zd\n", ob.data.length);
+    printf("ob.data[] = '%.*s'\n", cast(int)ob.data.length, ob.data.ptr);
     for (i = 0; i < 10; i++)
     {
         if (i < 3 || i >= 6)

--- a/test/runnable/test20.d
+++ b/test/runnable/test20.d
@@ -78,7 +78,7 @@ struct A4
 
 void test4()
 {
-    printf("A4.sizeof = %d\n", A4.sizeof);
+    printf("A4.sizeof = %zd\n", A4.sizeof);
     assert(A4.sizeof == 1 * int.sizeof);
 
     A4 q;
@@ -276,7 +276,7 @@ void test13()
 
 void write14(bool[] c)
 {
-    printf("[%2d]: ", c.length);
+    printf("[%2zd]: ", c.length);
     foreach (bool x; c)
         printf("%d,", x);
     printf("\n");
@@ -937,7 +937,7 @@ void test51()
 {
     bool[9][3] qwert;
 
-    printf("qwert.sizeof = %d\n", qwert.sizeof);
+    printf("qwert.sizeof = %zd\n", qwert.sizeof);
 
     for (int i = 0; i < 3; i++)
         for (int j = 0; j < 9; j++)
@@ -986,13 +986,13 @@ const char[3][13] month = [
 
 void test53()
 {
-    printf("%.*s\n", month[1].length, month[1].ptr);
-    printf("%.*s\n", month[2].length, month[2].ptr);
-    printf("%.*s\n", month[3].length, month[3].ptr);
-    printf("%.*s\n", month[4].length, month[4].ptr);
-    printf("%.*s\n", month[5].length, month[5].ptr);
-    printf("%.*s\n", month[6].length, month[6].ptr);
-    printf("%.*s\n", month[8].length, month[8].ptr);
+    printf("%.*s\n", cast(int)month[1].length, month[1].ptr);
+    printf("%.*s\n", cast(int)month[2].length, month[2].ptr);
+    printf("%.*s\n", cast(int)month[3].length, month[3].ptr);
+    printf("%.*s\n", cast(int)month[4].length, month[4].ptr);
+    printf("%.*s\n", cast(int)month[5].length, month[5].ptr);
+    printf("%.*s\n", cast(int)month[6].length, month[6].ptr);
+    printf("%.*s\n", cast(int)month[8].length, month[8].ptr);
 
     assert(month[1] == "Jan");
     assert(month[2] == "Feb");
@@ -1051,12 +1051,12 @@ void test55()
   str = str ~ c;
   uvw = c ~ uvw;
 
-  printf("%.*s\n", str.length, str.ptr);
+  printf("%.*s\n", cast(int)str.length, str.ptr);
   assert(str == "a");
   assert(uvw == "a");
 
   c = 'b';
-  printf("%.*s\n", str.length, str.ptr);
+  printf("%.*s\n", cast(int)str.length, str.ptr);
   assert(str == "a");
   assert(uvw == "a");
 }
@@ -1198,7 +1198,7 @@ void foo61(real[] arr)
     for (size_t j = i; j >= i; j -= i)
     {
         // interesting results follow from this:
-        printf("%d ", i);
+        printf("%zd ", i);
         // it prints a _lot_ of ones
 
         arr[j] = arr[j - i];

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -218,7 +218,7 @@ void test10()
 {
     auto i = 5u;
     auto s = typeid(typeof(i)).toString;
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     assert(typeid(typeof(i)) == typeid(uint));
 }
 
@@ -246,7 +246,7 @@ void assertEqual(real* a, real* b, string file = __FILE__, size_t line = __LINE_
     {
         if (x[i] != y[i])
         {
-            printf("%02d: %02x %02x\n", i, x[i], y[i]);
+            printf("%02zd: %02x %02x\n", i, x[i], y[i]);
             import core.exception;
             throw new AssertError(file, line);
         }
@@ -556,7 +556,7 @@ void test26()
   foreach( cdouble z; A )
   {
     s = toString26(z);
-    printf("%.*s  ", s.length, s.ptr);
+    printf("%.*s  ", cast(int)s.length, s.ptr);
   }
   printf("\n");
 
@@ -570,7 +570,7 @@ void test26()
   foreach( cdouble z; A )
   {
     s = toString26(z);
-    printf("%.*s  ", s.length, s.ptr);
+    printf("%.*s  ", cast(int)s.length, s.ptr);
   }
   printf("\n");
 }
@@ -581,7 +581,7 @@ void test27()
 {   int x;
 
     string s = (int*function(int ...)[]).mangleof;
-    printf("%.*s\n", s.length, s.ptr);
+    printf("%.*s\n", cast(int)s.length, s.ptr);
     assert((int*function(int ...)[]).mangleof == "APFiXPi");
     assert(typeof(x).mangleof == "i");
     assert(x.mangleof == "_D6test226test27FZ1xi");
@@ -602,7 +602,7 @@ void test29()
     ulong a = 10_000_000_000_000_000,
           b =  1_000_000_000_000_000;
 
-    printf("test29\n%lx\n%lx\n%lx\n", a, b, a / b);
+    printf("test29\n%llx\n%llx\n%llx\n", a, b, a / b);
     assert((a / b) == 10);
 }
 

--- a/test/runnable/test23.d
+++ b/test/runnable/test23.d
@@ -255,7 +255,7 @@ struct B12 {
 void test12()
 {
         A12 a;
-        printf("%d\n", A12.sizeof);
+        printf("%zd\n", A12.sizeof);
         assert(A12.sizeof == 12);
 }
 
@@ -1242,7 +1242,7 @@ void test63()
         arr = [1] ~ 2;
 
         // runtime crash, the length == 1
-        printf("%d\n", arr.length);
+        printf("%zd\n", arr.length);
         assert (arr.length == 2);
         assert(arr[0] == 1);
         assert(arr[1] == 2);

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -940,9 +940,9 @@ void test47()
 void test48()
 {
     Object o = new Object();
-    printf("%.*s\n", typeof(o).classinfo.name.length, typeof(o).classinfo.name.ptr);
-    printf("%.*s\n", (typeof(o)).classinfo.name.length, (typeof(o)).classinfo.name.ptr);
-    printf("%.*s\n", (Object).classinfo.name.length, (Object).classinfo.name.ptr);
+    printf("%.*s\n", cast(int)typeof(o).classinfo.name.length, typeof(o).classinfo.name.ptr);
+    printf("%.*s\n", cast(int)(typeof(o)).classinfo.name.length, (typeof(o)).classinfo.name.ptr);
+    printf("%.*s\n", cast(int)(Object).classinfo.name.length, (Object).classinfo.name.ptr);
 }
 
 /*******************************************/

--- a/test/runnable/test3.d
+++ b/test/runnable/test3.d
@@ -34,7 +34,7 @@ int main(string[] args)
     a.bar = "hello";
     a.bar = baz ~ "betty";
 
-    printf("a.bar = '%.*s'\n", a.bar.length, a.bar.ptr);
+    printf("a.bar = '%.*s'\n", cast(int)a.bar.length, a.bar.ptr);
     assert(a.bar == "lolobetty");
     return 0;
 }

--- a/test/runnable/test4.d
+++ b/test/runnable/test4.d
@@ -997,11 +997,11 @@ void test43()
 {
     string s;
 
-    s = __FILE__; printf("file = '%.*s'\n", s.length, s.ptr);
+    s = __FILE__; printf("file = '%.*s'\n", cast(int)s.length, s.ptr);
     printf("line = %d\n", __LINE__);
-    s = __DATE__; printf("date = '%.*s'\n", s.length, s.ptr);
-    s = __TIME__; printf("time = '%.*s'\n", s.length, s.ptr);
-    s = __TIMESTAMP__; printf("timestamp = '%.*s'\n", s.length, s.ptr);
+    s = __DATE__; printf("date = '%.*s'\n", cast(int)s.length, s.ptr);
+    s = __TIME__; printf("time = '%.*s'\n", cast(int)s.length, s.ptr);
+    s = __TIMESTAMP__; printf("timestamp = '%.*s'\n", cast(int)s.length, s.ptr);
 }
 
 /* ================================ */
@@ -1272,7 +1272,7 @@ void test54()
         }
         catch(Exception e)
         {
-                printf("catch %.*s\n", e.msg.length, e.msg.ptr);
+                printf("catch %.*s\n", cast(int)e.msg.length, e.msg.ptr);
                 assert(e.msg == "first");
                 assert(e.next.msg == "second");
         }
@@ -1292,7 +1292,7 @@ void foo55()
     catch (Exception e)
     {
         printf("inner catch %p\n", e);
-        printf("e.msg == %.*s\n", e.msg.length, e.msg.ptr);
+        printf("e.msg == %.*s\n", cast(int)e.msg.length, e.msg.ptr);
         assert(e.msg == "second");
         //assert(e.msg == "first");
         //assert(e.next.msg == "second");

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -195,7 +195,7 @@ void test12()
     assert((foo ~ cast(char[])"foo").length == foo.length + 1);
     assert((cast(char[])"foo" ~ foo).length == foo.length + 1);
 
-    printf("%d\n", (foo ~ cast(char[])"foo")[0].length);
+    printf("%zd\n", (foo ~ cast(char[])"foo")[0].length);
 
     assert((foo ~ [cast(char[])"foo"]).length == foo.length + 1);
 
@@ -801,7 +801,7 @@ void test54()
     string[] k=["adf","AsdfadSF","dfdsfassdf"];
     foreach(d;k)
     {
-        printf("%.*s\n", d.length, d.ptr);
+        printf("%.*s\n", cast(int)d.length, d.ptr);
         string foo() {assert(d!="");return d;}
         func54(&foo);
         func54(delegate string() {assert(d!="");return d;});
@@ -1378,7 +1378,7 @@ void test83()
 void test84()
 {
     int[0][10] arr;
-    printf("%u\n", &arr[9] - &arr[0]);
+    printf("%tu\n", &arr[9] - &arr[0]);
     auto i = &arr[9] - &arr[0];
     assert(i == 0);
 }
@@ -3274,7 +3274,7 @@ void test201() {
 
 
 void foo202(int x, ...) {
-    printf("%d arguments\n", _arguments.length);
+    printf("%zd arguments\n", _arguments.length);
     for (int i = 0; i < _arguments.length; i++) {
         int j = va_arg!(int)(_argptr);
         printf("\t%d\n", j);
@@ -3283,7 +3283,7 @@ void foo202(int x, ...) {
 }
 
 void fooRef202(ref int x, ...) {
-    printf("%d arguments\n", _arguments.length);
+    printf("%zd arguments\n", _arguments.length);
     for (int i = 0; i < _arguments.length; i++) {
         int j = va_arg!(int)(_argptr);
         printf("\t%d\n", j);

--- a/test/runnable/test48.d
+++ b/test/runnable/test48.d
@@ -16,26 +16,26 @@ void main()
     printf("i = %d\n", i);
     assert(i == 6);
 
-    printf("a = %d %d %d\n", S.tupleof.offsetof);
+    printf("a = %zd %zd %zd\n", S.tupleof.offsetof);
     auto o = S.tupleof.offsetof;
     assert(o[0] == 0);
     assert(o[1] == 4);
     assert(o[2] == 8);
-    printf("a = %d %d %d\n", S.tupleof[0].offsetof, S.tupleof[1].offsetof, S.tupleof[2].offsetof);
+    printf("a = %zd %zd %zd\n", S.tupleof[0].offsetof, S.tupleof[1].offsetof, S.tupleof[2].offsetof);
     assert(S.tupleof[0].offsetof == 0);
     assert(S.tupleof[1].offsetof == 4);
     assert(S.tupleof[2].offsetof == 8);
 
     auto offset0 = cast(void*)&s.tupleof[0] - cast(void*)&s;
-    printf("offset0 = %d\n", offset0);
+    printf("offset0 = %td\n", offset0);
     assert(offset0 == 0);
 
     auto offset1 = cast(void*)&s.tupleof[1] - cast(void*)&s;
-    printf("offset1 = %d\n", offset1);
+    printf("offset1 = %td\n", offset1);
     assert(offset1 == 4);
 
     auto offset2 = cast(void*)&s.tupleof[2] - cast(void*)&s;
-    printf("offset2 = %d\n", offset2);
+    printf("offset2 = %td\n", offset2);
     assert(offset2 == 8);
 
     int[S.tupleof.offsetof[1]] t1;

--- a/test/runnable/test5.d
+++ b/test/runnable/test5.d
@@ -40,7 +40,7 @@ class bar : foo
 
 int def(foo f)
 {
-    printf("def(%p), %p\n", f, (cast(int*)f)[0]);
+    printf("def(%p), %d\n", f, (cast(int*)f)[0]);
     assert(f.testc(3) == 50);
     assert(f.testd(7) == 54);
     assert(f.testd(10) == 57);
@@ -49,7 +49,7 @@ int def(foo f)
 
 void abc(bar b)
 {
-    printf("abc(%p), %p\n", b, (cast(int*)b)[3]);
+    printf("abc(%p), %d\n", b, (cast(int*)b)[3]);
     def(b);
 }
 
@@ -57,8 +57,8 @@ int main()
 {
     bar b = new bar();
 
-    printf("b.size = x%x\n", b.classinfo.initializer.length);
-    printf("bar.size = x%x\n", bar.classinfo.initializer.length);
+    printf("b.size = x%zx\n", b.classinfo.initializer.length);
+    printf("bar.size = x%zx\n", bar.classinfo.initializer.length);
     assert(b.classinfo.initializer.length == bar.classinfo.initializer.length);
     abc(b);
     return 0;

--- a/test/runnable/test8.d
+++ b/test/runnable/test8.d
@@ -322,11 +322,11 @@ void test17()
     string s;
 
     s = passString();
-    printf("passString() = %.*s\n", s.length, s.ptr);
+    printf("passString() = %.*s\n", cast(int)s.length, s.ptr);
     assert(s == "First stringConcatenated with second");
 
     s = butThisWorks();
-    printf("butThisWorks() = %.*s\n", s.length, s.ptr);
+    printf("butThisWorks() = %.*s\n", cast(int)s.length, s.ptr);
     assert(s == "Third stringConcatenated with fourth");
 }
 
@@ -652,7 +652,7 @@ void test36()
 {
     string s = testa36(26, 47, "a", "b", "c");
 
-    printf("s = '%.*s'\n", s.length, s.ptr);
+    printf("s = '%.*s'\n", cast(int)s.length, s.ptr);
     assert(s == "string 0;26string 1;47string 2;26string 3;");
 }
 
@@ -704,7 +704,7 @@ void test38()
     }
     catch(Throwable)
     {
-       printf("Exception: %d\n", k);
+       printf("Exception: %lld\n", k);
         assert(0);
     }
 }

--- a/test/runnable/testaa.d
+++ b/test/runnable/testaa.d
@@ -271,9 +271,9 @@ struct S12
 void test12()
 {
     S12[] x;
-    printf("size %d\n",S12.sizeof);
-    printf("align %d\n",S12.alignof);
-    printf("offset %d\n",S12.description.offsetof);
+    printf("size %zd\n",S12.sizeof);
+    printf("align %zd\n",S12.alignof);
+    printf("offset %zd\n",S12.description.offsetof);
 
     for (int i=0;i<3;i++) {
         S12 s;
@@ -293,8 +293,8 @@ void test12()
     x ~= s;
 */
     GC.collect();
-    printf("%.*s\n",x[0].font_face.length,x[0].font_face.ptr);
-    printf("%.*s\n",x[1].font_face.length,x[1].font_face.ptr);
+    printf("%.*s\n", cast(int)x[0].font_face.length, x[0].font_face.ptr);
+    printf("%.*s\n", cast(int)x[1].font_face.length, x[1].font_face.ptr);
 }
 
 
@@ -557,14 +557,14 @@ void test19()
     printf("%d\n", keys[1]);
 
     auto vs = aa.values;
-    printf("%.*s\n", vs[0].length, vs[0].ptr);
-    printf("%.*s\n", vs[1].length, vs[1].ptr);
+    printf("%.*s\n", cast(int)vs[0].length, vs[0].ptr);
+    printf("%.*s\n", cast(int)vs[1].length, vs[1].ptr);
 
     string aavalue_typeid = typeid(typeof(aa.values)).toString();
-    printf("%.*s\n", aavalue_typeid.length, aavalue_typeid.ptr);
+    printf("%.*s\n", cast(int)aavalue_typeid.length, aavalue_typeid.ptr);
 
-    printf("%.*s\n", aa[3].length, aa[3].ptr);
-    printf("%.*s\n", aa[4].length, aa[4].ptr);
+    printf("%.*s\n", cast(int)aa[3].length, aa[3].ptr);
+    printf("%.*s\n", cast(int)aa[4].length, aa[4].ptr);
 }
 
 /************************************************/
@@ -581,14 +581,14 @@ void test20()
     printf("%d\n", keys[1]);
 
     auto values = aa.values;
-    printf("%.*s\n", values[0].length, values[0].ptr);
-    printf("%.*s\n", values[1].length, values[1].ptr);
+    printf("%.*s\n", cast(int)values[0].length, values[0].ptr);
+    printf("%.*s\n", cast(int)values[1].length, values[1].ptr);
 
     string aavalue_typeid = typeid(typeof(aa.values)).toString();
-    printf("%.*s\n", aavalue_typeid.length, aavalue_typeid.ptr);
+    printf("%.*s\n", cast(int)aavalue_typeid.length, aavalue_typeid.ptr);
 
-    printf("%.*s\n", aa[3].length, aa[3].ptr);
-    printf("%.*s\n", aa[4].length, aa[4].ptr);
+    printf("%.*s\n", cast(int)aa[3].length, aa[3].ptr);
+    printf("%.*s\n", cast(int)aa[4].length, aa[4].ptr);
 }
 
 /************************************************/

--- a/test/runnable/testaa2.d
+++ b/test/runnable/testaa2.d
@@ -52,7 +52,7 @@ void foo2()
 
     for (i = 0; i < key.length; i++)
     {
-        printf("c[\"%.*s\"] = %d\n", key[i].length, key[i].ptr, value[i]);
+        printf("c[\"%.*s\"] = %d\n", cast(int)key[i].length, key[i].ptr, value[i]);
     }
 
     assert("foo" in c);
@@ -69,7 +69,7 @@ void foo2()
 void testaa()
 {
     size_t i = foo("abc");
-    printf("i = %d\n", i);
+    printf("i = %zd\n", i);
     assert(i == 0);
 
     foo2();

--- a/test/runnable/testconst.d
+++ b/test/runnable/testconst.d
@@ -53,7 +53,7 @@ template TypeTuple(T...) { alias T TypeTuple; }
 
 void showf(string f)
 {
-    printf("%.*s\n", f.length, f.ptr);
+    printf("%.*s\n", cast(int)f.length, f.ptr);
 }
 
 /************************************/
@@ -626,7 +626,7 @@ class C42
 
 void test42()
 {
-    printf("%d\n", C42.classinfo.initializer.length);
+    printf("%zd\n", C42.classinfo.initializer.length);
     assert(C42.classinfo.initializer.length == 12 + (void*).sizeof +
         (void*).sizeof);
     C42 c = new C42;
@@ -963,7 +963,7 @@ void test56()
 {
     S56 s;
     S56 t;
-    printf("S56.sizeof = %d\n", S56.sizeof);
+    printf("S56.sizeof = %zd\n", S56.sizeof);
     //t = s;
 }
 
@@ -2914,7 +2914,7 @@ void test7105()
 
 void test7202()
 {
-    void writeln(string s) @system { printf("%.*s\n", s.length, s.ptr); }
+    void writeln(string s) @system { printf("%.*s\n", cast(int)s.length, s.ptr); }
     void delegate() @system x = { writeln("I am @system"); };
     void delegate() @safe y = {  };
     auto px = &x;

--- a/test/runnable/testgc2.d
+++ b/test/runnable/testgc2.d
@@ -13,7 +13,7 @@ void test1()
     try
     {
         long[] l = new long[ptrdiff_t.max];
-        printf("%lu\n", cast(ulong)l.capacity); // Make sure l is not optimized out.
+        printf("%llu\n", cast(ulong)l.capacity); // Make sure l is not optimized out.
         assert(0);
     }
     catch (OutOfMemoryError o)
@@ -24,7 +24,7 @@ void test1()
     try
     {
         byte[] b = new byte[size_t.max / 3];
-        printf("%lu\n", cast(ulong)b.capacity); // Make sure b is not optimized out.
+        printf("%llu\n", cast(ulong)b.capacity); // Make sure b is not optimized out.
         version (Windows)
             assert(0);
     }

--- a/test/runnable/testinvariant.d
+++ b/test/runnable/testinvariant.d
@@ -17,7 +17,7 @@ int testinvariant()
     printf("hello\n");
     Foo f = new Foo();
     printf("f = %p\n", f);
-    printf("f.sizeof = x%x\n", Foo.sizeof);
+    printf("f.sizeof = x%zx\n", Foo.sizeof);
     printf("f.classinfo = %p\n", f.classinfo);
     printf("f.classinfo._invariant = %p\n", f.classinfo.base);
     f.test();

--- a/test/runnable/testpdb.d
+++ b/test/runnable/testpdb.d
@@ -1143,7 +1143,7 @@ void printSymbol(IDiaSymbol sym, int indent)
     hr = sym.get_name(&name);
     if (hr != S_OK)
         name = cast(BSTR) "no-name"w.ptr;
-    printf("%*s%02x %S\n", indent, "".ptr, tag, name);
+    printf("%*s%02x %ls\n", indent, "".ptr, tag, name);
     if (hr == S_OK)
         SysFreeString(name);
 }

--- a/test/runnable/testswitch.d
+++ b/test/runnable/testswitch.d
@@ -308,7 +308,7 @@ void bar14(A...)(int i)
         {
             goto case;
         case A[j]:
-            printf("a = %d, A[%d] = %d\n", a, j, A[j]);
+            printf("a = %d, A[%zd] = %d\n", a, j, A[j]);
         }
         break;
     default:

--- a/test/runnable/testtypeid.d
+++ b/test/runnable/testtypeid.d
@@ -18,7 +18,7 @@ FOO3 foox3;
 
 void foo3(int x, ...)
 {
-    printf("%d arguments\n", _arguments.length);
+    printf("%zd arguments\n", _arguments.length);
     for (int i = 0; i < _arguments.length; i++)
     {
         writeln(_arguments[i].toString());
@@ -367,7 +367,7 @@ class Bar32 { long y = 4; }
 
 void printargs(int x, ...)
 {
-    printf("%d arguments\n", _arguments.length);
+    printf("%zd arguments\n", _arguments.length);
     for (int i = 0; i < _arguments.length; i++)
     {
         writeln(_arguments[i].toString());

--- a/test/runnable/wc.d
+++ b/test/runnable/wc.d
@@ -36,14 +36,14 @@ int main (string[] args)
                 inword = 0;
             ++c_cnt;
         }
-        printf ("%8lu%8lu%8lu %.*s\n", l_cnt, w_cnt, c_cnt, arg.length, arg.ptr);
+        printf ("%8u%8u%8u %.*s\n", l_cnt, w_cnt, c_cnt, cast(int)arg.length, arg.ptr);
         l_total += l_cnt;
         w_total += w_cnt;
         c_total += c_cnt;
     }
     if (args.length > 2)
     {
-        printf ("--------------------------------------\n%8lu%8lu%8lu total",
+        printf ("--------------------------------------\n%8u%8u%8u total",
             l_total, w_total, c_total);
     }
     return 0;

--- a/test/runnable/wc2.d
+++ b/test/runnable/wc2.d
@@ -53,7 +53,7 @@ int main (string[] args)
         {   string w = input[wstart .. input.length];
             dictionary[w]++;
         }
-        printf("%8lu%8lu%8lu %.*s\n", l_cnt, w_cnt, c_cnt, arg.length, arg.ptr);
+        printf("%8u%8u%8u %.*s\n", l_cnt, w_cnt, c_cnt, cast(int)arg.length, arg.ptr);
         l_total += l_cnt;
         w_total += w_cnt;
         c_total += c_cnt;
@@ -61,14 +61,14 @@ int main (string[] args)
 
     if (args.length > 2)
     {
-        printf("--------------------------------------\n%8lu%8lu%8lu total",
+        printf("--------------------------------------\n%8u%8u%8u total",
             l_total, w_total, c_total);
     }
 
     printf("--------------------------------------\n");
     foreach (string word1; dictionary.keys)
     {
-        printf("%3d %.*s\n", dictionary[word1], word1.length, word1.ptr);
+        printf("%3d %.*s\n", dictionary[word1], cast(int)word1.length, word1.ptr);
     }
     return 0;
 }

--- a/test/runnable/xtest46.d
+++ b/test/runnable/xtest46.d
@@ -194,7 +194,7 @@ void test7()
 void foo8(int n1 = __LINE__ + 0, int n2 = __LINE__, string s = __FILE__)
 {
     assert(n1 < n2);
-    printf("n1 = %d, n2 = %d, s = %.*s\n", n1, n2, s.length, s.ptr);
+    printf("n1 = %d, n2 = %d, s = %.*s\n", n1, n2, cast(int)s.length, s.ptr);
 }
 
 void test8()
@@ -207,7 +207,7 @@ void test8()
 void foo9(int n1 = __LINE__ + 0, int n2 = __LINE__, string s = __FILE__)()
 {
     assert(n1 < n2);
-    printf("n1 = %d, n2 = %d, s = %.*s\n", n1, n2, s.length, s.ptr);
+    printf("n1 = %d, n2 = %d, s = %.*s\n", n1, n2, cast(int)s.length, s.ptr);
 }
 
 void test9()
@@ -1005,7 +1005,7 @@ struct S49
 
     this( string name )
     {
-        printf( "(ctor) &%.*s.x = %p\n", name.length, name.ptr, &x );
+        printf( "(ctor) &%.*s.x = %p\n", cast(int)name.length, name.ptr, &x );
         p = cast(void*)&x;
     }
 
@@ -1810,7 +1810,7 @@ struct S88
 {
     void opDispatch(string s, T)(T i)
     {
-        printf("S.opDispatch('%.*s', %d)\n", s.length, s.ptr, i);
+        printf("S.opDispatch('%.*s', %d)\n", cast(int)s.length, s.ptr, i);
     }
 }
 
@@ -1818,7 +1818,7 @@ class C88
 {
     void opDispatch(string s)(int i)
     {
-        printf("C.opDispatch('%.*s', %d)\n", s.length, s.ptr, i);
+        printf("C.opDispatch('%.*s', %d)\n", cast(int)s.length, s.ptr, i);
     }
 }
 
@@ -1852,7 +1852,7 @@ void test89() {
         int bar() { return x; }
     }
     X s;
-    printf("%d\n", s.sizeof);
+    printf("%zd\n", s.sizeof);
     assert(s.sizeof == 4);
 }
 
@@ -7020,7 +7020,7 @@ struct Function
 @property void meta(alias m)()
 {
     static Function md;
-    printf("length = %d\n", md.ai.length);
+    printf("length = %zd\n", md.ai.length);
     printf("ptr = %p\n", md.ai.ptr);
     md.ai[0] = 0;
 }
@@ -7888,7 +7888,7 @@ void test16466()
         real r;
     }
     real r;
-    printf("S.alignof: %x, r.alignof: %x\n", S.alignof, r.alignof);
+    printf("S.alignof: %zx, r.alignof: %zx\n", S.alignof, r.alignof);
     assert(S.alignof == r.alignof);
 }
 

--- a/test/runnable/xtestenum.d
+++ b/test/runnable/xtestenum.d
@@ -45,7 +45,7 @@ enum E3 : string
 
 void test3()
 {
-    printf("%.*s\n", E3.E3a.length, E3.E3a.ptr);
+    printf("%.*s\n", cast(int)E3.E3a.length, E3.E3a.ptr);
 
     assert(E3.E3a == "foo");
     assert(E3.E3b == "bar");


### PR DESCRIPTION
This wasn't that hard to do, so I just did it.

I know it needs a changelog.

It currently only works for `printf`, but I'll extend to any function with printf formatting after this is incorporated.
