### PR TITLE
fix issue 20653 .  Short circuit manifest constant evaluation

### DIFF
--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -805,9 +805,11 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             // so mark the scope as ctfe if required
             bool needctfe = (dsym.storage_class & (STC.manifest | STC.static_)) != 0;
             if (needctfe)
+            {
+                sc.flags |= SCOPE.condition;
                 sc = sc.startCTFE();
-
-            //printf("inferring type for %s with init %s\n", toChars(), _init.toChars());
+            }
+            //printf("inferring type for %s with init %s\n", dsym.toChars(), dsym._init.toChars());
             dsym._init = dsym._init.inferType(sc);
             dsym.type = dsym._init.initializerToExpression().type;
             if (needctfe)

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -750,11 +750,12 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
     {
         version (none)
         {
-            printf("VarDeclaration::semantic('%s', parent = '%s') sem = %d\n", toChars(), sc.parent ? sc.parent.toChars() : null, sem);
-            printf(" type = %s\n", type ? type.toChars() : "null");
-            printf(" stc = x%x\n", sc.stc);
-            printf(" storage_class = x%llx\n", storage_class);
-            printf("linkage = %d\n", sc.linkage);
+            printf("VarDeclaration::semantic('%s', parent = '%s') sem = %d\n",
+                   dsym.toChars(), sc.parent ? sc.parent.toChars() : null, dsym.semanticRun);
+            printf(" type = %s\n", dsym.type ? dsym.type.toChars() : "null");
+            printf(" stc = x%x\n", dsym.storage_class.stc);
+            printf(" storage_class = x%llx\n", dsym.storage_class);
+            printf("linkage = %d\n", dsym.linkage);
             //if (strcmp(toChars(), "mul") == 0) assert(0);
         }
         //if (semanticRun > PASS.init)
@@ -848,7 +849,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
         dsym.type.checkDeprecated(dsym.loc, sc);
         dsym.linkage = sc.linkage;
         dsym.parent = sc.parent;
-        //printf("this = %p, parent = %p, '%s'\n", this, parent, parent.toChars());
+        //printf("this = %p, parent = %p, '%s'\n", dsym, dsym.parent, dsym.parent.toChars());
         dsym.protection = sc.protection;
 
         /* If scope's alignment is the default, use the type's alignment,
@@ -5781,7 +5782,8 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
     {
         static if (LOG)
         {
-            printf("-TemplateInstance.dsymbolSemantic('%s', this=%p) already run\n", inst.toChars(), tempinst.inst);
+            printf("-TemplateInstance.dsymbolSemantic('%s', this=%p) already run\n",
+                   tempinst.inst.toChars(), tempinst.inst);
         }
         return;
     }
@@ -6043,7 +6045,7 @@ void templateInstanceSemantic(TemplateInstance tempinst, Scope* sc, Expressions*
      * member has the same name as the template instance.
      * If so, this template instance becomes an alias for that member.
      */
-    //printf("members.dim = %d\n", members.dim);
+    //printf("members.dim = %d\n", tempinst.members.dim);
     if (tempinst.members.dim)
     {
         Dsymbol s;
@@ -6318,7 +6320,7 @@ Laftersemantic:
 
     static if (LOG)
     {
-        printf("-TemplateInstance.dsymbolSemantic('%s', this=%p)\n", toChars(), this);
+        printf("-TemplateInstance.dsymbolSemantic('%s', this=%p)\n", tempinst.toChars(), tempinst);
     }
 }
 

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -573,7 +573,7 @@ extern (C++) final class TemplateDeclaration : ScopeDsymbol
         super(loc, ident);
         static if (LOG)
         {
-            printf("TemplateDeclaration(this = %p, id = '%s')\n", this, id.toChars());
+            printf("TemplateDeclaration(this = %p, id = '%s')\n", this, ident.toChars());
         }
         version (none)
         {
@@ -7272,7 +7272,7 @@ extern (C++) class TemplateInstance : ScopeDsymbol
 
         void symbolDg(Dsymbol s)
         {
-            //printf("\t[%d] semantic on '%s' %p kind %s in '%s'\n", i, s.toChars(), s, s.kind(), this.toChars());
+            //printf("\t semantic on '%s' %p kind %s in '%s'\n",  s.toChars(), s, s.kind(), this.toChars());
             //printf("test: enclosing = %d, sc2.parent = %s\n", enclosing, sc2.parent.toChars());
             //if (enclosing)
             //    s.parent = sc.parent;

--- a/src/dmd/expressionsem.d
+++ b/src/dmd/expressionsem.d
@@ -5288,8 +5288,10 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
          * is(targ id :  tok2)
          * is(targ id == tok2)
          */
-
-        //printf("IsExp::semantic(%s)\n", toChars());
+        static if (LOGSEMANTIC)
+        {
+            printf("IsExp::semantic(%s)\n", e.toChars());
+        }
         if (e.id && !(sc.flags & SCOPE.condition))
         {
             e.error("can only declare type aliases within `static if` conditionals or `static assert`s");
@@ -10592,6 +10594,11 @@ private extern (C++) final class ExpressionSemanticVisitor : Visitor
 
     override void visit(LogicalExp exp)
     {
+        static if (LOGSEMANTIC)
+        {
+            printf("LogicalExp::semantic() %s\n", exp.toChars());
+        }
+
         if (exp.type)
         {
             result = exp;

--- a/src/dmd/initsem.d
+++ b/src/dmd/initsem.d
@@ -642,7 +642,7 @@ Initializer inferType(Initializer init, Scope* sc)
 
     Initializer visitExp(ExpInitializer init)
     {
-        //printf("ExpInitializer::inferType() %s\n", toChars());
+        //printf("ExpInitializer::inferType() %s\n", init.toChars());
         init.exp = init.exp.expressionSemantic(sc);
 
         // for static alias this: https://issues.dlang.org/show_bug.cgi?id=17684

--- a/test/compilable/test20653.d
+++ b/test/compilable/test20653.d
@@ -1,4 +1,4 @@
-
+// LINK:
 enum x = 10;
 enum Thing { A, B }
 enum IsThing(T) = is(T == enum) || (__traits(getLinkage, T) == "C++");
@@ -9,3 +9,12 @@ static assert(Is);
 enum Another(T) = is(T == int) && (__traits(getLinkage, T) == "C++");
 
 static assert(!Another!Thing);
+
+T myFunc(T)() { return T.init; }
+enum Foo(T) = is(T == int) || myFunc!T();
+
+void main ()
+{
+    assert(myFunc!int() == 0);
+}
+

--- a/test/compilable/test20653.d
+++ b/test/compilable/test20653.d
@@ -1,0 +1,11 @@
+
+enum x = 10;
+enum Thing { A, B }
+enum IsThing(T) = is(T == enum) || (__traits(getLinkage, T) == "C++");
+enum Is = IsThing!Thing;
+
+static assert(Is);
+
+enum Another(T) = is(T == int) && (__traits(getLinkage, T) == "C++");
+
+static assert(!Another!Thing);


### PR DESCRIPTION
The fix is adding the SCOPE.condition flag when doing CTFE to infer the VarDecl type in dsymbolsem.  

The rest of the changes are fixes to the debug logging.  I can remove them if they're distracting