### PR TITLE
slit off StmtState from IRState

### DIFF
--- a/src/dmd/irstate.d
+++ b/src/dmd/irstate.d
@@ -41,11 +41,8 @@ struct Label
  */
 struct IRState
 {
-    IRState* prev;
-    Statement statement;
     Module m;                       // module
     private FuncDeclaration symbol; // function that code is being generate for
-    Identifier ident;
     Symbol* shidden;                // hidden parameter to function
     Symbol* sthis;                  // 'this' parameter to function (member and nested)
     Symbol* sclosure;               // pointer to closure instance
@@ -57,31 +54,6 @@ struct IRState
     Label*[void*]* labels;          // table of labels used/declared in function
     const Param* params;            // command line parameters
     bool mayThrow;                  // the expression being evaluated may throw
-
-    block* breakBlock;
-    block* contBlock;
-    block* switchBlock;
-    block* defaultBlock;
-    block* finallyBlock;
-
-    this(IRState* irs, Statement s)
-    {
-        prev = irs;
-        statement = s;
-        if (irs)
-        {
-            m = irs.m;
-            shidden = irs.shidden;
-            sclosure = irs.sclosure;
-            sthis = irs.sthis;
-            blx = irs.blx;
-            deferToObj = irs.deferToObj;
-            varsInScope = irs.varsInScope;
-            labels = irs.labels;
-            params = irs.params;
-            mayThrow = irs.mayThrow;
-        }
-    }
 
     this(Module m, FuncDeclaration fd, Array!(elem*)* varsInScope, Dsymbols* deferToObj, Label*[void*]* labels,
         const Param* params)
@@ -97,133 +69,9 @@ struct IRState
             && !(fd && fd.eh_none);
     }
 
