### PR TITLE
[RFC] Let tests include generated files in TEST_OUTPUT check

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -211,6 +211,23 @@ The following is a list of all available settings:
     LINK:                enables linking (used for the compilable and fail_compilable tests).
                          default: (none)
 
+    OUTPUT_FILES:       files generated during the compilation (separated by ';').
+                        The content of each file is appended to the output of the
+                        compilation (in the order of this list) according to the HAR
+                        format (https://code.dlang.org/packages/har).
+                        Example:
+                        ------------------------------------------
+                        <Compilation Output>
+                        --- <FILENAME_1>
+                        <CONTENT_1>
+                        --- <FILENAME_2>
+                        <CONTENT_2>
+                        [...]
+                        ------------------------------------------
+                        The merged output will then be prepared and compared to the
+                        expected TEST_OUTPUT as defined below.
+                        default: (none)
+
     TEST_OUTPUT:         the output is expected from the compilation (if the
                          output of the compilation doesn't match, the test
                          fails). You can use the this format for multi-line

--- a/test/compilable/extra-files/json2.out
+++ b/test/compilable/extra-files/json2.out
@@ -1,3 +1,4 @@
+--- ${RESULTS_DIR}/compilable/json2.out
 {
     "buildInfo": {
         "argv0": "VALUE_REMOVED_FOR_TEST",

--- a/test/compilable/json2.d
+++ b/test/compilable/json2.d
@@ -1,9 +1,9 @@
 /*
 PERMUTE_ARGS:
 REQUIRED_ARGS: -d -o- -Xf=${RESULTS_DIR}/compilable/json2.out -Xi=compilerInfo -Xi=buildInfo -Xi=modules -Xi=semantics
-POST_SCRIPT: compilable/extra-files/json-postscript.sh
-TEST_OUTPUT:
----
----
+OUTPUT_FILES: ${RESULTS_DIR}/compilable/json2.out
+TRANSFORM_OUTPUT: sanitize_json
+TEST_OUTPUT_FILE: extra-files/json2.out
 */
+
 import json;

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -81,6 +81,7 @@ struct TestArgs
     string   gdbScript;
     string   gdbMatch;
     string   postScript;
+    string[] outputFiles; /// generated files appended to the compilation output
     string   transformOutput; /// Transformations for the compiler output
     string   requiredArgs;
     string   requiredArgsForLink;
@@ -377,6 +378,10 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     }
     else
         findOutputParameter(file, "TEST_OUTPUT", testArgs.compileOutput, envData.sep);
+
+    string outFilesStr;
+    findTestParameter(envData, file, "OUTPUT_FILES", outFilesStr);
+    testArgs.outputFiles = outFilesStr.split(';');
 
     findTestParameter(envData, file, "TRANSFORM_OUTPUT", testArgs.transformOutput);
 
@@ -1126,19 +1131,56 @@ int tryMain(string[] args)
                 }
             }
 
-            compile_output = compile_output.unifyNewLine();
-            compile_output = std.regex.replaceAll(compile_output, regex(`^DMD v2\.[0-9]+.*\n? DEBUG$`, "m"), "");
-            compile_output = std.string.strip(compile_output);
-            // replace test_result path with fixed ones
-            compile_output = compile_output.replace(result_path, resultsDirReplacement);
-            compile_output = compile_output.replace(absoluteResultDirPath, resultsDirReplacement);
+            void prepare(ref string compile_output)
+            {
+                if (compile_output.empty)
+                    return;
+
+                compile_output = compile_output.unifyNewLine();
+                compile_output = std.regex.replaceAll(compile_output, regex(`^DMD v2\.[0-9]+.*\n? DEBUG$`, "m"), "");
+                compile_output = std.string.strip(compile_output);
+                // replace test_result path with fixed ones
+                compile_output = compile_output.replace(result_path, resultsDirReplacement);
+                compile_output = compile_output.replace(absoluteResultDirPath, resultsDirReplacement);
+
+                compile_output.applyOutputTransformations(testArgs.transformOutput);
+            }
+
+            prepare(compile_output);
 
             auto m = std.regex.match(compile_output, `Internal error: .*$`);
             enforce(!m, m.hit);
             m = std.regex.match(compile_output, `core.exception.AssertError@dmd.*`);
             enforce(!m, m.hit);
 
-            compile_output.applyOutputTransformations(testArgs.transformOutput);
+            // Prepare and append the content of each OUTPUT_FILE conforming to
+            // the HAR (https://code.dlang.org/packages/har) format, e.g.
+            // --- <FILENAME_1>
+            // <CONTENT_1>
+            // --- <FILENAME_2>
+            // <CONTENT_2>
+            // ...
+            foreach (const outfile; testArgs.outputFiles)
+            {
+                string path = outfile;
+                replaceResultsDir(path, envData);
+
+                // Don't abort if a file is missing, at least verify the remaining output.
+                string content = readText(path).ifThrown("<< File missing >>");
+                prepare(content);
+
+                // Make sure file starts on a new line
+                if (!compile_output.empty && !compile_output.endsWith("\n"))
+                    compile_output ~= '\n';
+
+                // Prepend a header listing the explicit file
+                compile_output.reserve(outfile.length + content.length + 5);
+
+                compile_output ~= "--- ";
+                compile_output ~= outfile;
+                compile_output ~= '\n';
+                compile_output ~= content;
+            }
 
             if (!compareOutput(compile_output, testArgs.compileOutput, envData))
             {


### PR DESCRIPTION
Test may list files generated during compilation in the `OUTPUT_FILES` variable. Each file will be appended to the output of the compilation before the joined output is preprocessed and compared to the expected `TEST_OUTPUT` as usual.

Refer to the second commit for an example.