### PR TITLE
Fix run.d on Windows

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -320,7 +320,7 @@ auto predefinedTargets(string[] targets)
         Target target = {
             filename: filename,
             args: [
-                resultsDir.buildPath(TestTools.testRunner.name),
+                resultsDir.buildPath(TestTools.testRunner.name.exeName),
                 Target.normalizedTestName(filename)
             ]
         };


### PR DESCRIPTION
Previosly run.d failed to execute d_do_test with an error message complaining that it isn't a valid executable.

I'm not sure why it worked previously but it stopped working some time ago.