-    /****
-     * Access labels AA from C++ code.
-     * Params:
-     *  s = key
-     * Returns:
-     *  pointer to value if it's there, null if not
-     */
-    Label** lookupLabel(Statement s)
-    {
-        return cast(void*)s in *labels;
-    }
-
-    /****
-     * Access labels AA from C++ code.
-     * Params:
-     *  s = key
-     *  label = value
-     */
-    void insertLabel(Statement s, Label* label)
-    {
-        (*labels)[cast(void*)s] = label;
-    }
-
-    block* getBreakBlock(Identifier ident)
-    {
-        IRState* bc;
-        if (ident)
-        {
-            Statement related = null;
-            block* ret = null;
-            for (bc = &this; bc; bc = bc.prev)
-            {
-                // The label for a breakBlock may actually be some levels up (e.g.
-                // on a try/finally wrapping a loop). We'll see if this breakBlock
-                // is the one to return once we reach that outer statement (which
-                // in many cases will be this same statement).
-                if (bc.breakBlock)
-                {
-                    related = bc.statement.getRelatedLabeled();
-                    ret = bc.breakBlock;
-                }
-                if (bc.statement == related && bc.prev.ident == ident)
-                    return ret;
-            }
-        }
-        else
-        {
-            for (bc = &this; bc; bc = bc.prev)
-            {
-                if (bc.breakBlock)
-                    return bc.breakBlock;
-            }
-        }
-        return null;
-    }
-
-    block* getContBlock(Identifier ident)
-    {
-        IRState* bc;
-        if (ident)
-        {
-            block* ret = null;
-            for (bc = &this; bc; bc = bc.prev)
-            {
-                // The label for a contBlock may actually be some levels up (e.g.
-                // on a try/finally wrapping a loop). We'll see if this contBlock
-                // is the one to return once we reach that outer statement (which
-                // in many cases will be this same statement).
-                if (bc.contBlock)
-                {
-                    ret = bc.contBlock;
-                }
-                if (bc.prev && bc.prev.ident == ident)
-                    return ret;
-            }
-        }
-        else
-        {
-            for (bc = &this; bc; bc = bc.prev)
-            {
-                if (bc.contBlock)
-                    return bc.contBlock;
-            }
-        }
-        return null;
-    }
-
-    block* getSwitchBlock()
-    {
-        IRState* bc;
-        for (bc = &this; bc; bc = bc.prev)
-        {
-            if (bc.switchBlock)
-                return bc.switchBlock;
-        }
-        return null;
-    }
-
-    block* getDefaultBlock()
-    {
-        IRState* bc;
-        for (bc = &this; bc; bc = bc.prev)
-        {
-            if (bc.defaultBlock)
-                return bc.defaultBlock;
-        }
-        return null;
-    }
-
-    block* getFinallyBlock()
-    {
-        IRState* bc;
-        for (bc = &this; bc; bc = bc.prev)
-        {
-            if (bc.finallyBlock)
-                return bc.finallyBlock;
-        }
-        return null;
-    }
-
     FuncDeclaration getFunc()
     {
-        for (auto bc = &this; 1; bc = bc.prev)
-        {
-            if (!bc.prev)
-                return bc.symbol;
-        }
+        return symbol;
     }
 
     /**********************
@@ -266,5 +114,121 @@ struct IRState
     bool isNothrow()
     {
         return !mayThrow;
+    }
+}
+
+struct StmtState
+{
+    StmtState* prev;
+    Statement statement;
+
+    Identifier ident;
+    block* breakBlock;
+    block* contBlock;
+    block* switchBlock;
+    block* defaultBlock;
+    block* finallyBlock;
+
+    this(StmtState* prev, Statement statement)
+    {
+        this.prev = prev;
+        this.statement = statement;
+    }
+
+    block* getBreakBlock(Identifier ident)
+    {
+        StmtState* bc;
+        if (ident)
+        {
+            Statement related = null;
+            block* ret = null;
+            for (bc = &this; bc; bc = bc.prev)
+            {
+                // The label for a breakBlock may actually be some levels up (e.g.
+                // on a try/finally wrapping a loop). We'll see if this breakBlock
+                // is the one to return once we reach that outer statement (which
+                // in many cases will be this same statement).
+                if (bc.breakBlock)
+                {
+                    related = bc.statement.getRelatedLabeled();
+                    ret = bc.breakBlock;
+                }
+                if (bc.statement == related && bc.prev.ident == ident)
+                    return ret;
+            }
+        }
+        else
+        {
+            for (bc = &this; bc; bc = bc.prev)
+            {
+                if (bc.breakBlock)
+                    return bc.breakBlock;
+            }
+        }
+        return null;
+    }
+
+    block* getContBlock(Identifier ident)
+    {
+        StmtState* bc;
+        if (ident)
+        {
+            block* ret = null;
+            for (bc = &this; bc; bc = bc.prev)
+            {
+                // The label for a contBlock may actually be some levels up (e.g.
+                // on a try/finally wrapping a loop). We'll see if this contBlock
+                // is the one to return once we reach that outer statement (which
+                // in many cases will be this same statement).
+                if (bc.contBlock)
+                {
+                    ret = bc.contBlock;
+                }
+                if (bc.prev && bc.prev.ident == ident)
+                    return ret;
+            }
+        }
+        else
+        {
+            for (bc = &this; bc; bc = bc.prev)
+            {
+                if (bc.contBlock)
+                    return bc.contBlock;
+            }
+        }
+        return null;
+    }
+
+    block* getSwitchBlock()
+    {
+        StmtState* bc;
+        for (bc = &this; bc; bc = bc.prev)
+        {
+            if (bc.switchBlock)
+                return bc.switchBlock;
+        }
+        return null;
+    }
+
+    block* getDefaultBlock()
+    {
+        StmtState* bc;
+        for (bc = &this; bc; bc = bc.prev)
+        {
+            if (bc.defaultBlock)
+                return bc.defaultBlock;
+        }
+        return null;
+    }
+
+    block* getFinallyBlock()
+    {
+        StmtState* bc;
+        for (bc = &this; bc; bc = bc.prev)
+        {
+            if (bc.finallyBlock)
+                return bc.finallyBlock;
+        }
+        return null;
     }
 }

--- a/src/dmd/s2ir.d
+++ b/src/dmd/s2ir.d
@@ -123,11 +123,13 @@ private void incUsage(IRState *irs, const ref Loc loc)
 
 private extern (C++) class S2irVisitor : Visitor
 {
-    IRState *irs;
+    IRState* irs;
+    StmtState* stmtstate;
 
-    this(IRState *irs)
+    this(IRState *irs, StmtState* stmtstate)
     {
         this.irs = irs;
+        this.stmtstate = stmtstate;
     }
 
     alias visit = Visitor.visit;
@@ -158,27 +160,27 @@ private extern (C++) class S2irVisitor : Visitor
 
         //printf("IfStatement.toIR('%s')\n", s.condition.toChars());
 
-        IRState mystate = IRState(irs, s);
+        StmtState mystate = StmtState(stmtstate, s);
 
         // bexit is the block that gets control after this IfStatement is done
         block *bexit = mystate.breakBlock ? mystate.breakBlock : dmd.backend.global.block_calloc();
 
         incUsage(irs, s.loc);
-        e = toElemDtor(s.condition, &mystate);
+        e = toElemDtor(s.condition, irs);
         block_appendexp(blx.curblock, e);
         block *bcond = blx.curblock;
         block_next(blx, BCiftrue, null);
 
         bcond.appendSucc(blx.curblock);
         if (s.ifbody)
-            Statement_toIR(s.ifbody, &mystate);
+            Statement_toIR(s.ifbody, irs, &mystate);
         blx.curblock.appendSucc(bexit);
 
         if (s.elsebody)
         {
             block_next(blx, BCgoto, null);
             bcond.appendSucc(blx.curblock);
-            Statement_toIR(s.elsebody, &mystate);
+            Statement_toIR(s.elsebody, irs, &mystate);
             blx.curblock.appendSucc(bexit);
         }
         else
@@ -202,8 +204,6 @@ private extern (C++) class S2irVisitor : Visitor
             FuncDeclaration f = sa.isFuncDeclaration();
             assert(f);
             Symbol *sym = toSymbol(f);
-            while (irs.prev)
-                irs = irs.prev;
             irs.startaddress = sym;
         }
     }
@@ -223,7 +223,7 @@ private extern (C++) class S2irVisitor : Visitor
     {
         Blockx *blx = irs.blx;
 
-        IRState mystate = IRState(irs,s);
+        StmtState mystate = StmtState(stmtstate, s);
         mystate.breakBlock = block_calloc(blx);
         mystate.contBlock = block_calloc(blx);
 
@@ -235,12 +235,12 @@ private extern (C++) class S2irVisitor : Visitor
         mystate.contBlock.appendSucc(mystate.breakBlock);
 
         if (s._body)
-            Statement_toIR(s._body, &mystate);
+            Statement_toIR(s._body, irs, &mystate);
         blx.curblock.appendSucc(mystate.contBlock);
 
         block_next(blx, BCgoto, mystate.contBlock);
         incUsage(irs, s.condition.loc);
-        block_appendexp(mystate.contBlock, toElemDtor(s.condition, &mystate));
+        block_appendexp(mystate.contBlock, toElemDtor(s.condition, irs));
         block_next(blx, BCiftrue, mystate.breakBlock);
 
     }
@@ -253,12 +253,12 @@ private extern (C++) class S2irVisitor : Visitor
         //printf("visit(ForStatement)) %u..%u\n", s.loc.linnum, s.endloc.linnum);
         Blockx *blx = irs.blx;
 
-        IRState mystate = IRState(irs,s);
+        StmtState mystate = StmtState(stmtstate, s);
         mystate.breakBlock = block_calloc(blx);
         mystate.contBlock = block_calloc(blx);
 
         if (s._init)
-            Statement_toIR(s._init, &mystate);
+            Statement_toIR(s._init, irs, &mystate);
         block *bpre = blx.curblock;
         block_next(blx,BCgoto,null);
         block *bcond = blx.curblock;
@@ -267,7 +267,7 @@ private extern (C++) class S2irVisitor : Visitor
         if (s.condition)
         {
             incUsage(irs, s.condition.loc);
-            block_appendexp(bcond, toElemDtor(s.condition, &mystate));
+            block_appendexp(bcond, toElemDtor(s.condition, irs));
             block_next(blx,BCiftrue,null);
             bcond.appendSucc(blx.curblock);
             bcond.appendSucc(mystate.breakBlock);
@@ -280,7 +280,7 @@ private extern (C++) class S2irVisitor : Visitor
         }
 
         if (s._body)
-            Statement_toIR(s._body, &mystate);
+            Statement_toIR(s._body, irs, &mystate);
         /* End of the body goes to the continue block
          */
         blx.curblock.appendSucc(mystate.contBlock);
