### PR TITLE
Enforce TEST_OUTPUT for runnable tests & add missing sections.

### DIFF
--- a/test/runnable/arrayop.d
+++ b/test/runnable/arrayop.d
@@ -366,9 +366,9 @@ template Integral(T)
         abc = null;
         A()[] = ~B()[];
         assert(abc == "AB");
-        assert(a[0] == ~cast(T)1);
-        assert(a[1] == ~cast(T)2);
-        assert(a[2] == ~cast(T)3);
+        assert(a[0] == cast(T) ~1);
+        assert(a[1] == cast(T) ~2);
+        assert(a[2] == cast(T) ~3);
 
         abc = null;
         A()[] = B()[] & 2;

--- a/test/runnable/complex.d
+++ b/test/runnable/complex.d
@@ -1,4 +1,5 @@
-// PERMUTE_ARGS:
+// Ignore deprecations due to https://issues.dlang.org/show_bug.cgi?id=7619
+// TRANSFORM_OUTPUT: remove_lines("Use std.complex")
 
 import std.stdio;
 import std.math;

--- a/test/runnable/cppa.d
+++ b/test/runnable/cppa.d
@@ -3,6 +3,9 @@
 // EXTRA_FILES: extra-files/cppb.h
 // CXXFLAGS(linux freebsd osx netbsd dragonflybsd): -std=c++11
 
+// Filter a spurious warning on Semaphore:
+// TRANSFORM_OUTPUT: remove_lines("warning: relocation refers to discarded section")
+
 // N.B MSVC doesn't have a C++11 switch, but it defaults to the latest fully-supported standard
 
 import core.stdc.stdio;

