### PR TITLE
Continue #10878: Remove unused code & fix parallelization in test/Makefile

### DIFF
--- a/.azure-pipelines/windows-msbuild.bat
+++ b/.azure-pipelines/windows-msbuild.bat
@@ -12,7 +12,7 @@ if "%ARCH%"=="x64" set MODEL=64
 set DMD=%DMD_DIR%\generated\Windows\%CONFIGURATION%\%PLATFORM%\dmd.exe
 
 set VISUALD_INSTALLER=VisualD-%VISUALD_VER%.exe
-set DMD_TESTSUITE_MAKE_ARGS=-j3
+set N=3
 set DM_MAKE=%DMD_DIR%\dm\path\make.exe
 set LDC_DIR=%DMD_DIR%\ldc2-%LDC_VERSION%-windows-multilib
 

--- a/.azure-pipelines/windows.sh
+++ b/.azure-pipelines/windows.sh
@@ -118,7 +118,7 @@ cd "${DMD_DIR}/test"
 # REASON: LIB argument doesn't seem to work
 cp "${DMD_DIR}/../phobos/$LIBNAME" .
 
-DMD_TESTSUITE_MAKE_ARGS="-j$N" "${GNU_MAKE}" -j1 start_all_tests ARGS="-O -inline -g" MODEL="$MODEL"  MODEL_FLAG="$MODEL_FLAG"
+"${GNU_MAKE}" -j1 start_all_tests ARGS="-O -inline -g" MODEL="$MODEL"  MODEL_FLAG="$MODEL_FLAG" N="$N"
 
 ################################################################################
 # Prepare artifacts

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -145,7 +145,7 @@ coverage()
 
     cp $build_path/dmd _${build_path}/host_dmd_cov
     make -j1 -C src -f posix.mak MODEL=$MODEL HOST_DMD=../_${build_path}/host_dmd_cov ENABLE_COVERAGE=1 PIC="$PIC" unittest
-    DMD_TESTSUITE_MAKE_ARGS=-j3 make -j1 -C test start_all_tests MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1 PIC="$PIC"
+    make -j1 -C test start_all_tests MODEL=$MODEL ARGS="-O -inline -release" DMD_TEST_COVERAGE=1 PIC="$PIC" N=3
 }
 
 # Checks that all files have been committed and no temporary, untracked files exist.

