### PR TITLE
Fix issue 20645 - printf deprecation for width + precision

### DIFF
--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -166,6 +166,7 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                     errorMsg(null, slice, e, "ptrdiff_t", t);
                 break;
 
+            case Format.lg:
             case Format.g:      // double
                 if (t.ty != Tfloat64 && t.ty != Timaginary64)
                     errorMsg(null, slice, e, "double", t);
@@ -245,7 +246,6 @@ bool checkPrintfFormat(ref const Loc loc, scope const char[] format, scope Expre
                 deprecation(loc, "format specifier `\"%.*s\"` is invalid", cast(int)slice.length, slice.ptr);
                 break;
 
-            case Format.lg:
             case Format.percent:
                 assert(0);
         }
@@ -671,7 +671,7 @@ Format parsePrintfFormatSpecifier(scope const char[] format, ref size_t idx,
      */
     char genSpec;
     Format specifier = parseGenericFormatSpecifier(format, i, genSpec);
-    if (specifier == Format.error || specifier == Format.lg)
+    if (specifier == Format.error)
         return error();
 
     switch (genSpec)
@@ -1055,7 +1055,7 @@ unittest
      assert(idx == 2);
 
      idx = 0;
-     assert(parsePrintfFormatSpecifier("%lg", idx, widthStar, precisionStar) == Format.error);
+     assert(parsePrintfFormatSpecifier("%lg", idx, widthStar, precisionStar) == Format.lg);
      assert(idx == 3);
 
      // width, precision

--- a/test/fail_compilation/chkformat.d
+++ b/test/fail_compilation/chkformat.d
@@ -5,7 +5,6 @@ TEST_OUTPUT:
 fail_compilation/chkformat.d(101): Deprecation: width argument `0L` for format specification `"%*.*d"` must be `int`, not `long`
 fail_compilation/chkformat.d(101): Deprecation: precision argument `1L` for format specification `"%*.*d"` must be `int`, not `long`
 fail_compilation/chkformat.d(101): Deprecation: argument `2L` for format specification `"%*.*d"` must be `int`, not `long`
-fail_compilation/chkformat.d(102): Deprecation: format specifier `"%2.2lf"` is invalid
 fail_compilation/chkformat.d(104): Deprecation: argument `4` for format specification `"%lld"` must be `long`, not `int`
 fail_compilation/chkformat.d(105): Deprecation: argument `5` for format specification `"%jd"` must be `core.stdc.stdint.intmax_t`, not `int`
 fail_compilation/chkformat.d(106): Deprecation: argument `6.00000` for format specification `"%zd"` must be `size_t`, not `double`
@@ -62,7 +61,7 @@ import core.stdc.stdio;
 #line 100
 
 void test1() {  printf("%*.*d\n", 0L, 1L, 2L); }
-void test2() { printf("%2.2lf\n", 3.0); }
+//void test2() { }
 //void test3() {  printf("%ld\n", 3.0); }
 void test4() {  printf("%lld\n", 4); }
 void test5() {  printf("%jd\n", 5); }

--- a/test/runnable/dhry.d
+++ b/test/runnable/dhry.d
@@ -2,12 +2,6 @@
 PERMUTE_ARGS:
 REQUIRED_ARGS: -release -O -g -inline
 DISABLED: freebsd dragonflybsd
-TEST_OUTPUT:
----
-runnable/dhry.d(625): Deprecation: format specifier `"%7.1lf"` is invalid
-runnable/dhry.d(627): Deprecation: format specifier `"%10.1lf"` is invalid
-runnable/dhry.d(628): Deprecation: format specifier `"%10.3lf"` is invalid
----
 
 Deprecation caused by https://issues.dlang.org/show_bug.cgi?id=20645
 */
@@ -622,19 +616,19 @@ void main ()
     printf ("Register option selected?  NO\n");
     strcpy(Reg_Define.ptr, "Register option not selected.");
     printf ("Microseconds for one run through Dhrystone: ");
-    printf ("%7.1lf \n", Microseconds);
+    printf ("%7.1f \n", Microseconds);
     printf ("Dhrystones per Second:                      ");
-    printf ("%10.1lf \n", Dhrystones_Per_Second);
-    printf ("VAX MIPS rating = %10.3lf \n",Vax_Mips);
+    printf ("%10.1f \n", Dhrystones_Per_Second);
+    printf ("VAX MIPS rating = %10.3f \n",Vax_Mips);
     printf ("\n");
 
    /+
   fprintf(Ap,"\n");
   fprintf(Ap,"Dhrystone Benchmark, Version 2.1 (Language: D)\n");
   fprintf(Ap,"%.*s\n",Reg_Define.length, Reg_Define.ptr);
-  fprintf(Ap,"Microseconds for one loop: %7.1lf\n",Microseconds);
-  fprintf(Ap,"Dhrystones per second: %10.1lf\n",Dhrystones_Per_Second);
-  fprintf(Ap,"VAX MIPS rating: %10.3lf\n",Vax_Mips);
+  fprintf(Ap,"Microseconds for one loop: %7.1f\n",Microseconds);
+  fprintf(Ap,"Dhrystones per second: %10.1f\n",Dhrystones_Per_Second);
+  fprintf(Ap,"VAX MIPS rating: %10.3f\n",Vax_Mips);
   fclose(Ap);
   +/
 


### PR DESCRIPTION
On top of this fix, the `%lf` format for `printf` is now allowed. Like that, it corresponds to the C99 standard.