### PR TITLE
Fix issue 20638: only offer correction for module property if symbol is visible.

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -11677,7 +11677,7 @@ Expression semanticY(DotIdExp exp, Scope* sc, int flag)
         if (flag)
             return null;
         s = ie.sds.search_correct(exp.ident);
-        if (s)
+        if (s && symbolIsVisible(sc, s))
         {
             if (s.isPackage())
                 exp.error("undefined identifier `%s` in %s `%s`, perhaps add `static import %s;`", exp.ident.toChars(), ie.sds.kind(), ie.sds.toPrettyChars(), s.toPrettyChars());

--- a/test/fail_compilation/dip22a.d
+++ b/test/fail_compilation/dip22a.d
@@ -4,7 +4,7 @@ TEST_OUTPUT:
 ---
 fail_compilation/dip22a.d(16): Error: no property `bar` for type `imports.dip22a.Klass`
 fail_compilation/dip22a.d(17): Error: no property `bar` for type `imports.dip22a.Struct`
-fail_compilation/dip22a.d(18): Error: undefined identifier `bar` in module `imports.dip22a`, did you mean function `bar`?
+fail_compilation/dip22a.d(18): Error: undefined identifier `bar` in module `imports.dip22a`
 fail_compilation/dip22a.d(19): Error: no property `bar` for type `void`
 fail_compilation/dip22a.d(20): Error: no property `bar` for type `int`
 ---

--- a/test/fail_compilation/fail10528.d
+++ b/test/fail_compilation/fail10528.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/fail10528.d(19): Error: undefined identifier `a`
-fail_compilation/fail10528.d(20): Error: undefined identifier `a` in module `a10528`, did you mean variable `a`?
+fail_compilation/fail10528.d(20): Error: undefined identifier `a` in module `a10528`
 fail_compilation/fail10528.d(22): Error: undefined identifier `b`
-fail_compilation/fail10528.d(23): Error: undefined identifier `b` in module `a10528`, did you mean enum member `b`?
+fail_compilation/fail10528.d(23): Error: undefined identifier `b` in module `a10528`
 fail_compilation/fail10528.d(25): Error: no property `c` for type `a10528.S`
 fail_compilation/fail10528.d(26): Error: no property `c` for type `a10528.S`
 fail_compilation/fail10528.d(28): Error: no property `d` for type `a10528.C`

--- a/test/fail_compilation/fail20638.d
+++ b/test/fail_compilation/fail20638.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/fail20638.d(12): Error: undefined identifier `foo` in module `imports.fail20638b`
+---
+*/
+module fail20638;
+
+import imports.fail20638b;
+
+void main() {
+    imports.fail20638b.foo;
+}

--- a/test/fail_compilation/imports/fail20638b.d
+++ b/test/fail_compilation/imports/fail20638b.d
@@ -1,0 +1,3 @@
+module imports.fail20638b;
+
+private void foo() { }


### PR DESCRIPTION
Similar to #10867 , but easier to check.