--- a/ci.sh
+++ b/ci.sh
@@ -86,9 +86,9 @@ test() {
 test_dmd() {
     # test fewer compiler argument permutations for PRs to reduce CI load
     if [ "$FULL_BUILD" == "true" ] && [ "$OS_NAME" == "linux"  ]; then
-        DMD_TESTSUITE_MAKE_ARGS=-j$N make -j1 -C test start_all_tests MODEL=$MODEL # all ARGS by default
+        make -j1 -C test start_all_tests MODEL=$MODEL N=$N # all ARGS by default
     else
-        DMD_TESTSUITE_MAKE_ARGS=-j$N make -j1 -C test start_all_tests MODEL=$MODEL ARGS="-O -inline -release"
+        make -j1 -C test start_all_tests MODEL=$MODEL N=$N ARGS="-O -inline -release"
     fi
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,14 +37,9 @@ endif
 QUIET=@
 export RESULTS_DIR=test_results
 export MODEL
-export REQUIRED_ARGS=
 
 ifeq ($(findstring win,$(OS)),win)
-    export ARGS=-inline -release -g -O
     export EXE=.exe
-    export OBJ=.obj
-    export DSEP=\\
-    export SEP=$(subst /,\,/)
 
     PIC?=0
 
@@ -64,11 +59,7 @@ ifeq ($(findstring win,$(OS)),win)
     export DMD=../generated/windows/$(BUILD)/$(DMD_MODEL)/dmd$(EXE)
 
 else
-    export ARGS=-inline -release -g -O -fPIC
     export EXE=
-    export OBJ=.o
-    export DSEP=/
-    export SEP=/
 
     # auto-tester might run the testsuite with a different $(MODEL) than DMD
     # has been compiled with. Hence we manually check which binary exists.
@@ -104,9 +95,6 @@ else
     endif
     export DFLAGS
 endif
-REQUIRED_ARGS+=$(PIC_FLAG)
-
-export DMD_TEST_COVERAGE=
 
 # Use the generated dmd instead of the host compiler because many CI systems use
 # older versions (which cannot compile the test runner anymore)
@@ -185,7 +173,7 @@ $(RESULTS_DIR)/d_do_test$(EXE): tools/d_do_test.d tools/sanitize_json.d $(RESULT
 	@echo "MODEL: '$(MODEL)'"
 	@echo "PIC: '$(PIC_FLAG)'"
 	$(DMD) -conf= $(MODEL_FLAG) $(PIC_FLAG) -g -lowmem -i -Itools -version=NoMain -unittest -run $<
-	$(DMD) -conf= $(MODEL_FLAG) $(PIC_FLAG) -g -lowmem -i -Itools -version=NoMain -od$(RESULTS_DIR) -of$(RESULTS_DIR)$(DSEP)d_do_test$(EXE) $<
+	$(DMD) -conf= $(MODEL_FLAG) $(PIC_FLAG) -g -lowmem -i -Itools -version=NoMain -od$(RESULTS_DIR) -of$@ $<
 
 # Build d_do_test here to run it's unittests
 # TODO: Migrate this to run.d

--- a/test/Makefile
+++ b/test/Makefile
@@ -147,37 +147,37 @@ unit_tests: $(RUNNER)
 run_runnable_tests: $(RUNNER)
 	$(EXECUTE_RUNNER) $@
 
-start_runnable_tests:
+start_runnable_tests: $(RUNNER)
 	@echo "Running runnable tests"
-	$(QUIET)$(MAKE) $(DMD_TESTSUITE_MAKE_ARGS) --no-print-directory run_runnable_tests
+	$(EXECUTE_RUNNER) run_runnable_tests
 
 run_compilable_tests: $(RUNNER)
 	$(EXECUTE_RUNNER) $@
 
-start_compilable_tests:
+start_compilable_tests: $(RUNNER)
 	@echo "Running compilable tests"
-	$(QUIET)$(MAKE) $(DMD_TESTSUITE_MAKE_ARGS) --no-print-directory run_compilable_tests
+	$(EXECUTE_RUNNER) run_compilable_tests
 
 run_fail_compilation_tests: $(RUNNER)
 	$(EXECUTE_RUNNER) $@
 
-start_fail_compilation_tests:
+start_fail_compilation_tests: $(RUNNER)
 	@echo "Running fail compilation tests"
-	$(QUIET)$(MAKE) $(DMD_TESTSUITE_MAKE_ARGS) --no-print-directory run_fail_compilation_tests
+	$(EXECUTE_RUNNER) run_fail_compilation_tests
 
 run_dshell_tests: $(RUNNER)
 	$(EXECUTE_RUNNER) $@
 
-start_dshell_tests:
+start_dshell_tests: $(RUNNER)
 	@echo "Running dshell tests"
-	$(QUIET)$(MAKE) $(DMD_TESTSUITE_MAKE_ARGS) --no-print-directory run_dshell_tests
+	$(EXECUTE_RUNNER) run_dshell_tests
 
 run_all_tests: $(RUNNER)
 	$(EXECUTE_RUNNER)
 
-start_all_tests:
+start_all_tests: $(RUNNER)
 	@echo "Running all tests"
-	$(QUIET)$(MAKE) $(DMD_TESTSUITE_MAKE_ARGS) --no-print-directory run_all_tests
+	$(EXECUTE_RUNNER) all
 
 $(RESULTS_DIR)/d_do_test$(EXE): tools/d_do_test.d tools/sanitize_json.d $(RESULTS_DIR)/.created
 	@echo "Building d_do_test tool"


### PR DESCRIPTION
~~Will remove more stuff, just checking that everything works as expected on the CI systems.~~

Removed most of the duplication between the makefile and `run.d` except those required to build the test runner. Also fixed the makefile to respect the `N` environment variable which determines the amount of jobs to start in parallel (can extract this in another PR if preferred).