### PR TITLE
Fix issue 20603 - 'cannot use non-constant CTFE pointer in an initializer' in recursive structure with overlap

### DIFF
--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -1330,6 +1330,10 @@ private bool hasNonConstPointers(Expression e)
     }
     if (auto ae = e.isAddrExp())
     {
+        if (ae.type.nextOf().isImmutable() || ae.type.nextOf().isConst())
+        {
+            return false;
+        }
         if (auto se = ae.e1.isStructLiteralExp())
         {
             if (!(se.stageflags & stageSearchPointers))

--- a/test/compilable/interpret3.d
+++ b/test/compilable/interpret3.d
@@ -2473,12 +2473,12 @@ static assert(checkPass("foobar") == 1);
 
 struct Toq
 {
-    const(char)* m;
+    char* m;
 }
 
 Toq ptrRet(bool b)
 {
-    string x = "abc";
+    char[] x = "abc".dup;
     return Toq(b ? x[0 .. 1].ptr : null);
 }
 

--- a/test/runnable/test20603.d
+++ b/test/runnable/test20603.d
@@ -1,0 +1,31 @@
+// https://issues.dlang.org/show_bug.cgi?id=20603
+
+enum immutable(int)* x = new int(3);
+enum const(int)* y = new int(5);
+
+struct Base {
+    union {
+        int overlap;
+        immutable(Sub)* sub;
+    }
+
+    this(Sub) {
+        sub = new Sub;
+    }
+}
+
+struct Sub {
+    Base base;
+}
+
+immutable c0 = Base(Sub.init);
+
+void main()
+{
+    enum const(int)* z = new int(9);
+
+    assert(*x == 3);
+    assert(*y == 5);
+    assert(*z == 9);
+    assert(c0.sub.base.sub == null);
+}


### PR DESCRIPTION
The function `hasNonConstPointers` was introduced in https://github.com/dlang/dmd/pull/102 (commit 
https://github.com/dlang/dmd/pull/102/commits/14d37a18e423ef55c05a582c8024990191979b71)

Despite the name, it notably seems to not take const/immutable into account. (Though I'm not sure transitive const already was a thing back in 2011).

This PR does not fix [issue 11268](https://issues.dlang.org/show_bug.cgi?id=11268) because this still fails:
```D
struct A {uint d;}
immutable A abc = { 42 };
immutable(uint)* xyz = &abc.d;
```

However, instead of failing in `initsem.d`, it fails in `todt.d` where `visitAddr(AddrExp e)` only supports a `StructLiteralExp`, not a `DotVarExp` like above.
A `DotVarExp` could be supported in that function, but maybe the `DotVarExp` should be dissected at an earlier stage. I think arrays initializers work this way: all array elements are visited separately instead of the entire array, which is why the 'non-constant CTFE pointer' error was not raised when taking the address of an element.