@@ -290,7 +290,7 @@ private extern (C++) class S2irVisitor : Visitor
         if (s.increment)
         {
             incUsage(irs, s.increment.loc);
-            block_appendexp(mystate.contBlock, toElemDtor(s.increment, &mystate));
+            block_appendexp(mystate.contBlock, toElemDtor(s.increment, irs));
         }
 
         /* The 'break' block follows the for statement.
@@ -327,7 +327,7 @@ private extern (C++) class S2irVisitor : Visitor
         block *b;
         Blockx *blx = irs.blx;
 
-        bbreak = irs.getBreakBlock(s.ident);
+        bbreak = stmtstate.getBreakBlock(s.ident);
         assert(bbreak);
         b = blx.curblock;
         incUsage(irs, s.loc);
@@ -355,7 +355,7 @@ private extern (C++) class S2irVisitor : Visitor
         Blockx *blx = irs.blx;
 
         //printf("ContinueStatement.toIR() %p\n", this);
-        bcont = irs.getContBlock(s.ident);
+        bcont = stmtstate.getContBlock(s.ident);
         assert(bcont);
         b = blx.curblock;
         incUsage(irs, s.loc);
@@ -398,7 +398,7 @@ private extern (C++) class S2irVisitor : Visitor
         //printf("LabelStatement.toIR() %p, statement: `%s`\n", this, s.statement.toChars());
         Blockx *blx = irs.blx;
         block *bc = blx.curblock;
-        IRState mystate = IRState(irs,s);
+        StmtState mystate = StmtState(stmtstate, s);
         mystate.ident = s.ident;
 
         block* bdest = cast(block*)s.extra;
@@ -408,7 +408,7 @@ private extern (C++) class S2irVisitor : Visitor
         block_next(blx, BCgoto, bdest);
         bc.appendSucc(blx.curblock);
         if (s.statement)
-            Statement_toIR(s.statement, &mystate);
+            Statement_toIR(s.statement, irs, &mystate);
     }
 
     /**************************************
@@ -419,7 +419,7 @@ private extern (C++) class S2irVisitor : Visitor
         Blockx *blx = irs.blx;
 
         //printf("SwitchStatement.toIR()\n");
-        IRState mystate = IRState(irs,s);
+        StmtState mystate = StmtState(stmtstate, s);
 
         mystate.switchBlock = blx.curblock;
 
@@ -446,7 +446,7 @@ private extern (C++) class S2irVisitor : Visitor
             }
 
         incUsage(irs, s.loc);
-        elem *econd = toElemDtor(s.condition, &mystate);
+        elem *econd = toElemDtor(s.condition, irs);
         if (s.hasVars)
         {   /* Generate a sequence of if-then-else blocks for the cases.
              */
