### PR TITLE
Add Ddoc headers for front-end modules

### DIFF
--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/attribute.html#visibility_attributes, Visibility Attributes)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/access.d
+++ b/src/dmd/access.d
@@ -1,4 +1,8 @@
 /**
+ * Enforce visibility contrains such as `public` and `private`.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/attribute.html#visibility_attributes, Visibility Attributes)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -4,9 +4,6 @@
  * Specification: $(LINK2 https://dlang.org/spec/struct.html, Structs, Unions),
  *                $(LINK2 https://dlang.org/spec/class.html, Class).
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -1,4 +1,9 @@
 /**
+ * Defines a `Dsymbol` representing an aggregate, which is a `struct`, `union` or `class`.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/struct.html, Structs, Unions),
+ *                $(LINK2 https://dlang.org/spec/class.html, Class).
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/class.html#alias-this, Alias This)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/aliasthis.d
+++ b/src/dmd/aliasthis.d
@@ -1,4 +1,8 @@
 /**
+ * Implements the `alias this` symbol.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/class.html#alias-this, Alias This)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -1,4 +1,6 @@
 /**
+ * A depth-first visitor for expressions.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -1,9 +1,6 @@
 /**
  * A depth-first visitor for expressions.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -1,9 +1,6 @@
 /**
  * Break down a D type into basic (register) types for the Itanium C++ ABI.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/argtypes.d
+++ b/src/dmd/argtypes.d
@@ -1,4 +1,6 @@
 /**
+ * Break down a D type into basic (register) types for the Itanium C++ ABI.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -1,4 +1,6 @@
 /**
+ * Break down a D type into basic (register) types for the x86_64 System V ABI.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/argtypes_sysv_x64.d
+++ b/src/dmd/argtypes_sysv_x64.d
@@ -1,9 +1,6 @@
 /**
  * Break down a D type into basic (register) types for the x86_64 System V ABI.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     Martin Kinkelin
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -1,5 +1,5 @@
 /**
- * Implement array opterations, such as `a[] = b[] + c[]`.
+ * Implement array operations, such as `a[] = b[] + c[]`.
  *
  * Specification: $(LINK2 https://dlang.org/spec/arrays.html#array-operations, Array Operations)
  *

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -1,4 +1,8 @@
 /**
+ * Implement array opterations, such as `a[] = b[] + c[]`.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/arrays.html#array-operations, Array Operations)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/arrayop.d
+++ b/src/dmd/arrayop.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/arrays.html#array-operations, Array Operations)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/arraytypes.d
+++ b/src/dmd/arraytypes.d
@@ -1,9 +1,6 @@
 /**
  * Provide aliases for arrays of certain declarations or statements.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/arraytypes.d
+++ b/src/dmd/arraytypes.d
@@ -1,4 +1,6 @@
 /**
+ * Provide aliases for arrays of certain declarations or statements.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/ast_node.d
+++ b/src/dmd/ast_node.d
@@ -1,5 +1,5 @@
 /**
- * Defines an abstract ASTNode class.
+ * Defines the base class for all nodes which are part of the AST.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/ast_node.d
+++ b/src/dmd/ast_node.d
@@ -1,9 +1,6 @@
 /**
  * Defines the base class for all nodes which are part of the AST.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/ast_node.d
+++ b/src/dmd/ast_node.d
@@ -1,4 +1,6 @@
 /**
+ * Defines an abstract ASTNode class.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1,7 +1,6 @@
 /**
  * Defines AST nodes for the parsing stage.
  *
- * Part of the Compiler implementation of the D programming language
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/astbase.d, _astbase.d)

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -1,8 +1,17 @@
+/**
+ * Defines AST nodes for the parsing stage.
+ *
+ * Part of the Compiler implementation of the D programming language
+ * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/astbase.d, _astbase.d)
+ * Documentation:  https://dlang.org/phobos/dmd_astbase.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astbase.d
+ */
+
 module dmd.astbase;
 
 /**
- * Documentation:  https://dlang.org/phobos/dmd_astbase.html
- * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astbase.d
  */
 
 import dmd.parsetimevisitor;

--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -11,9 +11,6 @@
 
 module dmd.astbase;
 
-/**
- */
-
 import dmd.parsetimevisitor;
 
 /** The ASTBase  family defines a family of AST nodes appropriate for parsing with

--- a/src/dmd/astcodegen.d
+++ b/src/dmd/astcodegen.d
@@ -1,9 +1,11 @@
-module dmd.astcodegen;
-
 /**
+ * Defines AST nodes for the code generation stage.
+ *
  * Documentation:  https://dlang.org/phobos/dmd_astcodegen.html
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/astcodegen.d
  */
