### PR TITLE
Fix issue 18439: Remove attributes applied to hidden lambda in static foreach

### DIFF
--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -291,6 +291,13 @@ extern (C++) final class StaticForeach : RootObject
 
     private void lowerNonArrayAggregate(Scope* sc)
     {
+        // attributes that pass through scope can interfer with the lambda used
+        // the lambda is only ever used at compile time, so they can be ignored
+        sc = sc.push();
+        sc.stc &= ~STCFlowThruFunction;
+        scope(exit)
+            sc = sc.pop();
+
         auto nvars = aggrfe ? aggrfe.parameters.dim : 1;
         auto aloc = aggrfe ? aggrfe.aggr.loc : rangefe.lwr.loc;
         // We need three sets of foreach loop variables because the

--- a/test/compilable/b18439.d
+++ b/test/compilable/b18439.d
@@ -1,0 +1,9 @@
+// https://issues.dlang.org/show_bug.cgi?id=18439
+// Internally `static foreach` builds an array using `~=` for ranges which uses the GC
+// this would cause a compiler error when @nogc is used, even though the code is only run at compile time
+
+@nogc:
+
+void test() {
+    static foreach(i; 0 .. 1)    {} // @nogc
+}


### PR DESCRIPTION
I think someone said they were making a patch that'd "fix" this issue, but it has been close to a year now with no "fix" in sight and I keep bumping up against this bug. Would rather have a simple imperfect 5 line patch than let perfection be the enemy of sanity.