### PR TITLE
Expression.copy should use allocmemory

### DIFF
--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -694,7 +694,7 @@ extern (C++) abstract class Expression : ASTNode
             }
             assert(0);
         }
-        e = cast(Expression)mem.xmalloc(size);
+        e = cast(Expression)_d_allocmemory(size);
         //printf("Expression::copy(op = %d) e = %p\n", op, e);
         return cast(Expression)memcpy(cast(void*)e, cast(void*)this, size);
     }

--- a/src/dmd/expression.d
+++ b/src/dmd/expression.d
@@ -694,6 +694,8 @@ extern (C++) abstract class Expression : ASTNode
             }
             assert(0);
         }
+
+        // memory never freed, so can use the faster bump-pointer-allocation
         e = cast(Expression)_d_allocmemory(size);
         //printf("Expression::copy(op = %d) e = %p\n", op, e);
         return cast(Expression)memcpy(cast(void*)e, cast(void*)this, size);


### PR DESCRIPTION
Since it's never freed anyway.
`xmalloc` and `xfree` are only supposed to be used in temporary allocations.
This reduces compile-times for template heavy projects by roughly 5-10% (probably 1-2% in the real world) based on my measurements.
(This 5-10% relating to frontend time only! (compiling with `-o-`))
