### PR TITLE
Fix issue 20637: Don't offer private type property corrections

### DIFF
--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -216,7 +216,7 @@ extern (C++) final class EnumDeclaration : ScopeDsymbol
             {
                 /* Allow these special enums to not need a member list
                  */
-                return memtype.getProperty(loc, id, 0);
+                return memtype.getProperty(_scope, loc, id, 0);
             }
 
             error("is forward referenced looking for `.%s`", id.toChars());

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2617,7 +2617,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
                 ? em.ed.memtype
                 : eprev.type;
 
-            Expression emax = tprev.getProperty(em.ed.loc, Id.max, 0);
+            Expression emax = tprev.getProperty(sc, em.ed.loc, Id.max, 0);
             emax = emax.expressionSemantic(sc);
             emax = emax.ctfeInterpret();
 

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -445,7 +445,7 @@ private Expression searchUFCS(Scope* sc, UnaExp ue, Identifier ident)
     }
 
     if (!s)
-        return ue.e1.type.Type.getProperty(loc, ident, 0);
+        return ue.e1.type.Type.getProperty(sc, loc, ident, 0);
 
     FuncDeclaration f = s.isFuncDeclaration();
     if (f)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2172,6 +2172,8 @@ Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier iden
                 s = mt.toDsymbol(null);
             if (s)
                 s = s.search_correct(ident);
+            if (s && !symbolIsVisible(scope_, s))
+                s = null;
             if (mt != Type.terror)
             {
                 if (s)

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -2101,13 +2101,14 @@ Type merge(Type type)
  *
  * Params:
  *  t = the type for which the property is calculated
+ *  scope_ = the scope from which the property is being accessed. Used for visibility checks only.
  *  loc = the location where the property is encountered
  *  ident = the identifier of the property
  *  flag = if flag & 1, don't report "not a property" error and just return NULL.
  * Returns:
  *      expression representing the property, or null if not a property and (flag & 1)
  */
-Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
+Expression getProperty(Type t, Scope* scope_, const ref Loc loc, Identifier ident, int flag)
 {
     Expression visitType(Type mt)
     {
@@ -2459,7 +2460,7 @@ Expression getProperty(Type t, const ref Loc loc, Identifier ident, int flag)
         }
         else
         {
-            e = mt.toBasetype().getProperty(loc, ident, flag);
+            e = mt.toBasetype().getProperty(scope_, loc, ident, flag);
         }
         return e;
     }
@@ -3173,7 +3174,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             e = new StringExp(e.loc, e.toString());
         }
         else
-            e = mt.getProperty(e.loc, ident, flag & DotExpFlag.gag);
+            e = mt.getProperty(sc, e.loc, ident, flag & DotExpFlag.gag);
 
     Lreturn:
         if (e)
@@ -3233,7 +3234,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 break;
 
             default:
-                e = mt.Type.getProperty(e.loc, ident, flag);
+                e = mt.Type.getProperty(sc, e.loc, ident, flag);
                 break;
             }
         }
@@ -3284,7 +3285,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
                 break;
 
             default:
-                e = mt.Type.getProperty(e.loc, ident, flag);
+                e = mt.Type.getProperty(sc, e.loc, ident, flag);
                 break;
             }
         }
