### PR TITLE
Remove deprecated CLI switches for import transition

### DIFF
--- a/changelog/bug10478-cli-switches.dd
+++ b/changelog/bug10478-cli-switches.dd
@@ -1,0 +1,4 @@
+CLI switches `-revert=import` and `-transition=checkimports` have been removed
+
+Those switched were already not doing anything and had been deprecated for a while.
+The compiler will no longer recognized them.

--- a/src/dmd/cli.d
+++ b/src/dmd/cli.d
@@ -719,8 +719,6 @@ dmd -cov -unittest myprog.d
     static immutable transitions = [
         Feature("field", "vfield",
             "list all non-mutable fields which occupy an object instance"),
-        Feature("checkimports", "check10378",
-            "give deprecation messages about 10378 anomalies", true, true),
         Feature("complex", "vcomplex",
             "give deprecation messages about all usages of complex or imaginary types"),
         Feature("tls", "vtls",
@@ -732,7 +730,6 @@ dmd -cov -unittest myprog.d
     /// Returns all available reverts
     static immutable reverts = [
         Feature("dip25", "noDIP25", "revert DIP25 changes https://github.com/dlang/DIPs/blob/master/DIPs/archive/DIP25.md"),
-        Feature("import", "bug10378", "revert to single phase name lookup", true, true),
     ];
 
     /// Returns all available previews

--- a/src/dmd/globals.d
+++ b/src/dmd/globals.d
@@ -168,8 +168,6 @@ extern (C++) struct Param
     bool betterC;           // be a "better C" compiler; no dependency on D runtime
     bool addMain;           // add a default main() function
     bool allInst;           // generate code for all template instantiations
-    bool check10378;        // check for issues transitioning to 10738 @@@DEPRECATED@@@ Remove in 2020-05 or later
-    bool bug10378;          // use pre- https://issues.dlang.org/show_bug.cgi?id=10378 search strategy  @@@DEPRECATED@@@ Remove in 2020-05 or later
     bool fix16997;          // fix integral promotions for unary + - ~ operators
                             // https://issues.dlang.org/show_bug.cgi?id=16997
     bool fixAliasThis;      // if the current scope has an alias this, check it before searching upper scopes

--- a/src/dmd/globals.h
+++ b/src/dmd/globals.h
@@ -146,8 +146,6 @@ struct Param
     bool betterC;       // be a "better C" compiler; no dependency on D runtime
     bool addMain;       // add a default main() function
     bool allInst;       // generate code for all template instantiations
-    bool check10378;    // check for issues transitioning to 10738
-    bool bug10378;      // use pre-bugzilla 10378 search strategy
     bool fix16997;      // fix integral promotions for unary + - ~ operators
                         // https://issues.dlang.org/show_bug.cgi?id=16997
     bool fixAliasThis;  // if the current scope has an alias this, check it before searching upper scopes

--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -1993,9 +1993,6 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                         case 3449:
                             params.vfield = true;
                             break;
-                        case 10378:
-                            params.bug10378 = true;
-                            break;
                         case 14246:
                             params.dtorFields = true;
                             break;
@@ -2016,9 +2013,6 @@ bool parseCommandLine(const ref Strings arguments, const size_t argc, ref Param 
                     const ident = p + len;
                     switch (ident.toDString())
                     {
-                        case "import":
-                            params.bug10378 = true;
-                            break;
                         case "dtorfields":
                             params.dtorFields = true;
                             break;


### PR DESCRIPTION
As per the comment, since we do a minor release every 3 months this will make it in 2.092 in June.