### PR TITLE
build.d: Forward "all" to the default "dmd" target...

### DIFF
--- a/src/build.d
+++ b/src/build.d
@@ -799,8 +799,9 @@ LtargetsLoop:
         switch (t)
         {
             case "all":
-                t = "dmd";
-                goto default;
+                // "all" must include dmd + dmd.conf
+                newTargets ~= dmdDefault;
+                break;
 
             default:
                 // check this last, target paths should be checked after predefined names


### PR DESCRIPTION
instead of searching all targets for a file named `dmd`. This would either
skip `dmd.conf` (because it matched `generated/$(OS)/$(BUILD)/$(MODEL)/dmd)
or fail entirely on windows.

Fix for #7528 