### PR TITLE
fix Issue 19959 - Eponymous template FQN's re-state the template name

### DIFF
--- a/compiler/include/dmd/aggregate.h
+++ b/compiler/include/dmd/aggregate.h
@@ -271,7 +271,7 @@ public:
     ObjcClassDeclaration objc;          // Data for a class declaration that is needed for the Objective-C integration
 
     static ClassDeclaration *create(Loc loc, Identifier *id, BaseClasses *baseclasses, Dsymbols *members, bool inObject);
-    const char *toPrettyChars(bool QualifyTypes = false) override;
+    const char *toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false) override;
     ClassDeclaration *syntaxCopy(Dsymbol *s) override;
 
     #define OFFSET_RUNTIME 0x76543210

--- a/compiler/include/dmd/attrib.h
+++ b/compiler/include/dmd/attrib.h
@@ -88,7 +88,7 @@ public:
 
     VisibilityDeclaration *syntaxCopy(Dsymbol *s) override;
     const char *kind() const override;
-    const char *toPrettyChars(bool unused) override;
+    const char *toPrettyChars(bool unused, bool unused2 = false) override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/include/dmd/declaration.h
+++ b/compiler/include/dmd/declaration.h
@@ -701,7 +701,7 @@ public:
 
     bool inUnittest();
     LabelDsymbol *searchLabel(Identifier *ident, Loc loc);
-    const char *toPrettyChars(bool QualifyTypes = false) override;
+    const char *toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false) override;
     const char *toFullSignature();  // for diagnostics, e.g. 'int foo(int x, int y) pure'
     bool isMain() const;
     bool isCMain() const;
@@ -753,7 +753,7 @@ public:
     AggregateDeclaration *isThis() override;
 
     const char *kind() const override;
-    const char *toPrettyChars(bool QualifyTypes = false) override;
+    const char *toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false) override;
     void accept(Visitor *v) override { v->visit(this); }
 };
 

--- a/compiler/include/dmd/dsymbol.h
+++ b/compiler/include/dmd/dsymbol.h
@@ -224,7 +224,7 @@ public:
     DYNCAST dyncast() const override final { return DYNCAST_DSYMBOL; }
 
     virtual Identifier *getIdent();
-    virtual const char *toPrettyChars(bool QualifyTypes = false);
+    virtual const char *toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false);
     virtual const char *kind() const;
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member

--- a/compiler/src/dmd/attrib.d
+++ b/compiler/src/dmd/attrib.d
@@ -364,7 +364,7 @@ extern (C++) final class VisibilityDeclaration : AttribDeclaration
         return "visibility attribute";
     }
 
-    override const(char)* toPrettyChars(bool)
+    override const(char)* toPrettyChars(bool, bool keepOneMember = false)
     {
         assert(visibility.kind > Visibility.Kind.undefined);
         OutBuffer buf;

--- a/compiler/src/dmd/dclass.d
+++ b/compiler/src/dmd/dclass.d
@@ -230,12 +230,12 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         return new ClassDeclaration(loc, id, baseclasses, members, inObject);
     }
 
-    override const(char)* toPrettyChars(bool qualifyTypes = false)
+    override const(char)* toPrettyChars(bool qualifyTypes = false, bool keepOneMember = false)
     {
         if (objc.isMeta)
             return .objc.toPrettyChars(this, qualifyTypes);
 
-        return super.toPrettyChars(qualifyTypes);
+        return super.toPrettyChars(qualifyTypes, keepOneMember);
     }
 
     override ClassDeclaration syntaxCopy(Dsymbol s)

--- a/compiler/src/dmd/dsymbol.d
+++ b/compiler/src/dmd/dsymbol.d
@@ -679,7 +679,7 @@ extern (C++) class Dsymbol : ASTNode
         return ident;
     }
 
-    const(char)* toPrettyChars(bool QualifyTypes = false)
+    const(char)* toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false)
     {
         //printf("Dsymbol::toPrettyChars() '%s'\n", toChars());
         if (!parent)
@@ -695,6 +695,24 @@ extern (C++) class Dsymbol : ASTNode
             if (p.parent)
             {
                 addQualifiers(p.parent);
+
+                bool isOneMember(T)(T t)
+                {
+                    import dmd.dsymbolsem;
+                    Dsymbol sym;
+                    if (auto ti = p.parent.isTemplateInstance())
+                        if (auto ident = p.getIdent())
+                            if (ident is ti.name)
+                                if (oneMembers(ti.members, sym, ident) && sym is p)
+                                    return true;
+                    return false;
+                }
+
+                if (!keepOneMember)
+                    if (isOneMember(p.parent.isTemplateInstance()) ||
+                        isOneMember(p.parent.isTemplateDeclaration()))
+                        return;
+
                 buf.writeByte('.');
             }
             const s = QualifyTypes ? p.toPrettyCharsHelper() : p.toChars();

--- a/compiler/src/dmd/func.d
+++ b/compiler/src/dmd/func.d
@@ -452,11 +452,11 @@ extern (C++) class FuncDeclaration : Declaration
         return cast(LabelDsymbol)s;
     }
 
-    override const(char)* toPrettyChars(bool QualifyTypes = false)
+    override const(char)* toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false)
     {
         if (isMain())
             return "D main";
-        return Dsymbol.toPrettyChars(QualifyTypes);
+        return Dsymbol.toPrettyChars(QualifyTypes, keepOneMember);
     }
 
     /** for diagnostics, e.g. 'int foo(int x, int y) pure' */
@@ -860,14 +860,14 @@ extern (C++) final class FuncLiteralDeclaration : FuncDeclaration
         return (tok != TOK.function_) ? "delegate" : "function";
     }
 
-    override const(char)* toPrettyChars(bool QualifyTypes = false)
+    override const(char)* toPrettyChars(bool QualifyTypes = false, bool keepOneMember = false)
     {
         if (parent)
         {
             if (TemplateInstance ti = parent.isTemplateInstance())
-                return ti.tempdecl.toPrettyChars(QualifyTypes);
+                return ti.tempdecl.toPrettyChars(QualifyTypes, keepOneMember);
         }
-        return Dsymbol.toPrettyChars(QualifyTypes);
+        return Dsymbol.toPrettyChars(QualifyTypes, keepOneMember);
     }
 
     override void accept(Visitor v)

--- a/compiler/src/dmd/glue/todt.d
+++ b/compiler/src/dmd/glue/todt.d
@@ -1323,7 +1323,7 @@ private extern (C++) class TypeInfoDtVisitor : Visitor
             dtb.size(0);
 
         // string name;
-        const(char)* name = sd.toPrettyChars();
+        const(char)* name = sd.toPrettyChars(false, true);
         size_t namelen = strlen(name);
         dtb.size(namelen);
         dtb.xoff(cast(Symbol*)d.csym, Type.typeinfoenum.structsize);

