### PR TITLE
fix issue 20421 - Exceptions don't work when linking through lld-link

### DIFF
--- a/.azure-pipelines/windows-msbuild.bat
+++ b/.azure-pipelines/windows-msbuild.bat
@@ -48,6 +48,13 @@ msbuild /target:dmd /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM% %LDC
 %DMD% --version
 grep --version
 
+rem compile run.d before changing the LIB environment variable
+if "%D_COMPILER%" == "ldc" set HOST_DMD=%LDC_DIR%\bin\ldmd2.exe
+if "%D_COMPILER%" == "dmd" set HOST_DMD=%DMD_DIR%\dmd2\windows\bin\dmd.exe
+
+cd "%DMD_DIR%\test"
+"%HOST_DMD%" -m%MODEL% -i run.d || exit /B 6
+
 set DRUNTIME_TESTS=test_all
 cd "%DMD_DIR%"
 if "%C_RUNTIME%" == "mingw" (
@@ -88,12 +95,7 @@ set OS=windows
 set CC=cl.exe
 set DMD_MODEL=%PLATFORM%
 set BUILD=%CONFIGURATION%
-if "%D_COMPILER%" == "ldc" set HOST_DMD=%LDC_DIR%\bin\ldmd2.exe
-if "%D_COMPILER%" == "dmd" set HOST_DMD=%DMD_DIR%\dmd2\windows\bin\dmd.exe
-
-if "%D_COMPILER%" == "ldc" set RDMD=%LDC_DIR%\bin\rdmd
-if "%D_COMPILER%" == "dmd" set RDMD=%DMD_DIR%\dmd2\windows\bin\rdmd
-"%RDMD%" -m%MODEL% run.d || exit /B 6
+run.exe || exit /B 6
 
 cd "%DMD_DIR%\..\phobos"
 REM Check: build phobos unittests

--- a/.azure-pipelines/windows-msbuild.bat
+++ b/.azure-pipelines/windows-msbuild.bat
@@ -1,3 +1,4 @@
+setlocal
 @echo on
 call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
 @echo on
@@ -15,7 +16,9 @@ set DMD_TESTSUITE_MAKE_ARGS=-j3
 set DM_MAKE=%DMD_DIR%\dm\path\make.exe
 set LDC_DIR=%DMD_DIR%\ldc2-%LDC_VERSION%-windows-multilib
 
-FOR /F "tokens=* USEBACKQ" %%F IN (`where cl.exe`) DO (SET MSVC_CC=%%~fsF)
+REM take the first found cl.exe, in case there was already one in the path when vcvarsall.bat was called
+FOR /F "tokens=* USEBACKQ" %%F IN (`where cl.exe`) DO (SET MSVC_CC=%%~fsF && goto CC_DONE)
+:CC_DONE
 FOR /F "tokens=* USEBACKQ" %%F IN (`where lib.exe`) DO (SET MSVC_AR=%%~fsF)
 REM this returns two lines (GNU's link.exe is on the second line)
 REM Just take the first one
@@ -23,14 +26,6 @@ FOR /F "tokens=* USEBACKQ" %%F IN (`where link.exe`) DO (SET MSVC_LD=%%~fsF
   GOTO :Next)
 :Next
 FOR /F "tokens=* USEBACKQ" %%F IN (`where make.exe`) DO (SET GNU_MAKE=%%~fsF)
-
-REM WORKAROUND: move files to a directory without spaces
-copy "%MSVC_AR%" "%DMD_DIR%\dm\path\lib.exe"
-copy "%MSVC_LD%" "%DMD_DIR%\dm\path\link.exe"
-copy "%MSVC_CC%" "%DMD_DIR%\dm\path\cl.exe"
-set MSVC_AR=%DMD_DIR%\dm\path\lib.exe
-set MSVC_CC=%DMD_DIR%\dm\path\cl.exe
-set MSVC_LD=%DMD_DIR%\dm\path\link.exe
 
 REM expose dm_make as default make
 set PATH=%DMD_DIR%\dm\path;%DMD_DIR%\tools;%PATH%
@@ -53,24 +48,52 @@ msbuild /target:dmd /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM% %LDC
 %DMD% --version
 grep --version
 
+set DRUNTIME_TESTS=test_all
+cd "%DMD_DIR%"
+if "%C_RUNTIME%" == "mingw" (
+    rem install recent LLD and mingw libraries to built dmd
+    powershell -command "& { iwr http://downloads.dlang.org/other/lld-link-9.0.0-seh.zip -OutFile lld.zip }" || exit /B 11
+    7z x lld.zip -o%DMD_DIR%\generated\Windows\%CONFIGURATION%\%PLATFORM% || exit /B 12
+
+    powershell -command "& { iwr https://github.com/dlang/installer/releases/download/mingw-libs-7.0.0-2/mingw-libs-7.0.0-2.zip -OutFile mingw.zip }" || exit /B 13
+    7z x mingw.zip -o%DMD_DIR%\mingw || exit /B 14
+    
+    set DFLAGS=-mscrtlib=msvcrt120
+    set LIB=%DMD_DIR%\mingw\dmd2\windows\lib%MODEL%\mingw
+    set REQUIRED_ARGS=-mscrtlib=msvcrt120 "-L/LIBPATH:%DMD_DIR%\mingw\dmd2\windows\lib%MODEL%\mingw"
+    rem delete C++ ABI tests
+    for /F "tokens=* USEBACKQ" %%F IN (`grep -l EXTRA_CPP_SOURCES test\runnable\*.d`) DO del %%F
+    rem FIXME: debug info incomplete when linking through lld-link
+    del test\runnable\testpdb.d
+
+    set DRUNTIME_TESTS=test_mingw
+)
+
 REM Check: run druntime unittests
 cd "%DMD_DIR%\..\druntime"
 "%DM_MAKE%" -f win64.mak MODEL=%MODEL% "DMD=%DMD%" "VCDIR=%VCINSTALLDIR%." "CC=%MSVC_CC%" "MAKE=%DM_MAKE%" target || exit /B 2
 echo "[DRUNTIME] running tests..."
 "%DM_MAKE%" -f win64.mak MODEL=%MODEL% "DMD=%DMD%" "VCDIR=%VCINSTALLDIR%." "CC=%MSVC_CC%" "MAKE=%DM_MAKE%" unittest || exit /B 3
-"%DM_MAKE%" -f win64.mak MODEL=%MODEL% "DMD=%DMD%" "VCDIR=%VCINSTALLDIR%." "CC=%MSVC_CC%" "MAKE=%DM_MAKE%" test_all || exit /B 4
+"%DM_MAKE%" -f win64.mak MODEL=%MODEL% "DMD=%DMD%" "VCDIR=%VCINSTALLDIR%." "CC=%MSVC_CC%" "MAKE=%DM_MAKE%" %DRUNTIME_TESTS% || exit /B 4
 
 REM Check: build phobos
 cd "%DMD_DIR%\..\phobos"
 "%DM_MAKE%" -f win64.mak MODEL=%MODEL% "DMD=%DMD%" "VCDIR=%VCINSTALLDIR%." "CC=%MSVC_CC%" "AR=%MSVC_AR%" "MAKE=%DM_MAKE%" || exit /B 5
 
-REM Build DMD VERSION + string imports (not built by VisualD)
-copy "%DMD_DIR%\VERSION" "%DMD_DIR%\generated\Windows\Release\Win32\VERSION"
-
 REM Run DMD testsuite
 cd "%DMD_DIR%\test"
 cp %DMD_DIR%\..\phobos\phobos%MODEL%.lib .
-"%GNU_MAKE%" -j%NUMBER_OF_PROCESSORS% all MODEL=%MODEL% ARGS="-O -inline -g" OS=windows DMD="%DMD%" "CC=%MSVC_CC%" DMD_MODEL=%PLATFORM% BUILD=%CONFIGURATION% || exit /B 6
+set ARGS=-O -inline -g
+set OS=windows
+set CC=cl.exe
+set DMD_MODEL=%PLATFORM%
+set BUILD=%CONFIGURATION%
+if "%D_COMPILER%" == "ldc" set HOST_DMD=%LDC_DIR%\bin\ldmd2.exe
+if "%D_COMPILER%" == "dmd" set HOST_DMD=%DMD_DIR%\dmd2\windows\bin\dmd.exe
+
+if "%D_COMPILER%" == "ldc" set RDMD=%LDC_DIR%\bin\rdmd
+if "%D_COMPILER%" == "dmd" set RDMD=%DMD_DIR%\dmd2\windows\bin\rdmd
+"%RDMD%" -m%MODEL% run.d || exit /B 6
 
 cd "%DMD_DIR%\..\phobos"
 REM Check: build phobos unittests

--- a/.azure-pipelines/windows-visual-studio.sh
+++ b/.azure-pipelines/windows-visual-studio.sh
@@ -53,10 +53,9 @@ dm_make() {
     cp "$DMC" "$DM_MAKE" "dm/path"
 }
 
-if [ "$D_COMPILER" == "dmd" ]; then
-    echo "[STEP]: Downloading DMD"
-    install_host_dmd
-elif [ "$D_COMPILER" == "ldc" ]; then
+echo "[STEP]: Downloading DMD"
+install_host_dmd
+if [ "$D_COMPILER" == "ldc" ]; then
     echo "[STEP]: Downloading LDC"
     ldc
 fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
     strategy:
       matrix:
-        x64-debug-ldc:
+        win32-ldc:
           OS: Win_32
           MODEL: 32mscoff
           ARCH: x86

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ jobs:
           D_COMPILER: dmd
     steps:
       - template: .azure-pipelines/windows.yml
+
   - job: Windows_OMF
     timeoutInMinutes: 120
     pool:
@@ -32,6 +33,7 @@ jobs:
           D_COMPILER: dmd
     steps:
       - template: .azure-pipelines/windows.yml
+
   - job: Windows_VisualD
     timeoutInMinutes: 120
     pool:
@@ -46,11 +48,11 @@ jobs:
           ARCH: x86
           D_COMPILER: ldc
           VISUALD_VER: v0.49.0
-          LDC_VERSION: 1.19.0
+          LDC_VERSION: 1.20.0
     steps:
       - template: .azure-pipelines/windows-visual-studio.yml
 
-  - job: Windows_VisualD_Debug
+  - job: Windows_LDC_Debug
     timeoutInMinutes: 120
     pool:
       vmImage: 'vs2017-win2016'
@@ -65,6 +67,25 @@ jobs:
           CONFIGURATION: Debug
           D_COMPILER: ldc
           VISUALD_VER: v0.49.0
-          LDC_VERSION: 1.19.0
+          LDC_VERSION: 1.20.0
+    steps:
+      - template: .azure-pipelines/windows-visual-studio.yml
+
+  - job: Windows_LDC_MinGW
+    timeoutInMinutes: 120
+    pool:
+      vmImage: 'vs2017-win2016'
+    variables:
+      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+    strategy:
+      matrix:
+        x64-debug-ldc:
+          OS: Win_32
+          MODEL: 32mscoff
+          ARCH: x86
+          D_COMPILER: ldc
+          C_RUNTIME: mingw
+          VISUALD_VER: v0.49.0
+          LDC_VERSION: 1.20.0
     steps:
       - template: .azure-pipelines/windows-visual-studio.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ jobs:
       vmImage: 'vs2017-win2016'
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+      HOST_DMD_VERSION: 2.090.0
     strategy:
       matrix:
         win32-ldc:
@@ -58,6 +59,7 @@ jobs:
       vmImage: 'vs2017-win2016'
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+      HOST_DMD_VERSION: 2.090.0
     strategy:
       matrix:
         x64-debug-ldc:
@@ -77,6 +79,7 @@ jobs:
       vmImage: 'vs2017-win2016'
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
+      HOST_DMD_VERSION: 2.090.0
     strategy:
       matrix:
         win32-ldc:

--- a/test/compilable/traits.d
+++ b/test/compilable/traits.d
@@ -18,7 +18,8 @@ class C19152
 static assert(is(typeof(__traits(getTargetInfo, "cppRuntimeLibrary")) == string));
 version (CppRuntime_Microsoft)
 {
-    static assert(__traits(getTargetInfo, "cppRuntimeLibrary") == "libcmt");
+    static assert(__traits(getTargetInfo, "cppRuntimeLibrary") == "libcmt" ||
+                  __traits(getTargetInfo, "cppRuntimeLibrary")[0..6] == "msvcrt"); // includes mingw import libs
 }
 
 version (D_HardFloat)
@@ -66,16 +67,16 @@ version(Windows)
     static assert(__traits(getLocation, MyStruct)[0] == `compilable\traits.d`);
 else
     static assert(__traits(getLocation, MyStruct)[0] == "compilable/traits.d");
-static assert(__traits(getLocation, MyStruct)[1] == 39);
+static assert(__traits(getLocation, MyStruct)[1] == 40);
 static assert(__traits(getLocation, MyStruct)[2] == 1);
 
 int foo();
 int foo(int);
 
-static assert(__traits(getLocation, __traits(getOverloads, traits, "foo")[1])[1] == 73);
+static assert(__traits(getLocation, __traits(getOverloads, traits, "foo")[1])[1] == 74);
 
 mixin("int bar;");
-static assert(__traits(getLocation, bar)[1] == 77);
+static assert(__traits(getLocation, bar)[1] == 78);
 
 struct Outer
 {
@@ -83,8 +84,8 @@ struct Outer
 
     void method() {}
 }
-static assert(__traits(getLocation, Outer.Nested)[1] == 82);
-static assert(__traits(getLocation, Outer.method)[1] == 84);
+static assert(__traits(getLocation, Outer.Nested)[1] == 83);
+static assert(__traits(getLocation, Outer.method)[1] == 85);
 
 /******************************************/
 // https://issues.dlang.org/show_bug.cgi?id=19902

--- a/test/run.d
+++ b/test/run.d
@@ -236,6 +236,7 @@ void ensureToolsExists(string[string] env, const TestTool[] tools ...)
             {
                 command = [
                     hostDMD,
+                    "-m"~env["MODEL"],
                     "-of"~targetBin,
                     sourceFile
                 ] ~ tool.extraArgs;

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -978,7 +978,6 @@ int tryMain(string[] args)
                         (testArgs.mode == TestMode.RUN || testArgs.link ? "" : "-c "),
                         join(testArgs.sources, " "),
                         (autoCompileImports ? "-i" : join(testArgs.compiledImports, " ")));
-                version(Windows) command ~= " -map nul.map";
 
                 compile_output = execute(fThisRun, command, testArgs.mode != TestMode.FAIL_COMPILE, result_path);
             }
@@ -1001,7 +1000,6 @@ int tryMain(string[] args)
                         autoCompileImports ? " -i" : "",
                         autoCompileImports ? "extraSourceIncludePaths" : "",
                         envData.required_args, testArgs.requiredArgsForLink, output_dir, test_app_dmd, join(toCleanup, " "));
-                    version(Windows) command ~= " -map nul.map";
 
                     execute(fThisRun, command, true, result_path);
                 }


### PR DESCRIPTION
when linking through lld-link, add /SAFESEH:NO to linker command line

add build on azure that uses lld and mingw import libraries
use run.d instead of gmake to run tests
d_do_test: remove legacy command line "-map nul.map"
update to build with LDC 1.20.0

This adds to https://github.com/dlang/installer/pull/433, some druntime fixes still necessary...