### PR TITLE
Restore old unittest behaviour for runnable tests

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1170,6 +1170,11 @@ int tryMain(string[] args)
                     command = test_app_dmd;
                     if (testArgs.executeArgs) command ~= " " ~ testArgs.executeArgs;
 
+                    // Always run main even if compiled with '-unittest' but let
+                    // tests switch to another behaviour if necessary
+                    if (!command.canFind("--DRT-testmode"))
+                        command ~= " --DRT-testmode=run-main";
+
                     const output = execute(fThisRun, command, true, result_path)
                                     .strip()
                                     .unifyNewLine();


### PR DESCRIPTION
In 2.090 the default behaviour was changed to not run `main` if unittests are present. Explicitly passing --DRT-testmode=run-main reverts to the old behaviour and ensures that all tests are run as intended.