@@ -3624,7 +3625,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         // https://issues.dlang.org/show_bug.cgi?id=14010
         if (ident == Id._mangleof)
         {
-            return mt.getProperty(e.loc, ident, flag & 1);
+            return mt.getProperty(sc, e.loc, ident, flag & 1);
         }
 
         /* If e.tupleof
@@ -3846,7 +3847,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         // https://issues.dlang.org/show_bug.cgi?id=14010
         if (ident == Id._mangleof)
         {
-            return mt.getProperty(e.loc, ident, flag & 1);
+            return mt.getProperty(sc, e.loc, ident, flag & 1);
         }
 
         if (mt.sym.semanticRun < PASS.semanticdone)
@@ -3874,7 +3875,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         {
             if (ident == Id.max || ident == Id.min || ident == Id._init)
             {
-                return mt.getProperty(e.loc, ident, flag & 1);
+                return mt.getProperty(sc, e.loc, ident, flag & 1);
             }
 
             Expression res = mt.sym.getMemtype(Loc.initial).dotExp(sc, e, ident, 1);
@@ -3907,7 +3908,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
         // https://issues.dlang.org/show_bug.cgi?id=12543
         if (ident == Id.__sizeof || ident == Id.__xalignof || ident == Id._mangleof)
         {
-            return mt.Type.getProperty(e.loc, ident, 0);
+            return mt.Type.getProperty(sc, e.loc, ident, 0);
         }
 
         /* If e.tupleof
@@ -3965,7 +3966,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             {
                 if (e.op == TOK.type)
                 {
-                    return mt.Type.getProperty(e.loc, ident, 0);
+                    return mt.Type.getProperty(sc, e.loc, ident, 0);
                 }
                 e = new DotTypeExp(e.loc, e, mt.sym);
                 e = e.expressionSemantic(sc);
@@ -3975,7 +3976,7 @@ Expression dotExp(Type mt, Scope* sc, Expression e, Identifier ident, int flag)
             {
                 if (e.op == TOK.type)
                 {
-                    return mt.Type.getProperty(e.loc, ident, 0);
+                    return mt.Type.getProperty(sc, e.loc, ident, 0);
                 }
                 if (auto ifbase = cbase.isInterfaceDeclaration())
                     e = new CastExp(e.loc, e, ifbase.type);

--- a/test/fail_compilation/diag10169.d
+++ b/test/fail_compilation/diag10169.d
@@ -1,7 +1,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag10169.d(11): Error: no property `x` for type `B`, did you mean `imports.a10169.B.x`?
+fail_compilation/diag10169.d(11): Error: no property `x` for type `imports.a10169.B`
 ---
 */
 import imports.a10169;

--- a/test/fail_compilation/diag5385.d
+++ b/test/fail_compilation/diag5385.d
@@ -1,14 +1,14 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/diag5385.d(19): Error: no property `privX` for type `imports.fail5385.C`, did you mean `imports.fail5385.C.privX`?
-fail_compilation/diag5385.d(20): Error: no property `packX` for type `imports.fail5385.C`, did you mean `imports.fail5385.C.packX`?
-fail_compilation/diag5385.d(21): Error: no property `privX2` for type `imports.fail5385.C`, did you mean `imports.fail5385.C.privX2`?
-fail_compilation/diag5385.d(22): Error: no property `packX2` for type `imports.fail5385.C`, did you mean `imports.fail5385.C.packX2`?
-fail_compilation/diag5385.d(23): Error: no property `privX` for type `S`, did you mean `imports.fail5385.S.privX`?
-fail_compilation/diag5385.d(24): Error: no property `packX` for type `S`, did you mean `imports.fail5385.S.packX`?
-fail_compilation/diag5385.d(25): Error: no property `privX2` for type `S`, did you mean `imports.fail5385.S.privX2`?
-fail_compilation/diag5385.d(26): Error: no property `packX2` for type `S`, did you mean `imports.fail5385.S.packX2`?
+fail_compilation/diag5385.d(19): Error: no property `privX` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(20): Error: no property `packX` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(21): Error: no property `privX2` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(22): Error: no property `packX2` for type `imports.fail5385.C`
+fail_compilation/diag5385.d(23): Error: no property `privX` for type `imports.fail5385.S`
+fail_compilation/diag5385.d(24): Error: no property `packX` for type `imports.fail5385.S`
+fail_compilation/diag5385.d(25): Error: no property `privX2` for type `imports.fail5385.S`
+fail_compilation/diag5385.d(26): Error: no property `packX2` for type `imports.fail5385.S`
 ---
 */
 

