### PR TITLE
Fix asttypename.d utility

### DIFF
--- a/src/dmd/asttypename.d
+++ b/src/dmd/asttypename.d
@@ -10,6 +10,7 @@
 
 module dmd.asttypename;
 
+import dmd.ast_node;
 import dmd.attrib;
 import dmd.aliasthis;
 import dmd.aggregate;
@@ -51,8 +52,8 @@ string astTypeName(RootObject node)
             return "RootObject";
         case DYNCAST.identifier:
             return "Identifier";
-        case DYNCAST.templateparameter:
-            return "TemplateParameter";
+        case DYNCAST.tuple:
+            return "Tuple";
 
         case DYNCAST.expression:
             return astTypeName(cast(Expression) node);
@@ -60,14 +61,14 @@ string astTypeName(RootObject node)
             return astTypeName(cast(Dsymbol) node);
         case DYNCAST.type:
             return astTypeName(cast(Type) node);
-        case DYNCAST.tuple:
-            return astTypeName(cast(Tuple) node);
         case DYNCAST.parameter:
             return astTypeName(cast(Parameter) node);
         case DYNCAST.statement:
             return astTypeName(cast(Statement) node);
         case DYNCAST.condition:
             return astTypeName(cast(Condition) node);
+        case DYNCAST.templateparameter:
+            return astTypeName(cast(TemplateParameter) node);
     }
 }
 
@@ -80,7 +81,7 @@ mixin
     {
         static if (is(typeof(ov) P == function))
         {
-            static if (is(P[0] S == super) && is(S[0] == RootObject))
+            static if (is(P[0] S == super) && is(S[0] == ASTNode))
             {
                 astTypeNameFunctions ~= `
 string astTypeName(` ~ P[0].stringof ~ ` node)
@@ -115,5 +116,9 @@ unittest
 {
     import dmd.globals : Loc;
     Expression e = new TypeidExp(Loc.initial, null);
+    Tuple t = new Tuple();
+    TemplateTypeParameter tp = new TemplateTypeParameter(Loc.initial, null, null, null);
     assert(e.astTypeName == "TypeidExp");
+    assert(t.astTypeName == "Tuple");
+    assert(tp.astTypeName == "TemplateTypeParameter");
 }


### PR DESCRIPTION
Not working since ASTNode replaced RootObject as base in almost everything.