### PR TITLE
Fix issue 20607 - Module constructors are visible as regular function

### DIFF
--- a/changelog/module-ctor-vis.dd
+++ b/changelog/module-ctor-vis.dd
@@ -1,0 +1,22 @@
+Module constructor and destructors are now anonymous
+
+Module constructor and destructor (shared or not) used to be accessible through
+a special name in the user's scope, hence the following code would happily compile and run:
+
+```
+--- b.d
+module b;
+shared static this () {} // Line 2
+--- a.d
+module a;
+import b;
+shared static ~this () {} // Line 3
+void main ()
+{
+    _sharedStaticDtor_L2_C1(); // Invoke module 'a' shared static dtor
+    _sharedStaticCtor_L3_C1(); // Invoke module 'b' shared static ctor
+}
+```
+
+Those identifiers have now been removed, hence they won't be callable directly,
+nor will they show up in `__traits(allMembers, mixin(__MODULE__))`.

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -738,6 +738,10 @@ extern (C++) class Dsymbol : ASTNode
         parent = sds;
         if (isAnonymous()) // no name, so can't add it to symbol table
             return;
+        // Symbol should not be visible, even within the module
+        // This happens for e.g. compiler-generated symbols
+        if (this.prot().kind == Prot.Kind.none)
+            return;
 
         if (!sds.symtabInsert(this)) // if name is already defined
         {

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -3240,8 +3240,14 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         else
             funcdecl.linkage = sc.linkage;
         funcdecl.inlining = sc.inlining;
-        funcdecl.protection = sc.protection;
         funcdecl.userAttribDecl = sc.userAttribDecl;
+
+        // Symbols which shouldn't be visible to the user under their identifer,
+        // e.g. `[shared] static [~]this`, `invariant`, or `unittest`
+        // can be marked as such with Prot.none in their constructor
+        // so they won't be inserted in the symtab.
+        if (funcdecl.prot().kind != Prot.Kind.none)
+            funcdecl.protection = sc.protection;
 
         if (!funcdecl.originalType)
             funcdecl.originalType = funcdecl.type.syntaxCopy();

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3666,6 +3666,7 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
     extern (D) private this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
+        this.protection = Prot(Prot.Kind.none);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)
@@ -3753,6 +3754,7 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
     extern (D) private this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
+        this.protection = Prot(Prot.Kind.none);
     }
 
     override Dsymbol syntaxCopy(Dsymbol s)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -3659,10 +3659,11 @@ extern (C++) class StaticCtorDeclaration : FuncDeclaration
 {
     extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
     {
-        super(loc, endloc, Identifier.generateIdWithLoc("_staticCtor", loc), STC.static_ | stc, null);
+        this(loc, endloc, "_staticCtor", stc);
     }
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
+    /// Exposing the `name` is needed for `SharedStaticCtorDeclaration`
+    extern (D) private this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }
@@ -3745,10 +3746,11 @@ extern (C++) class StaticDtorDeclaration : FuncDeclaration
 
     extern (D) this(const ref Loc loc, const ref Loc endloc, StorageClass stc)
     {
-        super(loc, endloc, Identifier.generateIdWithLoc("_staticDtor", loc), STC.static_ | stc, null);
+        this(loc, endloc, "_staticDtor", stc);
     }
 
-    extern (D) this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
+    /// Exposing the `name` is needed for `SharedStaticDtorDeclaration`
+    extern (D) private this(const ref Loc loc, const ref Loc endloc, string name, StorageClass stc)
     {
         super(loc, endloc, Identifier.generateIdWithLoc(name, loc), STC.static_ | stc, null);
     }

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1457,7 +1457,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
                 // https://issues.dlang.org/show_bug.cgi?id=10096
                 // https://issues.dlang.org/show_bug.cgi?id=10100
                 // Skip over internal members in __traits(allMembers)
