### PR TITLE
make Dysmbol.apply type safe by changing implementation 

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -18,6 +18,7 @@ import core.stdc.stdio;
 import core.checkedint;
 
 import dmd.aliasthis;
+import dmd.apply;
 import dmd.arraytypes;
 import dmd.gluelayer : Symbol;
 import dmd.declaration;
@@ -176,15 +177,13 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
         // determineFields can be called recursively from one of the fields's v.semantic
         fields.setDim(0);
 
-        extern (C++) static int func(Dsymbol s, void* param)
+        static int func(Dsymbol s, AggregateDeclaration ad)
         {
             auto v = s.isVarDeclaration();
             if (!v)
                 return 0;
             if (v.storage_class & STC.manifest)
                 return 0;
-
-            auto ad = cast(AggregateDeclaration)param;
 
             if (v.semanticRun < PASS.semanticdone)
                 v.dsymbolSemantic(null);
@@ -223,7 +222,7 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
             for (size_t i = 0; i < members.dim; i++)
             {
                 auto s = (*members)[i];
-                if (s.apply(&func, cast(void*)this))
+                if (s.apply(&func, this))
                 {
                     if (sizeok != Sizeok.none)
                     {

--- a/src/dmd/apply.d
+++ b/src/dmd/apply.d
@@ -12,6 +12,8 @@
 module dmd.apply;
 
 import dmd.arraytypes;
+import dmd.dsymbol;
+import dmd.dsymbolsem;
 import dmd.dtemplate;
 import dmd.expression;
 import dmd.visitor;
@@ -151,4 +153,37 @@ bool walkPostorder(Expression e, StoppableVisitor v)
     scope PostorderExpressionVisitor pv = new PostorderExpressionVisitor(v);
     e.accept(pv);
     return v.stop;
+}
+
+/*********************************
+ * Iterate this dsymbol or members of this scoped dsymbol, then
+ * call `fp` with the found symbol and `params`.
+ * Params:
+ *  symbol = the dsymbol or parent of members to call fp on
+ *  fp = function pointer to process the iterated symbol.
+ *       If it returns nonzero, the iteration will be aborted.
+ *  params = any parameters passed to fp.
+ * Returns:
+ *  nonzero if the iteration is aborted by the return value of fp,
+ *  or 0 if it's completed.
+ */
+int apply(FP, Params...)(Dsymbol symbol, FP fp, Params params)
+{
+    if (auto nd = symbol.isNspace())
+    {
+        return nd.members.foreachDsymbol( (s) { return s && s.apply(fp, params); } );
+    }
+    if (auto ad = symbol.isAttribDeclaration())
+    {
+        return ad.include(ad._scope).foreachDsymbol( (s) { return s && s.apply(fp, params); } );
+    }
+    if (auto tm = symbol.isTemplateMixin())
+    {
+        if (tm._scope) // if fwd reference
+            dsymbolSemantic(tm, null); // try to resolve it
+
+        return tm.members.foreachDsymbol( (s) { return s && s.apply(fp, params); } );
+    }
+
+    return fp(symbol, params);
 }

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -71,11 +71,6 @@ extern (C++) abstract class AttribDeclaration : Dsymbol
         return decl;
     }
 
-    override final int apply(Dsymbol_apply_ft_t fp, void* param)
-    {
-        return include(_scope).foreachDsymbol( (s) { return s && s.apply(fp, param); } );
-    }
-
     /****************************************
      * Create a new scope if one or more given attributes
      * are different from the sc's.

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -25,7 +25,6 @@ public:
     Dsymbols *decl;     // array of Dsymbol's
 
     virtual Dsymbols *include(Scope *sc);
-    int apply(Dsymbol_apply_ft_t fp, void *param);
     virtual Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);

--- a/src/dmd/dclass.d
+++ b/src/dmd/dclass.d
@@ -17,6 +17,7 @@ import core.stdc.stdio;
 import core.stdc.string;
 
 import dmd.aggregate;
+import dmd.apply;
 import dmd.arraytypes;
 import dmd.gluelayer;
 import dmd.declaration;
@@ -877,7 +878,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
          * Resolve forward references to all class member functions,
          * and determine whether this class is abstract.
          */
-        extern (C++) static int func(Dsymbol s, void* param)
+        static int func(Dsymbol s)
         {
             auto fd = s.isFuncDeclaration();
             if (!fd)
@@ -893,7 +894,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
         for (size_t i = 0; i < members.dim; i++)
         {
             auto s = (*members)[i];
-            if (s.apply(&func, cast(void*)this))
+            if (s.apply(&func))
             {
                 return yes();
             }
@@ -920,7 +921,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
              * each of the virtual functions,
              * which will fill in the vtbl[] overrides.
              */
-            extern (C++) static int virtualSemantic(Dsymbol s, void* param)
+            static int virtualSemantic(Dsymbol s)
             {
                 auto fd = s.isFuncDeclaration();
                 if (fd && !(fd.storage_class & STC.static_) && !fd.isUnitTestDeclaration())
@@ -931,7 +932,7 @@ extern (C++) class ClassDeclaration : AggregateDeclaration
             for (size_t i = 0; i < members.dim; i++)
             {
                 auto s = (*members)[i];
-                s.apply(&virtualSemantic, cast(void*)this);
+                s.apply(&virtualSemantic);
             }
         }
 

--- a/src/dmd/dsymbol.d
+++ b/src/dmd/dsymbol.d
@@ -220,8 +220,6 @@ enum : int
     IgnoreSymbolVisibility  = 0x80, // also find private and package protected symbols
 }
 
-extern (C++) alias Dsymbol_apply_ft_t = int function(Dsymbol, void*);
-
 /***********************************************************
  */
 extern (C++) class Dsymbol : ASTNode
@@ -711,22 +709,6 @@ extern (C++) class Dsymbol : ASTNode
     Dsymbol toAlias2()
     {
         return toAlias();
-    }
-
-    /*********************************
-     * Iterate this dsymbol or members of this scoped dsymbol, then
-     * call `fp` with the found symbol and `param`.
-     * Params:
-     *  fp = function pointer to process the iterated symbol.
-     *       If it returns nonzero, the iteration will be aborted.
-     *  param = a parameter passed to fp.
-     * Returns:
-     *  nonzero if the iteration is aborted by the return value of fp,
-     *  or 0 if it's completed.
-     */
-    int apply(Dsymbol_apply_ft_t fp, void* param)
-    {
-        return (*fp)(this, param);
     }
 
     void addMember(Scope* sc, ScopeDsymbol sds)

--- a/src/dmd/dsymbol.h
+++ b/src/dmd/dsymbol.h
@@ -140,8 +140,6 @@ enum
     IgnoreSymbolVisibility  = 0x80  // also find private and package protected symbols
 };
 
-typedef int (*Dsymbol_apply_ft_t)(Dsymbol *, void *);
-
 class Dsymbol : public ASTNode
 {
 public:
@@ -194,7 +192,6 @@ public:
     virtual const char *kind() const;
     virtual Dsymbol *toAlias();                 // resolve real symbol
     virtual Dsymbol *toAlias2();
-    virtual int apply(Dsymbol_apply_ft_t fp, void *param);
     virtual void addMember(Scope *sc, ScopeDsymbol *sds);
     virtual void setScope(Scope *sc);
     virtual void importAll(Scope *sc);

--- a/src/dmd/dtemplate.d
+++ b/src/dmd/dtemplate.d
@@ -7486,14 +7486,6 @@ extern (C++) final class TemplateMixin : TemplateInstance
         return Dsymbol.oneMember(ps, ident);
     }
 
-    override int apply(Dsymbol_apply_ft_t fp, void* param)
-    {
-        if (_scope) // if fwd reference
-            dsymbolSemantic(this, null); // try to resolve it
-
-        return members.foreachDsymbol( (s) { return s && s.apply(fp, param); } );
-    }
-
     override bool hasPointers()
     {
         //printf("TemplateMixin.hasPointers() %s\n", toChars());

--- a/src/dmd/nspace.d
+++ b/src/dmd/nspace.d
@@ -137,11 +137,6 @@ extern (C++) final class Nspace : ScopeDsymbol
         return ScopeDsymbol.search(loc, ident, flags);
     }
 
-    override int apply(Dsymbol_apply_ft_t fp, void* param)
-    {
-        return members.foreachDsymbol( (s) { return s && s.apply(fp, param); } );
-    }
-
     override bool hasPointers()
     {
         //printf("Nspace::hasPointers() %s\n", toChars());

--- a/src/dmd/nspace.h
+++ b/src/dmd/nspace.h
@@ -25,7 +25,6 @@ class Nspace : public ScopeDsymbol
     void setScope(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
     Dsymbol *search(const Loc &loc, Identifier *ident, int flags = SearchLocalsOnly);
-    int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind() const;

--- a/src/dmd/template.h
+++ b/src/dmd/template.h
@@ -295,7 +295,6 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     const char *kind() const;
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    int apply(Dsymbol_apply_ft_t fp, void *param);
     bool hasPointers();
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *toChars() const;

--- a/src/dmd/tocvdebug.d
+++ b/src/dmd/tocvdebug.d
@@ -24,6 +24,7 @@ import dmd.root.array;
 import dmd.root.rmem;
 
 import dmd.aggregate;
+import dmd.apply;
 import dmd.dclass;
 import dmd.declaration;
 import dmd.denum;
@@ -445,19 +446,16 @@ struct CvFieldList
 }
 
 // Lambda function
-int cv_mem_count(Dsymbol s, void *param)
+int cv_mem_count(Dsymbol s, CvFieldList *pmc)
 {
-    CvFieldList *pmc = cast(CvFieldList *)param;
-
     int nwritten = cvMember(s, null);
     pmc.count(nwritten);
     return 0;
 }
 
 // Lambda function
-int cv_mem_p(Dsymbol s, void *param)
+int cv_mem_p(Dsymbol s, CvFieldList *pmc)
 {
-    CvFieldList *pmc = cast(CvFieldList *)param;
     ubyte *p = pmc.writePtr();
     uint len = cvMember(s, p);
     pmc.written(len);


### PR DESCRIPTION
Replace virtual methods in Dsymbol, TemplateMixin, Nspace, and AttribDeclaration with dispatch in a standalone function in apply.d.  This avoids passing parameters as void*, and in one place eliminates the need to pass a param at all.

I looked through LDC source and didn't see it used anywhere... @kinke and @ibuclaw is this method used in ldc or gdc?