### PR TITLE
Make runnable/mixin1 test more deterministic

### DIFF
--- a/test/runnable/mixin1.d
+++ b/test/runnable/mixin1.d
@@ -47,11 +47,11 @@ opCall 2
 two
 one
 one
-Success
 Class39 dtor
 Mixed-in dtor
 Mixed-in dtor
 Base39 dtor
+Success
 ---
 */
 
@@ -987,7 +987,7 @@ class Class39 : Base39
 
 void test39()
 {
-    auto test = new Class39;
+    scope test = new Class39;
 }
 
 


### PR DESCRIPTION
This test sometimes fails on Windows + OMF.
Since destructors are not guaranteed to be run by the GC per spec, use deterministic destruction.