### PR TITLE
[stable] Fix issue 20700 -  Forward references leads to extern(C++, class|struct) being ignored

### DIFF
--- a/src/dmd/aggregate.d
+++ b/src/dmd/aggregate.d
@@ -82,6 +82,10 @@ extern (C++) abstract class AggregateDeclaration : ScopeDsymbol
 
     /// specifies whether this is a D, C++, Objective-C or anonymous struct/class/interface
     ClassKind classKind;
+    /// Specify whether to mangle the aggregate as a `class` or a `struct`
+    /// This information is used by the MSVC mangler
+    /// Only valid for class and struct. TODO: Merge with ClassKind ?
+    CPPMANGLE cppmangle;
 
     /* !=null if is nested
      * pointing to the dsymbol that directly enclosing it.

--- a/src/dmd/aggregate.h
+++ b/src/dmd/aggregate.h
@@ -84,6 +84,7 @@ public:
     Dsymbol *deferred;          // any deferred semantic2() or semantic3() symbol
 
     ClassKind::Type classKind;  // specifies the linkage type
+    CPPMANGLE cppmangle;
 
     /* !=NULL if is nested
      * pointing to the dsymbol that directly enclosing it.

--- a/src/dmd/attrib.d
+++ b/src/dmd/attrib.d
@@ -435,6 +435,13 @@ extern (C++) final class CPPMangleDeclaration : AttribDeclaration
             sc.aligndecl, sc.inlining);
     }
 
+    override void setScope(Scope* sc)
+    {
+        if (decl)
+            Dsymbol.setScope(sc); // for forward reference
+        return AttribDeclaration.setScope(sc);
+    }
+
     override const(char)* toChars() const
     {
         return toString().ptr;

--- a/src/dmd/attrib.h
+++ b/src/dmd/attrib.h
@@ -88,6 +88,7 @@ public:
 
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
+    void setScope(Scope *sc);
     const char *toChars() const;
     void accept(Visitor *v) { v->visit(this); }
 };

--- a/src/dmd/cppmanglewin.d
+++ b/src/dmd/cppmanglewin.d
@@ -16,8 +16,10 @@ import core.stdc.stdio;
 
 import dmd.arraytypes;
 import dmd.cppmangle : isPrimaryDtor, isCppOperator, CppOperator;
+import dmd.dclass;
 import dmd.declaration;
 import dmd.denum : isSpecialEnumIdent;
+import dmd.dstruct;
 import dmd.dsymbol;
 import dmd.dtemplate;
 import dmd.errors;
@@ -388,10 +390,11 @@ public:
             return;
         //printf("visit(TypeStruct); is_not_top_type = %d\n", (int)(flags & IS_NOT_TOP_TYPE));
         mangleModifier(type);
+        const agg = type.sym.isStructDeclaration();
         if (type.sym.isUnionDeclaration())
             buf.writeByte('T');
         else
-            buf.writeByte(type.cppmangle == CPPMANGLE.asClass ? 'V' : 'U');
+            buf.writeByte(agg.cppmangle == CPPMANGLE.asClass ? 'V' : 'U');
         mangleIdent(type.sym);
         flags &= ~IS_NOT_TOP_TYPE;
         flags &= ~IGNORE_CONST;
@@ -459,7 +462,8 @@ public:
             buf.writeByte('E');
         flags |= IS_NOT_TOP_TYPE;
         mangleModifier(type);
-        buf.writeByte(type.cppmangle == CPPMANGLE.asStruct ? 'U' : 'V');
+        const cldecl = type.sym.isClassDeclaration();
+        buf.writeByte(cldecl.cppmangle == CPPMANGLE.asStruct ? 'U' : 'V');
         mangleIdent(type.sym);
         flags &= ~IS_NOT_TOP_TYPE;
         flags &= ~IGNORE_CONST;

--- a/src/dmd/dsymbolsem.d
+++ b/src/dmd/dsymbolsem.d
@@ -4614,6 +4614,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (sc.linkage == LINK.cpp)
                 sd.classKind = ClassKind.cpp;
             sd.cppnamespace = sc.namespace;
+            sd.cppmangle = sc.cppmangle;
         }
         else if (sd.symtab && !scx)
             return;
@@ -4831,6 +4832,7 @@ private extern(C++) final class DsymbolSemanticVisitor : Visitor
             if (sc.linkage == LINK.cpp)
                 cldec.classKind = ClassKind.cpp;
             cldec.cppnamespace = sc.namespace;
+            cldec.cppmangle = sc.cppmangle;
             if (sc.linkage == LINK.objc)
                 objc.setObjc(cldec);
         }

--- a/src/dmd/mtype.h
+++ b/src/dmd/mtype.h
@@ -727,7 +727,6 @@ class TypeStruct : public Type
 public:
     StructDeclaration *sym;
     AliasThisRec att;
-    CPPMANGLE cppmangle;
 
     static TypeStruct *create(StructDeclaration *sym);
     const char *kind();

--- a/src/dmd/typesem.d
+++ b/src/dmd/typesem.d
@@ -1811,14 +1811,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
     {
         //printf("TypeStruct::semantic('%s')\n", mtype.toChars());
         if (mtype.deco)
-        {
-            if (sc && sc.cppmangle != CPPMANGLE.def)
-            {
-                if (mtype.cppmangle == CPPMANGLE.def)
-                    mtype.cppmangle = sc.cppmangle;
-            }
             return mtype;
-        }
 
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
@@ -1828,11 +1821,6 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
 
         if (mtype.sym.type.ty == Terror)
             return error();
-
-        if (sc && sc.cppmangle != CPPMANGLE.def)
-            mtype.cppmangle = sc.cppmangle;
-        else
-            mtype.cppmangle = CPPMANGLE.asStruct;
 
         return merge(mtype);
     }
@@ -1847,14 +1835,7 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
     {
         //printf("TypeClass::semantic(%s)\n", mtype.toChars());
         if (mtype.deco)
-        {
-            if (sc && sc.cppmangle != CPPMANGLE.def)
-            {
-                if (mtype.cppmangle == CPPMANGLE.def)
-                    mtype.cppmangle = sc.cppmangle;
-            }
             return mtype;
-        }
 
         /* Don't semantic for sym because it should be deferred until
          * sizeof needed or its members accessed.
@@ -1864,11 +1845,6 @@ extern(C++) Type typeSemantic(Type t, Loc loc, Scope* sc)
 
         if (mtype.sym.type.ty == Terror)
             return error();
-
-        if (sc && sc.cppmangle != CPPMANGLE.def)
-            mtype.cppmangle = sc.cppmangle;
-        else
-            mtype.cppmangle = CPPMANGLE.asClass;
 
         return merge(mtype);
     }

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -1251,3 +1251,31 @@ extern(C++, `bar`)
 {
     void func19542(T)();
 }
+
+// https://issues.dlang.org/show_bug.cgi?id=20700
+// Only testing on WIn64 because the mangling includes 'E',
+// and the bug can be tested on either platform
+version (Win64) extern(C++)
+{
+    void test20700_1(Struct20700);
+    extern(C++, class) struct Struct20700 {}
+    void test20700_2(Struct20700);
+
+    // Note: Needs to be `V` (`class`), not `U` (`struct`)
+    static assert(test20700_1.mangleof == `?test20700_1@@YAXVStruct20700@@@Z`);
+    static assert(test20700_2.mangleof == `?test20700_2@@YAXVStruct20700@@@Z`);
+
+    // Test that the scope is not "sticky" on the arguments
+    void test20700_3(TStruct20700_1!DefaultClass20700_1);
+    extern(C++, class) struct TStruct20700_1 (T1, T2 = DefaultStruct20700_1) {}
+    extern(C++, class) struct DefaultStruct20700_1 {}
+    extern(C++, struct) class DefaultClass20700_1 {}
+    static assert(test20700_3.mangleof == `?test20700_3@@YAXV?$TStruct20700_1@PEAUDefaultClass20700_1@@VDefaultStruct20700_1@@@@@Z`);
+
+    // Each test needs to be independent symbol to trigger a new semantic pass
+    void test20700_4(TStruct20700_2!(DefaultClass20700_2, DefaultStruct20700_2));
+    extern(C++, struct) class TStruct20700_2 (T1, T2 = DefaultClass20700_2) {}
+    extern(C++, class) struct DefaultStruct20700_2 {}
+    extern(C++, struct) class DefaultClass20700_2 {}
+    static assert(test20700_4.mangleof == `?test20700_4@@YAXPEAU?$TStruct20700_2@PEAUDefaultClass20700_2@@VDefaultStruct20700_2@@@@@Z`);
+}


### PR DESCRIPTION
```
On the long run, it looks like we should just move the setScope to AttribDeclaration,
but this is a simple bugfix to target stable.
```

Note: This is a WIP for the moment as I can't test on Windows. However, I'd like to be sure the test fails before I make it pass.