### PR TITLE
Make printenv.d print all variables except BUILD_SOURCEVERSIONAUTHOR

### DIFF
--- a/test/dshell/extra-files/printenv.d
+++ b/test/dshell/extra-files/printenv.d
@@ -4,7 +4,7 @@ auto filterEnv(T)(T env)
 {
     // Windows shell output is not in UTF-8
     // https://github.com/dlang/phobos/pull/7342#issuecomment-571154708
-    return env.filter!(e => e.key.among("BUILD_SOURCEVERSIONAUTHOR"));
+    return env.filter!(e => !e.key.among("BUILD_SOURCEVERSIONAUTHOR"));
 }
 
 void main()


### PR DESCRIPTION
Instead of only printing the value of `BUILD_SOURCEVERSIONAUTHOR`.

CC @wilzbach @Biotronic 