### PR TITLE
Fix issue 20627: Module ctors / dtors should always have D linkage

### DIFF
--- a/changelog/dep-non-externd-modulectordtors.dd
+++ b/changelog/dep-non-externd-modulectordtors.dd
@@ -1,0 +1,13 @@
+Module constructors and destructors which are not extern(D) are deprecated
+
+Module constructors and destructors (shared or not) could be marked with
+a different linkage than `extern(D)`, which would affect their mangling.
+Since such a mangling is simple and predictable, there was a very small
+chance of conflict if two same kind of constructor/destructors
+were declared in similar condition, for example if the third
+module constructor in module `a` was on line 479 and the third
+module constructor in module `b` was also on line 479,
+they would have the same mangling.
+
+While it's unlikely that such a bug is triggered in practice,
+affected symbols will now trigger a deprecation message.

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4293,7 +4293,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             scd.fbody = new CompoundStatement(Loc.initial, sa);
         }
 
+        const LINK save = sc.linkage;
+        if (save != LINK.d)
+        {
+            const(char)* s = (scd.isSharedStaticCtorDeclaration() ? "shared " : "");
+            deprecation(scd.loc, "`%sstatic` constructor can only be of D linkage", s);
+            // Just correct it
+            sc.linkage = LINK.d;
+        }
         funcDeclarationSemantic(scd);
+        sc.linkage = save;
 
         // We're going to need ModuleInfo
         Module m = scd.getModule();
@@ -4363,7 +4372,16 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             sdd.vgate = v;
         }
 
+        const LINK save = sc.linkage;
+        if (save != LINK.d)
+        {
+            const(char)* s = (sdd.isSharedStaticDtorDeclaration() ? "shared " : "");
+            deprecation(sdd.loc, "`%sstatic` destructor can only be of D linkage", s);
+            // Just correct it
+            sc.linkage = LINK.d;
+        }
         funcDeclarationSemantic(sdd);
+        sc.linkage = save;
 
         // We're going to need ModuleInfo
         Module m = sdd.getModule();

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -421,6 +421,17 @@ private immutable TOK[] keywords =
     TOK.immutable_,
 ];
 
+// Initialize the identifier pool
+shared static this() nothrow
+{
+    Identifier.initTable();
+    foreach (kw; keywords)
+    {
+        //printf("keyword[%d] = '%s'\n",kw, tochars[kw].ptr);
+        Identifier.idPool(Token.tochars[kw].ptr, Token.tochars[kw].length, cast(uint)kw);
+    }
+}
+
 /***********************************************************
  */
 extern (C++) struct Token
@@ -706,16 +717,6 @@ extern (C++) struct Token
     }());
 
 nothrow:
-
-    shared static this()
-    {
-        Identifier.initTable();
-        foreach (kw; keywords)
-        {
-            //printf("keyword[%d] = '%s'\n",kw, tochars[kw].ptr);
-            Identifier.idPool(tochars[kw].ptr, tochars[kw].length, cast(uint)kw);
-        }
-    }
 
     int isKeyword() const
     {

--- a/test/fail_compilation/issue20627.d
+++ b/test/fail_compilation/issue20627.d
@@ -1,0 +1,67 @@
+/**
+REQUIRED_ARGS: -de
+TEST_OUTPUT:
+---
+fail_compilation/issue20627.d(38): Deprecation: `shared static` constructor can only be of D linkage
+fail_compilation/issue20627.d(39): Deprecation: `shared static` destructor can only be of D linkage
+fail_compilation/issue20627.d(40): Deprecation: `static` constructor can only be of D linkage
+fail_compilation/issue20627.d(41): Deprecation: `static` destructor can only be of D linkage
+fail_compilation/issue20627.d(55): Deprecation: `shared static` constructor can only be of D linkage
+fail_compilation/issue20627.d(56): Deprecation: `shared static` destructor can only be of D linkage
+fail_compilation/issue20627.d(57): Deprecation: `static` constructor can only be of D linkage
+fail_compilation/issue20627.d(58): Deprecation: `static` destructor can only be of D linkage
+fail_compilation/issue20627.d(63): Deprecation: `shared static` constructor can only be of D linkage
+fail_compilation/issue20627.d(64): Deprecation: `shared static` destructor can only be of D linkage
+fail_compilation/issue20627.d(65): Deprecation: `static` constructor can only be of D linkage
+fail_compilation/issue20627.d(66): Deprecation: `static` destructor can only be of D linkage
+---
+*/
+
+// OK, default linkage
+shared static this () {}
+shared static ~this () {}
+static this () {}
+static ~this () {}
+
+// Still okay
+extern(D)
+{
+    shared static this () {}
+    shared static ~this () {}
+    static this () {}
+    static ~this () {}
+}
+
+// No!
+extern(C)
+{
+    shared static this () {}
+    shared static ~this () {}
+    static this () {}
+    static ~this () {}
+}
+
+// Disabled because platform specific
+version (none) extern(Objective-C)
+{
+    shared static this () {}
+    shared static ~this () {}
+    static this () {}
+    static ~this () {}
+}
+
+extern(C++)
+{
+    shared static this () {}
+    shared static ~this () {}
+    static this () {}
+    static ~this () {}
+}
+
+extern(System)
+{
+    shared static this () {}
+    shared static ~this () {}
+    static this () {}
+    static ~this () {}
+}


### PR DESCRIPTION
See the changelog for the rationale of this change (or the issue).