### PR TITLE
Fixup for PR10896: Avoid old compiler bug

### DIFF
--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -537,11 +537,11 @@ unittest
     strings.push("Hello");
     // Newer frontend versions will work with (e1, e2) and infer the type
     strings.sort!(function (scope const char** e1, scope const char** e2) => strcmp(*e1, *e2));
-    assert(strings[0] == "baguette");
-    assert(strings[1] == "Avocado");
-    assert(strings[2] == "Foo");
-    assert(strings[3] == "Hello");
-    assert(strings[4] == "World");
+    assert(strings[0] == "Avocado");
+    assert(strings[1] == "Foo");
+    assert(strings[2] == "Hello");
+    assert(strings[3] == "World");
+    assert(strings[4] == "baguette");
 
     /// opCmp automatically supported
     static struct MyStruct
@@ -562,9 +562,9 @@ unittest
     arr1.push(MyStruct(42));
     arr1.sort();
     assert(arr1[0].a == 256);
-    assert(arr1[0].a == 42);
-    assert(arr1[0].a == 4);
-    assert(arr1[0].a == 2);
+    assert(arr1[1].a == 42);
+    assert(arr1[2].a == 4);
+    assert(arr1[3].a == 2);
 
     /// But only if user defined
     static struct OtherStruct

--- a/src/dmd/root/array.d
+++ b/src/dmd/root/array.d
@@ -1,3 +1,4 @@
+
 /**
  * Dynamic array implementation.
  *
@@ -323,13 +324,11 @@ public:
         return this;
     }
 
-    static if (is(typeof(this.data[0].opCmp(this.data[1])) : int))
+    /// Ditto, but use `opCmp` by default
+    extern(D) ref typeof(this) sort () () nothrow
+        if (is(typeof(this.data[0].opCmp(this.data[1])) : int))
     {
-        /// Ditto, but use `opCmp` by default
-        extern(D) ref typeof(this) sort () () nothrow
-        {
-            return this.sort!((pe1, pe2) => pe1.opCmp(*pe2));
-        }
+        return this.sort!(function (scope const(T)* pe1, scope const(T)* pe2) => pe1.opCmp(*pe2));
     }
 
     alias opDollar = length;
@@ -536,7 +535,8 @@ unittest
     strings.push("baguette");
     strings.push("Avocado");
     strings.push("Hello");
-    strings.sort!((e1, e2) => strcmp(*e1, *e2));
+    // Newer frontend versions will work with (e1, e2) and infer the type
+    strings.sort!(function (scope const char** e1, scope const char** e2) => strcmp(*e1, *e2));
     assert(strings[0] == "baguette");
     assert(strings[1] == "Avocado");
     assert(strings[2] == "Foo");


### PR DESCRIPTION
```
The static if would trigger a forward reference bug which would corrupt
the vtable of other aggregates.
Using a template constraint changes the stage at which semantic is performed,
avoiding the bug altogether.
Note that the bug was fixed in v2.085 but compiling with older compilers is sometimes needed.
```

Discussion: https://github.com/dlang/dmd/pull/10896#discussion_r392059295
CC @ibuclaw @kinke 