### PR TITLE
backend.outbuf: Make member 'p' private

### DIFF
--- a/src/dmd/backend/cgobj.d
+++ b/src/dmd/backend/cgobj.d
@@ -4075,7 +4075,7 @@ version (MARS)
         return;
 
     ubyte *p = obj.ptrref_buf.buf;
-    ubyte *end = obj.ptrref_buf.p;
+    ubyte *end = obj.ptrref_buf.buf + obj.ptrref_buf.length();
     while (p < end)
     {
         Symbol* s = *cast(Symbol**)p;

--- a/src/dmd/backend/dwarfdbginf.d
+++ b/src/dmd/backend/dwarfdbginf.d
@@ -824,7 +824,7 @@ void writeDebugFrameFDE(IDXSEC dfseg, Symbol *sfunc)
         //debugFrameFDE64.initial_location = sfunc.Soffset;
 
         Outbuffer *debug_frame_buf = SegData[dfseg].SDbuf;
-        uint debug_frame_buf_offset = cast(uint)(debug_frame_buf.p - debug_frame_buf.buf);
+        uint debug_frame_buf_offset = cast(uint)debug_frame_buf.length();
         debug_frame_buf.reserve(1000);
         debug_frame_buf.writen(&debugFrameFDE64,debugFrameFDE64.sizeof);
         debug_frame_buf.write(cfa_buf[]);
@@ -864,7 +864,7 @@ static if (ELFOBJ)
         //debugFrameFDE32.initial_location = sfunc.Soffset;
 
         Outbuffer *debug_frame_buf = SegData[dfseg].SDbuf;
-        uint debug_frame_buf_offset = cast(uint)(debug_frame_buf.p - debug_frame_buf.buf);
+        uint debug_frame_buf_offset = cast(uint)debug_frame_buf.length();
         debug_frame_buf.reserve(1000);
         debug_frame_buf.writen(&debugFrameFDE32,debugFrameFDE32.sizeof);
         debug_frame_buf.write(cfa_buf[]);

--- a/src/dmd/backend/dwarfeh.d
+++ b/src/dmd/backend/dwarfeh.d
@@ -388,7 +388,7 @@ int actionTableInsert(Outbuffer *atbuf, int ttindex, int nextoffset)
 {
     //printf("actionTableInsert(%d, %d)\n", ttindex, nextoffset);
     ubyte *p;
-    for (p = atbuf.buf; p < atbuf.p; )
+    for (p = atbuf.buf; (p - atbuf.buf) < atbuf.length(); )
     {
         int offset = cast(int)(p - atbuf.buf);
         int TypeFilter = sLEB128(&p);
@@ -399,7 +399,7 @@ int actionTableInsert(Outbuffer *atbuf, int ttindex, int nextoffset)
             nextoffset == nrpoffset + NextRecordPtr)
             return offset;
     }
-    assert(p == atbuf.p);
+    assert(p == (*atbuf)[].ptr + atbuf.length());
     int offset = cast(int)atbuf.length();
     atbuf.writesLEB128(ttindex);
     if (nextoffset == -1)

--- a/src/dmd/backend/elfobj.d
+++ b/src/dmd/backend/elfobj.d
@@ -381,9 +381,7 @@ static if (0)
         name = s.Sfunc.Fredirect;
         len = strlen(name);
     }
-    symtab_strings.reserve(cast(uint)len+1);
-    memcpy(cast(char *)symtab_strings.p, name, len + 1);
-    symtab_strings.setsize(cast(uint)(namidx+len+1));
+    symtab_strings.writeString(name);
     if (destr != dest.ptr)                  // if we resized result
         mem_free(destr);
     //dbg_printf("\telf_addmagled symtab_strings %s namidx %d len %d size %d\n",name, namidx,len,symtab_strings.length());

--- a/src/dmd/backend/machobj.d
+++ b/src/dmd/backend/machobj.d
@@ -350,10 +350,7 @@ static if (0)
     }
     else if (tyfunc(s.ty()) && s.Sfunc && s.Sfunc.Fredirect)
         name = s.Sfunc.Fredirect;
-    size_t len = strlen(name);
-    symtab_strings.reserve(cast(uint)(len+1));
-    strcpy(cast(char *)symtab_strings.p,name);
-    symtab_strings.setsize(cast(uint)(namidx+len+1));
+    symtab_strings.writeString(name);
     if (destr != dest.ptr)                  // if we resized result
         mem_free(destr);
     //dbg_printf("\telf_addmagled symtab_strings %s namidx %d len %d size %d\n",name, namidx,len,symtab_strings.length());

--- a/src/dmd/backend/mscoffobj.d
+++ b/src/dmd/backend/mscoffobj.d
@@ -2486,7 +2486,7 @@ extern (D) private void objflush_pointerRefs()
         return;
 
     ubyte *p = ptrref_buf.buf;
-    ubyte *end = ptrref_buf.p;
+    ubyte *end = ptrref_buf.buf + ptrref_buf.length();
     while (p < end)
     {
         Symbol* s = *cast(Symbol**)p;

--- a/src/dmd/backend/outbuf.d
+++ b/src/dmd/backend/outbuf.d
@@ -28,7 +28,7 @@ struct Outbuffer
 {
     ubyte *buf;         // the buffer itself
     ubyte *pend;        // pointer past the end of the buffer
-    ubyte *p;           // current position in buffer
+    private ubyte *p;   // current position in buffer
 
   nothrow:
     this(size_t initialSize)


### PR DESCRIPTION
This avoids the users assuming too much about Outbuf's internal.