### PR TITLE
Split needspkgmod.d by TEST_OUTPUT

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -228,11 +228,18 @@ The following is a list of all available settings:
                         default: (none)
 
     TRANSFORM_OUTPUT:   steps to apply to the output of the compilation before it
-                        is compared to the expected TEST_OUTPUT.
+                        is compared to the expected TEST_OUTPUT. A step may take
+                        arguments akin to a function call, e.g. `step(arg)` and arguments
+                        may be quoted using "".
 
                         Supported transformations:
                         - sanitize_json:    Remove compiler specific information from output
                                             of -Xi (see test/tools/sanitize_json.d)
+                                            arguments: none
+
+                        - remove_lines:     Remove lines matching a given regex
+                                            arguments: the regex
+                                            note: patterns containing ')' must be quoted
 
     POST_SCRIPT:         name of script to execute after test run
                          note: arguments to the script may be included after the name.

--- a/test/fail_compilation/fail15616b.d
+++ b/test/fail_compilation/fail15616b.d
@@ -1,5 +1,7 @@
 /*
 REQUIRED_ARGS: -v
+TRANSFORM_OUTPUT: remove_lines("^(predefs|binary|version|config|DFLAG|parse|import|semantic|entry|\s*$)")
+TEST_OUTPUT:
 ---
 fail_compilation/fail15616b.d(44): Error: none of the overloads of `foo` are callable using argument types `(double)`, candidates are:
 fail_compilation/fail15616b.d(17):        `fail15616b.foo(int a)`
@@ -8,11 +10,24 @@ fail_compilation/fail15616b.d(29):        `fail15616b.foo(int a, int b, int c)`
 fail_compilation/fail15616b.d(32):        `fail15616b.foo(string a)`
 fail_compilation/fail15616b.d(35):        `fail15616b.foo(string a, string b)`
 fail_compilation/fail15616b.d(38):        `fail15616b.foo(string a, string b, string c)`
-fail_compilation/fail15616b.d(23):        `fail15616b.foo(T)(T a) if (is(T == float))`
-fail_compilation/fail15616b.d(26):        `fail15616b.foo(T)(T a) if (is(T == char))`
+fail_compilation/fail15616b.d(23):        `foo(T)(T a)`
+  with `T = double`
+  whose parameters have the following constraints:
+  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+`  > is(T == float)
+`  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+fail_compilation/fail15616b.d(26):        `foo(T)(T a)`
+  with `T = double`
+  whose parameters have the following constraints:
+  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+`  > is(T == char)
+`  `~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+fail_compilation/fail15616b.d(44):        All possible candidates are marked as `deprecated` or `@disable`
+  Tip: not satisfied constraints are marked with `>`
 ---
 */
 
+#line 17
 void foo(int a)
 {}
 

--- a/test/fail_compilation/needspkgmod.d
+++ b/test/fail_compilation/needspkgmod.d
@@ -1,4 +1,3 @@
-// ARG_SETS: -i=
 // ARG_SETS: -i=,
 // ARG_SETS: -i=imports.pkgmod313,
 // ARG_SETS: -i=,imports.pkgmod313
@@ -7,6 +6,18 @@
 // REQUIRED_ARGS: -Icompilable
 // PERMUTE_ARGS:
 // LINK:
+/*
+Can't really check for the missing function bar here because the error message
+varies A LOT between different linkers. Assume that there is no other cause
+of linking failure because then other tests would fail as well. Hence search
+for the linker failure message issued by DMD:
+
+TRANSFORM_OUTPUT: remove_lines("^(?!Error:).+$")
+TEST_OUTPUT:
+----
+Error: linker exited with status $n$
+----
+*/
 import imports.pkgmod313.mod;
 void main()
 {

--- a/test/fail_compilation/needspkgmod2.d
+++ b/test/fail_compilation/needspkgmod2.d
@@ -1,0 +1,10 @@
+/*
+REQUIRED_ARGS: -i=
+PERMUTE_ARGS:
+TEST_OUTPUT:
+----
+Error: invalid option '-i=', module patterns cannot be empty
+       run `dmd` to print the compiler manual
+       run `dmd -man` to open browser on manual
+----
+*/


### PR DESCRIPTION
This file actually represents two tests in one:
- wrong usage `-i`
- linkage failure because  a module is not compiled.

Side note:
This PR and #10836 contain the last missing `TEST_OUTPUT` sections for `fail_compilation`!