### PR TITLE
run.d: Use target model instead of DMD model in linker paths

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -458,7 +458,7 @@ string[string] getEnvironment()
     env["DMD"] = dmdPath;
     env.getDefault("DMD_TEST_COVERAGE", "0");
 
-    const generatedSuffix = "generated/%s/%s/%s".format(os, build, dmdModel);
+    const generatedSuffix = "generated/%s/%s/%s".format(os, build, model);
 
     version(Windows)
     {


### PR DESCRIPTION
Extracted from #10878.
This broke compiling 32-bit executables using a 64-bit compiler.