@@ -460,7 +460,7 @@ private extern (C++) class S2irVisitor : Visitor
             if (numcases)
                 foreach (cs; *s.cases)
                 {
-                    elem *ecase = toElemDtor(cs.exp, &mystate);
+                    elem *ecase = toElemDtor(cs.exp, irs);
                     elem *e = el_bin(OPeqeq, TYbool, el_copytree(econd), ecase);
                     block *b = blx.curblock;
                     block_appendexp(b, e);
@@ -476,7 +476,7 @@ private extern (C++) class S2irVisitor : Visitor
             block_next(blx, BCgoto, null);
             b.appendSucc(mystate.defaultBlock);
 
-            Statement_toIR(s._body, &mystate);
+            Statement_toIR(s._body, irs, &mystate);
 
             /* Have the end of the switch body fall through to the block
              * following the switch statement.
@@ -512,7 +512,7 @@ private extern (C++) class S2irVisitor : Visitor
             foreach (cs; *s.cases)
                 *pu++ = cs.exp.toInteger();
 
-        Statement_toIR(s._body, &mystate);
+        Statement_toIR(s._body, irs, &mystate);
 
         /* Have the end of the switch body fall through to the block
          * following the switch statement.
@@ -526,32 +526,32 @@ private extern (C++) class S2irVisitor : Visitor
         block *bcase = blx.curblock;
         block* cb = cast(block*)s.extra;
         block_next(blx, BCgoto, cb);
-        block *bsw = irs.getSwitchBlock();
+        block *bsw = stmtstate.getSwitchBlock();
         if (bsw.BC == BCswitch)
             bsw.appendSucc(cb);   // second entry in pair
         bcase.appendSucc(cb);
         incUsage(irs, s.loc);
         if (s.statement)
-            Statement_toIR(s.statement, irs);
+            Statement_toIR(s.statement, irs, stmtstate);
     }
 
     override void visit(DefaultStatement s)
     {
         Blockx *blx = irs.blx;
         block *bcase = blx.curblock;
-        block *bdefault = irs.getDefaultBlock();
+        block *bdefault = stmtstate.getDefaultBlock();
         block_next(blx,BCgoto,bdefault);
         bcase.appendSucc(blx.curblock);
         incUsage(irs, s.loc);
         if (s.statement)
-            Statement_toIR(s.statement, irs);
+            Statement_toIR(s.statement, irs, stmtstate);
     }
 
     override void visit(GotoDefaultStatement s)
     {
         block *b;
         Blockx *blx = irs.blx;
-        block *bdest = irs.getDefaultBlock();
+        block *bdest = stmtstate.getDefaultBlock();
 
         b = blx.curblock;
 
@@ -706,7 +706,7 @@ private extern (C++) class S2irVisitor : Visitor
         block *finallyBlock;
         if (config.ehmethod != EHmethod.EH_DWARF &&
             !irs.isNothrow() &&
-            (finallyBlock = irs.getFinallyBlock()) != null)
+            (finallyBlock = stmtstate.getFinallyBlock()) != null)
         {
             assert(finallyBlock.BC == BC_finally);
             blx.curblock.appendSucc(finallyBlock);
@@ -722,7 +722,7 @@ private extern (C++) class S2irVisitor : Visitor
     {
         Blockx *blx = irs.blx;
 
-        //printf("ExpStatement.toIR(), exp = %s\n", s.exp ? s.exp.toChars() : "");
+        //printf("ExpStatement.toIR(), exp: %p %s\n", s.exp, s.exp ? s.exp.toChars() : "");
         if (s.exp)
         {
             if (s.exp.hasCode)
@@ -742,7 +742,7 @@ private extern (C++) class S2irVisitor : Visitor
             foreach (s2; *s.statements)
             {
                 if (s2)
-                    Statement_toIR(s2, irs);
+                    Statement_toIR(s2, irs, stmtstate);
             }
         }
     }
@@ -755,7 +755,7 @@ private extern (C++) class S2irVisitor : Visitor
     {
         Blockx *blx = irs.blx;
 
-        IRState mystate = IRState(irs,s);
+        StmtState mystate = StmtState(stmtstate, s);
         mystate.breakBlock = block_calloc(blx);
 
         block *bpre = blx.curblock;
@@ -772,7 +772,7 @@ private extern (C++) class S2irVisitor : Visitor
             {
                 mystate.contBlock = block_calloc(blx);
 
-                Statement_toIR(s2, &mystate);
+                Statement_toIR(s2, irs, &mystate);
 
                 bdox = blx.curblock;
                 block_next(blx, BCgoto, mystate.contBlock);
@@ -794,12 +794,12 @@ private extern (C++) class S2irVisitor : Visitor
         if (s.statement)
         {
             Blockx *blx = irs.blx;
-            IRState mystate = IRState(irs,s);
+            StmtState mystate = StmtState(stmtstate, s);
 
             if (mystate.prev.ident)
                 mystate.ident = mystate.prev.ident;
 
-            Statement_toIR(s.statement, &mystate);
+            Statement_toIR(s.statement, irs, &mystate);
 
             if (mystate.breakBlock)
                 block_goto(blx,BCgoto,mystate.breakBlock);
@@ -833,7 +833,7 @@ private extern (C++) class S2irVisitor : Visitor
         }
         // Execute with block
         if (s._body)
-            Statement_toIR(s._body, irs);
+            Statement_toIR(s._body, irs, stmtstate);
     }
 
 
@@ -873,7 +873,7 @@ private extern (C++) class S2irVisitor : Visitor
         if (config.ehmethod == EHmethod.EH_WIN32)
             nteh_declarvars(blx);
 
-        IRState mystate = IRState(irs,s);
+        StmtState mystate = StmtState(stmtstate, s);
 
         block *tryblock = block_goto(blx,BCgoto,null);
 
@@ -892,7 +892,7 @@ private extern (C++) class S2irVisitor : Visitor
         block_goto(blx,BC_try,null);
         if (s._body)
         {
-            Statement_toIR(s._body, &mystate);
+            Statement_toIR(s._body, irs, &mystate);
         }
         blx.tryblock = tryblock.Btry;
 
@@ -1023,7 +1023,7 @@ private extern (C++) class S2irVisitor : Visitor
 
                 if (cs.handler !is null)
                 {
-                    IRState catchState = IRState(irs, s);
+                    StmtState catchState = StmtState(stmtstate, s);
 
                     /* Append to block:
                      *   *(sclosure + cs.var.offset) = cs.var;
@@ -1035,7 +1035,7 @@ private extern (C++) class S2irVisitor : Visitor
                         ex = el_bin(OPadd, TYnptr, ex, el_long(TYsize_t, cs.var.offset));
                         ex = el_una(OPind, tym, ex);
                         ex = el_bin(OPeq, tym, ex, el_var(toSymbol(cs.var)));
-                        block_appendexp(catchState.blx.curblock, ex);
+                        block_appendexp(irs.blx.curblock, ex);
                     }
                     if (isCPPclass)
                     {
@@ -1051,10 +1051,10 @@ private extern (C++) class S2irVisitor : Visitor
                         ecc.type = Type.tvoid;
                         Statement sf = ExpStatement.create(Loc.initial, ecc);
                         Statement stf = TryFinallyStatement.create(Loc.initial, cs.handler, sf);
-                        Statement_toIR(stf, &catchState);
+                        Statement_toIR(stf, irs, &catchState);
                     }
                     else
-                        Statement_toIR(cs.handler, &catchState);
+                        Statement_toIR(cs.handler, irs, &catchState);
                 }
                 blx.curblock.appendSucc(breakblock2);
                 if (i + 1 == numcases)
@@ -1091,7 +1091,7 @@ private extern (C++) class S2irVisitor : Visitor
                 block_goto(blx, BCjcatch, null);
                 if (cs.handler !is null)
                 {
-                    IRState catchState = IRState(irs, s);
+                    StmtState catchState = StmtState(stmtstate, s);
 
                     /* Append to block:
                      *   *(sclosure + cs.var.offset) = cs.var;
@@ -1103,9 +1103,9 @@ private extern (C++) class S2irVisitor : Visitor
                         ex = el_bin(OPadd, TYnptr, ex, el_long(TYsize_t, cs.var.offset));
                         ex = el_una(OPind, tym, ex);
                         ex = el_bin(OPeq, tym, ex, el_var(toSymbol(cs.var)));
-                        block_appendexp(catchState.blx.curblock, ex);
+                        block_appendexp(irs.blx.curblock, ex);
                     }
-                    Statement_toIR(cs.handler, &catchState);
+                    Statement_toIR(cs.handler, irs, &catchState);
                 }
                 blx.curblock.appendSucc(breakblock2);
                 block_next(blx, BCgoto, null);
@@ -1151,7 +1151,7 @@ private extern (C++) class S2irVisitor : Visitor
         blx.tryblock = tryblock;
         block_goto(blx,BC_try,null);
 
-        IRState bodyirs = IRState(irs, s);
+        StmtState bodyirs = StmtState(stmtstate, s);
 
         block *finallyblock = block_calloc(blx);
 
@@ -1160,7 +1160,7 @@ private extern (C++) class S2irVisitor : Visitor
         bodyirs.finallyBlock = finallyblock;
 
         if (s._body)
-            Statement_toIR(s._body, &bodyirs);
+            Statement_toIR(s._body, irs, &bodyirs);
         blx.tryblock = tryblock.Btry;     // back to previous tryblock
 
         setScopeIndex(blx,blx.curblock,previndex);
@@ -1221,11 +1221,11 @@ private extern (C++) class S2irVisitor : Visitor
             assert(!retblock.Belem);
             retblock.Belem = eu;
 
-            IRState finallyState = IRState(irs, s);
+            StmtState finallyState = StmtState(stmtstate, s);
 
             setScopeIndex(blx, blx.curblock, previndex);
             if (s.finalbody)
-                Statement_toIR(s.finalbody, &finallyState);
+                Statement_toIR(s.finalbody, irs, &finallyState);
             block_goto(blx, BCgoto, retblock);
 
             block_next(blx,BC_ret,breakblock);
@@ -1285,11 +1285,11 @@ private extern (C++) class S2irVisitor : Visitor
 
             landingPad.Belem = el_bin(OPeq, TYvoid, el_var(sflag), el_long(TYint, 0)); // __flag = 0;
 
-            IRState finallyState = IRState(irs, s);
+            StmtState finallyState = StmtState(stmtstate, s);
 
             setScopeIndex(blx, blx.curblock, previndex);
             if (s.finalbody)
-                Statement_toIR(s.finalbody, &finallyState);
+                Statement_toIR(s.finalbody, irs, &finallyState);
             block_goto(blx, BCgoto, retblock);
 
             block_next(blx,BC_ret,breakblock);
@@ -1305,11 +1305,11 @@ private extern (C++) class S2irVisitor : Visitor
              */
             block_goto(blx,BC_finally,null);
 
-            IRState finallyState = IRState(irs, s);
+            StmtState finallyState = StmtState(stmtstate, s);
 
             setScopeIndex(blx, blx.curblock, previndex);
             if (s.finalbody)
-                Statement_toIR(s.finalbody, &finallyState);
+                Statement_toIR(s.finalbody, irs, &finallyState);
             block_goto(blx, BCgoto, retblock);
 
             block_next(blx,BC_ret,null);
@@ -1472,9 +1472,9 @@ private extern (C++) class S2irVisitor : Visitor
     {
     }
 
-    static void Statement_toIR(Statement s, IRState *irs)
+    static void Statement_toIR(Statement s, IRState *irs, StmtState* stmtstate)
     {
-        scope v = new S2irVisitor(irs);
+        scope v = new S2irVisitor(irs, stmtstate);
         s.accept(v);
     }
 }
@@ -1493,7 +1493,8 @@ void Statement_toIR(Statement s, IRState *irs)
                 label.statement.extra = dmd.backend.global.block_calloc();
         }
 
-    scope v = new S2irVisitor(irs);
+    StmtState stmtstate;
+    scope v = new S2irVisitor(irs, &stmtstate);
     s.accept(v);
 }
 


### PR DESCRIPTION
These two structs did completely different things, but were aggregated confusingly together. Separating them makes each much more tractable.