### PR TITLE
Rework handling of disabled tests in d_do_test

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -1123,15 +1123,20 @@ int tryMain(string[] args)
 
     auto f = File(output_file, "a");
 
-    if (!testArgs.isDisabled && (
+    if (
         //prepare cpp extra sources
         !collectExtraSources(input_dir, output_dir, testArgs.cppSources, testArgs.sources, envData, envData.ccompiler, testArgs.cxxflags, f) ||
 
         //prepare objc extra sources
         !collectExtraSources(input_dir, output_dir, testArgs.objcSources, testArgs.sources, envData, "clang", null, f)
-    ))
+    )
     {
         writeln();
+
+        // Ignore failed test
+        if (testArgs.isDisabled)
+            return 0;
+
         f.close();
         printTestFailure(input_file, output_file);
         return 1;

--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -111,6 +111,7 @@ struct EnvData
     bool autoUpdate;
     bool printRuntime;          /// Print time spent on a single test
     bool usingMicrosoftCompiler;
+    bool tryDisabled;           /// Silently try disabled tests (ignore failure but report success)
 }
 
 /++
@@ -148,6 +149,7 @@ immutable(EnvData) processEnvironment()
     envData.coverage_build = environment.get("DMD_TEST_COVERAGE") == "1";
     envData.autoUpdate     = environment.get("AUTO_UPDATE", "") == "1";
     envData.printRuntime   = environment.get("PRINT_RUNTIME", "") == "1";
+    envData.tryDisabled    = environment.get("TRY_DISABLED") == "1";
 
     if (envData.ccompiler.empty)
     {
@@ -1117,7 +1119,14 @@ int tryMain(string[] args)
             testArgs.permuteArgs);
 
     if (testArgs.isDisabled)
+    {
         writef("!!! [DISABLED %s]", testArgs.disabledReason);
+        if (!envData.tryDisabled)
+        {
+            writeln();
+            return 0;
+        }
+    }
 
     removeIfExists(output_file);
 


### PR DESCRIPTION
Previously `d_do_test` executed disabled tests to check if they could be enabled. This would never succeed for C++/Objective-C tests because it didn't compile additional sources specified in `EXTRA_CPP_SOURCES` and `EXTRA_OBJC_SOURCES`.

Compiling these files obviously incurs some overhead for tests which are not likely to succeed. The third commit hence turns this behaviour into an opt-in feature to remove this burden from some of the already slow CI machines.