### PR TITLE
Made some fixes to the dtoh stuff out of the gate

### DIFF
--- a/test/compilable/dtoh_AliasDeclaration.d
+++ b/test/compilable/dtoh_AliasDeclaration.d
@@ -9,28 +9,13 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_AliasDeclaration
@@ -38,15 +23,15 @@ struct S;
 struct S2;
 class C;
 class C2;
-typedef _d_int T;
+typedef int32_t T;
 
-extern "C" _d_int x;
+extern "C" int32_t x;
 
 // ignored variable dtoh_AliasDeclaration.x
-extern "C" _d_int foo(_d_int x);
+extern "C" int32_t foo(int32_t x);
 
 // ignored function dtoh_AliasDeclaration.foo
-extern _d_int foo2(_d_int x);
+extern int32_t foo2(int32_t x);
 
 // ignored function dtoh_AliasDeclaration.foo2
 struct S;

--- a/test/compilable/dtoh_AnonDeclaration.d
+++ b/test/compilable/dtoh_AnonDeclaration.d
@@ -9,28 +9,13 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_AnonDeclaration
@@ -38,15 +23,15 @@ struct S
 {
     union
     {
-        _d_int x;
-        _d_char c[4$?:32=u|64=LLU$];
+        int32_t x;
+        char c[4$?:32=u|64=LLU$];
     };
     struct
     {
-        _d_int y;
-        _d_double z;
-        extern "C" _d_void foo();
-        _d_void bar();
+        int32_t y;
+        double z;
+        extern "C" void foo();
+        void bar();
     };
     S() {}
 };

