### PR TITLE
Fix Issue 20643 - printf without arguments aborts compilation

### DIFF
--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -2175,9 +2175,10 @@ private bool functionParameters(const ref Loc loc, Scope* sc,
 
         if (paramOffset && nparams >= paramOffset)
         {
-            auto se = (*arguments)[paramOffset - 1].isStringExp();
-            if (se && chkFn(se.loc, se.peekString(), (*arguments)[paramOffset .. nargs]))
-                 err = true;
+            if (auto se = (*arguments)[paramOffset - 1].isStringExp())
+            {
+                chkFn(se.loc, se.peekString(), (*arguments)[paramOffset .. nargs]);
+            }
         }
     }
 

--- a/test/compilable/chkformat.d
+++ b/test/compilable/chkformat.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=20644
+/*
+TEST_OUTPUT:
+----
+compilable/chkformat.d(12): Deprecation: more format specifiers than 0 arguments
+----
+*/
+import core.stdc.stdio;
+
+void main()
+{
+    printf("%d \n");
+}


### PR DESCRIPTION
We shouldn't return an error, because it is deprecated for the moment.