### PR TITLE
[dmd-cxx] Backport contentImportedFiles field

### DIFF
--- a/src/expressionsem.c
+++ b/src/expressionsem.c
@@ -2370,6 +2370,7 @@ public:
             return setError();
         }
 
+        sc->_module->contentImportedFiles.push(name);
         if (global.params.verbose)
             message("file      %.*s\t(%s)", (int)se->len, (char *)se->string, name);
         if (global.params.moduleDeps != NULL)

--- a/src/module.h
+++ b/src/module.h
@@ -76,6 +76,7 @@ public:
     unsigned numlines;  // number of lines in source file
     int isDocFile;      // if it is a documentation input file, not D source
     bool isPackageFile; // if it is a package.d
+    Strings contentImportedFiles;  // array of files whose content was imported
     int needmoduleinfo;
 
     int selfimports;            // 0: don't know, 1: does not, 2: does


### PR DESCRIPTION
This is required in order to emit file imports as make dependencies.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93038