--- a/compiler/src/dmd/glue/toobj.d
+++ b/compiler/src/dmd/glue/toobj.d
@@ -1286,7 +1286,7 @@ private void ClassInfoToDt(ref DtBuilder dtb, ClassDeclaration cd, Symbol* sinit
     size_t namelen = strlen(name);
     if (!(namelen > 9 && memcmp(name, "TypeInfo_".ptr, 9) == 0))
     {
-        name = cd.toPrettyChars(/*QualifyTypes=*/ true);
+        name = cd.toPrettyChars(/*QualifyTypes=*/ true, true);
         namelen = strlen(name);
     }
     dtb.size(namelen);
@@ -1535,7 +1535,7 @@ private void InterfaceInfoToDt(ref DtBuilder dtb, InterfaceDeclaration id)
     dtb.size(0);                        // initializer
 
     // name[]
-    const(char) *name = id.toPrettyChars(/*QualifyTypes=*/ true);
+    const(char) *name = id.toPrettyChars(/*QualifyTypes=*/ true, /*keepOneMember=*/ true);
     size_t namelen = strlen(name);
     dtb.size(namelen);
     auto csym = cast(Symbol*)id.csym;

--- a/compiler/src/dmd/json.d
+++ b/compiler/src/dmd/json.d
@@ -586,7 +586,7 @@ public:
         {
             if (cd.baseClass && cd.baseClass.ident != Id.Object)
             {
-                property("base", cd.baseClass.toPrettyChars(true).toDString);
+                property("base", cd.baseClass.toPrettyChars(true, true).toDString);
             }
             if (cd.interfaces.length)
             {
@@ -594,7 +594,7 @@ public:
                 arrayStart();
                 foreach (b; cd.interfaces)
                 {
-                    item(b.sym.toPrettyChars(true).toDString);
+                    item(b.sym.toPrettyChars(true, true).toDString);
                 }
                 arrayEnd();
             }
@@ -628,7 +628,7 @@ public:
             for (size_t i = 0; i < d.foverrides.length; i++)
             {
                 FuncDeclaration fd = d.foverrides[i];
-                item(fd.toPrettyChars().toDString);
+                item(fd.toPrettyChars(true, true).toDString);
             }
             arrayEnd();
         }

--- a/compiler/test/compilable/ftimetrace.d
+++ b/compiler/test/compilable/ftimetrace.d
@@ -6,14 +6,14 @@ TEST_OUTPUT:
 Code generation,
 Codegen: function add, object.add
 Codegen: function fun, object.fun
-Codegen: function id, object.id!int.id
+Codegen: function id, object.id!int
 Codegen: function uses, object.uses
 Codegen: module object, object
 Ctfe: add(4, 8), add(4, 8)
 Ctfe: call add, object.add(4, 8)
 DFA: add, object.add
 DFA: fun, object.fun
-DFA: id, object.id!int.id
+DFA: id, object.id!int
 DFA: uses, object.uses
 Import object.object, object.object
 Inlining,
@@ -21,7 +21,7 @@ Parse: Module object, object
 Parsing,
 Sema1: Function add, object.add
 Sema1: Function fun, object.fun
-Sema1: Function id, object.id!int.id
+Sema1: Function id, object.id!int
 Sema1: Function uses, object.uses
 Sema1: Module object, object
 Sema1: Overload Resolution: id!int, id!int
@@ -32,12 +32,12 @@ Sema1: Template Members: id!int, object.id!int
 Sema2: Template Instance: id!int, object.id!int
 Sema2: add, object.add
 Sema2: fun, object.fun
-Sema2: id, object.id!int.id
+Sema2: id, object.id!int
 Sema2: uses, object.uses
 Sema3: Template Instance: id!int, object.id!int
 Sema3: add, object.add
 Sema3: fun, object.fun
-Sema3: id, object.id!int.id
+Sema3: id, object.id!int
 Sema3: uses, object.uses
 Semantic analysis,
 ---

--- a/compiler/test/compilable/sw_transition_field.d
+++ b/compiler/test/compilable/sw_transition_field.d
@@ -5,8 +5,8 @@ TEST_OUTPUT:
 ---
 compilable/sw_transition_field.d(15): `sw_transition_field.S1.ix` is `immutable` field
 compilable/sw_transition_field.d(16): `sw_transition_field.S1.cx` is `const` field
-compilable/sw_transition_field.d(21): `sw_transition_field.S2!(immutable(int)).S2.f` is `immutable` field
-compilable/sw_transition_field.d(21): `sw_transition_field.S2!(const(int)).S2.f` is `const` field
+compilable/sw_transition_field.d(21): `sw_transition_field.S2!(immutable(int)).f` is `immutable` field
+compilable/sw_transition_field.d(21): `sw_transition_field.S2!(const(int)).f` is `const` field
 ---
 */
 

--- a/compiler/test/compilable/test16495.d
+++ b/compiler/test/compilable/test16495.d
@@ -60,13 +60,13 @@ void symbols()
     static assert(__traits(fullyQualifiedName, qnTests.Inner)           == prefix ~ "Inner");
     static assert(__traits(fullyQualifiedName, qnTests.func)            == prefix ~ "func");
 
-    static assert(__traits(fullyQualifiedName, qnTests.Data!int)        == prefix ~ "Data!int.Data");
-    static assert(__traits(fullyQualifiedName, qnTests.Data!int.x)      == prefix ~ "Data!int.Data.x");
-    static assert(__traits(fullyQualifiedName, qnTests.tfunc!(int[]))   == prefix ~ "tfunc!(int[]).tfunc");
+    static assert(__traits(fullyQualifiedName, qnTests.Data!int)        == prefix ~ "Data!int");
+    static assert(__traits(fullyQualifiedName, qnTests.Data!int.x)      == prefix ~ "Data!int.x");
+    static assert(__traits(fullyQualifiedName, qnTests.tfunc!(int[]))   == prefix ~ "tfunc!(int[])");
     static assert(__traits(fullyQualifiedName, qnTests.Inst!(Object))   == prefix ~ "Inst!(Object)");
     static assert(__traits(fullyQualifiedName, qnTests.Inst!(Object).x) == prefix ~ "Inst!(Object).x");
     static assert(__traits(fullyQualifiedName, qnTests.Test12309!(int, 10, "str"))
-                                                == prefix ~ "Test12309!(int, 10, \"str\").Test12309");
+                                                == prefix ~ "Test12309!(int, 10, \"str\")");
 }
 
 void names()

--- a/compiler/test/compilable/test20063.d
+++ b/compiler/test/compilable/test20063.d
@@ -1,7 +1,7 @@
 // REQUIRED_ARGS: -verrors=simple
 /* TEST_OUTPUT:
 ---
-compilable/test20063.d(11): Deprecation: function `test20063.main.f!(delegate () pure nothrow @safe => new C).f` function requires a dual-context, which is deprecated
+compilable/test20063.d(11): Deprecation: function `test20063.main.f!(delegate () pure nothrow @safe => new C)` function requires a dual-context, which is deprecated
 compilable/test20063.d(20):        instantiated from here: `f!(delegate () pure nothrow @safe => new C)`
 ---
 */

