### PR TITLE
Replace OUTPUT_FILES marker which collides with section delimiters

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -218,9 +218,9 @@ The following is a list of all available settings:
                         Example:
                         ------------------------------------------
                         <Compilation Output>
-                        --- <FILENAME_1>
+                        === <FILENAME_1>
                         <CONTENT_1>
-                        --- <FILENAME_2>
+                        === <FILENAME_2>
                         <CONTENT_2>
                         [...]
                         ------------------------------------------

--- a/test/compilable/extra-files/json2.out
+++ b/test/compilable/extra-files/json2.out
@@ -1,4 +1,4 @@
---- ${RESULTS_DIR}/compilable/json2.out
+=== ${RESULTS_DIR}/compilable/json2.out
 {
     "buildInfo": {
         "argv0": "VALUE_REMOVED_FOR_TEST",

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1220,9 +1220,9 @@ int tryMain(string[] args)
 
             // Prepare and append the content of each OUTPUT_FILE conforming to
             // the HAR (https://code.dlang.org/packages/har) format, e.g.
-            // --- <FILENAME_1>
+            // === <FILENAME_1>
             // <CONTENT_1>
-            // --- <FILENAME_2>
+            // === <FILENAME_2>
             // <CONTENT_2>
             // ...
             foreach (const outfile; testArgs.outputFiles)
@@ -1241,7 +1241,7 @@ int tryMain(string[] args)
                 // Prepend a header listing the explicit file
                 compile_output.reserve(outfile.length + content.length + 5);
 
-                compile_output ~= "--- ";
+                compile_output ~= "=== ";
                 compile_output ~= outfile;
                 compile_output ~= '\n';
                 compile_output ~= content;


### PR DESCRIPTION
The old marker `---` could be confused with the delimeter of a (TEST_OUTPUT) section. Hence replace it with another sequence "===".