### PR TITLE
Fix Issue 20649 - Trait isZeroInit gives false in certain scenarios

### DIFF
--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -5576,8 +5576,10 @@ extern (C++) final class TypeStruct : Type
         return structinit;
     }
 
-    override bool isZeroInit(const ref Loc loc) const
+    override bool isZeroInit(const ref Loc loc)
     {
+        // Determine zeroInit here, as this can be called before semantic2
+        sym.determineSize(sym.loc);
         return sym.zeroInit;
     }
 

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -737,7 +737,7 @@ public:
     Dsymbol *toDsymbol(Scope *sc);
     structalign_t alignment();
     Expression *defaultInitLiteral(const Loc &loc);
-    bool isZeroInit(const Loc &loc) /*const*/;
+    bool isZeroInit(const Loc &loc);
     bool isAssignable();
     bool isBoolean() /*const*/;
     bool needsDestruction() /*const*/;

--- a/test/runnable/test20649.d
+++ b/test/runnable/test20649.d
@@ -1,0 +1,15 @@
+struct S { int i; }
+
+auto f()
+{
+    S[] ss;
+    ss.length = 1;
+    return 0;
+}
+
+enum a = f();
+
+void main()
+{
+    f();
+}


### PR DESCRIPTION
In this test case the function `_d_arraysetlengthT` in the druntime [1] was incorrectly instantiated because `__traits(isZeroInit, S)` was `false` when it should have been `true`.

[1] [capacity.d](https://github.com/dlang/druntime/blob/f1c3d1020ea3913bb3fbc2e4ae4c27ea5d38f9ac/src/core/internal/array/capacity.d#L46-L49)