### PR TITLE
extend PR 10929 by excluding non-ptr vars

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -1466,9 +1466,12 @@ void escapeByValue(Expression e, EscapeByResults* er, bool live = false)
 
         override void visit(VarExp e)
         {
-            VarDeclaration v = e.var.isVarDeclaration();
-            if (v)
-                er.byvalue.push(v);
+            if (auto v = e.var.isVarDeclaration())
+            {
+                if (v.type.hasPointers() || // not tracking non-pointers
+                    v.storage_class & STC.lazy_) // lazy variables are actually pointers
+                    er.byvalue.push(v);
+            }
         }
 
         override void visit(ThisExp e)

--- a/test/fail_compilation/fail809.d
+++ b/test/fail_compilation/fail809.d
@@ -1,4 +1,4 @@
-// REQUIRED_ARGS: -dip1000
+// REQUIRED_ARGS: -preview=dip1000
 /*
 TEST_OUTPUT:
 ---


### PR DESCRIPTION
Extending https://github.com/dlang/dmd/pull/10929 to cover variables and not just struct fields. No tests are needed, as it's just a shortcut to do what happens anyway.