### PR TITLE
d_do_test: Remove obsolete -unittest filtering from PERMUTE_ARGS

### DIFF
--- a/test/tools/d_do_test.d
+++ b/test/tools/d_do_test.d
@@ -340,10 +340,6 @@ bool gatherTestParameters(ref TestArgs testArgs, string input_dir, string input_
     {
         if (testArgs.mode == TestMode.RUN)
             testArgs.permuteArgs = envData.all_args;
-
-        string unittestJunk;
-        if(!findTestParameter(envData, file, "unittest", unittestJunk))
-            testArgs.permuteArgs = replace(testArgs.permuteArgs, "-unittest", "");
     }
     replaceResultsDir(testArgs.permuteArgs, envData);
 


### PR DESCRIPTION
This code is obsolete because `-unittest` is no longer a default` PERMUTE_ARGS`(it was removed in #5912)