-                if ((sm.isCtorDeclaration() && sm.ident != Id.ctor) ||
+                if (sm.prot().kind == Prot.Kind.none ||
+                    (sm.isCtorDeclaration() && sm.ident != Id.ctor) ||
                     (sm.isDtorDeclaration() && sm.ident != Id.dtor) ||
                     (sm.isPostBlitDeclaration() && sm.ident != Id.postblit) ||
                     sm.isInvariantDeclaration() ||

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -11,6 +11,7 @@
                 "kind": "function",
                 "line": 13,
                 "name": "_staticCtor_L13_C1",
+                "protection": "none",
                 "storageClass": [
                     "static"
                 ]
@@ -23,6 +24,7 @@
                 "kind": "function",
                 "line": 15,
                 "name": "_staticDtor_L15_C1",
+                "protection": "none",
                 "storageClass": [
                     "static"
                 ]

--- a/test/fail_compilation/fail20607.d
+++ b/test/fail_compilation/fail20607.d
@@ -1,0 +1,88 @@
+/*
+TEST_OUTPUT:
+---
+tuple("object", "shared_ctor", "ctor", "Bar", "foobar", "main", "_d_run_main", "_Dmain")
+fail_compilation/fail20607.d(153): Error: undefined identifier `_sharedStaticCtor_L102_C1`
+fail_compilation/fail20607.d(154): Error: undefined identifier `_staticCtor_L108_C1`
+fail_compilation/fail20607.d(155): Error: undefined identifier `_sharedStaticDtor_L115_C1`
+fail_compilation/fail20607.d(156): Error: undefined identifier `_staticDtor_L119_C1`
+fail_compilation/fail20607.d(157): Error: function expected before `()`, not `__unittest_L126_C1`
+fail_compilation/fail20607.d(162): Error: no property `__invariant` for type `Bar`, did you mean `fail20607.Bar.__invariant1`?
+---
+*/
+
+// This line statement is really important, since the name of the ctors/dtors
+// and unittests depend on the line number
+#line 100
+// Ctors
+immutable bool shared_ctor;
+shared static this ()
+{
+    assert(!shared_ctor);
+    shared_ctor = true;
+}
+__gshared bool ctor;
+static this ()
+{
+    assert(shared_ctor);
+    assert(!ctor);
+    ctor = true;
+}
+// Dtors
+shared static ~this ()
+{
+    assert(shared_ctor);
+}
+static ~this ()
+{
+    assert(shared_ctor);
+    assert(ctor);
+    ctor = false;
+}
+
+unittest // This shouldn't be visible
+{
+    int x;
+    assert(x == 42);
+}
+
+struct Bar
+{
+    invariant() // Neither should this
+    {
+        assert(false);
+    }
+}
+
+int foobar()
+out
+{
+    assert(__result == 42); // Or this
+}
+do
+{
+    return 42;
+}
+
+void main ()
+{
+    pragma(msg, __traits(allMembers, mixin(__MODULE__)));
+    _sharedStaticCtor_L102_C1();
+    _staticCtor_L108_C1();
+    _sharedStaticDtor_L115_C1();
+    _staticDtor_L119_C1();
+    __unittest_L126_C1();
+
+    Bar b = Bar.init; // Bypass invariant
+    b.__invariant1();
+    // This should test that `impHint` does not know about hidden symbols
+    b.__invariant();
+
+    // Note: The following, along with the `out` contract test,
+    // the invariant, and the unittest, should fail.
+    // However this requires a more significant refactor.
+    // This issue is also present in foreach (with temporaries),
+    // and people might rely on it.
+    _d_run_main(0, null, null);
+    _Dmain(null);
+}


### PR DESCRIPTION
Contain two small refactorings, and an actual fix.

Side note: `__traits(allMembers)` is quite inconsistent: It shows the ctors / dtors, some hidden symbols like `_Dmain` and the `object` import, but not `__invariant1` (when used on `Bar`) or `__unittest_L126_C1`. And honestly I can see more reasons to call the unittest function directly than to call the `[shared] static [~]this`...