+module dmd.astcodegen;
+
 
 struct ASTCodegen
 {

--- a/src/dmd/asttypename.d
+++ b/src/dmd/asttypename.d
@@ -1,4 +1,6 @@
 /**
+ * Development utility for printing AST nodes by their internal name, instead of as D source code.
+ *
  * Part of the Compiler implementation of the D programming language
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     Stefan Koch

--- a/src/dmd/asttypename.d
+++ b/src/dmd/asttypename.d
@@ -1,7 +1,6 @@
 /**
  * Development utility for printing AST nodes by their internal name, instead of as D source code.
  *
- * Part of the Compiler implementation of the D programming language
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     Stefan Koch
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1,10 +1,12 @@
 /**
- * Defines declarations of various 'attributes'.
- * The term attribute is used very loosly, since it includes:
+ * Defines declarations of various attributes.
+ *
+ * The term 'attribute' refers to things that can apply to a larger scope than a single declaration.
+ * Among them are:
  * - Alignment (`align(8)`)
  * - User defined attributes (`@UDA`)
  * - Function Attributes (`@safe`)
- * - Storage classes (`ref`, `static`)
+ * - Storage classes (`static`, `__gshared`)
  * - Mixin declarations  (`mixin("int x;")`)
  * - Conditional compilation (`static if`, `static foreach`)
  * - Linkage (`extern(C)`)

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -1,4 +1,17 @@
 /**
+ * Defines declarations of various 'attributes'.
+ * The term attribute is used very loosly, since it includes:
+ * - Alignment (`align(8)`)
+ * - User defined attributes (`@UDA`)
+ * - Function Attributes (`@safe`)
+ * - Storage classes (`ref`, `static`)
+ * - Mixin declarations  (`mixin("int x;")`)
+ * - Conditional compilation (`static if`, `static foreach`)
+ * - Linkage (`extern(C)`)
+ * - Anonymous structs / unions
+ * - Protection (`private`, `public`)
+ * - Deprecated declarations (`@deprecated`)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -14,9 +14,6 @@
  * - Protection (`private`, `public`)
  * - Deprecated declarations (`@deprecated`)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -1,9 +1,6 @@
 /**
  * Find out in what ways control flow can exit a statement block.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/blockexit.d
+++ b/src/dmd/blockexit.d
@@ -1,4 +1,6 @@
 /**
+ * Find out in what ways control flow can exit a statement block.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -1,4 +1,7 @@
 /**
+ * Evaluate certain external functions for CTFE.
+ * Currently includes functions from `std.math`, `core.math` and `core.bitop`.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -1,5 +1,6 @@
 /**
- * Evaluate certain external functions for CTFE.
+ * Implement CTFE for intrinsic (builtin) functions.
+ *
  * Currently includes functions from `std.math`, `core.math` and `core.bitop`.
  *
  * Compiler implementation of the

--- a/src/dmd/builtin.d
+++ b/src/dmd/builtin.d
@@ -3,9 +3,6 @@
  *
  * Currently includes functions from `std.math`, `core.math` and `core.bitop`.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2, https://dlang.org/spec/function.html#nothrow-functions, Nothrow Functions)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -1,4 +1,8 @@
 /**
+ * Perform checks for `nothrow`.
+ *
+ * Specification: $(LINK2, https://dlang.org/spec/function.html#nothrow-functions, Nothrow Functions)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/canthrow.d
+++ b/src/dmd/canthrow.d
@@ -1,7 +1,7 @@
 /**
  * Perform checks for `nothrow`.
  *
- * Specification: $(LINK2, https://dlang.org/spec/function.html#nothrow-functions, Nothrow Functions)
+ * Specification: $(LINK2 https://dlang.org/spec/function.html#nothrow-functions, Nothrow Functions)
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/chkformat.d
+++ b/src/dmd/chkformat.d
@@ -1,9 +1,6 @@
 /**
  * Check the arguments to `printf` and `scanf` against the `format` string.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -5,9 +5,6 @@
  * However, this file will be used to generate the
  * $(LINK2 https://dlang.org/dmd-linux.html, online documentation) and MAN pages.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -1,5 +1,6 @@
 /**
- * This modules defines the help texts for the CLI options offered by DMD.
+ * Defines the help texts for the CLI options offered by DMD.
+ *
  * This file is not shared with other compilers which use the DMD front-end.
  * However, this file will be used to generate the
  * $(LINK2 https://dlang.org/dmd-linux.html, online documentation) and MAN pages.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -1,11 +1,11 @@
 /**
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * This modules defines the help texts for the CLI options offered by DMD.
  * This file is not shared with other compilers which use the DMD front-end.
  * However, this file will be used to generate the
  * $(LINK2 https://dlang.org/dmd-linux.html, online documentation) and MAN pages.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -1,9 +1,6 @@
 /**
  * Define the implicit `opEquals`, `opAssign`, post blit, copy constructor and destructor for structs.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/clone.d
+++ b/src/dmd/clone.d
@@ -1,4 +1,6 @@
 /**
+ * Define the implicit `opEquals`, `opAssign`, post blit, copy constructor and destructor for structs.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -1,4 +1,6 @@
 /**
+ * Describes a back-end compiler and implements compiler-specific actions.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/compiler.d
+++ b/src/dmd/compiler.d
@@ -1,9 +1,6 @@
 /**
  * Describes a back-end compiler and implements compiler-specific actions.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/complex.d
+++ b/src/dmd/complex.d
@@ -1,4 +1,6 @@
 /**
+ * Implements a complex number type.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/complex.d
+++ b/src/dmd/complex.d
@@ -1,9 +1,6 @@
 /**
  * Implements a complex number type.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/version.html, Conditional Compilation)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/cond.d
+++ b/src/dmd/cond.d
@@ -1,4 +1,8 @@
 /**
+ * Evaluate compile-time conditionals, such as `static if` `version` and `debug`.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/version.html, Conditional Compilation)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/console.d
+++ b/src/dmd/console.d
@@ -2,9 +2,6 @@
  * Control the various text mode attributes, such as color, when writing text
  * to the console.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/console.d
+++ b/src/dmd/console.d
@@ -1,4 +1,7 @@
 /**
+ * Control the various text mode attributes, such as color, when writing text
+ * to the console.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -8,11 +11,6 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/console.d, _console.d)
  * Documentation:  https://dlang.org/phobos/dmd_console.html
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/console.d
- */
-
-/********************************************
- * Control the various text mode attributes, such as color, when writing text
- * to the console.
  */
 
 module dmd.console;

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1,4 +1,9 @@
 /**
+ * Perform constant folding of arithmetic expressions.
+ * The routines in this module are called from `optimize.d`.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/float.html#fp_const_folding, Floating Point Constant Folding)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -1,5 +1,6 @@
 /**
  * Perform constant folding of arithmetic expressions.
+ *
  * The routines in this module are called from `optimize.d`.
  *
  * Specification: $(LINK2 https://dlang.org/spec/float.html#fp_const_folding, Floating Point Constant Folding)

--- a/src/dmd/constfold.d
+++ b/src/dmd/constfold.d
@@ -5,9 +5,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/float.html#fp_const_folding, Floating Point Constant Folding)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1,5 +1,6 @@
 /**
  * Do mangling for C++ linkage.
+ *
  * This is the POSIX side of the implementation.
  * It exports two functions to C++, `toCppMangleItanium` and `cppTypeInfoMangleItanium`.
  *

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -4,8 +4,6 @@
  * This is the POSIX side of the implementation.
  * It exports two functions to C++, `toCppMangleItanium` and `cppTypeInfoMangleItanium`.
  *
- * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
- *
  * Copyright: Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -1,9 +1,9 @@
 /**
- * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
- *
  * Do mangling for C++ linkage.
  * This is the POSIX side of the implementation.
  * It exports two functions to C++, `toCppMangleItanium` and `cppTypeInfoMangleItanium`.
+ *
+ * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
  *
  * Copyright: Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1,8 +1,6 @@
 /**
  * Do mangling for C++ linkage for Digital Mars C++ and Microsoft Visual C++.
  *
- * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
- *
  * Copyright: Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -1,4 +1,6 @@
 /**
+ * Do mangling for C++ linkage for Digital Mars C++ and Microsoft Visual C++.
+ *
  * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
  *
  * Copyright: Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
@@ -32,9 +34,6 @@ import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
 import dmd.visitor;
-
-/* Do mangling for C++ linkage for Digital Mars C++ and Microsoft Visual C++
- */
 
 extern (C++):
 

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1,9 +1,6 @@
 /**
  * CTFE for expressions involving pointers, slices, array concatenation etc.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/ctfeexpr.d
+++ b/src/dmd/ctfeexpr.d
@@ -1,4 +1,6 @@
 /**
+ * CTFE for expressions involving pointers, slices, array concatenation etc.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -1,8 +1,8 @@
 /**
+ * Manage flow analysis for constructors.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
- *
- * Manage flow analysis for constructors.
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/ctorflow.d
+++ b/src/dmd/ctorflow.d
@@ -1,9 +1,6 @@
 /**
  * Manage flow analysis for constructors.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1,9 +1,6 @@
 /**
  * Semantic analysis for cast-expressions.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -1,4 +1,6 @@
 /**
+ * Semantic analysis for cast-expressions.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2, https://dlang.org/spec/class.html, Classes)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -1,4 +1,8 @@
 /**
+ * Defines a `class` declaration.
+ *
+ * Specification: $(LINK2, https://dlang.org/spec/class.html, Classes)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -1,7 +1,7 @@
 /**
  * Defines a `class` declaration.
  *
- * Specification: $(LINK2, https://dlang.org/spec/class.html, Classes)
+ * Specification: $(LINK2 https://dlang.org/spec/class.html, Classes)
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -2,9 +2,6 @@
  * Miscellaneous declarations, including typedef, alias, variable declarations including the
  * implicit this declaration, type tuples, ClassInfo, ModuleInfo and various TypeInfos.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/declaration.d
+++ b/src/dmd/declaration.d
@@ -1,4 +1,7 @@
 /**
+ * Miscellaneous declarations, including typedef, alias, variable declarations including the
+ * implicit this declaration, type tuples, ClassInfo, ModuleInfo and various TypeInfos.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/function.html#lazy-params, Lazy Parameters)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/delegatize.d
+++ b/src/dmd/delegatize.d
@@ -1,4 +1,8 @@
 /**
+ * Implements conversion from expressions to delegates for lazy parameters.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/function.html#lazy-params, Lazy Parameters)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -1,5 +1,7 @@
 /**
- * Handle enums.
+ * Define enum declarations and enum members.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/enum.html, Enums)
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/enum.html, Enums)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/denum.d
+++ b/src/dmd/denum.d
@@ -1,5 +1,5 @@
 /**
- * Define enum declarations and enum members.
+ * Define `enum` declarations and `enum` members.
  *
  * Specification: $(LINK2 https://dlang.org/spec/enum.html, Enums)
  *

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -1,4 +1,6 @@
 /**
+ * A `Dsymbol` representing a renamed import.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dimport.d
+++ b/src/dmd/dimport.d
@@ -1,9 +1,6 @@
 /**
  * A `Dsymbol` representing a renamed import.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dinifile.d
+++ b/src/dmd/dinifile.d
@@ -1,4 +1,6 @@
 /**
+ * Parses compiler settings from a .ini file.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dinifile.d
+++ b/src/dmd/dinifile.d
@@ -1,9 +1,6 @@
 /**
  * Parses compiler settings from a .ini file.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
  *              Copyright (C) 2000-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -1,4 +1,8 @@
 /**
+ * The entry point for CTFE.
+ *
+ * Specification: ($LINK2 https://dlang.org/spec/function.html#interpretation, Compile Time Function Execution (CTFE))
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dinterpret.d
+++ b/src/dmd/dinterpret.d
@@ -3,9 +3,6 @@
  *
  * Specification: ($LINK2 https://dlang.org/spec/function.html#interpretation, Compile Time Function Execution (CTFE))
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dmacro.d
+++ b/src/dmd/dmacro.d
@@ -1,9 +1,6 @@
 /**
  * Text macro processor for Ddoc.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1,6 +1,5 @@
 /**
- * Does name mangling for D symbols, which generates a unique name for a linker symbol based
- * on the namespace, identifier and type.
+ * Does name mangling for `extern(D)` symbols.
  *
  * Specification: $(LINK2 https://dlang.org/spec/abi.html#name_mangling, Name Mangling)
  *

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -1,4 +1,9 @@
 /**
+ * Does name mangling for D symbols, which generates a unique name for a linker symbol based
+ * on the namespace, identifier and type.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/abi.html#name_mangling, Name Mangling)
+ *
  * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
  *
  * Copyright: Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved

--- a/src/dmd/dmangle.d
+++ b/src/dmd/dmangle.d
@@ -3,8 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/abi.html#name_mangling, Name Mangling)
  *
- * Compiler implementation of the $(LINK2 http://www.dlang.org, D programming language)
- *
  * Copyright: Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors: Walter Bright, http://www.digitalmars.com
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -1,4 +1,8 @@
 /**
+ * Defines a package and module.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/module.html, Modules)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dmodule.d
+++ b/src/dmd/dmodule.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/module.html, Modules)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -1,9 +1,6 @@
 /**
  * Configures and initializes the backend.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dmsc.d
+++ b/src/dmd/dmsc.d
@@ -1,4 +1,6 @@
 /**
+ * Configures and initializes the backend.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/ddoc.html, Documentation Generator)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/doc.d
+++ b/src/dmd/doc.d
@@ -1,4 +1,8 @@
 /**
+ * Ddoc documentation generation.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/ddoc.html, Documentation Generator)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -3,9 +3,6 @@
  *
  * Not to be confused with the `scope` storage class.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -1,4 +1,7 @@
 /**
+ * Defines a scope as defined by curly braces `{}` and provides symbol lookup.
+ * Not to be confused with the `scope` storage class.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dscope.d
+++ b/src/dmd/dscope.d
@@ -1,5 +1,6 @@
 /**
- * Defines a scope as defined by curly braces `{}` and provides symbol lookup.
+ * A scope as defined by curly braces `{}`.
+ *
  * Not to be confused with the `scope` storage class.
  *
  * Compiler implementation of the

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/struct.html, Structs, Unions)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dstruct.d
+++ b/src/dmd/dstruct.d
@@ -1,4 +1,8 @@
 /**
+ * Struct and union declarations.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/struct.html, Structs, Unions)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1,5 +1,5 @@
 /**
- * The base class for a D symbol, which can be a module, variable, function, enums, etc.
+ * The base class for a D symbol, which can be a module, variable, function, enum, etc.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1,9 +1,6 @@
 /**
  * The base class for a D symbol, which can be a module, variable, function, enum, etc.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -1,4 +1,6 @@
 /**
+ * The base class for a D symbol, which can be a module, variable, function, enums, etc.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -1,4 +1,7 @@
 /**
+ * Does the semantic 1 pass on the AST, which looks at symbol declarations but not initializers
+ * or function bodies.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2,9 +2,6 @@
  * Does the semantic 1 pass on the AST, which looks at symbol declarations but not initializers
  * or function bodies.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -2,9 +2,6 @@
  * This module contains the implementation of the C++ header generation available through
  * the command line switch -Hc.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dtoh.d
+++ b/src/dmd/dtoh.d
@@ -1,9 +1,9 @@
 /**
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * This module contains the implementation of the C++ header generation available through
  * the command line switch -Hc.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -4,9 +4,6 @@
  * Specification: $(LINK2 https://dlang.org/spec/version.html#version-specification, Version Specification),
  *                $(LINK2 https://dlang.org/spec/version.html#debug_specification, Debug Specification).
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/dversion.d
+++ b/src/dmd/dversion.d
@@ -1,4 +1,9 @@
 /**
+ * Defines a `Dsymbol` for `version = identifier` and `debug = identifier` statements.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/version.html#version-specification, Version Specification),
+ *                $(LINK2 https://dlang.org/spec/version.html#debug_specification, Debug Specification).
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1,9 +1,6 @@
 /**
  * Converts expressions to Intermediate Representation (IR) for the backend.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/e2ir.d
+++ b/src/dmd/e2ir.d
@@ -1,4 +1,6 @@
 /**
+ * Converts expressions to Intermediate Representation (IR) for the backend.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/eh.d
+++ b/src/dmd/eh.d
@@ -1,4 +1,6 @@
 /**
+ * Generate exception handling tables.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/eh.d
+++ b/src/dmd/eh.d
@@ -1,9 +1,6 @@
 /**
  * Generate exception handling tables.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1994-1998 by Symantec
  *              Copyright (C) 2000-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/entity.d
+++ b/src/dmd/entity.d
@@ -1,4 +1,8 @@
 /**
+ * Defines the named entities to support the "\\&amp;Entity;" escape sequence for strings / character literals.
+ *
+ * Specification $(LINK2 https://dlang.org/spec/entity.html, Named Character Entities)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/entity.d
+++ b/src/dmd/entity.d
@@ -3,9 +3,6 @@
  *
  * Specification $(LINK2 https://dlang.org/spec/entity.html, Named Character Entities)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/env.d
+++ b/src/dmd/env.d
@@ -1,3 +1,16 @@
+/**
+ * Functions for modifying environment variables.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/env.d, env.d)
+ * Documentation:  https://dlang.org/phobos/dmd_env.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/env.d
+ */
+
 module dmd.env;
 
 import core.stdc.string;

--- a/src/dmd/env.d
+++ b/src/dmd/env.d
@@ -1,9 +1,6 @@
 /**
  * Functions for modifying environment variables.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/env.d, env.d)

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -1,9 +1,6 @@
 /**
  * Functions for raising errors.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/errors.d
+++ b/src/dmd/errors.d
@@ -1,4 +1,6 @@
 /**
+ * Functions for raising errors.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1,9 +1,6 @@
 /**
  * Most of the logic to implement scoped pointers and scoped references is here.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -3,9 +3,6 @@
  *
  * Specification: ($LINK2 https://dlang.org/spec/expression.html, Expressions)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -1,4 +1,8 @@
 /**
+ * Defines the bulk of the classes which represent the AST at the expression level.
+ *
+ * Specification: ($LINK2 https://dlang.org/spec/expression.html, Expressions)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -3,9 +3,6 @@
  *
  * Specification: ($LINK2 https://dlang.org/spec/expression.html, Expressions)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -1,4 +1,8 @@
 /**
+ * Semantic analysis of expressions.
+ *
+ * Specification: ($LINK2 https://dlang.org/spec/expression.html, Expressions)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/filecache.d
+++ b/src/dmd/filecache.d
@@ -1,4 +1,6 @@
 /**
+ * Cache the contents from files read from disk into memory.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/filecache.d
+++ b/src/dmd/filecache.d
@@ -1,9 +1,6 @@
 /**
  * Cache the contents from files read from disk into memory.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/foreachvar.d
+++ b/src/dmd/foreachvar.d
@@ -1,4 +1,6 @@
 /**
+ * Utility to visit every variable in an expression.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/foreachvar.d
+++ b/src/dmd/foreachvar.d
@@ -1,9 +1,6 @@
 /**
  * Utility to visit every variable in an expression.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -1,9 +1,8 @@
 /**
+ * This module contains high-level interfaces for interacting with DMD as a library.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
- *
- * This module contains high-level interfaces for interacting
-  with DMD as a library.
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -1,5 +1,5 @@
 /**
- * This module contains high-level interfaces for interacting with DMD as a library.
+ * Contains high-level interfaces for interacting with DMD as a library.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/frontend.d
+++ b/src/dmd/frontend.d
@@ -1,9 +1,6 @@
 /**
  * Contains high-level interfaces for interacting with DMD as a library.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1,4 +1,12 @@
-/***
+/**
+ * Defines a function declaration.
+ * Includes:
+ * - function/delegate literals
+ * - function aliases
+ * - (static/shared) constructors/destructors/post-blits
+ * - `invariant`
+ * - `unittest`
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -8,9 +8,6 @@
  * - `invariant`
  * - `unittest`
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/func.d
+++ b/src/dmd/func.d
@@ -1,5 +1,6 @@
 /**
  * Defines a function declaration.
+ *
  * Includes:
  * - function/delegate literals
  * - function aliases

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -1,9 +1,6 @@
 /**
  * Stores command line options and contains other miscellaneous declarations.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -1,4 +1,6 @@
 /**
+ * Stores command line options and contains other miscellaneous declarations.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1,9 +1,6 @@
 /**
  * Generate the object file for function declarations and critical sections.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/glue.d
+++ b/src/dmd/glue.d
@@ -1,4 +1,6 @@
 /**
+ * Generate the object file for function declarations and critical sections.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -3,9 +3,6 @@
  *
  * This 'glues' either the DMC or GCC back-end to the front-end.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -1,4 +1,7 @@
 /**
+ * Declarations for back-end functions that the front-end invokes.
+ * This 'glues' either the DMC or GCC back-end to the front-end.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/gluelayer.d
+++ b/src/dmd/gluelayer.d
@@ -1,5 +1,6 @@
 /**
  * Declarations for back-end functions that the front-end invokes.
+ *
  * This 'glues' either the DMC or GCC back-end to the front-end.
  *
  * Compiler implementation of the

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -3,9 +3,6 @@
  *
  * Also used to convert AST nodes to D code in general, e.g. for error messages or `printf` debugging.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1,5 +1,6 @@
 /**
  * Generate $(LINK2 https://dlang.org/dmd-windows.html#interface-files, D interface files).
+ *
  * Also used to convert AST nodes to D code in general, e.g. for error messages or `printf` debugging.
  *
  * Compiler implementation of the

--- a/src/dmd/hdrgen.d
+++ b/src/dmd/hdrgen.d
@@ -1,4 +1,7 @@
 /**
+ * Generate $(LINK2 https://dlang.org/dmd-windows.html#interface-files, D interface files).
+ * Also used to convert AST nodes to D code in general, e.g. for error messages or `printf` debugging.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/iasm.html, Inline Assembler)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  *              Copyright (C) 2018-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/iasm.d
+++ b/src/dmd/iasm.d
@@ -1,4 +1,8 @@
 /**
+ * Inline assembler for the D programming language compiler.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/iasm.html, Inline Assembler)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -8,9 +12,6 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/iasm.d, _iasm.d)
  * Documentation:  https://dlang.org/phobos/dmd_iasm.html
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/iasm.d
- */
-
-/* Inline assembler for the D programming language compiler
  */
 
 module dmd.iasm;

--- a/src/dmd/iasmdmd.d
+++ b/src/dmd/iasmdmd.d
@@ -1,9 +1,6 @@
 /**
  * Inline assembler implementation for DMD.
  *
- * Part of the compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (c) 1992-1999 by Symantec
  *              Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     Mike Cote, John Micco and $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/iasmgcc.d
+++ b/src/dmd/iasmgcc.d
@@ -1,9 +1,6 @@
 /**
  * Inline assembler for the GCC D compiler.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  *              Copyright (C) 2018-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     Iain Buclaw
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/iasmgcc.d
+++ b/src/dmd/iasmgcc.d
@@ -1,4 +1,6 @@
 /**
+ * Inline assembler for the GCC D compiler.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *
@@ -8,9 +10,6 @@
  * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/iasmgcc.d, _iasmgcc.d)
  * Documentation:  https://dlang.org/phobos/dmd_iasmgcc.html
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/iasmgcc.d
- */
-
-/* Inline assembler for the GCC D compiler.
  */
 
 module dmd.iasmgcc;

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -1,9 +1,6 @@
 /**
  * Contains the `Id` struct with a list of predefined symbols the compiler knows about.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -1,9 +1,9 @@
 /**
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * This module contains the `Id` struct with a list of predefined symbols the
  * compiler knows about.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -1,6 +1,5 @@
 /**
- * This module contains the `Id` struct with a list of predefined symbols the
- * compiler knows about.
+ * Contains the `Id` struct with a list of predefined symbols the compiler knows about.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -1,4 +1,6 @@
 /**
+ * Defines an identifier, which is the name of a `Dsymbol`.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/identifier.d
+++ b/src/dmd/identifier.d
@@ -1,9 +1,6 @@
 /**
  * Defines an identifier, which is the name of a `Dsymbol`.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -1,5 +1,6 @@
 /**
  * Provides an implicit conversion table for basic types.
+ *
  * Used to determine integer promotions and common types.
  *
  * Specification: $(LINK2 https://dlang.org/spec/type.html#integer-promotions, Integer Promotions),

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -6,9 +6,6 @@
  * Specification: $(LINK2 https://dlang.org/spec/type.html#integer-promotions, Integer Promotions),
  *   $(LINK2 https://dlang.org/spec/type.html#usual-arithmetic-conversions, Usual Arithmetic Conversions).
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/impcnvtab.d
+++ b/src/dmd/impcnvtab.d
@@ -1,4 +1,10 @@
 /**
+ * Provides an implicit conversion table for basic types.
+ * Used to determine integer promotions and common types.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/type.html#integer-promotions, Integer Promotions),
+ *   $(LINK2 https://dlang.org/spec/type.html#usual-arithmetic-conversions, Usual Arithmetic Conversions).
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/imphint.d
+++ b/src/dmd/imphint.d
@@ -3,9 +3,6 @@
  *
  * For example, prompt to `import std.stdio` when using `writeln`.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/imphint.d
+++ b/src/dmd/imphint.d
@@ -1,6 +1,7 @@
 /**
- * Give import hints for common symbol names that couldn't be resolved,
- * e.g. prompting to `import std.stdio` when using `writeln`.
+ * Give import hints for common symbol names that couldn't be resolved.
+ *
+ * For example, prompt to `import std.stdio` when using `writeln`.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/imphint.d
+++ b/src/dmd/imphint.d
@@ -1,4 +1,7 @@
 /**
+ * Give import hints for common symbol names that couldn't be resolved,
+ * e.g. prompting to `import std.stdio` when using `writeln`.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -1,4 +1,6 @@
 /**
+ * Defines initializers of variables, e.g. the array literal in `int[3] x = [0, 1, 2]`.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/init.d
+++ b/src/dmd/init.d
@@ -1,9 +1,6 @@
 /**
  * Defines initializers of variables, e.g. the array literal in `int[3] x = [0, 1, 2]`.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -1,9 +1,6 @@
 /**
  * Semantic analysis of initializers.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -1,4 +1,6 @@
 /**
+ * Semantic analysis of initializers.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1,5 +1,6 @@
 /**
  * Performs inlining, which is an optimization pass enabled with the `-inline` flag.
+ *
  * The AST is traversed, and every function call is considered for inlining using `inlinecost.d`.
  * The function call is then inlined if this cost is below a threshold.
  *

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -4,9 +4,6 @@
  * The AST is traversed, and every function call is considered for inlining using `inlinecost.d`.
  * The function call is then inlined if this cost is below a threshold.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/inline.d
+++ b/src/dmd/inline.d
@@ -1,4 +1,8 @@
 /**
+ * Performs inlining, which is an optimization pass enabled with the `-inline` flag.
+ * The AST is traversed, and every function call is considered for inlining using `inlinecost.d`.
+ * The function call is then inlined if this cost is below a threshold.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -1,9 +1,6 @@
 /**
  * Compute the cost of inlining a function call by counting expressions.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/inlinecost.d
+++ b/src/dmd/inlinecost.d
@@ -1,4 +1,6 @@
 /**
+ * Compute the cost of inlining a function call by counting expressions.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -1,9 +1,6 @@
 /**
  * Implement $(LINK2 https://digitalmars.com/articles/b62.html, Value Range Propagation).
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/intrange.d
+++ b/src/dmd/intrange.d
@@ -1,4 +1,6 @@
 /**
+ * Implement $(LINK2 https://digitalmars.com/articles/b62.html, Value Range Propagation).
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/irstate.d
+++ b/src/dmd/irstate.d
@@ -1,4 +1,6 @@
 /**
+ * The state of Intermediate Representation, which is what the backend uses.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/irstate.d
+++ b/src/dmd/irstate.d
@@ -1,5 +1,5 @@
 /**
- * The state of Intermediate Representation, which is what the backend uses.
+ * The state of Intermediate Representation (IR), which is what the back-end uses.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/irstate.d
+++ b/src/dmd/irstate.d
@@ -1,9 +1,6 @@
 /**
  * The state of Intermediate Representation (IR), which is what the back-end uses.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -1,9 +1,6 @@
 /**
  * Code for generating .json descriptions of the module when passing the `-X` flag to dmd.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/json.d
+++ b/src/dmd/json.d
@@ -1,4 +1,6 @@
 /**
+ * Code for generating .json descriptions of the module when passing the `-X` flag to dmd.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -5,9 +5,6 @@
  * The serialization is a string which contains the type of the parameters and the string
  * represantation of the lambda expression.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -1,8 +1,9 @@
 /**
- * This modules implements the serialization of a lambda function. The serialization
- * is computed by visiting the abstract syntax subtree of the given lambda function.
- * The serialization is a string which contains the type of the parameters and the
- * string represantation of the lambda expression.
+ * Implements the serialization of a lambda function.
+ *
+ * The serializationis computed by visiting the abstract syntax subtree of the given lambda function.
+ * The serialization is a string which contains the type of the parameters and the string
+ * represantation of the lambda expression.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/lambdacomp.d
+++ b/src/dmd/lambdacomp.d
@@ -1,11 +1,11 @@
-/***
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
+/**
  * This modules implements the serialization of a lambda function. The serialization
  * is computed by visiting the abstract syntax subtree of the given lambda function.
  * The serialization is a string which contains the type of the parameters and the
  * string represantation of the lambda expression.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -1,4 +1,8 @@
 /**
+ * Implements the lexical analyzer, which converts source code into lexical tokens.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/lex.html, Lexical)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/lex.html, Lexical)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -2,9 +2,6 @@
  * A module defining an abstract library.
  * Implementations for various formats are in separate `libXXX.d` modules.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/lib.d
+++ b/src/dmd/lib.d
@@ -1,4 +1,7 @@
 /**
+ * A module defining an abstract library.
+ * Implementations for various formats are in separate `libXXX.d` modules.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/libelf.d
+++ b/src/dmd/libelf.d
@@ -1,4 +1,6 @@
 /**
+ * A library in the ELF format, used on Unix.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/libelf.d
+++ b/src/dmd/libelf.d
@@ -1,9 +1,6 @@
 /**
  * A library in the ELF format, used on Unix.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/libmach.d
+++ b/src/dmd/libmach.d
@@ -1,4 +1,6 @@
 /**
+ * A library in the Mach-O format, used on macOS.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/libmach.d
+++ b/src/dmd/libmach.d
@@ -1,9 +1,6 @@
 /**
  * A library in the Mach-O format, used on macOS.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/libmscoff.d
+++ b/src/dmd/libmscoff.d
@@ -1,9 +1,6 @@
 /**
  * A library in the COFF format, used on 32-bit and 64-bit Windows targets.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/libmscoff.d
+++ b/src/dmd/libmscoff.d
@@ -1,4 +1,6 @@
 /**
+ * A library in the COFF format, used on 32-bit and 64-bit Windows targets.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/libomf.d
+++ b/src/dmd/libomf.d
@@ -1,9 +1,6 @@
 /**
  * A library in the OMF format, a legacy format for 32-bit Windows.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/libomf.d
+++ b/src/dmd/libomf.d
@@ -1,4 +1,6 @@
 /**
+ * A library in the OMF format, a legacy format for 32-bit Windows.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1,4 +1,6 @@
 /**
+ * Invoke the linker as a separate process.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/link.d
+++ b/src/dmd/link.d
@@ -1,9 +1,6 @@
 /**
  * Invoke the linker as a separate process.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1,11 +1,12 @@
 /**
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
  * Entry point for DMD.
  *
  * This modules defines the entry point (main) for DMD, as well as related
  * utilities needed for arguments parsing, path manipulation, etc...
  * This file is not shared with other compilers which use the DMD front-end.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -5,9 +5,6 @@
  * utilities needed for arguments parsing, path manipulation, etc...
  * This file is not shared with other compilers which use the DMD front-end.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -1,9 +1,6 @@
 /**
  * Defines a D type.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -1,4 +1,6 @@
 /**
+ * Defines a D type.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -1,4 +1,8 @@
 /**
+ * Checks that a function marked `@nogc` does not invoke the Garbage Collector.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/function.html#nogc-functions, No-GC Functions)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/nogc.d
+++ b/src/dmd/nogc.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/function.html#nogc-functions, No-GC Functions)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/ob.d
+++ b/src/dmd/ob.d
@@ -1,9 +1,6 @@
 /**
  * Flow analysis for Ownership/Borrowing
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2019 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/objc_interface.html, Interfacing to Objective-C)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/objc.d
+++ b/src/dmd/objc.d
@@ -1,4 +1,8 @@
 /**
+ * Interfacing with Objective-C.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/objc_interface.html, Interfacing to Objective-C)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -1,9 +1,6 @@
 /**
  * Glue code for Objective-C interop.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 2015-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/objc_glue.d
+++ b/src/dmd/objc_glue.d
@@ -1,4 +1,6 @@
 /**
+ * Glue code for Objective-C interop.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -1,4 +1,8 @@
 /**
+ * Handles operator overloading.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/operatoroverloading.html, Operator Overloading)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/opover.d
+++ b/src/dmd/opover.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/operatoroverloading.html, Operator Overloading)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1,9 +1,6 @@
 /**
  * Perform constant folding.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/optimize.d
+++ b/src/dmd/optimize.d
@@ -1,4 +1,6 @@
 /**
+ * Perform constant folding.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -1,4 +1,8 @@
 /**
+ * Takes a token stream from the lexer, and parses it into an abstract syntax tree.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/grammar.html, D Grammar)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/parse.d
+++ b/src/dmd/parse.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/grammar.html, D Grammar)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -1,4 +1,7 @@
 /**
+ * Defines a visitor for the AST.
+ * Other visitors derive from this class.
+ *
  * Documentation:  https://dlang.org/phobos/dmd_parsetimevisitor.html
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/parsetimevisitor.d
  */

--- a/src/dmd/parsetimevisitor.d
+++ b/src/dmd/parsetimevisitor.d
@@ -1,5 +1,6 @@
 /**
  * Defines a visitor for the AST.
+ *
  * Other visitors derive from this class.
  *
  * Documentation:  https://dlang.org/phobos/dmd_parsetimevisitor.html

--- a/src/dmd/permissivevisitor.d
+++ b/src/dmd/permissivevisitor.d
@@ -1,4 +1,6 @@
 /**
+ * A visitor that facilitates the traversal of subsets of the AST.
+ *
  * Documentation:  https://dlang.org/phobos/dmd_permissivevisitor.html
  * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/permissivevisitor.d
  */

--- a/src/dmd/printast.d
+++ b/src/dmd/printast.d
@@ -1,9 +1,6 @@
 /**
  * Provides an AST printer for debugging.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/printast.d
+++ b/src/dmd/printast.d
@@ -1,4 +1,6 @@
 /**
+ * Provides an AST printer for debugging.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -1,4 +1,6 @@
 /**
+ * Convert statements to Intermediate Representation (IR) for the back-end.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -1,9 +1,6 @@
 /**
  * Convert statements to Intermediate Representation (IR) for the back-end.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(https://dlang.org/spec/function.html#function-safety, Function Safety)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -1,7 +1,7 @@
 /**
  * Checks whether member access or array casting is allowed in `@safe` code.
  *
- * Specification: $(https://dlang.org/spec/function.html#function-safety, Function Safety)
+ * Specification: $(LINK2 https://dlang.org/spec/function.html#function-safety, Function Safety)
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/safe.d
+++ b/src/dmd/safe.d
@@ -1,4 +1,8 @@
 /**
+ * Checks whether member access or array casting is allowed in `@safe` code.
+ *
+ * Specification: $(https://dlang.org/spec/function.html#function-safety, Function Safety)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/sapply.d
+++ b/src/dmd/sapply.d
@@ -1,9 +1,6 @@
 /**
  * Provides a depth-first statement visitor.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/sapply.d
+++ b/src/dmd/sapply.d
@@ -1,4 +1,6 @@
 /**
+ * Provides a depth-first statement visitor.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/scanelf.d
+++ b/src/dmd/scanelf.d
@@ -1,9 +1,6 @@
 /**
  * Extract symbols from an ELF object file.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/scanelf.d
+++ b/src/dmd/scanelf.d
@@ -1,4 +1,6 @@
 /**
+ * Extract symbols from an ELF object file.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/scanmach.d
+++ b/src/dmd/scanmach.d
@@ -1,9 +1,6 @@
 /**
  * Extract symbols from a Mach-O object file.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/scanmach.d
+++ b/src/dmd/scanmach.d
@@ -1,4 +1,6 @@
 /**
+ * Extract symbols from a Mach-O object file.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/scanmscoff.d
+++ b/src/dmd/scanmscoff.d
@@ -1,9 +1,6 @@
 /**
  * Extract symbols from a COFF object file.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/scanmscoff.d
+++ b/src/dmd/scanmscoff.d
@@ -1,4 +1,6 @@
 /**
+ * Extract symbols from a COFF object file.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/scanomf.d
+++ b/src/dmd/scanomf.d
@@ -1,9 +1,6 @@
 /**
  * Extract symbols from an OMF object file.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/scanomf.d
+++ b/src/dmd/scanomf.d
@@ -1,4 +1,6 @@
 /**
+ * Extract symbols from an OMF object file.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -1,4 +1,6 @@
 /**
+ * Performs the semantic2 stage, which deals with initializer expressions.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -1,9 +1,6 @@
 /**
  * Performs the semantic2 stage, which deals with initializer expressions.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1,4 +1,6 @@
 /**
+ * Performs the semantic3 stage, which deals with function bodies.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/semantic3.d
+++ b/src/dmd/semantic3.d
@@ -1,9 +1,6 @@
 /**
  * Performs the semantic3 stage, which deals with function bodies.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -1,4 +1,7 @@
 /**
+ * Find side-effects of expressions.
+ * Used for certain lowerings.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -1,9 +1,6 @@
 /**
  * Find side-effects of expressions.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/sideeffect.d
+++ b/src/dmd/sideeffect.d
@@ -1,6 +1,5 @@
 /**
  * Find side-effects of expressions.
- * Used for certain lowerings.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/statement.html, Statements)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/statement.d
+++ b/src/dmd/statement.d
@@ -1,4 +1,8 @@
 /**
+ * Defines AST nodes for statements.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/statement.html, Statements)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/statement_rewrite_walker.d
+++ b/src/dmd/statement_rewrite_walker.d
@@ -1,9 +1,6 @@
 /**
  * Provides a visitor for statements that allows rewriting the currently visited node.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/statement_rewrite_walker.d
+++ b/src/dmd/statement_rewrite_walker.d
@@ -1,4 +1,6 @@
 /**
+ * Provides a visitor for statements that allows rewriting the currently visited node.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -1,4 +1,8 @@
 /**
+ * Does semantic analysis for statements.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/statement.html, Statements)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/statementsem.d
+++ b/src/dmd/statementsem.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/statement.html, Statements)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/staticassert.d
+++ b/src/dmd/staticassert.d
@@ -1,4 +1,8 @@
 /**
+ * Defines the `Dsymbol` representing a `static assert()`.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/version.html#static-assert, Static Assert)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/staticassert.d
+++ b/src/dmd/staticassert.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/version.html#static-assert, Static Assert)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -1,4 +1,6 @@
 /**
+ * Lazily evaluate static conditions for `static if`, `static assert` and template constraints.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/staticcond.d
+++ b/src/dmd/staticcond.d
@@ -1,9 +1,6 @@
 /**
  * Lazily evaluate static conditions for `static if`, `static assert` and template constraints.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -1,8 +1,8 @@
 /**
+ * Template implementation.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
- *
- * Template implementation.
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -1,9 +1,6 @@
 /**
  * Semantic analysis of template parameters.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/templateparamsem.d
+++ b/src/dmd/templateparamsem.d
@@ -1,5 +1,5 @@
 /**
- * Template implementation.
+ * Semantic analysis of template parameters.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -1,5 +1,5 @@
 /**
- * Convert a D type to a type the backend understands.
+ * Convert a D symbol to a symbol the linker understands (with mangled name).
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -1,4 +1,6 @@
 /**
+ * Convert a D type to a type the backend understands.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/tocsym.d
+++ b/src/dmd/tocsym.d
@@ -1,9 +1,6 @@
 /**
  * Convert a D symbol to a symbol the linker understands (with mangled name).
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -1,9 +1,6 @@
 /**
  * Convert a D type to a type the backend understands.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -1,4 +1,6 @@
 /**
+ * Convert a D symbol to a symbol the linker understands (with mangled name)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/toctype.d
+++ b/src/dmd/toctype.d
@@ -1,5 +1,5 @@
 /**
- * Convert a D symbol to a symbol the linker understands (with mangled name)
+ * Convert a D type to a type the backend understands.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -1,9 +1,6 @@
 /**
  * Generate debug info in the CV4 debug format.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -1,4 +1,6 @@
 /**
+ * Generate debug info in the CV4 debug format.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -1,4 +1,7 @@
 /**
+ * Put initializers and objects created from CTFE into a `dt_t` data structure
+ * so the backend puts them into the data segment.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -2,9 +2,6 @@
  * Put initializers and objects created from CTFE into a `dt_t` data structure
  * so the backend puts them into the data segment.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1,9 +1,6 @@
 /**
  * Convert to Intermediate Representation (IR) for the back-end.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1,5 +1,5 @@
 /**
- * Convert to intermediate representation for the back-end.
+ * Convert to Intermediate Representation (IR) for the back-end.
  *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).

--- a/src/dmd/toir.d
+++ b/src/dmd/toir.d
@@ -1,4 +1,6 @@
 /**
+ * Convert to intermediate representation for the back-end.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/lex.html#tokens, Tokens)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/tokens.d
+++ b/src/dmd/tokens.d
@@ -1,4 +1,8 @@
 /**
+ * Defines lexical tokens.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/lex.html#tokens, Tokens)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1,9 +1,6 @@
 /**
  * Convert an AST that went through all semantic phases into an object file.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/toobj.d
+++ b/src/dmd/toobj.d
@@ -1,4 +1,6 @@
 /**
+ * Convert an AST that went through all semantic phases into an object file.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1,4 +1,8 @@
 /**
+ * Handle introspection using the `__traits()` construct.
+ *
+ * Specification: $(LINK2 https://dlang.org/spec/traits.html, Traits)
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -3,9 +3,6 @@
  *
  * Specification: $(LINK2 https://dlang.org/spec/traits.html, Traits)
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1,5 +1,5 @@
 /**
- * Handle introspection using the `__traits()` construct.
+ * Handle introspection functionality of the `__traits()` construct.
  *
  * Specification: $(LINK2 https://dlang.org/spec/traits.html, Traits)
  *

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1,4 +1,6 @@
 /**
+ * Semantic analysis for D types.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1,9 +1,6 @@
 /**
  * Semantic analysis for D types.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -1,4 +1,6 @@
 /**
+ * Generate `TypeInfo` objects, which are needed for run-time introspection of classes.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/typinf.d
+++ b/src/dmd/typinf.d
@@ -1,9 +1,6 @@
 /**
  * Generate `TypeInfo` objects, which are needed for run-time introspection of classes.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/utf.d
+++ b/src/dmd/utf.d
@@ -1,9 +1,6 @@
 /**
  * Functions related to UTF encoding.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/utf.d
+++ b/src/dmd/utf.d
@@ -1,4 +1,6 @@
 /**
+ * Functions related to UTF encoding.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -1,9 +1,6 @@
 /**
  * This module defines some utility functions for DMD.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/utils.d
+++ b/src/dmd/utils.d
@@ -1,9 +1,8 @@
 /**
+ * This module defines some utility functions for DMD.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
- * Utility functions for DMD.
- *
- * This modules defines some utility functions for DMD.
  *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -1,4 +1,6 @@
 /**
+ * Provides a visitor class visiting all AST nodes present in the compiler.
+ *
  * Compiler implementation of the
  * $(LINK2 http://www.dlang.org, D programming language).
  *

--- a/src/dmd/visitor.d
+++ b/src/dmd/visitor.d
@@ -1,9 +1,6 @@
 /**
  * Provides a visitor class visiting all AST nodes present in the compiler.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/vsoptions.d
+++ b/src/dmd/vsoptions.d
@@ -1,9 +1,6 @@
 /**
  * When compiling on Windows with the Microsoft toolchain, try to detect the Visual Studio setup.
  *
- * Compiler implementation of the
- * $(LINK2 http://www.dlang.org, D programming language).
- *
  * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
  * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
  * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)

--- a/src/dmd/vsoptions.d
+++ b/src/dmd/vsoptions.d
@@ -1,14 +1,16 @@
 /**
-* Compiler implementation of the
-* $(LINK2 http://www.dlang.org, D programming language).
-*
-* Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
-* Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
-* License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
-* Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/link.d, _vsoptions.d)
-* Documentation:  https://dlang.org/phobos/dmd_vsoptions.html
-* Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/vsoptions.d
-*/
+ * When compiling on Windows with the Microsoft toolchain, try to detect the Visual Studio setup.
+ *
+ * Compiler implementation of the
+ * $(LINK2 http://www.dlang.org, D programming language).
+ *
+ * Copyright:   Copyright (C) 1999-2020 by The D Language Foundation, All Rights Reserved
+ * Authors:     $(LINK2 http://www.digitalmars.com, Walter Bright)
+ * License:     $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source:      $(LINK2 https://github.com/dlang/dmd/blob/master/src/dmd/link.d, _vsoptions.d)
+ * Documentation:  https://dlang.org/phobos/dmd_vsoptions.html
+ * Coverage:    https://codecov.io/gh/dlang/dmd/src/master/src/dmd/vsoptions.d
+ */
 
 module dmd.vsoptions;
 


### PR DESCRIPTION
As suggested by Walter: https://github.com/dlang/dmd/pull/9844#issuecomment-495951635

- Adds missing module descriptions
- Consistently puts the description above the boilerplate
- Adds links to the specification where applicable

The descriptions are sometimes vague since I'm not always sure myself what each module does exactly, but it's a start.