### PR TITLE
Move `quick` target to run.d

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -110,8 +110,8 @@ endif
 
 all: run_tests
 
-quick:
-	$(MAKE) ARGS="" run_tests
+quick: $(RUNNER)
+	$(EXECUTE_RUNNER) $@
 
 clean:
 	@echo "Removing output directory: $(RESULTS_DIR)"

--- a/test/run.d
+++ b/test/run.d
@@ -124,6 +124,13 @@ Options:
     args.popFront;
     args2Environment(args);
 
+    // Run the test suite without default permutations
+    if (args == ["quick"])
+    {
+        args = null;
+        environment["ARGS"] = "";
+    }
+
     // allow overwrites from the environment
     hostDMD = environment.get("HOST_DMD", "dmd");
     unitTestRunnerCommand = resultsDir.buildPath("unit_test_runner");


### PR DESCRIPTION
Running the test suite without permutations by default takes considerably less time.