--- a/test/runnable/dhry.d
+++ b/test/runnable/dhry.d
@@ -1,6 +1,16 @@
-// PERMUTE_ARGS:
-// REQUIRED_ARGS: -release -O -g -inline
-// DISABLED: freebsd dragonflybsd
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -release -O -g -inline
+DISABLED: freebsd dragonflybsd
+TEST_OUTPUT:
+---
+runnable/dhry.d(625): Deprecation: format specifier `"%7.1lf"` is invalid
+runnable/dhry.d(627): Deprecation: format specifier `"%10.1lf"` is invalid
+runnable/dhry.d(628): Deprecation: format specifier `"%10.3lf"` is invalid
+---
+
+Deprecation caused by https://issues.dlang.org/show_bug.cgi?id=20645
+*/
 
 /*
  *************************************************************************

--- a/test/runnable/ifti.d
+++ b/test/runnable/ifti.d
@@ -34,8 +34,8 @@ class Tst(TST, int v = 2) {
 
 
 //
-    void opAdd(T)(T x) { this.x += x; writefln("opAdd(%s)",x); }
-    void opPos()() { writefln("opPos()"); }
+    void opBinary(string op : "+", T)(T x) { this.x += x; writefln("opAdd(%s)",x); }
+    void opUnary(string op : "+")() { writefln("opPos()"); }
     //void opPos() { writefln("xxx"); }
     void opIndex(T)(T x) { writefln("opIndex[%s]",x); }
 

--- a/test/runnable/ifti.d
+++ b/test/runnable/ifti.d
@@ -1,3 +1,6 @@
+// Ignore deprecations due to https://issues.dlang.org/show_bug.cgi?id=7619
+// TRANSFORM_OUTPUT: remove_lines("Use std.complex")
+
 import std.stdio;
 
 struct S {

--- a/test/runnable/imports/link15194std.d
+++ b/test/runnable/imports/link15194std.d
@@ -30,7 +30,6 @@ else
 
     struct SetUnion(Rs...)
     {
-        pragma(msg, Rs);
         Rs r;
 
         // Rs[0] == RBRange!(RBNode!int*)

--- a/test/runnable/integrate.d
+++ b/test/runnable/integrate.d
@@ -24,22 +24,22 @@ struct fl
     }
     static fl opCall(int x) { fl f; f.set(x); return f; }
     static fl opCall(double x) { fl f; f.set(x); return f; }
-    fl opAdd(fl y) { return fl(a+y.a); }
-    fl opAddAssign(fl y) { this=(this)+y; return this; }
-    fl opSub(fl y) { return fl(a-y.a); }
-    fl opSubAssign(fl y) { this=(this)-y; return this; }
-    fl opMul(fl y) { return fl(a*y.a); }
-    fl opDiv(fl y) { return fl(a/y.a); }
+    fl opBinary(string op : "+")(fl y) { return fl(a+y.a); }
+    fl opOpAssign(string op : "+")(fl y) { this=(this)+y; return this; }
+    fl opBinary(string op : "-")(fl y) { return fl(a-y.a); }
+    fl opOpAssign(string op : "+")(fl y) { this=(this)-y; return this; }
+    fl opBinary(string op : "*")(fl y) { return fl(a*y.a); }
+    fl opBinary(string op : "/")(fl y) { return fl(a/y.a); }
 
-    fl opAdd(int y) { return fl(a+y); }
-    fl opSub(int y) { return fl(a-y); }
-    fl opMul(int y) { return fl(a*y); }
-    fl opDiv(int y) { return fl(a/y); }
+    fl opBinary(string op : "+")(int y) { return fl(a+y); }
+    fl opBinary(string op : "-")(int y) { return fl(a-y); }
+    fl opBinary(string op : "*")(int y) { return fl(a*y); }
+    fl opBinary(string op : "/")(int y) { return fl(a/y); }
 
-    fl opAdd(double y) { return fl(a+y); }
-    fl opSub(double y) { return fl(a-y); }
-    fl opMul(double y) { return fl(a*y); }
-    fl opDiv(double y) { return fl(a/y); }
+    fl opBinary(string op : "+")(double y) { return fl(a+y); }
+    fl opBinary(string op : "-")(double y) { return fl(a-y); }
+    fl opBinary(string op : "*")(double y) { return fl(a*y); }
+    fl opBinary(string op : "/")(double y) { return fl(a/y); }
 }
 
 struct ad
@@ -49,12 +49,12 @@ struct ad
     static ad opCall(int y) { ad t; t.x = F(y); t.dx = F(0); return t; }
     static ad opCall(F y) { ad t; t.x = y; t.dx = F(0); return t; }
     static ad opCall(F X, F DX) { ad t; t.x = X; t.dx = DX; return t; }
-    ad opAdd(ad y) { return ad(x+y.x,dx+y.dx); }
-    ad opSub(ad y) { return ad(x-y.x,dx-y.dx); }
-    ad opMul(ad y) { return ad(x*y.x,dx*y.x+x*y.dx); }
-    ad opDiv(ad y) { return ad(x/y.x,(dx*y.x-x*y.dx)/(y.x*y.x)); }
-    ad opMul(F v) { return ad(x*v,dx*v); }
-    ad opAdd(F v) { return ad(x+v,dx); }
+    ad opBinary(string op : "+")(ad y) { return ad(x+y.x,dx+y.dx); }
+    ad opBinary(string op : "-")(ad y) { return ad(x-y.x,dx-y.dx); }
+    ad opBinary(string op : "*")(ad y) { return ad(x*y.x,dx*y.x+x*y.dx); }
+    ad opBinary(string op : "/")(ad y) { return ad(x/y.x,(dx*y.x-x*y.dx)/(y.x*y.x)); }
+    ad opBinary(string op : "*")(F v) { return ad(x*v,dx*v); }
+    ad opBinary(string op : "+")(F v) { return ad(x+v,dx); }
 }
 
 F sqr(F x) { return x * x; }

--- a/test/runnable/link10920.d
+++ b/test/runnable/link10920.d
@@ -10,7 +10,7 @@ void main()
     {
         // Run semantic3 of BitArray.toString()
         // before the FormatSpec instantiation in main().
-        pragma(msg, typeof(ba.toString()));
+        static assert(is(typeof(ba.toString())));
     }
 
     // The instance codegen should be run always, unrelated with -version=A.

--- a/test/runnable/opover.d
+++ b/test/runnable/opover.d
@@ -1,5 +1,7 @@
 
 // Test operator overloading
+// Ignore deprecation warnings for D1 style operator overloading
+// TRANSFORM_OUTPUT: remove_lines("Deprecation: `op")
 
 import core.stdc.stdio;
 

--- a/test/runnable/template2.d
+++ b/test/runnable/template2.d
@@ -20,24 +20,24 @@ template VecTemplate(tfloat, int dim:3)
    bool opEquals(Vector b) { for (int i=0; i<dim; ++i) if (d[i] != b.d[i]) return
 false; return true; }
    // negate (-a)
-   Vector opNeg() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = -d[i]; return
+   Vector opUnary(string op : "-")() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = -d[i]; return
 r;  }
    // complement (~a)
-   Vector opCom() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[(i+1)%dim];
+   Vector opUnary(string op : "~")() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[(i+1)%dim];
 d[0] = -d[0]; return r;  }
    // add (a + b)
-   Vector opAdd(Vector b) { Vector r; r.d[] = d[] + b.d[]; return r;  }
+   Vector opBinary(string op : "+")(Vector b) { Vector r; r.d[] = d[] + b.d[]; return r;  }
    // addto (a += b)
-   Vector opAddAssign(Vector b) { d[] += b.d[]; return r;  }
+   Vector opOpAssign(string op : "+")(Vector b) { d[] += b.d[]; return r;  }
    // subtract (a - b)
-   Vector opSub(Vector b) { Vector r; r.d[] = d[] - b.d[]; return r;  }
+   Vector opBinary(string op : "-")(Vector b) { Vector r; r.d[] = d[] - b.d[]; return r;  }
    // multiply by scalar (a * 2.0)
-   Vector opMul(tfloat b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i]
+   Vector opBinary(string op : "*")(tfloat b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i]
 * b; return r;  }
    // divide by scalar (a / b)
-   Vector opDiv(tfloat b) { return *this * (1/b);  }
+   Vector opBinary(string op : "/")(tfloat b) { return *this * (1/b);  }
    // dot product (a * b)
-   tfloat opMul(Vector b) { tfloat r=0; for (int i=0; i<dim; ++i) r += d[i];
+   tfloat opBinary(string op : "*")(Vector b) { tfloat r=0; for (int i=0; i<dim; ++i) r += d[i];
 return r;  }
    // outer product (a ^ b)
    //Vector opXor(Vector b) { Vector r; for (int i=0; i<dim; ++i) r += d[i]; return r;  }
@@ -48,27 +48,27 @@ return r;  }
   const bool opEquals(ref const Vector b) { for (int i=0; i<dim; ++i) if (d[i] != b.d[i]) return
 false; return true; }
   // negate (-a)
-  Vector opNeg() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = -d[i]; return
+  Vector opUnary(string op : "-")() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = -d[i]; return
 r;  }
   // complement (~a)
-  Vector opCom() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[(i+1)%dim];
+  Vector opUnary(string op : "~")() { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[(i+1)%dim];
 d[0] = -d[0]; return r;  }
   // add (a + b)
-  Vector opAdd(Vector b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i] +
+  Vector opBinary(string op : "+")(Vector b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i] +
 b.d[i]; return r;  }
   // addto (a += b)
-  Vector opAddAssign(Vector b) { for (int i=0; i<dim; ++i) d[i] += b.d[i]; return
+  Vector opOpAssign(string op : "+")(Vector b) { for (int i=0; i<dim; ++i) d[i] += b.d[i]; return
 this; }
   // subtract (a - b)
-  Vector opSub(Vector b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i] -
+  Vector opBinary(string op : "-")(Vector b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i] -
 b.d[i]; return r;  }
   // multiply by scalar (a * 2.0)
-  Vector opMul(tfloat b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i] *
+  Vector opBinary(string op : "*")(tfloat b) { Vector r; for (int i=0; i<dim; ++i) r.d[i] = d[i] *
 b; return r;  }
   // divide by scalar (a / b)
-  Vector opDiv(tfloat b) { return this * (1/b);  }
+  Vector opBinary(string op : "/")(tfloat b) { return this * (1/b);  }
   // dot product (a * b)
-  tfloat opMul(Vector b) { tfloat r=0; for (int i=0; i<dim; ++i) r += d[i];
+  tfloat opBinary(string op : "*")(Vector b) { tfloat r=0; for (int i=0; i<dim; ++i) r += d[i];
 return r;  }
   // outer product (a ^ b)
   //Vector opXor(Vector b) { Vector r; for (int i=0; i<dim; ++i) r += d[i]; return r;  }
@@ -109,6 +109,3 @@ int main(char[][] args)
  printf("closing\n");
  return 0;
 }
-
-
-

--- a/test/runnable/template9.d
+++ b/test/runnable/template9.d
@@ -1,5 +1,45 @@
-// REQUIRED_ARGS: -preview=rvaluerefparam
-// PERMUTE_ARGS:
+/*
+REQUIRED_ARGS: -preview=rvaluerefparam
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+func
+double
+All good 1
+All good 2
+All good 3
+_D7imports10testmangle12detectMangleFPSQBlQBg6DetectZQq
+_D7imports10testmangle__T10DetectTmplTiZQpFNaNbNiNfZv
+true
+false
+uint
+int[]
+int[]
+const(K5886)
+4 ; const(K5886)
+8 ; const(K5886)
+K5886
+immutable(K5886)
+4 ; K5886
+4 ; immutable(K5886)
+1 ; K5886
+2 ; const(K5886)
+3 ; immutable(K5886)
+8 ; K5886
+9 ; const(K5886)
+10 ; immutable(K5886)
+> U = int, N:$?:64=ulong = 3LU|32=uint = 3u$
+K=string, V=int
+K=char, V=string
+T = SA, E = int, dim = $?:64=5LU|32=5u$
+T = DA, E = int
+T = AA, K = string, V = int
+pure nothrow @nogc @safe void(int t)
+pure nothrow @nogc @safe void(int t)
+T = byte
+T = char
+---
+*/
 
 module breaker;
 

