### PR TITLE
follow up to PR10969.  Remove ischar

### DIFF
--- a/src/dmd/astbase.d
+++ b/src/dmd/astbase.d
@@ -262,7 +262,6 @@ struct ASTBase
         real_        = 8,
         imaginary    = 0x10,
         complex      = 0x20,
-        char_        = 0x40,
     }
 
     enum PKG : int
@@ -3590,17 +3589,17 @@ struct ASTBase
 
             case Tchar:
                 d = Token.toChars(TOK.char_);
-                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+                flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
             case Twchar:
                 d = Token.toChars(TOK.wchar_);
-                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+                flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
             case Tdchar:
                 d = Token.toChars(TOK.dchar_);
-                flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+                flags |= TFlags.integral | TFlags.unsigned;
                 break;
 
             default:

--- a/src/dmd/dcast.d
+++ b/src/dmd/dcast.d
@@ -2786,10 +2786,10 @@ bool typeMerge(Scope* sc, TOK op, Type* pt, Expression* pe1, Expression* pe2)
 
     if (op != TOK.question || t1b.ty != t2b.ty && (t1b.isTypeBasic() && t2b.isTypeBasic()))
     {
-        if (op == TOK.question && t1b.ischar() && t2b.ischar())
+        if (op == TOK.question && t1b.ty.isSomeChar() && t2b.ty.isSomeChar())
         {
-            e1 = charPromotions(e1, sc);
-            e2 = charPromotions(e2, sc);
+            e1 = e1.castTo(sc, Type.tdchar);
+            e2 = e2.castTo(sc, Type.tdchar);
         }
         else
         {
@@ -3483,29 +3483,6 @@ Expression integralPromotions(Expression e, Scope* sc)
 
     default:
         break;
-    }
-    return e;
-}
-
-/***********************************
- * Do char promotions.
- *   char  -> dchar
- *   wchar -> dchar
- *   dchar -> dchar
- */
-Expression charPromotions(Expression e, Scope* sc)
-{
-    //printf("charPromotions %s %s\n", e.toChars(), e.type.toChars());
-    switch (e.type.toBasetype().ty)
-    {
-    case Tchar:
-    case Twchar:
-    case Tdchar:
-        e = e.castTo(sc, Type.tdchar);
-        break;
-
-    default:
-        assert(0);
     }
     return e;
 }

--- a/src/dmd/mtype.d
+++ b/src/dmd/mtype.d
@@ -231,7 +231,6 @@ private enum TFlags
     real_        = 8,
     imaginary    = 0x10,
     complex      = 0x20,
-    char_        = 0x40,
 }
 
 enum ENUMTY : int
@@ -1031,11 +1030,6 @@ extern (C++) abstract class Type : ASTNode
     }
 
     bool isunsigned()
-    {
-        return false;
-    }
-
-    bool ischar()
     {
         return false;
     }
@@ -3139,17 +3133,17 @@ extern (C++) final class TypeBasic : Type
 
         case Tchar:
             d = Token.toChars(TOK.char_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned;
             break;
 
         case Twchar:
             d = Token.toChars(TOK.wchar_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned;
             break;
 
         case Tdchar:
             d = Token.toChars(TOK.dchar_);
-            flags |= TFlags.integral | TFlags.unsigned | TFlags.char_;
+            flags |= TFlags.integral | TFlags.unsigned;
             break;
 
         default:
@@ -3287,11 +3281,6 @@ extern (C++) final class TypeBasic : Type
     override bool isunsigned() const
     {
         return (flags & TFlags.unsigned) != 0;
-    }
-
-    override bool ischar() const
-    {
-        return (flags & TFlags.char_) != 0;
     }
 
     override MATCH implicitConvTo(Type to)
@@ -5880,11 +5869,6 @@ extern (C++) final class TypeEnum : Type
     override bool isunsigned()
     {
         return memType().isunsigned();
-    }
-
-    override bool ischar()
-    {
-        return memType().ischar();
     }
 
     override bool isBoolean()

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -243,7 +243,6 @@ public:
     virtual bool iscomplex();
     virtual bool isscalar();
     virtual bool isunsigned();
-    virtual bool ischar();
     virtual bool isscope();
     virtual bool isString();
     virtual bool isAssignable();
@@ -389,7 +388,6 @@ public:
     bool iscomplex() /*const*/;
     bool isscalar() /*const*/;
     bool isunsigned() /*const*/;
-    bool ischar() /*const*/;
     MATCH implicitConvTo(Type *to);
     bool isZeroInit(const Loc &loc) /*const*/;
 
@@ -770,7 +768,6 @@ public:
     bool iscomplex();
     bool isscalar();
     bool isunsigned();
-    bool ischar();
     bool isBoolean();
     bool isString();
     bool isAssignable();

--- a/test/compilable/implicitconv.d
+++ b/test/compilable/implicitconv.d
@@ -21,3 +21,13 @@ static assert(is(typeof(true ? char.init : dchar.init) == dchar));
 static assert(is(typeof(true ? wchar.init : wchar.init) == wchar));
 static assert(is(typeof(true ? wchar.init : dchar.init) == dchar));
 static assert(is(typeof(true ? dchar.init : dchar.init) == dchar));
+
+enum cenum : char { a }
+enum wenum : wchar{ b }
+enum denum : dchar{ c }
+
+static assert(is(typeof(true ? char.init : cenum.init) == char));
+static assert(is(typeof(true ? wchar.init : cenum.init) == dchar));
+static assert(is(typeof(true ? char.init : wenum.init) == dchar));
+static assert(is(typeof(true ? dchar.init : wenum.init) == dchar));
+static assert(is(typeof(true ? cenum.init : wenum.init) == dchar));


### PR DESCRIPTION
Per @ibuclaw 's comments on PR#10969 

Removes most of the code added by PR 9889 that was unneeded.

I added the tests with enum to make sure removing the isChar overload for enums didn't break anything