--- a/test/fail_compilation/dip22a.d
+++ b/test/fail_compilation/dip22a.d
@@ -2,8 +2,8 @@
 REQUIRED_ARGS:
 TEST_OUTPUT:
 ---
-fail_compilation/dip22a.d(16): Error: no property `bar` for type `imports.dip22a.Klass`, did you mean `imports.dip22a.Klass.bar`?
-fail_compilation/dip22a.d(17): Error: no property `bar` for type `Struct`, did you mean `imports.dip22a.Struct.bar`?
+fail_compilation/dip22a.d(16): Error: no property `bar` for type `imports.dip22a.Klass`
+fail_compilation/dip22a.d(17): Error: no property `bar` for type `imports.dip22a.Struct`
 fail_compilation/dip22a.d(18): Error: undefined identifier `bar` in module `imports.dip22a`, did you mean function `bar`?
 fail_compilation/dip22a.d(19): Error: no property `bar` for type `void`
 fail_compilation/dip22a.d(20): Error: no property `bar` for type `int`

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -5,10 +5,10 @@ fail_compilation/fail10528.d(19): Error: undefined identifier `a`
 fail_compilation/fail10528.d(20): Error: undefined identifier `a` in module `a10528`, did you mean variable `a`?
 fail_compilation/fail10528.d(22): Error: undefined identifier `b`
 fail_compilation/fail10528.d(23): Error: undefined identifier `b` in module `a10528`, did you mean enum member `b`?
-fail_compilation/fail10528.d(25): Error: no property `c` for type `S`, did you mean `a10528.S.c`?
-fail_compilation/fail10528.d(26): Error: no property `c` for type `S`, did you mean `a10528.S.c`?
-fail_compilation/fail10528.d(28): Error: no property `d` for type `a10528.C`, did you mean `a10528.C.d`?
-fail_compilation/fail10528.d(29): Error: no property `d` for type `a10528.C`, did you mean `a10528.C.d`?
+fail_compilation/fail10528.d(25): Error: no property `c` for type `a10528.S`
+fail_compilation/fail10528.d(26): Error: no property `c` for type `a10528.S`
+fail_compilation/fail10528.d(28): Error: no property `d` for type `a10528.C`
+fail_compilation/fail10528.d(29): Error: no property `d` for type `a10528.C`
 ---
 */
 

--- a/test/fail_compilation/fail18979.d
+++ b/test/fail_compilation/fail18979.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail18979.d(13): Error: no property `__ctor` for type `Foo`, did you mean `imports.imp18979.Foo.__ctor(A)(A a)`?
+fail_compilation/fail18979.d(13): Error: no property `__ctor` for type `imports.imp18979.Foo`
 ----
 */
 

--- a/test/fail_compilation/fail20637.d
+++ b/test/fail_compilation/fail20637.d
@@ -1,0 +1,11 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20637.d(11): Error: no property `foo` for type `imports.fail20637b.A`
+---
+*/
+module fail20637;
+
+import imports.fail20637b;
+
+void main() { A.foo; }

--- a/test/fail_compilation/imports/fail20637b.d
+++ b/test/fail_compilation/imports/fail20637b.d
@@ -1,0 +1,3 @@
+module imports.fail20637b;
+
+class A { private static void foo() { } }

--- a/test/fail_compilation/test15785.d
+++ b/test/fail_compilation/test15785.d
@@ -2,7 +2,7 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/test15785.d(16): Error: no property `foo` for type `imports.test15785.Base`, did you mean `imports.test15785.Base.foo`?
+fail_compilation/test15785.d(16): Error: no property `foo` for type `imports.test15785.Base`
 fail_compilation/test15785.d(17): Error: undefined identifier `bar`
 ---
 */


### PR DESCRIPTION
Check whether property is visible locally before offering a correction. Pass through scope to `getProperty` to enable this.