--- a/test/runnable/test12.d
+++ b/test/runnable/test12.d
@@ -311,15 +311,15 @@ void test12()
 
 class A13
 {
-    int opShl(char* v) { return 1; }
-    int opShl(string v) { return 2; }
+    int opBinary(string op : "<<")(char* v) { return 1; }
+    int opBinary(string op : "<<")(string v) { return 2; }
 }
 
 void test13()
 {
         A13 a = new A13();
         int i;
-        i = a.opShl(cast(string)"");
+        i = a << cast(string) "";
         assert(i == 2);
         i = a << cast(string)"";
         assert(i == 2);
@@ -433,7 +433,7 @@ class Cout17
   printf("%d",x);
   return this;
  }
- alias set opShl;
+ alias opBinary(string op : "<<") = set;
 }
 
 void test17()

--- a/test/runnable/test22.d
+++ b/test/runnable/test22.d
@@ -357,7 +357,7 @@ class Bar17
 
 class Foo17
 {
-        void opAdd (Bar17 b) {}
+        void opBinary(string op : "+") (Bar17 b) {}
 }
 
 void test17()

--- a/test/runnable/test28.d
+++ b/test/runnable/test28.d
@@ -1157,7 +1157,7 @@ struct Vector62
       z = _z;
     }
 
