### PR TITLE
Better compiler error message

### DIFF
--- a/src/dmd/traits.d
+++ b/src/dmd/traits.d
@@ -1420,7 +1420,9 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto s = getDsymbol(o);
         if (!s)
         {
-            e.error("argument has no members");
+            e.error("In expression `%s` `%s` can't have members", e.toChars(), o.toChars());
+            e.errorSupplemental("`%s` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation", o.toChars());
+
             return new ErrorExp();
         }
         if (auto imp = s.isImport())
@@ -1432,7 +1434,8 @@ Expression semanticTraits(TraitsExp e, Scope* sc)
         auto sds = s.isScopeDsymbol();
         if (!sds || sds.isTemplateDeclaration())
         {
-            e.error("%s `%s` has no members", s.kind(), s.toChars());
+            e.error("In expression `%s` %s `%s` has no members", e.toChars(), s.kind(), s.toChars());
+            e.errorSupplemental("`%s` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation", s.toChars());
             return new ErrorExp();
         }
 

--- a/test/fail_compilation/ice14844.d
+++ b/test/fail_compilation/ice14844.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/ice14844.d(20): Error: template `opDispatch(string name)` has no members
+fail_compilation/ice14844.d(21): Error: In expression `__traits(allMembers, opDispatch)` template `opDispatch(string name)` has no members
+fail_compilation/ice14844.d(21):        `opDispatch(string name)` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
 ---
 */
 

--- a/test/fail_compilation/traits.d
+++ b/test/fail_compilation/traits.d
@@ -16,6 +16,14 @@ fail_compilation/traits.d(200): Error: undefined identifier `imports.nonexistent
 fail_compilation/traits.d(201): Error: undefined identifier `imports.nonexistent`
 fail_compilation/traits.d(202): Error: expected 1 arguments for `isPackage` but had 0
 fail_compilation/traits.d(203): Error: expected 1 arguments for `isModule` but had 0
+fail_compilation/traits.d(300): Error: In expression `__traits(allMembers, float)` `float` can't have members
+fail_compilation/traits.d(300):        `float` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
+fail_compilation/traits.d(306): Error: In expression `__traits(allMembers, TemplatedStruct)` struct `TemplatedStruct(T)` has no members
+fail_compilation/traits.d(306):        `TemplatedStruct(T)` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
+fail_compilation/traits.d(309): Error: In expression `__traits(derivedMembers, float)` `float` can't have members
+fail_compilation/traits.d(309):        `float` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
+fail_compilation/traits.d(316): Error: In expression `__traits(derivedMembers, TemplatedStruct)` struct `TemplatedStruct(T)` has no members
+fail_compilation/traits.d(316):        `TemplatedStruct(T)` must evaluate to either a module, a struct, an union, a class, an interface or a template instantiation
 ---
 */
 
@@ -30,3 +38,29 @@ enum A2 = __traits(isPackage, imports.nonexistent);
 enum B2 = __traits(isModule, imports.nonexistent);
 enum C2 = __traits(isPackage);
 enum D2 = __traits(isModule);
+
+interface Interface {}
+struct TemplatedStruct(T) {}
+struct Struct {}
+union Union {}
+class Class {}
+
+#line 300
+enum AM0 = __traits(allMembers, float);                     // compile error
+enum AM1 = __traits(allMembers, Struct);                    // no error
+enum AM2 = __traits(allMembers, Union);                     // no error
+enum AM3 = __traits(allMembers, Class);                     // no error
+enum AM4 = __traits(allMembers, Interface);                 // no error
+enum AM5 = __traits(allMembers, TemplatedStruct!float);     // no error
+enum AM6 = __traits(allMembers, TemplatedStruct);           // compile error
+enum AM7 = __traits(allMembers, mixin(__MODULE__));         // no error
+
+enum DM0 = __traits(derivedMembers, float);                 // compile error
+enum DM1 = __traits(derivedMembers, Struct);                // no error
+enum DM2 = __traits(derivedMembers, Struct);                // no error
+enum DM3 = __traits(derivedMembers, Union);                 // no error
+enum DM4 = __traits(derivedMembers, Class);                 // no error
+enum DM5 = __traits(derivedMembers, Interface);             // no error
+enum DM6 = __traits(derivedMembers, TemplatedStruct!float); // no error
+enum DM7 = __traits(derivedMembers, TemplatedStruct);       // compile error
+enum DM8 = __traits(derivedMembers, mixin(__MODULE__));     // no error


### PR DESCRIPTION
Instead of laconic:
```
source/aux/traits.d(133,31): Error: argument has no members
```
we have now
```
source/aux/traits.d(133,31): Error: TaggedAlgebraic!(Payload)[] has no members
```