### PR TITLE
Fix Issue 18651 - ice: assert in glue.d:777 when building these three…

### DIFF
--- a/src/dmd/mars.d
+++ b/src/dmd/mars.d
@@ -635,6 +635,7 @@ private int tryMain(size_t argc, const(char)** argv, ref Param params)
     {
         foreach (i; 1 .. modules[0].aimports.dim)
             semantic3OnDependencies(modules[0].aimports[i]);
+        Module.runDeferredSemantic3();
 
         const data = (*ob)[];
         if (params.moduleDepsFile)

--- a/test/compilable/imports/test18651/algorithm.d
+++ b/test/compilable/imports/test18651/algorithm.d
@@ -1,0 +1,14 @@
+struct SortedRange(Range)
+{
+    Range _input;
+}
+
+auto sort(Range)(Range)
+{
+    return SortedRange!Range();
+}
+
+auto uniq(Range)(Range)
+{
+    return SortedRange!Range();
+}

--- a/test/compilable/imports/test18651/b.d
+++ b/test/compilable/imports/test18651/b.d
@@ -1,0 +1,1 @@
+import imports.test18651.c;

--- a/test/compilable/imports/test18651/c.d
+++ b/test/compilable/imports/test18651/c.d
@@ -1,0 +1,4 @@
+module imports.test18651.c;
+import imports.test18651.algorithm;
+
+const var = sort(string[].init);

--- a/test/compilable/imports/test18651/datetime.d
+++ b/test/compilable/imports/test18651/datetime.d
@@ -1,0 +1,7 @@
+void parseTZConversions()
+{
+    import imports.test18651.algorithm;
+
+    string[] value;
+    value.sort.uniq;
+}

--- a/test/compilable/test18651a.d
+++ b/test/compilable/test18651a.d
@@ -1,0 +1,5 @@
+// REQUIRED_ARGS: -deps=${RESULTS_DIR}/compilable/test18651a.deps
+// EXTRA_SOURCES: imports/test18651/b.d
+// EXTRA_FILES: imports/test18651/c.d imports/test18651/algorithm.d imports/test18651/datetime.d
+
+import imports.test18651.datetime;


### PR DESCRIPTION
… trivial files

The problem was that some functions were not with sematic3 pass done because their symbol parent was deferred and `runDeferredSemantic3()` wasn't run. In this case were two auto generated functions (`__xopEquals, __xtoHash` that start only with semantic2) of some instantiation of `SortedRange`.

The test case on bugzilla uses Phobos and consumes 550MB of RAM, moreover, I think crafting another reduced case could be really time consuming, just in this example there were like ten thousand symbols deferred but still only two functions left over.