### PR TITLE
Fix issue 19949: Implement support for C++ ABI tags

### DIFF
--- a/changelog/cpp_abi_tags.dd
+++ b/changelog/cpp_abi_tags.dd
@@ -1,0 +1,25 @@
+Added support for mangling C++'s GNU ABI tags
+
+GNU ABI tags are a feature that was added with C++11 in $(LINK2 https://gcc.gnu.org/gcc-5/changes.html#libstdcxx, GCC 5.1).
+In order for D to fully support the $(LINK2 http://www.cplusplus.com/reference/, standard C++ library),
+DMD now recognize the special UDA `gnuAbiTag`, declared in `core.attribute` and publicly aliased in `object`
+(so one need not import anything to use it).
+The ABI tags are a low level feature that most user will not need to interact with,
+but can be used to bind to C++ libraries that need it.
+In particular, it is required to bind $(LINK2 http://www.cplusplus.com/reference/string/, `std::string`)
+when targeting C++11 and higher (DMD switch `-extern-std={c++11,c++14,c++17}`).
+
+It can be used in the following way:
+---
+extern(C++):
+@gnuAbiTag("tagOnStruct")
+struct MyStruct {}
+@gnuAbiTag("Multiple", "Tags", "On", "Function")
+MyStruct func();
+---
+
+Only one `gnuAbiTag` can be present on a symbol at a time.
+The order of the array entries does not matter (they are sorted on output).
+The UDA will only have an effect if `-extern-std=c++11` or higher is passed
+to the compiler. The default (`-extern-std=c++98`) will ignore the UDA.
+This UDA can only be applied to `extern(C++)` symbols and cannot be applied to namespaces.

--- a/ci.sh
+++ b/ci.sh
@@ -86,9 +86,9 @@ test() {
 test_dmd() {
     # test fewer compiler argument permutations for PRs to reduce CI load
     if [ "$FULL_BUILD" == "true" ] && [ "$OS_NAME" == "linux"  ]; then
-        make -j1 -C test start_all_tests MODEL=$MODEL N=$N # all ARGS by default
+        make -j1 -C test auto-tester-test MODEL=$MODEL N=$N # all ARGS by default
     else
-        make -j1 -C test start_all_tests MODEL=$MODEL N=$N ARGS="-O -inline -release"
+        make -j1 -C test auto-tester-test MODEL=$MODEL N=$N ARGS="-O -inline -release"
     fi
 }
 

--- a/posix.mak
+++ b/posix.mak
@@ -19,7 +19,14 @@ ifneq (,$(findstring Darwin_64_32, $(PWD)))
 auto-tester-test:
 	echo "Darwin_64_32_disabled"
 else
+ifneq (,$(findstring windows, $(PWD)))
 auto-tester-test: test
+else # POSIX
+# Like test, but without runnable_cxx
+auto-tester-test:
+	$(QUIET)$(MAKE) -C src -f posix.mak unittest
+	$(QUIET)$(MAKE) -C test -f Makefile
+endif
 endif
 
 buildkite-test: test

--- a/posix.mak
+++ b/posix.mak
@@ -25,7 +25,7 @@ else # POSIX
 # Like test, but without runnable_cxx
 auto-tester-test:
 	$(QUIET)$(MAKE) -C src -f posix.mak unittest
-	$(QUIET)$(MAKE) -C test -f Makefile
+	$(QUIET)$(MAKE) -C test -f Makefile auto-tester-test
 endif
 endif
 

--- a/src/dmd/cppmangle.d
+++ b/src/dmd/cppmangle.d
@@ -40,8 +40,10 @@ import dmd.id;
 import dmd.identifier;
 import dmd.mtype;
 import dmd.nspace;
+import dmd.root.array;
 import dmd.root.outbuffer;
 import dmd.root.rootobject;
+import dmd.root.string;
 import dmd.target;
 import dmd.tokens;
 import dmd.typesem;
@@ -148,9 +150,10 @@ private final class CppMangleVisitor : Visitor
     /// Context used when processing pre-semantic AST
     private Context context;
 
-    Objects components;         // array of components available for substitution
-    OutBuffer* buf;             // append the mangling to buf[]
-    Loc loc;                    // location for use in error messages
+    ABITagContainer abiTags;    /// Container for already-written ABI tags
+    Objects components;         /// array of components available for substitution
+    OutBuffer* buf;             /// append the mangling to buf[]
+    Loc loc;                    /// location for use in error messages
 
     /**
      * Constructor
@@ -318,6 +321,36 @@ private final class CppMangleVisitor : Visitor
         const name = ident.toString();
         this.buf.print(name.length);
         this.buf.writestring(name);
+    }
+
+    /**
+     * Insert the leftover ABI tags to the buffer
+     *
+     * This inset ABI tags that hasn't already been written
+     * after the mangled name of the function.
+     * For more details, see the `abiTags` variable.
+     *
+     * Params:
+     *   off  = Offset to insert at
+     *   fd   = Type of the function to mangle the return type of
+     */
+    void writeRemainingTags(size_t off, TypeFunction tf)
+    {
+        scope remainingVisitor = new LeftoverVisitor(&this.abiTags.written);
+        tf.next.accept(remainingVisitor);
+        OutBuffer b2;
+        foreach (se; remainingVisitor.toWrite)
+        {
+            auto tag = se.peekString();
+            // We can only insert a slice, and each insert is a memmove,
+            // so use a temporary buffer to keep it efficient.
+            b2.reset();
+            b2.writestring("B");
+            b2.print(tag.length);
+            b2.writestring(tag);
+            this.buf.insert(off, b2[]);
+            off += b2.length;
+        }
     }
 
     /************************
@@ -592,6 +625,7 @@ private final class CppMangleVisitor : Visitor
             }
             else if (this.writeStdSubstitution(ti, needsTa))
             {
+                this.abiTags.writeSymbol(ti, this);
                 if (needsTa)
                     template_args(ti);
             }
@@ -601,13 +635,17 @@ private final class CppMangleVisitor : Visitor
                     s.cppnamespace, () {
                         this.writeIdentifier(ti.tempdecl.toAlias().ident);
                         append(ti.tempdecl);
+                        this.abiTags.writeSymbol(ti.tempdecl, this);
                         template_args(ti);
                     }, haveNE);
             }
         }
         else
-            this.writeNamespace(s.cppnamespace, () => this.writeIdentifier(s.ident),
-                                haveNE);
+            this.writeNamespace(s.cppnamespace, () {
+                    this.writeIdentifier(s.ident);
+                    this.abiTags.writeSymbol(s, this);
+                },
+                haveNE);
     }
 
     /********
@@ -730,6 +768,7 @@ private final class CppMangleVisitor : Visitor
                 auto ti = si.isTemplateInstance();
                 if (this.writeStdSubstitution(ti, needsTa))
                 {
+                    this.abiTags.writeSymbol(ti, this);
                     if (needsTa)
                     {
                         template_args(ti);
@@ -893,7 +932,7 @@ private final class CppMangleVisitor : Visitor
             }
         }
         else
-            source_name(se);
+            source_name(se, false);
         append(s);
     }
 
@@ -935,16 +974,28 @@ private final class CppMangleVisitor : Visitor
             source_name(d, true);
             buf.writeByte('E');
         }
-        //char beta[6] should mangle as "beta"
+        else if (isNested)
+        {
+            buf.writestring("_Z");
+            source_name(d, false);
+        }
         else
         {
-            if (!isNested)
-                buf.writestring(d.ident.toString());
-            else
+            if (auto varTags = ABITagContainer.forSymbol(d))
             {
                 buf.writestring("_Z");
-                source_name(d);
+                source_name(d, false);
+                return;
             }
+            if (auto typeTags = ABITagContainer.forSymbol(d.type.toDsymbol(null)))
+            {
+                buf.writestring("_Z");
+                source_name(d, false);
+                this.abiTags.write(*this.buf, typeTags);
+                return;
+            }
+            //char beta[6] should mangle as "beta"
+            buf.writestring(d.ident.toString());
         }
     }
 
@@ -993,11 +1044,18 @@ private final class CppMangleVisitor : Visitor
             }
             else
             {
-                source_name(d);
+                source_name(d, false);
             }
+
+            // Save offset for potentially writing tags
+            const size_t off = this.buf.length();
+
             // Template args accept extern "C" symbols with special mangling
             if (tf.linkage == LINK.cpp)
                 mangleFunctionParameters(tf.parameterList.parameters, tf.parameterList.varargs);
+
+            if (!tf.next.isTypeBasic())
+                this.writeRemainingTags(off, tf);
         }
     }
 
@@ -1071,7 +1129,7 @@ private final class CppMangleVisitor : Visitor
             if (nspace && nspace.isNspace())
                 this.writeChained(ti.toParent(), () => source_name(ti, true));
             else
-                source_name(ti);
+                source_name(ti, false);
             this.mangleReturnType(preSemantic);
             this.mangleFunctionParameters(preSemantic.parameterList.parameters, tf.parameterList.varargs);
             return;
@@ -1798,6 +1856,9 @@ extern(C++):
         // If substitution failed, write `TX_` where `X` is the index
         this.writeTemplateArgIndex(idx, param);
         this.append(param);
+        // Write the ABI tags, if any
+        if (auto sym = this.context.res.isDsymbol())
+            this.abiTags.writeSymbol(sym, this);
     }
 
     /// Ditto
@@ -2008,6 +2069,7 @@ private extern(C++) final class ComponentVisitor : Visitor
                 goto default;
             break;
 
+        // Note: ABI tags are also handled here (they are TupleExp of StringExp)
         default:
             this.object = base;
         }
@@ -2168,4 +2230,235 @@ private bool isNamespaceEqual (CPPNamespaceDeclaration a, CPPNamespaceDeclaratio
     if (a.ident != b.ident)
         return false;
     return a.cppnamespace is null ? true : isNamespaceEqual(a.cppnamespace, b.cppnamespace);
+}
+
+/**
+ * A container for ABI tags
+ *
+ * At its hearth, there is a sorted array of ABI tags having been written
+ * already. ABI tags can be present on parameters, template parameters,
+ * return value, and varaible. ABI tags for a given type needs to be written
+ * sorted. When a function returns a type that has ABI tags, only the tags that
+ * haven't been printed as part of the mangling (e.g. arguments) are written
+ * directly after the function name.
+ *
+ * This means that:
+ * ---
+ * /++ C++ type definitions:
+ * struct [[gnu::abi_tag("tag1")]] Struct1 {};
+ * struct [[gnu::abi_tag("tag2")]] Struct2 {};
+ * // Can also be: "tag2", "tag1", since tags are sorted.
+ * struct [[gnu::abi_tag("tag1", "tag2")]] Struct3 {};
+ * +/
+ * // Functions definitions:
+ * Struct3 func1 (Struct1);
+ * Struct3 func2 (Struct2);
+ * Struct3 func3 (Struct2, Struct1);
+ * ---
+ * Will be respectively pseudo-mangled (part of interest between stars) as:
+ * "_Z4 func1 *B4tag2* ParamsMangling" (ParamsMangling includes tag1),
+ * "_Z4 func2 *B4tag1* ParamsMangling" (ParamsMangling includes tag2),
+ * "_Z4 func2 *B4tag1* ParamsMangling" (ParamsMangling includes both).
+ *
+ * This is why why need to keep a list of tags that were written,
+ * and insert the missing one after parameter mangling has been written.
+ * Since there's a lot of operations that are not easily doable in DMD
+ * (since we can't use Phobos), this special container is implemented.
+ */
+private struct ABITagContainer
+{
+    private Array!StringExp written;
+
+    static ArrayLiteralExp forSymbol (Dsymbol s)
+    {
+        if (!s)
+            return null;
+        // If this is a template instance, we want the declaration,
+        // as that's where the UDAs are
+        if (auto ti = s.isTemplateInstance())
+            s = ti.tempdecl;
+        if (!s.userAttribDecl || !s.userAttribDecl.atts)
+            return null;
+
+        foreach (exp; *s.userAttribDecl.atts)
+        {
+            if (UserAttributeDeclaration.isGNUABITag(exp))
+                return (*exp.isStructLiteralExp().elements)[0]
+                    .isArrayLiteralExp();
+        }
+        return null;
+    }
+
+    void writeSymbol(Dsymbol s, CppMangleVisitor self)
+    {
+        auto tale = forSymbol(s);
+        if (!tale) return;
+        if (self.substitute(tale))
+            return;
+        this.write(*self.buf, tale);
+    }
+
+    /**
+     * Write an ArrayLiteralExp (expected to be an ABI tag) to the buffer
+     *
+     * Params:
+     *   buf = Buffer to write mangling to
+     *   ale = GNU ABI tag array literal expression, semantically analyzed
+     */
+    void write (ref OutBuffer buf, ArrayLiteralExp ale, bool skipKnown = false)
+    {
+        void writeElem (StringExp exp)
+        {
+            const tag = exp.peekString();
+            buf.writestring("B");
+            buf.print(tag.length);
+            buf.writestring(tag);
+        }
+
+        bool match;
+        foreach (exp; *ale.elements)
+        {
+            auto elem = exp.toStringExp();
+            auto idx = closestIndex(this.written[], elem, match);
+            if (!match)
+            {
+                writeElem(elem);
+                this.written.insert(idx, elem);
+            }
+            else if (!skipKnown)
+                writeElem(elem);
+        }
+    }
+}
+
+/**
+ * Returns the closest index to to `exp` in `slice`
+ *
+ * Performs a binary search on `slice` (assumes `slice` is sorted),
+ * and returns either `exp`'s index in `slice` if `exact` is `true`,
+ * or the index at which `exp` can be inserted in `slice` if `exact is `false`.
+ * Inserting `exp` at the return value will keep the array sorted.
+ *
+ * Params:
+ *   slice = The sorted slice to search into
+ *   exp   = The string expression to search for
+ *   exact = If `true` on return, `exp` was found in `slice`
+ *
+ * Returns:
+ *   Either the index to insert `exp` at (if `exact == false`),
+ *   or the index of `exp` in `slice`.
+ */
+private size_t closestIndex (const(StringExp)[] slice, StringExp exp, out bool exact)
+{
+    if (!slice.length) return 0;
+
+    const StringExp* first = slice.ptr;
+    while (true)
+    {
+        int res = dstrcmp(exp.peekString(), slice[$ / 2].peekString());
+        if (res == 0)
+        {
+            exact = true;
+            return (&slice[$/2] - first);
+        }
+
+        if (slice.length == 1)
+            return (slice.ptr - first) + (res > 0);
+        slice = slice[(res > 0 ? $ / 2 : 0) .. (res > 0 ? $ : $ / 2)];
+    }
+}
+
+//
+unittest
+{
+    bool match;
+    auto s1 = new StringExp(Loc.initial, "Amande");
+    auto s2 = new StringExp(Loc.initial, "Baguette");
+    auto s3 = new StringExp(Loc.initial, "Croissant");
+    auto s4 = new StringExp(Loc.initial, "Framboises");
+    auto s5 = new StringExp(Loc.initial, "Proscuitto");
+
+    // Found, odd size
+    assert(closestIndex([s1, s2, s3, s4, s5], s1, match) == 0 && match);
+    assert(closestIndex([s1, s2, s3, s4, s5], s2, match) == 1 && match);
+    assert(closestIndex([s1, s2, s3, s4, s5], s3, match) == 2 && match);
+    assert(closestIndex([s1, s2, s3, s4, s5], s4, match) == 3 && match);
+    assert(closestIndex([s1, s2, s3, s4, s5], s5, match) == 4 && match);
+
+    // Not found, even size
+    assert(closestIndex([s2, s3, s4, s5], s1, match) == 0 && !match);
+    assert(closestIndex([s1, s3, s4, s5], s2, match) == 1 && !match);
+    assert(closestIndex([s1, s2, s4, s5], s3, match) == 2 && !match);
+    assert(closestIndex([s1, s2, s3, s5], s4, match) == 3 && !match);
+    assert(closestIndex([s1, s2, s3, s4], s5, match) == 4 && !match);
+
+    // Found, even size
+    assert(closestIndex([s1, s2, s3, s4], s1, match) == 0 && match);
+    assert(closestIndex([s1, s2, s3, s4], s2, match) == 1 && match);
+    assert(closestIndex([s1, s2, s3, s4], s3, match) == 2 && match);
+    assert(closestIndex([s1, s2, s3, s4], s4, match) == 3 && match);
+    assert(closestIndex([s1, s3, s4, s5], s5, match) == 3 && match);
+
+    // Not found, odd size
+    assert(closestIndex([s2, s4, s5], s1, match) == 0 && !match);
+    assert(closestIndex([s1, s4, s5], s2, match) == 1 && !match);
+    assert(closestIndex([s1, s2, s4], s3, match) == 2 && !match);
+    assert(closestIndex([s1, s3, s5], s4, match) == 2 && !match);
+    assert(closestIndex([s1, s2, s4], s5, match) == 3 && !match);
+}
+
+/**
+ * Visits the return type of a function and writes leftover ABI tags
+ */
+extern(C++) private final class LeftoverVisitor : Visitor
+{
+    /// List of tags to write
+    private Array!StringExp toWrite;
+    /// List of tags to ignore
+    private const(Array!StringExp)* ignore;
+
+    ///
+    public this(const(Array!StringExp)* previous)
+    {
+        this.ignore = previous;
+    }
+
+    /// Reintroduce base class overloads
+    public alias visit = Visitor.visit;
+
+    /// Least specialized overload of each direct child of `RootObject`
+    public override void visit(Dsymbol o)
+    {
+        auto ale = ABITagContainer.forSymbol(o);
+        if (!ale) return;
+
+        bool match;
+        foreach (elem; *ale.elements)
+        {
+            auto se = elem.toStringExp();
+            closestIndex((*this.ignore)[], se, match);
+            if (match) continue;
+            auto idx = closestIndex(this.toWrite[], se, match);
+            if (!match)
+                this.toWrite.insert(idx, se);
+        }
+    }
+
+    /// Ditto
+    public override void visit(Type o)
+    {
+        if (auto sym = o.toDsymbol(null))
+            sym.accept(this);
+    }
+
+    /// Composite type
+    public override void visit(TypePointer o)
+    {
+        o.next.accept(this);
+    }
+
+    public override void visit(TypeReference o)
+    {
+        o.next.accept(this);
+    }
 }

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -2298,6 +2298,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         ed.cppnamespace = sc.namespace;
 
         ed.semanticRun = PASS.semantic;
+        UserAttributeDeclaration.checkGNUABITag(ed, sc.linkage);
 
         if (!ed.members && !ed.memtype) // enum ident;
         {
@@ -2716,6 +2717,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         tempdecl.protection = sc.protection;
         tempdecl.cppnamespace = sc.namespace;
         tempdecl.isstatic = tempdecl.toParent().isModule() || (tempdecl._scope.stc & STC.static_);
+        UserAttributeDeclaration.checkGNUABITag(tempdecl, sc.linkage);
 
         if (!tempdecl.isstatic)
         {
@@ -3130,6 +3132,9 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
 
         ns.semanticRun = PASS.semantic;
         ns.parent = sc.parent;
+        // Link does not matter here, if the UDA is present it will error
+        UserAttributeDeclaration.checkGNUABITag(ns, LINK.cpp);
+
         if (ns.members)
         {
             assert(sc);
@@ -3245,6 +3250,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         funcdecl.inlining = sc.inlining;
         funcdecl.protection = sc.protection;
         funcdecl.userAttribDecl = sc.userAttribDecl;
+        UserAttributeDeclaration.checkGNUABITag(funcdecl, funcdecl.linkage);
 
         if (!funcdecl.originalType)
             funcdecl.originalType = funcdecl.type.syntaxCopy();
@@ -4638,6 +4644,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
 
         sd.semanticRun = PASS.semantic;
+        UserAttributeDeclaration.checkGNUABITag(sd, sc.linkage);
 
         if (!sd.members) // if opaque declaration
         {
@@ -4858,6 +4865,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             return;
         }
         cldec.semanticRun = PASS.semantic;
+        UserAttributeDeclaration.checkGNUABITag(cldec, sc.linkage);
 
         if (cldec.baseok < Baseok.done)
         {
@@ -5566,6 +5574,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (!idec.baseclasses.dim && sc.linkage == LINK.cpp)
                 idec.classKind = ClassKind.cpp;
             idec.cppnamespace = sc.namespace;
+            UserAttributeDeclaration.checkGNUABITag(idec, sc.linkage);
 
             if (sc.linkage == LINK.objc)
             {

--- a/src/dmd/id.d
+++ b/src/dmd/id.d
@@ -471,6 +471,7 @@ immutable Msgtable[] msgtable =
     { "char_traits" },
 
     // Compiler recognized UDA's
+    { "udaGNUAbiTag", "gnuAbiTag" },
     { "udaSelector", "selector" },
 
     // C names, for undefined identifier error messages

--- a/src/dmd/semantic2.d
+++ b/src/dmd/semantic2.d
@@ -241,6 +241,8 @@ private extern(C++) final class Semantic2Visitor : Visitor
             return;
         }
 
+        UserAttributeDeclaration.checkGNUABITag(vd, vd.linkage);
+
         if (vd._init && !vd.toParent().isFuncDeclaration())
         {
             vd.inuse++;
@@ -450,6 +452,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
             return;
         TypeFunction f = cast(TypeFunction) fd.type;
 
+        UserAttributeDeclaration.checkGNUABITag(fd, fd.linkage);
         //semantic for parameters' UDAs
         foreach (i; 0 .. f.parameterList.length)
         {
@@ -483,6 +486,7 @@ private extern(C++) final class Semantic2Visitor : Visitor
         {
             printf("+Nspace::semantic2('%s')\n", ns.toChars());
         }
+        UserAttributeDeclaration.checkGNUABITag(ns, LINK.cpp);
         if (ns.members)
         {
             assert(sc);
@@ -542,11 +546,18 @@ private extern(C++) final class Semantic2Visitor : Visitor
         visit(cast(AttribDeclaration)ad);
     }
 
+    override void visit(CPPNamespaceDeclaration decl)
+    {
+        UserAttributeDeclaration.checkGNUABITag(decl, LINK.cpp);
+        visit(cast(AttribDeclaration)decl);
+    }
+
     override void visit(UserAttributeDeclaration uad)
     {
         if (uad.decl && uad.atts && uad.atts.dim && uad._scope)
         {
-            static void eval(Scope* sc, Expressions* exps)
+            Expression* lastTag;
+            static void eval(Scope* sc, Expressions* exps, ref Expression* lastTag)
             {
                 foreach (ref Expression e; *exps)
                 {
@@ -558,14 +569,18 @@ private extern(C++) final class Semantic2Visitor : Visitor
                         if (e.op == TOK.tuple)
                         {
                             TupleExp te = cast(TupleExp)e;
-                            eval(sc, te.exps);
+                            eval(sc, te.exps, lastTag);
                         }
+
+                        // Handles compiler-recognized `core.attribute.gnuAbiTag`
+                        if (UserAttributeDeclaration.isGNUABITag(e))
+                            doGNUABITagSemantic(e, lastTag);
                     }
                 }
             }
 
             uad._scope = null;
-            eval(sc, uad.atts);
+            eval(sc, uad.atts, lastTag);
         }
         visit(cast(AttribDeclaration)uad);
     }
@@ -582,6 +597,9 @@ private extern(C++) final class Semantic2Visitor : Visitor
             return;
         }
 
+        UserAttributeDeclaration.checkGNUABITag(
+            ad, ad.classKind == ClassKind.cpp ? LINK.cpp : LINK.d);
+
         auto sc2 = ad.newScope(sc);
 
         ad.determineSize(ad.loc);
@@ -595,4 +613,102 @@ private extern(C++) final class Semantic2Visitor : Visitor
 
         sc2.pop();
     }
+}
+
+/**
+ * Perform semantic analysis specific to the GNU ABI tags
+ *
+ * The GNU ABI tags are a feature introduced in C++11, specific to g++
+ * and the Itanium ABI.
+ * They are mandatory for C++ interfacing, simply because the templated struct
+ *`std::basic_string`, of which the ubiquitous `std::string` is a instantiation
+ * of, uses them.
+ *
+ * Params:
+ *   e = Expression to perform semantic on
+ *       See `Semantic2Visitor.visit(UserAttributeDeclaration)`
+ *   lastTag = When `!is null`, we already saw an ABI tag.
+ *            To simplify implementation and reflection code,
+ *            only one ABI tag object is allowed per symbol
+ *            (but it can have multiple tags as it's an array exp).
+ */
+private void doGNUABITagSemantic(ref Expression e, ref Expression* lastTag)
+{
+    import dmd.dmangle;
+
+    // When `@gnuAbiTag` is used, the type will be the UDA, not the struct literal
+    if (e.op == TOK.type)
+    {
+        e.error("`@%s` at least one argument expected", Id.udaGNUAbiTag.toChars());
+        return;
+    }
+
+    // Definition is in `core.attributes`. If it's not a struct literal,
+    // it shouldn't have passed semantic, hence the `assert`.
+    auto sle = e.isStructLiteralExp();
+    if (sle is null)
+    {
+        assert(global.errors);
+        return;
+    }
+    // The definition of `gnuAttributes` only have 1 member, `string[] tags`
+    assert(sle.elements && sle.elements.length == 1);
+    // `gnuAbiTag`'s constructor is defined as `this(string[] tags...)`
+    auto ale = (*sle.elements)[0].isArrayLiteralExp();
+    if (ale is null)
+    {
+        e.error("`@%s` at least one argument expected", Id.udaGNUAbiTag.toChars());
+        return;
+    }
+
+    // Check that it's the only tag on the symbol
+    if (lastTag !is null)
+    {
+        const str1 = (*lastTag.isStructLiteralExp().elements)[0].toString();
+        const str2 = ale.toString();
+        e.error("only one `@%s` allowed per symbol", Id.udaGNUAbiTag.toChars());
+        e.errorSupplemental("instead of `@%s @%s`, use `@%s(%.*s, %.*s)`",
+            lastTag.toChars(), e.toChars(), Id.udaGNUAbiTag.toChars(),
+            // Avoid [ ... ]
+            cast(int)str1.length - 2, str1.ptr + 1,
+            cast(int)str2.length - 2, str2.ptr + 1);
+        return;
+    }
+    lastTag = &e;
+
+    // We already know we have a valid array literal of strings.
+    // Now checks that elements are valid.
+    foreach (idx, elem; *ale.elements)
+    {
+        const str = elem.toStringExp().peekString();
+        if (!str.length)
+        {
+            e.error("argument `%d` to `@%s` cannot be %s", cast(int)(idx + 1),
+                    Id.udaGNUAbiTag.toChars(),
+                    elem.isNullExp() ? "`null`".ptr : "empty".ptr);
+            continue;
+        }
+
+        foreach (c; str)
+        {
+            if (!c.isValidMangling())
+            {
+                e.error("`@%s` char `0x%02x` not allowed in mangling",
+                        Id.udaGNUAbiTag.toChars(), c);
+                break;
+            }
+        }
+        // Valid element
+    }
+    // Since ABI tags need to be sorted, we sort them in place
+    // It might be surprising for users that inspects the UDAs,
+    // but it's a concession to practicality.
+    // Casts are unfortunately necessary as `implicitConvTo` is not
+    // `const` (and nor is `StringExp`, by extension).
+    static int predicate(const scope Expression* e1, const scope Expression* e2) nothrow
+    {
+        scope(failure) assert(0, "An exception was thrown");
+        return (cast(Expression*)e1).toStringExp().compare((cast(Expression*)e2).toStringExp());
+    }
+    ale.elements.sort!predicate;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -208,6 +208,10 @@ start_all_tests: $(RUNNER)
 	@echo "Running all tests"
 	$(EXECUTE_RUNNER) all
 
+# The auto-tester cannot run runnable_cxx as its compiler is too old
+auto-tester-test: $(RUNNER)
+	$(EXECUTE_RUNNER) runnable compilable fail_compilation dshell
+
 $(RESULTS_DIR)/d_do_test$(EXE): tools/d_do_test.d tools/sanitize_json.d $(RESULTS_DIR)/.created
 	@echo "Building d_do_test tool"
 	@echo "OS: '$(OS)'"

--- a/test/compilable/cpp_abi_tag_unused.d
+++ b/test/compilable/cpp_abi_tag_unused.d
@@ -1,0 +1,21 @@
+/* DISABLED: win32 win64
+REQUIRED_ARGS: -extern-std=c++11
+*/
+
+#line 100
+
+// Make sure that bad things don't happen if the user isn't using
+// `core.attribute`'s definition
+struct gnuAbiTag
+{
+    string[] args;
+}
+
+extern(C++):
+
+@gnuAbiTag(["42"])
+struct A {}
+
+__gshared A a;
+
+static assert(a.mangleof == "a");

--- a/test/compilable/cppmangle_abitag.d
+++ b/test/compilable/cppmangle_abitag.d
@@ -1,0 +1,106 @@
+// DISABLED: win32 win64
+// REQUIRED_ARGS: -extern-std=c++11
+/*
+ * Test C++ abi-tag name mangling.
+ * https://issues.dlang.org/show_bug.cgi?id=19949
+ */
+
+import core.attribute;
+
+extern(C++):
+
+alias Tuple(A...) = A;
+enum foo_bar = gnuAbiTag("foo", "bar");
+
+@foo_bar
+struct S
+{
+    int i;
+    this(int);
+}
+
+@foo_bar
+extern __gshared int a;
+static assert(a.mangleof == "_Z1aB3barB3foo");
+
+extern __gshared S b;
+static assert(b.mangleof == "_Z1bB3barB3foo");
+
+@foo_bar
+int f();
+static assert(f.mangleof == "_Z1fB3barB3foov");
+
+S gs(int);
+S gss(S, int);
+static assert(gs.mangleof == "_Z2gsB3barB3fooi");
+static assert(gss.mangleof == "_Z3gss1SB3barB3fooi");
+
+@foo_bar
+S fss(S, int);
+static assert(gs.mangleof == "_Z2gsB3barB3fooi");
+
+T gt(T)(int);
+T gtt(T)(T, int);
+static assert(gt!S.mangleof == "_Z2gtI1SB3barB3fooET_i");
+static assert(gtt!S.mangleof == "_Z3gttI1SB3barB3fooET_S1_i");
+
+@foo_bar
+T ft(T)(int);
+// matches Clang and GCC <= 6
+static assert(ft!S.mangleof == "_Z2ftB3barB3fooI1SB3barB3fooET_i");
+
+@foo_bar
+T ftt(T)(T, int);
+// matches Clang and GCC <= 6
+static assert(ftt!S.mangleof == "_Z3fttB3barB3fooI1SB3barB3fooET_S1_i");
+
+// GCC >= 6 only
+@gnuAbiTag("ENN")
+enum E0 { a = 0xa, }
+E0 fe();
+E0 fei(int i)();
+static assert(fe.mangleof == "_Z2feB3ENNv");
+static assert(fei!0.mangleof == "_Z3feiILi0EE2E0B3ENNv");
+
+// Linux std::string
+// https://issues.dlang.org/show_bug.cgi?id=14956#c13
+extern(C++, "std")
+{
+    struct allocator(T);
+    struct char_traits(CharT);
+
+    extern(C++,  "__cxx11")
+    {
+        @gnuAbiTag("cxx11")
+        struct basic_string(CharT, Traits=char_traits!CharT, Allocator=allocator!CharT)
+        {
+            const char* data();
+            size_t length() const;
+        }
+    }
+    alias string_ = basic_string!char;
+}
+string_* toString(const char*);
+static assert(toString.mangleof == "_Z8toStringB5cxx11PKc");
+
+@gnuAbiTag("A", "B")
+{
+    void fun0();
+    static assert(fun0.mangleof == "_Z4fun0B1AB1Bv");
+}
+
+@gnuAbiTag("C", "D"):
+
+void fun1();
+static assert(fun1.mangleof == "_Z4fun1B1CB1Dv");
+
+void fun2();
+static assert(fun2.mangleof == "_Z4fun2B1CB1Dv");
+
+auto fun3()
+{
+    @gnuAbiTag("Nested")
+    extern(C++) struct T {}
+    return T();
+}
+static assert(fun3.mangleof == "_Z4fun3B1CB1DB6Nestedv");

--- a/test/fail_compilation/cpp_abi_tag.d
+++ b/test/fail_compilation/cpp_abi_tag.d
@@ -1,0 +1,57 @@
+/* DISABLED: win32 win64
+REQUIRED_ARGS: -extern-std=c++11
+TEST_OUTPUT:
+---
+fail_compilation/cpp_abi_tag.d(102): Error: `@gnuAbiTag` at least one argument expected
+fail_compilation/cpp_abi_tag.d(105): Error: `@gnuAbiTag` at least one argument expected
+fail_compilation/cpp_abi_tag.d(108): Error: `@gnuAbiTag` char `0x99` not allowed in mangling
+fail_compilation/cpp_abi_tag.d(111): Error: `@gnuAbiTag` can only apply to C++ symbols
+fail_compilation/cpp_abi_tag.d(114): Error: argument `2` to `@gnuAbiTag` cannot be `null`
+fail_compilation/cpp_abi_tag.d(114): Error: argument `3` to `@gnuAbiTag` cannot be empty
+fail_compilation/cpp_abi_tag.d(117): Error: `@gnuAbiTag` at least one argument expected
+fail_compilation/cpp_abi_tag.d(131): Error: `@gnuAbiTag` cannot be applied to namespaces
+fail_compilation/cpp_abi_tag.d(137): Error: only one `@gnuAbiTag` allowed per symbol
+fail_compilation/cpp_abi_tag.d(137):        instead of `@gnuAbiTag(["x"]) @gnuAbiTag(["a"])`, use `@gnuAbiTag("x", "a")`
+---
+*/
+
+#line 100
+import core.attribute;
+
+@gnuAbiTag
+extern(C++) struct A {}
+
+@gnuAbiTag()
+extern(C++) struct B {}
+
+@gnuAbiTag("a\x99")
+extern(C++) struct D {}
+
+@gnuAbiTag("a")
+struct F {}
+
+@gnuAbiTag("a", null, "")
+extern(C++) struct G {}
+
+@gnuAbiTag((string[]).init)
+extern(C++) struct H {}
+
+// Note: There is no way to distinguish between
+// `extern(C++, "ns") { ... }` and `extern(C++, "ns") ...;`
+// So ABI tags have to be on the inside
+extern(C++, "ns") @gnuAbiTag("x") void func1();
+extern(C++, ns2)  @gnuAbiTag("x") void  func2();
+
+@gnuAbiTag("x")
+extern(C++, "ns3")
+{
+    void func3();
+}
+@gnuAbiTag("x")
+extern(C++, ns4)
+{
+    void func4();
+}
+
+@gnuAbiTag("x") @gnuAbiTag("a")
+extern(C++) void func5();

--- a/test/fail_compilation/cpp_abi_tag2.d
+++ b/test/fail_compilation/cpp_abi_tag2.d
@@ -1,0 +1,19 @@
+/* DISABLED: win32 win64
+REQUIRED_ARGS: -extern-std=c++11
+TEST_OUTPUT:
+---
+fail_compilation/cpp_abi_tag2.d(102): Error: constructor `core.attribute.gnuAbiTag.this(string[] tags...)` is not callable using argument types `(string, wstring, dstring)`
+fail_compilation/cpp_abi_tag2.d(102):        cannot pass argument `"b"w` of type `wstring` to parameter `string[] tags...`
+fail_compilation/cpp_abi_tag2.d(105): Error: constructor `core.attribute.gnuAbiTag.this(string[] tags...)` is not callable using argument types `(string, int, double)`
+fail_compilation/cpp_abi_tag2.d(105):        cannot pass argument `2` of type `int` to parameter `string[] tags...`
+---
+*/
+
+#line 100
+import core.attribute;
+
+@gnuAbiTag("a", "b"w, "c"d)
+extern(C++) struct C {}
+
+@gnuAbiTag("a", 2, 3.3)
+extern(C++) struct E {}

--- a/test/runnable_cxx/abi_tags.d
+++ b/test/runnable_cxx/abi_tags.d
@@ -1,0 +1,164 @@
+/*
+ * Test C++ abi-tag name mangling.
+ * They are a C++11 feature required to bind `std::string`,
+ * introduced in G++ 5.1 / clang++ 3.9
+ * https://issues.dlang.org/show_bug.cgi?id=19949
+ *
+ * DISABLED: win32 win64
+ * REQUIRED_ARGS: -extern-std=c++11
+ * EXTRA_CPP_SOURCES: abi_tags.cpp
+ * CXXFLAGS: -std=c++11
+ */
+
+#line 100
+import core.attribute;
+
+alias Tuple(A...) = A;
+enum foo_bar = gnuAbiTag("foo", "bar");
+
+extern(C++)
+{
+    @gnuAbiTag("tag1") struct Tagged1 {}
+    @gnuAbiTag("tag2") struct Tagged2 {}
+    @gnuAbiTag("tag1") struct Tagged1Too {}
+
+    // Note: Outer tags do not propagate, unlike in C++
+    @gnuAbiTag("tag1", "tag2") struct Tagged1_2
+    {
+        @gnuAbiTag("tag1", "tag2", "tag3") struct Tagged3
+        {
+            // _ZN9Tagged1_2B4tag1B4tag27Tagged3B4tag37Tagged4B4tag4Ev
+            @gnuAbiTag("tag1", "tag2", "tag3", "tag4") int Tagged4 ();
+        }
+    }
+
+    extern __gshared Tagged1_2 inst1;
+    extern __gshared Tagged1_2.Tagged3 inst2;
+
+    Tagged1_2 func0(int a);
+    Tagged1_2 func1(Tagged1_2 a);
+    Tagged1_2 func2(Tagged1 a);
+    Tagged1_2 func3(Tagged2 a);
+    Tagged1_2 func4(Tagged2 a, Tagged1 b);
+    Tagged1_2.Tagged3 func5(Tagged2 a, Tagged1 b);
+    void func6(Tagged2 a, Tagged2 b, Tagged1 c, Tagged1_2 d);
+    T func7(T)(T a, int);
+    void func8 (Tagged1, Tagged1Too);
+
+    @foo_bar struct S
+    {
+        int i;
+    }
+
+    @foo_bar extern __gshared int a;
+
+    extern __gshared S b;
+
+    @foo_bar int f();
+
+    S gs(int);
+    S gss(S, int);
+
+    @foo_bar S fss(S, int);
+
+    T gt(T)(int);
+    T gtt(T)(T, int);
+
+    @foo_bar T ft(T)(int);
+
+    @foo_bar T ftt(T)(T, int);
+
+    @("abc") extern(C++, "N")
+    {
+        @gnuAbiTag("AAA", "foo")
+        template K(int i)
+        {
+            @gnuAbiTag("bar", "AAA", "foo")
+            struct K
+            {
+                int i;
+                this(int);
+            }
+        }
+    }
+
+    //K!i fk(int i)(int);
+    K!1 fk1(int);
+
+    extern __gshared K!10 k10;
+
+    @gnuAbiTag("ENN") enum E0 { a = 0xa, }
+    E0 fe();
+    E0 fei(int i)();
+
+    version (linux)
+    {
+        // Linux std::string
+        // https://issues.dlang.org/show_bug.cgi?id=14956#c13
+        extern(C++, "std")
+        {
+            struct allocator(T);
+            struct char_traits(CharT);
+
+            extern(C++,  "__cxx11")
+            {
+                @gnuAbiTag("cxx11")
+                struct basic_string(CharT, Traits=char_traits!CharT, Allocator=allocator!CharT)
+                {
+                    const char* data();
+                    size_t length() const;
+                }
+            }
+            alias string_ = basic_string!char;
+        }
+        string_* toString(const char*);
+    }
+
+    void initVars();
+}
+
+void main()
+{
+    inst1 = func0(42);
+    inst2 = func5(Tagged2.init, Tagged1.init);
+    func1(inst1);
+    func2(Tagged1.init);
+    func3(Tagged2.init);
+    func4(Tagged2.init, Tagged1.init);
+
+    func6(Tagged2.init, Tagged2.init, Tagged1.init, Tagged1_2.init);
+    func7(Tagged1_2.init, 42);
+    func8(Tagged1.init, Tagged1Too.init);
+
+    initVars();
+    assert(a == 10);
+    assert(b.i == 20);
+    assert(k10.i == 30);
+
+    assert(f() == 0xf);
+    assert(gs(1).i == 1+0xe0);
+    assert(gss(S(1), 1).i == 2+0xe0);
+    assert(fss(S(1), 1).i == 2+0xf);
+    assert(gt!S(1).i == 1+0xe0);
+    assert(gtt!S(S(1), 1).i == 2+0xe0);
+
+    //version(gcc7) {}
+    //else
+    {
+        assert(ft!S(1).i == 1+0xf);        // GCC inconsistent
+        assert(ftt!S(S(1), 1).i == 2+0xf); // GCC inconsistent
+    }
+    //assert(fk!0(1).i == 1+0xf);
+    assert(fk1(1).i == 2+0xf);
+    version(gcc6)
+    {
+        assert(fei!0() == E0.a); // GCC only
+        assert(fe() == E0.a);    // GCC only
+    }
+
+    version (linux)
+    {
+        auto ss = toString("test013".ptr);
+        assert(ss.data()[0..ss.length()] == "test013");
+    }
+}

--- a/test/runnable_cxx/cpp_stdlib.d
+++ b/test/runnable_cxx/cpp_stdlib.d
@@ -1,10 +1,9 @@
-// DISABLED: win32 win64 osx32
+// DISABLED: win32 win64
 // EXTRA_CPP_SOURCES: cpp_stdlib.cpp
 // CXXFLAGS(osx linux freebsd openbsd netbsd dragonflybsd solaris): -std=c++11
 import core.stdc.stdio;
 
 // Disabled on windows because it needs bindings
-// Disabled on osx32 because size_t is not properly mangled
 
 version (CppRuntime_Clang)
 {

--- a/test/runnable_cxx/extra-files/abi_tags.cpp
+++ b/test/runnable_cxx/extra-files/abi_tags.cpp
@@ -1,0 +1,155 @@
+/*
+ * Test C++ abi-tag name mangling.
+ * https://issues.dlang.org/show_bug.cgi?id=19949
+ *
+ * ABI tags are only supported on Linux & OSX,
+ * however OSX doesn't use it in its standard library.
+ *
+ * Requires at minimum Clang 3.9.0 or GCC 5.1
+ */
+
+struct [[gnu::abi_tag("tag1")]] Tagged1 {};
+struct [[gnu::abi_tag("tag2")]] Tagged2 {};
+
+struct [[gnu::abi_tag("tag1", "tag2")]] Tagged1_2
+{
+    struct [[gnu::abi_tag("tag3")]] Tagged3
+    {
+        // _ZN9Tagged1_2B4tag1B4tag27Tagged3B4tag37Tagged4B4tag4Ev
+        [[gnu::abi_tag("tag4")]]
+        int Tagged4 () { return 42; }
+    };
+};
+struct [[gnu::abi_tag("tag1")]] Tagged1Too {};
+
+// _Z5inst1B4tag1B4tag2
+Tagged1_2 inst1;
+// _Z5inst2B4tag1B4tag2B4tag3
+Tagged1_2::Tagged3 inst2;
+
+// _Z5func0B4tag1B4tag2i
+Tagged1_2 func0(int a) { return Tagged1_2(); }
+// _Z5func19Tagged1_2B4tag1B4tag2
+Tagged1_2 func1(Tagged1_2 a) { return a; }
+// _Z5func2B4tag27Tagged1B4tag1
+Tagged1_2 func2(Tagged1 a) { return Tagged1_2(); }
+// _Z5func3B4tag17Tagged2B4tag2
+Tagged1_2 func3(Tagged2 a) { return Tagged1_2(); }
+// _Z5func47Tagged2B4tag27Tagged1B4tag1
+Tagged1_2 func4(Tagged2 a, Tagged1 b) { return Tagged1_2(); }
+// _Z5func5B4tag37Tagged2B4tag27Tagged1B4tag1
+Tagged1_2::Tagged3 func5(Tagged2 a, Tagged1 b) { return Tagged1_2::Tagged3(); }
+// _Z5func67Tagged2B4tag2S_7Tagged1B4tag19Tagged1_2B4tag1B4tag2
+void func6(Tagged2 a, Tagged2 b, Tagged1 c, Tagged1_2 d) {}
+// With T=Tagged1_2: _Z5func7I9Tagged1_2B4tag1B4tag2ET_S1_i
+template<typename T>
+T func7(T a, int) { return a; }
+// _Z5func87Tagged1B4tag110Tagged1TooB4tag1
+void func8 (Tagged1, Tagged1Too) {}
+
+void instantiateTemplates ()
+{
+    func7<Tagged1_2>(Tagged1_2(), 42);
+    inst2.Tagged4();
+}
+
+struct [[gnu::abi_tag("foo", "bar")]] S
+{
+public:
+    int i;
+    S(int);
+};
+
+S::S(int i) : i(i) {}
+
+[[gnu::abi_tag("foo", "bar")]]
+int a;
+
+S b(0);
+
+[[gnu::abi_tag("foo", "bar")]]
+int f() { return 0xf; }
+
+S gs(int i) { return S(i + 0xe0); }
+S gss(S s, int i) { return S(i + s.i + 0xe0); }
+
+[[gnu::abi_tag("foo", "bar")]]
+S fss(S s, int i) { return S(i + s.i + 0xf); }
+
+template <class T>
+T gt(int i) { return T(i + 0xe0); }
+
+template <class T>
+T gtt(T t, int i) { return T(i + t.i + 0xe0); }
+
+
+template <class T>
+[[gnu::abi_tag("foo", "bar")]] /* GCC is inconsistent here, <= 6 matches clang but >= 7 is different */
+T ft(int i) { return T(i + 0xf); }
+
+template <class T>
+[[gnu::abi_tag("foo", "bar")]] /* GCC is inconsistent here, <= 6 matches clang but >= 7 is different */
+T ftt(T t, int i) { return T(i + t.i + 0xf); }
+
+#ifdef __clang__
+inline namespace [[gnu::abi_tag("AAA")]] N
+#else
+inline namespace N [[gnu::abi_tag("AAA")]]
+#endif
+{
+    template <int>
+    struct [[gnu::abi_tag("foo", "bar")]] K
+    {
+    public:
+        int i;
+        K(int i);
+    };
+}
+
+template <int j>
+K<j>::K(int i) : i(i) {}
+
+// Note: This does not include the 'AAA' in the mangling
+// template <int j>
+// K<j> fk(int i) { return K<j>(i + j + 0xf); }
+
+K<1> fk1(int i) { return K<1>(i + 1 + 0xf); }
+
+K<10> k10(0);
+
+void initVars()
+{
+    a = 10;
+    b = S(20);
+    k10 = K<10>(30);
+}
+
+// doesn't compile on GCC < 6, and not at all on Clang (tested with 9.0.1)
+#if __GNUC__ >= 6
+enum [[gnu::abi_tag("ENN")]] E0
+{ E0a = 0xa };
+
+E0 fe() { return E0a; }
+
+template<int>
+E0 fei() { return E0a; }
+#endif
+
+void instatiate()
+{
+    gt<S>(1);
+    gtt<S>(S(1), 1);
+    ft<S>(1);
+    ftt<S>(S(1), 1);
+#if __GNUC__ >= 6
+    fei<0>();
+#endif
+}
+
+#ifdef __linux__
+#include <string>
+std::string* toString(const char* s)
+{
+    return new std::string(s);
+}
+#endif


### PR DESCRIPTION
```
Implements C++ ABI tags with a few more restriction than the previous PR (9995).
In particular, do not follow C++ source-level conventions when impractical
(e.g. propagation). Since this is a feature that will be seldom used by users,
I favored implementation simplicity over user-friendly semantics.
```

Previous PR by @SSoulaimane : https://github.com/dlang/dmd/pull/9995
Since the author has gone AWOL and there were some discussions on the initial PR, I had a go at implementing it. I mostly used the tests from the original PR, which were very comprehensive, but tried  to keep the special casing in semantic to a minimum.
Requires https://github.com/dlang/druntime/pull/2990 to pass tests.