### PR TITLE
Add tests for tuple-foreach with DIP1000

### DIFF
--- a/test/compilable/scope.d
+++ b/test/compilable/scope.d
@@ -51,3 +51,30 @@ auto callWrappedOops(scope string dArgs) {
 }
 
 /************************************/
+
+struct Constant
+{
+    int* member;
+
+    this(Repeat!(int*) grid) @safe
+    {
+        foreach(ref x; grid)
+            member = x;
+
+        foreach(ref x; grid)
+            x = member;
+    }
+
+    int* foo(return scope Repeat!(int*) grid) @safe
+    {
+        foreach(ref x; grid)
+            x = member;
+
+        foreach(ref x; grid)
+            return x;
+
+        return null;
+    }
+
+    alias Repeat(T...) = T;
+}

--- a/test/fail_compilation/retscope.d
+++ b/test/fail_compilation/retscope.d
@@ -660,3 +660,31 @@ int test21()
     foo22(s);
 }
 
+/*********************************************
+TEST_OUTPUT:
+---
+fail_compilation/retscope.d(1907): Error: scope variable `x` assigned to `this` with longer lifetime
+fail_compilation/retscope.d(1913): Error: scope variable `x` may not be returned
+---
+*/
+#line 1900
+struct Constant
+{
+    int* member;
+
+    int* foo(scope Repeat!(int*) grid) @safe
+    {
+        foreach(ref x; grid)
+            member = x;
+
+        foreach(ref x; grid)
+            x = member;
+
+        foreach(ref x; grid)
+            return x;
+
+        return null;
+    }
+
+    alias Repeat(T...) = T;
+}


### PR DESCRIPTION
These were only covered in MIR but not the core test suite AFAICT.

Extracted from #10787