### PR TITLE
Preserve the original type for AliasDeclarations

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -6314,6 +6314,10 @@ void aliasSemantic(AliasDeclaration ds, Scope* sc)
     scope(exit)
         sc.flags &= ~SCOPE.alias_;
 
+    // preserve the original type
+    if (!ds.originalType && ds.type)
+        ds.originalType = ds.type.syntaxCopy();
+
     if (ds.aliassym)
     {
         auto fd = ds.aliassym.isFuncLiteralDeclaration();

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -686,21 +686,24 @@
                 "file": "VALUE_REMOVED_FOR_TEST",
                 "kind": "alias",
                 "line": 145,
-                "name": "b0"
+                "name": "b0",
+                "originalType": "a"
             },
             {},
             {
                 "char": 1,
                 "kind": "alias",
                 "line": 145,
-                "name": "b1"
+                "name": "b1",
+                "originalType": "a"
             },
             {},
             {
                 "char": 1,
                 "kind": "alias",
                 "line": 145,
-                "name": "b2"
+                "name": "b2",
+                "originalType": "a"
             },
             {
                 "char": 9,
@@ -937,6 +940,14 @@
                         "name": "n"
                     }
                 ]
+            },
+            {
+                "char": 1,
+                "deco": "VALUE_REMOVED_FOR_TEST",
+                "kind": "alias",
+                "line": 210,
+                "name": "F",
+                "originalType": "size_t function(size_t a)"
             }
         ],
         "name": "json"

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -206,3 +206,5 @@ mixin template test18211(int n)
     }
     static if (true) {}
 }
+
+alias F = size_t function (size_t a);


### PR DESCRIPTION
Preserve the original type for aliases.
