### PR TITLE
[RFC] Allow filtering compilation output using a regex

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -228,11 +228,18 @@ The following is a list of all available settings:
                         default: (none)
 
     TRANSFORM_OUTPUT:   steps to apply to the output of the compilation before it
-                        is compared to the expected TEST_OUTPUT.
+                        is compared to the expected TEST_OUTPUT. A step may take
+                        arguments akin to a function call, e.g. `step(arg)` and arguments
+                        may be quoted using "".
 
                         Supported transformations:
                         - sanitize_json:    Remove compiler specific information from output
                                             of -Xi (see test/tools/sanitize_json.d)
+                                            arguments: none
+
+                        - remove_lines:     Remove lines matching a given regex
+                                            arguments: the regex
+                                            note: patterns containing ')' must be quoted
 
     POST_SCRIPT:         name of script to execute after test run
                          note: arguments to the script may be included after the name.

--- a/test/fail_compilation/fail15616b.d
+++ b/test/fail_compilation/fail15616b.d
@@ -1,5 +1,7 @@
 /*
 REQUIRED_ARGS: -v
+TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|semantic|entry|\s*$)")
+TEST_OUTPUT:
 ---
 fail_compilation/fail15616b.d(44): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
 fail_compilation/fail15616b.d(17):        `fail15616b.foo(int a)`
@@ -8,11 +10,24 @@ fail_compilation/fail15616b.d(29):        `fail15616b.foo(int a, int b, int c)`
 fail_compilation/fail15616b.d(32):        `fail15616b.foo(string a)`
 fail_compilation/fail15616b.d(35):        `fail15616b.foo(string a, string b)`
 fail_compilation/fail15616b.d(38):        `fail15616b.foo(string a, string b, string c)`
-fail_compilation/fail15616b.d(23):        `fail15616b.foo(T)(T a) if (is(T == float))`
-fail_compilation/fail15616b.d(26):        `fail15616b.foo(T)(T a) if (is(T == char))`
+fail_compilation/fail15616b.d(23):        `foo(T)(T a)`
+  with `T = double`
+  whose parameters have the following constraints:
+  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+`  > is(T == float)
+`  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+fail_compilation/fail15616b.d(26):        `foo(T)(T a)`
+  with `T = double`
+  whose parameters have the following constraints:
+  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+`  > is(T == char)
+`  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+fail_compilation/fail15616b.d(44):        All possible candidates are marked as `deprecated` or `@disable`
+  Tip: not satisfied constraints are marked with `>`
 ---
 */
 
+#line 17
 void foo(int a)
 {}
 


### PR DESCRIPTION
This adds `remove_lines_regex` as an option for `TRANSFORM_OUTPUT` to remove lines matching a given regex. This is an opt-in alternative to `remove_lines` because compilation output usually contains a lot of reserved character and hence would require escapes.

Refer to the last commit for an example.