-    Vector62 opMul(float s)
+    Vector62 opBinary(string op : "*")(float s)
     {
       Vector62 ret;
       ret.x = x*s;

--- a/test/runnable/test3449.d
+++ b/test/runnable/test3449.d
@@ -13,6 +13,10 @@ static this()
 {
     mg1 = 10;
     cg1 = 10;
+}
+
+shared static this()
+{
     ig1 = 10;
 }
 static assert(!__traits(compiles, { static assert(mg1 == 0); }));

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1,5 +1,19 @@
-// REQUIRED_ARGS:
-//
+/*
+REQUIRED_ARGS:
+TEST_OUTPUT:
+---
+success
+myInt int
+myBool bool
+i
+s
+C6test42__T4T219TiZ1C
+C6test427test219FZ8__mixin11C
+runnable/test42.d(4541): Deprecation: argument `cast(int)wsize` for format specification `"%hhu"` must be `byte`, not `int`
+---
+
+Deprecation caused by https://issues.dlang.org/show_bug.cgi?id=20644
+*/
 
 module test42;
 
@@ -51,7 +65,7 @@ void test3()
 {
     auto i = mixin("__LINE__");
     printf("%d\n", i);
-    assert(i == 52);
+    assert(i == 66);
 }
 
 /***************************************************/

--- a/test/runnable/test42.d
+++ b/test/runnable/test42.d
@@ -1972,7 +1972,7 @@ struct Foobar;
 int test124()
 {   int result;
     dchar[] aa;
-    alias uint foo_t;
+    alias size_t foo_t;
 
     foreach (foo_t i, dchar d; aa)
     {

--- a/test/runnable/testassign.d
+++ b/test/runnable/testassign.d
@@ -1,4 +1,18 @@
-// REQUIRED_ARGS: -preview=rvaluerefparam
+/*
+REQUIRED_ARGS: -preview=rvaluerefparam
+TEST_OUTPUT:
+---
+\	S1	S2a	S2b	S3a	S3b	S4a	S4b
+-	true	true	true	true	true	true	true
+Xa	true	true	true	true	true	true	true
+Xb	true	true	true	true	true	true	true
+Xc	true	true	true	true	true	true	true
+Xd	true	true	true	true	true	true	true
+Xe	true	true	true	true	true	true	true
+Xf	true	true	true	true	true	true	true
+Xg	true	true	true	true	true	true	true
+---
+*/
 
 import core.stdc.stdio;
 

--- a/test/runnable/testswitch.d
+++ b/test/runnable/testswitch.d
@@ -356,8 +356,12 @@ int foo15(int i)
 static this()
 {
     X15 = 4;
-    Y15 = 4;
     Z15 = 5;
+}
+
+shared static this()
+{
+    Y15 = 4;
 }
 
 void test15()

--- a/test/runnable/testthread2.d
+++ b/test/runnable/testthread2.d
@@ -32,7 +32,7 @@ struct LinearAA(K, V) {
         return val;
     }
 
-    V* opIn_r(K key) {
+    V* opBinaryRight(string op : "in")(K key) {
         foreach(i, k; keys) {
             if(key == k) {
                 return values.ptr + i;

--- a/test/runnable/traits.d
+++ b/test/runnable/traits.d
@@ -1,4 +1,18 @@
-// PERMUTE_ARGS:
+/*
+PERMUTE_ARGS:
+
+Windows linker may write something like:
+---
+Creating library {{RESULTS_DIR}}/runnable/traits_0.lib and object {{RESULTS_DIR}}/runnable/traits_0.exp
+---
+
+TRANSFORM_OUTPUT: remove_lines("Creating library")
+TEST_OUTPUT:
+---
+__lambda1
+---
+*/
+
 module traits;
 
 import std.stdio;

--- a/test/runnable/xtest46_gc.d
+++ b/test/runnable/xtest46_gc.d
@@ -1,3 +1,36 @@
-// REQUIRED_ARGS: -lowmem -Jrunnable -preview=rvaluerefparam
+/*
+REQUIRED_ARGS: -lowmem -Jrunnable -preview=rvaluerefparam
+TEST_OUTPUT:
+---
+Boo!double
+Boo!int
+true
+int
+!! immutable(int)[]
+int(int i, long j = 7L)
+long
+C10390(C10390(<recursion>))
+tuple(height)
+tuple(get, get)
+tuple(clear)
+tuple(draw, draw)
+runnable/xtest46_gc.d-mixin-$n$(184): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46_gc.d-mixin-$n$(186): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46_gc.d-mixin-$n$(187): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46_gc.d-mixin-$n$(189): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46_gc.d-mixin-$n$(216): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46_gc.d-mixin-$n$(218): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46_gc.d-mixin-$n$(219): Deprecation: `opDot` is deprecated. Use `alias this`
+runnable/xtest46_gc.d-mixin-$n$(221): Deprecation: `opDot` is deprecated. Use `alias this`
+const(int)
+string[]
+double[]
+double[]
+{}
+tuple("m")
+true
+TFunction1: extern (C) void function()
+---
+*/
 
 mixin(import("xtest46.d"));

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1178,9 +1178,7 @@ int tryMain(string[] args)
             {
                 // Allow any messages to come from tests if TEST_OUTPUT wasn't given.
                 // This will be removed in future once all tests have been updated.
-                if (testArgs.compileOutput !is null ||
-                    (testArgs.mode != TestMode.COMPILE &&
-                     testArgs.mode != TestMode.RUN))
+                if (testArgs.compileOutput !is null || testArgs.mode != TestMode.COMPILE)
                 {
                     const diff = generateDiff(testArgs.compileOutput, testArgs.compileOutputFile,
                                                 compile_output, test_base_name);


### PR DESCRIPTION
The first commit fixes some unrelated deprecation which are unrelated to the tests to keep the output sections focussed on the actual tests.
