### PR TITLE
Fix: DIP 1021: when len is smaller than escapeByStorage, only use first len fields

### DIFF
--- a/src/dmd/escape.d
+++ b/src/dmd/escape.d
@@ -89,6 +89,8 @@ bool checkMutableArguments(Scope* sc, FuncDeclaration fd, TypeFunction tf,
         escapeBy = newPtr[0 .. len];
         escapeByStorage = escapeBy;
     }
+    else
+        escapeBy = escapeBy[0 .. len];
 
     const paramLength = tf.parameterList.length;
 

--- a/test/compilable/issue20995.d
+++ b/test/compilable/issue20995.d
@@ -1,0 +1,12 @@
+/*
+REQUIRED_ARGS: -preview=dip1021
+
+https://issues.dlang.org/show_bug.cgi?id=20995
+*/
+
+void foo() @live
+{
+    throw new Exception("");
+}
+
+void main () {}


### PR DESCRIPTION
This seems right? In any case, the previous code crashes with `-preview=dip1021`.