--- a/compiler/test/compilable/test324.d
+++ b/compiler/test/compilable/test324.d
@@ -5,7 +5,7 @@ compilable/test324.d(18): Deprecation: function `test324.main.doStuff!((i)
 {
 return i;
 }
-).doStuff` function requires a dual-context, which is deprecated
+)` function requires a dual-context, which is deprecated
 compilable/test324.d(24):        instantiated from here: `doStuff!((i)
 {
 return i;

--- a/compiler/test/fail_compilation/bug8150b.d
+++ b/compiler/test/fail_compilation/bug8150b.d
@@ -3,7 +3,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/bug8150b.d(15): Error: `object.Exception` is thrown but not caught
-fail_compilation/bug8150b.d(13): Error: constructor `bug8150b.Foo.this!().this` may throw but is marked as `nothrow`
+fail_compilation/bug8150b.d(13): Error: constructor `bug8150b.Foo.this!()` may throw but is marked as `nothrow`
 fail_compilation/bug8150b.d(20): Error: template instance `bug8150b.Foo.this!()` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/bug9631.d
+++ b/compiler/test/fail_compilation/bug9631.d
@@ -92,7 +92,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/bug9631.d(108): Error: function `ft` is not callable using argument types `(S)`
 fail_compilation/bug9631.d(108):        cannot pass argument `x` of type `bug9631.S` to parameter `bug9631.tem!().S __param_0`
-fail_compilation/bug9631.d(107):        `bug9631.targ.ft!().ft(S __param_0)` declared here
+fail_compilation/bug9631.d(107):        `bug9631.targ.ft!()(S __param_0)` declared here
 fail_compilation/bug9631.d(109): Error: template `ft` is not callable using argument types `!()(S)`
 fail_compilation/bug9631.d(107):        Candidate is: `ft()(tem!().S)`
 fail_compilation/bug9631.d(111): Error: template `ft2` is not callable using argument types `!()(S, int)`

--- a/compiler/test/fail_compilation/diag10319.d
+++ b/compiler/test/fail_compilation/diag10319.d
@@ -4,13 +4,13 @@ TEST_OUTPUT:
 fail_compilation/diag10319.d(30): Error: `pure` function `D main` cannot call impure function `diag10319.foo`
 fail_compilation/diag10319.d(30): Error: `@safe` function `D main` cannot call `@system` function `diag10319.foo`
 fail_compilation/diag10319.d(19):        `diag10319.foo` is declared here
-fail_compilation/diag10319.d(31): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(31): Error: `pure` function `D main` cannot call impure function `diag10319.bar!int`
 fail_compilation/diag10319.d(23):        and accessing mutable static data `g` makes it fail to infer `pure`
-fail_compilation/diag10319.d(31): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int.bar`
+fail_compilation/diag10319.d(31): Error: `@safe` function `D main` cannot call `@system` function `diag10319.bar!int`
 fail_compilation/diag10319.d(24):        and taking the address of stack-allocated local variable `x` makes it fail to infer `@safe`
-fail_compilation/diag10319.d(21):        `diag10319.bar!int.bar` is declared here
+fail_compilation/diag10319.d(21):        `diag10319.bar!int` is declared here
 fail_compilation/diag10319.d(30): Error: function `diag10319.foo` is not `nothrow`
-fail_compilation/diag10319.d(31): Error: function `diag10319.bar!int.bar` is not `nothrow`
+fail_compilation/diag10319.d(31): Error: function `diag10319.bar!int` is not `nothrow`
 fail_compilation/diag10319.d(25):        and `object.Exception` being thrown but not caught makes it fail to infer `nothrow`
 fail_compilation/diag10319.d(28): Error: function `D main` may throw but is marked as `nothrow`
 ---

--- a/compiler/test/fail_compilation/diag14145.d
+++ b/compiler/test/fail_compilation/diag14145.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/diag14145.d(14): Error: no property `i` for `_` of type `diag14145.main.Capture!(i)`
 fail_compilation/diag14145.d(33): Error: expression `*this.ptr` of type `shared(int)` is not implicitly convertible to return type `ref int`
-fail_compilation/diag14145.d(14): Error: template instance `diag14145.main.Capture!(i).Capture.opDispatch!"i"` error instantiating
+fail_compilation/diag14145.d(14): Error: template instance `diag14145.main.Capture!(i).opDispatch!"i"` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/diag9620.d
+++ b/compiler/test/fail_compilation/diag9620.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag9620.d(19): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo1`
-fail_compilation/diag9620.d(20): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!().foo2`
+fail_compilation/diag9620.d(20): Error: `pure` function `diag9620.main.bar` cannot call impure function `diag9620.foo2!()`
 fail_compilation/diag9620.d(13):        and accessing mutable static data `x` makes it fail to infer `pure`
 ---
 */

--- a/compiler/test/fail_compilation/disable.d
+++ b/compiler/test/fail_compilation/disable.d
@@ -4,12 +4,12 @@ TEST_OUTPUT:
 fail_compilation/disable.d(56): Error: function `disable.DisabledOpAssign.opAssign` cannot be used because it is annotated with `@disable`
 fail_compilation/disable.d(59): Error: function `disable.DisabledPostblit.opAssign` cannot be used because it is annotated with `@disable`
 fail_compilation/disable.d(62): Error: function `disable.HasDtor.opAssign` cannot be used because it is annotated with `@disable`
-fail_compilation/disable.d(66): Error: generated function `disable.Nested!(DisabledOpAssign).Nested.opAssign` cannot be used because it is annotated with `@disable`
-fail_compilation/disable.d(69): Error: generated function `disable.Nested!(DisabledPostblit).Nested.opAssign` cannot be used because it is annotated with `@disable`
-fail_compilation/disable.d(72): Error: generated function `disable.Nested!(HasDtor).Nested.opAssign` cannot be used because it is annotated with `@disable`
-fail_compilation/disable.d(76): Error: generated function `disable.NestedDtor!(DisabledOpAssign).NestedDtor.opAssign` cannot be used because it is annotated with `@disable`
-fail_compilation/disable.d(79): Error: generated function `disable.NestedDtor!(DisabledPostblit).NestedDtor.opAssign` cannot be used because it is annotated with `@disable`
-fail_compilation/disable.d(82): Error: generated function `disable.NestedDtor!(HasDtor).NestedDtor.opAssign` cannot be used because it is annotated with `@disable`
+fail_compilation/disable.d(66): Error: generated function `disable.Nested!(DisabledOpAssign).opAssign` cannot be used because it is annotated with `@disable`
+fail_compilation/disable.d(69): Error: generated function `disable.Nested!(DisabledPostblit).opAssign` cannot be used because it is annotated with `@disable`
+fail_compilation/disable.d(72): Error: generated function `disable.Nested!(HasDtor).opAssign` cannot be used because it is annotated with `@disable`
+fail_compilation/disable.d(76): Error: generated function `disable.NestedDtor!(DisabledOpAssign).opAssign` cannot be used because it is annotated with `@disable`
+fail_compilation/disable.d(79): Error: generated function `disable.NestedDtor!(DisabledPostblit).opAssign` cannot be used because it is annotated with `@disable`
+fail_compilation/disable.d(82): Error: generated function `disable.NestedDtor!(HasDtor).opAssign` cannot be used because it is annotated with `@disable`
 fail_compilation/disable.d(84): Error: enum member `disable.Enum1.value` cannot be used because it is annotated with `@disable`
 ---
  */

--- a/compiler/test/fail_compilation/fail104.d
+++ b/compiler/test/fail_compilation/fail104.d
@@ -6,7 +6,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail104.d(26): Error: template instance `P!()` `P` is not a template declaration, it is a alias
-fail_compilation/fail104.d(26): Error: mixin `fail104.C!(S).C.T!()` is not defined
+fail_compilation/fail104.d(26): Error: mixin `fail104.C!(S).T!()` is not defined
 fail_compilation/fail104.d(31): Error: template instance `fail104.C!(S)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/fail11375.d
+++ b/compiler/test/fail_compilation/fail11375.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail11375.d(18): Error: constructor `fail11375.D!().D.this` is not `nothrow`
+fail_compilation/fail11375.d(18): Error: constructor `fail11375.D!().this` is not `nothrow`
        which calls `this`
 fail_compilation/fail11375.d(16): Error: function `D main` may throw but is marked as `nothrow`
 ---

--- a/compiler/test/fail_compilation/fail13120.d
+++ b/compiler/test/fail_compilation/fail13120.d
@@ -16,11 +16,11 @@ void g1(char[] s) pure @nogc
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(35): Error: `pure` function `fail13120.h2` cannot call impure function `fail13120.g2!()`
 fail_compilation/fail13120.d(30):        which calls `f2`
-fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!().g2`
-fail_compilation/fail13120.d(27):        `fail13120.g2!().g2` is declared here
-fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!().g2`
+fail_compilation/fail13120.d(35): Error: `@safe` function `fail13120.h2` cannot call `@system` function `fail13120.g2!()`
+fail_compilation/fail13120.d(27):        `fail13120.g2!()` is declared here
+fail_compilation/fail13120.d(35): Error: `@nogc` function `fail13120.h2` cannot call non-@nogc function `fail13120.g2!()`
 ---
 */
 void f2() {}

--- a/compiler/test/fail_compilation/fail17.d
+++ b/compiler/test/fail_compilation/fail17.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail17.d(11): Error: undefined identifier `B`
-fail_compilation/fail17.d(11): Error: mixin `fail17.A!int.A.B!(T, A!T)` is not defined
+fail_compilation/fail17.d(11): Error: mixin `fail17.A!int.B!(T, A!T)` is not defined
 fail_compilation/fail17.d(14): Error: template instance `fail17.A!int` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/fail17955.d
+++ b/compiler/test/fail_compilation/fail17955.d
@@ -14,8 +14,8 @@ fail_compilation/fail17955.d(33):        instantiated from here: `indicesOf!(isR
 fail_compilation/fail17955.d(68):        instantiated from here: `RedisStripped!(User, true)`
 fail_compilation/fail17955.d(94): Error: calling non-static function `fromISOExtString` requires an instance of type `SimpleTimeZone`
 fail_compilation/fail17955.d(96): Error: undefined identifier `DateTimeException`
-fail_compilation/fail17955.d(26): Error: variable `fail17955.isISOExtStringSerializable!(SysTime).isISOExtStringSerializable` - type `void` is inferred from initializer `fromISOExtString("")`, and variables cannot be of type `void`
-fail_compilation/fail17955.d(55): Error: function `fail17955.toRedis!(SysTime).toRedis` has no `return` statement, but is expected to return a value of type `string`
+fail_compilation/fail17955.d(26): Error: variable `fail17955.isISOExtStringSerializable!(SysTime)` - type `void` is inferred from initializer `fromISOExtString("")`, and variables cannot be of type `void`
+fail_compilation/fail17955.d(55): Error: function `fail17955.toRedis!(SysTime)` has no `return` statement, but is expected to return a value of type `string`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail17969.d
+++ b/compiler/test/fail_compilation/fail17969.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail17969.d(10): Error: no property `sum` for type `fail17969.__lambda_L10_C1!(int[]).__lambda_L10_C1.MapResult2!((b) => b)`
+fail_compilation/fail17969.d(10): Error: no property `sum` for type `fail17969.__lambda_L10_C1!(int[]).MapResult2!((b) => b)`
 fail_compilation/fail17969.d(16):        struct `MapResult2` defined here
 ---
  * https://issues.dlang.org/show_bug.cgi?id=17969

--- a/compiler/test/fail_compilation/fail18093.d
+++ b/compiler/test/fail_compilation/fail18093.d
@@ -1,8 +1,8 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/fail18093.d(20): Error: function `void fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen).visit()` does not override any function
-fail_compilation/fail18093.d(16):        did you mean to override `extern (C++) void fail18093.ParseTimeVisitor!(ASTCodegen).ParseTimeVisitor.visit()`?
-fail_compilation/fail18093.d(25): Error: mixin `fail18093.GenericTransitiveVisitor!(ASTCodegen).GenericTransitiveVisitor.ParseVisitMethods!(ASTCodegen)` error instantiating
+fail_compilation/fail18093.d(20): Error: function `void fail18093.GenericTransitiveVisitor!(ASTCodegen).ParseVisitMethods!(ASTCodegen).visit()` does not override any function
+fail_compilation/fail18093.d(16):        did you mean to override `extern (C++) void fail18093.ParseTimeVisitor!(ASTCodegen).visit()`?
+fail_compilation/fail18093.d(25): Error: mixin `fail18093.GenericTransitiveVisitor!(ASTCodegen).ParseVisitMethods!(ASTCodegen)` error instantiating
 fail_compilation/fail18093.d(28): Error: template instance `fail18093.GenericTransitiveVisitor!(ASTCodegen)` error instantiating
 ---
  * https://issues.dlang.org/show_bug.cgi?id=18093

--- a/compiler/test/fail_compilation/fail19202.d
+++ b/compiler/test/fail_compilation/fail19202.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail19202.d(12): Deprecation: variable `fail19202.X!().X` is deprecated
+fail_compilation/fail19202.d(12): Deprecation: variable `fail19202.X!()` is deprecated
 fail_compilation/fail19202.d(17):        `X` is declared here
 ---
 */

--- a/compiler/test/fail_compilation/fail20551.d
+++ b/compiler/test/fail_compilation/fail20551.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail20551.d(15): Error: taking address of lazy parameter `e` is not allowed in a `@safe` function
-fail_compilation/fail20551.d(26): Error: template instance `fail20551.LazyStore!int.LazyStore.opAssign!int` error instantiating
+fail_compilation/fail20551.d(26): Error: template instance `fail20551.LazyStore!int.opAssign!int` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/fail22157.d
+++ b/compiler/test/fail_compilation/fail22157.d
@@ -3,14 +3,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail22157.d(32): Error: `fail22157.S!true.S.foo` called with argument types `()` matches multiple overloads exactly:
-fail_compilation/fail22157.d(21):     `fail22157.S!true.S.foo()`
+fail_compilation/fail22157.d(32): Error: `fail22157.S!true.foo` called with argument types `()` matches multiple overloads exactly:
+fail_compilation/fail22157.d(21):     `fail22157.S!true.foo()`
 and:
-fail_compilation/fail22157.d(22):     `fail22157.S!true.S.foo()`
-fail_compilation/fail22157.d(33): Error: `fail22157.S!false.S.foo` called with argument types `()` matches multiple overloads exactly:
-fail_compilation/fail22157.d(26):     `fail22157.S!false.S.foo()`
+fail_compilation/fail22157.d(22):     `fail22157.S!true.foo()`
+fail_compilation/fail22157.d(33): Error: `fail22157.S!false.foo` called with argument types `()` matches multiple overloads exactly:
+fail_compilation/fail22157.d(26):     `fail22157.S!false.foo()`
 and:
-fail_compilation/fail22157.d(27):     `fail22157.S!false.S.foo()`
+fail_compilation/fail22157.d(27):     `fail22157.S!false.foo()`
 ---
 */
 

--- a/compiler/test/fail_compilation/fail270.d
+++ b/compiler/test/fail_compilation/fail270.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail270.d(12): Error: string slice `[1 .. 0]` is out of bounds
-fail_compilation/fail270.d(12): Error: mixin `fail270.Tuple!int.Tuple.Tuple!()` error instantiating
+fail_compilation/fail270.d(12): Error: mixin `fail270.Tuple!int.Tuple!()` error instantiating
 fail_compilation/fail270.d(14): Error: mixin `fail270.Tuple!int` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/fail272.d
+++ b/compiler/test/fail_compilation/fail272.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail272.d(9): Error: circular reference to variable `fail272.Ins!(Ins).Ins`
+fail_compilation/fail272.d(9): Error: circular reference to variable `fail272.Ins!(Ins)`
 fail_compilation/fail272.d(10): Error: template instance `fail272.Ins!(Ins)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/fail344.d
+++ b/compiler/test/fail_compilation/fail344.d
@@ -6,9 +6,9 @@ fail_compilation/fail344.d(20): Error: undefined identifier `Q`
 fail_compilation/fail344.d(20): Error: undefined identifier `Q`
 fail_compilation/fail344.d(20): Error: undefined identifier `V`
 fail_compilation/fail344.d(23):        while evaluating: `static assert(Alike!(SIB!(crayon)))`
-fail_compilation/fail344.d(23): Error: template instance `fail344.SIB!(crayon).SIB.Alike!(SIB!(crayon))` error instantiating
+fail_compilation/fail344.d(23): Error: template instance `fail344.SIB!(crayon).Alike!(SIB!(crayon))` error instantiating
 fail_compilation/fail344.d(23):        while evaluating: `static assert(Alike!(SIB!(crayon)))`
-fail_compilation/fail344.d(28): Error: template instance `fail344.SIB!(crayon).SIB.opDispatch!"E"` error instantiating
+fail_compilation/fail344.d(28): Error: template instance `fail344.SIB!(crayon).opDispatch!"E"` error instantiating
 ---
 */
 

--- a/compiler/test/fail_compilation/fail346.d
+++ b/compiler/test/fail_compilation/fail346.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail346.d(15): Error: undefined identifier `P`
-fail_compilation/fail346.d(15): Error: variable `fail346.S.T!0.T` - cannot use template to add field to aggregate `S`
+fail_compilation/fail346.d(15): Error: variable `fail346.S.T!0` - cannot use template to add field to aggregate `S`
 fail_compilation/fail346.d(20): Error: template instance `fail346.S.T!0` error instantiating
 fail_compilation/fail346.d(23):        instantiated from here: `V!(S, 0)`
 ---

--- a/compiler/test/fail_compilation/fail6968.d
+++ b/compiler/test/fail_compilation/fail6968.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/fail6968.d(26): Error: cannot pass type `int` as a function argument
 fail_compilation/fail6968.d(26): Error: cannot pass type `long` as a function argument
-fail_compilation/fail6968.d(26): Error: circular initialization of variable `fail6968.PredAny!(int, long, float).PredAny`
+fail_compilation/fail6968.d(26): Error: circular initialization of variable `fail6968.PredAny!(int, long, float)`
 fail_compilation/fail6968.d(31): Error: template instance `fail6968.PredAny!(int, long, float)` error instantiating
 fail_compilation/fail6968.d(31):        while evaluating `pragma(msg, PredAny!(int, long, float))`
 ---

--- a/compiler/test/fail_compilation/fail8373.d
+++ b/compiler/test/fail_compilation/fail8373.d
@@ -2,13 +2,13 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail8373.d(21): Error: `fail8373.fun1` called with argument types `(int)` matches multiple overloads exactly:
-fail_compilation/fail8373.d(15):     `fail8373.fun1!().fun1!int.fun1(int)`
+fail_compilation/fail8373.d(15):     `fail8373.fun1!().fun1!int(int)`
 and:
 fail_compilation/fail8373.d(16):     `fail8373.fun1!int.fun1(int)`
 fail_compilation/fail8373.d(22): Error: `fail8373.fun2` called with argument types `(int)` matches multiple overloads exactly:
 fail_compilation/fail8373.d(18):     `fail8373.fun2!int.fun2(int)`
 and:
-fail_compilation/fail8373.d(19):     `fail8373.fun2!().fun2!int.fun2(int)`
+fail_compilation/fail8373.d(19):     `fail8373.fun2!().fun2!int(int)`
 ---
 */
 

--- a/compiler/test/fail_compilation/failob2.d
+++ b/compiler/test/fail_compilation/failob2.d
@@ -3,14 +3,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/failob2.d(105): Error: variable `failob2.foo1!int.foo1.p` has undefined state and cannot be read
-fail_compilation/failob2.d(105): Error: variable `failob2.foo1!int.foo1.p` is returned but is Undefined
+fail_compilation/failob2.d(105): Error: variable `failob2.foo1!int.p` has undefined state and cannot be read
+fail_compilation/failob2.d(105): Error: variable `failob2.foo1!int.p` is returned but is Undefined
 fail_compilation/failob2.d(124): Error: template instance `failob2.foo1!int` error instantiating
-fail_compilation/failob2.d(111): Error: variable `failob2.foo2!int.foo2.p` has undefined state and cannot be read
-fail_compilation/failob2.d(111): Error: variable `failob2.foo2!int.foo2.p` is returned but is Undefined
+fail_compilation/failob2.d(111): Error: variable `failob2.foo2!int.p` has undefined state and cannot be read
+fail_compilation/failob2.d(111): Error: variable `failob2.foo2!int.p` is returned but is Undefined
 fail_compilation/failob2.d(125): Error: template instance `failob2.foo2!int` error instantiating
-fail_compilation/failob2.d(119): Error: variable `failob2.foo3!int.foo3.p` has undefined state and cannot be read
-fail_compilation/failob2.d(119): Error: variable `failob2.foo3!int.foo3.p` is returned but is Undefined
+fail_compilation/failob2.d(119): Error: variable `failob2.foo3!int.p` has undefined state and cannot be read
+fail_compilation/failob2.d(119): Error: variable `failob2.foo3!int.p` is returned but is Undefined
 fail_compilation/failob2.d(126): Error: template instance `failob2.foo3!int` error instantiating
 ---
 */
@@ -48,7 +48,7 @@ void test1() {
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/failob2.d(205): Error: variable `failob2.foo4!int.foo4.p` is not disposed of before return
+fail_compilation/failob2.d(205): Error: variable `failob2.foo4!int.p` is not disposed of before return
 fail_compilation/failob2.d(209): Error: template instance `failob2.foo4!int` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/ice11919.d
+++ b/compiler/test/fail_compilation/ice11919.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/ice11919.d(19): Error: initializer must be an expression, not `foo`
 fail_compilation/imports/a11919.d(16):        used in initialization here
-fail_compilation/imports/a11919.d(4): Error: template instance `a11919.doBar!(Foo).doBar.zoo!(t)` error instantiating
+fail_compilation/imports/a11919.d(4): Error: template instance `a11919.doBar!(Foo).zoo!(t)` error instantiating
 fail_compilation/imports/a11919.d(11):        instantiated from here: `doBar!(Foo)`
 fail_compilation/ice11919.d(27):        instantiated from here: `doBar!(Bar)`
 ---

--- a/compiler/test/fail_compilation/ice12727.d
+++ b/compiler/test/fail_compilation/ice12727.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ----
 fail_compilation/ice12727.d(16): Error: template instance `IndexTuple!(1, 0)` recursive template expansion
-fail_compilation/ice12727.d(16): Error: alias `ice12727.IndexTuple!(1, 0).IndexTuple` recursive alias declaration
+fail_compilation/ice12727.d(16): Error: alias `ice12727.IndexTuple!(1, 0)` recursive alias declaration
 fail_compilation/ice12727.d(23): Error: template instance `ice12727.IndexTuple!(1, 0)` error instantiating
 fail_compilation/ice12727.d(27):        instantiated from here: `Matrix!(float, 3)`
 fail_compilation/ice12727.d(28):        instantiated from here: `Vector!(float, 3)`

--- a/compiler/test/fail_compilation/ice13816.d
+++ b/compiler/test/fail_compilation/ice13816.d
@@ -2,7 +2,7 @@
 TEST_OUTPUT:
 ---
 fail_compilation/ice13816.d(17): Error: template instance `TypeTuple!(ItemProperty!())` recursive template expansion
-fail_compilation/ice13816.d(17): Error: alias `ice13816.ItemProperty!().ItemProperty` recursive alias declaration
+fail_compilation/ice13816.d(17): Error: alias `ice13816.ItemProperty!()` recursive alias declaration
 fail_compilation/ice13816.d(22): Error: template instance `ice13816.ItemProperty!()` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/ice14096.d
+++ b/compiler/test/fail_compilation/ice14096.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14096.d(29): Error: cannot access frame pointer of `ice14096.main.Baz!((i) => i).Baz`
-fail_compilation/ice14096.d(23): Error: template instance `ice14096.foo!(Tuple!(Baz!((i) => i))).foo.bar!(t)` error instantiating
+fail_compilation/ice14096.d(29): Error: cannot access frame pointer of `ice14096.main.Baz!((i) => i)`
+fail_compilation/ice14096.d(23): Error: template instance `ice14096.foo!(Tuple!(Baz!((i) => i))).bar!(t)` error instantiating
 fail_compilation/ice14096.d(40):        instantiated from here: `foo!(Tuple!(Baz!((i) => i)))`
 ---
 */

--- a/compiler/test/fail_compilation/ice14272.d
+++ b/compiler/test/fail_compilation/ice14272.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14272.d(11): Error: circular initialization of variable `ice14272.A14272!1.A14272.tag`
+fail_compilation/ice14272.d(11): Error: circular initialization of variable `ice14272.A14272!1.tag`
 fail_compilation/ice14272.d(14): Error: template instance `ice14272.A14272!1` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/ice15922.d
+++ b/compiler/test/fail_compilation/ice15922.d
@@ -1,8 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice15922.d(23): Error: function `ice15922.ValidSparseDataStore!int.ValidSparseDataStore.correctedInsert!false.correctedInsert` has no `return` statement, but is expected to return a value of type `int`
-fail_compilation/ice15922.d(21): Error: template instance `ice15922.ValidSparseDataStore!int.ValidSparseDataStore.correctedInsert!false` error instantiating
+fail_compilation/ice15922.d(23): Error: function `ice15922.ValidSparseDataStore!int.correctedInsert!false` has no `return` statement, but is expected to return a value of type `int`
+fail_compilation/ice15922.d(21): Error: template instance `ice15922.ValidSparseDataStore!int.correctedInsert!false` error instantiating
 fail_compilation/ice15922.d(26):        instantiated from here: `ValidSparseDataStore!int`
 fail_compilation/ice15922.d(14): Error: calling non-static function `insert` requires an instance of type `ValidSparseDataStore`
 fail_compilation/ice15922.d(26): Error: template instance `ice15922.StorageAttributes!(ValidSparseDataStore!int)` error instantiating

--- a/compiler/test/fail_compilation/ice18753.d
+++ b/compiler/test/fail_compilation/ice18753.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice18753.d(21): Error: variable `ice18753.isInputRange!(Group).isInputRange` - type `void` is inferred from initializer `ReturnType(func...)`, and variables cannot be of type `void`
+fail_compilation/ice18753.d(21): Error: variable `ice18753.isInputRange!(Group)` - type `void` is inferred from initializer `ReturnType(func...)`, and variables cannot be of type `void`
 fail_compilation/ice18753.d(23): Error: template instance `ice18753.isInputRange!(Group)` error instantiating
 fail_compilation/ice18753.d(18):        instantiated from here: `isForwardRange!(Group)`
 fail_compilation/ice18753.d(18):        while evaluating: `static assert(isForwardRange!(Group))`

--- a/compiler/test/fail_compilation/ice21095.d
+++ b/compiler/test/fail_compilation/ice21095.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice21095.d(14): Error: constructor `ice21095.Mutex.this!().this` `in` and `out` contracts can only appear without a body when they are virtual interface functions or abstract
+fail_compilation/ice21095.d(14): Error: constructor `ice21095.Mutex.this!()` `in` and `out` contracts can only appear without a body when they are virtual interface functions or abstract
 fail_compilation/ice21095.d(12): Error: template instance `ice21095.Mutex.this!()` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/ice23097.d
+++ b/compiler/test/fail_compilation/ice23097.d
@@ -5,7 +5,7 @@ fail_compilation/ice23097.d(13): Error: undefined identifier `ICE`
 fail_compilation/ice23097.d(28): Error: template instance `ice23097.ice23097!(S23097)` error instantiating
 fail_compilation/ice23097.d(28): Error: function `ice23097` is not callable using argument types `(S23097)`
 fail_compilation/ice23097.d(28):        generating a copy constructor for `struct S23097` failed, therefore instances of it are uncopyable
-fail_compilation/ice23097.d(11):        `ice23097.ice23097!(S23097).ice23097(S23097 __param_0)` declared here
+fail_compilation/ice23097.d(11):        `ice23097.ice23097!(S23097)(S23097 __param_0)` declared here
 ---
 */
 auto ice23097(I)(I)

--- a/compiler/test/fail_compilation/ice4094.d
+++ b/compiler/test/fail_compilation/ice4094.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice4094.d(11): Error: circular reference to variable `ice4094.Zug!0.Zug.bahn`
+fail_compilation/ice4094.d(11): Error: circular reference to variable `ice4094.Zug!0.bahn`
 fail_compilation/ice4094.d(19): Error: template instance `ice4094.Zug!0` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/ice9273a.d
+++ b/compiler/test/fail_compilation/ice9273a.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice9273a.d(19): Error: constructor `ice9273a.C.this!().this` no match for implicit `super()` call in constructor
+fail_compilation/ice9273a.d(19): Error: constructor `ice9273a.C.this!()` no match for implicit `super()` call in constructor
 fail_compilation/ice9273a.d(23): Error: template instance `ice9273a.C.this!()` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/ice9540.d
+++ b/compiler/test/fail_compilation/ice9540.d
@@ -3,7 +3,7 @@ TEST_OUTPUT:
 ----
 fail_compilation/ice9540.d(36): Error: function `dg` is not callable using argument types `()`
 fail_compilation/ice9540.d(36):        too few arguments, expected 1, got 0
-fail_compilation/ice9540.d(33):        `ice9540.A.test.AddFront!(this, f).AddFront.dg(int __param_0)` declared here
+fail_compilation/ice9540.d(33):        `ice9540.A.test.AddFront!(this, f).dg(int __param_0)` declared here
 fail_compilation/ice9540.d(27): Error: template instance `ice9540.A.test.AddFront!(this, f)` error instantiating
 ----
 */

--- a/compiler/test/fail_compilation/nestedtempl0.d
+++ b/compiler/test/fail_compilation/nestedtempl0.d
@@ -1,9 +1,9 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl0.d(18): Error: class `nestedtempl0.K.D!(1, B!(a)).D` doesn't need a frame pointer, but super class `B` needs the frame pointer of `main`
+fail_compilation/nestedtempl0.d(18): Error: class `nestedtempl0.K.D!(1, B!(a))` doesn't need a frame pointer, but super class `B` needs the frame pointer of `main`
 fail_compilation/nestedtempl0.d(28): Error: template instance `nestedtempl0.K.D!(1, B!(a))` error instantiating
-fail_compilation/nestedtempl0.d(18): Error: class `nestedtempl0.main.fun.D!(b, B!(a)).D` needs the frame pointer of `fun`, but super class `B` needs the frame pointer of `main`
+fail_compilation/nestedtempl0.d(18): Error: class `nestedtempl0.main.fun.D!(b, B!(a))` needs the frame pointer of `fun`, but super class `B` needs the frame pointer of `main`
 fail_compilation/nestedtempl0.d(33): Error: template instance `nestedtempl0.main.fun.D!(b, B!(a))` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/nestedtempl1.d
+++ b/compiler/test/fail_compilation/nestedtempl1.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl1.d(14): Deprecation: function `nestedtempl1.main.bar!(a).bar` function requires a dual-context, which is deprecated
+fail_compilation/nestedtempl1.d(14): Deprecation: function `nestedtempl1.main.bar!(a)` function requires a dual-context, which is deprecated
 fail_compilation/nestedtempl1.d(26):        instantiated from here: `bar!(a)`
 fail_compilation/nestedtempl1.d(26): Error: modify `inout` to `mutable` is not allowed inside `inout` function
 ---

--- a/compiler/test/fail_compilation/nestedtempl2.d
+++ b/compiler/test/fail_compilation/nestedtempl2.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl2.d(22): Deprecation: function `nestedtempl2.B.func!(n).func` function requires a dual-context, which is deprecated
+fail_compilation/nestedtempl2.d(22): Deprecation: function `nestedtempl2.B.func!(n)` function requires a dual-context, which is deprecated
 fail_compilation/nestedtempl2.d(34):        instantiated from here: `func!(n)`
 fail_compilation/nestedtempl2.d(34): Error: `this` is only defined in non-static member functions, not `test`
 fail_compilation/nestedtempl2.d(34): Error: need `this` of type `B` to call function `func`

--- a/compiler/test/fail_compilation/nestedtempl3.d
+++ b/compiler/test/fail_compilation/nestedtempl3.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/nestedtempl3.d(23): Error: cannot access frame pointer of `nestedtempl3.test.S!(i).S`
+fail_compilation/nestedtempl3.d(23): Error: cannot access frame pointer of `nestedtempl3.test.S!(i)`
 ---
 */
 

--- a/compiler/test/fail_compilation/objc_class3.d
+++ b/compiler/test/fail_compilation/objc_class3.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/objc_class3.d(15): Error: function `objc_class3.A.test!int.test` template cannot have an Objective-C selector attached
+fail_compilation/objc_class3.d(15): Error: function `objc_class3.A.test!int` template cannot have an Objective-C selector attached
 fail_compilation/objc_class3.d(21): Error: template instance `objc_class3.A.test!int` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/scope_infer_diagnostic.d
+++ b/compiler/test/fail_compilation/scope_infer_diagnostic.d
@@ -2,10 +2,10 @@
 REQUIRED_ARGS: -preview=dip1000
 TEST_OUTPUT:
 ---
-fail_compilation/scope_infer_diagnostic.d(34): Error: `@safe` function `scope_infer_diagnostic.outer` cannot call `@system` function `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe).inner`
+fail_compilation/scope_infer_diagnostic.d(34): Error: `@safe` function `scope_infer_diagnostic.outer` cannot call `@system` function `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe)`
 fail_compilation/scope_infer_diagnostic.d(28):        and assigning scope variable `w` to non-scope parameter `w` calling `callee` makes it fail to infer `@safe`
 fail_compilation/scope_infer_diagnostic.d(21):        `w` is not `scope` because of `globalPtr = & w`
-fail_compilation/scope_infer_diagnostic.d(25):        `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe).inner` is declared here
+fail_compilation/scope_infer_diagnostic.d(25):        `scope_infer_diagnostic.inner!(void delegate(const(char)[]) pure nothrow @nogc @safe)` is declared here
 ---
 */
 

--- a/compiler/test/fail_compilation/test17451.d
+++ b/compiler/test/fail_compilation/test17451.d
@@ -2,7 +2,7 @@
 ---
 fail_compilation/test17451.d(22): Error: undefined identifier `allocator`
 fail_compilation/test17451.d(23): Error: `false` has no effect
-fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).HashMap.__lambda_L30_C20.v` - size of type `ThreadSlot` is invalid
+fail_compilation/test17451.d(30): Error: variable `test17451.HashMap!(ThreadSlot).__lambda_L30_C20.v` - size of type `ThreadSlot` is invalid
 fail_compilation/test17451.d(44): Error: template instance `test17451.HashMap!(ThreadSlot)` error instantiating
 ---
 */

--- a/compiler/test/fail_compilation/test18607.d
+++ b/compiler/test/fail_compilation/test18607.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test18607.d(10): Error: function `test18607.test!int.test` no `return exp;` or `assert(0);` at end of function
+fail_compilation/test18607.d(10): Error: function `test18607.test!int` no `return exp;` or `assert(0);` at end of function
 & test
 ---
 */

--- a/compiler/test/fail_compilation/test20696.d
+++ b/compiler/test/fail_compilation/test20696.d
@@ -1,6 +1,6 @@
 /* TEST_OUTPUT:
 ---
-fail_compilation/test20696.d(106): Error: function `test20696.S!().S.test` cannot retrieve its `.mangleof` while inferring attributes
+fail_compilation/test20696.d(106): Error: function `test20696.S!().test` cannot retrieve its `.mangleof` while inferring attributes
 fail_compilation/test20696.d(106):        while evaluating `pragma(msg, test.mangleof)`
 fail_compilation/test20696.d(111): Error: template instance `test20696.S!()` error instantiating
 ---

--- a/compiler/test/fail_compilation/testInference.d
+++ b/compiler/test/fail_compilation/testInference.d
@@ -137,7 +137,7 @@ immutable(void)* g10063(inout int* p) pure
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int.foo14049`
+fail_compilation/testInference.d(154): Error: `pure` function `testInference.bar14049` cannot call impure function `testInference.foo14049!int`
 fail_compilation/testInference.d(149):        which calls `() => impure14049()`
 fail_compilation/testInference.d(148):        which calls `impure14049`
 fail_compilation/testInference.d(143):        and accessing mutable static data `i` makes it fail to infer `pure`
@@ -173,7 +173,7 @@ int* f14160() pure
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/testInference.d(180): Error: `pure` function `testInference.test12422` cannot call impure function `testInference.test12422.bar12422!().bar12422`
+fail_compilation/testInference.d(180): Error: `pure` function `testInference.test12422` cannot call impure function `testInference.test12422.bar12422!()`
 fail_compilation/testInference.d(179):        which calls `foo12422`
 ---
 */
@@ -191,7 +191,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/testInference.d(198): Error: `pure` function `testInference.test13729a` cannot call impure function `testInference.test13729a.foo`
 fail_compilation/testInference.d(196):        and accessing mutable static data `g13729` makes it fail to infer `pure`
-fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!().foo`
+fail_compilation/testInference.d(206): Error: `pure` function `testInference.test13729b` cannot call impure function `testInference.test13729b.foo!()`
 fail_compilation/testInference.d(204):        and accessing mutable static data `g13729` makes it fail to infer `pure`
 ---
 */

--- a/compiler/test/fail_compilation/testrvaluecpctor.d
+++ b/compiler/test/fail_compilation/testrvaluecpctor.d
@@ -4,9 +4,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/testrvaluecpctor.d(16): Error: cannot define both an rvalue constructor and a copy constructor for `struct Foo`
-fail_compilation/testrvaluecpctor.d(24):        Template instance `testrvaluecpctor.Foo!int.Foo.this!(immutable(Foo!int), immutable(Foo!int))` creates an rvalue constructor for `struct Foo`
+fail_compilation/testrvaluecpctor.d(24):        Template instance `testrvaluecpctor.Foo!int.this!(immutable(Foo!int), immutable(Foo!int))` creates an rvalue constructor for `struct Foo`
 fail_compilation/testrvaluecpctor.d(24): Error: none of the overloads of `this` can construct an immutable object with argument types `(immutable(Foo!int))`. Expected `immutable(immutable(Foo!int))`
-fail_compilation/testrvaluecpctor.d(18):        Candidates are: `testrvaluecpctor.Foo!int.Foo.this(ref scope Foo!int rhs)`
+fail_compilation/testrvaluecpctor.d(18):        Candidates are: `testrvaluecpctor.Foo!int.this(ref scope Foo!int rhs)`
 fail_compilation/testrvaluecpctor.d(16):                        `this(Rhs, this This)(scope Rhs rhs)`
 ---
 */

--- a/compiler/test/runnable/issue18919.d
+++ b/compiler/test/runnable/issue18919.d
@@ -12,8 +12,8 @@ imports.issue18919b.func4: issue18919.d:35 issue18919.main void issue18919.main(
 imports.issue18919b.func4b: issue18919.d:36 issue18919.main void issue18919.main() issue18919
 imports.issue18919b.func4c: issue18919.d:37 issue18919.main void issue18919.main() issue18919
 imports.issue18919b.func4d: issue18919.d:38 issue18919.main void issue18919.main() issue18919
-imports.issue18919b.func5!("issue18919.d", 39, "issue18919.main", "void issue18919.main()", "issue18919").func5: issue18919.d:39 issue18919.main void issue18919.main() issue18919
-imports.issue18919b.func6!("issue18919.d", 40, "issue18919.main", "void issue18919.main()", "issue18919").func6: issue18919.d:40 issue18919.main void issue18919.main() issue18919
+imports.issue18919b.func5!("issue18919.d", 39, "issue18919.main", "void issue18919.main()", "issue18919"): issue18919.d:39 issue18919.main void issue18919.main() issue18919
+imports.issue18919b.func6!("issue18919.d", 40, "issue18919.main", "void issue18919.main()", "issue18919"): issue18919.d:40 issue18919.main void issue18919.main() issue18919
 imports.issue18919b.func7: expr1=1082, file=issue18919.d func=issue18919.main, expr3=1
 imports.issue18919b.func8: expr1=[42, 1042, ], expr2=[issue18919.d: 42, ], expr3=constant2, expr4=issue18919
 imports.issue18919b.func9.fp: issue18919b.d:216 imports.issue18919b

--- a/compiler/test/runnable/template10.d
+++ b/compiler/test/runnable/template10.d
@@ -2,58 +2,58 @@
 // REQUIRED_ARGS: -verrors=simple -verrors=0
 /* TEST_OUTPUT:
 ---
-runnable/template10.d(89): Deprecation: function `template10.test1b.f0.f!(a).f` function requires a dual-context, which is deprecated
+runnable/template10.d(89): Deprecation: function `template10.test1b.f0.f!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(94):        instantiated from here: `f!(a)`
 runnable/template10.d(105): Deprecation: function `template10.test1c.f0.f1.v!(c).sum` function requires a dual-context, which is deprecated
 runnable/template10.d(122):        instantiated from here: `v!(c)`
-runnable/template10.d(170): Deprecation: function `template10.test3.exec!(set).exec` function requires a dual-context, which is deprecated
+runnable/template10.d(170): Deprecation: function `template10.test3.exec!(set)` function requires a dual-context, which is deprecated
 runnable/template10.d(182):        instantiated from here: `exec!(set)`
-runnable/template10.d(201): Deprecation: function `template10.get4i.inner!(a).inner` function requires a dual-context, which is deprecated
+runnable/template10.d(201): Deprecation: function `template10.get4i.inner!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(238):        instantiated from here: `inner!(a)`
-runnable/template10.d(196): Deprecation: function `template10.test4.add!(a).add` function requires a dual-context, which is deprecated
+runnable/template10.d(196): Deprecation: function `template10.test4.add!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(245):        instantiated from here: `add!(a)`
-runnable/template10.d(211): Deprecation: function `template10.test4i!(I).test4i.add2!(b).add2` function requires a dual-context, which is deprecated
+runnable/template10.d(211): Deprecation: function `template10.test4i!(I).add2!(b)` function requires a dual-context, which is deprecated
 runnable/template10.d(231):        instantiated from here: `add2!(b)`
 runnable/template10.d(251):        instantiated from here: `test4i!(I)`
-runnable/template10.d(201): Deprecation: function `template10.test4.inner!(a).inner` function requires a dual-context, which is deprecated
+runnable/template10.d(201): Deprecation: function `template10.test4.inner!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(256):        instantiated from here: `inner!(a)`
-runnable/template10.d(266): Deprecation: function `template10.test5.add!(fun).add` function requires a dual-context, which is deprecated
+runnable/template10.d(266): Deprecation: function `template10.test5.add!(fun)` function requires a dual-context, which is deprecated
 runnable/template10.d(282):        instantiated from here: `add!(fun)`
-runnable/template10.d(271): Deprecation: function `template10.test5.add!(fun).add.exec2!(fun, add).exec2` function requires a dual-context, which is deprecated
+runnable/template10.d(271): Deprecation: function `template10.test5.add!(fun).exec2!(fun, add)` function requires a dual-context, which is deprecated
 runnable/template10.d(269):        instantiated from here: `exec2!(fun, add)`
 runnable/template10.d(282):        instantiated from here: `add!(fun)`
-runnable/template10.d(299): Deprecation: function `template10.test6a.makeR!(j).makeR` function requires a dual-context, which is deprecated
+runnable/template10.d(299): Deprecation: function `template10.test6a.makeR!(j)` function requires a dual-context, which is deprecated
 runnable/template10.d(321):        instantiated from here: `makeR!(j)`
-runnable/template10.d(307): Deprecation: function `template10.test6a.inc!(k).inc` function requires a dual-context, which is deprecated
+runnable/template10.d(307): Deprecation: function `template10.test6a.inc!(k)` function requires a dual-context, which is deprecated
 runnable/template10.d(322):        instantiated from here: `inc!(k)`
-runnable/template10.d(333): Deprecation: function `template10.test6b.f0!(a).f0` function requires a dual-context, which is deprecated
+runnable/template10.d(333): Deprecation: function `template10.test6b.f0!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(358):        instantiated from here: `f0!(a)`
-runnable/template10.d(366): Deprecation: function `template10.test6c.f0.exec!(f).exec` function requires a dual-context, which is deprecated
+runnable/template10.d(366): Deprecation: function `template10.test6c.f0.exec!(f)` function requires a dual-context, which is deprecated
 runnable/template10.d(385):        instantiated from here: `exec!(f)`
 runnable/template10.d(410): Deprecation: function `template10.test7.C!(c).sum` function requires a dual-context, which is deprecated
 runnable/template10.d(437):        instantiated from here: `C!(c)`
-runnable/template10.d(464): Deprecation: constructor `template10.test8.this!(a).this` function requires a dual-context, which is deprecated
+runnable/template10.d(464): Deprecation: constructor `template10.test8.this!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(484):        instantiated from here: `this!(a)`
-runnable/template10.d(468): Deprecation: function `template10.test8.add!(b).add` function requires a dual-context, which is deprecated
+runnable/template10.d(468): Deprecation: function `template10.test8.add!(b)` function requires a dual-context, which is deprecated
 runnable/template10.d(486):        instantiated from here: `add!(b)`
-runnable/template10.d(446): Deprecation: function `template10.test8.sub!(b).sub` function requires a dual-context, which is deprecated
+runnable/template10.d(446): Deprecation: function `template10.test8.sub!(b)` function requires a dual-context, which is deprecated
 runnable/template10.d(487):        instantiated from here: `sub!(b)`
-runnable/template10.d(528): Deprecation: function `template10.test10.add!(fun).add` function requires a dual-context, which is deprecated
+runnable/template10.d(528): Deprecation: function `template10.test10.add!(fun)` function requires a dual-context, which is deprecated
 runnable/template10.d(544):        instantiated from here: `add!(fun)`
-runnable/template10.d(533): Deprecation: function `template10.test10.add!(fun).add.exec2!(fun, add).exec2` function requires a dual-context, which is deprecated
+runnable/template10.d(533): Deprecation: function `template10.test10.add!(fun).exec2!(fun, add)` function requires a dual-context, which is deprecated
 runnable/template10.d(531):        instantiated from here: `exec2!(fun, add)`
 runnable/template10.d(544):        instantiated from here: `add!(fun)`
-runnable/template10.d(552): Deprecation: function `template10.test11.getVal!(a).getVal` function requires a dual-context, which is deprecated
+runnable/template10.d(552): Deprecation: function `template10.test11.getVal!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(574):        instantiated from here: `getVal!(a)`
-runnable/template10.d(556): Deprecation: function `template10.test11.getRef!(a).getRef` function requires a dual-context, which is deprecated
+runnable/template10.d(556): Deprecation: function `template10.test11.getRef!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(578):        instantiated from here: `getRef!(a)`
-runnable/template10.d(588): Deprecation: function `template10.N12.sum!(n).sum` function requires a dual-context, which is deprecated
+runnable/template10.d(588): Deprecation: function `template10.N12.sum!(n)` function requires a dual-context, which is deprecated
 runnable/template10.d(624):        instantiated from here: `sum!(n)`
-runnable/template10.d(593): Deprecation: function `template10.N12.inner!(n).inner` function requires a dual-context, which is deprecated
+runnable/template10.d(593): Deprecation: function `template10.N12.inner!(n)` function requires a dual-context, which is deprecated
 runnable/template10.d(630):        instantiated from here: `inner!(n)`
-runnable/template10.d(692): Deprecation: function `template10.test13a.getI!(a).getI` function requires a dual-context, which is deprecated
+runnable/template10.d(692): Deprecation: function `template10.test13a.getI!(a)` function requires a dual-context, which is deprecated
 runnable/template10.d(719):        instantiated from here: `getI!(a)`
-runnable/template10.d(731): Deprecation: function `template10.test13b.getC.C.fun!(n).fun` function requires a dual-context, which is deprecated
+runnable/template10.d(731): Deprecation: function `template10.test13b.getC.C.fun!(n)` function requires a dual-context, which is deprecated
 runnable/template10.d(741):        instantiated from here: `fun!(n)`
 ---
 */

--- a/compiler/test/runnable/testkeyword.d
+++ b/compiler/test/runnable/testkeyword.d
@@ -124,8 +124,8 @@ void main(string[] args) nothrow
     {
         void func(string cs, T1, alias T2, T...)(int x) const
         {
-            enum thisFunc       = `testkeyword.main.S.func!("foo", int, symbol, int[], float[]).func`;
-            enum thisFunc2 = `void testkeyword.main.S.func!("foo", int, symbol, int[], float[]).func(int x) const`;
+            enum thisFunc       = `testkeyword.main.S.func!("foo", int, symbol, int[], float[])`;
+            enum thisFunc2 = `void testkeyword.main.S.func!("foo", int, symbol, int[], float[])(int x) const`;
 
             static assert(getFuncArgFile()  == thisFile);
             static assert(getFuncArgLine()  == 131);

--- a/compiler/test/unit/objc/protocols/optional_methods.d
+++ b/compiler/test/unit/objc/protocols/optional_methods.d
@@ -192,7 +192,7 @@ unittest
     auto expected = [
         Diagnostic(
             SourceLoc(filename, 6, 20),
-            "Error: function test.Foo.foo!().foo template cannot be optional"
+            "Error: function test.Foo.foo!() template cannot be optional"
         ),
         Diagnostic(
             SourceLoc(filename, 17, 10),


### PR DESCRIPTION
2 caveats:
- json output changes, too. Does it affect tools that might read and interpret the name?
- explicitly specified eponymous symbols get removed, too, e.g. in https://github.com/rainers/dmd/blob/a6bbb7216f76d48622b7e1cd75b4ba8cb649159c/test/fail_compilation/ice9540.d