--- a/test/compilable/dtoh_ClassDeclaration.d
+++ b/test/compilable/dtoh_ClassDeclaration.d
@@ -9,28 +9,13 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_ClassDeclaration
@@ -40,64 +25,64 @@ struct Inner;
 class C
 {
 public:
-    _d_byte a;
-    _d_int b;
-    _d_long c;
+    int8_t a;
+    int32_t b;
+    int64_t c;
 };
 
 class C2
 {
 public:
-    _d_int a;
-    _d_int b;
-    _d_long c;
-    C2(_d_int a);
+    int32_t a;
+    int32_t b;
+    int64_t c;
+    C2(int32_t a);
 };
 
 // ignoring non-cpp class C3
 class Aligned
 {
 public:
-    _d_byte a;
-    _d_int b;
-    _d_long c;
-    Aligned(_d_int a);
+    int8_t a;
+    int32_t b;
+    int64_t c;
+    Aligned(int32_t a);
 };
 
 class A
 {
 public:
-    _d_int a;
+    int32_t a;
     C* c;
-    virtual _d_void foo();
-    extern "C" virtual _d_void bar();
-    virtual _d_void baz(_d_int x = 42);
+    virtual void foo();
+    extern "C" virtual void bar();
+    virtual void baz(int32_t x = 42);
     struct
     {
-        _d_int x;
-        _d_int y;
+        int32_t x;
+        int32_t y;
     };
     union
     {
-        _d_int u1;
-        _d_char u2[4$?:32=u|64=LLU$];
+        int32_t u1;
+        char u2[4$?:32=u|64=LLU$];
     };
 struct Inner
 {
-    _d_int x;
+    int32_t x;
     Inner() : x() {}
 };
 
 class InnerC
 {
 public:
-    _d_int x;
+    int32_t x;
 };
 
 class NonStaticInnerC
 {
 public:
-    _d_int x;
+    int32_t x;
     A* this;
 };
 

--- a/test/compilable/dtoh_StructDeclaration.d
+++ b/test/compilable/dtoh_StructDeclaration.d
@@ -9,28 +9,13 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_StructDeclaration
@@ -38,27 +23,27 @@ struct S;
 struct Inner;
 struct S
 {
-    _d_byte a;
-    _d_int b;
-    _d_long c;
+    int8_t a;
+    int32_t b;
+    int64_t c;
     S() : a(), b(), c() {}
 };
 
 struct S2
 {
-    _d_int a;
-    _d_int b;
-    _d_long c;
-    S2(_d_int a);
+    int32_t a;
+    int32_t b;
+    int64_t c;
+    S2(int32_t a);
     S2() : a(42), b(), c() {}
 };
 
 struct S3
 {
-    _d_int a;
-    _d_int b;
-    _d_long c;
-    extern "C" S3(_d_int a);
+    int32_t a;
+    int32_t b;
+    int64_t c;
+    extern "C" S3(int32_t a);
     S3() : a(42), b(), c() {}
 };
 
@@ -72,10 +57,10 @@ struct
 #endif
 Aligned
 {
-    _d_byte a;
-    _d_int b;
-    _d_long c;
-    Aligned(_d_int a);
+    int8_t a;
+    int32_t b;
+    int64_t c;
+    Aligned(int32_t a);
     Aligned() : a(), b(), c() {}
 };
 #if defined(__DMC__)
@@ -84,24 +69,24 @@ Aligned
 
 struct A
 {
-    _d_int a;
+    int32_t a;
     S s;
     // ignoring extern () block because of linkage
-    extern "C" _d_void bar();
-    _d_void baz(_d_int x = 42);
+    extern "C" void bar();
+    void baz(int32_t x = 42);
     struct
     {
-        _d_int x;
-        _d_int y;
+        int32_t x;
+        int32_t y;
     };
     union
     {
-        _d_int u1;
-        _d_char u2[4$?:32=u|64=LLU$];
+        int32_t u1;
+        char u2[4$?:32=u|64=LLU$];
     };
 struct Inner
 {
-    _d_int x;
+    int32_t x;
     Inner() : x() {}
 };
 

--- a/test/compilable/dtoh_TemplateDeclaration.d
+++ b/test/compilable/dtoh_TemplateDeclaration.d
@@ -9,28 +9,13 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_TemplateDeclaration
@@ -44,7 +29,7 @@ struct A
 
 struct B
 {
-    A<_d_int> x;
+    A<int32_t> x;
     B() : x() {}
 };
 ---

--- a/test/compilable/dtoh_VarDeclaration.d
+++ b/test/compilable/dtoh_VarDeclaration.d
@@ -9,36 +9,21 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_VarDeclaration
 // ignoring variable dtoh_VarDeclaration.x because of linkage
 // ignoring variable dtoh_VarDeclaration.y because of linkage
-extern "C" _d_int z;
+extern "C" int32_t z;
 
-extern _d_int t;
+extern int32_t t;
 
 struct S;
 

--- a/test/compilable/dtoh_enum.d
+++ b/test/compilable/dtoh_enum.d
@@ -9,28 +9,13 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_enum

--- a/test/compilable/dtoh_functions.d
+++ b/test/compilable/dtoh_functions.d
@@ -9,45 +9,30 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_functions
 // ignoring function dtoh_functions.foo because of linkage
 // ignoring function dtoh_functions.fun because it's extern
 // ignoring function dtoh_functions.fun2 because it's extern
-extern "C" _d_int bar(_d_int x);
+extern "C" int32_t bar(int32_t x);
 
-extern "C" _d_int bar2(_d_int x);
+extern "C" int32_t bar2(int32_t x);
 
-extern "C" _d_int bar4(_d_int x = 42);
+extern "C" int32_t bar4(int32_t x = 42);
 
-extern _d_int baz(_d_int x);
+extern int32_t baz(int32_t x);
 
-extern _d_int baz2(_d_int x);
+extern int32_t baz2(int32_t x);
 
-extern _d_int baz3(_d_int x = 42);
+extern int32_t baz3(int32_t x = 42);
 ---
 */
 

--- a/test/compilable/dtoh_unittest_block.d
+++ b/test/compilable/dtoh_unittest_block.d
@@ -9,28 +9,13 @@ TEST_OUTPUT:
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#define _d_void void
-#define _d_bool bool
-#define _d_byte signed char
-#define _d_ubyte unsigned char
-#define _d_short short
-#define _d_ushort unsigned short
-#define _d_int int
-#define _d_uint unsigned
-#define _d_long $?:32=long long|64=long$
-#define _d_ulong unsigned $?:32=long long|64=long$
-#define _d_float float
-#define _d_double double
-#define _d_real long double
-#define _d_char char
-#define _d_wchar wchar_t
-#define _d_dchar unsigned
-typedef _d_long d_int64;
-
-#define _d_null NULL
+#if !defined(_d_real)
+# define _d_real long double
+#endif
 
 
 // Parsing module dtoh_unittest_block


### PR DESCRIPTION
* Removed a bunch of pointless macros
* Fixed `long`, `long long`, `wchar_t`

There is no world where the D types don't match the C sized types. There is no reason to give them pointless macro names, it just interferes with the cut-and-paste-ibility of the generated C code.

`wchar`/`dchar` are `char16_t`/`char32_t`, as defined by the mangling.
There is no world where `void` doesn't mean `void`.
Since we accepted C++11 as a min-spec a year or so back (by removing support for pre-`char16_t` types, etc), then we can safely assume `nullptr`. In the rare event a users C code is pre-C++11, they can `#define nullptr NULL` as they like.