### PR TITLE
Fix Issue 20687 - Allow member function address as const initializer

### DIFF
--- a/src/dmd/todt.d
+++ b/src/dmd/todt.d
@@ -465,7 +465,6 @@ extern (C++) void Expression_toDt(Expression e, ref DtBuilder dtb)
         //printf("SymOffExp.toDt('%s')\n", e.var.toChars());
         assert(e.var);
         if (!(e.var.isDataseg() || e.var.isCodeseg()) ||
-            e.var.needThis() ||
             e.var.isThreadlocal())
         {
             return nonConstExpError(e);

--- a/test/runnable/test20687.d
+++ b/test/runnable/test20687.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=20687
+
+struct S
+{
+    void foo(){}
+}
+
+void main()
+{
+    S i;
+    enum fp = &S.foo;
+    auto dg = &i.foo;
+    static immutable dgfp = &S.foo; // Allow this
+    assert(fp == dg.funcptr && fp == dgfp);
+}


### PR DESCRIPTION
It seems like an artificial restriction, seeing that you can use a manifest constant.