### PR TITLE
dmd.root.array: Add `sort` method, wrapping `qsort`

### DIFF
--- a/src/dmd/libomf.d
+++ b/src/dmd/libomf.d
@@ -46,6 +46,12 @@ struct OmfObjSymbol
 {
     char* name;
     OmfObjModule* om;
+
+    /// Predicate for `Array.sort`for name comparison
+    static int name_pred (scope const OmfObjSymbol** ppe1, scope const OmfObjSymbol** ppe2) nothrow @nogc pure
+    {
+        return strcmp((**ppe1).name, (**ppe2).name);
+    }
 }
 
 alias OmfObjModules = Array!(OmfObjModule*);
@@ -336,7 +342,7 @@ private:
                 return false;
         }
         // Sort the symbols
-        qsort(objsymbols.tdata(), objsymbols.dim, (objsymbols[0]).sizeof, cast(_compare_fp_t)&NameCompare);
+        objsymbols.sort!(OmfObjSymbol.name_pred);
         // Add each of the symbols
         foreach (os; objsymbols)
         {
@@ -502,16 +508,6 @@ struct OmfObjModule
     uint length; // in bytes
     ushort page; // page module starts in output file
     const(char)[] name; // module name, with terminating 0
-}
-
-/*****************************************************************************/
-/*****************************************************************************/
-extern (C)
-{
-    int NameCompare(const(void*) p1, const(void*) p2)
-    {
-        return strcmp((*cast(OmfObjSymbol**)p1).name, (*cast(OmfObjSymbol**)p2).name);
-    }
 }
 
 enum HASHMOD = 0x25;

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -2711,19 +2711,14 @@ else
 
             if (numcases)
             {
-                extern (C) static int sort_compare(const(void*) x, const(void*) y) @trusted
+                static int sort_compare(in CaseStatement* x, in CaseStatement* y) @trusted
                 {
-                    CaseStatement ox = *cast(CaseStatement *)x;
-                    CaseStatement oy = *cast(CaseStatement*)y;
-
-                    auto se1 = ox.exp.isStringExp();
-                    auto se2 = oy.exp.isStringExp();
+                    auto se1 = x.exp.isStringExp();
+                    auto se2 = y.exp.isStringExp();
                     return (se1 && se2) ? se1.compare(se2) : 0;
                 }
-
                 // Sort cases for efficient lookup
-                import core.stdc.stdlib : qsort, _compare_fp_t;
-                qsort((*csCopy)[].ptr, numcases, CaseStatement.sizeof, cast(_compare_fp_t)&sort_compare);
+                csCopy.sort!sort_compare;
             }
 
             // The actual lowering


### PR DESCRIPTION
This makes it way more user-friendly to work with.
Unfortunately I cannot use it in the backend because it is using `-betterC`.
Will be useful when implementing [GNU ABI Tags](https://github.com/dlang/dmd/pull/9995/files#diff-cdac99e531529cfe95dd9807bd22fda8R622) too.