### PR TITLE
run.d: Allow disabling shared druntime/phobos using SHARED=0

### DIFF
--- a/test/run.d
+++ b/test/run.d
@@ -494,7 +494,7 @@ string[string] getEnvironment()
         env["PIC_FLAG"]  = pic ? "-fPIC" : "";
         env["DFLAGS"] = "-I%s/import -I%s".format(druntimePath, phobosPath)
             ~ " -L-L%s/%s".format(phobosPath, generatedSuffix);
-        bool isShared = os.among("linux", "freebsd") > 0;
+        bool isShared = environment.get("SHARED") != "0" && os.among("linux", "freebsd") > 0;
         if (isShared)
             env["DFLAGS"] = env["DFLAGS"] ~ " -defaultlib=libphobos2.so -L-rpath=%s/%s".format(phobosPath, generatedSuffix);
 


### PR DESCRIPTION
This functionality was present in the Makefile but was probably missed when porting it to run.d.
 https://github.com/dlang/dmd/blob/1499a0d4bde7b2a6909cc31ef1108d67c54e86ae/test/Makefile#L99-L100